### PR TITLE
BREAKING: remove `Intl.v8BreakIterator`

### DIFF
--- a/cli/tests/unit/intl_test.ts
+++ b/cli/tests/unit/intl_test.ts
@@ -2,6 +2,6 @@
 import { assertEquals } from "./test_util.ts";
 
 Deno.test("Intl.v8BreakIterator should be undefined", () => {
-  // @ts-expect-error
+  // @ts-expect-error Intl.v8BreakIterator is not a standard API
   assertEquals(Intl.v8BreakIterator, undefined);
 });

--- a/cli/tests/unit/intl_test.ts
+++ b/cli/tests/unit/intl_test.ts
@@ -1,0 +1,7 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "./test_util.ts";
+
+Deno.test("Intl.v8BreakIterator should be undefined", () => {
+  // @ts-expect-error
+  assertEquals(Intl.v8BreakIterator, undefined);
+});

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1,9 +1,12 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+"use strict";
+
 // Removes the `__proto__` for security reasons.  This intentionally makes
 // Deno non compliant with ECMA-262 Annex B.2.2.1
-//
-"use strict";
 delete Object.prototype.__proto__;
+
+// Remove Intl.v8BreakIterator because it is a non-standard API.
+delete Intl.v8BreakIterator;
 
 ((window) => {
   const core = Deno.core;


### PR DESCRIPTION
This is a non-standard API that is mostly replaced by `Intl.Segmenter`.
