### PR TITLE
chore(test): report correct cwd when running tests via itest macro

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1930,7 +1930,7 @@ impl<'a> CheckOutputIntegrationTest<'a> {
       testdata_dir.as_path()
     };
     println!("deno_exe args {}", args.join(" "));
-    println!("deno_exe cwd {:?}", &testdata_dir);
+    println!("deno_exe cwd {:?}", &cwd);
     command.args(args.iter());
     if self.env_clear {
       command.env_clear();


### PR DESCRIPTION
Based on the few lines above, `cwd` is not always `testdata_dir`:

```rust
let cwd = if self.temp_cwd {
  deno_dir.path()
} else {
  testdata_dir.as_path()
};
```