### PR TITLE
fix(cli/vendor): Handle assert type json during vendoring

### DIFF
--- a/cli/tools/vendor/build.rs
+++ b/cli/tools/vendor/build.rs
@@ -473,7 +473,7 @@ mod test {
             "/mod.ts",
             r#"import data from "https://localhost/data.json" assert { type: "json" };"#,
           )
-          .add("https://localhost/data.json", "{}");
+          .add("https://localhost/data.json", "{ \"test\": test }");
       })
       .build()
       .await
@@ -489,7 +489,7 @@ mod test {
     );
     assert_eq!(
       output.files,
-      to_file_vec(&[("/vendor/localhost/data.json", "{}"),]),
+      to_file_vec(&[("/vendor/localhost/data.json", "{ \"test\": test }"),]),
     );
   }
 

--- a/cli/tools/vendor/build.rs
+++ b/cli/tools/vendor/build.rs
@@ -473,7 +473,7 @@ mod test {
             "/mod.ts",
             r#"import data from "https://localhost/data.json" assert { type: "json" };"#,
           )
-          .add("https://localhost/data.json", "{ \"test\": test }");
+          .add("https://localhost/data.json", "{ \"a\": \"b\" }");
       })
       .build()
       .await
@@ -489,7 +489,7 @@ mod test {
     );
     assert_eq!(
       output.files,
-      to_file_vec(&[("/vendor/localhost/data.json", "{ \"test\": test }"),]),
+      to_file_vec(&[("/vendor/localhost/data.json", "{ \"a\": \"b\" }"),]),
     );
   }
 

--- a/cli/tools/vendor/import_map.rs
+++ b/cli/tools/vendor/import_map.rs
@@ -4,6 +4,7 @@ use deno_ast::LineAndColumnIndex;
 use deno_ast::ModuleSpecifier;
 use deno_ast::SourceTextInfo;
 use deno_core::error::AnyError;
+use deno_graph::MediaType;
 use deno_graph::Module;
 use deno_graph::ModuleGraph;
 use deno_graph::Position;
@@ -204,6 +205,11 @@ fn visit_modules(
   parsed_source_cache: &ParsedSourceCache,
 ) -> Result<(), AnyError> {
   for module in modules {
+    if module.media_type == MediaType::Json {
+      // skip visiting Json modules as they are leaves
+      continue; 
+    }
+    
     let text_info =
       match parsed_source_cache.get_parsed_source_from_module(module)? {
         Some(source) => source.text_info().clone(),

--- a/cli/tools/vendor/import_map.rs
+++ b/cli/tools/vendor/import_map.rs
@@ -207,9 +207,9 @@ fn visit_modules(
   for module in modules {
     if module.media_type == MediaType::Json {
       // skip visiting Json modules as they are leaves
-      continue; 
+      continue;
     }
-    
+
     let text_info =
       match parsed_source_cache.get_parsed_source_from_module(module)? {
         Some(source) => source.text_info().clone(),


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
This is my attempt at fixing https://github.com/denoland/deno/issues/15634

Currently deno vendor tries to parse imported json files via deno_ast and swc. This seems to work fine if the json file looks like `{}` or ["data"] . However if it is something like { "a": "b" } then it fails.

This PR fixes the issue by actually skipping trying to parse the json file altogether. json files should not contain any import statement and so there does not seem to be a need to parse them.