### PR TITLE
chore(repl): update rustyline to 10.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "mitata",
- "nix 0.23.0",
+ "nix",
  "node_resolver",
  "notify",
  "once_cell",
@@ -1148,7 +1148,7 @@ dependencies = [
  "log 0.4.17",
  "lzzzz",
  "netif",
- "nix 0.23.0",
+ "nix",
  "notify",
  "once_cell",
  "regex",
@@ -2728,19 +2728,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
@@ -2748,6 +2735,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3647,7 +3635,7 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "memchr",
- "nix 0.24.2",
+ "nix",
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "mitata",
- "nix",
+ "nix 0.23.0",
  "node_resolver",
  "notify",
  "once_cell",
@@ -1148,7 +1148,7 @@ dependencies = [
  "log 0.4.17",
  "lzzzz",
  "netif",
- "nix",
+ "nix 0.23.0",
  "notify",
  "once_cell",
  "regex",
@@ -2740,6 +2740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "node_resolver"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "9.1.2"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3636,10 +3647,9 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "memchr",
- "nix",
+ "nix 0.24.2",
  "radix_trie",
  "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -3648,10 +3658,11 @@ dependencies = [
 
 [[package]]
 name = "rustyline-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb35a55ab810b5c0fe31606fe9b47d1354e4dc519bec0a102655f78ea2b38057"
+checksum = "107c3d5d7f370ac09efa62a78375f94d94b8a33c61d8c278b96683fb4dbf2d8d"
 dependencies = [
+ "proc-macro2 1.0.39",
  "quote 1.0.18",
  "syn 1.0.96",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -122,7 +122,7 @@ trust-dns-client = "=0.21.2"
 trust-dns-server = "=0.21.2"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = "=0.23.0"
+nix = "=0.24.2"
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -86,8 +86,8 @@ pin-project = "1.0.11" # don't pin because they yank crates from cargo
 rand = { version = "=0.8.5", features = ["small_rng"] }
 regex = "=1.5.6"
 ring = "=0.16.20"
-rustyline = { version = "=9.1.2", default-features = false }
-rustyline-derive = "=0.6.0"
+rustyline = { version = "=10.0.0", default-features = false, features = ["custom-bindings"] }
+rustyline-derive = "=0.7.0"
 secure_tempfile = { version = "=3.3.0", package = "tempfile" } # different name to discourage use in tests
 semver-parser = "=0.10.2"
 serde = { version = "=1.0.139", features = ["derive"] }

--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -363,7 +363,8 @@ impl ReplEditor {
       .completion_type(CompletionType::List)
       .build();
 
-    let mut editor = Editor::with_config(editor_config);
+    let mut editor =
+      Editor::with_config(editor_config).expect("Failed to create editor.");
     editor.set_helper(Some(helper));
     editor.load_history(&history_file_path).unwrap_or(());
     editor.bind_sequence(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -88,7 +88,7 @@ fwdansi = "1.1.0"
 winapi = { version = "0.3.9", features = ["commapi", "knownfolders", "mswsock", "objbase", "shlobj", "tlhelp32", "winbase", "winerror", "winsock2"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = "=0.23.0"
+nix = "=0.24.2"
 
 [dev-dependencies]
 # Used in benchmark


### PR DESCRIPTION
Its a small thing but I want to add https://github.com/kkawakam/rustyline/pull/640 , it landed in 10.0.0

This version have some breaking changes https://github.com/kkawakam/rustyline/releases/tag/v10.0.0

Editor now returns a result because rustlyine now tries to setup SIGWINCH signal handler without overriding the previous one if it exists https://github.com/kkawakam/rustyline/issues/606 https://github.com/kkawakam/rustyline/pull/608 I think its ok to just unwrap here.