### PR TITLE
fix: add types for `Response.json`

### DIFF
--- a/cli/dts/lib.dom.d.ts
+++ b/cli/dts/lib.dom.d.ts
@@ -11275,6 +11275,7 @@ interface Response extends Body {
 declare var Response: {
     prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
+    json(data: unknown, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string | URL, status?: number): Response;
 };

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1533,3 +1533,12 @@ Deno.test(
     assertEquals(length, 'Some("4")');
   },
 );
+
+Deno.test(async function staticResponseJson() {
+  const data = { hello: "world" };
+  const resp = Response.json(data);
+  assertEquals(resp.status, 200);
+  assertEquals(resp.headers.get("content-type"), "application/json");
+  const res = await resp.json();
+  assertEquals(res, data);
+});

--- a/ext/fetch/lib.deno_fetch.d.ts
+++ b/ext/fetch/lib.deno_fetch.d.ts
@@ -383,6 +383,7 @@ type ResponseType =
 /** This Fetch API interface represents the response to a request. */
 declare class Response implements Body {
   constructor(body?: BodyInit | null, init?: ResponseInit);
+  static json(data: unknown, init?: ResponseInit): Response;
   static error(): Response;
   static redirect(url: string, status?: number): Response;
 


### PR DESCRIPTION
Can't add the dom types to `dom.extras`, because `declare var Response` is not open ended, and thus can not be extended.
