### PR TITLE
test: disable run_watch_external_watch_files on macOS

### DIFF
--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -582,7 +582,7 @@ fn run_watch_no_dynamic() {
   check_alive_then_kill(child);
 }
 
-#[cfg(not(macos))]
+#[cfg(not(target_os = "macos"))]
 #[test]
 fn run_watch_external_watch_files() {
   let t = TempDir::new();

--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -582,6 +582,9 @@ fn run_watch_no_dynamic() {
   check_alive_then_kill(child);
 }
 
+// TODO(bartlomieju): this test became flaky on macOS runner; it is unclear
+// if that's because of a bug in code or the runner itself. We should reenable
+// it once we upgrade to XL runners for macOS.
 #[cfg(not(target_os = "macos"))]
 #[test]
 fn run_watch_external_watch_files() {

--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -582,6 +582,7 @@ fn run_watch_no_dynamic() {
   check_alive_then_kill(child);
 }
 
+#[cfg(not(macos))]
 #[test]
 fn run_watch_external_watch_files() {
   let t = TempDir::new();


### PR DESCRIPTION
This test has hung a lot recently on macOS. I am not sure if this is because
of a bug in the test or because of the macOS runner that is extremely slow
and flaky in general.