### PR TITLE
fix(ext/websocket): Reland make try_send ops infallible

### DIFF
--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -504,9 +504,12 @@ pub fn op_ws_try_send_string(
   state: &mut OpState,
   rid: ResourceId,
   text: String,
-) -> Result<bool, AnyError> {
-  let resource = state.resource_table.get::<WsStreamResource>(rid)?;
-  resource.try_send(Message::Text(text))
+) -> bool {
+  let resource = match state.resource_table.get::<WsStreamResource>(rid) {
+    Ok(resource) => resource,
+    Err(_) => return false,
+  };
+  resource.try_send(Message::Text(text)).is_ok()
 }
 
 #[op(fast)]
@@ -514,9 +517,12 @@ pub fn op_ws_try_send_binary(
   state: &mut OpState,
   rid: u32,
   value: &[u8],
-) -> Result<bool, AnyError> {
-  let resource = state.resource_table.get::<WsStreamResource>(rid)?;
-  resource.try_send(Message::Binary(value.to_vec()))
+) -> bool {
+  let resource = match state.resource_table.get::<WsStreamResource>(rid) {
+    Ok(resource) => resource,
+    Err(_) => return false,
+  };
+  resource.try_send(Message::Binary(value.to_vec())).is_ok()
 }
 
 #[op(deferred)]


### PR DESCRIPTION
Reverts denoland/deno#16743

This fixes the server hangs we were seeing in benchy. cc @billywhizz 