### PR TITLE
fix(npm): always require --unstable flag even for esm

### DIFF
--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -226,6 +226,7 @@ impl ProcState {
       &dir,
       cli_options.reload_flag(),
       cli_options.cache_setting(),
+      cli_options.unstable(),
     )?;
 
     Ok(ProcState(Arc::new(Inner {

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -10,7 +10,7 @@ use util::http_server;
 // by setting the DENO_TEST_UTIL_UPDATE_NPM=1 environment variable.
 
 itest!(esm_module {
-  args: "run --allow-read npm/esm/main.js",
+  args: "run --allow-read --unstable npm/esm/main.js",
   output: "npm/esm/main.out",
   envs: env_vars(),
   http_server: true,
@@ -19,6 +19,7 @@ itest!(esm_module {
 itest!(esm_module_eval {
   args_vec: vec![
     "eval",
+    "--unstable",
     "import chalk from 'npm:chalk@5'; console.log(chalk.green('chalk esm loads'));",
   ],
   output: "npm/esm/main.out",
@@ -27,7 +28,7 @@ itest!(esm_module_eval {
 });
 
 itest!(esm_module_deno_test {
-  args: "test --allow-read npm/esm/test.js",
+  args: "test --allow-read --unstable npm/esm/test.js",
   output: "npm/esm/test.out",
   envs: env_vars(),
   http_server: true,
@@ -57,6 +58,13 @@ itest!(dynamic_import {
 itest!(cached_only {
   args: "run --cached-only --unstable npm/cached_only/main.ts",
   output: "npm/cached_only/main.out",
+  envs: env_vars(),
+  exit_code: 1,
+});
+
+itest!(no_unstable {
+  args: "run npm/no_unstable/main.ts",
+  output: "npm/no_unstable/main.out",
   envs: env_vars(),
   exit_code: 1,
 });

--- a/cli/tests/testdata/npm/no_unstable/main.out
+++ b/cli/tests/testdata/npm/no_unstable/main.out
@@ -1,0 +1,1 @@
+error: Unstable use of npm specifiers. The --unstable flag must be provided.

--- a/cli/tests/testdata/npm/no_unstable/main.ts
+++ b/cli/tests/testdata/npm/no_unstable/main.ts
@@ -1,0 +1,3 @@
+import chalk from "npm:chalk@5";
+
+console.log(chalk.green("hello"));


### PR DESCRIPTION
To ensure these are locked down, always require `--unstable`. Previously only cjs would use an op that caused `--unstable` to be required.