### PR TITLE
fix(runtime): better error message with Deno.env.get/set

### DIFF
--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -128,6 +128,26 @@ Deno.test({ permissions: { env: true } }, function envInvalidChars() {
     TypeError,
     'Key contains invalid characters: "="',
   );
+  assertThrows(
+    () => Deno.env.set("", "foo"),
+    TypeError,
+    "Key is an empty string",
+  );
+  assertThrows(
+    () => Deno.env.set("\0", "foo"),
+    TypeError,
+    'Key contains invalid characters: "\\0"',
+  );
+  assertThrows(
+    () => Deno.env.set("=", "foo"),
+    TypeError,
+    'Key contains invalid characters: "="',
+  );
+  assertThrows(
+    () => Deno.env.set("foo", "\0"),
+    TypeError,
+    'Value contains invalid characters: "\\0"',
+  );
 });
 
 Deno.test(function osPid() {

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -116,6 +116,20 @@ Deno.test(
   },
 );
 
+Deno.test({ permissions: { env: true } }, function envInvalidChars() {
+  assertThrows(() => Deno.env.get(""), TypeError, "Key is an empty string");
+  assertThrows(
+    () => Deno.env.get("\0"),
+    TypeError,
+    'Key contains invalid characters: "\\0"',
+  );
+  assertThrows(
+    () => Deno.env.get("="),
+    TypeError,
+    'Key contains invalid characters: "="',
+  );
+});
+
 Deno.test(function osPid() {
   assert(Deno.pid > 0);
 });

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -80,10 +80,20 @@ fn op_set_env(
   value: String,
 ) -> Result<(), AnyError> {
   state.borrow_mut::<Permissions>().env.check(&key)?;
-  let invalid_key = key.is_empty() || key.contains(&['=', '\0'] as &[char]);
-  let invalid_value = value.contains('\0');
-  if invalid_key || invalid_value {
-    return Err(type_error("Key or value contains invalid characters."));
+  if key.is_empty() {
+    return Err(type_error("Key is an empty string."));
+  }
+  if key.contains(&['=', '\0'] as &[char]) {
+    return Err(type_error(format!(
+      "Key contains invalid characters: {:?}",
+      key
+    )));
+  }
+  if value.contains('\0') {
+    return Err(type_error(format!(
+      "Value contains invalid characters: {:?}",
+      value
+    )));
   }
   env::set_var(key, value);
   Ok(())

--- a/runtime/ops/os.rs
+++ b/runtime/ops/os.rs
@@ -108,9 +108,17 @@ fn op_get_env(
     state.borrow_mut::<Permissions>().env.check(&key)?;
   }
 
-  if key.is_empty() || key.contains(&['=', '\0'] as &[char]) {
-    return Err(type_error("Key contains invalid characters."));
+  if key.is_empty() {
+    return Err(type_error("Key is an empty string."));
   }
+
+  if key.contains(&['=', '\0'] as &[char]) {
+    return Err(type_error(format!(
+      "Key contains invalid characters: {:?}",
+      key
+    )));
+  }
+
   let r = match env::var(key) {
     Err(env::VarError::NotPresent) => None,
     v => Some(v?),


### PR DESCRIPTION
This PR improves the error message when `Deno.env.get` is called with invalid inputs.

`Deno.env.get` throws an error if the input is an empty string or contains "\0" or "=", but the error message is always `Key contains invalid characters.`. This PR fixes this error message, and gives more information about the invalid inputs.

Partially resolves https://github.com/denoland/deno_std/issues/2665