### PR TITLE
feat(unstable): add support for npm specifier cli arguments for 'deno cache'

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -393,6 +393,18 @@ async fn load_and_type_check(
 
   for file in files {
     let specifier = resolve_url_or_path(file)?;
+
+    // TODO(bartlomieju): in the future (after all relevant deno subcommands
+    // have support for npm: specifiers), it would be good to unify this code
+    // in `ProcState::prepare_module_load`.
+    if let Ok(package_ref) = NpmPackageReference::from_specifier(&specifier) {
+      ps.npm_resolver
+        .add_package_reqs(vec![package_ref.req.clone()])
+        .await?;
+      ps.prepare_node_std_graph().await?;
+      continue;
+    }
+
     ps.prepare_module_load(
       vec![specifier],
       false,

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -203,6 +203,13 @@ itest!(error_version_after_subpath {
   exit_code: 1,
 });
 
+itest!(deno_cache {
+  args: "cache --unstable --reload npm:chalk npm:mkdirp",
+  output: "npm/deno_cache.out",
+  envs: env_vars(),
+  http_server: true,
+});
+
 #[test]
 fn parallel_downloading() {
   let (out, _err) = util::run_and_collect_output_with_args(

--- a/cli/tests/testdata/npm/deno_cache.out
+++ b/cli/tests/testdata/npm/deno_cache.out
@@ -1,0 +1,5 @@
+Download http://localhost:4545/npm/registry/chalk
+Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
+Download http://localhost:4545/npm/registry/mkdirp
+Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
+Download http://localhost:4545/npm/registry/mkdirp/mkdirp-1.0.4.tgz


### PR DESCRIPTION
This commit adds support for npm specifier in "deno cache" subcommand.

```
$ deno cache --unstable npm:vite npm:chalk https://deno.land/std/http/file_server.ts
```

Besides downloading requested npm package(s), it will also download
necessary code from "std/node/".

Ref https://github.com/denoland/deno/issues/15960