### PR TITLE
feat(ext/ffi): BREAKING(unstable): Simplify FFI types

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -360,7 +360,7 @@ declare namespace Deno {
     | NativePointerType
     | NativeFunctionType;
 
-  type NativeResultType = NativeType | NativeVoidType;
+  export type NativeResultType = NativeType | NativeVoidType;
 
   /** Type conversion for foreign symbol parameters and unsafe callback return types */
   type ToNativeType<T extends NativeType = NativeType> = T extends

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -329,32 +329,86 @@ declare namespace Deno {
    */
   export function getGid(): number | null;
 
-  /** All possible types for interfacing with foreign functions */
-  export type NativeType =
-    | "void"
+  /** All plain number types for interfacing with foreign functions */
+  type NativeNumberType =
     | "u8"
     | "i8"
     | "u16"
     | "i16"
     | "u32"
     | "i32"
+    | "f32"
+    | "f64";
+
+  /** All BigInt number type sfor interfacing with foreign functions */
+  type NativeBigIntType =
     | "u64"
     | "i64"
     | "usize"
-    | "isize"
-    | "f32"
-    | "f64"
-    | "pointer";
+    | "isize";
 
-  type NativeParameterType =
-    | NativeType
-    | NativeCallbackType;
+  type NativePointerType = "pointer";
+
+  type NativeFunctionType = "function";
+
+  type NativeVoidType = "void";
+
+  /** All possible types for interfacing with foreign functions */
+  export type NativeType =
+    | NativeNumberType
+    | NativeBigIntType
+    | NativePointerType
+    | NativeFunctionType;
+
+  type NativeResultType = NativeType | NativeVoidType;
+
+  /** Type conversion for foreign symbol parameters and unsafe callback return types */
+  type ToNativeType<T extends NativeType = NativeType> = T extends
+    NativeNumberType ? number
+    : T extends NativeBigIntType ? bigint | number
+    : T extends NativePointerType ? TypedArray | bigint | null
+    : T extends NativeFunctionType ? bigint | null
+    : never;
+
+  /** Type conversion for unsafe callback return types */
+  type ToNativeResultType<T extends NativeResultType = NativeResultType> =
+    T extends NativeType ? ToNativeType<T>
+      : T extends NativeVoidType ? void
+      : never;
+
+  type ToNativeParameterTypes<T extends readonly NativeType[]> = T extends
+    readonly [] ? []
+    : T extends readonly [
+      infer U extends NativeType,
+      ...(infer V extends NativeType[]),
+    ] ? [ToNativeType<U>, ...ToNativeParameterTypes<V>]
+    : never;
+
+  /** Type conversion for foreign symbol return types and unsafe callback parameters */
+  type FromNativeType<T extends NativeType = NativeType> = T extends
+    NativeNumberType ? number
+    : T extends NativeBigIntType | NativePointerType | NativeFunctionType
+      ? bigint
+    : never;
+
+  /** Type conversion for foregin symbol return types */
+  type FromNativeResultType<T extends NativeResultType = NativeResultType> =
+    T extends NativeType ? FromNativeType<T>
+      : T extends NativeVoidType ? void
+      : never;
+
+  type FromNativeParameterTypes<T extends readonly NativeType[]> = T extends
+    readonly [] ? []
+    : T extends readonly [
+      infer U extends NativeType,
+      ...(infer V extends NativeType[]),
+    ] ? [FromNativeType<U>, ...FromNativeParameterTypes<V>]
+    : never;
 
   /** A foreign function as defined by its parameter and result types */
   export interface ForeignFunction<
-    Parameters extends readonly NativeParameterType[] =
-      readonly NativeParameterType[],
-    Result extends NativeType = NativeType,
+    Parameters extends readonly NativeType[] = readonly NativeType[],
+    Result extends NativeResultType = NativeResultType,
     NonBlocking extends boolean = boolean,
   > {
     /** Name of the symbol, defaults to the key name in symbols object. */
@@ -368,7 +422,7 @@ declare namespace Deno {
   export interface ForeignStatic<Type extends NativeType = NativeType> {
     /** Name of the symbol, defaults to the key name in symbols object. */
     name?: string;
-    type: Exclude<Type, "void">;
+    type: Type;
   }
 
   /** A foreign library interface descriptor */
@@ -376,49 +430,20 @@ declare namespace Deno {
     [name: string]: ForeignFunction | ForeignStatic;
   }
 
-  /** All possible number types interfacing with foreign functions */
-  type StaticNativeNumberType = Exclude<
-    NativeType,
-    "void" | "pointer" | StaticNativeBigIntType
-  >;
-
-  /** All possible bigint types interfacing with foreign functions */
-  type StaticNativeBigIntType = "u64" | "i64" | "usize" | "isize";
-
-  /** Infers a foreign function return type */
-  type StaticForeignFunctionResult<T extends NativeType> = T extends "void"
-    ? void
-    : T extends StaticNativeBigIntType ? bigint
-    : T extends StaticNativeNumberType ? number
-    : T extends "pointer" ? bigint
-    : never;
-
-  type StaticForeignFunctionParameter<T> = T extends "void" ? void
-    : T extends StaticNativeNumberType | StaticNativeBigIntType
-      ? number | bigint
-    : T extends "pointer" ? bigint | TypedArray | null
-    : T extends NativeCallbackType ? bigint | null
-    : unknown;
-
-  /** Infers a foreign function parameter list. */
-  type StaticForeignFunctionParameters<
-    T extends readonly NativeParameterType[],
-  > = [
-    ...{
-      [K in keyof T]: StaticForeignFunctionParameter<T[K]>;
-    },
-  ];
-
   /** Infers a foreign symbol */
   type StaticForeignSymbol<T extends ForeignFunction | ForeignStatic> =
-    T extends ForeignFunction ? (
-      ...args: StaticForeignFunctionParameters<T["parameters"]>
-    ) => ConditionalAsync<
-      T["nonblocking"],
-      StaticForeignFunctionResult<T["result"]>
-    >
-      : T extends ForeignStatic ? StaticForeignFunctionResult<T["type"]>
+    T extends ForeignFunction ? FromForeignFunction<T>
+      : T extends ForeignStatic ? FromNativeType<T["type"]>
       : never;
+
+  type FromForeignFunction<T extends ForeignFunction> = T["parameters"] extends
+    readonly [] ? () => StaticForeignSymbolReturnType<T>
+    : (
+      ...args: ToNativeParameterTypes<T["parameters"]>
+    ) => StaticForeignSymbolReturnType<T>;
+
+  type StaticForeignSymbolReturnType<T extends ForeignFunction> =
+    ConditionalAsync<T["nonblocking"], FromNativeResultType<T["result"]>>;
 
   type ConditionalAsync<IsAsync extends boolean | undefined, T> =
     IsAsync extends true ? Promise<T> : T;
@@ -504,63 +529,23 @@ declare namespace Deno {
 
     constructor(pointer: bigint, definition: Fn);
 
-    call(
-      ...args: StaticForeignFunctionParameters<Fn["parameters"]>
-    ): ConditionalAsync<
-      Fn["nonblocking"],
-      StaticForeignFunctionResult<Fn["result"]>
-    >;
+    call: FromForeignFunction<Fn>;
   }
 
   export interface UnsafeCallbackDefinition<
     Parameters extends readonly NativeType[] = readonly NativeType[],
-    Result extends NativeParameterType = NativeParameterType,
+    Result extends NativeResultType = NativeResultType,
   > {
     parameters: Parameters;
     result: Result;
   }
 
-  interface NativeCallbackType<
-    Parameters extends readonly NativeType[] = readonly NativeType[],
-    Result extends NativeParameterType = NativeParameterType,
-  > {
-    readonly function: UnsafeCallbackDefinition<Parameters, Result>;
-  }
-
-  type UnsafeCallbackParameters<T extends readonly NativeType[]> = T extends []
-    ? []
-    : T extends
-      readonly [infer U extends NativeType, ...(infer V extends NativeType[])]
-      ? [
-        UnsafeCallbackParameter<U>,
-        ...UnsafeCallbackParameters<V>,
-      ]
-    : never;
-
-  type UnsafeCallbackParameter<T extends NativeType> = T extends
-    StaticNativeBigIntType ? bigint
-    : T extends StaticNativeNumberType ? number
-    : T extends "pointer" ? bigint
-    : never;
-
-  type UnsafeCallbackResult<T extends NativeParameterType> = T extends "void"
-    ? void
-    : T extends StaticNativeBigIntType ? number | bigint
-    : T extends StaticNativeNumberType ? number
-    : T extends "pointer" ? bigint | TypedArray | null
-    : T extends NativeCallbackType ? bigint | null
-    : never;
-
   type UnsafeCallbackFunction<
     Parameters extends readonly NativeType[] = readonly NativeType[],
-    Result extends NativeParameterType = NativeParameterType,
-  > = Result extends NativeParameterType
-    ? Parameters extends readonly [] ? () => UnsafeCallbackResult<Result>
-    : Parameters extends readonly NativeType[] ? (
-      ...args: UnsafeCallbackParameters<Parameters>
-    ) => UnsafeCallbackResult<Result>
-    : never
-    : never;
+    Result extends NativeResultType = NativeResultType,
+  > = Parameters extends readonly [] ? () => ToNativeResultType<Result> : (
+    ...args: FromNativeParameterTypes<Parameters>
+  ) => ToNativeResultType<Result>;
 
   /**
    * **UNSTABLE**: Unsafe and new API, beware!
@@ -571,17 +556,22 @@ declare namespace Deno {
    * The function pointer remains valid until the `close()` method is called.
    */
   export class UnsafeCallback<
-    Parameters extends readonly NativeType[] = readonly NativeType[],
-    Result extends NativeParameterType = NativeParameterType,
+    Definition extends UnsafeCallbackDefinition = UnsafeCallbackDefinition,
   > {
     constructor(
-      definition: UnsafeCallbackDefinition<Parameters, Result>,
-      callback: UnsafeCallbackFunction<Parameters, Result>,
+      definition: Definition,
+      callback: UnsafeCallbackFunction<
+        Definition["parameters"],
+        Definition["result"]
+      >,
     );
 
     pointer: bigint;
-    definition: UnsafeCallbackDefinition<Parameters, Result>;
-    callback: UnsafeCallbackFunction<Parameters, Result>;
+    definition: Definition;
+    callback: UnsafeCallbackFunction<
+      Definition["parameters"],
+      Definition["result"]
+    >;
 
     close(): void;
   }

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -228,7 +228,7 @@ enum NativeType {
   F32,
   F64,
   Pointer,
-  Function {},
+  Function,
 }
 
 impl From<NativeType> for libffi::middle::Type {
@@ -248,7 +248,7 @@ impl From<NativeType> for libffi::middle::Type {
       NativeType::F32 => libffi::middle::Type::f32(),
       NativeType::F64 => libffi::middle::Type::f64(),
       NativeType::Pointer => libffi::middle::Type::pointer(),
-      NativeType::Function {} => libffi::middle::Type::pointer(),
+      NativeType::Function => libffi::middle::Type::pointer(),
     }
   }
 }
@@ -289,7 +289,7 @@ impl NativeValue {
       NativeType::ISize => Arg::new(&self.isize_value),
       NativeType::F32 => Arg::new(&self.f32_value),
       NativeType::F64 => Arg::new(&self.f64_value),
-      NativeType::Pointer | NativeType::Function {} => Arg::new(&self.pointer),
+      NativeType::Pointer | NativeType::Function => Arg::new(&self.pointer),
     }
   }
 
@@ -317,7 +317,7 @@ impl NativeValue {
       }
       NativeType::F32 => Value::from(self.f32_value),
       NativeType::F64 => Value::from(self.f64_value),
-      NativeType::Pointer | NativeType::Function {} => {
+      NativeType::Pointer | NativeType::Function => {
         json!(U32x2::from(self.pointer as u64))
       }
     }
@@ -394,7 +394,7 @@ impl NativeValue {
           v8::Number::new(scope, self.f64_value).into();
         local_value.into()
       }
-      NativeType::Pointer | NativeType::Function {} => {
+      NativeType::Pointer | NativeType::Function => {
         let local_value: v8::Local<v8::Value> =
           v8::BigInt::new_from_u64(scope, self.pointer as u64).into();
         local_value.into()
@@ -702,7 +702,7 @@ where
           return Err(type_error("Invalid FFI pointer type, expected null, BigInt, ArrayBuffer, or ArrayBufferView"));
         }
       }
-      NativeType::Function {} => {
+      NativeType::Function => {
         if value.is_null() {
           let value: *const u8 = ptr::null();
           ffi_args.push(NativeValue { pointer: value })
@@ -777,7 +777,7 @@ fn ffi_call(
     NativeType::F64 => NativeValue {
       f64_value: unsafe { cif.call::<f64>(fun_ptr, &call_args) },
     },
-    NativeType::Pointer | NativeType::Function {} => NativeValue {
+    NativeType::Pointer | NativeType::Function => NativeValue {
       pointer: unsafe { cif.call::<*const u8>(fun_ptr, &call_args) },
     },
   })
@@ -1245,7 +1245,7 @@ fn op_ffi_get_static<'scope>(
       let number = v8::Number::new(scope, result as f64);
       serde_v8::from_v8(scope, number.into())?
     }
-    NativeType::Pointer | NativeType::Function {} => {
+    NativeType::Pointer | NativeType::Function => {
       let result = data_ptr as *const u8 as u64;
       let big_int = v8::BigInt::new_from_u64(scope, result);
       serde_v8::from_v8(scope, big_int.into())?

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -127,44 +127,27 @@ const dylib = Deno.dlopen(libPath, {
   },
   // Callback function
   call_fn_ptr: {
-    parameters: [{ function: { parameters: [], result: "void" } }],
+    parameters: ["function"],
     result: "void",
   },
   call_fn_ptr_many_parameters: {
-    parameters: [{
-      function: {
-        parameters: [
-          "u8",
-          "i8",
-          "u16",
-          "i16",
-          "u32",
-          "i32",
-          "u64",
-          "i64",
-          "f32",
-          "f64",
-          "pointer",
-        ],
-        result: "void",
-      },
-    }],
+    parameters: ["function"],
     result: "void",
   },
   call_fn_ptr_return_u8: {
-    parameters: [{ function: { parameters: [], result: "u8" } }],
+    parameters: ["function"],
     result: "void",
   },
   call_fn_ptr_return_buffer: {
-    parameters: [{ function: { parameters: [], result: "pointer" } }],
+    parameters: ["function"],
     result: "void",
   },
   store_function: {
-    parameters: [{ function: { parameters: [], result: "void" } }],
+    parameters: ["function"],
     result: "void",
   },
   store_function_2: {
-    parameters: [{ function: { parameters: ["u8"], result: "u8" } }],
+    parameters: ["function"],
     result: "void",
   },
   call_stored_function: {


### PR DESCRIPTION
This PR simplifies the TypeScript types used for interacting with Deno FFI. The basis is that types are now first grouped into logical wholes, `NativeNumberType`, `NativeBigIntType` etc. These wholes are combined into the `NativeType` and `NativeResultType` general types.

Then, for both "To" and "From" direction (viewed from Deno's point of view), mapper types are set up to convert the type declaration to the actual TypeScript type.

So, as an example for the type declaration `"usize"` the `ToNativeType` result is `number | bigint`, as we'll allow either a number of BigInt to be passed as a usize into FFI. The `FromNativeType` result however is `bigint`, since FFI will only ever return `usize` type values as BigInts from FFI.

**BREAKING:** Additionally, this PR removes the `{ function: { parameters: [], result: "void" } }` type declaration from parameters (and result types) as PR #14915 made the type information gained from these declarations unusable. Now functions are merely passed and returned as `"function"`. For `FromNativeType` types there is no difference between `"pointer"` and `"function"`, both will always be given to users as BigInts. However, on the `ToNativeType` side there is a difference as `"pointer"` parameters and callback return values can be given TypedArrays whereas `"function"`s cannot accept those, and passing those would not work (luckily, as this would be a MASSIVE safety risk).