### PR TITLE
fix(http_cache): metadata.headers is optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  - push
+  - pull_request:
+    # dont run github actions on draft PRs
+    types:
+      - review_requested
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ !contains(github.event.pull_request.labels.*.name, 'test-flaky-ci') && github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: ci
 
 on:
   - push
+    branches:
+    - main
   - pull_request:
     # dont run github actions on draft PRs
     types:

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -1186,7 +1186,7 @@ mod tests {
       .get_cache_filename(&specifier)
       .unwrap();
     let mut metadata =
-      crate::http_cache::Metadata::read(&cache_filename).unwrap();
+      crate::http_cache::Metadata::read(&cache_filename, &specifier).unwrap();
     metadata.headers = HashMap::new();
     metadata
       .headers

--- a/cli/http_cache.rs
+++ b/cli/http_cache.rs
@@ -78,8 +78,10 @@ pub struct HttpCache {
   pub location: PathBuf,
 }
 
+// url is required, all other fields are optional.
 #[derive(Serialize, Deserialize)]
 pub struct Metadata {
+  #[serde(default)]
   pub headers: HeadersMap,
   pub url: String,
   #[serde(default = "SystemTime::now")]

--- a/cli/lsp/cache.rs
+++ b/cli/lsp/cache.rs
@@ -88,7 +88,7 @@ impl CacheMetadata {
     }
     let cache_filename = self.cache.get_cache_filename(specifier)?;
     let specifier_metadata =
-      http_cache::Metadata::read(&cache_filename).ok()?;
+      http_cache::Metadata::read(&cache_filename, specifier).ok()?;
     let values = Arc::new(parse_metadata(&specifier_metadata.headers));
     let version = calculate_fs_version(&cache_filename);
     let mut metadata_map = self.metadata.lock();

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -597,7 +597,7 @@ impl SpecifierResolver {
   ) -> Option<ModuleSpecifier> {
     let cache_filename = self.cache.get_cache_filename(specifier)?;
     if redirect_limit > 0 && cache_filename.is_file() {
-      let headers = http_cache::Metadata::read(&cache_filename)
+      let headers = http_cache::Metadata::read(&cache_filename, specifier)
         .ok()
         .map(|m| m.headers)?;
       if let Some(location) = headers.get("location") {
@@ -645,7 +645,7 @@ impl FileSystemDocuments {
     } else {
       let cache_filename = cache.get_cache_filename(specifier)?;
       let specifier_metadata =
-        http_cache::Metadata::read(&cache_filename).ok()?;
+        http_cache::Metadata::read(&cache_filename, specifier).ok()?;
       let maybe_content_type =
         specifier_metadata.headers.get("content-type").cloned();
       let maybe_headers = Some(&specifier_metadata.headers);

--- a/repro.sh
+++ b/repro.sh
@@ -1,0 +1,59 @@
+#! /bin/sh
+
+# error: missing field headers in $DENO_DIR/deps/**/*.metadata.json #16295
+
+# https://github.com/denoland/deno/issues/16295
+
+set -e
+#set -x
+
+gitdir=$(mktemp -d --suffix=-project)
+git clone --depth 1 https://github.com/hayd/deno-udd $gitdir
+
+mainScript=$gitdir/main.ts
+
+export DENO_DIR=$(mktemp -d --suffix=-deno-dir)
+echo "DENO_DIR: $DENO_DIR"
+mkdir -p $DENO_DIR
+
+alias deno=./target/debug/deno
+
+# note: $DENO_DIR/lock.json is a non-standard location
+deno cache --lock=$DENO_DIR/lock.json --lock-write ${mainScript}
+
+# make deterministic DENO_DIR
+find $DENO_DIR/deps -name '*.metadata.json' |
+while read j
+do
+  # error: missing field `headers` at line 3 column 1
+  cat $j | jq 'del(.headers) | del(.now)' >$j.new
+  # workaround:
+  #cat $j | jq '.headers={} | del(.now)' >$j.new
+  mv $j.new $j
+
+  # test: url is required
+  echo '{}' >$j
+
+  # TODO test: object is required
+  #echo '' >$j
+  #echo '""' >$j
+  #echo '0' >$j
+  #echo 'null' >$j
+done
+rm $DENO_DIR/dep_analysis_cache_v1
+
+
+
+# this throws: error: missing field `headers`
+# rebuild cache
+(
+  set -x
+  deno cache --lock=$DENO_DIR/lock.json ${mainScript} || true
+)
+
+
+
+echo "hit enter to cleanup tempdirs: rm -rf $DENO_DIR $gitdir"
+read
+
+rm -rf $DENO_DIR $gitdir


### PR DESCRIPTION
fix #16295 = metadata.headers is optional

adding a test for this trivial code seems wasteful.
should we keep the `repro.sh` somewhere?

also ...

### make errors more verbose

before

<pre>
<span color=red>error</span>: missing field `headers` at line 3 column 1
    at file:///tmp/project/deps.ts:1:36
</pre>

after

<pre>
<span color=red>error</span>: missing field `url` at line 1 column 2. Unable to parse metadata for https://deno.land/std@0.150.0/fmt/colors.ts from file:///home/user/.cache/deno/deps/https/deno.land/851d4afb1650b725c8358e5b5dcd71c16f5741d4df406497977206eeccaa745d.metadata.json
    at file:///tmp/project/deps.ts:1:36
</pre>

... with `{}` in `*.metadata.json` file, because now, only the `url` field is required

<details>

<summary>
out of scope: move file paths to the error stack
</summary>

waste of time, as this is a rare internal error

<pre>
<span color=red>error</span>: missing field `url` in metadata for https://deno.land/std@0.150.0/flags/mod.ts
    at file:///home/user/.cache/deno/deps/https/deno.land/851d4afb1650b725c8358e5b5dcd71c16f5741d4df406497977206eeccaa745d.metadata.json:1:2
    at file:///tmp/project/deps.ts:1:36
</pre>

error formatting is done in

https://github.com/denoland/deno/blob/7d78f58187cdcb9bed632992cde347fd5f3c83eb/cli/graph_util.rs#L348-L356

</details>

### CI tests should not run on draft PRs

no?

### CI tests should run only on push to main

no?
