### PR TITLE
chore(ci): update windows runners to 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
 
   publish-canary:
     name: publish canary
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs: ["build"]
     if: github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           - os: macos-12
             job: test
             profile: release
-          - os: ${{ github.repository == 'denoland/deno' && 'windows-2019-xl' || 'windows-2019' }}
+          - os: ${{ github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022' }}
             job: test
             profile: fastci
-          - os: ${{ github.repository == 'denoland/deno' && 'windows-2019-xl' || 'windows-2019' }}
+          - os: ${{ github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022' }}
             job: test
             profile: release
           - os: ${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}
@@ -595,7 +595,7 @@ jobs:
 
   publish-canary:
     name: publish canary
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: ["build"]
     if: github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
The 2022 runners are the default for GitHub Actions now.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
