### PR TITLE
refactor(core/error): Clarify JsError message fields

### DIFF
--- a/cli/fmt_errors.rs
+++ b/cli/fmt_errors.rs
@@ -283,7 +283,7 @@ impl fmt::Display for PrettyJsError {
       "{}",
       &format_stack(
         true,
-        &self.0.message,
+        &self.0.exception_message,
         cause.as_deref(),
         self.0.source_line.as_deref(),
         self.0.start_column,

--- a/cli/source_maps.rs
+++ b/cli/source_maps.rs
@@ -85,7 +85,9 @@ pub fn apply_source_map<G: SourceMapGetter>(
     .map(|cause| Box::new(apply_source_map(&*cause, getter)));
 
   JsError {
+    name: js_error.name.clone(),
     message: js_error.message.clone(),
+    exception_message: js_error.exception_message.clone(),
     cause,
     source_line,
     script_resource_name,
@@ -243,7 +245,9 @@ mod tests {
   #[test]
   fn apply_source_map_line() {
     let e = JsError {
-      message: "TypeError: baz".to_string(),
+      name: Some("TypeError".to_string()),
+      message: Some("baz".to_string()),
+      exception_message: "TypeError: baz".to_string(),
       cause: None,
       source_line: Some("foo".to_string()),
       script_resource_name: Some("foo_bar.ts".to_string()),

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1053,9 +1053,9 @@ pub(crate) fn exception_to_err_result<'s, T>(
 
   let mut js_error = JsError::from_v8_exception(scope, exception);
   if in_promise {
-    js_error.message = format!(
+    js_error.exception_message = format!(
       "Uncaught (in promise) {}",
-      js_error.message.trim_start_matches("Uncaught ")
+      js_error.exception_message.trim_start_matches("Uncaught ")
     );
   }
   let js_error = (state.js_error_create_fn)(js_error);
@@ -2044,7 +2044,7 @@ pub mod tests {
         .unwrap();
       let v = runtime.poll_value(&value_global, cx);
       assert!(
-        matches!(v, Poll::Ready(Err(e)) if e.downcast_ref::<JsError>().unwrap().message == "Uncaught Error: fail")
+        matches!(v, Poll::Ready(Err(e)) if e.downcast_ref::<JsError>().unwrap().exception_message == "Uncaught Error: fail")
       );
 
       let value_global = runtime
@@ -2087,7 +2087,7 @@ pub mod tests {
     let err = runtime.resolve_value(value_global).await.unwrap_err();
     assert_eq!(
       "Uncaught Error: fail",
-      err.downcast::<JsError>().unwrap().message
+      err.downcast::<JsError>().unwrap().exception_message
     );
 
     let value_global = runtime
@@ -2377,7 +2377,7 @@ pub mod tests {
       .expect_err("script should fail");
     assert_eq!(
       "Uncaught Error: execution terminated",
-      err.downcast::<JsError>().unwrap().message
+      err.downcast::<JsError>().unwrap().exception_message
     );
     assert!(callback_invoke_count.load(Ordering::SeqCst) > 0)
   }
@@ -2430,7 +2430,7 @@ pub mod tests {
       .expect_err("script should fail");
     assert_eq!(
       "Uncaught Error: execution terminated",
-      err.downcast::<JsError>().unwrap().message
+      err.downcast::<JsError>().unwrap().exception_message
     );
     assert_eq!(0, callback_invoke_count_first.load(Ordering::SeqCst));
     assert!(callback_invoke_count_second.load(Ordering::SeqCst) > 0);

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -1329,7 +1329,7 @@
   function reportException(error) {
     reportExceptionStackedCalls++;
     const jsError = core.destructureError(error);
-    const message = jsError.message;
+    const message = jsError.exception_message;
     let filename = "";
     let lineno = 0;
     let colno = 0;

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -1329,7 +1329,7 @@
   function reportException(error) {
     reportExceptionStackedCalls++;
     const jsError = core.destructureError(error);
-    const message = jsError.exception_message;
+    const message = jsError.exceptionMessage;
     let filename = "";
     let lineno = 0;
     let colno = 0;

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -92,7 +92,7 @@ impl Serialize for WorkerControlEvent {
       | WorkerControlEvent::Error(error) => {
         let value = match error.downcast_ref::<JsError>() {
           Some(js_error) => json!({
-            "message": js_error.message,
+            "message": js_error.exception_message,
             "fileName": js_error.script_resource_name,
             "lineNumber": js_error.line_number,
             "columnNumber": js_error.start_column,


### PR DESCRIPTION
Closes #13212. Also adds `message` and `name` fields to make `Deno.core.destructureError()` nicer to use.