### PR TITLE
fix(ext/ffi): allow setting a custom lib path for libtcc.a

### DIFF
--- a/ext/ffi/build.rs
+++ b/ext/ffi/build.rs
@@ -58,6 +58,10 @@ fn main() {}
 
 #[cfg(not(target_os = "windows"))]
 fn main() {
-  build_tcc();
+  if let Ok(tcc_path) = env::var("TCC_PATH") {
+    println!("cargo:rustc-link-search=native={}", tcc_path);
+  } else {
+    build_tcc();
+  }
   println!("cargo:rustc-link-lib=static=tcc");
 }


### PR DESCRIPTION
We broke Homebrew builds again :^)

At least the fix should be pretty simple this time. We just need to allow using a prebuilt tinycc, since we can't use the submodule in that context.