### PR TITLE
fix(lsp): handle get diagnostic errors better

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -752,25 +752,18 @@ delete Object.prototype.__proto__;
           /** @type {Record<string, any[]>} */
           const diagnosticMap = {};
           for (const specifier of request.specifiers) {
-            let diagnostics = [];
-            try {
-              diagnostics = [
-                ...languageService.getSemanticDiagnostics(specifier),
-                ...languageService.getSuggestionDiagnostics(specifier),
-                ...languageService.getSyntacticDiagnostics(specifier),
-              ];
-            } catch {
-              // just swallow errors here, as they are meaningless
-            }
-            diagnosticMap[specifier] = fromTypeScriptDiagnostic(
-              diagnostics.filter(({ code }) =>
-                !IGNORED_DIAGNOSTICS.includes(code)
-              ),
-            );
+            diagnosticMap[specifier] = fromTypeScriptDiagnostic([
+              ...languageService.getSemanticDiagnostics(specifier),
+              ...languageService.getSuggestionDiagnostics(specifier),
+              ...languageService.getSyntacticDiagnostics(specifier),
+            ].filter(({ code }) => !IGNORED_DIAGNOSTICS.includes(code)));
           }
           return respond(id, diagnosticMap);
         } catch (e) {
-          if (!(e instanceof OperationCanceledError)) {
+          if (
+            !(e instanceof OperationCanceledError ||
+              e instanceof ts.OperationCanceledException)
+          ) {
             if ("stack" in e) {
               error(e.stack);
             } else {

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -752,11 +752,21 @@ delete Object.prototype.__proto__;
           /** @type {Record<string, any[]>} */
           const diagnosticMap = {};
           for (const specifier of request.specifiers) {
-            diagnosticMap[specifier] = fromTypeScriptDiagnostic([
-              ...languageService.getSemanticDiagnostics(specifier),
-              ...languageService.getSuggestionDiagnostics(specifier),
-              ...languageService.getSyntacticDiagnostics(specifier),
-            ].filter(({ code }) => !IGNORED_DIAGNOSTICS.includes(code)));
+            let diagnostics = [];
+            try {
+              diagnostics = [
+                ...languageService.getSemanticDiagnostics(specifier),
+                ...languageService.getSuggestionDiagnostics(specifier),
+                ...languageService.getSyntacticDiagnostics(specifier),
+              ];
+            } catch {
+              // just swallow errors here, as they are meaningless
+            }
+            diagnosticMap[specifier] = fromTypeScriptDiagnostic(
+              diagnostics.filter(({ code }) =>
+                !IGNORED_DIAGNOSTICS.includes(code)
+              ),
+            );
           }
           return respond(id, diagnosticMap);
         } catch (e) {


### PR DESCRIPTION
This handles errors in `getDiagnostics` request where there are transient errors in getting the diagnostics which cause an output of:

```
ERROR TSLS = {}
```

In the debug console, which is distracting to users and doesn't impact the usage of the extension.  Also, when one specifier causes an issue, all requested specifiers get dropped, which isn't ideal.  This will handle the whole failure of getting diagnostics better.