### PR TITLE
fix(npm/types): resolve main entrypoint declaration file when no types entry

### DIFF
--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -306,6 +306,14 @@ itest!(types_entry_value_not_exists {
   exit_code: 0,
 });
 
+itest!(types_no_types_entry {
+  args: "run --check=all npm/types_no_types_entry/main.ts",
+  output: "npm/types_no_types_entry/main.out",
+  envs: env_vars(),
+  http_server: true,
+  exit_code: 0,
+});
+
 #[test]
 fn parallel_downloading() {
   let (out, _err) = util::run_and_collect_output_with_args(

--- a/cli/tests/testdata/npm/registry/@denotest/types-no-types-entry/1.0.0/dist/main.d.ts
+++ b/cli/tests/testdata/npm/registry/@denotest/types-no-types-entry/1.0.0/dist/main.d.ts
@@ -1,0 +1,1 @@
+export function getValue(): 5;

--- a/cli/tests/testdata/npm/registry/@denotest/types-no-types-entry/1.0.0/dist/main.js
+++ b/cli/tests/testdata/npm/registry/@denotest/types-no-types-entry/1.0.0/dist/main.js
@@ -1,0 +1,1 @@
+module.exports.getValue = () => 5;

--- a/cli/tests/testdata/npm/registry/@denotest/types-no-types-entry/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/types-no-types-entry/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/types-no-types-entry",
+  "version": "1.0.0",
+  "main": "./dist/main.js"
+}

--- a/cli/tests/testdata/npm/types_no_types_entry/main.out
+++ b/cli/tests/testdata/npm/types_no_types_entry/main.out
@@ -1,0 +1,4 @@
+Download http://localhost:4545/npm/registry/@denotest/types-no-types-entry
+Download http://localhost:4545/npm/registry/@denotest/types-no-types-entry/1.0.0.tgz
+Check file://[WILDCARD]/types_no_types_entry/main.ts
+5

--- a/cli/tests/testdata/npm/types_no_types_entry/main.ts
+++ b/cli/tests/testdata/npm/types_no_types_entry/main.ts
@@ -1,0 +1,4 @@
+import { getValue } from "npm:@denotest/types-no-types-entry";
+
+const result: 5 = getValue();
+console.log(result);


### PR DESCRIPTION
Makes `npm:@scriptserver/core` work.

Closes #16782