### PR TITLE
fix(doc): deno doc should parse modules if they haven't been parsed before

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,8 +979,6 @@ dependencies = [
 [[package]]
 name = "deno_doc"
 version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef056cd1ca61584e7db9e3a025676f880be5a67101aee54f295b8770100eeb53"
 dependencies = [
  "cfg-if",
  "deno_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.45.0"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "910f889d786d8b7ef40d50da4f2a4da01adf1c63c2f4a3b74324f6313eee8c59"
 dependencies = [
  "cfg-if",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,7 +49,7 @@ winres = "=0.1.12"
 [dependencies]
 deno_ast = { version = "0.19.0", features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "transpiling", "typescript", "view", "visit"] }
 deno_core = { version = "0.151.0", path = "../core" }
-deno_doc = { path = "../../deno_doc" }
+deno_doc = "0.46.0"
 deno_emit = "0.9.0"
 deno_graph = "0.34.0"
 deno_lint = { version = "0.33.0", features = ["docs"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,7 +49,7 @@ winres = "=0.1.12"
 [dependencies]
 deno_ast = { version = "0.19.0", features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "transpiling", "typescript", "view", "visit"] }
 deno_core = { version = "0.151.0", path = "../core" }
-deno_doc = "0.45.0"
+deno_doc = { path = "../../deno_doc" }
 deno_emit = "0.9.0"
 deno_graph = "0.34.0"
 deno_lint = { version = "0.33.0", features = ["docs"] }

--- a/cli/tests/testdata/deno_doc.out
+++ b/cli/tests/testdata/deno_doc.out
@@ -1,2 +1,0 @@
-[WILDCARD]
-function foo[WILDCARD]

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -53,7 +53,11 @@ pub async fn print_docs(
       None,
     )
     .await;
-    let doc_parser = doc::DocParser::new(graph, doc_flags.private, &analyzer);
+    let doc_parser = doc::DocParser::new(
+      graph,
+      doc_flags.private,
+      analyzer.as_capturing_parser(),
+    );
     doc_parser.parse_module(&source_file_specifier)?.definitions
   } else {
     let module_specifier = resolve_url_or_path(&source_file)?;
@@ -76,8 +80,11 @@ pub async fn print_docs(
     let graph = ps
       .create_graph(vec![(root_specifier.clone(), ModuleKind::Esm)])
       .await?;
-    let store = ps.parsed_source_cache.as_store();
-    let doc_parser = doc::DocParser::new(graph, doc_flags.private, &*store);
+    let doc_parser = doc::DocParser::new(
+      graph,
+      doc_flags.private,
+      ps.parsed_source_cache.as_capturing_parser(),
+    );
     doc_parser.parse_with_reexports(&root_specifier)?
   };
 


### PR DESCRIPTION
Depends on https://github.com/denoland/deno_doc/pull/292

This is the same fix that we did with eszip and deno compile.

Closes #15930