### PR TITLE
perf(serde_v8): smallvec ByteString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "smallvec",
  "v8",
 ]
 

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 derive_more = "0.99.17"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_bytes = "0.11"
+smallvec = { version = "1.8", features = ["union"] }
 v8 = "0.41.0"
 
 [dev-dependencies]

--- a/serde_v8/magic/bytestring.rs
+++ b/serde_v8/magic/bytestring.rs
@@ -3,7 +3,7 @@ use super::transl8::{FromV8, ToV8};
 use crate::magic::transl8::{impl_magic, impl_wrapper};
 use crate::Error;
 
-impl_wrapper! { pub struct ByteString(Vec<u8>); }
+impl_wrapper! { pub struct ByteString(smallvec::SmallVec<[u8; 16]>); }
 impl_magic!(ByteString);
 
 impl ToV8 for ByteString {
@@ -29,7 +29,7 @@ impl FromV8 for ByteString {
       return Err(Error::ExpectedLatin1);
     }
     let len = v8str.length();
-    let mut buffer = Vec::with_capacity(len);
+    let mut buffer = smallvec::SmallVec::with_capacity(len);
     // SAFETY: we set length == capacity (see previous line),
     // before immediately writing into that buffer and sanity check with an assert
     #[allow(clippy::uninit_vec)]


### PR DESCRIPTION
Avoiding heap allocs when deserializing ByteStrings with less than 16 chars

This comes at no memory overhead, since both `Vec<u8>` and `SmallVec<[u8; 16]>` (w/ union) are 24 bytes

Before:
```
test de_bstr_v8_1024_b    ... bench:          50 ns/iter (+/- 3)
test de_bstr_v8_12_b      ... bench:          35 ns/iter (+/- 1)
```

After:
```
test de_bstr_v8_1024_b    ... bench:          50 ns/iter (+/- 2)
test de_bstr_v8_12_b      ... bench:          15 ns/iter (+/- 0)
```

## TODO

- [ ] Fix some From/Into conversions