### PR TITLE
chore(ci): update actions to run on macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-10.15
+          - os: macos-12
             job: test
             profile: fastci
-          - os: macos-10.15
+          - os: macos-12
             job: test
             profile: release
           - os: ${{ github.repository == 'denoland/deno' && 'windows-2019-xl' || 'windows-2019' }}


### PR DESCRIPTION
To avoid any issues during build in the coming weeks, see https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/