### PR TITLE
fix(ext/web): throw if listener and signal are null

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -944,6 +944,18 @@
       if (!(ReflectHas(listeners, type))) {
         listeners[type] = [];
       }
+
+      for (const listener of listeners[type]) {
+        if (
+          ((typeof listener.options === "boolean" &&
+            listener.options === options.capture) ||
+            (typeof listener.options === "object" &&
+              listener.options.capture === options.capture)) &&
+          listener.callback === callback
+        ) {
+          return;
+        }
+      }
       if (options?.signal) {
         const signal = options?.signal;
         if (signal.aborted) {
@@ -955,18 +967,6 @@
           signal.addEventListener("abort", () => {
             this.removeEventListener(type, callback, options);
           });
-        }
-      }
-
-      for (const listener of listeners[type]) {
-        if (
-          ((typeof listener.options === "boolean" &&
-            listener.options === options.capture) ||
-            (typeof listener.options === "object" &&
-              listener.options.capture === options.capture)) &&
-          listener.callback === callback
-        ) {
-          return;
         }
       }
 

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -797,20 +797,6 @@
     }
   }
 
-  function normalizeAddEventHandlerOptions(
-    options,
-  ) {
-    if (typeof options === "boolean" || typeof options === "undefined") {
-      return {
-        capture: Boolean(options),
-        once: false,
-        passive: false,
-      };
-    } else {
-      return options;
-    }
-  }
-
   function normalizeEventHandlerOptions(
     options,
   ) {
@@ -889,6 +875,45 @@
     };
   }
 
+  // This is lazy loaded because there is a circular dependency with AbortSignal.
+  let addEventListenerOptionsConverter;
+
+  function lazyAddEventListenerOptionsConverter() {
+    addEventListenerOptionsConverter ??= webidl.createDictionaryConverter(
+      "AddEventListenerOptions",
+      [
+        {
+          key: "capture",
+          defaultValue: false,
+          converter: webidl.converters.boolean,
+        },
+        {
+          key: "passive",
+          defaultValue: false,
+          converter: webidl.converters.boolean,
+        },
+        {
+          key: "once",
+          defaultValue: false,
+          converter: webidl.converters.boolean,
+        },
+        {
+          key: "signal",
+          converter: webidl.converters.AbortSignal,
+        },
+      ],
+    );
+  }
+
+  webidl.converters.AddEventListenerOptions = (V, opts) => {
+    if (webidl.type(V) !== "Object" || V === null) {
+      V = { capture: Boolean(V) };
+    }
+
+    lazyAddEventListenerOptionsConverter();
+    return addEventListenerOptionsConverter(V, opts);
+  };
+
   class EventTarget {
     constructor() {
       this[eventTargetData] = getDefaultTargetData();
@@ -899,12 +924,26 @@
       callback,
       options,
     ) {
+      const prefix = "Failed to execute 'addEventListener' on 'EventTarget'";
+
       webidl.requiredArguments(arguments.length, 2, {
-        prefix: "Failed to execute 'addEventListener' on 'EventTarget'",
+        prefix,
       });
 
-      options = normalizeAddEventHandlerOptions(options);
+      options = webidl.converters.AddEventListenerOptions(options, {
+        prefix,
+        context: "Argument 3",
+      });
 
+      if (callback === null) {
+        return;
+      }
+
+      const { listeners } = (this ?? globalThis)[eventTargetData];
+
+      if (!(ReflectHas(listeners, type))) {
+        listeners[type] = [];
+      }
       if (options?.signal) {
         const signal = options?.signal;
         if (signal.aborted) {
@@ -917,18 +956,6 @@
             this.removeEventListener(type, callback, options);
           });
         }
-      } else if (options?.signal === null) {
-        throw new TypeError("signal must be non-null");
-      }
-
-      if (callback === null) {
-        return;
-      }
-
-      const { listeners } = (this ?? globalThis)[eventTargetData];
-
-      if (!(ReflectHas(listeners, type))) {
-        listeners[type] = [];
       }
 
       for (const listener of listeners[type]) {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -918,12 +918,8 @@
         "returnValue should be ignored if-and-only-if the passive option is true",
         "Equivalence of option values"
       ],
-      "AddEventListenerOptions-signal.any.html": [
-        "Passing null as the signal should throw (listener is also null)"
-      ],
-      "AddEventListenerOptions-signal.any.worker.html": [
-        "Passing null as the signal should throw (listener is also null)"
-      ],
+      "AddEventListenerOptions-signal.any.html": true,
+      "AddEventListenerOptions-signal.any.worker.html": true,
       "Event-isTrusted.any.html": true,
       "Event-isTrusted.any.worker.html": true,
       "EventTarget-add-remove-listener.any.html": true,

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -902,21 +902,13 @@
       "event.any.worker.html": true
     },
     "events": {
-      "AddEventListenerOptions-once.any.html": [
-        "Once listener should be added / removed like normal listeners"
-      ],
-      "AddEventListenerOptions-once.any.worker.html": [
-        "Once listener should be added / removed like normal listeners"
-      ],
+      "AddEventListenerOptions-once.any.html": true,
+      "AddEventListenerOptions-once.any.worker.html": true,
       "AddEventListenerOptions-passive.any.html": [
-        "Supports passive option on addEventListener only",
-        "returnValue should be ignored if-and-only-if the passive option is true",
-        "Equivalence of option values"
+        "returnValue should be ignored if-and-only-if the passive option is true"
       ],
       "AddEventListenerOptions-passive.any.worker.html": [
-        "Supports passive option on addEventListener only",
-        "returnValue should be ignored if-and-only-if the passive option is true",
-        "Equivalence of option values"
+        "returnValue should be ignored if-and-only-if the passive option is true"
       ],
       "AddEventListenerOptions-signal.any.html": true,
       "AddEventListenerOptions-signal.any.worker.html": true,


### PR DESCRIPTION
This commit fixes a failing WPT test by making `EventTarget`'s `addEventListener()` method throw if both the `listener` and the `signal` option are `null`.

Fixes: https://github.com/denoland/deno/issues/14593
Fixes: https://github.com/denoland/deno/issues/14254

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
