### PR TITLE
fix(ext/flash): fix listening port

### DIFF
--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -72,6 +72,23 @@ Deno.test({ permissions: { net: true } }, async function httpServerBasic() {
   await server;
 });
 
+Deno.test({ permissions: { net: true } }, async function httpServerPort0() {
+  const ac = new AbortController();
+
+  const server = Deno.serve({
+    fetch() {
+      return new Response("Hello World");
+    },
+    port: 0,
+    signal: ac.signal,
+    onListen({ port }) {
+      assert(port > 0 && port < 65536);
+      ac.abort();
+    },
+  });
+  await server;
+});
+
 // https://github.com/denoland/deno/issues/15107
 Deno.test(
   { permissions: { net: true } },

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -216,8 +216,8 @@
     const serverId = core.ops.op_flash_serve(opts);
     const serverPromise = core.opAsync("op_flash_drive_server", serverId);
 
-    core.opAsync("op_flash_wait_for_listening", serverId).then(() => {
-      onListen({ hostname: opts.hostname, port: opts.port });
+    core.opAsync("op_flash_wait_for_listening", serverId).then((port) => {
+      onListen({ hostname: opts.hostname, port });
     });
 
     const server = {

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -76,7 +76,7 @@ pub struct ServerContext {
   rx: mpsc::Receiver<Request>,
   requests: HashMap<u32, Request>,
   next_token: u32,
-  listening_rx: Option<mpsc::Receiver<()>>,
+  listening_rx: Option<mpsc::Receiver<u16>>,
   close_tx: mpsc::Sender<()>,
   cancel_handle: Rc<CancelHandle>,
 }
@@ -939,7 +939,7 @@ pub struct ListenOpts {
 
 fn run_server(
   tx: mpsc::Sender<Request>,
-  listening_tx: mpsc::Sender<()>,
+  listening_tx: mpsc::Sender<u16>,
   mut close_rx: mpsc::Receiver<()>,
   addr: SocketAddr,
   maybe_cert: Option<String>,
@@ -971,7 +971,9 @@ fn run_server(
     }
   };
 
-  listening_tx.blocking_send(()).unwrap();
+  listening_tx
+    .blocking_send(listener.local_addr().unwrap().port())
+    .unwrap();
   let mut sockets = HashMap::with_capacity(1000);
   let mut counter: usize = 1;
   let mut events = Events::with_capacity(1024);
@@ -1274,7 +1276,7 @@ where
 fn op_flash_wait_for_listening(
   state: &mut OpState,
   server_id: u32,
-) -> Result<impl Future<Output = Result<(), AnyError>> + 'static, AnyError> {
+) -> Result<impl Future<Output = Result<u16, AnyError>> + 'static, AnyError> {
   let mut listening_rx = {
     let flash_ctx = state.borrow_mut::<FlashContext>();
     let server_ctx = flash_ctx
@@ -1284,8 +1286,8 @@ fn op_flash_wait_for_listening(
     server_ctx.listening_rx.take().unwrap()
   };
   Ok(async move {
-    listening_rx.recv().await;
-    Ok(())
+    let port = listening_rx.recv().await.unwrap();
+    Ok(port)
   })
 }
 


### PR DESCRIPTION
This PR fixes the listening port number when `port: 0` is passed to Deno.serve.

closes #15515 