### PR TITLE
fix(cli/dts): change `ChildStatus.signal` from `string` to `Deno.Signal`

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1117,7 +1117,7 @@ declare namespace Deno {
     | {
       success: false;
       code: number;
-      signal: string | null;
+      signal: Signal | null;
     };
 
   export interface SpawnOutput<T extends SpawnOptions> {


### PR DESCRIPTION
Since #14643 the `ChildStatus.signal` changed from `number` to `string` which is great, but a more accurate typing would be `Deno.Signal`

Currently if you try to pass it down to a type/interface which expect a `Deno.Signal`, you must force the type assertion to avoid TypeScript complaining:
![image](https://user-images.githubusercontent.com/22963968/169625139-0a724b6e-e229-4fdd-bbc5-3ecd1f53b5aa.png)

Not complaining with assertion:
![image](https://user-images.githubusercontent.com/22963968/169625168-66a9c1d9-2576-4861-903d-61bcffc318f1.png)

