### PR TITLE
Move lint rules to cargo config for better editor integration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,3 +12,11 @@ rustflags = [
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+[target.'cfg(all())']
+rustflags = [
+  "-D", "clippy::all",
+  "-D", "clippy::await_holding_refcell_ref",
+  "-D", "clippy::missing_safety_doc",
+  "-D", "clippy::undocumented_unsafe_blocks",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,8 +15,12 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.'cfg(all())']
 rustflags = [
-  "-D", "clippy::all",
-  "-D", "clippy::await_holding_refcell_ref",
-  "-D", "clippy::missing_safety_doc",
-  "-D", "clippy::undocumented_unsafe_blocks",
+  "-D",
+  "clippy::all",
+  "-D",
+  "clippy::await_holding_refcell_ref",
+  "-D",
+  "clippy::missing_safety_doc",
+  "-D",
+  "clippy::undocumented_unsafe_blocks",
 ]

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -109,18 +109,7 @@ async function clippy() {
   }
 
   const { success } = await Deno.spawn("cargo", {
-    args: [
-      ...cmd,
-      "--",
-      "-D",
-      "clippy::all",
-      "-D",
-      "clippy::await_holding_refcell_ref",
-      "-D",
-      "clippy::missing_safety_doc",
-      "-D",
-      "clippy::undocumented_unsafe_blocks",
-    ],
+    args: cmd,
     stdout: "inherit",
     stderr: "inherit",
   });


### PR DESCRIPTION
Among other things, this allows rust-analyzer to show lint problems without having to run `lint.js` manually, and it makes it possible to use commands like `clippy fix`.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
