### PR TITLE
fix(types/unstable): change interface base for `CommandOutput`

### DIFF
--- a/cli/dts/lib.deno.unstable.d.ts
+++ b/cli/dts/lib.deno.unstable.d.ts
@@ -1805,7 +1805,7 @@ declare namespace Deno {
    *
    * @category Sub Process
    */
-  export interface CommandOutput extends ChildStatus {
+  export interface CommandOutput extends CommandStatus {
     /** The buffered output from the child process' `stdout`. */
     readonly stdout: Uint8Array;
     /** The buffered output from the child process' `stderr`. */


### PR DESCRIPTION
extend from `CommandStatus` instead of `ChildStatus`. Resolves #16680.