### PR TITLE
fix(inspector): send "isDefault" in aux data

### DIFF
--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -92,17 +92,19 @@ impl ReplSession {
     for notification in session.notifications() {
       let method = notification.get("method").unwrap().as_str().unwrap();
       let params = notification.get("params").unwrap();
-
       if method == "Runtime.executionContextCreated" {
-        context_id = params
-          .get("context")
+        let context = params.get("context").unwrap();
+        assert!(context
+          .get("auxData")
           .unwrap()
-          .get("id")
+          .get("isDefault")
           .unwrap()
-          .as_u64()
-          .unwrap();
+          .as_bool()
+          .unwrap());
+        context_id = context.get("id").unwrap().as_u64().unwrap();
       }
     }
+    assert_ne!(context_id, 0);
 
     let mut repl_session = ReplSession {
       worker,

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -150,6 +150,7 @@ impl JsRuntimeInspector {
   pub fn new(
     isolate: &mut v8::OwnedIsolate,
     context: v8::Global<v8::Context>,
+    is_main: bool,
   ) -> Rc<RefCell<Self>> {
     let scope = &mut v8::HandleScope::new(isolate);
 
@@ -183,13 +184,26 @@ impl JsRuntimeInspector {
     // Tell the inspector about the global context.
     let context = v8::Local::new(scope, context);
     let context_name = v8::inspector::StringView::from(&b"global context"[..]);
-    let aux_data = v8::inspector::StringView::from(&b""[..]);
+    // NOTE(bartlomieju): this is what Node.js does and it turns out some
+    // debuggers (like VSCode) rely on this information to disconnect after
+    // program completes
+    let aux_data = if is_main {
+      r#"{"isDefault": true}"#
+    } else {
+      r#"{"isDefault": false}"#
+    };
+    let aux_data_view = v8::inspector::StringView::from(aux_data.as_bytes());
     self_
       .v8_inspector
       .borrow_mut()
       .as_mut()
       .unwrap()
-      .context_created(context, Self::CONTEXT_GROUP_ID, context_name, aux_data);
+      .context_created(
+        context,
+        Self::CONTEXT_GROUP_ID,
+        context_name,
+        aux_data_view,
+      );
 
     // Poll the session handler so we will get notified whenever there is
     // new incoming debugger activity.

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -240,6 +240,7 @@ impl MainWorker {
       compiled_wasm_module_store: options.compiled_wasm_module_store.clone(),
       extensions,
       inspector: options.maybe_inspector_server.is_some(),
+      is_main: true,
       ..Default::default()
     });
 


### PR DESCRIPTION
With trial and error I found that most debuggers expect "isDefault" to be sent 
in "auxData" field of "executionContextCreated" notification. This stems from 
the fact that Node.js sends this data and eg. VSCode requires it to close 
connection to the debugger when the program finishes execution.