### PR TITLE
chore(scripts): allow running version_bump workflow without releasing deno_std yet

### DIFF
--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -97,24 +97,19 @@ async function getGitLog() {
 }
 
 async function updateStdVersion() {
-  const newStdVersion = await getLatestStdVersion();
   const compatFilePath = path.join(cliCrate.folderPath, "compat/mod.rs");
   const text = Deno.readTextFileSync(compatFilePath);
+  const versionRe = /std@([0-9]+\.[0-9]+\.[0-9]+)/;
+  const stdVersionText = versionRe.exec(text)?.[1];
+  const stdVersion = stdVersionText == null
+    ? undefined
+    : semver.parse(stdVersionText);
+  if (stdVersion == null) {
+    throw new Error(`Could not find the deno_std version in ${compatFilePath}`);
+  }
+  const newStdVersion = stdVersion.inc("minor");
   Deno.writeTextFileSync(
     compatFilePath,
-    text.replace(/std@[0-9]+\.[0-9]+\.[0-9]+/, `std@${newStdVersion}`),
+    text.replace(versionRe, `std@${newStdVersion}`),
   );
-}
-
-async function getLatestStdVersion() {
-  const url =
-    "https://raw.githubusercontent.com/denoland/deno_std/main/version.ts";
-  const result = await fetch(url);
-  const text = await result.text();
-  const version = /"([0-9]+\.[0-9]+\.[0-9]+)"/.exec(text);
-  if (version == null) {
-    throw new Error(`Could not find version in text: ${text}`);
-  } else {
-    return version[1];
-  }
 }

--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -98,7 +98,7 @@ async function getGitLog() {
 
 async function updateStdVersion() {
   const compatFilePath = path.join(cliCrate.folderPath, "compat/mod.rs");
-  const text = Deno.readTextFileSync(compatFilePath);
+  const text = await Deno.readTextFile(compatFilePath);
   const versionRe = /std@([0-9]+\.[0-9]+\.[0-9]+)/;
   const stdVersionText = versionRe.exec(text)?.[1];
   if (stdVersionText == null) {
@@ -106,7 +106,7 @@ async function updateStdVersion() {
   }
   const stdVersion = semver.parse(stdVersionText)!;
   const newStdVersion = stdVersion.inc("minor");
-  Deno.writeTextFileSync(
+  await Deno.writeTextFile(
     compatFilePath,
     text.replace(versionRe, `std@${newStdVersion}`),
   );

--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -101,12 +101,10 @@ async function updateStdVersion() {
   const text = Deno.readTextFileSync(compatFilePath);
   const versionRe = /std@([0-9]+\.[0-9]+\.[0-9]+)/;
   const stdVersionText = versionRe.exec(text)?.[1];
-  const stdVersion = stdVersionText == null
-    ? undefined
-    : semver.parse(stdVersionText);
-  if (stdVersion == null) {
+  if (stdVersionText == null) {
     throw new Error(`Could not find the deno_std version in ${compatFilePath}`);
   }
+  const stdVersion = semver.parse(stdVersionText)!;
   const newStdVersion = stdVersion.inc("minor");
   Deno.writeTextFileSync(
     compatFilePath,


### PR DESCRIPTION
The instructions say to do a deno_std release first and then start with the deno release, but when someone doesn't do that make sure the deno_std version gets bumped anyway.

This just now always increments the minor version.