### PR TITLE
[WIP] feat: support node built-in module imports

### DIFF
--- a/cli/cache/mod.rs
+++ b/cli/cache/mod.rs
@@ -103,7 +103,17 @@ impl Loader for FetchCacher {
       ));
     }
 
-    let specifier = specifier.clone();
+    let specifier = if specifier.scheme() == "node" {
+      match crate::node::resolve_builtin_node_module(
+        specifier.as_str().strip_prefix("node:").unwrap(),
+      ) {
+        Ok(specifier) => specifier,
+        Err(err) => return Box::pin(futures::future::ready(Err(err))),
+      }
+    } else {
+      specifier.clone()
+    };
+
     let mut permissions = if is_dynamic {
       self.dynamic_permissions.clone()
     } else {

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -591,6 +591,13 @@ impl ProcState {
       }
     }
 
+    // Built-in Node modules
+    if specifier.starts_with("node:") {
+      return node::resolve_builtin_node_module(
+        specifier.strip_prefix("node:").unwrap(),
+      );
+    }
+
     // FIXME(bartlomieju): this is a hacky way to provide compatibility with REPL
     // and `Deno.core.evalContext` API. Ideally we should always have a referrer filled
     // but sadly that's not the case due to missing APIs in V8.

--- a/node_builtin.js
+++ b/node_builtin.js
@@ -1,0 +1,8 @@
+import fs from "node:fs";
+
+try {
+  const data = fs.readFileSync("./node_builtin.ts", "utf8");
+  console.log(data);
+} catch (err) {
+  console.error(err);
+}

--- a/node_builtin.ts
+++ b/node_builtin.ts
@@ -1,0 +1,8 @@
+import fs from "node:fs";
+
+try {
+  const data = fs.readFileSync("./node_builtin.js", "utf8");
+  console.log(data);
+} catch (err) {
+  console.error(err);
+}


### PR DESCRIPTION
Work in progress, only handles imports prefixed with `node:` prefix and doesn't have type-checking ability yet.