### PR TITLE
fix(ext/web/streams): fix cancelPromise in ReadableStreamTee

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -2675,7 +2675,9 @@
               ],
             );
           }
-          cancelPromise.resolve(undefined);
+          if (canceled1 === false || canceled2 === false) {
+            cancelPromise.resolve(undefined);
+          }
         },
         errorSteps() {
           reading = false;

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1336,8 +1336,12 @@
       "patched-global.any.worker.html": true,
       "reentrant-strategies.any.html": true,
       "reentrant-strategies.any.worker.html": true,
-      "tee.any.html": false,
-      "tee.any.worker.html": false,
+      "tee.any.html": [
+        "ReadableStream teeing: enqueue() and close() while both branches are pulling"
+      ],
+      "tee.any.worker.html": [
+        "ReadableStream teeing: enqueue() and close() while both branches are pulling"
+      ],
       "templated.any.html": true,
       "templated.any.worker.html": true
     },


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/11252

Harness no longer crashes with this patch
https://wpt.fyi/results/streams/readable-streams/tee.any.html?label=master&product=deno%5Bexperimental%5D&product=chrome&product=firefox&aligned&view=subtest