### PR TITLE
fix(fetch/body): Fix TODOs about WebIDL conversions

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -452,15 +452,13 @@
   webidl.converters["BodyInit_DOMString"] = (V, opts) => {
     // Union for (ReadableStream or Blob or ArrayBufferView or ArrayBuffer or FormData or URLSearchParams or USVString)
     if (ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, V)) {
-      // TODO(lucacasonato): ReadableStream is not branded
-      return V;
+      return webidl.converters["ReadableStream"](V, opts);
     } else if (ObjectPrototypeIsPrototypeOf(BlobPrototype, V)) {
       return webidl.converters["Blob"](V, opts);
     } else if (ObjectPrototypeIsPrototypeOf(FormDataPrototype, V)) {
       return webidl.converters["FormData"](V, opts);
     } else if (ObjectPrototypeIsPrototypeOf(URLSearchParamsPrototype, V)) {
-      // TODO(lucacasonato): URLSearchParams is not branded
-      return V;
+      return webidl.converters["URLSearchParams"](V, opts);
     }
     if (typeof V === "object") {
       if (

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -301,7 +301,7 @@
   const URLSearchParamsPrototype = URLSearchParams.prototype;
 
   webidl.converters["URLSearchParams"] = webidl.createInterfaceConverter(
-    "Blob",
+    "URLSearchParams",
     URLSearchParamsPrototype,
   );
 

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -300,6 +300,11 @@
   webidl.configurePrototype(URLSearchParams);
   const URLSearchParamsPrototype = URLSearchParams.prototype;
 
+  webidl.converters["URLSearchParams"] = webidl.createInterfaceConverter(
+    "Blob",
+    URLSearchParamsPrototype,
+  );
+
   const _url = Symbol("url");
 
   class URL {


### PR DESCRIPTION
Adds a converter for `URLSearchParams`, and uses the two missing converters in fetch/body.