### PR TITLE
TRY perf(core): avoid borrows / multiple `get_slot` calls in poll_event_loop

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -189,7 +189,7 @@ macro_rules! include_js_files {
         Box::new(|| {
           let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
           let path = c.join($file);
-          println!("cargo:rerun-if-changed={}", path.display());
+          // println!("cargo:rerun-if-changed={}", path.display());
           let src = std::fs::read_to_string(path)?;
           Ok(src)
         }),

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -855,7 +855,7 @@ impl JsRuntime {
 
     // Ops
     {
-      self.resolve_async_ops(cx)?;
+      self.resolve_async_ops(state_rc.clone(), cx)?;
       self.drain_nexttick()?;
       self.drain_macrotasks()?;
       self.check_promise_exceptions()?;
@@ -1611,9 +1611,8 @@ impl JsRuntime {
   }
 
   // Send finished responses to JS
-  fn resolve_async_ops(&mut self, cx: &mut Context) -> Result<(), Error> {
-    let state_rc = Self::state(self.v8_isolate());
-
+  #[inline]
+  fn resolve_async_ops(&mut self, state_rc: Rc<RefCell<JsRuntimeState>>, cx: &mut Context) -> Result<(), Error> {
     let js_recv_cb_handle = state_rc.borrow().js_recv_cb.clone().unwrap();
     let scope = &mut self.handle_scope();
 


### PR DESCRIPTION
Async ops benchmark:

`main`:
```
op_void_async:       	n = 1000000, dt = 0.279s, r = 3584229/s, t = 279ns/op
read_128k:           	n = 50000, dt = 7.833s, r = 6383/s, t = 156660ns/op
```

This PR:
```
op_void_async:       	n = 1000000, dt = 0.258s, r = 3875969/s, t = 258ns/o
read_128k:           	n = 50000, dt = 7.164s, r = 6979/s, t = 143280ns/op
```

## note

opening pr for visibility, not super happy with improvements. Need to try a few more things.
