### PR TITLE
perf(ext,runtime): remove using `SafeArrayIterator` from `for-of`

### DIFF
--- a/ext/broadcast_channel/01_broadcast_channel.js
+++ b/ext/broadcast_channel/01_broadcast_channel.js
@@ -16,7 +16,6 @@
     ArrayPrototypeIndexOf,
     ArrayPrototypeSplice,
     ArrayPrototypePush,
-    SafeArrayIterator,
     Symbol,
     Uint8Array,
   } = window.__bootstrap.primordials;
@@ -44,7 +43,9 @@
   }
 
   function dispatch(source, name, data) {
-    for (const channel of new SafeArrayIterator(channels)) {
+    for (let i = 0; i < channels.length; ++i) {
+      const channel = channels[i];
+
       if (channel === source) continue; // Don't self-send.
       if (channel[_name] !== name) continue;
       if (channel[_closed]) continue;

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -6,7 +6,6 @@
   const webidl = window.__bootstrap.webidl;
   const {
     Symbol,
-    SafeArrayIterator,
     TypeError,
     ObjectPrototypeIsPrototypeOf,
   } = window.__bootstrap.primordials;
@@ -115,7 +114,8 @@
       const varyHeader = getHeader(innerResponse.headerList, "vary");
       if (varyHeader) {
         const fieldValues = varyHeader.split(",");
-        for (const field of new SafeArrayIterator(fieldValues)) {
+        for (let i = 0; i < fieldValues.length; ++i) {
+          const field = fieldValues[i];
           if (field.trim() === "*") {
             throw new TypeError("Vary header must not contain '*'");
           }

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -277,7 +277,8 @@
       }` +
       `${tableChars.rightMiddle}\n`;
 
-    for (const row of new SafeArrayIterator(rows)) {
+    for (let i = 0; i < rows.length; ++i) {
+      const row = rows[i];
       result += `${renderRow(row, columnWidths, columnRightAlign)}\n`;
     }
 
@@ -995,7 +996,8 @@
     }
 
     const refMap = new Map();
-    for (const cause of new SafeArrayIterator(causes)) {
+    for (let i = 0; i < causes.length; ++i) {
+      const cause = causes[i];
       if (circular !== undefined) {
         const index = MapPrototypeGet(circular, cause);
         if (index !== undefined) {
@@ -1172,7 +1174,8 @@
 
     inspectOptions.indentLevel++;
 
-    for (const key of new SafeArrayIterator(stringKeys)) {
+    for (let i = 0; i < stringKeys.length; ++i) {
+      const key = stringKeys[i];
       if (inspectOptions.getters) {
         let propertyValue;
         let error = null;
@@ -1208,7 +1211,8 @@
       }
     }
 
-    for (const key of new SafeArrayIterator(symbolKeys)) {
+    for (let i = 0; i < symbolKeys.length; ++i) {
+      const key = symbolKeys[i];
       if (
         !inspectOptions.showHidden &&
         !propertyIsEnumerable(value, key)
@@ -1640,7 +1644,8 @@
       currentPart = "";
     }
 
-    for (const [key, value] of new SafeArrayIterator(rawEntries)) {
+    for (let i = 0; i < rawEntries.length; ++i) {
+      const [key, value] = rawEntries[i];
       if (key == "background-color") {
         if (value != null) {
           css.backgroundColor = value;
@@ -1661,11 +1666,9 @@
         }
       } else if (key == "text-decoration-line") {
         css.textDecorationLine = [];
-        for (
-          const lineType of new SafeArrayIterator(
-            StringPrototypeSplit(value, /\s+/g),
-          )
-        ) {
+        const lineTypes = StringPrototypeSplit(value, /\s+/g);
+        for (let i = 0; i < lineTypes.length; ++i) {
+          const lineType = lineTypes[i];
           if (
             ArrayPrototypeIncludes(
               ["line-through", "overline", "underline"],
@@ -1683,11 +1686,9 @@
       } else if (key == "text-decoration") {
         css.textDecorationColor = null;
         css.textDecorationLine = [];
-        for (
-          const arg of new SafeArrayIterator(
-            StringPrototypeSplit(value, /\s+/g),
-          )
-        ) {
+        const args = StringPrototypeSplit(value, /\s+/g);
+        for (let i = 0; i < args.length; ++i) {
+          const arg = args[i];
           const maybeColor = parseCssColor(arg);
           if (maybeColor != null) {
             css.textDecorationColor = maybeColor;
@@ -2144,7 +2145,8 @@
         } else {
           const valueObj = value || {};
           const keys = properties || ObjectKeys(valueObj);
-          for (const k of new SafeArrayIterator(keys)) {
+          for (let i = 0; i < keys.length; ++i) {
+            const k = keys[i];
             if (!primitive && ReflectHas(valueObj, k)) {
               if (!(ReflectHas(objectValues, k))) {
                 objectValues[k] = ArrayPrototypeFill(new Array(numRows), "");
@@ -2339,7 +2341,9 @@
   function wrapConsole(consoleFromDeno, consoleFromV8) {
     const callConsole = core.callConsole;
 
-    for (const key of new SafeArrayIterator(ObjectKeys(consoleFromV8))) {
+    const keys = ObjectKeys(consoleFromV8);
+    for (let i = 0; i < keys.length; ++i) {
+      const key = keys[i];
       if (ObjectPrototypeHasOwnProperty(consoleFromDeno, key)) {
         consoleFromDeno[key] = FunctionPrototypeBind(
           callConsole,

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -68,7 +68,8 @@
    */
   function fillHeaders(headers, object) {
     if (ArrayIsArray(object)) {
-      for (const header of new SafeArrayIterator(object)) {
+      for (let i = 0; i < object.length; ++i) {
+        const header = object[i];
         if (header.length !== 2) {
           throw new TypeError(
             `Invalid header. Length must be 2, but is ${header.length}`,
@@ -205,7 +206,8 @@
       // spec but produce the same result.
       const headers = {};
       const cookies = [];
-      for (const entry of new SafeArrayIterator(list)) {
+      for (let i = 0; i < list.length; ++i) {
+        const entry = list[i];
         const name = byteLowerCase(entry[0]);
         const value = entry[1];
         if (value === null) throw new TypeError("Unreachable");

--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -25,7 +25,6 @@
     MathRandom,
     ObjectPrototypeIsPrototypeOf,
     Symbol,
-    SafeArrayIterator,
     StringFromCharCode,
     StringPrototypeTrim,
     StringPrototypeSlice,
@@ -163,7 +162,9 @@
         context: "Argument 1",
       });
 
-      for (const entry of new SafeArrayIterator(this[entryList])) {
+      const entries = this[entryList];
+      for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
         if (entry.name === name) return entry.value;
       }
       return null;
@@ -184,7 +185,9 @@
       });
 
       const returnList = [];
-      for (const entry of new SafeArrayIterator(this[entryList])) {
+      const entries = this[entryList];
+      for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
         if (entry.name === name) ArrayPrototypePush(returnList, entry.value);
       }
       return returnList;
@@ -204,7 +207,9 @@
         context: "Argument 1",
       });
 
-      for (const entry of new SafeArrayIterator(this[entryList])) {
+      const entries = this[entryList];
+      for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
         if (entry.name === name) return true;
       }
       return false;
@@ -374,7 +379,8 @@
     #parseHeaders(headersText) {
       const headers = new Headers();
       const rawHeaders = StringPrototypeSplit(headersText, "\r\n");
-      for (const rawHeader of new SafeArrayIterator(rawHeaders)) {
+      for (let i = 0; i < rawHeaders.length; ++i) {
+        const rawHeader = rawHeaders[i];
         const sepIndex = StringPrototypeIndexOf(rawHeader, ":");
         if (sepIndex < 0) {
           continue; // Skip this header

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -31,7 +31,6 @@
     PromisePrototype,
     PromisePrototypeCatch,
     PromisePrototypeThen,
-    SafeArrayIterator,
     SafePromiseAll,
     TypedArrayPrototypeSubarray,
     TypeError,
@@ -140,7 +139,8 @@
     // status-line = HTTP-version SP status-code SP reason-phrase CRLF
     // Date header: https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.2
     let str = `HTTP/1.1 ${status} ${statusCodes[status]}\r\nDate: ${date}\r\n`;
-    for (const [name, value] of new SafeArrayIterator(headerList)) {
+    for (let i = 0; i < headerList.length; ++i) {
+      const [name, value] = headerList[i];
       // header-field   = field-name ":" OWS field-value OWS
       str += `${name}: ${value}\r\n`;
     }

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -194,7 +194,9 @@
         context: "Argument 1",
       });
       const values = [];
-      for (const entry of new SafeArrayIterator(this[_list])) {
+      const entries = this[_list];
+      for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
         if (entry[0] === name) {
           ArrayPrototypePush(values, entry[1]);
         }
@@ -214,7 +216,9 @@
         prefix,
         context: "Argument 1",
       });
-      for (const entry of new SafeArrayIterator(this[_list])) {
+      const entries = this[_list];
+      for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
         if (entry[0] === name) {
           return entry[1];
         }

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -20,7 +20,6 @@
     RegExp,
     RegExpPrototypeExec,
     RegExpPrototypeTest,
-    SafeArrayIterator,
     Symbol,
     SymbolFor,
     TypeError,
@@ -72,7 +71,9 @@
 
       const components = ops.op_urlpattern_parse(input, baseURL);
 
-      for (const key of new SafeArrayIterator(ObjectKeys(components))) {
+      const keys = ObjectKeys(components);
+      for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
         try {
           components[key].regexp = new RegExp(
             components[key].regexpString,
@@ -156,7 +157,9 @@
 
       const [values] = res;
 
-      for (const key of new SafeArrayIterator(ObjectKeys(values))) {
+      const keys = ObjectKeys(values);
+      for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
         if (!RegExpPrototypeTest(this[_components][key].regexp, values[key])) {
           return false;
         }
@@ -201,8 +204,9 @@
       /** @type {URLPatternResult} */
       const result = { inputs };
 
-      /** @type {string} */
-      for (const key of new SafeArrayIterator(ObjectKeys(values))) {
+      const keys = ObjectKeys(values);
+      for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
         /** @type {Component} */
         const component = this[_components][key];
         const input = values[key];

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -19,7 +19,6 @@
     ObjectEntries,
     ObjectPrototypeIsPrototypeOf,
     ObjectSetPrototypeOf,
-    SafeArrayIterator,
     Symbol,
     SymbolFor,
   } = window.__bootstrap.primordials;
@@ -166,37 +165,35 @@
   webidl.configurePrototype(DOMException);
   const DOMExceptionPrototype = DOMException.prototype;
 
-  for (
-    const [key, value] of new SafeArrayIterator(
-      ObjectEntries({
-        INDEX_SIZE_ERR,
-        DOMSTRING_SIZE_ERR,
-        HIERARCHY_REQUEST_ERR,
-        WRONG_DOCUMENT_ERR,
-        INVALID_CHARACTER_ERR,
-        NO_DATA_ALLOWED_ERR,
-        NO_MODIFICATION_ALLOWED_ERR,
-        NOT_FOUND_ERR,
-        NOT_SUPPORTED_ERR,
-        INUSE_ATTRIBUTE_ERR,
-        INVALID_STATE_ERR,
-        SYNTAX_ERR,
-        INVALID_MODIFICATION_ERR,
-        NAMESPACE_ERR,
-        INVALID_ACCESS_ERR,
-        VALIDATION_ERR,
-        TYPE_MISMATCH_ERR,
-        SECURITY_ERR,
-        NETWORK_ERR,
-        ABORT_ERR,
-        URL_MISMATCH_ERR,
-        QUOTA_EXCEEDED_ERR,
-        TIMEOUT_ERR,
-        INVALID_NODE_TYPE_ERR,
-        DATA_CLONE_ERR,
-      }),
-    )
-  ) {
+  const entries = ObjectEntries({
+    INDEX_SIZE_ERR,
+    DOMSTRING_SIZE_ERR,
+    HIERARCHY_REQUEST_ERR,
+    WRONG_DOCUMENT_ERR,
+    INVALID_CHARACTER_ERR,
+    NO_DATA_ALLOWED_ERR,
+    NO_MODIFICATION_ALLOWED_ERR,
+    NOT_FOUND_ERR,
+    NOT_SUPPORTED_ERR,
+    INUSE_ATTRIBUTE_ERR,
+    INVALID_STATE_ERR,
+    SYNTAX_ERR,
+    INVALID_MODIFICATION_ERR,
+    NAMESPACE_ERR,
+    INVALID_ACCESS_ERR,
+    VALIDATION_ERR,
+    TYPE_MISMATCH_ERR,
+    SECURITY_ERR,
+    NETWORK_ERR,
+    ABORT_ERR,
+    URL_MISMATCH_ERR,
+    QUOTA_EXCEEDED_ERR,
+    TIMEOUT_ERR,
+    INVALID_NODE_TYPE_ERR,
+    DATA_CLONE_ERR,
+  });
+  for (let i = 0; i < entries.length; ++i) {
+    const [key, value] = entries[i];
     const desc = { value, enumerable: true };
     ObjectDefineProperty(DOMException, key, desc);
     ObjectDefineProperty(DOMException.prototype, key, desc);

--- a/ext/web/01_mimesniff.js
+++ b/ext/web/01_mimesniff.js
@@ -16,7 +16,6 @@
     MapPrototypeHas,
     MapPrototypeSet,
     RegExpPrototypeTest,
-    SafeArrayIterator,
     SafeMapIterator,
     StringPrototypeReplaceAll,
     StringPrototypeToLowerCase,
@@ -223,7 +222,8 @@
     let charset = null;
     let essence_ = null;
     let mimeType = null;
-    for (const value of new SafeArrayIterator(headerValues)) {
+    for (let i = 0; i < headerValues.length; ++i) {
+      const value = headerValues[i];
       const temporaryMimeType = parseMimeType(value);
       if (
         temporaryMimeType === null ||

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -428,7 +428,8 @@
     Ctor,
     props,
   ) {
-    for (const prop of new SafeArrayIterator(props)) {
+    for (let i = 0; i < props.length; ++i) {
+      const prop = props[i];
       ReflectDefineProperty(Ctor.prototype, prop, { enumerable: true });
     }
   }
@@ -969,7 +970,9 @@
         listeners[type] = [];
       }
 
-      for (const listener of new SafeArrayIterator(listeners[type])) {
+      const listenerList = listeners[type];
+      for (let i = 0; i < listenerList.length; ++i) {
+        const listener = listenerList[i];
         if (
           ((typeof listener.options === "boolean" &&
             listener.options === options.capture) ||
@@ -1454,7 +1457,9 @@
       colno = jsError.frames[0].columnNumber;
     } else {
       const jsError = core.destructureError(new Error());
-      for (const frame of new SafeArrayIterator(jsError.frames)) {
+      const frames = jsError.frames;
+      for (let i = 0; i < frames.length; ++i) {
+        const frame = frames[i];
         if (
           typeof frame.fileName == "string" &&
           !StringPrototypeStartsWith(frame.fileName, "deno:")

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -42,7 +42,6 @@
     queueMicrotask,
     RangeError,
     ReflectHas,
-    SafeArrayIterator,
     SafePromiseAll,
     SharedArrayBuffer,
     Symbol,
@@ -858,10 +857,11 @@
     }
 
     const finalBuffer = new Uint8Array(totalLength);
-    let i = 0;
-    for (const chunk of new SafeArrayIterator(chunks)) {
-      TypedArrayPrototypeSet(finalBuffer, chunk, i);
-      i += chunk.byteLength;
+    let offset = 0;
+    for (let i = 0; i < chunks.length; ++i) {
+      const chunk = chunks[i];
+      TypedArrayPrototypeSet(finalBuffer, chunk, offset);
+      offset += chunk.byteLength;
     }
     return finalBuffer;
   }
@@ -1346,7 +1346,8 @@
     if (reader !== undefined && isReadableStreamBYOBReader(reader)) {
       const readIntoRequests = reader[_readIntoRequests];
       reader[_readIntoRequests] = [];
-      for (const readIntoRequest of new SafeArrayIterator(readIntoRequests)) {
+      for (let i = 0; i < readIntoRequests.length; ++i) {
+        const readIntoRequest = readIntoRequests[i];
         readIntoRequest.closeSteps(undefined);
       }
     }
@@ -1372,7 +1373,8 @@
       /** @type {Array<ReadRequest<R>>} */
       const readRequests = reader[_readRequests];
       reader[_readRequests] = [];
-      for (const readRequest of new SafeArrayIterator(readRequests)) {
+      for (let i = 0; i < readRequests.length; ++i) {
+        const readRequest = readRequests[i];
         readRequest.closeSteps();
       }
     }
@@ -1594,7 +1596,8 @@
   function readableStreamDefaultReaderErrorReadRequests(reader, e) {
     const readRequests = reader[_readRequests];
     reader[_readRequests] = [];
-    for (const readRequest of new SafeArrayIterator(readRequests)) {
+    for (let i = 0; i < readRequests.length; ++i) {
+      const readRequest = readRequests[i];
       readRequest.errorSteps(e);
     }
   }
@@ -2614,7 +2617,8 @@
   function readableStreamBYOBReaderErrorReadIntoRequests(reader, e) {
     const readIntoRequests = reader[_readIntoRequests];
     reader[_readIntoRequests] = [];
-    for (const readIntoRequest of new SafeArrayIterator(readIntoRequests)) {
+    for (let i = 0; i < readIntoRequests.length; ++i) {
+      const readIntoRequest = readIntoRequests[i];
       readIntoRequest.errorSteps(e);
     }
   }
@@ -4238,7 +4242,9 @@
     stream[_state] = "errored";
     stream[_controller][_errorSteps]();
     const storedError = stream[_storedError];
-    for (const writeRequest of new SafeArrayIterator(stream[_writeRequests])) {
+    const writeRequests = stream[_writeRequests];
+    for (let i = 0; i < writeRequests.length; ++i) {
+      const writeRequest = writeRequests[i];
       writeRequest.reject(storedError);
     }
     stream[_writeRequests] = [];

--- a/ext/web/09_file.js
+++ b/ext/web/09_file.js
@@ -26,7 +26,6 @@
     MathMin,
     ObjectPrototypeIsPrototypeOf,
     RegExpPrototypeTest,
-    SafeArrayIterator,
     StringPrototypeCharAt,
     StringPrototypeToLowerCase,
     StringPrototypeSlice,
@@ -95,8 +94,8 @@
 
   /** @param {(BlobReference | Blob)[]} parts */
   async function* toIterator(parts) {
-    for (const part of new SafeArrayIterator(parts)) {
-      yield* part.stream();
+    for (let i = 0; i < parts.length; ++i) {
+      yield* parts[i].stream();
     }
   }
 
@@ -111,7 +110,8 @@
     /** @type {(BlobReference|Blob)[]} */
     const processedParts = [];
     let size = 0;
-    for (const element of new SafeArrayIterator(parts)) {
+    for (let i = 0; i < parts.length; ++i) {
+      const element = parts[i];
       if (ObjectPrototypeIsPrototypeOf(ArrayBufferPrototype, element)) {
         const chunk = new Uint8Array(ArrayBufferPrototypeSlice(element, 0));
         ArrayPrototypePush(processedParts, BlobReference.fromUint8Array(chunk));
@@ -159,7 +159,9 @@
    * @returns {string[]}
    */
   function getParts(blob, bag = []) {
-    for (const part of new SafeArrayIterator(blob[_parts])) {
+    const parts = blob[_parts];
+    for (let i = 0; i < parts.length; ++i) {
+      const part = parts[i];
       if (ObjectPrototypeIsPrototypeOf(BlobPrototype, part)) {
         getParts(part, bag);
       } else {
@@ -276,7 +278,9 @@
       const blobParts = [];
       let added = 0;
 
-      for (const part of new SafeArrayIterator(this[_parts])) {
+      const parts = this[_parts];
+      for (let i = 0; i < parts.length; ++i) {
+        const part = parts[i];
         // don't add the overflow to new blobParts
         if (added >= span) {
           // Could maybe be possible to remove variable `added`
@@ -600,7 +604,8 @@
     const parts = [];
     let totalSize = 0;
 
-    for (const { uuid, size } of new SafeArrayIterator(blobData.parts)) {
+    for (let i = 0; i < blobData.parts.length; ++i) {
+      const { uuid, size } = blobData.parts[i];
       ArrayPrototypePush(parts, new BlobReference(uuid, size));
       totalSize += size;
     }

--- a/ext/web/10_filereader.js
+++ b/ext/web/10_filereader.js
@@ -158,7 +158,8 @@
                 );
                 const bytes = new Uint8Array(size);
                 let offs = 0;
-                for (const chunk of new SafeArrayIterator(chunks)) {
+                for (let i = 0; i < chunks.length; ++i) {
+                  const chunk = chunks[i];
                   TypedArrayPrototypeSet(bytes, chunk, offs);
                   offs += chunk.byteLength;
                 }

--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -22,7 +22,6 @@
     ArrayPrototypePush,
     ObjectPrototypeIsPrototypeOf,
     ObjectSetPrototypeOf,
-    SafeArrayIterator,
     Symbol,
     SymbolFor,
     SymbolIterator,
@@ -205,9 +204,8 @@
     const arrayBufferIdsInTransferables = [];
     const transferredArrayBuffers = [];
 
-    for (
-      const transferable of new SafeArrayIterator(messageData.transferables)
-    ) {
+    for (let i = 0; i < messageData.transferables.length; ++i) {
+      const transferable = messageData.transferables[i];
       switch (transferable.kind) {
         case "messagePort": {
           const port = createMessagePort(transferable.data);
@@ -217,8 +215,8 @@
         }
         case "arrayBuffer": {
           ArrayPrototypePush(transferredArrayBuffers, transferable.data);
-          const i = ArrayPrototypePush(transferables, null);
-          ArrayPrototypePush(arrayBufferIdsInTransferables, i);
+          const index = ArrayPrototypePush(transferables, null);
+          ArrayPrototypePush(arrayBufferIdsInTransferables, index);
           break;
         }
         default:
@@ -274,7 +272,8 @@
     const serializedTransferables = [];
 
     let arrayBufferI = 0;
-    for (const transferable of new SafeArrayIterator(transferables)) {
+    for (let i = 0; i < transferables.length; ++i) {
+      const transferable = transferables[i];
       if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, transferable)) {
         webidl.assertBranded(transferable, MessagePortPrototype);
         const id = transferable[_id];

--- a/ext/webgpu/src/01_webgpu.js
+++ b/ext/webgpu/src/01_webgpu.js
@@ -316,7 +316,8 @@
         context: "Argument 1",
       });
       const requiredFeatures = descriptor.requiredFeatures ?? [];
-      for (const feature of new SafeArrayIterator(requiredFeatures)) {
+      for (let i = 0; i < requiredFeatures.length; ++i) {
+        const feature = requiredFeatures[i];
         if (!SetPrototypeHas(this[_adapter].features[_features], feature)) {
           throw new TypeError(
             `${prefix}: nonGuaranteedFeatures must be a subset of the adapter features.`,
@@ -1046,14 +1047,16 @@
         context: "Argument 1",
       });
       const device = assertDevice(this, { prefix, context: "this" });
-      for (const entry of new SafeArrayIterator(descriptor.entries)) {
-        let i = 0;
-        if (entry.buffer) i++;
-        if (entry.sampler) i++;
-        if (entry.texture) i++;
-        if (entry.storageTexture) i++;
+      for (let i = 0; i < descriptor.entries.length; ++i) {
+        const entry = descriptor.entries[i];
 
-        if (i !== 1) {
+        let count = 0;
+        if (entry.buffer) count++;
+        if (entry.sampler) count++;
+        if (entry.texture) count++;
+        if (entry.storageTexture) count++;
+
+        if (count !== 1) {
           throw new Error(); // TODO(@crowlKats): correct error
         }
       }
@@ -1591,8 +1594,8 @@
         device.rid,
         commandBufferRids,
       );
-      for (const commandBuffer of new SafeArrayIterator(commandBuffers)) {
-        commandBuffer[_rid] = undefined;
+      for (let i = 0; i < commandBuffers.length; ++i) {
+        commandBuffers[i][_rid] = undefined;
       }
       device.pushError(err);
     }
@@ -1934,7 +1937,8 @@
       if (!mappedRanges) {
         throw new DOMException(`${prefix}: invalid state.`, "OperationError");
       }
-      for (const [buffer, _rid, start] of new SafeArrayIterator(mappedRanges)) {
+      for (let i = 0; i < mappedRanges.length; ++i) {
+        const [buffer, _rid, start] = mappedRanges[i];
         // TODO(lucacasonato): is this logic correct?
         const end = start + buffer.byteLength;
         if (
@@ -2002,7 +2006,8 @@
         if (!mappedRanges) {
           throw new DOMException(`${prefix}: invalid state.`, "OperationError");
         }
-        for (const [buffer, mappedRid] of new SafeArrayIterator(mappedRanges)) {
+        for (let i = 0; i < mappedRanges.length; ++i) {
+          const [buffer, mappedRid] = mappedRanges[i];
           const { err } = ops.op_webgpu_buffer_unmap(
             bufferRid,
             mappedRid,

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -60,7 +60,6 @@
     ReflectHas,
     ReflectOwnKeys,
     RegExpPrototypeTest,
-    SafeArrayIterator,
     Set,
     // TODO(lucacasonato): add SharedArrayBuffer to primordials
     // SharedArrayBuffer,
@@ -633,8 +632,10 @@
   function createDictionaryConverter(name, ...dictionaries) {
     let hasRequiredKey = false;
     const allMembers = [];
-    for (const members of new SafeArrayIterator(dictionaries)) {
-      for (const member of new SafeArrayIterator(members)) {
+    for (let i = 0; i < dictionaries.length; ++i) {
+      const members = dictionaries[i];
+      for (let j = 0; j < members.length; ++j) {
+        const member = members[j];
         if (member.required) {
           hasRequiredKey = true;
         }
@@ -649,7 +650,8 @@
     });
 
     const defaultValues = {};
-    for (const member of new SafeArrayIterator(allMembers)) {
+    for (let i = 0; i < allMembers.length; ++i) {
+      const member = allMembers[i];
       if (ReflectHas(member, "defaultValue")) {
         const idlMemberValue = member.defaultValue;
         const imvType = typeof idlMemberValue;
@@ -695,7 +697,8 @@
         return idlDict;
       }
 
-      for (const member of new SafeArrayIterator(allMembers)) {
+      for (let i = 0; i < allMembers.length; ++i) {
+        const member = allMembers[i];
         const key = member.key;
 
         let esMemberValue;
@@ -821,7 +824,8 @@
       }
       // Slow path if Proxy (e.g: in WPT tests)
       const keys = ReflectOwnKeys(V);
-      for (const key of new SafeArrayIterator(keys)) {
+      for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
         const desc = ObjectGetOwnPropertyDescriptor(V, key);
         if (desc !== undefined && desc.enumerable === true) {
           const typedKey = keyConverter(key, opts);
@@ -891,7 +895,9 @@
   }
 
   function define(target, source) {
-    for (const key of new SafeArrayIterator(ReflectOwnKeys(source))) {
+    const keys = ReflectOwnKeys(source);
+    for (let i = 0; i < keys.length; ++i) {
+      const key = keys[i];
       const descriptor = ReflectGetOwnPropertyDescriptor(source, key);
       if (descriptor && !ReflectDefineProperty(target, key, descriptor)) {
         throw new TypeError(`Cannot redefine property: ${String(key)}`);

--- a/runtime/js/12_io.js
+++ b/runtime/js/12_io.js
@@ -12,7 +12,6 @@
     Uint8Array,
     ArrayPrototypePush,
     MathMin,
-    SafeArrayIterator,
     TypedArrayPrototypeSubarray,
     TypedArrayPrototypeSet,
   } = window.__bootstrap.primordials;
@@ -157,14 +156,15 @@
 
   function concatBuffers(buffers) {
     let totalLen = 0;
-    for (const buf of new SafeArrayIterator(buffers)) {
-      totalLen += buf.byteLength;
+    for (let i = 0; i < buffers.length; ++i) {
+      totalLen += buffers[i].byteLength;
     }
 
     const contents = new Uint8Array(totalLen);
 
     let n = 0;
-    for (const buf of new SafeArrayIterator(buffers)) {
+    for (let i = 0; i < buffers.length; ++i) {
+      const buf = buffers[i];
       TypedArrayPrototypeSet(contents, buf, n);
       n += buf.byteLength;
     }

--- a/runtime/js/30_fs.js
+++ b/runtime/js/30_fs.js
@@ -9,7 +9,6 @@
     DatePrototype,
     MathTrunc,
     ObjectPrototypeIsPrototypeOf,
-    SafeArrayIterator,
     SymbolAsyncIterator,
     SymbolIterator,
     Function,
@@ -212,7 +211,10 @@
     let offset = 0;
     let str =
       'const unix = Deno.build.os === "darwin" || Deno.build.os === "linux"; return {';
-    for (let [name, type] of new SafeArrayIterator(ObjectEntries(types))) {
+    const typeEntries = ObjectEntries(types);
+    for (let i = 0; i < typeEntries.length; ++i) {
+      let [name, type] = typeEntries[i];
+
       const optional = type.startsWith("?");
       if (optional) type = type.slice(1);
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -33,7 +33,6 @@ delete Intl.v8BreakIterator;
     SymbolFor,
     SymbolIterator,
     PromisePrototypeThen,
-    SafeArrayIterator,
     SafeWeakMap,
     TypeError,
     WeakMapPrototypeDelete,
@@ -206,7 +205,8 @@ delete Intl.v8BreakIterator;
     );
     loadedMainWorkerScript = true;
 
-    for (const { url, script } of new SafeArrayIterator(scripts)) {
+    for (let i = 0; i < scripts.length; ++i) {
+      const { url, script } = scripts[i];
       const err = core.evalContext(script, url)[1];
       if (err !== null) {
         throw err.thrown;


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->

I compared the results of `cli/bench/cache_api.js`.

before

```
cpu: Apple M1
runtime: deno 1.29.1 (aarch64-apple-darwin)

file:///Users/moriken/Developer/deno/cli/bench/cache_api.js
benchmark                  time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------- -----------------------------
cache_storage_open      29.02 µs/iter  (25.96 µs … 246.21 µs)  29.67 µs  49.33 µs  51.21 µs
cache_storage_has       16.53 µs/iter     (13 µs … 107.71 µs)  17.54 µs  21.08 µs  22.67 µs
cache_storage_delete    21.77 µs/iter  (20.17 µs … 109.17 µs)  21.92 µs  27.75 µs  28.71 µs
cache_put_body_10_KiB     5.1 ms/iter     (2.91 ms … 6.22 ms)   5.72 ms   6.21 ms   6.22 ms
cache_put_no_body          50 µs/iter    (33.75 µs … 8.83 ms)  47.29 µs 133.62 µs 152.42 µs
cache_match             48.67 µs/iter    (42.62 µs … 4.21 ms)  49.62 µs   61.5 µs  68.75 µs
cache_delete            21.26 µs/iter    (16.29 µs … 8.78 ms)  21.71 µs  25.62 µs  27.17 µs
```

after

```
cpu: Apple M1
runtime: deno 1.29.1 (aarch64-apple-darwin)

file:///Users/moriken/Developer/deno/cli/bench/cache_api.js
benchmark                  time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------- -----------------------------
cache_storage_open      26.46 µs/iter  (21.42 µs … 291.88 µs)  26.21 µs  47.67 µs  48.75 µs
cache_storage_has       15.58 µs/iter    (7.83 µs … 96.29 µs)   16.5 µs  21.62 µs  28.33 µs
cache_storage_delete    20.81 µs/iter  (17.92 µs … 111.25 µs)  22.58 µs  25.38 µs  27.33 µs
cache_put_body_10_KiB    5.02 ms/iter    (1.83 ms … 12.91 ms)   5.21 ms  11.35 ms  12.91 ms
cache_put_no_body       45.49 µs/iter  (28.92 µs … 767.92 µs)  44.25 µs 126.83 µs 148.04 µs
cache_match             46.88 µs/iter     (40.5 µs … 4.26 ms)  48.12 µs  61.79 µs     70 µs
cache_delete            20.77 µs/iter    (16.12 µs … 9.69 ms)  21.71 µs  25.04 µs  26.25 µs
```
