### PR TITLE
feat(ops): Automatic fast ops creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5315,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5d353ef04138242857d4f14f679659460f240275119424df31de5f6f1184fd"
+checksum = "e72791f754a6517e86d88e4521baad3a7d428ce54e266ba560b8747b2a99b946"
 dependencies = [
  "bitflags",
  "fslock",

--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -11,7 +11,7 @@ Deno.bench("date_now", { n: 5e5 }, () => {
   const { op_add } = Deno.core.ops;
   // deno-lint-ignore no-inner-declarations
   function add(a, b) {
-    return op_add.fast(a, b);
+    return op_add(a, b);
   }
   // deno-lint-ignore no-inner-declarations
   function addJS(a, b) {
@@ -24,7 +24,7 @@ Deno.bench("date_now", { n: 5e5 }, () => {
 // deno-lint-ignore camelcase
 const { op_void_sync } = Deno.core.ops;
 function sync() {
-  return op_void_sync.fast();
+  return op_void_sync();
 }
 sync(); // Warmup
 

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -312,7 +312,7 @@
     deserialize: (buffer, options) => ops.op_deserialize(buffer, options),
     getPromiseDetails: (promise) => ops.op_get_promise_details(promise),
     getProxyDetails: (proxy) => ops.op_get_proxy_details(proxy),
-    isProxy: (value) => ops.op_is_proxy.fast(value),
+    isProxy: (value) => ops.op_is_proxy(value),
     memoryUsage: () => ops.op_memory_usage(),
     setWasmStreamingCallback: (fn) => ops.op_set_wasm_streaming_callback(fn),
     abortWasmStreaming: (

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_v8 = { version = "0.62.0", path = "../serde_v8" }
 sourcemap = "6.1"
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
-v8 = { version = "0.50.0", default-features = false }
+v8 = { version = "0.51.0", default-features = false }
 
 [[example]]
 name = "http_bench_json_ops"

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -140,33 +140,21 @@ fn initialize_ops(
   op_ctxs: &[OpCtx],
   snapshot_loaded: bool,
 ) {
-  let object_template = v8::ObjectTemplate::new(scope);
-  assert!(object_template.set_internal_field_count(
-    (crate::runtime::V8_WRAPPER_OBJECT_INDEX + 1) as usize
-  ));
-
   for ctx in op_ctxs {
     let ctx_ptr = ctx as *const OpCtx as *const c_void;
 
     // If this is a fast op, we don't want it to be in the snapshot.
     // Only initialize once snapshot is loaded.
     if ctx.decl.fast_fn.is_some() && snapshot_loaded {
-      let method_obj = object_template.new_instance(scope).unwrap();
-      method_obj.set_aligned_pointer_in_internal_field(
-        crate::runtime::V8_WRAPPER_OBJECT_INDEX,
-        ctx_ptr,
-      );
       set_func_raw(
         scope,
-        method_obj,
-        "fast",
+        ops_obj,
+        ctx.decl.name,
         ctx.decl.v8_fn_ptr,
         ctx_ptr,
         &ctx.decl.fast_fn,
         snapshot_loaded,
       );
-      let method_key = v8::String::new(scope, ctx.decl.name).unwrap();
-      ops_obj.set(scope, method_key.into(), method_obj.into());
     } else {
       set_func_raw(
         scope,

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -31,7 +31,7 @@
   const hrU8 = new Uint8Array(8);
   const hr = new Uint32Array(hrU8.buffer);
   function opNow() {
-    ops.op_now.fast(hrU8);
+    ops.op_now(hrU8);
     return (hr[0] * 1000 + hr[1] / 1e6);
   }
 

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -295,14 +295,14 @@ fn codegen_fast_impl(
   must_be_fast: bool,
 ) -> (TokenStream2, TokenStream2) {
   if is_async {
+    if must_be_fast {
+      panic!("async op cannot be a fast api. enforced by #[op(fast)]")
+    }
     return (quote! {}, quote! { None });
   }
   let fast_info = can_be_fast_api(core, f);
   if must_be_fast && fast_info.is_none() {
     panic!("op cannot be a fast api. enforced by #[op(fast)]")
-  }
-  if must_be_fast && is_async {
-    panic!("async op cannot be a fast api. enforced by #[op(fast)]")
   }
   if !is_async {
     if let Some(FastApiSyn {

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = "0.99.17"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_bytes = "0.11"
 smallvec = { version = "1.8", features = ["union"] }
-v8 = { version = "0.50.0", default-features = false }
+v8 = { version = "0.51.0", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"


### PR DESCRIPTION
Use `options.data` to get access to the `OpCtx` struct instead of using the `receiver` object (essentially the `this` argument).

This puts fast ops' context access on essentially the same path as "slow ops", ie. both use the `external_data` argument.

I was hoping this would enable removing all or at least some of the `ExternalResource` stuff but that does not seem to be the case, though I do not understand why they're needed now and why they need to be kept out of the snapshot creation.

There might be a very nasty crash hidden in this PR: Once when running the `deno_common` benchmarks my whole computer froze...

I expect I'll need help to polish this PR to a proper level where it can be merged. Especially the `ExternalResource` stuff is something that I'd love to remove one way or another but I'm not sure how.

EDIT: As a test, I added a minor change with major effect to the fast ops macro: It's no longer opt in but instead is used for all sync ops if applicable. Also, I fixed the completely broken data extracting from the options bag. Build still passes, which is nice.