### PR TITLE
chore: temporarily disable `op_require_read_file`

### DIFF
--- a/cli/tests/integration/compat_tests.rs
+++ b/cli/tests/integration/compat_tests.rs
@@ -173,6 +173,7 @@ fn native_modules_as_global_vars() {
   assert!(out.contains("true"));
 }
 
+#[ignore] // todo(dsherret): re-enable
 #[test]
 fn ext_node_cjs_execution() {
   let (out, _err) = util::run_and_collect_output_with_args(

--- a/ext/node/01_require.js
+++ b/ext/node/01_require.js
@@ -476,7 +476,7 @@
     if (typeof options === "object" && options !== null) {
       if (ArrayIsArray(options.paths)) {
         const isRelative = core.opSync(
-          "op_require_specifier_is_relative",
+          "op_require_is_request_relative",
           request,
         );
 

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -311,7 +311,6 @@ fn op_require_try_self(
 }
 
 #[op]
-fn op_require_read_file(filename: String) -> Result<String, AnyError> {
-  let contents = std::fs::read_to_string(filename)?;
-  Ok(contents)
+fn op_require_read_file(_filename: String) -> Result<String, AnyError> {
+  todo!("not implemented");
 }


### PR DESCRIPTION
This function was missing permissions checks in #15362. This won't actually be used until an upcomming PR, so we're going to temporarily disable this.