### PR TITLE
fix(repl): respect --quiet flag

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -460,6 +460,13 @@ impl CliOptions {
     self.flags.log_level
   }
 
+  pub fn is_quiet(&self) -> bool {
+    self
+      .log_level()
+      .map(|l| l == log::Level::Error)
+      .unwrap_or(false)
+  }
+
   pub fn location_flag(&self) -> Option<&Url> {
     self.flags.location.as_ref()
   }

--- a/cli/tests/repl_tests.rs
+++ b/cli/tests/repl_tests.rs
@@ -732,7 +732,7 @@ mod repl {
     );
     assert_contains!(
       test_util::strip_ansi_codes(&out),
-      "error in --eval flag. parse error: Unexpected token `%`."
+      "Error in --eval flag: parse error: Unexpected token `%`."
     );
     assert_contains!(out, "2500"); // should not prevent input
     assert!(err.is_empty());
@@ -747,7 +747,7 @@ mod repl {
       None,
       false,
     );
-    assert_contains!(out, "error in --eval flag. Uncaught Error: Testing");
+    assert_contains!(out, "Error in --eval flag: Uncaught Error: Testing");
     assert_contains!(out, "2500"); // should not prevent input
     assert!(err.is_empty());
   }

--- a/cli/tests/repl_tests.rs
+++ b/cli/tests/repl_tests.rs
@@ -881,4 +881,19 @@ mod repl {
     assert_contains!(out, "AggregateError");
     assert!(err.is_empty());
   }
+
+  #[test]
+  fn repl_with_quiet_flag() {
+    let (out, err) = util::run_and_collect_output_with_args(
+      true,
+      vec!["repl", "--quiet"],
+      Some(vec!["await Promise.resolve('done')"]),
+      Some(vec![("NO_COLOR".to_owned(), "1".to_owned())]),
+      false,
+    );
+    assert!(!out.contains("Deno"));
+    assert!(!out.contains("exit using ctrl+d, ctrl+c, or close()"));
+    assert_ends_with!(out, "\"done\"\n");
+    assert!(err.is_empty());
+  }
 }

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -101,11 +101,14 @@ pub async fn run(
             .await?;
           // only output errors
           if let EvaluationOutput::Error(error_text) = output {
-            println!("error in --eval-file file {}. {}", eval_file, error_text);
+            println!(
+              "Error in --eval-file file \"{}\": {}",
+              eval_file, error_text
+            );
           }
         }
         Err(e) => {
-          println!("error in --eval-file file {}. {}", eval_file, e);
+          println!("Error in --eval-file file \"{}\": {}", eval_file, e);
         }
       }
     }
@@ -115,12 +118,12 @@ pub async fn run(
     let output = repl_session.evaluate_line_and_get_output(&eval).await?;
     // only output errors
     if let EvaluationOutput::Error(error_text) = output {
-      println!("error in --eval flag. {}", error_text);
+      println!("Error in --eval flag: {}", error_text);
     }
   }
 
-  println!("Deno {}", crate::version::deno());
-  println!("exit using ctrl+d, ctrl+c, or close()");
+  log::info!("Deno {}", crate::version::deno());
+  log::info!("exit using ctrl+d, ctrl+c, or close()");
 
   loop {
     let line = read_line_and_poll(

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -122,8 +122,12 @@ pub async fn run(
     }
   }
 
-  log::info!("Deno {}", crate::version::deno());
-  log::info!("exit using ctrl+d, ctrl+c, or close()");
+  // Doing this manually, instead of using `log::info!` because these messages
+  // are supposed to go to stdout, not stderr.
+  if !ps.options.is_quiet() {
+    println!("Deno {}", crate::version::deno());
+    println!("exit using ctrl+d, ctrl+c, or close()");
+  }
 
   loop {
     let line = read_line_and_poll(


### PR DESCRIPTION
This commit changes REPL behavior to respect --quiet flag. Once 
this flag is present REPL will not print a banner at the start.

Closes https://github.com/denoland/deno/issues/16868