### PR TITLE
perf(ext/http): increase buffer size to 64kb

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -384,9 +384,7 @@
       type: "bytes",
       async pull(controller) {
         try {
-          // This is the largest possible size for a single packet on a TLS
-          // stream.
-          const chunk = new Uint8Array(16 * 1024 + 256);
+          const chunk = new Uint8Array(64 * 1024);
           const read = await readRequest(streamRid, chunk);
           if (read > 0) {
             // We read some data. Enqueue it onto the stream.


### PR DESCRIPTION
Towards https://github.com/denoland/deno/issues/13608

The current buffer size is the bottleneck. This PR increases the buffer size to 64kb, even if the largest possible size for a TLS packet is `16 * 1024 + 256`, we're reading at a slower rate than the upload speed, so packets are being buffered, 

https://github.com/denoland/deno/blob/e2828ad762034a0e8d38387d4e5d38cafa409f13/ext/http/lib.rs#L851

You can check that `chunk.len()` is usually greater than the max TLS packet size.

The higher the buffer size the faster it'll be, 64kb seems like a reasonable default value.

On my computer, streaming a 2gb upload to disk, takes **2.4s** with this update down from 4.5s.

----
Adding a `bufSize/highWaterMark` option to `Deno.serveHttp` or `httpConn.nextRequest()`  to change the default value would be a good next step.
