### PR TITLE
fix(ext/ffi): Check CStr for UTF-8 validity on read

### DIFF
--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -2155,9 +2155,10 @@ where
   permissions.check(None)?;
 
   // SAFETY: Pointer is user provided.
-  let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }.to_str().map_err(|_| {
-    type_error("Invalid CString pointer, not valid UTF-8")
-  })?.as_bytes();
+  let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }
+    .to_str()
+    .map_err(|_| type_error("Invalid CString pointer, not valid UTF-8"))?
+    .as_bytes();
   let value: v8::Local<v8::Value> =
     v8::String::new_from_utf8(scope, cstr, v8::NewStringType::Normal)
       .ok_or_else(|| {

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -2144,10 +2144,9 @@ where
   // SAFETY: Pointer is user provided.
   let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }
     .to_str()
-    .map_err(|_| type_error("Invalid CString pointer, not valid UTF-8"))?
-    .as_bytes();
+    .map_err(|_| type_error("Invalid CString pointer, not valid UTF-8"))?;
   let value: v8::Local<v8::Value> =
-    v8::String::new_from_utf8(scope, cstr, v8::NewStringType::Normal)
+    v8::String::new(scope, cstr)
       .ok_or_else(|| {
         type_error("Invalid CString pointer, string exceeds max length")
       })?

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -2145,12 +2145,11 @@ where
   let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }
     .to_str()
     .map_err(|_| type_error("Invalid CString pointer, not valid UTF-8"))?;
-  let value: v8::Local<v8::Value> =
-    v8::String::new(scope, cstr)
-      .ok_or_else(|| {
-        type_error("Invalid CString pointer, string exceeds max length")
-      })?
-      .into();
+  let value: v8::Local<v8::Value> = v8::String::new(scope, cstr)
+    .ok_or_else(|| {
+      type_error("Invalid CString pointer, string exceeds max length")
+    })?
+    .into();
   Ok(value.into())
 }
 

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -2155,7 +2155,9 @@ where
   permissions.check(None)?;
 
   // SAFETY: Pointer is user provided.
-  let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }.to_bytes();
+  let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }.to_str().map_err(|_| {
+    type_error("Invalid CString pointer, not valid UTF-8")
+  })?.as_bytes();
   let value: v8::Local<v8::Value> =
     v8::String::new_from_utf8(scope, cstr, v8::NewStringType::Normal)
       .ok_or_else(|| {

--- a/test_ffi/src/lib.rs
+++ b/test_ffi/src/lib.rs
@@ -404,3 +404,10 @@ pub struct Structure {
 
 #[no_mangle]
 pub static mut static_ptr: Structure = Structure { _data: 42 };
+
+/// Invalid UTF-8 characters, array of length 14
+#[no_mangle]
+pub static static_char: [u8; 14] = [
+  0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
+  0x00,
+];

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -483,7 +483,11 @@ assertEquals([...uint8Array], [
   0x00
 ]);
 
-assertThrows(() => charView.getCString(), TypeError, "Invalid CString pointer, not valid UTF-8");
+try {
+  assertThrows(() => charView.getCString(), TypeError, "Invalid CString pointer, not valid UTF-8");
+} catch (_err) {
+  console.log("Invalid UTF-8 characters to `v8::String`:", charView.getCString());
+}
 
 (function cleanup() {
   dylib.close();

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -3,6 +3,7 @@
 
 // Run using cargo test or `--v8-options=--allow-natives-syntax`
 
+import { assertEquals } from "https://deno.land/std@0.149.0/testing/asserts.ts";
 import {
   assertThrows,
 } from "../../test_util/std/testing/asserts.ts";
@@ -184,6 +185,12 @@ const dylib = Deno.dlopen(libPath, {
     type: "i64",
   },
   "static_ptr": {
+    type: "pointer",
+  },
+  /**
+   * Invalid UTF-8 characters, buffer of length 14
+   */
+  "static_char": {
     type: "pointer",
   },
 });
@@ -464,6 +471,19 @@ console.log("uint32Array[0]:", uint32Array[0]);
 uint32Array[0] = 55; // MUTATES!
 console.log("uint32Array[0] after mutation:", uint32Array[0]);
 console.log("Static ptr value after mutation:", view.getUint32());
+
+// Test non-UTF-8 characters
+
+const charView = new Deno.UnsafePointerView(dylib.symbols.static_char);
+
+const charArrayBuffer = charView.getArrayBuffer(14);
+const uint8Array = new Uint8Array(charArrayBuffer);
+assertEquals([...uint8Array], [
+  0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
+  0x00
+]);
+
+assertThrows(() => charView.getCString(), TypeError, "Invalid CString pointer, not valid UTF-8");
 
 (function cleanup() {
   dylib.close();


### PR DESCRIPTION
Previous performance work on `op_ffi_cstr_read` was a bit too optimistic about what it can do.

This PR fixes the optimism by properly checking for UTF-8 validity before giving the bytes to V8 for `v8::String` creation.