### PR TITLE
fix(ext/crypto): use correct handle for public keys

### DIFF
--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -1983,7 +1983,7 @@
         WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
 
         const publicHandle = {};
-        WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+        WeakMapPrototypeSet(KEY_STORE, publicHandle, publicKeyData);
 
         const algorithm = {
           name: algorithmName,
@@ -2031,7 +2031,7 @@
         WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
 
         const publicHandle = {};
-        WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);
+        WeakMapPrototypeSet(KEY_STORE, publicHandle, publicKeyData);
 
         const algorithm = {
           name: algorithmName,


### PR DESCRIPTION
When storing public and private keys in the key store, use a different handle for each key so that they can be looked up in the future.

Refs: https://github.com/denoland/deno/pull/14119
Refs: https://github.com/denoland/deno_std/issues/2631

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
