### PR TITLE
chore: pin lsp types due to unstable "proposed" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "junction",
  "libc",
  "log",
+ "lsp-types",
  "mitata",
  "monch",
  "napi_sym",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,6 +84,7 @@ indicatif = "=0.17.1"
 jsonc-parser = { version = "=0.21.0", features = ["serde"] }
 libc = "=0.2.126"
 log = { version = "=0.4.17", features = ["serde"] }
+lsp-types = "=0.93.2" # used by tower-lsp and "proposed" feature is unstable in patch releases
 mitata = "=0.0.7"
 monch = "=0.2.1"
 notify = "=5.0.0"


### PR DESCRIPTION
The "proposed" feature that we depend upon in tower-lsp, turns on the "proposed" feature in lsp-types which has breaking changes in patch releases because it's explicitly unstable. We need to pin it to prevent it breaking cargo publish.