### PR TITLE
fix(require): tryPackage uses optional chaining

### DIFF
--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -109,7 +109,7 @@
       requestPath,
       "package.json",
     );
-    const pkg = core.ops.op_require_read_package_scope(packageJsonPath).main;
+    const pkg = core.ops.op_require_read_package_scope(packageJsonPath)?.main;
     if (!pkg) {
       return tryExtensions(
         pathResolve(requestPath, "index"),


### PR DESCRIPTION
I haven't been able to pin point the exact cause, but in some situations we get this error:
```
TypeError: Cannot read properties of null (reading 'main')
    at tryPackage (deno:ext/node/02_require.js:112:72)
    at Function.Module._findPath (deno:ext/node/02_require.js:387:20)
    at Function.Module._resolveFilename (deno:ext/node/02_require.js:598:29)
    at Function.Module._load (deno:ext/node/02_require.js:447:29)
    at Module.require (deno:ext/node/02_require.js:658:21)
    at require (deno:ext/node/02_require.js:789:18)
    at Object.<anonymous> (file:///Users/ib/dev/deno-react-vite/node_modules/.deno/@babel+core@7.18.13/node_modules/@babel/core/lib/config/helpers/config-api.js:20:9)
    at Object.<anonymous> (file:///Users/ib/dev/deno-react-vite/node_modules/.deno/@babel+core@7.18.13/node_modules/@babel/core/lib/config/helpers/config-api.js:110:4)
    at Module._compile (deno:ext/node/02_require.js:719:36)
    at Object.Module._extensions..js (deno:ext/node/02_require.js:752:12)
```

This PR changes `tryPackage` function in `require` implementation to match Node.js:
https://github.com/nodejs/node/blob/d8493c4f9752e329bffe044ada381b439b0bea37/lib/internal/modules/cjs/loader.js#L386

It makes the error go away.