### PR TITLE
fix(npm): add warning about DENO_NPM_REGISTRY env var being unstable

### DIFF
--- a/cli/npm/registry.rs
+++ b/cli/npm/registry.rs
@@ -234,18 +234,20 @@ impl RealNpmRegistryApi {
       let registry_url = format!("{}/", registry_url.trim_end_matches('/'));
       match Url::parse(&registry_url) {
         Ok(url) => {
-          log::warn!(
-            "{}",
-            colors::yellow(
-              "Note: DENO_NPM_REGISTRY is unstable and may change."
-            )
+          let message = format!(
+            "Note: {} is unstable and may break in a future release.",
+            env_var_name
           );
+          log::warn!("{}", colors::yellow(message));
           url
         }
         Err(err) => {
-          eprintln!("{}: Invalid {} environment variable. Please provide a valid url.\n\n{:#}",
-          colors::red_bold("error"),
-          env_var_name, err);
+          eprintln!(
+            "{}: Invalid {} environment variable. Please provide a valid url.\n\n{:#}",
+            colors::red_bold("error"),
+            env_var_name,
+            err,
+          );
           std::process::exit(1);
         }
       }

--- a/cli/npm/registry.rs
+++ b/cli/npm/registry.rs
@@ -233,7 +233,15 @@ impl RealNpmRegistryApi {
       // ensure there is a trailing slash for the directory
       let registry_url = format!("{}/", registry_url.trim_end_matches('/'));
       match Url::parse(&registry_url) {
-        Ok(url) => url,
+        Ok(url) => {
+          log::warn!(
+            "{}",
+            colors::yellow(
+              "Note: DENO_NPM_REGISTRY is unstable and may change."
+            )
+          );
+          url
+        }
         Err(err) => {
           eprintln!("{}: Invalid {} environment variable. Please provide a valid url.\n\n{:#}",
           colors::red_bold("error"),


### PR DESCRIPTION
This environment variable was purposefully never documented, but [has been discovered](https://github.com/denoland/deno/issues/16105#issuecomment-1335948130). It wasn't intended to be stable yet because it's not something we've discussed or thought out properly. Let's add a warning for now and stabilize a solution around this soon.