### PR TITLE
feat(runtime): add windowsRawArguments to SpawnOptions

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1542,6 +1542,10 @@ declare namespace Deno {
     stdout?: "piped" | "inherit" | "null";
     /** Defaults to "piped". */
     stderr?: "piped" | "inherit" | "null";
+
+    /** Skips quoting and escaping of the arguments on windows. This option
+     * is ignored on non-windows platforms. Defaults to "false". */
+    windowsRawArguments?: boolean;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/cli/tests/unit/spawn_test.ts
+++ b/cli/tests/unit/spawn_test.ts
@@ -733,7 +733,7 @@ const child = await Deno.spawnChild(Deno.execPath(), {
 });
 const readable = child.stdout.pipeThrough(new TextDecoderStream());
 const reader = readable.getReader();
-// set up an interval that will end after reading a few messages from stdout, 
+// set up an interval that will end after reading a few messages from stdout,
 // to verify that stdio streams are properly unrefed
 let count = 0;
 let interval;
@@ -785,5 +785,30 @@ setInterval(() => {
     assertThrows(() => {
       Deno.kill(pid, "SIGTERM");
     }, Deno.errors.NotFound);
+  },
+);
+
+Deno.test(
+  { ignore: Deno.build.os !== "windows" },
+  async function spawnWindowsRawArguments() {
+    let { success, stdout } = await Deno.spawn("cmd", {
+      args: ["/d", "/s", "/c", '"deno ^"--version^""'],
+      windowsRawArguments: true,
+    });
+    assert(success);
+    let stdoutText = new TextDecoder().decode(stdout);
+    assertStringIncludes(stdoutText, "deno");
+    assertStringIncludes(stdoutText, "v8");
+    assertStringIncludes(stdoutText, "typescript");
+
+    ({ success, stdout } = Deno.spawnSync("cmd", {
+      args: ["/d", "/s", "/c", '"deno ^"--version^""'],
+      windowsRawArguments: true,
+    }));
+    assert(success);
+    stdoutText = new TextDecoder().decode(stdout);
+    assertStringIncludes(stdoutText, "deno");
+    assertStringIncludes(stdoutText, "v8");
+    assertStringIncludes(stdoutText, "typescript");
   },
 );

--- a/runtime/js/40_spawn.js
+++ b/runtime/js/40_spawn.js
@@ -36,6 +36,7 @@
     stdout = "piped",
     stderr = "piped",
     signal = undefined,
+    windowsRawArguments = false,
   } = {}) {
     const child = ops.op_spawn_child({
       cmd: pathFromURL(command),
@@ -48,6 +49,7 @@
       stdin,
       stdout,
       stderr,
+      windowsRawArguments,
     }, apiName);
     return new Child(illegalConstructorKey, {
       ...child,
@@ -243,6 +245,7 @@
     stdin = "null",
     stdout = "piped",
     stderr = "piped",
+    windowsRawArguments = false,
   } = {}) {
     if (stdin === "piped") {
       throw new TypeError(
@@ -260,6 +263,7 @@
       stdin,
       stdout,
       stderr,
+      windowsRawArguments,
     });
     return {
       success: result.status.success,


### PR DESCRIPTION
This PR adds `windowsRawArguments` to `SpawnOptions`. The option enables skipping the default quoting and escaping while creating the command on windows.

The option works in a similar way as `windowsVerbatimArguments` in child_process.spawn options in Node.js, and is necessary for simulating it in `std/node`.

closes #8852