### PR TITLE
fix(cli/bench): strace numeric format

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -523,6 +523,7 @@ async fn main() -> Result<()> {
         ])
         .args(args.iter())
         .stdout(Stdio::null())
+        .env("LC_NUMERIC", "C")
         .spawn()?
         .wait()?;
       let expected_exit_code = expected_exit_code.unwrap_or(0);


### PR DESCRIPTION
`strace` number format depends on `LC_NUMERIC` environment variable.  This PR sets `LC_NUMERIC` to `C` to prevent `strace` from using decimal comma which causes the following line to panic:

https://github.com/denoland/deno/blob/f3dd13730c592b76778fa047a098214bc1934216/test_util/src/lib.rs#L2219

To reproduce (on linux)
```
LC_NUMERIC=es_ES.UTF-8 cargo bench --bench deno_bench -- strace
```

----

Output can be  tested by doing:

```
LC_NUMERIC=es_ES.UTF-8 strace -c -f -o /tmp/strace.out echo "deno"
```

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
  0,00    0,000000           0         1           read
  0,00    0,000000           0         1           write
------ ----------- ----------- --------- --------- ----------------
100.00    0,000000                    39         2 total
```
---

```
LC_NUMERIC=C strace -c -f -o /tmp/strace.out echo "deno"
```

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
  0.00    0.000000           0         3           read
  0.00    0.000000           0         1           write
------ ----------- ----------- --------- --------- ----------------
100.00    0.000000                    45         3 total
```


fixes #15743

https://github.com/denoland/deno/actions/runs/3134121413/jobs/5088284253