### PR TITLE
test: fix bad resource fixture

### DIFF
--- a/cli/tests/testdata/044_bad_resource.ts.out
+++ b/cli/tests/testdata/044_bad_resource.ts.out
@@ -1,2 +1,2 @@
-[WILDCARD]error: Uncaught [WILDCARD] BadResource: Bad resource ID
+[WILDCARD]error: Uncaught[WILDCARD] BadResource: Bad resource ID
 [WILDCARD]


### PR DESCRIPTION
Fixes #15791. I guess the wildcard is supposed to handle `(in promise)` not definitely being written but there was an extra space.