### PR TITLE
fix(cli):no header if the error is from stdio

### DIFF
--- a/cli/tests/repl_tests.rs
+++ b/cli/tests/repl_tests.rs
@@ -978,7 +978,8 @@ mod repl {
       .stdout(process_that_already_closed.stdin.take().unwrap())
       .output()
       .unwrap();
-    assert!(!output.status.success());
+    // NOTE: seem that status.success() is true in windows
+    // assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("failed printing to stdout: Broken pipe"));
     assert!(!stderr.contains("Deno has panicked"));

--- a/cli/tests/repl_tests.rs
+++ b/cli/tests/repl_tests.rs
@@ -973,13 +973,28 @@ mod repl {
       .stdin(std::process::Stdio::piped())
       .spawn()
       .unwrap();
-    let output = util::deno_cmd()
+
+    // NOTE: Running util::deno_cmd somehow doesn't error on windows
+    //       Use cmd /C deno instead
+    let deno_cmd = {
+      let mut p = target_dir().join("deno");
+      if cfg!(windows) {
+        p.set_extension("exe");
+      }
+      let deno_path = util::target_dir().join(p);
+      if cfg!(windows) {
+        Command::new("cmd").arg("/C").arg(deno_path)
+      } else {
+        Command::new(deno_path)
+      }
+    };
+
+    let output = deno_cmd
       .arg("repl")
       .stdout(process_that_already_closed.stdin.take().unwrap())
       .output()
       .unwrap();
-    // NOTE: seem that status.success() is true in windows
-    // assert!(!output.status.success());
+    assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("failed printing to stdout: Broken pipe"));
     assert!(!stderr.contains("Deno has panicked"));

--- a/cli/tests/repl_tests.rs
+++ b/cli/tests/repl_tests.rs
@@ -969,10 +969,12 @@ mod repl {
   #[test]
   fn no_cutom_panic_header_for_broken_pipe() {
     let mut process_that_already_closed = std::process::Command::new("echo")
+      .arg("1")
       .stdin(std::process::Stdio::piped())
       .spawn()
       .unwrap();
     let output = util::deno_cmd()
+      .arg("repl")
       .stdout(process_that_already_closed.stdin.take().unwrap())
       .output()
       .unwrap();

--- a/cli/tests/repl_tests.rs
+++ b/cli/tests/repl_tests.rs
@@ -965,4 +965,20 @@ mod repl {
       assert!(err.is_empty());
     }
   }
+
+  #[test]
+  fn no_cutom_panic_header_for_broken_pipe() {
+    let mut process_that_already_closed = std::process::Command::new("echo")
+      .stdin(std::process::Stdio::piped())
+      .spawn()
+      .unwrap();
+    let output = util::deno_cmd()
+      .stdout(process_that_already_closed.stdin.take().unwrap())
+      .output()
+      .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("failed printing to stdout: Broken pipe"));
+    assert!(!stderr.contains("Deno has panicked"));
+  }
 }


### PR DESCRIPTION
Currently if we get an error from rust stdio, like `Broken pipe` we print our usual header and advise the user to report this as a bug. But this is not a bug in deno, so this pr add a heuristic to detect this and if its the case (error coming from stdio), just do the normal panic without our deno header.

Relevant issues:

https://github.com/denoland/deno/issues/15767
https://github.com/denoland/deno/issues/14746
https://github.com/denoland/deno/issues/15045
https://github.com/denoland/deno/pull/15982

- [x] TODO tests

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
