### PR TITLE
refactor: strip utf8 BOM in file fetcher

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -8,6 +8,7 @@ use crate::http_util::CacheSemantics;
 use crate::http_util::FetchOnceArgs;
 use crate::http_util::FetchOnceResult;
 use crate::text_encoding;
+use crate::text_encoding::strip_bom_mut;
 use crate::version::get_user_agent;
 
 use data_url::DataUrl;
@@ -257,16 +258,17 @@ pub fn get_source_from_data_url(
 }
 
 /// Given a vector of bytes and optionally a charset, decode the bytes to a
-/// string.
+/// string, and strips a leading utf8 BOM if it exists.
 pub fn get_source_from_bytes(
   bytes: Vec<u8>,
   maybe_charset: Option<String>,
 ) -> Result<String, AnyError> {
-  let source = if let Some(charset) = maybe_charset {
+  let mut source = if let Some(charset) = maybe_charset {
     text_encoding::convert_to_utf8(&bytes, &charset)?.to_string()
   } else {
     String::from_utf8(bytes)?
   };
+  strip_bom_mut(&mut source);
 
   Ok(source)
 }
@@ -739,6 +741,8 @@ impl FileFetcher {
 
 #[cfg(test)]
 mod tests {
+  use crate::text_encoding::strip_bom;
+
   use super::*;
   use deno_core::error::get_custom_error_class;
   use deno_core::resolve_url;
@@ -1669,28 +1673,31 @@ mod tests {
 
   #[tokio::test]
   async fn test_fetch_local_utf_16be() {
-    let expected = String::from_utf8(
+    let mut expected = String::from_utf8(
       b"\xEF\xBB\xBFconsole.log(\"Hello World\");\x0A".to_vec(),
     )
     .unwrap();
+    strip_bom_mut(&mut expected);
     test_fetch_local_encoded("utf-16be", expected).await;
   }
 
   #[tokio::test]
   async fn test_fetch_local_utf_16le() {
-    let expected = String::from_utf8(
+    let mut expected = String::from_utf8(
       b"\xEF\xBB\xBFconsole.log(\"Hello World\");\x0A".to_vec(),
     )
     .unwrap();
+    strip_bom_mut(&mut expected);
     test_fetch_local_encoded("utf-16le", expected).await;
   }
 
   #[tokio::test]
   async fn test_fetch_local_utf8_with_bom() {
-    let expected = String::from_utf8(
+    let mut expected = String::from_utf8(
       b"\xEF\xBB\xBFconsole.log(\"Hello World\");\x0A".to_vec(),
     )
     .unwrap();
+    strip_bom_mut(&mut expected);
     test_fetch_local_encoded("utf-8", expected).await;
   }
 
@@ -1731,7 +1738,8 @@ mod tests {
     let expected =
       std::str::from_utf8(b"\xEF\xBB\xBFconsole.log(\"Hello World\");\x0A")
         .unwrap();
-    test_fetch_remote_encoded("utf-16le.ts", "utf-16le", expected).await;
+    test_fetch_remote_encoded("utf-16le.ts", "utf-16le", strip_bom(expected))
+      .await;
   }
 
   #[tokio::test]
@@ -1739,7 +1747,8 @@ mod tests {
     let expected =
       std::str::from_utf8(b"\xEF\xBB\xBFconsole.log(\"Hello World\");\x0A")
         .unwrap();
-    test_fetch_remote_encoded("utf-16be.ts", "utf-16be", expected).await;
+    test_fetch_remote_encoded("utf-16be.ts", "utf-16be", strip_bom(expected))
+      .await;
   }
 
   #[tokio::test]

--- a/cli/text_encoding.rs
+++ b/cli/text_encoding.rs
@@ -120,7 +120,7 @@ mod tests {
   #[test]
   fn strip_bom_without_bom() {
     let text = "text";
-    assert_eq!(strip_bom(&text), "text");
+    assert_eq!(strip_bom(text), "text");
   }
 
   #[test]

--- a/cli/text_encoding.rs
+++ b/cli/text_encoding.rs
@@ -54,6 +54,13 @@ pub fn strip_bom(text: &str) -> &str {
   }
 }
 
+/// Strips the byte order mark if it exists from the provided text.
+pub fn strip_bom_mut(text: &mut String) {
+  if text.starts_with(BOM_CHAR) {
+    text.drain(..BOM_CHAR.len_utf8());
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -102,5 +109,31 @@ mod tests {
     assert!(result.is_err());
     let err = result.expect_err("Err expected");
     assert!(err.kind() == ErrorKind::InvalidData);
+  }
+
+  #[test]
+  fn strip_bom_with_bom() {
+    let text = format!("{}text", BOM_CHAR);
+    assert_eq!(strip_bom(&text), "text");
+  }
+
+  #[test]
+  fn strip_bom_without_bom() {
+    let text = "text";
+    assert_eq!(strip_bom(&text), "text");
+  }
+
+  #[test]
+  fn strip_bom_mut_with_bom() {
+    let mut text = format!("{}text", BOM_CHAR);
+    strip_bom_mut(&mut text);
+    assert_eq!(text, "text");
+  }
+
+  #[test]
+  fn strip_bom_mut_without_bom() {
+    let mut text = "text".to_string();
+    strip_bom_mut(&mut text);
+    assert_eq!(text, "text");
   }
 }


### PR DESCRIPTION
Right now the BOM is being stripped in deno_ast (being moved to deno graph), but instead I believe we could remove it right at the start and not have to deal with it.

This would also reduce a copy of the source text that previously needed to be made when a file contained a BOM.