### PR TITLE
fix(ext/crypto): correct HMAC get key length op

### DIFF
--- a/cli/tests/unit/webcrypto_test.ts
+++ b/cli/tests/unit/webcrypto_test.ts
@@ -675,7 +675,7 @@ Deno.test(async function testDeriveKey() {
   const algorithm = derivedKey.algorithm as HmacKeyAlgorithm;
   assertEquals(algorithm.name, "HMAC");
   assertEquals(algorithm.hash.name, "SHA-256");
-  assertEquals(algorithm.length, 256);
+  assertEquals(algorithm.length, 512);
 });
 
 Deno.test(async function testAesCbcEncryptDecrypt() {

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -393,16 +393,16 @@
         if (algorithm.length === undefined) {
           switch (algorithm.hash.name) {
             case "SHA-1":
-              length = 160;
+              length = 512;
               break;
             case "SHA-256":
-              length = 256;
+              length = 512;
               break;
             case "SHA-384":
-              length = 384;
+              length = 1024;
               break;
             case "SHA-512":
-              length = 512;
+              length = 1024;
               break;
             default:
               throw new DOMException(


### PR DESCRIPTION
fixes #16180

`HMAC`'s `get key length` `op` uses the hash function's block size, not output size.

refs https://github.com/cloudflare/workerd/issues/68#issuecomment-1271189657