### PR TITLE
fix: do not panic on `TestOutputPipe::flush` when receiver dropped

### DIFF
--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1622,13 +1622,16 @@ impl TestOutputPipe {
     // We want to wake up the other thread and have it respond back
     // that it's done clearing out its pipe before returning.
     let (sender, receiver) = std::sync::mpsc::channel();
-    self.state.lock().replace(sender);
+    if let Some(sender) = self.state.lock().replace(sender) {
+      let _ = sender.send(()); // just in case
+    }
     // Bit of a hack in order to send a zero width space in order
     // to wake the thread up. It seems that sending zero bytes
     // does not work here on windows.
     self.writer.write_all(ZERO_WIDTH_SPACE.as_bytes()).unwrap();
     self.writer.flush().unwrap();
-    receiver.recv().unwrap();
+    // ignore the error as it might have been picked up and closed
+    let _ = receiver.recv();
   }
 
   pub fn as_file(&self) -> std::fs::File {


### PR DESCRIPTION
It would take a bit of setup to get a test for this, so I don't think it's worth it and it probably would be difficult to reproduce it on the CI.

Closes #14537