### PR TITLE
perf: optimize webstorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "rand",
  "regex",
  "ring",
+ "rusqlite",
  "rustyline",
  "rustyline-derive",
  "semver 1.0.13",
@@ -1302,7 +1303,7 @@ version = "0.61.0"
 dependencies = [
  "deno_core",
  "deno_web",
- "rusqlite",
+ "libsqlite3-sys",
  "serde",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -89,6 +89,7 @@ pin-project = "1.0.11" # don't pin because they yank crates from cargo
 rand = { version = "=0.8.5", features = ["small_rng"] }
 regex = "=1.6.0"
 ring = "=0.16.20"
+rusqlite = { version = "0.28.0", features = ["unlock_notify", "bundled"] }
 rustyline = { version = "=10.0.0", default-features = false, features = ["custom-bindings"] }
 rustyline-derive = "=0.7.0"
 secure_tempfile = { version = "=3.3.0", package = "tempfile" } # different name to discourage use in tests

--- a/cli/bench/webstorage.js
+++ b/cli/bench/webstorage.js
@@ -1,0 +1,21 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+// Note: when benchmarking across different Deno version, make sure to clear
+// the DENO_DIR cache.
+let [total, count] = typeof Deno !== "undefined" ? Deno.args : [];
+
+total = total ? parseInt(total, 0) : 50;
+count = count ? parseInt(count, 10) : 1000000;
+
+function bench(fun) {
+  const start = Date.now();
+  for (let i = 0; i < count; i++) fun(i);
+  const elapsed = Date.now() - start;
+  const rate = Math.floor(count / (elapsed / 1000));
+  console.log(`time ${elapsed} ms rate ${rate}`);
+  if (--total) queueMicrotask(() => bench(fun));
+}
+
+localStorage.clear();
+localStorage.setItem("foo", "bar");
+bench(() => localStorage.getItem("foo"));

--- a/cli/cache/check.rs
+++ b/cli/cache/check.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
-use deno_runtime::deno_webstorage::rusqlite::params;
-use deno_runtime::deno_webstorage::rusqlite::Connection;
+use rusqlite::params;
+use rusqlite::Connection;
 
 use super::common::run_sqlite_pragma;
 

--- a/cli/cache/common.rs
+++ b/cli/cache/common.rs
@@ -3,7 +3,7 @@
 use std::hash::Hasher;
 
 use deno_core::error::AnyError;
-use deno_runtime::deno_webstorage::rusqlite::Connection;
+use rusqlite::Connection;
 
 /// A very fast insecure hasher that uses the xxHash algorithm.
 #[derive(Default)]

--- a/cli/cache/incremental.rs
+++ b/cli/cache/incremental.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use deno_core::error::AnyError;
 use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
-use deno_runtime::deno_webstorage::rusqlite::params;
-use deno_runtime::deno_webstorage::rusqlite::Connection;
+use rusqlite::params;
+use rusqlite::Connection;
 use serde::Serialize;
 use tokio::task::JoinHandle;
 

--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -14,8 +14,8 @@ use deno_graph::DefaultModuleAnalyzer;
 use deno_graph::ModuleInfo;
 use deno_graph::ModuleParser;
 use deno_graph::ParsedSourceStore;
-use deno_runtime::deno_webstorage::rusqlite::params;
-use deno_runtime::deno_webstorage::rusqlite::Connection;
+use rusqlite::params;
+use rusqlite::Connection;
 
 use super::common::run_sqlite_pragma;
 use super::FastInsecureHasher;

--- a/ext/webstorage/Cargo.toml
+++ b/ext/webstorage/Cargo.toml
@@ -16,5 +16,5 @@ path = "lib.rs"
 [dependencies]
 deno_core = { version = "0.148.0", path = "../../core" }
 deno_web = { version = "0.97.0", path = "../web" }
-rusqlite = { version = "0.28.0", features = ["unlock_notify", "bundled"] }
+libsqlite3-sys = { version = "0.25.1", features = ["bundled"] }
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
`ext/webstorage` uses simple sqlite features. This commit removes rusqlite abstraction and directly interface with sqlite C API.

2.5x improvement in `localStorage.getItem()`

```
deno run -A --unstable cli/bench/webstorage.js 50 1000000 # main
time 2148 ms rate 465549
time 2120 ms rate 471698
time 2116 ms rate 472589
time 2112 ms rate 473484
time 2082 ms rate 480307
time 2079 ms rate 481000
```

```
target/release/deno run -A --unstable cli/bench/webstorage.js 50 1000000 # This patch
time 964 ms rate 1037344
time 966 ms rate 1035196
time 946 ms rate 1057082
time 942 ms rate 1061571
time 922 ms rate 1084598
time 931 ms rate 1074113
```