### PR TITLE
fix(ext/console): Fix a typo in a warning when .timeEnd is called on an unknown timer

### DIFF
--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -2146,7 +2146,7 @@
       label = String(label);
 
       if (!MapPrototypeHas(timerMap, label)) {
-        this.warn(`Timer '${label}' does not exists`);
+        this.warn(`Timer '${label}' does not exist`);
         return;
       }
 


### PR DESCRIPTION
Changes `does not exists` to `does not exist`.

This PR does not require any tests as it only changes one string.
