### PR TITLE
fix(ops): use qualified borrow in op macro

### DIFF
--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -476,7 +476,8 @@ fn codegen_v8_sync(
 
     let result = Self::call::<#type_params>(#args_head #args_tail);
 
-    let op_state = &*ctx.state.borrow();
+    // use RefCell::borrow instead of state.borrow to avoid clash with std::borrow::Borrow
+    let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
     op_state.tracker.track_sync(ctx.id);
 
     #ret


### PR DESCRIPTION
Fix https://github.com/denoland/deno/issues/15764

Use RefCell::borrow instead of state.borrow to avoid clash with std::borrow::Borrow

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
