### PR TITLE
fix(ext/fetch): fix illegal header regex

### DIFF
--- a/cli/tests/unit/headers_test.ts
+++ b/cli/tests/unit/headers_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "./test_util.ts";
+import { assert, assertEquals, assertThrows } from "./test_util.ts";
 const {
   inspectArgs,
   // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
@@ -384,5 +384,18 @@ Deno.test(function customInspectReturnsCorrectHeadersFormat() {
   assertEquals(
     stringify(multiParamHeader),
     `Headers { "content-length": "1337", "content-type": "application/json" }`,
+  );
+});
+
+Deno.test(function invalidHeadersFlaky() {
+  assertThrows(
+    () => new Headers([["x", "\u0000x"]]),
+    TypeError,
+    "Header value is not valid.",
+  );
+  assertThrows(
+    () => new Headers([["x", "\u0000x"]]),
+    TypeError,
+    "Header value is not valid.",
   );
 });

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -88,7 +88,7 @@
 
   // Regex matching illegal chars in a header value
   // deno-lint-ignore no-control-regex
-  const ILLEGAL_VALUE_CHARS = /[\x00\x0A\x0D]/g;
+  const ILLEGAL_VALUE_CHARS = /[\x00\x0A\x0D]/;
 
   /**
    * https://fetch.spec.whatwg.org/#concept-headers-append


### PR DESCRIPTION
This PR fixes invalid header parsing which is flaky because `g` flag is being used in the regex, which keeps track of `lastIndex`

```javascript
try {
  new Headers([["x", "\u0000x"]]);  // error
} catch(e) {}
new Headers([["x", "\u0000x"]]); // no error
```

This issue affects `Response` & `Request` constructors as well