### PR TITLE
chore(tools): update deprecated commands in format.js

### DIFF
--- a/tools/format.js
+++ b/tools/format.js
@@ -5,12 +5,15 @@ import { getPrebuiltToolPath, join, ROOT_PATH } from "./util.js";
 async function dprint() {
   const configFile = join(ROOT_PATH, ".dprint.json");
   const execPath = getPrebuiltToolPath("dprint");
-  const { success } = await Deno.spawn(execPath, {
+  const cmd = new Deno.Command(execPath, {
     args: ["fmt", "--config=" + configFile],
     stdout: "inherit",
     stderr: "inherit",
   });
-  if (!success) {
+  cmd.spawn();
+  const { code } = await cmd.output();
+
+  if (code > 0) {
     throw new Error("dprint failed");
   }
 }
@@ -20,12 +23,14 @@ async function main() {
   await dprint();
 
   if (Deno.args.includes("--check")) {
-    const { success, stdout } = await Deno.spawn("git", {
+    const cmd = new Deno.Command("git", {
       args: ["status", "-uno", "--porcelain", "--ignore-submodules"],
       stderr: "inherit",
     });
+    cmd.spawn();
+    const { code, stdout } = await cmd.output();
 
-    if (!success) {
+    if (code > 0) {
       throw new Error("git status failed");
     }
     const out = new TextDecoder().decode(stdout);


### PR DESCRIPTION
Updates tools/format.js from Deno.spawn to Deno.Command API.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
