### PR TITLE
chore: fix post_publish workflow trigger

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -1,6 +1,8 @@
 name: post_publish
 
-on: published
+on:
+  release:
+    types: [published]
 
 jobs:
   update-dl-version:


### PR DESCRIPTION
Hmmm... not sure where I got that "published" from as I can't find those docs I was looking at anymore, but it seems this is the way to do it: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release