### PR TITLE
[WIP] perf(ops): Prepare async ops for V8 Fast API

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+use crate::runtime::GetErrorClassFn;
 use crate::runtime::JsRuntime;
 use crate::source_map::apply_source_map;
 use crate::source_map::get_source_line;
@@ -89,6 +90,25 @@ impl std::error::Error for CustomError {}
 /// class name. In all other cases this function returns `None`.
 pub fn get_custom_error_class(error: &Error) -> Option<&'static str> {
   error.downcast_ref::<CustomError>().map(|e| e.class)
+}
+
+pub fn to_v8_error<'a>(
+  scope: &mut v8::HandleScope<'a>,
+  get_class: GetErrorClassFn,
+  error: &Error,
+) -> v8::Local<'a, v8::Value> {
+  let state_rc = JsRuntime::state(scope);
+  let state = state_rc.borrow();
+  let cb = state
+    .js_build_custom_error_cb
+    .as_ref()
+    .expect("Custom error builder must be set");
+  let cb = cb.open(scope);
+  let this = v8::undefined(scope).into();
+  let class = v8::String::new(scope, get_class(error)).unwrap();
+  let message = v8::String::new(scope, &error.to_string()).unwrap();
+  cb.call(scope, this, &[class.into(), message.into()])
+    .expect("Custom error class must have a builder registered")
 }
 
 /// A `JsError` represents an exception coming from V8, with stack frames and

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -21,14 +21,6 @@ declare namespace Deno {
       b?: any,
     ): Promise<any>;
 
-    /** Mark following promise as "ref", ie. event loop won't exit
-     * until all "ref" promises are resolved. All async ops are "ref" by default. */
-    function refOp(promiseId: number): void;
-
-    /** Mark following promise as "unref", ie. event loop will exit
-     * if there are only "unref" promises left. */
-    function unrefOps(promiseId: number): void;
-
     /**
      * Retrieve a list of all registered ops, in the form of a map that maps op
      * name to internal numerical op id.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -116,6 +116,7 @@ pub mod _ops {
   pub use super::ops::to_op_result;
   pub use super::ops::OpCtx;
   pub use super::runtime::queue_async_op;
+  pub use super::runtime::prepare_async_op;
 }
 
 /// A helper macro that will return a call site in Rust code. Should be

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -15,6 +15,7 @@ mod ops;
 mod ops_builtin;
 mod ops_builtin_v8;
 mod ops_metrics;
+mod promise_ring;
 mod resources;
 mod runtime;
 mod source_map;
@@ -115,8 +116,8 @@ pub mod _ops {
   pub use super::error_codes::get_error_code;
   pub use super::ops::to_op_result;
   pub use super::ops::OpCtx;
-  pub use super::runtime::queue_async_op;
   pub use super::runtime::prepare_async_op;
+  pub use super::runtime::queue_async_op;
 }
 
 /// A helper macro that will return a call site in Rust code. Should be

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -80,8 +80,8 @@ where
   }
 }
 
-pub type PromiseId = i32;
-pub type OpAsyncFuture = OpCall<(PromiseId, OpId, OpResult)>;
+pub type PromiseId = u32;
+pub type OpAsyncFuture = OpCall<(v8::Global<v8::PromiseResolver>, OpId, OpResult)>;
 pub type OpFn =
   fn(&mut v8::HandleScope, v8::FunctionCallbackArguments, v8::ReturnValue);
 pub type OpId = usize;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -81,7 +81,8 @@ where
 }
 
 pub type PromiseId = u32;
-pub type OpAsyncFuture = OpCall<(v8::Global<v8::PromiseResolver>, OpId, OpResult)>;
+pub type OpAsyncFuture =
+  OpCall<(v8::Global<v8::PromiseResolver>, OpId, OpResult)>;
 pub type OpFn =
   fn(&mut v8::HandleScope, v8::FunctionCallbackArguments, v8::ReturnValue);
 pub type OpId = usize;
@@ -113,9 +114,9 @@ impl OpResult {
 #[serde(rename_all = "camelCase")]
 pub struct OpError {
   #[serde(rename = "$err_class_name")]
-  class_name: &'static str,
-  message: String,
-  code: Option<&'static str>,
+  pub(crate) class_name: &'static str,
+  pub(crate) message: String,
+  pub(crate) code: Option<&'static str>,
 }
 
 impl OpError {

--- a/core/promise_ring.rs
+++ b/core/promise_ring.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use crate::PromiseId;
+use std::collections::btree_map::BTreeMap;
+
+type PromiseResolver = v8::Global<v8::PromiseResolver>;
+const RING_SIZE: usize = 4 * 1024;
+
+pub struct PromiseRing {
+  len: u32,
+  cursor: u32,
+  ring: Vec<Option<PromiseResolver>>,
+  map: BTreeMap<PromiseId, PromiseResolver>,
+}
+
+impl PromiseRing {
+  pub(crate) fn new() -> Self {
+    Self {
+      len: 0,
+      cursor: 0,
+      ring: vec![None; RING_SIZE],
+      map: BTreeMap::new(),
+    }
+  }
+
+  pub(crate) fn has(&self, id: PromiseId) -> bool {
+    let ring_start = if self.cursor < (RING_SIZE as u32) {
+      0
+    } else {
+      self.cursor - RING_SIZE as u32
+    };
+    if id >= ring_start {
+      self.ring[Self::ring_idx(id)].is_some()
+    } else {
+      self.map.contains_key(&id)
+    }
+  }
+
+  pub(crate) fn take(&mut self, id: PromiseId) -> Option<PromiseResolver> {
+    let ring_start = if self.cursor < (RING_SIZE as u32) {
+      0
+    } else {
+      self.cursor - RING_SIZE as u32
+    };
+    let resolver = if id >= ring_start {
+      self.ring.get_mut(Self::ring_idx(id)).unwrap().take()
+    } else {
+      self.map.remove(&id)
+    };
+    if resolver.is_some() {
+      self.len -= 1;
+    }
+    resolver
+  }
+
+  pub(crate) fn allocate(&mut self) -> PromiseId {
+    let id = self.cursor;
+    self.cursor += 1;
+    self.len += 1;
+    let slot = self.ring.get_mut(Self::ring_idx(id));
+    if let Some(old_resolver) = slot.unwrap().take() {
+      let old_id = id - RING_SIZE as PromiseId; // Since we're looping on the ring
+      self.map.insert(old_id, old_resolver);
+    }
+    id as PromiseId
+  }
+
+  pub(crate) fn set(&mut self, id: PromiseId, resolver: PromiseResolver) {
+    let slot = self.ring.get_mut(Self::ring_idx(id));
+    if slot.unwrap().replace(resolver).is_some() {
+      panic!("Trying to set resolver on non-allocated slot");
+    }
+  }
+
+  fn ring_idx(id: u32) -> usize {
+    (id as usize) % RING_SIZE
+  }
+}

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -249,12 +249,12 @@
 
     #refOpAccept() {
       if (typeof this.#promiseId === "number") {
-        core.refOp(this.#promiseId);
+        core.ops.op_ref_op(this.#promiseId);
       }
     }
     #unrefOpAccept() {
       if (typeof this.#promiseId === "number") {
-        core.unrefOp(this.#promiseId);
+        core.ops.op_unref_op(this.#promiseId);
       }
     }
   }

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -216,7 +216,7 @@
     timerInfo.promiseId =
       sleepPromise[SymbolFor("Deno.core.internalPromiseId")];
     if (!timerInfo.isRef) {
-      core.unrefOp(timerInfo.promiseId);
+      core.ops.op_unref_op(timerInfo.promiseId);
     }
 
     /** @type {ScheduledTimer} */
@@ -349,7 +349,7 @@
       return;
     }
     timerInfo.isRef = true;
-    core.refOp(timerInfo.promiseId);
+    core.ops.op_ref_op(timerInfo.promiseId);
   }
 
   function unrefTimer(id) {
@@ -358,7 +358,7 @@
       return;
     }
     timerInfo.isRef = false;
-    core.unrefOp(timerInfo.promiseId);
+    core.ops.op_unref_op(timerInfo.promiseId);
   }
 
   window.__bootstrap.timers = {

--- a/ext/webgpu/src/buffer.rs
+++ b/ext/webgpu/src/buffer.rs
@@ -10,7 +10,6 @@ use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::convert::TryFrom;
 use std::rc::Rc;
 use std::time::Duration;
 

--- a/ext/webgpu/src/lib.rs
+++ b/ext/webgpu/src/lib.rs
@@ -12,7 +12,6 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::convert::TryFrom;
 use std::rc::Rc;
 pub use wgpu_core;
 pub use wgpu_types;

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -189,7 +189,7 @@ fn codegen_v8_async(
       quote! { let result = Ok(result); },
     ),
     // sync fn which returns a `Result<impl Future<Output = Result<T>, AnyError>> + 'static, AnyError>`:
-    // call, match the result and await 
+    // call, match the result and await
     (false, true) => (
       quote! { let result = Self::call::<#type_params>(#args_head #args_tail); }, // TODO: Return error op result directly
       quote! {},
@@ -230,12 +230,12 @@ fn codegen_v8_async(
 
     #pre_result
     let promise_id = #core::_ops::prepare_async_op(scope);
-    rv.set_uint32(promise_id as u32);
     #core::_ops::queue_async_op(scope, async move {
       #result_fut
       #result_wrapper
       (promise_id, op_id, #core::_ops::to_op_result(get_class, result))
     });
+    rv.set_uint32(promise_id as u32);
   }
 }
 
@@ -312,9 +312,7 @@ fn codegen_args(
     .unwrap();
   let decls: TokenStream2 = inputs
     .clone()
-    .map(|(i, arg)| {
-      codegen_arg(core, arg, format!("arg_{i}").as_ref(), i)
-    })
+    .map(|(i, arg)| codegen_arg(core, arg, format!("arg_{i}").as_ref(), i))
     .collect();
   (decls, ident_seq)
 }
@@ -362,15 +360,15 @@ fn codegen_sync_ret(
   } else if is_i32_rv(output) {
     return quote! {
       rv.set_int32(result as i32);
-    }
+    };
   } else if is_double_rv(output) {
     return quote! {
       rv.set_double(result as f64);
-    }
+    };
   } else if is_bool_rv(output) {
     return quote! {
       rv.set_bool(result);
-    }
+    };
   }
 
   // Optimize Result<(), Err> to skip serde_v8 when Ok(...)
@@ -380,7 +378,7 @@ fn codegen_sync_ret(
     quote! {
       rv.set_uint32(result as u32);
     }
-    } else if is_i32_rv_result(output) {
+  } else if is_i32_rv_result(output) {
     quote! {
       rv.set_int32(result as i32);
     }
@@ -465,13 +463,15 @@ fn is_u32_rv_result(ty: impl ToTokens) -> bool {
 }
 
 fn is_i32_rv_result(ty: impl ToTokens) -> bool {
-  is_result(&ty) && (tokens(&ty).contains("Result < i32")
+  is_result(&ty)
+    && (tokens(&ty).contains("Result < i32")
       || tokens(&ty).contains("Result < i8")
       || tokens(&ty).contains("Result < i16"))
 }
 
 fn is_double_rv_result(ty: impl ToTokens) -> bool {
-  is_result(&ty) && (tokens(&ty).contains("Result < f32")
+  is_result(&ty)
+    && (tokens(&ty).contains("Result < f32")
       || tokens(&ty).contains("Result < f64"))
 }
 

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -15,7 +15,7 @@
 
   function pollSignal(rid) {
     const promise = core.opAsync("op_signal_poll", rid);
-    core.unrefOp(promise[SymbolFor("Deno.core.internalPromiseId")]);
+    core.ops.op_unref_op(promise[SymbolFor("Deno.core.internalPromiseId")]);
     return promise;
   }
 


### PR DESCRIPTION
Possibly quite a bit of work still in progress here. This is the synthesis of #15351 and #14396 PRs, together with some of the thoughts from #15337 working in the background.

The focal point is to make async ops calls V8 Fast API -compliant. This is enabled by moving the Promise Ring to Rust side, original work by @AaronO (I need to figure out how to do attributions) but unlike the original PR, the `PromiseResolver` is not allocated directly but instead the async op only returns the `u32` PromiseId value. A later call to a new `op_get_promise` is used to actually allocate the `PromiseResolver` and thus also get the promise.

The code in the branch currently calls this op synchronously. However, it might be beneficial to instead have the `PromiseRing` keep not an `Option<PromiseResolver>` but one of three possible values: `Some(PromiseResolver)`, `Allocated` and `None`. This would enable ref'ing and unref'ing of async ops before their `PromiseResolver` has been created. Unfortunately, it's also possible for a future to be resolved before the corresponding Promise is created, in which case a panic occurs since the resolver cannot be found. This could probably be worked around somehow, though.

Current performance seems to be good, though nothing spectacular. Main branch deno benches `op_async_void` usually around 600-620ns, occasionally below 600, whereas this branch is pretty stable around 580ns or so. I'm hoping there's a lot of stuff around in my code that can be further improved.