### PR TITLE
chore: upgrade to dprint 0.30.2 internally

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -49,6 +49,6 @@
     "https://plugins.dprint.dev/json-0.15.3.wasm",
     "https://plugins.dprint.dev/markdown-0.13.3.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
-    "https://plugins.dprint.dev/exec-0.2.1.exe-plugin@0a89a91810a212d9413e26d8946d41fbab3e2b5400362d764a1523839c4d78ea"
+    "https://plugins.dprint.dev/exec-0.3.1.json@9351b67ec7a6b58a69201c2834cba38cb3d191080aefc6422fb1320f03c8fc4d"
   ]
 }


### PR DESCRIPTION
I changed the internal cache, so want to keep this up-to-date with the latest dprint.