### PR TITLE
fix(ext/ffi): Use BufferSource for FFI buffer types

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -480,7 +480,7 @@ declare namespace Deno {
     & Record<NativeBooleanType, boolean>
     & Record<NativePointerType, PointerValue | null>
     & Record<NativeFunctionType, PointerValue | null>
-    & Record<NativeBufferType, TypedArray | null>;
+    & Record<NativeBufferType, BufferSource | null>;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
@@ -662,23 +662,6 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * @category FFI
-   */
-  type TypedArray =
-    | Int8Array
-    | Uint8Array
-    | Int16Array
-    | Uint16Array
-    | Int32Array
-    | Uint32Array
-    | Uint8ClampedArray
-    | Float32Array
-    | Float64Array
-    | BigInt64Array
-    | BigUint64Array;
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
    * Pointer type depends on the architecture and actual pointer value.
    *
    * On a 32 bit system all pointer values are plain numbers. On a 64 bit
@@ -700,7 +683,7 @@ declare namespace Deno {
     /**
      * Return the direct memory pointer to the typed array in memory
      */
-    static of(value: Deno.UnsafeCallback | TypedArray): PointerValue;
+    static of(value: Deno.UnsafeCallback | BufferSource): PointerValue;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.
@@ -752,11 +735,11 @@ declare namespace Deno {
       offset?: number,
     ): ArrayBuffer;
     /** Copies the memory of the pointer into a typed array. Length is determined from the typed array's `byteLength`. Also takes optional byte offset from the pointer. */
-    copyInto(destination: TypedArray, offset?: number): void;
+    copyInto(destination: BufferSource, offset?: number): void;
     /** Copies the memory of the specified pointer into a typed array. Length is determined from the typed array's `byteLength`. Also takes optional byte offset from the pointer. */
     static copyInto(
       pointer: PointerValue,
-      destination: TypedArray,
+      destination: BufferSource,
       offset?: number,
     ): void;
   }

--- a/test_ffi/tests/ffi_types.ts
+++ b/test_ffi/tests/ffi_types.ts
@@ -157,12 +157,12 @@ result2.then((_1: Deno.PointerValue) => {});
 
 const result3 = remote.symbols.method18();
 // @ts-expect-error: Invalid argument
-let r3_0: Deno.TypedArray = result3;
+let r3_0: Deno.BufferSource = result3;
 let r3_1: Deno.UnsafePointer = result3;
 
 const result4 = remote.symbols.method19();
 // @ts-expect-error: Invalid argument
-result4.then((_0: Deno.TypedArray) => {});
+result4.then((_0: Deno.BufferSource) => {});
 result4.then((_1: Deno.UnsafePointer) => {});
 
 const fnptr = new Deno.UnsafeFnPointer(
@@ -345,19 +345,6 @@ type AssertNotEqual<
   $ = [Equal<Expected, Got>] extends [true] ? never : Expected,
 > = never;
 
-type TypedArray =
-  | Int8Array
-  | Uint8Array
-  | Int16Array
-  | Uint16Array
-  | Int32Array
-  | Uint32Array
-  | Uint8ClampedArray
-  | Float32Array
-  | Float64Array
-  | BigInt64Array
-  | BigUint64Array;
-
 type __Tests__ = [
   empty: AssertEqual<
     { symbols: Record<never, never>; close(): void },
@@ -371,7 +358,7 @@ type __Tests__ = [
     {
       symbols: {
         pushBuf: (
-          buf: TypedArray | null,
+          buf: BufferSource | null,
           ptr: Deno.PointerValue | null,
           func: Deno.PointerValue | null,
         ) => void;
@@ -391,7 +378,7 @@ type __Tests__ = [
     {
       symbols: {
         pushBuf: (
-          buf: TypedArray | null,
+          buf: BufferSource | null,
           ptr: Deno.PointerValue | null,
           func: Deno.PointerValue | null,
         ) => Deno.PointerValue;


### PR DESCRIPTION
Potential fix for type-code mismatch in FFI buffer types. The code supports ArrayBuffers, but types only reflect TypedArray support.

There's also an existing type for this sort of stuff: `BufferSource`. (Although, it uses `ArrayBufferView` which doesn't actually connect with the TypedArray interfaces specifically, but it's just a type inheritance difference and nothing more.)