### PR TITLE
enable bench bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,18 @@ jobs:
           startsWith(github.ref, 'refs/tags/'))))
         run: cargo build --release --locked --all-targets
 
+      - name: Upload PR artifact (linux)
+        if: |
+          matrix.job == 'test' &&
+          matrix.profile == 'release' && (matrix.use_sysroot ||
+          (github.repository == 'denoland/deno' &&
+          (github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/tags/'))))
+        uses: actions/upload-artifact@v3
+        with:
+          name: deno-${{ github.event.number }}
+          path: target/release/deno
+
       - name: Pre-release (linux)
         if: |
           startsWith(matrix.os, 'ubuntu') &&
@@ -602,4 +614,3 @@ jobs:
         run: |
           echo ${{ github.sha }} > canary-latest.txt
           gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-latest.txt
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,3 +602,4 @@ jobs:
         run: |
           echo ${{ github.sha }} > canary-latest.txt
           gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-latest.txt
+


### PR DESCRIPTION
Run benchmarks on a bare metal server. The bot is a webhook on Deno deploy which can provision a spot instance on Equinix Metal. The machine type is `m3.small.x86` running a Ubuntu 22.04.

Commands:

`+bench` - Provision and schedule benchmarks for this PR.
`+bench status <id>` - Get current status of the metal instance.

The bot source is here: https://github.com/denoland/bench_bot