### PR TITLE
fix(lock): Additive lock file

### DIFF
--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -75,16 +75,16 @@ pub struct LockfileContent {
 
 #[derive(Debug, Clone)]
 pub struct Lockfile {
-  pub write: bool,
+  pub overwrite: bool,
   pub has_content_changed: bool,
   pub content: LockfileContent,
   pub filename: PathBuf,
 }
 
 impl Lockfile {
-  pub fn new(filename: PathBuf, write: bool) -> Result<Lockfile, AnyError> {
+  pub fn new(filename: PathBuf, overwrite: bool) -> Result<Lockfile, AnyError> {
     // Writing a lock file always uses the new format.
-    let content = if write {
+    let content = if overwrite {
       LockfileContent {
         version: "2".to_string(),
         remote: BTreeMap::new(),
@@ -115,7 +115,7 @@ impl Lockfile {
     };
 
     Ok(Lockfile {
-      write,
+      overwrite,
       has_content_changed: false,
       content,
       filename,
@@ -150,7 +150,7 @@ impl Lockfile {
     specifier: &str,
     code: &str,
   ) -> bool {
-    if self.write {
+    if self.overwrite {
       // In case --lock-write is specified check always passes
       self.insert(specifier, code);
       true
@@ -163,7 +163,7 @@ impl Lockfile {
     &mut self,
     package: &NpmResolutionPackage,
   ) -> Result<(), LockfileError> {
-    if self.write {
+    if self.overwrite {
       // In case --lock-write is specified check always passes
       self.insert_npm(package);
       Ok(())

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -124,7 +124,7 @@ impl Lockfile {
 
   // Synchronize lock file to disk - noop if --lock-write file is not specified.
   pub fn write(&self) -> Result<(), AnyError> {
-    if !self.has_content_changed {
+    if !self.has_content_changed && !self.overwrite {
       return Ok(());
     }
 

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -76,6 +76,7 @@ pub struct LockfileContent {
 #[derive(Debug, Clone)]
 pub struct Lockfile {
   pub write: bool,
+  pub has_content_changed: bool,
   pub content: LockfileContent,
   pub filename: PathBuf,
 }
@@ -115,6 +116,7 @@ impl Lockfile {
 
     Ok(Lockfile {
       write,
+      has_content_changed: false,
       content,
       filename,
     })
@@ -122,7 +124,7 @@ impl Lockfile {
 
   // Synchronize lock file to disk - noop if --lock-write file is not specified.
   pub fn write(&self) -> Result<(), AnyError> {
-    if !self.write {
+    if !self.has_content_changed {
       return Ok(());
     }
 
@@ -153,7 +155,7 @@ impl Lockfile {
       self.insert(specifier, code);
       true
     } else {
-      self.check(specifier, code)
+      self.check_or_insert(specifier, code)
     }
   }
 
@@ -163,16 +165,16 @@ impl Lockfile {
   ) -> Result<(), LockfileError> {
     if self.write {
       // In case --lock-write is specified check always passes
-      self.insert_npm_package(package);
+      self.insert_npm(package);
       Ok(())
     } else {
-      self.check_npm_package(package)
+      self.check_or_insert_npm(package)
     }
   }
 
-  /// Checks the given module is included.
-  /// Returns Ok(true) if check passed.
-  fn check(&mut self, specifier: &str, code: &str) -> bool {
+  /// Checks the given module is included, if so verify the checksum. If module
+  /// is not included, insert it.
+  fn check_or_insert(&mut self, specifier: &str, code: &str) -> bool {
     if specifier.starts_with("file:") {
       return true;
     }
@@ -180,7 +182,8 @@ impl Lockfile {
       let compiled_checksum = crate::checksum::gen(&[code.as_bytes()]);
       lockfile_checksum == &compiled_checksum
     } else {
-      false
+      self.insert(specifier, code);
+      true
     }
   }
 
@@ -190,9 +193,10 @@ impl Lockfile {
     }
     let checksum = crate::checksum::gen(&[code.as_bytes()]);
     self.content.remote.insert(specifier.to_string(), checksum);
+    self.has_content_changed = true;
   }
 
-  fn check_npm_package(
+  fn check_or_insert_npm(
     &mut self,
     package: &NpmResolutionPackage,
   ) -> Result<(), LockfileError> {
@@ -211,12 +215,14 @@ impl Lockfile {
           package.id, integrity, package_info.integrity
         )));
       }
+    } else {
+      self.insert_npm(package);
     }
 
     Ok(())
   }
 
-  fn insert_npm_package(&mut self, package: &NpmResolutionPackage) {
+  fn insert_npm(&mut self, package: &NpmResolutionPackage) {
     let dependencies = package
       .dependencies
       .iter()
@@ -235,6 +241,7 @@ impl Lockfile {
         dependencies,
       },
     );
+    self.has_content_changed = true;
   }
 
   pub fn insert_npm_specifier(
@@ -247,6 +254,7 @@ impl Lockfile {
         package_req.to_string(),
         format!("{}@{}", package_req.name, version),
       );
+      self.has_content_changed = true;
     }
   }
 }
@@ -454,9 +462,15 @@ mod tests {
     );
     assert!(check_true);
 
+    let check_false = lockfile.check_or_insert_remote(
+      "https://deno.land/std@0.71.0/textproto/mod.ts",
+      "Here is some NEW source code",
+    );
+    assert!(!check_false);
+
     // Not present in lockfile yet, should be inserted and check passed.
     let check_true = lockfile.check_or_insert_remote(
-      "https://deno.land/std@0.71.0/textproto/mod.ts",
+      "https://deno.land/std@0.71.0/http/file_server.ts",
       "This is new Source code",
     );
     assert!(check_true);
@@ -515,5 +529,21 @@ mod tests {
     // Not present in lockfile yet, should be inserted and check passed.
     let check_ok = lockfile.check_or_insert_npm_package(&npm_package);
     assert!(check_ok.is_ok());
+
+    let npm_package = NpmResolutionPackage {
+      id: NpmPackageId {
+        name: "source-map-js".to_string(),
+        version: NpmVersion::parse("1.0.2").unwrap(),
+      },
+      dist: NpmPackageVersionDistInfo {
+        tarball: "foo".to_string(),
+        shasum: "foo".to_string(),
+        integrity: Some("sha512-foobar".to_string()),
+      },
+      dependencies: HashMap::new(),
+    };
+    // Now present in lockfile, should file due to borked integrity
+    let check_err = lockfile.check_or_insert_npm_package(&npm_package);
+    assert!(check_err.is_err());
   }
 }

--- a/cli/lockfile.rs
+++ b/cli/lockfile.rs
@@ -249,13 +249,11 @@ impl Lockfile {
     package_req: &NpmPackageReq,
     version: String,
   ) {
-    if self.write {
-      self.content.npm.specifiers.insert(
-        package_req.to_string(),
-        format!("{}@{}", package_req.name, version),
-      );
-      self.has_content_changed = true;
-    }
+    self.content.npm.specifiers.insert(
+      package_req.to_string(),
+      format!("{}@{}", package_req.name, version),
+    );
+    self.has_content_changed = true;
   }
 }
 

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -7,7 +7,11 @@ mod resolvers;
 mod semver;
 mod tarball;
 
+#[cfg(test)]
+pub use self::semver::NpmVersion;
 pub use cache::NpmCache;
+#[cfg(test)]
+pub use registry::NpmPackageVersionDistInfo;
 pub use registry::NpmRegistryApi;
 pub use resolution::NpmPackageId;
 pub use resolution::NpmPackageReference;

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -236,7 +236,7 @@ impl ProcState {
       cli_options.cache_setting(),
       progress_bar.clone(),
     );
-    let maybe_lockfile = lockfile.as_ref().filter(|l| !l.lock().write).cloned();
+    let maybe_lockfile = lockfile.as_ref().filter(|l| !l.lock().overwrite).cloned();
     let mut npm_resolver = NpmPackageResolver::new(
       npm_cache.clone(),
       api,

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -236,7 +236,8 @@ impl ProcState {
       cli_options.cache_setting(),
       progress_bar.clone(),
     );
-    let maybe_lockfile = lockfile.as_ref().filter(|l| !l.lock().overwrite).cloned();
+    let maybe_lockfile =
+      lockfile.as_ref().filter(|l| !l.lock().overwrite).cloned();
     let mut npm_resolver = NpmPackageResolver::new(
       npm_cache.clone(),
       api,


### PR DESCRIPTION
This commit changes lockfile to be "additive" - ie. integrity check only fails if
file/package is already specified in the lockfile, but its integrity doesn't match.

If file/package is not present in the lockfile, it will be added to the lockfile and
the lockfile will be written to disk.