### PR TITLE
feat(task): add ability to specify task description

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -45,6 +45,8 @@ use crate::file_fetcher::CacheSetting;
 use crate::lockfile::Lockfile;
 use crate::version;
 
+use self::config_file::TaskDescriptor;
+
 /// Overrides for the options below that when set will
 /// use these values over the values derived from the
 /// CLI flags or config file.
@@ -202,7 +204,7 @@ impl CliOptions {
 
   pub fn resolve_tasks_config(
     &self,
-  ) -> Result<BTreeMap<String, String>, AnyError> {
+  ) -> Result<BTreeMap<String, TaskDescriptor>, AnyError> {
     if let Some(config_file) = &self.maybe_config_file {
       config_file.resolve_tasks_config()
     } else {

--- a/cli/tests/testdata/task/deno.json
+++ b/cli/tests/testdata/task/deno.json
@@ -1,8 +1,14 @@
 {
   "tasks": {
     "boolean_logic": "sleep 0.1 && echo 3 && echo 4 & echo 1 && echo 2 || echo NOPE",
-    "echo": "echo 1",
-    "deno_echo": "deno eval 'console.log(5)'",
+    "echo": {
+      "command": "echo 1",
+      "description": "Print value 1"
+    },
+    "deno_echo": {
+      "command": "deno eval 'console.log(5)'",
+      "description": "console.log value 5"
+    },
     "strings": "deno run main.ts && deno eval \"console.log(\\\"test\\\")\"",
     "piped": "echo 12345 | (deno eval 'const b = new Uint8Array(1);Deno.stdin.readSync(b);console.log(b)' && deno eval 'const b = new Uint8Array(1);Deno.stdin.readSync(b);console.log(b)')",
     "exit_code_5": "echo $(echo 10 ; exit 2) && exit 5",

--- a/cli/tests/testdata/task/task_no_args.out
+++ b/cli/tests/testdata/task/task_no_args.out
@@ -1,9 +1,9 @@
 Available tasks:
 - boolean_logic
     sleep 0.1 && echo 3 && echo 4 & echo 1 && echo 2 || echo NOPE
-- deno_echo
+- deno_echo console.log value 5
     deno eval 'console.log(5)'
-- echo
+- echo Print value 1
     echo 1
 - echo_cwd
     echo $(pwd)

--- a/cli/tests/testdata/task/task_non_existent.out
+++ b/cli/tests/testdata/task/task_non_existent.out
@@ -3,9 +3,9 @@ Task not found: non_existent
 Available tasks:
 - boolean_logic
     sleep 0.1 && echo 3 && echo 4 & echo 1 && echo 2 || echo NOPE
-- deno_echo
+- deno_echo console.log value 5
     deno eval 'console.log(5)'
-- echo
+- echo Print value 1
     echo 1
 - echo_cwd
     echo $(pwd)


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/14949

Allows to specify tasks using object notation and include a 
description for a task:
```json
{
  "tasks": {
    "echo": "echo 1",
    "eval": {
       "command": "deno eval 'console.log(3)'",
       "description": "Print value 3"
    }
}
```

```
$ deno task
Available tasks:
- echo
  echo 1
- eval Print value 3
  deno eval 'console.log(3)'
```

![Screenshot 2022-07-20 at 13 07 52](https://user-images.githubusercontent.com/13602871/179967663-ffd4ac1d-40ce-4e4f-8d5f-7a4c80d6a032.png)

