### PR TITLE
fix(net): don't panic on failed UDS removal

### DIFF
--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -144,7 +144,7 @@ pub fn listen_unix(
   addr: &Path,
 ) -> Result<(u32, tokio::net::unix::SocketAddr), AnyError> {
   if addr.exists() {
-    remove_file(&addr).unwrap();
+    remove_file(&addr)?;
   }
   let listener = UnixListener::bind(&addr)?;
   let local_addr = listener.local_addr()?;
@@ -162,7 +162,7 @@ pub fn listen_unix_packet(
   addr: &Path,
 ) -> Result<(u32, tokio::net::unix::SocketAddr), AnyError> {
   if addr.exists() {
-    remove_file(&addr).unwrap();
+    remove_file(&addr)?;
   }
   let socket = UnixDatagram::bind(&addr)?;
   let local_addr = socket.local_addr()?;


### PR DESCRIPTION
If a Unix Domain Socket cannot be removed, throw instead of
panicing.

Fixes: https://github.com/denoland/deno/issues/14213

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
