### PR TITLE
refactor(core): OpCtx

### DIFF
--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -655,7 +655,7 @@ Deno.test("Worker with invalid permission arg", function () {
         deno: { permissions: { env: "foo" } },
       }),
     TypeError,
-    'Error parsing args at position 1: (deno.permissions.env) invalid value: string "foo", expected "inherit" or boolean or string[]',
+    'Error parsing args at position 0: (deno.permissions.env) invalid value: string "foo", expected "inherit" or boolean or string[]',
   );
 });
 

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -27,10 +27,6 @@
     SymbolFor,
   } = window.__bootstrap.primordials;
   const ops = window.Deno.core.ops;
-  const opIds = Object.keys(ops).reduce((a, v, i) => {
-    a[v] = i;
-    return a;
-  }, {});
 
   // Available on start due to bindings.
   const { refOp_, unrefOp_ } = window.Deno.core;
@@ -154,7 +150,7 @@
 
   function opAsync(opName, ...args) {
     const promiseId = nextPromiseId++;
-    const maybeError = ops[opName](opIds[opName], promiseId, ...args);
+    const maybeError = ops[opName](promiseId, ...args);
     // Handle sync error (e.g: error parsing args)
     if (maybeError) return unwrapOpResult(maybeError);
     let p = PromisePrototypeThen(setPromise(promiseId), unwrapOpResult);
@@ -174,7 +170,7 @@
   }
 
   function opSync(opName, ...args) {
-    return unwrapOpResult(ops[opName](opIds[opName], ...args));
+    return unwrapOpResult(ops[opName](...args));
   }
 
   function refOp(promiseId) {

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -15,7 +15,6 @@
     ArrayPrototypeMap,
     ErrorCaptureStackTrace,
     Promise,
-    ObjectEntries,
     ObjectFromEntries,
     MapPrototypeGet,
     MapPrototypeDelete,

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -218,8 +218,8 @@
   function metrics() {
     const [aggregate, perOps] = opSync("op_metrics");
     aggregate.ops = ObjectFromEntries(ArrayPrototypeMap(
-      ObjectEntries(opIds),
-      ([opName, opId]) => [opName, perOps[opId]],
+      core.op_names,
+      (opName, opId) => [opName, perOps[opId]],
     ));
     return aggregate;
   }

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -5,7 +5,6 @@
 use deno_core::op;
 use deno_core::Extension;
 use deno_core::JsRuntime;
-use deno_core::OpState;
 use deno_core::RuntimeOptions;
 
 // This is a hack to make the `#[op]` macro work with

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -108,6 +108,7 @@ pub mod _ops {
   pub use super::bindings::throw_type_error;
   pub use super::error_codes::get_error_code;
   pub use super::ops::to_op_result;
+  pub use super::ops::OpCtx;
   pub use super::runtime::queue_async_op;
 }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -3,6 +3,7 @@
 use crate::gotham_state::GothamState;
 use crate::resources::ResourceTable;
 use crate::runtime::GetErrorClassFn;
+use crate::OpDecl;
 use crate::OpsTracker;
 use anyhow::Error;
 use futures::future::maybe_done;
@@ -12,10 +13,12 @@ use futures::ready;
 use futures::task::noop_waker;
 use futures::Future;
 use serde::Serialize;
+use std::cell::RefCell;
 use std::cell::UnsafeCell;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::task::Context;
 use std::task::Poll;
 
@@ -132,6 +135,13 @@ pub fn to_op_result<R: Serialize + 'static>(
     Ok(v) => OpResult::Ok(v.into()),
     Err(err) => OpResult::Err(OpError::new(get_class, err)),
   }
+}
+
+// TODO(@AaronO): optimize OpCtx(s) mem usage ?
+pub struct OpCtx {
+  pub id: OpId,
+  pub state: Rc<RefCell<OpState>>,
+  pub decl: OpDecl,
 }
 
 /// Maintains the resources and ops inside a JS runtime.

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -164,6 +164,9 @@ pub(crate) struct JsRuntimeState {
   pub(crate) unrefed_ops: HashSet<i32>,
   pub(crate) have_unpolled_ops: bool,
   pub(crate) op_state: Rc<RefCell<OpState>>,
+  #[allow(dead_code)]
+  // We don't explicitly re-read this prop but need the slice to live alongside the isolate
+  pub(crate) op_ctxs: Box<[OpCtx]>,
   pub(crate) shared_array_buffer_store: Option<SharedArrayBufferStore>,
   pub(crate) compiled_wasm_module_store: Option<CompiledWasmModuleStore>,
   waker: AtomicWaker,
@@ -298,6 +301,16 @@ impl JsRuntime {
     }
 
     let op_state = Rc::new(RefCell::new(op_state));
+    let op_ctxs = ops
+      .into_iter()
+      .enumerate()
+      .map(|(id, decl)| OpCtx {
+        id,
+        state: op_state.clone(),
+        decl,
+      })
+      .collect::<Vec<_>>()
+      .into_boxed_slice();
 
     let global_context;
     let (mut isolate, maybe_snapshot_creator) = if options.will_snapshot {
@@ -309,8 +322,7 @@ impl JsRuntime {
       let mut isolate = JsRuntime::setup_isolate(isolate);
       {
         let scope = &mut v8::HandleScope::new(&mut isolate);
-        let context =
-          bindings::initialize_context(scope, &ops, false, op_state.clone());
+        let context = bindings::initialize_context(scope, &op_ctxs, false);
         global_context = v8::Global::new(scope, context);
         creator.set_default_context(context);
       }
@@ -336,12 +348,8 @@ impl JsRuntime {
       let mut isolate = JsRuntime::setup_isolate(isolate);
       {
         let scope = &mut v8::HandleScope::new(&mut isolate);
-        let context = bindings::initialize_context(
-          scope,
-          &ops,
-          snapshot_loaded,
-          op_state.clone(),
-        );
+        let context =
+          bindings::initialize_context(scope, &op_ctxs, snapshot_loaded);
 
         global_context = v8::Global::new(scope, context);
       }
@@ -374,6 +382,7 @@ impl JsRuntime {
       shared_array_buffer_store: options.shared_array_buffer_store,
       compiled_wasm_module_store: options.compiled_wasm_module_store,
       op_state: op_state.clone(),
+      op_ctxs,
       have_unpolled_ops: false,
       waker: AtomicWaker::new(),
     })));


### PR DESCRIPTION
Avoiding need for js-visible OpIDs, alternative to https://github.com/denoland/deno/pull/14224

The core idea is that each op is provided with a single pointer providing its relevant rust-side context, what it points to may change (e.g: we might get rid of explicit op_ids and track OpMetrics in the ctx) and how we pass it will likely evolve from using the callback's data to a JS-side External 1st arg for Fast API callables

Moderate improvement of `op_baseline`:

```
Before:
test bench_is_proxy   ... bench:      17,695 ns/iter (+/- 487)
test bench_op_async   ... bench:     277,137 ns/iter (+/- 10,404)
test bench_op_nop     ... bench:      19,595 ns/iter (+/- 1,267)
test bench_op_pi_json ... bench:      23,339 ns/iter (+/- 1,257)

After:
test bench_is_proxy   ... bench:      17,738 ns/iter (+/- 953)
test bench_op_async   ... bench:     273,845 ns/iter (+/- 7,598)
test bench_op_nop     ... bench:      18,535 ns/iter (+/- 794)
test bench_op_pi_json ... bench:      23,068 ns/iter (+/- 1,499)
```

## TODO

- [x] Fix up metrics (getting op id/name pairs)