### PR TITLE
fix: regression - confirm should show prompt before input on Windows

### DIFF
--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -35,10 +35,9 @@ use tokio::process;
 use std::os::unix::io::FromRawFd;
 
 #[cfg(windows)]
-use {
-  std::os::windows::io::FromRawHandle,
-  winapi::um::{processenv::GetStdHandle, winbase},
-};
+use std::os::windows::io::FromRawHandle;
+#[cfg(windows)]
+use std::os::windows::prelude::AsRawHandle;
 
 #[cfg(unix)]
 static STDIN_HANDLE: Lazy<StdFile> =
@@ -60,15 +59,15 @@ static STDERR_HANDLE: Lazy<StdFile> =
 // TODO(ry) It should be possible to close stdout.
 #[cfg(windows)]
 static STDIN_HANDLE: Lazy<StdFile> = Lazy::new(|| unsafe {
-  StdFile::from_raw_handle(GetStdHandle(winbase::STD_INPUT_HANDLE))
+  StdFile::from_raw_handle(std::io::stdin().as_raw_handle())
 });
 #[cfg(windows)]
 static STDOUT_HANDLE: Lazy<StdFile> = Lazy::new(|| unsafe {
-  StdFile::from_raw_handle(GetStdHandle(winbase::STD_OUTPUT_HANDLE))
+  StdFile::from_raw_handle(std::io::stdout().as_raw_handle())
 });
 #[cfg(windows)]
 static STDERR_HANDLE: Lazy<StdFile> = Lazy::new(|| unsafe {
-  StdFile::from_raw_handle(GetStdHandle(winbase::STD_ERROR_HANDLE))
+  StdFile::from_raw_handle(std::io::stderr().as_raw_handle())
 });
 
 pub fn init() -> Extension {


### PR DESCRIPTION
The issue here is that the `op_print` was not actually flushing the data to stdout and so the screen would hang waiting for user input without a prompt.

I'm opening this as a draft PR, because I don't know what's going on here and why this fixes the problem. Why do we use the raw handles and why does this change fix the issue to actually flush? (I will continue looking into it)

https://github.com/denoland/deno/blob/d4ad2b809c62b59ee4c3767bf1ff096b30886bdb/runtime/ops/io.rs#L53-L54

You can see here that it's actually being flushed here in `op_print`... maybe if we use the previous code then we need to call `FlushFileBuffers` to actually flush it instead of just `flush()`? (https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers)

https://github.com/denoland/deno/blob/d4ad2b809c62b59ee4c3767bf1ff096b30886bdb/runtime/ops/io.rs#L436-L437

Closes #14545