### PR TITLE
chore(runtime): upgrade netif crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "netif"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96c14078e0dae0c847c413b31304d5563daeb2494a61ebb01cb66f19b8ba99f"
+checksum = "d29a01b9f018d6b7b277fef6c79fdbd9bf17bb2d1e298238055cafab49baa5ee"
 dependencies = [
  "libc",
  "winapi 0.3.9",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -75,7 +75,7 @@ hyper = { version = "0.14.18", features = ["server", "stream", "http1", "http2",
 libc = "0.2.126"
 log = "0.4.16"
 lzzzz = '1.0'
-netif = "0.1.3"
+netif = "0.1.6"
 notify = "5.0"
 once_cell = "1.10.0"
 regex = "1.6.0"


### PR DESCRIPTION
v0.1.3 contains code that will stop working with newer versions of libstd because the layout of some std::net types changed.

Refs: https://github.com/bnoordhuis/netif/pull/10

<hr>

The linked PR is the only code change relative to v0.1.3.