### PR TITLE
refactor: Combine ImportMapResolver and JsxResolver

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -19,8 +19,7 @@ use crate::node::NodeResolutionMode;
 use crate::npm::NpmPackageReference;
 use crate::npm::NpmPackageReq;
 use crate::npm::NpmPackageResolver;
-use crate::resolver::ImportMapResolver;
-use crate::resolver::JsxResolver;
+use crate::resolver::CliResolver;
 use crate::text_encoding;
 
 use deno_ast::MediaType;
@@ -707,10 +706,9 @@ pub struct Documents {
   /// Any imports to the context supplied by configuration files. This is like
   /// the imports into the a module graph in CLI.
   imports: Arc<HashMap<ModuleSpecifier, GraphImport>>,
-  /// The optional import map that should be used when resolving dependencies.
-  maybe_import_map: Option<ImportMapResolver>,
-  /// The optional JSX resolver, which is used when JSX imports are configured.
-  maybe_jsx_resolver: Option<JsxResolver>,
+  /// A resolver that takes into account currently loaded import map and JSX
+  /// settings.
+  resolver: CliResolver,
   /// The npm package requirements.
   npm_reqs: HashSet<NpmPackageReq>,
   /// Resolves a specifier to its final redirected to specifier.
@@ -726,8 +724,7 @@ impl Documents {
       open_docs: HashMap::default(),
       file_system_docs: Default::default(),
       imports: Default::default(),
-      maybe_import_map: None,
-      maybe_jsx_resolver: None,
+      resolver: CliResolver::default(),
       npm_reqs: HashSet::new(),
       specifier_resolver: Arc::new(SpecifierResolver::new(location)),
     }
@@ -1049,11 +1046,10 @@ impl Documents {
     maybe_config_file: Option<&ConfigFile>,
   ) {
     // TODO(@kitsonk) update resolved dependencies?
-    self.maybe_import_map = maybe_import_map.map(ImportMapResolver::new);
-    self.maybe_jsx_resolver = maybe_config_file.and_then(|cf| {
-      cf.to_maybe_jsx_import_source_config()
-        .map(|cfg| JsxResolver::new(cfg, self.maybe_import_map.clone()))
-    });
+    self.resolver = CliResolver::new(
+      maybe_config_file.and_then(|cf| cf.to_maybe_jsx_import_source_config()),
+      maybe_import_map,
+    );
     self.imports = Arc::new(
       if let Some(Ok(Some(imports))) =
         maybe_config_file.map(|cf| cf.to_maybe_imports())
@@ -1125,11 +1121,7 @@ impl Documents {
   }
 
   fn get_maybe_resolver(&self) -> Option<&dyn deno_graph::source::Resolver> {
-    if self.maybe_jsx_resolver.is_some() {
-      self.maybe_jsx_resolver.as_ref().map(|jr| jr.as_resolver())
-    } else {
-      self.maybe_import_map.as_ref().map(|im| im.as_resolver())
-    }
+    Some(self.resolver.as_graph_resolver())
   }
 
   fn resolve_dependency(

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -70,8 +70,7 @@ use crate::file_watcher::ResolutionResult;
 use crate::graph_util::graph_lock_or_exit;
 use crate::graph_util::graph_valid;
 use crate::proc_state::ProcState;
-use crate::resolver::ImportMapResolver;
-use crate::resolver::JsxResolver;
+use crate::resolver::CliResolver;
 use crate::tools::check;
 
 use args::CliOptions;
@@ -361,19 +360,10 @@ async fn create_graph_and_maybe_check(
   );
   let maybe_locker = lockfile::as_maybe_locker(ps.lockfile.clone());
   let maybe_imports = ps.options.to_maybe_imports()?;
-  let maybe_import_map_resolver =
-    ps.maybe_import_map.clone().map(ImportMapResolver::new);
-  let maybe_jsx_resolver = ps
-    .options
-    .to_maybe_jsx_import_source_config()
-    .map(|cfg| JsxResolver::new(cfg, maybe_import_map_resolver.clone()));
-  let maybe_resolver = if maybe_jsx_resolver.is_some() {
-    maybe_jsx_resolver.as_ref().map(|jr| jr.as_resolver())
-  } else {
-    maybe_import_map_resolver
-      .as_ref()
-      .map(|im| im.as_resolver())
-  };
+  let cli_resolver = CliResolver::new(
+    ps.options.to_maybe_jsx_import_source_config(),
+    ps.maybe_import_map.clone(),
+  );
   let analyzer = ps.parsed_source_cache.as_analyzer();
   let graph = Arc::new(
     deno_graph::create_graph(
@@ -382,7 +372,7 @@ async fn create_graph_and_maybe_check(
       deno_graph::GraphOptions {
         is_dynamic: false,
         imports: maybe_imports,
-        resolver: maybe_resolver,
+        resolver: Some(cli_resolver.as_graph_resolver()),
         locker: maybe_locker,
         module_analyzer: Some(&*analyzer),
         reporter: None,

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -4,10 +4,73 @@ use deno_core::resolve_import;
 use deno_core::ModuleSpecifier;
 use deno_graph::source::ResolveResponse;
 use deno_graph::source::Resolver;
+use deno_graph::source::DEFAULT_JSX_IMPORT_SOURCE_MODULE;
 use import_map::ImportMap;
 use std::sync::Arc;
 
 use crate::args::config_file::JsxImportSourceConfig;
+
+/// A resolver that takes care of resolution, taking into account loaded
+/// import map, JSX settings.
+#[derive(Debug, Clone)]
+pub struct CliResolver {
+  maybe_import_map: Option<Arc<ImportMap>>,
+  maybe_default_jsx_import_source: Option<String>,
+  maybe_jsx_import_source_module: Option<String>,
+}
+
+impl CliResolver {
+  pub fn new(
+    maybe_jsx_import_source_config: Option<JsxImportSourceConfig>,
+    maybe_import_map: Option<Arc<ImportMap>>,
+  ) -> Self {
+    Self {
+      maybe_import_map,
+      maybe_default_jsx_import_source: maybe_jsx_import_source_config
+        .as_ref()
+        .and_then(|c| c.default_specifier.clone()),
+      maybe_jsx_import_source_module: maybe_jsx_import_source_config
+        .map(|c| c.module),
+    }
+  }
+
+  pub fn as_graph_resolver(&self) -> &dyn Resolver {
+    self
+  }
+}
+
+impl Resolver for CliResolver {
+  fn default_jsx_import_source(&self) -> Option<String> {
+    self.maybe_default_jsx_import_source.clone()
+  }
+
+  fn jsx_import_source_module(&self) -> &str {
+    self
+      .maybe_jsx_import_source_module
+      .as_deref()
+      .unwrap_or(DEFAULT_JSX_IMPORT_SOURCE_MODULE)
+  }
+
+  fn resolve(
+    &self,
+    specifier: &str,
+    referrer: &ModuleSpecifier,
+  ) -> ResolveResponse {
+    if let Some(import_map) = &self.maybe_import_map {
+      match import_map.resolve(specifier, referrer) {
+        Ok(resolved_specifier) => {
+          ResolveResponse::Specifier(resolved_specifier)
+        }
+        Err(err) => ResolveResponse::Err(err.into()),
+      }
+    } else {
+      match resolve_import(specifier, referrer.as_str()) {
+        Ok(specifier) => ResolveResponse::Specifier(specifier),
+        Err(err) => ResolveResponse::Err(err.into()),
+      }
+    }
+  }
+}
 
 /// Wraps an import map to be used when building a deno_graph module graph.
 /// This is done to avoid having `import_map` be a direct dependency of

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -12,7 +12,7 @@ use crate::args::config_file::JsxImportSourceConfig;
 
 /// A resolver that takes care of resolution, taking into account loaded
 /// import map, JSX settings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CliResolver {
   maybe_import_map: Option<Arc<ImportMap>>,
   maybe_default_jsx_import_source: Option<String>,
@@ -69,82 +69,5 @@ impl Resolver for CliResolver {
         Err(err) => ResolveResponse::Err(err.into()),
       }
     }
-  }
-}
-
-/// Wraps an import map to be used when building a deno_graph module graph.
-/// This is done to avoid having `import_map` be a direct dependency of
-/// `deno_graph`.
-#[derive(Debug, Clone)]
-pub struct ImportMapResolver(Arc<ImportMap>);
-
-impl ImportMapResolver {
-  pub fn new(import_map: Arc<ImportMap>) -> Self {
-    Self(import_map)
-  }
-
-  pub fn as_resolver(&self) -> &dyn Resolver {
-    self
-  }
-}
-
-impl Resolver for ImportMapResolver {
-  fn resolve(
-    &self,
-    specifier: &str,
-    referrer: &ModuleSpecifier,
-  ) -> ResolveResponse {
-    match self.0.resolve(specifier, referrer) {
-      Ok(resolved_specifier) => ResolveResponse::Specifier(resolved_specifier),
-      Err(err) => ResolveResponse::Err(err.into()),
-    }
-  }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct JsxResolver {
-  default_jsx_import_source: Option<String>,
-  jsx_import_source_module: String,
-  maybe_import_map_resolver: Option<ImportMapResolver>,
-}
-
-impl JsxResolver {
-  pub fn new(
-    jsx_import_source_config: JsxImportSourceConfig,
-    maybe_import_map_resolver: Option<ImportMapResolver>,
-  ) -> Self {
-    Self {
-      default_jsx_import_source: jsx_import_source_config.default_specifier,
-      jsx_import_source_module: jsx_import_source_config.module,
-      maybe_import_map_resolver,
-    }
-  }
-
-  pub fn as_resolver(&self) -> &dyn Resolver {
-    self
-  }
-}
-
-impl Resolver for JsxResolver {
-  fn default_jsx_import_source(&self) -> Option<String> {
-    self.default_jsx_import_source.clone()
-  }
-
-  fn jsx_import_source_module(&self) -> &str {
-    self.jsx_import_source_module.as_str()
-  }
-
-  fn resolve(
-    &self,
-    specifier: &str,
-    referrer: &ModuleSpecifier,
-  ) -> ResolveResponse {
-    self.maybe_import_map_resolver.as_ref().map_or_else(
-      || match resolve_import(specifier, referrer.as_str()) {
-        Ok(specifier) => ResolveResponse::Specifier(specifier),
-        Err(err) => ResolveResponse::Err(err.into()),
-      },
-      |r| r.resolve(specifier, referrer),
-    )
   }
 }

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -6,7 +6,7 @@ use crate::file_fetcher::get_source_from_data_url;
 use crate::ops;
 use crate::proc_state::ProcState;
 use crate::version;
-use crate::ImportMapResolver;
+use crate::CliResolver;
 use deno_core::anyhow::anyhow;
 use deno_core::anyhow::Context;
 use deno_core::error::type_error;
@@ -125,7 +125,7 @@ fn u64_from_bytes(arr: &[u8]) -> Result<u64, AnyError> {
 
 struct EmbeddedModuleLoader {
   eszip: eszip::EszipV2,
-  maybe_import_map_resolver: Option<ImportMapResolver>,
+  maybe_import_map_resolver: Option<CliResolver>,
 }
 
 impl ModuleLoader for EmbeddedModuleLoader {
@@ -231,9 +231,12 @@ pub async fn run(
     eszip,
     maybe_import_map_resolver: metadata.maybe_import_map.map(
       |(base, source)| {
-        ImportMapResolver::new(Arc::new(
-          parse_from_json(&base, &source).unwrap().import_map,
-        ))
+        CliResolver::new(
+          None,
+          Some(Arc::new(
+            parse_from_json(&base, &source).unwrap().import_map,
+          )),
+        )
       },
     ),
   });

--- a/cli/tools/vendor/test.rs
+++ b/cli/tools/vendor/test.rs
@@ -21,7 +21,7 @@ use deno_graph::ModuleKind;
 use import_map::ImportMap;
 
 use crate::cache::ParsedSourceCache;
-use crate::resolver::ImportMapResolver;
+use crate::resolver::CliResolver;
 
 use super::build::VendorEnvironment;
 
@@ -265,14 +265,14 @@ async fn build_test_graph(
   analyzer: &dyn deno_graph::ModuleAnalyzer,
 ) -> ModuleGraph {
   let resolver =
-    original_import_map.map(|m| ImportMapResolver::new(Arc::new(m)));
+    original_import_map.map(|m| CliResolver::new(None, Some(Arc::new(m))));
   deno_graph::create_graph(
     roots,
     &mut loader,
     deno_graph::GraphOptions {
       is_dynamic: false,
       imports: None,
-      resolver: resolver.as_ref().map(|im| im.as_resolver()),
+      resolver: resolver.as_ref().map(|r| r.as_graph_resolver()),
       locker: None,
       module_analyzer: Some(analyzer),
       reporter: None,


### PR DESCRIPTION
These resolvers are used in `deno_graph` APIs. Combining them removes a lot of code and
unblocks me on https://github.com/denoland/deno/pull/16157