### PR TITLE
BREAKING(cli): remove version from navigator.userAgent

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -587,7 +587,7 @@ Deno.test({ permissions: { net: true } }, async function fetchUserAgent() {
     method: "POST",
     body: new TextEncoder().encode(data),
   });
-  assertEquals(response.headers.get("user-agent"), `Deno/${Deno.version.deno}`);
+  assertEquals(response.headers.get("user-agent"), "Deno");
   await response.text();
 });
 
@@ -643,7 +643,7 @@ Deno.test(
       "hello: World\r\n",
       "foo: Bar\r\n",
       "accept: */*\r\n",
-      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      `user-agent: Deno\r\n`,
       "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n\r\n`,
     ].join("");
@@ -678,7 +678,7 @@ Deno.test(
       "foo: Bar\r\n",
       "content-type: text/plain;charset=UTF-8\r\n",
       "accept: */*\r\n",
-      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      `user-agent: Deno\r\n`,
       "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n`,
       `content-length: ${body.length}\r\n\r\n`,
@@ -715,7 +715,7 @@ Deno.test(
       "hello: World\r\n",
       "foo: Bar\r\n",
       "accept: */*\r\n",
-      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      `user-agent: Deno\r\n`,
       "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n`,
       `content-length: ${body.byteLength}\r\n\r\n`,
@@ -1031,7 +1031,7 @@ Deno.test(
     });
     assertEquals(
       response.headers.get("user-agent"),
-      `Deno/${Deno.version.deno}`,
+      "Deno",
     );
     await response.text();
     client.close();
@@ -1072,7 +1072,7 @@ Deno.test(
       "hello: World\r\n",
       "foo: Bar\r\n",
       "accept: */*\r\n",
-      `user-agent: Deno/${Deno.version.deno}\r\n`,
+      `user-agent: Deno\r\n`,
       "accept-encoding: gzip, br\r\n",
       `host: ${addr}\r\n`,
       `transfer-encoding: chunked\r\n\r\n`,
@@ -1247,7 +1247,7 @@ Deno.test(
     });
     assertEquals(
       response.headers.get("user-agent"),
-      `Deno/${Deno.version.deno}`,
+      "Deno",
     );
     await response.text();
     client.close();

--- a/cli/tests/unit/navigator_test.ts
+++ b/cli/tests/unit/navigator_test.ts
@@ -6,6 +6,5 @@ Deno.test(function navigatorNumCpus() {
 });
 
 Deno.test(function navigatorUserAgent() {
-  const pattern = /Deno\/\d+\.\d+\.\d+/;
-  assert(pattern.test(navigator.userAgent));
+  assert(navigator.userAgent === "Deno");
 });

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -15,5 +15,5 @@ pub fn is_canary() -> bool {
 }
 
 pub fn get_user_agent() -> String {
-  format!("Deno/{}", deno())
+  "Deno".to_string()
 }


### PR DESCRIPTION
This commit removes the version portion of the `navigator.userAgent` string. As discussed in the WinterCG, version information should use `navigator.userAgentData`.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
