### PR TITLE
fix(test): typo ('finsihed') if text decoder not closed during test

### DIFF
--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -266,7 +266,7 @@
       case "timer":
         return ["A timer", "started", "fired/cleared"];
       case "textDecoder":
-        return ["A text decoder", "created", "finsihed"];
+        return ["A text decoder", "created", "finished"];
       case "messagePort":
         return ["A message port", "created", "closed"];
       case "webSocketStream":


### PR DESCRIPTION
Fixes a typo when running:

```
Deno.test("break during stream read", async () => {                                     
  const stream = new ReadableStream({                                                   
    start(controller) {                                                                 
      controller.enqueue(new Uint8Array([65]));                                         
      controller.enqueue(new Uint8Array([66]));                                         
      controller.close();                                                               
    }                                                                                   
  }).pipeThrough(new TextDecoderStream());                                              
                                                                                        
  for await (const chunk of stream) {                                                                                             
    console.log(chunk);                                                                 
    break;                                                                              
  }                                                                                     
});  
```

## Output Before:

```
> deno test ~/deno-text-decoder-test-fail.ts               
running 1 test from ../../deno-text-decoder-test-fail.ts
break during stream read ...
------- output -------
A
----- output end -----
break during stream read ... FAILED (17ms)

 ERRORS 

break during stream read => ../../deno-text-decoder-test-fail.ts:1:6
error: AssertionError: Test case is leaking 1 resource:

 - A text decoder (rid 3) was created during the test, but not finsihed during the test. Close the text decoder by calling `textDecoder.decode('')` or `await textDecoderStream.readable.cancel()`.

    at assert (deno:ext/web/00_infra.js:294:13)
    at resourceSanitizer (deno:runtime/js/40_testing.js:414:7)
    at async Object.exitSanitizer [as fn] (deno:runtime/js/40_testing.js:432:9)
    at async runTest (deno:runtime/js/40_testing.js:813:7)
    at async Object.runTests (deno:runtime/js/40_testing.js:1095:22)

 FAILURES 

break during stream read => ../../deno-text-decoder-test-fail.ts:1:6

FAILED | 0 passed | 1 failed (42ms)

error: Test failed
```


## Output After:

```
> ./target/debug/deno test ~/deno-text-decoder-test-fail.ts
running 1 test from ../../deno-text-decoder-test-fail.ts
break during stream read ...
------- output -------
A
----- output end -----
break during stream read ... FAILED (22ms)

 ERRORS 

break during stream read => ../../deno-text-decoder-test-fail.ts:1:6
error: AssertionError: Test case is leaking 1 resource:

 - A text decoder (rid 3) was created during the test, but not finished during the test. Close the text decoder by calling `textDecoder.decode('')` or `await textDecoderStream.readable.cancel()`.

    at assert (deno:ext/web/00_infra.js:294:13)
    at resourceSanitizer (deno:runtime/js/40_testing.js:414:7)
    at async Object.exitSanitizer [as fn] (deno:runtime/js/40_testing.js:432:9)
    at async runTest (deno:runtime/js/40_testing.js:822:7)
    at async Object.runTests (deno:runtime/js/40_testing.js:1111:22)

 FAILURES 

break during stream read => ../../deno-text-decoder-test-fail.ts:1:6

FAILED | 0 passed | 1 failed (59ms)

error: Test failed
```