### PR TITLE
perf(core): optimize encode on large strings

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -896,11 +896,11 @@ fn encode(
       return;
     }
   };
-  let text_str = text.to_rust_string_lossy(scope);
-  let bytes: Box<[u8]> = text_str.into_bytes().into_boxed_slice();
+  let text_str = serde_v8::to_utf8(text, scope);
+  let bytes = text_str.into_bytes();
   let len = bytes.len();
   let backing_store =
-    v8::ArrayBuffer::new_backing_store_from_boxed_slice(bytes).make_shared();
+    v8::ArrayBuffer::new_backing_store_from_vec(bytes).make_shared();
   let buffer = v8::ArrayBuffer::with_backing_store(scope, &backing_store);
   let u8array = v8::Uint8Array::new(scope, buffer, 0, len).unwrap();
   rv.set(u8array.into())

--- a/serde_v8/lib.rs
+++ b/serde_v8/lib.rs
@@ -8,7 +8,7 @@ mod ser;
 mod serializable;
 pub mod utils;
 
-pub use de::{from_v8, from_v8_cached, Deserializer};
+pub use de::{from_v8, from_v8_cached, to_utf8, Deserializer};
 pub use error::{Error, Result};
 pub use keys::KeyCache;
 pub use magic::buffer::ZeroCopyBuf;


### PR DESCRIPTION
Follow up to serde_v8's #14450

```
Before:
test bench_utf8_decode_12_b  ... bench:         188 ns/iter (+/- 41)
test bench_utf8_decode_12_kb ... bench:       3,480 ns/iter (+/- 2,226)
test bench_utf8_decode_12_mb ... bench:   1,549,520 ns/iter (+/- 210,202)
test bench_utf8_encode_12_b  ... bench:         400 ns/iter (+/- 69)
test bench_utf8_encode_12_kb ... bench:       5,813 ns/iter (+/- 469)
test bench_utf8_encode_12_mb ... bench:   5,149,035 ns/iter (+/- 160,745)

After:
test bench_utf8_decode_12_b  ... bench:         174 ns/iter (+/- 13)
test bench_utf8_decode_12_kb ... bench:       3,780 ns/iter (+/- 688)
test bench_utf8_decode_12_mb ... bench:   1,484,499 ns/iter (+/- 42,377)
test bench_utf8_encode_12_b  ... bench:         345 ns/iter (+/- 22)
test bench_utf8_encode_12_kb ... bench:       2,127 ns/iter (+/- 132)
test bench_utf8_encode_12_mb ... bench:   1,198,063 ns/iter (+/- 83,304)
```

We observe non-linear improvements as input string length grows, approaching ~3x for multi-kb strings and beyond