### PR TITLE
perf(ext/http): fast path for uncompressed bodies

### DIFF
--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -730,7 +730,6 @@ async fn op_http_write_resource(
       HttpResponseWriter::BodyUncompressed(body) => {
         if let Err(err) = body.send_data(Bytes::from(buf.to_temp())).await {
           assert!(err.is_closed());
-          // Don't return "broken pipe", that's an implementation detail.
           // Pull up the failure associated with the transport connection instead.
           http_stream.conn.closed().await?;
           // If there was no connection error, drop body_tx.
@@ -799,7 +798,6 @@ async fn op_http_write(
           Ok(_) => break Ok(()),
           Err(err) => {
             assert!(err.is_closed());
-            // Don't return "broken pipe", that's an implementation detail.
             // Pull up the failure associated with the transport connection instead.
             stream.conn.closed().await?;
             // If there was no connection error, drop body_tx.

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -38,6 +38,7 @@ use deno_websocket::ws_create_server_stream;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use fly_accept_encoding::Encoding;
+use hyper::body::Bytes;
 use hyper::server::conn::Http;
 use hyper::service::Service;
 use hyper::Body;
@@ -342,6 +343,7 @@ impl Default for HttpRequestReader {
 enum HttpResponseWriter {
   Headers(oneshot::Sender<Response<Body>>),
   Body(Pin<Box<dyn tokio::io::AsyncWrite>>),
+  BodyUncompressed(hyper::body::Sender),
   Closed,
 }
 
@@ -636,17 +638,15 @@ async fn op_http_write_headers(
     }
     None => {
       // If no buffer was passed, the caller will stream the response body.
-
-      // Create a one way pipe that implements tokio's async io traits. To do
-      // this we create a [tokio::io::DuplexStream], but then throw away one
-      // of the directions to create a one way pipe.
-      let (a, b) = tokio::io::duplex(64 * 1024);
-      let (reader, _) = tokio::io::split(a);
-      let (_, writer) = tokio::io::split(b);
-
-      let writer_body: Pin<Box<dyn tokio::io::AsyncWrite>>;
-
       if should_compress {
+        // Create a one way pipe that implements tokio's async io traits. To do
+        // this we create a [tokio::io::DuplexStream], but then throw away one
+        // of the directions to create a one way pipe.
+        let (a, b) = tokio::io::duplex(64 * 1024);
+        let (reader, _) = tokio::io::split(a);
+        let (_, writer) = tokio::io::split(b);
+
+        let writer_body: Pin<Box<dyn tokio::io::AsyncWrite>>;
         match *stream.accept_encoding.borrow() {
           Encoding::Brotli => {
             let writer = BrotliEncoder::new(writer);
@@ -660,12 +660,14 @@ async fn op_http_write_headers(
             builder = builder.header("content-encoding", "gzip");
           }
         }
-      } else {
-        writer_body = Box::pin(writer);
-      }
 
-      body = builder.body(Body::wrap_stream(ReaderStream::new(reader)))?;
-      new_wr = HttpResponseWriter::Body(writer_body);
+        body = builder.body(Body::wrap_stream(ReaderStream::new(reader)))?;
+        new_wr = HttpResponseWriter::Body(writer_body);
+      } else {
+        let (body_tx, body_rx) = Body::channel();
+        body = builder.body(body_rx)?;
+        new_wr = HttpResponseWriter::BodyUncompressed(body_tx);
+      }
     }
   }
 
@@ -697,14 +699,14 @@ async fn op_http_write_resource(
   let mut wr = RcRef::map(&http_stream, |r| &r.wr).borrow_mut().await;
   let resource = state.borrow().resource_table.get_any(stream)?;
   loop {
-    let body_writer = match &mut *wr {
-      HttpResponseWriter::Body(body_writer) => body_writer,
+    match *wr {
       HttpResponseWriter::Headers(_) => {
         return Err(http_error("no response headers"))
       }
       HttpResponseWriter::Closed => {
         return Err(http_error("response already completed"))
       }
+      _ => {}
     };
 
     let vec = vec![0u8; 64 * 1024]; // 64KB
@@ -713,17 +715,36 @@ async fn op_http_write_resource(
     if nread == 0 {
       break;
     }
-    match body_writer.write_all(&buf[..nread]).await {
-      Ok(_) => {}
-      Err(err) => {
-        assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
-        // Don't return "broken pipe", that's an implementation detail.
-        // Pull up the failure associated with the transport connection instead.
-        http_stream.conn.closed().await?;
-        // If there was no connection error, drop body_tx.
-        *wr = HttpResponseWriter::Closed;
+
+    match &mut *wr {
+      HttpResponseWriter::Body(body) => {
+        match body.write_all(&buf[..nread]).await {
+          Ok(_) => (),
+          Err(err) => {
+            assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+            // Don't return "broken pipe", that's an implementation detail.
+            // Pull up the failure associated with the transport connection instead.
+            http_stream.conn.closed().await?;
+            // If there was no connection error, drop body_tx.
+            *wr = HttpResponseWriter::Closed;
+          }
+        }
       }
-    }
+      HttpResponseWriter::BodyUncompressed(body) => {
+        match body.send_data(Bytes::from(buf.to_temp())).await {
+          Err(err) => {
+            assert!(err.is_closed());
+            // Don't return "broken pipe", that's an implementation detail.
+            // Pull up the failure associated with the transport connection instead.
+            http_stream.conn.closed().await?;
+            // If there was no connection error, drop body_tx.
+            *wr = HttpResponseWriter::Closed;
+          }
+          Ok(_) => {}
+        }
+      }
+      _ => unreachable!(),
+    };
   }
 
   let wr = take(&mut *wr);
@@ -754,30 +775,43 @@ async fn op_http_write(
   let mut wr = RcRef::map(&stream, |r| &r.wr).borrow_mut().await;
 
   loop {
-    let body_writer = match &mut *wr {
-      HttpResponseWriter::Body(body_tx) => body_tx,
+    match &mut *wr {
       HttpResponseWriter::Headers(_) => {
         break Err(http_error("no response headers"))
       }
       HttpResponseWriter::Closed => {
         break Err(http_error("response already completed"))
       }
-    };
-
-    let mut res = body_writer.write_all(&buf).await;
-    if res.is_ok() {
-      res = body_writer.flush().await;
-    }
-
-    match res {
-      Ok(_) => break Ok(()),
-      Err(err) => {
-        assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
-        // Don't return "broken pipe", that's an implementation detail.
-        // Pull up the failure associated with the transport connection instead.
-        stream.conn.closed().await?;
-        // If there was no connection error, drop body_tx.
-        *wr = HttpResponseWriter::Closed;
+      HttpResponseWriter::Body(body) => {
+        let mut result = body.write_all(&buf).await;
+        if result.is_ok() {
+          result = body.flush().await;
+        }
+        match result {
+          Ok(_) => break Ok(()),
+          Err(err) => {
+            assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+            // Don't return "broken pipe", that's an implementation detail.
+            // Pull up the failure associated with the transport connection instead.
+            stream.conn.closed().await?;
+            // If there was no connection error, drop body_tx.
+            *wr = HttpResponseWriter::Closed;
+          }
+        }
+      }
+      HttpResponseWriter::BodyUncompressed(body) => {
+        let bytes = Bytes::copy_from_slice(&buf[..]);
+        match body.send_data(bytes).await {
+          Ok(_) => break Ok(()),
+          Err(err) => {
+            assert!(err.is_closed());
+            // Don't return "broken pipe", that's an implementation detail.
+            // Pull up the failure associated with the transport connection instead.
+            stream.conn.closed().await?;
+            // If there was no connection error, drop body_tx.
+            *wr = HttpResponseWriter::Closed;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Brings back the nice juicy numbers seen in https://github.com/denoland/deno/pull/14284

sample.txt is 5MB

`main`:
```
wrk -t8 -c20 -d10s http://localhost:8080/sample.txt
Running 10s test @ http://localhost:8080/sample.txt
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    38.43ms    4.80ms  83.32ms   91.27%
    Req/Sec    51.87      9.99    60.00     62.87%
  4192 requests in 10.10s, 20.53GB read
Requests/sec:    414.91
Transfer/sec:      2.03GB
```

This PR:
```
Running 10s test @ http://localhost:8080/sample.txt
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    17.58ms    2.53ms  44.05ms   88.56%
    Req/Sec   114.07     12.06   141.00     67.20%
  9179 requests in 10.10s, 44.87GB read
Requests/sec:    908.86
Transfer/sec:      4.44GB
```

