### PR TITLE
chore: remove 'fix_exotic_specifier' test

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1255,11 +1255,6 @@ itest!(fix_emittable_skipped {
   output: "run/fix_emittable_skipped.ts.out",
 });
 
-itest!(fix_exotic_specifiers {
-  args: "run --quiet --reload run/fix_exotic_specifiers.ts",
-  output: "run/fix_exotic_specifiers.ts.out",
-});
-
 itest!(fix_js_import_js {
   args: "run --quiet --reload run/fix_js_import_js.ts",
   output: "run/fix_js_import_js.ts.out",

--- a/cli/tests/testdata/run/fix_exotic_specifiers.ts
+++ b/cli/tests/testdata/run/fix_exotic_specifiers.ts
@@ -1,3 +1,0 @@
-import clone from "https://jspm.dev/lodash@4/clone";
-
-console.log(clone);

--- a/cli/tests/testdata/run/fix_exotic_specifiers.ts.out
+++ b/cli/tests/testdata/run/fix_exotic_specifiers.ts.out
@@ -1,1 +1,0 @@
-[Function: clone]


### PR DESCRIPTION
It's a test that's been flaky for a week, and after offline discussion,
we're no longer sure what it's testing.