### PR TITLE
fix(cli): fix --help and bundle panic on broken pipe

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -94,6 +94,7 @@ use log::debug;
 use log::info;
 use npm::NpmPackageReference;
 use std::env;
+use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::iter::once;
@@ -636,7 +637,7 @@ async fn bundle_command(
           );
         }
       } else {
-        println!("{}", bundle_output.code);
+        io::stdout().write_all(bundle_output.code.as_bytes())?;
       }
 
       Ok(())
@@ -1078,7 +1079,7 @@ pub fn main() {
         if err.kind() == clap::ErrorKind::DisplayHelp
           || err.kind() == clap::ErrorKind::DisplayVersion =>
       {
-        err.print().unwrap();
+        unwrap_or_exit(err.print().map_err(AnyError::from));
         std::process::exit(0);
       }
       Err(err) => unwrap_or_exit(Err(AnyError::from(err))),

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -3373,6 +3373,49 @@ fn broken_stdout() {
   assert!(!stderr.contains("panic"));
 }
 
+#[test]
+fn broken_pipe_help() {
+  let (reader, writer) = os_pipe::pipe().unwrap();
+  // drop the reader to create a broken pipe
+  drop(reader);
+
+  let output = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("--help")
+    .stdout(writer)
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+
+  assert!(!output.status.success());
+  let stderr = std::str::from_utf8(output.stderr.as_ref()).unwrap().trim();
+  assert!(!stderr.contains("thread 'main' panicked"));
+}
+
+#[test]
+fn broken_pipe_bundle() {
+  let (reader, writer) = os_pipe::pipe().unwrap();
+  // drop the reader to create a broken pipe
+  drop(reader);
+
+  let output = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("bundle")
+    .arg("./run/001_hello.js")
+    .stdout(writer)
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+
+  assert!(!output.status.success());
+  let stderr = std::str::from_utf8(output.stderr.as_ref()).unwrap().trim();
+  assert!(!stderr.contains("thread 'main' panicked"));
+}
+
 itest!(error_cause {
   args: "run run/error_cause.ts",
   output: "run/error_cause.ts.out",


### PR DESCRIPTION
### Before
```console
$ RUST_BACKTRACE=1 deno --help | grep --bad-flag
/nix/store/ja8bi2cbpm36nwqy1hvklm3y9n7s3247-gnugrep-3.7/bin/grep: unrecognized option '--bad-flag'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.

============================================================
Deno has panicked. This is a bug in Deno. Please report this
at https://github.com/denoland/deno/issues/new.
If you can reliably reproduce this panic, include the
reproduction steps and re-run with the RUST_BACKTRACE=1 env
var set and include the backtrace in your report.

Platform: linux x86_64
Version: 1.25.3
Args: ["deno", "--help"]

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }', cli/main.rs:1081:21
stack backtrace:
   0: rust_begin_unwind
             at /rustc/95a992a68694d8bf3959bd2c0ac27ce9e9208b59/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/95a992a68694d8bf3959bd2c0ac27ce9e9208b59/library/core/src/panicking.rs:142:14
   2: core::result::unwrap_failed
             at /rustc/95a992a68694d8bf3959bd2c0ac27ce9e9208b59/library/core/src/result.rs:1785:5
   3: core::result::Result<T,E>::unwrap
   4: deno::main::{{closure}}
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   6: deno_runtime::tokio_util::run_local
   7: deno::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

$ deno bundle ./hello.js | grep --bad-flag
...(similar output)
```

### After

```console
$ deno --help | grep --bad-flag
/nix/store/ja8bi2cbpm36nwqy1hvklm3y9n7s3247-gnugrep-3.7/bin/grep: unrecognized option '--bad-flag'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
error: Broken pipe (os error 32)

$ deno bundle ./hello.js | grep --bad-flag
...(similar output)
```

Fixes #14060
