### PR TITLE
feat(compat): Allow --compat to be used with bundle command

### DIFF
--- a/cli/compat/esm_resolver.rs
+++ b/cli/compat/esm_resolver.rs
@@ -25,6 +25,10 @@ impl NodeEsmResolver {
       maybe_import_map_resolver,
     }
   }
+
+  pub fn as_resolver(&self) -> &dyn Resolver {
+    self
+  }
 }
 
 impl Resolver for NodeEsmResolver {

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -715,6 +715,7 @@ glob {*_,*.,}bench.{js,mjs,ts,jsx,tsx}:
 
 fn bundle_subcommand<'a>() -> Command<'a> {
   compile_args(Command::new("bundle"))
+    .arg(compat_arg())
     .arg(
       Arg::new("source_file")
         .takes_value(true)
@@ -2207,6 +2208,7 @@ fn bench_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 
 fn bundle_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   compile_args_parse(flags, matches);
+  compat_arg_parse(flags, matches);
 
   let source_file = matches.value_of("source_file").unwrap().to_string();
 

--- a/cli/tests/integration/compat_tests.rs
+++ b/cli/tests/integration/compat_tests.rs
@@ -118,6 +118,13 @@ itest!(cjs_esm_interop_dynamic {
   envs: vec![("DENO_NODE_COMPAT_URL".to_string(), std_file_url())],
 });
 
+itest!(bundle_compat {
+  args: "bundle --unstable --compat compat/bundle_compat.js",
+  // Output should match input, don't include compat std in bundle:
+  output: "compat/bundle_compat.js",
+  exit_code: 0,
+});
+
 #[test]
 fn globals_in_repl() {
   let (out, _err) = util::run_and_collect_output_with_args(

--- a/cli/tests/testdata/compat/bundle_compat.js
+++ b/cli/tests/testdata/compat/bundle_compat.js
@@ -1,0 +1,3 @@
+import { readFile } from "fs/promises";
+
+console.log(await readFile("./test.txt"));


### PR DESCRIPTION
This is the second part of https://github.com/denoland/deno/issues/14846.

The test won't succeed yet, because while this PR allows for passing `--compat` now, the generated bundle contains Deno's `std/node` library, which I think should be omitted for this use case, so that the bundle will become runnable on a real Node runtime. This means leaving the imports to Node's built-ins unaltered in the generated bundle, but I haven't found out exactly how to accomplish this. A pointer by one of the Deno maintainers on how to achieve this would be appreciated. Thanks!

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
