### PR TITLE
fix(lsp): use correct commit chars for completions

### DIFF
--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -31,7 +31,7 @@ static FILE_PROTO_RE: Lazy<Regex> =
 const CURRENT_PATH: &str = ".";
 const PARENT_PATH: &str = "..";
 const LOCAL_PATHS: &[&str] = &[CURRENT_PATH, PARENT_PATH];
-const IMPORT_COMMIT_CHARS: &[&str] = &["\"", "'", "/"];
+pub(crate) const IMPORT_COMMIT_CHARS: &[&str] = &["\"", "'"];
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+use super::completions::IMPORT_COMMIT_CHARS;
 use super::logging::lsp_log;
 use super::path_to_regex::parse;
 use super::path_to_regex::string_to_regex;
@@ -63,6 +64,8 @@ const COMPONENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
   .add(b'&')
   .add(b'+')
   .add(b',');
+
+const REGISTRY_IMPORT_COMMIT_CHARS: &[&str] = &["\"", "'", "/"];
 
 static REPLACEMENT_VARIABLE_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"\$\{\{?(\w+)\}?\}").unwrap());
@@ -493,6 +496,12 @@ impl ModuleRegistry {
         filter_text,
         sort_text: Some("1".to_string()),
         text_edit,
+        commit_characters: Some(
+          REGISTRY_IMPORT_COMMIT_CHARS
+            .iter()
+            .map(|&c| c.into())
+            .collect(),
+        ),
         ..Default::default()
       },
     );
@@ -784,6 +793,21 @@ impl ModuleRegistry {
                             &key,
                             &item,
                           );
+                          let commit_characters = if is_incomplete {
+                            Some(
+                              REGISTRY_IMPORT_COMMIT_CHARS
+                                .iter()
+                                .map(|&c| c.into())
+                                .collect(),
+                            )
+                          } else {
+                            Some(
+                              IMPORT_COMMIT_CHARS
+                                .iter()
+                                .map(|&c| c.into())
+                                .collect(),
+                            )
+                          };
                           completions.insert(
                             item,
                             lsp::CompletionItem {
@@ -796,6 +820,7 @@ impl ModuleRegistry {
                               command,
                               preselect,
                               data,
+                              commit_characters,
                               ..Default::default()
                             },
                           );
@@ -836,6 +861,12 @@ impl ModuleRegistry {
                           sort_text: Some("1".to_string()),
                           text_edit,
                           preselect: Some(true),
+                          commit_characters: Some(
+                            REGISTRY_IMPORT_COMMIT_CHARS
+                              .iter()
+                              .map(|&c| c.into())
+                              .collect(),
+                          ),
                           ..Default::default()
                         },
                       );
@@ -889,6 +920,21 @@ impl ModuleRegistry {
                             let preselect =
                               get_preselect(item.clone(), preselect.clone());
                             let data = get_data(registry, &specifier, k, &path);
+                            let commit_characters = if is_incomplete {
+                              Some(
+                                REGISTRY_IMPORT_COMMIT_CHARS
+                                  .iter()
+                                  .map(|&c| c.into())
+                                  .collect(),
+                              )
+                            } else {
+                              Some(
+                                IMPORT_COMMIT_CHARS
+                                  .iter()
+                                  .map(|&c| c.into())
+                                  .collect(),
+                              )
+                            };
                             completions.insert(
                               item.clone(),
                               lsp::CompletionItem {
@@ -901,6 +947,7 @@ impl ModuleRegistry {
                                 command,
                                 preselect,
                                 data,
+                                commit_characters,
                                 ..Default::default()
                               },
                             );
@@ -969,6 +1016,12 @@ impl ModuleRegistry {
             detail: Some("(registry)".to_string()),
             sort_text: Some("2".to_string()),
             text_edit,
+            commit_characters: Some(
+              REGISTRY_IMPORT_COMMIT_CHARS
+                .iter()
+                .map(|&c| c.into())
+                .collect(),
+            ),
             ..Default::default()
           })
         } else {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -775,7 +775,7 @@ fn lsp_import_map_import_completions() {
           "detail": "(local)",
           "sortText": "1",
           "insertText": ".",
-          "commitCharacters": ["\"", "'", "/"],
+          "commitCharacters": ["\"", "'"],
         },
         {
           "label": "..",
@@ -783,7 +783,7 @@ fn lsp_import_map_import_completions() {
           "detail": "(local)",
           "sortText": "1",
           "insertText": "..",
-          "commitCharacters": ["\"", "'", "/"],
+          "commitCharacters": ["\"", "'"],
         },
         {
           "label": "std",
@@ -791,7 +791,7 @@ fn lsp_import_map_import_completions() {
           "detail": "(import map)",
           "sortText": "std",
           "insertText": "std",
-          "commitCharacters": ["\"", "'", "/"],
+          "commitCharacters": ["\"", "'"],
         },
         {
           "label": "fs",
@@ -799,7 +799,7 @@ fn lsp_import_map_import_completions() {
           "detail": "(import map)",
           "sortText": "fs",
           "insertText": "fs",
-          "commitCharacters": ["\"", "'", "/"],
+          "commitCharacters": ["\"", "'"],
         },
         {
           "label": "/~",
@@ -807,7 +807,7 @@ fn lsp_import_map_import_completions() {
           "detail": "(import map)",
           "sortText": "/~",
           "insertText": "/~",
-          "commitCharacters": ["\"", "'", "/"],
+          "commitCharacters": ["\"", "'"],
         }
       ]
     }))
@@ -889,7 +889,7 @@ fn lsp_import_map_import_completions() {
             },
             "newText": "/~/b.ts"
           },
-          "commitCharacters": ["\"", "'", "/"],
+          "commitCharacters": ["\"", "'"],
         }
       ]
     }))

--- a/cli/tests/testdata/lsp/completion_request_response_empty.json
+++ b/cli/tests/testdata/lsp/completion_request_response_empty.json
@@ -9,8 +9,7 @@
       "insertText": ".",
       "commitCharacters": [
         "\"",
-        "'",
-        "/"
+        "'"
       ]
     },
     {
@@ -21,8 +20,7 @@
       "insertText": "..",
       "commitCharacters": [
         "\"",
-        "'",
-        "/"
+        "'"
       ]
     },
     {
@@ -42,7 +40,12 @@
           }
         },
         "newText": "http://localhost:4545"
-      }
+      },
+      "commitCharacters": [
+        "\"",
+        "'",
+        "/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes: #15252

This ensures that `"/"` is only a commit character on incomplete registry creations, not on other ones.