### PR TITLE
chore: fix pty_complete_imports test on linux/mac

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -185,10 +185,14 @@ fn pty_complete_imports() {
     let output = console.read_all_output();
     assert_contains!(output, "Hello World");
   });
+}
 
+#[test]
+fn pty_complete_imports_no_panic_empty_specifier() {
   // does not panic when tabbing when empty
   util::with_pty(&["repl"], |mut console| {
-    console.write_line("import '\t");
+    console.write_line("import '\t';");
+    console.write_line("close();");
   });
 }
 


### PR DESCRIPTION
This worked on Windows, but not on linux/mac. Tested on linux and it works now.

Closes #15185