### PR TITLE
chore(scripts): always run workflows against Deno's most recent version.

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.22.2
+          deno-version: v1.x
 
       - name: Publish
         env:

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.22.2
+          deno-version: v1.x
 
       - name: Run version bump
         run: |


### PR DESCRIPTION
`denoland/setup-deno` allows to install the [most recent stable version](https://github.com/denoland/setup-deno#latest-stable-for-a-major).

It seems to me that it makes sense to use this here as:

1. this notation is already used across most `denoland` organization
2. this enforces always testing against the most stable version
3. frequent update of the wokflow files can be avoided
