### PR TITLE
test(ext/fetch): enable null body status test on windows

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1014,14 +1014,8 @@ Deno.test(
   },
 );
 
-// FIXME(bartlomieju): for reasons unknown after working for
-// a few months without a problem; this test started failing
-// consistently on Windows CI with following error:
-// TypeError: error sending request for url (http://localhost:4545/echo_server):
-// connection error: An established connection was aborted by
-// the software in your host machine. (os error 10053)
 Deno.test(
-  { permissions: { net: true }, ignore: Deno.build.os == "windows" },
+  { permissions: { net: true } },
   async function fetchNullBodyStatus() {
     const nullBodyStatus = [101, 204, 205, 304];
 


### PR DESCRIPTION
It was disabled on windows almost 2 years ago (https://github.com/denoland/deno/pull/8987) with a different fetch implementation

