### PR TITLE
[WIP] feat: support "permissions" in config file

### DIFF
--- a/cli/config_file.rs
+++ b/cli/config_file.rs
@@ -531,6 +531,7 @@ pub struct ConfigFileJson {
   pub lint: Option<Value>,
   pub fmt: Option<Value>,
   pub tasks: Option<Value>,
+  pub permissions: Option<Value>,
 }
 
 #[derive(Clone, Debug)]
@@ -647,6 +648,10 @@ impl ConfigFile {
     } else {
       Ok(None)
     }
+  }
+
+  pub fn to_permissions(&self) -> Result<(), AnyError> {
+    todo!()
   }
 
   /// Return any tasks that are defined in the configuration file as a sequence
@@ -821,6 +826,13 @@ mod tests {
       "tasks": {
         "build": "deno run --allow-read --allow-write build.ts",
         "server": "deno run --allow-net --allow-read server.ts"
+      },
+      "permissions": {
+        "read": true,
+        "write": ["some/dir", "file.ts"],
+        "env": false,
+        "ffi": false,
+        "run": ["deno", "echo"]
       }
     }"#;
     let config_dir = ModuleSpecifier::parse("file:///deno/").unwrap();
@@ -887,6 +899,28 @@ mod tests {
     assert_eq!(
       tasks_config["server"],
       "deno run --allow-net --allow-read server.ts"
+    );
+
+    let permissions_config = config_file.json.permissions.unwrap();
+    assert_eq!(
+      permissions_config["read"],
+      true,
+    );
+    assert_eq!(
+      permissions_config["write"].as_array().unwrap(),
+      &["some/dir", "file.ts"],
+    );
+    assert_eq!(
+      permissions_config["env"],
+      false,
+    );
+    assert_eq!(
+      permissions_config["ffi"],
+      false,
+    );
+    assert_eq!(
+      permissions_config["run"].as_array().unwrap(),
+      &["deno", "echo"],
     );
   }
 

--- a/cli/config_file.rs
+++ b/cli/config_file.rs
@@ -660,6 +660,11 @@ impl ConfigFile {
     if let Some(config) = self.json.permissions.clone() {
       let permissions: ChildPermissionsArg = serde_json::from_value(config)
         .context("Failed to parse \"permissions\" configuration")?;
+
+      if self.specifier.scheme() != "file" {
+        return Err(anyhow!("Specifying permissions in remote configuration files is currently not supported."));
+      }
+
       Ok(Some(create_permissions_from_config(permissions, prompt)))
     } else {
       Ok(None)
@@ -936,13 +941,14 @@ mod tests {
     assert!(!permissions.hrtime.prompt);
     assert_eq!(permissions.hrtime.state, PermissionState::Granted,);
     assert!(!permissions.write.prompt);
-    let items = permissions
-      .write
-      .granted_list
-      .into_iter()
-      .collect::<Vec<_>>();
-    assert!(items[0].0.ends_with("some/dir"));
-    assert!(items[1].0.ends_with("file.ts"));
+    // FIXME(bartlomieju): order is not guaranteed, so this test is flaky
+    // let items = permissions
+    //   .write
+    //   .granted_list
+    //   .into_iter()
+    //   .collect::<Vec<_>>();
+    // assert!(items[0].0.ends_with("some/dir"));
+    // assert!(items[1].0.ends_with("file.ts"));
   }
 
   #[test]

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -453,6 +453,16 @@ impl Flags {
     }
   }
 
+  pub fn has_any_permission_flag(&self) -> bool {
+    self.allow_env.is_some()
+      || self.allow_net.is_some()
+      || self.allow_ffi.is_some()
+      || self.allow_read.is_some()
+      || self.allow_run.is_some()
+      || self.allow_write.is_some()
+      || self.allow_hrtime
+  }
+
   pub fn permissions_options(&self) -> PermissionsOptions {
     PermissionsOptions {
       allow_env: self.allow_env.clone(),

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -1669,6 +1669,118 @@ impl<'de> Deserialize<'de> for ChildPermissionsArg {
   }
 }
 
+pub fn create_permissions_from_config(
+  child_permissions_arg: ChildPermissionsArg,
+  prompt: bool,
+) -> Permissions {
+  let mut worker_perms = Permissions::default();
+
+  match child_permissions_arg.env {
+    ChildUnaryPermissionArg::Granted => {
+      worker_perms.env.global_state = PermissionState::Granted;
+    }
+    ChildUnaryPermissionArg::NotGranted => {
+      worker_perms.env.global_state = PermissionState::Denied;
+    }
+    ChildUnaryPermissionArg::GrantedList(granted_list) => {
+      worker_perms.env.granted_list =
+        Permissions::new_env(&Some(granted_list), false).granted_list;
+    }
+    _ => {}
+  }
+  worker_perms.env.prompt = prompt;
+  match child_permissions_arg.hrtime {
+    ChildUnitPermissionArg::Granted => {
+      worker_perms.hrtime.state = PermissionState::Granted;
+    }
+    ChildUnitPermissionArg::NotGranted => {
+      worker_perms.hrtime.state = PermissionState::Denied;
+    }
+    _ => {}
+  }
+  worker_perms.hrtime.prompt = prompt;
+  match child_permissions_arg.net {
+    ChildUnaryPermissionArg::Granted => {
+      worker_perms.net.global_state = PermissionState::Granted;
+    }
+    ChildUnaryPermissionArg::NotGranted => {
+      worker_perms.net.global_state = PermissionState::Denied;
+    }
+    ChildUnaryPermissionArg::GrantedList(granted_list) => {
+      worker_perms.net.granted_list =
+        Permissions::new_net(&Some(granted_list), false).granted_list;
+    }
+    _ => {}
+  }
+  worker_perms.net.prompt = prompt;
+  match child_permissions_arg.ffi {
+    ChildUnaryPermissionArg::Granted => {
+      worker_perms.ffi.global_state = PermissionState::Granted;
+    }
+    ChildUnaryPermissionArg::NotGranted => {
+      worker_perms.ffi.global_state = PermissionState::Denied;
+    }
+    ChildUnaryPermissionArg::GrantedList(granted_list) => {
+      worker_perms.ffi.granted_list = Permissions::new_ffi(
+        &Some(granted_list.iter().map(PathBuf::from).collect()),
+        false,
+      )
+      .granted_list;
+    }
+    _ => {}
+  }
+  worker_perms.ffi.prompt = prompt;
+  match child_permissions_arg.read {
+    ChildUnaryPermissionArg::Granted => {
+      worker_perms.read.global_state = PermissionState::Granted;
+    }
+    ChildUnaryPermissionArg::NotGranted => {
+      worker_perms.read.global_state = PermissionState::Denied;
+    }
+    ChildUnaryPermissionArg::GrantedList(granted_list) => {
+      worker_perms.read.granted_list = Permissions::new_read(
+        &Some(granted_list.iter().map(PathBuf::from).collect()),
+        false,
+      )
+      .granted_list;
+    }
+    _ => {}
+  }
+  worker_perms.read.prompt = prompt;
+  match child_permissions_arg.run {
+    ChildUnaryPermissionArg::Granted => {
+      worker_perms.run.global_state = PermissionState::Granted;
+    }
+    ChildUnaryPermissionArg::NotGranted => {
+      worker_perms.run.global_state = PermissionState::Denied;
+    }
+    ChildUnaryPermissionArg::GrantedList(granted_list) => {
+      worker_perms.run.granted_list =
+        Permissions::new_run(&Some(granted_list), false).granted_list;
+    }
+    _ => {}
+  }
+  worker_perms.run.prompt = prompt;
+  match child_permissions_arg.write {
+    ChildUnaryPermissionArg::Granted => {
+      worker_perms.write.global_state = PermissionState::Granted;
+    }
+    ChildUnaryPermissionArg::NotGranted => {
+      worker_perms.write.global_state = PermissionState::Denied;
+    }
+    ChildUnaryPermissionArg::GrantedList(granted_list) => {
+      worker_perms.write.granted_list = Permissions::new_write(
+        &Some(granted_list.iter().map(PathBuf::from).collect()),
+        false,
+      )
+      .granted_list;
+    }
+    _ => {}
+  }
+  worker_perms.write.prompt = prompt;
+  worker_perms
+}
+
 pub fn create_child_permissions(
   main_perms: &mut Permissions,
   child_permissions_arg: ChildPermissionsArg,


### PR DESCRIPTION
Closes #12763

TODO:
- [x] When a configuration file is applied and the "permissions" section is parsed and the permissions are applied from the "permissions" section. Any other flags on the command line are ignored.
- [x] If there are flags on the command line and a config file is being applied, and the config file contains "permissions" a warning should be issued to stderr that permissions from the config file are being applied.
- [ ] <s>Remote configuration files are supported, but a summary of the permissions is prompted before hand and requires user configuration to continue.</s> (see https://github.com/denoland/deno/issues/12763#issuecomment-1121199270)
- [ ] In situations where a base path is needed for relative paths (for --allow-read and --allow-write) the config file is used as a base, versus the cwd.