### PR TITLE
chore: Update devcontainer to a modern tag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+FROM mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye
 
 # Install Deno
 ENV DENO_INSTALL=/usr/local


### PR DESCRIPTION
It currently uses Debian 10 (buster) which is out of date