### PR TITLE
fix(ext/cache): acquire reader lock before async op

### DIFF
--- a/cli/tests/unit/cache_api_test.ts
+++ b/cli/tests/unit/cache_api_test.ts
@@ -94,3 +94,26 @@ Deno.test(async function cacheApi() {
   assert(await caches.delete(cacheName));
   assertFalse(await caches.has(cacheName));
 });
+
+Deno.test(async function cachePutReaderLock() {
+  const cacheName = "cache-v1";
+  const cache = await caches.open(cacheName);
+
+  const response = new Response('consumed');
+
+  const promise = cache.put(
+    new Request("https://example.com/"),
+    response,
+  );
+
+  assertRejects(
+    async () => {
+      await response.arrayBuffer();
+    },
+    TypeError,
+    "Body already consumed.",
+  );
+
+  await promise;
+
+});

--- a/cli/tests/unit/cache_api_test.ts
+++ b/cli/tests/unit/cache_api_test.ts
@@ -99,7 +99,7 @@ Deno.test(async function cachePutReaderLock() {
   const cacheName = "cache-v1";
   const cache = await caches.open(cacheName);
 
-  const response = new Response('consumed');
+  const response = new Response("consumed");
 
   const promise = cache.put(
     new Request("https://example.com/"),
@@ -115,5 +115,4 @@ Deno.test(async function cachePutReaderLock() {
   );
 
   await promise;
-
 });

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -119,8 +119,10 @@
 
       // Step 8.
       if (innerResponse.body !== null && innerResponse.body.unusable()) {
-        throw new TypeError("Response body must not already used");
+        throw new TypeError("Response body is already used");
       }
+      // acquire lock before async op
+      const reader = innerResponse.body?.stream.getReader();
 
       // Remove fragment from request URL before put.
       reqUrl.hash = "";
@@ -138,8 +140,7 @@
           responseStatusText: innerResponse.statusMessage,
         },
       );
-      if (innerResponse.body) {
-        const reader = innerResponse.body.stream.getReader();
+      if (reader) {
         while (true) {
           const { value, done } = await reader.read();
           if (done) {


### PR DESCRIPTION
The following snippet should throw instead of consuming the body
```js
  const cacheName = "cache-v1";
  const cache = await caches.open(cacheName);

  const response = new Response('consumed');

  const promise = cache.put(
    new Request("https://example.com/"),
    response,
  );
  console.log(await response.text()); // consumed
``` 

