### PR TITLE
refactor: Delete unused field from OpDecl

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -16,7 +16,6 @@ pub struct OpDecl {
   pub enabled: bool,
   pub is_async: bool, // TODO(@AaronO): enum sync/async/fast ?
   pub is_unstable: bool,
-  pub is_v8: bool,
 }
 
 impl OpDecl {

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -67,7 +67,10 @@ impl syn::parse::Parse for MacroArgs {
 #[proc_macro_attribute]
 pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
   let margs = syn::parse_macro_input!(attr as MacroArgs);
-  let MacroArgs { is_unstable, is_v8 } = margs;
+  let MacroArgs {
+    is_unstable,
+    is_v8: _,
+  } = margs;
   let func = syn::parse::<syn::ItemFn>(item).expect("expected a function");
   let name = &func.sig.ident;
   let generics = &func.sig.generics;
@@ -118,7 +121,6 @@ pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
           enabled: true,
           is_async: #is_async,
           is_unstable: #is_unstable,
-          is_v8: #is_v8,
         }
       }
 


### PR DESCRIPTION
This was user visible via .middleware, but it is not clear if that was
intentional.
