### PR TITLE
chore(cli/bench): benchmark for raw HTTP ops

### DIFF
--- a/cli/bench/http/deno_http_ops.js
+++ b/cli/bench/http/deno_http_ops.js
@@ -1,0 +1,37 @@
+const { opSync, opAsync } = Deno.core;
+
+const tcp = Deno.listen({ port: 4500 });
+
+class Http {
+  id;
+  constructor(id) {
+    this.id = id;
+  }
+  [Symbol.asyncIterator]() {
+    return {
+      next: async () => {
+        const reqEvt = await opAsync("op_http_accept", this.id);
+        return { value: reqEvt ?? undefined, done: reqEvt === null };
+      },
+    };
+  }
+}
+
+for await (const conn of tcp) {
+  const id = opSync("op_http_start", conn.rid);
+  const http = new Http(id);
+  (async () => {
+    for await (const req of http) {
+      if (req == null) continue;
+      const { 3: url, 0: stream, 1: method, 2: headers } = req;
+      opSync(
+        "op_http_write_headers_with_data",
+        stream,
+        200,
+        [],
+        "Hello World",
+        true,
+      );
+    }
+  })();
+}


### PR DESCRIPTION
Useful benchmark to track JS overhead. Interesting to note that this performs
almost similar to deno_http_native.js