### PR TITLE
fix(ext/fetch): handle errors in req body stream

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1839,13 +1839,11 @@ Deno.test(
       listener.close();
       const buf = new Uint8Array(160);
       const n = await conn.read(buf);
-      assertEquals(n, 160);
-      const buf2 = new Uint8Array(160);
-      const n2 = await conn.read(buf2);
-      assertEquals(n2, 6);
-      const buf3 = new Uint8Array(1);
-      const n3 = await conn.read(buf3);
-      assertEquals(n3, null);
+      assertEquals(n, 160); // this is the request headers + first body chunk
+      const n2 = await conn.read(buf);
+      assertEquals(n2, 6); // this is the second body chunk
+      const n3 = await conn.read(buf);
+      assertEquals(n3, null); // the connection now abruptly closes because the client has errored
       conn.close();
     })();
 

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -4,6 +4,7 @@ import {
   assertEquals,
   assertRejects,
   deferred,
+  delay,
   fail,
   unimplemented,
 } from "./test_util.ts";
@@ -1826,5 +1827,50 @@ Deno.test(
     req2.headers.set("x-foo", "bar"); // should not have any impact on req
     assertEquals(req.headers.get("x-foo"), null);
     assertEquals(req2.headers.get("x-foo"), "bar");
+  },
+);
+
+Deno.test(
+  { permissions: { net: true } },
+  async function fetchRequestBodyErrorCatchable() {
+    const listener = Deno.listen({ hostname: "127.0.0.1", port: 4514 });
+    const server = (async () => {
+      const conn = await listener.accept();
+      listener.close();
+      const buf = new Uint8Array(160);
+      const n = await conn.read(buf);
+      assertEquals(n, 160);
+      const buf2 = new Uint8Array(160);
+      const n2 = await conn.read(buf2);
+      assertEquals(n2, 6);
+      const buf3 = new Uint8Array(1);
+      const n3 = await conn.read(buf3);
+      assertEquals(n3, null);
+      conn.close();
+    })();
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        controller.enqueue(new TextEncoder().encode("a"));
+        await delay(1000);
+        controller.enqueue(new TextEncoder().encode("b"));
+        await delay(1000);
+        controller.error(new Error("foo"));
+      },
+    });
+
+    const err = await assertRejects(() =>
+      fetch("http://localhost:4514", {
+        body: stream,
+        method: "POST",
+      })
+    );
+
+    assert(err instanceof TypeError);
+    assert(err.cause);
+    assert(err.cause instanceof Error);
+    assertEquals(err.cause.message, "foo");
+
+    await server;
   },
 );

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -212,7 +212,7 @@
       const reader = reqBody.getReader();
       WeakMapPrototypeSet(requestBodyReaders, req, reader);
       (async () => {
-        let done;
+        let done = false;
         while (!done) {
           let val;
           try {

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -221,7 +221,7 @@
             val = res.value;
           } catch (err) {
             if (terminator.aborted) break;
-            // TODO: propagate error into response body stream
+            // TODO(lucacasonato): propagate error into response body stream
             requestSendError = err;
             requestSendErrorSet = true;
             break;
@@ -231,7 +231,7 @@
               "Item in request body ReadableStream is not a Uint8Array",
             );
             await reader.cancel(error);
-            // TODO: propagate error into response body stream
+            // TODO(lucacasonato): propagate error into response body stream
             requestSendError = error;
             requestSendErrorSet = true;
             break;

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -200,6 +200,8 @@
     }
     terminator[abortSignal.add](onAbort);
 
+    let requestSendError;
+    let requestSendErrorSet = false;
     if (requestBodyRid !== null) {
       if (
         reqBody === null ||
@@ -210,44 +212,56 @@
       const reader = reqBody.getReader();
       WeakMapPrototypeSet(requestBodyReaders, req, reader);
       (async () => {
-        while (true) {
-          const { value, done } = await PromisePrototypeCatch(
-            reader.read(),
-            (err) => {
-              if (terminator.aborted) return { done: true, value: undefined };
-              throw err;
-            },
-          );
-          if (done) break;
-          if (!ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, value)) {
-            await reader.cancel("value not a Uint8Array");
+        let done = false;
+        while (!done) {
+          let val;
+          try {
+            const res = await reader.read();
+            done = res.done;
+            val = res.value;
+          } catch (err) {
+            if (terminator.aborted) break;
+            // TODO: propagate error into response body stream
+            requestSendError = err;
+            requestSendErrorSet = true;
+            break;
+          }
+          if (!ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, val)) {
+            const error = new TypeError(
+              "Item in request body ReadableStream is not a Uint8Array",
+            );
+            await reader.cancel(error);
+            // TODO: propagate error into response body stream
+            requestSendError = error;
+            requestSendErrorSet = true;
             break;
           }
           try {
-            await PromisePrototypeCatch(
-              core.writeAll(requestBodyRid, value),
-              (err) => {
-                if (terminator.aborted) return;
-                throw err;
-              },
-            );
-            if (terminator.aborted) break;
+            await core.writeAll(requestBodyRid, val);
           } catch (err) {
+            if (terminator.aborted) break;
             await reader.cancel(err);
             break;
           }
         }
+        if (done) await core.shutdown(requestBodyRid);
         WeakMapPrototypeDelete(requestBodyReaders, req);
         core.tryClose(requestBodyRid);
       })();
     }
-
     let resp;
     try {
-      resp = await PromisePrototypeCatch(opFetchSend(requestRid), (err) => {
-        if (terminator.aborted) return;
-        throw err;
-      });
+      resp = await opFetchSend(requestRid);
+    } catch (err) {
+      if (terminator.aborted) return;
+      if (requestSendErrorSet) {
+        // if the request body stream errored, we want to propagate that error
+        // instead of the original error from opFetchSend
+        throw new TypeError("Failed to fetch: request body stream errored", {
+          cause: requestSendError,
+        });
+      }
+      throw err;
     } finally {
       if (cancelHandleRid !== null) {
         core.tryClose(cancelHandleRid);

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -248,7 +248,16 @@
             break;
           }
         }
-        if (done && !terminator.aborted) await core.shutdown(requestBodyRid);
+        if (done && !terminator.aborted) {
+          try {
+            await core.shutdown(requestBodyRid);
+          } catch (err) {
+            if (!terminator.aborted) {
+              requestSendError = err;
+              requestSendErrorSet = true;
+            }
+          }
+        }
         WeakMapPrototypeDelete(requestBodyReaders, req);
         core.tryClose(requestBodyRid);
       })();

--- a/ext/fetch/byte_stream.rs
+++ b/ext/fetch/byte_stream.rs
@@ -1,0 +1,87 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use deno_core::futures::Stream;
+use tokio::sync::mpsc;
+
+/// [MpscByteStream] is a stream of bytes that is backed by a mpsc channel. It is
+/// used to bridge between the fetch task and the HTTP body stream. The stream
+/// has the special property that it errors if the channel is closed before an
+/// explicit EOF is sent (in the form of a [None] value on the sender).
+pub struct MpscByteStream {
+  receiver: mpsc::Receiver<Option<bytes::Bytes>>,
+  shutdown: bool,
+}
+
+impl MpscByteStream {
+  pub fn new() -> (Self, mpsc::Sender<Option<bytes::Bytes>>) {
+    let (sender, receiver) = mpsc::channel::<Option<bytes::Bytes>>(1);
+    let this = Self {
+      receiver,
+      shutdown: false,
+    };
+    (this, sender)
+  }
+}
+
+impl Stream for MpscByteStream {
+  type Item = Result<bytes::Bytes, std::io::Error>;
+
+  fn poll_next(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Option<Self::Item>> {
+    let val = std::task::ready!(self.receiver.poll_recv(cx));
+    match val {
+      None if self.shutdown => Poll::Ready(None),
+      None => Poll::Ready(Some(Err(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "channel closed",
+      )))),
+      Some(None) => {
+        self.shutdown = true;
+        Poll::Ready(None)
+      }
+      Some(Some(val)) => Poll::Ready(Some(Ok(val))),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use bytes::Bytes;
+  use deno_core::futures::StreamExt;
+
+  #[tokio::test]
+  async fn success() {
+    let (mut stream, sender) = MpscByteStream::new();
+
+    sender.send(Some(Bytes::from("hello"))).await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("hello"));
+
+    sender.send(Some(Bytes::from("world"))).await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("world"));
+
+    sender.send(None).await.unwrap();
+    drop(sender);
+    assert!(stream.next().await.is_none());
+  }
+
+  #[tokio::test]
+  async fn error() {
+    let (mut stream, sender) = MpscByteStream::new();
+
+    sender.send(Some(Bytes::from("hello"))).await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("hello"));
+
+    drop(sender);
+    assert_eq!(
+      stream.next().await.unwrap().unwrap_err().kind(),
+      std::io::ErrorKind::UnexpectedEof
+    );
+  }
+}

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -527,9 +527,7 @@ impl Resource for FetchRequestBodyResource {
     Box::pin(async move {
       let body = RcRef::map(&self, |r| &r.body).borrow_mut().await;
       let cancel = RcRef::map(self, |r| &r.cancel);
-      body.send(None).or_cancel(cancel).await?.map_err(|_| {
-        type_error("request body receiver not connected (request closed)")
-      })?;
+      body.send(None).or_cancel(cancel).await?.ok(); // we don't care if the receiver is closed, because this is the shutdown
       Ok(())
     })
   }

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -54,8 +54,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::Context;
+use std::task::Poll;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 
 // Re-export reqwest and data_url
 pub use data_url;
@@ -256,7 +257,7 @@ where
         match data {
           None => {
             // If no body is passed, we return a writer for streaming the body.
-            let (tx, rx) = mpsc::channel::<std::io::Result<bytes::Bytes>>(1);
+            let (tx, rx) = mpsc::channel::<Option<bytes::Bytes>>(1);
 
             // If the size of the body is known, we include a content-length
             // header explicitly.
@@ -265,7 +266,7 @@ where
                 request.header(CONTENT_LENGTH, HeaderValue::from(body_size))
             }
 
-            request = request.body(Body::wrap_stream(ReceiverStream::new(rx)));
+            request = request.body(Body::wrap_stream(ByteStream::new(rx)));
 
             let request_body_rid =
               state.resource_table.add(FetchRequestBodyResource {
@@ -459,8 +460,45 @@ impl Resource for FetchCancelHandle {
 }
 
 pub struct FetchRequestBodyResource {
-  body: AsyncRefCell<mpsc::Sender<std::io::Result<bytes::Bytes>>>,
+  body: AsyncRefCell<mpsc::Sender<Option<bytes::Bytes>>>,
   cancel: CancelHandle,
+}
+
+pub struct ByteStream {
+  receiver: mpsc::Receiver<Option<bytes::Bytes>>,
+  shutdown: bool,
+}
+
+impl ByteStream {
+  fn new(receiver: mpsc::Receiver<Option<bytes::Bytes>>) -> Self {
+    Self {
+      receiver,
+      shutdown: false,
+    }
+  }
+}
+
+impl Stream for ByteStream {
+  type Item = Result<bytes::Bytes, std::io::Error>;
+
+  fn poll_next(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Option<Self::Item>> {
+    let val = std::task::ready!(self.receiver.poll_recv(cx));
+    match val {
+      None if self.shutdown => Poll::Ready(None),
+      None => Poll::Ready(Some(Err(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "channel closed",
+      )))),
+      Some(None) => {
+        self.shutdown = true;
+        Poll::Ready(None)
+      }
+      Some(Some(val)) => Poll::Ready(Some(Ok(val))),
+    }
+  }
 }
 
 impl Resource for FetchRequestBodyResource {
@@ -474,10 +512,25 @@ impl Resource for FetchRequestBodyResource {
       let nwritten = bytes.len();
       let body = RcRef::map(&self, |r| &r.body).borrow_mut().await;
       let cancel = RcRef::map(self, |r| &r.cancel);
-      body.send(Ok(bytes)).or_cancel(cancel).await?.map_err(|_| {
+      body
+        .send(Some(bytes))
+        .or_cancel(cancel)
+        .await?
+        .map_err(|_| {
+          type_error("request body receiver not connected (request closed)")
+        })?;
+      Ok(WriteOutcome::Full { nwritten })
+    })
+  }
+
+  fn shutdown(self: Rc<Self>) -> AsyncResult<()> {
+    Box::pin(async move {
+      let body = RcRef::map(&self, |r| &r.body).borrow_mut().await;
+      let cancel = RcRef::map(self, |r| &r.cancel);
+      body.send(None).or_cancel(cancel).await?.map_err(|_| {
         type_error("request body receiver not connected (request closed)")
       })?;
-      Ok(WriteOutcome::Full { nwritten })
+      Ok(())
     })
   }
 


### PR DESCRIPTION
Right now an error in a request body stream causes an uncatchable
global promise rejection. This PR fixes this to instead propagate the
error correctly into the promise returned from `fetch`.

It additionally fixes errored readable stream bodies being treated as
successfully completed bodies by Rust.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
