### PR TITLE
fix(ext/ffi): Avoid keeping JsRuntimeState RefCell borrowed for event loop middleware calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: 15-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
+          key: 16-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}
 
       # In main branch, always creates fresh cache
       - name: Cache build output (main)
@@ -251,7 +251,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: |
-            15-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
+            16-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}
 
       # Restore cache from the latest 'main' branch build.
       - name: Cache build output (PR)
@@ -267,7 +267,7 @@ jobs:
             !./target/*/*.tar.gz
           key: never_saved
           restore-keys: |
-            15-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
+            16-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-
 
       # Don't save cache after building PRs or branches other than 'main'.
       - name: Skip save cache (PR)

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -925,8 +925,7 @@ impl JsRuntime {
     // Event loop middlewares
     let mut maybe_scheduling = false;
     {
-      let state = state_rc.borrow();
-      let op_state = state.op_state.clone();
+      let op_state = state_rc.borrow().op_state.clone();
       for f in &self.event_loop_middlewares {
         if f(op_state.clone(), cx) {
           maybe_scheduling = true;

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -232,7 +232,9 @@
     }
 
     unref() {
-      if (--this.#refcount === 0) {
+      // Only decrement refcount if it is positive, and only
+      // unref the callback if refcount reaches zero.
+      if (this.#refcount > 0 && --this.#refcount === 0) {
         core.opSync("op_ffi_unsafe_callback_ref", false);
       }
     }

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -1307,20 +1307,7 @@ unsafe fn do_ffi_callback(
   }
 
   let recv = v8::undefined(&mut scope);
-  let policy = isolate.get_microtasks_policy();
-  if policy == v8::MicrotasksPolicy::Auto {
-    // Set the microtask policy to explicit so that callbacks can create promises
-    // without those getting executed before the callback returns. Without this
-    // thread safe callbacks would need to use `setTimeout()` to enqueue work. With this
-    // a `Promise.resolve().then()` can be used to enqueue work to be run directly on the
-    // next event loop tick.
-    isolate.set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
-  }
   let call_result = func.call(&mut scope, recv.into(), &params);
-  if policy == v8::MicrotasksPolicy::Auto {
-    // After calling, set microtasks policy back to auto.
-    isolate.set_microtasks_policy(v8::MicrotasksPolicy::Auto);
-  }
   std::mem::forget(callback);
 
   if call_result.is_none() {

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -1307,7 +1307,20 @@ unsafe fn do_ffi_callback(
   }
 
   let recv = v8::undefined(&mut scope);
+  let policy = isolate.get_microtasks_policy();
+  if policy == v8::MicrotasksPolicy::Auto {
+    // Set the microtask policy to explicit so that callbacks can create promises
+    // without those getting executed before the callback returns. Without this
+    // thread safe callbacks would need to use `setTimeout()` to enqueue work. With this
+    // a `Promise.resolve().then()` can be used to enqueue work to be run directly on the
+    // next event loop tick.
+    isolate.set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
+  }
   let call_result = func.call(&mut scope, recv.into(), &params);
+  if policy == v8::MicrotasksPolicy::Auto {
+    // After calling, set microtasks policy back to auto.
+    isolate.set_microtasks_policy(v8::MicrotasksPolicy::Auto);
+  }
   std::mem::forget(callback);
 
   if call_result.is_none() {

--- a/test_ffi/src/lib.rs
+++ b/test_ffi/src/lib.rs
@@ -224,6 +224,20 @@ pub extern "C" fn call_stored_function_thread_safe() {
   });
 }
 
+#[no_mangle]
+pub extern "C" fn call_stored_function_thread_safe_and_log() {
+  std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+    unsafe {
+      if STORED_FUNCTION.is_none() {
+        return;
+      }
+      STORED_FUNCTION.unwrap()();
+      println!("STORED_FUNCTION called");
+    }
+  });
+}
+
 // FFI performance helper functions
 #[no_mangle]
 pub extern "C" fn nop() {}

--- a/test_ffi/tests/event_loop_integration.ts
+++ b/test_ffi/tests/event_loop_integration.ts
@@ -33,7 +33,7 @@ const tripleLogCallback = () => {
   setTimeout(() => {
     console.log("Timeout");
     callback.unref();
-  });
+  }, 10);
 };
 
 const callback = new Deno.UnsafeCallback(

--- a/test_ffi/tests/event_loop_integration.ts
+++ b/test_ffi/tests/event_loop_integration.ts
@@ -1,0 +1,64 @@
+const targetDir = Deno.execPath().replace(/[^\/\\]+$/, "");
+const [libPrefix, libSuffix] = {
+  darwin: ["lib", "dylib"],
+  linux: ["lib", "so"],
+  windows: ["", "dll"],
+}[Deno.build.os];
+const libPath = `${targetDir}/${libPrefix}test_ffi.${libSuffix}`;
+
+const dylib = Deno.dlopen(
+  libPath,
+  {
+    store_function: {
+      parameters: ["function"],
+      result: "void",
+    },
+    call_stored_function: {
+      parameters: [],
+      result: "void",
+    },
+    call_stored_function_thread_safe_and_log: {
+      parameters: [],
+      result: "void",
+    },
+  } as const,
+);
+
+const tripleLogCallback = () => {
+  console.log("Sync");
+  Promise.resolve().then(() => {
+    console.log("Async");
+    callback.unref();
+  });
+  setTimeout(() => {
+    console.log("Timeout");
+    callback.unref();
+  });
+};
+
+const callback = new Deno.UnsafeCallback(
+  {
+    parameters: [],
+    result: "void",
+  } as const,
+  tripleLogCallback,
+);
+
+// Store function
+dylib.symbols.store_function(callback.pointer);
+
+// Synchronous callback logging
+console.log("SYNCHRONOUS");
+dylib.symbols.call_stored_function();
+console.log("STORED_FUNCTION called");
+
+// Wait to make sure synch logging and async logging
+await new Promise((res) => setTimeout(res, 100));
+
+// Ref twice to make sure both `Promise.resolve().then()` and `setTimeout()`
+// must resolve before isolate exists.
+callback.ref();
+callback.ref();
+
+console.log("THREAD SAFE");
+dylib.symbols.call_stored_function_thread_safe_and_log();

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -179,6 +179,16 @@ fn event_loop_integration() {
   }
   println!("{:?}", output.status);
   assert!(output.status.success());
+  // TODO(aapoalas): The order of logging in thread safe callbacks is
+  // unexpected: The callback logs synchronously and creates an asynchronous
+  // logging task, which then gets called synchronously before the callback
+  // actually yields to the calling thread. This is in contrast to what the
+  // logging would look like if the call was coming from within Deno itself,
+  // and may lead users to unknowingly run heavy asynchronous tasks from thread
+  // safe callbacks synchronously.
+  // The fix would be to make sure microtasks are only run after the event loop
+  // middleware that polls them has completed its work. This just does not seem
+  // to work properly with Linux release builds.
   let expected = "\
     SYNCHRONOUS\n\
     Sync\n\

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -156,3 +156,40 @@ fn thread_safe_callback() {
   assert_eq!(stdout, expected);
   assert_eq!(stderr, "");
 }
+
+#[test]
+fn event_loop_integration() {
+  build();
+
+  let output = deno_cmd()
+    .arg("run")
+    .arg("--allow-ffi")
+    .arg("--allow-read")
+    .arg("--unstable")
+    .arg("--quiet")
+    .arg("tests/event_loop_integration.ts")
+    .env("NO_COLOR", "1")
+    .output()
+    .unwrap();
+  let stdout = std::str::from_utf8(&output.stdout).unwrap();
+  let stderr = std::str::from_utf8(&output.stderr).unwrap();
+  if !output.status.success() {
+    println!("stdout {}", stdout);
+    println!("stderr {}", stderr);
+  }
+  println!("{:?}", output.status);
+  assert!(output.status.success());
+  let expected = "\
+    SYNCHRONOUS\n\
+    Sync\n\
+    STORED_FUNCTION called\n\
+    Async\n\
+    Timeout\n\
+    THREAD SAFE\n\
+    Sync\n\
+    STORED_FUNCTION called\n\
+    Async\n\
+    Timeout\n";
+  assert_eq!(stdout, expected);
+  assert_eq!(stderr, "");
+}

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -187,8 +187,8 @@ fn event_loop_integration() {
     Timeout\n\
     THREAD SAFE\n\
     Sync\n\
-    STORED_FUNCTION called\n\
     Async\n\
+    STORED_FUNCTION called\n\
     Timeout\n";
   assert_eq!(stdout, expected);
   assert_eq!(stderr, "");


### PR DESCRIPTION
JsRuntimeState was mistakenly kept borrowed during event loop middleware calls for the purpose of getting a clone of the `Rc<RefCell<OpState>>` even though the cloning removes the need for the borrow to be kept. With this change thread safe FFI callbacks can now safely call ops that themselves access the `JsRuntimeState` such as ops that create Promises etc.

At the same time, FFI callbacks are changed to set the Isolate's MicrotasksPolicy to `Explicit`. This is done in order to allow thread safe callbacks to return before any microtasks queued by it get executed.

As an example, imagine a thread safe callback using this JavaScript callback:
```ts
const callback = () => {
  console.log("Sync work");
  Promise.resolve().then(() => {
    console.log("Async work");
  });
};
```
If any JS code were to call the `callback()` and immediately log "Called 'callback'" on return, the output would be
> Sync work
> Called 'callback'
> Async work

For an equivalent FFI library call to the C callback that is `callback` wrapped in an `UnsafeCallback` the order of the two last lines would be reversed. The reason this is that the callback gets called from an empty stack, and as it finishes Deno would automatically run any pending microtasks. This is not how we want callbacks, especially thread safe callbacks, to work.

Thread safe callbacks are already being polled from inside the `event_loop_middleware`, which probably (I honestly am not exactly sure) already run microtasks after it is done, or at least on the next event loop tick. Thus, having these callbacks themselves run microtasks is a bit redundant and most importantly it makes it hard for these callbacks to schedule asynchronous work without themselves being blocked by said "asynchronous work". We want thread safe callbacks to have the ability to call "synchronously" into Deno JS code and after that synchronous work is done to immediately return control (unblock) to the calling thread.

Setting the MicrotasksPolicy could also be done only for thread safe callbacks. However, interrupt handlers being called on the main thread also suffer this same issue. They also suffer from other occasionally panic-inducing issues which make them quite inadvisable, but still this change is relevant for those as well. Normal synchronous callbacks are only affected this in the sense that they're now doing an unnecessary check on the policy value. Their scopes are not built on an empty stack, and as such they would not run pending microtasks anyway.