### PR TITLE
perf(ext/cache): set journal_mode=wal

### DIFF
--- a/ext/cache/sqlite.rs
+++ b/ext/cache/sqlite.rs
@@ -46,6 +46,16 @@ impl SqliteBackedCache {
       let connection = rusqlite::Connection::open(&path).unwrap_or_else(|_| {
         panic!("failed to open cache db at {}", path.display())
       });
+      // Enable write-ahead-logging mode.
+      let initial_pragmas = "
+        -- enable write-ahead-logging mode
+        PRAGMA journal_mode=WAL;
+        PRAGMA synchronous=NORMAL;
+        PRAGMA optimize;
+      ";
+      connection
+        .execute_batch(initial_pragmas)
+        .expect("failed to execute pragmas");
       connection
         .execute(
           "CREATE TABLE IF NOT EXISTS cache_storage (
@@ -118,7 +128,7 @@ impl Cache for SqliteBackedCache {
     tokio::task::spawn_blocking(move || {
       let db = db.lock();
       let cache_exists = db.query_row(
-        "SELECT count(cache_name) FROM cache_storage WHERE cache_name = ?1",
+        "SELECT count(id) FROM cache_storage WHERE cache_name = ?1",
         params![cache_name],
         |row| {
           let count: i64 = row.get(0)?;


### PR DESCRIPTION
Improves cache_put_no_body & cache_storage_open operations.

Before:

```
cpu: Apple M1 Pro
runtime: deno 1.26.1 (aarch64-apple-darwin)

file:///Users/sr/c/denoland/deno/cli/bench/cache_api.js
benchmark                  time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------- -----------------------------
cache_storage_open      96.57 µs/iter  (62.54 µs … 330.08 µs) 101.62 µs 111.29 µs 116.96 µs
cache_storage_has       62.92 µs/iter     (60.88 µs … 189 µs)  62.67 µs  75.67 µs  88.71 µs
cache_storage_delete    64.23 µs/iter  (61.38 µs … 173.83 µs)  63.12 µs 103.38 µs 106.88 µs
cache_put_body_10_KiB   23.94 ms/iter   (22.46 ms … 26.56 ms)  24.85 ms  26.56 ms  26.56 ms
cache_put_no_body      477.37 µs/iter (434.54 µs … 810.38 µs) 479.38 µs 663.83 µs 712.25 µs
cache_match            187.07 µs/iter (171.08 µs … 543.21 µs) 186.17 µs 256.67 µs 299.75 µs
cache_delete            86.72 µs/iter  (83.67 µs … 664.42 µs)  86.21 µs 119.67 µs 129.79 µs
```

After:
```
cpu: Apple M1 Pro
runtime: deno 1.26.1 (aarch64-apple-darwin)

file:///Users/sr/c/denoland/deno/cli/bench/cache_api.js
benchmark                  time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------- -----------------------------
cache_storage_open      65.26 µs/iter  (61.17 µs … 304.75 µs)  63.54 µs 106.17 µs 116.08 µs
cache_storage_has        63.3 µs/iter  (60.58 µs … 208.33 µs)  63.08 µs  82.46 µs  99.38 µs
cache_storage_delete    63.31 µs/iter  (60.96 µs … 173.54 µs)  62.67 µs 100.88 µs  103.5 µs
cache_put_body_10_KiB   25.38 ms/iter   (22.62 ms … 47.56 ms)  25.04 ms  47.56 ms  47.56 ms
cache_put_no_body      189.47 µs/iter   (156.42 µs … 1.76 ms) 182.21 µs 375.62 µs 479.62 µs
cache_match            180.33 µs/iter (170.17 µs … 582.62 µs) 180.17 µs 229.62 µs 257.04 µs
cache_delete            85.15 µs/iter  (82.79 µs … 489.54 µs)  84.96 µs  97.29 µs 103.17 µs
```