### PR TITLE
chore(npm): fix types tests

### DIFF
--- a/cli/tests/npm_tests.rs
+++ b/cli/tests/npm_tests.rs
@@ -320,27 +320,27 @@ mod npm {
   });
 
   itest!(types_entry_value_not_exists {
-    args: "run --check=all npm/types_entry_value_not_exists/main.ts",
+    args: "check --remote npm/types_entry_value_not_exists/main.ts",
     output: "npm/types_entry_value_not_exists/main.out",
     envs: env_vars_for_npm_tests(),
     http_server: true,
-    exit_code: 0,
+    exit_code: 1,
   });
 
   itest!(types_exports_import_types {
-    args: "run --check=all npm/types_exports_import_types/main.ts",
+    args: "check --remote npm/types_exports_import_types/main.ts",
     output: "npm/types_exports_import_types/main.out",
     envs: env_vars_for_npm_tests(),
     http_server: true,
-    exit_code: 0,
+    exit_code: 1,
   });
 
   itest!(types_no_types_entry {
-    args: "run --check=all npm/types_no_types_entry/main.ts",
+    args: "check --remote npm/types_no_types_entry/main.ts",
     output: "npm/types_no_types_entry/main.out",
     envs: env_vars_for_npm_tests(),
     http_server: true,
-    exit_code: 0,
+    exit_code: 1,
   });
 
   itest!(typescript_file_in_package {

--- a/cli/tests/testdata/npm/types_entry_value_not_exists/main.out
+++ b/cli/tests/testdata/npm/types_entry_value_not_exists/main.out
@@ -1,4 +1,7 @@
 Download http://localhost:4545/npm/registry/@denotest/types-entry-value-not-exists
 Download http://localhost:4545/npm/registry/@denotest/types-entry-value-not-exists/1.0.0.tgz
 Check file://[WILDCARD]/types_entry_value_not_exists/main.ts
-5
+error: TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
+const result: string = getValue();
+      ~~~~~~
+    at file:///[WILDCARD]/main.ts:4:7

--- a/cli/tests/testdata/npm/types_entry_value_not_exists/main.ts
+++ b/cli/tests/testdata/npm/types_entry_value_not_exists/main.ts
@@ -1,4 +1,5 @@
 import { getValue } from "npm:@denotest/types-entry-value-not-exists";
 
-const result: 5 = getValue();
+// should error here
+const result: string = getValue();
 console.log(result);

--- a/cli/tests/testdata/npm/types_exports_import_types/main.out
+++ b/cli/tests/testdata/npm/types_exports_import_types/main.out
@@ -1,4 +1,7 @@
 Download http://localhost:4545/npm/registry/@denotest/types-exports-import-types
 Download http://localhost:4545/npm/registry/@denotest/types-exports-import-types/1.0.0.tgz
 Check file://[WILDCARD]/types_exports_import_types/main.ts
-5
+error: TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
+const result: string = getValue();
+      ~~~~~~
+    at file:///[WILDCARD]/main.ts:4:7

--- a/cli/tests/testdata/npm/types_exports_import_types/main.ts
+++ b/cli/tests/testdata/npm/types_exports_import_types/main.ts
@@ -1,4 +1,5 @@
 import { getValue } from "npm:@denotest/types-exports-import-types";
 
-const result: 5 = getValue();
+// should error here
+const result: string = getValue();
 console.log(result);

--- a/cli/tests/testdata/npm/types_no_types_entry/main.out
+++ b/cli/tests/testdata/npm/types_no_types_entry/main.out
@@ -1,4 +1,7 @@
 Download http://localhost:4545/npm/registry/@denotest/types-no-types-entry
 Download http://localhost:4545/npm/registry/@denotest/types-no-types-entry/1.0.0.tgz
 Check file://[WILDCARD]/types_no_types_entry/main.ts
-5
+error: TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
+const result: string = getValue();
+      ~~~~~~
+    at file:///[WILDCARD]/main.ts:4:7

--- a/cli/tests/testdata/npm/types_no_types_entry/main.ts
+++ b/cli/tests/testdata/npm/types_no_types_entry/main.ts
@@ -1,4 +1,5 @@
 import { getValue } from "npm:@denotest/types-no-types-entry";
 
-const result: 5 = getValue();
+// should error here
+const result: string = getValue();
 console.log(result);


### PR DESCRIPTION
In #16880 I blindly copied the last types test and I just realized that these tests would not fail if the functionality became broken because then the type would be `any`. This fixes that.