### PR TITLE
feat(ext/fetch): Allow specifying a custom DNS resolver for `fetch` calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,7 @@ dependencies = [
  "deno_tls",
  "dyn-clone",
  "http",
+ "hyper",
  "reqwest",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ pin-project = "1.0.11" # don't pin because they yank crates from cargo
 pretty_assertions = "=1.3.0"
 rand = "=0.8.5"
 regex = "^1.7.0"
-reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks"] }
 ring = "=0.16.20"
 rusqlite = { version = "=0.28.0", features = ["unlock_notify", "bundled"] }
 rustls = "0.20.5"

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -1670,7 +1670,7 @@ mod tests {
 
   fn create_test_client() -> HttpClient {
     HttpClient::from_client(
-      create_http_client("test_client", None, vec![], None, None, None)
+      create_http_client("test_client", None, vec![], None, None, None, None)
         .unwrap(),
     )
   }
@@ -1878,6 +1878,7 @@ mod tests {
         None,
         None,
         None,
+        None,
       )
       .unwrap(),
     );
@@ -1912,6 +1913,7 @@ mod tests {
         version::get_user_agent(),
         None, // This will load mozilla certs by default
         vec![],
+        None,
         None,
         None,
         None,
@@ -1994,6 +1996,7 @@ mod tests {
         None,
         None,
         None,
+        None,
       )
       .unwrap(),
     );
@@ -2036,6 +2039,7 @@ mod tests {
             .unwrap(),
         )
         .unwrap()],
+        None,
         None,
         None,
         None,
@@ -2098,6 +2102,7 @@ mod tests {
             .unwrap(),
         )
         .unwrap()],
+        None,
         None,
         None,
         None,

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -232,6 +232,7 @@ impl HttpClient {
       None,
       unsafely_ignore_certificate_errors,
       None,
+      None,
     )?))
   }
 

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -20,6 +20,7 @@ deno_core.workspace = true
 deno_tls.workspace = true
 dyn-clone = "1"
 http.workspace = true
+hyper.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
Implements #17165

- Adds a new field to `deno_fetch::Options` to allow specifying a custom DNS resolver
- Bumps `reqwest` to the latest version to use this feature
