### PR TITLE
chore: improve release docs

### DIFF
--- a/tools/cut_a_release.md
+++ b/tools/cut_a_release.md
@@ -43,8 +43,7 @@ Before starting the process write a message in company's #general channel:
       1. Ensure the version in `version.ts` is updated correctly.
       2. Ensure `Releases.md` is updated correctly.
       3. Ensure all the tests pass with the latest build
-         - Use `../deno/target/release/deno test -A --unstable` and NOT
-           `deno task test`
+         - Use `../deno/target/release/deno test --doc --unstable --allow-all --ignore=node/`
    3. Open a PR with the changes and continue with the steps below.
    </details>
 
@@ -83,7 +82,7 @@ verify on GitHub that everything looks correct.
    actions: https://github.com/denoland/deno/actions/workflows/version_bump.yml
 
 2. Click on the "Run workflow" button.
-   1. In the drop down, select the minor branch if doing a path release or the
+   1. In the drop down, select the minor branch if doing a patch release or the
       main branch if doing a minor release.
    2. For the kind of release, select either "patch", "minor", or "major".
    3. Run the workflow.

--- a/tools/cut_a_release.md
+++ b/tools/cut_a_release.md
@@ -43,7 +43,8 @@ Before starting the process write a message in company's #general channel:
       1. Ensure the version in `version.ts` is updated correctly.
       2. Ensure `Releases.md` is updated correctly.
       3. Ensure all the tests pass with the latest build
-         - Use `../deno/target/release/deno test --doc --unstable --allow-all --ignore=node/`
+         - Use
+           `../deno/target/release/deno test --doc --unstable --allow-all --ignore=node/`
    3. Open a PR with the changes and continue with the steps below.
    </details>
 


### PR DESCRIPTION
This commit fixes a typo and the test command used in deno_std.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
