### PR TITLE
feat(ext/flash): add `reuseport` option on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile 1.0.1",
  "serde",
+ "socket2",
  "tokio",
 ]
 

--- a/cli/bench/http/deno_http_flash.js
+++ b/cli/bench/http/deno_http_flash.js
@@ -8,4 +8,4 @@ function handler() {
   return new Response("Hello World");
 }
 
-serve(handler, { hostname, port, reuseport: true });
+serve(handler, { hostname, port, reusePort: true });

--- a/cli/bench/http/deno_http_flash.js
+++ b/cli/bench/http/deno_http_flash.js
@@ -8,4 +8,4 @@ function handler() {
   return new Response("Hello World");
 }
 
-serve(handler, { hostname, port });
+serve(handler, { hostname, port, reuseport: true });

--- a/cli/bench/http/deno_http_flash_ops.js
+++ b/cli/bench/http/deno_http_flash_ops.js
@@ -11,7 +11,7 @@ const {
 } = Deno;
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const [hostname, port] = addr.split(":");
-const serverId = op_flash_serve({ hostname, port });
+const serverId = op_flash_serve({ hostname, port, reuseport: true });
 const serverPromise = opAsync("op_flash_drive_server", serverId);
 
 const fastOps = op_flash_make_request();

--- a/cli/bench/http/deno_http_flash_ops_spawn.js
+++ b/cli/bench/http/deno_http_flash_ops_spawn.js
@@ -8,7 +8,9 @@ const path = new URL("./deno_http_flash_ops.js", import.meta.url).pathname;
 const cpus = navigator.hardwareConcurrency / 2;
 const processes = new Array(cpus);
 for (let i = 0; i < cpus; i++) {
-  const proc = Deno.run({ cmd: [executable, "run", "-A", "--unstable", path] });
+  const proc = Deno.run({
+    cmd: [executable, "run", "-A", "--unstable", path, Deno.args[0]],
+  });
   processes.push(proc.status());
 }
 await Promise.all(processes);

--- a/cli/bench/http/deno_http_flash_ops_spawn.js
+++ b/cli/bench/http/deno_http_flash_ops_spawn.js
@@ -1,0 +1,14 @@
+if (Deno.build.os !== "linux") {
+  throw new Error("SO_REUSEPORT is only supported on Linux");
+}
+
+const executable = Deno.execPath();
+const path = new URL("./deno_http_flash_ops.js", import.meta.url).pathname;
+// single flash instance runs on ~1.8 cores
+const cpus = navigator.hardwareConcurrency / 2;
+const processes = new Array(cpus);
+for (let i = 0; i < cpus; i++) {
+  const proc = Deno.run({ cmd: [executable, "run", "-A", "--unstable", path] });
+  processes.push(proc.status());
+}
+await Promise.all(processes);

--- a/cli/bench/http/deno_http_flash_spawn.js
+++ b/cli/bench/http/deno_http_flash_spawn.js
@@ -8,7 +8,9 @@ const path = new URL("./deno_http_flash.js", import.meta.url).pathname;
 const cpus = navigator.hardwareConcurrency / 2;
 const processes = new Array(cpus);
 for (let i = 0; i < cpus; i++) {
-  const proc = Deno.run({ cmd: [executable, "run", "-A", "--unstable", path] });
+  const proc = Deno.run({
+    cmd: [executable, "run", "-A", "--unstable", path, Deno.args[0]],
+  });
   processes.push(proc.status());
 }
 await Promise.all(processes);

--- a/cli/bench/http/deno_http_flash_spawn.js
+++ b/cli/bench/http/deno_http_flash_spawn.js
@@ -1,0 +1,14 @@
+if (Deno.build.os !== "linux") {
+  throw new Error("SO_REUSEPORT is only supported on Linux");
+}
+
+const executable = Deno.execPath();
+const path = new URL("./deno_http_flash.js", import.meta.url).pathname;
+// single flash instance runs on ~1.8 cores
+const cpus = navigator.hardwareConcurrency / 2;
+const processes = new Array(cpus);
+for (let i = 0; i < cpus; i++) {
+  const proc = Deno.run({ cmd: [executable, "run", "-A", "--unstable", path] });
+  processes.push(proc.status());
+}
+await Promise.all(processes);

--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1417,6 +1417,9 @@ declare namespace Deno {
     /** An AbortSignal to close the server and all connections. */
     signal?: AbortSignal;
 
+    /** Sets SO_REUSEPORT on Linux. */
+    reusePort?: boolean;
+
     /** The handler to invoke when route handlers throw an error. */
     onError?: (error: unknown) => Response | Promise<Response>;
 

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -459,6 +459,7 @@
     const listenOpts = {
       hostname: options.hostname ?? "127.0.0.1",
       port: options.port ?? 9000,
+      reuseport: options.reuseport ?? false,
     };
     if (options.cert || options.key) {
       if (!options.cert || !options.key) {

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -459,7 +459,7 @@
     const listenOpts = {
       hostname: options.hostname ?? "127.0.0.1",
       port: options.port ?? 9000,
-      reuseport: options.reuseport ?? false,
+      reuseport: options.reusePort ?? false,
     };
     if (options.cert || options.key) {
       if (!options.cert || !options.key) {

--- a/ext/flash/Cargo.toml
+++ b/ext/flash/Cargo.toml
@@ -27,3 +27,4 @@ rustls = { version = "0.20" }
 rustls-pemfile = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1.21", features = ["full"] }
+socket2 = "0.4.7"

--- a/ext/flash/Cargo.toml
+++ b/ext/flash/Cargo.toml
@@ -26,5 +26,5 @@ mio = { version = "0.8.1", features = ["os-poll", "net"] }
 rustls = { version = "0.20" }
 rustls-pemfile = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
-tokio = { version = "1.21", features = ["full"] }
 socket2 = "0.4.7"
+tokio = { version = "1.21", features = ["full"] }

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -832,6 +832,13 @@ fn run_server(
         &one as *const _ as *const _,
         std::mem::size_of_val(&one) as _,
       );
+      libc::setsockopt(
+        fd,
+        libc::SOL_SOCKET,
+        libc::SO_REUSEADDR,
+        &one as *const _ as *const _,
+        std::mem::size_of_val(&one) as _,
+      );
     }
   }
 


### PR DESCRIPTION
Sets `SO_REUSEPORT` on Linux. MacOS and Windows is a nop.

Closes #15719 
