### PR TITLE
feat: `queueMicrotask()` error handling

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2745,6 +2745,17 @@ itest!(report_error_end_of_program {
   exit_code: 1,
 });
 
+itest!(queue_microtask_error {
+  args: "run --quiet queue_microtask_error.ts",
+  output: "queue_microtask_error.ts.out",
+  exit_code: 1,
+});
+
+itest!(queue_microtask_error_handled {
+  args: "run --quiet queue_microtask_error_handled.ts",
+  output: "queue_microtask_error_handled.ts.out",
+});
+
 itest!(spawn_stdout_inherit {
   args: "run --quiet --unstable -A spawn_stdout_inherit.ts",
   output: "spawn_stdout_inherit.ts.out",

--- a/cli/tests/testdata/queue_microtask_error.ts
+++ b/cli/tests/testdata/queue_microtask_error.ts
@@ -1,0 +1,5 @@
+queueMicrotask(() => {
+  throw new Error("foo");
+});
+console.log(1);
+Promise.resolve().then(() => console.log(2));

--- a/cli/tests/testdata/queue_microtask_error.ts.out
+++ b/cli/tests/testdata/queue_microtask_error.ts.out
@@ -1,0 +1,6 @@
+1
+error: Uncaught Error: foo
+  throw new Error("foo");
+        ^
+    at [WILDCARD]/queue_microtask_error.ts:2:9
+    at deno:core/[WILDCARD]

--- a/cli/tests/testdata/queue_microtask_error_handled.ts
+++ b/cli/tests/testdata/queue_microtask_error_handled.ts
@@ -1,0 +1,21 @@
+addEventListener("error", (event) => {
+  console.log({
+    cancelable: event.cancelable,
+    message: event.message,
+    filename: event.filename,
+    lineno: event.lineno,
+    colno: event.colno,
+    error: event.error,
+  });
+  event.preventDefault();
+});
+
+onerror = (event) => {
+  console.log("onerror() called", event.error);
+};
+
+queueMicrotask(() => {
+  throw new Error("foo");
+});
+console.log(1);
+Promise.resolve().then(() => console.log(2));

--- a/cli/tests/testdata/queue_microtask_error_handled.ts.out
+++ b/cli/tests/testdata/queue_microtask_error_handled.ts.out
@@ -1,0 +1,15 @@
+1
+{
+  cancelable: true,
+  message: "Uncaught Error: foo",
+  filename: "[WILDCARD]/queue_microtask_error_handled.ts",
+  lineno: 18,
+  colno: 9,
+  error: Error: foo
+    at [WILDCARD]/queue_microtask_error_handled.ts:18:9
+    at deno:core/[WILDCARD]
+}
+onerror() called Error: foo
+    at [WILDCARD]/queue_microtask_error_handled.ts:18:9
+    at deno:core/[WILDCARD]
+2

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -215,6 +215,8 @@
   // Used to report errors thrown from functions passed to `queueMicrotask()`.
   // The callback will be passed the thrown error. For example, you can use this
   // to dispatch an error event to the global scope.
+  // In other words, set the implementation for
+  // https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception
   function setReportExceptionCallback(cb) {
     if (typeof cb == "function") {
       reportExceptionCallback = cb;

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -218,12 +218,16 @@
   // In other words, set the implementation for
   // https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception
   function setReportExceptionCallback(cb) {
-    if (typeof cb == "function") {
-      reportExceptionCallback = cb;
+    if (typeof cb != "function") {
+      throw new TypeError("expected a function");
     }
+    reportExceptionCallback = cb;
   }
 
   function queueMicrotask(cb) {
+    if (typeof cb != "function") {
+      throw new TypeError("expected a function");
+    }
     return ops.op_queue_microtask(() => {
       try {
         cb();

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -210,14 +210,14 @@
     return aggregate;
   }
 
-  let reportErrorCallback = undefined;
+  let reportExceptionCallback = undefined;
 
   // Used to report errors thrown from functions passed to `queueMicrotask()`.
   // The callback will be passed the thrown error. For example, you can use this
   // to dispatch an error event to the global scope.
-  function setReportErrorCallback(cb) {
+  function setReportExceptionCallback(cb) {
     if (typeof cb == "function") {
-      reportErrorCallback = cb;
+      reportExceptionCallback = cb;
     }
   }
 
@@ -226,8 +226,8 @@
       try {
         cb();
       } catch (error) {
-        if (reportErrorCallback) {
-          reportErrorCallback(error);
+        if (reportExceptionCallback) {
+          reportExceptionCallback(error);
         } else {
           throw error;
         }
@@ -273,7 +273,7 @@
     opCallTraces,
     refOp,
     unrefOp,
-    setReportErrorCallback,
+    setReportExceptionCallback,
     close: (rid) => ops.op_close(rid),
     tryClose: (rid) => ops.op_try_close(rid),
     read: opAsync.bind(null, "op_read"),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -243,7 +243,7 @@ delete Intl.v8BreakIterator;
     core.setMacrotaskCallback(timers.handleTimerMacrotask);
     core.setMacrotaskCallback(promiseRejectMacrotaskCallback);
     core.setWasmStreamingCallback(fetch.handleWasmStreaming);
-    core.setReportErrorCallback(reportException);
+    core.setReportExceptionCallback(reportException);
     ops.op_set_format_exception_callback(formatException);
     version.setVersions(
       runtimeOptions.denoVersion,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -76,7 +76,7 @@ delete Intl.v8BreakIterator;
   const errors = window.__bootstrap.errors.errors;
   const webidl = window.__bootstrap.webidl;
   const domException = window.__bootstrap.domException;
-  const { defineEventHandler } = window.__bootstrap.event;
+  const { defineEventHandler, reportException } = window.__bootstrap.event;
   const { deserializeJsMessageData, serializeJsMessageData } =
     window.__bootstrap.messagePort;
 
@@ -243,6 +243,7 @@ delete Intl.v8BreakIterator;
     core.setMacrotaskCallback(timers.handleTimerMacrotask);
     core.setMacrotaskCallback(promiseRejectMacrotaskCallback);
     core.setWasmStreamingCallback(fetch.handleWasmStreaming);
+    core.setReportErrorCallback(reportException);
     ops.op_set_format_exception_callback(formatException);
     version.setVersions(
       runtimeOptions.denoVersion,

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -3615,7 +3615,7 @@
         "type-long-settimeout.any.worker.html": true
       },
       "microtask-queuing": {
-        "queue-microtask-exceptions.any.html": false,
+        "queue-microtask-exceptions.any.html": true,
         "queue-microtask.any.html": true,
         "queue-microtask.any.worker.html": true
       },


### PR DESCRIPTION
Adds error event dispatching for `queueMicrotask()`. Consequently unhandled errors are now reported with `Deno.core.terminate()`, which is immune to the existing quirk with plainly thrown errors (#14158).

Fixes #4350.
Fixes #14158.