### PR TITLE
fix(lsp): regression - error when removing file

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -312,7 +312,7 @@ delete Object.prototype.__proto__;
 
     releaseDocumentWithKey(path, key, _scriptKind, _impliedNodeFormat) {
       const mapKey = path + key;
-      documentRegistrySourceFileCache.remove(mapKey);
+      documentRegistrySourceFileCache.delete(mapKey);
     },
 
     reportStats() {


### PR DESCRIPTION
I was using canary and ran into this issue when removing a file while using the lsp. I accidentally used `remove` in the code instead of `delete` in a recent PR.

```
Failed to request to tsserver TypeError: documentRegistrySourceFileCache.remove is not a function
    at Object.releaseDocumentWithKey (deno:cli/tsc/99_main_compiler.js:315:39)
    at Object.onReleaseOldSourceFile (deno:cli/tsc/00_typescript.js:168037:34)
    at Object.createProgram (deno:cli/tsc/00_typescript.js:118701:26)
    at synchronizeHostData (deno:cli/tsc/00_typescript.js:167990:26)
    at Object.getApplicableRefactors (deno:cli/tsc/00_typescript.js:168996:13)
    at serverRequest (deno:cli/tsc/99_main_compiler.js:928:27)
    at [deno:cli\lsp\tsc.rs:3427:27]:1:12
```

Tested locally and it's fixed now.