### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,6 +23,4 @@ rustflags = [
   "clippy::missing_safety_doc",
   "-D",
   "clippy::undocumented_unsafe_blocks",
-  "-A",
-  "clippy::derive-partial-eq-without-eq",
 ]

--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -63,7 +63,7 @@ pub struct CompilerOptions {
 
 /// A structure that represents a set of options that were ignored and the
 /// path those options came from.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct IgnoredCompilerOptions {
   pub items: Vec<String>,
   pub maybe_specifier: Option<ModuleSpecifier>,

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -45,30 +45,30 @@ static SHORT_VERSION: Lazy<String> = Lazy::new(|| {
     .to_string()
 });
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BenchFlags {
   pub ignore: Vec<PathBuf>,
   pub include: Option<Vec<String>>,
   pub filter: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BundleFlags {
   pub source_file: String,
   pub out_file: Option<PathBuf>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CacheFlags {
   pub files: Vec<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CheckFlags {
   pub files: Vec<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CompileFlags {
   pub source_file: String,
   pub output: Option<PathBuf>,
@@ -76,12 +76,12 @@ pub struct CompileFlags {
   pub target: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CompletionsFlags {
   pub buf: Box<[u8]>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CoverageFlags {
   pub files: Vec<PathBuf>,
   pub output: Option<PathBuf>,
@@ -91,7 +91,7 @@ pub struct CoverageFlags {
   pub lcov: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DocFlags {
   pub private: bool,
   pub json: bool,
@@ -99,14 +99,14 @@ pub struct DocFlags {
   pub filter: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct EvalFlags {
   pub print: bool,
   pub code: String,
   pub ext: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct FmtFlags {
   pub check: bool,
   pub files: Vec<PathBuf>,
@@ -119,18 +119,18 @@ pub struct FmtFlags {
   pub prose_wrap: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InitFlags {
   pub dir: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InfoFlags {
   pub json: bool,
   pub file: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InstallFlags {
   pub module_url: String,
   pub args: Vec<String>,
@@ -139,13 +139,13 @@ pub struct InstallFlags {
   pub force: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct UninstallFlags {
   pub name: String,
   pub root: Option<PathBuf>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct LintFlags {
   pub files: Vec<PathBuf>,
   pub ignore: Vec<PathBuf>,
@@ -156,13 +156,13 @@ pub struct LintFlags {
   pub json: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ReplFlags {
   pub eval_files: Option<Vec<String>>,
   pub eval: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct RunFlags {
   pub script: String,
 }
@@ -173,13 +173,13 @@ impl RunFlags {
   }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct TaskFlags {
   pub cwd: Option<String>,
   pub task: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct TestFlags {
   pub ignore: Vec<PathBuf>,
   pub doc: bool,
@@ -193,7 +193,7 @@ pub struct TestFlags {
   pub trace_ops: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct UpgradeFlags {
   pub dry_run: bool,
   pub force: bool,
@@ -203,14 +203,14 @@ pub struct UpgradeFlags {
   pub ca_file: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct VendorFlags {
   pub specifiers: Vec<String>,
   pub output_path: Option<PathBuf>,
   pub force: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum DenoSubcommand {
   Bench(BenchFlags),
   Bundle(BundleFlags),
@@ -246,7 +246,7 @@ impl Default for DenoSubcommand {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TypeCheckMode {
   /// Type-check all modules.
   All,
@@ -264,7 +264,7 @@ impl Default for TypeCheckMode {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ConfigFlag {
   Discover,
   Path(String),
@@ -277,7 +277,7 @@ impl Default for ConfigFlag {
   }
 }
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct Flags {
   /// Vector of CLI arguments - these are user script arguments, all Deno
   /// specific flags are removed.

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -199,7 +199,7 @@ impl CacheSemantics {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum FetchOnceResult {
   Code(Vec<u8>, HeadersMap),
   NotModified,

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -41,7 +41,7 @@ struct BenchSpecifierOptions {
   filter: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BenchPlan {
   pub total: usize,
@@ -60,7 +60,7 @@ pub enum BenchEvent {
   Result(usize, BenchResult),
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BenchResult {
   Ok(BenchStats),
@@ -84,7 +84,7 @@ pub struct BenchDescription {
   pub group: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchStats {
   pub n: u64,
   pub min: f64,

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -59,7 +59,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::mpsc::UnboundedSender;
 
 /// The test mode is used to determine how a specifier is to be tested.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TestMode {
   /// Test as documentation, type-checking fenced code blocks.
   Documentation,
@@ -144,13 +144,14 @@ impl TestDescription {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TestOutput {
   String(String),
   Bytes(Vec<u8>),
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TestResult {
@@ -160,7 +161,7 @@ pub enum TestResult {
   Cancelled,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TestStepDescription {
   pub id: usize,
@@ -183,6 +184,7 @@ impl TestStepDescription {
   }
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TestStepResult {
@@ -202,7 +204,7 @@ impl TestStepResult {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TestPlan {
   pub origin: String,

--- a/core/error.rs
+++ b/core/error.rs
@@ -134,7 +134,7 @@ pub struct JsError {
   pub aggregated: Option<Vec<JsError>>,
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Eq, PartialEq, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsStackFrame {
   pub type_name: Option<String>,

--- a/ext/crypto/key.rs
+++ b/ext/crypto/key.rs
@@ -17,7 +17,7 @@ pub enum KeyType {
   Secret,
 }
 
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 pub enum CryptoHash {
   #[serde(rename = "SHA-1")]
   Sha1,
@@ -98,7 +98,7 @@ impl hkdf::KeyType for HkdfOutput<usize> {
   }
 }
 
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum KeyUsage {
   Encrypt,

--- a/ext/crypto/shared.rs
+++ b/ext/crypto/shared.rs
@@ -46,7 +46,7 @@ pub const ID_SECP384R1_OID: const_oid::ObjectIdentifier =
 pub const ID_SECP521R1_OID: const_oid::ObjectIdentifier =
   const_oid::ObjectIdentifier::new_unwrap("1.3.132.0.35");
 
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 pub enum ShaHash {
   #[serde(rename = "SHA-1")]
   Sha1,
@@ -58,7 +58,7 @@ pub enum ShaHash {
   Sha512,
 }
 
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 pub enum EcNamedCurve {
   #[serde(rename = "P-256")]
   P256,

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -86,7 +86,7 @@ pub struct ServerContext {
   cancel_handle: Rc<CancelHandle>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ParseStatus {
   None,
   Ongoing(usize),

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -569,7 +569,7 @@ where
   }
 }
 
-#[derive(Serialize, PartialEq, Debug)]
+#[derive(Serialize, Eq, PartialEq, Debug)]
 #[serde(untagged)]
 pub enum DnsReturnRecord {
   A(String),

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -128,7 +128,7 @@ fn parse_url(
   }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 #[repr(u8)]
 pub enum UrlSetter {
   Hash = 0,

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -32,7 +32,7 @@ pub fn init() -> Extension {
     .build()
 }
 
-#[derive(Copy, Clone, PartialEq, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Stdio {
   Inherit,
@@ -50,7 +50,7 @@ impl Stdio {
   }
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum StdioOrRid {
   Stdio(Stdio),
   Rid(ResourceId),

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -34,7 +34,7 @@ static DEBUG_LOG_ENABLED: Lazy<bool> =
   Lazy::new(|| log::log_enabled!(log::Level::Debug));
 
 /// Tri-state value for storing permission state
-#[derive(PartialEq, Debug, Clone, Copy, Deserialize, PartialOrd)]
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Deserialize, PartialOrd)]
 pub enum PermissionState {
   Granted = 0,
   Prompt = 1,
@@ -135,7 +135,7 @@ impl Default for PermissionState {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnitPermission {
   pub name: &'static str,
   pub description: &'static str,
@@ -207,7 +207,7 @@ impl AsRef<str> for EnvVarName {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnaryPermission<T: Eq + Hash> {
   pub name: &'static str,
   pub description: &'static str,
@@ -1133,7 +1133,7 @@ impl Default for UnaryPermission<FfiDescriptor> {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Permissions {
   pub read: UnaryPermission<ReadDescriptor>,
   pub write: UnaryPermission<WriteDescriptor>,
@@ -1158,7 +1158,7 @@ impl Default for Permissions {
   }
 }
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct PermissionsOptions {
   pub allow_env: Option<Vec<String>>,
   pub allow_hrtime: bool,
@@ -1490,7 +1490,7 @@ fn escalation_error() -> AnyError {
   )
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ChildUnitPermissionArg {
   Inherit,
   Granted,
@@ -1542,7 +1542,7 @@ impl<'de> Deserialize<'de> for ChildUnitPermissionArg {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ChildUnaryPermissionArg {
   Inherit,
   Granted,
@@ -1610,7 +1610,7 @@ impl<'de> Deserialize<'de> for ChildUnaryPermissionArg {
 }
 
 /// Directly deserializable from JS worker and test permission options.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ChildPermissionsArg {
   env: ChildUnaryPermissionArg,
   hrtime: ChildUnitPermissionArg,

--- a/serde_v8/error.rs
+++ b/serde_v8/error.rs
@@ -5,7 +5,7 @@ use serde::{de, ser};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
   Message(String),

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -319,7 +319,7 @@ detest!(
 defail!(defail_struct, MathOp, "123", |e| e
   == Err(Error::ExpectedObject));
 
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Deserialize)]
 pub struct SomeThing {
   pub a: String,
   #[serde(default)]
@@ -339,7 +339,7 @@ detest!(de_bstr, ByteString, "'hello'", "hello".into());
 defail!(defail_bstr, ByteString, "'👋bye'", |e| e
   == Err(Error::ExpectedLatin1));
 
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Deserialize)]
 pub struct StructWithBytes {
   #[serde(with = "serde_bytes")]
   a: Vec<u8>,


### PR DESCRIPTION
Stop allowing clippy::derive-partial-eq-without-eq and fix warnings about deriving PartialEq without also deriving Eq.

In one case I removed the PartialEq because it a) wasn't necessary, and b) sketchy because it was comparing floating point numbers.

IMO, that's a good argument for enforcing the lint rule, because it would most likely have been caught during review if it had been enabled.