### PR TITLE
chore(ci): update github actions

### DIFF
--- a/.github/workflows/bench_cron.yml
+++ b/.github/workflows/bench_cron.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           persist-credentials: false
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build release
         run: cargo build --release --locked --all-targets
-      
+
       - name: Worker info
         run: |
           cat /proc/cpuinfo

--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global fetch.parallel 32
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.DENOBOT_PAT }}
           submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           python-version: 3.8
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 17
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
           fi
 
       - name: Cache Cargo home
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           deno-version: v1.x
 
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -31,7 +31,7 @@ jobs:
           git config --global fetch.parallel 32
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.DENOBOT_PAT }}
           submodules: recursive

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -35,10 +35,9 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-          architecture: x64
 
       - name: Log versions
         run: |


### PR DESCRIPTION
1. update actions/checkout to v3
2. update actions/setup-node to v3
3. update actions/setup-python to v4
4. update actions/cache to v3 (Other two instances aren't updated. blocked by https://github.com/actions/cache/pull/489 (or  https://github.com/actions/cache/pull/571))