### PR TITLE
fix(ext/net): Remove unstable check from op_node_unstable_net_listen_udp

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -366,7 +366,6 @@ fn op_node_unstable_net_listen_udp<NP>(
 where
   NP: NetPermissions + 'static,
 {
-  super::check_unstable(state, "Deno.listenDatagram");
   net_listen_udp::<NP>(state, addr, reuse_address)
 }
 


### PR DESCRIPTION
The whole point of creating this alternative operation was to allow usage in node, without `--unstable` flag.
Introduced and I believe missed in https://github.com/denoland/deno/pull/16520/