### PR TITLE
fix: astro dev

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -5384,6 +5384,9 @@
      * @returns {void}
      */
     enqueue(chunk = undefined) {
+      if (chunk.byteLength === 0) {
+        return;
+      }
       webidl.assertBranded(this, ReadableStreamDefaultControllerPrototype);
       if (chunk !== undefined) {
         chunk = webidl.converters.any(chunk);

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -5384,7 +5384,7 @@
      * @returns {void}
      */
     enqueue(chunk = undefined) {
-      if (chunk.byteLength === 0) {
+      if (chunk?.byteLength === 0) {
         return;
       }
       webidl.assertBranded(this, ReadableStreamDefaultControllerPrototype);


### PR DESCRIPTION
Closes part of https://github.com/denoland/deno/issues/16659

So after a lot of debugging it seems like Astro sends a UIntArray of no length which seems to break the ReadableStream causing the server to just hang.

I am not sure if this is the right place to do this check but node must do it at some place.

I used this command to test `deno run -A --node-modules-dir npm:astro dev` in a brand new astro project with no changes.

Also something broke Astro in this commit (https://github.com/denoland/deno/commit/efcb93f8b9610bff896f21ecb5add7d17de40156) which Is why I branched before that

