### PR TITLE
[WIP] feat(npm): add missing APIs to run ts-node

### DIFF
--- a/ext/node/02_require.js
+++ b/ext/node/02_require.js
@@ -47,7 +47,7 @@
 
   function pathDirname(filepath) {
     if (filepath == null || filepath === "") {
-      throw new Error("Empty filepath.");
+      return ".";
     }
     return ops.op_require_path_dirname(filepath);
   }
@@ -888,6 +888,30 @@
   };
 
   Module.Module = Module;
+
+  Module._preloadModules = function (requests) {
+    if (!ArrayIsArray(requests)) {
+      return;
+    }
+
+    isPreloading = true;
+
+    const parent = new Module("internal/preload", null);
+    try {
+      parent.paths = Module._nodeModulePaths(core.ops.op_require_current_dir());
+    } catch (e) {
+      // FIXME(bartlomieju): this is wrong
+      if (e.code !== "ENOENT") {
+        isPreloading = false;
+        throw e;
+      }
+    }
+    for (let n = 0; n < requests.length; n++) {
+      parent.require(requests[n]);
+    }
+
+    isPreloading = false;
+  };
 
   node.nativeModuleExports.module = Module;
 

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -94,6 +94,7 @@ pub fn init<P: NodePermissions + 'static>(
       op_require_resolve_deno_dir::decl(),
       op_require_is_request_relative::decl(),
       op_require_resolve_lookup_paths::decl(),
+      op_require_current_dir::decl::<P>(),
       op_require_try_self_parent_path::decl::<P>(),
       op_require_try_self::decl(),
       op_require_real_path::decl::<P>(),
@@ -456,6 +457,16 @@ where
     }
   }
   Ok(None)
+}
+
+#[op]
+fn op_require_current_dir<P>(state: &mut OpState) -> Result<String, AnyError>
+where
+  P: NodePermissions + 'static,
+{
+  let cwd = std::env::current_dir()?;
+  ensure_read_permission::<P>(state, &cwd)?;
+  Ok(cwd.to_string_lossy().to_string())
 }
 
 #[op]


### PR DESCRIPTION
Towards https://github.com/denoland/deno/issues/17176

I want to keep this PR running and I will be breaking out relevant pieces into separate PRs.

Current problem:
```
../../deno/target/debug/deno run -A --node-modules-dir npm:ts-node foo.ts
error: Uncaught TypeError: Module.runMain is not a function
    at <anonymous> (file:///Users/ib/dev/test_rollup/mocha/node_modules/.deno/ts-node@10.9.1/node_modules/ts-node/dist/bin.js:465:20)
```