### PR TITLE
feat: make Child.kill argument optional

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1060,8 +1060,8 @@ declare namespace Deno {
 
     /** Waits for the child to exit completely, returning all its output and status. */
     output(): Promise<SpawnOutput<T>>;
-    /** Kills the process with given Signal. */
-    kill(signo: Signal): void;
+    /** Kills the process with given Signal. Defaults to SIGTERM. */
+    kill(signo?: Signal): void;
   }
 
   /**

--- a/cli/tests/unit/spawn_test.ts
+++ b/cli/tests/unit/spawn_test.ts
@@ -250,6 +250,29 @@ Deno.test(
 
 Deno.test(
   { permissions: { run: true, read: true } },
+  async function spawnKillOptional() {
+    const child = Deno.spawnChild(Deno.execPath(), {
+      args: ["eval", "setTimeout(() => {}, 10000)"],
+      stdout: "null",
+      stderr: "null",
+    });
+
+    child.kill();
+    const status = await child.status;
+
+    assertEquals(status.success, false);
+    if (Deno.build.os === "windows") {
+      assertEquals(status.code, 1);
+      assertEquals(status.signal, null);
+    } else {
+      assertEquals(status.code, 143);
+      assertEquals(status.signal, "SIGTERM");
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
   async function spawnAbort() {
     const ac = new AbortController();
     const child = Deno.spawnChild(Deno.execPath(), {

--- a/runtime/js/40_spawn.js
+++ b/runtime/js/40_spawn.js
@@ -168,7 +168,7 @@
       };
     }
 
-    kill(signo) {
+    kill(signo = "SIGTERM") {
       if (this.#rid === null) {
         throw new TypeError("Child process has already terminated.");
       }


### PR DESCRIPTION
will default to SIGTERM.
Since we dont have a `close()` with `Child`, `kill` will be used frequently, and most of the time one doesnt care how, they just want the process to end.