### PR TITLE
fix(runtime/ExitCode default): derive default for deno_runtime::ExitCode

### DIFF
--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -35,7 +35,7 @@ use std::task::Poll;
 
 pub type FormatJsErrorFn = dyn Fn(&JsError) -> String + Sync + Send;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ExitCode(Arc<AtomicI32>);
 
 impl ExitCode {


### PR DESCRIPTION
Fixes #15016 

Embeders can now

```rust
let exit_code: ExitCode = Default::default();
...
deno_runtime::ops::os::init(exit_code.clone())
...
```