### PR TITLE
fix(repl): doing two history searches exiting with ctrl+c should not exit repl

### DIFF
--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -372,6 +372,7 @@ pub struct ReplEditor {
   inner: Arc<Mutex<Editor<EditorHelper>>>,
   history_file_path: PathBuf,
   errored_on_history_save: Arc<AtomicBool>,
+  pub should_exit_on_interrupt: Arc<AtomicBool>,
 }
 
 impl ReplEditor {
@@ -395,6 +396,13 @@ impl ReplEditor {
       KeyEvent(KeyCode::Tab, Modifiers::NONE),
       EventHandler::Conditional(Box::new(TabEventHandler)),
     );
+    let should_exit_on_interrupt = Arc::new(AtomicBool::new(false));
+    editor.bind_sequence(
+      KeyEvent(KeyCode::Char('r'), Modifiers::CTRL),
+      EventHandler::Conditional(Box::new(ReverseSearchHistoryEventHandler(
+        should_exit_on_interrupt.clone(),
+      ))),
+    );
 
     let history_file_dir = history_file_path.parent().unwrap();
     std::fs::create_dir_all(history_file_dir).with_context(|| {
@@ -408,6 +416,7 @@ impl ReplEditor {
       inner: Arc::new(Mutex::new(editor)),
       history_file_path,
       errored_on_history_save: Arc::new(AtomicBool::new(false)),
+      should_exit_on_interrupt,
     })
   }
 
@@ -425,6 +434,21 @@ impl ReplEditor {
       self.errored_on_history_save.store(true, Relaxed);
       eprintln!("Unable to save history file: {}", e);
     }
+  }
+}
+
+/// Command to reverse search history , same as rustyline default C-R but that resets repl should_exit flag to false
+struct ReverseSearchHistoryEventHandler(Arc<AtomicBool>);
+impl ConditionalEventHandler for ReverseSearchHistoryEventHandler {
+  fn handle(
+    &self,
+    _: &Event,
+    _: RepeatCount,
+    _: bool,
+    _: &EventContext,
+  ) -> Option<Cmd> {
+    self.0.store(false, Relaxed);
+    return Some(Cmd::ReverseSearchHistory);
   }
 }
 

--- a/cli/tools/repl/editor.rs
+++ b/cli/tools/repl/editor.rs
@@ -448,7 +448,7 @@ impl ConditionalEventHandler for ReverseSearchHistoryEventHandler {
     _: &EventContext,
   ) -> Option<Cmd> {
     self.0.store(false, Relaxed);
-    return Some(Cmd::ReverseSearchHistory);
+    Some(Cmd::ReverseSearchHistory)
   }
 }
 

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -23,7 +23,6 @@ use editor::EditorHelper;
 use editor::ReplEditor;
 use session::EvaluationOutput;
 use session::ReplSession;
-use std::sync::atomic::Ordering::Relaxed;
 
 async fn read_line_and_poll(
   repl_session: &mut ReplSession,
@@ -154,7 +153,7 @@ pub async fn run(flags: Flags, repl_flags: ReplFlags) -> Result<i32, AnyError> {
     .await;
     match line {
       Ok(line) => {
-        editor.should_exit_on_interrupt.store(false, Relaxed);
+        editor.set_should_exit_on_interrupt(false);
         editor.update_history(line.clone());
         let output = repl_session.evaluate_line_and_get_output(&line).await?;
 
@@ -167,10 +166,10 @@ pub async fn run(flags: Flags, repl_flags: ReplFlags) -> Result<i32, AnyError> {
         println!("{}", output);
       }
       Err(ReadlineError::Interrupted) => {
-        if editor.should_exit_on_interrupt.load(Relaxed) {
+        if editor.should_exit_on_interrupt() {
           break;
         }
-        editor.should_exit_on_interrupt.store(true, Relaxed);
+        editor.set_should_exit_on_interrupt(true);
         println!("press ctrl+c again to exit");
         continue;
       }


### PR DESCRIPTION
fix https://github.com/denoland/deno/issues/16147

This sequence doesn't exit the repl anymore
    - a
    - ctrl-r
    - a
    - ctrl-c
    - ctrl-r
    - a
    - ctrlc

The next ctrlc will exit the repl, which is not the case in node, but its very clear since there is a message just says press ctrl-c again to exit