### PR TITLE
feat(console): pass options and depth to custom inspects

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -884,7 +884,14 @@ Deno.test(async function consoleTestStringifyPromises() {
 
 Deno.test(function consoleTestWithCustomInspector() {
   class A {
-    [customInspect](): string {
+    [customInspect](
+      inspect: unknown,
+      options: Deno.InspectOptions,
+      depth: number,
+    ): string {
+      assertEquals(typeof inspect, "function");
+      assertEquals(typeof options, "object");
+      assertEquals(depth, 0);
       return "b";
     }
   }

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -335,7 +335,7 @@
       ReflectHas(value, customInspect) &&
       typeof value[customInspect] === "function"
     ) {
-      return String(value[customInspect](inspect));
+      return String(value[customInspect](inspect, inspectOptions, level));
     }
     // Might be Function/AsyncFunction/GeneratorFunction/AsyncGeneratorFunction
     let cstrName = ObjectGetPrototypeOf(value)?.constructor?.name;
@@ -1258,7 +1258,7 @@
       ReflectHas(value, customInspect) &&
       typeof value[customInspect] === "function"
     ) {
-      return String(value[customInspect](inspect));
+      return String(value[customInspect](inspect, inspectOptions, level));
     }
     // This non-unique symbol is used to support op_crates, ie.
     // in extensions/web we don't want to depend on public
@@ -1273,7 +1273,9 @@
       // inspect implementations in `extensions` need it, but may not have access
       // to the `Deno` namespace in web workers. Remove when the `Deno`
       // namespace is always enabled.
-      return String(value[privateCustomInspect](inspect));
+      return String(
+        value[privateCustomInspect](inspect, inspectOptions, level),
+      );
     }
     if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, value)) {
       return inspectError(value, maybeColor(colors.cyan, inspectOptions));


### PR DESCRIPTION
This commit updates `Deno.inspect()` to pass inspect options and
the current inspect depth to custom inspect functions.

Refs: https://github.com/denoland/deno/issues/8099
Refs: https://github.com/denoland/deno/issues/14171

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
