### PR TITLE
fix(repl): use 'external printer' in REPL

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -858,7 +858,7 @@ async fn repl_command(
     &ps,
     main_module.clone(),
     Permissions::from_options(&ps.options.permissions_options()),
-    vec![],
+    tools::repl::create_extension(),
     Default::default(),
   );
   if ps.options.compat() {

--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -20,6 +20,7 @@ use rustyline::Config;
 use rustyline::Context;
 use rustyline::Editor;
 use rustyline::EventHandler;
+use rustyline::ExternalPrinter;
 use rustyline::KeyCode;
 use rustyline::KeyEvent;
 use rustyline::Modifiers;
@@ -384,6 +385,12 @@ impl ReplEditor {
 
   pub fn readline(&self) -> Result<String, ReadlineError> {
     self.inner.lock().readline("> ")
+  }
+
+  pub fn create_external_printer(
+    &self,
+  ) -> Result<Box<dyn ExternalPrinter>, AnyError> {
+    Ok(Box::new(self.inner.lock().create_external_printer()?))
   }
 
   pub fn add_history_entry(&self, entry: String) {


### PR DESCRIPTION
This commit changes REPL to use "external printer" available
in rustyline crate starting with v10. Using such printer allows
to better control output of the REPL and allows to prevent
interleaved output when there are some asynchronous
operations using console.logs.

Closes https://github.com/denoland/deno/issues/13125
Closes https://github.com/denoland/deno/issues/8049