### PR TITLE
perf(ext/web): flatten op arguments for text_encoding

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -125,24 +125,22 @@
         }
 
         if (!options.stream && this.#rid === null) {
-          return ops.op_encoding_decode_single(input, {
-            label: this.#encoding,
-            fatal: this.#fatal,
-            ignoreBom: this.#ignoreBOM,
-          });
+          return ops.op_encoding_decode_single(
+            input,
+            this.#encoding,
+            this.#fatal,
+            this.#ignoreBOM,
+          );
         }
 
         if (this.#rid === null) {
-          this.#rid = ops.op_encoding_new_decoder({
-            label: this.#encoding,
-            fatal: this.#fatal,
-            ignoreBom: this.#ignoreBOM,
-          });
+          this.#rid = ops.op_encoding_new_decoder(
+            this.#encoding,
+            this.#fatal,
+            this.#ignoreBOM,
+          );
         }
-        return ops.op_encoding_decode(input, {
-          rid: this.#rid,
-          stream: options.stream,
-        });
+        return ops.op_encoding_decode(input, this.#rid, options.stream);
       } finally {
         if (!options.stream && this.#rid !== null) {
           core.close(this.#rid);

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -181,8 +181,8 @@ fn op_encoding_normalize_label(label: String) -> Result<String, AnyError> {
 fn op_encoding_decode_single(
   data: ZeroCopyBuf,
   label: String,
-  ignore_bom: bool,
   fatal: bool,
+  ignore_bom: bool,
 ) -> Result<U16String, AnyError> {
   let encoding = Encoding::for_label(label.as_bytes()).ok_or_else(|| {
     range_error(format!(
@@ -235,8 +235,8 @@ fn op_encoding_decode_single(
 fn op_encoding_new_decoder(
   state: &mut OpState,
   label: String,
-  ignore_bom: bool,
   fatal: bool,
+  ignore_bom: bool,
 ) -> Result<ResourceId, AnyError> {
   let encoding = Encoding::for_label(label.as_bytes()).ok_or_else(|| {
     range_error(format!(

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -23,7 +23,6 @@ use encoding_rs::CoderResult;
 use encoding_rs::Decoder;
 use encoding_rs::DecoderResult;
 use encoding_rs::Encoding;
-use serde::Deserialize;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -166,14 +166,6 @@ fn forgiving_base64_encode(s: &[u8]) -> String {
   BASE64_STANDARD.encode_to_boxed_str(s).into_string()
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct DecoderOptions {
-  label: String,
-  ignore_bom: bool,
-  fatal: bool,
-}
-
 #[op]
 fn op_encoding_normalize_label(label: String) -> Result<String, AnyError> {
   let encoding = Encoding::for_label_no_replacement(label.as_bytes())
@@ -189,14 +181,10 @@ fn op_encoding_normalize_label(label: String) -> Result<String, AnyError> {
 #[op]
 fn op_encoding_decode_single(
   data: ZeroCopyBuf,
-  options: DecoderOptions,
+  label: String,
+  ignore_bom: bool,
+  fatal: bool,
 ) -> Result<U16String, AnyError> {
-  let DecoderOptions {
-    label,
-    ignore_bom,
-    fatal,
-  } = options;
-
   let encoding = Encoding::for_label(label.as_bytes()).ok_or_else(|| {
     range_error(format!(
       "The encoding label provided ('{}') is invalid.",
@@ -247,14 +235,10 @@ fn op_encoding_decode_single(
 #[op]
 fn op_encoding_new_decoder(
   state: &mut OpState,
-  options: DecoderOptions,
+  label: String,
+  ignore_bom: bool,
+  fatal: bool,
 ) -> Result<ResourceId, AnyError> {
-  let DecoderOptions {
-    label,
-    fatal,
-    ignore_bom,
-  } = options;
-
   let encoding = Encoding::for_label(label.as_bytes()).ok_or_else(|| {
     range_error(format!(
       "The encoding label provided ('{}') is invalid.",
@@ -276,21 +260,13 @@ fn op_encoding_new_decoder(
   Ok(rid)
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct DecodeOptions {
-  rid: ResourceId,
-  stream: bool,
-}
-
 #[op]
 fn op_encoding_decode(
   state: &mut OpState,
   data: ZeroCopyBuf,
-  options: DecodeOptions,
+  rid: ResourceId,
+  stream: bool,
 ) -> Result<U16String, AnyError> {
-  let DecodeOptions { rid, stream } = options;
-
   let resource = state.resource_table.get::<TextDecoderResource>(rid)?;
 
   let mut decoder = resource.decoder.borrow_mut();


### PR DESCRIPTION
 Towards #14893 
 
 1.4x improvement in CSV parsing.

```
# Before

time deno run --allow-env --allow-read --allow-hrtime deno-csv-CSVReader.ts 500000-Records.csv
Read 500001 lines for 19.435 seconds

________________________________________________________
Executed in   19.50 secs    fish           external
   usr time   17.47 secs    9.85 millis   17.46 secs
   sys time    3.55 secs    2.47 millis    3.54 secs
```

```
# After

time ../../deno/target/release/deno run --allow-env --allow-read --allow-hrtime deno-csv-CSVReader.ts 500000-Records.csv
Read 500001 lines for 14.889 seconds

________________________________________________________
Executed in   14.99 secs    fish           external
   usr time   13.13 secs    7.14 millis   13.13 secs
   sys time    3.18 secs    2.50 millis    3.18 secs
```