### PR TITLE
chore(docs): use cross-platform example in deno.run jsdoc

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2432,7 +2432,7 @@ declare namespace Deno {
    *
    * ```ts
    * const p = Deno.run({
-   *   cmd: ["echo", "hello"], // Use ["pwsh", "-c", "echo", "hello"] on Windows.
+   *  cmd: ["curl", "https://example.com"],
    * });
    * const status = await p.status();
    * ```

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2432,7 +2432,7 @@ declare namespace Deno {
    *
    * ```ts
    * const p = Deno.run({
-   *  cmd: ["curl", "https://example.com"],
+   *   cmd: ["curl", "https://example.com"],
    * });
    * const status = await p.status();
    * ```

--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -2427,13 +2427,14 @@ declare namespace Deno {
     stdin?: "inherit" | "piped" | "null" | number;
   }
 
-  /** Spawns new subprocess.  RunOptions must contain at a minimum the `opt.cmd`,
+  /** Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
    * an array of program arguments, the first of which is the binary.
    *
    * ```ts
    * const p = Deno.run({
-   *   cmd: ["echo", "hello"],
+   *   cmd: ["echo", "hello"], // Use ["pwsh", "-c", "echo", "hello"] on Windows.
    * });
+   * const status = await p.status();
    * ```
    *
    * Subprocess uses same working directory as parent process unless `opt.cwd`


### PR DESCRIPTION
This PR changes the `Deno.run` JSDoc to use a `curl` example that works the same on all the major platforms. Also adds `await p.status` so the program doesn't exit before the output is shown on the terminal.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
