### PR TITLE
fix(cli): Fixed bug where the progress bar did not clear

### DIFF
--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -292,6 +292,7 @@ impl ProcState {
     dynamic_permissions: Permissions,
     reload_on_watch: bool,
   ) -> Result<(), AnyError> {
+    let _pb_clear_gurad = self.progress_bar.clear_guard();
     let roots = roots
       .into_iter()
       .map(|s| (s, ModuleKind::Esm))
@@ -378,8 +379,6 @@ impl ProcState {
       maybe_file_watcher_reporter,
     )
     .await;
-
-    self.progress_bar.clear();
 
     // If there was a locker, validate the integrity of all the modules in the
     // locker.

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -379,6 +379,8 @@ impl ProcState {
     )
     .await;
 
+    self.progress_bar.clear();
+
     // If there was a locker, validate the integrity of all the modules in the
     // locker.
     graph_lock_or_exit(&graph);
@@ -411,8 +413,6 @@ impl ProcState {
         .await?;
       self.prepare_node_std_graph().await?;
     }
-
-    self.progress_bar.clear();
 
     // type check if necessary
     if self.options.type_check_mode() != TypeCheckMode::None {

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -413,6 +413,8 @@ impl ProcState {
       self.prepare_node_std_graph().await?;
     }
 
+    drop(_pb_clear_guard);
+
     // type check if necessary
     if self.options.type_check_mode() != TypeCheckMode::None {
       let maybe_config_specifier = self.options.maybe_config_file_specifier();

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -292,7 +292,7 @@ impl ProcState {
     dynamic_permissions: Permissions,
     reload_on_watch: bool,
   ) -> Result<(), AnyError> {
-    let _pb_clear_gurad = self.progress_bar.clear_guard();
+    let _pb_clear_guard = self.progress_bar.clear_guard();
     let roots = roots
       .into_iter()
       .map(|s| (s, ModuleKind::Esm))

--- a/cli/progress_bar.rs
+++ b/cli/progress_bar.rs
@@ -126,4 +126,18 @@ impl ProgressBar {
       inner.pb = None;
     }
   }
+
+  pub fn clear_guard(&self) -> ClearGuard {
+    ClearGuard { pb: self.clone() }
+  }
+}
+
+pub struct ClearGuard {
+  pb: ProgressBar,
+}
+
+impl Drop for ClearGuard {
+  fn drop(&mut self) {
+    self.pb.clear();
+  }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

## WHY 

fix: https://github.com/denoland/deno/issues/16381

> In REPL, importing a wrong url normally throw an error then indefinitely show download loader without possibility to continue.

`progress_bar.clear` is never called if an error occurs in these codes.

https://github.com/k-nasa/deno/blob/67984e9a314410371b05b2b6f2b701d192e000d3/cli/proc_state.rs#L395-L415

## WHAT

It looks like a simple solution to speed up the timing of clearing.

## Proof

I confirmed progress bar disappeared.

https://user-images.githubusercontent.com/23740172/197550467-39ca7907-1239-4fa8-af9c-c347d0224cbd.mov