### PR TITLE
refactor(core): SourceMapGetter doesn't need Send + Sync

### DIFF
--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -7,7 +7,7 @@ pub use sourcemap::SourceMap;
 use std::collections::HashMap;
 use std::str;
 
-pub trait SourceMapGetter: Sync + Send {
+pub trait SourceMapGetter {
   /// Returns the raw source map file.
   fn get_source_map(&self, file_name: &str) -> Option<Vec<u8>>;
   fn get_source_line(


### PR DESCRIPTION
Removes unnecessary trait bounds for `SourceMapGetter` trait.