### PR TITLE
refactor(ext/url): URLPattern structured matchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4936,8 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "urlpattern"
-version = "0.1.6"
-source = "git+https://github.com/lucacasonato/rust-urlpattern?branch=fast_matcher#22257d8fe8e0c415e66b3a2ab5091b5f4199a19c"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bd5ff03aea02fa45b13a7980151fe45009af1980ba69f651ec367121a31609"
 dependencies = [
  "derive_more",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,8 +4937,7 @@ dependencies = [
 [[package]]
 name = "urlpattern"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2761073dd27e1b88de9aa082bbc085c35fae2b848379cedfafefc40a54f809"
+source = "git+https://github.com/lucacasonato/rust-urlpattern?branch=fast_matcher#22257d8fe8e0c415e66b3a2ab5091b5f4199a19c"
 dependencies = [
  "derive_more",
  "regex",

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -638,7 +638,7 @@ fn clap_root(version: &str) -> Command {
 }
 
 fn bench_subcommand<'a>() -> Command<'a> {
-  runtime_args(Command::new("bench"), true, false)
+  runtime_args(Command::new("bench"), true, true)
     .trailing_var_arg(true)
     .arg(
       Arg::new("ignore")
@@ -2090,7 +2090,7 @@ fn unsafely_ignore_certificate_errors_arg<'a>() -> Arg<'a> {
 }
 
 fn bench_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
-  runtime_args_parse(flags, matches, true, false);
+  runtime_args_parse(flags, matches, true, true);
 
   // NOTE: `deno bench` always uses `--no-prompt`, tests shouldn't ever do
   // interactive prompts, unless done by user code

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -402,7 +402,7 @@ async fn bench_specifier(
         &specifier.to_file_path().unwrap().display().to_string(),
         false,
       )?;
-      worker.run_event_loop(false).await?;
+      worker.run_event_loop(true).await?;
     }
   } else {
     // We execute the module module as a side module so that import.meta.main is not set.
@@ -424,6 +424,8 @@ async fn bench_specifier(
   worker.js_runtime.resolve_value(bench_result).await?;
 
   worker.dispatch_unload_event(&located_script_name!())?;
+
+  worker.js_runtime.run_event_loop(true).await?;
 
   Ok(())
 }

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -58,17 +58,6 @@
     "hash",
   ];
 
-  const PARTS_OBJ = {
-    protocol: {},
-    username: {},
-    password: {},
-    hostname: {},
-    port: {},
-    pathname: {},
-    search: {},
-    hash: {},
-  };
-
   class URLPattern {
     /** @type {Components} */
     [_components];

--- a/ext/url/Cargo.toml
+++ b/ext/url/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core = { version = "0.132.0", path = "../../core" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_repr = "0.1.7"
-urlpattern = { git = "https://github.com/lucacasonato/rust-urlpattern", branch = "fast_matcher" }
+urlpattern = "0.2.0"
 
 [dev-dependencies]
 deno_bench_util = { version = "0.44.0", path = "../../bench_util" }

--- a/ext/url/Cargo.toml
+++ b/ext/url/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core = { version = "0.132.0", path = "../../core" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_repr = "0.1.7"
-urlpattern = "0.1.6"
+urlpattern = { git = "https://github.com/lucacasonato/rust-urlpattern", branch = "fast_matcher" }
 
 [dev-dependencies]
 deno_bench_util = { version = "0.44.0", path = "../../bench_util" }

--- a/ext/url/benches/urlpattern_bench.ts
+++ b/ext/url/benches/urlpattern_bench.ts
@@ -1,0 +1,88 @@
+const CASES = {
+  "literal": ["/about", "https://example.com/about"],
+  "segment": ["/:foo", "https://example.com/bar"],
+  "prefixed segment": ["/abc/:foo", "https://example.com/abc/bar"],
+  "prefixed + suffixed segment": [
+    "/abc/:foo.html",
+    "https://example.com/abc/bar.html",
+  ],
+  "wilcard": ["*", "https://example.com/abc/bar.html"],
+  "prefixed wilcard": ["/abc/*", "https://example.com/abc/bar.html"],
+  "prefixed + suffixed wilcard": [
+    "/abc/*.html",
+    "https://example.com/abc/bar.html",
+  ],
+  "custom regexp": [
+    "/abc/:foo(\\d+)",
+    "https://example.com/abc/123",
+  ],
+};
+
+for (const [name, cases] of Object.entries(CASES)) {
+  const pattern = new URLPattern({ pathname: cases[0] });
+  const url = cases[1];
+  Deno.bench(name, () => {
+    for (let i = 0; i < 10; i++) {
+      pattern.exec(url);
+    }
+  });
+}
+
+const ROUTES = [
+  "/",
+  "/about",
+  "/contact",
+  "/blog",
+  "/blog/:id",
+];
+
+const URL_PATTERNS = ROUTES.map((route) => new URLPattern({ pathname: route }));
+
+const TESTS = [
+  "/",
+  "/about",
+  "/contact",
+  "/blog",
+  "/blog/1",
+  "/blog/2",
+  "/blog/3",
+];
+
+function urlpattern(path: string) {
+  for (let i = 0; i < URL_PATTERNS.length; i++) {
+    const match = URL_PATTERNS[i].exec({ pathname: path });
+    if (match) return [i, match];
+  }
+}
+
+Deno.bench("urlpattern", { group: "1" }, () => {
+  for (const test of TESTS) {
+    urlpattern(test);
+  }
+});
+
+function handwritten(path: string) {
+  if (path === "/") {
+    return [0, {}];
+  }
+  if (path === "/about") {
+    return [1, {}];
+  }
+  if (path === "/contact") {
+    return [2, {}];
+  }
+  if (path === "/blog") {
+    return [3, {}];
+  }
+  if (path.startsWith("/blog")) {
+    const match = URL_PATTERNS[4].exec({ pathname: path });
+    if (match !== null) return [4, match.pathname.groups];
+  }
+  return null;
+}
+
+Deno.bench("handwritten", { group: "1" }, () => {
+  for (const test of TESTS) {
+    handwritten(test);
+  }
+});


### PR DESCRIPTION
This commit updates URLPattern to use a structured matcher instead of
always using a RegExp. This results in an approximately 0% change in performance
 in the cases I tested. The real value of this PR is that it allows for
 very fast matching in the upcoming URLPatternList, because this
interface can be implemented to use a radix tree matcher internally.

The new matcher still falls back to RegExp matching if the pattern is
too complicated to be handled by the simple cases (for example if
backtracking is required to match).

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
