### PR TITLE
perf(core): use single ObjectTemplate for ops in `initialize_ops`

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -140,17 +140,17 @@ fn initialize_ops(
   op_ctxs: &[OpCtx],
   snapshot_loaded: bool,
 ) {
+  let object_template = v8::ObjectTemplate::new(scope);
+  assert!(object_template.set_internal_field_count(
+    (crate::runtime::V8_WRAPPER_OBJECT_INDEX + 1) as usize
+  ));
+
   for ctx in op_ctxs {
     let ctx_ptr = ctx as *const OpCtx as *const c_void;
 
     // If this is a fast op, we don't want it to be in the snapshot.
     // Only initialize once snapshot is loaded.
     if ctx.decl.fast_fn.is_some() && snapshot_loaded {
-      let object_template = v8::ObjectTemplate::new(scope);
-      assert!(object_template.set_internal_field_count(
-        (crate::runtime::V8_WRAPPER_OBJECT_INDEX + 1) as usize
-      ));
-
       let method_obj = object_template.new_instance(scope).unwrap();
       method_obj.set_aligned_pointer_in_internal_field(
         crate::runtime::V8_WRAPPER_OBJECT_INDEX,


### PR DESCRIPTION
Towards https://github.com/denoland/deno/issues/15945