### PR TITLE
tests: unflake streaming compression tests

### DIFF
--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1254,7 +1254,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1359,7 +1359,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1413,7 +1413,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1464,7 +1464,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1518,7 +1518,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1575,7 +1575,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1632,7 +1632,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1686,7 +1686,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1745,7 +1745,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",
@@ -1869,7 +1869,7 @@ Deno.test({
       const url = `http://${hostname}:${port}/`;
       const cmd = [
         "curl",
-        "-I",
+        "-i",
         "--request",
         "GET",
         "--url",


### PR DESCRIPTION
`curl -I` closes the connection after headers have arrived, but we want it to
also receive the body (even if we don't use it), so the server doesn't encounter
an unexpected EOF. To do this we now use `curl -i`.