### PR TITLE
feat(serde_v8): Support StringObject as unit enum variant

### DIFF
--- a/serde_v8/de.rs
+++ b/serde_v8/de.rs
@@ -201,8 +201,8 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
   where
     V: Visitor<'de>,
   {
-    if self.input.is_string() {
-      let v8_string = v8::Local::<v8::String>::try_from(self.input).unwrap();
+    if self.input.is_string() || self.input.is_string_object() {
+      let v8_string = self.input.to_string(self.scope).unwrap();
       let string = to_utf8(v8_string, self.scope);
       visitor.visit_string(string)
     } else {
@@ -396,7 +396,7 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
     V: Visitor<'de>,
   {
     // Unit variant
-    if self.input.is_string() {
+    if self.input.is_string() || self.input.is_string_object() {
       let payload = v8::undefined(self.scope).into();
       visitor.visit_enum(EnumAccess {
         scope: self.scope,

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -125,8 +125,11 @@ detest!(
 
 // Unit enums
 detest!(de_enum_unit_a, EnumUnit, "'A'", EnumUnit::A);
+detest!(de_enum_unit_so_a, EnumUnit, "new String('A')", EnumUnit::A);
 detest!(de_enum_unit_b, EnumUnit, "'B'", EnumUnit::B);
+detest!(de_enum_unit_so_b, EnumUnit, "new String('B')", EnumUnit::B);
 detest!(de_enum_unit_c, EnumUnit, "'C'", EnumUnit::C);
+detest!(de_enum_unit_so_c, EnumUnit, "new String('C')", EnumUnit::C);
 
 // Enums with payloads (tuples & struct)
 detest!(


### PR DESCRIPTION
Allow passing `v8::StringObject` as unit enum variant alongside `v8::String`.

`v8::StringObject` is currently treated as an object and fails due to `LengthMismatch`.

Not sure about using `to_string` instead of `try_from`.
`try_from` fails due to: `BadType { actual: "v8::data::Value", expected: "v8::data::String" }`