### PR TITLE
fix(cli): Expand tsc roots when using checkJs

### DIFF
--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -213,50 +213,37 @@ pub fn get_ts_config_for_emit(
 /// Transform the graph into root specifiers that we can feed `tsc`. We have to
 /// provide the media type for root modules because `tsc` does not "resolve" the
 /// media type like other modules, as well as a root specifier needs any
-/// redirects resolved. If we aren't checking JavaScript, we need to include all
-/// the emittable files in the roots, so they get type checked and optionally
-/// emitted, otherwise they would be ignored if only imported into JavaScript.
+/// redirects resolved. We need to include all the emittable files in
+/// the roots, so they get type checked and optionally emitted,
+/// otherwise they would be ignored if only imported into JavaScript.
 fn get_tsc_roots(
-  roots: &[(ModuleSpecifier, ModuleKind)],
   graph_data: &GraphData,
   check_js: bool,
 ) -> Vec<(ModuleSpecifier, MediaType)> {
-  if !check_js {
-    graph_data
-      .entries()
-      .into_iter()
-      .filter_map(|(specifier, module_entry)| match module_entry {
-        ModuleEntry::Module {
-          media_type,
-          ts_check,
-          ..
-        } => match &media_type {
-          MediaType::TypeScript
-          | MediaType::Tsx
-          | MediaType::Mts
-          | MediaType::Cts
-          | MediaType::Jsx => Some((specifier.clone(), *media_type)),
-          MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs
-            if check_js || *ts_check =>
-          {
-            Some((specifier.clone(), *media_type))
-          }
-          _ => None,
-        },
-        _ => None,
-      })
-      .collect()
-  } else {
-    roots
-      .iter()
-      .filter_map(|(specifier, _)| match graph_data.get(specifier) {
-        Some(ModuleEntry::Module { media_type, .. }) => {
+  graph_data
+    .entries()
+    .into_iter()
+    .filter_map(|(specifier, module_entry)| match module_entry {
+      ModuleEntry::Module {
+        media_type,
+        ts_check,
+        ..
+      } => match &media_type {
+        MediaType::TypeScript
+        | MediaType::Tsx
+        | MediaType::Mts
+        | MediaType::Cts
+        | MediaType::Jsx => Some((specifier.clone(), *media_type)),
+        MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs
+          if check_js || *ts_check =>
+        {
           Some((specifier.clone(), *media_type))
         }
         _ => None,
-      })
-      .collect()
-  }
+      },
+      _ => None,
+    })
+    .collect()
 }
 
 /// A hashing function that takes the source code, version and optionally a
@@ -342,7 +329,7 @@ pub fn check(
     return Ok(Default::default());
   }
 
-  let root_names = get_tsc_roots(roots, &segment_graph_data, check_js);
+  let root_names = get_tsc_roots(&segment_graph_data, check_js);
   if options.log_checks {
     for (root, _) in roots {
       let root_str = root.to_string();

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2695,6 +2695,13 @@ fn check_local_then_remote() {
   assert_contains!(stderr, "Type 'string' is not assignable to type 'number'.");
 }
 
+// Regression test for https://github.com/denoland/deno/issues/15163
+itest!(check_js_points_to_ts {
+  args: "run --quiet --check --config checkjs.tsconfig.json run/check_js_points_to_ts/test.js",
+  output: "run/check_js_points_to_ts/test.js.out",
+  exit_code: 1,
+});
+
 itest!(no_prompt_flag {
   args: "run --quiet --unstable --no-prompt no_prompt.ts",
   output_str: Some(""),

--- a/cli/tests/testdata/run/check_js_points_to_ts/bar.ts
+++ b/cli/tests/testdata/run/check_js_points_to_ts/bar.ts
@@ -1,0 +1,3 @@
+export function bar(): string {
+  return 42;
+}

--- a/cli/tests/testdata/run/check_js_points_to_ts/foo.js
+++ b/cli/tests/testdata/run/check_js_points_to_ts/foo.js
@@ -1,0 +1,4 @@
+import { bar } from "./bar.ts";
+export function foo() {
+  bar();
+}

--- a/cli/tests/testdata/run/check_js_points_to_ts/test.js
+++ b/cli/tests/testdata/run/check_js_points_to_ts/test.js
@@ -1,0 +1,3 @@
+// @deno-types="./foo.d.ts"
+import { foo } from "./foo.js";
+foo();

--- a/cli/tests/testdata/run/check_js_points_to_ts/test.js.out
+++ b/cli/tests/testdata/run/check_js_points_to_ts/test.js.out
@@ -1,0 +1,4 @@
+error: TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
+  return 42;
+  ~~~~~~~~~~
+    at [WILDCARD]


### PR DESCRIPTION
A JS file can still point to a TS file, so we need to expand the roots
in the checkJs case too.

Fixes: #15163
