### PR TITLE
fix(url): properly indent when inspecting URLs

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2704,3 +2704,8 @@ itest!(error_name_non_string {
   output: "error_name_non_string.js.out",
   exit_code: 1,
 });
+
+itest!(custom_inspect_url {
+  args: "run custom_inspect_url.js",
+  output: "custom_inspect_url.js.out",
+});

--- a/cli/tests/testdata/custom_inspect_url.js
+++ b/cli/tests/testdata/custom_inspect_url.js
@@ -1,0 +1,3 @@
+console.log([new URL("https://example.com/path")]);
+console.log({ url: new URL("https://example.com/path") });
+console.log({ url: [new URL("https://example.com/path")] });

--- a/cli/tests/testdata/custom_inspect_url.js.out
+++ b/cli/tests/testdata/custom_inspect_url.js.out
@@ -1,0 +1,47 @@
+[
+  URL {
+    href: "https://example.com/path",
+    origin: "https://example.com",
+    protocol: "https:",
+    username: "",
+    password: "",
+    host: "example.com",
+    hostname: "example.com",
+    port: "",
+    pathname: "/path",
+    hash: "",
+    search: ""
+  }
+]
+{
+  url: URL {
+    href: "https://example.com/path",
+    origin: "https://example.com",
+    protocol: "https:",
+    username: "",
+    password: "",
+    host: "example.com",
+    hostname: "example.com",
+    port: "",
+    pathname: "/path",
+    hash: "",
+    search: ""
+  }
+}
+{
+  url: [
+    URL {
+      href: "https://example.com/path",
+      origin: "https://example.com",
+      protocol: "https:",
+      username: "",
+      password: "",
+      host: "example.com",
+      hostname: "example.com",
+      port: "",
+      pathname: "/path",
+      hash: "",
+      search: ""
+    }
+  ]
+}

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -887,11 +887,9 @@ Deno.test(function consoleTestWithCustomInspector() {
     [customInspect](
       inspect: unknown,
       options: Deno.InspectOptions,
-      depth: number,
     ): string {
       assertEquals(typeof inspect, "function");
       assertEquals(typeof options, "object");
-      assertEquals(depth, 0);
       return "b";
     }
   }

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -322,7 +322,7 @@
       this[_url] = opUrlParse(url, base);
     }
 
-    [SymbolFor("Deno.privateCustomInspect")](inspect) {
+    [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
       const object = {
         href: this.href,
         origin: this.origin,
@@ -336,7 +336,7 @@
         hash: this.hash,
         search: this.search,
       };
-      return `${this.constructor.name} ${inspect(object)}`;
+      return `${this.constructor.name} ${inspect(object, inspectOptions)}`;
     }
 
     #updateSearchParams() {


### PR DESCRIPTION
This PR contains two commits, which I think should land separately (unsquashed):

##### fix(console): constrol inspect() indent with option

This commit updates the `Deno.inspect()` logic to use the
(currently unused) `indentLevel` option to control indentation instead
of passing around separate indent/level parameters internally.

Refs: https://github.com/denoland/deno/issues/8099
Refs: https://github.com/denoland/deno/issues/14171

##### fix(url): properly indent when inspecting URLs

This commit updates the custom inspect function for URL objects
to pass the inspect options through so that the context is
propagated and the resulting indentation is correct.

Fixes: https://github.com/denoland/deno/issues/14171

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
