### PR TITLE
fix(lsp): "Add all missing imports" uses correct specifiers

### DIFF
--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -184,28 +184,33 @@ pub fn fix_ts_import_changes(
   for change in changes {
     let mut text_changes = Vec::new();
     for text_change in &change.text_changes {
-      if let Some(captures) =
-        IMPORT_SPECIFIER_RE.captures(&text_change.new_text)
-      {
-        let specifier = captures
-          .get(1)
-          .ok_or_else(|| anyhow!("Missing capture."))?
-          .as_str();
-        if let Some(new_specifier) =
-          check_specifier(specifier, referrer, documents)
-        {
-          let new_text =
-            text_change.new_text.replace(specifier, &new_specifier);
-          text_changes.push(tsc::TextChange {
-            span: text_change.span.clone(),
-            new_text,
-          });
+      let lines = text_change.new_text.split('\n');
+      let mut new_lines = vec![];
+
+      // This assumes that there's only one import per line.
+      for line in lines {
+        if let Some(captures) = IMPORT_SPECIFIER_RE.captures(line) {
+          let specifier = captures
+            .get(1)
+            .ok_or_else(|| anyhow!("Missing capture."))?
+            .as_str();
+          if let Some(new_specifier) =
+            check_specifier(specifier, referrer, documents)
+          {
+            let new_text = line.replace(specifier, &new_specifier);
+            new_lines.push(new_text);
+          } else {
+            new_lines.push(line.to_string());
+          }
         } else {
-          text_changes.push(text_change.clone());
+          new_lines.push(line.to_string());
         }
-      } else {
-        text_changes.push(text_change.clone());
       }
+
+      text_changes.push(tsc::TextChange {
+        span: text_change.span.clone(),
+        new_text: new_lines.join("\n"),
+      });
     }
     r.push(tsc::FileTextChanges {
       file_name: change.file_name.clone(),

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -43,7 +43,6 @@ use super::documents::AssetOrDocument;
 use super::documents::Document;
 use super::documents::Documents;
 use super::documents::LanguageId;
-use super::logging::lsp_debug;
 use super::logging::lsp_log;
 use super::lsp_custom;
 use super::parent_process_checker;
@@ -1498,7 +1497,6 @@ impl Inner {
     };
 
     self.performance.measure(mark);
-    lsp_debug!("code_action {:#?}", response);
     Ok(response)
   }
 
@@ -1595,7 +1593,6 @@ impl Inner {
     };
 
     self.performance.measure(mark);
-    lsp_debug!("code_action_resolve: {:?}", result);
     Ok(result)
   }
 

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -43,6 +43,7 @@ use super::documents::AssetOrDocument;
 use super::documents::Document;
 use super::documents::Documents;
 use super::documents::LanguageId;
+use super::logging::lsp_debug;
 use super::logging::lsp_log;
 use super::lsp_custom;
 use super::parent_process_checker;
@@ -1497,6 +1498,7 @@ impl Inner {
     };
 
     self.performance.measure(mark);
+    lsp_debug!("code_action {:#?}", response);
     Ok(response)
   }
 
@@ -1593,6 +1595,7 @@ impl Inner {
     };
 
     self.performance.measure(mark);
+    lsp_debug!("code_action_resolve: {:?}", result);
     Ok(result)
   }
 

--- a/cli/tests/lsp_tests.rs
+++ b/cli/tests/lsp_tests.rs
@@ -3390,7 +3390,16 @@ mod lsp {
         "uri": "file:///a/file00.ts",
         "languageId": "typescript",
         "version": 1,
-        "text": "export const abc = \"abc\";\nexport const def = \"def\";\n"
+        "text": r#"export interface MallardDuckConfigOptions extends DuckConfigOptions {
+  kind: "mallard";
+}
+
+export class MallardDuckConfig extends DuckConfig {
+  constructor(options: MallardDuckConfigOptions) {
+    super(options);
+  }
+}
+"#
       }
     }));
     session.did_open(json!({
@@ -3398,7 +3407,27 @@ mod lsp {
         "uri": "file:///a/file01.ts",
         "languageId": "typescript",
         "version": 1,
-        "text": "\nconsole.log(abc);\nconsole.log(def)\n"
+        "text": r#"import { DuckConfigOptions } from "./file02.ts";
+
+export class DuckConfig {
+  readonly kind;
+  constructor(options: DuckConfigOptions) {
+    this.kind = options.kind;
+  }
+}
+"#
+      }
+    }));
+    session.did_open(json!({
+      "textDocument": {
+        "uri": "file:///a/file02.ts",
+        "languageId": "typescript",
+        "version": 1,
+        "text": r#"export interface DuckConfigOptions {
+  kind: string;
+  quacks: boolean;
+}
+"#
       }
     }));
 

--- a/cli/tests/testdata/lsp/code_action_params_imports.json
+++ b/cli/tests/testdata/lsp/code_action_params_imports.json
@@ -1,15 +1,15 @@
 {
   "textDocument": {
-    "uri": "file:///a/file01.ts"
+    "uri": "file:///a/file00.ts"
   },
   "range": {
     "start": {
-      "line": 1,
-      "character": 12
+      "line": 0,
+      "character": 0
     },
     "end": {
-      "line": 1,
-      "character": 15
+      "line": 6,
+      "character": 0
     }
   },
   "context": {
@@ -17,34 +17,34 @@
       {
         "range": {
           "start": {
-            "line": 1,
-            "character": 12
+            "line": 0,
+            "character": 50
           },
           "end": {
-            "line": 1,
-            "character": 15
+            "line": 0,
+            "character": 67
           }
         },
         "severity": 1,
         "code": 2304,
         "source": "deno-ts",
-        "message": "Cannot find name 'abc'."
+        "message": "Cannot find name 'DuckConfigOptions'."
       },
       {
         "range": {
           "start": {
-            "line": 2,
-            "character": 12
+            "line": 4,
+            "character": 39
           },
           "end": {
-            "line": 2,
-            "character": 15
+            "line": 4,
+            "character": 49
           }
         },
         "severity": 1,
         "code": 2304,
         "source": "deno-ts",
-        "message": "Cannot find name 'def'."
+        "message": "Cannot find name 'DuckConfig'."
       }
     ],
     "only": [

--- a/cli/tests/testdata/lsp/code_action_resolve_params_imports.json
+++ b/cli/tests/testdata/lsp/code_action_resolve_params_imports.json
@@ -5,22 +5,38 @@
     {
       "range": {
         "start": {
-          "line": 1,
-          "character": 12
+          "line": 0,
+          "character": 50
         },
         "end": {
-          "line": 1,
-          "character": 15
+          "line": 0,
+          "character": 67
         }
       },
       "severity": 1,
       "code": 2304,
       "source": "deno-ts",
-      "message": "Cannot find name 'abc'."
+      "message": "Cannot find name 'DuckConfigOptions'."
+    },
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 39
+        },
+        "end": {
+          "line": 4,
+          "character": 49
+        }
+      },
+      "severity": 1,
+      "code": 2304,
+      "source": "deno-ts",
+      "message": "Cannot find name 'DuckConfig'."
     }
   ],
   "data": {
-    "specifier": "file:///a/file01.ts",
+    "specifier": "file:///a/file00.ts",
     "fixId": "fixMissingImport"
   }
 }

--- a/cli/tests/testdata/lsp/code_action_resolve_response_imports.json
+++ b/cli/tests/testdata/lsp/code_action_resolve_response_imports.json
@@ -5,25 +5,41 @@
     {
       "range": {
         "start": {
-          "line": 1,
-          "character": 12
+          "line": 0,
+          "character": 50
         },
         "end": {
-          "line": 1,
-          "character": 15
+          "line": 0,
+          "character": 67
         }
       },
       "severity": 1,
       "code": 2304,
       "source": "deno-ts",
-      "message": "Cannot find name 'abc'."
+      "message": "Cannot find name 'DuckConfigOptions'."
+    },
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 39
+        },
+        "end": {
+          "line": 4,
+          "character": 49
+        }
+      },
+      "severity": 1,
+      "code": 2304,
+      "source": "deno-ts",
+      "message": "Cannot find name 'DuckConfig'."
     }
   ],
   "edit": {
     "documentChanges": [
       {
         "textDocument": {
-          "uri": "file:///a/file01.ts",
+          "uri": "file:///a/file00.ts",
           "version": 1
         },
         "edits": [
@@ -38,14 +54,14 @@
                 "character": 0
               }
             },
-            "newText": "import { abc,def } from \"./file00.ts\";\n"
+            "newText": "import { DuckConfig } from \"./file01.ts\";\nimport { DuckConfigOptions } from \"./file02.ts\";\n\n"
           }
         ]
       }
     ]
   },
   "data": {
-    "specifier": "file:///a/file01.ts",
+    "specifier": "file:///a/file00.ts",
     "fixId": "fixMissingImport"
   }
 }

--- a/cli/tests/testdata/lsp/code_action_response_imports.json
+++ b/cli/tests/testdata/lsp/code_action_response_imports.json
@@ -1,30 +1,30 @@
 [
   {
-    "title": "Add import from \"./file00.ts\"",
+    "title": "Add import from \"./file02.ts\"",
     "kind": "quickfix",
     "diagnostics": [
       {
         "range": {
           "start": {
-            "line": 1,
-            "character": 12
+            "line": 0,
+            "character": 50
           },
           "end": {
-            "line": 1,
-            "character": 15
+            "line": 0,
+            "character": 67
           }
         },
         "severity": 1,
         "code": 2304,
         "source": "deno-ts",
-        "message": "Cannot find name 'abc'."
+        "message": "Cannot find name 'DuckConfigOptions'."
       }
     ],
     "edit": {
       "documentChanges": [
         {
           "textDocument": {
-            "uri": "file:///a/file01.ts",
+            "uri": "file:///a/file00.ts",
             "version": 1
           },
           "edits": [
@@ -39,7 +39,7 @@
                   "character": 0
                 }
               },
-              "newText": "import { abc } from \"./file00.ts\";\n"
+              "newText": "import { DuckConfigOptions } from \"./file02.ts\";\n\n"
             }
           ]
         }
@@ -53,51 +53,51 @@
       {
         "range": {
           "start": {
-            "line": 1,
-            "character": 12
+            "line": 0,
+            "character": 50
           },
           "end": {
-            "line": 1,
-            "character": 15
+            "line": 0,
+            "character": 67
           }
         },
         "severity": 1,
         "code": 2304,
         "source": "deno-ts",
-        "message": "Cannot find name 'abc'."
+        "message": "Cannot find name 'DuckConfigOptions'."
       }
     ],
     "data": {
-      "specifier": "file:///a/file01.ts",
+      "specifier": "file:///a/file00.ts",
       "fixId": "fixMissingImport"
     }
   },
   {
-    "title": "Add import from \"./file00.ts\"",
+    "title": "Add import from \"./file01.ts\"",
     "kind": "quickfix",
     "diagnostics": [
       {
         "range": {
           "start": {
-            "line": 2,
-            "character": 12
+            "line": 4,
+            "character": 39
           },
           "end": {
-            "line": 2,
-            "character": 15
+            "line": 4,
+            "character": 49
           }
         },
         "severity": 1,
         "code": 2304,
         "source": "deno-ts",
-        "message": "Cannot find name 'def'."
+        "message": "Cannot find name 'DuckConfig'."
       }
     ],
     "edit": {
       "documentChanges": [
         {
           "textDocument": {
-            "uri": "file:///a/file01.ts",
+            "uri": "file:///a/file00.ts",
             "version": 1
           },
           "edits": [
@@ -112,7 +112,7 @@
                   "character": 0
                 }
               },
-              "newText": "import { def } from \"./file00.ts\";\n"
+              "newText": "import { DuckConfig } from \"./file01.ts\";\n\n"
             }
           ]
         }


### PR DESCRIPTION
This commit fixes "Add all missing imports" quick fix; before
it was replacing all occurrences with the same specifier. Now
every line returned from TSC is processed individually.

Closes https://github.com/denoland/deno/issues/16016

Note that it's a partial fix, because of https://github.com/denoland/vscode_deno/issues/761
the conditions to make it work are somewhat specific.
