### PR TITLE
fix(ext/ffi): Fix pointer types

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -421,7 +421,7 @@ declare namespace Deno {
     & Record<NativeBigIntType, PointerValue>
     & Record<NativePointerType, PointerValue | null>
     & Record<NativeFunctionType, PointerValue | null>
-    & Record<NativeBufferType, TypedArray>;
+    & Record<NativeBufferType, TypedArray | null>;
 
   /** Type conversion for foreign symbol parameters and unsafe callback return
    * types.
@@ -633,12 +633,12 @@ declare namespace Deno {
     /** Gets a C string (null terminated string) at the specified byte offset from the pointer. */
     getCString(offset?: number): string;
     /** Gets a C string (null terminated string) at the specified byte offset from the specified pointer. */
-    static getCString(pointer: BigInt, offset?: number): string;
+    static getCString(pointer: PointerValue, offset?: number): string;
     /** Gets an ArrayBuffer of length `byteLength` at the specified byte offset from the pointer. */
     getArrayBuffer(byteLength: number, offset?: number): ArrayBuffer;
     /** Gets an ArrayBuffer of length `byteLength` at the specified byte offset from the specified pointer. */
     static getArrayBuffer(
-      pointer: BigInt,
+      pointer: PointerValue,
       byteLength: number,
       offset?: number,
     ): ArrayBuffer;
@@ -646,7 +646,7 @@ declare namespace Deno {
     copyInto(destination: TypedArray, offset?: number): void;
     /** Copies the memory of the specified pointer into a typed array. Length is determined from the typed array's `byteLength`. Also takes optional byte offset from the pointer. */
     static copyInto(
-      pointer: BigInt,
+      pointer: PointerValue,
       destination: TypedArray,
       offset?: number,
     ): void;

--- a/test_ffi/tests/ffi_types.ts
+++ b/test_ffi/tests/ffi_types.ts
@@ -143,12 +143,12 @@ remote.symbols.method15(0n);
 const result = remote.symbols.method16();
 // @ts-expect-error: Invalid argument
 let r_0: string = result;
-let r_1: number | bigint = result;
+let r_1: Deno.PointerValue = result;
 
 const result2 = remote.symbols.method17();
 // @ts-expect-error: Invalid argument
 result2.then((_0: string) => {});
-result2.then((_1: number | bigint) => {});
+result2.then((_1: Deno.PointerValue) => {});
 
 const result3 = remote.symbols.method18();
 // @ts-expect-error: Invalid argument
@@ -200,7 +200,7 @@ const unsafe_callback_wrong4 = new Deno.UnsafeCallback(
     parameters: ["u64"],
     result: "void",
   } as const,
-  // @ts-expect-error: Callback's 64bit parameters are always called as bigint
+  // @ts-expect-error: Callback's 64bit parameters are either number or bigint
   (_: number) => {},
 );
 const unsafe_callback_right1 = new Deno.UnsafeCallback(
@@ -208,7 +208,7 @@ const unsafe_callback_right1 = new Deno.UnsafeCallback(
     parameters: ["u8", "u32", "pointer"],
     result: "void",
   } as const,
-  (_1: number, _2: number, _3: Deno.UnsafePointer) => {},
+  (_1: number, _2: number, _3: Deno.PointerValue) => {},
 );
 const unsafe_callback_right2 = new Deno.UnsafeCallback(
   {
@@ -230,14 +230,14 @@ const unsafe_callback_right4 = new Deno.UnsafeCallback(
     parameters: ["u8", "u32", "pointer"],
     result: "u8",
   } as const,
-  (_1: number, _2: number, _3: Deno.UnsafePointer) => 3,
+  (_1: number, _2: number, _3: Deno.PointerValue) => 3,
 );
 const unsafe_callback_right5 = new Deno.UnsafeCallback(
   {
     parameters: ["u8", "i32", "pointer"],
     result: "void",
   } as const,
-  (_1: number, _2: number, _3: Deno.UnsafePointer) => {},
+  (_1: number, _2: number, _3: Deno.PointerValue) => {},
 );
 
 // @ts-expect-error: Must pass callback
@@ -256,7 +256,6 @@ remote.symbols.method23(new Uint8Array(1));
 remote.symbols.method23(0);
 // @ts-expect-error: Cannot pass pointer values as buffer.
 remote.symbols.method23(0n);
-// @ts-expect-error: Cannot pass pointer values as buffer.
 remote.symbols.method23(null);
 
 // @ts-expect-error: Invalid member type
@@ -348,9 +347,9 @@ type __Tests__ = [
     {
       symbols: {
         pushBuf: (
-          buf: TypedArray,
-          ptr: number | bigint | null,
-          func: number | bigint | null,
+          buf: TypedArray | null,
+          ptr: Deno.PointerValue | null,
+          func: Deno.PointerValue | null,
         ) => void;
       };
       close(): void;
@@ -368,10 +367,10 @@ type __Tests__ = [
     {
       symbols: {
         pushBuf: (
-          buf: TypedArray,
-          ptr: number | bigint | null,
-          func: number | bigint | null,
-        ) => number | bigint;
+          buf: TypedArray | null,
+          ptr: Deno.PointerValue | null,
+          func: Deno.PointerValue | null,
+        ) => Deno.PointerValue;
       };
       close(): void;
     },
@@ -388,8 +387,8 @@ type __Tests__ = [
     {
       symbols: {
         foo: (
-          ...args: (number | bigint | null)[]
-        ) => number | bigint;
+          ...args: (Deno.PointerValue | null)[]
+        ) => Deno.PointerValue;
       };
       close(): void;
     },


### PR DESCRIPTION
Some pointer types were mistakenly using `BigInt` which as the TS type, which doesn't really mean anything.

Also, the `"buffer"` arguments do also accept `null`.