### PR TITLE
experiment(ext/ffi): Replace pointer integers with `v8::External` objects

### DIFF
--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -39,84 +39,96 @@
     getUint8(offset = 0) {
       return core.opSync(
         "op_ffi_read_u8",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getInt8(offset = 0) {
       return core.opSync(
         "op_ffi_read_i8",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getUint16(offset = 0) {
       return core.opSync(
         "op_ffi_read_u16",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getInt16(offset = 0) {
       return core.opSync(
         "op_ffi_read_i16",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getUint32(offset = 0) {
       return core.opSync(
         "op_ffi_read_u32",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getInt32(offset = 0) {
       return core.opSync(
         "op_ffi_read_i32",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getBigUint64(offset = 0) {
       return core.opSync(
         "op_ffi_read_u64",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getBigInt64(offset = 0) {
       return core.opSync(
         "op_ffi_read_i64",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getFloat32(offset = 0) {
       return core.opSync(
         "op_ffi_read_f32",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getFloat64(offset = 0) {
       return core.opSync(
         "op_ffi_read_f64",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getCString(offset = 0) {
       return core.opSync(
         "op_ffi_cstr_read",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
       );
     }
 
     getArrayBuffer(byteLength, offset = 0) {
       return core.opSync(
         "op_ffi_get_buf",
-        offset ? this.pointer + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
         byteLength,
       );
     }
@@ -124,7 +136,8 @@
     copyInto(destination, offset = 0) {
       core.opSync(
         "op_ffi_buf_copy_into",
-        offset ? BigInt(this.pointer) + BigInt(offset) : this.pointer,
+        this.pointer,
+        offset,
         destination,
         destination.byteLength,
       );
@@ -137,6 +150,13 @@
         return value.pointer;
       }
       return core.opSync("op_ffi_ptr_of", value);
+    }
+
+    static getPointerValue(pointer) {
+      if (typeof pointer !== "object") {
+        throw new TypeError("Invalid FFI pointer value");
+      }
+      return core.opSync("op_ffi_get_ptr_value", pointer);
     }
   }
 

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -451,8 +451,9 @@ console.log("Static u32:", dylib.symbols.static_u32);
 console.log("Static i64:", dylib.symbols.static_i64);
 console.log(
   "Static ptr:",
-  typeof dylib.symbols.static_ptr === "number",
+  typeof dylib.symbols.static_ptr === "object",
 );
+debugger;
 const view = new Deno.UnsafePointerView(dylib.symbols.static_ptr);
 console.log("Static ptr value:", view.getUint32());
 


### PR DESCRIPTION
Currently FFI uses BigInts and numbers (as of today) to represent pointers. This is fine to a degree, but it also means that creating custom pointers is as easy as just writing a number. This probably makes Deno FFI one of the best developer experiences for potential hacks.

V8 offers a `v8::External` class that is specifically meant to stand for external pointers. From the JS perspective these are opaque pointers and there is no way to create these pointers from JS side directly, meaning that custom pointer creation / spoofing is no longer just writing a number.

This is pretty experimental since this throws into the trash can all of the safe number pointers work that I just got merged today. This also throws out the Fast API optimisations that PR just enabled. However, I'm hoping that adding Fast API support for `v8::External`s might not be that hard, where the external objects would stand for `void*` pointers in the C function world. This also adds friction when pointer values are needed for use in eg. inside a struct, where a new `Deno.UnsafePointer.getPointerValue(externalPointerObject)` call needs to be made to get the numeric pointer value.

The best thing about this PR is that I felt safe enough to remove a lot of FFI permissions checks. There are now no ways to get pointers without FFI permissions (except FFI symbol calls, but those can only exist if FFI permissions were given so those FFI symbols could be created), so reading data or getting an ArrayBuffer from a pointer isn't really ... well, not that dangerous anymore, I think? :)

I think it should even be safe to allow external pointer object creation from ArrayBuffers / TypedArrays without FFI permissions, but right now I added to that API so that the same call can also be used to create external pointer object creation from numbers / BigInts, and allowing that without FFI permissions is definitely not a good idea.


Aaanyway, that's that. We shall discuss!