### PR TITLE
cleanup(ops): simpler is_unit_result()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: 12-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          key: 13-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
       # In main branch, always creates fresh cache
       - name: Cache build output (main)
@@ -252,7 +252,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: |
-            12-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
+            13-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
 
       # Restore cache from the latest 'main' branch build.
       - name: Cache build output (PR)
@@ -268,7 +268,7 @@ jobs:
             !./target/*/*.tar.gz
           key: never_saved
           restore-keys: |
-            12-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
+            13-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
 
       # Don't save cache after building PRs or branches other than 'main'.
       - name: Skip save cache (PR)

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -365,27 +365,8 @@ fn is_result(ty: impl ToTokens) -> bool {
 }
 
 /// Detects if a type is of the form Result<(), Err>
-fn is_unit_result(ty: &syn::Type) -> bool {
-  let path = match ty {
-    syn::Type::Path(ref path) => path,
-    _ => return false,
-  };
-
-  let maybe_result = path.path.segments.first().expect("Invalid return type.");
-  if maybe_result.ident != "Result" {
-    return false;
-  }
-  assert!(!maybe_result.arguments.is_empty());
-
-  let args = match &maybe_result.arguments {
-    syn::PathArguments::AngleBracketed(args) => args,
-    _ => unreachable!(),
-  };
-
-  match args.args.first().unwrap() {
-    syn::GenericArgument::Type(syn::Type::Tuple(ty)) => ty.elems.is_empty(),
-    _ => false,
-  }
+fn is_unit_result(ty: impl ToTokens) -> bool {
+  is_result(&ty) && tokens(&ty).contains("Result < ()")
 }
 
 fn is_mut_ref_opstate(arg: &syn::FnArg) -> bool {


### PR DESCRIPTION
Rough token-string matching is robust enough and much easier to grok