### PR TITLE
fix(npm): conditional exports with --node-modules-dir

### DIFF
--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -303,7 +303,12 @@
   // 1. name/.*
   // 2. @scope/name/.*
   const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)?$/;
-  function resolveExports(modulesPath, request, parentPath) {
+  function resolveExports(
+    modulesPath,
+    request,
+    parentPath,
+    usesLocalNodeModulesDir,
+  ) {
     // The implementation's behavior is meant to mirror resolution in ESM.
     const [, name, expansion = ""] =
       StringPrototypeMatch(request, EXPORTS_PATTERN) || [];
@@ -312,6 +317,7 @@
     }
 
     return core.ops.op_require_resolve_exports(
+      usesLocalNodeModulesDir,
       modulesPath,
       request,
       name,
@@ -349,7 +355,12 @@
       if (curPath && stat(curPath) < 1) continue;
 
       if (!absoluteRequest) {
-        const exportsResolved = resolveExports(curPath, request, parentPath);
+        const exportsResolved = resolveExports(
+          curPath,
+          request,
+          parentPath,
+          usesLocalNodeModulesDir,
+        );
         if (exportsResolved) {
           return exportsResolved;
         }

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -542,6 +542,7 @@ pub fn op_require_as_file_path(file_or_url: String) -> String {
 #[op]
 fn op_require_resolve_exports(
   state: &mut OpState,
+  uses_local_node_modules_dir: bool,
   modules_path: String,
   _request: String,
   name: String,
@@ -550,7 +551,9 @@ fn op_require_resolve_exports(
 ) -> Result<Option<String>, AnyError> {
   let resolver = state.borrow::<Rc<dyn RequireNpmResolver>>().clone();
 
-  let pkg_path = if resolver.in_npm_package(&PathBuf::from(&modules_path)) {
+  let pkg_path = if resolver.in_npm_package(&PathBuf::from(&modules_path))
+    && !uses_local_node_modules_dir
+  {
     modules_path
   } else {
     path_resolve(vec![modules_path, name])


### PR DESCRIPTION
This commit fixes conditional exports in `require()` implementation
if `--node-modules-dir` flag is used.