### PR TITLE
fix(fmt): add the file path to the panic messages when formatting is unstable

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -454,8 +454,9 @@ fn format_ensure_stable(
                 "Formatting succeeded initially, but failed when ensuring a ",
                 "stable format. This indicates a bug in the formatter where ",
                 "the text it produces is not syntatically correct. As a temporary ",
-                "workfaround you can ignore this file.\n\n{:#}"
+                "workfaround you can ignore this file ({}).\n\n{:#}"
               ),
+              file_path.display(),
               err,
             )
           }
@@ -465,10 +466,11 @@ fn format_ensure_stable(
           panic!(
             concat!(
               "Formatting not stable. Bailed after {} tries. This indicates a bug ",
-              "in the formatter where it formats the file differently each time. As a ",
+              "in the formatter where it formats the file ({}) differently each time. As a ",
               "temporary workaround you can ignore this file."
             ),
-            count
+            count,
+            file_path.display(),
           )
         }
       }


### PR DESCRIPTION
Oversight where the file path wasn't added to these panic messages.