### PR TITLE
fix(ext/http): close stream on resp body error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "phf",
+ "pin-project",
  "ring",
  "serde",
  "tokio",

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -2614,6 +2614,317 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name:
+    "http server errors stream if response body errors (http/1.1)",
+  permissions: { net: true },
+  async fn() {
+    const hostname = "localhost";
+    const port = 4501;
+
+    let httpConn: Deno.HttpConn;
+    const server = (async () => {
+      const listener = Deno.listen({ hostname, port });
+      const conn = await listener.accept();
+      listener.close();
+      httpConn = Deno.serveHttp(conn);
+      const e = await httpConn.nextRequest();
+      assert(e);
+      const { respondWith } = e;
+      const originalErr = new Error("boom");
+      const rs = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new Uint8Array([65]));
+          await delay(1000);
+          controller.error(originalErr);
+        },
+      });
+      const err = await assertRejects(() => respondWith(new Response(rs)));
+      assert(err === originalErr);
+    })();
+
+    const conn = await Deno.connect({ hostname, port });
+    const msg = new TextEncoder().encode(
+      `GET / HTTP/1.1\r\nHost: ${hostname}:${port}\r\n\r\n`,
+    );
+    const nwritten = await await conn.write(msg);
+    assertEquals(nwritten, msg.byteLength);
+
+    const buf = new Uint8Array(1024);
+    const nread = await conn.read(buf);
+    assert(nread);
+    const data = new TextDecoder().decode(buf.subarray(0, nread));
+    assert(data.endsWith("1\r\nA\r\n"));
+    const nread2 = await conn.read(buf); // connection should be closed now because the stream errored
+    assertEquals(nread2, null);
+    conn.close();
+
+    await server;
+    httpConn!.close();
+  },
+});
+
+Deno.test({
+  name:
+    "http server errors stream if response body errors (http/1.1 + compression)",
+  permissions: { net: true },
+  async fn() {
+    const hostname = "localhost";
+    const port = 4501;
+
+    let httpConn: Deno.HttpConn;
+    const server = (async () => {
+      const listener = Deno.listen({ hostname, port });
+      const conn = await listener.accept();
+      listener.close();
+      httpConn = Deno.serveHttp(conn);
+      const e = await httpConn.nextRequest();
+      assert(e);
+      const { respondWith } = e;
+      const originalErr = new Error("boom");
+      const rs = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new Uint8Array([65]));
+          await delay(1000);
+          controller.error(originalErr);
+        },
+      });
+      const resp = new Response(rs, {
+        headers: { "content-type": "text/plain" },
+      });
+      const err = await assertRejects(() => respondWith(resp));
+      assert(err === originalErr);
+    })();
+
+    const conn = await Deno.connect({ hostname, port });
+    const msg = new TextEncoder().encode(
+      `GET / HTTP/1.1\r\nHost: ${hostname}:${port}\r\naccept-encoding: gzip\r\n\r\n`,
+    );
+    const nwritten = await conn.write(msg);
+    assertEquals(nwritten, msg.byteLength);
+
+    const buf = new Uint8Array(1024);
+    const nread = await conn.read(buf);
+    assert(nread);
+    const end = buf.subarray(nread - 23, nread);
+    assertEquals(
+      end,
+      // deno-fmt-ignore
+      new Uint8Array([
+        49, 49, 13, 10, 31, 139, 8, 0,
+        0, 0, 0, 0, 0, 255, 114, 4,
+        0, 0, 0, 255, 255, 13, 10
+      ]),
+    );
+    const nread2 = await conn.read(buf); // connection should be closed now because the stream errored
+    assertEquals(nread2, null);
+    conn.close();
+
+    await server;
+    httpConn!.close();
+  },
+});
+
+Deno.test({
+  name: "http server errors stream if response body errors (http/1.1 + fetch)",
+  permissions: { net: true },
+  async fn() {
+    const hostname = "localhost";
+    const port = 4501;
+
+    let httpConn: Deno.HttpConn;
+    const server = (async () => {
+      const listener = Deno.listen({ hostname, port });
+      const conn = await listener.accept();
+      listener.close();
+      httpConn = Deno.serveHttp(conn);
+      const e = await httpConn.nextRequest();
+      assert(e);
+      const { respondWith } = e;
+      const originalErr = new Error("boom");
+      const rs = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new Uint8Array([65]));
+          await delay(1000);
+          controller.error(originalErr);
+        },
+      });
+      const resp = new Response(rs);
+      const err = await assertRejects(() => respondWith(resp));
+      assert(err === originalErr);
+    })();
+
+    const resp = await fetch(`http://${hostname}:${port}/`);
+    assert(resp.body);
+    const reader = resp.body.getReader();
+    const result = await reader.read();
+    assert(!result.done);
+    assertEquals(result.value, new Uint8Array([65]));
+    const err = await assertRejects(() => reader.read());
+    assert(err instanceof TypeError);
+    assert(err.message.includes("unexpected EOF"));
+
+    await server;
+    httpConn!.close();
+  },
+});
+
+Deno.test({
+  name:
+    "http server errors stream if response body errors (http/1.1 + fetch + compression)",
+  permissions: { net: true },
+  async fn() {
+    const hostname = "localhost";
+    const port = 4501;
+
+    let httpConn: Deno.HttpConn;
+    const server = (async () => {
+      const listener = Deno.listen({ hostname, port });
+      const conn = await listener.accept();
+      listener.close();
+      httpConn = Deno.serveHttp(conn);
+      const e = await httpConn.nextRequest();
+      assert(e);
+      const { respondWith } = e;
+      const originalErr = new Error("boom");
+      const rs = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new Uint8Array([65]));
+          await delay(1000);
+          controller.error(originalErr);
+        },
+      });
+      const resp = new Response(rs, {
+        headers: { "content-type": "text/plain" },
+      });
+      const err = await assertRejects(() => respondWith(resp));
+      assert(err === originalErr);
+    })();
+
+    const resp = await fetch(`http://${hostname}:${port}/`);
+    assert(resp.body);
+    const reader = resp.body.getReader();
+    const result = await reader.read();
+    assert(!result.done);
+    assertEquals(result.value, new Uint8Array([65]));
+    const err = await assertRejects(() => reader.read());
+    assert(err instanceof TypeError);
+    assert(err.message.includes("unexpected EOF"));
+
+    await server;
+    httpConn!.close();
+  },
+});
+
+Deno.test({
+  name: "http server errors stream if response body errors (http/2 + fetch)",
+  permissions: { net: true, read: true },
+  async fn() {
+    const hostname = "localhost";
+    const port = 4501;
+
+    let httpConn: Deno.HttpConn;
+    const server = (async () => {
+      const listener = Deno.listenTls({
+        hostname,
+        port,
+        certFile: "cli/tests/testdata/tls/localhost.crt",
+        keyFile: "cli/tests/testdata/tls/localhost.key",
+        alpnProtocols: ["h2"],
+      });
+      const conn = await listener.accept();
+      listener.close();
+      httpConn = Deno.serveHttp(conn);
+      const e = await httpConn.nextRequest();
+      assert(e);
+      const { respondWith } = e;
+      const originalErr = new Error("boom");
+      const rs = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new Uint8Array([65]));
+          await delay(1000);
+          controller.error(originalErr);
+        },
+      });
+      const resp = new Response(rs);
+      const err = await assertRejects(() => respondWith(resp));
+      assert(err === originalErr);
+    })();
+
+    const caCert = Deno.readTextFileSync("cli/tests/testdata/tls/RootCA.pem");
+    const client = Deno.createHttpClient({ caCerts: [caCert] });
+    const resp = await fetch(`https://${hostname}:${port}/`, { client });
+    client.close();
+    assert(resp.body);
+    const reader = resp.body.getReader();
+    const result = await reader.read();
+    assert(!result.done);
+    assertEquals(result.value, new Uint8Array([65]));
+    const err = await assertRejects(() => reader.read());
+    assert(err instanceof TypeError);
+    assert(err.message.includes("unexpected internal error encountered"));
+
+    await server;
+    httpConn!.close();
+  },
+});
+
+Deno.test({
+  name:
+    "http server errors stream if response body errors (http/2 + fetch + compression)",
+  permissions: { net: true, read: true },
+  async fn() {
+    const hostname = "localhost";
+    const port = 4501;
+
+    let httpConn: Deno.HttpConn;
+    const server = (async () => {
+      const listener = Deno.listenTls({
+        hostname,
+        port,
+        certFile: "cli/tests/testdata/tls/localhost.crt",
+        keyFile: "cli/tests/testdata/tls/localhost.key",
+        alpnProtocols: ["h2"],
+      });
+      const conn = await listener.accept();
+      listener.close();
+      httpConn = Deno.serveHttp(conn);
+      const e = await httpConn.nextRequest();
+      assert(e);
+      const { respondWith } = e;
+      const originalErr = new Error("boom");
+      const rs = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new Uint8Array([65]));
+          await delay(1000);
+          controller.error(originalErr);
+        },
+      });
+      const resp = new Response(rs, {
+        headers: { "content-type": "text/plain" },
+      });
+      const err = await assertRejects(() => respondWith(resp));
+      assert(err === originalErr);
+    })();
+
+    const caCert = Deno.readTextFileSync("cli/tests/testdata/tls/RootCA.pem");
+    const client = Deno.createHttpClient({ caCerts: [caCert] });
+    const resp = await fetch(`https://${hostname}:${port}/`, { client });
+    client.close();
+    assert(resp.body);
+    const reader = resp.body.getReader();
+    const result = await reader.read();
+    assert(!result.done);
+    assertEquals(result.value, new Uint8Array([65]));
+    const err = await assertRejects(() => reader.read());
+    assert(err instanceof TypeError);
+    assert(err.message.includes("unexpected internal error encountered"));
+
+    await server;
+    httpConn!.close();
+  },
+});
+
 function chunkedBodyReader(h: Headers, r: BufReader): Deno.Reader {
   // Based on https://tools.ietf.org/html/rfc2616#section-19.4.6
   const tp = new TextProtoReader(r);

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -263,6 +263,7 @@
         }
 
         if (isStreamingResponseBody) {
+          let success = false;
           if (
             respBody === null ||
             !ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, respBody)
@@ -284,6 +285,7 @@
               );
               if (resourceBacking.autoClose) core.tryClose(resourceBacking.rid);
               readableStreamClose(respBody); // Release JS lock.
+              success = true;
             } catch (error) {
               const connError = httpConn[connErrorSymbol];
               if (
@@ -320,13 +322,16 @@
                 throw error;
               }
             }
+            success = true;
           }
 
-          try {
-            await core.opAsync("op_http_shutdown", streamRid);
-          } catch (error) {
-            await reader.cancel(error);
-            throw error;
+          if (success) {
+            try {
+              await core.opAsync("op_http_shutdown", streamRid);
+            } catch (error) {
+              await reader.cancel(error);
+              throw error;
+            }
           }
         }
 

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -30,8 +30,8 @@ fly-accept-encoding = "0.2.0"
 hyper = { workspace = true, features = ["server", "stream", "http1", "http2", "runtime"] }
 mime = "0.3.16"
 percent-encoding.workspace = true
-pin-project.workspace = true
 phf = { version = "0.10", features = ["macros"] }
+pin-project.workspace = true
 ring.workspace = true
 serde.workspace = true
 tokio.workspace = true

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -30,6 +30,7 @@ fly-accept-encoding = "0.2.0"
 hyper = { workspace = true, features = ["server", "stream", "http1", "http2", "runtime"] }
 mime = "0.3.16"
 percent-encoding.workspace = true
+pin-project.workspace = true
 phf = { version = "0.10", features = ["macros"] }
 ring.workspace = true
 serde.workspace = true

--- a/ext/http/reader_stream.rs
+++ b/ext/http/reader_stream.rs
@@ -1,0 +1,133 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use bytes::Bytes;
+use deno_core::futures::Stream;
+use pin_project::pin_project;
+use tokio::io::AsyncRead;
+use tokio_util::io::ReaderStream;
+
+/// [ExternallyAbortableByteStream] adapts a [tokio::AsyncRead] into a [Stream].
+/// It is used to bridge between the HTTP response body resource, and
+/// `hyper::Body`. The stream has the special property that it errors if the
+/// underlying reader is closed before an explicit EOF is sent (in the form of
+/// setting the `shutdown` flag to true).
+#[pin_project]
+pub struct ExternallyAbortableReaderStream<R: AsyncRead> {
+  #[pin]
+  inner: ReaderStream<R>,
+  done: Arc<AtomicBool>,
+}
+
+pub struct ShutdownHandle(Arc<AtomicBool>);
+
+impl ShutdownHandle {
+  pub fn shutdown(&self) {
+    self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+  }
+}
+
+impl<R: AsyncRead> ExternallyAbortableReaderStream<R> {
+  pub fn new(reader: R) -> (Self, ShutdownHandle) {
+    let done = Arc::new(AtomicBool::new(false));
+    let this = Self {
+      inner: ReaderStream::new(reader),
+      done: done.clone(),
+    };
+    (this, ShutdownHandle(done))
+  }
+}
+
+impl<R: AsyncRead> Stream for ExternallyAbortableReaderStream<R> {
+  type Item = std::io::Result<Bytes>;
+
+  fn poll_next(
+    self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Option<Self::Item>> {
+    let this = self.project();
+    let val = std::task::ready!(this.inner.poll_next(cx));
+    match val {
+      None if this.done.load(Ordering::Relaxed) => Poll::Ready(None),
+      None => Poll::Ready(Some(Err(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "channel closed",
+      )))),
+      Some(val) => Poll::Ready(Some(val)),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use bytes::Bytes;
+  use deno_core::futures::StreamExt;
+  use tokio::io::AsyncWriteExt;
+
+  #[tokio::test]
+  async fn success() {
+    let (a, b) = tokio::io::duplex(64 * 1024);
+    let (reader, _) = tokio::io::split(a);
+    let (_, mut writer) = tokio::io::split(b);
+
+    let (mut stream, shutdown_handle) =
+      ExternallyAbortableReaderStream::new(reader);
+
+    writer.write_all(b"hello").await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("hello"));
+
+    writer.write_all(b"world").await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("world"));
+
+    shutdown_handle.shutdown();
+    writer.shutdown().await.unwrap();
+    drop(writer);
+    assert!(stream.next().await.is_none());
+  }
+
+  #[tokio::test]
+  async fn error() {
+    let (a, b) = tokio::io::duplex(64 * 1024);
+    let (reader, _) = tokio::io::split(a);
+    let (_, mut writer) = tokio::io::split(b);
+
+    let (mut stream, _shutdown_handle) =
+      ExternallyAbortableReaderStream::new(reader);
+
+    writer.write_all(b"hello").await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("hello"));
+
+    drop(writer);
+    assert_eq!(
+      stream.next().await.unwrap().unwrap_err().kind(),
+      std::io::ErrorKind::UnexpectedEof
+    );
+  }
+
+  #[tokio::test]
+  async fn error2() {
+    let (a, b) = tokio::io::duplex(64 * 1024);
+    let (reader, _) = tokio::io::split(a);
+    let (_, mut writer) = tokio::io::split(b);
+
+    let (mut stream, _shutdown_handle) =
+      ExternallyAbortableReaderStream::new(reader);
+
+    writer.write_all(b"hello").await.unwrap();
+    assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("hello"));
+
+    writer.shutdown().await.unwrap();
+    drop(writer);
+    assert_eq!(
+      stream.next().await.unwrap().unwrap_err().kind(),
+      std::io::ErrorKind::UnexpectedEof
+    );
+  }
+}

--- a/ext/http/reader_stream.rs
+++ b/ext/http/reader_stream.rs
@@ -57,7 +57,7 @@ impl<R: AsyncRead> Stream for ExternallyAbortableReaderStream<R> {
       None if this.done.load(Ordering::Relaxed) => Poll::Ready(None),
       None => Poll::Ready(Some(Err(std::io::Error::new(
         std::io::ErrorKind::UnexpectedEof,
-        "channel closed",
+        "stream reader has shut down",
       )))),
       Some(val) => Poll::Ready(Some(val)),
     }

--- a/ext/http/reader_stream.rs
+++ b/ext/http/reader_stream.rs
@@ -54,7 +54,7 @@ impl<R: AsyncRead> Stream for ExternallyAbortableReaderStream<R> {
     let this = self.project();
     let val = std::task::ready!(this.inner.poll_next(cx));
     match val {
-      None if this.done.load(Ordering::Relaxed) => Poll::Ready(None),
+      None if this.done.load(Ordering::SeqCst) => Poll::Ready(None),
       None => Poll::Ready(Some(Err(std::io::Error::new(
         std::io::ErrorKind::UnexpectedEof,
         "stream reader has shut down",


### PR DESCRIPTION
Previously, errored streaming response bodies did not cause the HTTP stream
to be aborted. It instead caused the stream to be closed gracefully,
which had the result that the client could not detect the difference
between a successful response and an errored response.

This commit fixes the issue by aborting the stream on error.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
