### PR TITLE
fix(scripts/release): add unstable flag when running ./tools/format.js

### DIFF
--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -8,10 +8,6 @@ const repo = workspace.repo;
 const cliCrate = workspace.getCliCrate();
 const originalCliVersion = cliCrate.version;
 
-// update the std version used in the code
-console.log("Updating std version...");
-await updateStdVersion();
-
 // increment the cli version
 if (Deno.args.some((a) => a === "--patch")) {
   await cliCrate.increment("patch");
@@ -27,6 +23,10 @@ if (Deno.args.some((a) => a === "--patch")) {
 for (const crate of workspace.getCliDependencyCrates()) {
   await crate.increment("minor");
 }
+
+// update the std version used in the code
+console.log("Updating std version...");
+await updateStdVersion();
 
 // update the lock file
 await workspace.getCliCrate().cargoUpdate("--workspace");

--- a/tools/release/deno_workspace.ts
+++ b/tools/release/deno_workspace.ts
@@ -56,6 +56,7 @@ export class DenoWorkspace {
     return this.#repo.runCommandWithOutput([
       "deno",
       "run",
+      "--unstable",
       "--allow-write",
       "--allow-read",
       "--allow-run",


### PR DESCRIPTION
Need to use the unstable flag when launching ./tools/format.js

Closes #14739