### PR TITLE
fix(napi): support for env cleanup hooks

### DIFF
--- a/cli/napi/env.rs
+++ b/cli/napi/env.rs
@@ -64,8 +64,7 @@ fn napi_add_env_cleanup_hook(
     let mut env_cleanup_hooks = env.cleanup_hooks.borrow_mut();
     if env_cleanup_hooks
       .iter()
-      .find(|pair| pair.0 == hook && pair.1 == data)
-      .is_some()
+      .any(|pair| pair.0 == hook && pair.1 == data)
     {
       panic!("Cleanup hook with this data already registered");
     }
@@ -84,14 +83,18 @@ fn napi_remove_env_cleanup_hook(
 
   {
     let mut env_cleanup_hooks = env.cleanup_hooks.borrow_mut();
-    let index = env_cleanup_hooks
+    let maybe_index = env_cleanup_hooks
       .iter()
       .rev()
-      .position(|&pair| pair.0 == hook && pair.1 == data)
-      .unwrap();
-    // We've reversed the iterator so need to fix the index
-    let index = env_cleanup_hooks.len() - index - 1;
-    env_cleanup_hooks.remove(index);
+      .position(|&pair| pair.0 == hook && pair.1 == data);
+
+    if let Some(index) = maybe_index {
+      // We've reversed the iterator so need to fix the index
+      let index = env_cleanup_hooks.len() - index - 1;
+      env_cleanup_hooks.remove(index);
+    } else {
+      panic!("Cleanup hook with this data not found");
+    }
   }
 
   Ok(())

--- a/cli/napi/env.rs
+++ b/cli/napi/env.rs
@@ -86,12 +86,9 @@ fn napi_remove_env_cleanup_hook(
     // Hooks are supposed to be removed in LIFO order
     let maybe_index = env_cleanup_hooks
       .iter()
-      .rev()
-      .position(|&pair| pair.0 == hook && pair.1 == data);
+      .rposition(|&pair| pair.0 == hook && pair.1 == data);
 
     if let Some(index) = maybe_index {
-      // We've reversed the iterator so need to fix the index
-      let index = env_cleanup_hooks.len() - index - 1;
       env_cleanup_hooks.remove(index);
     } else {
       panic!("Cleanup hook with this data not found");

--- a/cli/napi/env.rs
+++ b/cli/napi/env.rs
@@ -83,6 +83,7 @@ fn napi_remove_env_cleanup_hook(
 
   {
     let mut env_cleanup_hooks = env.cleanup_hooks.borrow_mut();
+    // Hooks are supposed to be removed in LIFO order
     let maybe_index = env_cleanup_hooks
       .iter()
       .rev()

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -18,6 +18,7 @@ use std::cell::RefCell;
 use std::ffi::CString;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::task::Poll;
 use std::thread_local;
 
@@ -301,8 +302,19 @@ pub struct NapiState {
     mpsc::UnboundedReceiver<ThreadSafeFunctionStatus>,
   pub threadsafe_function_sender:
     mpsc::UnboundedSender<ThreadSafeFunctionStatus>,
+  pub env_cleanup_hooks:
+    Rc<RefCell<Vec<(extern "C" fn(*const c_void), *const c_void)>>>,
 }
 
+impl Drop for NapiState {
+  fn drop(&mut self) {
+    let mut hooks = self.env_cleanup_hooks.borrow_mut();
+    let hooks = hooks.drain(..).rev().collect::<Vec<_>>();
+    for (fn_ptr, data) in hooks {
+      (fn_ptr)(data);
+    }
+  }
+}
 #[repr(C)]
 #[derive(Debug)]
 /// Env that is shared between all contexts in same native module.
@@ -344,6 +356,8 @@ pub struct Env {
   pub async_work_sender: mpsc::UnboundedSender<PendingNapiAsyncWork>,
   pub threadsafe_function_sender:
     mpsc::UnboundedSender<ThreadSafeFunctionStatus>,
+  pub cleanup_hooks:
+    Rc<RefCell<Vec<(extern "C" fn(*const c_void), *const c_void)>>>,
 }
 
 unsafe impl Send for Env {}
@@ -355,6 +369,9 @@ impl Env {
     context: v8::Global<v8::Context>,
     sender: mpsc::UnboundedSender<PendingNapiAsyncWork>,
     threadsafe_function_sender: mpsc::UnboundedSender<ThreadSafeFunctionStatus>,
+    cleanup_hooks: Rc<
+      RefCell<Vec<(extern "C" fn(*const c_void), *const c_void)>>,
+    >,
   ) -> Self {
     let sc = sender.clone();
     ASYNC_WORK_SENDER.with(|s| {
@@ -372,6 +389,7 @@ impl Env {
       open_handle_scopes: 0,
       async_work_sender: sender,
       threadsafe_function_sender,
+      cleanup_hooks,
     }
   }
 
@@ -475,6 +493,7 @@ pub fn init<P: NapiPermissions + 'static>(unstable: bool) -> Extension {
         threadsafe_function_sender,
         threadsafe_function_receiver,
         active_threadsafe_functions: 0,
+        env_cleanup_hooks: Rc::new(RefCell::new(vec![])),
       });
       state.put(Unstable(unstable));
       Ok(())
@@ -511,13 +530,14 @@ where
   let permissions = op_state.borrow_mut::<NP>();
   permissions.check(Some(&PathBuf::from(&path)))?;
 
-  let (async_work_sender, tsfn_sender, isolate_ptr) = {
+  let (async_work_sender, tsfn_sender, isolate_ptr, cleanup_hooks) = {
     let napi_state = op_state.borrow::<NapiState>();
     let isolate_ptr = op_state.borrow::<*mut v8::OwnedIsolate>();
     (
       napi_state.async_work_sender.clone(),
       napi_state.threadsafe_function_sender.clone(),
       *isolate_ptr,
+      napi_state.env_cleanup_hooks.clone(),
     )
   };
 
@@ -539,6 +559,7 @@ where
     v8::Global::new(scope, ctx),
     async_work_sender,
     tsfn_sender,
+    cleanup_hooks,
   );
   env.shared = Box::into_raw(Box::new(env_shared));
   let env_ptr = Box::into_raw(Box::new(env)) as _;

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -309,6 +309,7 @@ pub struct NapiState {
 impl Drop for NapiState {
   fn drop(&mut self) {
     let mut hooks = self.env_cleanup_hooks.borrow_mut();
+    // Hooks are supposed to be run in LIFO order
     let hooks = hooks.drain(..).rev().collect::<Vec<_>>();
     for (fn_ptr, data) in hooks {
       (fn_ptr)(data);

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -342,7 +342,7 @@ impl Drop for NapiState {
   fn drop(&mut self) {
     let mut hooks = self.env_cleanup_hooks.borrow_mut();
     // Hooks are supposed to be run in LIFO order
-    let hooks = hooks.drain(..).rev().collect::<Vec<_>>();
+    let hooks = hooks.drain(..).rev();
     for (fn_ptr, data) in hooks {
       (fn_ptr)(data);
     }

--- a/test_napi/cleanup_hook_test.js
+++ b/test_napi/cleanup_hook_test.js
@@ -1,0 +1,33 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals, loadTestLibrary } from "./common.js";
+
+const properties = loadTestLibrary();
+
+if (import.meta.main) {
+  properties.installCleanupHook();
+  console.log("installed cleanup hook");
+} else {
+  Deno.test("napi cleanup hook", async () => {
+    const { stdout, stderr, code } = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-run",
+        "--allow-ffi",
+        "--unstable",
+        import.meta.url,
+      ],
+    }).output();
+
+    assertEquals(code, 0);
+    assertEquals(new TextDecoder().decode(stderr), "");
+
+    const stdoutText = new TextDecoder().decode(stdout);
+    const stdoutLines = stdoutText.split("\n");
+    assertEquals(stdoutLines.length, 4);
+    assertEquals(stdoutLines[0], "installed cleanup hook");
+    assertEquals(stdoutLines[1], "cleanup(18)");
+    assertEquals(stdoutLines[2], "cleanup(42)");
+  });
+}

--- a/test_napi/src/arraybuffer.rs
+++ b/test_napi/src/arraybuffer.rs
@@ -2,7 +2,6 @@
 
 use napi_sys::Status::napi_ok;
 use napi_sys::*;
-use std::ptr;
 
 extern "C" fn test_detached(
   env: napi_env,

--- a/test_napi/src/strings.rs
+++ b/test_napi/src/strings.rs
@@ -3,7 +3,6 @@
 use napi_sys::Status::napi_ok;
 use napi_sys::ValueType::napi_string;
 use napi_sys::*;
-use std::ptr;
 
 extern "C" fn test_utf8(env: napi_env, info: napi_callback_info) -> napi_value {
   let (args, argc, _) = crate::get_callback_info!(env, info, 1);

--- a/test_napi/tests/napi_tests.rs
+++ b/test_napi/tests/napi_tests.rs
@@ -30,6 +30,7 @@ fn napi_tests() {
     .arg("--allow-read")
     .arg("--allow-env")
     .arg("--allow-ffi")
+    .arg("--allow-run")
     .arg("--unstable")
     .spawn()
     .unwrap()
@@ -37,6 +38,7 @@ fn napi_tests() {
     .unwrap();
   let stdout = std::str::from_utf8(&output.stdout).unwrap();
   let stderr = std::str::from_utf8(&output.stderr).unwrap();
+
   if !output.status.success() {
     println!("stdout {}", stdout);
     println!("stderr {}", stderr);


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/16925

This commit adds support for "napi_add_env_cleanup_hook" and
"napi_remove_env_cleanup_hook" function for Node-API.