### PR TITLE
feat(test): format user code output

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -78,6 +78,7 @@ node_resolver = "=0.1.1"
 notify = "=5.0.0-pre.14"
 num-format = "=0.4.0"
 once_cell = "=1.10.0"
+os_pipe = "=1.0.1"
 percent-encoding = "=2.1.0"
 pin-project = "=1.0.8"
 rand = { version = "=0.8.4", features = ["small_rng"] }

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -14,6 +14,7 @@ use crate::lsp::client::TestingNotification;
 use crate::lsp::config;
 use crate::lsp::logging::lsp_log;
 use crate::ops;
+use crate::ops::testing::create_stdout_stderr_pipes;
 use crate::proc_state;
 use crate::tools::test;
 
@@ -183,11 +184,17 @@ async fn test_specifier(
   options: Option<Value>,
 ) -> Result<(), AnyError> {
   if !token.is_cancelled() {
+    let (stdout_writer, stderr_writer) =
+      create_stdout_stderr_pipes(channel.clone());
     let mut worker = create_main_worker(
       &ps,
       specifier.clone(),
       permissions,
-      vec![ops::testing::init(channel.clone())],
+      vec![ops::testing::init(
+        channel.clone(),
+        stdout_writer,
+        stderr_writer,
+      )],
     );
 
     worker

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -762,6 +762,9 @@ impl test::TestReporter for LspTestReporter {
           location: None,
         })
       }
+      test::TestOutput::Stdout(_) | test::TestOutput::Stderr(_) => {
+        // todo(@dsherret): handle
+      }
     }
   }
 

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -759,20 +759,20 @@ impl test::TestReporter for LspTestReporter {
         .get(origin)
         .and_then(|v| v.last().map(|td| td.into()))
     });
-    match output {
+    let value = match output {
       test::TestOutput::PrintStdout(value)
-      | test::TestOutput::PrintStderr(value) => {
-        self.progress(lsp_custom::TestRunProgressMessage::Output {
-          value: value.replace('\n', "\r\n"),
-          test,
-          // TODO(@kitsonk) test output should include a location
-          location: None,
-        })
+      | test::TestOutput::PrintStderr(value) => value.replace('\n', "\r\n"),
+      test::TestOutput::Stdout(bytes) | test::TestOutput::Stderr(bytes) => {
+        String::from_utf8_lossy(bytes).replace('\n', "\r\n")
       }
-      test::TestOutput::Stdout(_) | test::TestOutput::Stderr(_) => {
-        // todo(@dsherret): handle
-      }
-    }
+    };
+
+    self.progress(lsp_custom::TestRunProgressMessage::Output {
+      value,
+      test,
+      // TODO(@kitsonk) test output should include a location
+      location: None,
+    })
   }
 
   fn report_result(

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -753,7 +753,8 @@ impl test::TestReporter for LspTestReporter {
         .and_then(|v| v.last().map(|td| td.into()))
     });
     match output {
-      test::TestOutput::Console(value) => {
+      test::TestOutput::PrintStdout(value)
+      | test::TestOutput::PrintStderr(value) => {
         self.progress(lsp_custom::TestRunProgressMessage::Output {
           value: value.replace('\n', "\r\n"),
           test,

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::io::Read;
-use std::os::windows::prelude::FromRawHandle;
 use std::rc::Rc;
 
 use crate::tools::test::TestEvent;
@@ -85,17 +84,18 @@ fn start_output_redirect_thread(
   });
 }
 
+#[cfg(windows)]
 fn pipe_writer_to_file(writer: &os_pipe::PipeWriter) -> std::fs::File {
-  #[cfg(windows)]
-  unsafe {
-    use std::os::windows::prelude::AsRawHandle;
-    std::fs::File::from_raw_handle(writer.as_raw_handle())
-  }
-  #[cfg(unix)]
-  {
-    use std::os::unix::io::AsRawFd;
-    writer.as_raw_fd().into()
-  }
+  use std::os::windows::prelude::AsRawHandle;
+  use std::os::windows::prelude::FromRawHandle;
+  unsafe { std::fs::File::from_raw_handle(writer.as_raw_handle()) }
+}
+
+#[cfg(unix)]
+fn pipe_writer_to_file(writer: &os_pipe::PipeWriter) -> std::fs::File {
+  use std::os::unix::io::AsRawFd;
+  use std::os::unix::io::FromRawFd;
+  unsafe { std::fs::File::from_raw_fd(writer.as_raw_fd()) }
 }
 
 #[derive(Clone)]

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -753,7 +753,10 @@ fn websocket_server_multi_field_connection_header() {
   assert!(child.wait().unwrap().success());
 }
 
+// TODO(bartlomieju): this should use `deno run`, not `deno test`; but the
+// test hangs then. https://github.com/denoland/deno/issues/14283
 #[test]
+#[ignore]
 fn websocket_server_idletimeout() {
   let script = util::testdata_path().join("websocket_server_idletimeout.ts");
   let root_ca = util::testdata_path().join("tls/RootCA.pem");

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -281,6 +281,12 @@ itest!(steps_invalid_usage {
   output: "test/steps/invalid_usage.out",
 });
 
+itest!(steps_output_within {
+  args: "test test/steps/output_within.ts",
+  exit_code: 0,
+  output: "test/steps/output_within.out",
+});
+
 itest!(no_prompt_by_default {
   args: "test test/no_prompt_by_default.ts",
   exit_code: 1,

--- a/cli/tests/testdata/test/steps/output_within.out
+++ b/cli/tests/testdata/test/steps/output_within.out
@@ -1,0 +1,31 @@
+[WILDCARD]
+running 1 test from test/steps/output_within.ts
+description ...
+------- output -------
+1
+----- output end -----
+  step 1 ...
+------- output -------
+2
+----- output end -----
+    inner 1 ...
+------- output -------
+3
+----- output end -----
+    ok ([WILDCARD]ms)
+    inner 2 ...
+------- output -------
+4
+----- output end -----
+    ok ([WILDCARD]ms)
+
+------- output -------
+5
+----- output end -----
+  ok ([WILDCARD]ms)
+
+------- output -------
+6
+----- output end -----
+ok ([WILDCARD]ms)
+[WILDCARD]

--- a/cli/tests/testdata/test/steps/output_within.ts
+++ b/cli/tests/testdata/test/steps/output_within.ts
@@ -1,0 +1,15 @@
+Deno.test("description", async (t) => {
+  // the output is not great, but this is an extreme scenario
+  console.log(1);
+  await t.step("step 1", async (t) => {
+    console.log(2);
+    await t.step("inner 1", () => {
+      console.log(3);
+    });
+    await t.step("inner 2", () => {
+      console.log(4);
+    });
+    console.log(5);
+  });
+  console.log(6);
+});

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -326,7 +326,7 @@ impl TestReporter for PrettyTestReporter {
     if !self.did_have_user_output {
       self.did_have_user_output = true;
       println!();
-      println!("{}", colors::gray("-------output:-------"));
+      println!("{}", colors::gray("------- output -------"));
     }
     match output {
       TestOutput::PrintStdout(line) | TestOutput::PrintStderr(line) => {
@@ -372,7 +372,7 @@ impl TestReporter for PrettyTestReporter {
     }
 
     if self.did_have_user_output {
-      println!("{}", colors::gray("----end of output----"));
+      println!("{}", colors::gray("----- output end -----"));
       self.did_have_user_output = false;
     } else if self.last_wait_output_level == 0 {
       print!(" ");

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -83,6 +83,8 @@ pub enum TestOutput {
   // TODO(caspervonb): add stdout and stderr redirection.
   PrintStdout(String),
   PrintStderr(String),
+  Stdout(Vec<u8>),
+  Stderr(Vec<u8>),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -329,6 +331,12 @@ impl TestReporter for PrettyTestReporter {
     match output {
       TestOutput::PrintStdout(line) | TestOutput::PrintStderr(line) => {
         print!("{}", line)
+      }
+      TestOutput::Stdout(bytes) => {
+        std::io::stdout().write_all(bytes).unwrap();
+      }
+      TestOutput::Stderr(bytes) => {
+        std::io::stderr().write_all(bytes).unwrap();
       }
     }
   }

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -81,7 +81,8 @@ pub struct TestDescription {
 #[serde(rename_all = "camelCase")]
 pub enum TestOutput {
   // TODO(caspervonb): add stdout and stderr redirection.
-  Console(String),
+  PrintStdout(String),
+  PrintStderr(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -323,7 +324,9 @@ impl TestReporter for PrettyTestReporter {
     }
     if self.echo_output {
       match output {
-        TestOutput::Console(line) => print!("{}", line),
+        TestOutput::PrintStdout(line) | TestOutput::PrintStderr(line) => {
+          print!("{}", line)
+        }
       }
     }
   }

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -222,7 +222,7 @@ struct PrettyTestReporter {
   deferred_step_output: HashMap<TestDescription, Vec<DeferredStepOutput>>,
   last_wait_output_level: usize,
   cwd: Url,
-  did_test_have_output: bool,
+  did_have_user_output: bool,
 }
 
 impl PrettyTestReporter {
@@ -233,7 +233,7 @@ impl PrettyTestReporter {
       deferred_step_output: HashMap::new(),
       last_wait_output_level: 0,
       cwd: Url::from_directory_path(std::env::current_dir().unwrap()).unwrap(),
-      did_test_have_output: false,
+      did_have_user_output: false,
     }
   }
 
@@ -317,16 +317,18 @@ impl TestReporter for PrettyTestReporter {
   }
 
   fn report_output(&mut self, output: &TestOutput) {
-    if !self.did_test_have_output {
-      self.did_test_have_output = true;
+    if !self.echo_output {
+      return;
+    }
+
+    if !self.did_have_user_output {
+      self.did_have_user_output = true;
       println!();
       println!("{}", colors::gray("-------output:-------"));
     }
-    if self.echo_output {
-      match output {
-        TestOutput::PrintStdout(line) | TestOutput::PrintStderr(line) => {
-          print!("{}", line)
-        }
+    match output {
+      TestOutput::PrintStdout(line) | TestOutput::PrintStderr(line) => {
+        print!("{}", line)
       }
     }
   }
@@ -361,9 +363,9 @@ impl TestReporter for PrettyTestReporter {
       }
     }
 
-    if self.did_test_have_output {
+    if self.did_have_user_output {
       println!("{}", colors::gray("----end of output----"));
-      self.did_test_have_output = false;
+      self.did_have_user_output = false;
     } else if self.last_wait_output_level == 0 {
       print!(" ");
     }

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -329,8 +329,11 @@ impl TestReporter for PrettyTestReporter {
       println!("{}", colors::gray("------- output -------"));
     }
     match output {
-      TestOutput::PrintStdout(line) | TestOutput::PrintStderr(line) => {
+      TestOutput::PrintStdout(line) => {
         print!("{}", line)
+      }
+      TestOutput::PrintStderr(line) => {
+        eprint!("{}", line)
       }
       TestOutput::Stdout(bytes) => {
         std::io::stdout().write_all(bytes).unwrap();

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -147,6 +147,16 @@ impl ResourceTable {
       .ok_or_else(bad_resource_id)
   }
 
+  /// Replaces a resource with a new resource.
+  ///
+  /// Panics if the resource does not exist.
+  pub fn replace<T: Resource>(&mut self, rid: ResourceId, resource: T) {
+    let result = self
+      .index
+      .insert(rid, Rc::new(resource) as Rc<dyn Resource>);
+    assert!(result.is_some());
+  }
+
   /// Removes a resource of type `T` from the resource table and returns it.
   /// If a resource with the given `rid` exists but its type does not match `T`,
   /// it is not removed from the resource table. Note that the resource's

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -871,12 +871,6 @@
     });
   }
 
-  function reportTestConsoleOutput(console) {
-    core.opSync("op_dispatch_test_event", {
-      output: { console },
-    });
-  }
-
   function reportTestWait(test) {
     core.opSync("op_dispatch_test_event", {
       wait: test,
@@ -955,12 +949,6 @@
     core.setMacrotaskCallback(handleOpSanitizerDelayMacrotask);
 
     const origin = getTestOrigin();
-    const originalConsole = globalThis.console;
-
-    // TODO(bartlomieju): we should use regular console and instead
-    // override "op_print" on the Rust side to capture both console
-    // and `Deno.core.print`
-    globalThis.console = new Console(reportTestConsoleOutput);
 
     const only = ArrayPrototypeFilter(tests, (test) => test.only);
     const filtered = ArrayPrototypeFilter(
@@ -1007,8 +995,6 @@
 
       reportTestResult(description, result, elapsed);
     }
-
-    globalThis.console = originalConsole;
   }
 
   async function runBenchmarks({

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -957,6 +957,9 @@
     const origin = getTestOrigin();
     const originalConsole = globalThis.console;
 
+    // TODO(bartlomieju): we should use regular console and instead
+    // override "op_print" on the Rust side to capture both console
+    // and `Deno.core.print`
     globalThis.console = new Console(reportTestConsoleOutput);
 
     const only = ArrayPrototypeFilter(tests, (test) => test.only);


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/14192

This commit changes "deno test" to better denote user output coming
from test cases. 

This is done by printing "---- output ----" and "---- output end ----" 
markers if an output is produced. The output from "console" and 
"Deno.core.print" is captured, as well as direct writes to "Deno.stdout"
and "Deno.stderr".

To achieve that new APIs were added to "deno_core" crate, that allow
to replace an existing resource with a different one (while keeping resource
ids intact). Resources for stdout and stderr are replaced by pipes.

<img width="673" alt="Screenshot 2022-04-14 at 19 20 44" src="https://user-images.githubusercontent.com/13602871/163440841-c8357262-b2bf-4537-b1ae-ef6640b9371c.png">

