### PR TITLE
perf(http): sync op_http_write_headers

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -237,7 +237,7 @@
           ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, respBody)
         );
         try {
-          await core.opAsync(
+          core.opSync(
             "op_http_write_headers",
             streamRid,
             innerResp.status ?? 200,


### PR DESCRIPTION
Cuts time spent in `op_http_write_headers` by half, ~700ns/call to ~300ns/call

Needs a few other related changes