### PR TITLE
chore(ext/ffi): Remove unnecessary byte_offset conditional slicing

### DIFF
--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -1030,11 +1030,7 @@ fn ffi_parse_pointer_arg(
         type_error("Invalid FFI ArrayBufferView, expected data in the buffer")
       })?
       .get_backing_store();
-    if byte_offset > 0 {
-      &backing_store[byte_offset..] as *const _ as *const u8
-    } else {
-      &backing_store[..] as *const _ as *const u8
-    }
+    &backing_store[byte_offset..] as *const _ as *const u8
   } else if let Ok(value) = v8::Local::<v8::BigInt>::try_from(arg) {
     value.u64_value().0 as usize as *const u8
   } else if let Ok(value) = v8::Local::<v8::Number>::try_from(arg) {
@@ -1592,11 +1588,7 @@ unsafe fn do_ffi_callback(
           .buffer(scope)
           .expect("Unable to deserialize result parameter.")
           .get_backing_store();
-        if byte_offset > 0 {
-          &backing_store[byte_offset..] as *const _ as *const u8
-        } else {
-          &backing_store[..] as *const _ as *const u8
-        }
+        &backing_store[byte_offset..] as *const _ as *const u8
       } else if let Ok(value) = v8::Local::<v8::BigInt>::try_from(value) {
         value.u64_value().0 as usize as *const u8
       } else if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(value) {
@@ -2039,11 +2031,7 @@ where
       })?
       .get_backing_store();
     let byte_offset = value.byte_offset();
-    if byte_offset > 0 {
-      &backing_store[byte_offset..] as *const _ as *const u8
-    } else {
-      &backing_store[..] as *const _ as *const u8
-    }
+    &backing_store[byte_offset..] as *const _ as *const u8
   } else if let Ok(value) = v8::Local::<v8::ArrayBuffer>::try_from(buf.v8_value)
   {
     let backing_store = value.get_backing_store();


### PR DESCRIPTION
Previously I got panics in pointer TypedArray handling with empty arrays from slices with byte_offset as zero. I even checked it multiple times.

Somehow, that no longer occurs and these conditional slice handlings are unnecessary.