### PR TITLE
fix(cli): uninstall command accept short flags

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1312,8 +1312,7 @@ fn uninstall_subcommand<'a>() -> Command<'a> {
     .arg(
       Arg::new("name")
         .required(true)
-        .multiple_occurrences(false)
-        .allow_hyphen_values(true))
+        .multiple_occurrences(false))
     .arg(
       Arg::new("root")
         .long("root")


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

There is an error about short flags in uninstall subcommand and it will fixes #16763 

Current Situation
```
➜ deno uninstall -h
error: No installation found for -h
```

With this PR 

```
❯ ./target/debug/deno uninstall -h
deno-uninstall
Uninstall a script previously installed with deno install

USAGE:
    deno uninstall [OPTIONS] <name>

ARGS:
    <name>

OPTIONS:
    -h, --help           Print help information
    -q, --quiet          Suppress diagnostic output
        --root <root>    Installation root
        --unstable       Enable unstable features and APIs
```
