### PR TITLE
fix: cleanup `lib.deno.*.d.ts`

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -1866,8 +1866,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` permission for the target path.
-   * Also requires `allow-read` permission for the CWD if the target path is
-   * relative. */
+   * Also requires `allow-read` permission for the current working
+   * directory if the target path is relative. */
   export function realPathSync(path: string | URL): string;
 
   /** Resolves to the absolute normalized path, with symbolic links resolved.
@@ -1882,8 +1882,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` permission for the target path.
-   * Also requires `allow-read` permission for the CWD if the target path is
-   * relative. */
+   * Also requires `allow-read` permission for the current working
+   * directory if the target path is relative. */
   export function realPath(path: string | URL): Promise<string>;
 
   export interface DirEntry {
@@ -2455,18 +2455,8 @@ declare namespace Deno {
    * Subprocess uses same working directory as parent process unless `opt.cwd`
    * is specified.
    *
-   * Environmental variables from parent process can be cleared using `opt.clearEnv`.
-   * Doesn't guarantee that only `opt.env` variables are present,
-   * as the OS may set environmental variables for processes.
-   *
    * Environmental variables for subprocess can be specified using `opt.env`
    * mapping.
-   *
-   * `opt.uid` sets the child process’s user ID. This translates to a setuid call
-   * in the child process. Failure in the setuid call will cause the spawn to fail.
-   *
-   * `opt.gid` is similar to `opt.uid`, but sets the group ID of the child process.
-   * This has the same semantics as the uid field.
    *
    * By default subprocess inherits stdio of parent process. To change that
    * `opt.stdout`, `opt.stderr` and `opt.stdin` can be specified independently -

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -761,6 +761,49 @@ declare namespace Deno {
     mtime: number | Date,
   ): Promise<void>;
 
+  /** Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
+   * an array of program arguments, the first of which is the binary.
+   *
+   * ```ts
+   * const p = Deno.run({
+   *   cmd: ["curl", "https://example.com"],
+   * });
+   * const status = await p.status();
+   * ```
+   *
+   * Subprocess uses same working directory as parent process unless `opt.cwd`
+   * is specified.
+   *
+   * Environmental variables from parent process can be cleared using `opt.clearEnv`.
+   * Doesn't guarantee that only `opt.env` variables are present,
+   * as the OS may set environmental variables for processes.
+   *
+   * Environmental variables for subprocess can be specified using `opt.env`
+   * mapping.
+   *
+   * `opt.uid` sets the child process’s user ID. This translates to a setuid call
+   * in the child process. Failure in the setuid call will cause the spawn to fail.
+   *
+   * `opt.gid` is similar to `opt.uid`, but sets the group ID of the child process.
+   * This has the same semantics as the uid field.
+   *
+   * By default subprocess inherits stdio of parent process. To change that
+   * `opt.stdout`, `opt.stderr` and `opt.stdin` can be specified independently -
+   * they can be set to either an rid of open file or set to "inherit" "piped"
+   * or "null":
+   *
+   * `"inherit"` The default if unspecified. The child inherits from the
+   * corresponding parent descriptor.
+   *
+   * `"piped"` A new pipe should be arranged to connect the parent and child
+   * sub-processes.
+   *
+   * `"null"` This stream will be ignored. This is the equivalent of attaching
+   * the stream to `/dev/null`.
+   *
+   * Details of the spawned process are returned.
+   *
+   * Requires `allow-run` permission. */
   export function run<
     T extends RunOptions & {
       clearEnv?: boolean;

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1123,7 +1123,7 @@ declare namespace Deno {
     args?: string[];
     /**
      * The working directory of the process.
-     * If not specified, the cwd of the parent process is used.
+     * If not specified, the current working directory of the parent process is used.
      */
     cwd?: string | URL;
     /**

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -228,7 +228,7 @@ declare namespace Deno {
   export function loadavg(): number[];
 
   /** **Unstable** new API. yet to be vetted. Under consideration to possibly move to
-   * Deno.build or Deno.versions and if it should depend sys-info, which may not
+   * Deno.build or Deno.version and if it should depend sys-info, which may not
    * be desireable.
    *
    * Returns the release version of the Operating System.


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

There are some very old description about `Deno.run` in `lib.deno.ns.d.ts`, this pull requests removed them.

I also took the chance to fix a typo (`Deno.versions` -> `Deno.version`) and reduce jargon usage (if both the option and the description is using "CWD", users may not understand it).