### PR TITLE
fix(runtime): improve permission descriptor validation

### DIFF
--- a/cli/tests/unit/permissions_test.ts
+++ b/cli/tests/unit/permissions_test.ts
@@ -71,3 +71,18 @@ Deno.test(async function permissionURL() {
     command: new URL(".", import.meta.url),
   });
 });
+
+Deno.test(async function permissionDescriptorValidation() {
+  for (const value of [undefined, null, {}]) {
+    for (const method of ["query", "request", "revoke"]) {
+      await assertRejects(
+        async () => {
+          // deno-lint-ignore no-explicit-any
+          await (Deno.permissions as any)[method](value as any);
+        },
+        TypeError,
+        '"undefined" is not a valid permission name',
+      );
+    }
+  }
+});

--- a/runtime/js/10_permissions.js
+++ b/runtime/js/10_permissions.js
@@ -149,7 +149,7 @@
    * @returns {desc is Deno.PermissionDescriptor}
    */
   function isValidDescriptor(desc) {
-    return desc && desc !== null &&
+    return typeof desc === "object" && desc !== null &&
       ArrayPrototypeIncludes(permissionNames, desc.name);
   }
 
@@ -164,7 +164,8 @@
       if (!isValidDescriptor(desc)) {
         return PromiseReject(
           new TypeError(
-            `The provided value "${desc.name}" is not a valid permission name.`,
+            `The provided value "${desc
+              ?.name}" is not a valid permission name.`,
           ),
         );
       }
@@ -185,7 +186,8 @@
       if (!isValidDescriptor(desc)) {
         return PromiseReject(
           new TypeError(
-            `The provided value "${desc.name}" is not a valid permission name.`,
+            `The provided value "${desc
+              ?.name}" is not a valid permission name.`,
           ),
         );
       }
@@ -204,7 +206,8 @@
       if (!isValidDescriptor(desc)) {
         return PromiseReject(
           new TypeError(
-            `The provided value "${desc.name}" is not a valid permission name.`,
+            `The provided value "${desc
+              ?.name}" is not a valid permission name.`,
           ),
         );
       }


### PR DESCRIPTION
This commit improves the permission descriptor validation by
explicitly checking for object types and using optional
chaining when creating error messages in case the descriptor
is not an object.

Fixes: https://github.com/denoland/deno/issues/14675

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
