### PR TITLE
fix(compile): panic when running with a populated dep analysis cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22162c77cbcf8da271482b0facf45e4654cdf72dc09ebc7d8d534650ceb0effe"
+checksum = "f574fcfacf7b4ecce58c4cb67a3d76c025e4e010863e57f77827eaa9bf41248e"
 dependencies = [
  "cfg-if",
  "deno_ast",
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "deno_emit"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98268720377863f697b8e74955c33d237f527bdecb3e4b134b43390ba0aff40"
+checksum = "8ae998e26631299d03ba724cef7a2337e06777b6dfeae432dc932810679a5b68"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30317c100055c82f433bffb130c6dc62346f46a5d3de24d14e8913ad7c490c39"
+checksum = "a8d375dac1b6f7092c29c4603a7795c98b55257d39e108da02dd5b4e42f9d8a6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "eszip"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cd7d8f0b2f0de3a5f21b770974d6f293a2104536f7060033f17b4d63f8e91"
+checksum = "8043f99a09a1a1d4449ffcd2b068fabf2cb6d70b406e11c2b2d623ce8984baa7"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -48,9 +48,9 @@ winres = "=0.1.12"
 [dependencies]
 deno_ast = { version = "0.17.0", features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "transpiling", "typescript", "view", "visit"] }
 deno_core = { version = "0.148.0", path = "../core" }
-deno_doc = "0.43.0"
-deno_emit = "0.7.0"
-deno_graph = "0.32.0"
+deno_doc = "0.44.0"
+deno_emit = "0.8.0"
+deno_graph = "0.33.0"
 deno_lint = { version = "0.32.0", features = ["docs"] }
 deno_runtime = { version = "0.74.0", path = "../runtime" }
 deno_task_shell = "0.5.0"
@@ -69,7 +69,7 @@ dprint-plugin-markdown = "=0.14.0"
 dprint-plugin-typescript = "=0.71.2"
 encoding_rs = "=0.8.31"
 env_logger = "=0.9.0"
-eszip = "=0.25.0"
+eszip = "=0.26.0"
 fancy-regex = "=0.10.0"
 flate2 = "=1.0.24"
 http = "=0.2.6"

--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -88,7 +88,7 @@ impl ParsedSourceCache {
     source: Arc<str>,
     media_type: MediaType,
   ) -> deno_core::anyhow::Result<ParsedSource, deno_ast::Diagnostic> {
-    let parser = CapturingModuleParser::new(None, &self.sources);
+    let parser = self.as_capturing_parser();
     // this will conditionally parse because it's using a CapturingModuleParser
     parser.parse_module(specifier, source, media_type)
   }
@@ -123,6 +123,12 @@ impl ParsedSourceCache {
         ))
       }
     }
+  }
+
+  /// Creates a parser that will reuse a ParsedSource from the store
+  /// if it exists, or else parse.
+  pub fn as_capturing_parser(&self) -> CapturingModuleParser {
+    CapturingModuleParser::new(None, &self.sources)
   }
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -246,8 +246,8 @@ async fn compile_command(
 
   graph.valid().unwrap();
 
-  let store = ps.parsed_source_cache.as_store();
-  let eszip = eszip::EszipV2::from_graph(graph, &*store, Default::default())?;
+  let parser = ps.parsed_source_cache.as_capturing_parser();
+  let eszip = eszip::EszipV2::from_graph(graph, &parser, Default::default())?;
 
   info!(
     "{} {}",

--- a/cli/tests/integration/bundle_tests.rs
+++ b/cli/tests/integration/bundle_tests.rs
@@ -93,25 +93,29 @@ fn bundle_exports_no_check() {
 #[test]
 fn bundle_circular() {
   // First we have to generate a bundle of some module that has exports.
-  let circular1 = util::testdata_path().join("subdir/circular1.ts");
-  assert!(circular1.is_file());
+  let circular1_path = util::testdata_path().join("subdir/circular1.ts");
+  assert!(circular1_path.is_file());
   let t = TempDir::new();
-  let bundle = t.path().join("circular1.bundle.js");
-  let mut deno = util::deno_cmd()
-    .current_dir(util::testdata_path())
-    .arg("bundle")
-    .arg(circular1)
-    .arg(&bundle)
-    .spawn()
-    .unwrap();
-  let status = deno.wait().unwrap();
-  assert!(status.success());
-  assert!(bundle.is_file());
+  let bundle_path = t.path().join("circular1.bundle.js");
 
-  let output = util::deno_cmd()
+  // run this twice to ensure it works even when cached
+  for _ in 0..2 {
+    let mut deno = util::deno_cmd_with_deno_dir(&t)
+      .current_dir(util::testdata_path())
+      .arg("bundle")
+      .arg(&circular1_path)
+      .arg(&bundle_path)
+      .spawn()
+      .unwrap();
+    let status = deno.wait().unwrap();
+    assert!(status.success());
+    assert!(bundle_path.is_file());
+  }
+
+  let output = util::deno_cmd_with_deno_dir(&t)
     .current_dir(util::testdata_path())
     .arg("run")
-    .arg(&bundle)
+    .arg(&bundle_path)
     .output()
     .unwrap();
   // check the output of the the bundle program.

--- a/cli/tests/integration/compile_tests.rs
+++ b/cli/tests/integration/compile_tests.rs
@@ -13,27 +13,30 @@ fn compile() {
   } else {
     dir.path().join("welcome")
   };
-  let output = util::deno_cmd()
-    .current_dir(util::root_path())
-    .arg("compile")
-    .arg("--unstable")
-    .arg("--output")
-    .arg(&exe)
-    .arg("./test_util/std/examples/welcome.ts")
-    .stdout(std::process::Stdio::piped())
-    .spawn()
-    .unwrap()
-    .wait_with_output()
-    .unwrap();
-  assert!(output.status.success());
-  let output = Command::new(exe)
-    .stdout(std::process::Stdio::piped())
-    .spawn()
-    .unwrap()
-    .wait_with_output()
-    .unwrap();
-  assert!(output.status.success());
-  assert_eq!(output.stdout, "Welcome to Deno!\n".as_bytes());
+  // try this twice to ensure it works with the cache
+  for _ in 0..2 {
+    let output = util::deno_cmd_with_deno_dir(&dir)
+      .current_dir(util::root_path())
+      .arg("compile")
+      .arg("--unstable")
+      .arg("--output")
+      .arg(&exe)
+      .arg("./test_util/std/examples/welcome.ts")
+      .stdout(std::process::Stdio::piped())
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+    assert!(output.status.success());
+    let output = Command::new(&exe)
+      .stdout(std::process::Stdio::piped())
+      .spawn()
+      .unwrap()
+      .wait_with_output()
+      .unwrap();
+    assert!(output.status.success());
+    assert_eq!(output.stdout, "Welcome to Deno!\n".as_bytes());
+  }
 }
 
 #[test]


### PR DESCRIPTION
`deno compile` was panicking essentially every time. The fix was to have eszip parse the source if a `ParsedSource` didn't exist in the parsed source store.

The reason our tests did not catch this was because it would use a fresh cache each time. Updated the tests to check for this scenario, but the new design should not let this happen anymore.

Closes #15612