### PR TITLE
feat: import.meta.resolve()

### DIFF
--- a/meta.mjs
+++ b/meta.mjs
@@ -1,0 +1,4 @@
+console.log("I am", import.meta.url, import.meta);
+console.log("Resolving ./foo.js", await import.meta.resolve("./foo.js"));
+console.log("Resolving ./foo.js from ./bar.js", await import.meta.resolve("./foo.js", "./bar.js"));
+


### PR DESCRIPTION
Opening for a discussion purposes.

```
// meta.js
console.log("I am", import.meta.url, import.meta);
console.log("Resolving ./foo.js", await import.meta.resolve("./foo.js"));
console.log("Resolving ./foo.js from ./bar.js", await import.meta.resolve("./foo.js", "./bar.js"));
```

```
$ deno run meta.js
I am file:///Users/ib/dev/deno/meta.mjs {
  url: "file:///Users/ib/dev/deno/meta.mjs",
  main: true,
  resolve: [Function: resolve]
}
Resolving ./foo.js file:///Users/ib/dev/deno/foo.js
Resolving ./foo.js from ./bar.js file:///Users/ib/dev/deno/foo.js

```

@guybedford I'm a bit surprised in Node's behavior, when I try to run `node --experimental-import-meta-resolve meta.mjs` I get:
```
I am file:///Users/ib/dev/deno/meta.mjs [Object: null prototype] {
  resolve: [AsyncFunction: resolve],
  url: 'file:///Users/ib/dev/deno/meta.mjs'
}
node:internal/errors:466
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/ib/dev/deno/foo.js' imported from /Users/ib/dev/deno/meta.mjs
    at new NodeError (node:internal/errors:377:5)
    at finalizeResolution (node:internal/modules/esm/resolve:405:11)
    at moduleResolve (node:internal/modules/esm/resolve:966:10)
    at defaultResolve (node:internal/modules/esm/resolve:1174:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:605:30)
    at Object.resolve (node:internal/modules/esm/initialize_import_meta:15:26)
    at file:///Users/ib/dev/deno/meta.mjs:2:53
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:409:24) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v18.1.0

```
I would have thought that this function is for pure resolution and it won't touch file system to check for the existence of a specifier we're trying to resolve.

Closes https://github.com/denoland/deno/issues/7296
Closes https://github.com/denoland/deno/issues/15073
