### PR TITLE
fix: config file errors should not print specifier with debug formatting

### DIFF
--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -567,13 +567,13 @@ impl ConfigFile {
         Ok(Some(value)) if value.is_object() => value,
         Ok(Some(_)) => {
           return Err(anyhow!(
-            "config file JSON {:?} should be an object",
+            "config file JSON {} should be an object",
             specifier,
           ))
         }
         Err(e) => {
           return Err(anyhow!(
-            "Unable to parse config file JSON {:?} because of {}",
+            "Unable to parse config file JSON {} because of {}",
             specifier,
             e.to_string()
           ))


### PR DESCRIPTION
Gets rid of:

```
error: Unable to parse config file JSON Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/V:/dprint-plugin-typescript/deno.json", query: None, fragment: None } because of
```

and instead prints the specifier.