### PR TITLE
feat(repl): add global clear() function

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -761,3 +761,21 @@ fn eval_file_flag_multiple_files() {
   assert!(out.contains("helloFOO"));
   assert!(err.contains("Download"));
 }
+
+#[test]
+fn pty_clear_function() {
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line("console.log('hello');");
+    console.write_line("clear();");
+    console.write_line("const clear = 1 + 2;");
+    console.write_line("clear;");
+    console.write_line("close();");
+
+    let output = console.read_all_output();
+    assert!(output.contains("hello"));
+    assert!(output.contains("[1;1H"));
+    assert!(output.contains("undefined"));
+    assert!(output.contains("const clear = 1 + 2;"));
+    assert!(output.contains("3"));
+  });
+}

--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -776,6 +776,6 @@ fn pty_clear_function() {
     assert!(output.contains("[1;1H"));
     assert!(output.contains("undefined"));
     assert!(output.contains("const clear = 1 + 2;"));
-    assert!(output.contains("3"));
+    assert!(output.contains('3'));
   });
 }

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -41,6 +41,8 @@ Object.defineProperty(globalThis, "_error", {
    console.log("Last thrown error is no longer saved to _error.");
   },
 });
+
+globalThis.clear = console.clear.bind(console);
 "#;
 
 pub enum EvaluationOutput {


### PR DESCRIPTION
This commit adds a `clear()` function in the REPL which works similar to `console.clear()`.

Fixes: https://github.com/denoland/deno/issues/14226

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
