### PR TITLE
fix(vendor): do not panic on relative specifier with scheme-like folder name

### DIFF
--- a/cli/tools/vendor/import_map.rs
+++ b/cli/tools/vendor/import_map.rs
@@ -226,7 +226,8 @@ fn handle_dep_specifier(
       let mut local_base_specifier = mappings.local_uri(base_specifier);
       local_base_specifier.set_query(unresolved_specifier.query());
       local_base_specifier = local_base_specifier
-        .join(&unresolved_specifier.path()[1..])
+        // path includes "/" so make it relative
+        .join(&format!(".{}", unresolved_specifier.path()))
         .unwrap_or_else(|_| {
           panic!(
             "Error joining {} to {}",


### PR DESCRIPTION
I tried to vendor something for debugging purposes today and got a panic with jspm because it had some relative specifiers that looked like this:

```
import _regex2 from './npm:uc.micro@1.0.6/categories/Cc/regex!cjs';
```

```
============================================================
Deno has panicked. This is a bug in Deno. Please report this
at https://github.com/denoland/deno/issues/new.
If you can reliably reproduce this panic, include the
reproduction steps and re-run with the RUST_BACKTRACE=1 env
var set and include the backtrace in your report.

Platform: windows x86_64
Version: 1.21.1
Args: ["C:\\Users\\david\\AppData\\Local\\bvm\\binaries\\denoland\\deno\\1.21.1\\bin\\deno.exe", "vendor", "--force", "_config.ts"]

thread 'main' panicked at 'Could not find local path for npm:uc.micro@1/categories/Cc/regex!cjs', cli\tools\vendor\mappings.rs:143:11
```

The reason was a join was being done on `npm:uc.micro@1.0.6/categories/Cc/regex!cjs`, which would make it go absolute because "npm:" looks like a scheme.