### PR TITLE
fix(cli/repl): await Promise.any([])...

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -861,3 +861,17 @@ fn repl_report_error() {
   assert_contains!(out, "1\n2\nundefined\n");
   assert!(err.is_empty());
 }
+
+#[test]
+fn pty_aggregate_error() {
+  let (out, err) = util::run_and_collect_output(
+    true,
+    "repl",
+    Some(vec!["await Promise.any([])"]),
+    Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+    false,
+  );
+
+  assert_contains!(out, "AggregateError");
+  assert!(err.is_empty());
+}

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -2030,11 +2030,11 @@ Deno.test(function inspectStringAbbreviation() {
 
 Deno.test(async function inspectAggregateError() {
   try {
-    await Promise.any([])
+    await Promise.any([]);
   } catch (err) {
     assertEquals(
       Deno.inspect(err).trimEnd(),
-      'AggregateError: All promises were rejected',
-    )
+      "AggregateError: All promises were rejected",
+    );
   }
-})
+});

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -2027,3 +2027,14 @@ Deno.test(function inspectStringAbbreviation() {
     '[ "This is a ..." ]',
   );
 });
+
+Deno.test(async function inspectAggregateError() {
+  try {
+    await Promise.any([])
+  } catch (err) {
+    assertEquals(
+      Deno.inspect(err).trimEnd(),
+      'AggregateError: All promises were rejected',
+    )
+  }
+})

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -959,6 +959,8 @@
         if (RegExpPrototypeTest(/\s+at/, line)) {
           ArrayPrototypeUnshift(stackLines, line);
           break;
+        } else if (typeof line === "undefined") {
+          break;
         }
 
         finalMessage += line;


### PR DESCRIPTION
 in REPL crashes with Fatal javascript OOM in Ineffective mark-compacts near heap limit(#15443)

and

fix(ext/console): console.dir 'AggregateError: All promises were rejected' lead to ' Fatal javascript OOM in Ineffective mark-compacts near heap limit' (#14496)

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Fixed: #15443 
Fixed: #14496  Thanks to @0f-0b for telling me [how to](https://github.com/denoland/deno/issues/14496#issuecomment-1228559707)