### PR TITLE
experiment: io_uring support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,7 @@ dependencies = [
  "termcolor",
  "test_util",
  "tokio",
+ "tokio-uring",
  "uuid",
  "winapi 0.3.9",
  "winres",
@@ -2441,6 +2442,16 @@ name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
+name = "io-uring"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d32c9c053ad47572e11da8bce622ed4c9ae9dedac5b7f678a2e876d1494d4c4"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "ipconfig"
@@ -4076,6 +4087,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "smallvec",
+ "tokio-uring",
  "v8",
 ]
 
@@ -5008,6 +5020,18 @@ dependencies = [
  "tungstenite",
  "webpki",
  "webpki-roots",
+]
+
+[[package]]
+name = "tokio-uring"
+version = "0.3.0"
+dependencies = [
+ "io-uring",
+ "libc",
+ "scoped-tls",
+ "slab",
+ "socket2",
+ "tokio",
 ]
 
 [[package]]

--- a/cli/bench/read_file.js
+++ b/cli/bench/read_file.js
@@ -5,7 +5,7 @@ let [total, count] = typeof Deno !== "undefined"
   : [process.argv[2], process.argv[3]];
 
 total = total ? parseInt(total, 0) : 50;
-count = count ? parseInt(count, 10) : 100;
+count = count ? parseInt(count, 10) : 1000;
 
 async function bench(fun) {
   const start = Date.now();
@@ -17,6 +17,5 @@ async function bench(fun) {
 }
 
 const x = new TextEncoder().encode("lol\n".repeat(1024 * 1024));
-await bench(() => Deno.writeFile("a.txt", x));
-// const fs = require("fs").promises;
-// bench(() => fs.writeFile("/dev/null", x));
+await Deno.writeFile("a.txt", x);
+await bench(() => Deno.readFile("a.txt"));

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 [features]
 default = ["v8_use_custom_libcxx"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]
+enable_iouring = ["serde_v8/enable_iouring"]
 
 [dependencies]
 anyhow = "1.0.57"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,7 @@ description = "Provides the deno runtime library"
 [features]
 # "fake" feature that allows to generate docs on docs.rs
 docsrs = []
+enable_iouring = ["deno_core/enable_iouring", "tokio-uring"]
 
 [lib]
 name = "deno_runtime"
@@ -97,6 +98,7 @@ winapi = { version = "0.3.9", features = ["commapi", "knownfolders", "mswsock", 
 
 [target.'cfg(unix)'.dependencies]
 nix = "=0.24.2"
+tokio-uring = { version = "0.3.0", path = "../../tokio-uring", optional = true }
 
 [dev-dependencies]
 # Used in benchmark

--- a/runtime/ops/asyncfs/iouring/mod.rs
+++ b/runtime/ops/asyncfs/iouring/mod.rs
@@ -1,0 +1,159 @@
+use crate::ops::fs::write_open_options;
+
+use crate::ops::fs::OpenOptions;
+use crate::permissions::Permissions;
+use deno_core::error::AnyError;
+use deno_core::op;
+use deno_core::CancelFuture;
+use deno_core::CancelHandle;
+use deno_core::OpState;
+use deno_core::ResourceId;
+use deno_core::ZeroCopyBuf;
+use std::cell::RefCell;
+use std::path::Path;
+use std::path::PathBuf;
+use std::rc::Rc;
+use tokio_uring::fs::File;
+
+#[inline]
+pub(crate) fn open_helper_async(
+  state: &mut OpState,
+  path: &str,
+  mode: Option<u32>,
+  options: Option<&OpenOptions>,
+  api_name: &str,
+) -> Result<(PathBuf, tokio_uring::fs::OpenOptions), AnyError> {
+  let path = Path::new(path).to_path_buf();
+
+  let mut open_options = tokio_uring::fs::OpenOptions::new();
+
+  if let Some(mode) = mode {
+    // mode only used if creating the file on Unix
+    // if not specified, defaults to 0o666
+    #[cfg(unix)]
+    {
+      use std::os::unix::fs::OpenOptionsExt;
+      open_options.mode(mode & 0o777);
+    }
+    #[cfg(not(unix))]
+    let _ = mode; // avoid unused warning
+  }
+
+  let permissions = state.borrow_mut::<Permissions>();
+
+  match options {
+    None => {
+      permissions.read.check(&path, Some(api_name))?;
+      open_options
+        .read(true)
+        .create(false)
+        .write(false)
+        .truncate(false)
+        .append(false)
+        .create_new(false);
+    }
+    Some(options) => {
+      if options.read {
+        permissions.read.check(&path, Some(api_name))?;
+      }
+
+      if options.write || options.append {
+        permissions.write.check(&path, Some(api_name))?;
+      }
+
+      open_options
+        .read(options.read)
+        .create(options.create)
+        .write(options.write)
+        .truncate(options.truncate)
+        .append(options.append)
+        .create_new(options.create_new);
+    }
+  }
+
+  Ok((path, open_options))
+}
+
+#[op]
+pub async fn op_write_file_async(
+  state: Rc<RefCell<OpState>>,
+  path: String,
+  mode: Option<u32>,
+  append: bool,
+  create: bool,
+  data: ZeroCopyBuf,
+  cancel_rid: Option<ResourceId>,
+) -> Result<(), AnyError> {
+  let cancel_handle = match cancel_rid {
+    Some(cancel_rid) => state
+      .borrow_mut()
+      .resource_table
+      .get::<CancelHandle>(cancel_rid)
+      .ok(),
+    None => None,
+  };
+  let (path, open_options) = open_helper_async(
+    &mut *state.borrow_mut(),
+    &path,
+    mode,
+    Some(&write_open_options(create, append)),
+    "Deno.writeFile()",
+  )?;
+  let write_future = async move {
+    let file = open_options.open(&path).await?;
+    let (res, _) = file.write_all_at(data, 0).await;
+    res?;
+    Ok::<(), AnyError>(())
+  };
+  if let Some(cancel_handle) = cancel_handle {
+    write_future.or_cancel(cancel_handle).await??;
+  } else {
+    write_future.await?;
+  }
+  Ok(())
+}
+
+#[op]
+async fn op_readfile_async(
+  state: Rc<RefCell<OpState>>,
+  path: String,
+  cancel_rid: Option<ResourceId>,
+) -> Result<ZeroCopyBuf, AnyError> {
+  {
+    let path = Path::new(&path);
+    let mut state = state.borrow_mut();
+    state
+      .borrow_mut::<Permissions>()
+      .read
+      .check(path, Some("Deno.readFile()"))?;
+  }
+
+  // TODO(@littledivy): Stat file to get the size.
+  let fut = async move {
+    let path = Path::new(&path);
+    let file = File::open(&path).await?;
+    let mut buf = vec![0; 1024 * 16];
+    let mut offset: u64 = 0;
+    loop {
+      let (res, mut ret) =
+        file.read_at(buf.split_off(offset as usize), offset).await;
+      let nread = res? as u64;
+      offset = offset + nread;
+      if nread == 0 {
+        break Ok::<ZeroCopyBuf, AnyError>(ret.into());
+      }
+      ret.resize(offset as usize * 2, 0);
+      buf = ret;
+    }
+  };
+  if let Some(cancel_rid) = cancel_rid {
+    let cancel_handle = state
+      .borrow_mut()
+      .resource_table
+      .get::<CancelHandle>(cancel_rid);
+    if let Ok(cancel_handle) = cancel_handle {
+      return fut.or_cancel(cancel_handle).await?;
+    }
+  }
+  fut.await
+}

--- a/runtime/ops/asyncfs/mod.rs
+++ b/runtime/ops/asyncfs/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "enable_iouring")]
+pub mod iouring;
+#[cfg(not(feature = "enable_iouring"))]
+pub mod spawn_blocking;
+
+#[cfg(feature = "enable_iouring")]
+pub use iouring::*;
+
+#[cfg(not(feature = "enable_iouring"))]
+pub use spawn_blocking::*;

--- a/runtime/ops/asyncfs/spawn_blocking/mod.rs
+++ b/runtime/ops/asyncfs/spawn_blocking/mod.rs
@@ -1,0 +1,81 @@
+use crate::ops::fs::open_helper;
+use crate::ops::fs::write_file;
+use crate::ops::fs::write_open_options;
+
+use crate::permissions::Permissions;
+use deno_core::error::AnyError;
+use deno_core::op;
+use deno_core::CancelFuture;
+use deno_core::CancelHandle;
+use deno_core::OpState;
+use deno_core::ResourceId;
+use deno_core::ZeroCopyBuf;
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+#[op]
+pub async fn op_write_file_async(
+  state: Rc<RefCell<OpState>>,
+  path: String,
+  mode: Option<u32>,
+  append: bool,
+  create: bool,
+  data: ZeroCopyBuf,
+  cancel_rid: Option<ResourceId>,
+) -> Result<(), AnyError> {
+  let cancel_handle = match cancel_rid {
+    Some(cancel_rid) => state
+      .borrow_mut()
+      .resource_table
+      .get::<CancelHandle>(cancel_rid)
+      .ok(),
+    None => None,
+  };
+  let (path, open_options) = open_helper(
+    &mut *state.borrow_mut(),
+    &path,
+    mode,
+    Some(&write_open_options(create, append)),
+    "Deno.writeFile()",
+  )?;
+  let write_future = tokio::task::spawn_blocking(move || {
+    write_file(&path, open_options, mode, data)
+  });
+  if let Some(cancel_handle) = cancel_handle {
+    write_future.or_cancel(cancel_handle).await???;
+  } else {
+    write_future.await??;
+  }
+  Ok(())
+}
+
+#[op]
+async fn op_readfile_async(
+  state: Rc<RefCell<OpState>>,
+  path: String,
+  cancel_rid: Option<ResourceId>,
+) -> Result<ZeroCopyBuf, AnyError> {
+  {
+    let path = Path::new(&path);
+    let mut state = state.borrow_mut();
+    state
+      .borrow_mut::<Permissions>()
+      .read
+      .check(path, Some("Deno.readFile()"))?;
+  }
+  let fut = tokio::task::spawn_blocking(move || {
+    let path = Path::new(&path);
+    Ok(std::fs::read(path).map(ZeroCopyBuf::from)?)
+  });
+  if let Some(cancel_rid) = cancel_rid {
+    let cancel_handle = state
+      .borrow_mut()
+      .resource_table
+      .get::<CancelHandle>(cancel_rid);
+    if let Ok(cancel_handle) = cancel_handle {
+      return fut.or_cancel(cancel_handle).await??;
+    }
+  }
+  fut.await?
+}

--- a/runtime/ops/mod.rs
+++ b/runtime/ops/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+mod asyncfs;
 pub mod fs;
 pub mod fs_events;
 pub mod http;

--- a/runtime/tokio_util.rs
+++ b/runtime/tokio_util.rs
@@ -14,6 +14,7 @@ pub fn create_basic_runtime() -> tokio::runtime::Runtime {
     .unwrap()
 }
 
+#[cfg(not(feature = "enable_iouring"))]
 pub fn run_local<F, R>(future: F) -> R
 where
   F: std::future::Future<Output = R>,
@@ -21,4 +22,12 @@ where
   let rt = create_basic_runtime();
   let local = tokio::task::LocalSet::new();
   local.block_on(&rt, future)
+}
+
+#[cfg(feature = "enable_iouring")]
+pub fn run_local<F, R>(future: F) -> R
+where
+  F: std::future::Future<Output = R>,
+{
+  tokio_uring::start(future)
 }

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -12,12 +12,18 @@ description = "Rust to V8 serialization and deserialization"
 [lib]
 path = "lib.rs"
 
+[features]
+default = []
+# Requires a recent Linux kernel version (atleast )
+enable_iouring = ["tokio-uring"]
+
 [dependencies]
 bytes = "=1.2.1"
 derive_more = "0.99.17"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_bytes = "0.11"
 smallvec = { version = "1.8", features = ["union"] }
+tokio-uring = { version = "0.3.0", optional = true, path = "../../tokio-uring" }
 v8 = { version = "0.52.0", default-features = false }
 
 [dev-dependencies]

--- a/serde_v8/magic/buffer.rs
+++ b/serde_v8/magic/buffer.rs
@@ -155,3 +155,18 @@ impl From<ZeroCopyBuf> for bytes::Bytes {
     }
   }
 }
+
+#[cfg(feature = "enable_iouring")]
+unsafe impl tokio_uring::buf::IoBuf for ZeroCopyBuf {
+  fn stable_ptr(&self) -> *const u8 {
+    self.as_ptr()
+  }
+
+  fn bytes_init(&self) -> usize {
+    self.len()
+  }
+
+  fn bytes_total(&self) -> usize {
+    self.bytes_init()
+  }
+}


### PR DESCRIPTION
This PR does initial integration for using io_uring in Deno. See https://github.com/denoland/deno/issues/16232

Implements specialized tokio_iouring ops for `writeFile` and `readFile`. The tokio 
`current_thread` runtime is managed by `tokio_iouring::start`. We want to continue 
adding more ops specialized for iouring.

Additionally, all of io_uring functionality is behind the `enable_iouring` Cargo feature 
flag on `deno_runtime`. This is so that we do not distrupt workflow for people working 
on this repo. 

To compile Deno with io_uring support:
```
cargo build --release --features "deno_runtime/enable_iouring"
```

### `tokio_iouring`

It's early but has amazing integration with tokio's current_thread runtime. Blocked on the following tokio_iouring PRs:

- https://github.com/tokio-rs/tokio-uring/pull/44
- https://github.com/tokio-rs/tokio-uring/pull/131
- https://github.com/tokio-rs/tokio-uring/pull/132
- https://github.com/tokio-rs/tokio-uring/pull/133
- API for `opcode::Statx`

See [stuff that Deno needs](https://github.com/tokio-rs/tokio-uring/compare/master...littledivy:tokio-uring:deno) (ugly code alert).

Is it the right choice for Deno? This is what we aim to find out in the coming days with the experimental compilation flag.

### Benchmarks

4x improvement in `await Deno.writeFile(file, new Uint8Array(1024 * 1024 * 10))`:

```
divy@divy:~/deno$ target/release/deno run -A --unstable cli/bench/write_file.js # io_uring
time 433 ms rate 230
time 548 ms rate 182
time 540 ms rate 185
time 565 ms rate 176
^C

divy@divy:~/deno$ ~/.deno/bin/deno run -A --unstable cli/bench/write_file.js # main
time 2696 ms rate 37
time 2857 ms rate 35
time 2859 ms rate 34
time 2861 ms rate 34
^C
```

<details open><summary> main writeFile flamegraph </summary>


![main_write_file](https://user-images.githubusercontent.com/34997667/195647589-f683cbfd-5d0b-4dd5-80e4-1b368d2f4d95.svg)

</details>
<details open><summary> io_uring writeFile flamegraph </summary>


![io_uring_write_file](https://user-images.githubusercontent.com/34997667/195647829-9722685f-ccd4-4397-83b1-0c667cc7601d.svg)

</details>

