### PR TITLE
chore(ci): skip ci cache when doing a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
         # TODO(kt3k): Change the version to the released version
         # when https://github.com/actions/cache/pull/489 (or 571) is merged.
         uses: actions/cache@03e00da99d75a2204924908e1cca7902cafce66b
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         with:
           path: |
             ./target
@@ -274,7 +274,7 @@ jobs:
       - name: Skip save cache (PR)
         run: echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV
         shell: bash
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
 
       - name: Apply and update mtime cache
         if: matrix.profile == 'release'


### PR DESCRIPTION
Will hopefully fix: https://github.com/denoland/deno/runs/6105288097?check_suite_focus=true

Closes #13589