### PR TITLE
fix: don't panic on resolveDns if unsupported record type is specified

### DIFF
--- a/cli/tests/testdata/run/resolve_dns.ts
+++ b/cli/tests/testdata/run/resolve_dns.ts
@@ -62,3 +62,10 @@ try {
     } thrown for not-found-example.com`,
   );
 }
+
+try {
+  // @ts-ignore testing invalid overloads
+  await Deno.resolveDns("example.com", "SSHFP", nameServer);
+} catch (e) {
+  console.log(e.message);
+}

--- a/cli/tests/testdata/run/resolve_dns.ts.out
+++ b/cli/tests/testdata/run/resolve_dns.ts.out
@@ -23,3 +23,4 @@ SRV
 TXT
 [["I","am","a","txt","record"],["I","am","another","txt","record"],["I am a different","txt record"],["key=val"]]
 Error NotFound thrown for not-found-example.com
+Provided record type is not supported

--- a/cli/tests/testdata/run/resolve_dns.zone.in
+++ b/cli/tests/testdata/run/resolve_dns.zone.in
@@ -29,3 +29,4 @@ alias   CNAME   cname
 _service._tcp           SRV 0 100 1234 srv
 @   IN  NAPTR  10 0 "s" "SIPS+D2T" "" _sips._tcp.example.com.
 @   IN  NAPTR  10 0 "s" RELAY:turn.udp "" _turn._udp.example.com.
+@   IN	SSHFP  1 1 436C6F7564666C

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -612,7 +612,12 @@ fn rdata_to_return_record(
           .collect();
         DnsReturnRecord::Txt(texts)
       }),
-      _ => return Err(custom_error("NotSupported", "Provided record type is not supported")),
+      _ => {
+        return Err(custom_error(
+          "NotSupported",
+          "Provided record type is not supported",
+        ))
+      }
     };
     Ok(record)
   }
@@ -653,14 +658,20 @@ mod tests {
   fn rdata_to_return_record_aaaa() {
     let func = rdata_to_return_record(RecordType::AAAA);
     let rdata = RData::AAAA(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
-    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Aaaa("::1".to_string())));
+    assert_eq!(
+      func(&rdata).unwrap(),
+      Some(DnsReturnRecord::Aaaa("::1".to_string()))
+    );
   }
 
   #[test]
   fn rdata_to_return_record_aname() {
     let func = rdata_to_return_record(RecordType::ANAME);
     let rdata = RData::ANAME(Name::new());
-    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Aname("".to_string())));
+    assert_eq!(
+      func(&rdata).unwrap(),
+      Some(DnsReturnRecord::Aname("".to_string()))
+    );
   }
 
   #[test]
@@ -685,7 +696,10 @@ mod tests {
   fn rdata_to_return_record_cname() {
     let func = rdata_to_return_record(RecordType::CNAME);
     let rdata = RData::CNAME(Name::new());
-    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Cname("".to_string())));
+    assert_eq!(
+      func(&rdata).unwrap(),
+      Some(DnsReturnRecord::Cname("".to_string()))
+    );
   }
 
   #[test]
@@ -729,14 +743,20 @@ mod tests {
   fn rdata_to_return_record_ns() {
     let func = rdata_to_return_record(RecordType::NS);
     let rdata = RData::NS(Name::new());
-    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Ns("".to_string())));
+    assert_eq!(
+      func(&rdata).unwrap(),
+      Some(DnsReturnRecord::Ns("".to_string()))
+    );
   }
 
   #[test]
   fn rdata_to_return_record_ptr() {
     let func = rdata_to_return_record(RecordType::PTR);
     let rdata = RData::PTR(Name::new());
-    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Ptr("".to_string())));
+    assert_eq!(
+      func(&rdata).unwrap(),
+      Some(DnsReturnRecord::Ptr("".to_string()))
+    );
   }
 
   #[test]

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -484,7 +484,7 @@ where
 
   let resolver = AsyncResolver::tokio(config, opts)?;
 
-  let results = resolver
+  resolver
     .lookup(query, record_type)
     .await
     .map_err(|e| {
@@ -501,10 +501,8 @@ where
       }
     })?
     .iter()
-    .filter_map(rdata_to_return_record(record_type))
-    .collect();
-
-  Ok(results)
+    .filter_map(|rdata| rdata_to_return_record(record_type)(rdata).transpose())
+    .collect::<Result<Vec<DnsReturnRecord>, AnyError>>()
 }
 
 #[op]
@@ -531,10 +529,10 @@ pub fn op_set_keepalive(
 
 fn rdata_to_return_record(
   ty: RecordType,
-) -> impl Fn(&RData) -> Option<DnsReturnRecord> {
+) -> impl Fn(&RData) -> Result<Option<DnsReturnRecord>, AnyError> {
   use RecordType::*;
-  move |r: &RData| -> Option<DnsReturnRecord> {
-    match ty {
+  move |r: &RData| -> Result<Option<DnsReturnRecord>, AnyError> {
+    let record = match ty {
       A => r.as_a().map(ToString::to_string).map(DnsReturnRecord::A),
       AAAA => r
         .as_aaaa()
@@ -614,9 +612,9 @@ fn rdata_to_return_record(
           .collect();
         DnsReturnRecord::Txt(texts)
       }),
-      // TODO(magurotuna): Other record types are not supported
-      _ => todo!(),
-    }
+      _ => return Err(custom_error("NotSupported", "Provided record type is not supported")),
+    };
+    Ok(record)
   }
 }
 
@@ -646,7 +644,7 @@ mod tests {
     let func = rdata_to_return_record(RecordType::A);
     let rdata = RData::A(Ipv4Addr::new(127, 0, 0, 1));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::A("127.0.0.1".to_string()))
     );
   }
@@ -655,14 +653,14 @@ mod tests {
   fn rdata_to_return_record_aaaa() {
     let func = rdata_to_return_record(RecordType::AAAA);
     let rdata = RData::AAAA(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
-    assert_eq!(func(&rdata), Some(DnsReturnRecord::Aaaa("::1".to_string())));
+    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Aaaa("::1".to_string())));
   }
 
   #[test]
   fn rdata_to_return_record_aname() {
     let func = rdata_to_return_record(RecordType::ANAME);
     let rdata = RData::ANAME(Name::new());
-    assert_eq!(func(&rdata), Some(DnsReturnRecord::Aname("".to_string())));
+    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Aname("".to_string())));
   }
 
   #[test]
@@ -674,7 +672,7 @@ mod tests {
       vec![KeyValue::new("account", "123456")],
     ));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::Caa {
         critical: false,
         tag: "issue".to_string(),
@@ -687,7 +685,7 @@ mod tests {
   fn rdata_to_return_record_cname() {
     let func = rdata_to_return_record(RecordType::CNAME);
     let rdata = RData::CNAME(Name::new());
-    assert_eq!(func(&rdata), Some(DnsReturnRecord::Cname("".to_string())));
+    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Cname("".to_string())));
   }
 
   #[test]
@@ -695,7 +693,7 @@ mod tests {
     let func = rdata_to_return_record(RecordType::MX);
     let rdata = RData::MX(MX::new(10, Name::new()));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::Mx {
         preference: 10,
         exchange: "".to_string()
@@ -715,7 +713,7 @@ mod tests {
       Name::new(),
     ));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::Naptr {
         order: 1,
         preference: 2,
@@ -731,14 +729,14 @@ mod tests {
   fn rdata_to_return_record_ns() {
     let func = rdata_to_return_record(RecordType::NS);
     let rdata = RData::NS(Name::new());
-    assert_eq!(func(&rdata), Some(DnsReturnRecord::Ns("".to_string())));
+    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Ns("".to_string())));
   }
 
   #[test]
   fn rdata_to_return_record_ptr() {
     let func = rdata_to_return_record(RecordType::PTR);
     let rdata = RData::PTR(Name::new());
-    assert_eq!(func(&rdata), Some(DnsReturnRecord::Ptr("".to_string())));
+    assert_eq!(func(&rdata).unwrap(), Some(DnsReturnRecord::Ptr("".to_string())));
   }
 
   #[test]
@@ -754,7 +752,7 @@ mod tests {
       0,
     ));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::Soa {
         mname: "".to_string(),
         rname: "".to_string(),
@@ -772,7 +770,7 @@ mod tests {
     let func = rdata_to_return_record(RecordType::SRV);
     let rdata = RData::SRV(SRV::new(1, 2, 3, Name::new()));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::Srv {
         priority: 1,
         weight: 2,
@@ -792,7 +790,7 @@ mod tests {
       &[0xe3, 0x81, 0x82], // "あ" in UTF-8
     ]));
     assert_eq!(
-      func(&rdata),
+      func(&rdata).unwrap(),
       Some(DnsReturnRecord::Txt(vec![
         "foo".to_string(),
         "bar".to_string(),


### PR DESCRIPTION
Fixes #14373