### PR TITLE
serde_v8: fix pointer size assumptions

### DIFF
--- a/serde_v8/magic/bytestring.rs
+++ b/serde_v8/magic/bytestring.rs
@@ -5,6 +5,8 @@ use crate::Error;
 use smallvec::SmallVec;
 use std::mem::size_of;
 
+const USIZE2X: usize = size_of::<usize>() * 2;
+
 #[derive(
   PartialEq,
   Eq,
@@ -18,14 +20,15 @@ use std::mem::size_of;
 )]
 #[as_mut(forward)]
 #[as_ref(forward)]
-pub struct ByteString(SmallVec<[u8; 16]>);
+pub struct ByteString(SmallVec<[u8; USIZE2X]>);
 impl_magic!(ByteString);
 
-// const-assert that Vec<u8> and SmallVec<[u8; 16]> have a same size.
+// const-assert that Vec<u8> and SmallVec<[u8; size_of::<usize>() * 2]> have a same size.
 // Note from https://docs.rs/smallvec/latest/smallvec/#union -
 //   smallvec can still be larger than Vec if the inline buffer is
 //   larger than two machine words.
-const _: () = assert!(size_of::<Vec<u8>>() == size_of::<SmallVec<[u8; 16]>>());
+const _: () =
+  assert!(size_of::<Vec<u8>>() == size_of::<SmallVec<[u8; USIZE2X]>>());
 
 impl ToV8 for ByteString {
   fn to_v8<'a>(

--- a/serde_v8/magic/transl8.rs
+++ b/serde_v8/magic/transl8.rs
@@ -105,13 +105,13 @@ pub(crate) unsafe fn opaque_recv<T: ?Sized>(ptr: &T) -> u64 {
 
 /// Transmutes an "opaque" ptr back into a reference
 pub(crate) unsafe fn opaque_deref<'a, T>(ptr: u64) -> &'a T {
-  std::mem::transmute(ptr)
+  std::mem::transmute(ptr as usize)
 }
 
 /// Transmutes & copies the value from the "opaque" ptr
 /// NOTE: takes ownership & requires other end to forget its ownership
 pub(crate) unsafe fn opaque_take<T>(ptr: u64) -> T {
-  std::mem::transmute_copy::<T, T>(std::mem::transmute(ptr))
+  std::mem::transmute_copy::<T, T>(std::mem::transmute(ptr as usize))
 }
 
 macro_rules! impl_magic {


### PR DESCRIPTION
serde_v8 cannot currently be built for 32 bit targets such as armv7-unknown-linux-musleabihf due to the code assuming pointers are 64 bits:

```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> serde_v8/magic/transl8.rs:108:3
    |
108 |   std::mem::transmute(ptr)
    |   ^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `u64` (64 bits)
    = note: target type: `&T` (32 bits)
```

This PR casts the serialized u64 fields to `usize` before transmuting and removes the hardcoded assumption that `size_of::<usize>() == 8`.