### PR TITLE
chore(lsp/testing): refactor collectors test

### DIFF
--- a/cli/lsp/testing/collectors.rs
+++ b/cli/lsp/testing/collectors.rs
@@ -529,56 +529,8 @@ pub mod tests {
     )
   }
 
-  #[test]
-  fn test_test_collector() {
+  fn collect(source: &str) -> Vec<TestDefinition> {
     let specifier = resolve_url("file:///a/example.ts").unwrap();
-    let source = r#"
-      Deno.test({
-        name: "test a",
-        async fn(t) {
-          await t.step("a step", ({ step }) => {
-            await step({
-              name: "sub step",
-              fn() {}
-            })
-          });
-        }
-      });
-
-      Deno.test({
-        name: `test b`,
-        async fn(t) {
-          await t.step(`b step`, ({ step }) => {
-            await step({
-              name: `sub step`,
-              fn() {}
-            })
-          });
-        }
-      });
-
-      Deno.test(async function useFnName({ step: s }) {
-        await s("step c", () => {});
-      });
-
-      Deno.test("test c", () => {});
-
-      Deno.test(`test d`, () => {});
-
-      const { test } = Deno;
-      test("test e", () => {});
-
-      const t = Deno.test;
-      t("test f", () => {});
-
-      function someFunctionG() {}
-      Deno.test("test g", someFunctionG);
-
-      Deno.test(async function someFunctionH() {});
-
-      async function someFunctionI() {}
-      Deno.test(someFunctionI);
-    "#;
 
     let parsed_module = deno_ast::parse_module(deno_ast::ParseParams {
       specifier: specifier.to_string(),
@@ -591,118 +543,280 @@ pub mod tests {
     .unwrap();
     let mut collector = TestCollector::new(specifier);
     parsed_module.module().visit_with(&mut collector);
+    collector.take()
+  }
+
+  #[test]
+  fn test_test_collector_test() {
+    let res = collect(
+      r#"
+      Deno.test("test", () => {});
+    "#,
+    );
+
     assert_eq!(
-      collector.take(),
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(12, 16),
+        steps: vec![],
+      },]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_test_tpl() {
+    let res = collect(
+      r#"
+      Deno.test(`test`, () => {});
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(12, 16),
+        steps: vec![],
+      },]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_a() {
+    let res = collect(
+      r#"
+      Deno.test({
+        name: "test",
+        async fn(t) {
+          await t.step("step", ({ step }) => {
+            await step({
+              name: "sub step",
+              fn() {}
+            })
+          });
+        }
+      });
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(12, 16),
+        steps: vec![TestDefinition {
+          id:
+            "b3b2daad49e5c3095fe26aba0a840131f3d8f32e105e95507f5fc5118642b059"
+              .to_string(),
+          level: 1,
+          name: "step".to_string(),
+          range: new_range(81, 85),
+          steps: vec![TestDefinition {
+            id:
+              "abf356f59139b77574089615f896a6f501c010985d95b8a93abeb0069ccb2201"
+                .to_string(),
+            level: 2,
+            name: "sub step".to_string(),
+            range: new_range(128, 132),
+            steps: vec![],
+          }]
+        }],
+      },]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_a_tpl() {
+    let res = collect(
+      r#"
+      Deno.test({
+        name: `test`,
+        async fn(t) {
+          await t.step(`step`, ({ step }) => {
+            await step({
+              name: `sub step`,
+              fn() {}
+            })
+          });
+        }
+      });
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(12, 16),
+        steps: vec![TestDefinition {
+          id:
+            "b3b2daad49e5c3095fe26aba0a840131f3d8f32e105e95507f5fc5118642b059"
+              .to_string(),
+          level: 1,
+          name: "step".to_string(),
+          range: new_range(81, 85),
+          steps: vec![TestDefinition {
+            id:
+              "abf356f59139b77574089615f896a6f501c010985d95b8a93abeb0069ccb2201"
+                .to_string(),
+            level: 2,
+            name: "sub step".to_string(),
+            range: new_range(128, 132),
+            steps: vec![],
+          }]
+        }],
+      },]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_destructure() {
+    let res = collect(
+      r#"
+      const { test } = Deno;
+      test("test", () => {});
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(36, 40),
+        steps: vec![],
+      }]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_destructure_rebind_step() {
+    let res = collect(
+      r#"
+      Deno.test(async function useFnName({ step: s }) {
+        await s("step", () => {});
+      });
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "86b4c821900e38fc89f24bceb0e45193608ab3f9d2a6019c7b6a5aceff5d7df2"
+          .to_string(),
+        level: 0,
+        name: "useFnName".to_string(),
+        range: new_range(12, 16),
+        steps: vec![TestDefinition {
+          id:
+            "b3b2daad49e5c3095fe26aba0a840131f3d8f32e105e95507f5fc5118642b059"
+              .to_string(),
+          level: 1,
+          name: "step".to_string(),
+          range: new_range(71, 72),
+          steps: vec![],
+        }],
+      }]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_rebind() {
+    let res = collect(
+      r#"
+      const t = Deno.test;
+      t("test", () => {});
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(34, 35),
+        steps: vec![],
+      }]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_separate_test_function_with_string_name() {
+    let res = collect(
+      r#"
+      function someFunction() {}
+      Deno.test("test", someFunction);
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "4ebb361c93f76a0f1bac300638675609f1cf481e6f3b9006c3c98604b3a184e9"
+          .to_string(),
+        level: 0,
+        name: "test".to_string(),
+        range: new_range(45, 49),
+        steps: vec![],
+      }]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_function_only() {
+    let res = collect(
+      r#"
+      Deno.test(async function someFunction() {});
+    "#,
+    );
+
+    assert_eq!(
+      res,
+      vec![TestDefinition {
+        id: "e0f6a73647b763f82176c98a019e54200b799a32007f9859fb782aaa9e308568"
+          .to_string(),
+        level: 0,
+        name: "someFunction".to_string(),
+        range: new_range(12, 16),
+        steps: vec![]
+      }]
+    );
+  }
+
+  #[test]
+  fn test_test_collector_separate_test_function() {
+    let res = collect(
+      r#"
+      async function someFunction() {}
+      Deno.test(someFunction);
+    "#,
+    );
+
+    assert_eq!(
+      res,
       vec![
         TestDefinition {
-          id: "cf31850c831233526df427cdfd25b6b84b2af0d6ce5f8ee1d22c465234b46348".to_string(),
+          id: "e0f6a73647b763f82176c98a019e54200b799a32007f9859fb782aaa9e308568".to_string(),
           level: 0,
-          name: "test a".to_string(),
-          range: new_range(12, 16),
-          steps: vec![
-            TestDefinition {
-              id: "4c7333a1e47721631224408c467f32751fe34b876cab5ec1f6ac71980ff15ad3".to_string(),
-              level: 1,
-              name: "a step".to_string(),
-              range: new_range(83, 87),
-              steps: vec![
-                TestDefinition {
-                  id: "abf356f59139b77574089615f896a6f501c010985d95b8a93abeb0069ccb2201".to_string(),
-                  level: 2,
-                  name: "sub step".to_string(),
-                  range: new_range(132, 136),
-                  steps: vec![],
-                }
-              ]
-            }
-          ],
-        },
-        TestDefinition {
-          id: "580eda89d7f5e619774c20e13b7d07a8e77c39cba101d60565144d48faa837cb".to_string(),
-          level: 0,
-          name: "test b".to_string(),
-          range: new_range(254, 258),
-          steps: vec![
-            TestDefinition {
-              id: "888e28419fc6c00cadfaad26e1e3e16e09e4322b3579fdfa9cc3fdb75976704a".to_string(),
-              level: 1,
-              name: "b step".to_string(),
-              range: new_range(325, 329),
-              steps: vec![
-                TestDefinition {
-                  id: "abf356f59139b77574089615f896a6f501c010985d95b8a93abeb0069ccb2201".to_string(),
-                  level: 2,
-                  name: "sub step".to_string(),
-                  range: new_range(374, 378),
-                  steps: vec![],
-                }
-              ]
-            }
-          ],
-        },
-        TestDefinition {
-          id: "86b4c821900e38fc89f24bceb0e45193608ab3f9d2a6019c7b6a5aceff5d7df2".to_string(),
-          level: 0,
-          name: "useFnName".to_string(),
-          range: new_range(496, 500),
-          steps: vec![
-            TestDefinition {
-              id:
-              "67a390d0084ae5fb88f3510c470a72a553581f1d0d5ba5fa89aee7a754f3953a".to_string(),
-              level: 1,
-              name: "step c".to_string(),
-              range: new_range(555, 556),
-              steps: vec![],
-            }
-          ],
-        },
-        TestDefinition {
-          id: "0b7c6bf3cd617018d33a1bf982a08fe088c5bb54fcd5eb9e802e7c137ec1af94".to_string(),
-          level: 0,
-          name: "test c".to_string(),
-          range: new_range(600, 604),
-          steps: vec![],
-        },
-        TestDefinition {
-          id: "69d9fe87f64f5b66cb8b631d4fd2064e8224b8715a049be54276c42189ff8f9f".to_string(),
-          level: 0,
-          name: "test d".to_string(),
-          range: new_range(638, 642),
-          steps: vec![],
-        },
-        TestDefinition {
-          id: "b2fd155c2a5e468eddf77a5eb13f97ddeeeafab322f0fc223ec0810ab2a29d42".to_string(),
-          level: 0,
-          name: "test e".to_string(),
-          range: new_range(700, 704),
-          steps: vec![],
-        },
-        TestDefinition {
-          id: "6387faad3a1f27fb3078a7d350040f4e6b516994076c855a0446943927461f58".to_string(),
-          level: 0,
-          name: "test f".to_string(),
-          range: new_range(760, 761),
-          steps: vec![],
-        },
-        TestDefinition {
-          id: "a2291bd6f521a1c8720350f76bd6b1803074100fcf6b07f532679332d30ad1e9".to_string(),
-          level: 0,
-          name: "test g".to_string(),
-          range: new_range(829, 833),
-          steps: vec![],
-        },
-        TestDefinition {
-          id: "2e1990c92e19f9e7dcd4af5787d57f9a7058fdc540ddc55dacdf4a081011d123".to_string(),
-          level: 0,
-          name: "someFunctionH".to_string(),
-          range: new_range(872, 876),
-          steps: vec![]
-        },
-        TestDefinition {
-          id: "1fef1a040ad1be8b0579054c1f3d1e34690f41fbbfe3fe20dbe9f48e808527e1".to_string(),
-          level: 0,
-          name: "someFunctionI".to_string(),
-          range: new_range(965, 969),
+          name: "someFunction".to_string(),
+          range: new_range(51, 55),
           steps: vec![]
         }
       ]

--- a/cli/lsp/testing/collectors.rs
+++ b/cli/lsp/testing/collectors.rs
@@ -811,15 +811,14 @@ pub mod tests {
 
     assert_eq!(
       res,
-      vec![
-        TestDefinition {
-          id: "e0f6a73647b763f82176c98a019e54200b799a32007f9859fb782aaa9e308568".to_string(),
-          level: 0,
-          name: "someFunction".to_string(),
-          range: new_range(51, 55),
-          steps: vec![]
-        }
-      ]
+      vec![TestDefinition {
+        id: "e0f6a73647b763f82176c98a019e54200b799a32007f9859fb782aaa9e308568"
+          .to_string(),
+        level: 0,
+        name: "someFunction".to_string(),
+        range: new_range(51, 55),
+        steps: vec![]
+      }]
     );
   }
 }


### PR DESCRIPTION
Instead of having all tests in a single rust test with a huge assertion, this splits it up to use individual rust tests for each part of the assertion, making iterating on things a lot easier