### PR TITLE
fix(fmt/markdown): fix emoji width calculation in tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,15 +1445,16 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-markdown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cf3bc0cb9cc526a894b1d5af07c2ce2af1fa56b765990845ec781ab4cd1c91"
+checksum = "999e8891976e3b15b519b920db4ac70c6a85f0c6f0e0ddb6ef3b247373e8984d"
 dependencies = [
  "anyhow",
  "dprint-core",
  "pulldown-cmark",
  "regex",
  "serde",
+ "unicode-width",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,7 +62,7 @@ clap_complete_fig = "=3.1.5"
 data-url.workspace = true
 dissimilar = "=1.0.4"
 dprint-plugin-json = "=0.16.0"
-dprint-plugin-markdown = "=0.14.2"
+dprint-plugin-markdown = "=0.14.3"
 dprint-plugin-typescript = "=0.78.0"
 encoding_rs.workspace = true
 env_logger = "=0.9.0"


### PR DESCRIPTION
https://github.com/dprint/dprint-plugin-markdown/pull/67