### PR TITLE
fix(cli/lsp): remove excessive line breaks

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2972,7 +2972,7 @@ impl Inner {
       for average in averages {
         writeln!(
           contents,
-          "|{}|{}ms|{}|\n",
+          "|{}|{}ms|{}|",
           average.name, average.average_duration, average.count
         )
         .unwrap();


### PR DESCRIPTION
Fixes #15359