### PR TITLE
refactor: reuse `FastInsecureHasher` in `get_check_hash`

### DIFF
--- a/cli/cache/common.rs
+++ b/cli/cache/common.rs
@@ -24,6 +24,11 @@ impl FastInsecureHasher {
     self
   }
 
+  pub fn write_u8(&mut self, value: u8) -> &mut Self {
+    self.0.write_u8(value);
+    self
+  }
+
   pub fn write_u64(&mut self, value: u64) -> &mut Self {
     self.0.write_u64(value);
     self

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -382,11 +382,7 @@ fn get_check_hash(
   graph_data: &GraphData,
   options: &CheckOptions,
 ) -> CheckHashResult {
-  // twox hash is insecure, but fast so it works for our purposes
-  use std::hash::Hasher;
-  use twox_hash::XxHash64;
-
-  let mut hasher = XxHash64::default();
+  let mut hasher = FastInsecureHasher::new();
   hasher.write_u8(match options.type_check_mode {
     TypeCheckMode::All => 0,
     TypeCheckMode::Local => 1,
@@ -437,8 +433,8 @@ fn get_check_hash(
         | MediaType::Wasm
         | MediaType::Unknown => continue,
       }
-      hasher.write(specifier.as_str().as_bytes());
-      hasher.write(code.as_bytes());
+      hasher.write_str(specifier.as_str());
+      hasher.write_str(code);
     }
   }
 


### PR DESCRIPTION
Just a clean up that isolates the usages of xxhash to `FastInsecureHasher`.