### PR TITLE
fix(init): update comment style

### DIFF
--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -53,19 +53,19 @@ pub async fn init_project(init_flags: InitFlags) -> Result<(), AnyError> {
     info!("  cd {}", dir);
     info!("");
   }
-  info!("  {}", colors::gray("// Run the program"));
+  info!("  {}", colors::gray("# Run the program"));
   info!("  deno run main.ts");
   info!("");
   info!(
     "  {}",
-    colors::gray("// Run the program and watch for file changes")
+    colors::gray("# Run the program and watch for file changes")
   );
   info!("  deno task dev");
   info!("");
-  info!("  {}", colors::gray("// Run the tests"));
+  info!("  {}", colors::gray("# Run the tests"));
   info!("  deno test");
   info!("");
-  info!("  {}", colors::gray("// Run the benchmarks"));
+  info!("  {}", colors::gray("# Run the benchmarks"));
   info!("  deno bench");
   Ok(())
 }


### PR DESCRIPTION
The output of `init` are commands, so this should be treated as a "Shell script". In Shell script, comments must start with `#`, not `//`. (This also makes the commands example easier to be copied to somewhere.)