### PR TITLE
Remove the DENO_FUTURE_CHECK warning

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1150,11 +1150,6 @@ async fn run_command(
   flags: Flags,
   run_flags: RunFlags,
 ) -> Result<i32, AnyError> {
-  if !flags.has_check_flag && flags.type_check_mode == TypeCheckMode::All {
-    info!("{} In future releases `deno run` will not automatically type check without the --check flag.
-To opt into this new behavior now, specify DENO_FUTURE_CHECK=1.", colors::yellow("Warning"));
-  }
-
   // Read script content from stdin
   if run_flags.script == "-" {
     return run_from_stdin(flags).await;

--- a/cli/tests/testdata/future_check1.out
+++ b/cli/tests/testdata/future_check1.out
@@ -1,3 +1,1 @@
-Warning In future releases `deno run` will not automatically type check without the --check flag.
-To opt into this new behavior now, specify DENO_FUTURE_CHECK=1.
 Check [WILDCARD]/future_check.ts


### PR DESCRIPTION
It has good intentions, but it is a really terrible user experience. As
such we shouldn't print this warning.