### PR TITLE
feat(core): allow specifying name and dependencies of an Extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "async-trait",
  "base64-simd",
  "deno_bench_util",
+ "deno_console",
  "deno_core",
  "deno_url",
  "deno_webidl",

--- a/bench_util/benches/op_baseline.rs
+++ b/bench_util/benches/op_baseline.rs
@@ -6,7 +6,7 @@ use deno_core::op;
 use deno_core::Extension;
 
 fn setup() -> Vec<Extension> {
-  vec![Extension::builder()
+  vec![Extension::builder("bench_setup")
     .ops(vec![
       op_pi_json::decl(),
       op_pi_async::decl(),

--- a/bench_util/benches/utf8.rs
+++ b/bench_util/benches/utf8.rs
@@ -6,7 +6,7 @@ use deno_bench_util::BenchOptions;
 use deno_core::Extension;
 
 fn setup() -> Vec<Extension> {
-  vec![Extension::builder()
+  vec![Extension::builder("bench_setup")
     .js(vec![(
       "setup.js",
       r#"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -238,7 +238,7 @@ mod ts {
       cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
       snapshot_path,
       startup_snapshot: None,
-      extensions: vec![Extension::builder()
+      extensions: vec![Extension::builder("deno_tsc")
         .ops(vec![
           op_build_info::decl(),
           op_cwd::decl(),

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2805,7 +2805,7 @@ fn js_runtime(performance: Arc<Performance>) -> JsRuntime {
 }
 
 fn init_extension(performance: Arc<Performance>) -> Extension {
-  Extension::builder()
+  Extension::builder("deno_tsc")
     .ops(vec![
       op_exists::decl(),
       op_is_cancelled::decl(),

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -22,7 +22,7 @@ pub fn init(
   sender: UnboundedSender<BenchEvent>,
   filter: TestFilter,
 ) -> Extension {
-  Extension::builder()
+  Extension::builder("deno_bench")
     .ops(vec![
       op_pledge_test_permissions::decl(),
       op_restore_test_permissions::decl(),

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -14,7 +14,7 @@ pub fn cli_exts(ps: ProcState) -> Vec<Extension> {
 }
 
 fn init_proc_state(ps: ProcState) -> Extension {
-  Extension::builder("deno_npm")
+  Extension::builder("deno_cli")
     .ops(vec![op_npm_process_state::decl()])
     .state(move |state| {
       state.put(ps.clone());

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -14,7 +14,7 @@ pub fn cli_exts(ps: ProcState) -> Vec<Extension> {
 }
 
 fn init_proc_state(ps: ProcState) -> Extension {
-  Extension::builder()
+  Extension::builder("deno_npm")
     .ops(vec![op_npm_process_state::decl()])
     .state(move |state| {
       state.put(ps.clone());

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -30,7 +30,7 @@ pub fn init(
   fail_fast_tracker: FailFastTracker,
   filter: TestFilter,
 ) -> Extension {
-  Extension::builder()
+  Extension::builder("deno_test")
     .ops(vec![
       op_pledge_test_permissions::decl(),
       op_restore_test_permissions::decl(),

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -770,7 +770,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
     .collect();
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(compiler_snapshot()),
-    extensions: vec![Extension::builder()
+    extensions: vec![Extension::builder("deno_cli_tsc")
       .ops(vec![
         op_cwd::decl(),
         op_create_hash::decl(),

--- a/core/examples/disable_ops.rs
+++ b/core/examples/disable_ops.rs
@@ -7,7 +7,7 @@ use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
 
 fn main() {
-  let my_ext = Extension::builder()
+  let my_ext = Extension::builder("my_ext")
     .middleware(|op| match op.name {
       "op_print" => op.disable(),
       _ => op,

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -22,7 +22,7 @@ fn op_sum(nums: Vec<f64>) -> Result<f64, deno_core::error::AnyError> {
 
 fn main() {
   // Build a deno_core::Extension providing custom ops
-  let ext = Extension::builder()
+  let ext = Extension::builder("my_ext")
     .ops(vec![
       // An op for summing an array of numbers
       // The op-layer automatically deserializes inputs

--- a/core/examples/http_bench_json_ops.rs
+++ b/core/examples/http_bench_json_ops.rs
@@ -117,7 +117,7 @@ impl From<tokio::net::TcpStream> for TcpStream {
 }
 
 fn create_js_runtime() -> JsRuntime {
-  let ext = deno_core::Extension::builder()
+  let ext = deno_core::Extension::builder("my_ext")
     .ops(vec![op_listen::decl(), op_accept::decl()])
     .build();
 

--- a/core/examples/panik.rs
+++ b/core/examples/panik.rs
@@ -24,8 +24,9 @@ fn main() {
     panic!("panik !!!")
   }
 
-  let extensions =
-    vec![Extension::builder().ops(vec![op_panik::decl()]).build()];
+  let extensions = vec![Extension::builder("my_ext")
+    .ops(vec![op_panik::decl()])
+    .build()];
   let mut rt = JsRuntime::new(RuntimeOptions {
     extensions,
     ..Default::default()

--- a/core/examples/schedule_task.rs
+++ b/core/examples/schedule_task.rs
@@ -18,7 +18,7 @@ use deno_core::*;
 type Task = Box<dyn FnOnce()>;
 
 fn main() {
-  let my_ext = Extension::builder()
+  let my_ext = Extension::builder("my_ext")
     .ops(vec![op_schedule_task::decl()])
     .event_loop_middleware(|state_rc, cx| {
       let mut state = state_rc.borrow_mut();

--- a/core/examples/wasm.rs
+++ b/core/examples/wasm.rs
@@ -51,7 +51,7 @@ fn op_set_wasm_mem(
 
 fn main() {
   // Build a deno_core::Extension providing custom ops
-  let ext = Extension::builder()
+  let ext = Extension::builder("my_ext")
     .ops(vec![op_wasm::decl(), op_set_wasm_mem::decl()])
     .build();
 

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -67,7 +67,7 @@ impl Extension {
         }
 
         panic!(
-          "Extension {}missing dependency '{dep}'",
+          "Extension {}is missing dependency '{dep}'",
           self
             .name
             .map(|name| format!("'{name}' "))

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -42,40 +42,44 @@ pub struct Extension {
   event_loop_middleware: Option<Box<OpEventLoopFn>>,
   initialized: bool,
   enabled: bool,
-  name: Option<&'static str>,
+  name: &'static str,
   deps: Option<Vec<&'static str>>,
 }
 
 // Note: this used to be a trait, but we "downgraded" it to a single concrete type
 // for the initial iteration, it will likely become a trait in the future
 impl Extension {
-  pub fn builder() -> ExtensionBuilder {
-    Default::default()
+  pub fn builder(name: &'static str) -> ExtensionBuilder {
+    ExtensionBuilder {
+      name,
+      ..Default::default()
+    }
+  }
+
+  /// Check if dependencies have been loaded, and errors if either:
+  /// - The extension is depending on itself or an extension with the same name.
+  /// - A dependency hasn't been loaded yet.
+  pub fn check_dependencies(&self, previous_exts: &[&mut Extension]) {
+    if let Some(deps) = &self.deps {
+      'dep_loop: for dep in deps {
+        if dep == &self.name {
+          panic!("Extension '{}' is either depending on itself or there is another extension with the same name", self.name);
+        }
+
+        for ext in previous_exts {
+          if dep == &ext.name {
+            continue 'dep_loop;
+          }
+        }
+
+        panic!("Extension '{}' is missing dependency '{dep}'", self.name);
+      }
+    }
   }
 
   /// returns JS source code to be loaded into the isolate (either at snapshotting,
   /// or at startup).  as a vector of a tuple of the file name, and the source code.
-  pub fn init_js(&self, previous_exts: &[Extension]) -> &[SourcePair] {
-    if let Some(deps) = &self.deps {
-      'dep_loop: for dep in deps {
-        for ext in previous_exts {
-          if let Some(ext_name) = ext.name {
-            if dep == &ext_name {
-              continue 'dep_loop;
-            }
-          }
-        }
-
-        panic!(
-          "Extension {}is missing dependency '{dep}'",
-          self
-            .name
-            .map(|name| format!("'{name}' "))
-            .unwrap_or_default()
-        )
-      }
-    }
-
+  pub fn init_js(&self) -> &[SourcePair] {
     match &self.js_files {
       Some(files) => files,
       None => &[],
@@ -143,16 +147,11 @@ pub struct ExtensionBuilder {
   state: Option<Box<OpStateFn>>,
   middleware: Option<Box<OpMiddlewareFn>>,
   event_loop_middleware: Option<Box<OpEventLoopFn>>,
-  name: Option<&'static str>,
+  name: &'static str,
   deps: Vec<&'static str>,
 }
 
 impl ExtensionBuilder {
-  pub fn name(&mut self, name: &'static str) -> &mut Self {
-    self.name = Some(name);
-    self
-  }
-
   pub fn dependencies(&mut self, dependencies: Vec<&'static str>) -> &mut Self {
     self.deps.extend(dependencies);
     self
@@ -204,7 +203,7 @@ impl ExtensionBuilder {
       event_loop_middleware: self.event_loop_middleware.take(),
       initialized: false,
       enabled: true,
-      name: self.name.take(),
+      name: self.name,
       deps,
     }
   }

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -1479,7 +1479,9 @@ import "/a.js";
       43
     }
 
-    let ext = Extension::builder().ops(vec![op_test::decl()]).build();
+    let ext = Extension::builder("test_ext")
+      .ops(vec![op_test::decl()])
+      .build();
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
       extensions: vec![ext],

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -17,7 +17,7 @@ use std::io::{stderr, stdout, Write};
 use std::rc::Rc;
 
 pub(crate) fn init_builtins() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_builtins")
     .js(include_js_files!(
       prefix "deno:core",
       "00_primordials.js",

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -728,10 +728,13 @@ impl JsRuntime {
   /// Initializes JS of provided Extensions in the given realm
   fn init_extension_js(&mut self, realm: &JsRealm) -> Result<(), Error> {
     // Take extensions to avoid double-borrow
-    let mut extensions: Vec<Extension> =
-      std::mem::take(&mut self.extensions_with_js);
-    for m in extensions.iter_mut() {
-      let js_files = m.init_js();
+    let extensions = std::mem::take(&mut self.extensions_with_js);
+    for (ext, previous_exts) in extensions
+      .iter()
+      .enumerate()
+      .map(|(i, ext)| (ext, &extensions[..i]))
+    {
+      let js_files = ext.init_js(previous_exts);
       for (filename, source) in js_files {
         // TODO(@AaronO): use JsRuntime::execute_static() here to move src off heap
         realm.execute_script(self.v8_isolate(), filename, source)?;

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -729,12 +729,8 @@ impl JsRuntime {
   fn init_extension_js(&mut self, realm: &JsRealm) -> Result<(), Error> {
     // Take extensions to avoid double-borrow
     let extensions = std::mem::take(&mut self.extensions_with_js);
-    for (ext, previous_exts) in extensions
-      .iter()
-      .enumerate()
-      .map(|(i, ext)| (ext, &extensions[..i]))
-    {
-      let js_files = ext.init_js(previous_exts);
+    for ext in &extensions {
+      let js_files = ext.init_js();
       for (filename, source) in js_files {
         // TODO(@AaronO): use JsRuntime::execute_static() here to move src off heap
         realm.execute_script(self.v8_isolate(), filename, source)?;
@@ -754,6 +750,12 @@ impl JsRuntime {
     let mut exts = vec![];
     exts.extend(extensions);
     exts.extend(extensions_with_js);
+
+    for (ext, previous_exts) in
+      exts.iter().enumerate().map(|(i, ext)| (ext, &exts[..i]))
+    {
+      ext.check_dependencies(previous_exts);
+    }
 
     // Middleware
     let middleware: Vec<Box<OpMiddlewareFn>> = exts
@@ -2557,7 +2559,7 @@ pub mod tests {
   fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
     let dispatch_count = Arc::new(AtomicUsize::new(0));
     let dispatch_count2 = dispatch_count.clone();
-    let ext = Extension::builder()
+    let ext = Extension::builder("test_ext")
       .ops(vec![op_test::decl()])
       .state(move |state| {
         state.put(TestState {
@@ -2979,7 +2981,9 @@ pub mod tests {
     }
 
     run_in_task(|cx| {
-      let ext = Extension::builder().ops(vec![op_err::decl()]).build();
+      let ext = Extension::builder("test_ext")
+        .ops(vec![op_err::decl()])
+        .build();
       let mut runtime = JsRuntime::new(RuntimeOptions {
         extensions: vec![ext],
         get_error_class_fn: Some(&get_error_class_name),
@@ -3431,7 +3435,7 @@ main();
     }
 
     run_in_task(|cx| {
-      let ext = Extension::builder()
+      let ext = Extension::builder("test_ext")
         .ops(vec![op_err_sync::decl(), op_err_async::decl()])
         .build();
       let mut runtime = JsRuntime::new(RuntimeOptions {
@@ -3599,7 +3603,7 @@ assertEquals(1, notify_return_value);
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_async_borrow::decl()])
       .state(|state| {
         state.put(InnerState(42));
@@ -3634,7 +3638,7 @@ assertEquals(1, notify_return_value);
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_sync_serialize_object_with_numbers_as_keys::decl()])
       .build();
 
@@ -3676,7 +3680,7 @@ Deno.core.ops.op_sync_serialize_object_with_numbers_as_keys({
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_async_serialize_object_with_numbers_as_keys::decl()])
       .build();
 
@@ -3715,7 +3719,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_async_sleep::decl()])
       .build();
 
@@ -3795,7 +3799,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_macrotask::decl(), op_next_tick::decl()])
       .build();
 
@@ -3925,7 +3929,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_promise_reject::decl()])
       .build();
 
@@ -3985,7 +3989,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(())
     }
 
-    let extension = Extension::builder()
+    let extension = Extension::builder("test_ext")
       .ops(vec![op_promise_reject::decl()])
       .build();
 
@@ -4054,7 +4058,9 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok([(1, 2), (3, 4)].into_iter().collect()) // Maps can't have non-string keys in serde_v8
     }
 
-    let ext = Extension::builder().ops(vec![op_err::decl()]).build();
+    let ext = Extension::builder("test_ext")
+      .ops(vec![op_err::decl()])
+      .build();
     let mut runtime = JsRuntime::new(RuntimeOptions {
       extensions: vec![ext],
       ..Default::default()
@@ -4079,7 +4085,9 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(x1 + x2 + x3 + x4)
     }
 
-    let ext = Extension::builder().ops(vec![op_add_4::decl()]).build();
+    let ext = Extension::builder("test_ext")
+      .ops(vec![op_add_4::decl()])
+      .build();
     let mut runtime = JsRuntime::new(RuntimeOptions {
       extensions: vec![ext],
       ..Default::default()
@@ -4098,7 +4106,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(42)
     }
 
-    let ext = Extension::builder()
+    let ext = Extension::builder("test_ext")
       .ops(vec![op_foo::decl().disable()])
       .build();
     let mut runtime = JsRuntime::new(RuntimeOptions {
@@ -4128,7 +4136,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(b)
     }
 
-    let ext = Extension::builder()
+    let ext = Extension::builder("test_ext")
       .ops(vec![op_sum_take::decl(), op_boomerang::decl()])
       .build();
 
@@ -4196,7 +4204,7 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
       Ok(42)
     }
 
-    let ext = Extension::builder()
+    let ext = Extension::builder("test_ext")
       .ops(vec![op_foo::decl(), op_bar::decl()])
       .middleware(|op| if op.is_unstable { op.disable() } else { op })
       .build();
@@ -4248,7 +4256,9 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
     }
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
-      extensions: vec![Extension::builder().ops(vec![op_test::decl()]).build()],
+      extensions: vec![Extension::builder("test_ext")
+        .ops(vec![op_test::decl()])
+        .build()],
       ..Default::default()
     });
     let realm = runtime.create_realm().unwrap();
@@ -4278,7 +4288,9 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
       startup_snapshot: Some(Snapshot::Boxed(snapshot)),
-      extensions: vec![Extension::builder().ops(vec![op_test::decl()]).build()],
+      extensions: vec![Extension::builder("test_ext")
+        .ops(vec![op_test::decl()])
+        .build()],
       ..Default::default()
     });
     let realm = runtime.create_realm().unwrap();
@@ -4307,7 +4319,9 @@ Deno.core.ops.op_async_serialize_object_with_numbers_as_keys({
     }
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
-      extensions: vec![Extension::builder().ops(vec![op_test::decl()]).build()],
+      extensions: vec![Extension::builder("test_ext")
+        .ops(vec![op_test::decl()])
+        .build()],
       get_error_class_fn: Some(&|error| {
         crate::error::get_custom_error_class(error).unwrap()
       }),

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -110,6 +110,8 @@ pub fn init<BC: BroadcastChannel + 'static>(
   unstable: bool,
 ) -> Extension {
   Extension::builder()
+    .name("broadcast channel")
+    .dependencies(vec!["webidl", "web"])
     .js(include_js_files!(
       prefix "deno:ext/broadcast_channel",
       "01_broadcast_channel.js",

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -109,9 +109,8 @@ pub fn init<BC: BroadcastChannel + 'static>(
   bc: BC,
   unstable: bool,
 ) -> Extension {
-  Extension::builder()
-    .name("broadcast channel")
-    .dependencies(vec!["webidl", "web"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl", "deno_web"])
     .js(include_js_files!(
       prefix "deno:ext/broadcast_channel",
       "01_broadcast_channel.js",

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -27,6 +27,8 @@ pub fn init<CA: Cache + 'static>(
   maybe_create_cache: Option<CreateCache<CA>>,
 ) -> Extension {
   Extension::builder()
+    .name("cache")
+    .dependencies(vec!["webidl", "web", "url", "fetch"])
     .js(include_js_files!(
       prefix "deno:ext/cache",
       "01_cache.js",

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -26,9 +26,8 @@ pub struct CreateCache<C: Cache + 'static>(pub Arc<dyn Fn() -> C>);
 pub fn init<CA: Cache + 'static>(
   maybe_create_cache: Option<CreateCache<CA>>,
 ) -> Extension {
-  Extension::builder()
-    .name("cache")
-    .dependencies(vec!["webidl", "web", "url", "fetch"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl", "deno_web", "deno_url", "deno_fetch"])
     .js(include_js_files!(
       prefix "deno:ext/cache",
       "01_cache.js",

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -5,8 +5,7 @@ use deno_core::Extension;
 use std::path::PathBuf;
 
 pub fn init() -> Extension {
-  Extension::builder()
-    .name("console")
+  Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
       prefix "deno:ext/console",
       "01_colors.js",

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 pub fn init() -> Extension {
   Extension::builder()
+    .name("console")
     .js(include_js_files!(
       prefix "deno:ext/console",
       "01_colors.js",

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -73,9 +73,8 @@ use crate::key::HkdfOutput;
 use crate::shared::RawKeyData;
 
 pub fn init(maybe_seed: Option<u64>) -> Extension {
-  Extension::builder()
-    .name("crypto")
-    .dependencies(vec!["webidl", "web"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl", "deno_web"])
     .js(include_js_files!(
       prefix "deno:ext/crypto",
       "00_crypto.js",

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -74,6 +74,8 @@ use crate::shared::RawKeyData;
 
 pub fn init(maybe_seed: Option<u64>) -> Extension {
   Extension::builder()
+    .name("crypto")
+    .dependencies(vec!["webidl", "web"])
     .js(include_js_files!(
       prefix "deno:ext/crypto",
       "00_crypto.js",

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -95,6 +95,8 @@ where
   FP: FetchPermissions + 'static,
 {
   Extension::builder()
+    .name("fetch")
+    .dependencies(vec!["webidl", "web", "url", "console"])
     .js(include_js_files!(
       prefix "deno:ext/fetch",
       "01_fetch_util.js",

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -94,9 +94,8 @@ pub fn init<FP>(options: Options) -> Extension
 where
   FP: FetchPermissions + 'static,
 {
-  Extension::builder()
-    .name("fetch")
-    .dependencies(vec!["webidl", "web", "url", "console"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl", "deno_web", "deno_url", "deno_console"])
     .js(include_js_files!(
       prefix "deno:ext/fetch",
       "01_fetch_util.js",

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -84,7 +84,7 @@ pub(crate) struct FfiState {
 }
 
 pub fn init<P: FfiPermissions + 'static>(unstable: bool) -> Extension {
-  Extension::builder()
+  Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
       prefix "deno:ext/ffi",
       "00_ffi.js",

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1505,9 +1505,14 @@ pub trait FlashPermissions {
 }
 
 pub fn init<P: FlashPermissions + 'static>(unstable: bool) -> Extension {
-  Extension::builder()
-    .name("flash")
-    .dependencies(vec!["web", "net", "fetch", "websocket", "http"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec![
+      "deno_web",
+      "deno_net",
+      "deno_fetch",
+      "deno_websocket",
+      "deno_http",
+    ])
     .js(deno_core::include_js_files!(
       prefix "deno:ext/flash",
       "01_http.js",

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1506,6 +1506,8 @@ pub trait FlashPermissions {
 
 pub fn init<P: FlashPermissions + 'static>(unstable: bool) -> Extension {
   Extension::builder()
+    .name("flash")
+    .dependencies(vec!["web", "net", "fetch", "websocket", "http"])
     .js(deno_core::include_js_files!(
       prefix "deno:ext/flash",
       "01_http.js",

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -78,9 +78,8 @@ pub mod compressible;
 mod reader_stream;
 
 pub fn init() -> Extension {
-  Extension::builder()
-    .name("http")
-    .dependencies(vec!["web", "net", "fetch", "websocket"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_web", "deno_net", "deno_fetch", "deno_websocket"])
     .js(include_js_files!(
       prefix "deno:ext/http",
       "01_http.js",

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -79,6 +79,8 @@ mod reader_stream;
 
 pub fn init() -> Extension {
   Extension::builder()
+    .name("http")
+    .dependencies(vec!["web", "net", "fetch", "websocket"])
     .js(include_js_files!(
       prefix "deno:ext/http",
       "01_http.js",

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -410,7 +410,7 @@ impl Env {
 }
 
 pub fn init<P: NapiPermissions + 'static>(unstable: bool) -> Extension {
-  Extension::builder()
+  Extension::builder(env!("CARGO_PKG_NAME"))
     .ops(vec![op_napi_open::decl::<P>()])
     .event_loop_middleware(|op_state_rc, cx| {
       // `work` can call back into the runtime. It can also schedule an async task

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -85,9 +85,8 @@ pub fn init<P: NetPermissions + 'static>(
 ) -> Extension {
   let mut ops = ops::init::<P>();
   ops.extend(ops_tls::init::<P>());
-  Extension::builder()
-    .name("net")
-    .dependencies(vec!["web"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_web"])
     .js(include_js_files!(
       prefix "deno:ext/net",
       "01_net.js",

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -86,6 +86,8 @@ pub fn init<P: NetPermissions + 'static>(
   let mut ops = ops::init::<P>();
   ops.extend(ops_tls::init::<P>());
   Extension::builder()
+    .name("net")
+    .dependencies(vec!["web"])
     .js(include_js_files!(
       prefix "deno:ext/net",
       "01_net.js",

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -865,7 +865,7 @@ mod tests {
       let listener = TcpListener::bind(addr).await.unwrap();
       let _ = listener.accept().await;
     });
-    let my_ext = Extension::builder()
+    let my_ext = Extension::builder("test_ext")
       .state(move |state| {
         state.put(TestPermission {});
         state.put(UnstableChecker { unstable: true });

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -80,7 +80,7 @@ pub static NODE_ENV_VAR_ALLOWLIST: Lazy<HashSet<String>> = Lazy::new(|| {
 pub fn init<P: NodePermissions + 'static>(
   maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
 ) -> Extension {
-  Extension::builder()
+  Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
       prefix "deno:ext/node",
       "01_node.js",

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -37,7 +37,7 @@ use std::time::SystemTime;
 
 /// This extension has no runtime apis, it only exports some shared native functions.
 pub fn init() -> Extension {
-  Extension::builder().build()
+  Extension::builder(env!("CARGO_PKG_NAME")).build()
 }
 
 struct DefaultSignatureVerification;

--- a/ext/url/benches/url_ops.rs
+++ b/ext/url/benches/url_ops.rs
@@ -8,7 +8,7 @@ fn setup() -> Vec<Extension> {
   vec![
     deno_webidl::init(),
     deno_url::init(),
-    Extension::builder()
+    Extension::builder("bench_setup")
       .js(vec![(
         "setup",
         "const { URL } = globalThis.__bootstrap.url;",

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -19,6 +19,8 @@ use crate::urlpattern::op_urlpattern_process_match_input;
 
 pub fn init() -> Extension {
   Extension::builder()
+    .name("url")
+    .dependencies(vec!["webidl"])
     .js(include_js_files!(
       prefix "deno:ext/url",
       "00_url.js",

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -18,9 +18,8 @@ use crate::urlpattern::op_urlpattern_parse;
 use crate::urlpattern::op_urlpattern_process_match_input;
 
 pub fn init() -> Extension {
-  Extension::builder()
-    .name("url")
-    .dependencies(vec!["webidl"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl"])
     .js(include_js_files!(
       prefix "deno:ext/url",
       "00_url.js",

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -26,6 +26,7 @@ uuid = { workspace = true, features = ["serde"] }
 [dev-dependencies]
 deno_bench_util.workspace = true
 deno_url.workspace = true
+deno_console.workspace = true
 deno_webidl.workspace = true
 
 [[bench]]

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -25,8 +25,8 @@ uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 deno_bench_util.workspace = true
-deno_url.workspace = true
 deno_console.workspace = true
+deno_url.workspace = true
 deno_webidl.workspace = true
 
 [[bench]]

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -24,6 +24,7 @@ fn setup() -> Vec<Extension> {
   vec![
     deno_webidl::init(),
     deno_url::init(),
+    deno_console::init(),
     deno_web::init::<Permissions>(BlobStore::default(), None),
     Extension::builder()
       .js(vec![(

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -26,7 +26,7 @@ fn setup() -> Vec<Extension> {
     deno_url::init(),
     deno_console::init(),
     deno_web::init::<Permissions>(BlobStore::default(), None),
-    Extension::builder()
+    Extension::builder("bench_setup")
       .js(vec![(
         "setup",
         r#"

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -23,6 +23,7 @@ fn setup() -> Vec<Extension> {
   vec![
     deno_webidl::init(),
     deno_url::init(),
+    deno_console::init(),
     deno_web::init::<Permissions>(BlobStore::default(), None),
     Extension::builder()
     .js(vec![

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -25,7 +25,7 @@ fn setup() -> Vec<Extension> {
     deno_url::init(),
     deno_console::init(),
     deno_web::init::<Permissions>(BlobStore::default(), None),
-    Extension::builder()
+    Extension::builder("bench_setup")
     .js(vec![
       ("setup", r#"
       const { setTimeout, handleTimerMacrotask } = globalThis.__bootstrap.timers;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -63,6 +63,8 @@ pub fn init<P: TimersPermission + 'static>(
   maybe_location: Option<Url>,
 ) -> Extension {
   Extension::builder()
+    .name("web")
+    .dependencies(vec!["webidl", "console", "url"])
     .js(include_js_files!(
       prefix "deno:ext/web",
       "00_infra.js",

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -62,9 +62,8 @@ pub fn init<P: TimersPermission + 'static>(
   blob_store: BlobStore,
   maybe_location: Option<Url>,
 ) -> Extension {
-  Extension::builder()
-    .name("web")
-    .dependencies(vec!["webidl", "console", "url"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl", "deno_console", "deno_url"])
     .js(include_js_files!(
       prefix "deno:ext/web",
       "00_infra.js",

--- a/ext/webgpu/src/lib.rs
+++ b/ext/webgpu/src/lib.rs
@@ -104,9 +104,8 @@ impl Resource for WebGpuQuerySet {
 }
 
 pub fn init(unstable: bool) -> Extension {
-  Extension::builder()
-    .name("webgpu")
-    .dependencies(vec!["webidl", "web"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl", "deno_web"])
     .js(include_js_files!(
       prefix "deno:ext/webgpu",
       "01_webgpu.js",

--- a/ext/webgpu/src/lib.rs
+++ b/ext/webgpu/src/lib.rs
@@ -105,6 +105,8 @@ impl Resource for WebGpuQuerySet {
 
 pub fn init(unstable: bool) -> Extension {
   Extension::builder()
+    .name("webgpu")
+    .dependencies(vec!["webidl", "web"])
     .js(include_js_files!(
       prefix "deno:ext/webgpu",
       "01_webgpu.js",

--- a/ext/webidl/lib.rs
+++ b/ext/webidl/lib.rs
@@ -5,8 +5,7 @@ use deno_core::Extension;
 
 /// Load and execute the javascript code.
 pub fn init() -> Extension {
-  Extension::builder()
-    .name("webidl")
+  Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
       prefix "deno:ext/webidl",
       "00_webidl.js",

--- a/ext/webidl/lib.rs
+++ b/ext/webidl/lib.rs
@@ -6,6 +6,7 @@ use deno_core::Extension;
 /// Load and execute the javascript code.
 pub fn init() -> Extension {
   Extension::builder()
+    .name("webidl")
     .js(include_js_files!(
       prefix "deno:ext/webidl",
       "00_webidl.js",

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -603,6 +603,8 @@ pub fn init<P: WebSocketPermissions + 'static>(
   unsafely_ignore_certificate_errors: Option<Vec<String>>,
 ) -> Extension {
   Extension::builder()
+    .name("websocket")
+    .dependencies(vec!["url", "webidl"])
     .js(include_js_files!(
       prefix "deno:ext/websocket",
       "01_websocket.js",

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -602,9 +602,8 @@ pub fn init<P: WebSocketPermissions + 'static>(
   root_cert_store: Option<RootCertStore>,
   unsafely_ignore_certificate_errors: Option<Vec<String>>,
 ) -> Extension {
-  Extension::builder()
-    .name("websocket")
-    .dependencies(vec!["url", "webidl"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_url", "deno_webidl"])
     .js(include_js_files!(
       prefix "deno:ext/websocket",
       "01_websocket.js",

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -22,9 +22,8 @@ struct OriginStorageDir(PathBuf);
 const MAX_STORAGE_BYTES: u32 = 10 * 1024 * 1024;
 
 pub fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
-  Extension::builder()
-    .name("webstorage")
-    .dependencies(vec!["webidl"])
+  Extension::builder(env!("CARGO_PKG_NAME"))
+    .dependencies(vec!["deno_webidl"])
     .js(include_js_files!(
       prefix "deno:ext/webstorage",
       "01_webstorage.js",

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -23,6 +23,8 @@ const MAX_STORAGE_BYTES: u32 = 10 * 1024 * 1024;
 
 pub fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
   Extension::builder()
+    .name("webstorage")
+    .dependencies(vec!["webidl"])
     .js(include_js_files!(
       prefix "deno:ext/webstorage",
       "01_webstorage.js",

--- a/runtime/ops/fs.rs
+++ b/runtime/ops/fs.rs
@@ -42,7 +42,7 @@ use deno_core::error::generic_error;
 use deno_core::error::not_supported;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_fs")
     .ops(vec![
       op_open_sync::decl(),
       op_open_async::decl(),

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -30,7 +30,7 @@ use std::rc::Rc;
 use tokio::sync::mpsc;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_fs_events")
     .ops(vec![op_fs_events_open::decl(), op_fs_events_poll::decl()])
     .build()
 }

--- a/runtime/ops/http.rs
+++ b/runtime/ops/http.rs
@@ -27,7 +27,7 @@ use deno_net::io::UnixStreamResource;
 use tokio::net::UnixStream;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_http_runtime")
     .ops(vec![
       op_http_start::decl(),
       op_http_upgrade::decl(),

--- a/runtime/ops/io.rs
+++ b/runtime/ops/io.rs
@@ -76,7 +76,7 @@ pub static STDERR_HANDLE: Lazy<StdFile> = Lazy::new(|| {
 });
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_io")
     .ops(vec![op_read_sync::decl(), op_write_sync::decl()])
     .build()
 }
@@ -114,7 +114,7 @@ pub fn init_stdio(stdio: Stdio) -> Extension {
   // todo(dsheret): don't do this? Taking out the writers was necessary to prevent invalid handle panics
   let stdio = Rc::new(RefCell::new(Some(stdio)));
 
-  Extension::builder()
+  Extension::builder("deno_stdio")
     .middleware(|op| match op.name {
       "op_print" => op_print::decl(),
       _ => op,

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -40,7 +40,7 @@ fn init_ops(builder: &mut ExtensionBuilder) -> &mut ExtensionBuilder {
 }
 
 pub fn init(exit_code: ExitCode) -> Extension {
-  let mut builder = Extension::builder();
+  let mut builder = Extension::builder("deno_os");
   init_ops(&mut builder)
     .state(move |state| {
       state.put::<ExitCode>(exit_code.clone());
@@ -50,7 +50,7 @@ pub fn init(exit_code: ExitCode) -> Extension {
 }
 
 pub fn init_for_worker() -> Extension {
-  let mut builder = Extension::builder();
+  let mut builder = Extension::builder("deno_os_worker");
   init_ops(&mut builder)
     .middleware(|op| match op.name {
       "op_exit" => noop_op::decl(),

--- a/runtime/ops/permissions.rs
+++ b/runtime/ops/permissions.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use std::path::Path;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_permissions")
     .ops(vec![
       op_query_permission::decl(),
       op_revoke_permission::decl(),

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -27,7 +27,7 @@ use tokio::process::Command;
 use std::os::unix::process::ExitStatusExt;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_process")
     .ops(vec![op_run::decl(), op_run_status::decl(), op_kill::decl()])
     .build()
 }

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -9,7 +9,7 @@ use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 
 pub fn init(main_module: ModuleSpecifier) -> Extension {
-  Extension::builder()
+  Extension::builder("deno_runtime")
     .ops(vec![op_main_module::decl()])
     .state(move |state| {
       state.put::<ModuleSpecifier>(main_module.clone());

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -21,7 +21,7 @@ use tokio::signal::unix::{signal, Signal, SignalKind};
 use tokio::signal::windows::{ctrl_break, ctrl_c, CtrlBreak, CtrlC};
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_signal")
     .ops(vec![
       op_signal_bind::decl(),
       op_signal_unbind::decl(),

--- a/runtime/ops/spawn.rs
+++ b/runtime/ops/spawn.rs
@@ -28,7 +28,7 @@ use std::os::unix::prelude::ExitStatusExt;
 use std::os::unix::process::CommandExt;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_spawn")
     .ops(vec![
       op_spawn_child::decl(),
       op_node_unstable_spawn_child::decl(),

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -34,7 +34,7 @@ fn get_windows_handle(
 }
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_tty")
     .ops(vec![
       op_stdin_set_raw::decl(),
       op_isatty::decl(),

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 use self::sync_fetch::op_worker_sync_fetch;
 
 pub fn init() -> Extension {
-  Extension::builder()
+  Extension::builder("deno_web_worker")
     .ops(vec![
       op_worker_post_message::decl(),
       op_worker_recv_message::decl(),

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -94,7 +94,7 @@ pub fn init(
   pre_execute_module_cb: Arc<WorkerEventCb>,
   format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
 ) -> Extension {
-  Extension::builder()
+  Extension::builder("deno_worker_host")
     .state(move |state| {
       state.put::<WorkersTable>(WorkersTable::default());
       state.put::<WorkerId>(WorkerId::default());

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -370,7 +370,7 @@ impl WebWorker {
     // Permissions: many ops depend on this
     let unstable = options.bootstrap.unstable;
     let enable_testing_features = options.bootstrap.enable_testing_features;
-    let perm_ext = Extension::builder()
+    let perm_ext = Extension::builder("deno_permissions_web_worker")
       .state(move |state| {
         state.put::<PermissionsContainer>(permissions.clone());
         state.put(ops::UnstableChecker { unstable });

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -202,7 +202,7 @@ impl MainWorker {
     // Permissions: many ops depend on this
     let unstable = options.bootstrap.unstable;
     let enable_testing_features = options.bootstrap.enable_testing_features;
-    let perm_ext = Extension::builder()
+    let perm_ext = Extension::builder("deno_permissions_worker")
       .state(move |state| {
         state.put::<PermissionsContainer>(permissions.clone());
         state.put(ops::UnstableChecker { unstable });


### PR DESCRIPTION
This adds the ability to optionally specify a name and a set of dependencies (which are other `Extension`s) in an `Extension`, to provide a better error message when using the extension crates.

Unsure if additionally we should:

- make specifying a name mandatory
- panic if there are multiple extensions defined with the same name