### PR TITLE
refactor(core): use borrowed slices for read+write

### DIFF
--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -100,11 +100,11 @@ impl TcpStream {
 }
 
 impl Resource for TcpStream {
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.read(data))
   }
 
-  fn write<'a>(self: Rc<Self>, data: &[u8]) -> AsyncResult<usize> {
+  fn write(self: Rc<Self>, data: &[u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.write(data))
   }
 

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -165,7 +165,7 @@ async fn op_read(
   buf: ZeroCopyBuf,
 ) -> Result<u32, Error> {
   let resource = state.borrow().resource_table.get_any(rid)?;
-  resource.read_return(buf).await.map(|(n, _)| n as u32)
+  resource.read_owned(buf).await.map(|(n, _)| n as u32)
 }
 
 #[op]
@@ -175,7 +175,7 @@ async fn op_write(
   buf: ZeroCopyBuf,
 ) -> Result<u32, Error> {
   let resource = state.borrow().resource_table.get_any(rid)?;
-  resource.write(buf).await.map(|n| n as u32)
+  resource.write_owned(buf).await.map(|(n, _)| n as u32)
 }
 
 #[op]

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -40,7 +40,7 @@ pub trait Resource: Any + 'static {
   ///
   /// Callers should prefer calling `read_owned` if doing so does not result in
   /// any additional allocations on the caller's side.
-  fn read<'a>(self: Rc<Self>, _data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, _data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(futures::future::err(not_supported()))
   }
 
@@ -67,7 +67,7 @@ pub trait Resource: Any + 'static {
   ///
   /// Callers should prefer calling `write_owned` if doing so does not result in
   /// any additional allocations on the caller's side.
-  fn write<'a>(self: Rc<Self>, _data: &'a [u8]) -> AsyncResult<'a, usize> {
+  fn write(self: Rc<Self>, _data: &[u8]) -> AsyncResult<'_, usize> {
     Box::pin(futures::future::err(not_supported()))
   }
 

--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -390,7 +390,7 @@ impl CachePutResource {
   async fn write(self: Rc<Self>, data: &[u8]) -> Result<usize, AnyError> {
     let resource = deno_core::RcRef::map(&self, |r| &r.file);
     let mut file = resource.borrow_mut().await;
-    file.write_all(&data).await?;
+    file.write_all(data).await?;
     Ok(data.len())
   }
 
@@ -447,7 +447,7 @@ impl Resource for CacheResponseResource {
     "CacheResponseResource".into()
   }
 
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.read(data))
   }
 }

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -454,7 +454,7 @@ impl Resource for FetchRequestBodyResource {
     "fetchRequestBody".into()
   }
 
-  fn write<'a>(self: Rc<Self>, data: &'a [u8]) -> AsyncResult<'a, usize> {
+  fn write(self: Rc<Self>, data: &[u8]) -> AsyncResult<'_, usize> {
     Box::pin(async move {
       let data = data.to_owned();
       let len = data.len();
@@ -485,7 +485,7 @@ impl Resource for FetchResponseBodyResource {
     "fetchResponseBody".into()
   }
 
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(async move {
       let mut reader = RcRef::map(&self, |r| &r.reader).borrow_mut().await;
       let cancel = RcRef::map(self, |r| &r.cancel);

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -253,9 +253,8 @@ async fn op_flash_write_resource(
           .write_all(b"Transfer-Encoding: chunked\r\n\r\n")
           .await?;
         loop {
-          let vec = vec![0u8; 64 * 1024]; // 64KB
-          let buf = ZeroCopyBuf::new_temp(vec);
-          let (nread, buf) = resource.clone().read_return(buf).await?;
+          let mut buf = vec![0u8; 64 * 1024]; // 64KB
+          let nread = resource.clone().read(&mut buf).await?;
           if nread == 0 {
             stream.write_all(b"0\r\n\r\n").await?;
             break;

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -252,14 +252,14 @@ async fn op_flash_write_resource(
         stream
           .write_all(b"Transfer-Encoding: chunked\r\n\r\n")
           .await?;
+        let mut buf = ZeroCopyBuf::new_temp(vec![0u8; 64 * 1024]); // 64KB
         loop {
-          let buf = ZeroCopyBuf::new_temp(vec![0u8; 64 * 1024]); // 64KB
-          let (nread, buf) = resource.clone().read_owned(buf).await?;
+          let (nread, new_buf) = resource.clone().read_owned(buf).await?;
+          buf = new_buf;
           if nread == 0 {
             stream.write_all(b"0\r\n\r\n").await?;
             break;
           }
-
           let response = &buf[..nread];
           // TODO(@littledivy): use vectored writes.
           stream

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -253,8 +253,8 @@ async fn op_flash_write_resource(
           .write_all(b"Transfer-Encoding: chunked\r\n\r\n")
           .await?;
         loop {
-          let mut buf = vec![0u8; 64 * 1024]; // 64KB
-          let nread = resource.clone().read(&mut buf).await?;
+          let buf = ZeroCopyBuf::new_temp(vec![0u8; 64 * 1024]); // 64KB
+          let (nread, buf) = resource.clone().read_owned(buf).await?;
           if nread == 0 {
             stream.write_all(b"0\r\n\r\n").await?;
             break;

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -376,7 +376,7 @@ impl Resource for HttpStreamResource {
     "httpStream".into()
   }
 
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.read(data))
   }
 

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -96,11 +96,11 @@ impl Resource for TcpStreamResource {
     "tcpStream".into()
   }
 
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.read(data))
   }
 
-  fn write<'a>(self: Rc<Self>, data: &'a [u8]) -> AsyncResult<'a, usize> {
+  fn write(self: Rc<Self>, data: &[u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.write(data))
   }
 
@@ -151,7 +151,7 @@ pub struct UnixStreamResource;
 
 #[cfg(not(unix))]
 impl UnixStreamResource {
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     unreachable!()
   }
   fn write<'a>(self: Rc<Self>, data: &'a [u8]) -> AsyncResult<'a, usize> {
@@ -170,11 +170,11 @@ impl Resource for UnixStreamResource {
     "unixStream".into()
   }
 
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.read(data))
   }
 
-  fn write<'a>(self: Rc<Self>, data: &'a [u8]) -> AsyncResult<'a, usize> {
+  fn write(self: Rc<Self>, data: &[u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.write(data))
   }
 

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -736,11 +736,11 @@ impl Resource for TlsStreamResource {
     "tlsStream".into()
   }
 
-  fn read<'a>(self: Rc<Self>, data: &'a mut [u8]) -> AsyncResult<'a, usize> {
+  fn read(self: Rc<Self>, data: &mut [u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.read(data))
   }
 
-  fn write<'a>(self: Rc<Self>, data: &'a [u8]) -> AsyncResult<'a, usize> {
+  fn write(self: Rc<Self>, data: &[u8]) -> AsyncResult<'_, usize> {
     Box::pin(self.write(data))
   }
 

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -535,15 +535,12 @@ impl StdFileResource {
     self: Rc<Self>,
     mut buf: ZeroCopyBuf,
   ) -> Result<(usize, ZeroCopyBuf), AnyError> {
-    let nread = self
-      .with_inner_blocking_task(
-        move |inner| -> Result<(usize, ZeroCopyBuf), AnyError> {
-          let nread = inner.read(&mut buf)?;
-          Ok((nread, buf))
-        },
-      )
-      .await?;
-    Ok(nread)
+    self
+      .with_inner_blocking_task(move |inner| {
+        let nread = inner.read(&mut buf)?;
+        Ok((nread, buf))
+      })
+      .await
   }
 
   async fn write(self: Rc<Self>, data: &[u8]) -> Result<usize, AnyError> {


### PR DESCRIPTION
`Resource::read` and `Resource::write` now take `&mut [u8]` and `&[u8]`
respectively. For the ops that support writing borrowed data, this can speed up
splice operations by preventing some data copies. This comes with the downside
that an additional data copy is now needed for all `Resource::read` and
`Resource::write` operations, because the borrowed slices can not be sent to
block threads. To prevent this for cases where it is not necessary (ie the
existing cases), a new `Resource::read_owned` and `Resource::write_owned` have
been added. These allow for optimized read / write implementation if the buffer
is in fact owned.

Callers should prefer calling `Resource::read_owned` and `Resource::write_owned`
if they are able to do so without having to perform additional allocations.
