### PR TITLE
chore(core): Get rid of op ID's

### DIFF
--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -655,7 +655,7 @@ Deno.test("Worker with invalid permission arg", function () {
         deno: { permissions: { env: "foo" } },
       }),
     TypeError,
-    'Error parsing args at position 1: (deno.permissions.env) invalid value: string "foo", expected "inherit" or boolean or string[]',
+    'Error parsing args at position 0: (deno.permissions.env) invalid value: string "foo", expected "inherit" or boolean or string[]',
   );
 });
 

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -12,10 +12,8 @@
     Map,
     Array,
     ArrayPrototypeFill,
-    ArrayPrototypeMap,
     ErrorCaptureStackTrace,
     Promise,
-    ObjectEntries,
     ObjectFromEntries,
     MapPrototypeGet,
     MapPrototypeDelete,
@@ -27,10 +25,6 @@
     SymbolFor,
   } = window.__bootstrap.primordials;
   const ops = window.Deno.core.ops;
-  const opIds = Object.keys(ops).reduce((a, v, i) => {
-    a[v] = i;
-    return a;
-  }, {});
 
   // Available on start due to bindings.
   const { refOp_, unrefOp_ } = window.Deno.core;
@@ -154,7 +148,7 @@
 
   function opAsync(opName, ...args) {
     const promiseId = nextPromiseId++;
-    const maybeError = ops[opName](opIds[opName], promiseId, ...args);
+    const maybeError = ops[opName](promiseId, ...args);
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     let p = PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
@@ -174,7 +168,7 @@
   }
 
   function opSync(opName, ...args) {
-    return unwrapOpResult(ops[opName](opIds[opName], ...args));
+    return unwrapOpResult(ops[opName](...args));
   }
 
   function refOp(promiseId) {
@@ -221,10 +215,7 @@
 
   function metrics() {
     const [aggregate, perOps] = opSync("op_metrics");
-    aggregate.ops = ObjectFromEntries(ArrayPrototypeMap(
-      ObjectEntries(opIds),
-      ([opName, opId]) => [opName, perOps[opId]],
-    ));
+    aggregate.ops = perOps;
     return aggregate;
   }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -75,6 +75,7 @@ pub use crate::ops::OpCall;
 pub use crate::ops::OpError;
 pub use crate::ops::OpFn;
 pub use crate::ops::OpId;
+pub use crate::ops::OpName;
 pub use crate::ops::OpResult;
 pub use crate::ops::OpState;
 pub use crate::ops::PromiseId;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -12,7 +12,6 @@ use futures::ready;
 use futures::task::noop_waker;
 use futures::Future;
 use serde::Serialize;
-use std::cell::UnsafeCell;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -81,6 +80,7 @@ pub type OpAsyncFuture = OpCall<(PromiseId, OpId, OpResult)>;
 pub type OpFn =
   fn(&mut v8::HandleScope, v8::FunctionCallbackArguments, v8::ReturnValue);
 pub type OpId = usize;
+pub type OpName = &'static str;
 
 pub enum Op {
   Sync(OpResult),
@@ -143,14 +143,12 @@ pub struct OpState {
 }
 
 impl OpState {
-  pub fn new(ops_count: usize) -> OpState {
+  pub fn new(op_names: impl IntoIterator<Item = OpName>) -> OpState {
     OpState {
       resource_table: Default::default(),
       get_error_class_fn: &|_| "Error",
       gotham_state: Default::default(),
-      tracker: OpsTracker {
-        ops: UnsafeCell::new(vec![Default::default(); ops_count]),
-      },
+      tracker: OpsTracker::new(op_names),
     }
   }
 }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -3,12 +3,14 @@ use crate::include_js_files;
 use crate::ops_metrics::OpMetrics;
 use crate::resources::ResourceId;
 use crate::Extension;
+use crate::OpName;
 use crate::OpState;
 use crate::Resource;
 use crate::ZeroCopyBuf;
 use anyhow::Error;
 use deno_ops::op;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::io::{stderr, stdout, Write};
 use std::rc::Rc;
 
@@ -92,7 +94,7 @@ pub fn op_try_close(
 #[op]
 pub fn op_metrics(
   state: &mut OpState,
-) -> Result<(OpMetrics, Vec<OpMetrics>), Error> {
+) -> Result<(OpMetrics, HashMap<OpName, OpMetrics>), Error> {
   let aggregate = state.tracker.aggregate();
   let per_op = state.tracker.per_op();
   Ok((aggregate, per_op))

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -44,7 +44,7 @@ use std::sync::Once;
 use std::task::Context;
 use std::task::Poll;
 
-type PendingOpFuture = OpCall<(PromiseId, OpId, OpResult)>;
+type PendingOpFuture = OpCall<(PromiseId, OpName, OpResult)>;
 
 pub enum Snapshot {
   Static(&'static [u8]),
@@ -291,7 +291,7 @@ impl JsRuntime {
       .insert(0, crate::ops_builtin::init_builtins());
 
     let ops = Self::collect_ops(&mut options.extensions);
-    let mut op_state = OpState::new(ops.len());
+    let mut op_state = OpState::new(ops.iter().map(|decl| decl.name));
 
     if let Some(get_error_class_fn) = options.get_error_class_fn {
       op_state.get_error_class_fn = get_error_class_fn;
@@ -1734,7 +1734,7 @@ impl JsRuntime {
 #[inline]
 pub fn queue_async_op(
   scope: &v8::Isolate,
-  op: impl Future<Output = (PromiseId, OpId, OpResult)> + 'static,
+  op: impl Future<Output = (PromiseId, OpName, OpResult)> + 'static,
 ) {
   let state_rc = JsRuntime::state(scope);
   let mut state = state_rc.borrow_mut();

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -130,6 +130,7 @@ pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Generate the body of a v8 func for an async op
 fn codegen_v8_async(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
+  let op_name = &f.sig.ident;
   let arg0 = f.sig.inputs.first();
   let uses_opstate = arg0.map(is_rc_refcell_opstate).unwrap_or_default();
   let args_head = if uses_opstate {
@@ -138,17 +139,12 @@ fn codegen_v8_async(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
     quote! {}
   };
   let rust_i0 = if uses_opstate { 1 } else { 0 };
-  let (arg_decls, args_tail) = codegen_args(core, f, rust_i0, 2);
+  let (arg_decls, args_tail) = codegen_args(core, f, rust_i0, 1);
   let type_params = &f.sig.generics.params;
 
   quote! {
     use #core::futures::FutureExt;
-    // SAFETY: Called from Deno.core.opAsync. Which retrieves the index using opId table.
-    let op_id = unsafe {
-      #core::v8::Local::<#core::v8::Integer>::cast(args.get(0))
-    }.value() as usize;
-
-    let promise_id = args.get(1);
+    let promise_id = args.get(0);
     let promise_id = #core::v8::Local::<#core::v8::Integer>::try_from(promise_id)
       .map(|l| l.value() as #core::PromiseId)
       .map_err(#core::anyhow::Error::from);
@@ -178,19 +174,20 @@ fn codegen_v8_async(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
     // Track async call & get copy of get_error_class_fn
     let get_class = {
       let state = state.borrow();
-      state.tracker.track_async(op_id);
+      state.tracker.track_async(stringify!(#op_name));
       state.get_error_class_fn
     };
 
     #core::_ops::queue_async_op(scope, async move {
       let result = Self::call::<#type_params>(#args_head #args_tail).await;
-      (promise_id, op_id, #core::_ops::to_op_result(get_class, result))
+      (promise_id, stringify!(#op_name), #core::_ops::to_op_result(get_class, result))
     });
   }
 }
 
 /// Generate the body of a v8 func for a sync op
 fn codegen_v8_sync(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
+  let op_name = &f.sig.ident;
   let arg0 = f.sig.inputs.first();
   let uses_opstate = arg0.map(is_mut_ref_opstate).unwrap_or_default();
   let args_head = if uses_opstate {
@@ -199,16 +196,11 @@ fn codegen_v8_sync(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
     quote! {}
   };
   let rust_i0 = if uses_opstate { 1 } else { 0 };
-  let (arg_decls, args_tail) = codegen_args(core, f, rust_i0, 1);
+  let (arg_decls, args_tail) = codegen_args(core, f, rust_i0, 0);
   let ret = codegen_sync_ret(core, &f.sig.output);
   let type_params = &f.sig.generics.params;
 
   quote! {
-    // SAFETY: Called from Deno.core.opSync. Which retrieves the index using opId table.
-    let op_id = unsafe {
-      #core::v8::Local::<#core::v8::Integer>::cast(args.get(0)).value()
-    } as usize;
-
     #arg_decls
 
     // SAFETY: Unchecked cast to external since #core guarantees args.data() is a v8 External.
@@ -222,7 +214,7 @@ fn codegen_v8_sync(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
     let op_state = &mut state.borrow_mut();
     let result = Self::call::<#type_params>(#args_head #args_tail);
 
-    op_state.tracker.track_sync(op_id);
+    op_state.tracker.track_sync(stringify!(#op_name));
 
     #ret
   }


### PR DESCRIPTION
After the ops refactor, op ID's are only used for metrics anymore. However, the fact that there is a JS-managed `opIds` object that doesn't get updated with ops that are added after building the V8 snapshot is a problem for tsc, which uses such late op loading, although this only seems to be a problem for some build configurations and some versions of V8 (see https://github.com/denoland/rusty_v8/pull/895#issuecomment-1090603520). In any case, this change is an experiment in getting rid of op ID's, and it solves that issue.

TODO: Changing `OpsTracker` to be a `HashMap` whose keys are strings might regress performance. Consider using some map with immutable entries but mutable values, and/or atomic/interned strings.