### PR TITLE
fix(test): Format thrown non-errors properly

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -374,3 +374,9 @@ itest!(uncaught_errors {
   output: "test/uncaught_errors.out",
   exit_code: 1,
 });
+
+itest!(non_error_thrown {
+  args: "test --quiet test/non_error_thrown.ts",
+  output: "test/non_error_thrown.out",
+  exit_code: 1,
+});

--- a/cli/tests/testdata/test/non_error_thrown.out
+++ b/cli/tests/testdata/test/non_error_thrown.out
@@ -1,0 +1,40 @@
+running 6 tests from [WILDCARD]/non_error_thrown.ts
+foo ... FAILED ([WILDCARD])
+bar ... FAILED ([WILDCARD])
+baz ... FAILED ([WILDCARD])
+qux ... FAILED ([WILDCARD])
+quux ... FAILED ([WILDCARD])
+quuz ... FAILED ([WILDCARD])
+
+ ERRORS 
+
+foo => [WILDCARD]/non_error_thrown.ts:1:6
+error: undefined
+
+bar => [WILDCARD]/non_error_thrown.ts:5:6
+error: null
+
+baz => [WILDCARD]/non_error_thrown.ts:9:6
+error: 123
+
+qux => [WILDCARD]/non_error_thrown.ts:13:6
+error: "Hello, world!"
+
+quux => [WILDCARD]/non_error_thrown.ts:17:6
+error: [ 1, 2, 3 ]
+
+quuz => [WILDCARD]/non_error_thrown.ts:21:6
+error: { a: "Hello, world!", b: [ 1, 2, 3 ] }
+
+ FAILURES 
+
+foo => [WILDCARD]/non_error_thrown.ts:1:6
+bar => [WILDCARD]/non_error_thrown.ts:5:6
+baz => [WILDCARD]/non_error_thrown.ts:9:6
+qux => [WILDCARD]/non_error_thrown.ts:13:6
+quux => [WILDCARD]/non_error_thrown.ts:17:6
+quuz => [WILDCARD]/non_error_thrown.ts:21:6
+
+test result: FAILED. 0 passed; 6 failed; 0 ignored; 0 measured; 0 filtered out ([WILDCARD])
+
+error: Test failed

--- a/cli/tests/testdata/test/non_error_thrown.ts
+++ b/cli/tests/testdata/test/non_error_thrown.ts
@@ -1,0 +1,23 @@
+Deno.test("foo", () => {
+  throw undefined;
+});
+
+Deno.test("bar", () => {
+  throw null;
+});
+
+Deno.test("baz", () => {
+  throw 123;
+});
+
+Deno.test("qux", () => {
+  throw "Hello, world!";
+});
+
+Deno.test("quux", () => {
+  throw [1, 2, 3];
+});
+
+Deno.test("quuz", () => {
+  throw { a: "Hello, world!", b: [1, 2, 3] };
+});

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -326,7 +326,7 @@
   }
 
   function maybeColor(fn, inspectOptions) {
-    return inspectOptions.colors ? fn : (s) => s;
+    return inspectOptions.colors && !colors.getNoColor() ? fn : (s) => s;
   }
 
   function inspectFunction(value, level, inspectOptions) {
@@ -2322,5 +2322,6 @@
     inspect,
     wrapConsole,
     createFilteredInspectProxy,
+    quoteString,
   };
 })(this);


### PR DESCRIPTION
Fixes #14596.

I realised we also have this problem with exceptions in general. This only addresses it for testing. It would be good if we always applied nice formatting for `JsError::exception_message` (which is a different approach from this PR) but that would involve either moving inspect logic to core or the usual of adding a callback to core runtime options. But that callback would need to make a JS call to `Deno[Deno.internal].inspectArgs([error])`. I guess the callback could be registered on the JS-side, making it a lot easier? I have to look into it.