### PR TITLE
fix: prevent tampering of Deno.exit

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -919,6 +919,12 @@ itest!(set_exit_code_in_worker {
   exit_code: 42,
 });
 
+itest!(deno_exit_tampering {
+  args: "run --no-check --unstable deno_exit_tampering.ts",
+  output: "empty.out",
+  exit_code: 42,
+});
+
 itest!(heapstats {
   args: "run --quiet --unstable --v8-flags=--expose-gc heapstats.js",
   output: "heapstats.js.out",

--- a/cli/tests/testdata/deno_exit_tampering.ts
+++ b/cli/tests/testdata/deno_exit_tampering.ts
@@ -1,0 +1,3 @@
+delete globalThis.dispatchEvent;
+delete EventTarget.prototype.dispatchEvent;
+Deno.exit(42);

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -8,6 +8,8 @@
     SymbolFor,
   } = window.__bootstrap.primordials;
 
+  const windowDispatchEvent = window.dispatchEvent.bind(window);
+
   function loadavg() {
     return core.opSync("op_loadavg");
   }
@@ -51,7 +53,7 @@
     if (!window[SymbolFor("isUnloadDispatched")]) {
       // Invokes the `unload` hooks before exiting
       // ref: https://github.com/denoland/deno/issues/3603
-      window.dispatchEvent(new Event("unload"));
+      windowDispatchEvent(new Event("unload"));
     }
 
     if (exitHandler) {


### PR DESCRIPTION
This PR prevents Deno.exit to fail by tampering of dispatchEvent methods.

ref #14648