### PR TITLE
feat(runtime): add pre_execute_module_cb

### DIFF
--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -238,10 +238,10 @@ pub async fn run(
     ),
   });
   let create_web_worker_cb = Arc::new(|_| {
-    todo!("Worker are currently not supported in standalone binaries");
+    todo!("Workers are currently not supported in standalone binaries");
   });
-  let web_worker_preload_module_cb = Arc::new(|_| {
-    todo!("Worker are currently not supported in standalone binaries");
+  let web_worker_cb = Arc::new(|_| {
+    todo!("Workers are currently not supported in standalone binaries");
   });
 
   // Keep in sync with `main.rs`.
@@ -292,7 +292,8 @@ pub async fn run(
     source_map_getter: None,
     format_js_error_fn: Some(Arc::new(format_js_error)),
     create_web_worker_cb,
-    web_worker_preload_module_cb,
+    web_worker_preload_module_cb: web_worker_cb.clone(),
+    web_worker_pre_execute_module_cb: web_worker_cb,
     maybe_inspector_server: None,
     should_break_on_first_statement: false,
     module_loader,

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), AnyError> {
   let create_web_worker_cb = Arc::new(|_| {
     todo!("Web workers are not supported in the example");
   });
-  let web_worker_preload_module_cb = Arc::new(|_| {
+  let web_worker_event_cb = Arc::new(|_| {
     todo!("Web workers are not supported in the example");
   });
 
@@ -46,7 +46,8 @@ async fn main() -> Result<(), AnyError> {
     seed: None,
     source_map_getter: None,
     format_js_error_fn: None,
-    web_worker_preload_module_cb,
+    web_worker_preload_module_cb: web_worker_event_cb.clone(),
+    web_worker_pre_execute_module_cb: web_worker_event_cb,
     create_web_worker_cb,
     maybe_inspector_server: None,
     should_break_on_first_statement: false,

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -42,7 +42,7 @@ pub type CreateWebWorkerCb = dyn Fn(CreateWebWorkerArgs) -> (WebWorker, Sendable
   + Sync
   + Send;
 
-pub type PreloadModuleCb = dyn Fn(WebWorker) -> LocalFutureObj<'static, Result<WebWorker, AnyError>>
+pub type WorkerEventCb = dyn Fn(WebWorker) -> LocalFutureObj<'static, Result<WebWorker, AnyError>>
   + Sync
   + Send;
 
@@ -51,17 +51,16 @@ pub type PreloadModuleCb = dyn Fn(WebWorker) -> LocalFutureObj<'static, Result<W
 /// because `GothamState` used in `OpState` overrides
 /// value if type aliases have the same underlying type
 #[derive(Clone)]
-pub struct CreateWebWorkerCbHolder(Arc<CreateWebWorkerCb>);
+struct CreateWebWorkerCbHolder(Arc<CreateWebWorkerCb>);
 
 #[derive(Clone)]
-pub struct FormatJsErrorFnHolder(Option<Arc<FormatJsErrorFn>>);
+struct FormatJsErrorFnHolder(Option<Arc<FormatJsErrorFn>>);
 
-/// A holder for callback that can used to preload some modules into a WebWorker
-/// before actual worker code is executed. It's a struct instead of a type
-/// because `GothamState` used in `OpState` overrides
-/// value if type aliases have the same underlying type
 #[derive(Clone)]
-pub struct PreloadModuleCbHolder(Arc<PreloadModuleCb>);
+struct PreloadModuleCbHolder(Arc<WorkerEventCb>);
+
+#[derive(Clone)]
+struct PreExecuteModuleCbHolder(Arc<WorkerEventCb>);
 
 pub struct WorkerThread {
   worker_handle: WebWorkerHandle,
@@ -92,7 +91,8 @@ pub type WorkersTable = HashMap<WorkerId, WorkerThread>;
 
 pub fn init(
   create_web_worker_cb: Arc<CreateWebWorkerCb>,
-  preload_module_cb: Arc<PreloadModuleCb>,
+  preload_module_cb: Arc<WorkerEventCb>,
+  pre_execute_module_cb: Arc<WorkerEventCb>,
   format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
 ) -> Extension {
   Extension::builder()
@@ -106,6 +106,9 @@ pub fn init(
       let preload_module_cb_holder =
         PreloadModuleCbHolder(preload_module_cb.clone());
       state.put::<PreloadModuleCbHolder>(preload_module_cb_holder);
+      let pre_execute_module_cb_holder =
+        PreExecuteModuleCbHolder(pre_execute_module_cb.clone());
+      state.put::<PreExecuteModuleCbHolder>(pre_execute_module_cb_holder);
       let format_js_error_fn_holder =
         FormatJsErrorFnHolder(format_js_error_fn.clone());
       state.put::<FormatJsErrorFnHolder>(format_js_error_fn_holder);
@@ -174,6 +177,8 @@ fn op_create_worker(
   state.put::<CreateWebWorkerCbHolder>(create_web_worker_cb.clone());
   let preload_module_cb = state.take::<PreloadModuleCbHolder>();
   state.put::<PreloadModuleCbHolder>(preload_module_cb.clone());
+  let pre_execute_module_cb = state.take::<PreExecuteModuleCbHolder>();
+  state.put::<PreExecuteModuleCbHolder>(pre_execute_module_cb.clone());
   let format_js_error_fn = state.take::<FormatJsErrorFnHolder>();
   state.put::<FormatJsErrorFnHolder>(format_js_error_fn.clone());
   state.put::<WorkerId>(worker_id.next().unwrap());
@@ -219,6 +224,7 @@ fn op_create_worker(
       module_specifier,
       maybe_source_code,
       preload_module_cb.0,
+      pre_execute_module_cb.0,
       format_js_error_fn.0,
     )
   })?;

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -324,7 +324,8 @@ pub struct WebWorkerOptions {
   pub seed: Option<u64>,
   pub module_loader: Rc<dyn ModuleLoader>,
   pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
-  pub preload_module_cb: Arc<ops::worker_host::PreloadModuleCb>,
+  pub preload_module_cb: Arc<ops::worker_host::WorkerEventCb>,
+  pub pre_execute_module_cb: Arc<ops::worker_host::WorkerEventCb>,
   pub format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
   pub source_map_getter: Option<Box<dyn SourceMapGetter>>,
   pub worker_type: WebWorkerType,
@@ -406,6 +407,7 @@ impl WebWorker {
       ops::worker_host::init(
         options.create_web_worker_cb.clone(),
         options.preload_module_cb.clone(),
+        options.pre_execute_module_cb.clone(),
         options.format_js_error_fn.clone(),
       ),
       // Extensions providing Deno.* features
@@ -669,7 +671,8 @@ pub fn run_web_worker(
   worker: WebWorker,
   specifier: ModuleSpecifier,
   maybe_source_code: Option<String>,
-  preload_module_cb: Arc<ops::worker_host::PreloadModuleCb>,
+  preload_module_cb: Arc<ops::worker_host::WorkerEventCb>,
+  pre_execute_module_cb: Arc<ops::worker_host::WorkerEventCb>,
   format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
 ) -> Result<(), AnyError> {
   let name = worker.name.to_string();
@@ -704,6 +707,18 @@ pub fn run_web_worker(
       // script instead of module
       match worker.preload_main_module(&specifier).await {
         Ok(id) => {
+          worker = match (pre_execute_module_cb)(worker).await {
+            Ok(worker) => worker,
+            Err(e) => {
+              print_worker_error(&e, &name, format_js_error_fn.as_deref());
+              internal_handle
+                .post_event(WorkerControlEvent::TerminalError(e))
+                .expect("Failed to post message to host");
+
+              // Failure to execute script is a terminal error, bye, bye.
+              return Ok(());
+            }
+          };
           worker.start_polling_for_messages();
           worker.execute_main_module(id).await
         }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -69,7 +69,8 @@ pub struct WorkerOptions {
   pub module_loader: Rc<dyn ModuleLoader>,
   // Callbacks invoked when creating new instance of WebWorker
   pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
-  pub web_worker_preload_module_cb: Arc<ops::worker_host::PreloadModuleCb>,
+  pub web_worker_preload_module_cb: Arc<ops::worker_host::WorkerEventCb>,
+  pub web_worker_pre_execute_module_cb: Arc<ops::worker_host::WorkerEventCb>,
   pub format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
   pub source_map_getter: Option<Box<dyn SourceMapGetter>>,
   pub maybe_inspector_server: Option<Arc<InspectorServer>>,
@@ -148,6 +149,7 @@ impl MainWorker {
       ops::worker_host::init(
         options.create_web_worker_cb.clone(),
         options.web_worker_preload_module_cb.clone(),
+        options.web_worker_pre_execute_module_cb.clone(),
         options.format_js_error_fn.clone(),
       ),
       ops::spawn::init(),
@@ -420,6 +422,7 @@ mod tests {
       format_js_error_fn: None,
       source_map_getter: None,
       web_worker_preload_module_cb: Arc::new(|_| unreachable!()),
+      web_worker_pre_execute_module_cb: Arc::new(|_| unreachable!()),
       create_web_worker_cb: Arc::new(|_| unreachable!()),
       maybe_inspector_server: None,
       should_break_on_first_statement: false,


### PR DESCRIPTION
This is extracted out of #15484. Essentially in there, I need to pre-load the modules in order to get the npm package references, only then can I tell whether I need to initialize the node code in a worker. This pre_execute_module_cb does the initialization of the node code.