### PR TITLE
[wip] perf(ext/http): improve throughput by ~10k reqs

### DIFF
--- a/cli/bench/http/deno_http_native.js
+++ b/cli/bench/http/deno_http_native.js
@@ -8,12 +8,13 @@ console.log("Server listening on", addr);
 const encoder = new TextEncoder();
 const body = encoder.encode("Hello World");
 
+async function handle(conn) {
+  const requests = Deno.serveHttp(conn);
+  for await (const event of requests) {
+    event.respondWith(new Response(body));
+  }
+}
+
 for await (const conn of listener) {
-  (async () => {
-    const requests = Deno.serveHttp(conn);
-    for await (const event of requests) {
-      event.respondWith(new Response(body))
-        .catch((e) => console.log(e));
-    }
-  })();
+  handle(conn);
 }

--- a/cli/bench/http/deno_http_ops.js
+++ b/cli/bench/http/deno_http_ops.js
@@ -17,7 +17,7 @@ class Http {
     };
   }
 }
-
+const hello = Deno.core.encode("Hello World");
 for await (const conn of tcp) {
   const id = Deno.core.opSync("op_http_start", conn.rid);
   const http = new Http(id);
@@ -25,14 +25,14 @@ for await (const conn of tcp) {
     for await (const req of http) {
       if (req == null) continue;
       const { 0: stream } = req;
-      await Deno.core.opAsync(
-        "op_http_write_headers",
+      Deno.core.opSync(
+        "op_http_write_headers_with_data",
         stream,
         200,
         [],
-        "Hello World",
+        hello,
+        true,
       );
-      Deno.core.close(stream);
     }
   })();
 }

--- a/ext/fetch/internal.d.ts
+++ b/ext/fetch/internal.d.ts
@@ -87,9 +87,9 @@ declare namespace globalThis {
       function redirectStatus(status: number): boolean;
       function nullBodyStatus(status: number): boolean;
       function newInnerRequest(
-        method: string,
-        url: any,
-        headerList?: [string, string][],
+        method: () => string,
+        url: () => any,
+        headerList?: () => [string, string][],
         body?: globalThis.__bootstrap.fetchBody.InnerBody,
       ): InnerResponse;
       function toInnerResponse(response: Response): InnerResponse;

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -271,7 +271,6 @@
             );
           }
           if (streamClosed === true) {
-            core.opAsync("op_http_closed_conn", streamRid);
             SetPrototypeDelete(httpConn.managedResources, streamRid);
             return;
           }
@@ -290,6 +289,7 @@
           ) {
             await respBody.cancel(error);
           }
+          await core.opAsync("op_http_closed_conn", streamRid);
           throw error;
         }
 

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -361,7 +361,7 @@ fn codegen_sync_ret(
 
   if is_u32_rv(output) {
     return quote! {
-      rv.set_uint32(result);
+      rv.set_uint32(result as u32);
     };
   }
 
@@ -421,9 +421,7 @@ fn is_unit_result(ty: impl ToTokens) -> bool {
 
 /// Detects if the type can be set using `rv.set_uint32` fast path
 fn is_u32_rv(ty: impl ToTokens) -> bool {
-  ["u32", "u8", "u16"]
-    .iter()
-    .any(|&s| tokens(&ty).contains(s))
+  ["u32", "u8", "u16"].iter().any(|&s| tokens(&ty) == s)
 }
 
 fn is_mut_ref_opstate(arg: &syn::FnArg) -> bool {

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -359,6 +359,12 @@ fn codegen_sync_ret(
     return quote! {};
   }
 
+  if is_u32_rv(output) {
+    return quote! {
+      rv.set_uint32(result);
+    };
+  }
+
   // Optimize Result<(), Err> to skip serde_v8 when Ok(...)
   let ok_block = if is_unit_result(output) {
     quote! {}
@@ -411,6 +417,13 @@ fn is_result(ty: impl ToTokens) -> bool {
 /// Detects if a type is of the form Result<(), Err>
 fn is_unit_result(ty: impl ToTokens) -> bool {
   is_result(&ty) && tokens(&ty).contains("Result < ()")
+}
+
+/// Detects if the type can be set using `rv.set_uint32` fast path
+fn is_u32_rv(ty: impl ToTokens) -> bool {
+  ["u32", "u8", "u16"]
+    .iter()
+    .any(|&s| tokens(&ty).contains(s))
 }
 
 fn is_mut_ref_opstate(arg: &syn::FnArg) -> bool {

--- a/serde_v8/magic/v8slice.rs
+++ b/serde_v8/magic/v8slice.rs
@@ -66,12 +66,13 @@ impl V8Slice {
   }
 }
 
+#[inline]
 pub(crate) fn to_ranged_buffer<'s>(
   scope: &mut v8::HandleScope<'s>,
   value: v8::Local<v8::Value>,
 ) -> Result<(v8::Local<'s, v8::ArrayBuffer>, Range<usize>), v8::DataError> {
-  if value.is_array_buffer_view() {
-    let view: v8::Local<v8::ArrayBufferView> = value.try_into()?;
+  let view: Result<v8::Local<v8::ArrayBufferView>, _> = value.try_into();
+  if let Ok(view) = view {
     let (offset, len) = (view.byte_offset(), view.byte_length());
     let buffer = view.buffer(scope).ok_or(v8::DataError::NoData {
       expected: "view to have a buffer",
@@ -85,6 +86,7 @@ pub(crate) fn to_ranged_buffer<'s>(
 }
 
 impl FromV8 for V8Slice {
+  #[inline]
   fn from_v8(
     scope: &mut v8::HandleScope,
     value: v8::Local<v8::Value>,


### PR DESCRIPTION
This commit improves HTTP server 
throughput significantly through micro-optimizations.

- Lazy load request headers on-demand + cache.
- Make op_http_write_headers synchronous.
- Add op_http_write_headers_with_data for non-streaming bodies. Reduces ops per request to 1.
- Simplify op_http_accept and avoid RcRef path for getting hyper::Response.
- v8slice avoid double array buffer check.

`cli/bench/http/deno_http_native.js` benchmarks:

```
# Deno 1.23.2
~> wrk -d 10s --latency http://127.0.0.1:4500
Running 10s test @ http://127.0.0.1:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   110.65us  149.17us   7.18ms   99.13%
    Req/Sec    45.06k     3.01k   47.71k    95.05%
  Latency Distribution
     50%  101.00us
     75%  116.00us
     90%  138.00us
     99%  243.00us
  905406 requests in 10.10s, 94.98MB read
Requests/sec:  89643.30
Transfer/sec:      9.40MB
```

```
# Hyper (Rust, single-threaded)
~> wrk -d 10s --latency http://127.0.0.1:4500
Running 10s test @ http://127.0.0.1:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    58.32us   84.05us   4.77ms   99.52%
    Req/Sec    82.46k     3.73k   92.01k    93.07%
  Latency Distribution
     50%   53.00us
     75%   65.00us
     90%   77.00us
     99%  108.00us
  1657498 requests in 10.10s, 139.10MB read
Requests/sec: 164117.52
Transfer/sec:     13.77MB
```

```
# This patch
~> wrk -d 10s --latency http://127.0.0.1:4500
Running 10s test @ http://127.0.0.1:4500
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    92.36us   60.08us   3.45ms   98.01%
    Req/Sec    52.30k     5.02k   59.93k    77.72%
  Latency Distribution
     50%   84.00us
     75%  100.00us
     90%  117.00us
     99%  193.00us
  1050868 requests in 10.10s, 110.24MB read
Requests/sec: 104041.93
Transfer/sec:     10.91MB
```

