### PR TITLE
chore: align some Web API type definitions to lib.dom.d.ts

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -818,6 +818,14 @@ Deno.test(function responseRedirect() {
   assertEquals(redir.type, "default");
 });
 
+Deno.test(function responseRedirectTakeURLObjectAsParameter() {
+  const redir = Response.redirect(new URL("example.com/newLocation"));
+  assertEquals(
+    redir.headers.get("Location"),
+    "http://js-unit-tests/foo/example.com/newLocation",
+  );
+});
+
 Deno.test(async function responseWithoutBody() {
   const response = new Response();
   assertEquals(await response.arrayBuffer(), new ArrayBuffer(0));

--- a/cli/tests/unit/request_test.ts
+++ b/cli/tests/unit/request_test.ts
@@ -68,3 +68,10 @@ Deno.test(function customInspectFunction() {
   );
   assertStringIncludes(Deno.inspect(Request.prototype), "Request");
 });
+
+Deno.test(function requestConstructorTakeURLObjectAsParameter() {
+  assertEquals(
+    new Request(new URL("http://foo/")).url,
+    "http://foo/",
+  );
+});

--- a/cli/tests/unit/url_test.ts
+++ b/cli/tests/unit/url_test.ts
@@ -494,3 +494,15 @@ Deno.test(function urlSearchParamsIdentityPreserved() {
   const sp2 = u.searchParams;
   assertStrictEquals(sp1, sp2);
 });
+
+Deno.test(function urlTakeURLObjectAsParameter() {
+  const url = new URL(
+    new URL(
+      "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat",
+    ),
+  );
+  assertEquals(
+    url.href,
+    "https://foo:bar@baz.qat:8000/qux/quux?foo=bar&baz=12#qat",
+  );
+});

--- a/cli/tests/unit/websocket_test.ts
+++ b/cli/tests/unit/websocket_test.ts
@@ -1,9 +1,21 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { assertThrows } from "./test_util.ts";
+import { assertEquals, assertThrows, deferred, fail } from "./test_util.ts";
 
 Deno.test({ permissions: "none" }, function websocketPermissionless() {
   assertThrows(
     () => new WebSocket("ws://localhost"),
     Deno.errors.PermissionDenied,
   );
+});
+
+Deno.test(async function websocketConstructorTakeURLObjectAsParameter() {
+  const promise = deferred();
+  const ws = new WebSocket(new URL("ws://localhost:4242"));
+  assertEquals(ws.url, "ws://localhost:4242");
+  ws.onerror = () => fail();
+  ws.onopen = () => ws.close();
+  ws.onclose = () => {
+    promise.resolve();
+  };
+  await promise;
 });

--- a/ext/fetch/lib.deno_fetch.d.ts
+++ b/ext/fetch/lib.deno_fetch.d.ts
@@ -252,7 +252,7 @@ interface RequestInit {
 
 /** This Fetch API interface represents a resource request. */
 declare class Request implements Body {
-  constructor(input: RequestInfo, init?: RequestInit);
+  constructor(input: RequestInfo | URL, init?: RequestInit);
 
   /**
    * Returns the cache mode associated with request, which is a string
@@ -385,7 +385,7 @@ declare class Response implements Body {
   constructor(body?: BodyInit | null, init?: ResponseInit);
   static json(data: unknown, init?: ResponseInit): Response;
   static error(): Response;
-  static redirect(url: string, status?: number): Response;
+  static redirect(url: string | URL, status?: number): Response;
 
   readonly headers: Headers;
   readonly ok: boolean;

--- a/ext/url/lib.deno_url.d.ts
+++ b/ext/url/lib.deno_url.d.ts
@@ -153,7 +153,7 @@ declare class URLSearchParams {
 
 /** The URL interface represents an object providing static methods used for creating object URLs. */
 declare class URL {
-  constructor(url: string, base?: string | URL);
+  constructor(url: string | URL, base?: string | URL);
   static createObjectURL(blob: Blob): string;
   static revokeObjectURL(url: string): void;
 

--- a/ext/websocket/lib.deno_websocket.d.ts
+++ b/ext/websocket/lib.deno_websocket.d.ts
@@ -40,7 +40,7 @@ interface WebSocketEventMap {
  * If you are looking to create a WebSocket server, please take a look at `Deno.upgradeWebSocket()`.
  */
 declare class WebSocket extends EventTarget {
-  constructor(url: string, protocols?: string | string[]);
+  constructor(url: string | URL, protocols?: string | string[]);
 
   static readonly CLOSED: number;
   static readonly CLOSING: number;


### PR DESCRIPTION
Currently, the lib.dom.d.ts type definition and the deno type definition seem to be different for some functions.

The difference I've found is whether the URL is taken as a constructor argument.

<details>
<summary>example:</summary>

https://github.com/denoland/deno/blob/22a4998e299ca8658744c745d8f0afeba15730dc/cli/dts/lib.dom.d.ts#L14359-L14364

https://github.com/denoland/deno/blob/22a4998e299ca8658744c745d8f0afeba15730dc/ext/url/lib.deno_url.d.ts#L155-L156
----
https://github.com/denoland/deno/blob/22a4998e299ca8658744c745d8f0afeba15730dc/cli/dts/lib.dom.d.ts#L11576-L11579

https://github.com/denoland/deno/blob/22a4998e299ca8658744c745d8f0afeba15730dc/ext/fetch/lib.deno_fetch.d.ts#L254-L256

</details>

This PR modifies the deno type definition to match lib.dom.d.ts. (similar to #14113)