### PR TITLE
chore(ext/web): resource backed write stream util

### DIFF
--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -4,7 +4,8 @@
 ((window) => {
   const core = window.Deno.core;
   const { BadResourcePrototype, InterruptedPrototype, ops } = core;
-  const { WritableStream, readableStreamForRid } = window.__bootstrap.streams;
+  const { writableStreamForRid, readableStreamForRid } =
+    window.__bootstrap.streams;
   const {
     Error,
     ObjectPrototypeIsPrototypeOf,
@@ -63,39 +64,6 @@
 
   function resolveDns(query, recordType, options) {
     return core.opAsync("op_dns_resolve", { query, recordType, options });
-  }
-
-  function tryClose(rid) {
-    try {
-      core.close(rid);
-    } catch {
-      // Ignore errors
-    }
-  }
-
-  function writableStreamForRid(rid) {
-    return new WritableStream({
-      async write(chunk, controller) {
-        try {
-          let nwritten = 0;
-          while (nwritten < chunk.length) {
-            nwritten += await write(
-              rid,
-              TypedArrayPrototypeSubarray(chunk, nwritten),
-            );
-          }
-        } catch (e) {
-          controller.error(e);
-          tryClose(rid);
-        }
-      },
-      close() {
-        tryClose(rid);
-      },
-      abort() {
-        tryClose(rid);
-      },
-    });
   }
 
   class Conn {
@@ -352,8 +320,5 @@
     shutdown,
     Datagram,
     resolveDns,
-  };
-  window.__bootstrap.streamUtils = {
-    writableStreamForRid,
   };
 })(this);

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -780,7 +780,7 @@
    * @param {boolean=} autoClose If the resource should be auto-closed when the stream closes. Defaults to true.
    * @returns {WritableStream<Uint8Array>}
    */
-  function writableStreamForRid(rid, autoClose) {
+  function writableStreamForRid(rid, autoClose = true) {
     const stream = webidl.createBranded(WritableStream);
     stream[_resourceBacking] = { rid, autoClose };
     const underlyingSink = {

--- a/runtime/js/40_files.js
+++ b/runtime/js/40_files.js
@@ -7,8 +7,10 @@
   const { read, readSync, write, writeSync } = window.__bootstrap.io;
   const { ftruncate, ftruncateSync, fstat, fstatSync } = window.__bootstrap.fs;
   const { pathFromURL } = window.__bootstrap.util;
-  const { writableStreamForRid } = window.__bootstrap.streamUtils;
-  const { readableStreamForRid } = window.__bootstrap.streams;
+  const {
+    readableStreamForRid,
+    writableStreamForRid,
+  } = window.__bootstrap.streams;
   const {
     ArrayPrototypeFilter,
     Error,

--- a/runtime/js/40_spawn.js
+++ b/runtime/js/40_spawn.js
@@ -20,8 +20,8 @@
     readableStreamForRidUnrefable,
     readableStreamForRidUnrefableRef,
     readableStreamForRidUnrefableUnref,
+    writableStreamForRid,
   } = window.__bootstrap.streams;
-  const { writableStreamForRid } = window.__bootstrap.streamUtils;
 
   const promiseIdSymbol = SymbolFor("Deno.core.internalPromiseId");
 


### PR DESCRIPTION
This commit adds a new helper to ext/web to create resource backed
WritableStream objects. These resources are branded with the
information required to allow for participation in FastStreams. These
branded sinks are not yet integrated into any FastStream paths.
