### PR TITLE
perf(core): remove promise ring

### DIFF
--- a/cli/bench/sha256.js
+++ b/cli/bench/sha256.js
@@ -5,7 +5,7 @@ let [total, count] = typeof Deno !== "undefined"
   : [process.argv[2], process.argv[3]];
 
 total = total ? parseInt(total, 0) : 50;
-count = count ? parseInt(count, 10) : 1000000;
+count = count ? parseInt(count, 10) : 100000;
 
 async function bench(fun) {
   const start = Date.now();
@@ -16,4 +16,5 @@ async function bench(fun) {
   if (--total) queueMicrotask(() => bench(fun));
 }
 
-bench(() => Deno.core.opAsync("op_void_async"));
+const u8 = new Uint8Array(1024);
+bench(() => crypto.subtle.digest("SHA-256", u8));

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -161,15 +161,8 @@
 
   function opAsync(opName, ...args) {
     const promiseId = nextPromiseId++;
-    let p = setPromise(promiseId);
-    try {
-      ops[opName](promiseId, ...args);
-    } catch (err) {
-      // Cleanup the just-created promise
-      getPromise(promiseId);
-      // Rethrow the error
-      throw err;
-    }
+    let p = newPromise();
+    ops[opName](promiseId, p.resolve, ...args);
     p = PromisePrototypeThen(p, unwrapOpResult);
     if (opCallTracingEnabled) {
       // Capture a stack trace by creating a new `Error` object. We remove the


### PR DESCRIPTION
This PR removes the JS promise ID -> promise mapping used to represent promises in Rust. Also gets rid of batching results to opresolve by calling the resolver function handler directly from Rust.

### Benchmarks

<details><summary> `crypto.subtle.digest` </summary>

```
# this patch
time 967 ms rate 103412
time 1031 ms rate 96993
time 942 ms rate 106157
time 937 ms rate 106723
time 935 ms rate 106951
time 944 ms rate 105932
```

```
# main
time 1158 ms rate 86355
time 1203 ms rate 83125
time 1061 ms rate 94250
time 1066 ms rate 93808
time 1069 ms rate 93545
time 1067 ms rate 93720
```

this patch:

![sha256_new](https://user-images.githubusercontent.com/34997667/197117792-e3895737-5b7a-4964-abb3-4d31b65f42d9.svg)

main:
![sha256_main](https://user-images.githubusercontent.com/34997667/197117799-9ea59e70-0aff-45fb-a820-327acf442c6f.svg)

</details>

<details><summary> `writeFile` </summary>

![write_file_new](https://user-images.githubusercontent.com/34997667/197117803-38418bf8-64ed-487f-b29d-e2ce040eddaa.svg)
![write_file_main](https://user-images.githubusercontent.com/34997667/197117810-2629ed50-56dd-4fe1-addd-0745bd911bb5.svg)

</details>

<details><summary> Cache API </summary>

```
# this patch

benchmark                  time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------- -----------------------------
cache_storage_open      22.19 µs/iter  (18.58 µs … 303.42 µs)     23 µs  35.04 µs  40.54 µs
cache_storage_has       14.75 µs/iter   (10.79 µs … 92.58 µs)  15.54 µs     33 µs  43.12 µs
cache_storage_delete    20.07 µs/iter  (15.08 µs … 571.29 µs)     20 µs  48.17 µs  62.54 µs
cache_put_body_10_KiB   18.39 ms/iter    (2.44 ms … 20.23 ms)  19.87 ms  20.23 ms  20.23 ms
cache_put_no_body       45.96 µs/iter     (34.17 µs … 1.8 ms)   45.5 µs  92.62 µs 132.38 µs
cache_match             46.21 µs/iter   (38.46 µs … 10.05 ms)  45.58 µs     77 µs  89.62 µs
cache_delete            17.89 µs/iter    (15.46 µs … 1.14 ms)  18.17 µs  27.46 µs  30.88 µs
```

```
# main

benchmark                  time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------- -----------------------------
cache_storage_open      23.49 µs/iter  (19.54 µs … 309.58 µs)  24.46 µs  41.62 µs  43.04 µs
cache_storage_has       15.94 µs/iter     (8.5 µs … 97.33 µs)     17 µs   24.5 µs  26.54 µs
cache_storage_delete    20.69 µs/iter  (10.42 µs … 108.04 µs)  22.12 µs  30.33 µs  32.33 µs
cache_put_body_10_KiB   19.61 ms/iter   (18.69 ms … 20.78 ms)  20.01 ms  20.78 ms  20.78 ms
cache_put_no_body       48.15 µs/iter  (36.29 µs … 961.46 µs)  46.62 µs 119.08 µs 143.29 µs
cache_match             46.45 µs/iter    (38.92 µs … 8.15 ms)  46.75 µs  62.33 µs  73.75 µs
cache_delete             21.5 µs/iter    (12.62 µs … 1.04 ms)  22.17 µs  40.75 µs  52.88 µs
```

</details>