### PR TITLE
chore: fix pty_tab_handler test on windows

### DIFF
--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -411,7 +411,10 @@ impl ConditionalEventHandler for TabEventHandler {
     _: bool,
     ctx: &EventContext,
   ) -> Option<Cmd> {
-    debug_assert_eq!(*evt, Event::from(KeyEvent(KeyCode::Tab, Modifiers::NONE)));
+    debug_assert_eq!(
+      *evt,
+      Event::from(KeyEvent(KeyCode::Tab, Modifiers::NONE))
+    );
     if ctx.line().is_empty()
       || ctx.line()[..ctx.pos()]
         .chars()

--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -371,7 +371,7 @@ impl ReplEditor {
       EventHandler::Simple(Cmd::Newline),
     );
     editor.bind_sequence(
-      KeyEvent::from('\t'),
+      KeyEvent(KeyCode::Tab, Modifiers::NONE),
       EventHandler::Conditional(Box::new(TabEventHandler)),
     );
 
@@ -411,7 +411,7 @@ impl ConditionalEventHandler for TabEventHandler {
     _: bool,
     ctx: &EventContext,
   ) -> Option<Cmd> {
-    debug_assert_eq!(*evt, Event::from(KeyEvent::from('\t')));
+    debug_assert_eq!(*evt, Event::from(KeyEvent(KeyCode::Tab, Modifiers::NONE)));
     if ctx.line().is_empty()
       || ctx.line()[..ctx.pos()]
         .chars()


### PR DESCRIPTION
This fixes the test, but adding a tab is a little broken on Windows (the output gets offset). I think it's a rustyline bug... doesn't seem worth tracking though until someone complains because it's cosmetic I think.