### PR TITLE
fix(ext/fetch): support empty formdata

### DIFF
--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -401,6 +401,14 @@
     parse() {
       // Body must be at least 2 boundaries + \r\n + -- on the last boundary.
       if (this.body.length < (this.boundary.length * 2) + 4) {
+        const decodedBody = core.decode(this.body);
+        const lastBoundary = this.boundary + "--";
+        if (
+          decodedBody === lastBoundary ||
+          decodedBody === lastBoundary + "\r\n"
+        ) {
+          return new FormData();
+        }
         throw new TypeError("Form data too short to be valid.");
       }
 

--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -393,17 +393,19 @@
      * @returns {FormData}
      */
     parse() {
-      // Body must be at least 2 boundaries + \r\n + -- on the last boundary.
+      // To have fields body must be at least 2 boundaries + \r\n + --
+      // on the last boundary.
       if (this.body.length < (this.boundary.length * 2) + 4) {
         const decodedBody = core.decode(this.body);
         const lastBoundary = this.boundary + "--";
+        // check if it's an empty valid form data
         if (
           decodedBody === lastBoundary ||
           decodedBody === lastBoundary + "\r\n"
         ) {
           return new FormData();
         }
-        throw new TypeError("Form data too short to be valid.");
+        throw new TypeError("Unable to parse body as form data.");
       }
 
       const formData = new FormData();

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -3077,14 +3077,8 @@
         "response-static-json.any.worker.html": true
       },
       "body": {
-        "formdata.any.html": [
-          "Consume empty response.formData() as FormData",
-          "Consume empty request.formData() as FormData"
-        ],
-        "formdata.any.worker.html": [
-          "Consume empty response.formData() as FormData",
-          "Consume empty request.formData() as FormData"
-        ],
+        "formdata.any.html": true,
+        "formdata.any.worker.html": true,
         "mime-type.any.html": true,
         "mime-type.any.worker.html": true
       },

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -3225,14 +3225,8 @@
           "response.text() rejects if already aborted",
           "Call text() twice on aborted response"
         ],
-        "request.any.html": [
-          "Calling formData() on an aborted request",
-          "Aborting a request after calling formData()"
-        ],
-        "request.any.worker.html": [
-          "Calling formData() on an aborted request",
-          "Aborting a request after calling formData()"
-        ],
+        "request.any.html": true,
+        "request.any.worker.html": true,
         "cache.https.any.html": false,
         "cache.https.any.worker.html": false
       }


### PR DESCRIPTION
This PR adds support for empty `FormData` parsing in `Response`/`Request`

```js
new Response(new FormData()).formData()
```

ref: https://github.com/web-platform-tests/wpt/issues/28607