### PR TITLE
refactor(runtime): split up `MainWorker` and `WebWorker`'s `preload_module` method into two separate methods

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -485,7 +485,7 @@ async fn install_command(
     Default::default(),
   );
   // First, fetch and compile the module; this step ensures that the module exists.
-  worker.preload_module(&main_module, true).await?;
+  worker.preload_main_module(&main_module).await?;
   tools::installer::install(flags, install_flags)?;
   Ok(0)
 }

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -514,24 +514,26 @@ impl WebWorker {
     Ok(())
   }
 
-  /// Loads and instantiates specified JavaScript module
-  /// as "main" or "side" module.
-  pub async fn preload_module(
+  /// Loads and instantiates specified JavaScript module as "main" module.
+  pub async fn preload_main_module(
     &mut self,
     module_specifier: &ModuleSpecifier,
-    main: bool,
   ) -> Result<ModuleId, AnyError> {
-    if main {
-      self
-        .js_runtime
-        .load_main_module(module_specifier, None)
-        .await
-    } else {
-      self
-        .js_runtime
-        .load_side_module(module_specifier, None)
-        .await
-    }
+    self
+      .js_runtime
+      .load_main_module(module_specifier, None)
+      .await
+  }
+
+  /// Loads and instantiates specified JavaScript module as "side" module.
+  pub async fn preload_side_module(
+    &mut self,
+    module_specifier: &ModuleSpecifier,
+  ) -> Result<ModuleId, AnyError> {
+    self
+      .js_runtime
+      .load_side_module(module_specifier, None)
+      .await
   }
 
   /// Loads, instantiates and executes specified JavaScript module.
@@ -542,7 +544,7 @@ impl WebWorker {
     &mut self,
     module_specifier: &ModuleSpecifier,
   ) -> Result<(), AnyError> {
-    let id = self.preload_module(module_specifier, false).await?;
+    let id = self.preload_side_module(module_specifier).await?;
     let mut receiver = self.js_runtime.mod_evaluate(id);
     tokio::select! {
       biased;
@@ -700,7 +702,7 @@ pub fn run_web_worker(
     } else {
       // TODO(bartlomieju): add "type": "classic", ie. ability to load
       // script instead of module
-      match worker.preload_module(&specifier, true).await {
+      match worker.preload_main_module(&specifier).await {
         Ok(id) => {
           worker.start_polling_for_messages();
           worker.execute_main_module(id).await

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -217,24 +217,26 @@ impl MainWorker {
     Ok(())
   }
 
-  /// Loads and instantiates specified JavaScript module
-  /// as "main" or "side" module.
-  pub async fn preload_module(
+  /// Loads and instantiates specified JavaScript module as "main" module.
+  pub async fn preload_main_module(
     &mut self,
     module_specifier: &ModuleSpecifier,
-    main: bool,
   ) -> Result<ModuleId, AnyError> {
-    if main {
-      self
-        .js_runtime
-        .load_main_module(module_specifier, None)
-        .await
-    } else {
-      self
-        .js_runtime
-        .load_side_module(module_specifier, None)
-        .await
-    }
+    self
+      .js_runtime
+      .load_main_module(module_specifier, None)
+      .await
+  }
+
+  /// Loads and instantiates specified JavaScript module as "side" module.
+  pub async fn preload_side_module(
+    &mut self,
+    module_specifier: &ModuleSpecifier,
+  ) -> Result<ModuleId, AnyError> {
+    self
+      .js_runtime
+      .load_side_module(module_specifier, None)
+      .await
   }
 
   /// Executes specified JavaScript module.
@@ -242,6 +244,7 @@ impl MainWorker {
     &mut self,
     id: ModuleId,
   ) -> Result<(), AnyError> {
+    self.wait_for_inspector_session();
     let mut receiver = self.js_runtime.mod_evaluate(id);
     tokio::select! {
       // Not using biased mode leads to non-determinism for relatively simple
@@ -266,8 +269,7 @@ impl MainWorker {
     &mut self,
     module_specifier: &ModuleSpecifier,
   ) -> Result<(), AnyError> {
-    let id = self.preload_module(module_specifier, false).await?;
-    self.wait_for_inspector_session();
+    let id = self.preload_side_module(module_specifier).await?;
     self.evaluate_module(id).await
   }
 
@@ -278,8 +280,7 @@ impl MainWorker {
     &mut self,
     module_specifier: &ModuleSpecifier,
   ) -> Result<(), AnyError> {
-    let id = self.preload_module(module_specifier, true).await?;
-    self.wait_for_inspector_session();
+    let id = self.preload_main_module(module_specifier).await?;
     self.evaluate_module(id).await
   }
 


### PR DESCRIPTION
Boolean parameters to change functionality are not descriptive. This better aligns with the already existing `execute_main_module` and `execute_side_module` methods.