### PR TITLE
feat: allow exiting on two consecutive ctrl+c presses

### DIFF
--- a/cli/tests/integration/inspector_tests.rs
+++ b/cli/tests/integration/inspector_tests.rs
@@ -561,7 +561,7 @@ async fn inspector_runtime_evaluate_does_not_crash() {
 
   assert_eq!(
     &stdout_lines.next().unwrap(),
-    "exit using ctrl+d or close()"
+    "exit using ctrl+d, ctrl+c, or close()"
   );
 
   assert_inspector_messages(

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -81,6 +81,7 @@ pub async fn run(
 ) -> Result<i32, AnyError> {
   let mut repl_session = ReplSession::initialize(worker).await?;
   let mut rustyline_channel = rustyline_channel();
+  let mut should_exit_on_interrupt = false;
 
   let helper = EditorHelper {
     context_id: repl_session.context_id,
@@ -118,7 +119,7 @@ pub async fn run(
   }
 
   println!("Deno {}", crate::version::deno());
-  println!("exit using ctrl+d or close()");
+  println!("exit using ctrl+d, ctrl+c, or close()");
 
   loop {
     let line = read_line_and_poll(
@@ -129,6 +130,7 @@ pub async fn run(
     .await;
     match line {
       Ok(line) => {
+        should_exit_on_interrupt = false;
         let output = repl_session.evaluate_line_and_get_output(&line).await?;
 
         // We check for close and break here instead of making it a loop condition to get
@@ -142,7 +144,11 @@ pub async fn run(
         editor.add_history_entry(line);
       }
       Err(ReadlineError::Interrupted) => {
-        println!("exit using ctrl+d or close()");
+        if should_exit_on_interrupt {
+          break;
+        }
+        should_exit_on_interrupt = true;
+        println!("press ctrl+c again to exit");
         continue;
       }
       Err(ReadlineError::Eof) => {


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

Allow exiting the REPL by pressing ctrl+c twice consecutively.

For Node compat :^)
