### PR TITLE
fix: Cache passed type checks for many configs

### DIFF
--- a/cli/cache.rs
+++ b/cli/cache.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct EmitMetadata {
   pub version_hash: String,
-  pub type_checks_succeeded: HashSet<String>,
+  /// List of hashed configs for successful type checks.
+  pub type_check_hashes: HashSet<String>,
 }
 
 pub enum CacheType {

--- a/cli/cache.rs
+++ b/cli/cache.rs
@@ -14,11 +14,13 @@ use deno_graph::source::LoadFuture;
 use deno_graph::source::LoadResponse;
 use deno_graph::source::Loader;
 use deno_runtime::permissions::Permissions;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct EmitMetadata {
   pub version_hash: String,
+  pub type_checks_succeeded: HashSet<String>,
 }
 
 pub enum CacheType {
@@ -26,6 +28,8 @@ pub enum CacheType {
   SourceMap,
   TypeScriptBuildInfo,
   Version,
+  GetTypeCheckSucceeded(String),
+  SetTypeCheckSucceeded,
 }
 
 /// A trait which provides a concise implementation to getting and setting

--- a/cli/cache.rs
+++ b/cli/cache.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 pub struct EmitMetadata {
   pub version_hash: String,
   /// List of hashed configs for successful type checks.
+  #[serde(default)]
   pub type_check_hashes: HashSet<String>,
 }
 

--- a/cli/cache.rs
+++ b/cli/cache.rs
@@ -22,7 +22,7 @@ pub struct EmitMetadata {
   pub version_hash: String,
   /// List of hashed configs for successful type checks.
   #[serde(default)]
-  pub type_check_hashes: HashSet<String>,
+  pub check_config_hashes: HashSet<String>,
 }
 
 pub enum CacheType {

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -192,7 +192,7 @@ impl Cacher for DiskCache {
       // because `Cacher::get()` is constrained that way. Clean up.
       CacheType::GetTypeCheckSucceeded(config_hash) => {
         if let Some(metadata) = self.get_emit_metadata(specifier) {
-          if metadata.type_check_hashes.contains(&config_hash) {
+          if metadata.check_config_hashes.contains(&config_hash) {
             return Some("".to_string());
           }
         }
@@ -221,14 +221,14 @@ impl Cacher for DiskCache {
       CacheType::Version => {
         let data = if let Some(mut data) = self.get_emit_metadata(specifier) {
           if value != data.version_hash {
-            data.type_check_hashes.clear();
+            data.check_config_hashes.clear();
           }
           data.version_hash = value;
           data
         } else {
           EmitMetadata {
             version_hash: value,
-            type_check_hashes: Default::default(),
+            check_config_hashes: Default::default(),
           }
         };
         return self.set_emit_metadata(specifier, data);
@@ -238,7 +238,7 @@ impl Cacher for DiskCache {
         let mut data = self
           .get_emit_metadata(specifier)
           .expect("Must set emit before TypeCheckSucceeded");
-        if data.type_check_hashes.insert(value) {
+        if data.check_config_hashes.insert(value) {
           self.set_emit_metadata(specifier, data)?;
         }
         return Ok(());

--- a/cli/disk_cache.rs
+++ b/cli/disk_cache.rs
@@ -192,7 +192,7 @@ impl Cacher for DiskCache {
       // because `Cacher::get()` is constrained that way. Clean up.
       CacheType::GetTypeCheckSucceeded(config_hash) => {
         if let Some(metadata) = self.get_emit_metadata(specifier) {
-          if metadata.type_checks_succeeded.contains(&config_hash) {
+          if metadata.type_check_hashes.contains(&config_hash) {
             return Some("".to_string());
           }
         }
@@ -221,14 +221,14 @@ impl Cacher for DiskCache {
       CacheType::Version => {
         let data = if let Some(mut data) = self.get_emit_metadata(specifier) {
           if value != data.version_hash {
-            data.type_checks_succeeded.clear();
+            data.type_check_hashes.clear();
           }
           data.version_hash = value;
           data
         } else {
           EmitMetadata {
             version_hash: value,
-            type_checks_succeeded: Default::default(),
+            type_check_hashes: Default::default(),
           }
         };
         return self.set_emit_metadata(specifier, data);
@@ -238,7 +238,7 @@ impl Cacher for DiskCache {
         let mut data = self
           .get_emit_metadata(specifier)
           .expect("Must set emit before TypeCheckSucceeded");
-        if data.type_checks_succeeded.insert(value) {
+        if data.type_check_hashes.insert(value) {
           self.set_emit_metadata(specifier, data)?;
         }
         return Ok(());

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -175,7 +175,9 @@ fn hash_check_config(
   mode: TypeCheckMode,
   roots: &[(ModuleSpecifier, ModuleKind)],
 ) -> String {
-  let mut input = vec![ts_config.as_bytes(), vec![mode as u8]];
+  let mut input = Vec::with_capacity(2 + roots.len() * 2);
+  input.push(ts_config.as_bytes());
+  input.push(vec![mode as u8]);
   let mut roots = roots
     .iter()
     .map(|(s, k)| (s.as_str(), serde_json::to_string(k).unwrap()))


### PR DESCRIPTION
Discussed on Discord a couple times.
```ts
// temp.ts
console.log("Hello, world!");

// temp.json
{
  "compilerOptions": {
    "lib": [
      "dom",
      "dom.iterable",
      "esnext"
    ]
  }
}
```
Before:
```
$ deno check temp.ts
Check file:///home/nayeem/projects/deno/temp.ts
$ deno check -c temp.json temp.ts
Check file:///home/nayeem/projects/deno/temp.ts
$ deno check temp.ts
Check file:///home/nayeem/projects/deno/temp.ts
$ deno check -c temp.json temp.ts
Check file:///home/nayeem/projects/deno/temp.ts
```
After:
```
$ deno check temp.ts
Check file:///home/nayeem/projects/deno/temp.ts
$ deno check -c temp.json temp.ts
Check file:///home/nayeem/projects/deno/temp.ts
$ deno check temp.ts
$ deno check -c temp.json temp.ts
```