### PR TITLE
chore: remove unnecessary qualifier in declaration file

### DIFF
--- a/cli/dts/lib.deno.ns.d.ts
+++ b/cli/dts/lib.deno.ns.d.ts
@@ -967,7 +967,7 @@ declare namespace Deno {
      *
      * Defaults to "inherit".
      */
-    permissions?: Deno.PermissionOptions;
+    permissions?: PermissionOptions;
   }
 
   /**


### PR DESCRIPTION
This broke a build script in node_shims that was analyzing dependencies used by the `Deno.test` function. I'll update the script to handle this scenario, but the qualifier here is unnecessary so let's remove it.