### PR TITLE
chore: upgrade rusty_v8 to 0.53.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,9 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848795d431651537e90408672ec8960fe402522bc2dd7b7bf928fdc32025869a"
+checksum = "e952e936bcb610c9f22997f50dc7f65887afe76e1fedd37daf532a20211335ca"
 dependencies = [
  "bitflags",
  "fslock",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_v8 = { version = "0.65.0", path = "../serde_v8" }
 sourcemap = "6.1"
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
-v8 = { version = "0.53.0", default-features = false }
+v8 = { version = "0.53.1", default-features = false }
 
 [[example]]
 name = "http_bench_json_ops"

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = "0.99.17"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_bytes = "0.11"
 smallvec = { version = "1.8", features = ["union"] }
-v8 = { version = "0.53.0", default-features = false }
+v8 = { version = "0.53.1", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"


### PR DESCRIPTION
This commit fixes startup time regression, caused by update
to rusty_v8 v0.50.0.

```
./third_party/prebuilt/mac/hyperfine --warmup 3 'target/release/deno run a.js' 'deno run a.js'
Benchmark #1: target/release/deno run a.js

  Time (mean ± σ):      17.3 ms ±   0.8 ms    [User: 16.3 ms, System: 6.5 ms]

  Range (min … max):    15.9 ms …  19.9 ms

Benchmark #2: deno run a.js

  Time (mean ± σ):      23.3 ms ±   0.8 ms    [User: 22.2 ms, System: 6.8 ms]

  Range (min … max):    22.0 ms …  26.4 ms

Summary

  'target/release/deno run a.js' ran
    1.35x faster than 'deno run a.js'

```