### PR TITLE
fix(ext/webstorage): make web storages re-assignable

### DIFF
--- a/cli/tests/unit/webstorage_test.ts
+++ b/cli/tests/unit/webstorage_test.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// deno-lint-ignore-file no-explicit-any
+
+import { assert } from "./test_util.ts";
+
+Deno.test({ permissions: "none" }, function webStoragesReassignable() {
+  // Can reassign to web storages
+  globalThis.localStorage = 1 as any;
+  globalThis.sessionStorage = 1 as any;
+  // The actual values don't change
+  assert(globalThis.localStorage instanceof globalThis.Storage);
+  assert(globalThis.sessionStorage instanceof globalThis.Storage);
+});

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -587,11 +587,15 @@ delete Intl.v8BreakIterator;
       configurable: true,
       enumerable: true,
       get: webStorage.localStorage,
+      // Makes this reassignable to make astro work
+      set: () => {},
     },
     sessionStorage: {
       configurable: true,
       enumerable: true,
       get: webStorage.sessionStorage,
+      // Makes this reassignable to make astro work
+      set: () => {},
     },
     Storage: util.nonEnumerable(webStorage.Storage),
   };


### PR DESCRIPTION
This PR improves the compatibility of astro with `npm:` feature.

Astro tries to patch web storages for some reason. https://github.com/withastro/astro/blob/7191ed1c7c80c9d70d7d6f88e40ebc9a89787411/packages/webapi/src/lib/Storage.ts#L52
This PR adds empty setter to these properties to allow astro setting them.


part of #16659