### PR TITLE
fix: deno task should actually use current exe for `deno` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9223e08fb55a947fba5aca83ed41adc3d3d61f6882795e4e0e960fd07cea79ca"
+checksum = "c7a9169a6b8b1134f98642104ebf9bce4a33f89d4a5acabc7896090e21ef9dc1"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ deno_doc = "0.35.0"
 deno_graph = "0.27.0"
 deno_lint = { version = "0.30.0", features = ["docs"] }
 deno_runtime = { version = "0.61.0", path = "../runtime" }
-deno_task_shell = "0.3.0"
+deno_task_shell = "0.3.1"
 
 atty = "=0.2.14"
 base64 = "=0.13.0"

--- a/cli/tests/integration/task_tests.rs
+++ b/cli/tests/integration/task_tests.rs
@@ -78,3 +78,10 @@ itest!(task_additional_args_no_logic {
   output: "task/task_additional_args_no_logic.out",
   envs: vec![("NO_COLOR".to_string(), "1".to_string())],
 });
+
+itest!(task_deno_exe_no_env {
+  args_vec: vec!["task", "-q", "--config", "task/deno.json", "deno_echo"],
+  output: "task/task_deno_exe_no_env.out",
+  envs: vec![("NO_COLOR".to_string(), "1".to_string())],
+  env_clear: true,
+});

--- a/cli/tests/testdata/task/deno.json
+++ b/cli/tests/testdata/task/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "boolean_logic": "sleep 0.1 && echo 3 && echo 4 & echo 1 && echo 2 || echo NOPE",
     "echo": "echo 1",
+    "deno_echo": "deno eval 'console.log(5)'",
     "strings": "deno run main.ts && deno eval \"console.log(\\\"test\\\")\"",
     "exit_code_5": "echo $(echo 10 ; exit 2) && exit 5"
   }

--- a/cli/tests/testdata/task/task_deno_exe_no_env.out
+++ b/cli/tests/testdata/task/task_deno_exe_no_env.out
@@ -1,0 +1,2 @@
+[WILDCARD]
+5

--- a/cli/tests/testdata/task/task_no_args.out
+++ b/cli/tests/testdata/task/task_no_args.out
@@ -1,6 +1,8 @@
 Available tasks:
 - boolean_logic
     sleep 0.1 && echo 3 && echo 4 & echo 1 && echo 2 || echo NOPE
+- deno_echo
+    deno eval 'console.log(5)'
 - echo
     echo 1
 - exit_code_5

--- a/cli/tests/testdata/task/task_non_existent.out
+++ b/cli/tests/testdata/task/task_non_existent.out
@@ -3,6 +3,8 @@ Task not found: non_existent
 Available tasks:
 - boolean_logic
     sleep 0.1 && echo 3 && echo 4 & echo 1 && echo 2 || echo NOPE
+- deno_echo
+    deno eval 'console.log(5)'
 - echo
     echo 1
 - exit_code_5

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1737,6 +1737,7 @@ pub struct CheckOutputIntegrationTest<'a> {
   pub exit_code: i32,
   pub http_server: bool,
   pub envs: Vec<(String, String)>,
+  pub env_clear: bool,
 }
 
 impl<'a> CheckOutputIntegrationTest<'a> {
@@ -1766,6 +1767,9 @@ impl<'a> CheckOutputIntegrationTest<'a> {
     println!("deno_exe args {}", self.args);
     println!("deno_exe testdata path {:?}", &testdata_dir);
     command.args(args.iter());
+    if self.env_clear {
+      command.env_clear();
+    }
     command.envs(self.envs.clone());
     command.current_dir(&testdata_dir);
     command.stdin(Stdio::piped());


### PR DESCRIPTION
Added an integration test this time.

Has https://github.com/denoland/deno_task_shell/pull/40/files

Closes #14702