### PR TITLE
fix(ops): Fix typo on readme

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -37,7 +37,7 @@ The macro will infer and try to auto generate V8 fast API call trait impl for
 - arguments: integers / `&mut OpState`
 - return_type: integers
 
-The `#[op(fast)]` attribute shoukd be used to enforce fast call generation at
+The `#[op(fast)]` attribute should be used to enforce fast call generation at
 compile time.
 
 Trait gen for `async` ops & a ZeroCopyBuf equivalent type is planned and will be


### PR DESCRIPTION
# Description

This fixes the typo on `ops` README.