### PR TITLE
fix(ext/ffi): i64 arg to C mapping was wrong

### DIFF
--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -127,23 +127,43 @@ mod tests {
   fn test_gen_trampoline() {
     assert_eq!(
       codegen(vec![], NativeType::Void),
-      "#include <stdint.h>\n\nextern void func();\n\nvoid func_trampoline(void* recv) {\n  return func();\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern void func();\n\n\
+      void func_trampoline(void* recv) {\
+        \n  return func();\n\
+      }\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::U32, NativeType::U32], NativeType::U32),
-      "#include <stdint.h>\n\nextern uint32_t func(uint32_t p0, uint32_t p1);\n\nuint32_t func_trampoline(void* recv, uint32_t p0, uint32_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern uint32_t func(uint32_t p0, uint32_t p1);\n\n\
+      uint32_t func_trampoline(void* recv, uint32_t p0, uint32_t p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::I32, NativeType::I32], NativeType::I32),
-      "#include <stdint.h>\n\nextern int32_t func(int32_t p0, int32_t p1);\n\nint32_t func_trampoline(void* recv, int32_t p0, int32_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern int32_t func(int32_t p0, int32_t p1);\n\n\
+      int32_t func_trampoline(void* recv, int32_t p0, int32_t p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::F32, NativeType::F32], NativeType::F32),
-      "#include <stdint.h>\n\nextern float func(float p0, float p1);\n\nfloat func_trampoline(void* recv, float p0, float p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern float func(float p0, float p1);\n\n\
+      float func_trampoline(void* recv, float p0, float p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::F64, NativeType::F64], NativeType::F64),
-      "#include <stdint.h>\n\nextern double func(double p0, double p1);\n\ndouble func_trampoline(void* recv, double p0, double p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern double func(double p0, double p1);\n\n\
+      double func_trampoline(void* recv, double p0, double p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
   }
 
@@ -151,15 +171,27 @@ mod tests {
   fn test_gen_trampoline_implicit_cast() {
     assert_eq!(
       codegen(vec![NativeType::I8, NativeType::U8], NativeType::I8),
-      "#include <stdint.h>\n\nextern int8_t func(int8_t p0, uint8_t p1);\n\nint8_t func_trampoline(void* recv, int32_t p0, uint32_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern int8_t func(int8_t p0, uint8_t p1);\n\n\
+      int8_t func_trampoline(void* recv, int32_t p0, uint32_t p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::ISize, NativeType::U64], NativeType::Void),
-      "#include <stdint.h>\n\nextern void func(int64_t p0, uint64_t p1);\n\nvoid func_trampoline(void* recv, int64_t p0, uint64_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern void func(int64_t p0, uint64_t p1);\n\n\
+      void func_trampoline(void* recv, int64_t p0, uint64_t p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::USize, NativeType::USize], NativeType::U32),
-      "#include <stdint.h>\n\nextern uint32_t func(uint64_t p0, uint64_t p1);\n\nuint32_t func_trampoline(void* recv, uint64_t p0, uint64_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\n\
+      extern uint32_t func(uint64_t p0, uint64_t p1);\n\n\
+      uint32_t func_trampoline(void* recv, uint64_t p0, uint64_t p1) {\
+        \n  return func(p0, p1);\n\
+      }\n\n"
     );
   }
 }

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -22,10 +22,8 @@ fn native_arg_to_c(ty: &NativeType) -> &'static str {
   match ty {
     NativeType::U8 | NativeType::U16 | NativeType::U32 => "uint32_t",
     NativeType::I8 | NativeType::I16 | NativeType::I32 => "int32_t",
-    NativeType::U64
-    | NativeType::I64
-    | NativeType::USize
-    | NativeType::ISize => "uint64_t",
+    NativeType::U64 | NativeType::USize => "uint64_t",
+    NativeType::I64 | NativeType::ISize => "int64_t",
     NativeType::Void => "void",
     NativeType::F32 => "float",
     NativeType::F64 => "double",

--- a/ext/ffi/jit_trampoline.rs
+++ b/ext/ffi/jit_trampoline.rs
@@ -155,7 +155,7 @@ mod tests {
     );
     assert_eq!(
       codegen(vec![NativeType::ISize, NativeType::U64], NativeType::Void),
-      "#include <stdint.h>\n\nextern void func(int64_t p0, uint64_t p1);\n\nvoid func_trampoline(void* recv, uint64_t p0, uint64_t p1) {\n  return func(p0, p1);\n}\n\n"
+      "#include <stdint.h>\n\nextern void func(int64_t p0, uint64_t p1);\n\nvoid func_trampoline(void* recv, int64_t p0, uint64_t p1) {\n  return func(p0, p1);\n}\n\n"
     );
     assert_eq!(
       codegen(vec![NativeType::USize, NativeType::USize], NativeType::U32),

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -673,10 +673,8 @@ impl From<&NativeType> for fast_api::Type {
       NativeType::F32 => fast_api::Type::Float32,
       NativeType::F64 => fast_api::Type::Float64,
       NativeType::Void => fast_api::Type::Void,
-      NativeType::I64
-      | NativeType::ISize
-      | NativeType::U64
-      | NativeType::USize => fast_api::Type::Uint64,
+      NativeType::I64 | NativeType::ISize => fast_api::Type::Int64,
+      NativeType::U64 | NativeType::USize => fast_api::Type::Uint64,
       NativeType::Function | NativeType::Pointer => {
         panic!("Cannot be fast api")
       }


### PR DESCRIPTION
Small error slipped through in the 64 bit arguments mapping to C types for the Fast API trampoline functions. i64 and isize parameters were mapped to `uint64_t`.

This PR fixes the mistake, then fixes the test that was written to expect the `isize` to map into `uint64_t` to instead expect `int64_t`. Finally, I added some line breaks to the codegen'ed C output to make them more readable, hoping to avoid any future lapses like this. Now it's a bit more clear that the types wouldn't have matched originally.