### PR TITLE
perf(ext/web): optimize for single pass utf8 decoding

### DIFF
--- a/cli/tests/unit/buffer_test.ts
+++ b/cli/tests/unit/buffer_test.ts
@@ -456,6 +456,6 @@ Deno.test(function testThrowsErrorWhenBufferExceedsMaxLength() {
       new TextDecoder().decode(bytes);
     },
     TypeError,
-    "buffer exceeds maximum length",
+    "The string is too long to decode",
   );
 });

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -240,7 +240,7 @@ fn op_encode<'a>(
 fn op_decode<'a>(
   scope: &mut v8::HandleScope<'a>,
   zero_copy: ZeroCopyBuf,
-  ignore_bom: Option<bool>,
+  ignore_bom: Option<()>,
 ) -> Result<serde_v8::Value<'a>, Error> {
   let buf = &zero_copy;
 

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -240,16 +240,21 @@ fn op_encode<'a>(
 fn op_decode<'a>(
   scope: &mut v8::HandleScope<'a>,
   zero_copy: ZeroCopyBuf,
+  ignore_bom: Option<bool>,
 ) -> Result<serde_v8::Value<'a>, Error> {
   let buf = &zero_copy;
 
   // Strip BOM
-  let buf =
-    if buf.len() >= 3 && buf[0] == 0xef && buf[1] == 0xbb && buf[2] == 0xbf {
-      &buf[3..]
-    } else {
-      buf
-    };
+  let buf = if ignore_bom.is_some()
+    && buf.len() >= 3
+    && buf[0] == 0xef
+    && buf[1] == 0xbb
+    && buf[2] == 0xbf
+  {
+    &buf[3..]
+  } else {
+    buf
+  };
 
   // If `String::new_from_utf8()` returns `None`, this means that the
   // length of the decoded string would be longer than what V8 can

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -135,7 +135,7 @@
               return core.decode(input, this.#ignoreBOM);
             } catch (_) {
               // RangeError is thrown if input exceeds the maximum length.
-              throw new TypeError("buffer exceeds maximum length");
+              throw new TypeError("The string is too long to decode");
             }
           }
 
@@ -143,8 +143,8 @@
             "op_encoding_decode_single",
             input,
             this.#encoding,
-            this.#fatal,
             this.#ignoreBOM,
+            this.#fatal,
           );
         }
 

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -134,7 +134,7 @@
               return core.decode(input, this.#ignoreBOM);
             } catch (e) {
               // RangeError is thrown if input exceeds the maximum length.
-              throw new TypeError("buffer exxceeds maximum length");
+              throw new TypeError("buffer exceeds maximum length");
             }
           }
 

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -58,7 +58,7 @@
       this.#fatal = options.fatal;
       this.#ignoreBOM = options.ignoreBOM;
       this.#singlePassUTF8 = this.#encoding === "utf-8" &&
-        this.#fatal === false && this.#ignoreBOM === false;
+        this.#fatal === false;
       this[webidl.brand] = webidl.brand;
     }
 
@@ -130,7 +130,12 @@
         // Optimize for the common case of decoding single utf-8 input.
         if (!options.stream && this.#rid === null) {
           if (this.#singlePassUTF8 === true) {
-            return core.decode(input);
+            try {
+              return core.decode(input, this.#ignoreBOM);
+            } catch (e) {
+              // RangeError is thrown if input exceeds the maximum length.
+              throw new TypeError("buffer exxceeds maximum length");
+            }
           }
 
           return core.opSync(

--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -23,6 +23,7 @@
     StringPrototypeSlice,
     TypedArrayPrototypeSubarray,
     TypedArrayPrototypeSlice,
+    TypeError,
     Uint8Array,
   } = window.__bootstrap.primordials;
 
@@ -132,7 +133,7 @@
           if (this.#singlePassUTF8 === true) {
             try {
               return core.decode(input, this.#ignoreBOM);
-            } catch (e) {
+            } catch (_) {
               // RangeError is thrown if input exceeds the maximum length.
               throw new TypeError("buffer exceeds maximum length");
             }

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -217,14 +217,10 @@ fn op_encoding_normalize_label(label: String) -> Result<String, AnyError> {
 #[op]
 fn op_encoding_decode_single(
   data: ZeroCopyBuf,
-  options: DecoderOptions,
+  label: String,
+  ignore_bom: bool,
+  fatal: bool,
 ) -> Result<U16String, AnyError> {
-  let DecoderOptions {
-    label,
-    ignore_bom,
-    fatal,
-  } = options;
-
   let encoding = Encoding::for_label(label.as_bytes()).ok_or_else(|| {
     range_error(format!(
       "The encoding label provided ('{}') is invalid.",

--- a/serde_v8/magic/v8slice.rs
+++ b/serde_v8/magic/v8slice.rs
@@ -71,7 +71,9 @@ pub(crate) fn to_ranged_buffer<'s>(
   value: v8::Local<v8::Value>,
 ) -> Result<(v8::Local<'s, v8::ArrayBuffer>, Range<usize>), v8::DataError> {
   if value.is_array_buffer_view() {
-    let view: v8::Local<v8::ArrayBufferView> = value.try_into()?;
+    // SAFETY: is_array_buffer_view() check above
+    let view: v8::Local<v8::ArrayBufferView> =
+      unsafe { v8::Local::cast(value) };
     let (offset, len) = (view.byte_offset(), view.byte_length());
     let buffer = view.buffer(scope).ok_or(v8::DataError::NoData {
       expected: "view to have a buffer",


### PR DESCRIPTION
This commit implements a fast path for
decoding common non-streaming utf8
input data.

Benchmark results for decoding a 145MB 
CSV file using 1024 bytes as chunk size:
```
# This patch
{
  opsDispatched: 18635836,
  opsDispatchedSync: 18500048,
  opsDispatchedAsync: 135788,
  opsDispatchedAsyncUnref: 0,
  opsCompleted: 18635836,
  opsCompletedSync: 18500048,
  opsCompletedAsync: 135788,
  opsCompletedAsyncUnref: 0,
  bytesSentControl: 0,
  bytesSentData: 0,
  bytesReceived: 0
}
Read 500001 lines for 8.201 seconds

# Deno 1.23.0
{
  opsDispatched: 18635836,
  opsDispatchedSync: 18500048,
  opsDispatchedAsync: 135788,
  opsDispatchedAsyncUnref: 0,
  opsCompleted: 18635836,
  opsCompletedSync: 18500048,
  opsCompletedAsync: 135788,
  opsCompletedAsyncUnref: 0,
  bytesSentControl: 0,
  bytesSentData: 0,
  bytesReceived: 0
}
Read 500001 lines for 16.362 seconds
```

1024 * 1024 bytes chunk size:
```
# This patch
{
  opsDispatched: 18500183,
  opsDispatchedSync: 18500048,
  opsDispatchedAsync: 135,
  opsDispatchedAsyncUnref: 0,
  opsCompleted: 18500183,
  opsCompletedSync: 18500048,
  opsCompletedAsync: 135,
  opsCompletedAsyncUnref: 0,
  bytesSentControl: 0,
  bytesSentData: 0,
  bytesReceived: 0
}
Read 500001 lines for 11.447 seconds

# Deno 1.23.0
{
  opsDispatched: 18500183,
  opsDispatchedSync: 18500048,
  opsDispatchedAsync: 135,
  opsDispatchedAsyncUnref: 0,
  opsCompleted: 18500183,
  opsCompletedSync: 18500048,
  opsCompletedAsync: 135,
  opsCompletedAsyncUnref: 0,
  bytesSentControl: 0,
  bytesSentData: 0,
  bytesReceived: 0
}
Read 500001 lines for 20.987 seconds
```

Fixes #14893