### PR TITLE
fix: finish TLS handshake before shutting down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: 11-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          key: 12-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
       # In main branch, always creates fresh cache
       - name: Cache build output (main)
@@ -252,7 +252,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: |
-            11-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
+            12-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
 
       # Restore cache from the latest 'main' branch build.
       - name: Cache build output (PR)
@@ -268,7 +268,7 @@ jobs:
             !./target/*/*.tar.gz
           key: never_saved
           restore-keys: |
-            11-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
+            12-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
 
       # Don't save cache after building PRs or branches other than 'main'.
       - name: Skip save cache (PR)

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -438,6 +438,8 @@ impl TlsStreamInner {
       self.rd_state = State::StreamClosed;
     }
 
+    // Wait for the handshake to complete.
+    ready!(self.poll_io(cx, Flow::Handshake))?;
     // Send TLS 'CloseNotify' alert.
     ready!(self.poll_shutdown(cx))?;
     // Wait for 'CloseNotify', shut down TCP stream, wait for TCP FIN packet.


### PR DESCRIPTION
This commit ensures that the TLS handshake completes before
attempting to close the connection.

Fixes: https://github.com/denoland/deno/issues/14494

This fixes the bug in the linked issue, but creating a reproducible unit test has been... frustrating.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
