### PR TITLE
fix(coverage): ensure coverage is only collected in certain situations

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -162,6 +162,12 @@ pub struct RunFlags {
   pub script: String,
 }
 
+impl RunFlags {
+  pub fn is_stdin(&self) -> bool {
+    self.script == "-"
+  }
+}
+
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct TaskFlags {
   pub cwd: Option<String>,

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -278,8 +278,25 @@ impl CliOptions {
     self.flags.compat
   }
 
-  pub fn coverage_dir(&self) -> Option<&String> {
-    self.flags.coverage_dir.as_ref()
+  pub fn coverage_dir(&self) -> Option<String> {
+    fn allow_coverage(sub_command: &DenoSubcommand) -> bool {
+      match sub_command {
+        DenoSubcommand::Test(_) => true,
+        DenoSubcommand::Run(flags) => !flags.is_stdin(),
+        _ => false,
+      }
+    }
+
+    if allow_coverage(self.sub_command()) {
+      self
+        .flags
+        .coverage_dir
+        .as_ref()
+        .map(ToOwned::to_owned)
+        .or_else(|| env::var("DENO_UNSTABLE_COVERAGE_DIR").ok())
+    } else {
+      None
+    }
   }
 
   pub fn enable_testing_features(&self) -> bool {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -774,7 +774,7 @@ async fn run_command(
   run_flags: RunFlags,
 ) -> Result<i32, AnyError> {
   // Read script content from stdin
-  if run_flags.script == "-" {
+  if run_flags.is_stdin() {
     return run_from_stdin(flags).await;
   }
 

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -51,7 +51,6 @@ use deno_runtime::permissions::Permissions;
 use import_map::ImportMap;
 use log::warn;
 use std::collections::HashSet;
-use std::env;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -64,7 +63,6 @@ pub struct ProcState(Arc<Inner>);
 
 pub struct Inner {
   pub dir: deno_dir::DenoDir,
-  pub coverage_dir: Option<String>,
   pub file_fetcher: FileFetcher,
   pub options: Arc<CliOptions>,
   pub emit_cache: EmitCache,
@@ -176,11 +174,6 @@ impl ProcState {
     let maybe_inspector_server =
       cli_options.resolve_inspector_server().map(Arc::new);
 
-    let coverage_dir = cli_options
-      .coverage_dir()
-      .map(ToOwned::to_owned)
-      .or_else(|| env::var("DENO_UNSTABLE_COVERAGE_DIR").ok());
-
     // FIXME(bartlomieju): `NodeEsmResolver` is not aware of JSX resolver
     // created below
     let node_resolver = NodeEsmResolver::new(
@@ -220,7 +213,6 @@ impl ProcState {
 
     Ok(ProcState(Arc::new(Inner {
       dir,
-      coverage_dir,
       options: cli_options,
       emit_cache,
       emit_options_hash: FastInsecureHasher::new()

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -32,6 +32,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
   let status = util::deno_cmd_with_deno_dir(&deno_dir)
     .current_dir(util::testdata_path())
     .arg("test")
+    .arg("-A")
     .arg("--quiet")
     .arg("--unstable")
     .arg(format!("--coverage={}", tempdir.to_str().unwrap()))

--- a/cli/tests/testdata/coverage/complex_test.ts
+++ b/cli/tests/testdata/coverage/complex_test.ts
@@ -3,3 +3,35 @@ import { complex } from "./complex.ts";
 Deno.test("complex", function () {
   complex("foo", "bar", "baz");
 });
+
+Deno.test("sub process with stdin", async () => {
+  // ensure launching deno run with stdin doesn't affect coverage
+  const code = "console.log('5')";
+  const p = await Deno.run({
+    cmd: [Deno.execPath(), "run", "-"],
+    stdin: "piped",
+    stdout: "piped",
+  });
+  const encoder = new TextEncoder();
+  await p.stdin.write(encoder.encode(code));
+  await p.stdin.close();
+  const output = new TextDecoder().decode(await p.output());
+  p.close();
+  if (output.trim() !== "5") {
+    throw new Error("Failed");
+  }
+});
+
+Deno.test("sub process with deno eval", async () => {
+  // ensure launching deno eval doesn't affect coverage
+  const code = "console.log('5')";
+  const p = await Deno.run({
+    cmd: [Deno.execPath(), "eval", code],
+    stdout: "piped",
+  });
+  const output = new TextDecoder().decode(await p.output());
+  p.close();
+  if (output.trim() !== "5") {
+    throw new Error("Failed");
+  }
+});

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -390,7 +390,7 @@ impl CliMainWorker {
   async fn maybe_setup_coverage_collector(
     &mut self,
   ) -> Result<Option<CoverageCollector>, AnyError> {
-    if let Some(ref coverage_dir) = self.ps.coverage_dir {
+    if let Some(ref coverage_dir) = self.ps.options.coverage_dir() {
       let session = self.worker.create_inspector_session().await;
 
       let coverage_dir = PathBuf::from(coverage_dir);


### PR DESCRIPTION
Caused by code now being reused in #15459. The coverage directory should be ignored in certain scenarios.

Fixes deno_std.