### PR TITLE
fix: disallow unknown keys in deno.json

### DIFF
--- a/cli/tests/integration/vendor_tests.rs
+++ b/cli/tests/integration/vendor_tests.rs
@@ -161,10 +161,6 @@ fn import_map_output_dir() {
     "{ \"imports\": { \"https://localhost:4545/\": \"./localhost/\" }}",
   );
   t.write(
-    "deno.json",
-    "{ \"import_map\": \"./vendor/import_map.json\" }",
-  );
-  t.write(
     "my_app.ts",
     "import {Logger} from 'http://localhost:4545/vendor/logger.ts'; new Logger().log('outputted');",
   );


### PR DESCRIPTION
I believe this was an oversight when implementing deno.json as we did put this tag on the other structs.

The reasoning for disallowing unknown keys is mainily to prevent users from adding custom keys that could potentially confict with a runtime feature, but also it reduces confusion when a user accidentally mispells a key as they get an error message.

Draft because I'm not sure we're going to do this or maybe we should warn instead?