### PR TITLE
fix(docs): update description of `--check` flag

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -234,12 +234,12 @@ impl Default for DenoSubcommand {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeCheckMode {
-  /// Type check all modules.
+  /// type-check all modules.
   All,
-  /// Skip type checking of all modules. The default value for "deno run" and
+  /// Skip type-checking of all modules. The default value for "deno run" and
   /// several other subcommands.
   None,
-  /// Only type check local modules. The default value for "deno test" and
+  /// Only type-check local modules. The default value for "deno test" and
   /// several other subcommands.
   Local,
 }
@@ -1486,7 +1486,7 @@ fn test_subcommand<'a>() -> Command<'a> {
     .arg(
       Arg::new("doc")
         .long("doc")
-        .help("UNSTABLE: type check code blocks")
+        .help("UNSTABLE: type-check code blocks")
         .takes_value(false),
     )
     .arg(
@@ -2023,7 +2023,7 @@ fn no_check_arg<'a>() -> Arg<'a> {
     .min_values(0)
     .value_name("NO_CHECK_TYPE")
     .long("no-check")
-    .help("Skip type checking modules")
+    .help("Skip type-checking modules")
     .long_help(
       "Skip type-checking. If the value of '--no-check=remote' is supplied, \
       diagnostic errors from remote modules will be ignored.",
@@ -2038,7 +2038,7 @@ fn check_arg<'a>() -> Arg<'a> {
     .require_equals(true)
     .min_values(0)
     .value_name("CHECK_TYPE")
-    .help("Type check modules")
+    .help("type-check modules")
     .long_help(
       "Type-check modules.
 

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -2040,9 +2040,10 @@ fn check_arg<'a>() -> Arg<'a> {
     .value_name("CHECK_TYPE")
     .help("Type check modules")
     .long_help(
-      "Type check modules.
-Currently this is a default behavior to type check modules, but in future releases
-Deno will not automatically type check without the --check flag.
+      "Type-check modules.
+
+Deno does not type-check modules automatically from v1.23 onwards. Pass this \
+flag to enable type-checking or use the 'deno check' subcommand.
 
 If the value of '--check=all' is supplied, diagnostic errors from remote modules
 will be included.",

--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -234,7 +234,7 @@ impl Default for DenoSubcommand {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeCheckMode {
-  /// type-check all modules.
+  /// Type-check all modules.
   All,
   /// Skip type-checking of all modules. The default value for "deno run" and
   /// several other subcommands.
@@ -2038,7 +2038,7 @@ fn check_arg<'a>() -> Arg<'a> {
     .require_equals(true)
     .min_values(0)
     .value_name("CHECK_TYPE")
-    .help("type-check modules")
+    .help("Type-check modules")
     .long_help(
       "Type-check modules.
 


### PR DESCRIPTION
Fixes #14889. Updates help text for `--check` with the new behaviour.

Edit: I changed the spelling to type-check/type-checking which is consistent with what is used over at [typescript](https://www.typescriptlang.org/docs/handbook/2/basic-types.html#static-type-checking).
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
