### PR TITLE
perf(ext/web/encoding): avoid copy in decode

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -23,7 +23,6 @@
     StringPrototypeCharCodeAt,
     StringPrototypeSlice,
     TypedArrayPrototypeSubarray,
-    TypedArrayPrototypeSlice,
     Uint8Array,
     Uint32Array,
   } = window.__bootstrap.primordials;
@@ -404,27 +403,23 @@
    */
   function decode(bytes, encoding) {
     const BOMEncoding = BOMSniff(bytes);
-    let start = 0;
     if (BOMEncoding !== null) {
       encoding = BOMEncoding;
-      if (BOMEncoding === "UTF-8") start = 3;
-      else start = 2;
+      const start = BOMEncoding === "UTF-8" ? 3 : 2;
+      bytes = TypedArrayPrototypeSubarray(bytes, start);
     }
-    return new TextDecoder(encoding).decode(
-      TypedArrayPrototypeSlice(bytes, start),
-    );
+    return new TextDecoder(encoding).decode(bytes);
   }
 
   /**
    * @param {Uint8Array} bytes
    */
   function BOMSniff(bytes) {
-    const BOM = TypedArrayPrototypeSubarray(bytes, 0, 3);
-    if (BOM[0] === 0xEF && BOM[1] === 0xBB && BOM[2] === 0xBF) {
+    if (bytes[0] === 0xEF && bytes[1] === 0xBB && bytes[2] === 0xBF) {
       return "UTF-8";
     }
-    if (BOM[0] === 0xFE && BOM[1] === 0xFF) return "UTF-16BE";
-    if (BOM[0] === 0xFF && BOM[1] === 0xFE) return "UTF-16LE";
+    if (bytes[0] === 0xFE && bytes[1] === 0xFF) return "UTF-16BE";
+    if (bytes[0] === 0xFF && bytes[1] === 0xFE) return "UTF-16LE";
     return null;
   }
 


### PR DESCRIPTION
Avoid unnecessary copy in `decode(bytes, encoding)` which is only used in:

https://github.com/denoland/deno/blob/bfc1fb8d68f39b899e544eee66e3a08abfd350b0/ext/web/10_filereader.js#L207

This change increases performance of `reader.readAsText(blob)`