### PR TITLE
refactor(core/runtime): clean up extra type cast

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1942,7 +1942,7 @@ impl JsRuntime {
       let mut args = vec![];
 
       for (promise_id, resp) in results.into_iter() {
-        args.push(v8::Integer::new(scope, promise_id as i32).into());
+        args.push(v8::Integer::new(scope, promise_id).into());
         args.push(resp.to_v8(scope).unwrap());
       }
 


### PR DESCRIPTION
This removes a cast to `i32` of a type that is already `i32`.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
