### PR TITLE
feat(test): repeat test name if there's user output

### DIFF
--- a/cli/tests/testdata/test/pass.out
+++ b/cli/tests/testdata/test/pass.out
@@ -9,6 +9,11 @@ test 5 ... ok ([WILDCARD])
 test 6 ... ok ([WILDCARD])
 test 7 ... ok ([WILDCARD])
 test 8 ... ok ([WILDCARD])
+test 9 ...
+------- output -------
+console.log
+console.error
+----- output end -----
 test 9 ... ok ([WILDCARD])
 
 test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])

--- a/cli/tests/testdata/test/pass.ts
+++ b/cli/tests/testdata/test/pass.ts
@@ -7,4 +7,7 @@ Deno.test("test 5", () => {});
 Deno.test("test 6", () => {});
 Deno.test("test 7", () => {});
 Deno.test("test 8", () => {});
-Deno.test("test 9", () => {});
+Deno.test("test 9", () => {
+  console.log("console.log");
+  console.error("console.error");
+});

--- a/cli/tests/testdata/test/steps/output_within.out
+++ b/cli/tests/testdata/test/steps/output_within.out
@@ -12,20 +12,20 @@ description ...
 ------- output -------
 3
 ----- output end -----
-    ok ([WILDCARD]ms)
+    inner 1 ... ok ([WILDCARD]ms)
     inner 2 ...
 ------- output -------
 4
 ----- output end -----
-    ok ([WILDCARD]ms)
+    inner 2 ... ok ([WILDCARD]ms)
 
 ------- output -------
 5
 ----- output end -----
-  ok ([WILDCARD]ms)
+  step 1 ... ok ([WILDCARD]ms)
 
 ------- output -------
 6
 ----- output end -----
-ok ([WILDCARD]ms)
+description ... ok ([WILDCARD]ms)
 [WILDCARD]

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -303,6 +303,10 @@ impl PrettyTestReporter {
       print!("{}", "  ".repeat(description.level));
     }
 
+    if wrote_user_output {
+      print!("{} ... ", description.name);
+    }
+
     println!(
       "{} {}",
       status,
@@ -401,6 +405,10 @@ impl TestReporter for PrettyTestReporter {
     let wrote_user_output = self.write_output_end();
     if !wrote_user_output && self.last_wait_output_level == 0 {
       print!(" ");
+    }
+
+    if wrote_user_output {
+      print!("{} ... ", description.name);
     }
 
     let status = match result {


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/14315

This commit changes test report output to repeat test name before printing
result, but only if there's user output, denoted by markers.

```ts
$ cat foo_test.ts
Deno.test("my test", () => {
  console.log("console.log");
  console.log("console.error");
});
```

Before:
```
$ deno test foo_test.ts
Check file:///Users/ib/dev/deno/foo_test.ts
running 1 test from ./foo_test.ts
my test ...
------- output -------
console.log
console.error
----- output end -----
ok (6ms)

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (18ms)

```

After:
```
Check file:///Users/ib/dev/deno/foo_test.ts
running 1 test from ./foo_test.ts
my test ...
------- output -------
console.log
console.error
----- output end -----
my test ... ok (6ms)

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (18ms)

```