### PR TITLE
fix(core): Allow importMap to be an absolute URL within the deno config file

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -488,7 +488,9 @@ mod test {
     let actual = actual.unwrap();
     assert_eq!(
       actual,
-      Some(ModuleSpecifier::parse("https://example.com/import_map.json").unwrap())
+      Some(
+        ModuleSpecifier::parse("https://example.com/import_map.json").unwrap()
+      )
     );
   }
 

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -420,6 +420,10 @@ fn resolve_import_map_specifier(
     // and with config files, we support both local and remote config files,
     // so we have treat them differently.
     if let Some(import_map_path) = config_file.to_import_map_path() {
+      // if the import map is an absolute URL, use it as is
+      if let Ok(specifier) = deno_core::resolve_url(&import_map_path) {
+        return Ok(Some(specifier));
+      }
       let specifier =
           // with local config files, it might be common to specify an import
           // map like `"importMap": "import-map.json"`, which is resolvable if

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -472,6 +472,23 @@ mod test {
   }
 
   #[test]
+  fn resolve_import_map_remote_config_file_local() {
+    let config_text = r#"{
+      "importMap": "https://example.com/import_map.json"
+    }"#;
+    let config_specifier =
+      ModuleSpecifier::parse("file:///deno/deno.jsonc").unwrap();
+    let config_file = ConfigFile::new(config_text, &config_specifier).unwrap();
+    let actual = resolve_import_map_specifier(None, Some(&config_file));
+    assert!(actual.is_ok());
+    let actual = actual.unwrap();
+    assert_eq!(
+      actual,
+      Some(ModuleSpecifier::parse("https://example.com/import_map.json").unwrap())
+    );
+  }
+
+  #[test]
   fn resolve_import_map_config_file_remote() {
     let config_text = r#"{
       "importMap": "./import_map.json"


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

When the config is a local file, added a check for whether the importMap is an absolute URL, and just use that if so, before falling back to the existing behaviour of resolving as a file path.

Added test for an absolute importMap URL in a local config.

Fixes #16193