### PR TITLE
perf(cli): avoid `canonicalize_path` if config file does not exist

### DIFF
--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -526,13 +526,16 @@ impl ConfigFile {
     };
 
     if !config_file.exists() {
-      return Err(std::io::Error::new(
-        std::io::ErrorKind::InvalidInput,
-        format!(
-          "Could not find the config file: {}",
-          config_file.to_string_lossy()
-        ),
-      ).into());
+      return Err(
+        std::io::Error::new(
+          std::io::ErrorKind::InvalidInput,
+          format!(
+            "Could not find the config file: {}",
+            config_file.to_string_lossy()
+          ),
+        )
+        .into(),
+      );
     }
 
     let config_path = canonicalize_path(&config_file).map_err(|_| {

--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -525,6 +525,7 @@ impl ConfigFile {
       std::env::current_dir()?.join(path_ref)
     };
 
+    // perf: Check if the config file exists before canonicalizing path.
     if !config_file.exists() {
       return Err(
         std::io::Error::new(

--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -525,6 +525,16 @@ impl ConfigFile {
       std::env::current_dir()?.join(path_ref)
     };
 
+    if !config_file.exists() {
+      return Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+          "Could not find the config file: {}",
+          config_file.to_string_lossy()
+        ),
+      ).into());
+    }
+
     let config_path = canonicalize_path(&config_file).map_err(|_| {
       std::io::Error::new(
         std::io::ErrorKind::InvalidInput,


### PR DESCRIPTION
Towards #15945 