### PR TITLE
fix(bench): reset reporter context

### DIFF
--- a/cli/tests/integration/bench_tests.rs
+++ b/cli/tests/integration/bench_tests.rs
@@ -75,6 +75,12 @@ itest!(only {
   output: "bench/only.out",
 });
 
+itest!(multifile_summary {
+  args: "bench --unstable bench/pass.ts bench/group_baseline.ts",
+  exit_code: 0,
+  output: "bench/multifile_summary.out",
+});
+
 itest!(no_check {
   args: "bench --unstable --no-check bench/no_check.ts",
   exit_code: 1,

--- a/cli/tests/testdata/bench/multifile_summary.out
+++ b/cli/tests/testdata/bench/multifile_summary.out
@@ -1,0 +1,37 @@
+Check [WILDCARD]/bench/pass.ts
+Check [WILDCARD]/bench/group_baseline.ts
+cpu: [WILDCARD]
+runtime: deno [WILDCARD] ([WILDCARD])
+
+[WILDCARD]/bench/pass.ts
+benchmark      time (avg)             (min … max)       p75       p99      p995
+------------------------------------------------- -----------------------------
+bench0 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench1 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench2 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench3 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench4 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench5 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench6 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench7 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench8 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+bench9 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+
+[WILDCARD]/bench/group_baseline.ts
+benchmark         time (avg)             (min … max)       p75       p99      p995
+---------------------------------------------------- -----------------------------
+noop [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+noop2 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+
+summary
+  noo[WILDCARD]
+   [WILDCARD]x times [WILDCARD] than noo[WILDCARD]
+
+noop3 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+parse url 2x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+parse url 6x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
+
+summary
+  parse url 2x
+   [WILDCARD]x times slower than noop3
+   [WILDCARD]x times faster than parse url 6x

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -178,6 +178,10 @@ impl BenchReporter for ConsoleReporter {
     use std::sync::atomic::Ordering;
     static FIRST_PLAN: AtomicBool = AtomicBool::new(true);
 
+    self.group = None;
+    self.baseline = None;
+    self.name = String::new();
+    self.group_measurements.clear();
     self.options = Some(mitata::reporter::Options::new(
       &plan.names.iter().map(|x| x.as_str()).collect::<Vec<&str>>(),
     ));


### PR DESCRIPTION
This commit fixes previous file benchmarks leaking into the next file benchmarks summary.

fixes #14354 