### PR TITLE
feat(runtime): support creating workers with custom v8 snapshots

### DIFF
--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -287,6 +287,7 @@ pub async fn run(
       inspect: ps.options.is_inspecting(),
     },
     extensions: ops::cli_exts(ps.clone()),
+    startup_snapshot: None,
     unsafely_ignore_certificate_errors: metadata
       .unsafely_ignore_certificate_errors,
     root_cert_store: Some(root_cert_store),

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -430,6 +430,7 @@ pub async fn create_main_worker(
       inspect: ps.options.is_inspecting(),
     },
     extensions,
+    startup_snapshot: None,
     unsafely_ignore_certificate_errors: ps
       .options
       .unsafely_ignore_certificate_errors()

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<(), AnyError> {
       inspect: false,
     },
     extensions: vec![],
+    startup_snapshot: None,
     unsafely_ignore_certificate_errors: None,
     root_cert_store: None,
     seed: None,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -27,6 +27,7 @@ use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
 use deno_core::RuntimeOptions;
 use deno_core::SharedArrayBufferStore;
+use deno_core::Snapshot;
 use deno_core::SourceMapGetter;
 use deno_node::RequireNpmResolver;
 use deno_tls::rustls::RootCertStore;
@@ -74,6 +75,7 @@ pub struct MainWorker {
 pub struct WorkerOptions {
   pub bootstrap: BootstrapOptions,
   pub extensions: Vec<Extension>,
+  pub startup_snapshot: Option<Snapshot>,
   pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
   pub root_cert_store: Option<RootCertStore>,
   pub seed: Option<u64>,
@@ -135,6 +137,7 @@ impl Default for WorkerOptions {
       npm_resolver: Default::default(),
       blob_store: Default::default(),
       extensions: Default::default(),
+      startup_snapshot: Default::default(),
       bootstrap: Default::default(),
       stdio: Default::default(),
     }
@@ -242,7 +245,11 @@ impl MainWorker {
 
     let mut js_runtime = JsRuntime::new(RuntimeOptions {
       module_loader: Some(options.module_loader.clone()),
-      startup_snapshot: Some(js::deno_isolate_init()),
+      startup_snapshot: Some(
+        options
+          .startup_snapshot
+          .unwrap_or_else(js::deno_isolate_init),
+      ),
       source_map_getter: options.source_map_getter,
       get_error_class_fn: options.get_error_class_fn,
       shared_array_buffer_store: options.shared_array_buffer_store.clone(),
@@ -562,6 +569,7 @@ mod tests {
         inspect: false,
       },
       extensions: vec![],
+      startup_snapshot: None,
       unsafely_ignore_certificate_errors: None,
       root_cert_store: None,
       seed: None,


### PR DESCRIPTION
This PR makes it possible for applications to create workers from custom snapshots to improve runtime performance (without having to fork/copy `runtime/workers.rs`).

Note: I know that [extensions](https://github.com/denoland/deno/blob/23a04b15c1540a1374bf27c46a7d41adcb8feab0/runtime/worker.rs#L179) depend on the snapshot for core functionality (and more?), so this feature is probably only useful if the custom snapshot is based on the one provided by `js::deno_isolate_init`.
