### PR TITLE
fix: resolve clippy errors in windows build

### DIFF
--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -360,7 +360,8 @@ pub fn os_uptime() -> u64 {
   }
 
   #[cfg(target_family = "windows")]
-  // SAFETY: 🔥 this is fine. 🔥
+  #[allow(clippy::undocumented_unsafe_blocks)]
+  // TODO: add safety comment
   unsafe {
     // Windows is the only one that returns `uptime` in milisecond precision,
     // so we need to get the seconds out of it to be in sync with other envs.

--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -302,7 +302,7 @@ pub fn mem_info() -> Option<MemInfo> {
 }
 
 pub fn os_uptime() -> u64 {
-  let mut uptime: u64 = 0;
+  let uptime: u64;
 
   #[cfg(target_os = "linux")]
   {
@@ -356,10 +356,11 @@ pub fn os_uptime() -> u64 {
   }
 
   #[cfg(target_family = "windows")]
+  // SAFETY: 🔥 this is fine. 🔥
   unsafe {
     // Windows is the only one that returns `uptime` in milisecond precision,
     // so we need to get the seconds out of it to be in sync with other envs.
-    uptime = winapi::um::sysinfoapi::GetTickCount64() as u64 / 1000;
+    uptime = winapi::um::sysinfoapi::GetTickCount64() / 1000;
   }
 
   uptime

--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -360,8 +360,7 @@ pub fn os_uptime() -> u64 {
   }
 
   #[cfg(target_family = "windows")]
-  #[allow(clippy::undocumented_unsafe_blocks)]
-  // TODO: add safety comment
+  // SAFETY: windows API usage
   unsafe {
     // Windows is the only one that returns `uptime` in milisecond precision,
     // so we need to get the seconds out of it to be in sync with other envs.

--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -313,6 +313,8 @@ pub fn os_uptime() -> u64 {
       // SAFETY: `sysinfo` initializes the struct.
       let info = unsafe { info.assume_init() };
       uptime = info.uptime as u64;
+    } else {
+      panic!("result is not 0")
     }
   }
 
@@ -352,6 +354,8 @@ pub fn os_uptime() -> u64 {
           .as_secs()
         })
         .unwrap_or_default();
+    } else {
+      panic!("result is not 0")
     }
   }
 

--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -309,12 +309,12 @@ pub fn os_uptime() -> u64 {
     let mut info = std::mem::MaybeUninit::uninit();
     // SAFETY: `info` is a valid pointer to a `libc::sysinfo` struct.
     let res = unsafe { libc::sysinfo(info.as_mut_ptr()) };
-    if res == 0 {
+    uptime = if res == 0 {
       // SAFETY: `sysinfo` initializes the struct.
       let info = unsafe { info.assume_init() };
-      uptime = info.uptime as u64;
+      info.uptime as u64
     } else {
-      panic!("result is not 0")
+      0
     }
   }
 
@@ -343,8 +343,8 @@ pub fn os_uptime() -> u64 {
         0,
       )
     };
-    if res == 0 {
-      uptime = SystemTime::now()
+    uptime = if res == 0 {
+      SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| {
           (d - Duration::new(
@@ -353,9 +353,9 @@ pub fn os_uptime() -> u64 {
           ))
           .as_secs()
         })
-        .unwrap_or_default();
+        .unwrap_or_default()
     } else {
-      panic!("result is not 0")
+      0
     }
   }
 


### PR DESCRIPTION
After fetching the latest upstream on main I got a few clippy errors locally. They likely only happen on windows and were introduced in https://github.com/denoland/deno/commit/7ce2b58bcf412924464578f3469c210b34894c8b.

One of the errors requires a safety comment but I do not know the context, so a suggestion for that would be welcome.

```
 deno run --allow-read --allow-write --allow-run --unstable .\tools\lint.js
dlint
prefer-primordials
clippy
   Compiling deno_runtime v0.90.0 (C:\Users\GJZwiers\repos\deno\runtime)
error: value assigned to `uptime` is never read
   --> runtime\ops\os\sys_info.rs:305:11
    |
305 |   let mut uptime: u64 = 0;
    |           ^^^^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `-D unused-assignments` implied by `-D warnings`

error: unsafe block missing a safety comment
   --> runtime\ops\os\sys_info.rs:359:3
    |
359 |   unsafe {
    |   ^^^^^^^^
    |
    = help: consider adding a safety comment on the preceding line
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks
    = note: requested on the command line with `-D clippy::undocumented-unsafe-blocks`

error: casting to the same type is unnecessary (`u64` -> `u64`)
   --> runtime\ops\os\sys_info.rs:362:14
    |
362 |     uptime = winapi::um::sysinfoapi::GetTickCount64() as u64 / 1000;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `winapi::um::sysinfoapi::GetTickCount64()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `-D clippy::unnecessary-cast` implied by `-D clippy::all`

error: could not compile `deno_runtime` due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `deno_runtime` due to 3 previous errors
error: could not compile `deno_runtime` due to 3 previous errors
error: Uncaught (in promise) Error: clippy failed
    throw new Error("clippy failed");
          ^
    at clippy (file:///C:/Users/GJZwiers/repos/deno/tools/lint.js:131:11)
    at async main (file:///C:/Users/GJZwiers/repos/deno/tools/lint.js:154:5)
    at async file:///C:/Users/GJZwiers/repos/deno/tools/lint.js:158:1
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
