### PR TITLE
perf(core): minimize trivial heap allocations in `resolve_async_ops`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_v8",
+ "smallvec",
  "sourcemap",
  "tokio",
  "url",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,10 +32,10 @@ pin-project = "1.0.11"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_v8 = { version = "0.69.0", path = "../serde_v8" }
+smallvec = "1.8"
 sourcemap = "6.1"
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
 v8 = { version = "0.54.0", default-features = false }
-smallvec = "1.8"
 
 [[example]]
 name = "http_bench_json_ops"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,7 @@ serde_v8 = { version = "0.69.0", path = "../serde_v8" }
 sourcemap = "6.1"
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
 v8 = { version = "0.54.0", default-features = false }
+smallvec = "1.8"
 
 [[example]]
 name = "http_bench_json_ops"


### PR DESCRIPTION
* Use stack allocated array for 16 promises and spill rest to heap. the exact number can change, maybe 128? (tokio's coop budget limit)
* Avoid v8::Global::clone for global context.
* Do not open global opresolve when its not needed.