### PR TITLE
fix(ext/ffi): allow opting out of fast ffi calls

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -430,6 +430,8 @@ declare namespace Deno {
     result: Result;
     /** When true, function calls will run on a dedicated blocking thread and will return a Promise resolving to the `result`. */
     nonblocking?: NonBlocking;
+    /** When true, function calls can safely callback into JS or trigger a GC event. Default is `false`. */
+    callback?: boolean;
   }
 
   export interface ForeignStatic<Type extends NativeType = NativeType> {

--- a/test_ffi/tests/ffi_types.ts
+++ b/test_ffi/tests/ffi_types.ts
@@ -5,7 +5,7 @@
 const remote = Deno.dlopen(
   "dummy_lib.so",
   {
-    method1: { parameters: ["usize", "usize"], result: "void" },
+    method1: { parameters: ["usize", "usize"], result: "void", callback: true },
     method2: { parameters: [], result: "void" },
     method3: { parameters: ["usize"], result: "void" },
     method4: { parameters: ["isize"], result: "void" },

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -164,10 +164,12 @@ const dylib = Deno.dlopen(libPath, {
   call_stored_function: {
     parameters: [],
     result: "void",
+    callback: true,
   },
   call_stored_function_2: {
     parameters: ["u8"],
     result: "void",
+    callback: true,
   },
   // Statics
   "static_u32": {
@@ -372,12 +374,14 @@ assertThrows(
   "hi",
 );
 
+const { call_stored_function } = dylib.symbols;
+
 dylib.symbols.call_fn_ptr(ptr(logCallback));
 dylib.symbols.call_fn_ptr_many_parameters(ptr(logManyParametersCallback));
 dylib.symbols.call_fn_ptr_return_u8(ptr(returnU8Callback));
 dylib.symbols.call_fn_ptr_return_buffer(ptr(returnBufferCallback));
 dylib.symbols.store_function(ptr(logCallback));
-dylib.symbols.call_stored_function();
+call_stored_function();
 dylib.symbols.store_function_2(ptr(add10Callback));
 dylib.symbols.call_stored_function_2(20);
 


### PR DESCRIPTION
Fast API calls must not trigger a GC event or callback into JS. It can happen that an FFI library stores a function pointer to call later, this patch adds a new option to hint this. Opting out seems better than opting in because this is a less common use case.

cc @aapoalas 