### PR TITLE
perf(core): replace FuturesUnordered with handcrafted FuturesList

### DIFF
--- a/core/futures_list.rs
+++ b/core/futures_list.rs
@@ -1,0 +1,53 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// FuturesList only makes a few allocations whereas FuturesUnordered
+/// allocate per item push.
+///
+/// We see a 9-20% improvement in TCP throughput micro benchmarks.
+pub struct FuturesList<Fut>(Vec<Fut>);
+
+impl<Fut: Future + Unpin> FuturesList<Fut> {
+  #[inline]
+  pub fn new() -> Self {
+    Self(Vec::new())
+  }
+
+  #[inline]
+  pub fn push(&mut self, fut: Fut) {
+    self.0.push(fut);
+  }
+
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+}
+
+impl<Fut: Future + Unpin> futures::Stream for FuturesList<Fut> {
+  type Item = Fut::Output;
+
+  fn poll_next(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context,
+  ) -> Poll<Option<Self::Item>> {
+    let futures = &mut self.as_mut().0;
+    let mut i = 0;
+    while i < futures.len() {
+      if let Poll::Ready(r) = Pin::new(&mut futures[i]).poll(cx) {
+        futures.swap_remove(i);
+        return Poll::Ready(Some(r));
+      }
+      i += 1;
+    }
+    Poll::Pending
+  }
+}
+
+impl<Fut: Future + Unpin> futures::stream::FusedStream for FuturesList<Fut> {
+  fn is_terminated(&self) -> bool {
+    false
+  }
+}

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 mod error_codes;
 mod extensions;
 mod flags;
+mod futures_list;
 mod gotham_state;
 mod inspector;
 mod io;

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -6,6 +6,7 @@ use crate::error::to_v8_type_error;
 use crate::error::JsError;
 use crate::extensions::OpDecl;
 use crate::extensions::OpEventLoopFn;
+use crate::futures_list::FuturesList;
 use crate::inspector::JsRuntimeInspector;
 use crate::module_specifier::ModuleSpecifier;
 use crate::modules::ModuleError;
@@ -29,7 +30,6 @@ use futures::channel::oneshot;
 use futures::future::poll_fn;
 use futures::future::Future;
 use futures::future::FutureExt;
-use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use futures::task::AtomicWaker;
 use std::any::Any;
@@ -164,7 +164,7 @@ pub struct JsRuntimeState {
   dyn_module_evaluate_idle_counter: u32,
   pub(crate) source_map_getter: Option<Box<dyn SourceMapGetter>>,
   pub(crate) source_map_cache: SourceMapCache,
-  pub(crate) pending_ops: FuturesUnordered<PendingOpFuture>,
+  pub(crate) pending_ops: FuturesList<PendingOpFuture>,
   pub(crate) unrefed_ops: HashSet<i32>,
   pub(crate) have_unpolled_ops: bool,
   pub(crate) op_state: Rc<RefCell<OpState>>,
@@ -336,7 +336,7 @@ impl JsRuntime {
       js_wasm_streaming_cb: None,
       source_map_getter: options.source_map_getter,
       source_map_cache: Default::default(),
-      pending_ops: FuturesUnordered::new(),
+      pending_ops: FuturesList::new(),
       unrefed_ops: HashSet::new(),
       shared_array_buffer_store: options.shared_array_buffer_store,
       compiled_wasm_module_store: options.compiled_wasm_module_store,


### PR DESCRIPTION
FuturesList only makes a few allocations whereas FuturesUnordered allocate per item push. This is noticable in micro benchmarks. 

Taken from @bnoordhuis' polloi project