### PR TITLE
fix(ext/fetch): throw TypeError on non-Uint8Array chunk

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -813,6 +813,12 @@
       const { value: chunk, done } = await reader.read();
       if (done) break;
 
+      if (!ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, chunk)) {
+        throw new TypeError(
+          "Can't convert value to Uint8Array while consuming the stream",
+        );
+      }
+
       ArrayPrototypePush(chunks, chunk);
       totalLength += chunk.byteLength;
     }

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -2999,6 +2999,8 @@
         "response-static-error.any.worker.html": true,
         "response-static-redirect.any.html": true,
         "response-static-redirect.any.worker.html": true,
+        "response-stream-bad-chunk.any.html": true,
+        "response-stream-bad-chunk.any.worker.html": true,
         "response-stream-disturbed-1.any.html": true,
         "response-stream-disturbed-1.any.worker.html": true,
         "response-stream-disturbed-2.any.html": true,


### PR DESCRIPTION
If chunk is not a `Uint8Array` a `TypeError` must be thrown.

https://wpt.fyi/results/fetch/api/response/response-stream-bad-chunk.any.html?label=master&product=deno%5Bexperimental%5D&product=chrome&product=firefox&product=safari&aligned&view=subtest