### PR TITLE
fix(ext/web): add EventTarget brand checking

### DIFF
--- a/cli/tests/unit/event_target_test.ts
+++ b/cli/tests/unit/event_target_test.ts
@@ -244,3 +244,13 @@ Deno.test(function eventTargetDispatchShouldSetTargetInListener() {
   target.dispatchEvent(event);
   assertEquals(called, true);
 });
+
+Deno.test(function eventTargetAddEventListenerGlobalAbort() {
+  return new Promise((resolve) => {
+    const c = new AbortController();
+
+    c.signal.addEventListener("abort", () => resolve());
+    addEventListener("test", () => {}, { signal: c.signal });
+    c.abort();
+  });
+});

--- a/cli/tests/unit/event_target_test.ts
+++ b/cli/tests/unit/event_target_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-window-prefix
-import { assertEquals } from "./test_util.ts";
+import { assertEquals, assertThrows } from "./test_util.ts";
 
 Deno.test(function addEventListenerTest() {
   const document = new EventTarget();
@@ -253,4 +253,29 @@ Deno.test(function eventTargetAddEventListenerGlobalAbort() {
     addEventListener("test", () => {}, { signal: c.signal });
     c.abort();
   });
+});
+
+Deno.test(function eventTargetBrandChecking() {
+  const self = {};
+
+  assertThrows(
+    () => {
+      EventTarget.prototype.addEventListener.call(self, "test", null);
+    },
+    TypeError,
+  );
+
+  assertThrows(
+    () => {
+      EventTarget.prototype.removeEventListener.call(self, "test", null);
+    },
+    TypeError,
+  );
+
+  assertThrows(
+    () => {
+      EventTarget.prototype.dispatchEvent.call(self, new Event("test"));
+    },
+    TypeError,
+  );
 });

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -142,6 +142,7 @@ declare type EventListenerOrEventListenerObject =
 interface AddEventListenerOptions extends EventListenerOptions {
   once?: boolean;
   passive?: boolean;
+  signal?: AbortSignal;
 }
 
 interface EventListenerOptions {

--- a/tools/wpt/testharnessreport.js
+++ b/tools/wpt/testharnessreport.js
@@ -18,5 +18,12 @@ window.add_completion_callback((_tests, harnessStatus) => {
   while (bytesWritten < data.byteLength) {
     bytesWritten += Deno.stderr.writeSync(data.subarray(bytesWritten));
   }
+
+  // TODO(cjihrig): Restore the prototype of globalThis to be an EventTarget
+  // again. There are WPTs that change the prototype, which causes brand
+  // checking to fail. Once the globalThis prototype is frozen properly, this
+  // line can be removed.
+  Object.setPrototypeOf(globalThis, EventTarget.prototype);
+
   Deno.exit(harnessStatus.status === 0 ? 0 : 1);
 });


### PR DESCRIPTION
This commit adds brand checking to `EventTarget`. It also fixes a bug where deno would crash if an abort signal was aborted via the global `addEventListener()`.

Fixes: https://github.com/denoland/deno/issues/12666

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
