### PR TITLE
refactor: remove serde_json::Value from inspector

### DIFF
--- a/cli/cdp.rs
+++ b/cli/cdp.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-awaitPromise
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AwaitPromiseArgs {
@@ -18,7 +18,7 @@ pub struct AwaitPromiseArgs {
   pub generate_preview: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-awaitPromise
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AwaitPromiseResponse {
@@ -26,7 +26,7 @@ pub struct AwaitPromiseResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-callFunctionOn
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunctionOnArgs {
@@ -53,7 +53,7 @@ pub struct CallFunctionOnArgs {
   pub throw_on_side_effect: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-callFunctionOn
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunctionOnResponse {
@@ -61,7 +61,7 @@ pub struct CallFunctionOnResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-compileScript
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompileScriptArgs {
@@ -72,7 +72,7 @@ pub struct CompileScriptArgs {
   pub execution_context_id: Option<ExecutionContextId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-compileScript
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompileScriptResponse {
@@ -80,7 +80,7 @@ pub struct CompileScriptResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-evaluate
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateArgs {
@@ -119,7 +119,7 @@ pub struct EvaluateArgs {
   pub unique_context_id: Option<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-evaluate
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateResponse {
@@ -127,7 +127,7 @@ pub struct EvaluateResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-getProperties
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertiesArgs {
@@ -142,7 +142,7 @@ pub struct GetPropertiesArgs {
   pub non_indexed_properties_only: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-getProperties
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertiesResponse {
@@ -152,7 +152,7 @@ pub struct GetPropertiesResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-globalLexicalScopeNames
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalLexicalScopeNamesArgs {
@@ -160,14 +160,14 @@ pub struct GlobalLexicalScopeNamesArgs {
   pub execution_context_id: Option<ExecutionContextId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-globalLexicalScopeNames
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalLexicalScopeNamesResponse {
   pub names: Vec<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-queryObjects
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryObjectsArgs {
@@ -176,28 +176,28 @@ pub struct QueryObjectsArgs {
   pub object_group: Option<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-queryObjects
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryObjectsResponse {
   pub objects: RemoteObject,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObject
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-releaseObject
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseObjectArgs {
   pub object_id: RemoteObjectId,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObjectGroup
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-releaseObjectGroup
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseObjectGroupArgs {
   pub object_group: String,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-runScript
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunScriptArgs {
@@ -221,7 +221,7 @@ pub struct RunScriptArgs {
   pub await_promise: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-runScript
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunScriptResponse {
@@ -229,16 +229,51 @@ pub struct RunScriptResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-setAsyncCallStackDepth
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-setAsyncCallStackDepth
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetAsyncCallStackDepthArgs {
   pub max_depth: u64,
 }
 
+// events
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Event {
+  Runtime(RuntimeEvent),
+  Other(serde::de::IgnoredAny),
+}
+
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#events
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "method", content = "params")]
+pub enum RuntimeEvent {
+  #[serde(rename = "Runtime.executionContextCreated")]
+  ExecutionContextCreated(RuntimeExecutionContextCreated),
+}
+
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#event-executionContextCreated
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeExecutionContextCreated {
+  pub context: ExecutionContextDescription,
+}
+
 // types
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-ExecutionContextDescription
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionContextDescription {
+  pub id: ExecutionContextId,
+  pub origin: String,
+  pub name: String,
+  pub unique_id: String,
+  pub aux_data: Option<Value>,
+}
+
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-RemoteObject
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteObject {
@@ -265,7 +300,7 @@ where
   Deserialize::deserialize(deserializer).map(Some)
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ObjectPreview
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-ObjectPreview
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectPreview {
@@ -278,7 +313,7 @@ pub struct ObjectPreview {
   pub entries: Option<Vec<EntryPreview>>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PropertyPreview
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-PropertyPreview
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyPreview {
@@ -290,7 +325,7 @@ pub struct PropertyPreview {
   pub subtype: Option<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-EntryPreview
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-EntryPreview
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryPreview {
@@ -298,7 +333,7 @@ pub struct EntryPreview {
   pub value: ObjectPreview,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CustomPreview
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-CustomPreview
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomPreview {
@@ -306,7 +341,7 @@ pub struct CustomPreview {
   pub body_getter_id: RemoteObjectId,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExceptionDetails
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-ExceptionDetails
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionDetails {
@@ -322,7 +357,7 @@ pub struct ExceptionDetails {
   pub exception_meta_data: Option<serde_json::Map<String, Value>>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-StackTrace
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-StackTrace
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackTrace {
@@ -332,7 +367,7 @@ pub struct StackTrace {
   pub parent_id: Option<StackTraceId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallFrame
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-CallFrame
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFrame {
@@ -343,7 +378,7 @@ pub struct CallFrame {
   pub column_number: u64,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-StackTraceId
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-StackTraceId
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackTraceId {
@@ -351,7 +386,7 @@ pub struct StackTraceId {
   pub debugger_id: Option<UniqueDebuggerId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallArgument
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-CallArgument
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallArgument {
@@ -373,7 +408,7 @@ impl From<&RemoteObject> for CallArgument {
   }
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-InternalPropertyDescriptor
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-InternalPropertyDescriptor
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyDescriptor {
@@ -389,7 +424,7 @@ pub struct PropertyDescriptor {
   pub symbol: Option<RemoteObject>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-InternalPropertyDescriptor
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-InternalPropertyDescriptor
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InternalPropertyDescriptor {
@@ -397,7 +432,7 @@ pub struct InternalPropertyDescriptor {
   pub value: Option<RemoteObject>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PrivatePropertyDescriptor
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-PrivatePropertyDescriptor
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivatePropertyDescriptor {
@@ -407,20 +442,20 @@ pub struct PrivatePropertyDescriptor {
   pub set: Option<RemoteObject>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObjectId
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-RemoteObjectId
 pub type RemoteObjectId = String;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextId
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-ExecutionContextId
 pub type ExecutionContextId = u64;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ScriptId
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-ScriptId
 pub type ScriptId = String;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-TimeDelta
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-TimeDelta
 pub type TimeDelta = u64;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UnserializableValue
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-UnserializableValue
 pub type UnserializableValue = String;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UniqueDebuggerId
+/// https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-UniqueDebuggerId
 pub type UniqueDebuggerId = String;

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -34,11 +34,23 @@ async fn read_line_and_poll(
       }
       result = message_handler.recv() => {
         match result {
-          Some(RustylineSyncMessage::PostMessage { method, params }) => {
+          Some(RustylineSyncMessage::RuntimeGlobalLexicalScopeNames(args)) => {
             let result = repl_session
-              .post_message_with_event_loop(&method, params)
+              .post_message_with_event_loop("Runtime.globalLexicalScopeNames", args)
               .await;
-            message_handler.send(RustylineSyncResponse::PostMessage(result)).unwrap();
+            message_handler.send(RustylineSyncResponse::RuntimeGlobalLexicalScopeNames(result)).unwrap();
+          },
+          Some(RustylineSyncMessage::RuntimeGetProperties(args)) => {
+            let result = repl_session
+              .post_message_with_event_loop("Runtime.getProperties", args)
+              .await;
+            message_handler.send(RustylineSyncResponse::RuntimeGetProperties(result)).unwrap();
+          },
+          Some(RustylineSyncMessage::RuntimeEvaluate(args)) => {
+            let result = repl_session
+              .post_message_with_event_loop("Runtime.evaluate", args)
+              .await;
+            message_handler.send(RustylineSyncResponse::RuntimeEvaluate(result)).unwrap();
           },
           Some(RustylineSyncMessage::LspCompletions {
             line_text,

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -673,7 +673,7 @@ async fn test_specifier(
   let mut maybe_coverage_collector = if let Some(ref coverage_dir) =
     ps.coverage_dir
   {
-    let session = worker.create_inspector_session().await;
+    let session = worker.create_inspector_session::<()>().await;
     let coverage_dir = PathBuf::from(coverage_dir);
     let mut coverage_collector = CoverageCollector::new(coverage_dir, session);
     worker

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -274,7 +274,9 @@ impl MainWorker {
 
   /// Create new inspector session. This function panics if Worker
   /// was not configured to create inspector.
-  pub async fn create_inspector_session(&mut self) -> LocalInspectorSession {
+  pub async fn create_inspector_session<N: serde::de::DeserializeOwned>(
+    &mut self,
+  ) -> LocalInspectorSession<N> {
     let inspector = self.js_runtime.inspector();
     inspector.create_local_session()
   }


### PR DESCRIPTION
This commit removes the `serde_json::Value` intermediary from the
`LocalInspectorSession`. This is done as preparatory work for fixing the
error that occurs when the REPL evaluates an expression that returns a
string that contains invalid surrogates sequences.

As a side-effect to the changes to the parsing of notifications, this
fixes the panic that occurs in the REPL when logging strings
containing lone surrogates. This does not yet resolve the error when a
REPL expression returns a string that contains lone surrogates.

TODO:
- [ ] add test for the thing that was fixed

Fixes #12226