### PR TITLE
feat(ops): allow passing scope handle to sync ops

### DIFF
--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -184,16 +184,31 @@ fn codegen_v8_async(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
 
 /// Generate the body of a v8 func for a sync op
 fn codegen_v8_sync(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
-  let arg0 = f.sig.inputs.first();
+  let args = f.sig.inputs.iter().collect::<Vec<_>>();
+  let mut arg0 = args.first();
+  let has_scope = match arg0 {
+    Some(arg0) => is_handle_scope(arg0),
+    None => false,
+  };
+  let rust_i0;
+  let scope_arg = if has_scope {
+    arg0 = args.get(1); // Next arg might be OpState.
+    rust_i0 = 1;
+    quote! { scope, }
+  } else {
+    rust_i0 = 0;
+    quote! {}
+  };
   let (rust_i0, args_head) = match arg0 {
     Some(arg0) if is_rc_refcell_opstate(arg0) => {
-      (1, quote! { ctx.state.clone(), })
+      (rust_i0 + 1, quote! { ctx.state.clone(), })
     }
     Some(arg0) if is_mut_ref_opstate(arg0) => {
-      (1, quote! { &mut ctx.state.borrow_mut(), })
+      (rust_i0 + 1, quote! { &mut ctx.state.borrow_mut(), })
     }
-    _ => (0, quote! {}),
+    _ => (rust_i0, quote! {}),
   };
+
   let (arg_decls, args_tail) = codegen_args(core, f, rust_i0, 0);
   let ret = codegen_sync_ret(core, &f.sig.output);
   let type_params = &f.sig.generics.params;
@@ -207,7 +222,7 @@ fn codegen_v8_sync(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
 
     #arg_decls
 
-    let result = Self::call::<#type_params>(#args_head #args_tail);
+    let result = Self::call::<#type_params>(#scope_arg #args_head #args_tail);
 
     let op_state = &mut ctx.state.borrow();
     op_state.tracker.track_sync(ctx.id);
@@ -338,6 +353,11 @@ fn is_mut_ref_opstate(arg: &syn::FnArg) -> bool {
 fn is_rc_refcell_opstate(arg: &syn::FnArg) -> bool {
   tokens(arg).ends_with(": Rc < RefCell < OpState > >")
     || tokens(arg).ends_with(": Rc < RefCell < deno_core :: OpState > >")
+}
+
+fn is_handle_scope(arg: &syn::FnArg) -> bool {
+  tokens(arg).ends_with(": & mut v8 :: HandleScope")
+    || tokens(arg).ends_with(": & mut deno_core :: v8 :: HandleScope")
 }
 
 fn tokens(x: impl ToTokens) -> String {


### PR DESCRIPTION
To be able to leverage `serde_v8::Value` APIs (as required in #14556)