### PR TITLE
fix(docs): --watch arg is stable

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -1986,7 +1986,7 @@ fn compat_arg<'a>() -> Arg<'a> {
 fn watch_arg<'a>(takes_files: bool) -> Arg<'a> {
   let arg = Arg::new("watch")
     .long("watch")
-    .help("UNSTABLE: Watch for file changes and restart automatically");
+    .help("Watch for file changes and restart automatically");
 
   if takes_files {
     arg
@@ -1996,14 +1996,14 @@ fn watch_arg<'a>(takes_files: bool) -> Arg<'a> {
       .use_value_delimiter(true)
       .require_equals(true)
       .long_help(
-        "UNSTABLE: Watch for file changes and restart process automatically.
+        "Watch for file changes and restart process automatically.
 Local files from entry point module graph are watched by default.
 Additional paths might be watched by passing them as arguments to this flag.",
       )
       .value_hint(ValueHint::AnyPath)
   } else {
     arg.long_help(
-      "UNSTABLE: Watch for file changes and restart process automatically. \
+      "Watch for file changes and restart process automatically. \
       Only local files from entry point module graph are watched.",
     )
   }


### PR DESCRIPTION
This updates the docs in cli/flags.rs to no longer mention --watch mode as unstable.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
