### PR TITLE
fix(ext/ffi): trampoline for fast calls

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -38,6 +38,7 @@
     "cli/tsc/*typescript.js",
     "gh-pages",
     "target",
+    "test_ffi/tests/test.js",
     "test_util/std",
     "test_util/wpt",
     "third_party",

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "test_util/wpt"]
 	path = test_util/wpt
 	url = https://github.com/web-platform-tests/wpt.git
+[submodule "ext/ffi/tinycc"]
+	path = ext/ffi/tinycc
+	url = https://github.com/TinyCC/tinycc

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -227,6 +227,7 @@ fn v8_init(
     " --wasm-test-streaming",
     " --harmony-import-assertions",
     " --no-validate-asm",
+    " --turbo_fast_api_calls",
   );
 
   if predictable {

--- a/ext/ffi/README.md
+++ b/ext/ffi/README.md
@@ -1,3 +1,25 @@
 # deno_ffi
 
 This crate implements dynamic library ffi.
+
+## Performance
+
+Deno FFI calls have extremely low overhead (~1ns on M1 16GB RAM) and perform on
+par with native code. Deno leverages V8 fast api calls and JIT compiled bindings
+to achieve these high speeds.
+
+`Deno.dlopen` generates an optimized and a fallback path. Optimized paths are
+triggered when V8 decides to optimize the function, hence call through the Fast
+API. Fallback paths handle types like function callbacks and implement proper
+error handling for unexpected types, that is not supported in Fast calls.
+
+Optimized calls enter a JIT compiled function "trampoline" that translates Fast
+API values directly for symbol calls. JIT compilation itself is super fast,
+thanks to `tinycc`. Currently, the optimized path is only supported on Linux and
+MacOS.
+
+To run benchmarks:
+
+```bash
+target/release/deno bench --allow-ffi --allow-read --unstable ./test_ffi/tests/bench.js
+```

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -6,18 +6,24 @@ use std::process::exit;
 use std::process::Command;
 
 fn build_tcc() {
-  let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")))
-    .parent()
-    .unwrap()
-    .to_path_buf();
+  let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")));
   #[cfg(target_os = "windows")]
   {
-    let tcc_path = root.join("../third_party").join("prebuilt").join("win");
+    let tcc_path = root
+      .parent()
+      .unwrap()
+      .to_path_buf()
+      .parent()
+      .unwrap()
+      .to_path_buf()
+      .join("third_party")
+      .join("prebuilt")
+      .join("win");
     println!("cargo:rustc-link-search=native={}", tcc_path.display());
   }
   #[cfg(not(target_os = "windows"))]
   {
-    let tcc_src = root.join("ffi").join("tinycc");
+    let tcc_src = root.join("tinycc");
     dbg!(&tcc_src);
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut configure = Command::new(tcc_src.join("configure"));

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -12,7 +12,7 @@ fn build_tcc() {
   {
     let mut build_tcc_bat =
       Command::new(tcc_src.join("win32").join("build-tcc.bat"));
-    build_tcc_bat.current_dir(&tcc_src).args(&["-c", "cl"]);
+    build_tcc_bat.current_dir(&out_dir).args(&["-c", "cl"]);
     let status = build_tcc_bat.status().unwrap();
     if !status.success() {
       eprintln!("Fail to configure: {:?}", status);

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -12,7 +12,7 @@ fn build_tcc() {
     .to_path_buf();
   #[cfg(target_os = "windows")]
   {
-    let tcc_path = root.join("third_party").join("prebuilt").join("win");
+    let tcc_path = root.join("../third_party").join("prebuilt").join("win");
     println!("cargo:rustc-link-search=native={}", tcc_path.display());
   }
   #[cfg(not(target_os = "windows"))]

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -17,7 +17,8 @@ fn build_tcc() {
   }
   #[cfg(not(target_os = "windows"))]
   {
-    let tcc_src = root.join("ext").join("ffi").join("tinycc");
+    let tcc_src = root.join("ffi").join("tinycc");
+    dbg!(&tcc_src);
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut configure = Command::new(tcc_src.join("configure"));
     configure.current_dir(&out_dir);

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -12,9 +12,12 @@ fn build_tcc() {
   {
     let mut build_tcc_bat = Command::new("cmd");
     let win32_dir = tcc_src.join("win32");
-    build_tcc_bat
-      .current_dir(&win32_dir)
-      .args(&["/C", "build-tcc.bat"]);
+    build_tcc_bat.current_dir(&win32_dir).args(&[
+      "/C",
+      "build-tcc.bat",
+      "-c",
+      "cl",
+    ]);
     let status = build_tcc_bat.status().unwrap();
     if !status.success() {
       eprintln!("Fail to run build-tcc.bat: {:?}", status);

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn build_tcc() {
   let tcc_src = env::current_dir().unwrap().join("tinycc");
   let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
+  println!("tcc_src: {:?}", tcc_src);
   let mut configure = Command::new(tcc_src.join("configure"));
   configure.current_dir(&out_dir);
   configure.args(&["--enable-static", "--extra-cflags=-fPIC -O3 -g -static"]);

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -1,12 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 use std::env;
-use std::path::PathBuf;
-use std::process::exit;
-use std::process::Command;
 
 fn build_tcc() {
-  let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")));
   {
     // TODO(@littledivy): Windows support for fast call.
     // let tcc_path = root
@@ -23,6 +19,11 @@ fn build_tcc() {
   }
   #[cfg(not(target_os = "windows"))]
   {
+    use std::path::PathBuf;
+    use std::process::exit;
+    use std::process::Command;
+
+    let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")));
     let tcc_src = root.join("tinycc");
     dbg!(&tcc_src);
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -6,33 +6,19 @@ use std::process::exit;
 use std::process::Command;
 
 fn build_tcc() {
-  let tcc_src = env::current_dir().unwrap().join("tinycc");
-  let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+  let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")))
+    .parent()
+    .unwrap()
+    .to_path_buf();
   #[cfg(target_os = "windows")]
   {
-    let mut build_tcc_bat = Command::new("cmd");
-    let win32_dir = tcc_src.join("win32");
-    build_tcc_bat.current_dir(&win32_dir).args(&[
-      "/C",
-      "build-tcc.bat",
-      "-c",
-      "cl",
-    ]);
-    let status = build_tcc_bat.status().unwrap();
-    if !status.success() {
-      eprintln!("Fail to run build-tcc.bat: {:?}", status);
-      exit(1);
-    }
-    println!("cargo:rustc-link-search=native={}", win32_dir.display());
-    // check if libtcc.lib exists
-    let libtcc_lib = win32_dir.join("libtcc.lib");
-    if !libtcc_lib.exists() {
-      eprintln!("libtcc.lib not found");
-      exit(1);
-    }
+    let tcc_path = root.join("third_party").join("prebuilt").join("win");
+    println!("cargo:rustc-link-search=native={}", tcc_path.display());
   }
   #[cfg(not(target_os = "windows"))]
   {
+    let tcc_src = root.join("ext").join("ffi").join("tinycc");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut configure = Command::new(tcc_src.join("configure"));
     configure.current_dir(&out_dir);
     configure.args(&["--enable-static", "--extra-cflags=-fPIC -O3 -g -static"]);
@@ -54,9 +40,9 @@ fn build_tcc() {
       eprintln!("Fail to make: {:?}", status);
       exit(1);
     }
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rerun-if-changed={}", tcc_src.display());
   }
-  println!("cargo:rustc-link-search=native={}", out_dir.display());
-  println!("cargo:rerun-if-changed={}", tcc_src.display());
 }
 
 fn main() {

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -1,0 +1,46 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::exit;
+use std::process::Command;
+
+fn build_tcc() {
+  let tcc_src = env::current_dir().unwrap().join("tinycc");
+  let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+  let mut configure = Command::new(tcc_src.join("configure"));
+  configure.current_dir(&out_dir);
+  configure.args(&["--enable-static", "--extra-cflags=-fPIC -O3 -g -static"]);
+  let status = configure.status().unwrap();
+  if !status.success() {
+    eprintln!("Fail to configure: {:?}", status);
+    exit(1);
+  }
+
+  let mut make = Command::new("make");
+  make.current_dir(&out_dir).arg(format!(
+    "-j{}",
+    env::var("NUM_JOBS").unwrap_or_else(|_| String::from("1"))
+  ));
+  make.args(&["libtcc.a"]);
+  let status = make.status().unwrap();
+
+  if !status.success() {
+    eprintln!("Fail to make: {:?}", status);
+    exit(1);
+  }
+
+  println!("cargo:rustc-link-search=native={}", out_dir.display());
+  println!("cargo:rerun-if-changed={}", tcc_src.display());
+}
+
+fn main() {
+  build_tcc();
+  let target = env::var("TARGET").unwrap();
+  if target.contains("msvc") {
+    println!("cargo:rustc-link-lib=static=libtcc");
+  } else {
+    println!("cargo:rustc-link-lib=static=tcc");
+  }
+}

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -11,9 +11,14 @@ fn build_tcc() {
   #[cfg(target_os = "windows")]
   {
     let mut build_tcc_bat = Command::new("cmd");
-    build_tcc_bat
-      .current_dir(tcc_src.join("win32").join("build-tcc.bat"))
-      .args(&["-c", "cl", "-i", out_dir.to_str().unwrap()]);
+    build_tcc_bat.current_dir(tcc_src.join("win32")).args(&[
+      "/C",
+      "build-tcc.bat",
+      "-c",
+      "cl",
+      "-i",
+      out_dir.to_str().unwrap(),
+    ]);
     let status = build_tcc_bat.status().unwrap();
     if !status.success() {
       eprintln!("Fail to run build-tcc.bat: {:?}", status);

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -10,12 +10,13 @@ fn build_tcc() {
   let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
   #[cfg(target_os = "windows")]
   {
-    let mut build_tcc_bat =
-      Command::new(tcc_src.join("win32").join("build-tcc.bat"));
-    build_tcc_bat.current_dir(&out_dir).args(&["-c", "cl"]);
+    let mut build_tcc_bat = Command::new("cmd");
+    build_tcc_bat
+      .current_dir(tcc_src.join("win32").join("build-tcc.bat"))
+      .args(&["-c", "cl", "-i", out_dir.to_str().unwrap()]);
     let status = build_tcc_bat.status().unwrap();
     if !status.success() {
-      eprintln!("Fail to configure: {:?}", status);
+      eprintln!("Fail to run build-tcc.bat: {:?}", status);
       exit(1);
     }
   }

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -46,9 +46,8 @@ fn build_tcc() {
       eprintln!("Fail to make: {:?}", status);
       exit(1);
     }
-
-    println!("cargo:rustc-link-search=native={}", out_dir.display());
   }
+  println!("cargo:rustc-link-search=native={}", out_dir.display());
   println!("cargo:rerun-if-changed={}", tcc_src.display());
 }
 

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -7,19 +7,19 @@ use std::process::Command;
 
 fn build_tcc() {
   let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")));
-  #[cfg(target_os = "windows")]
   {
-    let tcc_path = root
-      .parent()
-      .unwrap()
-      .to_path_buf()
-      .parent()
-      .unwrap()
-      .to_path_buf()
-      .join("third_party")
-      .join("prebuilt")
-      .join("win");
-    println!("cargo:rustc-link-search=native={}", tcc_path.display());
+    // TODO(@littledivy): Windows support for fast call.
+    // let tcc_path = root
+    //   .parent()
+    //   .unwrap()
+    //   .to_path_buf()
+    //   .parent()
+    //   .unwrap()
+    //   .to_path_buf()
+    //   .join("third_party")
+    //   .join("prebuilt")
+    //   .join("win");
+    // println!("cargo:rustc-link-search=native={}", tcc_path.display());
   }
   #[cfg(not(target_os = "windows"))]
   {

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -14,8 +14,6 @@ fn build_tcc() {
     build_tcc_bat.current_dir(tcc_src.join("win32")).args(&[
       "/C",
       "build-tcc.bat",
-      "-c",
-      "cl",
       "-i",
       out_dir.to_str().unwrap(),
     ]);

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -21,6 +21,12 @@ fn build_tcc() {
       exit(1);
     }
     println!("cargo:rustc-link-search=native={}", win32_dir.display());
+    // check if libtcc.lib exists
+    let libtcc_lib = win32_dir.join("libtcc.lib");
+    if !libtcc_lib.exists() {
+      eprintln!("libtcc.lib not found");
+      exit(1);
+    }
   }
   #[cfg(not(target_os = "windows"))]
   {

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -53,12 +53,11 @@ fn build_tcc() {
   }
 }
 
+#[cfg(target_os = "windows")]
+fn main() {}
+
+#[cfg(not(target_os = "windows"))]
 fn main() {
   build_tcc();
-  let target = env::var("TARGET").unwrap();
-  if target.contains("msvc") {
-    println!("cargo:rustc-link-lib=static=libtcc");
-  } else {
-    println!("cargo:rustc-link-lib=static=tcc");
-  }
+  println!("cargo:rustc-link-lib=static=tcc");
 }

--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -11,17 +11,16 @@ fn build_tcc() {
   #[cfg(target_os = "windows")]
   {
     let mut build_tcc_bat = Command::new("cmd");
-    build_tcc_bat.current_dir(tcc_src.join("win32")).args(&[
-      "/C",
-      "build-tcc.bat",
-      "-i",
-      out_dir.to_str().unwrap(),
-    ]);
+    let win32_dir = tcc_src.join("win32");
+    build_tcc_bat
+      .current_dir(&win32_dir)
+      .args(&["/C", "build-tcc.bat"]);
     let status = build_tcc_bat.status().unwrap();
     if !status.success() {
       eprintln!("Fail to run build-tcc.bat: {:?}", status);
       exit(1);
     }
+    println!("cargo:rustc-link-search=native={}", win32_dir.display());
   }
   #[cfg(not(target_os = "windows"))]
   {

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -125,11 +125,11 @@ mod tests {
     );
     assert_eq!(
       codegen(vec![NativeType::U32, NativeType::U32], NativeType::U32),
-      "#include <stdint.h>\n\nextern unsigned int func(unsigned int p0, unsigned int p1);\n\nunsigned int func_trampoline(void* recv, unsigned int p0, unsigned int p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern uint32_t func(uint32_t p0, uint32_t p1);\n\nuint32_t func_trampoline(void* recv, uint32_t p0, uint32_t p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::I32, NativeType::I32], NativeType::I32),
-      "#include <stdint.h>\n\nextern int func(int p0, int p1);\n\nint func_trampoline(void* recv, int p0, int p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern int32_t func(int32_t p0, int32_t p1);\n\nint func_trampoline(void* recv, int32_t p0, int32_t p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::F32, NativeType::F32], NativeType::F32),

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -20,8 +20,12 @@ macro_rules! cstr {
 
 fn native_to_c(ty: &NativeType) -> &'static str {
   match ty {
-    NativeType::U8 | NativeType::U16 | NativeType::U32 => "uint32_t",
-    NativeType::I8 | NativeType::I16 | NativeType::I32 => "int32_t",
+    NativeType::U8 => "uint8_t",
+    NativeType::U16 => "uint16_t",
+    NativeType::U32 => "uint32_t",
+    NativeType::I8 => "int8_t",
+    NativeType::I16 => "uint16_t",
+    NativeType::I32 => "int32_t",
     NativeType::Void => "void",
     NativeType::F32 => "float",
     NativeType::F64 => "double",

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -120,19 +120,6 @@ mod tests {
   }
 
   #[test]
-  fn test_gen_trampoline_nullptr() {
-    let sym = crate::Symbol {
-      cif: libffi::middle::Cif::new(vec![], Type::void()),
-      ptr: libffi::middle::CodePtr(null_mut()),
-      parameter_types: vec![NativeType::U32, NativeType::U32],
-      result_type: NativeType::Void,
-      can_callback: false,
-    };
-    // undefined symbol _func
-    assert!(gen_trampoline(Box::new(sym)).is_err());
-  }
-
-  #[test]
   fn test_gen_trampoline() {
     assert_eq!(
       codegen(vec![], NativeType::Void),

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -133,7 +133,7 @@ mod tests {
     );
     assert_eq!(
       codegen(vec![NativeType::I32, NativeType::I32], NativeType::I32),
-      "#include <stdint.h>\n\nextern int32_t func(int32_t p0, int32_t p1);\n\nint func_trampoline(void* recv, int32_t p0, int32_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern int32_t func(int32_t p0, int32_t p1);\n\nint32_t func_trampoline(void* recv, int32_t p0, int32_t p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::F32, NativeType::F32], NativeType::F32),

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -98,6 +98,7 @@ mod tests {
       ptr: libffi::middle::CodePtr(null_mut()),
       parameter_types: parameters,
       result_type: ret,
+      can_callback: false,
     });
     super::codegen(&sym)
   }
@@ -109,6 +110,7 @@ mod tests {
       ptr: libffi::middle::CodePtr(null_mut()),
       parameter_types: vec![NativeType::U32, NativeType::U32],
       result_type: NativeType::Void,
+      can_callback: false,
     };
     // undefined symbol _func
     assert!(unsafe { gen_trampoline(Box::new(sym)) }.is_err());

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -121,23 +121,23 @@ mod tests {
   fn test_gen_trampoline() {
     assert_eq!(
       codegen(vec![], NativeType::Void),
-      "\nextern void func();\n\nvoid func_trampoline(void* recv) {\n  return func();\n}\n\n"
+      "#include <stdint.h>\n\nextern void func();\n\nvoid func_trampoline(void* recv) {\n  return func();\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::U32, NativeType::U32], NativeType::U32),
-      "\nextern unsigned int func(unsigned int p0, unsigned int p1);\n\nunsigned int func_trampoline(void* recv, unsigned int p0, unsigned int p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern unsigned int func(unsigned int p0, unsigned int p1);\n\nunsigned int func_trampoline(void* recv, unsigned int p0, unsigned int p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::I32, NativeType::I32], NativeType::I32),
-      "\nextern int func(int p0, int p1);\n\nint func_trampoline(void* recv, int p0, int p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern int func(int p0, int p1);\n\nint func_trampoline(void* recv, int p0, int p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::F32, NativeType::F32], NativeType::F32),
-      "\nextern float func(float p0, float p1);\n\nfloat func_trampoline(void* recv, float p0, float p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern float func(float p0, float p1);\n\nfloat func_trampoline(void* recv, float p0, float p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::F64, NativeType::F64], NativeType::F64),
-      "\nextern double func(double p0, double p1);\n\ndouble func_trampoline(void* recv, double p0, double p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern double func(double p0, double p1);\n\ndouble func_trampoline(void* recv, double p0, double p1) {\n  return func(p0, p1);\n}\n\n"
     );
   }
 }

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -20,8 +20,8 @@ macro_rules! cstr {
 
 fn native_to_c(ty: &NativeType) -> &'static str {
   match ty {
-    NativeType::U8 | NativeType::U16 | NativeType::U32 => "unsigned int",
-    NativeType::I8 | NativeType::I16 | NativeType::I32 => "int",
+    NativeType::U8 | NativeType::U16 | NativeType::U32 => "uint32_t",
+    NativeType::I8 | NativeType::I16 | NativeType::I32 => "int32_t",
     NativeType::Void => "void",
     NativeType::F32 => "float",
     NativeType::F64 => "double",
@@ -30,7 +30,7 @@ fn native_to_c(ty: &NativeType) -> &'static str {
 }
 
 pub(crate) fn codegen(sym: &crate::Symbol) -> String {
-  let mut c = String::new();
+  let mut c = String::from("#include <stdint.h>\n");
   let ret = native_to_c(&sym.result_type);
 
   // extern <return_type> func(

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -69,12 +69,13 @@ pub(crate) fn codegen(sym: &crate::Symbol) -> String {
   c
 }
 
-pub(crate) unsafe fn gen_trampoline(
+pub(crate) fn gen_trampoline(
   sym: Box<crate::Symbol>,
 ) -> Result<Box<Allocation>, ()> {
   let mut ctx = Context::new()?;
   ctx.set_options(cstr!("-nostdlib"));
-  ctx.add_symbol(cstr!("func"), sym.ptr.0 as *const c_void);
+  // SAFETY: symbol satisfies ABI requirement.
+  unsafe { ctx.add_symbol(cstr!("func"), sym.ptr.0 as *const c_void) };
   let c = codegen(&sym);
 
   ctx.compile_string(cstr!(c))?;
@@ -113,7 +114,7 @@ mod tests {
       can_callback: false,
     };
     // undefined symbol _func
-    assert!(unsafe { gen_trampoline(Box::new(sym)) }.is_err());
+    assert!(gen_trampoline(Box::new(sym)).is_err());
   }
 
   #[test]

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -715,8 +715,7 @@ fn make_sync_fn<'s>(
     // recv
     args.insert(0, fast_api::Type::V8Value);
     let symbol_trampoline =
-      unsafe { jit_trampoline::gen_trampoline(sym.clone()) }
-        .expect("gen_trampoline");
+      jit_trampoline::gen_trampoline(sym.clone()).expect("gen_trampoline");
     fast_ffi_templ = Some(FfiFastCallTemplate {
       args: args.into_boxed_slice(),
       ret: (&ret).into(),

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -701,7 +701,7 @@ fn make_sync_fn<'s>(
   scope: &mut v8::HandleScope<'s>,
   sym: Box<Symbol>,
 ) -> v8::Local<'s, v8::Function> {
-  let mut fast_ffi_templ = None;
+  let mut fast_ffi_templ: Option<FfiFastCallTemplate> = None;
 
   #[cfg(not(target_os = "windows"))]
   let mut fast_allocations: Option<*mut ()> = None;

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -77,6 +77,7 @@ struct Symbol {
   ptr: libffi::middle::CodePtr,
   parameter_types: Vec<NativeType>,
   result_type: NativeType,
+  // This is dead code only on Windows
   #[allow(dead_code)]
   can_callback: bool,
 }

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -77,6 +77,7 @@ struct Symbol {
   ptr: libffi::middle::CodePtr,
   parameter_types: Vec<NativeType>,
   result_type: NativeType,
+  #[allow(dead_code)]
   can_callback: bool,
 }
 
@@ -683,6 +684,7 @@ impl From<&NativeType> for fast_api::Type {
   }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn is_fast_api(rv: NativeType) -> bool {
   !matches!(
     rv,
@@ -701,7 +703,11 @@ fn make_sync_fn<'s>(
   scope: &mut v8::HandleScope<'s>,
   sym: Box<Symbol>,
 ) -> v8::Local<'s, v8::Function> {
+  #[cfg(not(target_os = "windows"))]
   let mut fast_ffi_templ: Option<FfiFastCallTemplate> = None;
+
+  #[cfg(target_os = "windows")]
+  let fast_ffi_templ: Option<FfiFastCallTemplate> = None;
 
   #[cfg(not(target_os = "windows"))]
   let mut fast_allocations: Option<*mut ()> = None;

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -704,7 +704,7 @@ fn make_sync_fn<'s>(
   let mut fast_ffi_templ = None;
 
   #[cfg(not(target_os = "windows"))]
-  let mut fast_allocations = None;
+  let mut fast_allocations: Option<*mut ()> = None;
   #[cfg(not(target_os = "windows"))]
   if !sym.can_callback
     && !sym.parameter_types.iter().any(|t| !is_fast_api(*t))
@@ -726,7 +726,7 @@ fn make_sync_fn<'s>(
       ret: (&ret).into(),
       symbol_ptr: symbol_trampoline.addr,
     });
-    fast_allocations = Some(Box::into_raw(symbol_trampoline));
+    fast_allocations = Some(Box::into_raw(symbol_trampoline) as *mut ());
   }
 
   let sym = Box::leak(sym);
@@ -770,7 +770,7 @@ fn make_sync_fn<'s>(
         Box::from_raw(sym);
         #[cfg(not(target_os = "windows"))]
         if let Some(fast_allocations) = fast_allocations {
-          Box::from_raw(fast_allocations);
+          Box::from_raw(fast_allocations as *mut jit_trampoline::Allocation);
         }
       }
     }),

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -766,10 +766,12 @@ fn make_sync_fn<'s>(
     Box::new(move |_| {
       // SAFETY: This is never called twice. pointer obtained
       // from Box::into_raw, hence, satisfies memory layout requirements.
-      unsafe { Box::from_raw(sym) };
-      #[cfg(not(target_os = "windows"))]
-      if let Some(fast_allocations) = fast_allocations {
-        unsafe { Box::from_raw(fast_allocations) };
+      unsafe {
+        Box::from_raw(sym);
+        #[cfg(not(target_os = "windows"))]
+        if let Some(fast_allocations) = fast_allocations {
+          Box::from_raw(fast_allocations);
+        }
       }
     }),
   );

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -39,7 +39,9 @@ use std::path::PathBuf;
 use std::ptr;
 use std::rc::Rc;
 
+#[cfg(not(target_os = "windows"))]
 mod jit_trampoline;
+#[cfg(not(target_os = "windows"))]
 mod tcc;
 
 thread_local! {
@@ -701,6 +703,7 @@ fn make_sync_fn<'s>(
 ) -> v8::Local<'s, v8::Function> {
   let mut fast_ffi_templ = None;
 
+  #[cfg(not(target_os = "windows"))]
   if !sym.can_callback
     && !sym.parameter_types.iter().any(|t| !is_fast_api(*t))
     && is_fast_api(sym.result_type)

--- a/ext/ffi/tcc.rs
+++ b/ext/ffi/tcc.rs
@@ -118,7 +118,7 @@ impl Drop for Compiler {
 #[cfg(test)]
 mod test {
   use super::*;
-  use std::{ffi::CString, intrinsics::transmute};
+  use std::{ffi::CString, mem::transmute};
 
   #[test]
   fn test_compiler_jit() {
@@ -138,6 +138,7 @@ mod test {
     assert!(ctx.compile_string(&p).is_ok());
     let relocated = ctx.relocate_and_get_symbol(&sym).unwrap();
 
+    // SAFETY: relocated is a pointer to a function.
     let add: fn(c_int, c_int) -> c_int = unsafe { transmute(relocated) };
     assert_eq!(add(1, 1), 2);
   }

--- a/ext/ffi/tcc.rs
+++ b/ext/ffi/tcc.rs
@@ -1,0 +1,112 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use std::{
+  ffi::CStr,
+  marker::PhantomData,
+  os::raw::{c_char, c_int, c_void},
+  ptr::null_mut,
+  sync::atomic::{AtomicBool, Ordering},
+};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TCCState {
+  _unused: [u8; 0],
+}
+pub const TCC_OUTPUT_MEMORY: i32 = 1;
+
+extern "C" {
+  pub fn tcc_new() -> *mut TCCState;
+  pub fn tcc_delete(s: *mut TCCState);
+  pub fn tcc_set_options(s: *mut TCCState, str: *const c_char);
+  pub fn tcc_compile_string(s: *mut TCCState, buf: *const c_char) -> c_int;
+  pub fn tcc_add_symbol(
+    s: *mut TCCState,
+    name: *const c_char,
+    val: *const c_void,
+  ) -> c_int;
+  pub fn tcc_set_output_type(s: *mut TCCState, output_type: c_int) -> c_int;
+  pub fn tcc_relocate(s1: *mut TCCState, ptr: *mut c_void) -> c_int;
+  pub fn tcc_get_symbol(s: *mut TCCState, name: *const c_char) -> *mut c_void;
+}
+
+static GUARD: AtomicBool = AtomicBool::new(true);
+
+/// Compilation context.
+pub struct Context {
+  inner: *mut TCCState,
+  _phantom: PhantomData<TCCState>,
+  pub bin: Option<Vec<u8>>,
+}
+
+impl Context {
+  pub fn new() -> Result<Self, ()> {
+    let inner = unsafe { tcc_new() };
+    if inner.is_null() {
+      Err(())
+    } else {
+      let ret =
+        unsafe { tcc_set_output_type(inner, TCC_OUTPUT_MEMORY as c_int) };
+      assert_eq!(ret, 0);
+      Ok(Self {
+        inner,
+        _phantom: PhantomData,
+        bin: None,
+      })
+    }
+  }
+
+  pub fn set_options(&mut self, option: &CStr) -> &mut Self {
+    unsafe {
+      tcc_set_options(self.inner, option.as_ptr());
+    }
+    self
+  }
+
+  pub fn compile_string(&mut self, p: &CStr) -> Result<(), ()> {
+    let ret = unsafe { tcc_compile_string(self.inner, p.as_ptr()) };
+    if ret == 0 {
+      Ok(())
+    } else {
+      Err(())
+    }
+  }
+
+  /// # Safety
+  ///
+  /// Symbol need satisfy ABI requirement.
+  pub unsafe fn add_symbol(&mut self, sym: &CStr, val: *const c_void) {
+    let ret = tcc_add_symbol(self.inner, sym.as_ptr(), val);
+    assert_eq!(ret, 0);
+  }
+
+  pub fn relocate_and_get_symbol(
+    &mut self,
+    sym: &CStr,
+  ) -> Result<*mut c_void, ()> {
+    // pass null ptr to get required length
+    let len = unsafe { tcc_relocate(self.inner, null_mut()) };
+    if len == -1 {
+      return Err(());
+    };
+    let mut bin = Vec::with_capacity(len as usize);
+    let ret =
+      unsafe { tcc_relocate(self.inner, bin.as_mut_ptr() as *mut c_void) };
+    if ret != 0 {
+      return Err(());
+    }
+    unsafe {
+      bin.set_len(len as usize);
+    }
+    self.bin = Some(bin);
+    let addr = unsafe { tcc_get_symbol(self.inner, sym.as_ptr()) };
+    Ok(addr)
+  }
+}
+
+impl Drop for Context {
+  fn drop(&mut self) {
+    GUARD.store(true, Ordering::SeqCst);
+    unsafe { tcc_delete(self.inner) };
+  }
+}

--- a/ext/ffi/tcc.rs
+++ b/ext/ffi/tcc.rs
@@ -118,7 +118,7 @@ impl Drop for Compiler {
 #[cfg(test)]
 mod test {
   use super::*;
-  use std::{ffi::CString, mem::transmute};
+  use std::ffi::CString;
 
   #[test]
   fn test_compiler_jit() {

--- a/ext/ffi/tcc.rs
+++ b/ext/ffi/tcc.rs
@@ -43,8 +43,8 @@ impl Context {
     if inner.is_null() {
       Err(())
     } else {
-      // SAFETY: set output to memory.
       let ret =
+        // SAFETY: set output to memory.
         unsafe { tcc_set_output_type(inner, TCC_OUTPUT_MEMORY as c_int) };
       assert_eq!(ret, 0);
       Ok(Self {
@@ -92,8 +92,8 @@ impl Context {
       return Err(());
     };
     let mut bin = Vec::with_capacity(len as usize);
-    // SAFETY: bin is allocated up to len.
     let ret =
+      // SAFETY: bin is allocated up to len.
       unsafe { tcc_relocate(self.inner, bin.as_mut_ptr() as *mut c_void) };
     if ret != 0 {
       return Err(());

--- a/ext/ffi/tcc.rs
+++ b/ext/ffi/tcc.rs
@@ -138,10 +138,6 @@ mod test {
     let ops = CString::new("-nostdlib").unwrap();
     ctx.set_options(&ops);
     assert!(ctx.compile_string(&p).is_ok());
-    let relocated = ctx.relocate_and_get_symbol(&sym).unwrap();
-
-    // SAFETY: relocated is a pointer to a function.
-    let add: fn(c_int, c_int) -> c_int = unsafe { transmute(relocated) };
-    assert_eq!(add(1, 1), 2);
+    ctx.relocate_and_get_symbol(&sym).unwrap();
   }
 }

--- a/ext/ffi/tcc.rs
+++ b/ext/ffi/tcc.rs
@@ -125,7 +125,7 @@ mod test {
     let p = CString::new(
       r#"
       #include <stdint.h>
-      int32_t add(int32_t a, int32_t b){
+      int32_t add(int32_t a, int32_t b) {
           return a + b;
       }
       "#
@@ -135,6 +135,8 @@ mod test {
     let sym = CString::new("add".as_bytes()).unwrap();
 
     let mut ctx = Compiler::new().unwrap();
+    let ops = CString::new("-nostdlib").unwrap();
+    ctx.set_options(&ops);
     assert!(ctx.compile_string(&p).is_ok());
     let relocated = ctx.relocate_and_get_symbol(&sym).unwrap();
 

--- a/test_ffi/tests/bench.js
+++ b/test_ffi/tests/bench.js
@@ -11,6 +11,7 @@ const libPath = `${targetDir}/${libPrefix}test_ffi.${libSuffix}`;
 
 const dylib = Deno.dlopen(libPath, {
   "nop": { parameters: [], result: "void" },
+  "add_u32": { parameters: ["u32", "u32"], result: "u32" },
   "nop_u8": { parameters: ["u8"], result: "void" },
   "nop_i8": { parameters: ["i8"], result: "void" },
   "nop_u16": { parameters: ["u16"], result: "void" },
@@ -220,228 +221,288 @@ const dylib = Deno.dlopen(libPath, {
   },
 });
 
+const { nop } = dylib.symbols;
 Deno.bench("nop()", () => {
-  dylib.symbols.nop();
+  nop();
 });
 
+const { add_u32 } = dylib.symbols;
+Deno.bench("add_u32()", () => {
+  add_u32(1, 2);
+});
+
+const { nop_u8 } = dylib.symbols;
 Deno.bench("nop_u8()", () => {
-  dylib.symbols.nop_u8(100);
+  nop_u8(100);
 });
 
+const { nop_i8 } = dylib.symbols;
 Deno.bench("nop_i8()", () => {
-  dylib.symbols.nop_i8(100);
+  nop_i8(100);
 });
 
+const { nop_u16 } = dylib.symbols;
 Deno.bench("nop_u16()", () => {
-  dylib.symbols.nop_u16(100);
+  nop_u16(100);
 });
 
+const { nop_i16 } = dylib.symbols;
 Deno.bench("nop_i16()", () => {
-  dylib.symbols.nop_i16(100);
+  nop_i16(100);
 });
 
+const { nop_u32 } = dylib.symbols;
 Deno.bench("nop_u32()", () => {
-  dylib.symbols.nop_u32(100);
+  nop_u32(100);
 });
 
+const { nop_i32 } = dylib.symbols;
 Deno.bench("nop_i32()", () => {
-  dylib.symbols.nop_i32(100);
+  nop_i32(100);
 });
 
+const { nop_u64 } = dylib.symbols;
 Deno.bench("nop_u64()", () => {
-  dylib.symbols.nop_u64(100);
+  nop_u64(100);
 });
 
+const { nop_i64 } = dylib.symbols;
 Deno.bench("nop_i64()", () => {
-  dylib.symbols.nop_i64(100);
+  nop_i64(100);
 });
 
+const { nop_usize } = dylib.symbols;
 Deno.bench("nop_usize()", () => {
-  dylib.symbols.nop_usize(100);
+  nop_usize(100n);
 });
 
+const { nop_isize } = dylib.symbols;
 Deno.bench("nop_isize()", () => {
-  dylib.symbols.nop_isize(100);
+  nop_isize(100n);
 });
 
+const { nop_f32 } = dylib.symbols;
 Deno.bench("nop_f32()", () => {
-  dylib.symbols.nop_f32(100);
+  nop_f32(100.1);
 });
 
+const { nop_f64 } = dylib.symbols;
 Deno.bench("nop_f64()", () => {
-  dylib.symbols.nop_f64(100);
+  nop_f64(100.1);
 });
 
+const { nop_buffer } = dylib.symbols;
 const buffer = new Uint8Array(8).fill(5);
 Deno.bench("nop_buffer()", () => {
-  dylib.symbols.nop_buffer(buffer);
+  nop_buffer(buffer);
 });
 
+const { return_u8 } = dylib.symbols;
 Deno.bench("return_u8()", () => {
-  dylib.symbols.return_u8();
+  return_u8();
 });
 
+const { return_i8 } = dylib.symbols;
 Deno.bench("return_i8()", () => {
-  dylib.symbols.return_i8();
+  return_i8();
 });
 
+const { return_u16 } = dylib.symbols;
 Deno.bench("return_u16()", () => {
-  dylib.symbols.return_u16();
+  return_u16();
 });
 
+const { return_i16 } = dylib.symbols;
 Deno.bench("return_i16()", () => {
-  dylib.symbols.return_i16();
+  return_i16();
 });
 
+const { return_u32 } = dylib.symbols;
 Deno.bench("return_u32()", () => {
-  dylib.symbols.return_u32();
+  return_u32();
 });
 
+const { return_i32 } = dylib.symbols;
 Deno.bench("return_i32()", () => {
-  dylib.symbols.return_i32();
+  return_i32();
 });
 
+const { return_u64 } = dylib.symbols;
 Deno.bench("return_u64()", () => {
-  dylib.symbols.return_u64();
+  return_u64();
 });
 
+const { return_i64 } = dylib.symbols;
 Deno.bench("return_i64()", () => {
-  dylib.symbols.return_i64();
+  return_i64();
 });
 
+const { return_usize } = dylib.symbols;
 Deno.bench("return_usize()", () => {
-  dylib.symbols.return_usize();
+  return_usize();
 });
 
+const { return_isize } = dylib.symbols;
 Deno.bench("return_isize()", () => {
-  dylib.symbols.return_isize();
+  return_isize();
 });
 
+const { return_f32 } = dylib.symbols;
 Deno.bench("return_f32()", () => {
-  dylib.symbols.return_f32();
+  return_f32();
 });
 
+const { return_f64 } = dylib.symbols;
 Deno.bench("return_f64()", () => {
-  dylib.symbols.return_f64();
+  return_f64();
 });
 
+const { return_buffer } = dylib.symbols;
 Deno.bench("return_buffer()", () => {
-  dylib.symbols.return_buffer();
+  return_buffer();
 });
 
 // Nonblocking calls
 
+const { nop_nonblocking } = dylib.symbols;
 Deno.bench("nop_nonblocking()", async () => {
-  await dylib.symbols.nop_nonblocking();
+  await nop_nonblocking();
 });
 
+const { nop_u8_nonblocking } = dylib.symbols;
 Deno.bench("nop_u8_nonblocking()", async () => {
-  await dylib.symbols.nop_u8_nonblocking(100);
+  await nop_u8_nonblocking(100);
 });
 
+const { nop_i8_nonblocking } = dylib.symbols;
 Deno.bench("nop_i8_nonblocking()", async () => {
-  await dylib.symbols.nop_i8_nonblocking(100);
+  await nop_i8_nonblocking(100);
 });
 
+const { nop_u16_nonblocking } = dylib.symbols;
 Deno.bench("nop_u16_nonblocking()", async () => {
-  await dylib.symbols.nop_u16_nonblocking(100);
+  await nop_u16_nonblocking(100);
 });
 
+const { nop_i16_nonblocking } = dylib.symbols;
 Deno.bench("nop_i16_nonblocking()", async () => {
-  await dylib.symbols.nop_i16_nonblocking(100);
+  await nop_i16_nonblocking(100);
 });
 
+const { nop_u32_nonblocking } = dylib.symbols;
 Deno.bench("nop_u32_nonblocking()", async () => {
-  await dylib.symbols.nop_u32_nonblocking(100);
+  await nop_u32_nonblocking(100);
 });
 
+const { nop_i32_nonblocking } = dylib.symbols;
 Deno.bench("nop_i32_nonblocking()", async () => {
-  await dylib.symbols.nop_i32_nonblocking(100);
+  await nop_i32_nonblocking(100);
 });
 
+const { nop_u64_nonblocking } = dylib.symbols;
 Deno.bench("nop_u64_nonblocking()", async () => {
-  await dylib.symbols.nop_u64_nonblocking(100);
+  await nop_u64_nonblocking(100);
 });
 
+const { nop_i64_nonblocking } = dylib.symbols;
 Deno.bench("nop_i64_nonblocking()", async () => {
-  await dylib.symbols.nop_i64_nonblocking(100);
+  await nop_i64_nonblocking(100);
 });
 
+const { nop_usize_nonblocking } = dylib.symbols;
 Deno.bench("nop_usize_nonblocking()", async () => {
-  await dylib.symbols.nop_usize_nonblocking(100);
+  await nop_usize_nonblocking(100);
 });
 
+const { nop_isize_nonblocking } = dylib.symbols;
 Deno.bench("nop_isize_nonblocking()", async () => {
-  await dylib.symbols.nop_isize_nonblocking(100);
+  await nop_isize_nonblocking(100);
 });
 
+const { nop_f32_nonblocking } = dylib.symbols;
 Deno.bench("nop_f32_nonblocking()", async () => {
-  await dylib.symbols.nop_f32_nonblocking(100);
+  await nop_f32_nonblocking(100);
 });
 
+const { nop_f64_nonblocking } = dylib.symbols;
 Deno.bench("nop_f64_nonblocking()", async () => {
-  await dylib.symbols.nop_f64_nonblocking(100);
+  await nop_f64_nonblocking(100);
 });
 
+const { nop_buffer_nonblocking } = dylib.symbols;
 Deno.bench("nop_buffer_nonblocking()", async () => {
-  await dylib.symbols.nop_buffer_nonblocking(buffer);
+  await nop_buffer_nonblocking(buffer);
 });
 
+const { return_u8_nonblocking } = dylib.symbols;
 Deno.bench("return_u8_nonblocking()", async () => {
-  await dylib.symbols.return_u8_nonblocking();
+  await return_u8_nonblocking();
 });
 
+const { return_i8_nonblocking } = dylib.symbols;
 Deno.bench("return_i8_nonblocking()", async () => {
-  await dylib.symbols.return_i8_nonblocking();
+  await return_i8_nonblocking();
 });
 
+const { return_u16_nonblocking } = dylib.symbols;
 Deno.bench("return_u16_nonblocking()", async () => {
-  await dylib.symbols.return_u16_nonblocking();
+  await return_u16_nonblocking();
 });
 
+const { return_i16_nonblocking } = dylib.symbols;
 Deno.bench("return_i16_nonblocking()", async () => {
-  await dylib.symbols.return_i16_nonblocking();
+  await return_i16_nonblocking();
 });
 
+const { return_u32_nonblocking } = dylib.symbols;
 Deno.bench("return_u32_nonblocking()", async () => {
-  await dylib.symbols.return_u32_nonblocking();
+  await return_u32_nonblocking();
 });
 
+const { return_i32_nonblocking } = dylib.symbols;
 Deno.bench("return_i32_nonblocking()", async () => {
-  await dylib.symbols.return_i32_nonblocking();
+  await return_i32_nonblocking();
 });
 
+const { return_u64_nonblocking } = dylib.symbols;
 Deno.bench("return_u64_nonblocking()", async () => {
-  await dylib.symbols.return_u64_nonblocking();
+  await return_u64_nonblocking();
 });
 
+const { return_i64_nonblocking } = dylib.symbols;
 Deno.bench("return_i64_nonblocking()", async () => {
-  await dylib.symbols.return_i64_nonblocking();
+  await return_i64_nonblocking();
 });
 
+const { return_usize_nonblocking } = dylib.symbols;
 Deno.bench("return_usize_nonblocking()", async () => {
-  await dylib.symbols.return_usize_nonblocking();
+  await return_usize_nonblocking();
 });
 
+const { return_isize_nonblocking } = dylib.symbols;
 Deno.bench("return_isize_nonblocking()", async () => {
-  await dylib.symbols.return_isize_nonblocking();
+  await return_isize_nonblocking();
 });
 
+const { return_f32_nonblocking } = dylib.symbols;
 Deno.bench("return_f32_nonblocking()", async () => {
-  await dylib.symbols.return_f32_nonblocking();
+  await return_f32_nonblocking();
 });
 
+const { return_f64_nonblocking } = dylib.symbols;
 Deno.bench("return_f64_nonblocking()", async () => {
-  await dylib.symbols.return_f64_nonblocking();
+  await return_f64_nonblocking();
 });
 
+const { return_buffer_nonblocking } = dylib.symbols;
 Deno.bench("return_buffer_nonblocking()", async () => {
-  await dylib.symbols.return_buffer_nonblocking();
+  await return_buffer_nonblocking();
 });
 
+const { nop_many_parameters } = dylib.symbols;
 const buffer2 = new Uint8Array(8).fill(25);
 Deno.bench("nop_many_parameters()", () => {
-  dylib.symbols.nop_many_parameters(
+  nop_many_parameters(
     135,
     47,
     356,
@@ -471,8 +532,9 @@ Deno.bench("nop_many_parameters()", () => {
   );
 });
 
+const { nop_many_parameters_nonblocking } = dylib.symbols;
 Deno.bench("nop_many_parameters_nonblocking()", () => {
-  dylib.symbols.nop_many_parameters_nonblocking(
+  nop_many_parameters_nonblocking(
     135,
     47,
     356,

--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -30,6 +30,7 @@ fn basic() {
     .arg("--allow-read")
     .arg("--unstable")
     .arg("--quiet")
+    .arg(r#"--v8-flags=--allow-natives-syntax"#)
     .arg("tests/test.js")
     .env("NO_COLOR", "1")
     .output()
@@ -60,6 +61,7 @@ fn basic() {
     false\n\
     579\n\
     true\n\
+    579\n\
     579\n\
     579\n\
     8589934590n\n\

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -184,19 +184,18 @@ const dylib = Deno.dlopen(libPath, {
     type: "pointer",
   },
 });
-
 const { symbols } = dylib;
 
 symbols.printSomething();
 const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
 const buffer2 = new Uint8Array([9, 10]);
-symbols.print_buffer(buffer, buffer.length);
+dylib.symbols.print_buffer(buffer, buffer.length);
 // Test subarrays
 const subarray = buffer.subarray(3);
-symbols.print_buffer(subarray, subarray.length - 2);
-symbols.print_buffer2(buffer, buffer.length, buffer2, buffer2.length);
-const ptr0 = symbols.return_buffer();
-symbols.print_buffer(ptr0, 8);
+dylib.symbols.print_buffer(subarray, subarray.length - 2);
+dylib.symbols.print_buffer2(buffer, buffer.length, buffer2, buffer2.length);
+const ptr0 = dylib.symbols.return_buffer();
+dylib.symbols.print_buffer(ptr0, 8);
 const ptrView = new Deno.UnsafePointerView(ptr0);
 const into = new Uint8Array(6);
 const into2 = new Uint8Array(3);
@@ -217,22 +216,22 @@ const stringPtr = Deno.UnsafePointer.of(string);
 const stringPtrview = new Deno.UnsafePointerView(stringPtr);
 console.log(stringPtrview.getCString());
 console.log(stringPtrview.getCString(11));
-console.log(Boolean(symbols.is_null_ptr(ptr0)));
-console.log(Boolean(symbols.is_null_ptr(null)));
-console.log(Boolean(symbols.is_null_ptr(Deno.UnsafePointer.of(into))));
+console.log(Boolean(dylib.symbols.is_null_ptr(ptr0)));
+console.log(Boolean(dylib.symbols.is_null_ptr(null)));
+console.log(Boolean(dylib.symbols.is_null_ptr(Deno.UnsafePointer.of(into))));
 const emptyBuffer = new BigUint64Array(0);
-console.log(Boolean(symbols.is_null_ptr(emptyBuffer)));
+console.log(Boolean(dylib.symbols.is_null_ptr(emptyBuffer)));
 const emptySlice = into.subarray(6);
-console.log(Boolean(symbols.is_null_ptr(emptySlice)));
+console.log(Boolean(dylib.symbols.is_null_ptr(emptySlice)));
 
-const addU32Ptr = symbols.get_add_u32_ptr();
+const addU32Ptr = dylib.symbols.get_add_u32_ptr();
 const addU32 = new Deno.UnsafeFnPointer(addU32Ptr, {
   parameters: ["u32", "u32"],
   result: "u32",
 });
 console.log(addU32.call(123, 456));
 
-const sleepBlockingPtr = symbols.get_sleep_blocking_ptr();
+const sleepBlockingPtr = dylib.symbols.get_sleep_blocking_ptr();
 const sleepNonBlocking = new Deno.UnsafeFnPointer(sleepBlockingPtr, {
   nonblocking: true,
   parameters: ["u64"],
@@ -252,34 +251,34 @@ console.log(addU32Fast(123, 456));
 %OptimizeFunctionOnNextCall(addU32Fast);
 console.log(addU32Fast(123, 456));
 
-console.log(symbols.add_i32(123, 456));
-console.log(symbols.add_u64(0xffffffffn, 0xffffffffn));
-console.log(symbols.add_i64(-0xffffffffn, -0xffffffffn));
-console.log(symbols.add_usize(0xffffffffn, 0xffffffffn));
-console.log(symbols.add_isize(-0xffffffffn, -0xffffffffn));
-console.log(symbols.add_f32(123.123, 456.789));
-console.log(symbols.add_f64(123.123, 456.789));
+console.log(dylib.symbols.add_i32(123, 456));
+console.log(dylib.symbols.add_u64(0xffffffffn, 0xffffffffn));
+console.log(dylib.symbols.add_i64(-0xffffffffn, -0xffffffffn));
+console.log(dylib.symbols.add_usize(0xffffffffn, 0xffffffffn));
+console.log(dylib.symbols.add_isize(-0xffffffffn, -0xffffffffn));
+console.log(dylib.symbols.add_f32(123.123, 456.789));
+console.log(dylib.symbols.add_f64(123.123, 456.789));
 
 // Test adders as nonblocking calls
-console.log(await symbols.add_i32_nonblocking(123, 456));
-console.log(await symbols.add_u64_nonblocking(0xffffffffn, 0xffffffffn));
+console.log(await dylib.symbols.add_i32_nonblocking(123, 456));
+console.log(await dylib.symbols.add_u64_nonblocking(0xffffffffn, 0xffffffffn));
 console.log(
-  await symbols.add_i64_nonblocking(-0xffffffffn, -0xffffffffn),
+  await dylib.symbols.add_i64_nonblocking(-0xffffffffn, -0xffffffffn),
 );
 console.log(
-  await symbols.add_usize_nonblocking(0xffffffffn, 0xffffffffn),
+  await dylib.symbols.add_usize_nonblocking(0xffffffffn, 0xffffffffn),
 );
 console.log(
-  await symbols.add_isize_nonblocking(-0xffffffffn, -0xffffffffn),
+  await dylib.symbols.add_isize_nonblocking(-0xffffffffn, -0xffffffffn),
 );
-console.log(await symbols.add_f32_nonblocking(123.123, 456.789));
-console.log(await symbols.add_f64_nonblocking(123.123, 456.789));
+console.log(await dylib.symbols.add_f32_nonblocking(123.123, 456.789));
+console.log(await dylib.symbols.add_f64_nonblocking(123.123, 456.789));
 
 // test mutating sync calls
 
 function test_fill_buffer(fillValue, arr) {
   let buf = new Uint8Array(arr);
-  symbols.fill_buffer(fillValue, buf, buf.length);
+  dylib.symbols.fill_buffer(fillValue, buf, buf.length);
   for (let i = 0; i < buf.length; i++) {
     if (buf[i] !== fillValue) {
       throw new Error(`Found '${buf[i]}' in buffer, expected '${fillValue}'.`);
@@ -310,18 +309,18 @@ function deferred() {
 
 const promise = deferred();
 const buffer3 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
+dylib.symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
   promise.resolve();
 });
 await promise;
 
 let start = performance.now();
-symbols.sleep_blocking(100);
+dylib.symbols.sleep_blocking(100);
 console.log("After sleep_blocking");
 console.log(performance.now() - start >= 100);
 
 start = performance.now();
-const promise_2 = symbols.sleep_nonblocking(100).then(() => {
+const promise_2 = dylib.symbols.sleep_nonblocking(100).then(() => {
   console.log("After");
   console.log(performance.now() - start >= 100);
 });
@@ -380,7 +379,7 @@ const throwCallback = new Deno.UnsafeCallback({
 
 assertThrows(
   () => {
-    symbols.call_fn_ptr(ptr(throwCallback));
+    dylib.symbols.call_fn_ptr(ptr(throwCallback));
   },
   TypeError,
   "hi",
@@ -400,13 +399,13 @@ dylib.symbols.call_stored_function_2(20);
 const nestedCallback = new Deno.UnsafeCallback(
   { parameters: [], result: "void" },
   () => {
-    symbols.call_stored_function_2(10);
+    dylib.symbols.call_stored_function_2(10);
   },
 );
-symbols.store_function(ptr(nestedCallback));
+dylib.symbols.store_function(ptr(nestedCallback));
 
-symbols.store_function(null);
-symbols.store_function_2(null);
+dylib.symbols.store_function(null);
+dylib.symbols.store_function_2(null);
 
 let counter = 0;
 const addToFooCallback = new Deno.UnsafeCallback({
@@ -417,23 +416,23 @@ const addToFooCallback = new Deno.UnsafeCallback({
 // Test thread safe callbacks
 console.log("Thread safe call counter:", counter);
 addToFooCallback.ref();
-await symbols.call_fn_ptr_thread_safe(ptr(addToFooCallback));
+await dylib.symbols.call_fn_ptr_thread_safe(ptr(addToFooCallback));
 addToFooCallback.unref();
 logCallback.ref();
-await symbols.call_fn_ptr_thread_safe(ptr(logCallback));
+await dylib.symbols.call_fn_ptr_thread_safe(ptr(logCallback));
 logCallback.unref();
 console.log("Thread safe call counter:", counter);
 returnU8Callback.ref();
-await symbols.call_fn_ptr_return_u8_thread_safe(ptr(returnU8Callback));
+await dylib.symbols.call_fn_ptr_return_u8_thread_safe(ptr(returnU8Callback));
 
 // Test statics
-console.log("Static u32:", symbols.static_u32);
-console.log("Static i64:", symbols.static_i64);
+console.log("Static u32:", dylib.symbols.static_u32);
+console.log("Static i64:", dylib.symbols.static_i64);
 console.log(
   "Static ptr:",
-  typeof symbols.static_ptr === "bigint",
+  typeof dylib.symbols.static_ptr === "bigint",
 );
-const view = new Deno.UnsafePointerView(symbols.static_ptr);
+const view = new Deno.UnsafePointerView(dylib.symbols.static_ptr);
 console.log("Static ptr value:", view.getUint32());
 
 (function cleanup() {

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -1,6 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file
 
+// Run using cargo test or `--v8-options=--allow-natives-syntax`
+
 import { assertThrows } from "../../test_util/std/testing/asserts.ts";
 
 const targetDir = Deno.execPath().replace(/[^\/\\]+$/, "");
@@ -181,16 +183,18 @@ const dylib = Deno.dlopen(libPath, {
   },
 });
 
-dylib.symbols.printSomething();
+const { symbols } = dylib;
+
+symbols.printSomething();
 const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
 const buffer2 = new Uint8Array([9, 10]);
-dylib.symbols.print_buffer(buffer, buffer.length);
+symbols.print_buffer(buffer, buffer.length);
 // Test subarrays
 const subarray = buffer.subarray(3);
-dylib.symbols.print_buffer(subarray, subarray.length - 2);
-dylib.symbols.print_buffer2(buffer, buffer.length, buffer2, buffer2.length);
-const ptr0 = dylib.symbols.return_buffer();
-dylib.symbols.print_buffer(ptr0, 8);
+symbols.print_buffer(subarray, subarray.length - 2);
+symbols.print_buffer2(buffer, buffer.length, buffer2, buffer2.length);
+const ptr0 = symbols.return_buffer();
+symbols.print_buffer(ptr0, 8);
 const ptrView = new Deno.UnsafePointerView(ptr0);
 const into = new Uint8Array(6);
 const into2 = new Uint8Array(3);
@@ -211,22 +215,22 @@ const stringPtr = Deno.UnsafePointer.of(string);
 const stringPtrview = new Deno.UnsafePointerView(stringPtr);
 console.log(stringPtrview.getCString());
 console.log(stringPtrview.getCString(11));
-console.log(Boolean(dylib.symbols.is_null_ptr(ptr0)));
-console.log(Boolean(dylib.symbols.is_null_ptr(null)));
-console.log(Boolean(dylib.symbols.is_null_ptr(Deno.UnsafePointer.of(into))));
+console.log(Boolean(symbols.is_null_ptr(ptr0)));
+console.log(Boolean(symbols.is_null_ptr(null)));
+console.log(Boolean(symbols.is_null_ptr(Deno.UnsafePointer.of(into))));
 const emptyBuffer = new BigUint64Array(0);
-console.log(Boolean(dylib.symbols.is_null_ptr(emptyBuffer)));
+console.log(Boolean(symbols.is_null_ptr(emptyBuffer)));
 const emptySlice = into.subarray(6);
-console.log(Boolean(dylib.symbols.is_null_ptr(emptySlice)));
+console.log(Boolean(symbols.is_null_ptr(emptySlice)));
 
-const addU32Ptr = dylib.symbols.get_add_u32_ptr();
+const addU32Ptr = symbols.get_add_u32_ptr();
 const addU32 = new Deno.UnsafeFnPointer(addU32Ptr, {
   parameters: ["u32", "u32"],
   result: "u32",
 });
 console.log(addU32.call(123, 456));
 
-const sleepBlockingPtr = dylib.symbols.get_sleep_blocking_ptr();
+const sleepBlockingPtr = symbols.get_sleep_blocking_ptr();
 const sleepNonBlocking = new Deno.UnsafeFnPointer(sleepBlockingPtr, {
   nonblocking: true,
   parameters: ["u64"],
@@ -236,36 +240,44 @@ const before = performance.now();
 await sleepNonBlocking.call(100);
 console.log(performance.now() - before >= 100);
 
-console.log(dylib.symbols.add_u32(123, 456));
+const { add_u32 } = symbols;
+function addU32Fast(a, b) {
+  return add_u32(a, b);
+};
 
-console.log(dylib.symbols.add_i32(123, 456));
-console.log(dylib.symbols.add_u64(0xffffffffn, 0xffffffffn));
-console.log(dylib.symbols.add_i64(-0xffffffffn, -0xffffffffn));
-console.log(dylib.symbols.add_usize(0xffffffffn, 0xffffffffn));
-console.log(dylib.symbols.add_isize(-0xffffffffn, -0xffffffffn));
-console.log(dylib.symbols.add_f32(123.123, 456.789));
-console.log(dylib.symbols.add_f64(123.123, 456.789));
+%PrepareFunctionForOptimization(addU32Fast);
+console.log(addU32Fast(123, 456));
+%OptimizeFunctionOnNextCall(addU32Fast);
+console.log(addU32Fast(123, 456));
+
+console.log(symbols.add_i32(123, 456));
+console.log(symbols.add_u64(0xffffffffn, 0xffffffffn));
+console.log(symbols.add_i64(-0xffffffffn, -0xffffffffn));
+console.log(symbols.add_usize(0xffffffffn, 0xffffffffn));
+console.log(symbols.add_isize(-0xffffffffn, -0xffffffffn));
+console.log(symbols.add_f32(123.123, 456.789));
+console.log(symbols.add_f64(123.123, 456.789));
 
 // Test adders as nonblocking calls
-console.log(await dylib.symbols.add_i32_nonblocking(123, 456));
-console.log(await dylib.symbols.add_u64_nonblocking(0xffffffffn, 0xffffffffn));
+console.log(await symbols.add_i32_nonblocking(123, 456));
+console.log(await symbols.add_u64_nonblocking(0xffffffffn, 0xffffffffn));
 console.log(
-  await dylib.symbols.add_i64_nonblocking(-0xffffffffn, -0xffffffffn),
+  await symbols.add_i64_nonblocking(-0xffffffffn, -0xffffffffn),
 );
 console.log(
-  await dylib.symbols.add_usize_nonblocking(0xffffffffn, 0xffffffffn),
+  await symbols.add_usize_nonblocking(0xffffffffn, 0xffffffffn),
 );
 console.log(
-  await dylib.symbols.add_isize_nonblocking(-0xffffffffn, -0xffffffffn),
+  await symbols.add_isize_nonblocking(-0xffffffffn, -0xffffffffn),
 );
-console.log(await dylib.symbols.add_f32_nonblocking(123.123, 456.789));
-console.log(await dylib.symbols.add_f64_nonblocking(123.123, 456.789));
+console.log(await symbols.add_f32_nonblocking(123.123, 456.789));
+console.log(await symbols.add_f64_nonblocking(123.123, 456.789));
 
 // test mutating sync calls
 
 function test_fill_buffer(fillValue, arr) {
   let buf = new Uint8Array(arr);
-  dylib.symbols.fill_buffer(fillValue, buf, buf.length);
+  symbols.fill_buffer(fillValue, buf, buf.length);
   for (let i = 0; i < buf.length; i++) {
     if (buf[i] !== fillValue) {
       throw new Error(`Found '${buf[i]}' in buffer, expected '${fillValue}'.`);
@@ -296,18 +308,18 @@ function deferred() {
 
 const promise = deferred();
 const buffer3 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-dylib.symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
+symbols.nonblocking_buffer(buffer3, buffer3.length).then(() => {
   promise.resolve();
 });
 await promise;
 
 let start = performance.now();
-dylib.symbols.sleep_blocking(100);
+symbols.sleep_blocking(100);
 console.log("After sleep_blocking");
 console.log(performance.now() - start >= 100);
 
 start = performance.now();
-const promise_2 = dylib.symbols.sleep_nonblocking(100).then(() => {
+const promise_2 = symbols.sleep_nonblocking(100).then(() => {
   console.log("After");
   console.log(performance.now() - start >= 100);
 });
@@ -366,31 +378,31 @@ const throwCallback = new Deno.UnsafeCallback({
 
 assertThrows(
   () => {
-    dylib.symbols.call_fn_ptr(ptr(throwCallback));
+    symbols.call_fn_ptr(ptr(throwCallback));
   },
   TypeError,
   "hi",
 );
 
-dylib.symbols.call_fn_ptr(ptr(logCallback));
-dylib.symbols.call_fn_ptr_many_parameters(ptr(logManyParametersCallback));
-dylib.symbols.call_fn_ptr_return_u8(ptr(returnU8Callback));
-dylib.symbols.call_fn_ptr_return_buffer(ptr(returnBufferCallback));
-dylib.symbols.store_function(ptr(logCallback));
-dylib.symbols.call_stored_function();
-dylib.symbols.store_function_2(ptr(add10Callback));
-dylib.symbols.call_stored_function_2(20);
+symbols.call_fn_ptr(ptr(logCallback));
+symbols.call_fn_ptr_many_parameters(ptr(logManyParametersCallback));
+symbols.call_fn_ptr_return_u8(ptr(returnU8Callback));
+symbols.call_fn_ptr_return_buffer(ptr(returnBufferCallback));
+symbols.store_function(ptr(logCallback));
+symbols.call_stored_function();
+symbols.store_function_2(ptr(add10Callback));
+symbols.call_stored_function_2(20);
 
 const nestedCallback = new Deno.UnsafeCallback(
   { parameters: [], result: "void" },
   () => {
-    dylib.symbols.call_stored_function_2(10);
+    symbols.call_stored_function_2(10);
   },
 );
-dylib.symbols.store_function(ptr(nestedCallback));
+symbols.store_function(ptr(nestedCallback));
 
-dylib.symbols.store_function(null);
-dylib.symbols.store_function_2(null);
+symbols.store_function(null);
+symbols.store_function_2(null);
 
 let counter = 0;
 const addToFooCallback = new Deno.UnsafeCallback({
@@ -401,23 +413,23 @@ const addToFooCallback = new Deno.UnsafeCallback({
 // Test thread safe callbacks
 console.log("Thread safe call counter:", counter);
 addToFooCallback.ref();
-await dylib.symbols.call_fn_ptr_thread_safe(ptr(addToFooCallback));
+await symbols.call_fn_ptr_thread_safe(ptr(addToFooCallback));
 addToFooCallback.unref();
 logCallback.ref();
-await dylib.symbols.call_fn_ptr_thread_safe(ptr(logCallback));
+await symbols.call_fn_ptr_thread_safe(ptr(logCallback));
 logCallback.unref();
 console.log("Thread safe call counter:", counter);
 returnU8Callback.ref();
-await dylib.symbols.call_fn_ptr_return_u8_thread_safe(ptr(returnU8Callback));
+await symbols.call_fn_ptr_return_u8_thread_safe(ptr(returnU8Callback));
 
 // Test statics
-console.log("Static u32:", dylib.symbols.static_u32);
-console.log("Static i64:", dylib.symbols.static_i64);
+console.log("Static u32:", symbols.static_u32);
+console.log("Static i64:", symbols.static_i64);
 console.log(
   "Static ptr:",
-  typeof dylib.symbols.static_ptr === "bigint",
+  typeof symbols.static_ptr === "bigint",
 );
-const view = new Deno.UnsafePointerView(dylib.symbols.static_ptr);
+const view = new Deno.UnsafePointerView(symbols.static_ptr);
 console.log("Static ptr value:", view.getUint32());
 
 (function cleanup() {


### PR DESCRIPTION
Pointed out by @aapoalas #15125 introduced a bug in FFI calls. The first parameter of a fast function must be a V8Value receiver. This patch implements a fix by patching symbol calls to ignore the receiver.