### PR TITLE
feat(ext/fetch): Add socks proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url 2.2.2",
@@ -4714,6 +4715,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -20,7 +20,7 @@ deno_core = { version = "0.145.0", path = "../../core" }
 deno_tls = { version = "0.50.0", path = "../tls" }
 dyn-clone = "1"
 http = "0.2.6"
-reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli"] }
+reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks"] }
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1.17", features = ["full"] }
 tokio-stream = "0.1.8"


### PR DESCRIPTION
Adds socks proxy support by enabling the reqwest feature flag, as mentioned in #11609. No new tests as the issue mentioned that internal discussions OK'ed the change without new tests.