### PR TITLE
chore: disable wgpu tests in WSL

### DIFF
--- a/cli/tests/unit/webgpu_test.ts
+++ b/cli/tests/unit/webgpu_test.ts
@@ -7,7 +7,7 @@ try {
   isCI = true;
 }
 
-// Skip these tests on Linux and Mac CI, because the vulkan emulator is not good enough
+// Skip these tests on linux CI, because the vulkan emulator is not good enough
 // yet, and skip on macOS because these do not have virtual GPUs.
 const isLinuxOrMacCI =
   (Deno.build.os === "linux" || Deno.build.os === "darwin") && isCI;

--- a/cli/tests/unit/webgpu_test.ts
+++ b/cli/tests/unit/webgpu_test.ts
@@ -9,13 +9,14 @@ try {
 
 // Skip these tests on Linux and Mac CI, because the vulkan emulator is not good enough
 // yet, and skip on macOS because these do not have virtual GPUs.
-const isMacOrLinuxCi = (Deno.build.os === "linux" || Deno.build.os === "darwin") && isCI;
+const isLinuxOrMacCI =
+  (Deno.build.os === "linux" || Deno.build.os === "darwin") && isCI;
 // Skip these tests in WSL because it doesn't have good GPU support.
 const isWsl = await checkIsWsl();
 
 Deno.test({
   permissions: { read: true, env: true },
-  ignore: isWsl || isMacOrLinuxCi,
+  ignore: isWsl || isLinuxOrMacCI,
 }, async function webgpuComputePass() {
   const adapter = await navigator.gpu.requestAdapter();
   assert(adapter);
@@ -105,7 +106,7 @@ Deno.test({
 
 Deno.test({
   permissions: { read: true, env: true },
-  ignore: isWsl || isMacOrLinuxCi,
+  ignore: isWsl || isLinuxOrMacCI,
 }, async function webgpuHelloTriangle() {
   const adapter = await navigator.gpu.requestAdapter();
   assert(adapter);

--- a/cli/tests/unit/webgpu_test.ts
+++ b/cli/tests/unit/webgpu_test.ts
@@ -217,6 +217,7 @@ async function checkIsWsl() {
   return Deno.build.os === "linux" && await hasMicrosoftProcVersion();
 
   async function hasMicrosoftProcVersion() {
+    // https://github.com/microsoft/WSL/issues/423#issuecomment-221627364
     try {
       const procVersion = await Deno.readTextFile("/proc/version");
       return /microsoft/i.test(procVersion);

--- a/cli/tests/unit/webgpu_test.ts
+++ b/cli/tests/unit/webgpu_test.ts
@@ -8,7 +8,7 @@ try {
 }
 
 // Skip these tests on linux CI, because the vulkan emulator is not good enough
-// yet, and skip on macOS because these do not have virtual GPUs.
+// yet, and skip on macOS CI because these do not have virtual GPUs.
 const isLinuxOrMacCI =
   (Deno.build.os === "linux" || Deno.build.os === "darwin") && isCI;
 // Skip these tests in WSL because it doesn't have good GPU support.


### PR DESCRIPTION
WSL doesn't have good support for GPU so we should disable these tests for it.

Closes #14152.