### PR TITLE
fix: do not panic running .d.cts and .d.mts files

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2709,3 +2709,26 @@ itest!(custom_inspect_url {
   args: "run custom_inspect_url.js",
   output: "custom_inspect_url.js.out",
 });
+
+#[test]
+fn running_declaration_files() {
+  let temp_dir = TempDir::new();
+  let files = vec![
+    "file.d.ts",
+    "file.d.cts",
+    "file.d.mts",
+  ];
+
+  for file in files {
+    temp_dir.write(file, "");
+    let mut deno_cmd = util::deno_cmd_with_deno_dir(&temp_dir);
+    let output = deno_cmd
+      .current_dir(temp_dir.path())
+      .args(["run", file])
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+    assert!(output.status.success());
+  }
+}


### PR DESCRIPTION
There was a match clause that was not correct, probably due to these being added and this code previously not throwing an error, so moved away from `_ =>` matching here too.