### PR TITLE
fix: allow resolve_url_or_path error to bubble up

### DIFF
--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -554,7 +554,7 @@ impl ProcState {
     {
       deno_core::resolve_url_or_path("./$deno$repl.ts").unwrap()
     } else {
-      deno_core::resolve_url_or_path(referrer).unwrap()
+      deno_core::resolve_url_or_path(referrer)?
     };
 
     let maybe_resolver: Option<&dyn deno_graph::source::Resolver> =


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/15849

Instead of panicking this allows the "invalid module path" error to bubble up

<img width="913" alt="image" src="https://user-images.githubusercontent.com/184235/189510333-df7f6386-534c-4e23-ace6-1f4327f55a7b.png">
