### PR TITLE
fix: allow setting `globalThis.location` when no `--location` is provided

### DIFF
--- a/cli/tests/testdata/070_location.ts
+++ b/cli/tests/testdata/070_location.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-global-assign
 console.log(Location);
 console.log(Location.prototype);
 console.log(location);

--- a/cli/tests/testdata/070_location.ts
+++ b/cli/tests/testdata/070_location.ts
@@ -2,6 +2,13 @@ console.log(Location);
 console.log(Location.prototype);
 console.log(location);
 try {
+  location = {};
+} catch (error) {
+  if (error instanceof Error) {
+    console.log(error.toString());
+  }
+}
+try {
   location.hostname = "bar";
 } catch (error) {
   if (error instanceof Error) {

--- a/cli/tests/testdata/070_location.ts.out
+++ b/cli/tests/testdata/070_location.ts.out
@@ -11,5 +11,6 @@ Location {
   protocol: "https:",
   search: "?baz"
 }
+NotSupportedError: Cannot set "location".
 NotSupportedError: Cannot set "location.hostname".
 [WILDCARD]

--- a/cli/tests/testdata/071_location_unset.ts
+++ b/cli/tests/testdata/071_location_unset.ts
@@ -1,3 +1,16 @@
 console.log(Location);
 console.log(Location.prototype);
 console.log(location);
+
+globalThis.location = {
+  hash: "#bat",
+  host: "foo",
+  hostname: "foo",
+  href: "https://foo/bar?baz#bat",
+  origin: "https://foo",
+  pathname: "/bar",
+  port: "",
+  protocol: "https:",
+  search: "?baz"
+};
+console.log(location.pathname);

--- a/cli/tests/testdata/071_location_unset.ts
+++ b/cli/tests/testdata/071_location_unset.ts
@@ -11,6 +11,6 @@ globalThis.location = {
   pathname: "/bar",
   port: "",
   protocol: "https:",
-  search: "?baz"
+  search: "?baz",
 };
 console.log(location.pathname);

--- a/cli/tests/testdata/071_location_unset.ts.out
+++ b/cli/tests/testdata/071_location_unset.ts.out
@@ -1,4 +1,5 @@
 [WILDCARD][Function: Location]
 Location {}
 undefined
+/bar
 [WILDCARD]

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -639,6 +639,18 @@ delete Intl.v8BreakIterator;
       throw new Error("Worker runtime already bootstrapped");
     }
 
+    const {
+      args,
+      location: locationHref,
+      noColor,
+      isTty,
+      pid,
+      ppid,
+      unstableFlag,
+      cpuCount,
+      userAgent: userAgentInfo,
+    } = runtimeOptions;
+
     performance.setTimeOrigin(DateNow());
     const consoleFromV8 = window.console;
     const wrapConsole = window.__bootstrap.console.wrapConsole;
@@ -648,6 +660,18 @@ delete Intl.v8BreakIterator;
     delete globalThis.bootstrap;
     util.log("bootstrapMainRuntime");
     hasBootstrapped = true;
+
+    // If the `--location` flag isn't set, make `globalThis.location` `undefined` and
+    // writable, so that they can mock it themselves if they like. If the flag was
+    // set, define `globalThis.location`, using the provided value.
+    if (locationHref == null) {
+      mainRuntimeGlobalProperties.location = {
+        writable: true,
+      };
+    } else {
+      location.setLocationHref(locationHref);
+    }
+
     ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
     if (runtimeOptions.unstableFlag) {
       ObjectDefineProperties(globalThis, unstableWindowOrWorkerGlobalScope);
@@ -678,22 +702,8 @@ delete Intl.v8BreakIterator;
     });
 
     runtimeStart(runtimeOptions);
-    const {
-      args,
-      location: locationHref,
-      noColor,
-      isTty,
-      pid,
-      ppid,
-      unstableFlag,
-      cpuCount,
-      userAgent: userAgentInfo,
-    } = runtimeOptions;
 
     colors.setNoColor(noColor || !isTty);
-    if (locationHref != null) {
-      location.setLocationHref(locationHref);
-    }
     numCpus = cpuCount;
     userAgent = userAgentInfo;
     registerErrors();


### PR DESCRIPTION
This mirrors the behavior of Deploy, since it has no `--location` flag, and always allows writing to `globalThis.location`.