### PR TITLE
feat(ops): infallible / result-free ops

### DIFF
--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -43,26 +43,19 @@ pub(crate) fn init_builtins() -> Extension {
 /// Return map of resources with id as key
 /// and string representation as value.
 #[op]
-pub fn op_resources(
-  state: &mut OpState,
-) -> Result<Vec<(ResourceId, String)>, Error> {
-  let serialized_resources = state
+pub fn op_resources(state: &mut OpState) -> Vec<(ResourceId, String)> {
+  state
     .resource_table
     .names()
     .map(|(rid, name)| (rid, name.to_string()))
-    .collect();
-  Ok(serialized_resources)
+    .collect()
 }
 
 #[op]
-pub fn op_void_sync() -> Result<(), Error> {
-  Ok(())
-}
+pub fn op_void_sync() {}
 
 #[op]
-pub async fn op_void_async() -> Result<(), Error> {
-  Ok(())
-}
+pub async fn op_void_async() {}
 
 /// Remove a resource from the resource table.
 #[op]
@@ -92,12 +85,10 @@ pub fn op_try_close(
 }
 
 #[op]
-pub fn op_metrics(
-  state: &mut OpState,
-) -> Result<(OpMetrics, Vec<OpMetrics>), Error> {
+pub fn op_metrics(state: &mut OpState) -> (OpMetrics, Vec<OpMetrics>) {
   let aggregate = state.tracker.aggregate();
   let per_op = state.tracker.per_op();
-  Ok((aggregate, per_op))
+  (aggregate, per_op)
 }
 
 /// Builtin utility to print to stdout/stderr
@@ -187,6 +178,6 @@ async fn op_shutdown(
 }
 
 #[op]
-fn op_format_file_name(file_name: String) -> Result<String, Error> {
-  Ok(format_file_name(&file_name))
+fn op_format_file_name(file_name: String) -> String {
+  format_file_name(&file_name)
 }

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -142,6 +142,11 @@ fn codegen_v8_async(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
   let (arg_decls, args_tail) = codegen_args(core, f, rust_i0, 1);
   let type_params = &f.sig.generics.params;
 
+  let result_wrapper = match is_result(&f.sig.output) {
+    true => quote! {},
+    false => quote! { let result = Ok(result); },
+  };
+
   quote! {
     use #core::futures::FutureExt;
     // SAFETY: #core guarantees args.data() is a v8 External pointing to an OpCtx for the isolates lifetime
@@ -177,6 +182,7 @@ fn codegen_v8_async(core: &TokenStream2, f: &syn::ItemFn) -> TokenStream2 {
 
     #core::_ops::queue_async_op(scope, async move {
       let result = Self::call::<#type_params>(#args_head #args_tail).await;
+      #result_wrapper
       (promise_id, op_id, #core::_ops::to_op_result(get_class, result))
     });
   }
@@ -308,7 +314,14 @@ fn codegen_sync_ret(
     }
   };
 
+  let result_wrapper = match is_result(&**ret_type) {
+    true => quote! {},
+    false => quote! { let result = Ok(result); },
+  };
+
   quote! {
+    #result_wrapper
+
     match result {
       Ok(v) => {
         #ok_block
@@ -318,6 +331,19 @@ fn codegen_sync_ret(
         rv.set(#core::serde_v8::to_v8(scope, err).unwrap());
       },
     };
+  }
+}
+
+fn is_result(ty: impl ToTokens) -> bool {
+  let tokens = tokens(ty);
+  if tokens.trim_start_matches("-> ").starts_with("Result <") {
+    return true;
+  }
+  // Detect `io::Result<...>`, `anyhow::Result<...>`, etc...
+  // i.e: Result aliases/shorthands which are unfortunately "opaque" at macro-time
+  match tokens.find(":: Result <") {
+    Some(idx) => !tokens.split_at(idx).0.contains('<'),
+    None => false,
   }
 }
 


### PR DESCRIPTION
Allows ops to be `-> T` instead of `-> Result<T, AnyError>` if they are indeed infallible

NOTE: removed Result returns from infallible ops in `ops_builtin.rs`, but there are likely more in the codebase