### PR TITLE
feat(web): add performance.timeOrigin

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -450,6 +450,7 @@ declare class Worker extends EventTarget {
 declare type PerformanceEntryList = PerformanceEntry[];
 
 declare class Performance {
+  readonly timeOrigin: number;
   constructor();
 
   /** Removes the stored timestamp with the associated name. */

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -12,6 +12,7 @@
 /// <reference lib="deno.websocket" />
 /// <reference lib="deno.crypto" />
 /// <reference lib="deno.broadcast_channel" />
+/// <reference lib="dom.extras" />
 
 declare namespace WebAssembly {
   /**
@@ -450,7 +451,7 @@ declare class Worker extends EventTarget {
 declare type PerformanceEntryList = PerformanceEntry[];
 
 declare class Performance {
-  readonly timeOrigin: number;
+  readonly timeOrigin: DOMHighResTimeStamp;
   constructor();
 
   /** Removes the stored timestamp with the associated name. */

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -12,7 +12,7 @@
 /// <reference lib="deno.websocket" />
 /// <reference lib="deno.crypto" />
 /// <reference lib="deno.broadcast_channel" />
-/// <reference lib="dom.extras" />
+/// <reference lib="dom" />
 
 declare namespace WebAssembly {
   /**

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -12,7 +12,6 @@
 /// <reference lib="deno.websocket" />
 /// <reference lib="deno.crypto" />
 /// <reference lib="deno.broadcast_channel" />
-/// <reference lib="dom" />
 
 declare namespace WebAssembly {
   /**
@@ -451,7 +450,7 @@ declare class Worker extends EventTarget {
 declare type PerformanceEntryList = PerformanceEntry[];
 
 declare class Performance {
-  readonly timeOrigin: DOMHighResTimeStamp;
+  readonly timeOrigin: number;
   constructor();
 
   /** Removes the stored timestamp with the associated name. */

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -450,7 +450,7 @@ declare class Worker extends EventTarget {
 declare type PerformanceEntryList = PerformanceEntry[];
 
 declare class Performance {
-  readonly timeOrigin: number;
+  readonly timeOrigin: DOMHighResTimeStamp;
   constructor();
 
   /** Removes the stored timestamp with the associated name. */

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -450,7 +450,7 @@ declare class Worker extends EventTarget {
 declare type PerformanceEntryList = PerformanceEntry[];
 
 declare class Performance {
-  readonly timeOrigin: DOMHighResTimeStamp;
+  readonly timeOrigin: number;
   constructor();
 
   /** Removes the stored timestamp with the associated name. */

--- a/cli/tests/unit/performance_test.ts
+++ b/cli/tests/unit/performance_test.ts
@@ -20,6 +20,13 @@ Deno.test({ permissions: { hrtime: false } }, async function performanceNow() {
   assert(totalTime >= 10);
 });
 
+Deno.test(function timeOrigin() {
+  const origin = performance.timeOrigin;
+
+  assert(origin > 0);
+  assert(Date.now() >= origin);
+});
+
 Deno.test(function performanceMark() {
   const mark = performance.mark("test");
   assert(mark instanceof PerformanceMark);

--- a/ext/web/15_performance.js
+++ b/ext/web/15_performance.js
@@ -24,6 +24,7 @@
   const illegalConstructorKey = Symbol("illegalConstructorKey");
   const customInspect = SymbolFor("Deno.customInspect");
   let performanceEntries = [];
+  let timeOrigin;
 
   webidl.converters["PerformanceMarkOptions"] = webidl
     .createDictionaryConverter(
@@ -76,6 +77,10 @@
     }
     return webidl.converters.DOMString(V, opts);
   };
+
+  function setTimeOrigin(origin) {
+    timeOrigin = origin;
+  }
 
   function findMostRecent(
     name,
@@ -327,6 +332,10 @@
       webidl.illegalConstructor();
     }
 
+    get timeOrigin() {
+      return timeOrigin;
+    }
+
     clearMarks(markName = undefined) {
       webidl.assertBranded(this, PerformancePrototype);
       if (markName !== undefined) {
@@ -566,5 +575,6 @@
     PerformanceMeasure,
     Performance,
     performance: webidl.createBranded(Performance),
+    setTimeOrigin,
   };
 })(this);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -9,6 +9,7 @@ delete Object.prototype.__proto__;
   const core = Deno.core;
   const {
     ArrayPrototypeMap,
+    DateNow,
     Error,
     FunctionPrototypeCall,
     FunctionPrototypeBind,
@@ -530,7 +531,7 @@ delete Object.prototype.__proto__;
       throw new Error("Worker runtime already bootstrapped");
     }
 
-    performance.setTimeOrigin(window.__bootstrap.primordials["Date"].now());
+    performance.setTimeOrigin(DateNow());
     const consoleFromV8 = window.console;
     const wrapConsole = window.__bootstrap.console.wrapConsole;
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -564,6 +564,7 @@ delete Object.prototype.__proto__;
     window.addEventListener("unload", () => {
       window[isUnloadDispatched] = true;
     });
+
     runtimeStart(runtimeOptions);
     const {
       args,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -530,6 +530,7 @@ delete Object.prototype.__proto__;
       throw new Error("Worker runtime already bootstrapped");
     }
 
+    // deno-lint-ignore prefer-primordials
     performance.setTimeOrigin(Date.now());
     const consoleFromV8 = window.console;
     const wrapConsole = window.__bootstrap.console.wrapConsole;

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -530,6 +530,7 @@ delete Object.prototype.__proto__;
       throw new Error("Worker runtime already bootstrapped");
     }
 
+    performance.setTimeOrigin(Date.now());
     const consoleFromV8 = window.console;
     const wrapConsole = window.__bootstrap.console.wrapConsole;
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -530,8 +530,7 @@ delete Object.prototype.__proto__;
       throw new Error("Worker runtime already bootstrapped");
     }
 
-    // deno-lint-ignore prefer-primordials
-    performance.setTimeOrigin(Date.now());
+    performance.setTimeOrigin(window.__bootstrap.primordials["Date"].now());
     const consoleFromV8 = window.console;
     const wrapConsole = window.__bootstrap.console.wrapConsole;
 
@@ -564,7 +563,6 @@ delete Object.prototype.__proto__;
     window.addEventListener("unload", () => {
       window[isUnloadDispatched] = true;
     });
-
     runtimeStart(runtimeOptions);
     const {
       args,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -624,6 +624,7 @@ delete Object.prototype.__proto__;
       throw new Error("Worker runtime already bootstrapped");
     }
 
+    performance.setTimeOrigin(DateNow());
     const consoleFromV8 = window.console;
     const wrapConsole = window.__bootstrap.console.wrapConsole;
 

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1179,7 +1179,6 @@
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",
       "Performance interface: attribute timeOrigin",
-      "Performance interface: performance must inherit property \"timeOrigin\" with the proper type",
       "Performance interface: default toJSON operation on performance",
       "Window interface: attribute performance"
     ],

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1178,7 +1178,7 @@
     "idlharness.any.html": [
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",
-      "Performance interface: attribute timeOrigin",
+
       "Performance interface: default toJSON operation on performance",
       "Window interface: attribute performance"
     ],

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1186,12 +1186,11 @@
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",
       "Performance interface: attribute timeOrigin",
-      "Performance interface: performance must inherit property \"timeOrigin\" with the proper type",
       "Performance interface: default toJSON operation on performance",
       "WorkerGlobalScope interface: attribute performance",
       "WorkerGlobalScope interface: self must inherit property \"performance\" with the proper type"
     ],
-    "window-worker-timeOrigin.window.html": false,
+    "window-worker-timeOrigin.window.html": true,
     "idlharness-shadowrealm.window.html": false
   },
   "streams": {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1178,7 +1178,7 @@
     "idlharness.any.html": [
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",
-
+      "Performance interface: attribute timeOrigin",
       "Performance interface: default toJSON operation on performance",
       "Window interface: attribute performance"
     ],


### PR DESCRIPTION
Revival of #10843.

Adds the `timeOrigin` property of the Performance API. Closes #10837.



<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
