### PR TITLE
feat(ext/console): Add string abbreviation size option for "Deno.inspect"

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2491,6 +2491,8 @@ declare namespace Deno {
     getters?: boolean;
     /** Show an object's non-enumerable properties. Defaults to false. */
     showHidden?: boolean;
+    /** The maximum length of a string before it is truncated with an ellipsis */
+    strAbbreviateSize?: number;
   }
 
   /** Converts the input into a string that has the same format as printed by

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1938,3 +1938,22 @@ Deno.test(function inspectColors() {
   assertEquals(Deno.inspect(1), "1");
   assertStringIncludes(Deno.inspect(1, { colors: true }), "\x1b[");
 });
+
+Deno.test(function inspectStringAbbreviation() {
+  const LONG_STRING =
+    "This is a really long string which will be abbreviated with ellipsis.";
+  const obj = {
+    str: LONG_STRING,
+  };
+  const arr = [LONG_STRING];
+
+  assertEquals(
+    Deno.inspect(obj, { strAbbreviateSize: 10 }),
+    '{ str: "This is a ..." }',
+  );
+
+  assertEquals(
+    Deno.inspect(arr, { strAbbreviateSize: 10 }),
+    '[ "This is a ..." ]',
+  );
+});

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -787,9 +787,10 @@
     level,
     inspectOptions,
   ) {
-    const abbreviateSize = typeof inspectOptions.strAbbreviateSize === "undefined"
-      ? STR_ABBREVIATE_SIZE
-      : inspectOptions.strAbbreviateSize;
+    const abbreviateSize =
+      typeof inspectOptions.strAbbreviateSize === "undefined"
+        ? STR_ABBREVIATE_SIZE
+        : inspectOptions.strAbbreviateSize;
     const green = maybeColor(colors.green, inspectOptions);
     switch (typeof value) {
       case "string": {

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -298,6 +298,7 @@
     colors: false,
     getters: false,
     showHidden: false,
+    strAbbreviateSize: 100,
   };
 
   const DEFAULT_INDENT = "  "; // Default indent string
@@ -786,11 +787,14 @@
     level,
     inspectOptions,
   ) {
+    const abbreviateSize = typeof inspectOptions.strAbbreviateSize === "undefined"
+      ? STR_ABBREVIATE_SIZE
+      : inspectOptions.strAbbreviateSize;
     const green = maybeColor(colors.green, inspectOptions);
     switch (typeof value) {
       case "string": {
-        const trunc = value.length > STR_ABBREVIATE_SIZE
-          ? StringPrototypeSlice(value, 0, STR_ABBREVIATE_SIZE) + "..."
+        const trunc = value.length > abbreviateSize
+          ? StringPrototypeSlice(value, 0, abbreviateSize) + "..."
           : value;
         return green(quoteString(trunc)); // Quoted strings are green
       }


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
Implements an option on `Deno.inspect` to set the maximum string size before it is truncated with an ellipsis.

This is required to fix [this issue in denoland/deno_std](https://github.com/denoland/deno_std/issues/2140).