### PR TITLE
fix(cli/bench): skip strace table border

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -2198,9 +2198,12 @@ pub fn parse_strace_output(output: &str) -> HashMap<String, StraceOutput> {
   // Filter out non-relevant lines. See the error log at
   // https://github.com/denoland/deno/pull/3715/checks?check_run_id=397365887
   // This is checked in testdata/strace_summary2.out
-  let mut lines = output
-    .lines()
-    .filter(|line| !line.is_empty() && !line.contains("detached ..."));
+  let mut lines = output.lines().filter(|line| {
+    !line.is_empty()
+      && !line.contains("detached ...")
+      && !line.contains("unfinished ...")
+      && !line.contains("????")
+  });
   let count = lines.clone().count();
 
   if count < 4 {
@@ -2215,7 +2218,7 @@ pub fn parse_strace_output(output: &str) -> HashMap<String, StraceOutput> {
     let syscall_fields = line.split_whitespace().collect::<Vec<_>>();
     let len = syscall_fields.len();
     let syscall_name = syscall_fields.last().unwrap();
-    if !line.starts_with('-') && (5..=6).contains(&len) {
+    if (5..=6).contains(&len) {
       summary.insert(
         syscall_name.to_string(),
         StraceOutput {

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -2215,8 +2215,7 @@ pub fn parse_strace_output(output: &str) -> HashMap<String, StraceOutput> {
     let syscall_fields = line.split_whitespace().collect::<Vec<_>>();
     let len = syscall_fields.len();
     let syscall_name = syscall_fields.last().unwrap();
-
-    if (5..=6).contains(&len) {
+    if !line.starts_with('-') && (5..=6).contains(&len) {
       summary.insert(
         syscall_name.to_string(),
         StraceOutput {


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/16302

It crashes due to the table border output from `strace`,

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ---------------- # this is skipped correctly
 61.27    6.012053         678      8860       637 futex
   0.00    0.000000           0         4           geteuid
------ ----------- ----------- --------- --------- ----------------  # this causes the crash
100.00   11.732230                 25552      1205 total

```

It's flaky because that line is not always skipped from the output, for some reason that I've yet to find out. 

https://github.com/denoland/deno/blob/323ddc8c967dc07272d4083f143bd0af1ecb0475/test_util/src/lib.rs#L2201-L2212
