### PR TITLE
perf(ext/console): break on iterableLimit & better sparse array handling

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -759,7 +759,54 @@ Deno.test(function consoleTestStringifyIterable() {
     `[ <4 empty items>, 0, 0, <4 empty items> ]`,
   );
 
-  /* TODO(ry) Fix this test
+  const emptyArray = Array(5000);
+  assertEquals(
+    stringify(emptyArray),
+    `[ <5000 empty items> ]`,
+  );
+
+  assertEquals(
+    stringify(Array(1)),
+    `[ <1 empty item> ]`,
+  );
+
+  const withEmptyElAndMoreItems = Array(500);
+  withEmptyElAndMoreItems.fill(0, 50, 80);
+  withEmptyElAndMoreItems.fill(2, 100, 120);
+  withEmptyElAndMoreItems.fill(3, 140, 160);
+  withEmptyElAndMoreItems.fill(4, 180);
+  assertEquals(
+    stringify(withEmptyElAndMoreItems),
+    `[
+  <50 empty items>, 0,                0, 0,
+  0,                0,                0, 0,
+  0,                0,                0, 0,
+  0,                0,                0, 0,
+  0,                0,                0, 0,
+  0,                0,                0, 0,
+  0,                0,                0, 0,
+  0,                0,                0, <20 empty items>,
+  2,                2,                2, 2,
+  2,                2,                2, 2,
+  2,                2,                2, 2,
+  2,                2,                2, 2,
+  2,                2,                2, 2,
+  <20 empty items>, 3,                3, 3,
+  3,                3,                3, 3,
+  3,                3,                3, 3,
+  3,                3,                3, 3,
+  3,                3,                3, 3,
+  3,                <20 empty items>, 4, 4,
+  4,                4,                4, 4,
+  4,                4,                4, 4,
+  4,                4,                4, 4,
+  4,                4,                4, 4,
+  4,                4,                4, 4,
+  4,                4,                4, 4,
+  ... 294 more items
+]`,
+  );
+
   const lWithEmptyEl = Array(200);
   lWithEmptyEl.fill(0, 50, 80);
   assertEquals(
@@ -776,9 +823,8 @@ Deno.test(function consoleTestStringifyIterable() {
   0,                0,                 0,
   0,                0,                 0,
   0,                <120 empty items>
-]`
+]`,
   );
-  */
 });
 
 Deno.test(function consoleTestStringifyIterableWhenGrouped() {

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -59,6 +59,7 @@
     SafeSet,
     SetPrototype,
     SetPrototypeEntries,
+    SetPrototypeGetSize,
     Symbol,
     SymbolPrototype,
     SymbolPrototypeToString,
@@ -90,6 +91,7 @@
     MapPrototypeDelete,
     MapPrototypeEntries,
     MapPrototypeForEach,
+    MapPrototypeGetSize,
     Error,
     ErrorPrototype,
     ErrorCaptureStackTrace,
@@ -110,6 +112,7 @@
     ReflectGetOwnPropertyDescriptor,
     ReflectGetPrototypeOf,
     ReflectHas,
+    TypedArrayPrototypeGetLength,
     WeakMapPrototype,
     WeakSetPrototype,
   } = window.__bootstrap.primordials;
@@ -395,18 +398,18 @@
     switch (options.typeName) {
       case "Map":
         iter = MapPrototypeEntries(value);
-        entriesLength = value.size;
+        entriesLength = MapPrototypeGetSize(value);
         break;
       case "Set":
         iter = SetPrototypeEntries(value);
-        entriesLength = value.size;
+        entriesLength = SetPrototypeGetSize(value);
         break;
       case "Array":
         entriesLength = value.length;
         break;
       default:
         if (isTypedArray(value)) {
-          entriesLength = value.length;
+          entriesLength = TypedArrayPrototypeGetLength(value);
           iter = ArrayPrototypeEntries(value);
           valueIsTypedArray = true;
         } else {
@@ -417,7 +420,7 @@
     if (options.typeName === "Array") {
       for (
         let i = 0, j = 0;
-        i < value.length && j < inspectOptions.iterableLimit;
+        i < entriesLength && j < inspectOptions.iterableLimit;
         i++, j++
       ) {
         inspectOptions.indentLevel++;
@@ -842,14 +845,13 @@
         if (!ObjectPrototypeHasOwnProperty(value, i)) {
           let skipTo;
           keys = keys || ObjectKeys(value);
+          i = value.length;
           if (keys.length === 0) {
             // fast path, all items are empty
-            i = value.length;
             skipTo = i;
           } else {
             // Not all indexes are empty or there's a non-index property
             // Find first non-empty array index
-            i = value.length;
             while (keys.length) {
               const key = keys.shift();
               // check if it's a valid array index

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -432,7 +432,7 @@
         inspectOptions.indentLevel--;
 
         if (skipTo) {
-          // substract skipped (empty) items
+          // subtract skipped (empty) items
           entriesLength -= skipTo - i;
           i = skipTo;
         }

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -835,7 +835,7 @@
       typeName: "Array",
       displayName: "",
       delims: ["[", "]"],
-      entryHandler: (entry, inspectOptions, next) => {
+      entryHandler: (entry, inspectOptions) => {
         const [index, val] = entry;
         let i = index;
         lastValidIndex = index;

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -853,7 +853,7 @@
             // Not all indexes are empty or there's a non-index property
             // Find first non-empty array index
             while (keys.length) {
-              const key = keys.shift();
+              const key = ArrayPrototypeShift(keys);
               // check if it's a valid array index
               if (key > lastValidIndex && key < 2 ** 32 - 1) {
                 i = Number(key);


### PR DESCRIPTION
This PR improves `console.log` performance for `TypedArray`, `Set`, `Map` and `Array` above `iterableLimit`. It also improves performance for sparse arrays.

fixes #14656

```js
console.time('sparse');console.log(new Array(16777216*10));console.timeEnd('sparse');
console.time('typed');console.log(new Uint8Array(16777216*10));console.timeEnd('typed');
```

**Deno**
```
[ <167772160 empty items> ]
sparse: 5445ms
Uint8Array(167772160) [
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  ... 167772060 more items
]
typed: 3160ms
```

**Node**
```
[ <167772160 empty items> ]
sparse: 2.815ms
Uint8Array(167772160) [
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0,
  ... 167772060 more items
]
typed: 0.994ms

```

**This patch**
```
[ <167772160 empty items> ]
sparse: 1ms
Uint8Array(167772160) [
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  ... 167772060 more items
]
typed: 1ms
```


<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
