### PR TITLE
chore: remove flaky writeSyncWhileAsyncFails test

### DIFF
--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -263,38 +263,6 @@ Deno.test(
   },
 );
 
-Deno.test(
-  { permissions: { write: true } },
-  async function writeSyncWhileAsyncFails() {
-    const tempDir = await Deno.makeTempDir();
-    try {
-      const filePath = tempDir + "/file.txt";
-      const file = await Deno.open(filePath, { create: true, write: true });
-      const rid = file.rid;
-      try {
-        // set a file lock so the async write will be held up
-        await Deno.flock(rid, true);
-        let p: Promise<number> | undefined;
-        try {
-          p = Deno.write(rid, new TextEncoder().encode("test"));
-          assertThrows(
-            () => Deno.writeSync(rid, new TextEncoder().encode("test")),
-            Error,
-            "Resource is unavailable because it is in use by a promise",
-          );
-        } finally {
-          await Deno.funlock(rid);
-        }
-        await p;
-      } finally {
-        file.close();
-      }
-    } finally {
-      Deno.removeSync(tempDir, { recursive: true });
-    }
-  },
-);
-
 Deno.test(async function openOptions() {
   const filename = "cli/tests/testdata/fixture.json";
   await assertRejects(


### PR DESCRIPTION
In #15092 I added this extra writeSyncWhileAsyncFails test which is invalid and flaky. It immediately failed once merged to main: https://github.com/denoland/deno/runs/7324003869?check_suite_focus=true This functionality is hard to test so let's just remove this test.