### PR TITLE
refactor(cli): clean up clones

### DIFF
--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -112,7 +112,7 @@ impl Lockfile {
       None => match maybe_config_file {
         Some(config_file) => {
           if config_file.specifier.scheme() == "file" {
-            match config_file.clone().to_lock_config()? {
+            match config_file.to_lock_config()? {
               Some(LockConfig::Bool(lock)) if !lock => {
                 return Ok(None);
               }

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -597,7 +597,7 @@ pub fn error_for_any_npm_specifier(
     .specifiers()
     .filter_map(|(_, r)| match r {
       Ok((specifier, kind, _)) if kind == deno_graph::ModuleKind::External => {
-        Some(specifier.clone())
+        Some(specifier)
       }
       _ => None,
     })

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -239,7 +239,7 @@ impl ProcState {
         .resolve_local_node_modules_folder()
         .with_context(|| "Resolving local node_modules folder.")?,
     );
-    if let Some(lockfile) = maybe_lockfile.clone() {
+    if let Some(lockfile) = maybe_lockfile {
       npm_resolver
         .add_lockfile_and_maybe_regenerate_snapshot(lockfile)
         .await?;
@@ -328,8 +328,8 @@ impl ProcState {
     let mut cache = cache::FetchCacher::new(
       self.emit_cache.clone(),
       self.file_fetcher.clone(),
-      root_permissions.clone(),
-      dynamic_permissions.clone(),
+      root_permissions,
+      dynamic_permissions,
     );
     let maybe_imports = self.options.to_maybe_imports()?;
     let maybe_resolver =

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -286,7 +286,7 @@ pub async fn run(
       user_agent: version::get_user_agent(),
       inspect: ps.options.is_inspecting(),
     },
-    extensions: ops::cli_exts(ps.clone()),
+    extensions: ops::cli_exts(ps),
     extensions_with_js: vec![],
     startup_snapshot: Some(crate::js::deno_isolate_init()),
     unsafely_ignore_certificate_errors: metadata

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -510,28 +510,28 @@ fn op_load(state: &mut OpState, args: Value) -> Result<Value, AnyError> {
     let specifier = if let Some(remapped_specifier) =
       state.remapped_specifiers.get(&v.specifier)
     {
-      remapped_specifier.clone()
+      remapped_specifier
     } else if let Some(remapped_specifier) = state.root_map.get(&v.specifier) {
-      remapped_specifier.clone()
+      remapped_specifier
     } else {
-      specifier
+      &specifier
     };
     let maybe_source = if let Some(ModuleEntry::Module {
       code,
       media_type: mt,
       ..
     }) =
-      graph_data.get(&graph_data.follow_redirect(&specifier))
+      graph_data.get(&graph_data.follow_redirect(specifier))
     {
       media_type = *mt;
       Some(Cow::Borrowed(code as &str))
     } else if state
       .maybe_npm_resolver
       .as_ref()
-      .map(|resolver| resolver.in_npm_package(&specifier))
+      .map(|resolver| resolver.in_npm_package(specifier))
       .unwrap_or(false)
     {
-      media_type = MediaType::from(&specifier);
+      media_type = MediaType::from(specifier);
       let file_path = specifier.to_file_path().unwrap();
       let code = std::fs::read_to_string(&file_path)
         .with_context(|| format!("Unable to load {}", file_path.display()))?;


### PR DESCRIPTION
This PR removes some more unneeded calls to `clone()` in various places.
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
