### PR TITLE
refactor: make MainWorker::evaluate_module public

### DIFF
--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -236,7 +236,11 @@ impl MainWorker {
     }
   }
 
-  async fn evaluate_module(&mut self, id: ModuleId) -> Result<(), AnyError> {
+  /// Executes specified JavaScript module.
+  pub async fn evaluate_module(
+    &mut self,
+    id: ModuleId,
+  ) -> Result<(), AnyError> {
     let mut receiver = self.js_runtime.mod_evaluate(id);
     tokio::select! {
       // Not using biased mode leads to non-determinism for relatively simple


### PR DESCRIPTION
I noticed that it's not possible to pass any source code as a string to `execute_main_module`. That means I end up reimplementing the code inside it with slightly different params (passing code to `load_main_module` instead
of None). That's mostly trivial except for `evaluate_module`, which is currently private. Making it public allows to load modules from strings without copying any code.

Alternatively, I might add a param to `execute_main_module` and `preload_module` but that would break backward compat, which is something I wanted to avoid.

Happy to add a test if you think this change is acceptable.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
