### PR TITLE
chore: temporarily disable `ext/node` and use unstable ops

### DIFF
--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -5,9 +5,12 @@ use deno_core::include_js_files;
 use deno_core::normalize_path;
 use deno_core::op;
 use deno_core::Extension;
+use deno_core::OpState;
 use std::path::PathBuf;
 
-pub fn init() -> Extension {
+pub struct Unstable(pub bool);
+
+pub fn init(unstable: bool) -> Extension {
   Extension::builder()
     .js(include_js_files!(
       prefix "deno:ext/node",
@@ -29,11 +32,26 @@ pub fn init() -> Extension {
       op_require_path_basename::decl(),
       op_require_read_file::decl(),
     ])
+    .state(move |state| {
+      state.put(Unstable(unstable));
+      Ok(())
+    })
     .build()
 }
 
-#[op(unstable)]
-pub fn op_require_init_paths() -> Vec<String> {
+fn check_unstable(state: &OpState) {
+  let unstable = state.borrow::<Unstable>();
+
+  if !unstable.0 {
+    eprintln!("Unstable API 'require'. The --unstable flag must be provided.",);
+    std::process::exit(70);
+  }
+}
+
+#[op]
+pub fn op_require_init_paths(state: &mut OpState) -> Vec<String> {
+  check_unstable(state);
+
   let (home_dir, node_path) = if cfg!(windows) {
     (
       std::env::var("USERPROFILE").unwrap_or_else(|_| "".into()),
@@ -79,8 +97,12 @@ pub fn op_require_init_paths() -> Vec<String> {
   paths
 }
 
-#[op(unstable)]
-pub fn op_require_node_module_paths(from: String) -> Vec<String> {
+#[op]
+pub fn op_require_node_module_paths(
+  state: &mut OpState,
+  from: String,
+) -> Vec<String> {
+  check_unstable(state);
   // Guarantee that "from" is absolute.
   let from = deno_core::resolve_path(&from)
     .unwrap()
@@ -125,8 +147,9 @@ pub fn op_require_node_module_paths(from: String) -> Vec<String> {
   paths
 }
 
-#[op(unstable)]
-fn op_require_proxy_path(filename: String) -> String {
+#[op]
+fn op_require_proxy_path(state: &mut OpState, filename: String) -> String {
+  check_unstable(state);
   // Allow a directory to be passed as the filename
   let trailing_slash = if cfg!(windows) {
     filename.ends_with('\\')
@@ -142,8 +165,12 @@ fn op_require_proxy_path(filename: String) -> String {
   }
 }
 
-#[op(unstable)]
-fn op_require_is_request_relative(request: String) -> bool {
+#[op]
+fn op_require_is_request_relative(
+  state: &mut OpState,
+  request: String,
+) -> bool {
+  check_unstable(state);
   if request.starts_with("./") {
     return true;
   }
@@ -165,12 +192,14 @@ fn op_require_is_request_relative(request: String) -> bool {
   false
 }
 
-#[op(unstable)]
+#[op]
 fn op_require_resolve_lookup_paths(
+  state: &mut OpState,
   request: String,
   maybe_parent_paths: Option<Vec<String>>,
   parent_filename: String,
 ) -> Option<Vec<String>> {
+  check_unstable(state);
   if !request.starts_with('.')
     || (request.len() > 1
       && !request.starts_with("..")
@@ -206,13 +235,15 @@ fn op_require_resolve_lookup_paths(
   Some(vec![p.parent().unwrap().to_string_lossy().to_string()])
 }
 
-#[op(unstable)]
-fn op_require_path_is_absolute(p: String) -> bool {
+#[op]
+fn op_require_path_is_absolute(state: &mut OpState, p: String) -> bool {
+  check_unstable(state);
   PathBuf::from(p).is_absolute()
 }
 
-#[op(unstable)]
-fn op_require_stat(filename: String) -> i32 {
+#[op]
+fn op_require_stat(state: &mut OpState, filename: String) -> i32 {
+  check_unstable(state);
   if let Ok(metadata) = std::fs::metadata(&filename) {
     if metadata.is_file() {
       return 0;
@@ -224,8 +255,12 @@ fn op_require_stat(filename: String) -> i32 {
   -1
 }
 
-#[op(unstable)]
-fn op_require_real_path(request: String) -> Result<String, AnyError> {
+#[op]
+fn op_require_real_path(
+  state: &mut OpState,
+  request: String,
+) -> Result<String, AnyError> {
+  check_unstable(state);
   let mut canonicalized_path = PathBuf::from(request).canonicalize()?;
   if cfg!(windows) {
     canonicalized_path = PathBuf::from(
@@ -238,8 +273,9 @@ fn op_require_real_path(request: String) -> Result<String, AnyError> {
   Ok(canonicalized_path.to_string_lossy().to_string())
 }
 
-#[op(unstable)]
-fn op_require_path_resolve(parts: Vec<String>) -> String {
+#[op]
+fn op_require_path_resolve(state: &mut OpState, parts: Vec<String>) -> String {
+  check_unstable(state);
   assert!(!parts.is_empty());
   let mut p = PathBuf::from(&parts[0]);
   if parts.len() > 1 {
@@ -250,24 +286,28 @@ fn op_require_path_resolve(parts: Vec<String>) -> String {
   normalize_path(p).to_string_lossy().to_string()
 }
 
-#[op(unstable)]
-fn op_require_path_dirname(request: String) -> String {
+#[op]
+fn op_require_path_dirname(state: &mut OpState, request: String) -> String {
+  check_unstable(state);
   let p = PathBuf::from(request);
   p.parent().unwrap().to_string_lossy().to_string()
 }
 
-#[op(unstable)]
-fn op_require_path_basename(request: String) -> String {
+#[op]
+fn op_require_path_basename(state: &mut OpState, request: String) -> String {
+  check_unstable(state);
   let p = PathBuf::from(request);
   p.file_name().unwrap().to_string_lossy().to_string()
 }
 
-#[op(unstable)]
+#[op]
 fn op_require_try_self_parent_path(
+  state: &mut OpState,
   has_parent: bool,
   maybe_parent_filename: Option<String>,
   maybe_parent_id: Option<String>,
 ) -> Option<String> {
+  check_unstable(state);
   if !has_parent {
     return None;
   }
@@ -286,12 +326,14 @@ fn op_require_try_self_parent_path(
   None
 }
 
-#[op(unstable)]
+#[op]
 fn op_require_try_self(
+  state: &mut OpState,
   has_parent: bool,
   maybe_parent_filename: Option<String>,
   maybe_parent_id: Option<String>,
 ) -> Option<String> {
+  check_unstable(state);
   if !has_parent {
     return None;
   }
@@ -310,7 +352,11 @@ fn op_require_try_self(
   None
 }
 
-#[op(unstable)]
-fn op_require_read_file(_filename: String) -> Result<String, AnyError> {
+#[op]
+fn op_require_read_file(
+  state: &mut OpState,
+  _filename: String,
+) -> Result<String, AnyError> {
+  check_unstable(state);
   todo!("not implemented");
 }

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -32,7 +32,7 @@ pub fn init() -> Extension {
     .build()
 }
 
-#[op]
+#[op(unstable)]
 pub fn op_require_init_paths() -> Vec<String> {
   let (home_dir, node_path) = if cfg!(windows) {
     (
@@ -79,7 +79,7 @@ pub fn op_require_init_paths() -> Vec<String> {
   paths
 }
 
-#[op]
+#[op(unstable)]
 pub fn op_require_node_module_paths(from: String) -> Vec<String> {
   // Guarantee that "from" is absolute.
   let from = deno_core::resolve_path(&from)
@@ -125,7 +125,7 @@ pub fn op_require_node_module_paths(from: String) -> Vec<String> {
   paths
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_proxy_path(filename: String) -> String {
   // Allow a directory to be passed as the filename
   let trailing_slash = if cfg!(windows) {
@@ -142,7 +142,7 @@ fn op_require_proxy_path(filename: String) -> String {
   }
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_is_request_relative(request: String) -> bool {
   if request.starts_with("./") {
     return true;
@@ -165,7 +165,7 @@ fn op_require_is_request_relative(request: String) -> bool {
   false
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_resolve_lookup_paths(
   request: String,
   maybe_parent_paths: Option<Vec<String>>,
@@ -206,12 +206,12 @@ fn op_require_resolve_lookup_paths(
   Some(vec![p.parent().unwrap().to_string_lossy().to_string()])
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_path_is_absolute(p: String) -> bool {
   PathBuf::from(p).is_absolute()
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_stat(filename: String) -> i32 {
   if let Ok(metadata) = std::fs::metadata(&filename) {
     if metadata.is_file() {
@@ -224,7 +224,7 @@ fn op_require_stat(filename: String) -> i32 {
   -1
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_real_path(request: String) -> Result<String, AnyError> {
   let mut canonicalized_path = PathBuf::from(request).canonicalize()?;
   if cfg!(windows) {
@@ -238,7 +238,7 @@ fn op_require_real_path(request: String) -> Result<String, AnyError> {
   Ok(canonicalized_path.to_string_lossy().to_string())
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_path_resolve(parts: Vec<String>) -> String {
   assert!(!parts.is_empty());
   let mut p = PathBuf::from(&parts[0]);
@@ -250,19 +250,19 @@ fn op_require_path_resolve(parts: Vec<String>) -> String {
   normalize_path(p).to_string_lossy().to_string()
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_path_dirname(request: String) -> String {
   let p = PathBuf::from(request);
   p.parent().unwrap().to_string_lossy().to_string()
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_path_basename(request: String) -> String {
   let p = PathBuf::from(request);
   p.file_name().unwrap().to_string_lossy().to_string()
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_try_self_parent_path(
   has_parent: bool,
   maybe_parent_filename: Option<String>,
@@ -286,7 +286,7 @@ fn op_require_try_self_parent_path(
   None
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_try_self(
   has_parent: bool,
   maybe_parent_filename: Option<String>,
@@ -310,7 +310,7 @@ fn op_require_try_self(
   None
 }
 
-#[op]
+#[op(unstable)]
 fn op_require_read_file(_filename: String) -> Result<String, AnyError> {
   todo!("not implemented");
 }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -158,7 +158,7 @@ mod not_docs {
         deno_broadcast_channel::InMemoryBroadcastChannel::default(),
         false, // No --unstable.
       ),
-      deno_node::init(),
+      // deno_node::init(), // todo(dsherret): re-enable
       deno_ffi::init::<Permissions>(false),
       deno_net::init::<Permissions>(
         None, false, // No --unstable.

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -419,7 +419,7 @@ impl WebWorker {
         unstable,
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_node::init(),
+      // deno_node::init(), // todo(dsherret): re-enable
       ops::os::init_for_worker(),
       ops::permissions::init(),
       ops::process::init(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -161,7 +161,7 @@ impl MainWorker {
         unstable,
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_node::init(),
+      // deno_node::init() // todo(dsherret): re-enable,
       ops::os::init(exit_code.clone()),
       ops::permissions::init(),
       ops::process::init(),


### PR DESCRIPTION
This code was not using unstable ops and isn't properly permission checked.

Also opened #15437.