### PR TITLE
Modernize codebase to pass rust-2018-idioms lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,4 +23,6 @@ rustflags = [
   "clippy::missing_safety_doc",
   "-D",
   "clippy::undocumented_unsafe_blocks",
+  "-D",
+  "rust-2018-idioms",
 ]

--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -66,7 +66,7 @@ pub struct IgnoredCompilerOptions {
 }
 
 impl fmt::Display for IgnoredCompilerOptions {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let mut codes = self.items.clone();
     codes.sort();
     if let Some(specifier) = &self.maybe_specifier {

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -583,7 +583,7 @@ fn handle_repl_flags(flags: &mut Flags, repl_flags: ReplFlags) {
   flags.allow_hrtime = true;
 }
 
-fn clap_root(version: &str) -> Command {
+fn clap_root(version: &str) -> Command<'_> {
   clap::Command::new("deno")
     .bin_name("deno")
     .color(ColorChoice::Never)
@@ -1707,7 +1707,7 @@ Remote modules and multiple modules may also be specified:
     .arg(ca_file_arg())
 }
 
-fn compile_args(app: Command) -> Command {
+fn compile_args(app: Command<'_>) -> Command<'_> {
   app
     .arg(import_map_arg())
     .arg(no_remote_arg())
@@ -1721,7 +1721,7 @@ fn compile_args(app: Command) -> Command {
     .arg(ca_file_arg())
 }
 
-fn compile_args_without_check_args(app: Command) -> Command {
+fn compile_args_without_check_args(app: Command<'_>) -> Command<'_> {
   app
     .arg(import_map_arg())
     .arg(no_remote_arg())
@@ -1733,7 +1733,7 @@ fn compile_args_without_check_args(app: Command) -> Command {
     .arg(ca_file_arg())
 }
 
-fn permission_args(app: Command) -> Command {
+fn permission_args(app: Command<'_>) -> Command<'_> {
   app
     .arg(
       Arg::new("allow-read")
@@ -1824,10 +1824,10 @@ fn permission_args(app: Command) -> Command {
 }
 
 fn runtime_args(
-  app: Command,
+  app: Command<'_>,
   include_perms: bool,
   include_inspector: bool,
-) -> Command {
+) -> Command<'_> {
   let app = compile_args(app);
   let app = if include_perms {
     permission_args(app)
@@ -1848,7 +1848,7 @@ fn runtime_args(
     .arg(compat_arg())
 }
 
-fn inspect_args(app: Command) -> Command {
+fn inspect_args(app: Command<'_>) -> Command<'_> {
   app
     .arg(
       Arg::new("inspect")
@@ -2265,7 +2265,7 @@ fn compile_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
 fn completions_parse(
   flags: &mut Flags,
   matches: &clap::ArgMatches,
-  mut app: clap::Command,
+  mut app: clap::Command<'_>,
 ) {
   use clap_complete::generate;
   use clap_complete::shells::{Bash, Fish, PowerShell, Zsh};

--- a/cli/auth_tokens.rs
+++ b/cli/auth_tokens.rs
@@ -18,7 +18,7 @@ pub struct AuthToken {
 }
 
 impl fmt::Display for AuthToken {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match &self.token {
       AuthTokenData::Bearer(token) => write!(f, "Bearer {}", token),
       AuthTokenData::Basic { username, password } => {

--- a/cli/compat/esm_resolver.rs
+++ b/cli/compat/esm_resolver.rs
@@ -501,7 +501,7 @@ fn resolve_package_target_string(
       if !is_url {
         let export_target = if pattern {
           pattern_re
-            .replace(&target, |_caps: &regex::Captures| subpath.clone())
+            .replace(&target, |_caps: &regex::Captures<'_>| subpath.clone())
             .to_string()
         } else {
           format!("{}{}", target, subpath)
@@ -563,7 +563,9 @@ fn resolve_package_target_string(
 
   if pattern {
     let replaced = pattern_re
-      .replace(resolved.as_str(), |_caps: &regex::Captures| subpath.clone());
+      .replace(resolved.as_str(), |_caps: &regex::Captures<'_>| {
+        subpath.clone()
+      });
     let url = Url::parse(&replaced)?;
     return Ok(url);
   }

--- a/cli/diagnostics.rs
+++ b/cli/diagnostics.rs
@@ -117,7 +117,7 @@ pub enum DiagnosticCategory {
 }
 
 impl fmt::Display for DiagnosticCategory {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(
       f,
       "{}",
@@ -218,7 +218,7 @@ pub struct Diagnostic {
 }
 
 impl Diagnostic {
-  fn fmt_category_and_code(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt_category_and_code(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let category = match self.category {
       DiagnosticCategory::Error => "ERROR",
       DiagnosticCategory::Warning => "WARN",
@@ -238,7 +238,7 @@ impl Diagnostic {
     }
   }
 
-  fn fmt_frame(&self, f: &mut fmt::Formatter, level: usize) -> fmt::Result {
+  fn fmt_frame(&self, f: &mut fmt::Formatter<'_>, level: usize) -> fmt::Result {
     if let (Some(file_name), Some(start)) =
       (self.file_name.as_ref(), self.start.as_ref())
     {
@@ -256,7 +256,11 @@ impl Diagnostic {
     }
   }
 
-  fn fmt_message(&self, f: &mut fmt::Formatter, level: usize) -> fmt::Result {
+  fn fmt_message(
+    &self,
+    f: &mut fmt::Formatter<'_>,
+    level: usize,
+  ) -> fmt::Result {
     if let Some(message_chain) = &self.message_chain {
       write!(f, "{}", message_chain.format_message(level))
     } else {
@@ -272,7 +276,7 @@ impl Diagnostic {
 
   fn fmt_source_line(
     &self,
-    f: &mut fmt::Formatter,
+    f: &mut fmt::Formatter<'_>,
     level: usize,
   ) -> fmt::Result {
     if let (Some(source_line), Some(start), Some(end)) =
@@ -313,7 +317,7 @@ impl Diagnostic {
     Ok(())
   }
 
-  fn fmt_related_information(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt_related_information(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if let Some(related_information) = self.related_information.as_ref() {
       write!(f, "\n\n")?;
       for info in related_information {
@@ -324,7 +328,7 @@ impl Diagnostic {
     Ok(())
   }
 
-  fn fmt_stack(&self, f: &mut fmt::Formatter, level: usize) -> fmt::Result {
+  fn fmt_stack(&self, f: &mut fmt::Formatter<'_>, level: usize) -> fmt::Result {
     self.fmt_category_and_code(f)?;
     self.fmt_message(f, level)?;
     self.fmt_source_line(f, level)?;
@@ -337,7 +341,7 @@ impl Diagnostic {
 }
 
 impl fmt::Display for Diagnostic {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     self.fmt_stack(f, 0)?;
     self.fmt_related_information(f)
   }
@@ -387,7 +391,7 @@ impl Serialize for Diagnostics {
 }
 
 impl fmt::Display for Diagnostics {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let mut i = 0;
     for item in &self.0 {
       if i > 0 {

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -63,7 +63,7 @@ impl Serialize for Stats {
 }
 
 impl fmt::Display for Stats {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     writeln!(f, "Compilation statistics:")?;
     for (key, value) in self.0.clone() {
       writeln!(f, "  {}: {}", key, value)?;

--- a/cli/logger.rs
+++ b/cli/logger.rs
@@ -15,11 +15,11 @@ impl CliLogger {
 }
 
 impl log::Log for CliLogger {
-  fn enabled(&self, metadata: &log::Metadata) -> bool {
+  fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
     self.0.enabled(metadata)
   }
 
-  fn log(&self, record: &log::Record) {
+  fn log(&self, record: &log::Record<'_>) {
     if self.enabled(record.metadata()) {
       self.0.log(record);
     }

--- a/cli/lsp/path_to_regex.rs
+++ b/cli/lsp/path_to_regex.rs
@@ -218,7 +218,7 @@ pub enum StringOrNumber {
 }
 
 impl fmt::Display for StringOrNumber {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match &self {
       Self::Number(n) => write!(f, "{}", n),
       Self::String(s) => write!(f, "{}", s),
@@ -871,7 +871,7 @@ mod tests {
   fn test_path(
     path: &str,
     maybe_options: Option<PathToRegexOptions>,
-    fixtures: &[Fixture],
+    fixtures: &[Fixture<'_>],
   ) {
     let result = string_to_regex(path, maybe_options);
     assert!(result.is_ok(), "Could not parse path: \"{}\"", path);

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -50,7 +50,7 @@ pub struct PerformanceMeasure {
 }
 
 impl fmt::Display for PerformanceMeasure {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "{} ({}ms)", self.name, self.duration.as_millis())
   }
 }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -335,7 +335,7 @@ fn get_tag_body_text(
       "example" => {
         if CAPTION_RE.is_match(&text) {
           CAPTION_RE
-            .replace(&text, |c: &Captures| {
+            .replace(&text, |c: &Captures<'_>| {
               format!("{}\n\n{}", &c[1], make_codeblock(&c[2]))
             })
             .to_string()
@@ -344,7 +344,7 @@ fn get_tag_body_text(
         }
       }
       "author" => EMAIL_MATCH_RE
-        .replace(&text, |c: &Captures| format!("{} {}", &c[1], &c[2]))
+        .replace(&text, |c: &Captures<'_>| format!("{} {}", &c[1], &c[2]))
         .to_string(),
       "default" => make_codeblock(&text),
       _ => replace_links(&text),
@@ -404,7 +404,7 @@ fn make_codeblock(text: &str) -> String {
 /// Replace JSDoc like links (`{@link http://example.com}`) with markdown links
 fn replace_links<S: AsRef<str>>(text: S) -> String {
   JSDOC_LINKS_RE
-    .replace_all(text.as_ref(), |c: &Captures| match &c[1] {
+    .replace_all(text.as_ref(), |c: &Captures<'_>| match &c[1] {
       "linkcode" => format!(
         "[`{}`]({})",
         if c.get(3).is_none() {
@@ -2163,7 +2163,9 @@ impl CompletionEntry {
       if insert_text.starts_with('[') {
         return Some(
           BRACKET_ACCESSOR_RE
-            .replace(insert_text, |caps: &Captures| format!(".{}", &caps[1]))
+            .replace(insert_text, |caps: &Captures<'_>| {
+              format!(".{}", &caps[1])
+            })
             .to_string(),
         );
       }

--- a/cli/tools/coverage/merge.rs
+++ b/cli/tools/coverage/merge.rs
@@ -120,7 +120,7 @@ pub fn merge_functions(
   let rta_capacity: usize =
     funcs.iter().fold(0, |acc, func| acc + func.ranges.len());
   let rta = RangeTreeArena::with_capacity(rta_capacity);
-  let mut trees: Vec<&mut RangeTree> = Vec::new();
+  let mut trees: Vec<&mut RangeTree<'_>> = Vec::new();
   for func in funcs {
     if let Some(tree) = RangeTree::from_sorted_ranges(&rta, &func.ranges) {
       trees.push(tree);
@@ -160,7 +160,9 @@ struct StartEvent<'a> {
   trees: Vec<(usize, &'a mut RangeTree<'a>)>,
 }
 
-fn into_start_events<'a>(trees: Vec<&'a mut RangeTree<'a>>) -> Vec<StartEvent> {
+fn into_start_events<'a>(
+  trees: Vec<&'a mut RangeTree<'a>>,
+) -> Vec<StartEvent<'_>> {
   let mut result: BTreeMap<usize, Vec<(usize, &'a mut RangeTree<'a>)>> =
     BTreeMap::new();
   for (parent_index, tree) in trees.into_iter().enumerate() {

--- a/cli/tools/coverage/range_tree.rs
+++ b/cli/tools/coverage/range_tree.rs
@@ -130,7 +130,7 @@ impl<'rt> RangeTree<'rt> {
 
   pub fn to_ranges(&self) -> Vec<CoverageRange> {
     let mut ranges: Vec<CoverageRange> = Vec::new();
-    let mut stack: Vec<(&RangeTree, i64)> = vec![(self, 0)];
+    let mut stack: Vec<(&RangeTree<'_>, i64)> = vec![(self, 0)];
     while let Some((cur, parent_count)) = stack.pop() {
       let count: i64 = parent_count + cur.delta;
       ranges.push(CoverageRange {
@@ -175,7 +175,7 @@ impl<'rt> RangeTree<'rt> {
     let end: usize = range.end_char_offset;
     let count: i64 = range.count;
     let delta: i64 = count - parent_count;
-    let mut children: Vec<&mut RangeTree> = Vec::new();
+    let mut children: Vec<&mut RangeTree<'_>> = Vec::new();
     while let Some(child) =
       Self::from_sorted_ranges_inner(rta, ranges, end, count)
     {
@@ -197,9 +197,9 @@ mod tests {
       end_char_offset: 9,
       count: 1,
     }];
-    let actual: Option<&mut RangeTree> =
+    let actual: Option<&mut RangeTree<'_>> =
       RangeTree::from_sorted_ranges(&rta, &inputs);
-    let expected: Option<&mut RangeTree> =
+    let expected: Option<&mut RangeTree<'_>> =
       Some(rta.alloc(RangeTree::new(0, 9, 1, Vec::new())));
 
     assert_eq!(actual, expected);

--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -224,7 +224,7 @@ impl Completer for EditorHelper {
 impl Validator for EditorHelper {
   fn validate(
     &self,
-    ctx: &mut ValidationContext,
+    ctx: &mut ValidationContext<'_>,
   ) -> Result<ValidationResult, ReadlineError> {
     let mut stack: Vec<Token> = Vec::new();
     let mut in_template = false;
@@ -423,7 +423,7 @@ impl ConditionalEventHandler for TabEventHandler {
     evt: &Event,
     n: RepeatCount,
     _: bool,
-    ctx: &EventContext,
+    ctx: &EventContext<'_>,
   ) -> Option<Cmd> {
     debug_assert_eq!(
       *evt,

--- a/cli/tools/vendor/import_map.rs
+++ b/cli/tools/vendor/import_map.rs
@@ -196,7 +196,7 @@ fn visit_modules(
   graph: &ModuleGraph,
   modules: &[&Module],
   mappings: &Mappings,
-  import_map: &mut ImportMapBuilder,
+  import_map: &mut ImportMapBuilder<'_>,
 ) {
   for module in modules {
     let text_info = match &module.maybe_parsed_source {
@@ -246,7 +246,7 @@ fn visit_modules(
 fn visit_maybe_resolved(
   maybe_resolved: &Resolved,
   graph: &ModuleGraph,
-  import_map: &mut ImportMapBuilder,
+  import_map: &mut ImportMapBuilder<'_>,
   referrer: &ModuleSpecifier,
   mappings: &Mappings,
   text_info: &SourceTextInfo,
@@ -270,7 +270,7 @@ fn handle_dep_specifier(
   text: &str,
   unresolved_specifier: &ModuleSpecifier,
   graph: &ModuleGraph,
-  import_map: &mut ImportMapBuilder,
+  import_map: &mut ImportMapBuilder<'_>,
   referrer: &ModuleSpecifier,
   mappings: &Mappings,
 ) {
@@ -301,7 +301,7 @@ fn handle_remote_dep_specifier(
   text: &str,
   unresolved_specifier: &ModuleSpecifier,
   specifier: &ModuleSpecifier,
-  import_map: &mut ImportMapBuilder,
+  import_map: &mut ImportMapBuilder<'_>,
   referrer: &ModuleSpecifier,
   mappings: &Mappings,
 ) {
@@ -385,7 +385,7 @@ fn handle_local_dep_specifier(
   text: &str,
   unresolved_specifier: &ModuleSpecifier,
   specifier: &ModuleSpecifier,
-  import_map: &mut ImportMapBuilder,
+  import_map: &mut ImportMapBuilder<'_>,
   referrer: &ModuleSpecifier,
   mappings: &Mappings,
 ) {

--- a/core/async_cell.rs
+++ b/core/async_cell.rs
@@ -57,7 +57,7 @@ impl<T: 'static> AsyncRefCell<T> {
 }
 
 impl<T> Debug for AsyncRefCell<T> {
-  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
     write!(f, "AsyncRefCell<{}>", type_name::<T>())
   }
 }
@@ -315,7 +315,7 @@ mod internal {
     fn poll_waiter<M: BorrowModeTrait>(
       &self,
       id: usize,
-      cx: &mut Context,
+      cx: &mut Context<'_>,
     ) -> Poll<()> {
       let borrow_count = self.borrow_count.get();
       let turn = self.turn.get();

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -26,11 +26,11 @@ use deno_core::*;
 struct Logger;
 
 impl log::Log for Logger {
-  fn enabled(&self, metadata: &log::Metadata) -> bool {
+  fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
     metadata.level() <= log::max_level()
   }
 
-  fn log(&self, record: &log::Record) {
+  fn log(&self, record: &log::Record<'_>) {
     if self.enabled(record.metadata()) {
       println!("{} - {}", record.level(), record.args());
     }

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -7,7 +7,7 @@ pub type SourcePair = (&'static str, &'static str);
 pub type OpFnRef = v8::FunctionCallback;
 pub type OpMiddlewareFn = dyn Fn(OpDecl) -> OpDecl;
 pub type OpStateFn = dyn Fn(&mut OpState) -> Result<(), Error>;
-pub type OpEventLoopFn = dyn Fn(Rc<RefCell<OpState>>, &mut Context) -> bool;
+pub type OpEventLoopFn = dyn Fn(Rc<RefCell<OpState>>, &mut Context<'_>) -> bool;
 
 #[derive(Clone, Copy)]
 pub struct OpDecl {
@@ -91,7 +91,7 @@ impl Extension {
   pub fn run_event_loop_middleware(
     &self,
     op_state_rc: Rc<RefCell<OpState>>,
-    cx: &mut Context,
+    cx: &mut Context<'_>,
   ) -> bool {
     self
       .event_loop_middleware
@@ -148,7 +148,7 @@ impl ExtensionBuilder {
 
   pub fn event_loop_middleware<F>(&mut self, middleware_fn: F) -> &mut Self
   where
-    F: Fn(Rc<RefCell<OpState>>, &mut Context) -> bool + 'static,
+    F: Fn(Rc<RefCell<OpState>>, &mut Context<'_>) -> bool + 'static,
   {
     self.event_loop_middleware = Some(Box::new(middleware_fn));
     self

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -137,7 +137,7 @@ impl v8::inspector::V8InspectorClientImpl for JsRuntimeInspector {
 /// function.
 impl Future for JsRuntimeInspector {
   type Output = ();
-  fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+  fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
     self.poll_sessions(Some(cx)).unwrap()
   }
 }
@@ -202,7 +202,7 @@ impl JsRuntimeInspector {
 
   fn poll_sessions(
     &self,
-    mut invoker_cx: Option<&mut Context>,
+    mut invoker_cx: Option<&mut Context<'_>>,
   ) -> Result<Poll<()>, BorrowMutError> {
     // The futures this function uses do not have re-entrant poll() functions.
     // However it is can happpen that poll_sessions() gets re-entered, e.g.
@@ -608,7 +608,7 @@ impl Stream for InspectorSession {
 
   fn poll_next(
     self: Pin<&mut Self>,
-    cx: &mut Context,
+    cx: &mut Context<'_>,
   ) -> Poll<Option<Self::Item>> {
     let inner = self.get_mut();
     if let Poll::Ready(maybe_msg) = inner.proxy.rx.poll_next_unpin(cx) {

--- a/core/module_specifier.rs
+++ b/core/module_specifier.rs
@@ -30,7 +30,7 @@ impl Error for ModuleResolutionError {
 }
 
 impl fmt::Display for ModuleResolutionError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       InvalidUrl(ref err) => write!(f, "invalid URL: {}", err),
       InvalidBaseUrl(ref err) => {

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -41,7 +41,7 @@ const SUPPORTED_TYPE_ASSERTIONS: &[&str] = &["json"];
 
 /// Throws V8 exception if assertions are invalid
 pub(crate) fn validate_import_assertions(
-  scope: &mut v8::HandleScope,
+  scope: &mut v8::HandleScope<'_>,
   assertions: &HashMap<String, String>,
 ) {
   for (key, value) in assertions {
@@ -65,8 +65,8 @@ pub(crate) enum ImportAssertionsKind {
 }
 
 pub(crate) fn parse_import_assertions(
-  scope: &mut v8::HandleScope,
-  import_assertions: v8::Local<v8::FixedArray>,
+  scope: &mut v8::HandleScope<'_>,
+  import_assertions: v8::Local<'_, v8::FixedArray>,
   kind: ImportAssertionsKind,
 ) -> HashMap<String, String> {
   let mut assertions: HashMap<String, String> = HashMap::default();
@@ -120,7 +120,7 @@ pub(crate) fn get_asserted_module_type_from_assertions(
 #[allow(clippy::unnecessary_wraps)]
 fn json_module_evaluation_steps<'a>(
   context: v8::Local<'a, v8::Context>,
-  module: v8::Local<v8::Module>,
+  module: v8::Local<'_, v8::Module>,
 ) -> Option<v8::Local<'a, v8::Value>> {
   // SAFETY: `CallbackScope` can be safely constructed from `Local<Context>`
   let scope = &mut unsafe { v8::CallbackScope::new(context) };
@@ -166,7 +166,7 @@ pub enum ModuleType {
 }
 
 impl std::fmt::Display for ModuleType {
-  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       Self::JavaScript => write!(f, "JavaScript"),
       Self::Json => write!(f, "JSON"),
@@ -499,7 +499,7 @@ impl RecursiveModuleLoad {
 
   pub(crate) fn register_and_recurse(
     &mut self,
-    scope: &mut v8::HandleScope,
+    scope: &mut v8::HandleScope<'_>,
     module_request: &ModuleRequest,
     module_source: &ModuleSource,
   ) -> Result<(), ModuleError> {
@@ -617,7 +617,7 @@ impl Stream for RecursiveModuleLoad {
 
   fn poll_next(
     self: Pin<&mut Self>,
-    cx: &mut Context,
+    cx: &mut Context<'_>,
   ) -> Poll<Option<Self::Item>> {
     let inner = self.get_mut();
     // IMPORTANT: Do not borrow `inner.module_map_rc` here. It may not be
@@ -708,7 +708,7 @@ impl From<ModuleType> for AssertedModuleType {
 }
 
 impl std::fmt::Display for AssertedModuleType {
-  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       Self::JavaScriptOrWasm => write!(f, "JavaScriptOrWasm"),
       Self::Json => write!(f, "JSON"),
@@ -821,7 +821,7 @@ impl ModuleMap {
 
   fn new_json_module(
     &mut self,
-    scope: &mut v8::HandleScope,
+    scope: &mut v8::HandleScope<'_>,
     name: &str,
     source: &[u8],
   ) -> Result<ModuleId, ModuleError> {
@@ -866,7 +866,7 @@ impl ModuleMap {
   // Create and compile an ES module.
   pub(crate) fn new_es_module(
     &mut self,
-    scope: &mut v8::HandleScope,
+    scope: &mut v8::HandleScope<'_>,
     main: bool,
     name: &str,
     source: &[u8],
@@ -1285,7 +1285,7 @@ import "/a.js";
   }
 
   impl fmt::Display for MockError {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
       unimplemented!()
     }
   }
@@ -1304,7 +1304,7 @@ import "/a.js";
   impl Future for DelayedSourceCodeFuture {
     type Output = Result<ModuleSource, Error>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
       let inner = self.get_mut();
       inner.counter += 1;
       if inner.url == "file:///never_ready.js" {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -82,8 +82,11 @@ where
 
 pub type PromiseId = i32;
 pub type OpAsyncFuture = OpCall<(PromiseId, OpId, OpResult)>;
-pub type OpFn =
-  fn(&mut v8::HandleScope, v8::FunctionCallbackArguments, v8::ReturnValue);
+pub type OpFn = fn(
+  &mut v8::HandleScope<'_>,
+  v8::FunctionCallbackArguments<'_>,
+  v8::ReturnValue<'_>,
+);
 pub type OpId = usize;
 
 pub enum Op {

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -186,6 +186,6 @@ fn op_format_file_name(file_name: String) -> String {
 }
 
 #[op]
-fn op_is_proxy(value: serde_v8::Value) -> bool {
+fn op_is_proxy(value: serde_v8::Value<'_>) -> bool {
   value.v8_value.is_proxy()
 }

--- a/core/ops_metrics.rs
+++ b/core/ops_metrics.rs
@@ -61,7 +61,7 @@ impl OpsTracker {
   }
 
   #[inline]
-  fn metrics_mut(&self, id: OpId) -> RefMut<OpMetrics> {
+  fn metrics_mut(&self, id: OpId) -> RefMut<'_, OpMetrics> {
     RefMut::map(self.ops.borrow_mut(), |ops| &mut ops[id])
   }
 

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -31,7 +31,7 @@ pub trait Resource: Any + 'static {
   /// to JavaScript code through `op_resources`. The default implementation
   /// returns the Rust type name, but specific resource types may override this
   /// trait method.
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     type_name::<Self>().into()
   }
 
@@ -214,7 +214,7 @@ impl ResourceTable {
   /// # let resource_table = ResourceTable::default();
   /// let resource_names = resource_table.names().collect::<Vec<_>>();
   /// ```
-  pub fn names(&self) -> impl Iterator<Item = (ResourceId, Cow<str>)> {
+  pub fn names(&self) -> impl Iterator<Item = (ResourceId, Cow<'_, str>)> {
     self
       .index
       .iter()

--- a/ext/crypto/export_key.rs
+++ b/ext/crypto/export_key.rs
@@ -106,7 +106,7 @@ pub fn op_crypto_export_key(
   }
 }
 
-fn uint_to_b64(bytes: UIntRef) -> String {
+fn uint_to_b64(bytes: UIntRef<'_>) -> String {
   base64::encode_config(bytes.as_bytes(), base64::URL_SAFE_NO_PAD)
 }
 

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -757,17 +757,15 @@ impl<'a> TryFrom<rsa::pkcs8::der::asn1::AnyRef<'a>>
     any: rsa::pkcs8::der::asn1::AnyRef<'a>,
   ) -> rsa::pkcs8::der::Result<PssPrivateKeyParameters<'a>> {
     any.sequence(|decoder| {
-      let hash_algorithm =
-        decode_content_tag::<rsa::pkcs8::AlgorithmIdentifier>(
-          decoder,
-          HASH_ALGORITHM_TAG,
-        )?
-        .map(TryInto::try_into)
-        .transpose()?
-        .unwrap_or(*SHA1_HASH_ALGORITHM);
+      let hash_algorithm = decode_content_tag::<
+        rsa::pkcs8::AlgorithmIdentifier<'_>,
+      >(decoder, HASH_ALGORITHM_TAG)?
+      .map(TryInto::try_into)
+      .transpose()?
+      .unwrap_or(*SHA1_HASH_ALGORITHM);
 
       let mask_gen_algorithm = decode_content_tag::<
-        rsa::pkcs8::AlgorithmIdentifier,
+        rsa::pkcs8::AlgorithmIdentifier<'_>,
       >(decoder, MASK_GEN_ALGORITHM_TAG)?
       .map(TryInto::try_into)
       .transpose()?
@@ -810,24 +808,22 @@ impl<'a> TryFrom<rsa::pkcs8::der::asn1::AnyRef<'a>>
     any: rsa::pkcs8::der::asn1::AnyRef<'a>,
   ) -> rsa::pkcs8::der::Result<OaepPrivateKeyParameters<'a>> {
     any.sequence(|decoder| {
-      let hash_algorithm =
-        decode_content_tag::<rsa::pkcs8::AlgorithmIdentifier>(
-          decoder,
-          HASH_ALGORITHM_TAG,
-        )?
-        .map(TryInto::try_into)
-        .transpose()?
-        .unwrap_or(*SHA1_HASH_ALGORITHM);
+      let hash_algorithm = decode_content_tag::<
+        rsa::pkcs8::AlgorithmIdentifier<'_>,
+      >(decoder, HASH_ALGORITHM_TAG)?
+      .map(TryInto::try_into)
+      .transpose()?
+      .unwrap_or(*SHA1_HASH_ALGORITHM);
 
       let mask_gen_algorithm = decode_content_tag::<
-        rsa::pkcs8::AlgorithmIdentifier,
+        rsa::pkcs8::AlgorithmIdentifier<'_>,
       >(decoder, MASK_GEN_ALGORITHM_TAG)?
       .map(TryInto::try_into)
       .transpose()?
       .unwrap_or(*MGF1_SHA1_MASK_ALGORITHM);
 
       let p_source_algorithm = decode_content_tag::<
-        rsa::pkcs8::AlgorithmIdentifier,
+        rsa::pkcs8::AlgorithmIdentifier<'_>,
       >(decoder, P_SOURCE_ALGORITHM_TAG)?
       .map(TryInto::try_into)
       .transpose()?

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -419,7 +419,7 @@ struct FetchRequestResource(
 );
 
 impl Resource for FetchRequestResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "fetchRequest".into()
   }
 }
@@ -427,7 +427,7 @@ impl Resource for FetchRequestResource {
 struct FetchCancelHandle(Rc<CancelHandle>);
 
 impl Resource for FetchCancelHandle {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "fetchCancelHandle".into()
   }
 
@@ -442,7 +442,7 @@ pub struct FetchRequestBodyResource {
 }
 
 impl Resource for FetchRequestBodyResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "fetchRequestBody".into()
   }
 
@@ -474,7 +474,7 @@ struct FetchResponseBodyResource {
 }
 
 impl Resource for FetchResponseBodyResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "fetchResponseBody".into()
   }
 
@@ -500,7 +500,7 @@ struct HttpClientResource {
 }
 
 impl Resource for HttpClientResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "httpClient".into()
   }
 }

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -212,7 +212,7 @@ impl HttpConnResource {
 }
 
 impl Resource for HttpConnResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "httpConn".into()
   }
 
@@ -330,7 +330,7 @@ impl HttpStreamResource {
 }
 
 impl Resource for HttpStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "httpStream".into()
   }
 
@@ -404,7 +404,7 @@ fn req_url(
   scheme: &'static str,
   addr: &HttpSocketAddr,
 ) -> String {
-  let host: Cow<str> = match addr {
+  let host: Cow<'_, str> = match addr {
     HttpSocketAddr::IpSocket(addr) => {
       if let Some(auth) = req.uri().authority() {
         match addr.port() {

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -99,7 +99,7 @@ pub type TcpStreamResource =
   FullDuplexResource<tcp::OwnedReadHalf, tcp::OwnedWriteHalf>;
 
 impl Resource for TcpStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "tcpStream".into()
   }
 
@@ -138,7 +138,7 @@ impl TcpStreamResource {
 
   fn map_socket(
     self: Rc<Self>,
-    map: Box<dyn FnOnce(SockRef) -> Result<(), AnyError>>,
+    map: Box<dyn FnOnce(SockRef<'_>) -> Result<(), AnyError>>,
   ) -> Result<(), AnyError> {
     if let Some(wr) = RcRef::map(self, |r| &r.wr).try_borrow() {
       let stream = wr.as_ref().as_ref();
@@ -181,7 +181,7 @@ impl UnixStreamResource {
 }
 
 impl Resource for UnixStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "unixStream".into()
   }
 

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -385,7 +385,7 @@ pub struct TcpListenerResource {
 }
 
 impl Resource for TcpListenerResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "tcpListener".into()
   }
 
@@ -400,7 +400,7 @@ struct UdpSocketResource {
 }
 
 impl Resource for UdpSocketResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "udpSocket".into()
   }
 
@@ -1028,7 +1028,7 @@ mod tests {
     let set_nodelay = Box::new(|state: &mut OpState, rid| {
       op_set_nodelay::call::<TestPermission>(state, rid, true).unwrap();
     });
-    let test_fn = Box::new(|socket: SockRef| {
+    let test_fn = Box::new(|socket: SockRef<'_>| {
       assert!(socket.nodelay().unwrap());
       assert!(!socket.keepalive().unwrap());
     });
@@ -1040,7 +1040,7 @@ mod tests {
     let set_keepalive = Box::new(|state: &mut OpState, rid| {
       op_set_keepalive::call::<TestPermission>(state, rid, true).unwrap();
     });
-    let test_fn = Box::new(|socket: SockRef| {
+    let test_fn = Box::new(|socket: SockRef<'_>| {
       assert!(!socket.nodelay().unwrap());
       assert!(socket.keepalive().unwrap());
     });
@@ -1050,7 +1050,7 @@ mod tests {
   async fn check_sockopt(
     addr: String,
     set_sockopt_fn: Box<dyn Fn(&mut OpState, u32)>,
-    test_fn: Box<dyn FnOnce(SockRef)>,
+    test_fn: Box<dyn FnOnce(SockRef<'_>)>,
   ) {
     let clone_addr = addr.clone();
     tokio::spawn(async move {

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -736,7 +736,7 @@ impl TlsStreamResource {
 }
 
 impl Resource for TlsStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "tlsStream".into()
   }
 
@@ -1009,7 +1009,7 @@ pub struct TlsListenerResource {
 }
 
 impl Resource for TlsListenerResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "tlsListener".into()
   }
 

--- a/ext/net/ops_unix.rs
+++ b/ext/net/ops_unix.rs
@@ -41,7 +41,7 @@ struct UnixListenerResource {
 }
 
 impl Resource for UnixListenerResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "unixListener".into()
   }
 
@@ -56,7 +56,7 @@ pub struct UnixDatagramResource {
 }
 
 impl Resource for UnixDatagramResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "unixDatagram".into()
   }
 

--- a/ext/web/compression.rs
+++ b/ext/web/compression.rs
@@ -33,7 +33,7 @@ enum Inner {
 }
 
 impl Resource for CompressionResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "compression".into()
   }
 }

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -334,7 +334,7 @@ struct TextDecoderResource {
 }
 
 impl Resource for TextDecoderResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "textDecoder".into()
   }
 }
@@ -418,12 +418,12 @@ impl DomExceptionInvalidCharacterError {
 }
 
 impl fmt::Display for DomExceptionQuotaExceededError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.pad(&self.msg)
   }
 }
 impl fmt::Display for DomExceptionInvalidCharacterError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.pad(&self.msg)
   }
 }

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -97,7 +97,7 @@ pub struct MessagePortResource {
 }
 
 impl Resource for MessagePortResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "messagePort".into()
   }
 

--- a/ext/web/timers.rs
+++ b/ext/web/timers.rs
@@ -50,7 +50,7 @@ where
 pub struct TimerHandle(Rc<CancelHandle>);
 
 impl Resource for TimerHandle {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "timer".into()
   }
 

--- a/ext/webgpu/src/binding.rs
+++ b/ext/webgpu/src/binding.rs
@@ -14,14 +14,14 @@ pub(crate) struct WebGpuBindGroupLayout(
   pub(crate) wgpu_core::id::BindGroupLayoutId,
 );
 impl Resource for WebGpuBindGroupLayout {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUBindGroupLayout".into()
   }
 }
 
 pub(crate) struct WebGpuBindGroup(pub(crate) wgpu_core::id::BindGroupId);
 impl Resource for WebGpuBindGroup {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUBindGroup".into()
   }
 }

--- a/ext/webgpu/src/buffer.rs
+++ b/ext/webgpu/src/buffer.rs
@@ -19,14 +19,14 @@ use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuBuffer(pub(crate) wgpu_core::id::BufferId);
 impl Resource for WebGpuBuffer {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUBuffer".into()
   }
 }
 
 struct WebGpuBufferMapped(*mut u8, usize);
 impl Resource for WebGpuBufferMapped {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUBufferMapped".into()
   }
 }

--- a/ext/webgpu/src/bundle.rs
+++ b/ext/webgpu/src/bundle.rs
@@ -17,14 +17,14 @@ struct WebGpuRenderBundleEncoder(
   RefCell<wgpu_core::command::RenderBundleEncoder>,
 );
 impl Resource for WebGpuRenderBundleEncoder {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPURenderBundleEncoder".into()
   }
 }
 
 pub(crate) struct WebGpuRenderBundle(pub(crate) wgpu_core::id::RenderBundleId);
 impl Resource for WebGpuRenderBundle {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPURenderBundle".into()
   }
 }

--- a/ext/webgpu/src/command_encoder.rs
+++ b/ext/webgpu/src/command_encoder.rs
@@ -16,7 +16,7 @@ pub(crate) struct WebGpuCommandEncoder(
   pub(crate) wgpu_core::id::CommandEncoderId,
 );
 impl Resource for WebGpuCommandEncoder {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUCommandEncoder".into()
   }
 }
@@ -25,7 +25,7 @@ pub(crate) struct WebGpuCommandBuffer(
   pub(crate) wgpu_core::id::CommandBufferId,
 );
 impl Resource for WebGpuCommandBuffer {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUCommandBuffer".into()
   }
 }

--- a/ext/webgpu/src/compute_pass.rs
+++ b/ext/webgpu/src/compute_pass.rs
@@ -15,7 +15,7 @@ pub(crate) struct WebGpuComputePass(
   pub(crate) RefCell<wgpu_core::command::ComputePass>,
 );
 impl Resource for WebGpuComputePass {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUComputePass".into()
   }
 }

--- a/ext/webgpu/src/error.rs
+++ b/ext/webgpu/src/error.rs
@@ -295,7 +295,7 @@ impl DomExceptionOperationError {
 }
 
 impl fmt::Display for DomExceptionOperationError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.pad(&self.msg)
   }
 }

--- a/ext/webgpu/src/lib.rs
+++ b/ext/webgpu/src/lib.rs
@@ -84,21 +84,21 @@ type Instance = wgpu_core::hub::Global<wgpu_core::hub::IdentityManagerFactory>;
 
 struct WebGpuAdapter(wgpu_core::id::AdapterId);
 impl Resource for WebGpuAdapter {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUAdapter".into()
   }
 }
 
 struct WebGpuDevice(wgpu_core::id::DeviceId);
 impl Resource for WebGpuDevice {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUDevice".into()
   }
 }
 
 struct WebGpuQuerySet(wgpu_core::id::QuerySetId);
 impl Resource for WebGpuQuerySet {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUQuerySet".into()
   }
 }

--- a/ext/webgpu/src/pipeline.rs
+++ b/ext/webgpu/src/pipeline.rs
@@ -18,7 +18,7 @@ pub(crate) struct WebGpuPipelineLayout(
   pub(crate) wgpu_core::id::PipelineLayoutId,
 );
 impl Resource for WebGpuPipelineLayout {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUPipelineLayout".into()
   }
 }
@@ -27,7 +27,7 @@ pub(crate) struct WebGpuComputePipeline(
   pub(crate) wgpu_core::id::ComputePipelineId,
 );
 impl Resource for WebGpuComputePipeline {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUComputePipeline".into()
   }
 }
@@ -36,7 +36,7 @@ pub(crate) struct WebGpuRenderPipeline(
   pub(crate) wgpu_core::id::RenderPipelineId,
 );
 impl Resource for WebGpuRenderPipeline {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPURenderPipeline".into()
   }
 }

--- a/ext/webgpu/src/render_pass.rs
+++ b/ext/webgpu/src/render_pass.rs
@@ -17,7 +17,7 @@ pub(crate) struct WebGpuRenderPass(
   pub(crate) RefCell<wgpu_core::command::RenderPass>,
 );
 impl Resource for WebGpuRenderPass {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPURenderPass".into()
   }
 }

--- a/ext/webgpu/src/sampler.rs
+++ b/ext/webgpu/src/sampler.rs
@@ -12,7 +12,7 @@ use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuSampler(pub(crate) wgpu_core::id::SamplerId);
 impl Resource for WebGpuSampler {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUSampler".into()
   }
 }

--- a/ext/webgpu/src/shader.rs
+++ b/ext/webgpu/src/shader.rs
@@ -11,7 +11,7 @@ use super::error::WebGpuResult;
 
 pub(crate) struct WebGpuShaderModule(pub(crate) wgpu_core::id::ShaderModuleId);
 impl Resource for WebGpuShaderModule {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUShaderModule".into()
   }
 }

--- a/ext/webgpu/src/texture.rs
+++ b/ext/webgpu/src/texture.rs
@@ -11,14 +11,14 @@ use std::borrow::Cow;
 use super::error::WebGpuResult;
 pub(crate) struct WebGpuTexture(pub(crate) wgpu_core::id::TextureId);
 impl Resource for WebGpuTexture {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUTexture".into()
   }
 }
 
 pub(crate) struct WebGpuTextureView(pub(crate) wgpu_core::id::TextureViewId);
 impl Resource for WebGpuTextureView {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webGPUTextureView".into()
   }
 }

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -183,7 +183,7 @@ impl WsStreamResource {
 }
 
 impl Resource for WsStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webSocketStream".into()
   }
 }
@@ -191,7 +191,7 @@ impl Resource for WsStreamResource {
 pub struct WsCancelResource(Rc<CancelHandle>);
 
 impl Resource for WsCancelResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "webSocketCancel".into()
   }
 
@@ -532,7 +532,7 @@ impl DomExceptionNetworkError {
 }
 
 impl fmt::Display for DomExceptionNetworkError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.pad(&self.msg)
   }
 }

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -238,7 +238,7 @@ impl DomExceptionNotSupportedError {
 }
 
 impl fmt::Display for DomExceptionNotSupportedError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.pad(&self.msg)
   }
 }

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -47,7 +47,7 @@ struct MacroArgs {
 }
 
 impl syn::parse::Parse for MacroArgs {
-  fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+  fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
     let vars =
       syn::punctuated::Punctuated::<Ident, syn::Token![,]>::parse_terminated(
         input,

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -43,7 +43,7 @@ struct FsEventsResource {
 }
 
 impl Resource for FsEventsResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "fsEvents".into()
   }
 

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -257,7 +257,7 @@ where
 pub type ChildStdinResource = WriteOnlyResource<process::ChildStdin>;
 
 impl Resource for ChildStdinResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "childStdin".into()
   }
 
@@ -273,7 +273,7 @@ impl Resource for ChildStdinResource {
 pub type ChildStdoutResource = ReadOnlyResource<process::ChildStdout>;
 
 impl Resource for ChildStdoutResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "childStdout".into()
   }
 
@@ -292,7 +292,7 @@ impl Resource for ChildStdoutResource {
 pub type ChildStderrResource = ReadOnlyResource<process::ChildStderr>;
 
 impl Resource for ChildStderrResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "childStderr".into()
   }
 
@@ -568,7 +568,7 @@ impl StdFileResource {
 }
 
 impl Resource for StdFileResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     self.name.as_str().into()
   }
 

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -119,7 +119,7 @@ struct ChildResource {
 }
 
 impl Resource for ChildResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "child".into()
   }
 }

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -40,7 +40,7 @@ struct SignalStreamResource {
 
 #[cfg(unix)]
 impl Resource for SignalStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "signal".into()
   }
 

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -89,7 +89,7 @@ struct SignalStreamResource {
 
 #[cfg(windows)]
 impl Resource for SignalStreamResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "signal".into()
   }
 

--- a/runtime/ops/spawn.rs
+++ b/runtime/ops/spawn.rs
@@ -38,7 +38,7 @@ pub fn init() -> Extension {
 struct ChildResource(tokio::process::Child);
 
 impl Resource for ChildResource {
-  fn name(&self) -> Cow<str> {
+  fn name(&self) -> Cow<'_, str> {
     "child".into()
   }
 }

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -1473,7 +1473,7 @@ impl<'de> Deserialize<'de> for ChildUnitPermissionArg {
     impl<'de> de::Visitor<'de> for ChildUnitPermissionArgVisitor {
       type Value = ChildUnitPermissionArg;
 
-      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+      fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("\"inherit\" or boolean")
       }
 
@@ -1526,7 +1526,7 @@ impl<'de> Deserialize<'de> for ChildUnaryPermissionArg {
     impl<'de> de::Visitor<'de> for ChildUnaryPermissionArgVisitor {
       type Value = ChildUnaryPermissionArg;
 
-      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+      fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("\"inherit\" or boolean or string[]")
       }
 
@@ -1623,7 +1623,7 @@ impl<'de> Deserialize<'de> for ChildPermissionsArg {
     impl<'de> de::Visitor<'de> for ChildPermissionsArgVisitor {
       type Value = ChildPermissionsArg;
 
-      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+      fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("\"inherit\" or \"none\" or object")
       }
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -594,7 +594,7 @@ impl WebWorker {
 
   fn poll_event_loop(
     &mut self,
-    cx: &mut Context,
+    cx: &mut Context<'_>,
     wait_for_inspector: bool,
   ) -> Poll<Result<(), AnyError>> {
     // If awakened because we are terminating, just return Ok

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -302,7 +302,7 @@ impl MainWorker {
 
   pub fn poll_event_loop(
     &mut self,
-    cx: &mut Context,
+    cx: &mut Context<'_>,
     wait_for_inspector: bool,
   ) -> Poll<Result<(), AnyError>> {
     self.js_runtime.poll_event_loop(cx, wait_for_inspector)

--- a/serde_v8/benches/de.rs
+++ b/serde_v8/benches/de.rs
@@ -15,7 +15,7 @@ struct MathOp {
 
 fn dedo(
   code: &str,
-  f: impl FnOnce(&mut v8::HandleScope, v8::Local<v8::Value>),
+  f: impl FnOnce(&mut v8::HandleScope<'_>, v8::Local<'_, v8::Value>),
 ) {
   v8_do(|| {
     let isolate = &mut v8::Isolate::new(v8::CreateParams::default());

--- a/serde_v8/benches/ser.rs
+++ b/serde_v8/benches/ser.rs
@@ -13,7 +13,7 @@ struct MathOp {
   operator: Option<String>,
 }
 
-fn serdo(f: impl FnOnce(&mut v8::HandleScope)) {
+fn serdo(f: impl FnOnce(&mut v8::HandleScope<'_>)) {
   v8_do(|| {
     let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
     let handle_scope = &mut v8::HandleScope::new(isolate);

--- a/serde_v8/de.rs
+++ b/serde_v8/de.rs
@@ -326,7 +326,7 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
       visitor.visit_map(map)
     } else {
       let prop_names = obj.get_own_property_names(self.scope);
-      let keys: Vec<magic::Value> = match prop_names {
+      let keys: Vec<magic::Value<'_>> = match prop_names {
         Some(names) => from_v8(self.scope, names.into()).unwrap(),
         None => vec![],
       };
@@ -685,7 +685,7 @@ impl<'de, 'a, 'b, 's> de::VariantAccess<'de>
   }
 }
 
-fn bigint_to_f64(b: v8::Local<v8::BigInt>) -> f64 {
+fn bigint_to_f64(b: v8::Local<'_, v8::BigInt>) -> f64 {
   // log2(f64::MAX) == log2(1.7976931348623157e+308) == 1024
   let mut words: [u64; 16] = [0; 16]; // 1024/64 => 16 64bit words
   let (neg, words) = b.to_words_array(&mut words);
@@ -705,15 +705,15 @@ fn bigint_to_f64(b: v8::Local<v8::BigInt>) -> f64 {
 }
 
 pub fn to_utf8(
-  s: v8::Local<v8::String>,
-  scope: &mut v8::HandleScope,
+  s: v8::Local<'_, v8::String>,
+  scope: &mut v8::HandleScope<'_>,
 ) -> String {
   to_utf8_fast(s, scope).unwrap_or_else(|| to_utf8_slow(s, scope))
 }
 
 fn to_utf8_fast(
-  s: v8::Local<v8::String>,
-  scope: &mut v8::HandleScope,
+  s: v8::Local<'_, v8::String>,
+  scope: &mut v8::HandleScope<'_>,
 ) -> Option<String> {
   // Over-allocate by 20% to avoid checking string twice
   let len = s.length();
@@ -743,8 +743,8 @@ fn to_utf8_fast(
 }
 
 fn to_utf8_slow(
-  s: v8::Local<v8::String>,
-  scope: &mut v8::HandleScope,
+  s: v8::Local<'_, v8::String>,
+  scope: &mut v8::HandleScope<'_>,
 ) -> String {
   let capacity = s.utf8_length(scope);
   let mut buf = Vec::with_capacity(capacity);

--- a/serde_v8/error.rs
+++ b/serde_v8/error.rs
@@ -40,7 +40,7 @@ impl de::Error for Error {
 }
 
 impl Display for Error {
-  fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Error::Message(msg) => formatter.write_str(msg),
       err => formatter.write_str(format!("serde_v8 error: {:?}", err).as_ref()),

--- a/serde_v8/examples/basic.rs
+++ b/serde_v8/examples/basic.rs
@@ -47,7 +47,7 @@ fn main() {
     let hi: Vec<String> = serde_v8::from_v8(scope, v).unwrap();
     println!("hi = {:?}", hi);
 
-    let v: v8::Local<v8::Value> = v8::Number::new(scope, 12345.0).into();
+    let v: v8::Local<'_, v8::Value> = v8::Number::new(scope, 12345.0).into();
     let x: f64 = serde_v8::from_v8(scope, v).unwrap();
     println!("x = {}", x);
   }

--- a/serde_v8/magic/buffer.rs
+++ b/serde_v8/magic/buffer.rs
@@ -138,8 +138,8 @@ impl ToV8 for ZeroCopyBuf {
 
 impl FromV8 for ZeroCopyBuf {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     Ok(Self::FromV8(V8Slice::from_v8(scope, value)?))
   }

--- a/serde_v8/magic/bytestring.rs
+++ b/serde_v8/magic/bytestring.rs
@@ -41,8 +41,8 @@ impl ToV8 for ByteString {
 
 impl FromV8 for ByteString {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     let v8str = v8::Local::<v8::String>::try_from(value)
       .map_err(|_| Error::ExpectedString)?;

--- a/serde_v8/magic/detached_buffer.rs
+++ b/serde_v8/magic/detached_buffer.rs
@@ -54,8 +54,8 @@ impl ToV8 for DetachedBuffer {
 
 impl FromV8 for DetachedBuffer {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     let (b, range) =
       to_ranged_buffer(scope, value).or(Err(crate::Error::ExpectedBuffer))?;

--- a/serde_v8/magic/global.rs
+++ b/serde_v8/magic/global.rs
@@ -32,8 +32,8 @@ impl ToV8 for Global {
 
 impl FromV8 for Global {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     let global = v8::Global::new(scope, value);
     Ok(global.into())

--- a/serde_v8/magic/string_or_buffer.rs
+++ b/serde_v8/magic/string_or_buffer.rs
@@ -37,8 +37,8 @@ impl ToV8 for StringOrBuffer {
 
 impl FromV8 for StringOrBuffer {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     if let Ok(buf) = ZeroCopyBuf::from_v8(scope, value) {
       return Ok(Self::Buffer(buf));

--- a/serde_v8/magic/transl8.rs
+++ b/serde_v8/magic/transl8.rs
@@ -21,8 +21,8 @@ pub(crate) trait ToV8 {
 
 pub(crate) trait FromV8: Sized {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error>;
 }
 
@@ -58,7 +58,7 @@ where
 
     fn expecting(
       &self,
-      formatter: &mut std::fmt::Formatter,
+      formatter: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
       formatter.write_str("a ")?;
       formatter.write_str(T::NAME)

--- a/serde_v8/magic/u16string.rs
+++ b/serde_v8/magic/u16string.rs
@@ -27,8 +27,8 @@ impl ToV8 for U16String {
 
 impl FromV8 for U16String {
   fn from_v8(
-    scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     let v8str = v8::Local::<v8::String>::try_from(value)
       .map_err(|_| Error::ExpectedString)?;

--- a/serde_v8/magic/value.rs
+++ b/serde_v8/magic/value.rs
@@ -39,10 +39,10 @@ impl ToV8 for Value<'_> {
 
 impl FromV8 for Value<'_> {
   fn from_v8(
-    _scope: &mut v8::HandleScope,
-    value: v8::Local<v8::Value>,
+    _scope: &mut v8::HandleScope<'_>,
+    value: v8::Local<'_, v8::Value>,
   ) -> Result<Self, crate::Error> {
     // SAFETY: not fully safe, since lifetimes are detached from original scope
-    Ok(unsafe { transmute::<Value, Value>(value.into()) })
+    Ok(unsafe { transmute::<Value<'_>, Value<'_>>(value.into()) })
   }
 }

--- a/serde_v8/payload.rs
+++ b/serde_v8/payload.rs
@@ -17,7 +17,7 @@ pub enum ValueType {
 }
 
 impl ValueType {
-  pub fn from_v8(v: v8::Local<v8::Value>) -> ValueType {
+  pub fn from_v8(v: v8::Local<'_, v8::Value>) -> ValueType {
     if v.is_boolean() {
       return Self::Bool;
     } else if v.is_number() {

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -31,7 +31,7 @@ enum EnumPayloads {
 
 fn dedo(
   code: &str,
-  f: impl FnOnce(&mut v8::HandleScope, v8::Local<v8::Value>),
+  f: impl FnOnce(&mut v8::HandleScope<'_>, v8::Local<'_, v8::Value>),
 ) {
   v8_do(|| {
     let isolate = &mut v8::Isolate::new(v8::CreateParams::default());

--- a/serde_v8/tests/magic.rs
+++ b/serde_v8/tests/magic.rs
@@ -31,9 +31,9 @@ fn magic_basic() {
 
     // Decode
     let v = js_exec(scope, "({a: 1, b: 3, c: 'abracadabra'})");
-    let mop: MagicOp = serde_v8::from_v8(scope, v).unwrap();
+    let mop: MagicOp<'_> = serde_v8::from_v8(scope, v).unwrap();
     // Check string
-    let v8_value: v8::Local<v8::Value> = mop.c.into();
+    let v8_value: v8::Local<'_, v8::Value> = mop.c.into();
     let vs = v8::Local::<v8::String>::try_from(v8_value).unwrap();
     let s = vs.to_rust_string_lossy(scope);
     assert_eq!(s, "abracadabra");

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -975,7 +975,7 @@ impl hyper::server::accept::Accept for HyperAcceptor<'_> {
 
   fn poll_accept(
     mut self: Pin<&mut Self>,
-    cx: &mut Context,
+    cx: &mut Context<'_>,
   ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
     Pin::new(&mut self.acceptor).poll_next(cx)
   }
@@ -1522,7 +1522,7 @@ pub fn http_server() -> HttpServerGuard {
 }
 
 /// Helper function to strip ansi codes.
-pub fn strip_ansi_codes(s: &str) -> std::borrow::Cow<str> {
+pub fn strip_ansi_codes(s: &str) -> std::borrow::Cow<'_, str> {
   STRIP_ANSI_RE.replace_all(s, "")
 }
 


### PR DESCRIPTION
By adding the lint rule and running `clippy fix`.

As far as I can see, all of the changes fix `error: hidden lifetime parameters in types are deprecated` aka `-D elided-lifetimes-in-paths`, which is implied by `-D rust-2018-idioms`.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
