### PR TITLE
chore: more debug logging and avoid allocating strings in ts logging when not debug

### DIFF
--- a/cli/cache/check.rs
+++ b/cli/cache/check.rs
@@ -17,6 +17,7 @@ pub struct TypeCheckCache(Option<Connection>);
 
 impl TypeCheckCache {
   pub fn new(db_file_path: &Path) -> Self {
+    log::debug!("Loading type check cache.");
     match Self::try_new(db_file_path) {
       Ok(cache) => cache,
       Err(err) => {

--- a/cli/cache/incremental.rs
+++ b/cli/cache/incremental.rs
@@ -164,6 +164,7 @@ struct SqlIncrementalCache {
 
 impl SqlIncrementalCache {
   pub fn new(db_file_path: &Path, state_hash: u64) -> Result<Self, AnyError> {
+    log::debug!("Loading incremental cache.");
     let conn = Connection::open(db_file_path)?;
     Self::from_connection(conn, state_hash, crate::version::deno())
   }

--- a/cli/cache/node.rs
+++ b/cli/cache/node.rs
@@ -142,6 +142,7 @@ impl NodeAnalysisCacheInner {
     db_file_path: Option<&Path>,
     version: String,
   ) -> Result<Self, AnyError> {
+    log::debug!("Opening node analysis cache.");
     let conn = match db_file_path {
       Some(path) => Connection::open(path)?,
       None => Connection::open_in_memory()?,

--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -143,6 +143,7 @@ impl ParsedSourceCacheModuleAnalyzer {
     cli_version: String,
     sources: ParsedSourceCacheSources,
   ) -> Result<Self, AnyError> {
+    log::debug!("Loading cached module analyzer.");
     let conn = match db_file_path {
       Some(path) => Connection::open(path)?,
       None => Connection::open_in_memory()?,

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -286,6 +286,7 @@ impl ProcState {
     dynamic_permissions: Permissions,
     reload_on_watch: bool,
   ) -> Result<(), AnyError> {
+    log::debug!("Preparing module load.");
     let _pb_clear_guard = self.progress_bar.clear_guard();
 
     let has_root_npm_specifier = roots.iter().any(|r| {
@@ -369,6 +370,7 @@ impl ProcState {
       };
 
     let analyzer = self.parsed_source_cache.as_analyzer();
+    log::debug!("Creating module graph.");
     let graph = create_graph(
       roots.clone(),
       &mut loader,
@@ -417,6 +419,7 @@ impl ProcState {
 
     // type check if necessary
     if self.options.type_check_mode() != TypeCheckMode::None {
+      log::debug!("Type checking.");
       let maybe_config_specifier = self.options.maybe_config_file_specifier();
       let roots = roots.clone();
       let options = check::CheckOptions {
@@ -457,6 +460,8 @@ impl ProcState {
       let g = lockfile.lock();
       g.write()?;
     }
+
+    log::debug!("Prepared module load.");
 
     Ok(())
   }

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -480,12 +480,16 @@ delete Object.prototype.__proto__;
    * @type {ts.CompilerHost & ts.LanguageServiceHost} */
   const host = {
     fileExists(specifier) {
-      debug(`host.fileExists("${specifier}")`);
+      if (logDebug) {
+        debug(`host.fileExists("${specifier}")`);
+      }
       specifier = normalizedToOriginalMap.get(specifier) ?? specifier;
       return ops.op_exists({ specifier });
     },
     readFile(specifier) {
-      debug(`host.readFile("${specifier}")`);
+      if (logDebug) {
+        debug(`host.readFile("${specifier}")`);
+      }
       return ops.op_load({ specifier }).data;
     },
     getCancellationToken() {
@@ -499,11 +503,13 @@ delete Object.prototype.__proto__;
       _shouldCreateNewSourceFile,
     ) {
       const createOptions = getCreateSourceFileOptions(languageVersion);
-      debug(
-        `host.getSourceFile("${specifier}", ${
-          ts.ScriptTarget[createOptions.languageVersion]
-        })`,
-      );
+      if (logDebug) {
+        debug(
+          `host.getSourceFile("${specifier}", ${
+            ts.ScriptTarget[createOptions.languageVersion]
+          })`,
+        );
+      }
 
       // Needs the original specifier
       specifier = normalizedToOriginalMap.get(specifier) ?? specifier;
@@ -546,13 +552,17 @@ delete Object.prototype.__proto__;
       return ASSETS;
     },
     writeFile(fileName, data, _writeByteOrderMark, _onError, _sourceFiles) {
-      debug(`host.writeFile("${fileName}")`);
+      if (logDebug) {
+        debug(`host.writeFile("${fileName}")`);
+      }
       return ops.op_emit(
         { fileName, data },
       );
     },
     getCurrentDirectory() {
-      debug(`host.getCurrentDirectory()`);
+      if (logDebug) {
+        debug(`host.getCurrentDirectory()`);
+      }
       return cwd ?? ops.op_cwd();
     },
     getCanonicalFileName(fileName) {
@@ -609,9 +619,11 @@ delete Object.prototype.__proto__;
       });
     },
     resolveModuleNames(specifiers, base) {
-      debug(`host.resolveModuleNames()`);
-      debug(`  base: ${base}`);
-      debug(`  specifiers: ${specifiers.join(", ")}`);
+      if (logDebug) {
+        debug(`host.resolveModuleNames()`);
+        debug(`  base: ${base}`);
+        debug(`  specifiers: ${specifiers.join(", ")}`);
+      }
       /** @type {Array<[string, ts.Extension] | undefined>} */
       const resolved = ops.op_resolve({
         specifiers,
@@ -646,11 +658,15 @@ delete Object.prototype.__proto__;
 
     // LanguageServiceHost
     getCompilationSettings() {
-      debug("host.getCompilationSettings()");
+      if (logDebug) {
+        debug("host.getCompilationSettings()");
+      }
       return compilationSettings;
     },
     getScriptFileNames() {
-      debug("host.getScriptFileNames()");
+      if (logDebug) {
+        debug("host.getScriptFileNames()");
+      }
       // tsc requests the script file names multiple times even though it can't
       // possibly have changed, so we will memoize it on a per request basis.
       if (scriptFileNamesCache) {
@@ -659,7 +675,9 @@ delete Object.prototype.__proto__;
       return scriptFileNamesCache = ops.op_script_names();
     },
     getScriptVersion(specifier) {
-      debug(`host.getScriptVersion("${specifier}")`);
+      if (logDebug) {
+        debug(`host.getScriptVersion("${specifier}")`);
+      }
       const sourceFile = sourceFileCache.get(specifier);
       if (sourceFile) {
         return sourceFile.version ?? "1";
@@ -674,7 +692,9 @@ delete Object.prototype.__proto__;
       return scriptVersion;
     },
     getScriptSnapshot(specifier) {
-      debug(`host.getScriptSnapshot("${specifier}")`);
+      if (logDebug) {
+        debug(`host.getScriptSnapshot("${specifier}")`);
+      }
       const sourceFile = sourceFileCache.get(specifier);
       if (sourceFile) {
         return {
@@ -807,8 +827,10 @@ delete Object.prototype.__proto__;
 
     setLogDebug(debugFlag, "TS");
     performanceStart();
-    debug(">>> exec start", { rootNames });
-    debug(config);
+    if (logDebug) {
+      debug(">>> exec start", { rootNames });
+      debug(config);
+    }
 
     rootNames.forEach(checkNormalizedPath);
 
@@ -877,7 +899,9 @@ delete Object.prototype.__proto__;
    * @param {LanguageServerRequest} request
    */
   function serverRequest({ id, ...request }) {
-    debug(`serverRequest()`, { id, ...request });
+    if (logDebug) {
+      debug(`serverRequest()`, { id, ...request });
+    }
 
     // reset all memoized source files names
     scriptFileNamesCache = undefined;
@@ -1000,7 +1024,9 @@ delete Object.prototype.__proto__;
         );
       }
       case "getCompletionDetails": {
-        debug("request", request);
+        if (logDebug) {
+          debug("request", request);
+        }
         return respond(
           id,
           languageService.getCompletionEntryDetails(


### PR DESCRIPTION
Adds more debug logging for #16577 and avoids allocating strings when not debug logging in the typescript code.