### PR TITLE
deps: bump textwrap to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4803,9 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 
 [[package]]
 name = "thiserror"


### PR DESCRIPTION
As [textwrap 0.15.1 got yanked](https://github.com/mgeisler/textwrap/issues/484), it caused some build issue [in the homebrew side](https://github.com/Homebrew/homebrew-core/pull/116662), bumping the dependency to 0.15.2.
