### PR TITLE
perf(serde_v8): zero-copy StringOrBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,6 @@ dependencies = [
  "bencher",
  "derive_more",
  "serde",
- "serde_bytes",
  "serde_json",
  "v8",
 ]

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -15,7 +15,6 @@ path = "lib.rs"
 [dependencies]
 derive_more = "0.99.17"
 serde = { version = "1.0.130", features = ["derive"] }
-serde_bytes = "0.11"
 v8 = "0.42.0"
 
 [dev-dependencies]

--- a/serde_v8/benches/de.rs
+++ b/serde_v8/benches/de.rs
@@ -155,6 +155,54 @@ fn de_bstr_v8_1024_b(b: &mut Bencher) {
   );
 }
 
+fn de_sob_str_6b(b: &mut Bencher) {
+  dedo("'byebye'", |scope, v| {
+    b.iter(move || {
+      let _: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
+    })
+  })
+}
+
+fn de_sob_str_1kb(b: &mut Bencher) {
+  dedo("'deno'.repeat(256)", |scope, v| {
+    b.iter(move || {
+      let _: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
+    })
+  })
+}
+
+fn de_sob_buf_1b(b: &mut Bencher) {
+  dedo("new Uint8Array([97])", |scope, v| {
+    b.iter(move || {
+      let _: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
+    })
+  })
+}
+
+fn de_sob_buf_1kb(b: &mut Bencher) {
+  dedo("(new Uint8Array(1*1024)).fill(42)", |scope, v| {
+    b.iter(move || {
+      let _: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
+    })
+  })
+}
+
+fn de_sob_buf_16kb(b: &mut Bencher) {
+  dedo("(new Uint8Array(16*1024)).fill(42)", |scope, v| {
+    b.iter(move || {
+      let _: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
+    })
+  })
+}
+
+fn de_sob_buf_512kb(b: &mut Bencher) {
+  dedo("(new Uint8Array(512*1024)).fill(42)", |scope, v| {
+    b.iter(move || {
+      let _: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
+    })
+  })
+}
+
 benchmark_group!(
   benches,
   de_struct_v8,
@@ -174,6 +222,12 @@ benchmark_group!(
   de_tuple_v8_opt,
   de_bstr_v8_12_b,
   de_bstr_v8_1024_b,
+  de_sob_str_6b,
+  de_sob_str_1kb,
+  de_sob_buf_1b,
+  de_sob_buf_1kb,
+  de_sob_buf_16kb,
+  de_sob_buf_512kb,
 );
 
 benchmark_main!(benches);

--- a/serde_v8/de.rs
+++ b/serde_v8/de.rs
@@ -7,7 +7,9 @@ use crate::keys::{v8_struct_key, KeyCache};
 use crate::magic::transl8::FromV8;
 use crate::magic::transl8::{visit_magic, MagicType};
 use crate::payload::ValueType;
-use crate::{magic, Buffer, ByteString, DetachedBuffer, U16String};
+use crate::{
+  magic, Buffer, ByteString, DetachedBuffer, StringOrBuffer, U16String,
+};
 
 pub struct Deserializer<'a, 'b, 's> {
   input: v8::Local<'a, v8::Value>,
@@ -358,6 +360,9 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
       }
       U16String::MAGIC_NAME => {
         visit_magic(visitor, U16String::from_v8(self.scope, self.input)?)
+      }
+      StringOrBuffer::MAGIC_NAME => {
+        visit_magic(visitor, StringOrBuffer::from_v8(self.scope, self.input)?)
       }
       magic::Value::MAGIC_NAME => {
         visit_magic(visitor, magic::Value::from_v8(self.scope, self.input)?)

--- a/serde_v8/magic/buffer.rs
+++ b/serde_v8/magic/buffer.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+use std::fmt::Debug;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Mutex;
@@ -20,6 +21,12 @@ pub enum MagicBuffer {
 }
 
 impl_magic!(MagicBuffer);
+
+impl Debug for MagicBuffer {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_list().entries(self.as_ref().iter()).finish()
+  }
+}
 
 impl MagicBuffer {
   pub fn empty() -> Self {

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -178,24 +178,24 @@ fn de_map() {
 fn de_string_or_buffer() {
   dedo("'hello'", |scope, v| {
     let sob: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
-    assert_eq!(sob.as_slice(), &[0x68, 0x65, 0x6C, 0x6C, 0x6F]);
+    assert_eq!(sob.as_ref(), &[0x68, 0x65, 0x6C, 0x6C, 0x6F]);
   });
 
   dedo("new Uint8Array([97])", |scope, v| {
     let sob: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
-    assert_eq!(sob.as_slice(), &[97]);
+    assert_eq!(sob.as_ref(), &[97]);
   });
 
   dedo("new Uint8Array([128])", |scope, v| {
     let sob: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
-    assert_eq!(sob.as_slice(), &[128]);
+    assert_eq!(sob.as_ref(), &[128]);
   });
 
   dedo(
     "(Uint8Array.from([0x68, 0x65, 0x6C, 0x6C, 0x6F]))",
     |scope, v| {
       let sob: serde_v8::StringOrBuffer = serde_v8::from_v8(scope, v).unwrap();
-      assert_eq!(sob.as_slice(), &[0x68, 0x65, 0x6C, 0x6C, 0x6F]);
+      assert_eq!(sob.as_ref(), &[0x68, 0x65, 0x6C, 0x6C, 0x6F]);
     },
   );
 }


### PR DESCRIPTION
```
Before:
test de_sob_buf_16kb      ... bench:         597 ns/iter (+/- 16)
test de_sob_buf_1b        ... bench:          90 ns/iter (+/- 3)
test de_sob_buf_1kb       ... bench:         169 ns/iter (+/- 3)
test de_sob_buf_512kb     ... bench:      23,829 ns/iter (+/- 441)
test de_sob_str_1kb       ... bench:         555 ns/iter (+/- 6)
test de_sob_str_6b        ... bench:          76 ns/iter (+/- 0)

After:
test de_sob_buf_16kb      ... bench:          32 ns/iter (+/- 1)
test de_sob_buf_1b        ... bench:          32 ns/iter (+/- 2)
test de_sob_buf_1kb       ... bench:          32 ns/iter (+/- 1)
test de_sob_buf_512kb     ... bench:          32 ns/iter (+/- 2)
test de_sob_str_1kb       ... bench:         465 ns/iter (+/- 14)
test de_sob_str_6b        ... bench:          48 ns/iter (+/- 1)
```