### PR TITLE
fix(ext/web): brand check in `performance.timeOrigin`

### DIFF
--- a/ext/web/15_performance.js
+++ b/ext/web/15_performance.js
@@ -333,6 +333,7 @@
     }
 
     get timeOrigin() {
+      webidl.assertBranded(this, PerformancePrototype);
       return timeOrigin;
     }
 

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1178,14 +1178,12 @@
     "idlharness.any.html": [
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",
-      "Performance interface: attribute timeOrigin",
       "Performance interface: default toJSON operation on performance",
       "Window interface: attribute performance"
     ],
     "idlharness.any.worker.html": [
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",
-      "Performance interface: attribute timeOrigin",
       "Performance interface: default toJSON operation on performance",
       "WorkerGlobalScope interface: attribute performance",
       "WorkerGlobalScope interface: self must inherit property \"performance\" with the proper type"


### PR DESCRIPTION
This commit fixes a few WPTs related to the recently landed `performance.timeOrigin`.