### PR TITLE
fix(ext/node): handle URL in createRequire

### DIFF
--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -1470,6 +1470,14 @@ itest!(info_peer_deps_json {
   http_server: true,
 });
 
+itest!(create_require {
+  args: "run --reload npm/create_require/main.ts",
+  output: "npm/create_require/main.out",
+  exit_code: 0,
+  envs: env_vars(),
+  http_server: true,
+});
+
 fn env_vars_no_sync_download() -> Vec<(String, String)> {
   vec![
     ("DENO_NODE_COMPAT_URL".to_string(), util::std_file_url()),

--- a/cli/tests/testdata/npm/create_require/main.out
+++ b/cli/tests/testdata/npm/create_require/main.out
@@ -1,0 +1,6 @@
+[WILDCARD]
+function
+function
+The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received https://example.com/
+The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received https://example.com/
+The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received 1

--- a/cli/tests/testdata/npm/create_require/main.ts
+++ b/cli/tests/testdata/npm/create_require/main.ts
@@ -1,0 +1,1 @@
+import "npm:@denotest/create-require@1.0.0";

--- a/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/index.js
@@ -1,0 +1,19 @@
+import { createRequire } from "module";
+
+console.log(typeof createRequire(import.meta.url));
+console.log(typeof createRequire(new URL(import.meta.url)));
+try {
+  createRequire("https://example.com/");
+} catch (e) {
+  console.log(e.message);
+}
+try {
+  createRequire(new URL("https://example.com/"));
+} catch (e) {
+  console.log(e.message);
+}
+try {
+  createRequire(1);
+} catch (e) {
+  console.log(e.message);
+}

--- a/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@denotest/create-require",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -819,8 +819,28 @@
   }
 
   function createRequire(filenameOrUrl) {
-    // FIXME: handle URLs and validation
-    const filename = core.ops.op_require_as_file_path(filenameOrUrl);
+    let fileUrlStr;
+    // TODO(kt3k): Support node.js Url object
+    if (filenameOrUrl instanceof URL) {
+      if (filenameOrUrl.protocol !== "file:") {
+        throw new Error(
+          `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ${filenameOrUrl}`,
+        );
+      }
+      fileUrlStr = filenameOrUrl.toString();
+    } else if (typeof filenameOrUrl === "string") {
+      if (!filenameOrUrl.startsWith("file:")) {
+        throw new Error(
+          `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ${filenameOrUrl}`,
+        );
+      }
+      fileUrlStr = filenameOrUrl;
+    } else {
+      throw new Error(
+        `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ${filenameOrUrl}`,
+      );
+    }
+    const filename = core.ops.op_require_as_file_path(fileUrlStr);
     return createRequireFromPath(filename);
   }
 

--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -820,7 +820,6 @@
 
   function createRequire(filenameOrUrl) {
     let fileUrlStr;
-    // TODO(kt3k): Support node.js Url object
     if (filenameOrUrl instanceof URL) {
       if (filenameOrUrl.protocol !== "file:") {
         throw new Error(


### PR DESCRIPTION
This PR implements handling of `URL` input for `createRequire` in `ext/node`.

part of #16659