### PR TITLE
fix(compat): use mjs extension for stream/promises

### DIFF
--- a/cli/compat/mod.rs
+++ b/cli/compat/mod.rs
@@ -93,8 +93,12 @@ pub fn get_node_imports() -> Vec<(Url, Vec<String>)> {
 
 fn try_resolve_builtin_module(specifier: &str) -> Option<Url> {
   if SUPPORTED_MODULES.contains(&specifier) {
+    let ext = match specifier {
+      "stream/promises" => "mjs",
+      _ => "ts",
+    };
     let module_url =
-      format!("{}node/{}.ts", NODE_COMPAT_URL.as_str(), specifier);
+      format!("{}node/{}.{}", NODE_COMPAT_URL.as_str(), specifier, ext);
     Some(Url::parse(&module_url).unwrap())
   } else {
     None


### PR DESCRIPTION
stream/promises uses an mjs extension

https://deno.land/std@0.150.0/node/stream

No test because this is a simple change, it's unstable compat mode, and this code will probably change soon (also, some code I have incoming will hit this code path every time anyway).