### PR TITLE
add missing `use serde_v8;` (one line change)

### DIFF
--- a/core/examples/eval_js_value.rs
+++ b/core/examples/eval_js_value.rs
@@ -9,6 +9,7 @@
 use deno_core::v8;
 use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
+use serde_v8;
 
 fn main() {
   let mut runtime = JsRuntime::new(RuntimeOptions::default());


### PR DESCRIPTION
```
40 |             let deserialized_value = serde_v8::from_v8::<serde_json::Value>(scope, local);
    |                                      ^^^^^^^^ use of undeclared crate or module `serde_v8`
```