### PR TITLE
fix(ext/web/streams): enqueue to second branch before closing

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -2610,6 +2610,7 @@
     assert(typeof cloneForBranch2 === "boolean");
     const reader = acquireReadableStreamDefaultReader(stream);
     let reading = false;
+    let readAgain = false;
     let canceled1 = false;
     let canceled2 = false;
     /** @type {any} */
@@ -2628,6 +2629,7 @@
 
     function pullAlgorithm() {
       if (reading === true) {
+        readAgain = true;
         return resolvePromiseWith(undefined);
       }
       reading = true;
@@ -2635,7 +2637,7 @@
       const readRequest = {
         chunkSteps(value) {
           queueMicrotask(() => {
-            reading = false;
+            readAgain = false;
             const value1 = value;
             const value2 = value;
 
@@ -2656,6 +2658,11 @@
                 ],
                 value2,
               );
+            }
+
+            reading = false;
+            if (readAgain === true) {
+              pullAlgorithm();
             }
           });
         },

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1336,8 +1336,8 @@
       "patched-global.any.worker.html": true,
       "reentrant-strategies.any.html": true,
       "reentrant-strategies.any.worker.html": true,
-      "tee.any.html": false,
-      "tee.any.worker.html": false,
+      "tee.any.html": true,
+      "tee.any.worker.html": true,
       "templated.any.html": true,
       "templated.any.worker.html": true
     },


### PR DESCRIPTION
Fixes the following test: 

```
ReadableStream teeing: enqueue() and close() while both branches are pulling
```

https://github.com/web-platform-tests/wpt/blob/88c13c311c7dbfbb08451489b38255383f3a0e0f/streams/readable-streams/tee.any.js#L479

tests blocked by https://github.com/denoland/deno/pull/16266