### PR TITLE
fix(npm/check): prioritize exports over types entry

### DIFF
--- a/cli/node/mod.rs
+++ b/cli/node/mod.rs
@@ -665,17 +665,7 @@ fn package_config_resolve(
   let package_config =
     PackageJson::load(npm_resolver, package_json_path.clone())?;
   if let Some(exports) = &package_config.exports {
-    let is_types = conditions == TYPES_CONDITIONS;
-    if is_types && package_subpath == "." {
-      if let Ok(Some(path)) =
-        legacy_main_resolve(&package_config, referrer_kind, conditions)
-      {
-        return Ok(Some(path));
-      } else {
-        return Ok(None);
-      }
-    }
-    return package_exports_resolve(
+    let result = package_exports_resolve(
       &package_json_path,
       package_subpath.to_string(),
       exports,
@@ -683,8 +673,23 @@ fn package_config_resolve(
       referrer_kind,
       conditions,
       npm_resolver,
-    )
-    .map(Some);
+    );
+    match result {
+      Ok(found) => return Ok(Some(found)),
+      Err(exports_err) => {
+        let is_types = conditions == TYPES_CONDITIONS;
+        if is_types && package_subpath == "." {
+          if let Ok(Some(path)) =
+            legacy_main_resolve(&package_config, referrer_kind, conditions)
+          {
+            return Ok(Some(path));
+          } else {
+            return Ok(None);
+          }
+        }
+        return Err(exports_err);
+      }
+    }
   }
   if package_subpath == "." {
     return legacy_main_resolve(&package_config, referrer_kind, conditions);

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -424,7 +424,8 @@ impl ProcState {
     drop(_pb_clear_guard);
 
     // type check if necessary
-    if self.options.type_check_mode() != TypeCheckMode::None {
+    let is_std_node = roots.len() == 1 && roots[0].0 == *node::MODULE_ALL_URL;
+    if self.options.type_check_mode() != TypeCheckMode::None && !is_std_node {
       log::debug!("Type checking.");
       let maybe_config_specifier = self.options.maybe_config_file_specifier();
       let roots = roots.clone();

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -298,6 +298,14 @@ itest!(no_types_in_conditional_exports {
   http_server: true,
 });
 
+itest!(types_entry_value_not_exists {
+  args: "run --check=all npm/types_entry_value_not_exists/main.ts",
+  output: "npm/types_entry_value_not_exists/main.out",
+  envs: env_vars(),
+  http_server: true,
+  exit_code: 0,
+});
+
 #[test]
 fn parallel_downloading() {
   let (out, _err) = util::run_and_collect_output_with_args(

--- a/cli/tests/testdata/npm/compare_globals/main.out
+++ b/cli/tests/testdata/npm/compare_globals/main.out
@@ -3,6 +3,5 @@ Download http://localhost:4545/npm/registry/@types/node
 Download http://localhost:4545/npm/registry/@denotest/globals/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@types/node/node-18.8.2.tgz
 Check file:///[WILDCARD]/npm/compare_globals/main.ts
-Check file:///[WILDCARD]/std/node/module_all.ts
 true
 []

--- a/cli/tests/testdata/npm/esm/test.out
+++ b/cli/tests/testdata/npm/esm/test.out
@@ -1,6 +1,5 @@
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
-Check [WILDCARD]/std/node/module_all.ts
 running 1 test from ./npm/esm/test.js
 test ...
 ------- output -------

--- a/cli/tests/testdata/npm/no_types_in_conditional_exports/main.out
+++ b/cli/tests/testdata/npm/no_types_in_conditional_exports/main.out
@@ -1,5 +1,4 @@
 Download http://localhost:4545/npm/registry/@denotest/no-types-in-conditional-exports
 Download http://localhost:4545/npm/registry/@denotest/no-types-in-conditional-exports/1.0.0.tgz
 Check [WILDCARD]npm/no_types_in_conditional_exports/main.ts
-[WILDCARD]
 { foo: "bar" }

--- a/cli/tests/testdata/npm/registry/@denotest/types-entry-value-not-exists/1.0.0/dist/main.d.ts
+++ b/cli/tests/testdata/npm/registry/@denotest/types-entry-value-not-exists/1.0.0/dist/main.d.ts
@@ -1,0 +1,1 @@
+export function getValue(): 5;

--- a/cli/tests/testdata/npm/registry/@denotest/types-entry-value-not-exists/1.0.0/dist/main.js
+++ b/cli/tests/testdata/npm/registry/@denotest/types-entry-value-not-exists/1.0.0/dist/main.js
@@ -1,0 +1,1 @@
+module.exports.getValue = () => 5;

--- a/cli/tests/testdata/npm/registry/@denotest/types-entry-value-not-exists/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/types-entry-value-not-exists/1.0.0/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@denotest/types-entry-value-not-exists",
+  "version": "1.0.0",
+  "main": "./dist/main.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/main.d.ts",
+      "node": "./dist/main.js",
+      "require": "./dist/main.js"
+    }
+  }
+}

--- a/cli/tests/testdata/npm/types_entry_value_not_exists/main.out
+++ b/cli/tests/testdata/npm/types_entry_value_not_exists/main.out
@@ -1,0 +1,4 @@
+Download http://localhost:4545/npm/registry/@denotest/types-entry-value-not-exists
+Download http://localhost:4545/npm/registry/@denotest/types-entry-value-not-exists/1.0.0.tgz
+Check file://[WILDCARD]/types_entry_value_not_exists/main.ts
+5

--- a/cli/tests/testdata/npm/types_entry_value_not_exists/main.ts
+++ b/cli/tests/testdata/npm/types_entry_value_not_exists/main.ts
@@ -1,0 +1,4 @@
+import { getValue } from "npm:@denotest/types-entry-value-not-exists";
+
+const result: 5 = getValue();
+console.log(result);


### PR DESCRIPTION
Fixes part of #16782.

This makes rxjs work and aligns more with what the typescript compiler does.