### PR TITLE
fix(runtime): pin netif version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "netif"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96c14078e0dae0c847c413b31304d5563daeb2494a61ebb01cb66f19b8ba99f"
+checksum = "97ea59a9e719be226ab85078ed524f1cf62b43c0ebf3014d50aa22f988996dfe"
 dependencies = [
  "libc",
  "winapi 0.3.9",

--- a/cli/tests/unit/network_interfaces_test.ts
+++ b/cli/tests/unit/network_interfaces_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "./test_util.ts";
+import { assert, assertEquals } from "./test_util.ts";
 
 Deno.test(
   { name: "Deno.networkInterfaces", permissions: { env: true } },
@@ -21,5 +21,19 @@ Deno.test(
       assert(typeof cidr === "string");
       assert(typeof mac === "string");
     }
+  },
+);
+
+Deno.test(
+  {
+    name: "Deno.networkInterfaces has an ipv4 loopback",
+    permissions: { env: true },
+  },
+  () => {
+    const networkInterfaces = Deno.networkInterfaces();
+    assertEquals(
+      networkInterfaces.filter((item) => item.address === "127.0.0.1").length,
+      1,
+    );
   },
 );

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -75,7 +75,7 @@ hyper = { version = "0.14.18", features = ["server", "stream", "http1", "http2",
 libc = "0.2.126"
 log = "0.4.16"
 lzzzz = '1.0'
-netif = "0.1.3"
+netif = "=0.1.3"
 notify = "5.0"
 once_cell = "1.10.0"
 regex = "1.6.0"


### PR DESCRIPTION
`netif` was upgraded to 0.1.4 in #15914, but it has broken the node compat test case in deno_std. (see https://github.com/denoland/deno_std/pull/2670 )

This PR temporarily pins `netif`'s version to 0.1.3 to avoid the above failure until the root issue is fixed in `netif`