### PR TITLE
chore(test): fix `test_collect_specifiers` windows path to specifier code

### DIFF
--- a/cli/fs_util.rs
+++ b/cli/fs_util.rs
@@ -721,7 +721,7 @@ mod tests {
           .join("child")
           .to_str()
           .unwrap()
-          .replace('/', "\\")
+          .replace('\\', "/")
       )],
       &[],
       predicate,


### PR DESCRIPTION
This corrects the wrong implementation of @dsherret's suggestion.[1]

[1] https://github.com/denoland/deno/pull/15002#discussion_r913016582
