### PR TITLE
docs(lsp): correct header name in comments

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -574,7 +574,7 @@ struct DiagnosticDataRedirect {
 
 /// An enum which represents diagnostic errors which originate from Deno itself.
 pub enum DenoDiagnostic {
-  /// A `x-deno-warn` is associated with the specifier and should be displayed
+  /// A `x-deno-warning` is associated with the specifier and should be displayed
   /// as a warning to the user.
   DenoWarn(String),
   /// The import assertion type is incorrect.
@@ -763,7 +763,7 @@ fn diagnose_dependency(
       specifier, range, ..
     } => {
       let range = documents::to_lsp_range(range);
-      // If the module is a remote module and has a `X-Deno-Warn` header, we
+      // If the module is a remote module and has a `X-Deno-Warning` header, we
       // want a warning diagnostic with that message.
       if let Some(metadata) = cache_metadata.get(specifier) {
         if let Some(message) =


### PR DESCRIPTION
The comments refer to the header `x-deno-warn`, but [the actual header name](https://github.com/denoland/deno/blob/53dac7451bbdd527aa91e01653b678547624fc39/cli/lsp/cache.rs#L142) is `x-deno-warning`.