### PR TITLE
[wip] experiment(http): introduce `requestEvent.sendFile` fast path

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -140,7 +140,8 @@
         this.#localAddr,
       );
 
-      return { request, respondWith };
+      const sendFile = createSendFile(streamRid);
+      return { request, respondWith, sendFile };
     }
 
     /** @returns {void} */
@@ -170,6 +171,20 @@
 
   function readRequest(streamRid, buf) {
     return core.opAsync("op_http_read", streamRid, buf);
+  }
+
+  function createSendFile(
+    streamRid,
+  ) {
+    return async function sendWith(path) {
+      await core.opAsync(
+        "op_http_sendfile",
+        streamRid,
+        path,
+      );
+
+      await core.opAsync("op_http_shutdown", streamRid);
+    };
   }
 
   function createRespondWith(

--- a/node_server.js
+++ b/node_server.js
@@ -1,0 +1,16 @@
+const http = require("http");
+const fs = require("fs");
+
+http.createServer(function (req, res) {
+    const filename = __dirname + req.url;
+
+    const readStream = fs.createReadStream(filename);
+
+    readStream.on("open", function() {
+        readStream.pipe(res);
+    });
+
+    readStream.on("error", function(err) {
+        res.end(err);
+    })
+}).listen(8081);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+import { readableStreamFromReader } from "https://deno.land/std@0.134.0/streams/mod.ts";
+
+const server = Deno.listen({ port: 8080 });
+console.log("File server running on http://localhost:8080/");
+
+for await (const conn of server) {
+  handleHttp(conn);
+}
+
+async function handleHttp(conn) {
+  const httpConn = Deno.serveHttp(conn);
+  for await (const requestEvent of httpConn) {
+    // Use the request pathname as filepath
+    const url = new URL(requestEvent.request.url);
+    const filepath = decodeURIComponent(url.pathname);
+
+    requestEvent.sendFile("." + filepath);
+    //
+    // const file = await Deno.open("." + filepath, { read: true });
+    // const readableStream = readableStreamFromReader(file);
+    // const response = new Response(readableStream);
+    // await requestEvent.respondWith(response);
+  }
+}


### PR DESCRIPTION
A new method to handle sending files to the socket. In the future, this could _also_ use the `sendfile(2)` syscall to avoid file copy in the userspace.

`main`:
```
Running 10s test @ http://localhost:8080/README.md
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   759.55us  121.38us   4.67ms   83.20%
    Req/Sec     2.64k    86.82     2.76k    92.20%
  212156 requests in 10.10s, 558.63MB read
Requests/sec:  21005.52
Transfer/sec:     55.31MB
```

This PR (`sendFile`):
```
Running 10s test @ http://localhost:8080/README.md
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   470.52us  126.24us   3.43ms   77.33%
    Req/Sec     4.27k   199.36     4.68k    80.57%
  343083 requests in 10.10s, 0.88GB read
Requests/sec:  33968.47
Transfer/sec:     89.44MB
```

Node:
```
Running 10s test @ http://localhost:8081/README.md
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   610.48us  782.74us  29.18ms   99.41%
    Req/Sec     3.47k   326.92     3.64k    92.08%
  279390 requests in 10.10s, 748.21MB read
Requests/sec:  27662.49
Transfer/sec:     74.08MB
```