### PR TITLE
fix(ext/flash): fix default onListen callback

### DIFF
--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -205,11 +205,9 @@
       return new Response("Internal Server Error", { status: 500 });
     };
     delete opts.onError;
-    const onListen = opts.onListen ?? function () {
+    const onListen = opts.onListen ?? function ({ port }) {
       console.log(
-        `Listening on http://${
-          hostnameForDisplay(opts.hostname)
-        }:${opts.port}/`,
+        `Listening on http://${hostnameForDisplay(opts.hostname)}:${port}/`,
       );
     };
     delete opts.onListen;


### PR DESCRIPTION
This PR fixes the default onListen callback to use actual port number, and also adds test case for it.