### PR TITLE
perf(ext/web): optimize timer cancellation

### DIFF
--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -245,7 +245,12 @@
     // 1.
     PromisePrototypeThen(
       sleepPromise,
-      () => {
+      (cancelled) => {
+        if (cancelled) {
+          // The timer was cancelled.
+          removeFromScheduledTimers(timerObject);
+          return;
+        }
         // 2. Wait until any invocations of this algorithm that had the same
         // global and orderingIdentifier, that started before this one, and
         // whose milliseconds is equal to or less than this one's, have
@@ -276,14 +281,6 @@
           }
 
           currentEntry = currentEntry.next;
-        }
-      },
-      (err) => {
-        if (ObjectPrototypeIsPrototypeOf(core.InterruptedPrototype, err)) {
-          // The timer was cancelled.
-          removeFromScheduledTimers(timerObject);
-        } else {
-          throw err;
         }
       },
     );

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -18,7 +18,6 @@
     // deno-lint-ignore camelcase
     NumberPOSITIVE_INFINITY,
     PromisePrototypeThen,
-    ObjectPrototypeIsPrototypeOf,
     SafeArrayIterator,
     SymbolFor,
     TypeError,

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -245,7 +245,7 @@
     PromisePrototypeThen(
       sleepPromise,
       (cancelled) => {
-        if (cancelled) {
+        if (!cancelled) {
           // The timer was cancelled.
           removeFromScheduledTimers(timerObject);
           return;

--- a/ext/web/timers.rs
+++ b/ext/web/timers.rs
@@ -82,10 +82,10 @@ pub async fn op_sleep(
   state: Rc<RefCell<OpState>>,
   millis: u64,
   rid: ResourceId,
-) -> Result<(), AnyError> {
+) -> Result<bool, AnyError> {
   let handle = state.borrow().resource_table.get::<TimerHandle>(rid)?;
-  tokio::time::sleep(Duration::from_millis(millis))
+  let res = tokio::time::sleep(Duration::from_millis(millis))
     .or_cancel(handle.0.clone())
-    .await?;
-  Ok(())
+    .await;
+  Ok(res.is_err())
 }

--- a/ext/web/timers.rs
+++ b/ext/web/timers.rs
@@ -77,6 +77,8 @@ pub fn op_timer_handle(state: &mut OpState) -> ResourceId {
 
 /// Waits asynchronously until either `millis` milliseconds have passed or the
 /// [`TimerHandle`] resource given by `rid` has been canceled.
+///
+/// If the timer is canceled, this returns `false`. Otherwise, it returns `true`.
 #[op(deferred)]
 pub async fn op_sleep(
   state: Rc<RefCell<OpState>>,
@@ -87,5 +89,5 @@ pub async fn op_sleep(
   let res = tokio::time::sleep(Duration::from_millis(millis))
     .or_cancel(handle.0.clone())
     .await;
-  Ok(res.is_err())
+  Ok(res.is_ok())
 }


### PR DESCRIPTION
Towards #16315 

It created a bunch of Error objects and rejected the promise. This patch changes `op_sleep` to resolve with `true` if it was cancelled.