### PR TITLE
chore: improve panic! message when string buffer exceeds v8 limit

### DIFF
--- a/serde_v8/magic/u16string.rs
+++ b/serde_v8/magic/u16string.rs
@@ -13,7 +13,9 @@ impl ToV8 for U16String {
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     let v =
       v8::String::new_from_two_byte(scope, self, v8::NewStringType::Normal)
-        .unwrap();
+        .expect(
+          "Cannot allocate String from UTF-16: buffer exceeds maximum length.",
+        );
     Ok(v.into())
   }
 }


### PR DESCRIPTION
When using `TextDecoder` on very large data (> 512MB) Rust will panic, because the buffer passed to `v8::String::new_from_two_byte` exceeds `v8::String::max_length`.  This PR adds a more descriptive error message in case this happens.

Related to #13648

before:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', serde_v8\magic\u16string.rs:16:10
```

after:

```
thread 'main' panicked at 'Cannot allocate String from UTF-16: buffer exceeds maximum length.', serde_v8\magic\u16string.rs:16:10
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
