### PR TITLE
chore(ext/flash): disable flaky flash test

### DIFF
--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -1417,11 +1417,12 @@ createServerLengthTest("autoResponseWithKnownLengthEmpty", {
   expects_con_len: true,
 });
 
-createServerLengthTest("autoResponseWithUnknownLengthEmpty", {
-  body: stream(""),
-  expects_chunked: true,
-  expects_con_len: false,
-});
+// FIXME: https://github.com/denoland/deno/issues/15892
+// createServerLengthTest("autoResponseWithUnknownLengthEmpty", {
+//   body: stream(""),
+//   expects_chunked: true,
+//   expects_con_len: false,
+// });
 
 Deno.test(
   {


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/15892

Happening too often in CI. This is to unblock other PRs until we find a solution.