### PR TITLE
chore: pin aes-gcm to fix cargo publish

### DIFF
--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 aes = "0.8.1"
 # TODO(@littledivy): Move to stable release
 # https://github.com/RustCrypto/AEADs/issues/411
-aes-gcm = "0.10.0-pre"
+aes-gcm = "=0.10.0-pre"
 aes-kw = { version = "0.2.1", features = ["alloc"] }
 base64 = "0.13.0"
 block-modes = "0.9.1"


### PR DESCRIPTION
Fixes publishing.

https://github.com/denoland/deno/runs/7199683659?check_suite_focus=true