### PR TITLE
fix(task): subcommand parser skips global args

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5662,7 +5662,6 @@ mod tests {
       }
     );
 
-    eprintln!("HERE");
     let r = flags_from_vec(svec!["deno", "task", "--cwd", "foo", "build"]);
     assert_eq!(
       r.unwrap(),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -554,15 +554,7 @@ pub fn flags_from_vec(args: Vec<String>) -> clap::Result<Flags> {
     Some(("lsp", m)) => lsp_parse(&mut flags, m),
     Some(("repl", m)) => repl_parse(&mut flags, m),
     Some(("run", m)) => run_parse(&mut flags, m),
-    Some(("task", m)) => task_parse(
-      &mut flags,
-      m,
-      // temporary workaround until https://github.com/clap-rs/clap/issues/1538 is fixed
-      &args[args
-        .iter()
-        .position(|el| el == matches.subcommand_name().unwrap())
-        .unwrap()..],
-    ),
+    Some(("task", m)) => task_parse(&mut flags, m, &args),
     Some(("test", m)) => test_parse(&mut flags, m),
     Some(("types", m)) => types_parse(&mut flags, m),
     Some(("uninstall", m)) => uninstall_parse(&mut flags, m),
@@ -2569,9 +2561,6 @@ fn run_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   flags.subcommand = DenoSubcommand::Run(RunFlags { script });
 }
 
-/// raw_args is the subcommand's command line, eg. for the deno invocation
-/// `deno task echo`
-/// raw_args has value ["task", "echo"]
 fn task_parse(
   flags: &mut Flags,
   matches: &clap::ArgMatches,
@@ -2593,6 +2582,9 @@ fn task_parse(
   }
 
   if let Some(mut index) = matches.index_of("task_name_and_args") {
+    let task_word_index = raw_args.iter().position(|el| el == "task").unwrap();
+    let raw_args = &raw_args[task_word_index..];
+
     // temporary workaround until https://github.com/clap-rs/clap/issues/1538 is fixed
     while index < raw_args.len() {
       match raw_args[index].as_str() {
@@ -5670,6 +5662,7 @@ mod tests {
       }
     );
 
+    eprintln!("HERE");
     let r = flags_from_vec(svec!["deno", "task", "--cwd", "foo", "build"]);
     assert_eq!(
       r.unwrap(),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -554,7 +554,15 @@ pub fn flags_from_vec(args: Vec<String>) -> clap::Result<Flags> {
     Some(("lsp", m)) => lsp_parse(&mut flags, m),
     Some(("repl", m)) => repl_parse(&mut flags, m),
     Some(("run", m)) => run_parse(&mut flags, m),
-    Some(("task", m)) => task_parse(&mut flags, m, &args),
+    Some(("task", m)) => task_parse(
+      &mut flags,
+      m,
+      // temporary workaround until https://github.com/clap-rs/clap/issues/1538 is fixed
+      &args[args
+        .iter()
+        .position(|el| el == matches.subcommand_name().unwrap())
+        .unwrap()..],
+    ),
     Some(("test", m)) => test_parse(&mut flags, m),
     Some(("types", m)) => types_parse(&mut flags, m),
     Some(("uninstall", m)) => uninstall_parse(&mut flags, m),
@@ -2561,6 +2569,9 @@ fn run_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   flags.subcommand = DenoSubcommand::Run(RunFlags { script });
 }
 
+/// raw_args is the subcommand's command line, eg. for the deno invocation
+/// `deno task echo`
+/// raw_args has value ["task", "echo"]
 fn task_parse(
   flags: &mut Flags,
   matches: &clap::ArgMatches,
@@ -2582,9 +2593,6 @@ fn task_parse(
   }
 
   if let Some(mut index) = matches.index_of("task_name_and_args") {
-    let task_word_index = raw_args.iter().position(|el| el == "task").unwrap();
-    index = std::cmp::max(task_word_index + 1, index); // ensure skip `task`
-
     // temporary workaround until https://github.com/clap-rs/clap/issues/1538 is fixed
     while index < raw_args.len() {
       match raw_args[index].as_str() {

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -554,15 +554,7 @@ pub fn flags_from_vec(args: Vec<String>) -> clap::Result<Flags> {
     Some(("lsp", m)) => lsp_parse(&mut flags, m),
     Some(("repl", m)) => repl_parse(&mut flags, m),
     Some(("run", m)) => run_parse(&mut flags, m),
-    Some(("task", m)) => task_parse(
-      &mut flags,
-      m,
-      // temporary workaround until https://github.com/clap-rs/clap/issues/1538 is fixed
-      &args[args
-        .iter()
-        .position(|el| el == matches.subcommand_name().unwrap())
-        .unwrap()..],
-    ),
+    Some(("task", m)) => task_parse(&mut flags, m, &args),
     Some(("test", m)) => test_parse(&mut flags, m),
     Some(("types", m)) => types_parse(&mut flags, m),
     Some(("uninstall", m)) => uninstall_parse(&mut flags, m),
@@ -2569,9 +2561,6 @@ fn run_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
   flags.subcommand = DenoSubcommand::Run(RunFlags { script });
 }
 
-/// raw_args is the subcommand's command line, eg. for the deno invocation
-/// `deno task echo`
-/// raw_args has value ["task", "echo"]
 fn task_parse(
   flags: &mut Flags,
   matches: &clap::ArgMatches,
@@ -2593,6 +2582,9 @@ fn task_parse(
   }
 
   if let Some(mut index) = matches.index_of("task_name_and_args") {
+    let task_word_index = raw_args.iter().position(|el| el == "task").unwrap();
+    index = std::cmp::max(task_word_index + 1, index); // ensure skip `task`
+
     // temporary workaround until https://github.com/clap-rs/clap/issues/1538 is fixed
     while index < raw_args.len() {
       match raw_args[index].as_str() {


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Fixes #15290

I decided to slice `args` in `flags_from_vec()`, rather than in `task_parse()`, to avoid passing `task_parse()` more data than is necessary. This makes it easier to see that `task_parse()` doesn't care about the "--quiet" in `deno --quiet task echo`.

Not happy with the way I'm slicing the subcommand's args from `args`. I couldn't find anything in clap to get the index of the subcommand name, or a function like `index_of()` for subcommands. Suggestions are welcome.