### PR TITLE
perf(streams): optimize pipeTo for resource backed streams

### DIFF
--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -4,7 +4,8 @@
 ((window) => {
   const core = window.Deno.core;
   const { BadResourcePrototype, InterruptedPrototype } = core;
-  const { WritableStream, readableStreamForRid } = window.__bootstrap.streams;
+  const { readableStreamForRid, writableStreamForRid } =
+    window.__bootstrap.streams;
   const {
     Error,
     ObjectPrototypeIsPrototypeOf,
@@ -71,31 +72,6 @@
     } catch {
       // Ignore errors
     }
-  }
-
-  function writableStreamForRid(rid) {
-    return new WritableStream({
-      async write(chunk, controller) {
-        try {
-          let nwritten = 0;
-          while (nwritten < chunk.length) {
-            nwritten += await write(
-              rid,
-              TypedArrayPrototypeSubarray(chunk, nwritten),
-            );
-          }
-        } catch (e) {
-          controller.error(e);
-          tryClose(rid);
-        }
-      },
-      close() {
-        tryClose(rid);
-      },
-      abort() {
-        tryClose(rid);
-      },
-    });
   }
 
   class Conn {

--- a/runtime/js/40_files.js
+++ b/runtime/js/40_files.js
@@ -6,8 +6,8 @@
   const { read, readSync, write, writeSync } = window.__bootstrap.io;
   const { ftruncate, ftruncateSync, fstat, fstatSync } = window.__bootstrap.fs;
   const { pathFromURL } = window.__bootstrap.util;
-  const { writableStreamForRid } = window.__bootstrap.streamUtils;
-  const { readableStreamForRid } = window.__bootstrap.streams;
+  const { readableStreamForRid, writableStreamForRid } =
+    window.__bootstrap.streams;
   const {
     ArrayPrototypeFilter,
     Error,

--- a/runtime/js/40_spawn.js
+++ b/runtime/js/40_spawn.js
@@ -15,7 +15,7 @@
     PromiseAll,
   } = window.__bootstrap.primordials;
   const { readableStreamForRid, writableStreamForRid } =
-    window.__bootstrap.streamUtils;
+    window.__bootstrap.streams;
 
   function spawnChild(command, {
     args = [],


### PR DESCRIPTION
https://github.com/denoland/deno/issues/13608

Uploading a 1000M file down from ~5s to ~2s
```
time curl -H "Content-Type:application/octet-stream" --data-binary @foo1000M.bin  http://127.0.0.1:8080/upload/foo.bin
upload complete!
________________________________________________________
Executed in    1.98 secs      fish           external
   usr time  157.90 millis    7.35 millis  150.55 millis
   sys time  360.99 millis    1.95 millis  359.04 millis
```