### PR TITLE
refactor(core): simplify json_module_evaluation_steps

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -145,11 +145,7 @@ fn json_module_evaluation_steps<'a>(
   );
   assert!(!tc_scope.has_caught());
 
-  // Since TLA is active we need to return a promise.
-  let resolver = v8::PromiseResolver::new(tc_scope).unwrap();
-  let undefined = v8::undefined(tc_scope);
-  resolver.resolve(tc_scope, undefined.into());
-  Some(resolver.get_promise(tc_scope).into())
+  Some(v8::undefined(tc_scope).into())
 }
 
 /// A type of module to be executed.


### PR DESCRIPTION
When working on https://github.com/denoland/deno/pull/14485 and digging through
V8 code, we noticed that the return value of synthetic module evaluation steps callback
doesn't matter, and the promise is not used in any way. Changed to just returned
`undefined` so we're not getting confused. I originally took this idea from `d8`.