### PR TITLE
chore(core): remove `core.opSync`

### DIFF
--- a/cli/tsc/compiler.d.ts
+++ b/cli/tsc/compiler.d.ts
@@ -38,8 +38,6 @@ declare global {
   interface DenoCore {
     encode(value: string): Uint8Array;
     // deno-lint-ignore no-explicit-any
-    opSync<T>(name: string, params: T): any;
-    // deno-lint-ignore no-explicit-any
     ops: Record<string, (...args: unknown[]) => any>;
     print(msg: string, stderr: boolean): void;
     registerErrorClass(

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -186,10 +186,6 @@
     return p;
   }
 
-  function opSync(opName, ...args) {
-    return ops[opName](...args);
-  }
-
   function refOp(promiseId) {
     if (!hasPromise(promiseId)) {
       return;
@@ -307,7 +303,6 @@
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
     opAsync,
-    opSync,
     resources,
     metrics,
     registerErrorBuilder,

--- a/core/README.md
+++ b/core/README.md
@@ -17,9 +17,9 @@ responsibility to drive that loop by using `JsRuntime::run_event_loop` method -
 it must be executed in the context of Rust's future executor (eg. tokio, smol).
 
 Rust functions can be registered in JavaScript using `deno_core::Extension`. Use
-the `Deno.core.opSync()` and `Deno.core.opAsync()` functions to trigger the op
-function callback. A conventional way to write ops is using the
-[`deno_ops`](https://github.com/denoland/deno/blob/main/ops) crate.
+the `Deno.core.ops.op_name()` and `Deno.core.opAsync("op_name", ...)` functions
+to trigger the op function callback. A conventional way to write ops is using
+the [`deno_ops`](https://github.com/denoland/deno/blob/main/ops) crate.
 
 Documentation for this crate is thin at the moment. Please see
 [hello_world.rs](https://github.com/denoland/deno/blob/main/core/examples/hello_world.rs)

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -7,12 +7,6 @@
 
 declare namespace Deno {
   namespace core {
-    /** Call an op in Rust, and synchronously receive the result. */
-    function opSync(
-      opName: string,
-      ...args: any[]
-    ): any;
-
     /** Call an op in Rust, and asynchronously receive the result. */
     function opAsync(
       opName: string,

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -186,7 +186,7 @@
   }
 
   function prepareFastCalls() {
-    return core.opSync("op_flash_make_request");
+    return core.ops.op_flash_make_request();
   }
 
   function hostnameForDisplay(hostname) {

--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -351,8 +351,7 @@
         }
       }
 
-      const isDenoDirPackage = Deno.core.opSync(
-        "op_require_is_deno_dir_package",
+      const isDenoDirPackage = Deno.core.ops.op_require_is_deno_dir_package(
         curPath,
       );
       const isRelative = ops.op_require_is_request_relative(
@@ -403,8 +402,7 @@
   Module._resolveLookupPaths = function (request, parent) {
     const paths = [];
     if (parent?.filename && parent.filename.length > 0) {
-      const denoDirPath = core.opSync(
-        "op_require_resolve_deno_dir",
+      const denoDirPath = core.ops.op_require_resolve_deno_dir(
         request,
         parent.filename,
       );
@@ -813,7 +811,7 @@
 
   function createRequire(filenameOrUrl) {
     // FIXME: handle URLs and validation
-    const filename = core.opSync("op_require_as_file_path", filenameOrUrl);
+    const filename = core.ops.op_require_as_file_path(filenameOrUrl);
     return createRequireFromPath(filename);
   }
 


### PR DESCRIPTION
This patch removes the last uses of `core.opSync` from Deno.

The new and JIT-friendly way to call sync ops is `core.ops.op_name()`.