### PR TITLE
refactor: cleanup redundant call

### DIFF
--- a/cli/tools/vendor/mappings.rs
+++ b/cli/tools/vendor/mappings.rs
@@ -133,7 +133,6 @@ impl Mappings {
       self
         .mappings
         .get(specifier)
-        .as_ref()
         .unwrap_or_else(|| {
           panic!("Could not find local path for {}", specifier)
         })


### PR DESCRIPTION
The call to `as_ref` is not needed because the type returned by `HashMap.get()` is already `Option<&T>`

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
