### PR TITLE
fix(coverage): do not report transpiled files with no lines 

### DIFF
--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -236,3 +236,76 @@ fn no_snaps_included(test_name: &str, extension: &str) {
 
   assert!(output.status.success());
 }
+
+#[test]
+fn no_transpiled_lines() {
+  let deno_dir = TempDir::new();
+  let tempdir = TempDir::new();
+  let tempdir = tempdir.path().join("cov");
+
+  let status = util::deno_cmd_with_deno_dir(&deno_dir)
+    .current_dir(util::testdata_path())
+    .arg("test")
+    .arg("--quiet")
+    .arg(format!("--coverage={}", tempdir.to_str().unwrap()))
+    .arg("coverage/no_transpiled_lines/")
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::inherit())
+    .status()
+    .unwrap();
+
+  assert!(status.success());
+
+  let output = util::deno_cmd_with_deno_dir(&deno_dir)
+    .current_dir(util::testdata_path())
+    .arg("coverage")
+    .arg(format!("{}/", tempdir.to_str().unwrap()))
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped())
+    .output()
+    .unwrap();
+
+  let actual =
+    util::strip_ansi_codes(std::str::from_utf8(&output.stdout).unwrap())
+      .to_string();
+
+  let expected = fs::read_to_string(
+    util::testdata_path().join("coverage/no_transpiled_lines/expected.out"),
+  )
+  .unwrap();
+
+  if !util::wildcard_match(&expected, &actual) {
+    println!("OUTPUT\n{}\nOUTPUT", actual);
+    println!("EXPECTED\n{}\nEXPECTED", expected);
+    panic!("pattern match failed");
+  }
+
+  assert!(output.status.success());
+
+  let output = util::deno_cmd_with_deno_dir(&deno_dir)
+    .current_dir(util::testdata_path())
+    .arg("coverage")
+    .arg("--lcov")
+    .arg(format!("{}/", tempdir.to_str().unwrap()))
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::inherit())
+    .output()
+    .unwrap();
+
+  let actual =
+    util::strip_ansi_codes(std::str::from_utf8(&output.stdout).unwrap())
+      .to_string();
+
+  let expected = fs::read_to_string(
+    util::testdata_path().join("coverage/no_transpiled_lines/expected.lcov"),
+  )
+  .unwrap();
+
+  if !util::wildcard_match(&expected, &actual) {
+    println!("OUTPUT\n{}\nOUTPUT", actual);
+    println!("EXPECTED\n{}\nEXPECTED", expected);
+    panic!("pattern match failed");
+  }
+
+  assert!(output.status.success());
+}

--- a/cli/tests/testdata/coverage/no_transpiled_lines/expected.lcov
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/expected.lcov
@@ -1,0 +1,12 @@
+SF:[WILDCARD]index.ts
+FNF:0
+FNH:0
+BRF:0
+BRH:0
+DA:1,1
+DA:2,1
+DA:3,1
+DA:5,1
+LH:4
+LF:4
+end_of_record

--- a/cli/tests/testdata/coverage/no_transpiled_lines/expected.out
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/expected.out
@@ -1,0 +1,1 @@
+cover [WILDCARD]index.ts ... 100.000% (4/4)

--- a/cli/tests/testdata/coverage/no_transpiled_lines/index.ts
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/index.ts
@@ -1,5 +1,5 @@
 export {
   assertStrictEquals,
-} from 'https://deno.land/std@0.139.0/testing/asserts.ts';
+} from "https://deno.land/std@0.139.0/testing/asserts.ts";
 
-export * from './interface.ts';
+export * from "./interface.ts";

--- a/cli/tests/testdata/coverage/no_transpiled_lines/index.ts
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/index.ts
@@ -1,0 +1,5 @@
+export {
+  assertStrictEquals,
+} from 'https://deno.land/std@0.139.0/testing/asserts.ts';
+
+export * from './interface.ts';

--- a/cli/tests/testdata/coverage/no_transpiled_lines/interface.ts
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/interface.ts
@@ -1,0 +1,3 @@
+export interface TestInterface {
+  id: string;
+}

--- a/cli/tests/testdata/coverage/no_transpiled_lines/repro_test.ts
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/repro_test.ts
@@ -1,7 +1,7 @@
-import { assertStrictEquals, TestInterface } from './index.ts';
+import { assertStrictEquals, TestInterface } from "./index.ts";
 
 Deno.test(function noTranspiledLines() {
-  const foo: TestInterface = { id: 'id' };
+  const foo: TestInterface = { id: "id" };
 
-  assertStrictEquals(foo.id, 'id');
+  assertStrictEquals(foo.id, "id");
 });

--- a/cli/tests/testdata/coverage/no_transpiled_lines/repro_test.ts
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/repro_test.ts
@@ -1,0 +1,7 @@
+import { assertStrictEquals, TestInterface } from './index.ts';
+
+Deno.test(function noTranspiledLines() {
+  const foo: TestInterface = { id: 'id' };
+
+  assertStrictEquals(foo.id, 'id');
+});

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -703,7 +703,7 @@ pub async fn cover_files(
       &out_mode,
     );
 
-    if coverage_report.found_lines.len() > 0 {
+    if !coverage_report.found_lines.is_empty() {
       reporter.report(&coverage_report, original_source)?;
     }
   }

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -703,7 +703,9 @@ pub async fn cover_files(
       &out_mode,
     );
 
-    reporter.report(&coverage_report, original_source)?;
+    if coverage_report.found_lines.len() > 0 {
+      reporter.report(&coverage_report, original_source)?;
+    }
   }
 
   reporter.done();


### PR DESCRIPTION
This commit omits files from the coverage report that have no lines of code to report coverage for.

Fixes: https://github.com/denoland/deno/issues/14683

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
