### PR TITLE
fix(unstable): finish HTTP response for 205 and 304 responses

### DIFF
--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -1844,6 +1844,7 @@ Deno.test(
     const msg = decoder.decode(buf.subarray(0, readResult));
 
     assert(msg.startsWith("HTTP/1.1 304 Not Modified"));
+    assert(msg.endsWith("\r\n\r\n"));
 
     conn.close();
 

--- a/cli/tests/unit/spawn_test.ts
+++ b/cli/tests/unit/spawn_test.ts
@@ -714,7 +714,12 @@ Deno.test(function spawnSyncStdinPipedFails() {
 });
 
 Deno.test(
-  { permissions: { write: true, run: true, read: true } },
+  // TODO(bartlomieju): this test became flaky on Windows CI
+  // raising "PermissionDenied" instead of "NotFound".
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { write: true, run: true, read: true },
+  },
   async function spawnChildUnref() {
     const enc = new TextEncoder();
     const cwd = await Deno.makeTempDir({ prefix: "deno_command_test" });

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -140,7 +140,7 @@
       // MUST NOT generate a payload in a 205 response.
       // indicate a zero-length body for the response by
       // including a Content-Length header field with a value of 0.
-      str += "Content-Length: 0\r\n";
+      str += "Content-Length: 0\r\n\r\n";
       return str;
     }
 


### PR DESCRIPTION
This commit fixes "Deno.serve()" API by making sure that
205 and 304 responses end with "\r\n\r\n".