### PR TITLE
Revert "fix(core): handle exception from Wasm termination (#15014)"

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -787,7 +787,7 @@ impl JsRuntime {
     }
   }
 
-  fn pump_v8_message_loop(&mut self) -> Result<(), Error> {
+  fn pump_v8_message_loop(&mut self) {
     let scope = &mut self.handle_scope();
     while v8::Platform::pump_message_loop(
       &v8::V8::get_current_platform(),
@@ -797,12 +797,7 @@ impl JsRuntime {
       // do nothing
     }
 
-    let tc_scope = &mut v8::TryCatch::new(scope);
-    tc_scope.perform_microtask_checkpoint();
-    match tc_scope.exception() {
-      None => Ok(()),
-      Some(exception) => exception_to_err_result(tc_scope, exception, false),
-    }
+    scope.perform_microtask_checkpoint();
   }
 
   pub fn poll_value(
@@ -884,7 +879,7 @@ impl JsRuntime {
       state.waker.register(cx.waker());
     }
 
-    self.pump_v8_message_loop()?;
+    self.pump_v8_message_loop();
 
     // Ops
     {
@@ -2303,56 +2298,6 @@ pub mod tests {
       "Promise resolution is still pending but the event loop has already resolved.",
       error_string,
     );
-  }
-
-  #[test]
-  fn terminate_execution_webassembly() {
-    let (mut isolate, _dispatch_count) = setup(Mode::Async);
-    let v8_isolate_handle = isolate.v8_isolate().thread_safe_handle();
-
-    let terminator_thread = std::thread::spawn(move || {
-      // allow deno to boot and run
-      std::thread::sleep(std::time::Duration::from_millis(1000));
-
-      // terminate execution
-      let ok = v8_isolate_handle.terminate_execution();
-      assert!(ok);
-    });
-
-    // Run an infinite loop in Webassemby code, which should be terminated.
-    isolate.execute_script("infinite_wasm_loop.js",
-                                 r#"
-                                 (async () => {
-                                 console.log("Begin");
-                                  const wasmCode = new Uint8Array([
-                                      0,    97,   115,  109,  1,    0,    0,    0,    1,   4,    1,
-                                      96,   0,    0,    3,    2,    1,    0,    7,    17,  1,    13,
-                                      105,  110,  102,  105,  110,  105,  116,  101,  95,  108,  111,
-                                      111,  112,  0,    0,    10,   9,    1,    7,    0,   3,    64,
-                                      12,   0,    11,   11,
-                                  ]);
-                                  const wasmModule = await WebAssembly.compile(wasmCode);
-                                  const wasmInstance = new WebAssembly.Instance(wasmModule);
-                                  wasmInstance.exports.infinite_loop();
-                                  })();
-                                      "#).expect("wasm infinite loop failed");
-    match futures::executor::block_on(isolate.run_event_loop(false)) {
-      Ok(_) => panic!("execution should be terminated"),
-      Err(e) => {
-        assert_eq!(e.to_string(), "Uncaught Error: execution terminated")
-      }
-    }
-    // Cancel the execution-terminating exception in order to allow script
-    // execution again.
-    let ok = isolate.v8_isolate().cancel_terminate_execution();
-    assert!(ok);
-
-    // Verify that the isolate usable again.
-    isolate
-      .execute_script("simple.js", "1 + 1")
-      .expect("execution should be possible again");
-
-    terminator_thread.join().unwrap();
   }
 
   #[test]


### PR DESCRIPTION
This reverts commit 77c25beaa59d64035c20ef59d93ed5a99677bc93.

The test is flaky on Windows: https://github.com/denoland/deno/runs/7205317217?check_suite_focus=true
```
failures:
---- runtime::tests::terminate_execution_webassembly stdout ----
thread 'runtime::tests::terminate_execution_webassembly' panicked at 'execution should be terminated', core\runtime.rs:2340:16
stack backtrace:
   0:     0x7ff6a715259f - std::backtrace_rs::backtrace::dbghelp::trace
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\..\..\backtrace\src\backtrace\dbghelp.rs:98
   1:     0x7ff6a715259f - std::backtrace_rs::backtrace::trace_unsynchronized
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2:     0x7ff6a715259f - std::sys_common::backtrace::_print_fmt
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\sys_common\backtrace.rs:66
   3:     0x7ff6a715259f - std::sys_common::backtrace::_print::impl$0::fmt
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\sys_common\backtrace.rs:45
   4:     0x7ff6a71713ca - core::fmt::write
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\core\src\fmt\mod.rs:1196
   5:     0x7ff6a714a429 - std::io::Write::write_fmt<alloc::vec::Vec<u8,alloc::alloc::Global> >
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\io\mod.rs:1654
   6:     0x7ff6a715521b - std::sys_common::backtrace::_print
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\sys_common\backtrace.rs:48
   7:     0x7ff6a715521b - std::sys_common::backtrace::print
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\sys_common\backtrace.rs:35
   8:     0x7ff6a715521b - std::panicking::default_hook::closure$1
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\panicking.rs:295
   9:     0x7ff6a7154e3f - std::panicking::default_hook
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\panicking.rs:311
  10:     0x7ff6a7155811 - std::panicking::rust_panic_with_hook
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\panicking.rs:698
  11:     0x7ff6a7155692 - std::panicking::begin_panic_handler::closure$0
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\panicking.rs:586
  12:     0x7ff6a7153157 - std::sys_common::backtrace::__rust_end_short_backtrace<std::panicking::begin_panic_handler::closure_env$0,never$>
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\sys_common\backtrace.rs:138
  13:     0x7ff6a71553a9 - std::panicking::begin_panic_handler
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\panicking.rs:584
  14:     0x7ff6a732a135 - core::panicking::panic_fmt
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\core\src\panicking.rs:142
  15:     0x7ff6a6121a5e - deno_core::runtime::tests::terminate_execution_webassembly::h978ce78a8af6a9aa
  16:     0x7ff6a6048b19 - deno_core::runtime::tests::terminate_execution_webassembly::***closure***::h563d1ea7214156f2
  17:     0x7ff6a61a63eb - core::ops::function::FnOnce::call_once::h7fee07914818ceab
  18:     0x7ff6a6242d06 - core::ops::function::FnOnce::call_once
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\core\src\ops\function.rs:248
  19:     0x7ff6a6242d06 - test::__rust_begin_short_backtrace<void (*)()>
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\test\src\lib.rs:573
  20:     0x7ff6a6241458 - alloc::boxed::impl$44::call_once
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\alloc\src\boxed.rs:1872
  21:     0x7ff6a6241458 - core::panic::unwind_safe::impl$23::call_once
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\core\src\panic\unwind_safe.rs:271
  22:     0x7ff6a6241458 - std::panicking::try::do_call
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\panicking.rs:492
  23:     0x7ff6a6241458 - std::panicking::try
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\panicking.rs:456
  24:     0x7ff6a6241458 - std::panic::catch_unwind
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\panic.rs:137
  25:     0x7ff6a6241458 - test::run_test_in_process
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\test\src\lib.rs:596
  26:     0x7ff6a6241458 - test::run_test::run_test_inner::closure$0
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\test\src\lib.rs:490
  27:     0x7ff6a6203f14 - test::run_test::run_test_inner::closure$1
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\test\src\lib.rs:517
  28:     0x7ff6a6203f14 - std::sys_common::backtrace::__rust_begin_short_backtrace<test::run_test::run_test_inner::closure_env$1,tuple$<> >
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\sys_common\backtrace.rs:122
  29:     0x7ff6a620b430 - std::thread::impl$0::spawn_unchecked_::closure$1::closure$0
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\thread\mod.rs:501
  30:     0x7ff6a620b430 - core::panic::unwind_safe::impl$23::call_once
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\core\src\panic\unwind_safe.rs:271
  31:     0x7ff6a620b430 - std::panicking::try::do_call
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\panicking.rs:492
  32:     0x7ff6a620b430 - std::panicking::try
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\panicking.rs:456
  33:     0x7ff6a620b430 - std::panic::catch_unwind
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\panic.rs:137
  34:     0x7ff6a620b430 - std::thread::impl$0::spawn_unchecked_::closure$1
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\std\src\thread\mod.rs:500
  35:     0x7ff6a620b430 - core::ops::function::FnOnce::call_once<std::thread::impl$0::spawn_unchecked_::closure_env$1<test::run_test::run_test_inner::closure_env$1,tuple$<> >,tuple$<> >
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\core\src\ops\function.rs:248
  36:     0x7ff6a71609dc - alloc::boxed::impl$44::call_once
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\alloc\src\boxed.rs:1872
  37:     0x7ff6a71609dc - alloc::boxed::impl$44::call_once
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc\library\alloc\src\boxed.rs:1872
  38:     0x7ff6a71609dc - std::sys::windows::thread::impl$0::new::thread_start
                               at /rustc/a8314ef7d0ec7b75c336af2c9857bfaf43002bfc/library\std\src\sys\windows\thread.rs:56
  39:     0x7ffcdbe37974 - BaseThreadInitThunk
  40:     0x7ffcde1ea2f1 - RtlUserThreadStart
failures:
    runtime::tests::terminate_execution_webassembly
test result: FAILED. 84 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.10s
error: test failed, to rerun pass '-p deno_core --lib'
Error: Process completed with exit code 1.
```

CC @joao-bellomo 