### PR TITLE
fix(typescript): allow synthetic default imports when using `ModuleKind.ESNext`

### DIFF
--- a/cli/tests/integration/check_tests.rs
+++ b/cli/tests/integration/check_tests.rs
@@ -57,6 +57,11 @@ itest!(check_npm_install_diagnostics {
   exit_code: 1,
 });
 
+itest!(check_export_equals_declaration_file {
+  args: "check --quiet check/export_equals_declaration_file/main.ts",
+  exit_code: 0,
+});
+
 #[test]
 fn cache_switching_config_then_no_config() {
   let deno_dir = util::new_deno_dir();

--- a/cli/tests/testdata/check/export_equals_declaration_file/main.ts
+++ b/cli/tests/testdata/check/export_equals_declaration_file/main.ts
@@ -1,4 +1,6 @@
 // @deno-types="./other.d.ts"
 import Test, { type Attributes } from "./other.js";
 
+const other: Attributes = {};
 console.log(Test());
+console.log(other);

--- a/cli/tests/testdata/check/export_equals_declaration_file/main.ts
+++ b/cli/tests/testdata/check/export_equals_declaration_file/main.ts
@@ -1,0 +1,4 @@
+// @deno-types="./other.d.ts"
+import Test, { type Attributes } from "./other.js";
+
+console.log(Test());

--- a/cli/tests/testdata/check/export_equals_declaration_file/other.d.ts
+++ b/cli/tests/testdata/check/export_equals_declaration_file/other.d.ts
@@ -1,0 +1,9 @@
+export = other;
+
+declare function other(): string;
+
+declare namespace other {
+  interface Attributes {
+    [attr: string]: string;
+  }
+}

--- a/cli/tests/testdata/check/export_equals_declaration_file/other.js
+++ b/cli/tests/testdata/check/export_equals_declaration_file/other.js
@@ -1,0 +1,3 @@
+export default function other() {
+  return "test";
+}


### PR DESCRIPTION
Closes #16437