### PR TITLE
fix(dts/ffi): non-exact types break FFI inference

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -383,8 +383,8 @@ declare namespace Deno {
       : [readonly (T[number])[]] extends [T]
         ? readonly ToNativeType<T[number]>[]
       : T extends readonly [...NativeType[]] ? {
-        [K in keyof T]: ToNativeType<T[K]>;
-      }
+          [K in keyof T]: ToNativeType<T[K]>;
+        }
       : never;
 
   type FromNativeTypeMap =
@@ -412,8 +412,8 @@ declare namespace Deno {
       : [readonly (T[number])[]] extends [T]
         ? readonly FromNativeType<T[number]>[]
       : T extends readonly [...NativeType[]] ? {
-        [K in keyof T]: FromNativeType<T[K]>;
-      }
+          [K in keyof T]: FromNativeType<T[K]>;
+        }
       : never;
 
   /** A foreign function as defined by its parameter and result types */


### PR DESCRIPTION
Closes #14963

Notes:
- The tuple item mapping method is more efficient than recursion and supports as many iterations as a union can have: ~50,000 parameters instead of the 1,000 that regular tail-end recursion optimized (which the other implementation was not) generics.
- The `FooMap` and `Foo<Key>` method was previously encouraged by Ryan Kavanaugh and it allows TypeScript to inline some types and for composition between things that may want to also check if something is `Foo` via `FooMap`.