### PR TITLE
fix(core): Do not print errors prop for non-AggregateError errors

### DIFF
--- a/cli/tests/run_tests.rs
+++ b/cli/tests/run_tests.rs
@@ -2780,6 +2780,7 @@ mod run {
     exit_code: 1,
   });
 
+  // Regression test for https://github.com/denoland/deno/issues/16340.
   itest!(error_with_errors_prop {
     args: "run --quiet run/error_with_errors_prop.js",
     output: "run/error_with_errors_prop.js.out",

--- a/cli/tests/run_tests.rs
+++ b/cli/tests/run_tests.rs
@@ -2780,6 +2780,12 @@ mod run {
     exit_code: 1,
   });
 
+  itest!(error_with_errors_prop {
+    args: "run --quiet run/error_with_errors_prop.js",
+    output: "run/error_with_errors_prop.js.out",
+    exit_code: 1,
+  });
+
   // Regression test for https://github.com/denoland/deno/issues/12143.
   itest!(js_root_with_ts_check {
     args: "run --quiet --check run/js_root_with_ts_check.js",

--- a/cli/tests/testdata/run/error_with_errors_prop.js
+++ b/cli/tests/testdata/run/error_with_errors_prop.js
@@ -1,0 +1,10 @@
+const error = new Error("Error with errors prop.");
+error.errors = [
+  new Error("Error message 1."),
+  new Error("Error message 2."),
+];
+console.log(error.stack);
+console.log();
+console.log(error);
+console.log();
+throw error;

--- a/cli/tests/testdata/run/error_with_errors_prop.js.out
+++ b/cli/tests/testdata/run/error_with_errors_prop.js.out
@@ -1,0 +1,10 @@
+Error: Error with errors prop.
+    at [WILDCARD]/error_with_errors_prop.js:1:15
+
+Error: Error with errors prop.
+    at [WILDCARD]/error_with_errors_prop.js:1:15
+
+error: Uncaught Error: Error with errors prop.
+const error = new Error("Error with errors prop.");
+              ^
+    at [WILDCARD]/error_with_errors_prop.js:1:15


### PR DESCRIPTION
As mentioned in the comment, there is currently no way to detect `AggregateError` via `rusty_v8`.
We can migrate to it once v8 itself exposes `v8__Exception__AggregateError`, and we add binding for it.

Fixes https://github.com/denoland/deno/issues/16340