### PR TITLE
feat(test): Represent uncaught errors

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -20,6 +20,7 @@ use crate::tools::test::TestEventSender;
 
 use deno_core::anyhow::anyhow;
 use deno_core::error::AnyError;
+use deno_core::error::JsError;
 use deno_core::futures::future;
 use deno_core::futures::stream;
 use deno_core::futures::StreamExt;
@@ -403,6 +404,9 @@ impl TestRun {
               }
 
               reporter.report_result(&description, &result, elapsed);
+            }
+            test::TestEvent::UncaughtError(origin, error) => {
+              summary.uncaught_errors.push((origin, error));
             }
             test::TestEvent::StepWait(description) => {
               reporter.report_step_wait(&description);
@@ -803,6 +807,10 @@ impl test::TestReporter for LspTestReporter {
         })
       }
     }
+  }
+
+  fn report_uncaught_error(&mut self, _origin: &str, _error: &JsError) {
+    // TODO(nayeemrmn)
   }
 
   fn report_step_wait(&mut self, desc: &test::TestStepDescription) {

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -165,7 +165,7 @@ pub enum TestRunProgressMessage {
   End,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TestMessage {
   pub message: lsp::MarkupContent,

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -368,3 +368,9 @@ fn file_protocol() {
   })
   .run();
 }
+
+itest!(uncaught_errors {
+  args: "test --quiet test/uncaught_errors_1.ts test/uncaught_errors_2.ts test/uncaught_errors_3.ts",
+  output: "test/uncaught_errors.out",
+  exit_code: 1,
+});

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -27,7 +27,7 @@ itest!(overloads {
 });
 
 itest!(meta {
-  args: "test test/meta.ts",
+  args: "test --quiet test/meta.ts",
   exit_code: 0,
   output: "test/meta.out",
 });

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -27,7 +27,7 @@ itest!(overloads {
 });
 
 itest!(meta {
-  args: "test --quiet test/meta.ts",
+  args: "test test/meta.ts",
   exit_code: 0,
   output: "test/meta.out",
 });

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_cjs.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_cjs.out
@@ -1,7 +1,9 @@
+Uncaught error from ./compat/test_runner/top_level_fail_cjs.js FAILED
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+failures:
 
-error: Uncaught (in promise) AssertionError: Values are not strictly equal:
+[./compat/test_runner/top_level_fail_cjs.js]
+error: (in promise) AssertionError: Values are not strictly equal:
 
 
     [Diff] Actual / Expected
@@ -10,4 +12,16 @@ error: Uncaught (in promise) AssertionError: Values are not strictly equal:
 -   10
 +   20
 
-[WILDCARD]
+    Error.captureStackTrace(this, stackStartFn || stackStartFunction);
+          ^
+    at [WILDCARD]
+This error was not caught from a test and caused the test runner to fail on the referenced module.
+It most likely originated from a dangling promise, event/timeout handler or top-level code.
+
+failures:
+
+[./compat/test_runner/top_level_fail_cjs.js]
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_cjs.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_cjs.out
@@ -2,7 +2,7 @@ Uncaught error from ./compat/test_runner/top_level_fail_cjs.js FAILED
 
 failures:
 
-[./compat/test_runner/top_level_fail_cjs.js]
+./compat/test_runner/top_level_fail_cjs.js (uncaught error)
 error: (in promise) AssertionError: Values are not strictly equal:
 
 
@@ -20,7 +20,7 @@ It most likely originated from a dangling promise, event/timeout handler or top-
 
 failures:
 
-[./compat/test_runner/top_level_fail_cjs.js]
+./compat/test_runner/top_level_fail_cjs.js (uncaught error)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_cjs.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_cjs.out
@@ -1,6 +1,6 @@
 Uncaught error from ./compat/test_runner/top_level_fail_cjs.js FAILED
 
-failures:
+ ERRORS 
 
 ./compat/test_runner/top_level_fail_cjs.js (uncaught error)
 error: (in promise) AssertionError: Values are not strictly equal:
@@ -18,7 +18,7 @@ error: (in promise) AssertionError: Values are not strictly equal:
 This error was not caught from a test and caused the test runner to fail on the referenced module.
 It most likely originated from a dangling promise, event/timeout handler or top-level code.
 
-failures:
+ FAILURES 
 
 ./compat/test_runner/top_level_fail_cjs.js (uncaught error)
 

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
@@ -1,6 +1,6 @@
 Uncaught error from ./compat/test_runner/top_level_fail_esm.mjs FAILED
 
-failures:
+ ERRORS 
 
 ./compat/test_runner/top_level_fail_esm.mjs (uncaught error)
 error: AssertionError: Values are not strictly equal:
@@ -18,7 +18,7 @@ error: AssertionError: Values are not strictly equal:
 This error was not caught from a test and caused the test runner to fail on the referenced module.
 It most likely originated from a dangling promise, event/timeout handler or top-level code.
 
-failures:
+ FAILURES 
 
 ./compat/test_runner/top_level_fail_esm.mjs (uncaught error)
 

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
@@ -1,8 +1,8 @@
-Uncaught error from ./compat/test_runner/top_level_fail_esm.mjs FAILED
+Uncaught error from./compat/test_runner/top_level_fail_esm.mjs FAILE (uncaught error)
 
 failures:
 
-[./compat/test_runner/top_level_fail_esm.mjs]
+./compat/test_runner/top_level_fail_esm.mjs (uncaught error)
 error: AssertionError: Values are not strictly equal:
 
 
@@ -20,7 +20,7 @@ It most likely originated from a dangling promise, event/timeout handler or top-
 
 failures:
 
-[./compat/test_runner/top_level_fail_esm.mjs]
+./compat/test_runner/top_level_fail_esm.mjs (uncaught error)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
@@ -1,4 +1,4 @@
-Uncaught error from./compat/test_runner/top_level_fail_esm.mjs FAILE (uncaught error)
+Uncaught error from ./compat/test_runner/top_level_fail_esm.mjs FAILED
 
 failures:
 

--- a/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
+++ b/cli/tests/testdata/compat/test_runner/top_level_fail_esm.out
@@ -1,7 +1,9 @@
+Uncaught error from ./compat/test_runner/top_level_fail_esm.mjs FAILED
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+failures:
 
-error: Uncaught AssertionError: Values are not strictly equal:
+[./compat/test_runner/top_level_fail_esm.mjs]
+error: AssertionError: Values are not strictly equal:
 
 
     [Diff] Actual / Expected
@@ -10,4 +12,16 @@ error: Uncaught AssertionError: Values are not strictly equal:
 -   10
 +   20
 
-[WILDCARD]
+    Error.captureStackTrace(this, stackStartFn || stackStartFunction);
+          ^
+    at [WILDCARD]
+This error was not caught from a test and caused the test runner to fail on the referenced module.
+It most likely originated from a dangling promise, event/timeout handler or top-level code.
+
+failures:
+
+[./compat/test_runner/top_level_fail_esm.mjs]
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/meta.out
+++ b/cli/tests/testdata/test/meta.out
@@ -1,4 +1,3 @@
-Check [WILDCARD]/test/meta.ts
 import.meta.main: false
 import.meta.url: [WILDCARD]/test/meta.ts
 running 0 tests from ./test/meta.ts

--- a/cli/tests/testdata/test/meta.out
+++ b/cli/tests/testdata/test/meta.out
@@ -1,3 +1,4 @@
+Check [WILDCARD]/test/meta.ts
 import.meta.main: false
 import.meta.url: [WILDCARD]/test/meta.ts
 running 0 tests from ./test/meta.ts

--- a/cli/tests/testdata/test/no_check.out
+++ b/cli/tests/testdata/test/no_check.out
@@ -1,6 +1,6 @@
 Uncaught error from ./test/no_check.ts FAILED
 
-failures:
+ ERRORS 
 
 ./test/no_check.ts (uncaught error)
 error: TypeError: Cannot read properties of undefined (reading 'fn')
@@ -10,7 +10,7 @@ Deno.test();
 This error was not caught from a test and caused the test runner to fail on the referenced module.
 It most likely originated from a dangling promise, event/timeout handler or top-level code.
 
-failures:
+ FAILURES 
 
 ./test/no_check.ts (uncaught error)
 

--- a/cli/tests/testdata/test/no_check.out
+++ b/cli/tests/testdata/test/no_check.out
@@ -1,8 +1,19 @@
+Uncaught error from ./test/no_check.ts FAILED
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+failures:
 
-error: Uncaught TypeError: Cannot read properties of undefined (reading 'fn')
+[./test/no_check.ts]
+error: TypeError: Cannot read properties of undefined (reading 'fn')
 Deno.test();
      ^
-    at [WILDCARD]
     at [WILDCARD]/test/no_check.ts:1:6
+This error was not caught from a test and caused the test runner to fail on the referenced module.
+It most likely originated from a dangling promise, event/timeout handler or top-level code.
+
+failures:
+
+[./test/no_check.ts]
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/no_check.out
+++ b/cli/tests/testdata/test/no_check.out
@@ -2,7 +2,7 @@ Uncaught error from ./test/no_check.ts FAILED
 
 failures:
 
-[./test/no_check.ts]
+./test/no_check.ts (uncaught error)
 error: TypeError: Cannot read properties of undefined (reading 'fn')
 Deno.test();
      ^
@@ -12,7 +12,7 @@ It most likely originated from a dangling promise, event/timeout handler or top-
 
 failures:
 
-[./test/no_check.ts]
+./test/no_check.ts (uncaught error)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/test/uncaught_errors.out
+++ b/cli/tests/testdata/test/uncaught_errors.out
@@ -17,7 +17,7 @@ error: Error: foo 1 message
         ^
     at [WILDCARD]/test/uncaught_errors_1.ts:2:9
 
-[./test/uncaught_errors_1.ts]
+./test/uncaught_errors_1.ts (uncaught error)
 error: (in promise) Error: foo 3 message
   Promise.reject(new Error("foo 3 message"));
                  ^
@@ -37,7 +37,7 @@ error: Error: bar 3 message
         ^
     at [WILDCARD]/test/uncaught_errors_2.ts:7:9
 
-[./test/uncaught_errors_3.ts]
+./test/uncaught_errors_3.ts (uncaught error)
 error: Error: baz
 throw new Error("baz");
       ^
@@ -48,10 +48,10 @@ It most likely originated from a dangling promise, event/timeout handler or top-
 failures:
 
 foo 1 => ./test/uncaught_errors_1.ts:1:6
-[./test/uncaught_errors_1.ts]
+./test/uncaught_errors_1.ts (uncaught error)
 bar 2 => ./test/uncaught_errors_2.ts:3:6
 bar 3 => ./test/uncaught_errors_2.ts:6:6
-[./test/uncaught_errors_3.ts]
+./test/uncaught_errors_3.ts (uncaught error)
 
 test result: FAILED. 2 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/test/uncaught_errors.out
+++ b/cli/tests/testdata/test/uncaught_errors.out
@@ -9,7 +9,7 @@ bar 2 ... FAILED ([WILDCARD])
 bar 3 ... FAILED ([WILDCARD])
 Uncaught error from ./test/uncaught_errors_3.ts FAILED
 
-failures:
+ ERRORS 
 
 foo 1 => ./test/uncaught_errors_1.ts:1:6
 error: Error: foo 1 message
@@ -45,7 +45,7 @@ throw new Error("baz");
 This error was not caught from a test and caused the test runner to fail on the referenced module.
 It most likely originated from a dangling promise, event/timeout handler or top-level code.
 
-failures:
+ FAILURES 
 
 foo 1 => ./test/uncaught_errors_1.ts:1:6
 ./test/uncaught_errors_1.ts (uncaught error)

--- a/cli/tests/testdata/test/uncaught_errors.out
+++ b/cli/tests/testdata/test/uncaught_errors.out
@@ -1,0 +1,58 @@
+running 3 tests from ./test/uncaught_errors_1.ts
+foo 1 ... FAILED ([WILDCARD])
+foo 2 ... ok ([WILDCARD])
+foo 3 ...
+Uncaught error from ./test/uncaught_errors_1.ts FAILED
+running 3 tests from ./test/uncaught_errors_2.ts
+bar 1 ... ok ([WILDCARD])
+bar 2 ... FAILED ([WILDCARD])
+bar 3 ... FAILED ([WILDCARD])
+Uncaught error from ./test/uncaught_errors_3.ts FAILED
+
+failures:
+
+foo 1 => ./test/uncaught_errors_1.ts:1:6
+error: Error: foo 1 message
+  throw new Error("foo 1 message");
+        ^
+    at [WILDCARD]/test/uncaught_errors_1.ts:2:9
+
+[./test/uncaught_errors_1.ts]
+error: (in promise) Error: foo 3 message
+  Promise.reject(new Error("foo 3 message"));
+                 ^
+    at [WILDCARD]/test/uncaught_errors_1.ts:8:18
+This error was not caught from a test and caused the test runner to fail on the referenced module.
+It most likely originated from a dangling promise, event/timeout handler or top-level code.
+
+bar 2 => ./test/uncaught_errors_2.ts:3:6
+error: Error: bar 2
+  throw new Error("bar 2");
+        ^
+    at [WILDCARD]/test/uncaught_errors_2.ts:4:9
+
+bar 3 => ./test/uncaught_errors_2.ts:6:6
+error: Error: bar 3 message
+  throw new Error("bar 3 message");
+        ^
+    at [WILDCARD]/test/uncaught_errors_2.ts:7:9
+
+[./test/uncaught_errors_3.ts]
+error: Error: baz
+throw new Error("baz");
+      ^
+    at [WILDCARD]/test/uncaught_errors_3.ts:1:7
+This error was not caught from a test and caused the test runner to fail on the referenced module.
+It most likely originated from a dangling promise, event/timeout handler or top-level code.
+
+failures:
+
+foo 1 => ./test/uncaught_errors_1.ts:1:6
+[./test/uncaught_errors_1.ts]
+bar 2 => ./test/uncaught_errors_2.ts:3:6
+bar 3 => ./test/uncaught_errors_2.ts:6:6
+[./test/uncaught_errors_3.ts]
+
+test result: FAILED. 2 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/uncaught_errors_1.ts
+++ b/cli/tests/testdata/test/uncaught_errors_1.ts
@@ -1,0 +1,9 @@
+Deno.test("foo 1", () => {
+  throw new Error("foo 1 message");
+});
+
+Deno.test("foo 2", () => {});
+
+Deno.test("foo 3", () => {
+  Promise.reject(new Error("foo 3 message"));
+});

--- a/cli/tests/testdata/test/uncaught_errors_2.ts
+++ b/cli/tests/testdata/test/uncaught_errors_2.ts
@@ -1,0 +1,8 @@
+Deno.test("bar 1", () => {});
+
+Deno.test("bar 2", () => {
+  throw new Error("bar 2");
+});
+Deno.test("bar 3", () => {
+  throw new Error("bar 3 message");
+});

--- a/cli/tests/testdata/test/uncaught_errors_3.ts
+++ b/cli/tests/testdata/test/uncaught_errors_3.ts
@@ -1,0 +1,1 @@
+throw new Error("baz");

--- a/cli/tests/testdata/test/unhandled_rejection.out
+++ b/cli/tests/testdata/test/unhandled_rejection.out
@@ -1,7 +1,7 @@
 Check [WILDCARD]/test/unhandled_rejection.ts
 Uncaught error from ./test/unhandled_rejection.ts FAILED
 
-failures:
+ ERRORS 
 
 ./test/unhandled_rejection.ts (uncaught error)
 error: (in promise) Error: rejection
@@ -13,7 +13,7 @@ error: (in promise) Error: rejection
 This error was not caught from a test and caused the test runner to fail on the referenced module.
 It most likely originated from a dangling promise, event/timeout handler or top-level code.
 
-failures:
+ FAILURES 
 
 ./test/unhandled_rejection.ts (uncaught error)
 

--- a/cli/tests/testdata/test/unhandled_rejection.out
+++ b/cli/tests/testdata/test/unhandled_rejection.out
@@ -3,7 +3,7 @@ Uncaught error from ./test/unhandled_rejection.ts FAILED
 
 failures:
 
-[./test/unhandled_rejection.ts]
+./test/unhandled_rejection.ts (uncaught error)
 error: (in promise) Error: rejection
   reject(new Error("rejection"));
          ^
@@ -15,7 +15,7 @@ It most likely originated from a dangling promise, event/timeout handler or top-
 
 failures:
 
-[./test/unhandled_rejection.ts]
+./test/unhandled_rejection.ts (uncaught error)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
 

--- a/cli/tests/testdata/test/unhandled_rejection.out
+++ b/cli/tests/testdata/test/unhandled_rejection.out
@@ -1,10 +1,22 @@
 Check [WILDCARD]/test/unhandled_rejection.ts
+Uncaught error from ./test/unhandled_rejection.ts FAILED
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+failures:
 
-error: Uncaught (in promise) Error: rejection
+[./test/unhandled_rejection.ts]
+error: (in promise) Error: rejection
   reject(new Error("rejection"));
          ^
     at [WILDCARD]/test/unhandled_rejection.ts:2:10
     at new Promise (<anonymous>)
     at [WILDCARD]/test/unhandled_rejection.ts:1:1
+This error was not caught from a test and caused the test runner to fail on the referenced module.
+It most likely originated from a dangling promise, event/timeout handler or top-level code.
+
+failures:
+
+[./test/unhandled_rejection.ts]
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -51,6 +51,7 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use regex::Regex;
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::Read;
@@ -149,6 +150,7 @@ pub enum TestEvent {
   Wait(TestDescription),
   Output(Vec<u8>),
   Result(TestDescription, TestResult, u64),
+  UncaughtError(String, Box<JsError>),
   StepWait(TestStepDescription),
   StepResult(TestStepDescription, TestStepResult, u64),
 }
@@ -166,6 +168,7 @@ pub struct TestSummary {
   pub filtered_out: usize,
   pub measured: usize,
   pub failures: Vec<(TestDescription, Box<JsError>)>,
+  pub uncaught_errors: Vec<(String, Box<JsError>)>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -192,6 +195,7 @@ impl TestSummary {
       filtered_out: 0,
       measured: 0,
       failures: Vec::new(),
+      uncaught_errors: Vec::new(),
     }
   }
 
@@ -214,6 +218,7 @@ pub trait TestReporter {
     result: &TestResult,
     elapsed: u64,
   );
+  fn report_uncaught_error(&mut self, origin: &str, error: &JsError);
   fn report_step_wait(&mut self, description: &TestStepDescription);
   fn report_step_result(
     &mut self,
@@ -234,6 +239,7 @@ struct PrettyTestReporter {
   echo_output: bool,
   deferred_step_output: HashMap<TestDescription, Vec<DeferredStepOutput>>,
   in_test_count: usize,
+  in_new_line: bool,
   last_wait_output_level: usize,
   cwd: Url,
   did_have_user_output: bool,
@@ -245,6 +251,7 @@ impl PrettyTestReporter {
       concurrent,
       echo_output,
       in_test_count: 0,
+      in_new_line: true,
       deferred_step_output: HashMap::new(),
       last_wait_output_level: 0,
       cwd: Url::from_directory_path(std::env::current_dir().unwrap()).unwrap(),
@@ -254,6 +261,7 @@ impl PrettyTestReporter {
 
   fn force_report_wait(&mut self, description: &TestDescription) {
     print!("{} ...", description.name);
+    self.in_new_line = false;
     // flush for faster feedback when line buffered
     std::io::stdout().flush().unwrap();
     self.last_wait_output_level = 0;
@@ -278,6 +286,7 @@ impl PrettyTestReporter {
       println!();
     }
     print!("{}{} ...", "  ".repeat(description.level), description.name);
+    self.in_new_line = false;
     // flush for faster feedback when line buffered
     std::io::stdout().flush().unwrap();
     self.last_wait_output_level = description.level;
@@ -316,11 +325,13 @@ impl PrettyTestReporter {
         println!("{}{}", "  ".repeat(description.level + 1), line);
       }
     }
+    self.in_new_line = true;
   }
 
   fn write_output_end(&mut self) -> bool {
     if self.did_have_user_output {
       println!("{}", colors::gray("----- output end -----"));
+      self.in_new_line = true;
       self.did_have_user_output = false;
       true
     } else {
@@ -341,6 +352,7 @@ impl TestReporter for PrettyTestReporter {
         self.to_relative_path_or_remote_url(&plan.origin)
       ))
     );
+    self.in_new_line = true;
   }
 
   fn report_wait(&mut self, description: &TestDescription) {
@@ -359,6 +371,7 @@ impl TestReporter for PrettyTestReporter {
       self.did_have_user_output = true;
       println!();
       println!("{}", colors::gray("------- output -------"));
+      self.in_new_line = true;
     }
 
     // output everything to stdout in order to prevent
@@ -414,6 +427,22 @@ impl TestReporter for PrettyTestReporter {
       status,
       colors::gray(format!("({})", display::human_elapsed(elapsed.into())))
     );
+    self.in_new_line = true;
+  }
+
+  fn report_uncaught_error(&mut self, origin: &str, _error: &JsError) {
+    if !self.in_new_line {
+      println!();
+    }
+    println!(
+      "Uncaught error from {} {}",
+      self.to_relative_path_or_remote_url(origin),
+      colors::red("FAILED")
+    );
+    self.in_test_count = 0;
+    self.in_new_line = true;
+    self.last_wait_output_level = 0;
+    self.did_have_user_output = false;
   }
 
   fn report_step_wait(&mut self, description: &TestStepDescription) {
@@ -450,31 +479,63 @@ impl TestReporter for PrettyTestReporter {
   }
 
   fn report_summary(&mut self, summary: &TestSummary, elapsed: &Duration) {
-    if !summary.failures.is_empty() {
+    if !summary.failures.is_empty() || !summary.uncaught_errors.is_empty() {
+      #[allow(clippy::type_complexity)] // Type alias doesn't look better here
+      let mut failures_by_origin: BTreeMap<
+        String,
+        (Vec<(&TestDescription, &JsError)>, Option<&JsError>),
+      > = BTreeMap::default();
       let mut failure_titles = vec![];
-      println!("\nfailures:\n");
       for (description, js_error) in &summary.failures {
-        let failure_title = format!(
-          "{} {}",
-          &description.name,
-          colors::gray(format!(
-            "=> {}:{}:{}",
-            self
-              .to_relative_path_or_remote_url(&description.location.file_name),
-            description.location.line_number,
-            description.location.column_number
-          ))
-        );
-        println!("{}", &failure_title);
-        println!(
-          "{}: {}",
-          colors::red_bold("error"),
-          format_test_error(js_error)
-        );
-        println!();
-        failure_titles.push(failure_title);
+        let (failures, _) = failures_by_origin
+          .entry(description.origin.clone())
+          .or_default();
+        failures.push((description, js_error.as_ref()));
       }
-
+      for (origin, js_error) in &summary.uncaught_errors {
+        let (_, uncaught_error) =
+          failures_by_origin.entry(origin.clone()).or_default();
+        let _ = uncaught_error.insert(js_error.as_ref());
+      }
+      println!("\nfailures:\n");
+      for (origin, (failures, uncaught_error)) in failures_by_origin {
+        for (description, js_error) in failures {
+          let failure_title = format!(
+            "{} {}",
+            &description.name,
+            colors::gray(format!(
+              "=> {}:{}:{}",
+              self.to_relative_path_or_remote_url(
+                &description.location.file_name
+              ),
+              description.location.line_number,
+              description.location.column_number
+            ))
+          );
+          println!("{}", &failure_title);
+          println!(
+            "{}: {}",
+            colors::red_bold("error"),
+            format_test_error(js_error)
+          );
+          println!();
+          failure_titles.push(failure_title);
+        }
+        if let Some(js_error) = uncaught_error {
+          let failure_title =
+            format!("[{}]", self.to_relative_path_or_remote_url(&origin));
+          println!("{}", &failure_title);
+          println!(
+            "{}: {}",
+            colors::red_bold("error"),
+            format_test_error(js_error)
+          );
+          println!("This error was not caught from a test and caused the test runner to fail on the referenced module.");
+          println!("It most likely originated from a dangling promise, event/timeout handler or top-level code.");
+          println!();
+          failure_titles.push(failure_title);
+        }
+      }
       println!("failures:\n");
       for failure_title in failure_titles {
         println!("{}", failure_title);
@@ -510,6 +571,7 @@ impl TestReporter for PrettyTestReporter {
       colors::gray(
         format!("({})", display::human_elapsed(elapsed.as_millis()))),
     );
+    self.in_new_line = true;
   }
 }
 
@@ -959,14 +1021,30 @@ async fn test_specifiers(
       let permissions = permissions.clone();
       let specifier = specifier.clone();
       let mode = mode.clone();
-      let sender = sender.clone();
+      let mut sender = sender.clone();
       let options = options.clone();
 
       tokio::task::spawn_blocking(move || {
-        let future =
-          test_specifier(ps, permissions, specifier, mode, sender, options);
-
-        run_basic(future)
+        let origin = specifier.to_string();
+        let file_result = run_basic(test_specifier(
+          ps,
+          permissions,
+          specifier,
+          mode,
+          sender.clone(),
+          options,
+        ));
+        if let Err(error) = file_result {
+          if error.is::<JsError>() {
+            sender.send(TestEvent::UncaughtError(
+              origin,
+              Box::new(error.downcast::<JsError>().unwrap()),
+            ))?;
+          } else {
+            return Err(error);
+          }
+        }
+        Ok(())
       })
     });
 
@@ -1019,6 +1097,12 @@ async fn test_specifiers(
             }
 
             reporter.report_result(&description, &result, elapsed);
+          }
+
+          TestEvent::UncaughtError(origin, error) => {
+            reporter.report_uncaught_error(&origin, &error);
+            summary.failed += 1;
+            summary.uncaught_errors.push((origin, error));
           }
 
           TestEvent::StepWait(description) => {

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -522,8 +522,10 @@ impl TestReporter for PrettyTestReporter {
           failure_titles.push(failure_title);
         }
         if let Some(js_error) = uncaught_error {
-          let failure_title =
-            format!("[{}]", self.to_relative_path_or_remote_url(&origin));
+          let failure_title = format!(
+            "{} (uncaught error)",
+            self.to_relative_path_or_remote_url(&origin)
+          );
           println!("{}", &failure_title);
           println!(
             "{}: {}",

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -242,6 +242,7 @@ struct PrettyTestReporter {
   last_wait_output_level: usize,
   cwd: Url,
   did_have_user_output: bool,
+  started_tests: bool,
 }
 
 impl PrettyTestReporter {
@@ -254,6 +255,7 @@ impl PrettyTestReporter {
       last_wait_output_level: 0,
       cwd: Url::from_directory_path(std::env::current_dir().unwrap()).unwrap(),
       did_have_user_output: false,
+      started_tests: false,
     }
   }
 
@@ -357,6 +359,7 @@ impl TestReporter for PrettyTestReporter {
     if !self.concurrent {
       self.force_report_wait(description);
     }
+    self.started_tests = true;
   }
 
   fn report_output(&mut self, output: &[u8]) {
@@ -364,7 +367,7 @@ impl TestReporter for PrettyTestReporter {
       return;
     }
 
-    if !self.did_have_user_output {
+    if !self.did_have_user_output && self.started_tests {
       self.did_have_user_output = true;
       println!();
       println!("{}", colors::gray("------- output -------"));

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -648,7 +648,7 @@ async fn test_specifier(
   permissions: Permissions,
   specifier: ModuleSpecifier,
   mode: TestMode,
-  sender: TestEventSender,
+  sender: &TestEventSender,
   options: TestSpecifierOptions,
 ) -> Result<(), AnyError> {
   let mut worker = create_main_worker(
@@ -1031,7 +1031,7 @@ async fn test_specifiers(
           permissions,
           specifier,
           mode,
-          sender.clone(),
+          &sender,
           options,
         ));
         if let Err(error) = file_result {

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -238,7 +238,6 @@ struct PrettyTestReporter {
   concurrent: bool,
   echo_output: bool,
   deferred_step_output: HashMap<TestDescription, Vec<DeferredStepOutput>>,
-  in_test_count: usize,
   in_new_line: bool,
   last_wait_output_level: usize,
   cwd: Url,
@@ -250,7 +249,6 @@ impl PrettyTestReporter {
     PrettyTestReporter {
       concurrent,
       echo_output,
-      in_test_count: 0,
       in_new_line: true,
       deferred_step_output: HashMap::new(),
       last_wait_output_level: 0,
@@ -359,7 +357,6 @@ impl TestReporter for PrettyTestReporter {
     if !self.concurrent {
       self.force_report_wait(description);
     }
-    self.in_test_count += 1;
   }
 
   fn report_output(&mut self, output: &[u8]) {
@@ -367,7 +364,7 @@ impl TestReporter for PrettyTestReporter {
       return;
     }
 
-    if !self.did_have_user_output && self.in_test_count > 0 {
+    if !self.did_have_user_output {
       self.did_have_user_output = true;
       println!();
       println!("{}", colors::gray("------- output -------"));
@@ -385,8 +382,6 @@ impl TestReporter for PrettyTestReporter {
     result: &TestResult,
     elapsed: u64,
   ) {
-    self.in_test_count -= 1;
-
     if self.concurrent {
       self.force_report_wait(description);
 
@@ -439,7 +434,6 @@ impl TestReporter for PrettyTestReporter {
       self.to_relative_path_or_remote_url(origin),
       colors::red("FAILED")
     );
-    self.in_test_count = 0;
     self.in_new_line = true;
     self.last_wait_output_level = 0;
     self.did_have_user_output = false;


### PR DESCRIPTION
Closes #14449.
```ts
Deno.test("failing test", () => {
  throw new Error("message");
});

Deno.test("passing test", () => {});

Deno.test("test with dangling rejection", () => {
  Promise.reject(new Error("foo 3 message"));
});
```
![image](https://user-images.githubusercontent.com/29990554/167166971-3548bd23-94c3-4c49-9038-bcb4ede918fc.png)
cc @bartlomieju 