### PR TITLE
perf(ext/url): lazy cache for URL keys

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -56,6 +56,13 @@ function benchUrlParse() {
   });
 }
 
+function benchUrlParseGetPath() {
+  benchSync("url_parse_get_path", 5e4, (i) => {
+    const url = new URL(`http://www.google.com/${i}`);
+    url.pathname;
+  });
+}
+
 function benchLargeBlobText() {
   const input = "long-string".repeat(999_999);
   benchSync("blob_text_large", 100, () => {
@@ -130,6 +137,7 @@ async function main() {
   // A common "language feature", that should be fast
   // also a decent representation of a non-trivial JSON-op
   benchUrlParse();
+  benchUrlParseGetPath();
   benchLargeBlobText();
   benchB64RtLong();
   benchB64RtShort();

--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -51,14 +51,11 @@ function benchB64RtShort() {
 }
 
 function benchUrlParse() {
+  let url;
   benchSync("url_parse", 5e4, (i) => {
-    new URL(`http://www.google.com/${i}`);
+    url = new URL(`http://www.google.com/${i}`);
   });
-}
-
-function benchUrlParseGetPath() {
   benchSync("url_parse_get_path", 5e4, (i) => {
-    const url = new URL(`http://www.google.com/${i}`);
     url.pathname;
   });
 }
@@ -137,7 +134,6 @@ async function main() {
   // A common "language feature", that should be fast
   // also a decent representation of a non-trivial JSON-op
   benchUrlParse();
-  benchUrlParseGetPath();
   benchLargeBlobText();
   benchB64RtLong();
   benchB64RtShort();

--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -55,7 +55,8 @@ function benchUrlParse() {
   benchSync("url_parse", 5e4, (i) => {
     url = new URL(`http://www.google.com/${i}`);
   });
-  benchSync("url_parse_get_path", 5e4, (i) => {
+  console.log(url.toString());
+  benchSync("url_parse_get_path", 5e4, () => {
     url.pathname;
   });
 }
@@ -124,6 +125,7 @@ function benchOpVoidAsync() {
 }
 
 async function main() {
+  benchRequestNew();
   // v8 builtin that's close to the upper bound non-NOPs
   benchDateNow();
   // Void ops measure op-overhead
@@ -141,6 +143,5 @@ async function main() {
   benchReadZero();
   benchWriteNull();
   await benchRead128k();
-  benchRequestNew();
 }
 await main();

--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -55,7 +55,6 @@ function benchUrlParse() {
   benchSync("url_parse", 5e4, (i) => {
     url = new URL(`http://www.google.com/${i}`);
   });
-  console.log(url.toString());
   benchSync("url_parse_get_path", 5e4, () => {
     url.pathname;
   });

--- a/cli/tests/testdata/fetch_response_finalization.js.out
+++ b/cli/tests/testdata/fetch_response_finalization.js.out
@@ -1,2 +1,8 @@
-{ "0": "stdin", "1": "stdout", "2": "stderr", "3": "urlResource", "6": "fetchResponseBody" }
+{
+  "0": "stdin",
+  "1": "stdout",
+  "2": "stderr",
+  "3": "urlResource",
+  "6": "fetchResponseBody"
+}
 { "0": "stdin", "1": "stdout", "2": "stderr" }

--- a/cli/tests/testdata/fetch_response_finalization.js.out
+++ b/cli/tests/testdata/fetch_response_finalization.js.out
@@ -1,2 +1,2 @@
-{ "0": "stdin", "1": "stdout", "2": "stderr", "3": "url", "6": "fetchResponseBody" }
+{ "0": "stdin", "1": "stdout", "2": "stderr", "3": "urlResource", "6": "fetchResponseBody" }
 { "0": "stdin", "1": "stdout", "2": "stderr" }

--- a/cli/tests/testdata/fetch_response_finalization.js.out
+++ b/cli/tests/testdata/fetch_response_finalization.js.out
@@ -1,2 +1,2 @@
-{ "0": "stdin", "1": "stdout", "2": "stderr", "5": "fetchResponseBody" }
+{ "0": "stdin", "1": "stdout", "2": "stderr", "3": "url", "6": "fetchResponseBody" }
 { "0": "stdin", "1": "stdout", "2": "stderr" }

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1025,7 +1025,7 @@ Deno.test(
       delete resourcesAfter[Number(rid)];
     }
 
-    assertEquals(Object.keys(resourcesAfter).length, 1);
+    assertEquals(Object.keys(resourcesAfter).length, 3);
 
     listener!.close();
     httpConn!.close();

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -409,7 +409,11 @@
         context: "Argument 1",
       });
       try {
-        this[_url].hostname = opUrlReparse(this[_rid], SET_HOSTNAME, value);
+        this[_url][SET_HOSTNAME] = opUrlReparse(
+          this[_rid],
+          SET_HOSTNAME,
+          value,
+        );
       } catch {
         /* pass */
       }

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -307,7 +307,13 @@
       this[_rid] = opUrlParse(url, base);
       RESOURCE_REGISTRY.register(this, this[_rid]);
       // Lazy loaded object
-      this[_url] = new Array(11);
+      // array literal used to avoid primodials.
+      // deno-fmt-ignore
+      this[_url] = [
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined,
+        undefined
+      ];
     }
 
     [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -100,6 +100,7 @@
       if (url === null) {
         return;
       }
+      url[_invalidateCache]();
       url[_url][SET_SEARCH] = opUrlReparse(
         url[_rid],
         SET_SEARCH,
@@ -283,6 +284,7 @@
 
   const _url = Symbol("url");
   const _rid = Symbol("rid");
+  const _invalidateCache = Symbol("invalidate cache");
 
   class URL {
     [_url];
@@ -355,6 +357,15 @@
       return this[_url][name];
     }
 
+    [_invalidateCache]() {
+      // deno-fmt-ignore
+      this[_url] = [
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined,
+        undefined
+      ];
+    }
+
     /** @return {string} */
     get hash() {
       webidl.assertBranded(this, URLPrototype);
@@ -371,6 +382,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_HASH] = opUrlReparse(this[_rid], SET_HASH, value);
       } catch {
         /* pass */
@@ -393,6 +405,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_HOST] = opUrlReparse(this[_rid], SET_HOST, value);
       } catch {
         /* pass */
@@ -415,6 +428,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_HOSTNAME] = opUrlReparse(
           this[_rid],
           SET_HOSTNAME,
@@ -441,13 +455,7 @@
         context: "Argument 1",
       });
       this[_rid] = opUrlParse(value);
-      // deno-fmt-ignore
-      this[_url] = [
-        undefined, undefined, undefined, undefined, undefined,
-        undefined, undefined, undefined, undefined, undefined,
-        undefined
-      ];
-
+      this[_invalidateCache]();
       this.#updateSearchParams();
     }
 
@@ -473,6 +481,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_PASSWORD] = opUrlReparse(
           this[_rid],
           SET_PASSWORD,
@@ -499,6 +508,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_PATHNAME] = opUrlReparse(
           this[_rid],
           SET_PATHNAME,
@@ -525,6 +535,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_PORT] = opUrlReparse(this[_rid], SET_PORT, value);
       } catch {
         /* pass */
@@ -547,6 +558,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_PROTOCOL] = opUrlReparse(
           this[_rid],
           SET_PROTOCOL,
@@ -573,6 +585,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_SEARCH] = opUrlReparse(this[_rid], SET_SEARCH, value);
         this.#updateSearchParams();
       } catch {
@@ -596,6 +609,7 @@
         context: "Argument 1",
       });
       try {
+        this[_invalidateCache]();
         this[_url][SET_USERNAME] = opUrlReparse(
           this[_rid],
           SET_USERNAME,

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -344,7 +344,7 @@
     }
 
     #lazyGet(name) {
-      if (this[_url][name] === null) {
+      if (this[_url][name] === undefined) {
         this[_url][name] = core.opSync("op_url_get", this[_rid], name);
       }
       return this[_url][name];
@@ -375,7 +375,7 @@
     /** @return {string} */
     get host() {
       webidl.assertBranded(this, URLPrototype);
-      return this.#lazyGet(SET_HASH);
+      return this.#lazyGet(SET_HOST);
     }
 
     /** @param {string} value */

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -276,6 +276,11 @@
   webidl.configurePrototype(URLSearchParams);
   const URLSearchParamsPrototype = URLSearchParams.prototype;
 
+  // A finalization registry to clean up underlying fetch resources that are GC'ed.
+  const RESOURCE_REGISTRY = new FinalizationRegistry((rid) => {
+    core.tryClose(rid);
+  });
+
   const _url = Symbol("url");
   const _rid = Symbol("rid");
 
@@ -299,6 +304,7 @@
       }
       this[webidl.brand] = webidl.brand;
       this[_rid] = opUrlParse(url, base);
+      RESOURCE_REGISTRY.register(this, this[_rid]);
       // Lazy loaded object
       this[_url] = new Array(11);
     }

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -11,7 +11,6 @@
   const core = window.Deno.core;
   const webidl = window.__bootstrap.webidl;
   const {
-    Array,
     ArrayIsArray,
     ArrayPrototypeMap,
     ArrayPrototypePush,
@@ -442,7 +441,13 @@
         context: "Argument 1",
       });
       this[_rid] = opUrlParse(value);
-      this[_url] = new Array(11);
+      // deno-fmt-ignore
+      this[_url] = [
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined,
+        undefined
+      ];
+
       this.#updateSearchParams();
     }
 

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -11,6 +11,7 @@
   const core = window.Deno.core;
   const webidl = window.__bootstrap.webidl;
   const {
+    Array,
     ArrayIsArray,
     ArrayPrototypeMap,
     ArrayPrototypePush,

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -14,7 +14,6 @@ use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ZeroCopyBuf;
-use std::cell::Ref;
 use std::cell::RefCell;
 use std::path::PathBuf;
 

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -13,6 +13,7 @@ use deno_core::url::Url;
 use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::Resource;
+use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -56,7 +57,7 @@ pub fn op_url_parse(
   state: &mut OpState,
   href: String,
   base_href: Option<String>,
-) -> Result<u32, AnyError> {
+) -> Result<ResourceId, AnyError> {
   let base_url = base_href
     .as_ref()
     .map(|b| Url::parse(b).map_err(|_| type_error("Invalid base URL")))
@@ -89,7 +90,7 @@ pub enum UrlSetter {
 #[op]
 pub fn op_url_get(
   state: &mut OpState,
-  rid: u32,
+  rid: ResourceId,
   getter: u8,
 ) -> Result<String, AnyError> {
   let resource = state.resource_table.get::<UrlResource>(rid)?;
@@ -118,7 +119,7 @@ pub fn op_url_get(
 #[op]
 pub fn op_url_reparse(
   state: &mut OpState,
-  rid: u32,
+  rid: ResourceId,
   setter_opts: (u8, String),
 ) -> Result<String, AnyError> {
   let resource = state.resource_table.get::<UrlResource>(rid)?;

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -14,6 +14,7 @@ use deno_core::Extension;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ZeroCopyBuf;
+use std::cell::Ref;
 use std::cell::RefCell;
 use std::path::PathBuf;
 
@@ -45,7 +46,7 @@ struct UrlResource {
 
 impl Resource for UrlResource {
   fn name(&self) -> std::borrow::Cow<str> {
-    "url".into()
+    "urlResource".into()
   }
 }
 

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -397,7 +397,7 @@
         const preResource = pre[resource];
         const postResource = post[resource];
         if (preResource === postResource) continue;
-        if (ArrayPrototypeIncludes(resourceAllowList, preResource)) continue;
+        if (ArrayPrototypeIncludes(resourceAllowList, postResource)) continue;
 
         if (preResource === undefined) {
           const [name, action1, action2] = prettyResourceNames(postResource);

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -16,6 +16,7 @@
     ArrayPrototypeShift,
     ArrayPrototypeSome,
     ArrayPrototypeSort,
+    ArrayPrototypeIncludes,
     DateNow,
     Error,
     FunctionPrototype,

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -397,7 +397,11 @@
         const preResource = pre[resource];
         const postResource = post[resource];
         if (preResource === postResource) continue;
-        if (ArrayPrototypeIncludes(resourceAllowList, postResource)) continue;
+        if (
+          ArrayPrototypeIncludes(resourceAllowList, preResource || postResource)
+        ) {
+          continue;
+        }
 
         if (preResource === undefined) {
           const [name, action1, action2] = prettyResourceNames(postResource);

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -363,6 +363,12 @@
     }
   }
 
+  // Some resources cannot be explicitly closed and depend on
+  // garbage collection.
+  const resourceAllowList = [
+    "urlResource",
+  ];
+
   // Wrap test function in additional assertion that makes sure
   // the test case does not "leak" resources - ie. resource table after
   // the test has exactly the same contents as before the test.
@@ -390,6 +396,7 @@
         const preResource = pre[resource];
         const postResource = post[resource];
         if (preResource === postResource) continue;
+        if (ArrayPrototypeIncludes(resourceAllowList, preResource)) continue;
 
         if (preResource === undefined) {
           const [name, action1, action2] = prettyResourceNames(postResource);

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -2177,8 +2177,6 @@
     "url-setters.any.worker.html": [
       "URL: Setting <http://example.net/path>.hostname = 'example.com:8080' : delimiter invalidates entire value",
       "URL: Setting <http://example.net:8080/path>.hostname = 'example.com:' : delimiter invalidates entire value",
-      "URL: Setting <non-spec:/.//p>.hostname = 'h' Drop /. from path",
-      "URL: Setting <non-spec:/.//p>.hostname = ''",
       "URL: Setting <foo://somehost/some/path>.pathname = '' Non-special URLs can have their paths erased",
       "URL: Setting <foo:///some/path>.pathname = '' Non-special URLs with an empty host can have their paths erased",
       "URL: Setting <file://monkey/>.pathname = '\\\\' File URLs and (back)slashes",
@@ -2186,8 +2184,7 @@
       "URL: Setting <file:///unicorn>.pathname = '//monkey/..//' File URLs and (back)slashes",
       "URL: Setting <non-spec:/>.pathname = '/.//p' Serialize /. in path",
       "URL: Setting <non-spec:/>.pathname = '/..//p'",
-      "URL: Setting <non-spec:/>.pathname = '//p'",
-      "URL: Setting <non-spec:/.//>.pathname = 'p' Drop /. from path"
+      "URL: Setting <non-spec:/>.pathname = '//p'"
     ],
     "idlharness-shadowrealm.window.html": false,
     "percent-encoding.window.html": [

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -2165,8 +2165,6 @@
     "url-setters.any.html": [
       "URL: Setting <http://example.net/path>.hostname = 'example.com:8080' : delimiter invalidates entire value",
       "URL: Setting <http://example.net:8080/path>.hostname = 'example.com:' : delimiter invalidates entire value",
-      "URL: Setting <non-spec:/.//p>.hostname = 'h' Drop /. from path",
-      "URL: Setting <non-spec:/.//p>.hostname = ''",
       "URL: Setting <foo://somehost/some/path>.pathname = '' Non-special URLs can have their paths erased",
       "URL: Setting <foo:///some/path>.pathname = '' Non-special URLs with an empty host can have their paths erased",
       "URL: Setting <file://monkey/>.pathname = '\\\\' File URLs and (back)slashes",
@@ -2174,8 +2172,7 @@
       "URL: Setting <file:///unicorn>.pathname = '//monkey/..//' File URLs and (back)slashes",
       "URL: Setting <non-spec:/>.pathname = '/.//p' Serialize /. in path",
       "URL: Setting <non-spec:/>.pathname = '/..//p'",
-      "URL: Setting <non-spec:/>.pathname = '//p'",
-      "URL: Setting <non-spec:/.//>.pathname = 'p' Drop /. from path"
+      "URL: Setting <non-spec:/>.pathname = '//p'"
     ],
     "url-setters.any.worker.html": [
       "URL: Setting <http://example.net/path>.hostname = 'example.com:8080' : delimiter invalidates entire value",


### PR DESCRIPTION
This commits adds a key cache for URL parts. This has real performance
impact, like in Fresh -> https://github.com/denoland/fresh/pull/368

```
# This patch
url_parse:              n = 50000, dt = 0.043s, r = 1162791/s, t = 859ns/op
url_parse_get_path:     n = 50000, dt = 0.002s, r = 25000000/s, t = 40ns/op
```

```
# main
url_parse:              n = 50000, dt = 0.066s, r = 757576/s, t = 1320ns/op
url_parse_get_path:     n = 50000, dt = 0.002s, r = 25000000/s, t = 40ns/op
```