### PR TITLE
chore(cli/cache): Remove CacheType::Declaration

### DIFF
--- a/cli/cache.rs
+++ b/cli/cache.rs
@@ -23,7 +23,6 @@ pub struct EmitMetadata {
 }
 
 pub enum CacheType {
-  Declaration,
   Emit,
   SourceMap,
   TypeScriptBuildInfo,
@@ -181,7 +180,6 @@ impl Cacher for FetchCacher {
     specifier: &ModuleSpecifier,
   ) -> Option<String> {
     let extension = match cache_type {
-      CacheType::Declaration => "d.ts",
       CacheType::Emit => "js",
       CacheType::SourceMap => "js.map",
       CacheType::TypeScriptBuildInfo => "buildinfo",
@@ -206,7 +204,6 @@ impl Cacher for FetchCacher {
     value: String,
   ) -> Result<(), AnyError> {
     let extension = match cache_type {
-      CacheType::Declaration => "d.ts",
       CacheType::Emit => "js",
       CacheType::SourceMap => "js.map",
       CacheType::TypeScriptBuildInfo => "buildinfo",

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -443,11 +443,6 @@ pub fn check_and_maybe_emit(
           MediaType::SourceMap => {
             cache.set(CacheType::SourceMap, &specifier, emit.data)?;
           }
-          // this only occurs with the runtime emit, but we are using the same
-          // code paths, so we handle it here.
-          MediaType::Dts | MediaType::Dcts | MediaType::Dmts => {
-            cache.set(CacheType::Declaration, &specifier, emit.data)?;
-          }
           _ => unreachable!(
             "unexpected media_type {} {}",
             emit.media_type, specifier

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -81,7 +81,6 @@
     "op_dgram_recv": ["receive a datagram message", "awaiting the result of `Deno.DatagramConn#receive` call, or not breaking out of a for await loop looping over a `Deno.DatagramConn`"],
     "op_dgram_send": ["send a datagram message", "awaiting the result of `Deno.DatagramConn#send` call"],
     "op_dns_resolve": ["resolve a DNS name", "awaiting the result of a `Deno.resolveDns` call"],
-    "op_emit": ["transpile code", "awaiting the result of a `Deno.emit` call"],
     "op_fdatasync_async": ["flush pending data operations for a file to disk", "awaiting the result of a `Deno.fdatasync` call"],
     "op_fetch_send": ["send a HTTP request", "awaiting the result of a `fetch` call"],
     "op_ffi_call_nonblocking": ["do a non blocking ffi call", "awaiting the returned promise"] ,


### PR DESCRIPTION
Dead code from `Deno.emit()` removal