### PR TITLE
feat(test): use gray color for 'running n tests from ...'

### DIFF
--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -287,7 +287,13 @@ impl PrettyTestReporter {
 impl TestReporter for PrettyTestReporter {
   fn report_plan(&mut self, plan: &TestPlan) {
     let inflection = if plan.total == 1 { "test" } else { "tests" };
-    println!("running {} {} from {}", plan.total, inflection, plan.origin);
+    println!(
+      "{}",
+      colors::gray(format!(
+        "running {} {} from {}",
+        plan.total, inflection, plan.origin
+      ))
+    );
   }
 
   fn report_wait(&mut self, description: &TestDescription) {

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -289,6 +289,8 @@ impl TestReporter for PrettyTestReporter {
     let inflection = if plan.total == 1 { "test" } else { "tests" };
     println!(
       "{}",
+      // TODO(bartlomieju): plan.origin should be formatted as a relative path
+      // or remote URL
       colors::gray(format!(
         "running {} {} from {}",
         plan.total, inflection, plan.origin
@@ -404,8 +406,10 @@ impl TestReporter for PrettyTestReporter {
     }
 
     if !summary.failures.is_empty() {
-      println!("\n{}\n", colors::yellow("failures:"));
+      println!("\nfailures:\n");
       for (description, error) in &summary.failures {
+        // TODO(bartlomieju): description.origin should be formatted as a relative
+        // path or remote URL
         println!("{} > {}", &description.origin, description.name);
         println!("{}", format_error(error));
         println!();
@@ -446,13 +450,17 @@ impl TestReporter for PrettyTestReporter {
       summary.failed,
       get_steps_text(summary.failed_steps)
     );
-    println!(
-      "    {} {}{}",
-      colors::gray("ignored:"),
-      summary.ignored,
-      get_steps_text(summary.ignored_steps)
-    );
-    println!("   {} {}", colors::gray("filtered:"), summary.filtered_out);
+    if summary.ignored > 0 {
+      println!(
+        "    {} {}{}",
+        colors::gray("ignored:"),
+        summary.ignored,
+        get_steps_text(summary.ignored_steps)
+      );
+    }
+    if summary.filtered_out > 0 {
+      println!("   {} {}", colors::gray("filtered:"), summary.filtered_out);
+    }
     println!(
       "       {} {}",
       colors::gray("time:"),

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,15 @@
+Deno.test('name', async () => {
+  // console.log("hello world");
+});
+
+Deno.test('boom', async () => {
+  throw new Error("boom boom!")
+});
+
+Deno.test('boom2', async () => {
+  throw new Error("boom boom!")
+});
+
+Deno.test('boom3', async () => {
+  throw new Error("boom boom!")
+});


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/14186

Alternative to https://github.com/denoland/deno/pull/13930

<img width="676" alt="Screenshot 2022-04-02 at 21 02 44" src="https://user-images.githubusercontent.com/13602871/161397615-f1361515-25d6-4e54-b76a-bf81551bad82.png">
<img width="1088" alt="Screenshot 2022-04-02 at 21 00 16" src="https://user-images.githubusercontent.com/13602871/161397619-6ac08a9f-7415-4a5a-8c67-a9502497df2b.png">

I'm tempted to do the same for `test` on each lines before the test name