### PR TITLE
chore: fix flaky esm_module_deno_test test

### DIFF
--- a/cli/tests/testdata/npm/esm/main.js
+++ b/cli/tests/testdata/npm/esm/main.js
@@ -1,6 +1,8 @@
 import chalk from "npm:chalk@5";
 
-console.log(chalk.green("chalk esm loads"));
+if (import.meta.main) {
+  console.log(chalk.green("chalk esm loads"));
+}
 
 export function test(value) {
   return chalk.red(value);

--- a/cli/tests/testdata/npm/esm/main.js
+++ b/cli/tests/testdata/npm/esm/main.js
@@ -1,8 +1,6 @@
 import chalk from "npm:chalk@5";
 
-if (import.meta.main) {
-  console.log(chalk.green("chalk esm loads"));
-}
+console.log(chalk.green("chalk esm loads"));
 
 export function test(value) {
   return chalk.red(value);

--- a/cli/tests/testdata/npm/esm/test.out
+++ b/cli/tests/testdata/npm/esm/test.out
@@ -1,7 +1,6 @@
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
 Check [WILDCARD]/std/node/module_all.ts
-chalk esm loads
 running 1 test from ./npm/esm/test.js
 test ...
 ------- output -------

--- a/cli/tests/testdata/npm/esm/test.out
+++ b/cli/tests/testdata/npm/esm/test.out
@@ -1,6 +1,7 @@
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
 Check [WILDCARD]/std/node/module_all.ts
+chalk esm loads
 running 1 test from ./npm/esm/test.js
 test ...
 ------- output -------

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1000,12 +1000,11 @@ async fn test_specifiers(
   };
 
   let (sender, mut receiver) = unbounded_channel::<TestEvent>();
-  let mut sender = TestEventSender::new(sender);
+  let sender = TestEventSender::new(sender);
   let concurrent_jobs = options.concurrent_jobs;
   let fail_fast = options.fail_fast;
 
-  let join_handles = {
-    let sender = sender.clone();
+  let join_handles =
     specifiers_with_mode.iter().map(move |(specifier, mode)| {
       let ps = ps.clone();
       let permissions = permissions.clone();
@@ -1036,8 +1035,7 @@ async fn test_specifiers(
         }
         Ok(())
       })
-    })
-  };
+    });
 
   let join_stream = stream::iter(join_handles)
     .buffer_unordered(concurrent_jobs.get())
@@ -1076,12 +1074,6 @@ async fn test_specifiers(
           }
 
           TestEvent::Wait(id) => {
-            if !reporter.started_tests {
-              // if tests haven't started, flush the stdout and stderr
-              // capture so that any logging that occurs outside a test
-              // will not end up being captured in a test
-              sender.flush_stdout_and_stderr();
-            }
             reporter.report_wait(tests.get(&id).unwrap());
           }
 

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1000,11 +1000,12 @@ async fn test_specifiers(
   };
 
   let (sender, mut receiver) = unbounded_channel::<TestEvent>();
-  let sender = TestEventSender::new(sender);
+  let mut sender = TestEventSender::new(sender);
   let concurrent_jobs = options.concurrent_jobs;
   let fail_fast = options.fail_fast;
 
-  let join_handles =
+  let join_handles = {
+    let sender = sender.clone();
     specifiers_with_mode.iter().map(move |(specifier, mode)| {
       let ps = ps.clone();
       let permissions = permissions.clone();
@@ -1035,7 +1036,8 @@ async fn test_specifiers(
         }
         Ok(())
       })
-    });
+    })
+  };
 
   let join_stream = stream::iter(join_handles)
     .buffer_unordered(concurrent_jobs.get())
@@ -1074,6 +1076,12 @@ async fn test_specifiers(
           }
 
           TestEvent::Wait(id) => {
+            if !reporter.started_tests {
+              // if tests haven't started, flush the stdout and stderr
+              // capture so that any logging that occurs outside a test
+              // will not end up being captured in a test
+              sender.flush_stdout_and_stderr();
+            }
             reporter.report_wait(tests.get(&id).unwrap());
           }
 


### PR DESCRIPTION
Fixes #16416

The root problem here is that due to a race condition, logging outside the test can sometimes be captured within a test. This is because the output is captured on a separate thread. We should investigate this in the future (as long as it doesn't have performance implications I think). I briefly tried to fix it in this PR, but it caused a deadlock, so I reverted to just fixing the flaky test for now.