### PR TITLE
fix(ext/body): .bodyUsed for static body

### DIFF
--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -94,10 +94,9 @@ Deno.test(function customInspectFunction() {
 Deno.test(async function responseBodyUsed() {
   const response = new Response("body");
   assert(!response.bodyUsed);
-  await response.text(); // consume body
+  await response.text();
   assert(response.bodyUsed);
-  // .body getter is needed so we can test the faulty
-  // code path
+  // .body getter is needed so we can test the faulty code path
   response.body;
   assert(response.bodyUsed);
 });

--- a/cli/tests/unit/response_test.ts
+++ b/cli/tests/unit/response_test.ts
@@ -90,3 +90,14 @@ Deno.test(function customInspectFunction() {
   );
   assertStringIncludes(Deno.inspect(Response.prototype), "Response");
 });
+
+Deno.test(async function responseBodyUsed() {
+  const response = new Response("body");
+  assert(!response.bodyUsed);
+  await response.text(); // consume body
+  assert(response.bodyUsed);
+  // .body getter is needed so we can test the faulty
+  // code path
+  response.body;
+  assert(response.bodyUsed);
+});

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -29,7 +29,7 @@
     isReadableStreamDisturbed,
     errorReadableStream,
     readableStreamClose,
-    _disturbed,
+    readableStreamDisturb,
     createProxy,
     ReadableStreamPrototype,
   } = globalThis.__bootstrap.streams;
@@ -94,7 +94,7 @@
         if (consumed) {
           this.streamOrStatic = new ReadableStream();
           this.streamOrStatic.getReader();
-          this.streamOrStatic[_disturbed] = true;
+          readableStreamDisturb(this.streamOrStatic);
           readableStreamClose(this.streamOrStatic);
         } else {
           this.streamOrStatic = new ReadableStream({

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -28,6 +28,8 @@
   const {
     isReadableStreamDisturbed,
     errorReadableStream,
+    readableStreamClose,
+    _disturbed,
     createProxy,
     ReadableStreamPrototype,
   } = globalThis.__bootstrap.streams;
@@ -92,6 +94,8 @@
         if (consumed) {
           this.streamOrStatic = new ReadableStream();
           this.streamOrStatic.getReader();
+          this.streamOrStatic[_disturbed] = true;
+          readableStreamClose(this.streamOrStatic);
         } else {
           this.streamOrStatic = new ReadableStream({
             start(controller) {

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -5905,6 +5905,7 @@
   window.__bootstrap.streams = {
     // Non-Public
     _state,
+    _disturbed,
     isReadableStreamDisturbed,
     errorReadableStream,
     createProxy,

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -1153,6 +1153,15 @@
     reader[_closedPromise].resolve(undefined);
   }
 
+  /**
+   * @template R
+   * @param {ReadableStream<R>} stream
+   * @returns {void}
+   */
+  function readableStreamDisturb(stream) {
+    stream[_disturbed] = true;
+  }
+
   /** @param {ReadableStreamDefaultController<any>} controller */
   function readableStreamDefaultControllerCallPullIfNeeded(controller) {
     const shouldPull = readableStreamDefaultcontrollerShouldCallPull(
@@ -5905,12 +5914,12 @@
   window.__bootstrap.streams = {
     // Non-Public
     _state,
-    _disturbed,
     isReadableStreamDisturbed,
     errorReadableStream,
     createProxy,
     writableStreamClose,
     readableStreamClose,
+    readableStreamDisturb,
     readableStreamForRid,
     getReadableStreamRid,
     Deferred,


### PR DESCRIPTION
Fixes an edge case for `.bodyUsed` for static bodies when `.body` getter is called after consuming the body.

```javascript
const response = new Response("body");
await response.text();
console.log(response.bodyUsed); // true
response.body;
console.log(response.bodyUsed); // false
```