### PR TITLE
feat(cli): add warning for incorrectly ordered flags

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -507,14 +507,14 @@ impl Flags {
 
   pub fn has_permission_in_argv(&self) -> bool {
     self.argv.iter().any(|arg| {
-      arg.starts_with("--allow-env")
-        || arg.starts_with("--allow-hrtime")
+      arg == "--allow-all"
+        || arg == "--allow-hrtime"
+        || arg.starts_with("--allow-env")
         || arg.starts_with("--allow-net")
         || arg.starts_with("--allow-read")
         || arg.starts_with("--allow-run")
         || arg.starts_with("--allow-sys")
         || arg.starts_with("--allow-write")
-        || arg.starts_with("--allow-all")
     })
   }
 }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -493,6 +493,30 @@ impl Flags {
       prompt: !self.no_prompt,
     }
   }
+
+  pub fn has_permission(&self) -> bool {
+    self.allow_all
+      || self.allow_hrtime
+      || self.allow_env.is_some()
+      || self.allow_ffi.is_some()
+      || self.allow_net.is_some()
+      || self.allow_read.is_some()
+      || self.allow_sys.is_some()
+      || self.allow_write.is_some()
+  }
+
+  pub fn has_permission_in_argv(&self) -> bool {
+    self.argv.iter().any(|arg| {
+      arg.starts_with("--allow-env")
+        || arg.starts_with("--allow-hrtime")
+        || arg.starts_with("--allow-net")
+        || arg.starts_with("--allow-read")
+        || arg.starts_with("--allow-run")
+        || arg.starts_with("--allow-sys")
+        || arg.starts_with("--allow-write")
+        || arg.starts_with("--allow-all")
+    })
+  }
 }
 
 static ENV_VARIABLES_HELP: &str = r#"ENVIRONMENT VARIABLES:
@@ -3386,6 +3410,24 @@ mod tests {
         ..Flags::default()
       }
     );
+  }
+
+  #[test]
+  fn has_permission() {
+    let r = flags_from_vec(svec!["deno", "run", "--allow-read", "x.ts"]);
+    assert_eq!(r.unwrap().has_permission(), true);
+
+    let r = flags_from_vec(svec!["deno", "run", "x.ts"]);
+    assert_eq!(r.unwrap().has_permission(), false);
+  }
+
+  #[test]
+  fn has_permission_in_argv() {
+    let r = flags_from_vec(svec!["deno", "run", "x.ts", "--allow-read"]);
+    assert_eq!(r.unwrap().has_permission_in_argv(), true);
+
+    let r = flags_from_vec(svec!["deno", "run", "x.ts"]);
+    assert_eq!(r.unwrap().has_permission_in_argv(), false);
   }
 
   #[test]

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -501,6 +501,7 @@ impl Flags {
       || self.allow_ffi.is_some()
       || self.allow_net.is_some()
       || self.allow_read.is_some()
+      || self.allow_run.is_some()
       || self.allow_sys.is_some()
       || self.allow_write.is_some()
   }
@@ -510,6 +511,7 @@ impl Flags {
       arg == "--allow-all"
         || arg == "--allow-hrtime"
         || arg.starts_with("--allow-env")
+        || arg.starts_with("--allow-ffi")
         || arg.starts_with("--allow-net")
         || arg.starts_with("--allow-read")
         || arg.starts_with("--allow-run")

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -702,7 +702,14 @@ async fn run_command(
   }
 
   if !flags.has_permission() && flags.has_permission_in_argv() {
-    log::warn!("Permission flags have likely been incorrectly set after the script argument. To grant permissions, define them before the script argument.")
+    log::warn!(
+      r#"
+Permission flags have likely been incorrectly set after the script argument.
+
+To grant permissions, set them before the script argument. For example:
+    deno run --allow-read=. main.js
+"#
+    )
   }
 
   if flags.watch.is_some() {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -702,7 +702,7 @@ async fn run_command(
   }
 
   if !flags.has_permission() && flags.has_permission_in_argv() {
-    log::warn!("Permission flags have likely been incorrectly set after the module name. To grant permissions, define them before the module name.")
+    log::warn!("Permission flags have likely been incorrectly set after the script argument. To grant permissions, define them before the script argument.")
   }
 
   if flags.watch.is_some() {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -703,10 +703,13 @@ async fn run_command(
 
   if !flags.has_permission() && flags.has_permission_in_argv() {
     log::warn!(
-      r#"Permission flags have likely been incorrectly set after the script argument.
+      "{}",
+      crate::colors::yellow(
+        r#"Permission flags have likely been incorrectly set after the script argument.
 To grant permissions, set them before the script argument. For example:
     deno run --allow-read=. main.js"#
-    )
+      )
+    );
   }
 
   if flags.watch.is_some() {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -705,7 +705,6 @@ async fn run_command(
     log::warn!(
       r#"
 Permission flags have likely been incorrectly set after the script argument.
-
 To grant permissions, set them before the script argument. For example:
     deno run --allow-read=. main.js
 "#

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -701,18 +701,7 @@ async fn run_command(
     return run_from_stdin(flags).await;
   }
 
-  if flags.to_permission_args().is_empty()
-    && flags.argv.iter().any(|arg| {
-      arg.contains("--allow-env")
-        || arg.contains("--allow-hrtime")
-        || arg.contains("--allow-net")
-        || arg.contains("--allow-read")
-        || arg.contains("--allow-run")
-        || arg.contains("--allow-sys")
-        || arg.contains("--allow-write")
-        || arg.contains("--allow-all")
-    })
-  {
+  if !flags.has_permission() && flags.has_permission_in_argv() {
     log::warn!("Permission flags have likely been incorrectly set after the module name. To grant permissions, define them before the module name.")
   }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -713,7 +713,7 @@ async fn run_command(
         || arg.contains("--allow-all")
     })
   {
-    log::warn!("Permission flags have likely been incorrectly set after the script location. To grant permissions, define them before the script location.")
+    log::warn!("Permission flags have likely been incorrectly set after the module name. To grant permissions, define them before the module name.")
   }
 
   if flags.watch.is_some() {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -703,11 +703,9 @@ async fn run_command(
 
   if !flags.has_permission() && flags.has_permission_in_argv() {
     log::warn!(
-      r#"
-Permission flags have likely been incorrectly set after the script argument.
+      r#"Permission flags have likely been incorrectly set after the script argument.
 To grant permissions, set them before the script argument. For example:
-    deno run --allow-read=. main.js
-"#
+    deno run --allow-read=. main.js"#
     )
   }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -701,6 +701,21 @@ async fn run_command(
     return run_from_stdin(flags).await;
   }
 
+  if flags.to_permission_args().is_empty()
+    && flags.argv.iter().any(|arg| {
+      arg.contains("--allow-env")
+        || arg.contains("--allow-hrtime")
+        || arg.contains("--allow-net")
+        || arg.contains("--allow-read")
+        || arg.contains("--allow-run")
+        || arg.contains("--allow-sys")
+        || arg.contains("--allow-write")
+        || arg.contains("--allow-all")
+    })
+  {
+    log::warn!("Permission flags have likely been incorrectly set after the script location. To grant permissions, define them before the script location.")
+  }
+
   if flags.watch.is_some() {
     return run_with_watch(flags, run_flags.script).await;
   }

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -3651,6 +3651,7 @@ itest!(flash_shutdown {
 itest!(permission_args {
   args: "run run/001_hello.js --allow-net",
   output: "run/permission_args.out",
+  envs: vec![("NO_COLOR".to_string(), "1".to_string())],
 });
 
 itest!(permission_args_quiet {

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -3647,3 +3647,13 @@ itest!(flash_shutdown {
   args: "run --unstable --allow-net run/flash_shutdown/main.ts",
   exit_code: 0,
 });
+
+itest!(permission_args {
+  args: "run run/001_hello.js --allow-net",
+  output: "run/permission_args.out",
+});
+
+itest!(permission_args_quiet {
+  args: "run --quiet run/001_hello.js --allow-net",
+  output: "run/001_hello.js.out",
+});

--- a/cli/tests/testdata/run/permission_args.out
+++ b/cli/tests/testdata/run/permission_args.out
@@ -1,2 +1,7 @@
-Permission flags have likely been incorrectly set after the script argument. To grant permissions, define them before the script argument.
+
+Permission flags have likely been incorrectly set after the script argument.
+
+To grant permissions, set them before the script argument. For example:
+    deno run --allow-read=. main.js
+
 Hello World

--- a/cli/tests/testdata/run/permission_args.out
+++ b/cli/tests/testdata/run/permission_args.out
@@ -1,2 +1,2 @@
-Permission flags have likely been incorrectly set after the module name. To grant permissions, define them before the module name.
+Permission flags have likely been incorrectly set after the script argument. To grant permissions, define them before the script argument.
 Hello World

--- a/cli/tests/testdata/run/permission_args.out
+++ b/cli/tests/testdata/run/permission_args.out
@@ -1,6 +1,5 @@
 
 Permission flags have likely been incorrectly set after the script argument.
-
 To grant permissions, set them before the script argument. For example:
     deno run --allow-read=. main.js
 

--- a/cli/tests/testdata/run/permission_args.out
+++ b/cli/tests/testdata/run/permission_args.out
@@ -1,0 +1,2 @@
+Permission flags have likely been incorrectly set after the module name. To grant permissions, define them before the module name.
+Hello World

--- a/cli/tests/testdata/run/permission_args.out
+++ b/cli/tests/testdata/run/permission_args.out
@@ -1,6 +1,4 @@
-
 Permission flags have likely been incorrectly set after the script argument.
 To grant permissions, set them before the script argument. For example:
     deno run --allow-read=. main.js
-
 Hello World


### PR DESCRIPTION
This code checks if permission flags are incorrectly defined after the module name (e.g. `deno run mod.ts --allow-read` instead of the correct `deno run --allow-read mod.ts`). If so, a simple warning is displayed.

Is it worth adding a test for this case? If so, where's the best place for it?

Closes #16630. CC @bartlomieju 