### PR TITLE
fix(ext/node): allow absolute path in createRequire

### DIFF
--- a/cli/tests/npm_tests.rs
+++ b/cli/tests/npm_tests.rs
@@ -1506,7 +1506,7 @@ mod npm {
   });
 
   itest!(create_require {
-    args: "run --reload npm/create_require/main.ts",
+    args: "run --reload --allow-read npm/create_require/main.ts",
     output: "npm/create_require/main.out",
     exit_code: 0,
     envs: env_vars(),

--- a/cli/tests/testdata/npm/create_require/main.out
+++ b/cli/tests/testdata/npm/create_require/main.out
@@ -1,6 +1,11 @@
 [WILDCARD]
 function
 function
+function
+function
+function
 The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received https://example.com/
 The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received https://example.com/
 The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received 1
+The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received foo
+The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ./foo

--- a/cli/tests/testdata/npm/create_require/main.out
+++ b/cli/tests/testdata/npm/create_require/main.out
@@ -4,6 +4,7 @@ function
 function
 function
 function
+function
 The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received https://example.com/
 The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received https://example.com/
 The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received 1

--- a/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/index.js
@@ -2,6 +2,9 @@ import { createRequire } from "module";
 
 console.log(typeof createRequire(import.meta.url));
 console.log(typeof createRequire(new URL(import.meta.url)));
+console.log(typeof createRequire("/"));
+console.log(typeof createRequire("/foo"));
+console.log(typeof createRequire("c:\\foo"));
 try {
   createRequire("https://example.com/");
 } catch (e) {
@@ -14,6 +17,16 @@ try {
 }
 try {
   createRequire(1);
+} catch (e) {
+  console.log(e.message);
+}
+try {
+  createRequire("foo");
+} catch (e) {
+  console.log(e.message);
+}
+try {
+  createRequire("./foo");
 } catch (e) {
   console.log(e.message);
 }

--- a/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/create-require/1.0.0/index.js
@@ -4,6 +4,7 @@ console.log(typeof createRequire(import.meta.url));
 console.log(typeof createRequire(new URL(import.meta.url)));
 console.log(typeof createRequire("/"));
 console.log(typeof createRequire("/foo"));
+console.log(typeof createRequire("/foo/"));
 console.log(typeof createRequire("c:\\foo"));
 try {
   createRequire("https://example.com/");

--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -818,6 +818,17 @@
     return require;
   }
 
+  // Matches to:
+  // - /foo/...
+  // - \foo\...
+  // - C:/foo/...
+  // - C:\foo\...
+  const RE_START_OF_ABS_PATH = /^([/\\]|[a-zA-Z]:[/\\])/;
+
+  function isAbsolute(filenameOrUrl) {
+    return RE_START_OF_ABS_PATH.test(filenameOrUrl);
+  }
+
   function createRequire(filenameOrUrl) {
     let fileUrlStr;
     if (filenameOrUrl instanceof URL) {
@@ -828,7 +839,7 @@
       }
       fileUrlStr = filenameOrUrl.toString();
     } else if (typeof filenameOrUrl === "string") {
-      if (!filenameOrUrl.startsWith("file:")) {
+      if (!filenameOrUrl.startsWith("file:") && !isAbsolute(filenameOrUrl)) {
         throw new Error(
           `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ${filenameOrUrl}`,
         );

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -242,7 +242,10 @@ where
 fn op_require_proxy_path(filename: String) -> String {
   // Allow a directory to be passed as the filename
   let trailing_slash = if cfg!(windows) {
-    filename.ends_with('\\')
+    // Node also counts a trailing forward slash as a
+    // directory for node on Windows, but not backslashes
+    // on non-Windows platforms
+    filename.ends_with('\\') || filename.ends_with('/')
   } else {
     filename.ends_with('/')
   };


### PR DESCRIPTION
This PR updates `createRequire` in `ext/node`. Now `createRequire` allows absolute paths as the arg. (Currently this implementation ignores the platform difference (allows both patterns `/`, `C:\`))

closes #16832