### PR TITLE
fix(core): remove unsafe in OpsTracker

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -14,7 +14,6 @@ use futures::task::noop_waker;
 use futures::Future;
 use serde::Serialize;
 use std::cell::RefCell;
-use std::cell::UnsafeCell;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -160,9 +159,7 @@ impl OpState {
       resource_table: Default::default(),
       get_error_class_fn: &|_| "Error",
       gotham_state: Default::default(),
-      tracker: OpsTracker {
-        ops: UnsafeCell::new(vec![Default::default(); ops_count]),
-      },
+      tracker: OpsTracker::new(ops_count),
     }
   }
 }

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -293,7 +293,7 @@ fn codegen_v8_sync(
 
     let result = Self::call::<#type_params>(#args_head #args_tail);
 
-    let op_state = &mut ctx.state.borrow();
+    let op_state = &*ctx.state.borrow();
     op_state.tracker.track_sync(ctx.id);
 
     #ret


### PR DESCRIPTION
The current `OpsTracker` is unsound. It may violate the alias rules of rust reference type. Therefore the `SAFETY` comments are **wrong**.

This commit removes all unsafe usages in `core/ops_metrics.rs`.

Related:
+ #15020 
+ #13868
+ #12525