### PR TITLE
fix(core): make errors more resistant to tampering

### DIFF
--- a/cli/tests/unit/error_test.ts
+++ b/cli/tests/unit/error_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { assert } from "./test_util.ts";
+import { assert, assertThrows, fail } from "./test_util.ts";
 
 Deno.test("Errors work", () => {
   assert(new Deno.errors.NotFound("msg") instanceof Error);
@@ -21,4 +21,12 @@ Deno.test("Errors work", () => {
   assert(new Deno.errors.Http("msg") instanceof Error);
   assert(new Deno.errors.Busy("msg") instanceof Error);
   assert(new Deno.errors.NotSupported("msg") instanceof Error);
+});
+
+Deno.test("Errors have some tamper resistance", () => {
+  // deno-lint-ignore no-explicit-any
+  (Object.prototype as any).get = () => {};
+  assertThrows(() => fail("test error"), Error, "test error");
+  // deno-lint-ignore no-explicit-any
+  delete (Object.prototype as any).get;
 });

--- a/core/02_error.js
+++ b/core/02_error.js
@@ -127,7 +127,7 @@
     let callSiteEvals = ArrayPrototypeMap(callSites, evaluateCallSite);
     callSiteEvals = ArrayPrototypeMap(callSiteEvals, sourceMapCallSiteEval);
     ObjectDefineProperties(error, {
-      __callSiteEvals: { value: [], configurable: true },
+      __callSiteEvals: { __proto__: null, value: [], configurable: true },
     });
     const formattedCallSites = [];
     for (const cse of callSiteEvals) {


### PR DESCRIPTION
This commit makes error objects more resistant to prototype tampering.

This bug was found when updating the deno_std Node compatibility layer to Node 18. The Node test `parallel/test-assert-fail.js` was breaking std's assertion library.

Refs: https://github.com/denoland/deno_std/pull/2585

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
