### PR TITLE
chore(bench,test): list `.mts` under supported file extensions in cli docs

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -683,7 +683,7 @@ and report results to standard output:
   deno bench src/fetch_bench.ts src/signal_bench.ts
 
 Directory arguments are expanded to all contained files matching the \
-glob {*_,*.,}bench.{js,mjs,ts,jsx,tsx}:
+glob {*_,*.,}bench.{js,mjs,ts,mts,jsx,tsx}:
 
   deno bench src/",
     )
@@ -1599,7 +1599,7 @@ report results to standard output:
   deno test src/fetch_test.ts src/signal_test.ts
 
 Directory arguments are expanded to all contained files matching the glob
-{*_,*.,}test.{js,mjs,ts,jsx,tsx}:
+{*_,*.,}test.{js,mjs,ts,mts,jsx,tsx}:
 
   deno test src/",
     )


### PR DESCRIPTION
This adds `.mts` to the list of file extensions that can be run with `deno test` and `bench`.

Fixes  #15476

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
