### PR TITLE
chore(npm): add explicit tests for `module.exports` assignment with type checking

### DIFF
--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -117,6 +117,13 @@ itest!(cjs_module_export_assignment {
   http_server: true,
 });
 
+itest!(cjs_module_export_assignment_number {
+  args: "run -A --unstable --quiet --check=all npm/cjs_module_export_assignment_number/main.ts",
+  output: "npm/cjs_module_export_assignment_number/main.out",
+  envs: env_vars(),
+  http_server: true,
+});
+
 // FIXME(bartlomieju): npm: specifiers are not handled in dynamic imports
 // at the moment
 // itest!(dynamic_import {

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -110,6 +110,13 @@ itest!(child_process_fork_test {
   http_server: true,
 });
 
+itest!(cjs_module_export_assignment {
+  args: "run -A --unstable --quiet --check=all npm/cjs_module_export_assignment/main.ts",
+  output: "npm/cjs_module_export_assignment/main.out",
+  envs: env_vars(),
+  http_server: true,
+});
+
 // FIXME(bartlomieju): npm: specifiers are not handled in dynamic imports
 // at the moment
 // itest!(dynamic_import {

--- a/cli/tests/testdata/npm/cjs_module_export_assignment/main.out
+++ b/cli/tests/testdata/npm/cjs_module_export_assignment/main.out
@@ -1,0 +1,3 @@
+{ func: [Function: func] }
+Module { default: { func: [Function: func] }, func: [Function: func] }
+5

--- a/cli/tests/testdata/npm/cjs_module_export_assignment/main.ts
+++ b/cli/tests/testdata/npm/cjs_module_export_assignment/main.ts
@@ -1,0 +1,6 @@
+import defaultImport, * as namespaceImport from "npm:@denotest/cjs-module-export-assignment";
+import { func } from "npm:@denotest/cjs-module-export-assignment";
+
+console.log(defaultImport);
+console.log(namespaceImport);
+console.log(func());

--- a/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.out
+++ b/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.out
@@ -1,2 +1,3 @@
 5
+5
 Module { default: 5 }

--- a/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.out
+++ b/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.out
@@ -1,0 +1,2 @@
+5
+Module { default: 5 }

--- a/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.ts
+++ b/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.ts
@@ -1,4 +1,7 @@
 import defaultImport, * as namespaceImport from "npm:@denotest/cjs-module-export-assignment-number";
 
-console.log(defaultImport);
+const testDefault: 5 = defaultImport;
+console.log(testDefault);
+const testNamespace: 5 = namespaceImport.default;
+console.log(testNamespace);
 console.log(namespaceImport);

--- a/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.ts
+++ b/cli/tests/testdata/npm/cjs_module_export_assignment_number/main.ts
@@ -1,0 +1,4 @@
+import defaultImport, * as namespaceImport from "npm:@denotest/cjs-module-export-assignment-number";
+
+console.log(defaultImport);
+console.log(namespaceImport);

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/index.d.ts
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/index.d.ts
@@ -1,0 +1,2 @@
+declare const value = 5;
+export = value;

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = 5;

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/package.json
@@ -1,4 +1,5 @@
 {
   "name": "@denotest/cjs-module-export-assignment-number",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "types": "./index.d.ts"
 }

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment-number/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@denotest/cjs-module-export-assignment-number",
+  "version": "1.0.0"
+}

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment/1.0.0/index.d.ts
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment/1.0.0/index.d.ts
@@ -1,0 +1,5 @@
+declare module ThisModule {
+  function func(): 5;
+}
+
+export = ThisModule;

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment/1.0.0/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  func() {
+    return 5;
+  },
+};

--- a/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/cjs-module-export-assignment/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/cjs-module-export-assignment",
+  "version": "1.0.0",
+  "types": "./index.d.ts"
+}


### PR DESCRIPTION
Was investigating our behaviour and noticed there wasn't an explicit test for both of these. Everything seems to align with node.