### PR TITLE
fix(repl): Accept tab when previous character is space

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -804,3 +804,25 @@ fn pty_clear_function() {
     assert!(output.contains("3234"));
   });
 }
+
+#[test]
+fn pty_tab_handler() {
+  // If the last character is **not** whitespace, we show the completions
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line("a\t\t");
+    console.write_line("close();");
+    let output = console.read_all_output();
+    assert!(output.contains("addEventListener"));
+    assert!(output.contains("alert"));
+    assert!(output.contains("atob"));
+  });
+  // If the last character is whitespace, we just insert a tab
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line("a \t\t"); // last character is whitespace
+    console.write_line("close();");
+    let output = console.read_all_output();
+    assert!(!output.contains("addEventListener"));
+    assert!(!output.contains("alert"));
+    assert!(!output.contains("atob"));
+  });
+}

--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -397,6 +397,11 @@ impl ReplEditor {
   }
 }
 
+/// A custom tab key event handler
+/// It uses a heuristic to determine if the user is requesting completion or if they want to insert an actual tab
+/// The heuristic goes like this:
+///   - If the last character before the cursor is whitespace, the the user wants to insert a tab
+///   - Else the user is requesting completion
 struct TabEventHandler;
 impl ConditionalEventHandler for TabEventHandler {
   fn handle(


### PR DESCRIPTION
This adds a heuristic that allows tabbing, if the user hits tab and the previous character on the line is white space he's most likely asking for an actual tab not completion.
Python repl for example does this.


https://user-images.githubusercontent.com/22427111/174358649-64c58ee3-5670-4583-ba44-44ceb31ac6e0.mov

