### PR TITLE
chore: rewrite tests and utils to use Deno.Command API

### DIFF
--- a/cli/tests/testdata/run/045_proxy_test.ts
+++ b/cli/tests/testdata/run/045_proxy_test.ts
@@ -31,7 +31,7 @@ async function handler(req: Request): Promise<Response> {
 }
 
 async function testFetch() {
-  const { code } = await Deno.spawn(Deno.execPath(), {
+  const { code } = await new Deno.Command(Deno.execPath(), {
     args: [
       "run",
       "--quiet",
@@ -42,13 +42,13 @@ async function testFetch() {
     env: {
       HTTP_PROXY: `http://${addr}`,
     },
-  });
+  }).output();
 
   assertEquals(code, 0);
 }
 
 async function testModuleDownload() {
-  const { code } = await Deno.spawn(Deno.execPath(), {
+  const { code } = await new Deno.Command(Deno.execPath(), {
     args: [
       "cache",
       "--reload",
@@ -58,13 +58,13 @@ async function testModuleDownload() {
     env: {
       HTTP_PROXY: `http://${addr}`,
     },
-  });
+  }).output();
 
   assertEquals(code, 0);
 }
 
 async function testFetchNoProxy() {
-  const { code } = await Deno.spawn(Deno.execPath(), {
+  const { code } = await new Deno.Command(Deno.execPath(), {
     args: [
       "run",
       "--quiet",
@@ -76,13 +76,13 @@ async function testFetchNoProxy() {
       HTTP_PROXY: "http://not.exising.proxy.server",
       NO_PROXY: "localhost",
     },
-  });
+  }).output();
 
   assertEquals(code, 0);
 }
 
 async function testModuleDownloadNoProxy() {
-  const { code } = await Deno.spawn(Deno.execPath(), {
+  const { code } = await new Deno.Command(Deno.execPath(), {
     args: [
       "cache",
       "--reload",
@@ -93,13 +93,13 @@ async function testModuleDownloadNoProxy() {
       HTTP_PROXY: "http://not.exising.proxy.server",
       NO_PROXY: "localhost",
     },
-  });
+  }).output();
 
   assertEquals(code, 0);
 }
 
 async function testFetchProgrammaticProxy() {
-  const { code } = await Deno.spawn(Deno.execPath(), {
+  const { code } = await new Deno.Command(Deno.execPath(), {
     args: [
       "run",
       "--quiet",
@@ -108,7 +108,7 @@ async function testFetchProgrammaticProxy() {
       "--unstable",
       "run/045_programmatic_proxy_client.ts",
     ],
-  });
+  }).output();
   assertEquals(code, 0);
 }
 

--- a/cli/tests/testdata/run/089_run_allow_list.ts
+++ b/cli/tests/testdata/run/089_run_allow_list.ts
@@ -1,12 +1,12 @@
 try {
-  await Deno.spawn("ls");
+  await new Deno.Command("ls").output();
 } catch (e) {
   console.log(e);
 }
 
-const { success } = await Deno.spawn("curl", {
+const { success } = await new Deno.Command("curl", {
   args: ["--help"],
   stdout: "null",
   stderr: "inherit",
-});
+}).output();
 console.log(success);

--- a/cli/tests/testdata/run/lock_write_fetch/main.ts
+++ b/cli/tests/testdata/run/lock_write_fetch/main.ts
@@ -4,7 +4,7 @@ try {
   // pass
 }
 
-const fetchProc = await Deno.spawn(Deno.execPath(), {
+const fetchProc = await new Deno.Command(Deno.execPath(), {
   stdout: "null",
   stderr: "null",
   args: [
@@ -15,11 +15,11 @@ const fetchProc = await Deno.spawn(Deno.execPath(), {
     "--cert=tls/RootCA.pem",
     "run/https_import.ts",
   ],
-});
+}).output();
 
 console.log(`fetch code: ${fetchProc.code}`);
 
-const fetchCheckProc = await Deno.spawn(Deno.execPath(), {
+const fetchCheckProc = await new Deno.Command(Deno.execPath(), {
   stdout: "null",
   stderr: "null",
   args: [
@@ -28,13 +28,13 @@ const fetchCheckProc = await Deno.spawn(Deno.execPath(), {
     "--cert=tls/RootCA.pem",
     "run/https_import.ts",
   ],
-});
+}).output();
 
 console.log(`fetch check code: ${fetchCheckProc.code}`);
 
 Deno.removeSync("./lock_write_fetch.json");
 
-const runProc = await Deno.spawn(Deno.execPath(), {
+const runProc = await new Deno.Command(Deno.execPath(), {
   stdout: "null",
   stderr: "null",
   args: [
@@ -45,7 +45,7 @@ const runProc = await Deno.spawn(Deno.execPath(), {
     "run/lock_write_fetch/file_exists.ts",
     "lock_write_fetch.json",
   ],
-});
+}).output();
 
 console.log(`run code: ${runProc.code}`);
 

--- a/cli/tests/testdata/run/no_prompt.ts
+++ b/cli/tests/testdata/run/no_prompt.ts
@@ -1,10 +1,10 @@
 new Worker("data:,setTimeout(() => Deno.exit(2), 200)", { type: "module" });
 
 try {
-  await Deno.spawn("ps", {
+  await new Deno.Command("ps", {
     stdout: "inherit",
     stderr: "inherit",
-  });
+  }).output();
 } catch {
   Deno.exit(0);
 }

--- a/cli/tests/testdata/run/permission_test.ts
+++ b/cli/tests/testdata/run/permission_test.ts
@@ -16,9 +16,9 @@ const test: { [key: string]: (...args: any[]) => void | Promise<void> } = {
     Deno.listen({ transport: "tcp", port: 4541 });
   },
   async runRequired() {
-    await Deno.spawn(Deno.build.os === "windows" ? "cmd.exe" : "printf", {
+    await new Deno.Command(Deno.build.os === "windows" ? "cmd.exe" : "printf", {
       args: Deno.build.os === "windows" ? ["/c", "echo hello"] : ["hello"],
-    });
+    }).output();
   },
 };
 

--- a/cli/tests/testdata/run/spawn_stdout_inherit.ts
+++ b/cli/tests/testdata/run/spawn_stdout_inherit.ts
@@ -1,8 +1,8 @@
-await Deno.spawn(Deno.execPath(), {
+await new Deno.Command(Deno.execPath(), {
   args: ["eval", "--quiet", "console.log('Hello, world! 1')"],
   stdout: "inherit",
-});
-Deno.spawnSync(Deno.execPath(), {
+}).output();
+new Deno.Command(Deno.execPath(), {
   args: ["eval", "--quiet", "console.log('Hello, world! 2')"],
   stdout: "inherit",
-});
+}).outputSync();

--- a/cli/tests/testdata/test/captured_output.ts
+++ b/cli/tests/testdata/test/captured_output.ts
@@ -4,21 +4,21 @@ Deno.test("output", async () => {
   });
   await p.status();
   await p.close();
-  Deno.spawnSync(Deno.execPath(), {
+  new Deno.Command(Deno.execPath(), {
     args: ["eval", "console.log(2); console.error(3);"],
     stdout: "inherit",
     stderr: "inherit",
-  });
+  }).outputSync();
   await new Deno.Command(Deno.execPath(), {
     args: ["eval", "console.log(4); console.error(5);"],
     stdout: "inherit",
     stderr: "inherit",
   }).output();
-  const c = await Deno.spawnChild(Deno.execPath(), {
+  const c = new Deno.Command(Deno.execPath(), {
     args: ["eval", "console.log(6); console.error(7);"],
     stdout: "inherit",
     stderr: "inherit",
-  });
+  }).spawn();
   await c.status;
   const worker = new Worker(
     import.meta.resolve("./captured_output.worker.js"),

--- a/cli/tests/testdata/test/captured_output.ts
+++ b/cli/tests/testdata/test/captured_output.ts
@@ -9,11 +9,11 @@ Deno.test("output", async () => {
     stdout: "inherit",
     stderr: "inherit",
   });
-  await Deno.spawn(Deno.execPath(), {
+  await new Deno.Command(Deno.execPath(), {
     args: ["eval", "console.log(4); console.error(5);"],
     stdout: "inherit",
     stderr: "inherit",
-  });
+  }).output();
   const c = await Deno.spawnChild(Deno.execPath(), {
     args: ["eval", "console.log(6); console.error(7);"],
     stdout: "inherit",

--- a/cli/tests/unit/chown_test.ts
+++ b/cli/tests/unit/chown_test.ts
@@ -5,12 +5,12 @@ import { assertEquals, assertRejects, assertThrows } from "./test_util.ts";
 
 async function getUidAndGid(): Promise<{ uid: number; gid: number }> {
   // get the user ID and group ID of the current process
-  const uidProc = await Deno.spawn("id", {
+  const uidProc = await new Deno.Command("id", {
     args: ["-u"],
-  });
-  const gidProc = await Deno.spawn("id", {
+  }).output();
+  const gidProc = await new Deno.Command("id", {
     args: ["-g"],
-  });
+  }).output();
 
   assertEquals(uidProc.code, 0);
   assertEquals(gidProc.code, 0);

--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -1033,11 +1033,11 @@ Deno.test(
     await listeningPromise;
     const url = `http://${hostname}:${port}/`;
     const args = ["-X", "DELETE", url];
-    const { success } = await Deno.spawn("curl", {
+    const { success } = await new Deno.Command("curl", {
       args,
       stdout: "null",
       stderr: "null",
-    });
+    }).output();
     assert(success);
     await promise;
     ac.abort();

--- a/cli/tests/unit/flock_test.ts
+++ b/cli/tests/unit/flock_test.ts
@@ -148,10 +148,10 @@ function runFlockTestProcess(opts: { exclusive: boolean; sync: boolean }) {
     console.log(JSON.stringify({ enterTime, exitTime }));
 `;
 
-  const process = Deno.spawnChild(Deno.execPath(), {
+  const process = new Deno.Command(Deno.execPath(), {
     args: ["eval", "--unstable", scriptText],
     stdin: "piped",
-  });
+  }).spawn();
 
   const waitSignal = async () => {
     const reader = process.stdout.getReader({ mode: "byob" });

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1430,7 +1430,7 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const proc = Deno.spawnChild("curl", { args, stderr: "null" });
+      const proc = new Deno.Command("curl", { args, stderr: "null" }).spawn();
       const status = await proc.status;
       assert(status.success);
       const stdout = proc.stdout
@@ -1939,7 +1939,7 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const proc = Deno.spawnChild("curl", { args, stderr: "null" });
+      const proc = new Deno.Command("curl", { args, stderr: "null" }).spawn();
       const status = await proc.status;
       assert(status.success);
       const stdout = proc.stdout
@@ -2569,7 +2569,7 @@ Deno.test({
         "Accept-Encoding: gzip, deflate, br",
         "--no-buffer",
       ];
-      const proc = Deno.spawnChild("curl", { args, stderr: "null" });
+      const proc = new Deno.Command("curl", { args, stderr: "null" }).spawn();
       const stdout = proc.stdout
         .pipeThrough(new DecompressionStream("gzip"))
         .pipeThrough(new TextDecoderStream());

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1249,11 +1249,11 @@ Deno.test(
     async function client() {
       const url = `http://${hostname}:${port}/`;
       const args = ["-X", "DELETE", url];
-      const { success } = await Deno.spawn("curl", {
+      const { success } = await new Deno.Command("curl", {
         args,
         stdout: "null",
         stderr: "null",
-      });
+      }).output();
       assert(success);
     }
 
@@ -1380,10 +1380,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -1485,10 +1485,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout).toLocaleLowerCase();
       assert(output.includes("vary: accept-encoding\r\n"));
@@ -1540,10 +1540,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip;q=0.8, br;q=1.0, *;q=0.1",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -1592,10 +1592,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding, Accept\r\n"));
@@ -1648,10 +1648,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -1706,10 +1706,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -1764,10 +1764,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -1819,10 +1819,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -1880,10 +1880,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));
@@ -2004,10 +2004,10 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const { success, stdout } = await Deno.spawn("curl", {
+      const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
-      });
+      }).output();
       assert(success);
       const output = decoder.decode(stdout);
       assert(output.includes("vary: Accept-Encoding\r\n"));

--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -74,10 +74,10 @@ Deno.test(
       console.log(
         ${JSON.stringify(Object.keys(expectedEnv))}.map(k => Deno.env.get(k))
       )`;
-      const { success, stdout } = await Deno.spawn(Deno.execPath(), {
+      const { success, stdout } = await new Deno.Command(Deno.execPath(), {
         args: ["eval", src],
         env: { ...inputEnv, NO_COLOR: "1" },
-      });
+      }).output();
       assertEquals(success, true);
       const expectedValues = Object.values(expectedEnv);
       const actualValues = JSON.parse(new TextDecoder().decode(stdout));
@@ -162,10 +162,10 @@ Deno.test(
   { permissions: { run: true, read: true } },
   async function osPpidIsEqualToPidOfParentProcess() {
     const decoder = new TextDecoder();
-    const { stdout } = await Deno.spawn(Deno.execPath(), {
+    const { stdout } = await new Deno.Command(Deno.execPath(), {
       args: ["eval", "-p", "--unstable", "Deno.ppid"],
       env: { NO_COLOR: "true" },
-    });
+    }).output();
 
     const expected = Deno.pid;
     const actual = parseInt(decoder.decode(stdout));
@@ -212,9 +212,9 @@ Deno.test(
   { permissions: { run: [Deno.execPath()], read: true } },
   // See https://github.com/denoland/deno/issues/16527
   async function hostnameWithoutOtherNetworkUsages() {
-    const { stdout } = await Deno.spawn(Deno.execPath(), {
+    const { stdout } = await new Deno.Command(Deno.execPath(), {
       args: ["eval", "-p", "Deno.hostname()"],
-    });
+    }).output();
     const hostname = new TextDecoder().decode(stdout).trim();
     assert(hostname.length > 0);
   },

--- a/cli/tests/unit/remove_test.ts
+++ b/cli/tests/unit/remove_test.ts
@@ -260,10 +260,10 @@ if (Deno.build.os === "windows") {
   Deno.test(
     { permissions: { run: true, write: true, read: true } },
     async function removeFileSymlink() {
-      const { success } = await Deno.spawn("cmd", {
+      const { success } = await new Deno.Command("cmd", {
         args: ["/c", "mklink", "file_link", "bar"],
         stdout: "null",
-      });
+      }).output();
 
       assert(success);
       await Deno.remove("file_link");
@@ -276,10 +276,10 @@ if (Deno.build.os === "windows") {
   Deno.test(
     { permissions: { run: true, write: true, read: true } },
     async function removeDirSymlink() {
-      const { success } = await Deno.spawn("cmd", {
+      const { success } = await new Deno.Command("cmd", {
         args: ["/c", "mklink", "/d", "dir_link", "bar"],
         stdout: "null",
-      });
+      }).output();
 
       assert(success);
       await Deno.remove("dir_link");

--- a/cli/tests/unit/signal_test.ts
+++ b/cli/tests/unit/signal_test.ts
@@ -185,13 +185,13 @@ Deno.test(
     permissions: { run: true, read: true },
   },
   async function canExitWhileListeningToSignal() {
-    const { code } = await Deno.spawn(Deno.execPath(), {
+    const { code } = await new Deno.Command(Deno.execPath(), {
       args: [
         "eval",
         "--unstable",
         "Deno.addSignalListener('SIGINT', () => {})",
       ],
-    });
+    }).output();
     assertEquals(code, 0);
   },
 );

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -32,13 +32,13 @@ export function pathToAbsoluteFileUrl(path: string): URL {
 const decoder = new TextDecoder();
 
 export async function execCode(code: string): Promise<[number, string]> {
-  const output = await Deno.spawn(Deno.execPath(), {
+  const output = await new Deno.Command(Deno.execPath(), {
     args: [
       "eval",
       "--unstable",
       "--no-check",
       code,
     ],
-  });
+  }).output();
   return [output.code, decoder.decode(output.stdout)];
 }

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -1046,9 +1046,9 @@ function createHttpsListener(port: number): Deno.Listener {
 }
 
 async function curl(url: string): Promise<string> {
-  const { success, code, stdout } = await Deno.spawn("curl", {
+  const { success, code, stdout } = await new Deno.Command("curl", {
     args: ["--insecure", url],
-  });
+  }).output();
 
   if (!success) {
     throw new Error(`curl ${url} failed: ${code}`);

--- a/cli/tests/unit/tty_color_test.ts
+++ b/cli/tests/unit/tty_color_test.ts
@@ -6,9 +6,9 @@ import { assertEquals } from "./test_util.ts";
 Deno.test(
   { permissions: { run: true, read: true } },
   async function noColorIfNotTty() {
-    const { stdout } = await Deno.spawn(Deno.execPath(), {
+    const { stdout } = await new Deno.Command(Deno.execPath(), {
       args: ["eval", "console.log(1)"],
-    });
+    }).output();
     const output = new TextDecoder().decode(stdout);
     assertEquals(output, "1\n");
   },

--- a/tools/flamebench.js
+++ b/tools/flamebench.js
@@ -3,11 +3,11 @@
 import { join, ROOT_PATH as ROOT } from "./util.js";
 
 async function bashOut(subcmd) {
-  const { success, stdout } = await Deno.spawn("bash", {
+  const { success, stdout } = await new Deno.Command("bash", {
     args: ["-c", subcmd],
     stdout: "piped",
     stderr: "null",
-  });
+  }).output();
 
   // Check for failure
   if (!success) {
@@ -20,12 +20,12 @@ async function bashOut(subcmd) {
 }
 
 async function bashThrough(subcmd, opts = {}) {
-  const { success, code } = await Deno.spawn("bash", {
+  const { success, code } = await new Deno.Command("bash", {
     ...opts,
     args: ["-c", subcmd],
     stdout: "inherit",
     stderr: "inherit",
-  });
+  }).output();
 
   // Exit process on failure
   if (!success) {

--- a/tools/util.js
+++ b/tools/util.js
@@ -14,10 +14,10 @@ export { delay } from "../test_util/std/async/delay.ts";
 export const ROOT_PATH = dirname(dirname(fromFileUrl(import.meta.url)));
 
 async function getFilesFromGit(baseDir, args) {
-  const { success, stdout } = await Deno.spawn("git", {
+  const { success, stdout } = await new Deno.Command("git", {
     stderr: "inherit",
     args,
-  });
+  }).output();
   const output = new TextDecoder().decode(stdout);
   if (!success) {
     throw new Error("gitLsFiles failed");

--- a/tools/wgpu_sync.js
+++ b/tools/wgpu_sync.js
@@ -9,12 +9,12 @@ const V_WGPU = "0.13";
 const TARGET_DIR = join(ROOT_PATH, "ext", "webgpu");
 
 async function bash(subcmd, opts = {}) {
-  const { success, code } = await Deno.spawn("bash", {
+  const { success, code } = await new Deno.Command("bash", {
     ...opts,
     args: ["-c", subcmd],
     stdout: "inherit",
     sdterr: "inherit",
-  });
+  }).output();
 
   // Exit process on failure
   if (!success) {

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -107,14 +107,14 @@ export async function runSingleTest(
       "[]",
     );
 
-    const proc = Deno.spawnChild(denoBinary(), {
+    const proc = new Deno.Command(denoBinary(), {
       args,
       env: {
         NO_COLOR: "1",
       },
       stdout: "null",
       stderr: "piped",
-    });
+    }).spawn();
 
     const cases = [];
     let stderr = "";

--- a/tools/wpt/utils.ts
+++ b/tools/wpt/utils.ts
@@ -148,12 +148,12 @@ export async function checkPy3Available() {
 
 export async function cargoBuild() {
   if (binary) return;
-  const { success } = await Deno.spawn("cargo", {
+  const { success } = await new Deno.Command("cargo", {
     args: ["build", ...(release ? ["--release"] : [])],
     cwd: ROOT_PATH,
     stdout: "inherit",
     stderr: "inherit",
-  });
+  }).output();
   assert(success, "cargo build failed");
 }
 
@@ -175,16 +175,16 @@ export async function generateRunInfo(): Promise<unknown> {
     "darwin": "mac",
     "linux": "linux",
   };
-  const proc = await Deno.spawn("git", {
+  const proc = await new Deno.Command("git", {
     args: ["rev-parse", "HEAD"],
     cwd: join(ROOT_PATH, "test_util", "wpt"),
     stderr: "inherit",
-  });
+  }).output();
   const revision = (new TextDecoder().decode(proc.stdout)).trim();
-  const proc2 = await Deno.spawn(denoBinary(), {
+  const proc2 = await new Deno.Command(denoBinary(), {
     args: ["eval", "console.log(JSON.stringify(Deno.version))"],
     cwd: join(ROOT_PATH, "test_util", "wpt"),
-  });
+  }).output();
   const version = JSON.parse(new TextDecoder().decode(proc2.stdout));
   const runInfo = {
     "os": oses[Deno.build.os],

--- a/tools/wpt/utils.ts
+++ b/tools/wpt/utils.ts
@@ -118,18 +118,18 @@ export function assert(condition: unknown, message: string): asserts condition {
   }
 }
 
-export function runPy<T extends Omit<Deno.SpawnOptions, "cwd">>(
+export function runPy<T extends Omit<Deno.CommandOptions, "cwd">>(
   args: string[],
   options: T,
-): Deno.Child<T> {
+): Deno.ChildProcess {
   const cmd = Deno.build.os == "windows" ? "python.exe" : "python3";
-  return Deno.spawnChild(cmd, {
+  return new Deno.Command(cmd, {
     args,
     stdout: "inherit",
     stderr: "inherit",
     ...options,
     cwd: join(ROOT_PATH, "./test_util/wpt/"),
-  });
+  }).spawn();
 }
 
 export async function checkPy3Available() {


### PR DESCRIPTION
Since "Deno.spawn()", "Deno.spawnSync()" and "Deno.spawnChild"
are getting deprecated, this commits rewrites all tests and utilities to
use "Deno.Command" API instead.