### PR TITLE
fix(cli): Do not clear screen for non-TTY environments in watch mode

### DIFF
--- a/cli/tests/watcher_tests.rs
+++ b/cli/tests/watcher_tests.rs
@@ -8,6 +8,8 @@ use test_util::assert_contains;
 use test_util::TempDir;
 
 mod watcher {
+  use util::assert_not_contains;
+
   use super::*;
 
   const CLEAR_SCREEN: &str = r#"[2J"#;
@@ -82,7 +84,7 @@ mod watcher {
       .lines()
       .map(|r| {
         let line = r.unwrap();
-        eprintln!("STERR: {}", line);
+        eprintln!("STDERR: {}", line);
         line
       });
     (stdout_lines, stderr_lines)
@@ -124,7 +126,7 @@ mod watcher {
     let expected = std::fs::read_to_string(badly_linted_output).unwrap();
     assert_eq!(output, expected);
 
-    // Change content of the file again to be badly-linted1
+    // Change content of the file again to be badly-linted
     std::fs::copy(badly_linted_fixed1, &badly_linted).unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
 
@@ -132,7 +134,7 @@ mod watcher {
     let expected = std::fs::read_to_string(badly_linted_fixed1_output).unwrap();
     assert_eq!(output, expected);
 
-    // Change content of the file again to be badly-linted1
+    // Change content of the file again to be badly-linted
     std::fs::copy(badly_linted_fixed2, &badly_linted).unwrap();
 
     output = read_all_lints(&mut stderr_lines);
@@ -182,14 +184,14 @@ mod watcher {
     let expected = std::fs::read_to_string(badly_linted_output).unwrap();
     assert_eq!(output, expected);
 
-    // Change content of the file again to be badly-linted1
+    // Change content of the file again to be badly-linted
     std::fs::copy(badly_linted_fixed1, &badly_linted).unwrap();
 
     output = read_all_lints(&mut stderr_lines);
     let expected = std::fs::read_to_string(badly_linted_fixed1_output).unwrap();
     assert_eq!(output, expected);
 
-    // Change content of the file again to be badly-linted1
+    // Change content of the file again to be badly-linted
     std::fs::copy(badly_linted_fixed2, &badly_linted).unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
 
@@ -425,7 +427,8 @@ mod watcher {
 
     assert_contains!(stderr_lines.next().unwrap(), "Check");
     let next_line = stderr_lines.next().unwrap();
-    assert_contains!(&next_line, CLEAR_SCREEN);
+    // Should not clear screen, as we are in non-TTY environment
+    assert_not_contains!(&next_line, CLEAR_SCREEN);
     assert_contains!(&next_line, "File change detected!");
     assert_contains!(stderr_lines.next().unwrap(), "file_to_watch.ts");
     assert_contains!(stderr_lines.next().unwrap(), "mod6.bundle.js");
@@ -476,7 +479,8 @@ mod watcher {
 
     assert_contains!(stderr_lines.next().unwrap(), "Check");
     let next_line = stderr_lines.next().unwrap();
-    assert_contains!(&next_line, CLEAR_SCREEN);
+    // Should not clear screen, as we are in non-TTY environment
+    assert_not_contains!(&next_line, CLEAR_SCREEN);
     assert_contains!(&next_line, "File change detected!");
     assert_contains!(stderr_lines.next().unwrap(), "file_to_watch.ts");
     assert_contains!(stderr_lines.next().unwrap(), "target.js");

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -119,13 +119,13 @@ where
 pub struct PrintConfig {
   /// printing watcher status to terminal.
   pub job_name: String,
-  /// determine whether to clear the terminal screen
+  /// determine whether to clear the terminal screen; applicable to TTY environments only.
   pub clear_screen: bool,
 }
 
 fn create_print_after_restart_fn(clear_screen: bool) -> impl Fn() {
   move || {
-    if clear_screen {
+    if clear_screen && atty::is(atty::Stream::Stderr) {
       eprint!("{}", CLEAR_SCREEN);
     }
     info!(


### PR DESCRIPTION
Unfortunately adding a test to this is not trivial, as `with_pty` test helper is not well-suited for this purpose.
We'd most likely need to pull https://docs.rs/fake-tty/latest/fake_tty/ which does not support all environments Deno is interested in. I'm open to suggestions in case this change requires adding a unit test.

Tested it manually (see attached screenshot).

Fixes https://github.com/denoland/deno/issues/15041

<img width="732" alt="image" src="https://user-images.githubusercontent.com/1523305/208471948-c0025f13-52dc-4a55-9d84-84f9dc74ef8c.png">