### PR TITLE
perf(cli): use -O3 instead of -Oz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ exclude = ["test_util/std/hash/_wasm"]
 codegen-units = 1
 incremental = true
 lto = true
-opt-level = 'z' # Optimize for size
+opt-level = 3 # Optimize for speed
 
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.bench]
 codegen-units = 1
 incremental = true
 lto = true
-opt-level = 'z' # Optimize for size
+opt-level = 3 # Optimize for speed
 
 # Key generation is too slow on `debug`
 [profile.dev.package.num-bigint-dig]


### PR DESCRIPTION
Towards #15945

OS | Binary size (-Oz) | Binary size (-O3) 
---|---|---|
MacOS m1 | 91M | **85M** (reduction)
Linux x64 | 96M | **97M** (increase)
