### PR TITLE
chore: remove unnecessary lifetimes

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -634,7 +634,7 @@ struct FileSystemDocuments {
 }
 
 impl FileSystemDocuments {
-  pub fn get<'a>(
+  pub fn get(
     &mut self,
     cache: &HttpCache,
     maybe_resolver: Option<&dyn deno_graph::source::Resolver>,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1279,8 +1279,8 @@ impl JsRuntime {
   }
 }
 
-fn get_stalled_top_level_await_message_for_module<'s>(
-  scope: &'s mut v8::HandleScope,
+fn get_stalled_top_level_await_message_for_module(
+  scope: &mut v8::HandleScope,
   module_id: ModuleId,
 ) -> Vec<v8::Global<v8::Message>> {
   let module_map = JsRuntime::module_map(scope);
@@ -1296,8 +1296,8 @@ fn get_stalled_top_level_await_message_for_module<'s>(
   messages
 }
 
-fn find_stalled_top_level_await<'s>(
-  scope: &'s mut v8::HandleScope,
+fn find_stalled_top_level_await(
+  scope: &mut v8::HandleScope,
 ) -> Vec<v8::Global<v8::Message>> {
   let module_map = JsRuntime::module_map(scope);
   let module_map = module_map.borrow();

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -117,13 +117,6 @@ async function clippy() {
       "--",
       "-D",
       "warnings",
-      "-A",
-      // https://github.com/rust-lang/rust-clippy/issues/407
-      "clippy::extra_unused_lifetimes",
-      "-A",
-      // https://github.com/rust-lang/rust-clippy/issues/7271
-      // False positives in core/resources.rs for lifetime elision.
-      "clippy::needless_lifetimes",
     ],
     stdout: "inherit",
     stderr: "inherit",


### PR DESCRIPTION
It seems we don't really need to allow these clippy rules.