### PR TITLE
fix(ext/fetch): Guard against invalid URL before its used by reqwest

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -93,6 +93,19 @@ Deno.test(
   },
 );
 
+Deno.test(
+  { permissions: { net: true } },
+  async function fetchMalformedUriError() {
+    await assertRejects(
+      async () => {
+        const url = new URL("http://{{google/");
+        await fetch(url);
+      },
+      TypeError,
+    );
+  },
+);
+
 Deno.test({ permissions: { net: true } }, async function fetchJsonSuccess() {
   const response = await fetch("http://localhost:4545/assets/fixture.json");
   const json = await response.json();

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -217,12 +217,6 @@ where
   let method = Method::from_bytes(&method)?;
   let url = Url::parse(&url)?;
 
-  // Make sure that we have a valid URI early, as reqwest's `RequestBuilder::send`
-  // internally uses `expect_uri`, which panics instead of returning a usable `Result`.
-  if url.as_str().parse::<Uri>().is_err() {
-    return Err(type_error("Invalid URL"));
-  }
-
   // Check scheme before asking for net permission
   let scheme = url.scheme();
   let (request_rid, request_body_rid, cancel_handle_rid) = match scheme {
@@ -257,6 +251,12 @@ where
     "http" | "https" => {
       let permissions = state.borrow_mut::<FP>();
       permissions.check_net_url(&url, "fetch()")?;
+
+      // Make sure that we have a valid URI early, as reqwest's `RequestBuilder::send`
+      // internally uses `expect_uri`, which panics instead of returning a usable `Result`.
+      if url.as_str().parse::<Uri>().is_err() {
+        return Err(type_error("Invalid URL"));
+      }
 
       let mut request = client.request(method.clone(), url);
 


### PR DESCRIPTION
When `reqwest` is checking for the URL validity 

https://github.com/seanmonstar/reqwest/blob/cdbf84feb1d86b8288796631f2120de5363b3ba9/src/async_impl/client.rs#L1544

it's already too late, as it will panic, without a way to intercept the error

https://github.com/seanmonstar/reqwest/blob/cdbf84feb1d86b8288796631f2120de5363b3ba9/src/into_url.rs#L67-L71


Fixes https://github.com/denoland/deno/issues/17154

~_Note: I see CI is failing, will fix it soon_~