### PR TITLE
chore(serde_v8): take mutable reference in `ToV8::to_v8`

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -99,7 +99,7 @@ pub enum OpResult {
 
 impl OpResult {
   pub fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, serde_v8::Error> {
     match self {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1944,7 +1944,7 @@ impl JsRuntime {
       // and then each tuple is used to resolve or reject promises
       let mut args = vec![];
 
-      for (promise_id, resp) in results.into_iter() {
+      for (promise_id, mut resp) in results.into_iter() {
         args.push(v8::Integer::new(scope, promise_id).into());
         args.push(resp.to_v8(scope).unwrap());
       }

--- a/serde_v8/magic/buffer.rs
+++ b/serde_v8/magic/buffer.rs
@@ -103,7 +103,7 @@ impl From<Vec<u8>> for ZeroCopyBuf {
 
 impl ToV8 for ZeroCopyBuf {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     let buf: Box<[u8]> = match self {

--- a/serde_v8/magic/bytestring.rs
+++ b/serde_v8/magic/bytestring.rs
@@ -32,7 +32,7 @@ const _: () =
 
 impl ToV8 for ByteString {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     let v =

--- a/serde_v8/magic/detached_buffer.rs
+++ b/serde_v8/magic/detached_buffer.rs
@@ -41,7 +41,7 @@ impl DerefMut for DetachedBuffer {
 
 impl ToV8 for DetachedBuffer {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     let buffer = v8::ArrayBuffer::with_backing_store(scope, &self.0.store);

--- a/serde_v8/magic/global.rs
+++ b/serde_v8/magic/global.rs
@@ -23,7 +23,7 @@ impl From<Global> for v8::Global<v8::Value> {
 
 impl ToV8 for Global {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     Ok(v8::Local::new(scope, self.v8_value.clone()))

--- a/serde_v8/magic/string_or_buffer.rs
+++ b/serde_v8/magic/string_or_buffer.rs
@@ -25,7 +25,7 @@ impl Deref for StringOrBuffer {
 
 impl ToV8 for StringOrBuffer {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     match self {

--- a/serde_v8/magic/transl8.rs
+++ b/serde_v8/magic/transl8.rs
@@ -14,7 +14,7 @@ pub(crate) trait MagicType {
 
 pub(crate) trait ToV8 {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error>;
 }
@@ -104,7 +104,7 @@ pub(crate) unsafe fn opaque_recv<T: ?Sized>(ptr: &T) -> u64 {
 }
 
 /// Transmutes an "opaque" ptr back into a reference
-pub(crate) unsafe fn opaque_deref<'a, T>(ptr: u64) -> &'a T {
+pub(crate) unsafe fn opaque_deref_mut<'a, T>(ptr: u64) -> &'a mut T {
   std::mem::transmute(ptr as usize)
 }
 

--- a/serde_v8/magic/u16string.rs
+++ b/serde_v8/magic/u16string.rs
@@ -8,7 +8,7 @@ impl_magic!(U16String);
 
 impl ToV8 for U16String {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     let maybe_v =

--- a/serde_v8/magic/value.rs
+++ b/serde_v8/magic/value.rs
@@ -29,7 +29,7 @@ impl<'s> From<Value<'s>> for v8::Local<'s, v8::Value> {
 
 impl ToV8 for Value<'_> {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     _scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     // SAFETY: not fully safe, since lifetimes are detached from original scope

--- a/serde_v8/ser.rs
+++ b/serde_v8/ser.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use crate::error::{Error, Result};
 use crate::keys::v8_struct_key;
 use crate::magic::transl8::MAGIC_FIELD;
-use crate::magic::transl8::{opaque_deref, opaque_recv, MagicType, ToV8};
+use crate::magic::transl8::{opaque_deref_mut, opaque_recv, MagicType, ToV8};
 use crate::{
   magic, ByteString, DetachedBuffer, StringOrBuffer, U16String, ZeroCopyBuf,
 };
@@ -253,7 +253,7 @@ impl<'a, 'b, 'c, T: MagicType + ToV8> ser::SerializeStruct
 
   fn end(self) -> JsResult<'a> {
     // SAFETY: transerialization assumptions imply `T` is still alive.
-    let x: &T = unsafe { opaque_deref(self.opaque) };
+    let x: &mut T = unsafe { opaque_deref_mut(self.opaque) };
     let scope = &mut *self.scope.borrow_mut();
     x.to_v8(scope)
   }

--- a/serde_v8/serializable.rs
+++ b/serde_v8/serializable.rs
@@ -12,7 +12,7 @@ use crate::ZeroCopyBuf;
 /// (and thus doesn't have to have generic outputs, etc...)
 pub trait Serializable {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error>;
 }
@@ -20,7 +20,7 @@ pub trait Serializable {
 /// Allows all implementors of `serde::Serialize` to implement Serializable
 impl<T: serde::Serialize> Serializable for T {
   fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     crate::to_v8(scope, self)
@@ -36,7 +36,7 @@ pub enum SerializablePkg {
 
 impl SerializablePkg {
   pub fn to_v8<'a>(
-    &self,
+    &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
     match self {


### PR DESCRIPTION
Currently, its not possible to mutatate return value during serialization stage; which is required to support V8 external strings that take ownership of the bytes. Ideally, `to_v8` should take ownership but that doesn't seem possible. With this patch, you could use `Option::take` to take ownership (& leak) `ByteString`, etc inside `to_v8`.