### PR TITLE
fix(unstable): better error for invalid hostname in Deno.serve()

### DIFF
--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -36,6 +36,18 @@ function onListen<T>(
   };
 }
 
+Deno.test(async function httpServerInvalidHostname() {
+  assertThrows(
+    () =>
+      Deno.serve({
+        fetch: (_req) => new Response("ok"),
+        hostname: "localhost",
+      }),
+    TypeError,
+    "hostname could not be parsed as an IP address",
+  );
+});
+
 Deno.test({ permissions: { net: true } }, async function httpServerBasic() {
   const ac = new AbortController();
   const promise = deferred();

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1244,7 +1244,11 @@ where
   state
     .borrow_mut::<P>()
     .check_net(&(&opts.hostname, Some(opts.port)))?;
-  let addr = SocketAddr::new(opts.hostname.parse()?, opts.port);
+  let parsed_hostname = opts
+    .hostname
+    .parse()
+    .map_err(|_| type_error("hostname could not be parsed as an IP address"))?;
+  let addr = SocketAddr::new(parsed_hostname, opts.port);
   let (tx, rx) = mpsc::channel(100);
   let (close_tx, close_rx) = mpsc::channel(1);
   let (listening_tx, listening_rx) = mpsc::channel(1);


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/15520