### PR TITLE
feat(ops): Fallible fast ops

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -159,7 +159,7 @@ pub struct OpState {
   pub resource_table: ResourceTable,
   pub get_error_class_fn: GetErrorClassFn,
   pub tracker: OpsTracker,
-  pub fast_op_error: Option<AnyError>,
+  pub last_fast_op_error: Option<AnyError>,
   gotham_state: GothamState,
 }
 
@@ -169,7 +169,7 @@ impl OpState {
       resource_table: Default::default(),
       get_error_class_fn: &|_| "Error",
       gotham_state: Default::default(),
-      fast_op_error: None,
+      last_fast_op_error: None,
       tracker: OpsTracker::new(ops_count),
     }
   }

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+use crate::error::AnyError;
 use crate::gotham_state::GothamState;
 use crate::resources::ResourceTable;
 use crate::runtime::GetErrorClassFn;
@@ -158,6 +159,7 @@ pub struct OpState {
   pub resource_table: ResourceTable,
   pub get_error_class_fn: GetErrorClassFn,
   pub tracker: OpsTracker,
+  pub fast_op_error: Option<AnyError>,
   gotham_state: GothamState,
 }
 
@@ -167,6 +169,7 @@ impl OpState {
       resource_table: Default::default(),
       get_error_class_fn: &|_| "Error",
       gotham_state: Default::default(),
+      fast_op_error: None,
       tracker: OpsTracker::new(ops_count),
     }
   }

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -113,13 +113,16 @@ pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
 
   let asyncness = func.sig.asyncness.is_some();
   let is_async = asyncness || is_future(&func.sig.output);
+
+  // First generate fast call bindings to opt-in to error handling in slow call
+  let (has_fast_call, fast_impl, fast_field) =
+    codegen_fast_impl(&core, &func, name, is_async, must_be_fast);
+
   let v8_body = if is_async {
     codegen_v8_async(&core, &func, margs, asyncness, deferred)
   } else {
-    codegen_v8_sync(&core, &func, margs)
+    codegen_v8_sync(&core, &func, margs, has_fast_call)
   };
-  let (fast_impl, fast_field) =
-    codegen_fast_impl(&core, &func, name, is_async, must_be_fast);
 
   let docline = format!("Use `{name}::decl()` to get an op-declaration");
   // Generate wrapper
@@ -293,12 +296,12 @@ fn codegen_fast_impl(
   name: &syn::Ident,
   is_async: bool,
   must_be_fast: bool,
-) -> (TokenStream2, TokenStream2) {
+) -> (bool, TokenStream2, TokenStream2) {
   if is_async {
     if must_be_fast {
       panic!("async op cannot be a fast api. enforced by #[op(fast)]")
     }
-    return (quote! {}, quote! { None });
+    return (false, quote! {}, quote! { None });
   }
   let fast_info = can_be_fast_api(core, f);
   if must_be_fast && fast_info.is_none() {
@@ -455,6 +458,7 @@ fn codegen_fast_impl(
           )
         };
       return (
+        true,
         quote! {
           #[allow(non_camel_case_types)]
           #[doc(hidden)]
@@ -480,7 +484,7 @@ fn codegen_fast_impl(
   }
 
   // Default impl to satisfy generic bounds for non-fast ops
-  (quote! {}, quote! { None })
+  (false, quote! {}, quote! { None })
 }
 
 /// Generate the body of a v8 func for a sync op
@@ -488,6 +492,7 @@ fn codegen_v8_sync(
   core: &TokenStream2,
   f: &syn::ItemFn,
   margs: MacroArgs,
+  has_fast_call: bool,
 ) -> TokenStream2 {
   let MacroArgs { is_v8, .. } = margs;
   let special_args = f
@@ -504,6 +509,21 @@ fn codegen_v8_sync(
   let ret = codegen_sync_ret(core, &f.sig.output);
   let type_params = exclude_lifetime_params(&f.sig.generics.params);
 
+  let fast_error_handler = if has_fast_call {
+    quote! {
+      {
+        let op_state = &mut ctx.state.borrow_mut();
+        if let Some(err) = op_state.fast_op_error.take() {
+          let exception = #core::error::to_v8_error(scope, op_state.get_error_class_fn, &err);
+          scope.throw_exception(exception);
+          return;
+        }
+      }
+    }
+  } else {
+    quote! {}
+  };
+
   quote! {
     // SAFETY: #core guarantees args.data() is a v8 External pointing to an OpCtx for the isolates lifetime
     let ctx = unsafe {
@@ -511,6 +531,7 @@ fn codegen_v8_sync(
       as *const #core::_ops::OpCtx)
     };
 
+    #fast_error_handler
     #arg_decls
 
     let result = Self::call::<#type_params>(#args_head #args_tail);

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -452,7 +452,7 @@ fn codegen_fast_impl(
                 result
               },
               Err(err) => {
-                #op_state_name.fast_op_error.replace(err);
+                #op_state_name.last_fast_op_error.replace(err);
                 opts.fallback = true;
                 Default::default()
               },
@@ -543,7 +543,7 @@ fn codegen_v8_sync(
     quote! {
       {
         let op_state = &mut ctx.state.borrow_mut();
-        if let Some(err) = op_state.fast_op_error.take() {
+        if let Some(err) = op_state.last_fast_op_error.take() {
           let exception = #core::error::to_v8_error(scope, op_state.get_error_class_fn, &err);
           scope.throw_exception(exception);
           return;

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -431,7 +431,7 @@ fn codegen_fast_impl(
         let recv_decl = if use_op_state || returns_result {
           quote! {
             // SAFETY: V8 calling convention guarantees that the callback options pointer is non-null.
-            let opts: &#core::v8::fast_api::FastApiCallbackOptions = unsafe { &*fast_api_callback_options };
+            let opts: &mut #core::v8::fast_api::FastApiCallbackOptions = unsafe { &mut *fast_api_callback_options };
             // SAFETY: data union is always created as the `v8::Local<v8::Value>` version.
             let data = unsafe { opts.data.data };
             // SAFETY: #core guarantees data is a v8 External pointing to an OpCtx for the isolates lifetime
@@ -453,6 +453,7 @@ fn codegen_fast_impl(
               },
               Err(err) => {
                 #op_state_name.fast_op_error.replace(err);
+                opts.fallback = true;
                 Default::default()
               },
             }

--- a/ops/tests/compile_fail/unsupported.rs
+++ b/ops/tests/compile_fail/unsupported.rs
@@ -3,11 +3,6 @@
 use deno_ops::op;
 
 #[op(fast)]
-fn op_result_return(a: i32, b: i32) -> Result<(), ()> {
-  a + b
-}
-
-#[op(fast)]
 fn op_u8_arg(a: u8, b: u8) {
   //
 }

--- a/ops/tests/compile_fail/unsupported.stderr
+++ b/ops/tests/compile_fail/unsupported.stderr
@@ -15,9 +15,9 @@ error: custom attribute panicked
    = help: message: op cannot be a fast api. enforced by #[op(fast)]
 
 error: custom attribute panicked
-  --> tests/compile_fail/unsupported.rs:15:1
+  --> tests/compile_fail/unsupported.rs:17:1
    |
-15 | #[op(fast)]
+17 | #[op(fast)]
    | ^^^^^^^^^^^
    |
    = help: message: op cannot be a fast api. enforced by #[op(fast)]
@@ -28,20 +28,12 @@ error: custom attribute panicked
 22 | #[op(fast)]
    | ^^^^^^^^^^^
    |
-   = help: message: op cannot be a fast api. enforced by #[op(fast)]
-
-error: custom attribute panicked
-  --> tests/compile_fail/unsupported.rs:27:1
-   |
-27 | #[op(fast)]
-   | ^^^^^^^^^^^
-   |
    = help: message: async op cannot be a fast api. enforced by #[op(fast)]
 
 warning: unused import: `deno_core::v8::fast_api::FastApiCallbackOptions`
-  --> tests/compile_fail/unsupported.rs:20:5
+  --> tests/compile_fail/unsupported.rs:15:5
    |
-20 | use deno_core::v8::fast_api::FastApiCallbackOptions;
+15 | use deno_core::v8::fast_api::FastApiCallbackOptions;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default


### PR DESCRIPTION
Add support for fast ops to fail at any (sync) phase. If a fallible fast op returns an Err variant, the fallback option will be set true and the error gets saved to `OpState`. V8 will immediately, synchronously call the normal binding function, and the `#[op]` macro takes care of injecting a check for saved errors at the top of the binding.

The op macro and especially its fast side is starting to get pretty ugly, and this makes it uglier still. Big points of ugliness and undefined behaviour:
1. In normal op side, the `OpState` borrowing is done several times at worst. There is no combined logic to figure out if `OpState` is needed and if it is needed as shared or unique (mut), thus leading to multiple places needing to borrow it individually.
2. With fast call codegen, the `FastApiCallbackOptions` is starting to get quite confused about when it should be added into the inputs.
3. Worse yet, if an op explicitly requires a `Option<&mut FastApiCallbackOptions>` parameter AND returns a `Result` or uses `OpState`, then the macro will generate two mutable borrows or one mutable and one shared borrow for the `FastApiCallbackOptions`, breaking Rust rules. This is likely "safe" in that its currently not used anywhere and its unlikely that it could lead to any issues since this is all synchronous code and thus race conditions are not possible. Still, it's not correct and shouldn't really be like this.

A further point that should be pondered is if it's correct to add `fast_op_error` into `OpState` or if it would be better to just use the gotham state with some core, or perhaps `ops/lib.rs`, defined `FastOpError(Err)` type.