### PR TITLE
feat: add 32 bits support for serde_v8

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,9 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
 [target.'cfg(all(windows, debug_assertions))']
 rustflags = [
   "-C",

--- a/serde_v8/ser.rs
+++ b/serde_v8/ser.rs
@@ -218,7 +218,13 @@ impl<'a, 'b, 'c> ser::SerializeStruct for ObjectSerializer<'a, 'b, 'c> {
 
 pub struct MagicalSerializer<'a, 'b, 'c, T> {
   scope: ScopePtr<'a, 'b, 'c>,
+
+  #[cfg(target_pointer_width = "64")]
   opaque: u64,
+
+  #[cfg(target_pointer_width = "32")]
+  opaque: u32,
+
   p1: std::marker::PhantomData<T>,
 }
 
@@ -245,7 +251,7 @@ impl<'a, 'b, 'c, T: MagicType + ToV8> ser::SerializeStruct
   ) -> Result<()> {
     assert_eq!(key, MAGIC_FIELD);
     let ptr: &U = value;
-    // SAFETY: MagicalSerializer only ever receives single field u64s,
+    // SAFETY: MagicalSerializer only ever receives single field u64s/u32s,
     // type-safety is ensured by MAGIC_NAME checks in `serialize_struct()`
     self.opaque = unsafe { opaque_recv(ptr) };
     Ok(())


### PR DESCRIPTION
This is the initial effort for enabling 32 bits support for deno, and this PR doesn't even compile if you don't modify the part which isn't relevant to this PR.

There's still two test cases failed after the modification.
![image](https://user-images.githubusercontent.com/20559490/169226389-5ade69a3-5e4c-4b18-b392-89721c26e901.png)
![image](https://user-images.githubusercontent.com/20559490/169226055-dd583e9e-c92c-43db-b86f-7592d11db9f8.png)
