### PR TITLE
fix(npm): ignore the unstable error in the lsp

### DIFF
--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -226,7 +226,9 @@ impl ProcState {
       &dir,
       cli_options.reload_flag(),
       cli_options.cache_setting(),
-      cli_options.unstable(),
+      cli_options.unstable()
+        // don't do the unstable error when in the lsp
+        || matches!(cli_options.sub_command(), DenoSubcommand::Lsp),
     )?;
 
     Ok(ProcState(Arc::new(Inner {


### PR DESCRIPTION
Not an ideal fix, but this is temporary code until it's stabilized. I also didn't add any lsp tests because those will come later once we get better lsp support.