### PR TITLE
ci: use a known good version of deno instead of latest in publish scripts

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -31,7 +31,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # use a recent version instead of the latest version in case
-          # the latest version ever has issues
+          # the latest version ever has issues that breaks publishing
           deno-version: v1.23.2
 
       - name: Publish

--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Install deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          # use a recent version instead of the latest version in case
+          # the latest version ever has issues
+          deno-version: v1.23.2
 
       - name: Publish
         env:

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -42,7 +42,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # use a recent version instead of the latest version in case
-          # the latest version ever has issues
+          # the latest version ever has issues that breaks publishing
           deno-version: v1.23.2
 
       - name: Run version bump

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Install deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          # use a recent version instead of the latest version in case
+          # the latest version ever has issues
+          deno-version: v1.23.2
 
       - name: Run version bump
         run: |


### PR DESCRIPTION
Reverts #14819 and adds a comment explaining why. This was done purposefully, but not explained by a comment. Obviously rare scenario, but I think the publish scripts should use a known good version in case anything ever goes super wrong with a release of deno such that the latest version breaks publishing (circular problem where we can't publish to fix).