### PR TITLE
fix(ext/ffi): Empty buffers error with index out of bounds on FFI

### DIFF
--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -999,13 +999,17 @@ where
               )
             })?
             .get_backing_store();
-          let pointer = &backing_store[byte_offset] as *const _ as *const u8;
+          let pointer = if byte_offset > 0 {
+            &backing_store[byte_offset..] as *const _ as *const u8
+          } else {
+            &backing_store[..] as *const _ as *const u8
+          };
 
           ffi_args.push(NativeValue { pointer });
         } else if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(value)
         {
           let backing_store = value.get_backing_store();
-          let pointer = &backing_store as *const _ as *const u8;
+          let pointer = &backing_store[..] as *const _ as *const u8;
 
           ffi_args.push(NativeValue { pointer });
         } else {

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -810,12 +810,16 @@ where
               )
             })?
             .get_backing_store();
-          let pointer = &backing_store[byte_offset] as *const _ as *const u8;
+          let pointer = if byte_offset > 0 {
+            &backing_store[byte_offset..] as *const _ as *const u8
+          } else {
+            &backing_store[..] as *const _ as *const u8
+          };
           ffi_args.push(NativeValue { pointer });
         } else if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(value)
         {
           let backing_store = value.get_backing_store();
-          let pointer = &backing_store as *const _ as *const u8;
+          let pointer = &backing_store[..] as *const _ as *const u8;
           ffi_args.push(NativeValue { pointer });
         } else {
           return Err(type_error("Invalid FFI pointer type, expected null, BigInt, ArrayBuffer, or ArrayBufferView"));
@@ -1367,11 +1371,15 @@ unsafe fn do_ffi_callback(
           .buffer(&mut scope)
           .expect("Unable to deserialize result parameter.")
           .get_backing_store();
-        let pointer = &backing_store[byte_offset] as *const _ as *const u8;
+        let pointer = if byte_offset > 0 {
+          &backing_store[byte_offset..] as *const _ as *const u8
+        } else {
+          &backing_store[..] as *const _ as *const u8
+        };
         *(result as *mut *const u8) = pointer;
       } else if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(value) {
         let backing_store = value.get_backing_store();
-        let pointer = &backing_store as *const _ as *const u8;
+        let pointer = &backing_store[..] as *const _ as *const u8;
         *(result as *mut *const u8) = pointer;
       } else if let Ok(value) = v8::Local::<v8::BigInt>::try_from(value) {
         *(result as *mut u64) = value.u64_value().0;

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -56,6 +56,7 @@ fn basic() {
     false\n\
     true\n\
     false\n\
+    false\n\
     579\n\
     true\n\
     579\n\

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -57,6 +57,7 @@ fn basic() {
     true\n\
     false\n\
     false\n\
+    false\n\
     579\n\
     true\n\
     579\n\

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -214,6 +214,8 @@ console.log(stringPtrview.getCString(11));
 console.log(Boolean(dylib.symbols.is_null_ptr(ptr0)));
 console.log(Boolean(dylib.symbols.is_null_ptr(null)));
 console.log(Boolean(dylib.symbols.is_null_ptr(Deno.UnsafePointer.of(into))));
+const emptyBuffer = new BigUint64Array(0);
+console.log(Boolean(dylib.symbols.is_null_ptr(emptyBuffer)));
 
 const addU32Ptr = dylib.symbols.get_add_u32_ptr();
 const addU32 = new Deno.UnsafeFnPointer(addU32Ptr, {

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -216,6 +216,8 @@ console.log(Boolean(dylib.symbols.is_null_ptr(null)));
 console.log(Boolean(dylib.symbols.is_null_ptr(Deno.UnsafePointer.of(into))));
 const emptyBuffer = new BigUint64Array(0);
 console.log(Boolean(dylib.symbols.is_null_ptr(emptyBuffer)));
+const emptySlice = into.subarray(6);
+console.log(Boolean(dylib.symbols.is_null_ptr(emptySlice)));
 
 const addU32Ptr = dylib.symbols.get_add_u32_ptr();
 const addU32 = new Deno.UnsafeFnPointer(addU32Ptr, {


### PR DESCRIPTION
Fixes #14993.

So, it turns out sometimes people create empty buffers and use them as FFI parameters. These sorts of pointers are absolutely not for writing or reading from (doing so is UB in at least C++ and LLVM), but they can serve a useful function as "end of buffer" pointers.

One way or another, these must not crash Deno.