### PR TITLE
fix: `deno task` should forward double hyphens

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -300,7 +300,8 @@ impl TestRun {
   ) -> Result<(), AnyError> {
     let args = self.get_args();
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
-    let flags = flags::flags_from_vec(args)?;
+    let flags =
+      flags::flags_from_vec(args.into_iter().map(String::from).collect())?;
     let ps = proc_state::ProcState::build(Arc::new(flags)).await?;
     let permissions =
       Permissions::from_options(&ps.flags.permissions_options());


### PR DESCRIPTION
When someone runs:

```
deno task node:test -- test-assert.js
```

It should forward everything after the task name like so:

```
Task node:test deno test --unstable --allow-all node/_tools/test.ts "--" "test-assert.js"
```

Currently it does:

```
Task node:test deno test --unstable --allow-all node/_tools/test.ts "test-assert.js"
```