### PR TITLE
fix(runtime): freeze globalThis prototype chain

### DIFF
--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1584,12 +1584,8 @@
       "class-string-iterator-prototype-object.any.html": true,
       "class-string-iterator-prototype-object.any.worker.html": true,
       "class-string-named-properties-object.window.html": false,
-      "global-immutable-prototype.any.html": [
-        "Setting to a different prototype"
-      ],
-      "global-immutable-prototype.any.worker.html": [
-        "Setting to a different prototype"
-      ],
+      "global-immutable-prototype.any.html": true,
+      "global-immutable-prototype.any.worker.html": true,
       "global-object-implicit-this-value.any.html": [
         "Global object's getter throws when called on incompatible object",
         "Global object's setter throws when called on incompatible object",


### PR DESCRIPTION
The `globalThis` prototype chain should be frozen. There is a WPT for this behavior. This is also desirable in order to add webidl brand checking to `EventTarget`.

Fixes: https://github.com/denoland/deno/issues/14649
Refs: https://github.com/denoland/deno/pull/14637

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
