### PR TITLE
chore(cli): exclude npm registry data from crate package

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/denoland/deno"
 description = "Provides the deno executable"
+exclude = ["tests/testdata/npm/registry/*"]
 
 [[bin]]
 name = "deno"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,10 +6,10 @@ version = "1.25.1"
 authors = ["the Deno authors"]
 default-run = "deno"
 edition = "2021"
+exclude = ["tests/testdata/npm/registry/*"]
 license = "MIT"
 repository = "https://github.com/denoland/deno"
 description = "Provides the deno executable"
-exclude = ["tests/testdata/npm/registry/*"]
 
 [[bin]]
 name = "deno"


### PR DESCRIPTION
`cli/tests/testdata/npm/registry/` contains 22MB of data and that causes the error `max upload size is: 10485760` while publishing `deno` crate.

This PR excludes `cli/tests/testdata/npm/registry/` and avoids the upload error.