### PR TITLE
fix(npm): allow to read package.json if permissions are granted

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -33,6 +33,7 @@ use deno_core::ModuleSpecifier;
 use deno_graph::GraphImport;
 use deno_graph::Resolved;
 use deno_runtime::deno_node::NodeResolutionMode;
+use deno_runtime::permissions::PermissionsContainer;
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -1004,6 +1005,7 @@ impl Documents {
               referrer,
               NodeResolutionMode::Types,
               npm_resolver,
+              &mut PermissionsContainer::allow_all(),
             )
             .ok()
             .flatten(),
@@ -1040,6 +1042,7 @@ impl Documents {
               &npm_ref,
               NodeResolutionMode::Types,
               npm_resolver,
+              &mut PermissionsContainer::allow_all(),
             )
             .ok()
             .flatten(),
@@ -1208,6 +1211,7 @@ impl Documents {
             &npm_ref,
             NodeResolutionMode::Types,
             npm_resolver,
+            &mut PermissionsContainer::allow_all(),
           )
           .ok()
           .flatten(),

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -20,6 +20,7 @@ use deno_core::ModuleSource;
 use deno_core::ModuleSpecifier;
 use deno_core::ModuleType;
 use deno_core::OpState;
+use deno_core::ResolutionKind;
 use deno_core::SourceMapGetter;
 use deno_runtime::permissions::PermissionsContainer;
 use std::cell::RefCell;
@@ -220,10 +221,9 @@ impl ModuleLoader for CliModuleLoader {
     &self,
     specifier: &str,
     referrer: &str,
-    _is_main: bool,
-    is_dynamic: bool,
+    kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, AnyError> {
-    let mut permissions = if is_dynamic {
+    let mut permissions = if matches!(kind, ResolutionKind::DynamicImport) {
       self.dynamic_permissions.clone()
     } else {
       self.root_permissions.clone()

--- a/cli/node/mod.rs
+++ b/cli/node/mod.rs
@@ -14,6 +14,7 @@ use deno_core::anyhow::Context;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
 use deno_core::located_script_name;
+use deno_core::parking_lot::Mutex;
 use deno_core::serde_json::Value;
 use deno_core::url::Url;
 use deno_core::JsRuntime;
@@ -31,8 +32,10 @@ use deno_runtime::deno_node::PathClean;
 use deno_runtime::deno_node::RequireNpmResolver;
 use deno_runtime::deno_node::DEFAULT_CONDITIONS;
 use deno_runtime::deno_node::NODE_GLOBAL_THIS_NAME;
+use deno_runtime::permissions::Permissions;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 use crate::cache::NodeAnalysisCache;
 use crate::deno_std::CURRENT_STD_URL;
@@ -554,10 +557,12 @@ pub fn node_resolve_binary_export(
   bin_name: Option<&str>,
   npm_resolver: &NpmPackageResolver,
 ) -> Result<NodeResolution, AnyError> {
+  let permissions = Arc::new(Mutex::new(Permissions::allow_all()));
   let package_folder =
     npm_resolver.resolve_package_folder_from_deno_module(pkg_req)?;
   let package_json_path = package_folder.join("package.json");
-  let package_json = PackageJson::load(npm_resolver, package_json_path)?;
+  let package_json =
+    PackageJson::load(npm_resolver, permissions, package_json_path)?;
   let bin = match &package_json.bin {
     Some(bin) => bin,
     None => bail!(
@@ -668,8 +673,12 @@ fn package_config_resolve(
 ) -> Result<Option<PathBuf>, AnyError> {
   let package_json_path = package_dir.join("package.json");
   let referrer = ModuleSpecifier::from_directory_path(package_dir).unwrap();
-  let package_config =
-    PackageJson::load(npm_resolver, package_json_path.clone())?;
+  let permissions = Arc::new(Mutex::new(Permissions::allow_all()));
+  let package_config = PackageJson::load(
+    npm_resolver,
+    permissions.clone(),
+    package_json_path.clone(),
+  )?;
   if let Some(exports) = &package_config.exports {
     let result = package_exports_resolve(
       &package_json_path,
@@ -680,6 +689,7 @@ fn package_config_resolve(
       conditions,
       mode,
       npm_resolver,
+      permissions,
     );
     match result {
       Ok(found) => return Ok(Some(found)),
@@ -712,7 +722,11 @@ pub fn url_to_node_resolution(
   if url_str.starts_with("http") {
     Ok(NodeResolution::Esm(url))
   } else if url_str.ends_with(".js") || url_str.ends_with(".d.ts") {
-    let package_config = get_closest_package_json(&url, npm_resolver)?;
+    let package_config = get_closest_package_json(
+      &url,
+      npm_resolver,
+      Arc::new(Mutex::new(Permissions::allow_all())),
+    )?;
     if package_config.typ == "module" {
       Ok(NodeResolution::Esm(url))
     } else {
@@ -787,6 +801,7 @@ fn module_resolve(
   mode: NodeResolutionMode,
   npm_resolver: &dyn RequireNpmResolver,
 ) -> Result<Option<ModuleSpecifier>, AnyError> {
+  let permissions = Arc::new(Mutex::new(Permissions::allow_all()));
   // note: if we're here, the referrer is an esm module
   let url = if should_be_treated_as_relative_or_absolute_path(specifier) {
     let resolved_specifier = referrer.join(specifier)?;
@@ -811,6 +826,7 @@ fn module_resolve(
         conditions,
         mode,
         npm_resolver,
+        permissions,
       )
       .map(|p| ModuleSpecifier::from_file_path(p).unwrap())?,
     )
@@ -824,6 +840,7 @@ fn module_resolve(
       conditions,
       mode,
       npm_resolver,
+      permissions,
     )?
     .map(|p| ModuleSpecifier::from_file_path(p).unwrap())
   };
@@ -1053,10 +1070,14 @@ fn resolve(
     mode,
   )?;
 
+  let permissions = Arc::new(Mutex::new(Permissions::allow_all()));
   let package_json_path = module_dir.join("package.json");
   if package_json_path.exists() {
-    let package_json =
-      PackageJson::load(npm_resolver, package_json_path.clone())?;
+    let package_json = PackageJson::load(
+      npm_resolver,
+      permissions.clone(),
+      package_json_path.clone(),
+    )?;
 
     if let Some(exports) = &package_json.exports {
       return package_exports_resolve(
@@ -1068,6 +1089,7 @@ fn resolve(
         conditions,
         mode,
         npm_resolver,
+        permissions,
       );
     }
 
@@ -1080,7 +1102,7 @@ fn resolve(
           let package_json_path = d.join("package.json");
           if package_json_path.exists() {
             let package_json =
-              PackageJson::load(npm_resolver, package_json_path)?;
+              PackageJson::load(npm_resolver, permissions, package_json_path)?;
             if let Some(main) = package_json.main(NodeModuleKind::Cjs) {
               return Ok(d.join(main).clean());
             }

--- a/cli/npm/resolvers/common.rs
+++ b/cli/npm/resolvers/common.rs
@@ -9,11 +9,9 @@ use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
 use deno_core::futures;
 use deno_core::futures::future::BoxFuture;
-use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
 use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
-use std::sync::Arc;
 
 use crate::args::Lockfile;
 use crate::npm::cache::should_sync_download;
@@ -59,7 +57,7 @@ pub trait InnerNpmPackageResolver: Send + Sync {
 
   fn ensure_read_permission(
     &self,
-    permissions: Arc<Mutex<dyn NodePermissions>>,
+    permissions: &mut dyn NodePermissions,
     path: &Path,
   ) -> Result<(), AnyError>;
 
@@ -110,7 +108,7 @@ pub async fn cache_packages(
 }
 
 pub fn ensure_registry_read_permission(
-  permissions: Arc<Mutex<dyn NodePermissions>>,
+  permissions: &mut dyn NodePermissions,
   registry_path: &Path,
   path: &Path,
 ) -> Result<(), AnyError> {
@@ -134,7 +132,7 @@ pub fn ensure_registry_read_permission(
     }
   }
 
-  permissions.lock().check_read(path)
+  permissions.check_read(path)
 }
 
 /// Gets the corresponding @types package for the provided package name.

--- a/cli/npm/resolvers/global.rs
+++ b/cli/npm/resolvers/global.rs
@@ -11,7 +11,6 @@ use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
 use deno_core::futures::future::BoxFuture;
 use deno_core::futures::FutureExt;
-use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
 use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
@@ -158,7 +157,7 @@ impl InnerNpmPackageResolver for GlobalNpmPackageResolver {
 
   fn ensure_read_permission(
     &self,
-    permissions: Arc<Mutex<dyn NodePermissions>>,
+    permissions: &mut dyn NodePermissions,
     path: &Path,
   ) -> Result<(), AnyError> {
     let registry_path = self.cache.registry_folder(&self.registry_url);

--- a/cli/npm/resolvers/global.rs
+++ b/cli/npm/resolvers/global.rs
@@ -11,7 +11,9 @@ use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
 use deno_core::futures::future::BoxFuture;
 use deno_core::futures::FutureExt;
+use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
+use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
 
 use crate::args::Lockfile;
@@ -154,9 +156,13 @@ impl InnerNpmPackageResolver for GlobalNpmPackageResolver {
     async move { cache_packages_in_resolver(&resolver).await }.boxed()
   }
 
-  fn ensure_read_permission(&self, path: &Path) -> Result<(), AnyError> {
+  fn ensure_read_permission(
+    &self,
+    permissions: Arc<Mutex<dyn NodePermissions>>,
+    path: &Path,
+  ) -> Result<(), AnyError> {
     let registry_path = self.cache.registry_folder(&self.registry_url);
-    ensure_registry_read_permission(&registry_path, path)
+    ensure_registry_read_permission(permissions, &registry_path, path)
   }
 
   fn snapshot(&self) -> NpmResolutionSnapshot {

--- a/cli/npm/resolvers/local.rs
+++ b/cli/npm/resolvers/local.rs
@@ -17,8 +17,10 @@ use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
 use deno_core::futures::future::BoxFuture;
 use deno_core::futures::FutureExt;
+use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
 use deno_runtime::deno_core::futures;
+use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
 use deno_runtime::deno_node::PackageJson;
 use tokio::task::JoinHandle;
@@ -245,8 +247,16 @@ impl InnerNpmPackageResolver for LocalNpmPackageResolver {
     .boxed()
   }
 
-  fn ensure_read_permission(&self, path: &Path) -> Result<(), AnyError> {
-    ensure_registry_read_permission(&self.root_node_modules_path, path)
+  fn ensure_read_permission(
+    &self,
+    permissions: Arc<Mutex<dyn NodePermissions>>,
+    path: &Path,
+  ) -> Result<(), AnyError> {
+    ensure_registry_read_permission(
+      permissions,
+      &self.root_node_modules_path,
+      path,
+    )
   }
 
   fn snapshot(&self) -> NpmResolutionSnapshot {

--- a/cli/npm/resolvers/local.rs
+++ b/cli/npm/resolvers/local.rs
@@ -17,7 +17,6 @@ use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
 use deno_core::futures::future::BoxFuture;
 use deno_core::futures::FutureExt;
-use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
 use deno_runtime::deno_core::futures;
 use deno_runtime::deno_node::NodePermissions;
@@ -249,7 +248,7 @@ impl InnerNpmPackageResolver for LocalNpmPackageResolver {
 
   fn ensure_read_permission(
     &self,
-    permissions: Arc<Mutex<dyn NodePermissions>>,
+    permissions: &mut dyn NodePermissions,
     path: &Path,
   ) -> Result<(), AnyError> {
     ensure_registry_read_permission(

--- a/cli/npm/resolvers/mod.rs
+++ b/cli/npm/resolvers/mod.rs
@@ -370,7 +370,7 @@ impl RequireNpmResolver for NpmPackageResolver {
 
   fn ensure_read_permission(
     &self,
-    permissions: Arc<Mutex<dyn NodePermissions>>,
+    permissions: &mut dyn NodePermissions,
     path: &Path,
   ) -> Result<(), AnyError> {
     self.inner.ensure_read_permission(permissions, path)

--- a/cli/npm/resolvers/mod.rs
+++ b/cli/npm/resolvers/mod.rs
@@ -11,6 +11,7 @@ use deno_core::error::custom_error;
 use deno_core::error::AnyError;
 use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
+use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
 use deno_runtime::deno_node::PathClean;
 use deno_runtime::deno_node::RequireNpmResolver;
@@ -367,8 +368,12 @@ impl RequireNpmResolver for NpmPackageResolver {
       .is_ok()
   }
 
-  fn ensure_read_permission(&self, path: &Path) -> Result<(), AnyError> {
-    self.inner.ensure_read_permission(path)
+  fn ensure_read_permission(
+    &self,
+    permissions: Arc<Mutex<dyn NodePermissions>>,
+    path: &Path,
+  ) -> Result<(), AnyError> {
+    self.inner.ensure_read_permission(permissions, path)
   }
 }
 

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -532,7 +532,7 @@ impl ProcState {
     &self,
     specifier: &str,
     referrer: &str,
-    permissions: PermissionsContainer,
+    permissions: &mut PermissionsContainer,
   ) -> Result<ModuleSpecifier, AnyError> {
     if let Ok(referrer) = deno_core::resolve_url_or_path(referrer) {
       if self.npm_resolver.in_npm_package(&referrer) {
@@ -543,7 +543,7 @@ impl ProcState {
             &referrer,
             NodeResolutionMode::Execution,
             &self.npm_resolver,
-            &mut permissions,
+            permissions,
           ))
           .with_context(|| {
             format!("Could not resolve '{}' from '{}'.", specifier, referrer)
@@ -577,7 +577,7 @@ impl ProcState {
                 &reference,
                 NodeResolutionMode::Execution,
                 &self.npm_resolver,
-                &mut permissions,
+                permissions,
               ))
               .with_context(|| format!("Could not resolve '{}'.", reference));
           } else {
@@ -621,7 +621,7 @@ impl ProcState {
               &reference,
               deno_runtime::deno_node::NodeResolutionMode::Execution,
               &self.npm_resolver,
-              &mut permissions,
+              permissions,
             ))
             .with_context(|| format!("Could not resolve '{}'.", reference));
         }

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -532,6 +532,7 @@ impl ProcState {
     &self,
     specifier: &str,
     referrer: &str,
+    permissions: PermissionsContainer,
   ) -> Result<ModuleSpecifier, AnyError> {
     if let Ok(referrer) = deno_core::resolve_url_or_path(referrer) {
       if self.npm_resolver.in_npm_package(&referrer) {
@@ -542,6 +543,7 @@ impl ProcState {
             &referrer,
             NodeResolutionMode::Execution,
             &self.npm_resolver,
+            &mut permissions,
           ))
           .with_context(|| {
             format!("Could not resolve '{}' from '{}'.", specifier, referrer)
@@ -575,6 +577,7 @@ impl ProcState {
                 &reference,
                 NodeResolutionMode::Execution,
                 &self.npm_resolver,
+                &mut permissions,
               ))
               .with_context(|| format!("Could not resolve '{}'.", reference));
           } else {
@@ -618,6 +621,7 @@ impl ProcState {
               &reference,
               deno_runtime::deno_node::NodeResolutionMode::Execution,
               &self.npm_resolver,
+              &mut permissions,
             ))
             .with_context(|| format!("Could not resolve '{}'.", reference));
         }

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -138,6 +138,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
     specifier: &str,
     referrer: &str,
     _is_main: bool,
+    _is_dynamic: bool,
   ) -> Result<ModuleSpecifier, AnyError> {
     // Try to follow redirects when resolving.
     let referrer = match self.eszip.get_module(referrer) {

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -23,6 +23,7 @@ use deno_core::url::Url;
 use deno_core::v8_set_flags;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
+use deno_core::ResolutionKind;
 use deno_graph::source::Resolver;
 use deno_runtime::deno_broadcast_channel::InMemoryBroadcastChannel;
 use deno_runtime::deno_tls::rustls_pemfile;
@@ -137,8 +138,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
     &self,
     specifier: &str,
     referrer: &str,
-    _is_main: bool,
-    _is_dynamic: bool,
+    _kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, AnyError> {
     // Try to follow redirects when resolving.
     let referrer = match self.eszip.get_module(referrer) {

--- a/cli/tests/npm_tests.rs
+++ b/cli/tests/npm_tests.rs
@@ -360,6 +360,13 @@ mod npm {
     exit_code: 1,
   });
 
+  itest!(permissions_outside_package {
+    args: "run --allow-read npm/permissions_outside_package/main.ts",
+    output: "npm/permissions_outside_package/main.out",
+    envs: env_vars_for_npm_tests(),
+    http_server: true,
+  });
+
   #[test]
   fn parallel_downloading() {
     let (out, _err) = util::run_and_collect_output_with_args(

--- a/cli/tests/testdata/npm/permissions_outside_package/foo/config.js
+++ b/cli/tests/testdata/npm/permissions_outside_package/foo/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "name": "foobar",
+  "version": "0.0.1",
+};

--- a/cli/tests/testdata/npm/permissions_outside_package/foo/package.json
+++ b/cli/tests/testdata/npm/permissions_outside_package/foo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foobar",
+  "version": "0.0.1"
+}

--- a/cli/tests/testdata/npm/permissions_outside_package/main.out
+++ b/cli/tests/testdata/npm/permissions_outside_package/main.out
@@ -1,0 +1,3 @@
+Download http://localhost:4545/npm/registry/@denotest/permissions-outside-package
+Download http://localhost:4545/npm/registry/@denotest/permissions-outside-package/1.0.0.tgz
+{ name: "foobar", version: "0.0.1" }

--- a/cli/tests/testdata/npm/permissions_outside_package/main.ts
+++ b/cli/tests/testdata/npm/permissions_outside_package/main.ts
@@ -1,0 +1,5 @@
+import { loadConfigFile } from "npm:@denotest/permissions-outside-package";
+
+const url = import.meta.resolve("./foo/config.js");
+const config = loadConfigFile(url.slice(7));
+console.log(config);

--- a/cli/tests/testdata/npm/permissions_outside_package/main.ts
+++ b/cli/tests/testdata/npm/permissions_outside_package/main.ts
@@ -1,5 +1,5 @@
 import { loadConfigFile } from "npm:@denotest/permissions-outside-package";
 
-const url = import.meta.resolve("./foo/config.js");
-const config = loadConfigFile(url.slice(7));
+const fileName = `${Deno.cwd()}/npm/permissions_outside_package/foo/config.js`;
+const config = loadConfigFile(fileName);
 console.log(config);

--- a/cli/tests/testdata/npm/registry/@denotest/permissions-outside-package/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/permissions-outside-package/1.0.0/index.js
@@ -1,0 +1,5 @@
+function loadConfigFile(fileName) {
+  return require(fileName);
+}
+
+module.exports.loadConfigFile = loadConfigFile;

--- a/cli/tests/testdata/npm/registry/@denotest/permissions-outside-package/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/permissions-outside-package/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/permissions-outside-package",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -33,6 +33,7 @@ use deno_core::RuntimeOptions;
 use deno_core::Snapshot;
 use deno_graph::Resolved;
 use deno_runtime::deno_node::NodeResolutionMode;
+use deno_runtime::permissions::PermissionsContainer;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -647,6 +648,7 @@ fn op_resolve(
                   &referrer,
                   NodeResolutionMode::Types,
                   npm_resolver,
+                  &mut PermissionsContainer::allow_all(),
                 )
                 .ok()
                 .flatten(),
@@ -703,6 +705,7 @@ pub fn resolve_npm_package_reference_types(
     npm_ref,
     NodeResolutionMode::Types,
     npm_resolver,
+    &mut PermissionsContainer::allow_all(),
   )?;
   Ok(NodeResolution::into_specifier_and_media_type(
     maybe_resolution,

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -474,7 +474,11 @@ async fn create_main_worker_internal(
     (main_module, false)
   };
 
-  let module_loader = CliModuleLoader::new(ps.clone());
+  let module_loader = CliModuleLoader::new(
+    ps.clone(),
+    PermissionsContainer::allow_all(),
+    permissions.clone(),
+  );
 
   let maybe_inspector_server = ps.maybe_inspector_server.clone();
 
@@ -650,6 +654,7 @@ fn create_web_worker_callback(
     let module_loader = CliModuleLoader::new_for_worker(
       ps.clone(),
       args.parent_permissions.clone(),
+      args.permissions.clone(),
     );
     let create_web_worker_cb =
       create_web_worker_callback(ps.clone(), stdio.clone());

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -459,6 +459,7 @@ async fn create_main_worker_internal(
       &package_ref.req,
       package_ref.sub_path.as_deref(),
       &ps.npm_resolver,
+      &mut PermissionsContainer::allow_all(),
     )?;
     let is_main_cjs =
       matches!(node_resolution, node::NodeResolution::CommonJs(_));

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -13,6 +13,7 @@ use crate::modules::parse_import_assertions;
 use crate::modules::validate_import_assertions;
 use crate::modules::ImportAssertionsKind;
 use crate::modules::ModuleMap;
+use crate::modules::ResolutionKind;
 use crate::ops::OpCtx;
 use crate::runtime::SnapshotOptions;
 use crate::JsRuntime;
@@ -378,7 +379,8 @@ fn import_meta_resolve(
     return;
   }
 
-  match loader.resolve(&specifier_str, &referrer, false, true) {
+  match loader.resolve(&specifier_str, &referrer, ResolutionKind::DynamicImport)
+  {
     Ok(resolved) => {
       let resolved_val = serde_v8::to_v8(scope, resolved.as_str()).unwrap();
       rv.set(resolved_val);

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -378,7 +378,7 @@ fn import_meta_resolve(
     return;
   }
 
-  match loader.resolve(&specifier_str, &referrer, false) {
+  match loader.resolve(&specifier_str, &referrer, false, true) {
     Ok(resolved) => {
       let resolved_val = serde_v8::to_v8(scope, resolved.as_str()).unwrap();
       rv.set(resolved_val);

--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -32,6 +32,7 @@ impl ModuleLoader for TypescriptModuleLoader {
     specifier: &str,
     referrer: &str,
     _is_main: bool,
+    _is_dynamic: bool,
   ) -> Result<ModuleSpecifier, Error> {
     Ok(resolve_import(specifier, referrer)?)
   }

--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -21,6 +21,7 @@ use deno_core::ModuleSource;
 use deno_core::ModuleSourceFuture;
 use deno_core::ModuleSpecifier;
 use deno_core::ModuleType;
+use deno_core::ResolutionKind;
 use deno_core::RuntimeOptions;
 use futures::FutureExt;
 
@@ -31,8 +32,7 @@ impl ModuleLoader for TypescriptModuleLoader {
     &self,
     specifier: &str,
     referrer: &str,
-    _is_main: bool,
-    _is_dynamic: bool,
+    _kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, Error> {
     Ok(resolve_import(specifier, referrer)?)
   }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -77,6 +77,7 @@ pub use crate::modules::ModuleSource;
 pub use crate::modules::ModuleSourceFuture;
 pub use crate::modules::ModuleType;
 pub use crate::modules::NoopModuleLoader;
+pub use crate::modules::ResolutionKind;
 pub use crate::normalize_path::normalize_path;
 pub use crate::ops::Op;
 pub use crate::ops::OpAsyncFuture;

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2494,6 +2494,7 @@ pub mod tests {
   use crate::modules::ModuleSource;
   use crate::modules::ModuleSourceFuture;
   use crate::modules::ModuleType;
+  use crate::modules::ResolutionKind;
   use crate::ZeroCopyBuf;
   use deno_ops::op;
   use futures::future::lazy;
@@ -3134,8 +3135,7 @@ pub mod tests {
         &self,
         specifier: &str,
         referrer: &str,
-        _is_main: bool,
-        _is_dynamic: bool,
+        _kind: ResolutionKind,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");
@@ -3305,8 +3305,7 @@ pub mod tests {
         &self,
         specifier: &str,
         referrer: &str,
-        _is_main: bool,
-        _is_dynamic: bool,
+        _kind: ResolutionKind,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");
@@ -3873,8 +3872,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
         &self,
         specifier: &str,
         referrer: &str,
-        _is_main: bool,
-        _is_dynamic: bool,
+        _kind: ResolutionKind,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");
@@ -4006,8 +4004,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
         &self,
         specifier: &str,
         referrer: &str,
-        _is_main: bool,
-        _is_dynamic: bool,
+        _kind: ResolutionKind,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2038,6 +2038,7 @@ impl JsRuntime {
           true,
           specifier.as_str(),
           code.as_bytes(),
+          false,
         )
         .map_err(|e| match e {
           ModuleError::Exception(exception) => {
@@ -2097,6 +2098,7 @@ impl JsRuntime {
           false,
           specifier.as_str(),
           code.as_bytes(),
+          false,
         )
         .map_err(|e| match e {
           ModuleError::Exception(exception) => {
@@ -3133,6 +3135,7 @@ pub mod tests {
         specifier: &str,
         referrer: &str,
         _is_main: bool,
+        _is_dynamic: bool,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");
@@ -3303,6 +3306,7 @@ pub mod tests {
         specifier: &str,
         referrer: &str,
         _is_main: bool,
+        _is_dynamic: bool,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");
@@ -3870,6 +3874,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
         specifier: &str,
         referrer: &str,
         _is_main: bool,
+        _is_dynamic: bool,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");
@@ -4002,6 +4007,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
         specifier: &str,
         referrer: &str,
         _is_main: bool,
+        _is_dynamic: bool,
       ) -> Result<ModuleSpecifier, Error> {
         assert_eq!(specifier, "file:///main.js");
         assert_eq!(referrer, ".");

--- a/ext/node/package_json.rs
+++ b/ext/node/package_json.rs
@@ -1,17 +1,20 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use crate::NodeModuleKind;
+use crate::NodePermissions;
 
 use super::RequireNpmResolver;
 use deno_core::anyhow;
 use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
+use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
 use deno_core::serde_json::Map;
 use deno_core::serde_json::Value;
 use serde::Serialize;
 use std::io::ErrorKind;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct PackageJson {
@@ -47,9 +50,10 @@ impl PackageJson {
 
   pub fn load(
     resolver: &dyn RequireNpmResolver,
+    permissions: Arc<Mutex<dyn NodePermissions>>,
     path: PathBuf,
   ) -> Result<PackageJson, AnyError> {
-    resolver.ensure_read_permission(&path)?;
+    resolver.ensure_read_permission(permissions, &path)?;
     Self::load_skip_read_permission(path)
   }
 

--- a/ext/node/package_json.rs
+++ b/ext/node/package_json.rs
@@ -7,14 +7,12 @@ use super::RequireNpmResolver;
 use deno_core::anyhow;
 use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
-use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
 use deno_core::serde_json::Map;
 use deno_core::serde_json::Value;
 use serde::Serialize;
 use std::io::ErrorKind;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct PackageJson {
@@ -50,7 +48,7 @@ impl PackageJson {
 
   pub fn load(
     resolver: &dyn RequireNpmResolver,
-    permissions: Arc<Mutex<dyn NodePermissions>>,
+    permissions: &mut dyn NodePermissions,
     path: PathBuf,
   ) -> Result<PackageJson, AnyError> {
     resolver.ensure_read_permission(permissions, &path)?;

--- a/ext/node/resolution.rs
+++ b/ext/node/resolution.rs
@@ -6,15 +6,18 @@ use std::path::PathBuf;
 use deno_core::anyhow::bail;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
+use deno_core::parking_lot::Mutex;
 use deno_core::serde_json::Map;
 use deno_core::serde_json::Value;
 use deno_core::url::Url;
 use deno_core::ModuleSpecifier;
 use regex::Regex;
+use std::sync::Arc;
 
 use crate::errors;
 use crate::package_json::PackageJson;
 use crate::path::PathClean;
+use crate::NodePermissions;
 use crate::RequireNpmResolver;
 
 pub static DEFAULT_CONDITIONS: &[&str] = &["deno", "node", "import"];
@@ -188,6 +191,7 @@ pub fn package_imports_resolve(
   conditions: &[&str],
   mode: NodeResolutionMode,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<PathBuf, AnyError> {
   if name == "#" || name.starts_with("#/") || name.ends_with('/') {
     let reason = "is not a valid internal imports specifier name";
@@ -198,7 +202,8 @@ pub fn package_imports_resolve(
     ));
   }
 
-  let package_config = get_package_scope_config(referrer, npm_resolver)?;
+  let package_config =
+    get_package_scope_config(referrer, npm_resolver, permissions.clone())?;
   let mut package_json_path = None;
   if package_config.exists {
     package_json_path = Some(package_config.path.clone());
@@ -216,6 +221,7 @@ pub fn package_imports_resolve(
           conditions,
           mode,
           npm_resolver,
+          permissions,
         )?;
         if let Some(resolved) = maybe_resolved {
           return Ok(resolved);
@@ -258,6 +264,7 @@ pub fn package_imports_resolve(
             conditions,
             mode,
             npm_resolver,
+            permissions,
           )?;
           if let Some(resolved) = maybe_resolved {
             return Ok(resolved);
@@ -322,6 +329,7 @@ fn resolve_package_target_string(
   conditions: &[&str],
   mode: NodeResolutionMode,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<PathBuf, AnyError> {
   if !subpath.is_empty() && !pattern && !target.ends_with('/') {
     return Err(throw_invalid_package_target(
@@ -355,6 +363,7 @@ fn resolve_package_target_string(
           conditions,
           mode,
           npm_resolver,
+          permissions,
         ) {
           Ok(Some(path)) => Ok(path),
           Ok(None) => Err(generic_error("not found")),
@@ -430,6 +439,7 @@ fn resolve_package_target(
   conditions: &[&str],
   mode: NodeResolutionMode,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<Option<PathBuf>, AnyError> {
   if let Some(target) = target.as_str() {
     return resolve_package_target_string(
@@ -444,6 +454,7 @@ fn resolve_package_target(
       conditions,
       mode,
       npm_resolver,
+      permissions,
     )
     .map(|path| {
       if mode.is_types() {
@@ -471,6 +482,7 @@ fn resolve_package_target(
         conditions,
         mode,
         npm_resolver,
+        permissions.clone(),
       );
 
       match resolved_result {
@@ -520,6 +532,7 @@ fn resolve_package_target(
           conditions,
           mode,
           npm_resolver,
+          permissions.clone(),
         )?;
         match resolved {
           Some(resolved) => return Ok(Some(resolved)),
@@ -564,6 +577,7 @@ pub fn package_exports_resolve(
   conditions: &[&str],
   mode: NodeResolutionMode,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<PathBuf, AnyError> {
   if package_exports.contains_key(&package_subpath)
     && package_subpath.find('*').is_none()
@@ -582,6 +596,7 @@ pub fn package_exports_resolve(
       conditions,
       mode,
       npm_resolver,
+      permissions,
     )?;
     if resolved.is_none() {
       return Err(throw_exports_not_found(
@@ -641,6 +656,7 @@ pub fn package_exports_resolve(
       conditions,
       mode,
       npm_resolver,
+      permissions,
     )?;
     if let Some(resolved) = maybe_resolved {
       return Ok(resolved);
@@ -718,12 +734,14 @@ pub fn package_resolve(
   conditions: &[&str],
   mode: NodeResolutionMode,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<Option<PathBuf>, AnyError> {
   let (package_name, package_subpath, _is_scoped) =
     parse_package_name(specifier, referrer)?;
 
   // ResolveSelf
-  let package_config = get_package_scope_config(referrer, npm_resolver)?;
+  let package_config =
+    get_package_scope_config(referrer, npm_resolver, permissions.clone())?;
   if package_config.exists
     && package_config.name.as_ref() == Some(&package_name)
   {
@@ -737,6 +755,7 @@ pub fn package_resolve(
         conditions,
         mode,
         npm_resolver,
+        permissions,
       )
       .map(Some);
     }
@@ -763,7 +782,8 @@ pub fn package_resolve(
   // ))
 
   // Package match.
-  let package_json = PackageJson::load(npm_resolver, package_json_path)?;
+  let package_json =
+    PackageJson::load(npm_resolver, permissions.clone(), package_json_path)?;
   if let Some(exports) = &package_json.exports {
     return package_exports_resolve(
       &package_json.path,
@@ -774,6 +794,7 @@ pub fn package_resolve(
       conditions,
       mode,
       npm_resolver,
+      permissions,
     )
     .map(Some);
   }
@@ -795,19 +816,21 @@ pub fn package_resolve(
 pub fn get_package_scope_config(
   referrer: &ModuleSpecifier,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<PackageJson, AnyError> {
   let root_folder = npm_resolver
     .resolve_package_folder_from_path(&referrer.to_file_path().unwrap())?;
   let package_json_path = root_folder.join("package.json");
-  PackageJson::load(npm_resolver, package_json_path)
+  PackageJson::load(npm_resolver, permissions, package_json_path)
 }
 
 pub fn get_closest_package_json(
   url: &ModuleSpecifier,
   npm_resolver: &dyn RequireNpmResolver,
+  permissions: Arc<Mutex<dyn NodePermissions>>,
 ) -> Result<PackageJson, AnyError> {
   let package_json_path = get_closest_package_json_path(url, npm_resolver)?;
-  PackageJson::load(npm_resolver, package_json_path)
+  PackageJson::load(npm_resolver, permissions, package_json_path)
 }
 
 fn get_closest_package_json_path(


### PR DESCRIPTION
<s>Blocked by https://github.com/denoland/deno/pull/17134</s>

Fixes https://github.com/denoland/deno/issues/15845

This commit changes signature of "deno_core::ModuleLoader::resolve" to pass
an enum indicating whether or not we're resolving a specifier for dynamic import.

Additionally "CliModuleLoader" was changes to store both "parent permissions" (or
"root permissions") as well as "dynamic permissions" that allow to check for permissions
in top-level module load an dynamic imports.

Then all code paths that have anything to do with Node/npm compat are now checking
for permissions which are passed from module loader instance associated with given
worker.