### PR TITLE
fix(ext/flash): set libc::sendfile count to Content-Length

### DIFF
--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -250,6 +250,7 @@ async fn op_flash_write_resource(
           let tx = sendfile::SendFile {
             io: (fd, stream_handle),
             written: 0,
+            count: stat.st_size as usize,
           };
           tx.await?;
           return Ok(());


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/15573

Gracefully handles the case when file is being written to. If the file is being truncated, the syscall might fail with `EOVERFLOW` (and throw in JS).