### PR TITLE
fix(core): opAsync leaks a promise on type error

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -161,9 +161,14 @@
   function opAsync(opName, ...args) {
     const promiseId = nextPromiseId++;
     let p = setPromise(promiseId);
-    const maybeError = ops[opName](promiseId, ...args);
-    // Handle sync error (e.g: error parsing args)
-    if (maybeError) return unwrapOpResult(maybeError);
+    try {
+      ops[opName](promiseId, ...args);
+    } catch (err) {
+      // Cleanup the just-created promise
+      getPromise(promiseId);
+      // Rethrow the error
+      throw err;
+    }
     p = PromisePrototypeThen(p, unwrapOpResult);
     if (opCallTracingEnabled) {
       // Capture a stack trace by creating a new `Error` object. We remove the


### PR DESCRIPTION
Two minor changes to `opAsync`:

1. Ops never return `maybeError` anymore. A type error is thrown directly, whereas synchronous errors from async ops are handled by rejecting the promise. Thus there's no need to check the return value.
2. If the async op throws, it would now leave the promise in the promise ring. We need to try-catch the error, remove the error and rethrow the error.