### PR TITLE
fix: make Performance global an EventTarget

### DIFF
--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -449,7 +449,7 @@ declare class Worker extends EventTarget {
 
 declare type PerformanceEntryList = PerformanceEntry[];
 
-declare class Performance {
+declare class Performance extends EventTarget {
   /** Returns a timestamp representing the start of the performance measurement. */
   readonly timeOrigin: number;
   constructor();

--- a/cli/tests/unit/performance_test.ts
+++ b/cli/tests/unit/performance_test.ts
@@ -140,3 +140,16 @@ Deno.test(function performanceMeasureIllegalConstructor() {
     "Illegal constructor",
   );
 });
+
+Deno.test(function performanceIsEventTarget() {
+  assert(performance instanceof EventTarget);
+
+  return new Promise((resolve) => {
+    const handler = () => {
+      resolve();
+    };
+
+    performance.addEventListener("test", handler, { once: true });
+    performance.dispatchEvent(new Event("test"));
+  });
+});

--- a/ext/web/15_performance.js
+++ b/ext/web/15_performance.js
@@ -327,9 +327,14 @@
   }
   webidl.configurePrototype(PerformanceMeasure);
   const PerformanceMeasurePrototype = PerformanceMeasure.prototype;
-  class Performance {
-    constructor() {
-      webidl.illegalConstructor();
+  class Performance extends EventTarget {
+    constructor(key = null) {
+      if (key != illegalConstructorKey) {
+        webidl.illegalConstructor();
+      }
+
+      super();
+      this[webidl.brand] = webidl.brand;
     }
 
     get timeOrigin() {
@@ -572,12 +577,17 @@
   webidl.configurePrototype(Performance);
   const PerformancePrototype = Performance.prototype;
 
+  webidl.converters["Performance"] = webidl.createInterfaceConverter(
+    "Performance",
+    PerformancePrototype,
+  );
+
   window.__bootstrap.performance = {
     PerformanceEntry,
     PerformanceMark,
     PerformanceMeasure,
     Performance,
-    performance: webidl.createBranded(Performance),
+    performance: new Performance(illegalConstructorKey),
     setTimeOrigin,
   };
 })(this);

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1161,12 +1161,8 @@
   "hr-time": {
     "monotonic-clock.any.html": true,
     "monotonic-clock.any.worker.html": true,
-    "basic.any.html": [
-      "Performance interface extends EventTarget."
-    ],
-    "basic.any.worker.html": [
-      "Performance interface extends EventTarget."
-    ],
+    "basic.any.html": true,
+    "basic.any.worker.html": true,
     "idlharness.any.html": [
       "Performance interface: existence and properties of interface object",
       "Performance interface: existence and properties of interface prototype object",

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1164,13 +1164,9 @@
     "basic.any.html": true,
     "basic.any.worker.html": true,
     "idlharness.any.html": [
-      "Performance interface: existence and properties of interface object",
-      "Performance interface: existence and properties of interface prototype object",
       "Window interface: attribute performance"
     ],
     "idlharness.any.worker.html": [
-      "Performance interface: existence and properties of interface object",
-      "Performance interface: existence and properties of interface prototype object",
       "WorkerGlobalScope interface: attribute performance",
       "WorkerGlobalScope interface: self must inherit property \"performance\" with the proper type"
     ],


### PR DESCRIPTION
This commit updates the `Performance` global to extend `EventTarget`.

Fixes: https://github.com/denoland/deno/issues/10995

The CI should fail for the same reason (and with the same test failures) as #14548.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
