### PR TITLE
refactor: move lockfile.rs to args module

### DIFF
--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -95,6 +95,15 @@ pub struct Lockfile {
 }
 
 impl Lockfile {
+  pub fn as_maybe_locker(
+    lockfile: Option<Arc<Mutex<Lockfile>>>,
+  ) -> Option<Rc<RefCell<dyn deno_graph::source::Locker>>> {
+    lockfile.as_ref().map(|lf| {
+      Rc::new(RefCell::new(Locker(Some(lf.clone()))))
+        as Rc<RefCell<dyn deno_graph::source::Locker>>
+    })
+  }
+
   pub fn discover(
     flags: &Flags,
     maybe_config_file: Option<&ConfigFile>,
@@ -357,15 +366,6 @@ impl deno_graph::source::Locker for Locker {
     let lock_file = self.0.as_ref()?.lock();
     lock_file.filename.to_str().map(|s| s.to_string())
   }
-}
-
-pub fn as_maybe_locker(
-  lockfile: Option<Arc<Mutex<Lockfile>>>,
-) -> Option<Rc<RefCell<dyn deno_graph::source::Locker>>> {
-  lockfile.as_ref().map(|lf| {
-    Rc::new(RefCell::new(Locker(Some(lf.clone()))))
-      as Rc<RefCell<dyn deno_graph::source::Locker>>
-  })
 }
 
 #[cfg(test)]

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1,7 +1,8 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-pub mod config_file;
-pub mod flags;
+mod config_file;
+mod flags;
+mod lockfile;
 
 mod flags_allow_net;
 
@@ -10,6 +11,8 @@ pub use config_file::ConfigFile;
 pub use config_file::EmitConfigOptions;
 pub use config_file::FmtConfig;
 pub use config_file::FmtOptionsConfig;
+pub use config_file::IgnoredCompilerOptions;
+pub use config_file::JsxImportSourceConfig;
 pub use config_file::LintConfig;
 pub use config_file::LintRulesConfig;
 pub use config_file::MaybeImportsResult;
@@ -17,6 +20,8 @@ pub use config_file::ProseWrap;
 pub use config_file::TestConfig;
 pub use config_file::TsConfig;
 pub use flags::*;
+pub use lockfile::Lockfile;
+pub use lockfile::LockfileError;
 
 use deno_ast::ModuleSpecifier;
 use deno_core::anyhow::anyhow;
@@ -36,7 +41,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::args::config_file::JsxImportSourceConfig;
 use crate::deno_dir::DenoDir;
 use crate::emit::get_ts_config_for_emit;
 use crate::emit::TsConfigType;
@@ -45,7 +49,6 @@ use crate::emit::TsTypeLib;
 use crate::file_fetcher::get_root_cert_store;
 use crate::file_fetcher::CacheSetting;
 use crate::fs_util;
-use crate::lockfile::Lockfile;
 use crate::version;
 
 /// Overrides for the options below that when set will

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -4,9 +4,9 @@
 //! populate a cache, emit files, and transform a graph into the structures for
 //! loading into an isolate.
 
-use crate::args::config_file::IgnoredCompilerOptions;
 use crate::args::ConfigFile;
 use crate::args::EmitConfigOptions;
+use crate::args::IgnoredCompilerOptions;
 use crate::args::TsConfig;
 use crate::cache::EmitCache;
 use crate::cache::FastInsecureHasher;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -19,7 +19,6 @@ mod graph_util;
 mod http_cache;
 mod http_util;
 mod js;
-mod lockfile;
 mod logger;
 mod lsp;
 mod module_loader;
@@ -74,6 +73,7 @@ use crate::resolver::CliResolver;
 use crate::tools::check;
 
 use args::CliOptions;
+use args::Lockfile;
 use deno_ast::MediaType;
 use deno_core::anyhow::bail;
 use deno_core::error::generic_error;
@@ -327,7 +327,7 @@ async fn create_graph_and_maybe_check(
     Permissions::allow_all(),
     Permissions::allow_all(),
   );
-  let maybe_locker = lockfile::as_maybe_locker(ps.lockfile.clone());
+  let maybe_locker = Lockfile::as_maybe_locker(ps.lockfile.clone());
   let maybe_imports = ps.options.to_maybe_imports()?;
   let maybe_cli_resolver = CliResolver::maybe_new(
     ps.options.to_maybe_jsx_import_source_config(),
@@ -937,7 +937,7 @@ fn unwrap_or_exit<T>(result: Result<T, AnyError>) -> T {
 
       if let Some(e) = error.downcast_ref::<JsError>() {
         error_string = format_js_error(e);
-      } else if let Some(e) = error.downcast_ref::<lockfile::LockfileError>() {
+      } else if let Some(e) = error.downcast_ref::<args::LockfileError>() {
         error_string = e.to_string();
         error_code = 10;
       }

--- a/cli/npm/resolution/mod.rs
+++ b/cli/npm/resolution/mod.rs
@@ -10,7 +10,7 @@ use deno_core::parking_lot::RwLock;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::lockfile::Lockfile;
+use crate::args::Lockfile;
 
 use self::graph::GraphDependencyResolver;
 use self::snapshot::NpmPackagesPartitioned;

--- a/cli/npm/resolution/snapshot.rs
+++ b/cli/npm/resolution/snapshot.rs
@@ -13,7 +13,7 @@ use deno_core::parking_lot::Mutex;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::lockfile::Lockfile;
+use crate::args::Lockfile;
 use crate::npm::cache::should_sync_download;
 use crate::npm::cache::NpmPackageCacheFolderId;
 use crate::npm::registry::NpmPackageVersionDistInfo;

--- a/cli/npm/resolvers/common.rs
+++ b/cli/npm/resolvers/common.rs
@@ -11,7 +11,7 @@ use deno_core::futures;
 use deno_core::futures::future::BoxFuture;
 use deno_core::url::Url;
 
-use crate::lockfile::Lockfile;
+use crate::args::Lockfile;
 use crate::npm::cache::should_sync_download;
 use crate::npm::resolution::NpmResolutionSnapshot;
 use crate::npm::NpmCache;

--- a/cli/npm/resolvers/global.rs
+++ b/cli/npm/resolvers/global.rs
@@ -15,8 +15,8 @@ use deno_core::url::Url;
 use deno_runtime::deno_node::PackageJson;
 use deno_runtime::deno_node::TYPES_CONDITIONS;
 
+use crate::args::Lockfile;
 use crate::fs_util;
-use crate::lockfile::Lockfile;
 use crate::npm::resolution::NpmResolution;
 use crate::npm::resolution::NpmResolutionSnapshot;
 use crate::npm::resolvers::common::cache_packages;

--- a/cli/npm/resolvers/local.rs
+++ b/cli/npm/resolvers/local.rs
@@ -22,8 +22,8 @@ use deno_runtime::deno_node::PackageJson;
 use deno_runtime::deno_node::TYPES_CONDITIONS;
 use tokio::task::JoinHandle;
 
+use crate::args::Lockfile;
 use crate::fs_util;
-use crate::lockfile::Lockfile;
 use crate::npm::cache::mixed_case_package_name_encode;
 use crate::npm::cache::should_sync_download;
 use crate::npm::cache::NpmPackageCacheFolderId;

--- a/cli/npm/resolvers/mod.rs
+++ b/cli/npm/resolvers/mod.rs
@@ -22,8 +22,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::args::Lockfile;
 use crate::fs_util;
-use crate::lockfile::Lockfile;
 
 use self::common::InnerNpmPackageResolver;
 use self::local::LocalNpmPackageResolver;

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -3,6 +3,7 @@
 use crate::args::CliOptions;
 use crate::args::DenoSubcommand;
 use crate::args::Flags;
+use crate::args::Lockfile;
 use crate::args::TypeCheckMode;
 use crate::cache;
 use crate::cache::EmitCache;
@@ -20,8 +21,6 @@ use crate::graph_util::GraphData;
 use crate::graph_util::ModuleEntry;
 use crate::http_cache;
 use crate::http_util::HttpClient;
-use crate::lockfile::as_maybe_locker;
-use crate::lockfile::Lockfile;
 use crate::node;
 use crate::node::NodeResolution;
 use crate::npm::resolve_npm_package_reqs;
@@ -330,7 +329,7 @@ impl ProcState {
       root_permissions.clone(),
       dynamic_permissions.clone(),
     );
-    let maybe_locker = as_maybe_locker(self.lockfile.clone());
+    let maybe_locker = Lockfile::as_maybe_locker(self.lockfile.clone());
     let maybe_imports = self.options.to_maybe_imports()?;
     let maybe_resolver =
       self.maybe_resolver.as_ref().map(|r| r.as_graph_resolver());
@@ -640,7 +639,7 @@ impl ProcState {
     roots: Vec<(ModuleSpecifier, ModuleKind)>,
     loader: &mut dyn Loader,
   ) -> Result<deno_graph::ModuleGraph, AnyError> {
-    let maybe_locker = as_maybe_locker(self.lockfile.clone());
+    let maybe_locker = Lockfile::as_maybe_locker(self.lockfile.clone());
     let maybe_imports = self.options.to_maybe_imports()?;
 
     let maybe_cli_resolver = CliResolver::maybe_new(

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -8,7 +8,7 @@ use deno_graph::source::DEFAULT_JSX_IMPORT_SOURCE_MODULE;
 use import_map::ImportMap;
 use std::sync::Arc;
 
-use crate::args::config_file::JsxImportSourceConfig;
+use crate::args::JsxImportSourceConfig;
 
 /// A resolver that takes care of resolution, taking into account loaded
 /// import map, JSX settings.


### PR DESCRIPTION
This should be in the `args` folder as it's similar to `config_file`