### PR TITLE
fix(ext/fetch): new Request should soft clone

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -315,12 +315,25 @@
         if (!ObjectPrototypeIsPrototypeOf(RequestPrototype, input)) {
           throw new TypeError("Unreachable");
         }
-        request = input[_request];
+        const originalReq = input[_request];
+        const originalMethod = originalReq.method;
+        const originalUrl = originalReq.url();
+        const clonedHeaders = ArrayPrototypeMap(
+          originalReq.headerList,
+          (x) => [x[0], x[1]],
+        );
+        request = newInnerRequest(
+          () => originalMethod,
+          () => originalUrl,
+          () => clonedHeaders,
+          null,
+          false,
+        );
+        request.redirectMode = originalReq.redirectMode;
         signal = input[_signal];
       }
 
-      // 12.
-      // TODO(lucacasonato): create a copy of `request`
+      // 12. is folded into the else statement of step 6 above.
 
       // 22.
       if (init.redirect !== undefined) {

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -157,14 +157,14 @@
    * @param {InnerRequest} request
    * @returns {InnerRequest}
    */
-  function cloneInnerRequest(request) {
+  function cloneInnerRequest(request, skipBody = false) {
     const headerList = ArrayPrototypeMap(
       request.headerList,
       (x) => [x[0], x[1]],
     );
 
     let body = null;
-    if (request.body !== null) {
+    if (request.body !== null && !skipBody) {
       body = request.body.clone();
     }
 
@@ -316,20 +316,9 @@
           throw new TypeError("Unreachable");
         }
         const originalReq = input[_request];
-        const originalMethod = originalReq.method;
-        const originalUrl = originalReq.url();
-        const clonedHeaders = ArrayPrototypeMap(
-          originalReq.headerList,
-          (x) => [x[0], x[1]],
-        );
-        request = newInnerRequest(
-          () => originalMethod,
-          () => originalUrl,
-          () => clonedHeaders,
-          null,
-          false,
-        );
-        request.redirectMode = originalReq.redirectMode;
+        // fold in of step 12 from below
+        request = cloneInnerRequest(originalReq, true);
+        request.redirectCount = 0; // reset to 0 - cloneInnerRequest copies the value
         signal = input[_signal];
       }
 

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -2555,13 +2555,9 @@
         "request-consume.any.html": true,
         "request-consume.any.worker.html": true,
         "request-disturbed.any.html": [
-          "Request construction failure should not set \"bodyUsed\"",
-          "Input request used for creating new request became disturbed",
           "Input request used for creating new request became disturbed even if body is not used"
         ],
         "request-disturbed.any.worker.html": [
-          "Request construction failure should not set \"bodyUsed\"",
-          "Input request used for creating new request became disturbed",
           "Input request used for creating new request became disturbed even if body is not used"
         ],
         "request-error.any.html": [


### PR DESCRIPTION
Previously the inner request object of the original and the new request
were the same, causing the requests to be entangled and mutable changes
to one to be visible to the other. This fixes that.

Fixes #16855