### PR TITLE
fix: rejected dynamic import should retain error context

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -537,7 +537,8 @@ pub(crate) fn to_v8_type_error(
   scope: &mut v8::HandleScope,
   err: Error,
 ) -> v8::Global<v8::Value> {
-  let message = err.to_string();
+  // Note: using format string here, so that context of the error is included.
+  let message = format!("{:?}", err);
   let message = v8::String::new(scope, &message).unwrap();
   let exception = v8::Exception::type_error(scope, message);
   v8::Global::new(scope, exception)

--- a/core/error.rs
+++ b/core/error.rs
@@ -537,8 +537,24 @@ pub(crate) fn to_v8_type_error(
   scope: &mut v8::HandleScope,
   err: Error,
 ) -> v8::Global<v8::Value> {
-  // Note: using format string here, so that context of the error is included.
-  let message = format!("{:?}", err);
+  let err_string = err.to_string();
+  let error_chain = err
+    .chain()
+    .skip(1)
+    .filter(|e| e.to_string() != err_string)
+    .map(|e| e.to_string())
+    .collect::<Vec<_>>();
+
+  let message = if !error_chain.is_empty() {
+    format!(
+      "{}\n  Caused by:\n    {}",
+      err_string,
+      error_chain.join("\n    ")
+    )
+  } else {
+    err_string
+  };
+
   let message = v8::String::new(scope, &message).unwrap();
   let exception = v8::Exception::type_error(scope, message);
   v8::Global::new(scope, exception)


### PR DESCRIPTION
Found this while debugging https://github.com/denoland/deno/issues/16280.

Before:
```
TypeError: Could not resolve 'file:///Users/ib/dev/test_rollup/mocha/rollup.config.js' from 'file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/shared/loadConfigFile.js'.
    at async getConfigFileExport (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/shared/loadConfigFile.js:432:17)
    at async Object.loadConfigFile (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/shared/loadConfigFile.js:391:59)
    at async getConfigs (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/bin/rollup:1679:39)
    at async runRollup (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/bin/rollup:1656:43)
```

After:
```
TypeError: Could not resolve 'file:///Users/ib/dev/test_rollup/mocha/rollup.config.js' from 'file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/shared/loadConfigFile.js'.
  Caused by: 
    Reading /Users/ib/dev/test_rollup/mocha/package.json is not allowed
    at async getConfigFileExport (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/shared/loadConfigFile.js:432:17)
    at async Object.loadConfigFile (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/shared/loadConfigFile.js:391:59)
    at async getConfigs (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/bin/rollup:1679:39)
    at async runRollup (file:///Users/ib/Library/Caches/deno/npm/registry.npmjs.org/rollup/3.7.3/dist/bin/rollup:1656:43)
```