### PR TITLE
fix(compat): canonicalize import paths

### DIFF
--- a/cli/compat/esm_resolver.rs
+++ b/cli/compat/esm_resolver.rs
@@ -261,7 +261,8 @@ fn finalize_resolution(
     ));
   }
 
-  Ok(resolved)
+  // OK to unwrap, path came from to_file_path
+  Ok(ModuleSpecifier::from_file_path(path.canonicalize()?).unwrap())
 }
 
 fn throw_import_not_defined(


### PR DESCRIPTION
Node resolution algo "follows symlinks"
See https://github.com/nodejs/node/blob/61fefe1959a8ab9e796f409346ff619c14036c81/lib/internal/modules/esm/resolve.js#L409

PNPM relies on this behavior to have a "nested node_modules" without tons of bloated duplicated packages, see https://pnpm.io/blog/2020/05/27/flat-node-modules-is-not-the-only-way for full explanation

This PR canonicalizes import path to replicate node resolve.js behavior