### PR TITLE
perf(web): improve encodeInto performance

### DIFF
--- a/ext/web/08_text_encoding.js
+++ b/ext/web/08_text_encoding.js
@@ -162,6 +162,11 @@
   webidl.configurePrototype(TextDecoder);
   const TextDecoderPrototype = TextDecoder.prototype;
 
+  const encodeIntoResult = {
+    read: 0,
+    written: 0,
+  };
+
   class TextEncoder {
     constructor() {
       this[webidl.brand] = webidl.brand;
@@ -195,24 +200,10 @@
      * @returns {TextEncoderEncodeIntoResult}
      */
     encodeInto(source, destination) {
-      webidl.assertBranded(this, TextEncoderPrototype);
-      const prefix = "Failed to execute 'encodeInto' on 'TextEncoder'";
-      // The WebIDL type of `source` is `USVString`, but the ops bindings
-      // already convert lone surrogates to the replacement character.
-      source = webidl.converters.DOMString(source, {
-        prefix,
-        context: "Argument 1",
-      });
-      destination = webidl.converters.Uint8Array(destination, {
-        prefix,
-        context: "Argument 2",
-        allowShared: true,
-      });
       ops.op_encoding_encode_into(source, destination, encodeIntoBuf);
-      return {
-        read: encodeIntoBuf[0],
-        written: encodeIntoBuf[1],
-      };
+      encodeIntoResult.read = encodeIntoBuf[0];
+      encodeIntoResult.written = encodeIntoBuf[1];
+      return encodeIntoResult;
     }
   }
 

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -388,7 +388,7 @@ fn op_encoding_encode_into(
     Cow::Borrowed(v) => v[..boundary].len() as u32,
     Cow::Owned(v) => v[..boundary].encode_utf16().count() as u32,
   };
-  out_buf[1] = boundary as u32;
+  out_buf[1] = boundary as u32
 }
 
 #[op(v8)]

--- a/ops/optimizer.rs
+++ b/ops/optimizer.rs
@@ -123,13 +123,8 @@ impl Transform {
           parse_quote! { *const #core::v8::fast_api::FastApiTypedArray<u32> };
 
         q!(Vars { var: &ident }, {
-          let var = match unsafe { &*var }.get_storage_if_aligned() {
-            Some(v) => v,
-            None => {
-              unsafe { &mut *fast_api_callback_options }.fallback = true;
-              return Default::default();
-            }
-          };
+          let var =
+            unsafe { (&*var).get_storage_if_aligned().unwrap_unchecked() };
         })
       }
       // &[u8]
@@ -138,13 +133,8 @@ impl Transform {
           parse_quote! { *const #core::v8::fast_api::FastApiTypedArray<u8> };
 
         q!(Vars { var: &ident }, {
-          let var = match unsafe { &*var }.get_storage_if_aligned() {
-            Some(v) => v,
-            None => {
-              unsafe { &mut *fast_api_callback_options }.fallback = true;
-              return Default::default();
-            }
-          };
+          let var =
+            unsafe { (&*var).get_storage_if_aligned().unwrap_unchecked() };
         })
       }
       // &str
@@ -678,7 +668,6 @@ impl Optimizer {
               match segment {
                 // Is `T` a u8?
                 PathSegment { ident, .. } if ident == "u8" => {
-                  self.needs_fast_callback_option = true;
                   self.fast_parameters.push(FastValue::Uint8Array);
                   assert!(self
                     .transforms
@@ -687,7 +676,6 @@ impl Optimizer {
                 }
                 // Is `T` a u32?
                 PathSegment { ident, .. } if ident == "u32" => {
-                  self.needs_fast_callback_option = true;
                   self.fast_parameters.push(FastValue::Uint32Array);
                   assert!(self
                     .transforms

--- a/ops/optimizer_tests/async_result.expected
+++ b/ops/optimizer_tests/async_result.expected
@@ -3,7 +3,7 @@ returns_result: true
 has_ref_opstate: false
 has_rc_opstate: true
 has_fast_callback_option: false
-needs_fast_callback_option: true
+needs_fast_callback_option: false
 fast_result: None
 fast_parameters: [V8Value, I32, U32, Uint8Array]
 transforms: {2: Transform { kind: SliceU8(true), index: 2 }}

--- a/ops/optimizer_tests/async_result.out
+++ b/ops/optimizer_tests/async_result.out
@@ -168,13 +168,7 @@ fn op_read_fast_fn<'scope>(
             as *const _ops::OpCtx)
     };
     let state = __ctx.state.clone();
-    let buf = match unsafe { &*buf }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
+    let buf = unsafe { (&*buf).get_storage_if_aligned().unwrap_unchecked() };
     let result = op_read::call(state, rid, buf);
     let __op_id = __ctx.id;
     let __state = ::std::cell::RefCell::borrow(&__ctx.state);

--- a/ops/optimizer_tests/op_state_with_transforms.expected
+++ b/ops/optimizer_tests/op_state_with_transforms.expected
@@ -3,7 +3,7 @@ returns_result: false
 has_ref_opstate: true
 has_rc_opstate: false
 has_fast_callback_option: false
-needs_fast_callback_option: true
+needs_fast_callback_option: false
 fast_result: Some(Void)
 fast_parameters: [V8Value, Uint8Array]
 transforms: {1: Transform { kind: SliceU8(true), index: 1 }}

--- a/ops/optimizer_tests/op_state_with_transforms.out
+++ b/ops/optimizer_tests/op_state_with_transforms.out
@@ -142,13 +142,7 @@ where
             as *const _ops::OpCtx)
     };
     let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let buf = match unsafe { &*buf }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
+    let buf = unsafe { (&*buf).get_storage_if_aligned().unwrap_unchecked() };
     let result = op_now::call::<TP>(state, buf);
     result
 }

--- a/ops/optimizer_tests/raw_ptr.out
+++ b/ops/optimizer_tests/raw_ptr.out
@@ -176,13 +176,7 @@ where
             return Default::default();
         }
     };
-    let out = match unsafe { &*out }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
+    let out = unsafe { (&*out).get_storage_if_aligned().unwrap_unchecked() };
     let result = op_ffi_ptr_of::call::<FP>(state, buf, out);
     result
 }

--- a/ops/optimizer_tests/uint8array.expected
+++ b/ops/optimizer_tests/uint8array.expected
@@ -3,7 +3,7 @@ returns_result: false
 has_ref_opstate: false
 has_rc_opstate: false
 has_fast_callback_option: false
-needs_fast_callback_option: true
+needs_fast_callback_option: false
 fast_result: Some(Bool)
 fast_parameters: [V8Value, Uint8Array, Uint8Array]
 transforms: {0: Transform { kind: SliceU8(false), index: 0 }, 1: Transform { kind: SliceU8(true), index: 1 }}

--- a/ops/optimizer_tests/uint8array.out
+++ b/ops/optimizer_tests/uint8array.out
@@ -158,7 +158,7 @@ impl<'scope> deno_core::v8::fast_api::FastFunction for op_import_spki_x25519_fas
     fn args(&self) -> &'static [deno_core::v8::fast_api::Type] {
         use deno_core::v8::fast_api::Type::*;
         use deno_core::v8::fast_api::CType;
-        &[V8Value, TypedArray(CType::Uint8), TypedArray(CType::Uint8), CallbackOptions]
+        &[V8Value, TypedArray(CType::Uint8), TypedArray(CType::Uint8)]
     }
     fn return_type(&self) -> deno_core::v8::fast_api::CType {
         deno_core::v8::fast_api::CType::Bool
@@ -168,24 +168,11 @@ fn op_import_spki_x25519_fast_fn<'scope>(
     _: deno_core::v8::Local<deno_core::v8::Object>,
     key_data: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
     out: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
 ) -> bool {
     use deno_core::v8;
     use deno_core::_ops;
-    let key_data = match unsafe { &*key_data }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
-    let out = match unsafe { &*out }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
+    let key_data = unsafe { (&*key_data).get_storage_if_aligned().unwrap_unchecked() };
+    let out = unsafe { (&*out).get_storage_if_aligned().unwrap_unchecked() };
     let result = op_import_spki_x25519::call(key_data, out);
     result
 }


### PR DESCRIPTION
1.7x improvement for small strings.

```
time 133 ms rate 75187969
```

```
time 222 ms rate 45045045
```