### PR TITLE
fix(runtime): refresh perm prompt 3 lines instead of 4

### DIFF
--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -2104,13 +2104,13 @@ fn permission_prompt(message: &str, name: &str) -> bool {
     };
     match ch.to_ascii_lowercase() {
       'y' => {
-        clear_n_lines(4);
+        clear_n_lines(3);
         let msg = format!("Granted {}.", message);
         eprintln!("✅ {}", colors::bold(&msg));
         return true;
       }
       'n' => {
-        clear_n_lines(4);
+        clear_n_lines(3);
         let msg = format!("Denied {}.", message);
         eprintln!("❌ {}", colors::bold(&msg));
         return false;


### PR DESCRIPTION
Currently permission prompt shows 3 lines and clear 4 lines back. This removes one line above the permission prompt.

CURRENT BEHAVIOR
<img width="632" alt="スクリーンショット 2022-09-27 16 08 20" src="https://user-images.githubusercontent.com/613956/192457945-2e9c859e-97cc-416c-885f-41bfe336ebef.png">

<img width="628" alt="スクリーンショット 2022-09-27 16 08 27" src="https://user-images.githubusercontent.com/613956/192457965-39f55cf3-ac47-4b6a-9fa7-e865cc626469.png">

This updates it to clear only 3 lines.

This PR:
<img width="630" alt="スクリーンショット 2022-09-27 16 08 43" src="https://user-images.githubusercontent.com/613956/192458244-e95eb9db-26cd-4ebe-b987-b6ab1704f9b0.png">

<img width="627" alt="スクリーンショット 2022-09-27 16 08 53" src="https://user-images.githubusercontent.com/613956/192458287-a1c7bb4f-c3cf-4952-8ca2-e9d328210b7a.png">
