### PR TITLE
fix(ext/dom_exception): align better with spec

### DIFF
--- a/cli/tests/unit/dom_exception_test.ts
+++ b/cli/tests/unit/dom_exception_test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertStringIncludes } from "./test_util.ts";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "./test_util.ts";
 
 Deno.test(function customInspectFunction() {
   const blob = new DOMException("test");
@@ -7,4 +11,14 @@ Deno.test(function customInspectFunction() {
     `DOMException: test`,
   );
   assertStringIncludes(Deno.inspect(DOMException.prototype), "DOMException");
+});
+
+Deno.test(function nameToCodeMappingPrototypeAccess() {
+  const newCode = 100;
+  const objectPrototype = Object.prototype as unknown as {
+    pollution: number;
+  };
+  objectPrototype.pollution = newCode;
+  assertNotEquals(newCode, new DOMException("test", "pollution").code);
+  Reflect.deleteProperty(objectPrototype, "pollution");
 });

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -25,7 +25,7 @@
   const consoleInternal = window.__bootstrap.console;
 
   const _name = Symbol("name");
-  const _messsage = Symbol("message");
+  const _message = Symbol("message");
   const _code = Symbol("code");
 
   // Defined in WebIDL 4.3.

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -15,6 +15,7 @@
     Error,
     ErrorPrototype,
     ObjectDefineProperty,
+    ObjectCreate,
     ObjectEntries,
     ObjectPrototypeIsPrototypeOf,
     ObjectSetPrototypeOf,
@@ -59,31 +60,32 @@
   // Defined in WebIDL 2.8.1.
   // https://webidl.spec.whatwg.org/#dfn-error-names-table
   /** @type {Record<string, number>} */
-  const nameToCodeMapping = {
-    __proto__: null,
-    IndexSizeError: INDEX_SIZE_ERR,
-    HierarchyRequestError: HIERARCHY_REQUEST_ERR,
-    WrongDocumentError: WRONG_DOCUMENT_ERR,
-    InvalidCharacterError: INVALID_CHARACTER_ERR,
-    NoModificationAllowedError: NO_MODIFICATION_ALLOWED_ERR,
-    NotFoundError: NOT_FOUND_ERR,
-    NotSupportedError: NOT_SUPPORTED_ERR,
-    InUseAttributeError: INUSE_ATTRIBUTE_ERR,
-    InvalidStateError: INVALID_STATE_ERR,
-    SyntaxError: SYNTAX_ERR,
-    InvalidModificationError: INVALID_MODIFICATION_ERR,
-    NamespaceError: NAMESPACE_ERR,
-    InvalidAccessError: INVALID_ACCESS_ERR,
-    TypeMismatchError: TYPE_MISMATCH_ERR,
-    SecurityError: SECURITY_ERR,
-    NetworkError: NETWORK_ERR,
-    AbortError: ABORT_ERR,
-    URLMismatchError: URL_MISMATCH_ERR,
-    QuotaExceededError: QUOTA_EXCEEDED_ERR,
-    TimeoutError: TIMEOUT_ERR,
-    InvalidNodeTypeError: INVALID_NODE_TYPE_ERR,
-    DataCloneError: DATA_CLONE_ERR,
-  };
+  // the prototype should be null, to prevent user code from looking
+  // up Object.prototype properties, such as "toString"
+  const nameToCodeMapping = ObjectCreate(null, {
+    IndexSizeError: { value: INDEX_SIZE_ERR },
+    HierarchyRequestError: { value: HIERARCHY_REQUEST_ERR },
+    WrongDocumentError: { value: WRONG_DOCUMENT_ERR },
+    InvalidCharacterError: { value: INVALID_CHARACTER_ERR },
+    NoModificationAllowedError: { value: NO_MODIFICATION_ALLOWED_ERR },
+    NotFoundError: { value: NOT_FOUND_ERR },
+    NotSupportedError: { value: NOT_SUPPORTED_ERR },
+    InUseAttributeError: { value: INUSE_ATTRIBUTE_ERR },
+    InvalidStateError: { value: INVALID_STATE_ERR },
+    SyntaxError: { value: SYNTAX_ERR },
+    InvalidModificationError: { value: INVALID_MODIFICATION_ERR },
+    NamespaceError: { value: NAMESPACE_ERR },
+    InvalidAccessError: { value: INVALID_ACCESS_ERR },
+    TypeMismatchError: { value: TYPE_MISMATCH_ERR },
+    SecurityError: { value: SECURITY_ERR },
+    NetworkError: { value: NETWORK_ERR },
+    AbortError: { value: ABORT_ERR },
+    URLMismatchError: { value: URL_MISMATCH_ERR },
+    QuotaExceededError: { value: QUOTA_EXCEEDED_ERR },
+    TimeoutError: { value: TIMEOUT_ERR },
+    InvalidNodeTypeError: { value: INVALID_NODE_TYPE_ERR },
+    DataCloneError: { value: DATA_CLONE_ERR },
+  });
 
   // Defined in WebIDL 4.3.
   // https://webidl.spec.whatwg.org/#idl-DOMException

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -106,6 +106,7 @@
       this[_message] = message
       this[_name] = name;
       this[_code] = code;
+      this[webidl.brand] = webidl.brand;
 
       const error = new Error(message);
       error.name = "DOMException";

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -103,7 +103,7 @@
       });
       const code = nameToCodeMapping[name] ?? 0;
 
-      this[_message] = message
+      this[_message] = message;
       this[_name] = name;
       this[_code] = code;
       this[webidl.brand] = webidl.brand;

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -93,11 +93,11 @@
 
     // https://webidl.spec.whatwg.org/#dom-domexception-domexception
     constructor(message = "", name = "Error") {
-      const message = webidl.converters.DOMString(message, {
+      message = webidl.converters.DOMString(message, {
         prefix: "Failed to construct 'DOMException'",
         context: "Argument 1",
       });
-      const name = webidl.converters.DOMString(name, {
+      name = webidl.converters.DOMString(name, {
         prefix: "Failed to construct 'DOMException'",
         context: "Argument 2",
       });

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -18,6 +18,7 @@
     ObjectEntries,
     ObjectPrototypeIsPrototypeOf,
     ObjectSetPrototypeOf,
+    Symbol,
     SymbolFor,
   } = window.__bootstrap.primordials;
   const webidl = window.__bootstrap.webidl;


### PR DESCRIPTION
Fixes #12927.
There were no issues open about the current implementation.

Uses symbolic members for `DOMException`, and applies branding to its getters.
Uses a null prototype for the error string->code mapping object, to avoid prototype access.
Also updates outdated specification links.