### PR TITLE
Chore: Added onbeforeunload to window type definition + updated test

### DIFF
--- a/cli/dts/lib.deno.window.d.ts
+++ b/cli/dts/lib.deno.window.d.ts
@@ -21,6 +21,7 @@ declare class Window extends EventTarget {
   readonly self: Window & typeof globalThis;
   onerror: ((this: Window, ev: ErrorEvent) => any) | null;
   onload: ((this: Window, ev: Event) => any) | null;
+  onbeforeunload: ((this: Window, ev: Event) => any) | null;
   onunload: ((this: Window, ev: Event) => any) | null;
   onunhandledrejection:
     | ((this: Window, ev: PromiseRejectionEvent) => any)
@@ -75,6 +76,8 @@ declare var self: Window & typeof globalThis;
 declare var onerror: ((this: Window, ev: ErrorEvent) => any) | null;
 /** @category DOM Events */
 declare var onload: ((this: Window, ev: Event) => any) | null;
+/** @category DOM Events */
+declare var onbeforeunload: ((this: Window, ev: Event) => any) | null;
 /** @category DOM Events */
 declare var onunload: ((this: Window, ev: Event) => any) | null;
 /** @category Observability */

--- a/cli/tests/testdata/run/onload/imported.ts
+++ b/cli/tests/testdata/run/onload/imported.ts
@@ -3,7 +3,7 @@ import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 import "./nest_imported.ts";
 
 const handler = (e: Event) => {
-  assert(e.type === 'beforeunload' ? e.cancelable : !e.cancelable);
+  assert(e.type === "beforeunload" ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (imported)`);
 };
 

--- a/cli/tests/testdata/run/onload/imported.ts
+++ b/cli/tests/testdata/run/onload/imported.ts
@@ -3,10 +3,11 @@ import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 import "./nest_imported.ts";
 
 const handler = (e: Event) => {
-  assert(!e.cancelable);
+  assert(e.type === 'beforeunload' ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (imported)`);
 };
 
 window.addEventListener("load", handler);
+window.addEventListener("beforeunload", handler);
 window.addEventListener("unload", handler);
 console.log("log from imported script");

--- a/cli/tests/testdata/run/onload/main.out
+++ b/cli/tests/testdata/run/onload/main.out
@@ -5,6 +5,10 @@ got load event in event handler (nest_imported)
 got load event in event handler (imported)
 got load event in event handler (main)
 got load event in onload function
+got beforeunload event in event handler (nest_imported)
+got beforeunload event in event handler (imported)
+got beforeunload event in event handler (main)
+got beforeunload event in onbeforeunload function
 got unload event in event handler (nest_imported)
 got unload event in event handler (imported)
 got unload event in event handler (main)

--- a/cli/tests/testdata/run/onload/main.ts
+++ b/cli/tests/testdata/run/onload/main.ts
@@ -6,17 +6,24 @@ assert(window.hasOwnProperty("onload"));
 assert(window.onload === null);
 
 const eventHandler = (e: Event) => {
-  assert(!e.cancelable);
+  assert(e.type === 'beforeunload' ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (main)`);
 };
 
 window.addEventListener("load", eventHandler);
+
+window.addEventListener("beforeunload", eventHandler);
 
 window.addEventListener("unload", eventHandler);
 
 window.onload = (e: Event) => {
   assert(!e.cancelable);
   console.log(`got ${e.type} event in onload function`);
+};
+
+window.onbeforeunload = (e: BeforeUnloadEvent) => {
+  assert(e.cancelable);
+  console.log(`got ${e.type} event in onbeforeunload function`);
 };
 
 window.onunload = (e: Event) => {

--- a/cli/tests/testdata/run/onload/main.ts
+++ b/cli/tests/testdata/run/onload/main.ts
@@ -6,7 +6,7 @@ assert(window.hasOwnProperty("onload"));
 assert(window.onload === null);
 
 const eventHandler = (e: Event) => {
-  assert(e.type === 'beforeunload' ? e.cancelable : !e.cancelable);
+  assert(e.type === "beforeunload" ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (main)`);
 };
 

--- a/cli/tests/testdata/run/onload/nest_imported.ts
+++ b/cli/tests/testdata/run/onload/nest_imported.ts
@@ -2,7 +2,7 @@
 import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 
 const handler = (e: Event) => {
-  assert(e.type === 'beforeunload' ? e.cancelable : !e.cancelable);
+  assert(e.type === "beforeunload" ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (nest_imported)`);
 };
 

--- a/cli/tests/testdata/run/onload/nest_imported.ts
+++ b/cli/tests/testdata/run/onload/nest_imported.ts
@@ -2,10 +2,11 @@
 import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 
 const handler = (e: Event) => {
-  assert(!e.cancelable);
+  assert(e.type === 'beforeunload' ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (nest_imported)`);
 };
 
 window.addEventListener("load", handler);
+window.addEventListener("beforeunload", handler);
 window.addEventListener("unload", handler);
 console.log("log from nest_imported script");


### PR DESCRIPTION
I've been playing with Deno a bit recently (since becoming FUNemployed as a result of layoff) 🥳

In playing around with globalThis and event handlers/listener, I noticed that onbeforeunload wasn't present on the window type definition, resulting in the following warning: 

`Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.deno-ts(7017)`

The observation is discussed a bit more here in this somewhat related thread: https://github.com/denoland/deno/issues/13390

I figured this presented me with an opportunity to learn a bit more about Deno, so I set out to address this by updating the typings to include onbeforeunload.

Additionally, I've updated the onload integration test to the update update.

Please let me know if I've missed anything.

Thanks!
-Matt