### PR TITLE
Fix android support

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,9 @@ sourcemap = "=6.0.1"
 url = { version = "2.2.2", features = ["serde"] }
 v8 = "0.42.0"
 
+[features]
+standalone = []
+
 [[example]]
 name = "http_bench_json_ops"
 path = "examples/http_bench_json_ops.rs"

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -187,16 +187,15 @@ macro_rules! include_js_files {
       $((
         concat!($prefix, "/", $file),
         Box::new(|| {
-          if cfg!(feature = "standalone"){
-            let src = include_str!(concat!( env!("CARGO_MANIFEST_DIR"), "/", $file )).to_string();
-            Ok(src)
-          }else{
             let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             let path = c.join($file);
             println!("cargo:rerun-if-changed={}", path.display());
-            let src = std::fs::read_to_string(path)?;
+            let src = if cfg!(feature = "standalone") {
+              include_str!(concat!( env!("CARGO_MANIFEST_DIR"), "/", $file )).to_string()
+            } else {
+              std::fs::read_to_string(path)?
+            };
             Ok(src)
-          }
         }),
       ),)+
     ]

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -187,11 +187,16 @@ macro_rules! include_js_files {
       $((
         concat!($prefix, "/", $file),
         Box::new(|| {
-          let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-          let path = c.join($file);
-          println!("cargo:rerun-if-changed={}", path.display());
-          let src = std::fs::read_to_string(path)?;
-          Ok(src)
+          if cfg!(feature = "standalone"){
+            let src = include_str!(concat!( env!("CARGO_MANIFEST_DIR"), "/", $file )).to_string();
+            Ok(src)
+          }else{
+            let c = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let path = c.join($file);
+            println!("cargo:rerun-if-changed={}", path.display());
+            let src = std::fs::read_to_string(path)?;
+            Ok(src)
+          }
         }),
       ),)+
     ]

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -101,12 +101,20 @@ pub fn op_metrics(
 /// Builtin utility to print to stdout/stderr
 #[op]
 pub fn op_print(msg: String, is_err: bool) -> Result<(), Error> {
-  if is_err {
-    stderr().write_all(msg.as_bytes())?;
-    stderr().flush().unwrap();
+  if cfg!(target_os = "android") {
+    if is_err {
+      log::error!("{}", msg);
+    } else {
+      log::info!("{}", msg);
+    }
   } else {
-    stdout().write_all(msg.as_bytes())?;
-    stdout().flush().unwrap();
+    if is_err {
+      stderr().write_all(msg.as_bytes())?;
+      stderr().flush().unwrap();
+    } else {
+      stdout().write_all(msg.as_bytes())?;
+      stdout().flush().unwrap();
+    }
   }
   Ok(())
 }

--- a/ext/broadcast_channel/Cargo.toml
+++ b/ext/broadcast_channel/Cargo.toml
@@ -13,6 +13,9 @@ description = "Implementation of BroadcastChannel API for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 async-trait = "0.1"
 deno_core = { version = "0.132.0", path = "../../core" }

--- a/ext/console/Cargo.toml
+++ b/ext/console/Cargo.toml
@@ -13,5 +13,8 @@ description = "Implementation of Console API for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -13,6 +13,9 @@ description = "Web Cryptography API implementation for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 aes = "0.7.5"
 aes-gcm = "0.9.4"

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -13,6 +13,9 @@ description = "Fetch API implementation for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 bytes = "1.1.0"
 data-url = "0.1.0"

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -13,6 +13,9 @@ description = "Dynamic library ffi for deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 dlopen = "0.1.8"

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -13,6 +13,9 @@ description = "HTTP server implementation for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [[bench]]
 name = "compressible"
 harness = false

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -13,6 +13,9 @@ description = "Networking for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 deno_tls = { version = "0.37.0", path = "../tls" }

--- a/ext/tls/Cargo.toml
+++ b/ext/tls/Cargo.toml
@@ -13,6 +13,9 @@ description = "TLS for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 once_cell = "1.10.0"

--- a/ext/url/Cargo.toml
+++ b/ext/url/Cargo.toml
@@ -13,6 +13,9 @@ description = "URL API implementation for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 serde = { version = "1.0.129", features = ["derive"] }

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -13,6 +13,9 @@ description = "Collection of Web APIs"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 async-trait = "0.1.51"
 base64 = "0.13.0"

--- a/ext/webgpu/Cargo.toml
+++ b/ext/webgpu/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 repository = "https://github.com/gfx-rs/wgpu"
 description = "WebGPU implementation for Deno"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ext/webidl/Cargo.toml
+++ b/ext/webidl/Cargo.toml
@@ -13,5 +13,8 @@ description = "WebIDL implementation for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -13,6 +13,9 @@ description = "Implementation of WebSocket API for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 deno_tls = { version = "0.37.0", path = "../tls" }

--- a/ext/webstorage/Cargo.toml
+++ b/ext/webstorage/Cargo.toml
@@ -13,6 +13,9 @@ description = "Implementation of WebStorage API for Deno"
 [lib]
 path = "lib.rs"
 
+[features]
+standalone = ["deno_core/standalone"]
+
 [dependencies]
 deno_core = { version = "0.132.0", path = "../../core" }
 deno_web = { version = "0.81.0", path = "../web" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,24 @@ description = "Provides the deno runtime library"
 [features]
 # "fake" feature that allows to generate docs on docs.rs
 docsrs = []
+standalone = [
+    "deno_broadcast_channel/standalone",
+    "deno_console/standalone",
+    "deno_core/standalone",
+    "deno_crypto/standalone",
+    "deno_fetch/standalone",
+    "deno_ffi/standalone",
+    "deno_http/standalone",
+    "deno_net/standalone",
+    "deno_tls/standalone",
+    "deno_url/standalone",
+    "deno_web/standalone",
+    "deno_webgpu/standalone",
+    "deno_webidl/standalone",
+    "deno_websocket/standalone",
+    "deno_webstorage/standalone",
+]
+
 
 [lib]
 name = "deno_runtime"
@@ -67,7 +85,13 @@ encoding_rs = "0.8.29"
 filetime = "0.2.15"
 fs3 = "0.5.0"
 http = "0.2.4"
-hyper = { version = "0.14.12", features = ["server", "stream", "http1", "http2", "runtime"] }
+hyper = { version = "0.14.12", features = [
+    "server",
+    "stream",
+    "http1",
+    "http2",
+    "runtime",
+] }
 libc = "0.2.121"
 log = "0.4.14"
 lzzzz = '=0.8.0'
@@ -85,7 +109,17 @@ uuid = { version = "0.8.2", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "1.1.0"
-winapi = { version = "0.3.9", features = ["commapi", "knownfolders", "mswsock", "objbase", "shlobj", "tlhelp32", "winbase", "winerror", "winsock2"] }
+winapi = { version = "0.3.9", features = [
+    "commapi",
+    "knownfolders",
+    "mswsock",
+    "objbase",
+    "shlobj",
+    "tlhelp32",
+    "winbase",
+    "winerror",
+    "winsock2",
+] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "=0.23.0"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,23 +13,22 @@ description = "Provides the deno runtime library"
 # "fake" feature that allows to generate docs on docs.rs
 docsrs = []
 standalone = [
-    "deno_broadcast_channel/standalone",
-    "deno_console/standalone",
-    "deno_core/standalone",
-    "deno_crypto/standalone",
-    "deno_fetch/standalone",
-    "deno_ffi/standalone",
-    "deno_http/standalone",
-    "deno_net/standalone",
-    "deno_tls/standalone",
-    "deno_url/standalone",
-    "deno_web/standalone",
-    "deno_webgpu/standalone",
-    "deno_webidl/standalone",
-    "deno_websocket/standalone",
-    "deno_webstorage/standalone",
+  "deno_broadcast_channel/standalone",
+  "deno_console/standalone",
+  "deno_core/standalone",
+  "deno_crypto/standalone",
+  "deno_fetch/standalone",
+  "deno_ffi/standalone",
+  "deno_http/standalone",
+  "deno_net/standalone",
+  "deno_tls/standalone",
+  "deno_url/standalone",
+  "deno_web/standalone",
+  "deno_webgpu/standalone",
+  "deno_webidl/standalone",
+  "deno_websocket/standalone",
+  "deno_webstorage/standalone",
 ]
-
 
 [lib]
 name = "deno_runtime"
@@ -85,13 +84,7 @@ encoding_rs = "0.8.29"
 filetime = "0.2.15"
 fs3 = "0.5.0"
 http = "0.2.4"
-hyper = { version = "0.14.12", features = [
-    "server",
-    "stream",
-    "http1",
-    "http2",
-    "runtime",
-] }
+hyper = { version = "0.14.12", features = ["server", "stream", "http1", "http2", "runtime"] }
 libc = "0.2.121"
 log = "0.4.14"
 lzzzz = '=0.8.0'
@@ -109,17 +102,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "1.1.0"
-winapi = { version = "0.3.9", features = [
-    "commapi",
-    "knownfolders",
-    "mswsock",
-    "objbase",
-    "shlobj",
-    "tlhelp32",
-    "winbase",
-    "winerror",
-    "winsock2",
-] }
+winapi = { version = "0.3.9", features = ["commapi", "knownfolders", "mswsock", "objbase", "shlobj", "tlhelp32", "winbase", "winerror", "winsock2"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "=0.23.0"


### PR DESCRIPTION
When we want to use deno_core directly (for example, in an Android application), the application cannot contain js directly by default, so we add a configurable item standalone through FEATURES to say that js files are built into deno_core.

In Android's NDK environment, the way to output logs is logcat, so use the log library instead of stdout/stderr