### PR TITLE
perf(ops): support `Cow<'_, str>`

### DIFF
--- a/cli/bench/url_parse.js
+++ b/cli/bench/url_parse.js
@@ -1,0 +1,21 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
+let [total, count] = typeof Deno !== "undefined"
+  ? Deno.args
+  : [process.argv[2], process.argv[3]];
+
+total = total ? parseInt(total, 0) : 50;
+count = count ? parseInt(count, 10) : 10000000;
+
+function bench(fun) {
+  const start = Date.now();
+  for (let i = 0; i < count; i++) fun();
+  const elapsed = Date.now() - start;
+  const rate = Math.floor(count / (elapsed / 1000));
+  console.log(`time ${elapsed} ms rate ${rate}`);
+  if (--total) queueMicrotask(() => bench(fun));
+}
+
+bench(() => {
+  new URL("http://example.com/");
+});

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -214,12 +214,9 @@ fn op_create_host_object<'a>(
 #[op(v8)]
 fn op_encode<'a>(
   scope: &mut v8::HandleScope<'a>,
-  text: serde_v8::Value<'a>,
+  text: String,
 ) -> Result<serde_v8::Value<'a>, Error> {
-  let text = v8::Local::<v8::String>::try_from(text.v8_value)
-    .map_err(|_| type_error("Invalid argument"))?;
-  let text_str = serde_v8::to_utf8(text, scope);
-  let bytes = text_str.into_bytes();
+  let bytes = text.into_bytes();
   let len = bytes.len();
   let backing_store =
     v8::ArrayBuffer::new_backing_store_from_vec(bytes).make_shared();

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -12,6 +12,7 @@ use deno_core::url::quirks;
 use deno_core::url::Url;
 use deno_core::Extension;
 use deno_core::ZeroCopyBuf;
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use crate::urlpattern::op_urlpattern_parse;
@@ -57,7 +58,7 @@ type UrlParts = String;
 /// optional part to "set" after parsing. Return `UrlParts`.
 #[op]
 pub fn op_url_parse(
-  href: String,
+  href: Cow<'_, str>,
   base_href: Option<String>,
 ) -> Result<UrlParts, AnyError> {
   let base_url = base_href
@@ -88,7 +89,7 @@ pub enum UrlSetter {
 
 #[op]
 pub fn op_url_reparse(
-  href: String,
+  href: Cow<'_, str>,
   setter_opts: (u8, String),
 ) -> Result<UrlParts, AnyError> {
   let mut url = Url::options()

--- a/ext/web/blob.rs
+++ b/ext/web/blob.rs
@@ -6,6 +6,7 @@ use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
 use deno_core::ZeroCopyBuf;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -252,7 +253,7 @@ pub fn op_blob_create_object_url(
 #[op]
 pub fn op_blob_revoke_object_url(
   state: &mut deno_core::OpState,
-  url: String,
+  url: Cow<'_, str>,
 ) -> Result<(), AnyError> {
   let url = Url::parse(&url)?;
   let blob_store = state.borrow::<BlobStore>();
@@ -275,7 +276,7 @@ pub struct ReturnBlobPart {
 #[op]
 pub fn op_blob_from_object_url(
   state: &mut deno_core::OpState,
-  url: String,
+  url: Cow<'_, str>,
 ) -> Result<Option<ReturnBlob>, AnyError> {
   let url = Url::parse(&url)?;
   if url.scheme() != "blob" {

--- a/ext/web/compression.rs
+++ b/ext/web/compression.rs
@@ -41,11 +41,11 @@ impl Resource for CompressionResource {
 #[op]
 pub fn op_compression_new(
   state: &mut OpState,
-  format: String,
+  format: Cow<'_, str>,
   is_decoder: bool,
 ) -> ResourceId {
   let w = Vec::new();
-  let inner = match (format.as_str(), is_decoder) {
+  let inner = match (format.as_ref(), is_decoder) {
     ("deflate", true) => Inner::DeflateDecoder(ZlibDecoder::new(w)),
     ("deflate", false) => {
       Inner::DeflateEncoder(ZlibEncoder::new(w, Compression::default()))

--- a/serde_v8/lib.rs
+++ b/serde_v8/lib.rs
@@ -8,7 +8,7 @@ mod ser;
 mod serializable;
 pub mod utils;
 
-pub use de::{from_v8, from_v8_cached, to_utf8, Deserializer};
+pub use de::{from_v8, from_v8_cached, to_utf8, to_utf8_borrowed, Deserializer};
 pub use error::{Error, Result};
 pub use keys::KeyCache;
 pub use magic::buffer::ZeroCopyBuf;


### PR DESCRIPTION
Inline `String` and `Option<String>` args in the #[op] macro. Also implements deserialization of `Cow<'_, str>` from v8::String - it is backed by a global stack allocated buffer.

5% improvement in op_url_parse by switching `href: String` to `href: Cow<'_, str>`

```
# main

deno run -A --unstable cli/bench/url_parse.js 50 1000000
time 1076 ms rate 929368
time 1057 ms rate 946073
time 1047 ms rate 955109
time 1045 ms rate 956937
time 1043 ms rate 958772
time 1046 ms rate 956022
time 1049 ms rate 953288
```

```
# This patch

target/release/deno run -A --unstable cli/bench/url_parse.js 50 1000000
time 1020 ms rate 980392
time 1012 ms rate 988142
time 1004 ms rate 996015
time 1001 ms rate 999000
time 1000 ms rate 1000000
time 1000 ms rate 1000000
time 1000 ms rate 1000000
```