### PR TITLE
chore: add perf and needs investigation to stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,8 @@ exemptLabels:
   - build
   - docs
   - flaky
+  - perf
+  - needs investigation
 
 exemptMilestones: true
 


### PR DESCRIPTION
Adds two labels that stalebot tries to mark stale that shouldn't go stale.  Have been adding `"bug"` in order to ward the bot off, but should just update the config.