### PR TITLE
chore(ci): fix post publish for forwarding release commit back to main

### DIFF
--- a/tools/release/04_post_publish.ts
+++ b/tools/release/04_post_publish.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run=cargo,git --allow-net --no-check --lock=tools/deno.lock.json
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run=cargo,git --allow-net --allow-env --no-check --lock=tools/deno.lock.json
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { DenoWorkspace } from "./deno_workspace.ts";
 import { createOctoKit, getGitHubRepository } from "./deps.ts";


### PR DESCRIPTION
```
Opening PR...
Failed. Please manually open a PR. PermissionDenied: Requires env access to "GITHUB_TOKEN", run again with the --allow-env flag
    at Object.opSync (deno:core/01_core.js:170:12)
    at Object.getEnv [as get] (deno:runtime/js/30_os.js:77:17)
    at getEnvVarOrThrow (https://raw.githubusercontent.com/denoland/automation/0.11.0/github_actions.ts:23:26)
    at getGitHubToken (https://raw.githubusercontent.com/denoland/automation/0.11.0/github_actions.ts:19:10)
    at createOctoKit (https://raw.githubusercontent.com/denoland/automation/0.11.0/github_actions.ts:14:11)
    at forwardReleaseCommitToMain (file:///home/runner/work/deno/deno/tools/release/04_post_publish.ts:65:26)
    at async file:///home/runner/work/deno/deno/tools/release/04_post_publish.ts:15:3
```