### PR TITLE
chore(cli/bench): Add bun HTTP server

### DIFF
--- a/cli/bench/http.rs
+++ b/cli/bench/http.rs
@@ -56,6 +56,7 @@ pub fn benchmark(
     } else if name.starts_with("bun") && !cfg!(target_os = "windows") {
       // Bun does not support Windows.
       #[cfg(target_arch = "x86_64")]
+      #[cfg(not(target_vendor = "apple"))]
       let bun_exe = test_util::prebuilt_tool_path("bun");
       #[cfg(target_vendor = "apple")]
       #[cfg(target_arch = "x86_64")]

--- a/cli/bench/http.rs
+++ b/cli/bench/http.rs
@@ -53,6 +53,28 @@ pub fn benchmark(
           maybe_lua,
         )?,
       );
+    } else if name.starts_with("bun") && !cfg!(target_os = "windows") {
+      // Bun does not support Windows.
+      #[cfg(target_arch = "x86_64")]
+      let bun_exe = test_util::prebuilt_tool_path("bun");
+      #[cfg(target_vendor = "apple")]
+      #[cfg(target_arch = "x86_64")]
+      let bun_exe = test_util::prebuilt_tool_path("bun-x64");
+      #[cfg(target_vendor = "apple")]
+      #[cfg(target_arch = "aarch64")]
+      let bun_exe = test_util::prebuilt_tool_path("bun-aarch64");
+
+      // bun <path> <port>
+      res.insert(
+        file_stem.to_string(),
+        run(
+          &[bun_exe.to_str().unwrap(), path, &port.to_string()],
+          port,
+          None,
+          None,
+          maybe_lua,
+        )?,
+      );
     } else {
       // deno run -A --unstable <path> <addr>
       res.insert(

--- a/cli/bench/http/bun_http.js
+++ b/cli/bench/http/bun_http.js
@@ -1,8 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 const port = Bun.argv[2] || "4545";
 Bun.serve({
-	fetch(_req) {
-		return new Response("Hello World");
-	},
-	port: Number(port),
+  fetch(_req) {
+    return new Response("Hello World");
+  },
+  port: Number(port),
 });

--- a/cli/bench/http/bun_http.js
+++ b/cli/bench/http/bun_http.js
@@ -1,0 +1,8 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+const port = Bun.argv[2] || "4545";
+Bun.serve({
+	fetch(_req) {
+		return new Response("Hello World");
+	},
+	port: Number(port),
+});

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -139,7 +139,7 @@ pub fn prebuilt_tool_path(tool: &str) -> PathBuf {
   prebuilt_path().join(platform_dir_name()).join(exe)
 }
 
-fn platform_dir_name() -> &'static str {
+pub fn platform_dir_name() -> &'static str {
   if cfg!(target_os = "linux") {
     "linux64"
   } else if cfg!(target_os = "macos") {


### PR DESCRIPTION
This commit adds Bun to our HTTP benchmark suite. 

- [x] Depends on https://github.com/denoland/deno_third_party/pull/106