### PR TITLE
Fix: Honor linter rules in CI and locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,6 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Error on warning
-        run: echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
-
       - name: Configure canary build
         if: |
           matrix.job == 'test' &&

--- a/ext/flash/sendfile.rs
+++ b/ext/flash/sendfile.rs
@@ -21,8 +21,8 @@ impl SendFile {
       let count = 0x7ffff000;
       let mut offset = self.written as libc::off_t;
 
-      // SAFETY: call to libc::sendfile()
       let res =
+        // SAFETY: call to libc::sendfile()
         unsafe { libc::sendfile(self.io.1, self.io.0, &mut offset, count) };
       if res == -1 {
         Err(io::Error::last_os_error())

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -110,7 +110,7 @@ async function clippy() {
   }
 
   const { success } = await Deno.spawn("cargo", {
-    args: cmd,
+    args: [...cmd, "--", "-D", "warnings"],
     stdout: "inherit",
     stderr: "inherit",
   });


### PR DESCRIPTION
`RUSTFLAGS` take precedence over `target.<triple>.rustflags`. Therefore, setting the env var globally in CI would always override whatever linter rules are allowed or denied in `.cargo/config.toml`.

With this change, we ensure that problems are detected both in CI and locally, using either `cargo clippy` or `lint.js`.

---

For context, in [#15453](https://github.com/denoland/deno/pull/15453) I moved the lint rules to `.cargo/config.toml`.

This fix would also unblock https://github.com/denoland/deno/pull/15464 by allowing `clippy::derive-partial-eq-without-eq` in CI.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
