### PR TITLE
perf(ext/flash): vectored writes for sendfile headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "deno_websocket",
  "http",
  "httparse",
+ "itoa 1.0.3",
  "libc",
  "log 0.4.17",
  "mio",
@@ -2118,7 +2119,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.3",
 ]
 
 [[package]]
@@ -2165,7 +2166,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2346,9 +2347,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
@@ -3843,7 +3844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "indexmap",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -3866,7 +3867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]

--- a/ext/flash/Cargo.toml
+++ b/ext/flash/Cargo.toml
@@ -20,6 +20,7 @@ deno_tls = { version = "0.53.0", path = "../tls" }
 deno_websocket = { version = "0.71.0", path = "../websocket" }
 http = "0.2.6"
 httparse = "1.7"
+itoa = "1.0.3"
 libc = "0.2"
 log = "0.4.17"
 mio = { version = "0.8.1", features = ["os-poll", "net"] }

--- a/ext/flash/sendfile.rs
+++ b/ext/flash/sendfile.rs
@@ -86,10 +86,10 @@ impl<'a> SendFile<'a> {
       // sendfile() with TCP_CORK
       if self.sending_headers {
         let opt = 1;
-        libc::setsockopt(self.io.1, libc::SOL_SOCKET, libc::TCP_CORK, &opt, 4);
+        libc::setsockopt(self.io.1, libc::SOL_SOCKET, libc::TCP_CORK, &opt as *const _ as _, 4);
         let length = libc::writev(
           self.io.1,
-          self.slices.as_ptr(),
+          self.slices.as_ptr() as _,
           self.slices.len() as i32,
         );
 
@@ -107,7 +107,7 @@ impl<'a> SendFile<'a> {
         unsafe { libc::sendfile(self.io.1, self.io.0, &mut offset, count) };
 
       let opt = 0;
-      libc::setsockopt(self.io.1, libc::SOL_SOCKET, libc::TCP_CORK, &opt, 4);
+      libc::setsockopt(self.io.1, libc::SOL_SOCKET, libc::TCP_CORK, &opt as *const _ as _, 4);
 
       if res == -1 {
         Err(io::Error::last_os_error())


### PR DESCRIPTION
This felt like a good place to introduce the `UnixIoSlice` abstraction - which we will need for normal vectored writes in #15571 