### PR TITLE
fix: don't error if Deno.bench() or Deno.test() are used in run subcommand

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2728,3 +2728,8 @@ fn running_declaration_files() {
     assert!(output.status.success());
   }
 }
+
+itest!(test_and_bench_are_noops_in_run {
+  args: "run test_and_bench_in_run.js",
+  output_str: Some(""),
+});

--- a/cli/tests/testdata/test_and_bench_in_run.js
+++ b/cli/tests/testdata/test_and_bench_in_run.js
@@ -1,0 +1,5 @@
+Deno.test(function foo() {
+});
+
+Deno.bench(function bar() {
+});

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -554,6 +554,7 @@
   const tests = [];
   /** @type {BenchDescription[]} */
   const benchDescs = [];
+  let isTestOrBenchSubcommand = false;
 
   // Main test function provided by Deno.
   function test(
@@ -561,6 +562,10 @@
     optionsOrFn,
     maybeFn,
   ) {
+    if (!isTestOrBenchSubcommand) {
+      return;
+    }
+
     let testDef;
     const defaults = {
       ignore: false,
@@ -669,6 +674,10 @@
     optionsOrFn,
     maybeFn,
   ) {
+    if (!isTestOrBenchSubcommand) {
+      return;
+    }
+
     core.opSync("op_bench_check_unstable");
     let benchDesc;
     const defaults = {
@@ -1041,6 +1050,13 @@
 
   function benchNow() {
     return core.opSync("op_bench_now");
+  }
+
+  // This function is called by Rust side if we're in `deno test` or
+  // `deno bench` subcommand. If this function is not called then `Deno.test()`
+  // and `Deno.bench()` become noops.
+  function enableTestAndBench() {
+    isTestOrBenchSubcommand = true;
   }
 
   async function runTests({
@@ -1507,6 +1523,7 @@
 
   window.__bootstrap.internals = {
     ...window.__bootstrap.internals ?? {},
+    enableTestAndBench,
     runTests,
     runBenchmarks,
   };


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/14862