### PR TITLE
feat(task): support `sleep` suffixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4e1c86712e2cded9046ac6748cbe5dba87042f045265a51b1ac2629a7fa6c5"
+checksum = "a275d3f78e828b4adddf20a472d9ac1927ac311aac48dca869bb8653d5a4a0b9"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -57,7 +57,7 @@ deno_emit = "0.10.0"
 deno_graph = "0.37.1"
 deno_lint = { version = "0.34.0", features = ["docs"] }
 deno_runtime = { version = "0.81.0", path = "../runtime" }
-deno_task_shell = "0.6.0"
+deno_task_shell = "0.7.0"
 napi_sym = { path = "./napi_sym", version = "0.3.0" }
 
 atty = "=0.2.14"


### PR DESCRIPTION
Updates deno_task_shell with https://github.com/denoland/deno_task_shell/pull/60 by @sigmaSd 

Co-authored-by: sigmaSd <sigmasd@users.noreply.github.com>