### PR TITLE
chore: fix flaky steps_output_within - part 2

### DIFF
--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1623,9 +1623,9 @@ impl TestOutputPipe {
     // that it's done clearing out its pipe before returning.
     let (sender, receiver) = std::sync::mpsc::channel();
     self.state.lock().replace(sender);
-    // Bit of a hack in order to send a zero width space in order
-    // to wake the thread up. It seems that sending zero bytes
-    // does not work here on windows.
+    // Bit of a hack to send a zero width space in order to wake
+    // the thread up. It seems that sending zero bytes here does
+    // not work on windows.
     self.writer.write_all(ZERO_WIDTH_SPACE.as_bytes()).unwrap();
     self.writer.flush().unwrap();
     receiver.recv().unwrap();

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1819,6 +1819,13 @@ impl<'a> CheckOutputIntegrationTest<'a> {
 
     actual = strip_ansi_codes(&actual).to_string();
 
+    // deno test's output capturing flushes with a zero-width space in order to
+    // synchronize the output pipes. Occassionally this zero width space
+    // might end up in the output so strip it from the output comparison here.
+    if args.get(0) == Some(&"test") {
+      actual = actual.replace("\u{200B}", "");
+    }
+
     let expected = if let Some(s) = self.output_str {
       s.to_owned()
     } else {

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1823,7 +1823,7 @@ impl<'a> CheckOutputIntegrationTest<'a> {
     // synchronize the output pipes. Occassionally this zero width space
     // might end up in the output so strip it from the output comparison here.
     if args.get(0) == Some(&"test") {
-      actual = actual.replace("\u{200B}", "");
+      actual = actual.replace('\u{200B}', "");
     }
 
     let expected = if let Some(s) = self.output_str {


### PR DESCRIPTION
The zero width space was ending up in the output as sometimes expected, but that made the tests flaky.

It's unfortunate this hack exists, but it makes the output more stable. The fix here is to remove the zero width space when doing the comparison in the test utility.

![image](https://user-images.githubusercontent.com/1609021/167705232-efb62227-db5a-43c4-be14-d31e4e3edbeb.png)

Closes #14478