### PR TITLE
perf(url): return early if url has no query string

### DIFF
--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -92,6 +92,11 @@
           { prefix, context: "Argument 1" },
         );
       this[webidl.brand] = webidl.brand;
+      if (!init) {
+        // if there is no query string, return early
+        this[_list] = [];
+        return;
+      }
 
       if (typeof init === "string") {
         // Overload: USVString


### PR DESCRIPTION
This small change returns early if the url being parsed has no query string. This gives a nice performance improvement when tested on Ubuntu 22.04 docker in unprivileged mode:

![Screenshot from 2022-09-10 23-50-54](https://user-images.githubusercontent.com/159073/189504669-0bc45351-eff2-4b63-bec8-6cb50785a79c.png)

I ran wpt tests as follows and all are passing.

```
deno run -A --unstable ./tools/wpt.ts setup
deno run -A --unstable ./tools/wpt.ts run -- url
deno run -A --unstable ./tools/wpt.ts run --
```

I can't bench right now on Mac or Windows so if anyone can verify they can see same thing there, that would be great.

this is my first Deno PR so let me know if i have missed something out.