### PR TITLE
chore(ci): fix flaky lsp bench due to notification that was accidentally added

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1063,13 +1063,12 @@ impl Inner {
       };
 
       match format_result {
-        Ok(new_text) => new_text.map(|new_text| {
-          text::get_edits(
-            document.content().as_str(),
-            &new_text,
-            document.line_index().as_ref(),
-          )
-        }),
+        Ok(Some(new_text)) => Some(text::get_edits(
+          document.content().as_str(),
+          &new_text,
+          document.line_index().as_ref(),
+        )),
+        Ok(None) => Some(Vec::new()),
         Err(err) => {
           // TODO(lucacasonato): handle error properly
           warn!("Format error: {}", err);


### PR DESCRIPTION
I'll follow up with another PR that adds tests. I'm working on it, but it's a larger change. Just want to fix the flaky CI right now.

https://github.com/denoland/deno/pull/14146#discussion_r837814179

I'm not categorizing this as a "fix" because it doesn't need to be in the release notes.