### PR TITLE
chore(ops): Remove unused arguments from ops

### DIFF
--- a/cli/tsc.rs
+++ b/cli/tsc.rs
@@ -315,7 +315,7 @@ fn op_create_hash(s: &mut OpState, args: Value) -> Result<Value, AnyError> {
 }
 
 #[op]
-fn op_cwd(s: &mut OpState, _args: Value) -> Result<String, AnyError> {
+fn op_cwd(s: &mut OpState) -> Result<String, AnyError> {
   let state = s.borrow_mut::<State>();
   if let Some(config_specifier) = &state.maybe_config_specifier {
     let cwd = config_specifier.join("./")?;

--- a/ext/web/timers.rs
+++ b/ext/web/timers.rs
@@ -28,7 +28,7 @@ pub type StartTime = Instant;
 // If the High precision flag is not set, the
 // nanoseconds are rounded on 2ms.
 #[op]
-pub fn op_now<TP>(state: &mut OpState, _argument: ()) -> f64
+pub fn op_now<TP>(state: &mut OpState) -> f64
 where
   TP: TimersPermission + 'static,
 {

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -53,7 +53,7 @@ pub fn init_for_worker() -> Extension {
 }
 
 #[op]
-fn noop_op(_code: i32) -> Result<(), AnyError> {
+fn noop_op() -> Result<(), AnyError> {
   Ok(())
 }
 


### PR DESCRIPTION
Remove a few unused arguments from ops. These are not used anywhere and are no longer needed in the signature since the ops macro merge.