### PR TITLE
feat(ext/net): return [] when no DNS record found

### DIFF
--- a/cli/tests/testdata/resolve_dns.ts
+++ b/cli/tests/testdata/resolve_dns.ts
@@ -53,12 +53,6 @@ console.log(JSON.stringify(srv));
 console.log("TXT");
 console.log(JSON.stringify(txt));
 
-try {
-  await Deno.resolveDns("not-found-example.com", "A", nameServer);
-} catch (e) {
-  console.log(
-    `Error ${
-      e instanceof Error ? e.name : "[non-error]"
-    } thrown for not-found-example.com`,
-  );
-}
+const notFound = await Deno.resolveDns("not-found-example.com", "A", nameServer);
+console.log("Not found example")
+console.log(notFound)

--- a/cli/tests/testdata/resolve_dns.ts
+++ b/cli/tests/testdata/resolve_dns.ts
@@ -53,6 +53,10 @@ console.log(JSON.stringify(srv));
 console.log("TXT");
 console.log(JSON.stringify(txt));
 
-const notFound = await Deno.resolveDns("not-found-example.com", "A", nameServer);
-console.log("Not found example")
-console.log(notFound)
+const notFound = await Deno.resolveDns(
+  "not-found-example.com",
+  "A",
+  nameServer,
+);
+console.log("Not found example");
+console.log(notFound);

--- a/cli/tests/testdata/resolve_dns.ts.out
+++ b/cli/tests/testdata/resolve_dns.ts.out
@@ -22,4 +22,5 @@ SRV
 [{"priority":0,"weight":100,"port":1234,"target":"srv.example.com."}]
 TXT
 [["I","am","a","txt","record"],["I","am","another","txt","record"],["I am a different","txt record"],["key=val"]]
-Error NotFound thrown for not-found-example.com
+Not found example
+[]


### PR DESCRIPTION
This make `Deno.resolveDns` return empty `Vec<DnsReturnRecord>` instead throw an error when there're no records found for the name.

Closes #14695.