### PR TITLE
fix(upgrade/windows): correct command in windows access denied message

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -132,6 +132,14 @@ mod ts {
     }
     println!(
       "cargo:rerun-if-changed={}",
+      cwd.join("tsc").join("00_typescript.js").display()
+    );
+    println!(
+      "cargo:rerun-if-changed={}",
+      cwd.join("tsc").join("99_main_compiler.js").display()
+    );
+    println!(
+      "cargo:rerun-if-changed={}",
       cwd.join("js").join("40_testing.js").display()
     );
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -132,14 +132,6 @@ mod ts {
     }
     println!(
       "cargo:rerun-if-changed={}",
-      cwd.join("tsc").join("00_typescript.js").display()
-    );
-    println!(
-      "cargo:rerun-if-changed={}",
-      cwd.join("tsc").join("99_main_compiler.js").display()
-    );
-    println!(
-      "cargo:rerun-if-changed={}",
       cwd.join("js").join("40_testing.js").display()
     );
 

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -379,13 +379,14 @@ pub async fn upgrade(
         return Err(err).with_context(|| {
           format!(
             concat!(
-              "Access denied: Could not replace the deno executable. This may be ",
-              "because an existing deno process is running. Please ensure there ",
-              "are no running deno processes (ex. Stop-Process -Name deno ; deno {}), ",
-              "close any editors before upgrading, and ensure you have sufficient ",
-              "permission to '{}'."
+              "Could not replace the deno executable. This may be because an ",
+              "existing deno process is running. Please ensure there are no ",
+              "running deno processes (ex. Stop-Process -Name deno ; deno {}), ",
+              "close any editors before upgrading, and ensure you have ",
+              "sufficient permission to '{}'."
             ),
-            std::env::args().collect::<Vec<_>>().join(" "),
+            // skip the first argument, which is the executable path
+            std::env::args().skip(1).collect::<Vec<_>>().join(" "),
             output_exe_path.display(),
           )
         });


### PR DESCRIPTION
Just ran into this when testing upgrading. The message is nice, but slightly wrong.

This should not have the path of the executable in it (also, "access denied" is duplicate info, so I removed it):

```
Deno is upgrading to version 1.28.3
error: Access denied: Could not replace the deno executable. This may be because an existing deno process
is running. Please ensure there are no running deno processes (ex. Stop-Process -Name deno ; deno
C:\Users\david\.deno\bin\deno.exe upgrade), close any editors before upgrading, and ensure you have
sufficient permission to 'C:\Users\david\.deno\bin\deno.exe'.

Caused by:
    Access is denied. (os error 5)
```