### PR TITLE
refactor(cli): use shared sys kind parser in flags.rs

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5,9 +5,11 @@ use clap::ArgMatches;
 use clap::ColorChoice;
 use clap::Command;
 use clap::ValueHint;
+use deno_core::error::AnyError;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use deno_core::url::Url;
+use deno_runtime::permissions::parse_sys_kind;
 use deno_runtime::permissions::PermissionsOptions;
 use log::debug;
 use log::Level;
@@ -1842,15 +1844,9 @@ fn permission_args(app: Command) -> Command {
         .help("Allow access to system info")
         .validator(|keys| {
           for key in keys.split(',') {
-            match key {
-              "hostname" | "osRelease" | "loadavg" | "networkInterfaces"
-              | "systemMemoryInfo" | "getUid" | "getGid" => {}
-              _ => {
-                return Err(format!("unknown system info kind \"{}\"", key));
-              }
-            }
+            parse_sys_kind(key)?;
           }
-          Ok(())
+          Ok::<(), AnyError>(())
         }),
     )
     .arg(

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -3,6 +3,7 @@
 use crate::colors;
 use crate::fs_util::resolve_from_cwd;
 use deno_core::error::custom_error;
+use deno_core::error::type_error;
 use deno_core::error::uri_error;
 use deno_core::error::AnyError;
 #[cfg(test)]
@@ -303,6 +304,14 @@ impl ToString for RunDescriptor {
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct SysDescriptor(pub String);
+
+pub fn parse_sys_kind(kind: &str) -> Result<&str, AnyError> {
+  match kind {
+    "hostname" | "osRelease" | "loadavg" | "networkInterfaces"
+    | "systemMemoryInfo" | "getUid" | "getGid" => Ok(kind),
+    _ => Err(type_error(format!("unknown system info kind \"{}\"", kind))),
+  }
+}
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct FfiDescriptor(pub PathBuf);


### PR DESCRIPTION
This PR makes sys kind name validation shared between flag validators and permission ops.