### PR TITLE
chore(web, worker): Use `DetachedBuffer` for `postMessage` ops

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -27,6 +27,7 @@ pub use serde;
 pub use serde_json;
 pub use serde_v8;
 pub use serde_v8::ByteString;
+pub use serde_v8::DetachedBuffer;
 pub use serde_v8::StringOrBuffer;
 pub use serde_v8::U16String;
 pub use serde_v8::ZeroCopyBuf;

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -6,7 +6,7 @@ use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::op;
 
-use deno_core::ZeroCopyBuf;
+use deno_core::DetachedBuffer;
 use deno_core::{CancelFuture, Resource};
 use deno_core::{CancelHandle, OpState};
 use deno_core::{RcRef, ResourceId};
@@ -21,7 +21,7 @@ enum Transferable {
   ArrayBuffer(u32),
 }
 
-type MessagePortMessage = (Vec<u8>, Vec<Transferable>);
+type MessagePortMessage = (DetachedBuffer, Vec<Transferable>);
 
 pub struct MessagePort {
   rx: RefCell<UnboundedReceiver<MessagePortMessage>>,
@@ -40,7 +40,7 @@ impl MessagePort {
     // Swallow the failed to send error. It means the channel was disentangled,
     // but not cleaned up.
     if let Some(tx) = &*self.tx.borrow() {
-      tx.send((data.data.to_vec(), transferables)).ok();
+      tx.send((data.data, transferables)).ok();
     }
 
     Ok(())
@@ -59,7 +59,7 @@ impl MessagePort {
       let js_transferables =
         serialize_transferables(&mut state.borrow_mut(), transferables);
       return Ok(Some(JsMessageData {
-        data: ZeroCopyBuf::from(data),
+        data,
         transferables: js_transferables,
       }));
     }
@@ -182,7 +182,7 @@ fn serialize_transferables(
 
 #[derive(Deserialize, Serialize)]
 pub struct JsMessageData {
-  data: ZeroCopyBuf,
+  data: DetachedBuffer,
   transferables: Vec<JsTransferable>,
 }
 


### PR DESCRIPTION
This commit uses `DetachedBuffer` instead of `ZeroCopyBuf` in the ops that back `Worker.prototype.postMessage` and `MessagePort.prototype.postMessage`. This is done because the serialized buffer is then copied to the destination isolate, even though it is internal to runtime code and not used for anything else, so detaching it and transferring it instead saves an unnecessary copy.

Towards #15129.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
