### PR TITLE
fix(npm): correct exact matching of pre-release versions

### DIFF
--- a/cli/npm/resolution.rs
+++ b/cli/npm/resolution.rs
@@ -514,7 +514,7 @@ fn get_resolved_package_version_and_info(
     None => bail!(
       concat!(
         "Could not find npm package '{}' matching {}{}. ",
-        "Try retreiving the latest npm package information by running with --reload",
+        "Try retrieving the latest npm package information by running with --reload",
       ),
       pkg_name,
       version_matcher.version_text(),

--- a/cli/npm/semver/mod.rs
+++ b/cli/npm/semver/mod.rs
@@ -313,9 +313,7 @@ fn simple(input: &str) -> ParseResult<VersionRange> {
         }
       }
     }),
-    map(partial, |partial| {
-      partial.as_greater_range(VersionBoundKind::Inclusive)
-    }),
+    map(partial, |partial| partial.as_equal_range()),
   )(input)
 }
 
@@ -842,6 +840,8 @@ mod tests {
       ("1.0.0 - x", "1.9.7"),
       ("1.x - x", "1.9.7"),
       ("<=7.x", "7.9.9"),
+      // additional tests
+      ("1.0.0-alpha.13", "1.0.0-alpha.13"),
     ];
     for (req_text, version_text) in fixtures {
       let req = NpmVersionReq::parse(req_text).unwrap();

--- a/cli/npm/semver/specifier.rs
+++ b/cli/npm/semver/specifier.rs
@@ -6,7 +6,6 @@ use monch::*;
 
 use super::errors::with_failure_handling;
 use super::range::Partial;
-use super::range::VersionBoundKind;
 use super::range::VersionRange;
 use super::range::XRange;
 use super::NpmVersion;
@@ -57,9 +56,7 @@ fn version_range(input: &str) -> ParseResult<VersionRange> {
     map(preceded(ch('^'), partial), |partial| {
       partial.as_caret_version_range()
     }),
-    map(partial, |partial| {
-      partial.as_greater_range(VersionBoundKind::Inclusive)
-    }),
+    map(partial, |partial| partial.as_equal_range()),
   )(input)
 }
 
@@ -186,6 +183,10 @@ mod tests {
     assert!(tester.matches("1.0.1"));
     assert!(!tester.matches("1.0.2"));
     assert!(!tester.matches("1.1.1"));
+
+    // pre-release
+    let tester = VersionReqTester::new("1.0.0-alpha.13");
+    assert!(tester.matches("1.0.0-alpha.13"));
   }
 
   #[test]

--- a/cli/tests/testdata/npm/deno_run_non_existent.out
+++ b/cli/tests/testdata/npm/deno_run_non_existent.out
@@ -1,2 +1,2 @@
 Download http://localhost:4545/npm/registry/mkdirp
-error: Could not find npm package 'mkdirp' matching 0.5.125. Try retreiving the latest npm package information by running with --reload
+error: Could not find npm package 'mkdirp' matching 0.5.125. Try retrieving the latest npm package information by running with --reload


### PR DESCRIPTION
This broke with the re-write of the npm semver, but should be fixed now.

Will do a follow up PR for latest tag matching.

Closes #15739