### PR TITLE
feat(test): Add throwOnFailure option to test steps

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -309,6 +309,11 @@ declare namespace Deno {
      * for example via a call to `Deno.exit`. Defaults to the parent test or
      * step's value. */
     sanitizeExit?: boolean;
+    /** Throws an error when the step fails. Normally a step resolves with a
+     * boolean indicating if the step failed or not. But you can set this to
+     * `true` to throw an error instead. This ensures that any step after this
+     * one will not run. Defaults to the parent test or step's value. */
+    throwOnFailure?: boolean;
   }
 
   export interface TestDefinition {

--- a/runtime/js/40_testing.js
+++ b/runtime/js/40_testing.js
@@ -1282,6 +1282,7 @@
         stepDesc.sanitizeOps ??= desc.sanitizeOps;
         stepDesc.sanitizeResources ??= desc.sanitizeResources;
         stepDesc.sanitizeExit ??= desc.sanitizeExit;
+        stepDesc.throwOnFailure ??= desc.throwOnFailure;
         stepDesc.origin = getTestOrigin();
         const jsError = Deno.core.destructureError(new Error());
         stepDesc.location = {
@@ -1351,7 +1352,16 @@
             stepReportResult(stepDesc);
           }
 
-          return state.status === "ok";
+          const statusOk = state.status === "ok";
+          if (stepDesc.throwOnFailure) {
+            if (!statusOk) {
+              throw state.error;
+            } else {
+              return true;
+            }
+          } else {
+            return statusOk;
+          }
         } finally {
           if (canStreamReporting(stepDesc.parent)) {
             const parentState = MapPrototypeGet(testStates, stepDesc.parent.id);


### PR DESCRIPTION
This adds a `throwOnFailure` option to test steps that can be used like so:
```js
Deno.test({
  name: "root",
  async fn(ctx) {
    await ctx.step({
      name: "step 1",
      throwOnFailure: true,
      fn() {
        throw new Error("oh no");
      },
    });

    await ctx.step({
      name: "step 2",
      async fn() {
        // This second and potentially long running step will not be executed
        // because the first step failed.
        await new Promise((r) => setTimeout(r, 5_000));
      },
    });
  },
});
```

The command line output looks like this:
![image](https://user-images.githubusercontent.com/2737650/180581230-e386a220-0f06-4825-90ec-f09e151c9aa2.png)

Fixes #14635