### PR TITLE
docs: add category tag for built-in APIs

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -6,7 +6,10 @@
 
 /** Deno provides extra properties on `import.meta`.  These are included here
  * to ensure that these are still available when using the Deno namespace in
- * conjunction with other type libs, like `dom`. */
+ * conjunction with other type libs, like `dom`.
+ *
+ * @category ES Modules
+ */
 declare interface ImportMeta {
   /** A string representation of the fully qualified module URL. */
   url: string;
@@ -36,7 +39,10 @@ declare interface ImportMeta {
 /** Deno supports user timing Level 3 (see: https://w3c.github.io/user-timing)
  * which is not widely supported yet in other runtimes.  These types are here
  * so that these features are still available when using the Deno namespace
- * in conjunction with other type libs, like `dom`. */
+ * in conjunction with other type libs, like `dom`.
+ *
+ * @category Performance API
+ */
 declare interface Performance {
   /** Stores a timestamp with the associated name (a "mark"). */
   mark(markName: string, options?: PerformanceMarkOptions): PerformanceMark;
@@ -49,6 +55,9 @@ declare interface Performance {
   ): PerformanceMeasure;
 }
 
+/**
+ * @category Performance API
+ */
 declare interface PerformanceMarkOptions {
   /** Metadata to be included in the mark. */
   // deno-lint-ignore no-explicit-any
@@ -58,6 +67,9 @@ declare interface PerformanceMarkOptions {
   startTime?: number;
 }
 
+/**
+ * @category Performance API
+ */
 declare interface PerformanceMeasureOptions {
   /** Metadata to be included in the measure. */
   // deno-lint-ignore no-explicit-any
@@ -75,37 +87,65 @@ declare interface PerformanceMeasureOptions {
 }
 
 declare namespace Deno {
-  /** A set of error constructors that are raised by Deno APIs. */
+  /** A set of error constructors that are raised by Deno APIs.
+   *
+   * @category Errors
+   */
   export namespace errors {
+    /** @category Errors */
     export class NotFound extends Error {}
+    /** @category Errors */
     export class PermissionDenied extends Error {}
+    /** @category Errors */
     export class ConnectionRefused extends Error {}
+    /** @category Errors */
     export class ConnectionReset extends Error {}
+    /** @category Errors */
     export class ConnectionAborted extends Error {}
+    /** @category Errors */
     export class NotConnected extends Error {}
+    /** @category Errors */
     export class AddrInUse extends Error {}
+    /** @category Errors */
     export class AddrNotAvailable extends Error {}
+    /** @category Errors */
     export class BrokenPipe extends Error {}
+    /** @category Errors */
     export class AlreadyExists extends Error {}
+    /** @category Errors */
     export class InvalidData extends Error {}
+    /** @category Errors */
     export class TimedOut extends Error {}
+    /** @category Errors */
     export class Interrupted extends Error {}
+    /** @category Errors */
     export class WriteZero extends Error {}
+    /** @category Errors */
     export class UnexpectedEof extends Error {}
+    /** @category Errors */
     export class BadResource extends Error {}
+    /** @category Errors */
     export class Http extends Error {}
+    /** @category Errors */
     export class Busy extends Error {}
+    /** @category Errors */
     export class NotSupported extends Error {}
   }
 
-  /** The current process id of the runtime. */
+  /** The current process id of the runtime.
+   *
+   * @category Runtime Environment
+   */
   export const pid: number;
 
   /**
    * The pid of the current process's parent.
+   *
+   * @category Runtime Environment
    */
   export const ppid: number;
 
+  /** @category Runtime Environment */
   export interface MemoryUsage {
     rss: number;
     heapTotal: number;
@@ -116,16 +156,23 @@ declare namespace Deno {
   /**
    * Returns an object describing the memory usage of the Deno process measured
    * in bytes.
+   *
+   * @category Runtime Environment
    */
   export function memoryUsage(): MemoryUsage;
 
   /** Reflects the `NO_COLOR` environment variable at program start.
    *
-   * See: https://no-color.org/ */
+   * See: https://no-color.org/
+   *
+   * @category Runtime Environment
+   */
   export const noColor: boolean;
 
+  /** @category Permissions */
   export type PermissionOptions = "inherit" | "none" | PermissionOptionsObject;
 
+  /** @category Permissions */
   export interface PermissionOptionsObject {
     /** Specifies if the `env` permission should be requested or revoked.
      * If set to `"inherit"`, the current `env` permission will be inherited.
@@ -259,6 +306,7 @@ declare namespace Deno {
     write?: "inherit" | boolean | Array<string | URL>;
   }
 
+  /** @category Testing */
   export interface TestContext {
     /**
      * The current test name.
@@ -291,6 +339,7 @@ declare namespace Deno {
     ): Promise<boolean>;
   }
 
+  /** @category Testing */
   export interface TestStepDefinition {
     fn: (t: TestContext) => void | Promise<void>;
     /**
@@ -311,6 +360,7 @@ declare namespace Deno {
     sanitizeExit?: boolean;
   }
 
+  /** @category Testing */
   export interface TestDefinition {
     fn: (t: TestContext) => void | Promise<void>;
     /**
@@ -371,6 +421,8 @@ declare namespace Deno {
    *   }
    * });
    * ```
+   *
+   * @category Testing
    */
   export function test(t: TestDefinition): void;
 
@@ -391,6 +443,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function test(
     name: string,
@@ -414,6 +468,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function test(fn: (t: TestContext) => void | Promise<void>): void;
 
@@ -434,6 +490,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function test(
     name: string,
@@ -458,6 +516,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function test(
     options: Omit<TestDefinition, "fn">,
@@ -481,6 +541,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function test(
     options: Omit<TestDefinition, "fn" | "name">,
@@ -495,9 +557,12 @@ declare namespace Deno {
    * ```ts
    * Deno.exit(5);
    * ```
+   *
+   * @category Runtime Environment
    */
   export function exit(code?: number): never;
 
+  /** @category Runtime Environment */
   export const env: {
     /** Retrieve the value of an environment variable. Returns `undefined` if that
      * key doesn't exist.
@@ -551,6 +616,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` permission.
+   *
+   * @category Runtime Environment
    */
   export function execPath(): string;
 
@@ -568,6 +635,8 @@ declare namespace Deno {
    * rights
    *
    * Requires --allow-read.
+   *
+   * @category Runtime Environment
    */
   export function chdir(directory: string | URL): void;
 
@@ -584,6 +653,8 @@ declare namespace Deno {
    * Throws `Deno.errors.NotFound` if directory not available.
    *
    * Requires --allow-read
+   *
+   * @category Runtime Environment
    */
   export function cwd(): string;
 
@@ -594,7 +665,10 @@ declare namespace Deno {
    * Deno.linkSync("old/name", "new/name");
    * ```
    *
-   * Requires `allow-read` and `allow-write` permissions. */
+   * Requires `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
+   */
   export function linkSync(oldpath: string, newpath: string): void;
 
   /**
@@ -604,15 +678,20 @@ declare namespace Deno {
    * await Deno.link("old/name", "new/name");
    * ```
    *
-   * Requires `allow-read` and `allow-write` permissions. */
+   * Requires `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
+   */
   export function link(oldpath: string, newpath: string): Promise<void>;
 
+  /** @category I/O */
   export enum SeekMode {
     Start = 0,
     Current = 1,
     End = 2,
   }
 
+  /** @category I/O */
   export interface Reader {
     /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number of
      * bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -639,6 +718,7 @@ declare namespace Deno {
     read(p: Uint8Array): Promise<number | null>;
   }
 
+  /** @category I/O */
   export interface ReaderSync {
     /** Reads up to `p.byteLength` bytes into `p`. It resolves to the number
      * of bytes read (`0` < `n` <= `p.byteLength`) and rejects if any error
@@ -664,6 +744,7 @@ declare namespace Deno {
     readSync(p: Uint8Array): number | null;
   }
 
+  /** @category I/O */
   export interface Writer {
     /** Writes `p.byteLength` bytes from `p` to the underlying data stream. It
      * resolves to the number of bytes written from `p` (`0` <= `n` <=
@@ -677,6 +758,7 @@ declare namespace Deno {
     write(p: Uint8Array): Promise<number>;
   }
 
+  /** @category I/O */
   export interface WriterSync {
     /** Writes `p.byteLength` bytes from `p` to the underlying data
      * stream. It returns the number of bytes written from `p` (`0` <= `n`
@@ -690,10 +772,12 @@ declare namespace Deno {
     writeSync(p: Uint8Array): number;
   }
 
+  /** @category I/O */
   export interface Closer {
     close(): void;
   }
 
+  /** @category I/O */
   export interface Seeker {
     /** Seek sets the offset for the next `read()` or `write()` to offset,
      * interpreted according to `whence`: `Start` means relative to the
@@ -709,6 +793,7 @@ declare namespace Deno {
     seek(offset: number, whence: SeekMode): Promise<number>;
   }
 
+  /** @category I/O */
   export interface SeekerSync {
     /** Seek sets the offset for the next `readSync()` or `writeSync()` to
      * offset, interpreted according to `whence`: `Start` means relative
@@ -736,6 +821,8 @@ declare namespace Deno {
    *
    * @deprecated Use `copy` from https://deno.land/std/streams/conversion.ts
    * instead. `Deno.copy` will be removed in Deno 2.0.
+   *
+   * @category I/O
    *
    * @param src The source to copy from
    * @param dst The destination to copy to
@@ -782,6 +869,8 @@ declare namespace Deno {
    * @deprecated Use `iterateReader` from
    * https://deno.land/std/streams/conversion.ts instead. `Deno.iter` will be
    * removed in Deno 2.0.
+   *
+   * @category I/O
    */
   export function iter(
     r: Reader,
@@ -823,6 +912,8 @@ declare namespace Deno {
    * @deprecated Use `iterateReaderSync` from
    * https://deno.land/std/streams/conversion.ts instead. `Deno.iterSync` will
    * be removed in Deno 2.0.
+   *
+   * @category I/O
    */
   export function iterSync(
     r: ReaderSync,
@@ -843,6 +934,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` and/or `allow-write` permissions depending on options.
+   *
+   * @category File System
    */
   export function openSync(path: string | URL, options?: OpenOptions): FsFile;
 
@@ -858,6 +951,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` and/or `allow-write` permissions depending on options.
+   *
+   * @category File System
    */
   export function open(
     path: string | URL,
@@ -872,6 +967,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
    */
   export function createSync(path: string | URL): FsFile;
 
@@ -883,6 +980,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
    */
   export function create(path: string | URL): Promise<FsFile>;
 
@@ -908,6 +1007,8 @@ declare namespace Deno {
    * const text = new TextDecoder().decode(buf);  // "hello world"
    * Deno.close(file.rid);
    * ```
+   *
+   * @category I/O
    */
   export function readSync(rid: number, buffer: Uint8Array): number | null;
 
@@ -933,6 +1034,8 @@ declare namespace Deno {
    * const text = new TextDecoder().decode(buf);  // "hello world"
    * Deno.close(file.rid);
    * ```
+   *
+   * @category I/O
    */
   export function read(rid: number, buffer: Uint8Array): Promise<number | null>;
 
@@ -953,6 +1056,8 @@ declare namespace Deno {
    * const bytesWritten = Deno.writeSync(file.rid, data); // 11
    * Deno.close(file.rid);
    * ```
+   *
+   * @category I/O
    */
   export function writeSync(rid: number, data: Uint8Array): number;
 
@@ -972,6 +1077,8 @@ declare namespace Deno {
    * const bytesWritten = await Deno.write(file.rid, data); // 11
    * Deno.close(file.rid);
    * ```
+   *
+   * @category I/O
    */
   export function write(rid: number, data: Uint8Array): Promise<number>;
 
@@ -1005,6 +1112,8 @@ declare namespace Deno {
    * // Seek backwards 2 bytes from the end of the file
    * console.log(Deno.seekSync(file.rid, -2, Deno.SeekMode.End)); // "9" (e.g. 11-2)
    * ```
+   *
+   * @category I/O
    */
   export function seekSync(
     rid: number,
@@ -1042,6 +1151,8 @@ declare namespace Deno {
    * // Seek backwards 2 bytes from the end of the file
    * console.log(await Deno.seek(file.rid, -2, Deno.SeekMode.End)); // "9" (e.g. 11-2)
    * ```
+   *
+   * @category I/O
    */
   export function seek(
     rid: number,
@@ -1050,37 +1161,49 @@ declare namespace Deno {
   ): Promise<number>;
 
   /**
-   * Synchronously flushes any pending data and metadata operations of the given file stream to disk.
-   *  ```ts
+   * Synchronously flushes any pending data and metadata operations of the given
+   * file stream to disk.
+   *
+   * ```ts
    * const file = Deno.openSync("my_file.txt", { read: true, write: true, create: true });
    * Deno.writeSync(file.rid, new TextEncoder().encode("Hello World"));
    * Deno.ftruncateSync(file.rid, 1);
    * Deno.fsyncSync(file.rid);
    * console.log(new TextDecoder().decode(Deno.readFileSync("my_file.txt"))); // H
    * ```
+   *
+   * @category I/O
    */
   export function fsyncSync(rid: number): void;
 
   /**
-   * Flushes any pending data and metadata operations of the given file stream to disk.
-   *  ```ts
+   * Flushes any pending data and metadata operations of the given file stream
+   * to disk.
+   *
+   * ```ts
    * const file = await Deno.open("my_file.txt", { read: true, write: true, create: true });
    * await Deno.write(file.rid, new TextEncoder().encode("Hello World"));
    * await Deno.ftruncate(file.rid, 1);
    * await Deno.fsync(file.rid);
    * console.log(new TextDecoder().decode(await Deno.readFile("my_file.txt"))); // H
    * ```
+   *
+   * @category I/O
    */
   export function fsync(rid: number): Promise<void>;
 
-  /*
-   * Synchronously flushes any pending data operations of the given file stream to disk.
+  /**
+   * Synchronously flushes any pending data operations of the given file stream
+   * to disk.
+   *
    *  ```ts
    * const file = Deno.openSync("my_file.txt", { read: true, write: true, create: true });
    * Deno.writeSync(file.rid, new TextEncoder().encode("Hello World"));
    * Deno.fdatasyncSync(file.rid);
    * console.log(new TextDecoder().decode(Deno.readFileSync("my_file.txt"))); // Hello World
    * ```
+   *
+   * @category I/O
    */
   export function fdatasyncSync(rid: number): void;
 
@@ -1092,6 +1215,8 @@ declare namespace Deno {
    * await Deno.fdatasync(file.rid);
    * console.log(new TextDecoder().decode(await Deno.readFile("my_file.txt"))); // Hello World
    * ```
+   *
+   * @category I/O
    */
   export function fdatasync(rid: number): Promise<void>;
 
@@ -1103,11 +1228,16 @@ declare namespace Deno {
    * const file = await Deno.open("my_file.txt");
    * // do work with "file" object
    * Deno.close(file.rid);
-   * ````
+   * ```
+   *
+   * @category I/O
    */
   export function close(rid: number): void;
 
-  /** The Deno abstraction for reading and writing files. */
+  /** The Deno abstraction for reading and writing files.
+   *
+   * @category File System
+   */
   export class FsFile
     implements
       Reader,
@@ -1136,9 +1266,10 @@ declare namespace Deno {
   }
 
   /**
-   * @deprecated Use `Deno.FsFile` instead. `Deno.File` will be removed in Deno 2.0.
-   *
    * The Deno abstraction for reading and writing files.
+   *
+   * @deprecated Use `Deno.FsFile` instead. `Deno.File` will be removed in Deno 2.0.
+   * @category File System
    */
   export class File
     implements
@@ -1167,12 +1298,18 @@ declare namespace Deno {
     readonly writable: WritableStream<Uint8Array>;
   }
 
-  /** A handle for `stdin`. */
+  /** A handle for `stdin`.
+   *
+   * @category I/O
+   */
   export const stdin: Reader & ReaderSync & Closer & {
     readonly rid: number;
     readonly readable: ReadableStream<Uint8Array>;
   };
-  /** A handle for `stdout`. */
+  /** A handle for `stdout`.
+   *
+   * @category I/O
+   */
   export const stdout: Writer & WriterSync & Closer & {
     readonly rid: number;
     readonly writable: WritableStream<Uint8Array>;
@@ -1183,6 +1320,7 @@ declare namespace Deno {
     readonly writable: WritableStream<Uint8Array>;
   };
 
+  /** @category File System */
   export interface OpenOptions {
     /** Sets the option for read access. This option, when `true`, means that the
      * file should be read-able if opened. */
@@ -1217,6 +1355,7 @@ declare namespace Deno {
     mode?: number;
   }
 
+  /** @category File System */
   export interface ReadFileOptions {
     /**
      * An abort signal to allow cancellation of the file read operation.
@@ -1238,12 +1377,12 @@ declare namespace Deno {
    * Deno.close(nonTTYRid);
    * Deno.close(ttyRid);
    * ```
+   *
+   * @category I/O
    */
   export function isatty(rid: number): boolean;
 
   /**
-   * @deprecated Use Buffer from https://deno.land/std/io/buffer.ts instead. Deno.Buffer will be removed in Deno 2.0.
-   *
    * A variable-sized buffer of bytes with `read()` and `write()` methods.
    *
    * Deno.Buffer is almost always used with some I/O like files and sockets. It
@@ -1257,7 +1396,11 @@ declare namespace Deno {
    * ArrayBuffer is a fixed memory allocation. Deno.Buffer is implemented on top
    * of ArrayBuffer.
    *
-   * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer). */
+   * Based on [Go Buffer](https://golang.org/pkg/bytes/#Buffer).
+   *
+   * @deprecated Use Buffer from https://deno.land/std/io/buffer.ts instead. Deno.Buffer will be removed in Deno 2.0.
+   * @category I/O
+   */
   export class Buffer implements Reader, ReaderSync, Writer, WriterSync {
     constructor(ab?: ArrayBuffer);
     /** Returns a slice holding the unread portion of the buffer.
@@ -1346,6 +1489,8 @@ declare namespace Deno {
    *
    * @deprecated Use `readAll` from https://deno.land/std/streams/conversion.ts
    * instead. `Deno.readAll` will be removed in Deno 2.0.
+   *
+   * @category I/O
    */
   export function readAll(r: Reader): Promise<Uint8Array>;
 
@@ -1372,6 +1517,8 @@ declare namespace Deno {
    * @deprecated Use `readAllSync` from
    * https://deno.land/std/streams/conversion.ts instead. `Deno.readAllSync`
    * will be removed in Deno 2.0.
+   *
+   * @category I/O
    */
   export function readAllSync(r: ReaderSync): Uint8Array;
 
@@ -1402,6 +1549,8 @@ declare namespace Deno {
    *
    * @deprecated Use `writeAll` from https://deno.land/std/streams/conversion.ts
    * instead. `Deno.writeAll` will be removed in Deno 2.0.
+   *
+   * @category I/O
    */
   export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
 
@@ -1434,9 +1583,12 @@ declare namespace Deno {
    * @deprecated Use `writeAllSync` from
    * https://deno.land/std/streams/conversion.ts instead. `Deno.writeAllSync`
    * will be removed in Deno 2.0.
+   *
+   * @category I/O
    */
   export function writeAllSync(w: WriterSync, arr: Uint8Array): void;
 
+  /** @category File System */
   export interface MkdirOptions {
     /** Defaults to `false`. If set to `true`, means that any intermediate
      * directories will also be created (as with the shell command `mkdir -p`).
@@ -1461,7 +1613,10 @@ declare namespace Deno {
    *
    * Defaults to throwing error if the directory already exists.
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function mkdirSync(path: string | URL, options?: MkdirOptions): void;
 
   /** Creates a new directory with the specified path.
@@ -1474,12 +1629,16 @@ declare namespace Deno {
    *
    * Defaults to throwing error if the directory already exists.
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function mkdir(
     path: string | URL,
     options?: MkdirOptions,
   ): Promise<void>;
 
+  /** @category File System */
   export interface MakeTempOptions {
     /** Directory where the temporary directory should be created (defaults to
      * the env variable TMPDIR, or the system's default, usually /tmp).
@@ -1512,7 +1671,10 @@ declare namespace Deno {
    * const tempDirName1 = Deno.makeTempDirSync({ prefix: 'my_temp' });  // e.g. /tmp/my_temp339c944d
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   // TODO(ry) Doesn't check permissions.
   export function makeTempDirSync(options?: MakeTempOptions): string;
 
@@ -1532,7 +1694,10 @@ declare namespace Deno {
    * const tempDirName1 = await Deno.makeTempDir({ prefix: 'my_temp' }); // e.g. /tmp/my_temp339c944d
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   // TODO(ry) Doesn't check permissions.
   export function makeTempDir(options?: MakeTempOptions): Promise<string>;
 
@@ -1552,7 +1717,10 @@ declare namespace Deno {
    * const tempFileName1 = Deno.makeTempFileSync({ prefix: 'my_temp' });  // e.g. /tmp/my_temp754d3098
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function makeTempFileSync(options?: MakeTempOptions): string;
 
   /** Creates a new temporary file in the default directory for temporary
@@ -1571,7 +1739,10 @@ declare namespace Deno {
    * const tmpFileName1 = await Deno.makeTempFile({ prefix: 'my_temp' });  // e.g. /tmp/my_temp754d3098
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function makeTempFile(options?: MakeTempOptions): Promise<string>;
 
   /** Synchronously changes the permission of a specific file/directory of
@@ -1585,7 +1756,10 @@ declare namespace Deno {
    *
    * NOTE: This API currently throws on Windows
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function chmodSync(path: string | URL, mode: number): void;
 
   /** Changes the permission of a specific file/directory of specified path.
@@ -1615,7 +1789,10 @@ declare namespace Deno {
    *
    * NOTE: This API currently throws on Windows
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function chmod(path: string | URL, mode: number): Promise<void>;
 
   /** Synchronously change owner of a regular file or directory. This functionality
@@ -1628,6 +1805,8 @@ declare namespace Deno {
    * Requires `allow-write` permission.
    *
    * Throws Error (not implemented) if executed on Windows
+   *
+   * @category File System
    *
    * @param path path to the file
    * @param uid user id (UID) of the new owner, or `null` for no change
@@ -1650,6 +1829,8 @@ declare namespace Deno {
    *
    * Throws Error (not implemented) if executed on Windows
    *
+   * @category File System
+   *
    * @param path path to the file
    * @param uid user id (UID) of the new owner, or `null` for no change
    * @param gid group id (GID) of the new owner, or `null` for no change
@@ -1660,6 +1841,7 @@ declare namespace Deno {
     gid: number | null,
   ): Promise<void>;
 
+  /** @category File System */
   export interface RemoveOptions {
     /** Defaults to `false`. If set to `true`, path will be removed even if
      * it's a non-empty directory. */
@@ -1676,7 +1858,10 @@ declare namespace Deno {
    * Throws error if permission denied, path not found, or path is a non-empty
    * directory and the `recursive` option isn't set to `true`.
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function removeSync(path: string | URL, options?: RemoveOptions): void;
 
   /** Removes the named file or directory.
@@ -1689,7 +1874,10 @@ declare namespace Deno {
    * Throws error if permission denied, path not found, or path is a non-empty
    * directory and the `recursive` option isn't set to `true`.
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function remove(
     path: string | URL,
     options?: RemoveOptions,
@@ -1709,7 +1897,10 @@ declare namespace Deno {
    * It varies between platforms when the operation throws errors, and if so what
    * they are. It's always an error to rename anything to a non-empty directory.
    *
-   * Requires `allow-read` and `allow-write` permissions. */
+   * Requires `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
+   */
   export function renameSync(
     oldpath: string | URL,
     newpath: string | URL,
@@ -1729,7 +1920,10 @@ declare namespace Deno {
    * It varies between platforms when the operation throws errors, and if so what
    * they are. It's always an error to rename anything to a non-empty directory.
    *
-   * Requires `allow-read` and `allow-write` permission. */
+   * Requires `allow-read` and `allow-write` permission.
+   *
+   * @category File System
+   */
   export function rename(
     oldpath: string | URL,
     newpath: string | URL,
@@ -1743,7 +1937,10 @@ declare namespace Deno {
    * console.log(data);
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readTextFileSync(path: string | URL): string;
 
   /** Asynchronously reads and returns the entire contents of a file as utf8
@@ -1754,7 +1951,10 @@ declare namespace Deno {
    * console.log(data);
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readTextFile(
     path: string | URL,
     options?: ReadFileOptions,
@@ -1770,7 +1970,10 @@ declare namespace Deno {
    * console.log(decoder.decode(data));
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readFileSync(path: string | URL): Uint8Array;
 
   /** Reads and resolves to the entire contents of a file as an array of bytes.
@@ -1783,14 +1986,20 @@ declare namespace Deno {
    * console.log(decoder.decode(data));
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readFile(
     path: string | URL,
     options?: ReadFileOptions,
   ): Promise<Uint8Array>;
 
   /** A FileInfo describes a file and is returned by `stat`, `lstat`,
-   * `statSync`, `lstatSync`. */
+   * `statSync`, `lstatSync`.
+   *
+   * @category File System
+   */
   export interface FileInfo {
     /** True if this is info for a regular file. Mutually exclusive to
      * `FileInfo.isDirectory` and `FileInfo.isSymlink`. */
@@ -1867,7 +2076,10 @@ declare namespace Deno {
    *
    * Requires `allow-read` permission for the target path.
    * Also requires `allow-read` permission for the CWD if the target path is
-   * relative. */
+   * relative.
+   *
+   * @category File System
+   */
   export function realPathSync(path: string | URL): string;
 
   /** Resolves to the absolute normalized path, with symbolic links resolved.
@@ -1883,7 +2095,10 @@ declare namespace Deno {
    *
    * Requires `allow-read` permission for the target path.
    * Also requires `allow-read` permission for the CWD if the target path is
-   * relative. */
+   * relative.
+   *
+   * @category File System
+   */
   export function realPath(path: string | URL): Promise<string>;
 
   export interface DirEntry {
@@ -1904,7 +2119,10 @@ declare namespace Deno {
    *
    * Throws error if `path` is not a directory.
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readDirSync(path: string | URL): Iterable<DirEntry>;
 
   /** Reads the directory given by `path` and returns an async iterable of
@@ -1918,7 +2136,10 @@ declare namespace Deno {
    *
    * Throws error if `path` is not a directory.
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readDir(path: string | URL): AsyncIterable<DirEntry>;
 
   /** Synchronously copies the contents and permissions of one file to another
@@ -1930,7 +2151,10 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` permission on fromPath.
-   * Requires `allow-write` permission on toPath. */
+   * Requires `allow-write` permission on toPath.
+   *
+   * @category File System
+   */
   export function copyFileSync(
     fromPath: string | URL,
     toPath: string | URL,
@@ -1945,7 +2169,10 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-read` permission on fromPath.
-   * Requires `allow-write` permission on toPath. */
+   * Requires `allow-write` permission on toPath.
+   *
+   * @category File System
+   */
   export function copyFile(
     fromPath: string | URL,
     toPath: string | URL,
@@ -1960,7 +2187,10 @@ declare namespace Deno {
    *
    * Throws TypeError if called with a hard link
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readLinkSync(path: string | URL): string;
 
   /** Resolves to the full path destination of the named symbolic link.
@@ -1972,7 +2202,10 @@ declare namespace Deno {
    *
    * Throws TypeError if called with a hard link
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function readLink(path: string | URL): Promise<string>;
 
   /** Resolves to a `Deno.FileInfo` for the specified `path`. If `path` is a
@@ -1985,7 +2218,10 @@ declare namespace Deno {
    * assert(fileInfo.isFile);
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function lstat(path: string | URL): Promise<FileInfo>;
 
   /** Synchronously returns a `Deno.FileInfo` for the specified `path`. If
@@ -1998,7 +2234,10 @@ declare namespace Deno {
    * assert(fileInfo.isFile);
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function lstatSync(path: string | URL): FileInfo;
 
   /** Resolves to a `Deno.FileInfo` for the specified `path`. Will always
@@ -2010,7 +2249,10 @@ declare namespace Deno {
    * assert(fileInfo.isFile);
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function stat(path: string | URL): Promise<FileInfo>;
 
   /** Synchronously returns a `Deno.FileInfo` for the specified `path`. Will
@@ -2022,10 +2264,16 @@ declare namespace Deno {
    * assert(fileInfo.isFile);
    * ```
    *
-   * Requires `allow-read` permission. */
+   * Requires `allow-read` permission.
+   *
+   * @category File System
+   */
   export function statSync(path: string | URL): FileInfo;
 
-  /** Options for writing to a file. */
+  /** Options for writing to a file.
+   *
+   * @category File System
+   */
   export interface WriteFileOptions {
     /** Defaults to `false`. If set to `true`, will append to a file instead of
      * overwriting previous contents. */
@@ -2057,6 +2305,8 @@ declare namespace Deno {
    *
    * Requires `allow-write` permission, and `allow-read` if `options.create` is
    * `false`.
+   *
+   * @category File System
    */
   export function writeFileSync(
     path: string | URL,
@@ -2077,6 +2327,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-write` permission, and `allow-read` if `options.create` is `false`.
+   *
+   * @category File System
    */
   export function writeFile(
     path: string | URL,
@@ -2092,6 +2344,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-write` permission, and `allow-read` if `options.create` is `false`.
+   *
+   * @category File System
    */
   export function writeTextFileSync(
     path: string | URL,
@@ -2107,6 +2361,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-write` permission, and `allow-read` if `options.create` is `false`.
+   *
+   * @category File System
    */
   export function writeTextFile(
     path: string | URL,
@@ -2130,7 +2386,10 @@ declare namespace Deno {
    * console.log(new TextDecoder().decode(data));
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function truncateSync(name: string, len?: number): void;
 
   /** Truncates or extends the specified file, to reach the specified `len`. If
@@ -2148,9 +2407,13 @@ declare namespace Deno {
    * console.log(new TextDecoder().decode(data));  // "Hello W"
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function truncate(name: string, len?: number): Promise<void>;
 
+  /** @category Observability */
   export interface OpMetrics {
     opsDispatched: number;
     opsDispatchedSync: number;
@@ -2165,6 +2428,7 @@ declare namespace Deno {
     bytesReceived: number;
   }
 
+  /** @category Observability */
   export interface Metrics extends OpMetrics {
     ops: Record<string, OpMetrics>;
   }
@@ -2189,9 +2453,12 @@ declare namespace Deno {
    *      │      bytesSentData      │   0    │
    *      │      bytesReceived      │  375   │
    *      └─────────────────────────┴────────┘
+   *
+   * @category Observability
    */
   export function metrics(): Metrics;
 
+  /** @category Observability */
   interface ResourceMap {
     // deno-lint-ignore no-explicit-any
     [rid: number]: any;
@@ -2208,6 +2475,8 @@ declare namespace Deno {
    * console.log(Deno.resources());
    * // { 0: "stdin", 1: "stdout", 2: "stderr", 3: "fsFile" }
    * ```
+   *
+   * @category Observability
    */
   export function resources(): ResourceMap;
 
@@ -2221,9 +2490,12 @@ declare namespace Deno {
    *    An application that keeps an in-memory representation of the filesystem
    *    will need to care, and will need to refresh that representation directly
    *    from the filesystem.
+   *
+   * @category File System
    */
   export type FsEventFlag = "rescan";
 
+  /** @category File System */
   export interface FsEvent {
     kind: "any" | "access" | "create" | "modify" | "remove" | "other";
     paths: string[];
@@ -2235,6 +2507,8 @@ declare namespace Deno {
    * the file system. You can iterate over this interface to get the file
    * system events, and also you can stop watching the file system by calling
    * `.close()` method.
+   *
+   * @category File System
    */
   export interface FsWatcher extends AsyncIterable<FsEvent> {
     /** The resource id of the `FsWatcher`. */
@@ -2281,12 +2555,15 @@ declare namespace Deno {
    *    console.log(">>>> event", event);
    * }
    * ```
+   *
+   * @category File System
    */
   export function watchFs(
     paths: string | string[],
     options?: { recursive: boolean },
   ): FsWatcher;
 
+  /** @category Runtime Environment */
   export class Process<T extends RunOptions = RunOptions> {
     readonly rid: number;
     readonly pid: number;
@@ -2351,6 +2628,7 @@ declare namespace Deno {
     kill(signo: Signal): void;
   }
 
+  /** @category Runtime Environment */
   export type Signal =
     | "SIGABRT"
     | "SIGALRM"
@@ -2396,6 +2674,8 @@ declare namespace Deno {
    * ```
    *
    * NOTE: On Windows only SIGINT (ctrl+c) and SIGBREAK (ctrl+break) are supported.
+   *
+   * @category Runtime Environment
    */
   export function addSignalListener(signal: Signal, handler: () => void): void;
 
@@ -2411,6 +2691,8 @@ declare namespace Deno {
    * ```
    *
    * NOTE: On Windows only SIGINT (ctrl+c) and SIGBREAK (ctrl+break) are supported.
+   *
+   * @category Runtime Environment
    */
   export function removeSignalListener(
     signal: Signal,
@@ -2429,6 +2711,7 @@ declare namespace Deno {
       signal?: number;
     };
 
+  /** @category Sub Process */
   export interface RunOptions {
     /** Arguments to pass. Note, the first element needs to be a path to the
      * binary */
@@ -2484,9 +2767,13 @@ declare namespace Deno {
    *
    * Details of the spawned process are returned.
    *
-   * Requires `allow-run` permission. */
+   * Requires `allow-run` permission.
+   *
+   * @category Sub Process
+   */
   export function run<T extends RunOptions = RunOptions>(opt: T): Process<T>;
 
+  /** @category Console and Debugging */
   export interface InspectOptions {
     /** Stylize output with ANSI colors. Defaults to false. */
     colors?: boolean;
@@ -2544,10 +2831,15 @@ declare namespace Deno {
    * ```ts
    * Deno.inspect({a: {b: {c: {d: 'hello'}}}}, {depth: 2}); // { a: { b: [Object] } }
    * ```
+   *
+   * @category Console and Debugging
    */
   export function inspect(value: unknown, options?: InspectOptions): string;
 
-  /** The name of a "powerful feature" which needs permission. */
+  /** The name of a "powerful feature" which needs permission.
+   *
+   * @category Permissions
+   */
   export type PermissionName =
     | "run"
     | "read"
@@ -2557,24 +2849,31 @@ declare namespace Deno {
     | "ffi"
     | "hrtime";
 
-  /** The current status of the permission. */
+  /** The current status of the permission.
+   *
+   * @category Permissions
+   */
   export type PermissionState = "granted" | "denied" | "prompt";
 
+  /** @category Permissions */
   export interface RunPermissionDescriptor {
     name: "run";
     command?: string | URL;
   }
 
+  /** @category Permissions */
   export interface ReadPermissionDescriptor {
     name: "read";
     path?: string | URL;
   }
 
+  /** @category Permissions */
   export interface WritePermissionDescriptor {
     name: "write";
     path?: string | URL;
   }
 
+  /** @category Permissions */
   export interface NetPermissionDescriptor {
     name: "net";
     /** Optional host string of the form `"<hostname>[:<port>]"`. Examples:
@@ -2585,22 +2884,28 @@ declare namespace Deno {
     host?: string;
   }
 
+  /** @category Permissions */
   export interface EnvPermissionDescriptor {
     name: "env";
     variable?: string;
   }
 
+  /** @category Permissions */
   export interface FfiPermissionDescriptor {
     name: "ffi";
     path?: string | URL;
   }
 
+  /** @category Permissions */
   export interface HrtimePermissionDescriptor {
     name: "hrtime";
   }
 
   /** Permission descriptors which define a permission and can be queried,
-   * requested, or revoked. */
+   * requested, or revoked.
+   *
+   * @category Permissions
+   */
   export type PermissionDescriptor =
     | RunPermissionDescriptor
     | ReadPermissionDescriptor
@@ -2610,10 +2915,12 @@ declare namespace Deno {
     | FfiPermissionDescriptor
     | HrtimePermissionDescriptor;
 
+  /** @category Permissions */
   export interface PermissionStatusEventMap {
     "change": Event;
   }
 
+  /** @category Permissions */
   export class PermissionStatus extends EventTarget {
     // deno-lint-ignore no-explicit-any
     onchange: ((this: PermissionStatus, ev: Event) => any) | null;
@@ -2646,6 +2953,7 @@ declare namespace Deno {
     ): void;
   }
 
+  /** @category Permissions */
   export class Permissions {
     /** Resolves to the current status of a permission.
      *
@@ -2681,10 +2989,16 @@ declare namespace Deno {
     request(desc: PermissionDescriptor): Promise<PermissionStatus>;
   }
 
-  /** Deno's permission management API. */
+  /** Deno's permission management API.
+   *
+   * @category Permissions
+   */
   export const permissions: Permissions;
 
-  /** Build related information. */
+  /** Build related information.
+   *
+   * @category Runtime Environment
+   */
   export const build: {
     /** The LLVM target triple */
     target: string;
@@ -2698,7 +3012,10 @@ declare namespace Deno {
     env?: string;
   };
 
-  /** Version related information. */
+  /** Version related information.
+   *
+   * @category Runtime Environment
+   */
   export const version: {
     /** Deno's version. For example: `"1.0.0"` */
     deno: string;
@@ -2716,6 +3033,8 @@ declare namespace Deno {
    * Then `Deno.args` will contain:
    *
    * [ "/etc/passwd" ]
+   *
+   * @category Runtime Environment
    */
   export const args: string[];
 
@@ -2726,12 +3045,18 @@ declare namespace Deno {
    *
    * @deprecated This symbol is deprecated since 1.9. Use
    * `Symbol.for("Deno.customInspect")` instead.
+   *
+   * @category Console and Debugging
    */
   export const customInspect: unique symbol;
 
-  /** The URL of the entrypoint module entered from the command-line. */
+  /** The URL of the entrypoint module entered from the command-line.
+   *
+   * @category Runtime Environment
+   */
   export const mainModule: string;
 
+  /** @category File System */
   export type SymlinkOptions = {
     type: "file" | "dir";
   };
@@ -2746,7 +3071,10 @@ declare namespace Deno {
    * Deno.symlinkSync("old/name", "new/name");
    * ```
    *
-   * Requires full `allow-read` and `allow-write` permissions. */
+   * Requires full `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
+   */
   export function symlinkSync(
     oldpath: string | URL,
     newpath: string | URL,
@@ -2763,7 +3091,10 @@ declare namespace Deno {
    * await Deno.symlink("old/name", "new/name");
    * ```
    *
-   * Requires full `allow-read` and `allow-write` permissions. */
+   * Requires full `allow-read` and `allow-write` permissions.
+   *
+   * @category File System
+   */
   export function symlink(
     oldpath: string | URL,
     newpath: string | URL,
@@ -2796,6 +3127,8 @@ declare namespace Deno {
    * Deno.readSync(file.rid, data);
    * console.log(new TextDecoder().decode(data)); // Hello W
    * ```
+   *
+   * @category File System
    */
   export function ftruncateSync(rid: number, len?: number): void;
 
@@ -2823,6 +3156,8 @@ declare namespace Deno {
    * await Deno.read(file.rid, data);
    * console.log(new TextDecoder().decode(data)); // Hello W
    * ```
+   *
+   * @category File System
    */
   export function ftruncate(rid: number, len?: number): Promise<void>;
 
@@ -2835,6 +3170,8 @@ declare namespace Deno {
    * const fileInfo = Deno.fstatSync(file.rid);
    * assert(fileInfo.isFile);
    * ```
+   *
+   * @category File System
    */
   export function fstatSync(rid: number): FileInfo;
 
@@ -2847,14 +3184,18 @@ declare namespace Deno {
    * const fileInfo = await Deno.fstat(file.rid);
    * assert(fileInfo.isFile);
    * ```
+   *
+   * @category File System
    */
   export function fstat(rid: number): Promise<FileInfo>;
 
+  /** @category HTTP Server */
   export interface RequestEvent {
     readonly request: Request;
     respondWith(r: Response | Promise<Response>): Promise<void>;
   }
 
+  /** @category HTTP Server */
   export interface HttpConn extends AsyncIterable<RequestEvent> {
     readonly rid: number;
 
@@ -2890,14 +3231,18 @@ declare namespace Deno {
    *   handleHttp(conn);
    * }
    * ```
+   *
+   * @category HTTP Server
    */
   export function serveHttp(conn: Conn): HttpConn;
 
+  /** @category Web Sockets */
   export interface WebSocketUpgrade {
     response: Response;
     socket: WebSocket;
   }
 
+  /** @category Web Sockets */
   export interface UpgradeWebSocketOptions {
     protocol?: string;
     /**
@@ -2941,6 +3286,8 @@ declare namespace Deno {
    *
    * This operation does not yet consume the request or open the websocket. This
    * only happens once the returned response has been passed to `respondWith`.
+   *
+   * @category Web Sockets
    */
   export function upgradeWebSocket(
     request: Request,
@@ -2961,11 +3308,17 @@ declare namespace Deno {
    * Deno.kill(p.pid, "SIGINT");
    * ```
    *
-   * Requires `allow-run` permission. */
+   * Requires `allow-run` permission.
+   *
+   * @category Sub Process
+   */
   export function kill(pid: number, signo: Signal): void;
 
   /** The type of the resource record.
-   * Only the listed types are supported currently. */
+   * Only the listed types are supported currently.
+   *
+   * @category Network
+   */
   export type RecordType =
     | "A"
     | "AAAA"
@@ -2980,6 +3333,7 @@ declare namespace Deno {
     | "SRV"
     | "TXT";
 
+  /** @category Network */
   export interface ResolveDnsOptions {
     /** The name server to be used for lookups.
      * If not specified, defaults to the system configuration e.g. `/etc/resolv.conf` on Unix. */
@@ -2992,20 +3346,32 @@ declare namespace Deno {
     };
   }
 
-  /** If `resolveDns` is called with "CAA" record type specified, it will return an array of this interface. */
+  /** If `resolveDns` is called with "CAA" record type specified, it will return
+   * an array of this interface.
+   *
+   * @category Network
+   */
   export interface CAARecord {
     critical: boolean;
     tag: string;
     value: string;
   }
 
-  /** If `resolveDns` is called with "MX" record type specified, it will return an array of this interface. */
+  /** If `resolveDns` is called with "MX" record type specified, it will return
+   * an array of this interface.
+   *
+   * @category Network
+   */
   export interface MXRecord {
     preference: number;
     exchange: string;
   }
 
-  /** If `resolveDns` is called with "NAPTR" record type specified, it will return an array of this interface. */
+  /** If `resolveDns` is called with "NAPTR" record type specified, it will
+   * return an array of this interface.
+   *
+   * @category Network
+   */
   export interface NAPTRRecord {
     order: number;
     preference: number;
@@ -3015,7 +3381,11 @@ declare namespace Deno {
     replacement: string;
   }
 
-  /** If `resolveDns` is called with "SOA" record type specified, it will return an array of this interface. */
+  /** If `resolveDns` is called with "SOA" record type specified, it will return
+   * an array of this interface.
+   *
+   * @category Network
+   */
   export interface SOARecord {
     mname: string;
     rname: string;
@@ -3026,7 +3396,11 @@ declare namespace Deno {
     minimum: number;
   }
 
-  /** If `resolveDns` is called with "SRV" record type specified, it will return an array of this interface. */
+  /** If `resolveDns` is called with "SRV" record type specified, it will return
+   * an array of this interface.
+   *
+   * @category Network
+   */
   export interface SRVRecord {
     priority: number;
     weight: number;
@@ -3034,42 +3408,49 @@ declare namespace Deno {
     target: string;
   }
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "A" | "AAAA" | "ANAME" | "CNAME" | "NS" | "PTR",
     options?: ResolveDnsOptions,
   ): Promise<string[]>;
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "CAA",
     options?: ResolveDnsOptions,
   ): Promise<CAARecord[]>;
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "MX",
     options?: ResolveDnsOptions,
   ): Promise<MXRecord[]>;
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "NAPTR",
     options?: ResolveDnsOptions,
   ): Promise<NAPTRRecord[]>;
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "SOA",
     options?: ResolveDnsOptions,
   ): Promise<SOARecord[]>;
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "SRV",
     options?: ResolveDnsOptions,
   ): Promise<SRVRecord[]>;
 
+  /** @category Network */
   export function resolveDns(
     query: string,
     recordType: "TXT",
@@ -3092,6 +3473,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-net` permission.
+   *
+   * @category Network
    */
   export function resolveDns(
     query: string,

--- a/cli/dts/lib.deno.shared_globals.d.ts
+++ b/cli/dts/lib.deno.shared_globals.d.ts
@@ -13,11 +13,14 @@
 /// <reference lib="deno.crypto" />
 /// <reference lib="deno.broadcast_channel" />
 
+/** @category WebAssembly */
 declare namespace WebAssembly {
   /**
    * The `WebAssembly.CompileError` object indicates an error during WebAssembly decoding or validation.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError)
+   *
+   * @category WebAssembly
    */
   export class CompileError extends Error {
     /** Creates a new `WebAssembly.CompileError` object. */
@@ -30,6 +33,8 @@ declare namespace WebAssembly {
    * instances. This allows dynamic linking of multiple modules.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global)
+   *
+   * @category WebAssembly
    */
   export class Global {
     /** Creates a new `Global` object. */
@@ -51,6 +56,8 @@ declare namespace WebAssembly {
    * WebAssembly code from JavaScript.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance)
+   *
+   * @category WebAssembly
    */
   export class Instance {
     /** Creates a new Instance object. */
@@ -69,6 +76,8 @@ declare namespace WebAssembly {
    * (besides traps from the start function).
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError)
+   *
+   * @category WebAssembly
    */
   export class LinkError extends Error {
     /** Creates a new WebAssembly.LinkError object. */
@@ -83,6 +92,8 @@ declare namespace WebAssembly {
    * from both JavaScript and WebAssembly.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory)
+   *
+   * @category WebAssembly
    */
   export class Memory {
     /** Creates a new `Memory` object. */
@@ -103,6 +114,8 @@ declare namespace WebAssembly {
    * by the browser — this can be efficiently shared with Workers, and instantiated multiple times.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module)
+   *
+   * @category WebAssembly
    */
   export class Module {
     /** Creates a new `Module` object. */
@@ -129,6 +142,8 @@ declare namespace WebAssembly {
    * specifies a trap.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError)
+   *
+   * @category WebAssembly
    */
   export class RuntimeError extends Error {
     /** Creates a new `WebAssembly.RuntimeError` object. */
@@ -142,6 +157,8 @@ declare namespace WebAssembly {
    * and WebAssembly.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table)
+   *
+   * @category WebAssembly
    */
   export class Table {
     /** Creates a new `Table` object. */
@@ -160,40 +177,63 @@ declare namespace WebAssembly {
     set(index: number, value: Function | null): void;
   }
 
-  /** The `GlobalDescriptor` describes the options you can pass to `new WebAssembly.Global()`. */
+  /** The `GlobalDescriptor` describes the options you can pass to
+   * `new WebAssembly.Global()`.
+   *
+   * @category WebAssembly
+   */
   export interface GlobalDescriptor {
     mutable?: boolean;
     value: ValueType;
   }
 
-  /** The `MemoryDescriptor` describes the options you can pass to `new WebAssembly.Memory()`. */
+  /** The `MemoryDescriptor` describes the options you can pass to
+   * `new WebAssembly.Memory()`.
+   *
+   * @category WebAssembly
+   */
   export interface MemoryDescriptor {
     initial: number;
     maximum?: number;
     shared?: boolean;
   }
 
-  /** A `ModuleExportDescriptor` is the description of a declared export in a `WebAssembly.Module`. */
+  /** A `ModuleExportDescriptor` is the description of a declared export in a
+   * `WebAssembly.Module`.
+   *
+   * @category WebAssembly
+   */
   export interface ModuleExportDescriptor {
     kind: ImportExportKind;
     name: string;
   }
 
-  /** A `ModuleImportDescriptor` is the description of a declared import in a `WebAssembly.Module`. */
+  /** A `ModuleImportDescriptor` is the description of a declared import in a
+   * `WebAssembly.Module`.
+   *
+   * @category WebAssembly
+   */
   export interface ModuleImportDescriptor {
     kind: ImportExportKind;
     module: string;
     name: string;
   }
 
-  /** The `TableDescriptor` describes the options you can pass to `new WebAssembly.Table()`. */
+  /** The `TableDescriptor` describes the options you can pass to
+   * `new WebAssembly.Table()`.
+   *
+   * @category WebAssembly
+   */
   export interface TableDescriptor {
     element: TableKind;
     initial: number;
     maximum?: number;
   }
 
-  /** The value returned from `WebAssembly.instantiate`. */
+  /** The value returned from `WebAssembly.instantiate`.
+   *
+   * @category WebAssembly
+   */
   export interface WebAssemblyInstantiatedSource {
     /* A `WebAssembly.Instance` object that contains all the exported WebAssembly functions. */
     instance: Instance;
@@ -205,13 +245,21 @@ declare namespace WebAssembly {
     module: Module;
   }
 
+  /** @category WebAssembly */
   export type ImportExportKind = "function" | "global" | "memory" | "table";
+  /** @category WebAssembly */
   export type TableKind = "anyfunc";
+  /** @category WebAssembly */
   export type ValueType = "f32" | "f64" | "i32" | "i64";
+  /** @category WebAssembly */
   export type ExportValue = Function | Global | Memory | Table;
+  /** @category WebAssembly */
   export type Exports = Record<string, ExportValue>;
+  /** @category WebAssembly */
   export type ImportValue = ExportValue | number;
+  /** @category WebAssembly */
   export type ModuleImports = Record<string, ImportValue>;
+  /** @category WebAssembly */
   export type Imports = Record<string, ModuleImports>;
 
   /**
@@ -221,6 +269,8 @@ declare namespace WebAssembly {
    * function should be used).
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compile)
+   *
+   * @category WebAssembly
    */
   export function compile(bytes: BufferSource): Promise<Module>;
 
@@ -231,6 +281,8 @@ declare namespace WebAssembly {
    * `WebAssembly.instantiateStreaming()` function should be used).
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming)
+   *
+   * @category WebAssembly
    */
   export function compileStreaming(
     source: Response | Promise<Response>,
@@ -246,6 +298,8 @@ declare namespace WebAssembly {
    * WebAssembly.Instance.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate)
+   *
+   * @category WebAssembly
    */
   export function instantiate(
     bytes: BufferSource,
@@ -261,6 +315,8 @@ declare namespace WebAssembly {
    * if the Module has already been compiled.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate)
+   *
+   * @category WebAssembly
    */
   export function instantiate(
     moduleObject: Module,
@@ -273,6 +329,8 @@ declare namespace WebAssembly {
    * efficient, optimized way to load wasm code.
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming)
+   *
+   * @category WebAssembly
    */
   export function instantiateStreaming(
     response: Response | PromiseLike<Response>,
@@ -285,6 +343,8 @@ declare namespace WebAssembly {
    * module (`true`) or not (`false`).
    *
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate)
+   *
+   * @category WebAssembly
    */
   export function validate(bytes: BufferSource): boolean;
 }
@@ -295,6 +355,8 @@ declare namespace WebAssembly {
  * ```ts
  * setTimeout(() => { console.log('hello'); }, 500);
  * ```
+ *
+ * @category Timers
  */
 declare function setTimeout(
   /** callback function to execute when timer expires */
@@ -311,6 +373,8 @@ declare function setTimeout(
  * // Outputs 'hello' to the console every 500ms
  * setInterval(() => { console.log('hello'); }, 500);
  * ```
+ *
+ * @category Timers
  */
 declare function setInterval(
   /** callback function to execute when timer expires */
@@ -329,6 +393,8 @@ declare function setInterval(
  * // ...
  * clearInterval(id);
  * ```
+ *
+ * @category Timers
  */
 declare function clearInterval(id?: number): void;
 
@@ -339,9 +405,12 @@ declare function clearInterval(id?: number): void;
  * // ...
  * clearTimeout(id);
  * ```
+ *
+ * @category Timers
  */
 declare function clearTimeout(id?: number): void;
 
+/** @category Scheduling */
 interface VoidFunction {
   (): void;
 }
@@ -355,6 +424,8 @@ interface VoidFunction {
  * ```ts
  * queueMicrotask(() => { console.log('This event loop stack is complete'); });
  * ```
+ *
+ * @category Scheduling
  */
 declare function queueMicrotask(func: VoidFunction): void;
 
@@ -366,9 +437,12 @@ declare function queueMicrotask(func: VoidFunction): void;
  * ```ts
  * dispatchEvent(new Event('unload'));
  * ```
+ *
+ * @category DOM Events
  */
 declare function dispatchEvent(event: Event): boolean;
 
+/** @category DOM */
 interface DOMStringList {
   /** Returns the number of strings in strings. */
   readonly length: number;
@@ -379,10 +453,13 @@ interface DOMStringList {
   [index: number]: string;
 }
 
+/** @category Typed Arrays */
 type BufferSource = ArrayBufferView | ArrayBuffer;
 
+/** @category Console and Debugging */
 declare var console: Console;
 
+/** @category DOM Events */
 interface ErrorEventInit extends EventInit {
   message?: string;
   filename?: string;
@@ -391,6 +468,7 @@ interface ErrorEventInit extends EventInit {
   error?: any;
 }
 
+/** @category DOM Events */
 declare class ErrorEvent extends Event {
   readonly message: string;
   readonly filename: string;
@@ -400,31 +478,37 @@ declare class ErrorEvent extends Event {
   constructor(type: string, eventInitDict?: ErrorEventInit);
 }
 
+/** @category Observability */
 interface PromiseRejectionEventInit extends EventInit {
   promise: Promise<any>;
   reason?: any;
 }
 
+/** @category Observability */
 declare class PromiseRejectionEvent extends Event {
   readonly promise: Promise<any>;
   readonly reason: any;
   constructor(type: string, eventInitDict?: PromiseRejectionEventInit);
 }
 
+/** @category Web Workers */
 interface AbstractWorkerEventMap {
   "error": ErrorEvent;
 }
 
+/** @category Web Workers */
 interface WorkerEventMap extends AbstractWorkerEventMap {
   "message": MessageEvent;
   "messageerror": MessageEvent;
 }
 
+/** @category Web Workers */
 interface WorkerOptions {
   type?: "classic" | "module";
   name?: string;
 }
 
+/** @category Web Workers */
 declare class Worker extends EventTarget {
   onerror?: (e: ErrorEvent) => void;
   onmessage?: (e: MessageEvent) => void;
@@ -458,8 +542,10 @@ declare class Worker extends EventTarget {
   terminate(): void;
 }
 
+/** @category Performance API */
 declare type PerformanceEntryList = PerformanceEntry[];
 
+/** @category Performance API */
 declare class Performance extends EventTarget {
   /** Returns a timestamp representing the start of the performance measurement. */
   readonly timeOrigin: number;
@@ -507,8 +593,10 @@ declare class Performance extends EventTarget {
   toJSON(): any;
 }
 
+/** @category Performance API */
 declare var performance: Performance;
 
+/** @category Performance API */
 declare interface PerformanceMarkOptions {
   /** Metadata to be included in the mark. */
   detail?: any;
@@ -535,7 +623,10 @@ declare interface PerformanceMeasureOptions {
 /** Encapsulates a single performance metric that is part of the performance
  * timeline. A performance entry can be directly created by making a performance
  * mark or measure (for example by calling the `.mark()` method) at an explicit
- * point in an application. */
+ * point in an application.
+ *
+ * @category Performance API
+ */
 declare class PerformanceEntry {
   readonly duration: number;
   readonly entryType: string;
@@ -547,7 +638,10 @@ declare class PerformanceEntry {
 /** `PerformanceMark` is an abstract interface for `PerformanceEntry` objects
  * with an entryType of `"mark"`. Entries of this type are created by calling
  * `performance.mark()` to add a named `DOMHighResTimeStamp` (the mark) to the
- * performance timeline. */
+ * performance timeline.
+ *
+ * @category Performance API
+ */
 declare class PerformanceMark extends PerformanceEntry {
   readonly detail: any;
   readonly entryType: "mark";
@@ -557,16 +651,21 @@ declare class PerformanceMark extends PerformanceEntry {
 /** `PerformanceMeasure` is an abstract interface for `PerformanceEntry` objects
  * with an entryType of `"measure"`. Entries of this type are created by calling
  * `performance.measure()` to add a named `DOMHighResTimeStamp` (the measure)
- * between two marks to the performance timeline. */
+ * between two marks to the performance timeline.
+ *
+ * @category Performance API
+ */
 declare class PerformanceMeasure extends PerformanceEntry {
   readonly detail: any;
   readonly entryType: "measure";
 }
 
+/** @category DOM Events */
 declare interface CustomEventInit<T = any> extends EventInit {
   detail?: T;
 }
 
+/** @category DOM Events */
 declare class CustomEvent<T = any> extends Event {
   constructor(typeArg: string, eventInitDict?: CustomEventInit<T>);
   /** Returns any custom data event was created with. Typically used for

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -6,6 +6,7 @@
 declare namespace Deno {
   export {}; // stop default export type behavior
 
+  /** @category Testing */
   export interface BenchDefinition {
     fn: () => void | Promise<void>;
     name: string;
@@ -62,6 +63,8 @@ declare namespace Deno {
    *   }
    * });
    * ```
+   *
+   * @category Testing
    */
   export function bench(t: BenchDefinition): void;
 
@@ -82,6 +85,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function bench(
     name: string,
@@ -105,6 +110,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function bench(fn: () => void | Promise<void>): void;
 
@@ -125,6 +132,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function bench(
     name: string,
@@ -149,6 +158,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function bench(
     options: Omit<BenchDefinition, "fn">,
@@ -172,6 +183,8 @@ declare namespace Deno {
    *   assertEquals(decoder.decode(data), "Hello world");
    * });
    * ```
+   *
+   * @category Testing
    */
   export function bench(
     options: Omit<BenchDefinition, "fn" | "name">,
@@ -192,6 +205,8 @@ declare namespace Deno {
    * ```
    *
    * NOTE:  This API is not implemented on Windows
+   *
+   * @category File System
    */
   export function umask(mask?: number): number;
 
@@ -202,6 +217,8 @@ declare namespace Deno {
    * ```ts
    * const { columns, rows } = Deno.consoleSize(Deno.stdout.rid);
    * ```
+   *
+   * @category I/O
    */
   export function consoleSize(
     rid: number,
@@ -224,6 +241,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-env` permission.
+   *
+   * @category Observability
    */
   export function loadavg(): number[];
 
@@ -238,6 +257,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-env` permission.
+   *
+   * @category Runtime Environment
    */
   export function osRelease(): string;
 
@@ -253,6 +274,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-env` permission.
+   *
+   * @category Runtime Environment
    */
   export function systemMemoryInfo(): SystemMemoryInfo;
 
@@ -277,7 +300,10 @@ declare namespace Deno {
     swapFree: number;
   }
 
-  /** The information of the network interface */
+  /** The information of the network interface.
+   *
+   * @category Network
+   */
   export interface NetworkInterfaceInfo {
     /** The network interface name */
     name: string;
@@ -304,6 +330,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-env` permission.
+   *
+   * @category Network
    */
   export function networkInterfaces(): NetworkInterfaceInfo[];
 
@@ -316,6 +344,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-env` permission.
+   *
+   * @category Runtime Environment
    */
   export function getUid(): number | null;
 
@@ -328,10 +358,15 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-env` permission.
+   *
+   * @category Runtime Environment
    */
   export function getGid(): number | null;
 
-  /** All plain number types for interfacing with foreign functions */
+  /** All plain number types for interfacing with foreign functions.
+   *
+   * @category FFI
+   */
   type NativeNumberType =
     | "u8"
     | "i8"
@@ -342,7 +377,10 @@ declare namespace Deno {
     | "f32"
     | "f64";
 
-  /** All BigInt number types for interfacing with foreign functions */
+  /** All BigInt number types for interfacing with foreign functions.
+   *
+   * @category FFI
+   */
   type NativeBigIntType =
     | "u64"
     | "i64"
@@ -355,30 +393,44 @@ declare namespace Deno {
 
   type NativeVoidType = "void";
 
-  /** All possible types for interfacing with foreign functions */
+  /** All possible types for interfacing with foreign functions.
+   *
+   * @category FFI
+   */
   export type NativeType =
     | NativeNumberType
     | NativeBigIntType
     | NativePointerType
     | NativeFunctionType;
 
+  /** @category FFI */
   export type NativeResultType = NativeType | NativeVoidType;
 
+  /** @category FFI */
   type ToNativeTypeMap =
     & Record<NativeNumberType, number>
     & Record<NativeBigIntType, PointerValue>
     & Record<NativePointerType, TypedArray | PointerValue | null>
     & Record<NativeFunctionType, PointerValue | null>;
 
-  /** Type conversion for foreign symbol parameters and unsafe callback return types */
+  /** Type conversion for foreign symbol parameters and unsafe callback return
+   * types.
+   *
+   * @category FFI
+   */
   type ToNativeType<T extends NativeType = NativeType> = ToNativeTypeMap[T];
 
+  /** @category FFI */
   type ToNativeResultTypeMap = ToNativeTypeMap & Record<NativeVoidType, void>;
 
-  /** Type conversion for unsafe callback return types */
+  /** Type conversion for unsafe callback return types.
+   *
+   * @category FFI
+   */
   type ToNativeResultType<T extends NativeResultType = NativeResultType> =
     ToNativeResultTypeMap[T];
 
+  /** @category FFI */
   type ToNativeParameterTypes<T extends readonly NativeType[]> =
     //
     [(T[number])[]] extends [T] ? ToNativeType<T[number]>[]
@@ -389,23 +441,33 @@ declare namespace Deno {
         }
       : never;
 
+  /** @category FFI */
   type FromNativeTypeMap =
     & Record<NativeNumberType, number>
     & Record<NativeBigIntType, PointerValue>
     & Record<NativePointerType, PointerValue>
     & Record<NativeFunctionType, PointerValue>;
 
-  /** Type conversion for foreign symbol return types and unsafe callback parameters */
+  /** Type conversion for foreign symbol return types and unsafe callback
+   * parameters.
+   *
+   * @category FFI
+   */
   type FromNativeType<T extends NativeType = NativeType> = FromNativeTypeMap[T];
 
+  /** @category FFI */
   type FromNativeResultTypeMap =
     & FromNativeTypeMap
     & Record<NativeVoidType, void>;
 
-  /** Type conversion for foregin symbol return types */
+  /** Type conversion for foreign symbol return types.
+   *
+   * @category FFI
+   */
   type FromNativeResultType<T extends NativeResultType = NativeResultType> =
     FromNativeResultTypeMap[T];
 
+  /** @category FFI */
   type FromNativeParameterTypes<
     T extends readonly NativeType[],
   > =
@@ -418,7 +480,10 @@ declare namespace Deno {
         }
       : never;
 
-  /** A foreign function as defined by its parameter and result types */
+  /** A foreign function as defined by its parameter and result types.
+   *
+   * @category FFI
+   */
   export interface ForeignFunction<
     Parameters extends readonly NativeType[] = readonly NativeType[],
     Result extends NativeResultType = NativeResultType,
@@ -434,40 +499,54 @@ declare namespace Deno {
     callback?: boolean;
   }
 
+  /** @category FFI */
   export interface ForeignStatic<Type extends NativeType = NativeType> {
     /** Name of the symbol, defaults to the key name in symbols object. */
     name?: string;
     type: Type;
   }
 
-  /** A foreign library interface descriptor */
+  /** A foreign library interface descriptor.
+   *
+   * @category FFI
+   */
   export interface ForeignLibraryInterface {
     [name: string]: ForeignFunction | ForeignStatic;
   }
 
-  /** Infers a foreign symbol */
+  /** Infers a foreign symbol.
+   *
+   * @category FFI
+   */
   type StaticForeignSymbol<T extends ForeignFunction | ForeignStatic> =
     T extends ForeignFunction ? FromForeignFunction<T>
       : T extends ForeignStatic ? FromNativeType<T["type"]>
       : never;
 
+  /** @category FFI */
   type FromForeignFunction<T extends ForeignFunction> = T["parameters"] extends
     readonly [] ? () => StaticForeignSymbolReturnType<T>
     : (
       ...args: ToNativeParameterTypes<T["parameters"]>
     ) => StaticForeignSymbolReturnType<T>;
 
+  /** @category FFI */
   type StaticForeignSymbolReturnType<T extends ForeignFunction> =
     ConditionalAsync<T["nonblocking"], FromNativeResultType<T["result"]>>;
 
+  /** @category FFI */
   type ConditionalAsync<IsAsync extends boolean | undefined, T> =
     IsAsync extends true ? Promise<T> : T;
 
-  /** Infers a foreign library interface */
+  /** Infers a foreign library interface.
+   *
+   * @category FFI
+   */
   type StaticForeignLibraryInterface<T extends ForeignLibraryInterface> = {
     [K in keyof T]: StaticForeignSymbol<T[K]>;
   };
 
+  /** @category FFI */
   type TypedArray =
     | Int8Array
     | Uint8Array
@@ -487,12 +566,17 @@ declare namespace Deno {
    * On a 32 bit system all pointer values are plain numbers. On a 64 bit
    * system pointer values are represented as numbers if the value is below
    * `Number.MAX_SAFE_INTEGER`.
+   *
+   * @category FFI
    */
   export type PointerValue = number | bigint;
 
   /** **UNSTABLE**: Unsafe and new API, beware!
    *
-   * An unsafe pointer to a memory location for passing and returning pointers to and from the ffi
+   * An unsafe pointer to a memory location for passing and returning pointers
+   * to and from the FFI.
+   *
+   * @category FFI
    */
   export class UnsafePointer {
     /**
@@ -507,6 +591,8 @@ declare namespace Deno {
    * value. The `UnsafePointerView` API mimics the standard built in interface
    * `DataView` for accessing the underlying types at an memory location
    * (numbers, strings and raw bytes).
+   *
+   * @category FFI
    */
   export class UnsafePointerView {
     constructor(pointer: bigint);
@@ -560,6 +646,8 @@ declare namespace Deno {
    *
    * An unsafe pointer to a function, for calling functions that are not
    * present as symbols.
+   *
+   * @category FFI
    */
   export class UnsafeFnPointer<Fn extends ForeignFunction> {
     pointer: bigint;
@@ -595,6 +683,8 @@ declare namespace Deno {
    *
    * The callback can be explicitly ref'ed and deref'ed to stop Deno's
    * process from exiting.
+   *
+   * @category FFI
    */
   export class UnsafeCallback<
     Definition extends UnsafeCallbackDefinition = UnsafeCallbackDefinition,
@@ -651,56 +741,15 @@ declare namespace Deno {
   /** **UNSTABLE**: Unsafe and new API, beware!
    *
    * Opens a dynamic library and registers symbols
+   *
+   * @category FFI
    */
   export function dlopen<S extends ForeignLibraryInterface>(
     filename: string | URL,
     symbols: S,
   ): DynamicLibrary<S>;
 
-  /** The log category for a diagnostic message. */
-  export enum DiagnosticCategory {
-    Warning = 0,
-    Error = 1,
-    Suggestion = 2,
-    Message = 3,
-  }
-
-  export interface DiagnosticMessageChain {
-    messageText: string;
-    category: DiagnosticCategory;
-    code: number;
-    next?: DiagnosticMessageChain[];
-  }
-
-  export interface Diagnostic {
-    /** A string message summarizing the diagnostic. */
-    messageText?: string;
-    /** An ordered array of further diagnostics. */
-    messageChain?: DiagnosticMessageChain;
-    /** Information related to the diagnostic. This is present when there is a
-     * suggestion or other additional diagnostic information */
-    relatedInformation?: Diagnostic[];
-    /** The text of the source line related to the diagnostic. */
-    sourceLine?: string;
-    source?: string;
-    /** The start position of the error. Zero based index. */
-    start?: {
-      line: number;
-      character: number;
-    };
-    /** The end position of the error.  Zero based index. */
-    end?: {
-      line: number;
-      character: number;
-    };
-    /** The filename of the resource related to the diagnostic message. */
-    fileName?: string;
-    /** The category of the diagnostic. */
-    category: DiagnosticCategory;
-    /** A number identifier. */
-    code: number;
-  }
-
+  /** @category I/O */
   export type SetRawOptions = {
     cbreak: boolean;
   };
@@ -720,6 +769,8 @@ declare namespace Deno {
    * ```ts
    * Deno.setRaw(Deno.stdin.rid, true, { cbreak: true });
    * ```
+   *
+   * @category I/O
    */
   export function setRaw(
     rid: number,
@@ -737,7 +788,10 @@ declare namespace Deno {
    * Deno.utimeSync("myfile.txt", 1556495550, new Date());
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function utimeSync(
     path: string | URL,
     atime: number | Date,
@@ -754,13 +808,17 @@ declare namespace Deno {
    * await Deno.utime("myfile.txt", 1556495550, new Date());
    * ```
    *
-   * Requires `allow-write` permission. */
+   * Requires `allow-write` permission.
+   *
+   * @category File System
+   */
   export function utime(
     path: string | URL,
     atime: number | Date,
     mtime: number | Date,
   ): Promise<void>;
 
+  /** @category Sub Process */
   export function run<
     T extends RunOptions & {
       clearEnv?: boolean;
@@ -783,6 +841,8 @@ declare namespace Deno {
    * ```
    *
    *  Requires `allow-env` permission.
+   *
+   * @category Runtime Environment
    */
   export function hostname(): string;
 
@@ -794,6 +854,8 @@ declare namespace Deno {
    * const client = Deno.createHttpClient({ caCerts: [ caCert ] });
    * const req = await fetch("https://myserver.com", { client });
    * ```
+   *
+   * @category Fetch API
    */
   export class HttpClient {
     rid: number;
@@ -802,6 +864,8 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    * The options used when creating a [HttpClient].
+   *
+   * @category Fetch API
    */
   export interface CreateHttpClientOptions {
     /** A list of root certificates that will be used in addition to the
@@ -817,11 +881,13 @@ declare namespace Deno {
     privateKey?: string;
   }
 
+  /** @category Fetch API */
   export interface Proxy {
     url: string;
     basicAuth?: BasicAuth;
   }
 
+  /** @category Fetch API */
   export interface BasicAuth {
     username: string;
     password: string;
@@ -840,6 +906,8 @@ declare namespace Deno {
    * const client = Deno.createHttpClient({ proxy: { url: "http://myproxy.com:8080" } });
    * const response = await fetch("https://myserver.com", { client });
    * ```
+   *
+   * @category Fetch API
    */
   export function createHttpClient(
     options: CreateHttpClientOptions,
@@ -855,6 +923,8 @@ declare namespace Deno {
    * const file = Deno.openSync("file.txt", { create: true, write: true });
    * Deno.futimeSync(file.rid, 1556495550, new Date());
    * ```
+   *
+   * @category File System
    */
   export function futimeSync(
     rid: number,
@@ -872,6 +942,8 @@ declare namespace Deno {
    * const file = await Deno.open("file.txt", { create: true, write: true });
    * await Deno.futime(file.rid, 1556495550, new Date());
    * ```
+   *
+   * @category File System
    */
   export function futime(
     rid: number,
@@ -881,7 +953,10 @@ declare namespace Deno {
 
   /** **UNSTABLE**: new API, yet to be vetted.
    *
-   * A generic transport listener for message-oriented protocols. */
+   * A generic transport listener for message-oriented protocols.
+   *
+   * @category Network
+   */
   export interface DatagramConn extends AsyncIterable<[Uint8Array, Addr]> {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
@@ -901,6 +976,7 @@ declare namespace Deno {
     [Symbol.asyncIterator](): AsyncIterableIterator<[Uint8Array, Addr]>;
   }
 
+  /** @category Network */
   export interface UnixListenOptions {
     /** A Path to the Unix Socket. */
     path: string;
@@ -914,7 +990,10 @@ declare namespace Deno {
    * const listener = Deno.listen({ path: "/foo/bar.sock", transport: "unix" })
    * ```
    *
-   * Requires `allow-read` and `allow-write` permission. */
+   * Requires `allow-read` and `allow-write` permission.
+   *
+   * @category Network
+   */
   export function listen(
     options: UnixListenOptions & { transport: "unix" },
   ): Listener;
@@ -935,7 +1014,10 @@ declare namespace Deno {
    * });
    * ```
    *
-   * Requires `allow-net` permission. */
+   * Requires `allow-net` permission.
+   *
+   * @category Network
+   */
   export function listenDatagram(
     options: ListenOptions & { transport: "udp" },
   ): DatagramConn;
@@ -951,7 +1033,10 @@ declare namespace Deno {
    * });
    * ```
    *
-   * Requires `allow-read` and `allow-write` permission. */
+   * Requires `allow-read` and `allow-write` permission.
+   *
+   * @category Network
+   */
   export function listenDatagram(
     options: UnixListenOptions & { transport: "unixpacket" },
   ): DatagramConn;
@@ -975,7 +1060,10 @@ declare namespace Deno {
    * const conn5 = await Deno.connect({ path: "/foo/bar.sock", transport: "unix" });
    * ```
    *
-   * Requires `allow-net` permission for "tcp" and `allow-read` for "unix". */
+   * Requires `allow-net` permission for "tcp" and `allow-read` for "unix".
+   *
+   * @category Network
+   */
   export function connect(
     options: ConnectOptions,
   ): Promise<TcpConn>;
@@ -997,6 +1085,7 @@ declare namespace Deno {
     alpnProtocols?: string[];
   }
 
+  /** @category Network */
   export interface TlsHandshakeInfo {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
@@ -1006,6 +1095,7 @@ declare namespace Deno {
     alpnProtocol: string | null;
   }
 
+  /** @category Network */
   export interface TlsConn extends Conn {
     /** Runs the client or server handshake protocol to completion if that has
      * not happened yet. Calling this method is optional; the TLS handshake
@@ -1027,9 +1117,12 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-net` permission.
+   *
+   * @category Network
    */
   export function connectTls(options: ConnectTlsOptions): Promise<TlsConn>;
 
+  /** @category Network */
   export interface ListenTlsOptions {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
@@ -1040,6 +1133,7 @@ declare namespace Deno {
     alpnProtocols?: string[];
   }
 
+  /** @category Network */
   export interface StartTlsOptions {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
@@ -1050,6 +1144,7 @@ declare namespace Deno {
     alpnProtocols?: string[];
   }
 
+  /** @category Network */
   export interface Listener extends AsyncIterable<Conn> {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
@@ -1070,6 +1165,8 @@ declare namespace Deno {
    *
    * Acquire an advisory file-system lock for the provided file. `exclusive`
    * defaults to `false`.
+   *
+   * @category File System
    */
   export function flock(rid: number, exclusive?: boolean): Promise<void>;
 
@@ -1077,24 +1174,32 @@ declare namespace Deno {
    *
    * Acquire an advisory file-system lock for the provided file. `exclusive`
    * defaults to `false`.
+   *
+   * @category File System
    */
   export function flockSync(rid: number, exclusive?: boolean): void;
 
   /** **UNSTABLE**: New API should be tested first.
    *
    * Release an advisory file-system lock for the provided file.
+   *
+   * @category File System
    */
   export function funlock(rid: number): Promise<void>;
 
   /** **UNSTABLE**: New API should be tested first.
    *
    * Release an advisory file-system lock for the provided file.
+   *
+   * @category File System
    */
   export function funlockSync(rid: number): void;
 
   /** **UNSTABLE**: new API, yet to be vetted.
    *
-   * Make the timer of the given id blocking the event loop from finishing
+   * Make the timer of the given id blocking the event loop from finishing.
+   *
+   * @category
    */
   export function refTimer(id: number): void;
 
@@ -1104,7 +1209,7 @@ declare namespace Deno {
    */
   export function unrefTimer(id: number): void;
 
-  /** **UNSTABLE**: new API, yet to be vetter.
+  /** **UNSTABLE**: new API, yet to be vetted.
    *
    * Allows to "hijack" a connection that the request is associated with.
    * Can be used to implement protocols that build on top of HTTP (eg.
@@ -1113,11 +1218,14 @@ declare namespace Deno {
    * The returned promise returns underlying connection and first packet
    * received. The promise shouldn't be awaited before responding to the
    * `request`, otherwise event loop might deadlock.
+   *
+   * @category HTTP Server
    */
   export function upgradeHttp(
     request: Request,
   ): Promise<[Deno.Conn, Uint8Array]>;
 
+  /** @category Sub Process */
   export interface SpawnOptions {
     /** Arguments to pass to the process. */
     args?: string[];
@@ -1181,12 +1289,15 @@ declare namespace Deno {
    * child.stdin.close();
    * const status = await child.status;
    * ```
+   *
+   * @category Sub Process
    */
   export function spawnChild(
     command: string | URL,
     options?: SpawnOptions,
   ): Child;
 
+  /** @category Sub Process */
   export class Child {
     get stdin(): WritableStream<Uint8Array>;
     get stdout(): ReadableStream<Uint8Array>;
@@ -1223,6 +1334,8 @@ declare namespace Deno {
    * console.assert("hello\n" === new TextDecoder().decode(stdout));
    * console.assert("world\n" === new TextDecoder().decode(stderr));
    * ```
+   *
+   * @category Sub Process
    */
   export function spawn(
     command: string | URL,
@@ -1248,6 +1361,8 @@ declare namespace Deno {
    * console.assert("hello\n" === new TextDecoder().decode(stdout));
    * console.assert("world\n" === new TextDecoder().decode(stderr));
    * ```
+   *
+   * @category Sub Process
    */
   export function spawnSync(
     command: string | URL,
@@ -1266,11 +1381,13 @@ declare namespace Deno {
   }
 }
 
+/** @category Fetch API */
 declare function fetch(
   input: Request | URL | string,
   init?: RequestInit & { client: Deno.HttpClient },
 ): Promise<Response>;
 
+/** @category Web Workers */
 declare interface WorkerOptions {
   /** UNSTABLE: New API.
    *
@@ -1304,12 +1421,14 @@ declare interface WorkerOptions {
   };
 }
 
+/** @category Web Sockets */
 declare interface WebSocketStreamOptions {
   protocols?: string[];
   signal?: AbortSignal;
   headers?: HeadersInit;
 }
 
+/** @category Web Sockets */
 declare interface WebSocketConnection {
   readable: ReadableStream<string | Uint8Array>;
   writable: WritableStream<string | Uint8Array>;
@@ -1317,11 +1436,13 @@ declare interface WebSocketConnection {
   protocol: string;
 }
 
+/** @category Web Sockets */
 declare interface WebSocketCloseInfo {
   code?: number;
   reason?: string;
 }
 
+/** @category Web Sockets */
 declare class WebSocketStream {
   constructor(url: string, options?: WebSocketStreamOptions);
   url: string;

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1199,13 +1199,15 @@ declare namespace Deno {
    *
    * Make the timer of the given id blocking the event loop from finishing.
    *
-   * @category
+   * @category Timers
    */
   export function refTimer(id: number): void;
 
   /** **UNSTABLE**: new API, yet to be vetted.
    *
-   * Make the timer of the given id not blocking the event loop from finishing
+   * Make the timer of the given id not blocking the event loop from finishing.
+   *
+   * @category Timers
    */
   export function unrefTimer(id: number): void;
 

--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -7,11 +7,13 @@
 /// <reference lib="deno.webstorage" />
 /// <reference lib="esnext" />
 
+/** @category Web APIs */
 interface WindowEventMap {
   "error": ErrorEvent;
   "unhandledrejection": PromiseRejectionEvent;
 }
 
+/** @category Web APIs */
 declare class Window extends EventTarget {
   new(): Window;
   readonly window: Window & typeof globalThis;
@@ -63,17 +65,26 @@ declare class Window extends EventTarget {
   ): void;
 }
 
+/** @category Web APIs */
 declare var window: Window & typeof globalThis;
+/** @category Web APIs */
 declare var self: Window & typeof globalThis;
+/** @category DOM Events */
 declare var onerror: ((this: Window, ev: ErrorEvent) => any) | null;
+/** @category DOM Events */
 declare var onload: ((this: Window, ev: Event) => any) | null;
+/** @category DOM Events */
 declare var onunload: ((this: Window, ev: Event) => any) | null;
+/** @category Observability */
 declare var onunhandledrejection:
   | ((this: Window, ev: PromiseRejectionEvent) => any)
   | null;
+/** @category Web Storage API */
 declare var localStorage: Storage;
+/** @category Web Storage API */
 declare var sessionStorage: Storage;
 
+/** @category Web APIs */
 declare class Navigator {
   constructor();
   readonly gpu: GPU;
@@ -81,29 +92,45 @@ declare class Navigator {
   readonly userAgent: string;
 }
 
+/** @category Web APIs */
 declare var navigator: Navigator;
 
 /**
  * Shows the given message and waits for the enter key pressed.
+ *
  * If the stdin is not interactive, it does nothing.
+ *
+ * @category Web APIs
+ *
  * @param message
  */
 declare function alert(message?: string): void;
 
 /**
  * Shows the given message and waits for the answer. Returns the user's answer as boolean.
+ *
  * Only `y` and `Y` are considered as true.
+ *
  * If the stdin is not interactive, it returns false.
+ *
+ * @category Web APIs
+ *
  * @param message
  */
 declare function confirm(message?: string): boolean;
 
 /**
  * Shows the given message and waits for the user's input. Returns the user's input as string.
+ *
  * If the default value is given and the user inputs the empty string, then it returns the given
  * default value.
+ *
  * If the default value is not given and the user inputs the empty string, it returns null.
+ *
  * If the stdin is not interactive, it returns null.
+ *
+ * @category Web APIs
+ *
  * @param message
  * @param defaultValue
  */
@@ -117,6 +144,8 @@ declare function prompt(message?: string, defaultValue?: string): string | null;
  * ...
  * dispatchEvent(new Event('unload'));
  * ```
+ *
+ * @category DOM Events
  */
 declare function addEventListener<
   K extends keyof WindowEventMap,
@@ -125,6 +154,7 @@ declare function addEventListener<
   listener: (this: Window, ev: WindowEventMap[K]) => any,
   options?: boolean | AddEventListenerOptions,
 ): void;
+/** @category DOM Events */
 declare function addEventListener(
   type: string,
   listener: EventListenerOrEventListenerObject,
@@ -138,6 +168,8 @@ declare function addEventListener(
  * addEventListener('load', listener);
  * removeEventListener('load', listener);
  * ```
+ *
+ * @category DOM Events
  */
 declare function removeEventListener<
   K extends keyof WindowEventMap,
@@ -156,7 +188,10 @@ declare function removeEventListener(
 // The types there must first be split into window, worker and global types.
 /** The location (URL) of the object it is linked to. Changes done on it are
  * reflected on the object it relates to. Accessible via
- * `globalThis.location`. */
+ * `globalThis.location`.
+ *
+ * @category Web APIs
+ */
 declare class Location {
   constructor();
   /** Returns a DOMStringList object listing the origins of the ancestor
@@ -222,4 +257,5 @@ declare class Location {
 
 // TODO(nayeemrmn): Move this to `extensions/web` where its implementation is.
 // The types there must first be split into window, worker and global types.
+/** @category Web APIs */
 declare var location: Location;

--- a/cli/dts/lib.deno.worker.d.ts
+++ b/cli/dts/lib.deno.worker.d.ts
@@ -6,11 +6,13 @@
 /// <reference lib="deno.webgpu" />
 /// <reference lib="esnext" />
 
+/** @category Web Workers */
 interface WorkerGlobalScopeEventMap {
   "error": ErrorEvent;
   "unhandledrejection": PromiseRejectionEvent;
 }
 
+/** @category Web Workers */
 declare class WorkerGlobalScope extends EventTarget {
   readonly location: WorkerLocation;
   readonly navigator: WorkerNavigator;
@@ -51,6 +53,7 @@ declare class WorkerGlobalScope extends EventTarget {
   Deno: typeof Deno;
 }
 
+/** @category Web APIs */
 declare class WorkerNavigator {
   constructor();
   readonly gpu: GPU;
@@ -58,13 +61,16 @@ declare class WorkerNavigator {
   readonly userAgent: string;
 }
 
+/** @category Web APIs */
 declare var navigator: WorkerNavigator;
 
+/** @category Web Workers */
 interface DedicatedWorkerGlobalScopeEventMap extends WorkerGlobalScopeEventMap {
   "message": MessageEvent;
   "messageerror": MessageEvent;
 }
 
+/** @category Web APIs */
 declare class DedicatedWorkerGlobalScope extends WorkerGlobalScope {
   readonly name: string;
   onmessage:
@@ -104,27 +110,38 @@ declare class DedicatedWorkerGlobalScope extends WorkerGlobalScope {
   ): void;
 }
 
+/** @category Web Workers */
 declare var name: string;
+/** @category Web Workers */
 declare var onmessage:
   | ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any)
   | null;
+/** @category Web Workers */
 declare var onmessageerror:
   | ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any)
   | null;
+/** @category Web Workers */
 declare function close(): void;
+/** @category Web Workers */
 declare function postMessage(message: any, transfer: Transferable[]): void;
+/** @category Web Workers */
 declare function postMessage(
   message: any,
   options?: StructuredSerializeOptions,
 ): void;
+/** @category Web APIs */
 declare var navigator: WorkerNavigator;
+/** @category Web APIs */
 declare var onerror:
   | ((this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any)
   | null;
+/** @category Observability */
 declare var onunhandledrejection:
   | ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any)
   | null;
+/** @category Web Workers */
 declare var self: WorkerGlobalScope & typeof globalThis;
+/** @category DOM Events */
 declare function addEventListener<
   K extends keyof DedicatedWorkerGlobalScopeEventMap,
 >(
@@ -135,11 +152,13 @@ declare function addEventListener<
   ) => any,
   options?: boolean | AddEventListenerOptions,
 ): void;
+/** @category DOM Events */
 declare function addEventListener(
   type: string,
   listener: EventListenerOrEventListenerObject,
   options?: boolean | AddEventListenerOptions,
 ): void;
+/** @category DOM Events */
 declare function removeEventListener<
   K extends keyof DedicatedWorkerGlobalScopeEventMap,
 >(
@@ -150,6 +169,7 @@ declare function removeEventListener<
   ) => any,
   options?: boolean | EventListenerOptions,
 ): void;
+/** @category DOM Events */
 declare function removeEventListener(
   type: string,
   listener: EventListenerOrEventListenerObject,
@@ -160,7 +180,10 @@ declare function removeEventListener(
 // The types there must first be split into window, worker and global types.
 /** The absolute location of the script executed by the Worker. Such an object
  * is initialized for each worker and is available via the
- * WorkerGlobalScope.location property obtained by calling self.location. */
+ * WorkerGlobalScope.location property obtained by calling self.location.
+ *
+ * @category Web APIs
+ */
 declare class WorkerLocation {
   constructor();
   readonly hash: string;
@@ -177,4 +200,5 @@ declare class WorkerLocation {
 
 // TODO(nayeemrmn): Move this to `extensions/web` where its implementation is.
 // The types there must first be split into window, worker and global types.
+/** @category Web APIs */
 declare var location: WorkerLocation;

--- a/cli/dts/lib.deno_webgpu.d.ts
+++ b/cli/dts/lib.deno_webgpu.d.ts
@@ -5,14 +5,17 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category WebGPU */
 interface GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUObjectDescriptorBase {
   label?: string;
 }
 
+/** @category WebGPU */
 declare class GPUSupportedLimits {
   maxTextureDimension1D?: number;
   maxTextureDimension2D?: number;
@@ -42,6 +45,7 @@ declare class GPUSupportedLimits {
   maxComputeWorkgroupsPerDimension?: number;
 }
 
+/** @category WebGPU */
 declare class GPUSupportedFeatures {
   forEach(
     callbackfn: (
@@ -62,6 +66,7 @@ declare class GPUSupportedFeatures {
   values(): IterableIterator<GPUFeatureName>;
 }
 
+/** @category WebGPU */
 declare class GPUAdapterInfo {
   readonly vendor: string;
   readonly architecture: string;
@@ -69,6 +74,7 @@ declare class GPUAdapterInfo {
   readonly description: string;
 }
 
+/** @category WebGPU */
 declare class GPU {
   requestAdapter(
     options?: GPURequestAdapterOptions,
@@ -80,8 +86,10 @@ declare interface GPURequestAdapterOptions {
   forceFallbackAdapter?: boolean;
 }
 
+/** @category WebGPU */
 declare type GPUPowerPreference = "low-power" | "high-performance";
 
+/** @category WebGPU */
 declare class GPUAdapter {
   readonly features: GPUSupportedFeatures;
   readonly limits: GPUSupportedLimits;
@@ -91,11 +99,13 @@ declare class GPUAdapter {
   requestAdapterInfo(unmaskHints?: string[]): Promise<GPUAdapterInfo>;
 }
 
+/** @category WebGPU */
 declare interface GPUDeviceDescriptor extends GPUObjectDescriptorBase {
   requiredFeatures?: GPUFeatureName[];
   requiredLimits?: Record<string, number>;
 }
 
+/** @category WebGPU */
 declare type GPUFeatureName =
   | "depth-clip-control"
   | "depth24unorm-stencil8"
@@ -121,6 +131,7 @@ declare type GPUFeatureName =
   | "shader-float64"
   | "vertex-attribute-64bit";
 
+/** @category WebGPU */
 declare class GPUDevice extends EventTarget implements GPUObjectBase {
   label: string;
 
@@ -173,6 +184,7 @@ declare class GPUDevice extends EventTarget implements GPUObjectBase {
   createQuerySet(descriptor: GPUQuerySetDescriptor): GPUQuerySet;
 }
 
+/** @category WebGPU */
 declare class GPUBuffer implements GPUObjectBase {
   label: string;
 
@@ -187,13 +199,17 @@ declare class GPUBuffer implements GPUObjectBase {
   destroy(): undefined;
 }
 
+/** @category WebGPU */
 declare interface GPUBufferDescriptor extends GPUObjectDescriptorBase {
   size: number;
   usage: GPUBufferUsageFlags;
   mappedAtCreation?: boolean;
 }
 
+/** @category WebGPU */
 declare type GPUBufferUsageFlags = number;
+
+/** @category WebGPU */
 declare class GPUBufferUsage {
   static MAP_READ: 0x0001;
   static MAP_WRITE: 0x0002;
@@ -207,12 +223,16 @@ declare class GPUBufferUsage {
   static QUERY_RESOLVE: 0x0200;
 }
 
+/** @category WebGPU */
 declare type GPUMapModeFlags = number;
+
+/** @category WebGPU */
 declare class GPUMapMode {
   static READ: 0x0001;
   static WRITE: 0x0002;
 }
 
+/** @category WebGPU */
 declare class GPUTexture implements GPUObjectBase {
   label: string;
 
@@ -220,6 +240,7 @@ declare class GPUTexture implements GPUObjectBase {
   destroy(): undefined;
 }
 
+/** @category WebGPU */
 declare interface GPUTextureDescriptor extends GPUObjectDescriptorBase {
   size: GPUExtent3D;
   mipLevelCount?: number;
@@ -229,9 +250,13 @@ declare interface GPUTextureDescriptor extends GPUObjectDescriptorBase {
   usage: GPUTextureUsageFlags;
 }
 
+/** @category WebGPU */
 declare type GPUTextureDimension = "1d" | "2d" | "3d";
 
+/** @category WebGPU */
 declare type GPUTextureUsageFlags = number;
+
+/** @category WebGPU */
 declare class GPUTextureUsage {
   static COPY_SRC: 0x01;
   static COPY_DST: 0x02;
@@ -240,10 +265,12 @@ declare class GPUTextureUsage {
   static RENDER_ATTACHMENT: 0x10;
 }
 
+/** @category WebGPU */
 declare class GPUTextureView implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUTextureViewDescriptor extends GPUObjectDescriptorBase {
   format?: GPUTextureFormat;
   dimension?: GPUTextureViewDimension;
@@ -254,6 +281,7 @@ declare interface GPUTextureViewDescriptor extends GPUObjectDescriptorBase {
   arrayLayerCount?: number;
 }
 
+/** @category WebGPU */
 declare type GPUTextureViewDimension =
   | "1d"
   | "2d"
@@ -262,8 +290,10 @@ declare type GPUTextureViewDimension =
   | "cube-array"
   | "3d";
 
+/** @category WebGPU */
 declare type GPUTextureAspect = "all" | "stencil-only" | "depth-only";
 
+/** @category WebGPU */
 declare type GPUTextureFormat =
   | "r8unorm"
   | "r8snorm"
@@ -361,10 +391,12 @@ declare type GPUTextureFormat =
   | "astc-12x12-unorm"
   | "astc-12x12-unorm-srgb";
 
+/** @category WebGPU */
 declare class GPUSampler implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUSamplerDescriptor extends GPUObjectDescriptorBase {
   addressModeU?: GPUAddressMode;
   addressModeV?: GPUAddressMode;
@@ -378,12 +410,16 @@ declare interface GPUSamplerDescriptor extends GPUObjectDescriptorBase {
   maxAnisotropy?: number;
 }
 
+/** @category WebGPU */
 declare type GPUAddressMode = "clamp-to-edge" | "repeat" | "mirror-repeat";
 
+/** @category WebGPU */
 declare type GPUFilterMode = "nearest" | "linear";
 
+/** @category WebGPU */
 declare type GPUMipmapFilterMode = "nearest" | "linear";
 
+/** @category WebGPU */
 declare type GPUCompareFunction =
   | "never"
   | "less"
@@ -394,14 +430,17 @@ declare type GPUCompareFunction =
   | "greater-equal"
   | "always";
 
+/** @category WebGPU */
 declare class GPUBindGroupLayout implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUBindGroupLayoutDescriptor extends GPUObjectDescriptorBase {
   entries: GPUBindGroupLayoutEntry[];
 }
 
+/** @category WebGPU */
 declare interface GPUBindGroupLayoutEntry {
   binding: number;
   visibility: GPUShaderStageFlags;
@@ -412,36 +451,45 @@ declare interface GPUBindGroupLayoutEntry {
   storageTexture?: GPUStorageTextureBindingLayout;
 }
 
+/** @category WebGPU */
 declare type GPUShaderStageFlags = number;
+
+/** @category WebGPU */
 declare class GPUShaderStage {
   static VERTEX: 0x1;
   static FRAGMENT: 0x2;
   static COMPUTE: 0x4;
 }
 
+/** @category WebGPU */
 declare interface GPUBufferBindingLayout {
   type?: GPUBufferBindingType;
   hasDynamicOffset?: boolean;
   minBindingSize?: number;
 }
 
+/** @category WebGPU */
 declare type GPUBufferBindingType = "uniform" | "storage" | "read-only-storage";
 
+/** @category WebGPU */
 declare interface GPUSamplerBindingLayout {
   type?: GPUSamplerBindingType;
 }
 
+/** @category WebGPU */
 declare type GPUSamplerBindingType =
   | "filtering"
   | "non-filtering"
   | "comparison";
 
+/** @category WebGPU */
 declare interface GPUTextureBindingLayout {
   sampleType?: GPUTextureSampleType;
   viewDimension?: GPUTextureViewDimension;
   multisampled?: boolean;
 }
 
+/** @category WebGPU */
 declare type GPUTextureSampleType =
   | "float"
   | "unfilterable-float"
@@ -449,49 +497,60 @@ declare type GPUTextureSampleType =
   | "sint"
   | "uint";
 
+/** @category WebGPU */
 declare type GPUStorageTextureAccess = "write-only";
 
+/** @category WebGPU */
 declare interface GPUStorageTextureBindingLayout {
   access: GPUStorageTextureAccess;
   format: GPUTextureFormat;
   viewDimension?: GPUTextureViewDimension;
 }
 
+/** @category WebGPU */
 declare class GPUBindGroup implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUBindGroupDescriptor extends GPUObjectDescriptorBase {
   layout: GPUBindGroupLayout;
   entries: GPUBindGroupEntry[];
 }
 
+/** @category WebGPU */
 declare type GPUBindingResource =
   | GPUSampler
   | GPUTextureView
   | GPUBufferBinding;
 
+/** @category WebGPU */
 declare interface GPUBindGroupEntry {
   binding: number;
   resource: GPUBindingResource;
 }
 
+/** @category WebGPU */
 declare interface GPUBufferBinding {
   buffer: GPUBuffer;
   offset?: number;
   size?: number;
 }
 
+/** @category WebGPU */
 declare class GPUPipelineLayout implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUPipelineLayoutDescriptor extends GPUObjectDescriptorBase {
   bindGroupLayouts: GPUBindGroupLayout[];
 }
 
+/** @category WebGPU */
 declare type GPUCompilationMessageType = "error" | "warning" | "info";
 
+/** @category WebGPU */
 declare interface GPUCompilationMessage {
   readonly message: string;
   readonly type: GPUCompilationMessageType;
@@ -499,53 +558,64 @@ declare interface GPUCompilationMessage {
   readonly linePos: number;
 }
 
+/** @category WebGPU */
 declare interface GPUCompilationInfo {
   readonly messages: ReadonlyArray<GPUCompilationMessage>;
 }
 
+/** @category WebGPU */
 declare class GPUShaderModule implements GPUObjectBase {
   label: string;
 
   compilationInfo(): Promise<GPUCompilationInfo>;
 }
 
+/** @category WebGPU */
 declare interface GPUShaderModuleDescriptor extends GPUObjectDescriptorBase {
   code: string;
   sourceMap?: any;
 }
 
+/** @category WebGPU */
 declare type GPUAutoLayoutMode = "auto";
 
+/** @category WebGPU */
 declare interface GPUPipelineDescriptorBase extends GPUObjectDescriptorBase {
   layout: GPUPipelineLayout | GPUAutoLayoutMode;
 }
 
+/** @category WebGPU */
 declare interface GPUPipelineBase {
   getBindGroupLayout(index: number): GPUBindGroupLayout;
 }
 
+/** @category WebGPU */
 declare interface GPUProgrammableStage {
   module: GPUShaderModule;
   entryPoint: string;
 }
 
+/** @category WebGPU */
 declare class GPUComputePipeline implements GPUObjectBase, GPUPipelineBase {
   label: string;
 
   getBindGroupLayout(index: number): GPUBindGroupLayout;
 }
 
+/** @category WebGPU */
 declare interface GPUComputePipelineDescriptor
   extends GPUPipelineDescriptorBase {
   compute: GPUProgrammableStage;
 }
 
+/** @category WebGPU */
 declare class GPURenderPipeline implements GPUObjectBase, GPUPipelineBase {
   label: string;
 
   getBindGroupLayout(index: number): GPUBindGroupLayout;
 }
 
+/** @category WebGPU */
 declare interface GPURenderPipelineDescriptor
   extends GPUPipelineDescriptorBase {
   vertex: GPUVertexState;
@@ -555,6 +625,7 @@ declare interface GPURenderPipelineDescriptor
   fragment?: GPUFragmentState;
 }
 
+/** @category WebGPU */
 declare interface GPUPrimitiveState {
   topology?: GPUPrimitiveTopology;
   stripIndexFormat?: GPUIndexFormat;
@@ -563,6 +634,7 @@ declare interface GPUPrimitiveState {
   unclippedDepth?: boolean;
 }
 
+/** @category WebGPU */
 declare type GPUPrimitiveTopology =
   | "point-list"
   | "line-list"
@@ -570,20 +642,25 @@ declare type GPUPrimitiveTopology =
   | "triangle-list"
   | "triangle-strip";
 
+/** @category WebGPU */
 declare type GPUFrontFace = "ccw" | "cw";
 
+/** @category WebGPU */
 declare type GPUCullMode = "none" | "front" | "back";
 
+/** @category WebGPU */
 declare interface GPUMultisampleState {
   count?: number;
   mask?: number;
   alphaToCoverageEnabled?: boolean;
 }
 
+/** @category WebGPU */
 declare interface GPUFragmentState extends GPUProgrammableStage {
   targets: (GPUColorTargetState | null)[];
 }
 
+/** @category WebGPU */
 declare interface GPUColorTargetState {
   format: GPUTextureFormat;
 
@@ -591,12 +668,16 @@ declare interface GPUColorTargetState {
   writeMask?: GPUColorWriteFlags;
 }
 
+/** @category WebGPU */
 declare interface GPUBlendState {
   color: GPUBlendComponent;
   alpha: GPUBlendComponent;
 }
 
+/** @category WebGPU */
 declare type GPUColorWriteFlags = number;
+
+/** @category WebGPU */
 declare class GPUColorWrite {
   static RED: 0x1;
   static GREEN: 0x2;
@@ -605,12 +686,14 @@ declare class GPUColorWrite {
   static ALL: 0xF;
 }
 
+/** @category WebGPU */
 declare interface GPUBlendComponent {
   operation?: GPUBlendOperation;
   srcFactor?: GPUBlendFactor;
   dstFactor?: GPUBlendFactor;
 }
 
+/** @category WebGPU */
 declare type GPUBlendFactor =
   | "zero"
   | "one"
@@ -626,6 +709,7 @@ declare type GPUBlendFactor =
   | "constant"
   | "one-minus-constant";
 
+/** @category WebGPU */
 declare type GPUBlendOperation =
   | "add"
   | "subtract"
@@ -633,6 +717,7 @@ declare type GPUBlendOperation =
   | "min"
   | "max";
 
+/** @category WebGPU */
 declare interface GPUDepthStencilState {
   format: GPUTextureFormat;
 
@@ -650,6 +735,7 @@ declare interface GPUDepthStencilState {
   depthBiasClamp?: number;
 }
 
+/** @category WebGPU */
 declare interface GPUStencilFaceState {
   compare?: GPUCompareFunction;
   failOp?: GPUStencilOperation;
@@ -657,6 +743,7 @@ declare interface GPUStencilFaceState {
   passOp?: GPUStencilOperation;
 }
 
+/** @category WebGPU */
 declare type GPUStencilOperation =
   | "keep"
   | "zero"
@@ -667,8 +754,10 @@ declare type GPUStencilOperation =
   | "increment-wrap"
   | "decrement-wrap";
 
+/** @category WebGPU */
 declare type GPUIndexFormat = "uint16" | "uint32";
 
+/** @category WebGPU */
 declare type GPUVertexFormat =
   | "uint8x2"
   | "uint8x4"
@@ -700,18 +789,23 @@ declare type GPUVertexFormat =
   | "sint32x2"
   | "sint32x3"
   | "sint32x4";
+
+/** @category WebGPU */
 declare type GPUVertexStepMode = "vertex" | "instance";
 
+/** @category WebGPU */
 declare interface GPUVertexState extends GPUProgrammableStage {
   buffers?: (GPUVertexBufferLayout | null)[];
 }
 
+/** @category WebGPU */
 declare interface GPUVertexBufferLayout {
   arrayStride: number;
   stepMode?: GPUVertexStepMode;
   attributes: GPUVertexAttribute[];
 }
 
+/** @category WebGPU */
 declare interface GPUVertexAttribute {
   format: GPUVertexFormat;
   offset: number;
@@ -719,12 +813,15 @@ declare interface GPUVertexAttribute {
   shaderLocation: number;
 }
 
+/** @category WebGPU */
 declare class GPUCommandBuffer implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPUCommandBufferDescriptor extends GPUObjectDescriptorBase {}
 
+/** @category WebGPU */
 declare class GPUCommandEncoder implements GPUObjectBase {
   label: string;
 
@@ -782,18 +879,22 @@ declare class GPUCommandEncoder implements GPUObjectBase {
   finish(descriptor?: GPUCommandBufferDescriptor): GPUCommandBuffer;
 }
 
+/** @category WebGPU */
 declare interface GPUCommandEncoderDescriptor extends GPUObjectDescriptorBase {}
 
+/** @category WebGPU */
 declare interface GPUImageDataLayout {
   offset?: number;
   bytesPerRow?: number;
   rowsPerImage?: number;
 }
 
+/** @category WebGPU */
 declare interface GPUImageCopyBuffer extends GPUImageDataLayout {
   buffer: GPUBuffer;
 }
 
+/** @category WebGPU */
 declare interface GPUImageCopyTexture {
   texture: GPUTexture;
   mipLevel?: number;
@@ -801,6 +902,7 @@ declare interface GPUImageCopyTexture {
   aspect?: GPUTextureAspect;
 }
 
+/** @category WebGPU */
 interface GPUProgrammablePassEncoder {
   setBindGroup(
     index: number,
@@ -821,6 +923,7 @@ interface GPUProgrammablePassEncoder {
   insertDebugMarker(markerLabel: string): undefined;
 }
 
+/** @category WebGPU */
 declare class GPUComputePassEncoder
   implements GPUObjectBase, GPUProgrammablePassEncoder {
   label: string;
@@ -857,8 +960,10 @@ declare class GPUComputePassEncoder
   end(): undefined;
 }
 
+/** @category WebGPU */
 declare interface GPUComputePassDescriptor extends GPUObjectDescriptorBase {}
 
+/** @category WebGPU */
 interface GPURenderEncoderBase {
   setPipeline(pipeline: GPURenderPipeline): undefined;
 
@@ -896,6 +1001,7 @@ interface GPURenderEncoderBase {
   ): undefined;
 }
 
+/** @category WebGPU */
 declare class GPURenderPassEncoder
   implements GPUObjectBase, GPUProgrammablePassEncoder, GPURenderEncoderBase {
   label: string;
@@ -980,12 +1086,14 @@ declare class GPURenderPassEncoder
   end(): undefined;
 }
 
+/** @category WebGPU */
 declare interface GPURenderPassDescriptor extends GPUObjectDescriptorBase {
   colorAttachments: (GPURenderPassColorAttachment | null)[];
   depthStencilAttachment?: GPURenderPassDepthStencilAttachment;
   occlusionQuerySet?: GPUQuerySet;
 }
 
+/** @category WebGPU */
 declare interface GPURenderPassColorAttachment {
   view: GPUTextureView;
   resolveTarget?: GPUTextureView;
@@ -995,6 +1103,7 @@ declare interface GPURenderPassColorAttachment {
   storeOp: GPUStoreOp;
 }
 
+/** @category WebGPU */
 declare interface GPURenderPassDepthStencilAttachment {
   view: GPUTextureView;
 
@@ -1009,16 +1118,21 @@ declare interface GPURenderPassDepthStencilAttachment {
   stencilReadOnly?: boolean;
 }
 
+/** @category WebGPU */
 declare type GPULoadOp = "load" | "clear";
 
+/** @category WebGPU */
 declare type GPUStoreOp = "store" | "discard";
 
+/** @category WebGPU */
 declare class GPURenderBundle implements GPUObjectBase {
   label: string;
 }
 
+/** @category WebGPU */
 declare interface GPURenderBundleDescriptor extends GPUObjectDescriptorBase {}
 
+/** @category WebGPU */
 declare class GPURenderBundleEncoder
   implements GPUObjectBase, GPUProgrammablePassEncoder, GPURenderEncoderBase {
   label: string;
@@ -1072,17 +1186,20 @@ declare class GPURenderBundleEncoder
   finish(descriptor?: GPURenderBundleDescriptor): GPURenderBundle;
 }
 
+/** @category WebGPU */
 declare interface GPURenderPassLayout extends GPUObjectDescriptorBase {
   colorFormats: (GPUTextureFormat | null)[];
   depthStencilFormat?: GPUTextureFormat;
   sampleCount?: number;
 }
 
+/** @category WebGPU */
 declare interface GPURenderBundleEncoderDescriptor extends GPURenderPassLayout {
   depthReadOnly?: boolean;
   stencilReadOnly?: boolean;
 }
 
+/** @category WebGPU */
 declare class GPUQueue implements GPUObjectBase {
   label: string;
 
@@ -1106,20 +1223,24 @@ declare class GPUQueue implements GPUObjectBase {
   ): undefined;
 }
 
+/** @category WebGPU */
 declare class GPUQuerySet implements GPUObjectBase {
   label: string;
 
   destroy(): undefined;
 }
 
+/** @category WebGPU */
 declare interface GPUQuerySetDescriptor extends GPUObjectDescriptorBase {
   type: GPUQueryType;
   count: number;
   pipelineStatistics?: GPUPipelineStatisticName[];
 }
 
+/** @category WebGPU */
 declare type GPUQueryType = "occlusion" | "pipeline-statistics" | "timestamp";
 
+/** @category WebGPU */
 declare type GPUPipelineStatisticName =
   | "vertex-shader-invocations"
   | "clipper-invocations"
@@ -1127,27 +1248,34 @@ declare type GPUPipelineStatisticName =
   | "fragment-shader-invocations"
   | "compute-shader-invocations";
 
+/** @category WebGPU */
 declare type GPUDeviceLostReason = "destroyed";
 
+/** @category WebGPU */
 declare interface GPUDeviceLostInfo {
   readonly reason: GPUDeviceLostReason | undefined;
   readonly message: string;
 }
 
+/** @category WebGPU */
 declare class GPUError {
   readonly message: string;
 }
 
+/** @category WebGPU */
 declare type GPUErrorFilter = "out-of-memory" | "validation";
 
+/** @category WebGPU */
 declare class GPUOutOfMemoryError extends GPUError {
   constructor(message: string);
 }
 
+/** @category WebGPU */
 declare class GPUValidationError extends GPUError {
   constructor(message: string);
 }
 
+/** @category WebGPU */
 declare class GPUUncapturedErrorEvent extends Event {
   constructor(
     type: string,
@@ -1156,10 +1284,12 @@ declare class GPUUncapturedErrorEvent extends Event {
   readonly error: GPUError;
 }
 
+/** @category WebGPU */
 declare interface GPUUncapturedErrorEventInit extends EventInit {
   error?: GPUError;
 }
 
+/** @category WebGPU */
 declare interface GPUColorDict {
   r: number;
   g: number;
@@ -1167,20 +1297,25 @@ declare interface GPUColorDict {
   a: number;
 }
 
+/** @category WebGPU */
 declare type GPUColor = number[] | GPUColorDict;
 
+/** @category WebGPU */
 declare interface GPUOrigin3DDict {
   x?: number;
   y?: number;
   z?: number;
 }
 
+/** @category WebGPU */
 declare type GPUOrigin3D = number[] | GPUOrigin3DDict;
 
+/** @category WebGPU */
 declare interface GPUExtent3DDict {
   width: number;
   height?: number;
   depthOrArrayLayers?: number;
 }
 
+/** @category WebGPU */
 declare type GPUExtent3D = number[] | GPUExtent3DDict;

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -935,7 +935,8 @@ fn lsp_hover() {
           "language": "typescript",
           "value": "const Deno.args: string[]"
         },
-        "Returns the script arguments to the program. If for example we run a\nprogram:\n\ndeno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd\n\nThen `Deno.args` will contain:\n\n[ \"/etc/passwd\" ]"
+        "Returns the script arguments to the program. If for example we run a\nprogram:\n\ndeno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd\n\nThen `Deno.args` will contain:\n\n[ \"/etc/passwd\" ]",
+        "\n\n*@category* - Runtime Environment",
       ],
       "range": {
         "start": {
@@ -1359,7 +1360,8 @@ fn lsp_hover_unstable_enabled() {
           "language":"typescript",
           "value":"const Deno.ppid: number"
         },
-        "The pid of the current process's parent."
+        "The pid of the current process's parent.",
+        "\n\n*@category* - Runtime Environment",
       ],
       "range":{
         "start":{

--- a/cli/tests/testdata/lsp/completion_resolve_response.json
+++ b/cli/tests/testdata/lsp/completion_resolve_response.json
@@ -4,7 +4,7 @@
   "detail": "const Deno.build: {\n    target: string;\n    arch: \"x86_64\" | \"aarch64\";\n    os: \"darwin\" | \"linux\" | \"windows\";\n    vendor: string;\n    env?: string | undefined;\n}",
   "documentation": {
     "kind": "markdown",
-    "value": "Build related information."
+    "value": "Build related information.\n\n*@category* - Runtime Environment"
   },
   "sortText": "1",
   "insertTextFormat": 1

--- a/ext/broadcast_channel/lib.deno_broadcast_channel.d.ts
+++ b/ext/broadcast_channel/lib.deno_broadcast_channel.d.ts
@@ -5,11 +5,13 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category Broadcast Channel */
 interface BroadcastChannelEventMap {
   "message": MessageEvent;
   "messageerror": MessageEvent;
 }
 
+/** @category Broadcast Channel */
 interface BroadcastChannel extends EventTarget {
   /**
    * Returns the channel name (as passed to the constructor).
@@ -49,6 +51,7 @@ interface BroadcastChannel extends EventTarget {
   ): void;
 }
 
+/** @category Broadcast Channel */
 declare var BroadcastChannel: {
   prototype: BroadcastChannel;
   new (name: string): BroadcastChannel;

--- a/ext/console/lib.deno_console.d.ts
+++ b/ext/console/lib.deno_console.d.ts
@@ -5,6 +5,7 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category Console and Debugging */
 declare interface Console {
   assert(condition?: boolean, ...data: any[]): void;
   clear(): void;

--- a/ext/crypto/lib.deno_crypto.d.ts
+++ b/ext/crypto/lib.deno_crypto.d.ts
@@ -5,19 +5,26 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category Web Crypto API */
 declare var crypto: Crypto;
 
+/** @category Web Crypto API */
 interface Algorithm {
   name: string;
 }
 
+/** @category Web Crypto API */
 interface KeyAlgorithm {
   name: string;
 }
 
+/** @category Web Crypto API */
 type AlgorithmIdentifier = string | Algorithm;
+/** @category Web Crypto API */
 type HashAlgorithmIdentifier = AlgorithmIdentifier;
+/** @category Web Crypto API */
 type KeyType = "private" | "public" | "secret";
+/** @category Web Crypto API */
 type KeyUsage =
   | "decrypt"
   | "deriveBits"
@@ -27,15 +34,19 @@ type KeyUsage =
   | "unwrapKey"
   | "verify"
   | "wrapKey";
+/** @category Web Crypto API */
 type KeyFormat = "jwk" | "pkcs8" | "raw" | "spki";
+/** @category Web Crypto API */
 type NamedCurve = string;
 
+/** @category Web Crypto API */
 interface RsaOtherPrimesInfo {
   d?: string;
   r?: string;
   t?: string;
 }
 
+/** @category Web Crypto API */
 interface JsonWebKey {
   alg?: string;
   crv?: string;
@@ -58,111 +69,138 @@ interface JsonWebKey {
   y?: string;
 }
 
+/** @category Web Crypto API */
 interface AesCbcParams extends Algorithm {
   iv: BufferSource;
 }
 
+/** @category Web Crypto API */
 interface AesGcmParams extends Algorithm {
   iv: BufferSource;
   additionalData?: BufferSource;
   tagLength?: number;
 }
 
+/** @category Web Crypto API */
 interface AesCtrParams extends Algorithm {
   counter: BufferSource;
   length: number;
 }
 
+/** @category Web Crypto API */
 interface HmacKeyGenParams extends Algorithm {
   hash: HashAlgorithmIdentifier;
   length?: number;
 }
 
+/** @category Web Crypto API */
 interface EcKeyGenParams extends Algorithm {
   namedCurve: NamedCurve;
 }
 
+/** @category Web Crypto API */
 interface EcKeyImportParams extends Algorithm {
   namedCurve: NamedCurve;
 }
 
+/** @category Web Crypto API */
 interface EcdsaParams extends Algorithm {
   hash: HashAlgorithmIdentifier;
 }
 
+/** @category Web Crypto API */
 interface RsaHashedImportParams extends Algorithm {
   hash: HashAlgorithmIdentifier;
 }
 
+/** @category Web Crypto API */
 interface RsaHashedKeyGenParams extends RsaKeyGenParams {
   hash: HashAlgorithmIdentifier;
 }
 
+/** @category Web Crypto API */
 interface RsaKeyGenParams extends Algorithm {
   modulusLength: number;
   publicExponent: Uint8Array;
 }
 
+/** @category Web Crypto API */
 interface RsaPssParams extends Algorithm {
   saltLength: number;
 }
 
+/** @category Web Crypto API */
 interface RsaOaepParams extends Algorithm {
   label?: Uint8Array;
 }
 
+/** @category Web Crypto API */
 interface HmacImportParams extends Algorithm {
   hash: HashAlgorithmIdentifier;
   length?: number;
 }
 
+/** @category Web Crypto API */
 interface EcKeyAlgorithm extends KeyAlgorithm {
   namedCurve: NamedCurve;
 }
 
+/** @category Web Crypto API */
 interface HmacKeyAlgorithm extends KeyAlgorithm {
   hash: KeyAlgorithm;
   length: number;
 }
 
+/** @category Web Crypto API */
 interface RsaHashedKeyAlgorithm extends RsaKeyAlgorithm {
   hash: KeyAlgorithm;
 }
 
+/** @category Web Crypto API */
 interface RsaKeyAlgorithm extends KeyAlgorithm {
   modulusLength: number;
   publicExponent: Uint8Array;
 }
 
+/** @category Web Crypto API */
 interface HkdfParams extends Algorithm {
   hash: HashAlgorithmIdentifier;
   info: BufferSource;
   salt: BufferSource;
 }
 
+/** @category Web Crypto API */
 interface Pbkdf2Params extends Algorithm {
   hash: HashAlgorithmIdentifier;
   iterations: number;
   salt: BufferSource;
 }
 
+/** @category Web Crypto API */
 interface AesDerivedKeyParams extends Algorithm {
   length: number;
 }
 
+/** @category Web Crypto API */
 interface EcdhKeyDeriveParams extends Algorithm {
   public: CryptoKey;
 }
 
+/** @category Web Crypto API */
 interface AesKeyGenParams extends Algorithm {
   length: number;
 }
 
+/** @category Web Crypto API */
 interface AesKeyAlgorithm extends KeyAlgorithm {
   length: number;
 }
 
-/** The CryptoKey dictionary of the Web Crypto API represents a cryptographic key. */
+/** The CryptoKey dictionary of the Web Crypto API represents a cryptographic
+ * key.
+ *
+ * @category Web Crypto API
+ */
 interface CryptoKey {
   readonly algorithm: KeyAlgorithm;
   readonly extractable: boolean;
@@ -170,23 +208,34 @@ interface CryptoKey {
   readonly usages: KeyUsage[];
 }
 
+/** @category Web Crypto API */
 declare var CryptoKey: {
   prototype: CryptoKey;
   new (): CryptoKey;
 };
 
-/** The CryptoKeyPair dictionary of the Web Crypto API represents a key pair for an asymmetric cryptography algorithm, also known as a public-key algorithm. */
+/** The CryptoKeyPair dictionary of the Web Crypto API represents a key pair for
+ * an asymmetric cryptography algorithm, also known as a public-key algorithm.
+ *
+ * @category Web Crypto API
+ */
 interface CryptoKeyPair {
   privateKey: CryptoKey;
   publicKey: CryptoKey;
 }
 
+/** @category Web Crypto API */
 declare var CryptoKeyPair: {
   prototype: CryptoKeyPair;
   new (): CryptoKeyPair;
 };
 
-/** This Web Crypto API interface provides a number of low-level cryptographic functions. It is accessed via the Crypto.subtle properties available in a window context (via Window.crypto). */
+/** This Web Crypto API interface provides a number of low-level cryptographic
+ * functions. It is accessed via the Crypto.subtle properties available in a
+ * window context (via Window.crypto).
+ *
+ * @category Web Crypto API
+ */
 interface SubtleCrypto {
   generateKey(
     algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
@@ -319,6 +368,7 @@ interface SubtleCrypto {
   ): Promise<CryptoKey>;
 }
 
+/** @category Web Crypto API */
 declare interface Crypto {
   readonly subtle: SubtleCrypto;
   getRandomValues<
@@ -338,6 +388,7 @@ declare interface Crypto {
   randomUUID(): string;
 }
 
+/** @category Web Crypto API */
 declare var SubtleCrypto: {
   prototype: SubtleCrypto;
   new (): SubtleCrypto;

--- a/ext/fetch/lib.deno_fetch.d.ts
+++ b/ext/fetch/lib.deno_fetch.d.ts
@@ -5,6 +5,7 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category DOM APIs */
 interface DomIterable<K, V> {
   keys(): IterableIterator<K>;
   values(): IterableIterator<V>;
@@ -16,12 +17,16 @@ interface DomIterable<K, V> {
   ): void;
 }
 
+/** @category Fetch API */
 type FormDataEntryValue = File | string;
 
 /** Provides a way to easily construct a set of key/value pairs representing
  * form fields and their values, which can then be easily sent using the
  * XMLHttpRequest.send() method. It uses the same format a form would use if the
- * encoding type were set to "multipart/form-data". */
+ * encoding type were set to "multipart/form-data".
+ *
+ * @category Fetch API
+ */
 interface FormData {
   append(name: string, value: string | Blob, fileName?: string): void;
   delete(name: string): void;
@@ -39,11 +44,13 @@ interface FormData {
   ): void;
 }
 
+/** @category Fetch API */
 declare var FormData: {
   prototype: FormData;
   new (): FormData;
 };
 
+/** @category Fetch API */
 interface Body {
   /** A simple getter used to expose a `ReadableStream` of the body contents. */
   readonly body: ReadableStream<Uint8Array> | null;
@@ -73,6 +80,7 @@ interface Body {
   text(): Promise<string>;
 }
 
+/** @category Fetch API */
 type HeadersInit = Headers | string[][] | Record<string, string>;
 
 /** This Fetch API interface allows you to perform various actions on HTTP
@@ -81,7 +89,10 @@ type HeadersInit = Headers | string[][] | Record<string, string>;
  * which is initially empty and consists of zero or more name and value pairs.
  * You can add to this using methods like append() (see Examples). In all
  * methods of this interface, header names are matched by case-insensitive byte
- * sequence. */
+ * sequence.
+ *
+ * @category Fetch API
+ */
 interface Headers {
   append(name: string, value: string): void;
   delete(name: string): void;
@@ -94,6 +105,7 @@ interface Headers {
   ): void;
 }
 
+/** @category Fetch API */
 declare class Headers implements DomIterable<string, string> {
   constructor(init?: HeadersInit);
 
@@ -138,7 +150,9 @@ declare class Headers implements DomIterable<string, string> {
   [Symbol.iterator](): IterableIterator<[string, string]>;
 }
 
+/** @category Fetch API */
 type RequestInfo = Request | string;
+/** @category Fetch API */
 type RequestCache =
   | "default"
   | "force-cache"
@@ -146,9 +160,13 @@ type RequestCache =
   | "no-store"
   | "only-if-cached"
   | "reload";
+/** @category Fetch API */
 type RequestCredentials = "include" | "omit" | "same-origin";
+/** @category Fetch API */
 type RequestMode = "cors" | "navigate" | "no-cors" | "same-origin";
+/** @category Fetch API */
 type RequestRedirect = "error" | "follow" | "manual";
+/** @category Fetch API */
 type ReferrerPolicy =
   | ""
   | "no-referrer"
@@ -159,6 +177,7 @@ type ReferrerPolicy =
   | "strict-origin"
   | "strict-origin-when-cross-origin"
   | "unsafe-url";
+/** @category Fetch API */
 type BodyInit =
   | Blob
   | BufferSource
@@ -166,6 +185,7 @@ type BodyInit =
   | URLSearchParams
   | ReadableStream<Uint8Array>
   | string;
+/** @category Fetch API */
 type RequestDestination =
   | ""
   | "audio"
@@ -186,6 +206,7 @@ type RequestDestination =
   | "worker"
   | "xslt";
 
+/** @category Fetch API */
 interface RequestInit {
   /**
    * A BodyInit object or null to set request's body.
@@ -250,7 +271,10 @@ interface RequestInit {
   window?: any;
 }
 
-/** This Fetch API interface represents a resource request. */
+/** This Fetch API interface represents a resource request.
+ *
+ * @category Fetch API
+ */
 declare class Request implements Body {
   constructor(input: RequestInfo | URL, init?: RequestInit);
 
@@ -366,12 +390,14 @@ declare class Request implements Body {
   text(): Promise<string>;
 }
 
+/** @category Fetch API */
 interface ResponseInit {
   headers?: HeadersInit;
   status?: number;
   statusText?: string;
 }
 
+/** @category Fetch API */
 type ResponseType =
   | "basic"
   | "cors"
@@ -380,7 +406,10 @@ type ResponseType =
   | "opaque"
   | "opaqueredirect";
 
-/** This Fetch API interface represents the response to a request. */
+/** This Fetch API interface represents the response to a request.
+ *
+ * @category Fetch API
+ */
 declare class Response implements Body {
   constructor(body?: BodyInit | null, init?: ResponseInit);
   static json(data: unknown, init?: ResponseInit): Response;
@@ -434,6 +463,8 @@ declare class Response implements Body {
  * console.log(response.statusText); // e.g. "OK"
  * const jsonData = await response.json();
  * ```
+ *
+ * @category Fetch API
  */
 declare function fetch(
   input: URL | Request | string,

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -4,20 +4,26 @@
 /// <reference lib="esnext" />
 
 declare namespace Deno {
+  /** @category Network */
   export interface NetAddr {
     transport: "tcp" | "udp";
     hostname: string;
     port: number;
   }
 
+  /** @category Network */
   export interface UnixAddr {
     transport: "unix" | "unixpacket";
     path: string;
   }
 
+  /** @category Network */
   export type Addr = NetAddr | UnixAddr;
 
-  /** A generic network listener for stream-oriented protocols. */
+  /** A generic network listener for stream-oriented protocols.
+   *
+   * @category Network
+   */
   export interface Listener extends AsyncIterable<Conn> {
     /** Waits for and resolves to the next connection to the `Listener`. */
     accept(): Promise<Conn>;
@@ -33,13 +39,17 @@ declare namespace Deno {
     [Symbol.asyncIterator](): AsyncIterableIterator<Conn>;
   }
 
-  /** Specialized listener that accepts TLS connections. */
+  /** Specialized listener that accepts TLS connections.
+   *
+   * @category Network
+   */
   export interface TlsListener extends Listener, AsyncIterable<TlsConn> {
     /** Waits for a TLS client to connect and accepts the connection. */
     accept(): Promise<TlsConn>;
     [Symbol.asyncIterator](): AsyncIterableIterator<TlsConn>;
   }
 
+  /** @category Network */
   export interface Conn extends Reader, Writer, Closer {
     /** The local address of the connection. */
     readonly localAddr: Addr;
@@ -55,9 +65,11 @@ declare namespace Deno {
     readonly writable: WritableStream<Uint8Array>;
   }
 
+  /** @category Network */
   // deno-lint-ignore no-empty-interface
   export interface TlsHandshakeInfo {}
 
+  /** @category Network */
   export interface TlsConn extends Conn {
     /** Runs the client or server handshake protocol to completion if that has
      * not happened yet. Calling this method is optional; the TLS handshake
@@ -65,6 +77,7 @@ declare namespace Deno {
     handshake(): Promise<TlsHandshakeInfo>;
   }
 
+  /** @category Network */
   export interface ListenOptions {
     /** The port to listen on. */
     port: number;
@@ -87,11 +100,15 @@ declare namespace Deno {
    * const listener4 = Deno.listen({ hostname: "golang.org", port: 80, transport: "tcp" });
    * ```
    *
-   * Requires `allow-net` permission. */
+   * Requires `allow-net` permission.
+   *
+   * @category Network
+   */
   export function listen(
     options: ListenOptions & { transport?: "tcp" },
   ): Listener;
 
+  /** @category Network */
   export interface ListenTlsOptions extends ListenOptions {
     /** Server private key in PEM format */
     key?: string;
@@ -119,9 +136,13 @@ declare namespace Deno {
    * const lstnr = Deno.listenTls({ port: 443, certFile: "./server.crt", keyFile: "./server.key" });
    * ```
    *
-   * Requires `allow-net` permission. */
+   * Requires `allow-net` permission.
+   *
+   * @category Network
+   */
   export function listenTls(options: ListenTlsOptions): TlsListener;
 
+  /** @category Network */
   export interface ConnectOptions {
     /** The port to connect to. */
     port: number;
@@ -142,9 +163,13 @@ declare namespace Deno {
    * const conn4 = await Deno.connect({ hostname: "golang.org", port: 80, transport: "tcp" });
    * ```
    *
-   * Requires `allow-net` permission for "tcp". */
+   * Requires `allow-net` permission for "tcp".
+   *
+   * @category Network
+   */
   export function connect(options: ConnectOptions): Promise<TcpConn>;
 
+  /** @category Network */
   export interface TcpConn extends Conn {
     /**
      * **UNSTABLE**: new API, see https://github.com/denoland/deno/issues/13617.
@@ -160,9 +185,11 @@ declare namespace Deno {
     setKeepAlive(keepalive?: boolean): void;
   }
 
+  /** @category Network */
   // deno-lint-ignore no-empty-interface
   export interface UnixConn extends Conn {}
 
+  /** @category Network */
   export interface ConnectTlsOptions {
     /** The port to connect to. */
     port: number;
@@ -197,9 +224,12 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-net` permission.
+   *
+   * @category Network
    */
   export function connectTls(options: ConnectTlsOptions): Promise<TlsConn>;
 
+  /** @category Network */
   export interface StartTlsOptions {
     /** A literal IP address or host name that can be resolved to an IP address.
      * If not specified, defaults to `127.0.0.1`. */
@@ -224,6 +254,8 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-net` permission.
+   *
+   * @category Network
    */
   export function startTls(
     conn: Conn,
@@ -239,6 +271,8 @@ declare namespace Deno {
    * const conn = await listener.accept();
    * Deno.shutdown(conn.rid);
    * ```
+   *
+   * @category Network
    */
   export function shutdown(rid: number): Promise<void>;
 }

--- a/ext/url/lib.deno_url.d.ts
+++ b/ext/url/lib.deno_url.d.ts
@@ -5,6 +5,7 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category Web APIs */
 declare class URLSearchParams {
   constructor(
     init?: string[][] | Record<string, string> | string | URLSearchParams,
@@ -151,7 +152,11 @@ declare class URLSearchParams {
   toString(): string;
 }
 
-/** The URL interface represents an object providing static methods used for creating object URLs. */
+/** The URL interface represents an object providing static methods used for
+ * creating object URLs.
+ *
+ * @category Web APIs
+ */
 declare class URL {
   constructor(url: string | URL, base?: string | URL);
   static createObjectURL(blob: Blob): string;
@@ -173,6 +178,7 @@ declare class URL {
   toJSON(): string;
 }
 
+/** @category Web APIs */
 declare interface URLPatternInit {
   protocol?: string;
   username?: string;
@@ -185,14 +191,19 @@ declare interface URLPatternInit {
   baseURL?: string;
 }
 
+/** @category Web APIs */
 declare type URLPatternInput = string | URLPatternInit;
 
+/** @category Web APIs */
 declare interface URLPatternComponentResult {
   input: string;
   groups: Record<string, string>;
 }
 
-/** `URLPatternResult` is the object returned from `URLPattern.exec`. */
+/** `URLPatternResult` is the object returned from `URLPattern.exec`.
+ *
+ * @category Web APIs
+ */
 declare interface URLPatternResult {
   /** The inputs provided when matching. */
   inputs: [URLPatternInit] | [URLPatternInit, string];
@@ -242,6 +253,8 @@ declare interface URLPatternResult {
  * console.log(pattern.test("https://blog.example.com/article")); // true
  * console.log(pattern.test("https://blog.example.com/article/123")); // false
  * ```
+ *
+ * @category Web APIs
  */
 declare class URLPattern {
   constructor(input: URLPatternInput, baseURL?: string);

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -5,6 +5,7 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category DOM Events */
 declare class DOMException extends Error {
   constructor(message?: string, name?: string);
   readonly name: string;
@@ -12,13 +13,17 @@ declare class DOMException extends Error {
   readonly code: number;
 }
 
+/** @category DOM Events */
 interface EventInit {
   bubbles?: boolean;
   cancelable?: boolean;
   composed?: boolean;
 }
 
-/** An event which takes place in the DOM. */
+/** An event which takes place in the DOM.
+ *
+ * @category DOM Events
+ */
 declare class Event {
   constructor(type: string, eventInitDict?: EventInit);
   /** Returns true or false depending on how event was initialized. True if
@@ -84,6 +89,8 @@ declare class Event {
 /**
  * EventTarget is a DOM interface implemented by objects that can receive events
  * and may have listeners for them.
+ *
+ * @category DOM Events
  */
 declare class EventTarget {
   /** Appends an event listener for events whose type attribute value is type.
@@ -127,28 +134,34 @@ declare class EventTarget {
   ): void;
 }
 
+/** @category DOM Events */
 interface EventListener {
   (evt: Event): void | Promise<void>;
 }
 
+/** @category DOM Events */
 interface EventListenerObject {
   handleEvent(evt: Event): void | Promise<void>;
 }
 
+/** @category DOM Events */
 declare type EventListenerOrEventListenerObject =
   | EventListener
   | EventListenerObject;
 
+/** @category DOM Events */
 interface AddEventListenerOptions extends EventListenerOptions {
   once?: boolean;
   passive?: boolean;
   signal?: AbortSignal;
 }
 
+/** @category DOM Events */
 interface EventListenerOptions {
   capture?: boolean;
 }
 
+/** @category DOM Events */
 interface ProgressEventInit extends EventInit {
   lengthComputable?: boolean;
   loaded?: number;
@@ -157,7 +170,10 @@ interface ProgressEventInit extends EventInit {
 
 /** Events measuring progress of an underlying process, like an HTTP request
  * (for an XMLHttpRequest, or the loading of the underlying resource of an
- * <img>, <audio>, <video>, <style> or <link>). */
+ * <img>, <audio>, <video>, <style> or <link>).
+ *
+ * @category DOM Events
+ */
 declare class ProgressEvent<T extends EventTarget = EventTarget> extends Event {
   constructor(type: string, eventInitDict?: ProgressEventInit);
   readonly lengthComputable: boolean;
@@ -171,6 +187,8 @@ declare class ProgressEvent<T extends EventTarget = EventTarget> extends Event {
  * ```
  * console.log(atob("aGVsbG8gd29ybGQ=")); // outputs 'hello world'
  * ```
+ *
+ * @category Encoding API
  */
 declare function atob(s: string): string;
 
@@ -179,18 +197,23 @@ declare function atob(s: string): string;
  * ```
  * console.log(btoa("hello world"));  // outputs "aGVsbG8gd29ybGQ="
  * ```
+ *
+ * @category Encoding API
  */
 declare function btoa(s: string): string;
 
+/** @category Encoding API */
 declare interface TextDecoderOptions {
   fatal?: boolean;
   ignoreBOM?: boolean;
 }
 
+/** @category Encoding API */
 declare interface TextDecodeOptions {
   stream?: boolean;
 }
 
+/** @category Encoding API */
 interface TextDecoder {
   /** Returns encoding's name, lowercased. */
   readonly encoding: string;
@@ -203,16 +226,19 @@ interface TextDecoder {
   decode(input?: BufferSource, options?: TextDecodeOptions): string;
 }
 
+/** @category Encoding API */
 declare var TextDecoder: {
   prototype: TextDecoder;
   new (label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
+/** @category Encoding API */
 declare interface TextEncoderEncodeIntoResult {
   read: number;
   written: number;
 }
 
+/** @category Encoding API */
 interface TextEncoder {
   /** Returns "utf-8". */
   readonly encoding: "utf-8";
@@ -221,11 +247,13 @@ interface TextEncoder {
   encodeInto(input: string, dest: Uint8Array): TextEncoderEncodeIntoResult;
 }
 
+/** @category Encoding API */
 declare var TextEncoder: {
   prototype: TextEncoder;
   new (): TextEncoder;
 };
 
+/** @category Encoding API */
 interface TextDecoderStream {
   /** Returns encoding's name, lowercased. */
   readonly encoding: string;
@@ -238,11 +266,13 @@ interface TextDecoderStream {
   readonly [Symbol.toStringTag]: string;
 }
 
+/** @category Encoding API */
 declare var TextDecoderStream: {
   prototype: TextDecoderStream;
   new (label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
+/** @category Encoding API */
 interface TextEncoderStream {
   /** Returns "utf-8". */
   readonly encoding: "utf-8";
@@ -251,13 +281,17 @@ interface TextEncoderStream {
   readonly [Symbol.toStringTag]: string;
 }
 
+/** @category Encoding API */
 declare var TextEncoderStream: {
   prototype: TextEncoderStream;
   new (): TextEncoderStream;
 };
 
 /** A controller object that allows you to abort one or more DOM requests as and
- * when desired. */
+ * when desired.
+ *
+ * @category Web APIs
+ */
 declare class AbortController {
   /** Returns the AbortSignal object associated with this object. */
   readonly signal: AbortSignal;
@@ -266,12 +300,16 @@ declare class AbortController {
   abort(reason?: any): void;
 }
 
+/** @category Web APIs */
 interface AbortSignalEventMap {
   abort: Event;
 }
 
 /** A signal object that allows you to communicate with a DOM request (such as a
- * Fetch) and abort it if required via an AbortController object. */
+ * Fetch) and abort it if required via an AbortController object.
+ *
+ * @category Web APIs
+ */
 interface AbortSignal extends EventTarget {
   /** Returns true if this AbortSignal's AbortController has signaled to abort,
    * and false otherwise. */
@@ -304,6 +342,7 @@ interface AbortSignal extends EventTarget {
   throwIfAborted(): void;
 }
 
+/** @category Web APIs */
 declare var AbortSignal: {
   prototype: AbortSignal;
   new (): AbortSignal;
@@ -311,6 +350,7 @@ declare var AbortSignal: {
   timeout(milliseconds: number): AbortSignal;
 };
 
+/** @category Web File API */
 interface FileReaderEventMap {
   "abort": ProgressEvent<FileReader>;
   "error": ProgressEvent<FileReader>;
@@ -320,7 +360,12 @@ interface FileReaderEventMap {
   "progress": ProgressEvent<FileReader>;
 }
 
-/** Lets web applications asynchronously read the contents of files (or raw data buffers) stored on the user's computer, using File or Blob objects to specify the file or data to read. */
+/** Lets web applications asynchronously read the contents of files (or raw data
+ * buffers) stored on the user's computer, using File or Blob objects to specify
+ * the file or data to read.
+ *
+ * @category Web File API
+ */
 interface FileReader extends EventTarget {
   readonly error: DOMException | null;
   onabort: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
@@ -363,6 +408,7 @@ interface FileReader extends EventTarget {
   ): void;
 }
 
+/** @category Web File API */
 declare var FileReader: {
   prototype: FileReader;
   new (): FileReader;
@@ -371,14 +417,22 @@ declare var FileReader: {
   readonly LOADING: number;
 };
 
+/** @category Web File API */
 type BlobPart = BufferSource | Blob | string;
 
+/** @category Web File API */
 interface BlobPropertyBag {
   type?: string;
   endings?: "transparent" | "native";
 }
 
-/** A file-like object of immutable, raw data. Blobs represent data that isn't necessarily in a JavaScript-native format. The File interface is based on Blob, inheriting blob functionality and expanding it to support files on the user's system. */
+/** A file-like object of immutable, raw data. Blobs represent data that isn't
+ * necessarily in a JavaScript-native format. The File interface is based on
+ * Blob, inheriting blob functionality and expanding it to support files on the
+ * user's system.
+ *
+ * @category Web File API
+ */
 declare class Blob {
   constructor(blobParts?: BlobPart[], options?: BlobPropertyBag);
 
@@ -390,12 +444,16 @@ declare class Blob {
   text(): Promise<string>;
 }
 
+/** @category Web File API */
 interface FilePropertyBag extends BlobPropertyBag {
   lastModified?: number;
 }
 
 /** Provides information about files and allows JavaScript in a web page to
- * access their content. */
+ * access their content.
+ *
+ * @category Web File API
+ */
 declare class File extends Blob {
   constructor(
     fileBits: BlobPart[],
@@ -407,20 +465,24 @@ declare class File extends Blob {
   readonly name: string;
 }
 
+/** @category Streams API */
 interface ReadableStreamReadDoneResult<T> {
   done: true;
   value?: T;
 }
 
+/** @category Streams API */
 interface ReadableStreamReadValueResult<T> {
   done: false;
   value: T;
 }
 
+/** @category Streams API */
 type ReadableStreamReadResult<T> =
   | ReadableStreamReadValueResult<T>
   | ReadableStreamReadDoneResult<T>;
 
+/** @category Streams API */
 interface ReadableStreamDefaultReader<R = any> {
   readonly closed: Promise<void>;
   cancel(reason?: any): Promise<void>;
@@ -428,20 +490,24 @@ interface ReadableStreamDefaultReader<R = any> {
   releaseLock(): void;
 }
 
+/** @category Streams API */
 interface ReadableStreamBYOBReadDoneResult<V extends ArrayBufferView> {
   done: true;
   value?: V;
 }
 
+/** @category Streams API */
 interface ReadableStreamBYOBReadValueResult<V extends ArrayBufferView> {
   done: false;
   value: V;
 }
 
+/** @category Streams API */
 type ReadableStreamBYOBReadResult<V extends ArrayBufferView> =
   | ReadableStreamBYOBReadDoneResult<V>
   | ReadableStreamBYOBReadValueResult<V>;
 
+/** @category Streams API */
 interface ReadableStreamBYOBReader {
   readonly closed: Promise<void>;
   cancel(reason?: any): Promise<void>;
@@ -451,32 +517,38 @@ interface ReadableStreamBYOBReader {
   releaseLock(): void;
 }
 
+/** @category Streams API */
 interface ReadableStreamBYOBRequest {
   readonly view: ArrayBufferView | null;
   respond(bytesWritten: number): void;
   respondWithNewView(view: ArrayBufferView): void;
 }
 
+/** @category Streams API */
 declare var ReadableStreamDefaultReader: {
   prototype: ReadableStreamDefaultReader;
   new <R>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
+/** @category Streams API */
 interface ReadableStreamReader<R = any> {
   cancel(): Promise<void>;
   read(): Promise<ReadableStreamReadResult<R>>;
   releaseLock(): void;
 }
 
+/** @category Streams API */
 declare var ReadableStreamReader: {
   prototype: ReadableStreamReader;
   new (): ReadableStreamReader;
 };
 
+/** @category Streams API */
 interface ReadableByteStreamControllerCallback {
   (controller: ReadableByteStreamController): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface UnderlyingByteSource {
   autoAllocateChunkSize?: number;
   cancel?: ReadableStreamErrorCallback;
@@ -485,6 +557,7 @@ interface UnderlyingByteSource {
   type: "bytes";
 }
 
+/** @category Streams API */
 interface UnderlyingSink<W = any> {
   abort?: WritableStreamErrorCallback;
   close?: WritableStreamDefaultControllerCloseCallback;
@@ -493,6 +566,7 @@ interface UnderlyingSink<W = any> {
   write?: WritableStreamDefaultControllerWriteCallback<W>;
 }
 
+/** @category Streams API */
 interface UnderlyingSource<R = any> {
   cancel?: ReadableStreamErrorCallback;
   pull?: ReadableStreamDefaultControllerCallback<R>;
@@ -500,14 +574,17 @@ interface UnderlyingSource<R = any> {
   type?: undefined;
 }
 
+/** @category Streams API */
 interface ReadableStreamErrorCallback {
   (reason: any): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface ReadableStreamDefaultControllerCallback<R> {
   (controller: ReadableStreamDefaultController<R>): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface ReadableStreamDefaultController<R = any> {
   readonly desiredSize: number | null;
   close(): void;
@@ -515,11 +592,13 @@ interface ReadableStreamDefaultController<R = any> {
   error(error?: any): void;
 }
 
+/** @category Streams API */
 declare var ReadableStreamDefaultController: {
   prototype: ReadableStreamDefaultController;
   new (): ReadableStreamDefaultController;
 };
 
+/** @category Streams API */
 interface ReadableByteStreamController {
   readonly byobRequest: ReadableStreamBYOBRequest | null;
   readonly desiredSize: number | null;
@@ -528,11 +607,13 @@ interface ReadableByteStreamController {
   error(error?: any): void;
 }
 
+/** @category Streams API */
 declare var ReadableByteStreamController: {
   prototype: ReadableByteStreamController;
   new (): ReadableByteStreamController;
 };
 
+/** @category Streams API */
 interface PipeOptions {
   preventAbort?: boolean;
   preventCancel?: boolean;
@@ -540,32 +621,40 @@ interface PipeOptions {
   signal?: AbortSignal;
 }
 
+/** @category Streams API */
 interface QueuingStrategySizeCallback<T = any> {
   (chunk: T): number;
 }
 
+/** @category Streams API */
 interface QueuingStrategy<T = any> {
   highWaterMark?: number;
   size?: QueuingStrategySizeCallback<T>;
 }
 
 /** This Streams API interface provides a built-in byte length queuing strategy
- * that can be used when constructing streams. */
+ * that can be used when constructing streams.
+ *
+ * @category Streams API
+ */
 interface CountQueuingStrategy extends QueuingStrategy {
   highWaterMark: number;
   size(chunk: any): 1;
 }
 
+/** @category Streams API */
 declare var CountQueuingStrategy: {
   prototype: CountQueuingStrategy;
   new (options: { highWaterMark: number }): CountQueuingStrategy;
 };
 
+/** @category Streams API */
 interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
   highWaterMark: number;
   size(chunk: ArrayBufferView): number;
 }
 
+/** @category Streams API */
 declare var ByteLengthQueuingStrategy: {
   prototype: ByteLengthQueuingStrategy;
   new (options: { highWaterMark: number }): ByteLengthQueuingStrategy;
@@ -573,7 +662,10 @@ declare var ByteLengthQueuingStrategy: {
 
 /** This Streams API interface represents a readable stream of byte data. The
  * Fetch API offers a concrete instance of a ReadableStream through the body
- * property of a Response object. */
+ * property of a Response object.
+ *
+ * @category Streams API
+ */
 interface ReadableStream<R = any> {
   readonly locked: boolean;
   cancel(reason?: any): Promise<void>;
@@ -593,6 +685,7 @@ interface ReadableStream<R = any> {
   }): AsyncIterableIterator<R>;
 }
 
+/** @category Streams API */
 declare var ReadableStream: {
   prototype: ReadableStream;
   new (
@@ -605,14 +698,17 @@ declare var ReadableStream: {
   ): ReadableStream<R>;
 };
 
+/** @category Streams API */
 interface WritableStreamDefaultControllerCloseCallback {
   (): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface WritableStreamDefaultControllerStartCallback {
   (controller: WritableStreamDefaultController): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface WritableStreamDefaultControllerWriteCallback<W> {
   (chunk: W, controller: WritableStreamDefaultController):
     | void
@@ -621,13 +717,17 @@ interface WritableStreamDefaultControllerWriteCallback<W> {
     >;
 }
 
+/** @category Streams API */
 interface WritableStreamErrorCallback {
   (reason: any): void | PromiseLike<void>;
 }
 
 /** This Streams API interface provides a standard abstraction for writing
  * streaming data to a destination, known as a sink. This object comes with
- * built-in backpressure and queuing. */
+ * built-in backpressure and queuing.
+ *
+ * @category Streams API
+ */
 interface WritableStream<W = any> {
   readonly locked: boolean;
   abort(reason?: any): Promise<void>;
@@ -635,6 +735,7 @@ interface WritableStream<W = any> {
   getWriter(): WritableStreamDefaultWriter<W>;
 }
 
+/** @category Streams API */
 declare var WritableStream: {
   prototype: WritableStream;
   new <W = any>(
@@ -646,18 +747,25 @@ declare var WritableStream: {
 /** This Streams API interface represents a controller allowing control of a
  * WritableStream's state. When constructing a WritableStream, the underlying
  * sink is given a corresponding WritableStreamDefaultController instance to
- * manipulate. */
+ * manipulate.
+ *
+ * @category Streams API
+ */
 interface WritableStreamDefaultController {
   signal: AbortSignal;
   error(error?: any): void;
 }
 
+/** @category Streams API */
 declare var WritableStreamDefaultController: WritableStreamDefaultController;
 
 /** This Streams API interface is the object returned by
  * WritableStream.getWriter() and once created locks the < writer to the
  * WritableStream ensuring that no other streams can write to the underlying
- * sink. */
+ * sink.
+ *
+ * @category Streams API
+ */
 interface WritableStreamDefaultWriter<W = any> {
   readonly closed: Promise<void>;
   readonly desiredSize: number | null;
@@ -668,16 +776,19 @@ interface WritableStreamDefaultWriter<W = any> {
   write(chunk: W): Promise<void>;
 }
 
+/** @category Streams API */
 declare var WritableStreamDefaultWriter: {
   prototype: WritableStreamDefaultWriter;
   new (): WritableStreamDefaultWriter;
 };
 
+/** @category Streams API */
 interface TransformStream<I = any, O = any> {
   readonly readable: ReadableStream<O>;
   readonly writable: WritableStream<I>;
 }
 
+/** @category Streams API */
 declare var TransformStream: {
   prototype: TransformStream;
   new <I = any, O = any>(
@@ -687,6 +798,7 @@ declare var TransformStream: {
   ): TransformStream<I, O>;
 };
 
+/** @category Streams API */
 interface TransformStreamDefaultController<O = any> {
   readonly desiredSize: number | null;
   enqueue(chunk: O): void;
@@ -694,8 +806,10 @@ interface TransformStreamDefaultController<O = any> {
   terminate(): void;
 }
 
+/** @category Streams API */
 declare var TransformStreamDefaultController: TransformStreamDefaultController;
 
+/** @category Streams API */
 interface Transformer<I = any, O = any> {
   flush?: TransformStreamDefaultControllerCallback<O>;
   readableType?: undefined;
@@ -704,10 +818,12 @@ interface Transformer<I = any, O = any> {
   writableType?: undefined;
 }
 
+/** @category Streams API */
 interface TransformStreamDefaultControllerCallback<O> {
   (controller: TransformStreamDefaultController<O>): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface TransformStreamDefaultControllerTransformCallback<I, O> {
   (
     chunk: I,
@@ -715,12 +831,14 @@ interface TransformStreamDefaultControllerTransformCallback<I, O> {
   ): void | PromiseLike<void>;
 }
 
+/** @category Streams API */
 interface MessageEventInit<T = any> extends EventInit {
   data?: T;
   origin?: string;
   lastEventId?: string;
 }
 
+/** @category Streams API */
 declare class MessageEvent<T = any> extends Event {
   /**
    * Returns the data of the message.
@@ -740,26 +858,32 @@ declare class MessageEvent<T = any> extends Event {
 type Transferable = ArrayBuffer | MessagePort;
 
 /**
- * @deprecated
- *
  * This type has been renamed to StructuredSerializeOptions. Use that type for
  * new code.
+ *
+ * @deprecated use `StructuredSerializeOptions` instead.
+ * @category DOM APIs
  */
 type PostMessageOptions = StructuredSerializeOptions;
 
+/** @category DOM APIs */
 interface StructuredSerializeOptions {
   transfer?: Transferable[];
 }
 
 /** The MessageChannel interface of the Channel Messaging API allows us to
  * create a new message channel and send data through it via its two MessagePort
- * properties. */
+ * properties.
+ *
+ * @category DOM APIs
+ */
 declare class MessageChannel {
   constructor();
   readonly port1: MessagePort;
   readonly port2: MessagePort;
 }
 
+/** @category DOM APIs */
 interface MessagePortEventMap {
   "message": MessageEvent;
   "messageerror": MessageEvent;
@@ -767,7 +891,10 @@ interface MessagePortEventMap {
 
 /** The MessagePort interface of the Channel Messaging API represents one of the
  * two ports of a MessageChannel, allowing messages to be sent from one port and
- * listening out for them arriving at the other. */
+ * listening out for them arriving at the other.
+ *
+ * @category DOM APIs
+ */
 declare class MessagePort extends EventTarget {
   onmessage: ((this: MessagePort, ev: MessageEvent) => any) | null;
   onmessageerror: ((this: MessagePort, ev: MessageEvent) => any) | null;
@@ -836,6 +963,8 @@ declare class MessagePort extends EventTarget {
  * // shallowCopy.x is pointing to the same location in memory as object.x
  * console.log(shallowCopy.x, object.x); // 1 1
  * ```
+ *
+ * @category DOM APIs
  */
 declare function structuredClone(
   value: any,
@@ -851,6 +980,8 @@ declare function structuredClone(
  *   .pipeThrough(new CompressionStream("gzip"))
  *   .pipeTo(Deno.stdout.writable);
  * ```
+ *
+ * @category Compression Streams API
  */
 declare class CompressionStream {
   /**
@@ -878,6 +1009,8 @@ declare class CompressionStream {
  *   .pipeThrough(new DecompressionStream("gzip"))
  *   .pipeTo(output.writable);
  * ```
+ *
+ * @category Compression Streams API
  */
 declare class DecompressionStream {
   /**
@@ -907,6 +1040,8 @@ declare class DecompressionStream {
  * reportError(new Error("foo")); // Will not be reported.
  * ```
  * In Deno, this error will terminate the process if not intercepted like above.
+ *
+ * @category Web APIs
  */
 declare function reportError(
   error: any,

--- a/ext/websocket/lib.deno_websocket.d.ts
+++ b/ext/websocket/lib.deno_websocket.d.ts
@@ -5,12 +5,14 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
+/** @category Web Sockets */
 interface CloseEventInit extends EventInit {
   code?: number;
   reason?: string;
   wasClean?: boolean;
 }
 
+/** @category Web Sockets */
 declare class CloseEvent extends Event {
   constructor(type: string, eventInitDict?: CloseEventInit);
   /**
@@ -27,6 +29,7 @@ declare class CloseEvent extends Event {
   readonly wasClean: boolean;
 }
 
+/** @category Web Sockets */
 interface WebSocketEventMap {
   close: CloseEvent;
   error: Event;
@@ -35,9 +38,13 @@ interface WebSocketEventMap {
 }
 
 /**
- * Provides the API for creating and managing a WebSocket connection to a server, as well as for sending and receiving data on the connection.
+ * Provides the API for creating and managing a WebSocket connection to a
+ * server, as well as for sending and receiving data on the connection.
  *
- * If you are looking to create a WebSocket server, please take a look at `Deno.upgradeWebSocket()`.
+ * If you are looking to create a WebSocket server, please take a look at
+ * `Deno.upgradeWebSocket()`.
+ *
+ * @category Web Sockets
  */
 declare class WebSocket extends EventTarget {
   constructor(url: string | URL, protocols?: string | string[]);
@@ -113,4 +120,5 @@ declare class WebSocket extends EventTarget {
   ): void;
 }
 
+/** @category Web Sockets */
 type BinaryType = "arraybuffer" | "blob";

--- a/ext/webstorage/lib.deno_webstorage.d.ts
+++ b/ext/webstorage/lib.deno_webstorage.d.ts
@@ -5,7 +5,12 @@
 /// <reference no-default-lib="true" />
 /// <reference lib="esnext" />
 
-/** This Web Storage API interface provides access to a particular domain's session or local storage. It allows, for example, the addition, modification, or deletion of stored data items. */
+/** This Web Storage API interface provides access to a particular domain's
+ * session or local storage. It allows, for example, the addition, modification,
+ * or deletion of stored data items.
+ *
+ * @category Web Storage API
+ */
 interface Storage {
   /**
    * Returns the number of key/value pairs currently present in the list associated with the object.
@@ -36,6 +41,7 @@ interface Storage {
   [name: string]: any;
 }
 
+/** @category Web Storage API */
 declare var Storage: {
   prototype: Storage;
   new (): Storage;


### PR DESCRIPTION
This adds the `@category` JSDoc tag to the built-in APIs, which will allow us to generate documentation where we can break up our built-in APIs into seperate categories when displaying documentation without having to maintain a list outside of the code.