### PR TITLE
feat(task): add `--cwd` flag for configuring the working directory

### DIFF
--- a/cli/tests/integration/task_tests.rs
+++ b/cli/tests/integration/task_tests.rs
@@ -12,6 +12,13 @@ itest!(task_no_args {
   exit_code: 1,
 });
 
+itest!(task_cwd {
+  args: "task -q --config task/deno.json --cwd .. echo_cwd",
+  output: "task/task_cwd.out",
+  envs: vec![("NO_COLOR".to_string(), "1".to_string())],
+  exit_code: 0,
+});
+
 itest!(task_non_existent {
   args: "task --config task/deno.json non_existent",
   output: "task/task_non_existent.out",

--- a/cli/tests/testdata/task/deno.json
+++ b/cli/tests/testdata/task/deno.json
@@ -5,6 +5,7 @@
     "deno_echo": "deno eval 'console.log(5)'",
     "strings": "deno run main.ts && deno eval \"console.log(\\\"test\\\")\"",
     "piped": "echo 12345 | (deno eval 'const b = new Uint8Array(1);Deno.stdin.readSync(b);console.log(b)' && deno eval 'const b = new Uint8Array(1);Deno.stdin.readSync(b);console.log(b)')",
-    "exit_code_5": "echo $(echo 10 ; exit 2) && exit 5"
+    "exit_code_5": "echo $(echo 10 ; exit 2) && exit 5",
+    "echo_cwd": "echo $(pwd)"
   }
 }

--- a/cli/tests/testdata/task/task_cwd.out
+++ b/cli/tests/testdata/task/task_cwd.out
@@ -1,0 +1,1 @@
+[WILDCARD]tests

--- a/cli/tests/testdata/task/task_no_args.out
+++ b/cli/tests/testdata/task/task_no_args.out
@@ -5,6 +5,8 @@ Available tasks:
     deno eval 'console.log(5)'
 - echo
     echo 1
+- echo_cwd
+    echo $(pwd)
 - exit_code_5
     echo $(echo 10 ; exit 2) && exit 5
 - piped

--- a/cli/tests/testdata/task/task_non_existent.out
+++ b/cli/tests/testdata/task/task_non_existent.out
@@ -7,6 +7,8 @@ Available tasks:
     deno eval 'console.log(5)'
 - echo
     echo 1
+- echo_cwd
+    echo $(pwd)
 - exit_code_5
     echo $(echo 10 ; exit 2) && exit 5
 - piped


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Fixes #14820

Adds a `--cwd` flag to `deno task` that can control the directory the task will be executed in
