### PR TITLE
perf(web): fast path for utf8 decoding - part 1

### DIFF
--- a/cli/bench/decoding.js
+++ b/cli/bench/decoding.js
@@ -1,0 +1,24 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
+let [total, count] = typeof Deno !== "undefined"
+  ? Deno.args
+  : [process.argv[2], process.argv[3]];
+
+total = total ? parseInt(total, 0) : 50;
+count = count ? parseInt(count, 10) : 10000000;
+
+function bench(fun) {
+  const start = Date.now();
+  for (let i = 0; i < count; i++) fun();
+  const elapsed = Date.now() - start;
+  const rate = Math.floor(count / (elapsed / 1000));
+  console.log(`time ${elapsed} ms rate ${rate}`);
+  if (--total) queueMicrotask(() => bench(fun));
+}
+
+const decoder = new TextDecoder();
+const buf = new Uint8Array([0x61, 0x62, 0x63]);
+
+bench(() => {
+  decoder.decode(buf);
+});


### PR DESCRIPTION
- [x] Avoid copying buffers.

https://encoding.spec.whatwg.org/#dom-textdecoder-decode

> Implementations are strongly encouraged to use an implementation strategy that avoids this copy. When doing so they will have to make sure that changes to input do not affect future calls to [decode()](https://encoding.spec.whatwg.org/#dom-textdecoder-decode).

- [x] Special op to avoid string label deserialization and parsing. (Ideally we should map labels to integers in JS)
- [x] Avoid webidl `Object.assign` when options is undefined.

Upto ~1.8x improvement on small data.
```
# This patch
time 1893 ms rate 5282620
time 2067 ms rate 4837929
```

```
# main
time 3284 ms rate 3045066
time 3252 ms rate 3075030
```