### PR TITLE
fix: panic when trying to pledge permissions before restoring previous pledge

### DIFF
--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -63,6 +63,10 @@ pub fn op_pledge_test_permissions(
   let worker_permissions = create_child_permissions(parent_permissions, args)?;
   let parent_permissions = parent_permissions.clone();
 
+  if state.try_take::<PermissionsHolder>().is_some() {
+    panic!("pledge test permissions called before restoring previous pledge");
+  }
+
   state.put::<PermissionsHolder>(PermissionsHolder(token, parent_permissions));
 
   // NOTE: This call overrides current permission set for the worker

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -122,6 +122,9 @@ pub fn op_pledge_test_permissions(
   let worker_permissions = create_child_permissions(parent_permissions, args)?;
   let parent_permissions = parent_permissions.clone();
 
+  if state.try_take::<PermissionsHolder>().is_some() {
+    panic!("pledge test permissions called before restoring previous pledge");
+  }
   state.put::<PermissionsHolder>(PermissionsHolder(token, parent_permissions));
 
   // NOTE: This call overrides current permission set for the worker

--- a/cli/tests/integration/bench_tests.rs
+++ b/cli/tests/integration/bench_tests.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use crate::itest;
+use test_util as util;
 
 itest!(requires_unstable {
   args: "bench bench/requires_unstable.js",
@@ -139,3 +140,21 @@ itest!(no_prompt_with_denied_perms {
   exit_code: 1,
   output: "bench/no_prompt_with_denied_perms.out",
 });
+
+#[test]
+fn recursive_permissions_pledge() {
+  let output = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("bench")
+    .arg("--unstable")
+    .arg("bench/recursive_permissions_pledge.js")
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(!output.status.success());
+  assert!(String::from_utf8(output.stderr).unwrap().contains(
+    "pledge test permissions called before restoring previous pledge"
+  ));
+}

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -298,3 +298,21 @@ itest!(no_prompt_with_denied_perms {
   exit_code: 1,
   output: "test/no_prompt_with_denied_perms.out",
 });
+
+#[test]
+fn recursive_permissions_pledge() {
+  let output = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("test")
+    .arg("test/recursive_permissions_pledge.js")
+    .stderr(std::process::Stdio::piped())
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+  assert!(!output.status.success());
+  assert!(String::from_utf8(output.stderr).unwrap().contains(
+    "pledge test permissions called before restoring previous pledge"
+  ));
+}

--- a/cli/tests/testdata/bench/recursive_permissions_pledge.js
+++ b/cli/tests/testdata/bench/recursive_permissions_pledge.js
@@ -1,0 +1,8 @@
+Deno.core.opSync(
+  "op_pledge_test_permissions",
+  "none",
+);
+Deno.core.opSync(
+  "op_pledge_test_permissions",
+  "inherit",
+);

--- a/cli/tests/testdata/test/recursive_permissions_pledge.js
+++ b/cli/tests/testdata/test/recursive_permissions_pledge.js
@@ -1,0 +1,8 @@
+Deno.core.opSync(
+  "op_pledge_test_permissions",
+  "none",
+);
+Deno.core.opSync(
+  "op_pledge_test_permissions",
+  "inherit",
+);


### PR DESCRIPTION
This commit fixes and edge case, where testing/benching code could pledge new
permission set before restoring the previous pledge. 

Appropriate panics were added and tests that assert that process is killed
in case of "recursive pledge".

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
