### PR TITLE
feat(runtime/workers): add `close` event

### DIFF
--- a/cli/tests/testdata/workers/close_worker.js
+++ b/cli/tests/testdata/workers/close_worker.js
@@ -1,0 +1,3 @@
+setTimeout(() => {
+  close();
+}, 1000);

--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -889,3 +889,26 @@ Deno.test({
     w.terminate();
   },
 });
+
+Deno.test({
+  name: "handle worker close event",
+  fn: async function () {
+    let closeHandlersCalled = false;
+
+    const promise = deferred();
+    const worker = new Worker(
+      new URL("close_worker.js", import.meta.url),
+      { type: "module" },
+    );
+
+    worker.addEventListener("close", () => {
+      closeHandlersCalled = true;
+      promise.resolve();
+    });
+
+    await promise;
+
+    assertEquals(closeHandlersCalled, true);
+    worker.terminate();
+  },
+});

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -174,6 +174,7 @@
           case 3: { // Close
             log(`Host got "close" message from worker: ${this.#name}`);
             this.#status = "CLOSED";
+            this.dispatchEvent(new Event("close"));
             return;
           }
           default: {


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

The `close` event is emitted once the worker has closed. That will help the developer to handle the worker exit. And it is a little something like https://nodejs.org/api/worker_threads.html#event-exit.