### PR TITLE
chore: make the start_release workflow go faster

### DIFF
--- a/.github/workflows/start_release.yml
+++ b/.github/workflows/start_release.yml
@@ -31,12 +31,9 @@ jobs:
           git config --global fetch.parallel 32
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.DENOBOT_PAT }}
-          submodules: recursive
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - name: Install deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/start_release.yml
+++ b/.github/workflows/start_release.yml
@@ -40,7 +40,7 @@ jobs:
           # the latest version ever has issues that breaks publishing
           deno-version: v1.23.2
 
-      - name: Run start release
+      - name: Create Gist URL
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_GIST_PAT }}
           GH_WORKFLOW_ACTOR: ${{ github.actor }}

--- a/.github/workflows/start_release.yml
+++ b/.github/workflows/start_release.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.DENOBOT_PAT }}
 
       - name: Install deno
         uses: denoland/setup-deno@v1
@@ -44,6 +42,6 @@ jobs:
 
       - name: Run start release
         env:
-          GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.DENOBOT_GIST_PAT }}
           GH_WORKFLOW_ACTOR: ${{ github.actor }}
         run: ./tools/release/00_start_release.ts --${{github.event.inputs.releaseKind}}

--- a/tools/cut_a_release.md
+++ b/tools/cut_a_release.md
@@ -5,4 +5,4 @@
 1. Select the kind of release, then run the workflow.
 1. In the "Run start release" step, look at the bottom of the output to get the
    gist url.
-1. Fork the gist, and follow the instructions.
+1. Follow the instructions in the gist.

--- a/tools/cut_a_release.md
+++ b/tools/cut_a_release.md
@@ -3,6 +3,6 @@
 1. Go to this workflow:
    https://github.com/denoland/deno/actions/workflows/start_release.yml
 1. Select the kind of release, then run the workflow.
-1. In the "Run start release" step, look at the bottom of the output to get the
-   gist url.
+1. Wait for the "Create Gist URL" step to complete and look at its output for
+   the Gist URL.
 1. Follow the instructions in the gist.

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { DenoWorkspace } from "./deno_workspace.ts";
 import { $, createOctoKit, semver } from "./deps.ts";
 
 const currentDirPath = $.path.dirname($.path.fromFileUrl(import.meta.url));

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -3,10 +3,10 @@
 import { DenoWorkspace } from "./deno_workspace.ts";
 import { $, createOctoKit, semver } from "./deps.ts";
 
-$.logStep("Loading cli crate...");
-const workspace = await DenoWorkspace.load();
-const cliCrate = workspace.getCliCrate();
-const nextVersion = getNextVersion(semver.parse(cliCrate.version)!);
+const currentDirPath = $.path.dirname($.path.fromFileUrl(import.meta.url));
+
+$.logStep("Getting next version...");
+const nextVersion = getNextVersion(semver.parse(getCliVersion())!);
 
 $.logStep("Creating gist with instructions...");
 const octoKit = createOctoKit();
@@ -41,9 +41,23 @@ function getNextVersion(originalVersion: semver.SemVer) {
 }
 
 function buildDenoReleaseInstructionsDoc() {
-  const currentDirPath = $.path.dirname($.path.fromFileUrl(import.meta.url));
   const templateText = Deno.readTextFileSync(
     $.path.join(currentDirPath, "release_doc_template.md"),
   );
   return `# Deno CLI ${nextVersion.toString()} Release Checklist\n\n${templateText}`;
+}
+
+function getCliVersion() {
+  const cargoTomlText = Deno.readTextFileSync(
+    $.path.join(currentDirPath, "../../cli/Cargo.toml"),
+  );
+  const result = cargoTomlText.match(/^version\s*=\s*"([^"]+)"$/m);
+  if (result == null || result.length !== 2) {
+    $.log("Cargo.toml");
+    $.log("==========");
+    $.log(cargoTomlText);
+    $.log("==========");
+    throw new Error("Could not find version in text.");
+  }
+  return result[1];
 }

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -22,7 +22,7 @@ const result = await octoKit.request("POST /gists", {
 $.log("==============================================");
 $.log("Created gist with instructions!");
 $.log("");
-$.log(`  ${result.html_url}`);
+$.log(`  ${result.data.html_url}`);
 $.log("");
 $.log("Please fork the gist and follow the checklist.");
 $.log("==============================================");

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -10,10 +10,10 @@ const nextVersion = getNextVersion(semver.parse(getCliVersion())!);
 $.logStep("Creating gist with instructions...");
 const octoKit = createOctoKit();
 const result = await octoKit.request("POST /gists", {
-  description: `Deno CLI v${nextVersion.toString()} release checklist`,
+  description: `Deno CLI v${nextVersion} release checklist`,
   public: false,
   files: {
-    "release_instructions.md": {
+    [`release_instructions_${nextVersion}.md`]: {
       content: buildDenoReleaseInstructionsDoc(),
     },
   },
@@ -22,7 +22,7 @@ const result = await octoKit.request("POST /gists", {
 $.log("==============================================");
 $.log("Created gist with instructions!");
 $.log("");
-$.log(`  ${result.url}`);
+$.log(`  ${result.html_url}`);
 $.log("");
 $.log("Please fork the gist and follow the checklist.");
 $.log("==============================================");

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -13,7 +13,7 @@ const result = await octoKit.request("POST /gists", {
   description: `Deno CLI v${nextVersion} release checklist`,
   public: false,
   files: {
-    [`release_instructions_${nextVersion}.md`]: {
+    [`release_${nextVersion}.md`]: {
       content: buildDenoReleaseInstructionsDoc(),
     },
   },

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
+#!/usr/bin/env -S deno run -A --quiet --lock=tools/deno.lock.json
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 import { $, createOctoKit, semver } from "./deps.ts";
 

--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -1,4 +1,6 @@
-## Pre-flight checklist
+- [ ] Fork this gist and follow the instructions there.
+
+## Pre-flight
 
 - Forks and local clones of
   [`denoland/deno`](https://github.com/denoland/deno/),
@@ -13,7 +15,7 @@ release from) should be frozen and no commits should land until the release is
 cut.**
 
 - [ ] Write a message in company's #cli channel:
-      `:lock: deno and deno_std are now locked (<LINK TO THIS GIST GOES HERE>)`
+      `:lock: deno and deno_std are now locked (<LINK TO THIS FORKED GIST GOES HERE>)`
 
 ## Patch release preparation
 
@@ -90,7 +92,7 @@ verify on GitHub that everything looks correct.
 - [ ] Wait for the workflow to complete and for a pull request to be
       automatically opened. Review the pull request, make any necessary changes,
       and merge it.
-  - ⛔ DO NOT create a release tag manually.
+  - ⛔ DO NOT create a release tag manually That will automatically happen.
 
   <details>
      <summary>❌ Failure Steps</summary>

--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -53,7 +53,7 @@ verify on GitHub that everything looks correct.
   - ⛔ DO NOT create a release tag manually. That will automatically happen.
 
   <details>
-    <summary>❌ Failure Steps</summary>
+    <summary>Failure Steps</summary>
 
   1. Checkout the latest main.
   2. Manually run `./_tools/release/01_bump_version.ts --minor`
@@ -69,7 +69,7 @@ verify on GitHub that everything looks correct.
   - [ ] Review the draft release and then publish it.
 
   <details>
-    <summary>❌ Failure Steps</summary>
+    <summary>Failure Steps</summary>
 
   1. Tag the repo manually in the format `x.x.x`
   2. Draft a new GH release by copying and pasting the release notes from
@@ -95,7 +95,7 @@ verify on GitHub that everything looks correct.
   - ⛔ DO NOT create a release tag manually That will automatically happen.
 
   <details>
-     <summary>❌ Failure Steps</summary>
+     <summary>Failure Steps</summary>
 
   1. Checkout the branch the release is being made on.
   2. Manually run `./tools/release/01_bump_crate_versions.ts`
@@ -112,7 +112,7 @@ verify on GitHub that everything looks correct.
   1. Run it on the same branch that you used before and wait for it to complete.
 
   <details>
-     <summary>❌ Failure Steps</summary>
+     <summary>Failure Steps</summary>
 
   1. The workflow was designed to be restartable. Try restarting it.
   2. If that doesn't work, then do the following:
@@ -142,7 +142,8 @@ verify on GitHub that everything looks correct.
 
 - ⛔ Verify that:
   - [ ] There are 8 assets on the release draft.
-  - [ ] There are 4 zip files for this version on dl.deno.land
+  - [ ] There are 4 zip files for this version on
+        [dl.deno.land](https://console.cloud.google.com/storage/browser/dl.deno.land/release).
   - [ ] The aarch64 Mac build was built from the correct branch AFTER the
         version bump and has the same version as the release when doing
         `deno -V` (ask someone with an M1 Mac to verify this if you don't have
@@ -156,7 +157,7 @@ verify on GitHub that everything looks correct.
   - [ ] This should open a PR. Review and merge it.
 
   <details>
-     <summary>❌ Failure Steps</summary>
+     <summary>Failure Steps</summary>
 
   1. Update https://github.com/denoland/dotland/blob/main/versions.json
      manually.
@@ -185,7 +186,7 @@ queries the GitHub API to determine what it needs to change and update.
   - This will open a PR. Review it and merge, which will trigger a deployment.
 
   <details>
-     <summary>❌ Failure Steps</summary>
+     <summary>Failure Steps</summary>
 
   1. Checkout a new branch for docland (e.g. `git checkout -b deno_1.17.0`).
   2. Execute `deno task build`


### PR DESCRIPTION
This reduces the time from a minute and a half to 17 seconds. ~~I need to update the deno bot PAT to make it work first though (to have gist permissions). I will do that and run a test on this branch before merging.~~ Also, it has some fixes to make it actually work.

Example output: https://gist.github.com/denobot/6c9117bd751e4e92434aecb16e9e49ff