### PR TITLE
fix(bench): update typo in bench summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "mitata"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975d43e4088e68e8b18c81e866185c71d1682d3cf923ed6e98be0c6173d80f77"
+checksum = "21fd49a3bd69c5be5d2c21899e2995ed99193b48e2c9f3ac09596a0d69f7fa79"
 dependencies = [
  "clap",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ import_map = "=0.9.0"
 jsonc-parser = { version = "=0.19.0", features = ["serde"] }
 libc = "=0.2.124"
 log = { version = "=0.4.16", features = ["serde"] }
-mitata = '=0.0.6'
+mitata = '=0.0.7'
 node_resolver = "=0.1.1"
 notify = "=5.0.0-pre.14"
 once_cell = "=1.10.0"

--- a/cli/tests/testdata/bench/group_baseline.out
+++ b/cli/tests/testdata/bench/group_baseline.out
@@ -6,7 +6,7 @@ noop2 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
 
 summary
   noo[WILDCARD]
-   [WILDCARD]x times [WILDCARD] than noo[WILDCARD]
+   [WILDCARD]x [WILDCARD] than noo[WILDCARD]
 
 noop3 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
 parse url 2x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
@@ -14,5 +14,5 @@ parse url 6x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WI
 
 summary
   parse url 2x
-   [WILDCARD]x times slower than noop3
-   [WILDCARD]x times faster than parse url 6x
+   [WILDCARD]x slower than noop3
+   [WILDCARD]x faster than parse url 6x

--- a/cli/tests/testdata/bench/multifile_summary.out
+++ b/cli/tests/testdata/bench/multifile_summary.out
@@ -12,7 +12,7 @@ noop2 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
 
 summary
   noo[WILDCARD]
-   [WILDCARD]x times [WILDCARD] than noo[WILDCARD]
+   [WILDCARD]x [WILDCARD] than noo[WILDCARD]
 
 noop3 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
 parse url 2x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
@@ -20,8 +20,8 @@ parse url 6x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WI
 
 summary
   parse url 2x
-   [WILDCARD]x times slower than noop3
-   [WILDCARD]x times faster than parse url 6x
+   [WILDCARD]x slower than noop3
+   [WILDCARD]x faster than parse url 6x
 
 [WILDCARD]/bench/pass.ts
 benchmark      time (avg)             (min … max)       p75       p99      p995
@@ -45,7 +45,7 @@ noop2 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
 
 summary
   noo[WILDCARD]
-   [WILDCARD]x times [WILDCARD] than noo[WILDCARD]
+   [WILDCARD]x [WILDCARD] than noo[WILDCARD]
 
 noop3 [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
 parse url 2x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WILDCARD]
@@ -53,5 +53,5 @@ parse url 6x [WILDCARD] [WILDCARD]/iter[WILDCARD]([WILDCARD] … [WILDCARD]) [WI
 
 summary
   parse url 2x
-   [WILDCARD]x times slower than noop3
-   [WILDCARD]x times faster than parse url 6x
+   [WILDCARD]x slower than noop3
+   [WILDCARD]x faster than parse url 6x


### PR DESCRIPTION
This PR updates a small issue in the benchmark summary output. Previously it would print e.g. `2x times faster` which is a duplication because it would read as `2 times times faster`. It was updated in `mitata` 0.0.7 to `2x faster` instead,

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
