### PR TITLE
docs: turn bare URLs into clickable links

### DIFF
--- a/cli/cdp.rs
+++ b/cli/cdp.rs
@@ -1,13 +1,13 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/
+/// <https://chromedevtools.github.io/devtools-protocol/tot/>
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AwaitPromiseArgs {
@@ -18,7 +18,7 @@ pub struct AwaitPromiseArgs {
   pub generate_preview: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AwaitPromiseResponse {
@@ -26,7 +26,7 @@ pub struct AwaitPromiseResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunctionOnArgs {
@@ -53,7 +53,7 @@ pub struct CallFunctionOnArgs {
   pub throw_on_side_effect: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunctionOnResponse {
@@ -61,7 +61,7 @@ pub struct CallFunctionOnResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompileScriptArgs {
@@ -72,7 +72,7 @@ pub struct CompileScriptArgs {
   pub execution_context_id: Option<ExecutionContextId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompileScriptResponse {
@@ -80,7 +80,7 @@ pub struct CompileScriptResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateArgs {
@@ -119,7 +119,7 @@ pub struct EvaluateArgs {
   pub unique_context_id: Option<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateResponse {
@@ -127,7 +127,7 @@ pub struct EvaluateResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertiesArgs {
@@ -142,7 +142,7 @@ pub struct GetPropertiesArgs {
   pub non_indexed_properties_only: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertiesResponse {
@@ -152,7 +152,7 @@ pub struct GetPropertiesResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalLexicalScopeNamesArgs {
@@ -160,14 +160,14 @@ pub struct GlobalLexicalScopeNamesArgs {
   pub execution_context_id: Option<ExecutionContextId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalLexicalScopeNamesResponse {
   pub names: Vec<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryObjectsArgs {
@@ -176,28 +176,28 @@ pub struct QueryObjectsArgs {
   pub object_group: Option<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryObjectsResponse {
   pub objects: RemoteObject,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObject
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObject>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseObjectArgs {
   pub object_id: RemoteObjectId,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObjectGroup
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObjectGroup>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseObjectGroupArgs {
   pub object_group: String,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunScriptArgs {
@@ -221,7 +221,7 @@ pub struct RunScriptArgs {
   pub await_promise: Option<bool>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunScriptResponse {
@@ -229,7 +229,7 @@ pub struct RunScriptResponse {
   pub exception_details: Option<ExceptionDetails>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-setAsyncCallStackDepth
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-setAsyncCallStackDepth>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetAsyncCallStackDepthArgs {
@@ -238,7 +238,7 @@ pub struct SetAsyncCallStackDepthArgs {
 
 // types
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteObject {
@@ -265,7 +265,7 @@ where
   Deserialize::deserialize(deserializer).map(Some)
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ObjectPreview
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ObjectPreview>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectPreview {
@@ -278,7 +278,7 @@ pub struct ObjectPreview {
   pub entries: Option<Vec<EntryPreview>>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PropertyPreview
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PropertyPreview>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyPreview {
@@ -290,7 +290,7 @@ pub struct PropertyPreview {
   pub subtype: Option<String>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-EntryPreview
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-EntryPreview>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EntryPreview {
@@ -298,7 +298,7 @@ pub struct EntryPreview {
   pub value: ObjectPreview,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CustomPreview
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CustomPreview>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomPreview {
@@ -306,7 +306,7 @@ pub struct CustomPreview {
   pub body_getter_id: RemoteObjectId,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExceptionDetails
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExceptionDetails>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionDetails {
@@ -322,7 +322,7 @@ pub struct ExceptionDetails {
   pub exception_meta_data: Option<serde_json::Map<String, Value>>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-StackTrace
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-StackTrace>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackTrace {
@@ -332,7 +332,7 @@ pub struct StackTrace {
   pub parent_id: Option<StackTraceId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallFrame
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallFrame>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFrame {
@@ -343,7 +343,7 @@ pub struct CallFrame {
   pub column_number: u64,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-StackTraceId
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-StackTraceId>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackTraceId {
@@ -351,7 +351,7 @@ pub struct StackTraceId {
   pub debugger_id: Option<UniqueDebuggerId>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallArgument
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallArgument>
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallArgument {
@@ -373,7 +373,7 @@ impl From<&RemoteObject> for CallArgument {
   }
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-InternalPropertyDescriptor
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-InternalPropertyDescriptor>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyDescriptor {
@@ -389,7 +389,7 @@ pub struct PropertyDescriptor {
   pub symbol: Option<RemoteObject>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-InternalPropertyDescriptor
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-InternalPropertyDescriptor>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InternalPropertyDescriptor {
@@ -397,7 +397,7 @@ pub struct InternalPropertyDescriptor {
   pub value: Option<RemoteObject>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PrivatePropertyDescriptor
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PrivatePropertyDescriptor>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivatePropertyDescriptor {
@@ -407,20 +407,20 @@ pub struct PrivatePropertyDescriptor {
   pub set: Option<RemoteObject>,
 }
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObjectId
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObjectId>
 pub type RemoteObjectId = String;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextId
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextId>
 pub type ExecutionContextId = u64;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ScriptId
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ScriptId>
 pub type ScriptId = String;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-TimeDelta
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-TimeDelta>
 pub type TimeDelta = u64;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UnserializableValue
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UnserializableValue>
 pub type UnserializableValue = String;
 
-/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UniqueDebuggerId
+/// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UniqueDebuggerId>
 pub type UniqueDebuggerId = String;

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -55,7 +55,7 @@ pub type HeadersMap = HashMap<String, String>;
 /// A structure used to determine if a entity in the http cache can be used.
 ///
 /// This is heavily influenced by
-/// https://github.com/kornelski/rusty-http-cache-semantics which is BSD
+/// <https://github.com/kornelski/rusty-http-cache-semantics> which is BSD
 /// 2-Clause Licensed and copyright Kornel Lesiński
 pub struct CacheSemantics {
   cache_control: CacheControl,


### PR DESCRIPTION
Thereby fixing all `cargo doc` warnings of this kind:

```
  warning: this URL is not a hyperlink
     --> cli/cdp.rs:413:5
      |
  413 | /// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextId
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextId>`
      |
      = note: bare URLs are not automatically turned into clickable links
```
