### PR TITLE
perf(ext/flash): remove string->buffer cache

### DIFF
--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -111,7 +111,6 @@
 
   let dateInterval;
   let date;
-  let stringResources = {};
 
   // Construct an HTTP response message.
   // All HTTP/1.1 messages consist of a start-line followed by a sequence
@@ -209,18 +208,12 @@
       nwritten = respondFast(requestId, response, end);
     } else {
       // string
-      const maybeResponse = stringResources[response];
-      if (maybeResponse === undefined) {
-        stringResources[response] = core.encode(response);
-        nwritten = core.ops.op_flash_respond(
-          server,
-          requestId,
-          stringResources[response],
-          end,
-        );
-      } else {
-        nwritten = respondFast(requestId, maybeResponse, end);
-      }
+      nwritten = core.ops.op_flash_respond(
+        server,
+        requestId,
+        response,
+        end,
+      );
     }
 
     if (nwritten < responseLen) {
@@ -578,7 +571,6 @@
       date = new Date().toUTCString();
       dateInterval = setInterval(() => {
         date = new Date().toUTCString();
-        stringResources = {};
       }, 1000);
     }
 


### PR DESCRIPTION
Removes an unecessary optimization: Apart from the possibility that the cache might explode due to uncertainties of timer callbacks, there is also a megamorphic property access hit which kinda cancels out its usefulness.

1.3x improvement on Linux. No change on OSX.
![image](https://user-images.githubusercontent.com/34997667/189491398-f0bd92df-c9c0-40ee-b51c-ccf3578ffc45.png)
