### PR TITLE
fix: default to `"inherit"` for `Deno.Command#spawn()`'s `stdout` & `stderr`

### DIFF
--- a/cli/tests/unit/command_test.ts
+++ b/cli/tests/unit/command_test.ts
@@ -91,6 +91,7 @@ Deno.test(
         "await Deno.stdout.write(new TextEncoder().encode('hello'))",
       ],
       stderr: "null",
+      stdout: "piped",
     });
     const child = command.spawn();
 
@@ -124,6 +125,7 @@ Deno.test(
         "await Deno.stderr.write(new TextEncoder().encode('hello'))",
       ],
       stdout: "null",
+      stderr: "piped",
     });
     const child = command.spawn();
 
@@ -163,6 +165,8 @@ Deno.test(
         "eval",
         "Deno.stderr.write(new TextEncoder().encode('error\\n')); Deno.stdout.write(new TextEncoder().encode('output\\n'));",
       ],
+      stdout: "piped",
+      stderr: "piped",
     });
     const child = command.spawn();
     await child.stdout.pipeTo(file.writable, {

--- a/cli/tests/unit/flock_test.ts
+++ b/cli/tests/unit/flock_test.ts
@@ -151,6 +151,8 @@ function runFlockTestProcess(opts: { exclusive: boolean; sync: boolean }) {
   const process = new Deno.Command(Deno.execPath(), {
     args: ["eval", "--unstable", scriptText],
     stdin: "piped",
+    stdout: "piped",
+    stderr: "null",
   }).spawn();
 
   const waitSignal = async () => {

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -1383,6 +1383,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1430,7 +1431,11 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const proc = new Deno.Command("curl", { args, stderr: "null" }).spawn();
+      const proc = new Deno.Command("curl", {
+        args,
+        stderr: "null",
+        stdout: "piped",
+      }).spawn();
       const status = await proc.status;
       assert(status.success);
       const stdout = proc.stdout
@@ -1488,6 +1493,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout).toLocaleLowerCase();
@@ -1543,6 +1549,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1595,6 +1602,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1651,6 +1659,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1709,6 +1718,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1767,6 +1777,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1822,6 +1833,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1883,6 +1895,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -1939,7 +1952,11 @@ Deno.test({
         "--header",
         "Accept-Encoding: gzip, deflate, br",
       ];
-      const proc = new Deno.Command("curl", { args, stderr: "null" }).spawn();
+      const proc = new Deno.Command("curl", {
+        args,
+        stderr: "null",
+        stdout: "piped",
+      }).spawn();
       const status = await proc.status;
       assert(status.success);
       const stdout = proc.stdout
@@ -2007,6 +2024,7 @@ Deno.test({
       const { success, stdout } = await new Deno.Command("curl", {
         args,
         stderr: "null",
+        stdout: "piped",
       }).output();
       assert(success);
       const output = decoder.decode(stdout);
@@ -2569,7 +2587,11 @@ Deno.test({
         "Accept-Encoding: gzip, deflate, br",
         "--no-buffer",
       ];
-      const proc = new Deno.Command("curl", { args, stderr: "null" }).spawn();
+      const proc = new Deno.Command("curl", {
+        args,
+        stderr: "null",
+        stdout: "piped",
+      }).spawn();
       const stdout = proc.stdout
         .pipeThrough(new DecompressionStream("gzip"))
         .pipeThrough(new TextDecoderStream());

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1456,11 +1456,13 @@ declare namespace Deno {
     stdin?: "piped" | "inherit" | "null";
     /**  How `stdout` of the spawned process should be handled.
      *
-     * Defaults to `"piped"`. */
+     * Defaults to `"piped"` for `output` & `outputSync`,
+     * and `"inherit"` for `spawn`. */
     stdout?: "piped" | "inherit" | "null";
     /**  How `stderr` of the spawned process should be handled.
      *
-     * Defaults to "piped". */
+     * Defaults to "piped" for `output` & `outputSync`,
+     * and `"inherit"` for `spawn`. */
     stderr?: "piped" | "inherit" | "null";
 
     /** Skips quoting and escaping of the arguments on windows. This option

--- a/runtime/js/40_spawn.js
+++ b/runtime/js/40_spawn.js
@@ -307,7 +307,12 @@
       }
 
       spawn() {
-        return spawnChild(this.#command, this.#options);
+        const options = {
+          ...(this.#options ?? {}),
+          stdout: this.#options?.stdout ?? "inherit",
+          stderr: this.#options?.stderr ?? "inherit",
+        };
+        return spawnChild(this.#command, options);
       }
     };
   }


### PR DESCRIPTION
Closes #16891