### PR TITLE
fix(lsp): Only apply import-map-remap to bare map keys

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -885,7 +885,7 @@ fn diagnose_dependency(
     } = &dependency.maybe_code
     {
       let key = import_map.lookup(specifier, referrer).filter(|key| {
-        !(key.starts_with("/")
+        !(key.starts_with('/')
           || key.starts_with("./")
           || key.starts_with("../"))
       });


### PR DESCRIPTION
Fixes #15266.

The diagnostic should only be given when the suggested map key is a bare specifier. Applying it to relative specifiers is too opinionated as to which of the alternative import forms is preferred.