### PR TITLE
refactor(runtime/signal): revert SIGINT and SIGBREAK `Deno.kill` Windows changes

### DIFF
--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -204,10 +204,10 @@ Deno.test(
   function windowsThrowsOnNegativeProcessIdTest() {
     assertThrows(
       () => {
-        Deno.kill(-1, "SIGINT");
+        Deno.kill(-1, "SIGKILL");
       },
       TypeError,
-      "Invalid process id (pid) -1 for signal SIGINT.",
+      "Invalid pid",
     );
   },
 );
@@ -225,7 +225,7 @@ Deno.test(
         Deno.kill(0, signal);
       },
       TypeError,
-      `Cannot use ${signal} on PID 0`,
+      `Invalid pid`,
     );
 
     signal = "SIGTERM";
@@ -234,7 +234,7 @@ Deno.test(
         Deno.kill(0, signal);
       },
       TypeError,
-      `Cannot use ${signal} on PID 0`,
+      `Invalid pid`,
     );
   },
 );


### PR DESCRIPTION
Reverts the `Deno.kill` changes in https://github.com/denoland/deno/pull/14694/files

FYI @GJZwiers - I tried to [add some tests](https://gist.github.com/dsherret/89d05d333bb8dca3475b257d48bec269) for that PR, but got unexpected behaviour due to: https://github.com/denoland/deno/pull/14694/files#r885888645 so I think we should revert the `Deno.kill` changes in that PR for now.

Opened #14866