### PR TITLE
chore(ext/http): custom arity

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -239,7 +239,9 @@
         try {
           await core.opAsync(
             "op_http_write_headers",
-            [streamRid, innerResp.status ?? 200, innerResp.headerList],
+            streamRid,
+            innerResp.status ?? 200,
+            innerResp.headerList,
             isStreamingResponseBody ? null : respBody,
           );
         } catch (error) {

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -43,7 +43,6 @@ use hyper::service::Service;
 use hyper::Body;
 use hyper::Request;
 use hyper::Response;
-use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -484,24 +483,14 @@ fn req_headers(
   headers
 }
 
-// We use a tuple instead of struct to avoid serialization overhead of the keys.
-#[derive(Deserialize)]
-struct RespondArgs(
-  // rid:
-  u32,
-  // status:
-  u16,
-  // headers:
-  Vec<(ByteString, ByteString)>,
-);
-
 #[op]
 async fn op_http_write_headers(
   state: Rc<RefCell<OpState>>,
-  args: RespondArgs,
+  rid: u32,
+  status: u16,
+  headers: Vec<(ByteString, ByteString)>,
   data: Option<StringOrBuffer>,
 ) -> Result<(), AnyError> {
-  let RespondArgs(rid, status, headers) = args;
   let stream = state
     .borrow_mut()
     .resource_table


### PR DESCRIPTION
## `deno_http`

LLVM lines:

Before:
```
175790 (100%)  3829 (100%)  (TOTAL)
```

After:
```
174414 (100%)  3796 (100%)  (TOTAL)
```

There is also a consistent ~1kreq/sec improvement (funny):

`main`:
```
Summary:
  Total:	12.7902 secs
  Slowest:	0.0076 secs
  Fastest:	0.0000 secs
  Average:	0.0006 secs
  Requests/sec:	78184.8032

  Total data:	11000000 bytes
  Size/request:	11 bytes
```

This PR:
```
Summary:
  Total:	12.5289 secs
  Slowest:	0.0205 secs
  Fastest:	0.0000 secs
  Average:	0.0006 secs
  Requests/sec:	79815.3870

  Total data:	11000000 bytes
  Size/request:	11 bytes
```