### PR TITLE
fix: update env to sys permission in jsdoc for Deno.osRelease

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -351,11 +351,11 @@ declare namespace Deno {
    * console.log(Deno.osRelease());
    * ```
    *
-   * Requires `allow-env` permission.
+   * Requires `allow-sys` permission.
    * Under consideration to possibly move to Deno.build or Deno.versions and if
    * it should depend sys-info, which may not be desirable.
    *
-   * @tags allow-env
+   * @tags allow-sys
    * @category Runtime Environment
    */
   export function osRelease(): string;


### PR DESCRIPTION
This API needs `--allow-sys` permissions nowadays, but the docs still mention `--allow-env` permissions.

```
deno run .\file.ts
⚠️  ┌ Deno requests sys access to "osRelease".
   ├ Requested by `Deno.osRelease()` API      
   ├ Run again with --allow-sys to bypass this prompt.
   └ Allow? [y/n] (y = yes, allow; n = no, deny) >
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
