### PR TITLE
fix(lsp): add ServerCapabilities::encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.1"
+version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bcfee315dde785ba887edb540b08765fd7df75a7d948844be6bf5712246734"
+checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
 dependencies = [
  "bitflags",
  "serde",

--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -142,5 +142,6 @@ pub fn server_capabilities(
       "testingApi":true,
     })),
     inlay_hint_provider: Some(OneOf::Left(true)),
+    position_encoding: None,
   }
 }


### PR DESCRIPTION
This caused v1.27.0 publishing to fail.