### PR TITLE
chore: fix flaky integration::test::pass test

### DIFF
--- a/cli/tests/testdata/test/pass.out
+++ b/cli/tests/testdata/test/pass.out
@@ -8,10 +8,13 @@ test 4 ... ok ([WILDCARD])
 test 5 ... ok ([WILDCARD])
 test 6 ... ok ([WILDCARD])
 test 7 ... ok ([WILDCARD])
+test 8 ...
+------- output -------
+console.log
+----- output end -----
 test 8 ... ok ([WILDCARD])
 test 9 ...
 ------- output -------
-console.log
 console.error
 ----- output end -----
 test 9 ... ok ([WILDCARD])

--- a/cli/tests/testdata/test/pass.ts
+++ b/cli/tests/testdata/test/pass.ts
@@ -6,8 +6,9 @@ Deno.test("test 4", () => {});
 Deno.test("test 5", () => {});
 Deno.test("test 6", () => {});
 Deno.test("test 7", () => {});
-Deno.test("test 8", () => {});
-Deno.test("test 9", () => {
+Deno.test("test 8", () => {
   console.log("console.log");
+});
+Deno.test("test 9", () => {
   console.error("console.error");
 });


### PR DESCRIPTION
The test output for stdout and stderr gets collected on two separate threads via pipes. Which thread wakes up first (even with flushing) can be somewhat random especially on the CI where there are only two cores.

In order to make this less random, I separated out the stdout and stderr outputs to two separate test steps.

Closes #14570