### PR TITLE
fix(ext/tls): ability to ignore IP-address certificate errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "a024a432ae760ab3bff924ad91ce1cfa52cb57ed16e1ef32d0d249cfee1a6c13"
 dependencies = [
  "log",
  "ring",

--- a/cli/tests/integration/mod.rs
+++ b/cli/tests/integration/mod.rs
@@ -539,6 +539,12 @@ itest!(deno_land_unsafe_ssl {
   output: "deno_land_unsafe_ssl.ts.out",
 });
 
+itest!(ip_address_unsafe_ssl {
+  args:
+    "run --quiet --reload --allow-net --unsafely-ignore-certificate-errors=1.1.1.1 ip_address_unsafe_ssl.ts",
+  output: "ip_address_unsafe_ssl.ts.out",
+});
+
 itest!(localhost_unsafe_ssl {
   args:
     "run --quiet --reload --allow-net --unsafely-ignore-certificate-errors=deno.land cafile_url_imports.ts",

--- a/cli/tests/testdata/ip_address_unsafe_ssl.ts
+++ b/cli/tests/testdata/ip_address_unsafe_ssl.ts
@@ -1,0 +1,2 @@
+const r = await fetch("https://1.1.1.1");
+console.log(r.status);

--- a/cli/tests/testdata/ip_address_unsafe_ssl.ts.out
+++ b/cli/tests/testdata/ip_address_unsafe_ssl.ts.out
@@ -1,0 +1,2 @@
+DANGER: TLS certificate validation is disabled for: 1.1.1.1
+200

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -36,18 +36,9 @@ Deno.test({ permissions: { net: false } }, async function connectTLSNoPerm() {
 Deno.test(
   { permissions: { read: true, net: true } },
   async function connectTLSInvalidHost() {
-    const listener = await Deno.listenTls({
-      hostname: "localhost",
-      port: 3567,
-      certFile: "cli/tests/testdata/tls/localhost.crt",
-      keyFile: "cli/tests/testdata/tls/localhost.key",
-    });
-
     await assertRejects(async () => {
-      await Deno.connectTls({ hostname: "127.0.0.1", port: 3567 });
+      await Deno.connectTls({ hostname: "256.0.0.0", port: 3567 });
     }, TypeError);
-
-    listener.close();
   },
 );
 

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -50,6 +50,9 @@ impl ServerCertVerifier for NoCertificateVerification {
     ocsp_response: &[u8],
     now: SystemTime,
   ) -> Result<ServerCertVerified, Error> {
+    if self.0.is_empty() {
+      return Ok(ServerCertVerified::assertion());
+    }
     let dns_name_or_ip_address = match server_name {
       ServerName::DnsName(dns_name) => dns_name.as_ref().to_owned(),
       ServerName::IpAddress(ip_address) => ip_address.to_string(),
@@ -59,7 +62,7 @@ impl ServerCertVerifier for NoCertificateVerification {
         return Err(Error::General("Unknown `ServerName` variant".to_string()));
       }
     };
-    if self.0.is_empty() || self.0.contains(&dns_name_or_ip_address) {
+    if self.0.contains(&dns_name_or_ip_address) {
       Ok(ServerCertVerified::assertion())
     } else {
       let root_store = create_default_root_cert_store();

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -12,10 +12,12 @@ use deno_core::error::AnyError;
 use deno_core::parking_lot::Mutex;
 use deno_core::Extension;
 
+use rustls::client::HandshakeSignatureValid;
 use rustls::client::ServerCertVerified;
 use rustls::client::ServerCertVerifier;
 use rustls::client::StoresClientSessions;
 use rustls::client::WebPkiVerifier;
+use rustls::internal::msgs::handshake::DigitallySignedStruct;
 use rustls::Certificate;
 use rustls::ClientConfig;
 use rustls::Error;
@@ -76,6 +78,24 @@ impl ServerCertVerifier for NoCertificateVerification {
         now,
       )
     }
+  }
+
+  fn verify_tls12_signature(
+    &self,
+    _message: &[u8],
+    _cert: &rustls::Certificate,
+    _dss: &DigitallySignedStruct,
+  ) -> Result<HandshakeSignatureValid, Error> {
+    Ok(HandshakeSignatureValid::assertion())
+  }
+
+  fn verify_tls13_signature(
+    &self,
+    _message: &[u8],
+    _cert: &rustls::Certificate,
+    _dss: &DigitallySignedStruct,
+  ) -> Result<HandshakeSignatureValid, Error> {
+    Ok(HandshakeSignatureValid::assertion())
   }
 }
 


### PR DESCRIPTION
Fixes #14609.

- rustls was updated to v0.20.5
- `ext/tls/lib.rs` was changed to understand IP-addresses
- TS TLS test of invalid host handling was updated to check truly invalid host