### PR TITLE
chore(ci): do not run CI on draft PRs unless explicitly run via commit message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,6 @@ Before submitting a PR, please read http://deno.land/manual/contributing
 4. Ensure `cargo test` passes.
 5. Ensure `./tools/format.js` passes without changing files.
 6. Ensure `./tools/lint.js` passes.
+7. Open as a draft PR if your work is still in progress. The CI won't run
+   all steps, but you can add '[ci]' to the commit message to force it to.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,5 +19,5 @@ Before submitting a PR, please read http://deno.land/manual/contributing
 5. Ensure `./tools/format.js` passes without changing files.
 6. Ensure `./tools/lint.js` passes.
 7. Open as a draft PR if your work is still in progress. The CI won't run
-   all steps, but you can add '[ci]' to the commit message to force it to.
+   all steps, but you can add '[ci]' to a commit message to force it to.
 -->

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -117,7 +117,7 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       if: [
-        "github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:') &&",
+        "(github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:')) &&",
         "(github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -124,9 +124,9 @@ function cancelEarlyIfDraftPr(nextSteps: Record<string, unknown>[]): unknown[] {
       if: "github.event.pull_request.draft == true",
       shell: "bash",
       run: [
-        "GIT_MESSAGE=$(git show -s --format=%s)",
+        "GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})",
         "echo Commit message: $GIT_MESSAGE",
-        "echo $GIT_MESSAGE | grep -c '\\[ci\\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)",
+        "echo $GIT_MESSAGE | grep '\\[ci\\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)",
       ].join("\n"),
     },
     ...nextSteps.map((step) => {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -116,10 +116,8 @@ const ci = {
   jobs: {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
-      if: [
-        "(github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:')) &&",
-        "(github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
-      ].join("\n"),
+      if:
+        "github.event_name == 'push' && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,
       strategy: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -122,10 +122,6 @@ function cancelEarlyIfDraftPr(steps: Record<string, unknown>[]): unknown[] {
       run:
         "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT) || exit 0",
     },
-    {
-      name: "TEMP - Check output",
-      run: "echo ${{ steps.exit_early.outputs.EXIT_EARLY }}",
-    },
     ...steps.map((step) => {
       const condition = "steps.exit_early.outputs.EXIT_EARLY != 'true'";
       step.if = "if" in step ? `${condition} && (${step.if})` : condition;

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -117,7 +117,7 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       if:
-        "github.event_name == 'push' && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
+        "github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]')",
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,
       strategy: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -120,7 +120,7 @@ function cancelEarlyIfDraftPr(steps: Record<string, unknown>[]): unknown[] {
       if: "github.event.pull_request.draft == true",
       shell: "bash",
       run:
-        "git show -s --format=%s | grep -c '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT) || exit 0",
+        "git show -s --format=%s | grep -c '[ci]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)",
     },
     ...steps.map((step) => {
       const condition = "steps.exit_early.outputs.EXIT_EARLY != 'true'";

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -123,7 +123,7 @@ function cancelEarlyIfDraftPr(steps: Record<string, unknown>[]): unknown[] {
         "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo \"EXIT_EARLY=true\" >> $GITHUB_STATE) || exit 0",
     },
     ...steps.map((step) => {
-      const condition = "${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true'";
+      const condition = "steps.exit_early.outputs.EXIT_EARLY != 'true'";
       step.if = "if" in step ? `${condition} && (${step.if})` : condition;
       return step;
     }),

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -150,7 +150,7 @@ const ci = {
         "reopened",
         "synchronize",
         // need to re-run the action when converting from draft because
-        // draft PRs will not necessarily run all the PR steps
+        // draft PRs will not necessarily run all the steps
         "ready_for_review",
       ],
     },

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -123,8 +123,11 @@ function cancelEarlyIfDraftPr(nextSteps: Record<string, unknown>[]): unknown[] {
       id: "exit_early",
       if: "github.event.pull_request.draft == true",
       shell: "bash",
-      run:
-        "git show -s --format=%s | grep -c '[ci]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)",
+      run: [
+        "GIT_MESSAGE=$(git show -s --format=%s)",
+        "echo Commit message: $GIT_MESSAGE",
+        "echo $GIT_MESSAGE | grep -c '\\[ci\\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)",
+      ].join("\n"),
     },
     ...nextSteps.map((step) => {
       const condition = "steps.exit_early.outputs.EXIT_EARLY != 'true'";

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -118,9 +118,9 @@ const ci = {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       if: [
         "(",
-        "  github.event_name == 'push' && ",
-        "  (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
-        ") || !startsWith(github.event.pull_request.head.label, 'denoland:')",
+        "  github.event_name == 'push' &&",
+        "  || !startsWith(github.event.pull_request.head.label, 'denoland:')",
+        ") && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -119,7 +119,7 @@ const ci = {
       if: [
         "(",
         "  github.event_name == 'push' && ",
-        "  (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]')",
+        "  (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
         ") || !startsWith(github.event.pull_request.head.label, 'denoland:')",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -120,7 +120,11 @@ function cancelEarlyIfDraftPr(steps: Record<string, unknown>[]): unknown[] {
       if: "github.event.pull_request.draft == true",
       shell: "bash",
       run:
-        "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo \"EXIT_EARLY=true\" >> $GITHUB_STATE) || exit 0",
+        "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_STATE) || exit 0",
+    },
+    {
+      name: "TEMP - Check output",
+      run: "echo ${{ steps.exit_early.outputs.EXIT_EARLY }}",
     },
     ...steps.map((step) => {
       const condition = "steps.exit_early.outputs.EXIT_EARLY != 'true'";

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -116,7 +116,10 @@ const ci = {
   jobs: {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
-      if: "contains(github.event.head_commit.message, '[ci]')",
+      if: [
+        "github.event_name == 'push' ||",
+        "!startsWith(github.event.pull_request.head.label, 'denoland:')",
+      ].join("\n"),
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,
       strategy: {
@@ -198,541 +201,566 @@ const ci = {
             submodules: false,
           },
         },
-        submoduleStep("./test_util/std"),
         {
-          ...submoduleStep("./test_util/wpt"),
-          if: "matrix.job == 'test'",
-        },
-        {
-          ...submoduleStep("./third_party"),
-          if: "matrix.job == 'lint' || matrix.job == 'bench'",
-        },
-        {
-          name: "Create source tarballs (release, linux)",
-          if: [
-            "startsWith(matrix.os, 'ubuntu') &&",
-            "matrix.profile == 'release' &&",
-            "matrix.job == 'test' &&",
-            "github.repository == 'denoland/deno' &&",
-            "startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          run: [
-            "mkdir -p target/release",
-            'tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \\',
-            "    -czvf target/release/deno_src.tar.gz -C .. deno",
-          ].join("\n"),
-        },
-        installRustStep,
-        {
-          if: "matrix.job == 'lint' || matrix.job == 'test'",
-          ...installDenoStep,
-        },
-        ...installPythonSteps,
-        installNodeStep,
-        {
-          name: "Setup gcloud (unix)",
-          if: [
-            "runner.os != 'Windows' &&",
-            "matrix.profile == 'release' &&",
-            "matrix.job == 'test' &&",
-            "github.repository == 'denoland/deno' &&",
-            "(github.ref == 'refs/heads/main' ||",
-            "startsWith(github.ref, 'refs/tags/'))",
-          ].join("\n"),
-          uses: "google-github-actions/setup-gcloud@v0",
-          with: {
-            project_id: "denoland",
-            service_account_key: "${{ secrets.GCP_SA_KEY }}",
-            export_default_credentials: true,
-          },
-        },
-        {
-          name: "Setup gcloud (windows)",
-          if: [
-            "runner.os == 'Windows' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "(github.ref == 'refs/heads/main' ||",
-            "startsWith(github.ref, 'refs/tags/'))",
-          ].join("\n"),
-          uses: "google-github-actions/setup-gcloud@v0",
-          env: {
-            CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-          },
-          with: {
-            project_id: "denoland",
-            service_account_key: "${{ secrets.GCP_SA_KEY }}",
-            export_default_credentials: true,
-          },
-        },
-        {
-          name: "Configure canary build",
-          if: [
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main'",
-          ].join("\n"),
+          name: "Cancel if draft PR",
+          id: "exit_early",
+          if: "github.event.pull_request.draft == true",
           shell: "bash",
-          run: 'echo "DENO_CANARY=true" >> $GITHUB_ENV',
+          run:
+            "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo \"::set-output name=EXIT_EARLY::true\") || exit 0",
         },
-        {
-          if: "matrix.use_sysroot",
-          ...sysRootStep,
-        },
-        {
-          name: "Log versions",
-          shell: "bash",
-          run: [
-            "node -v",
-            "python --version",
-            "rustc --version",
-            "cargo --version",
-            "# Deno is installed when linting.",
-            'if [ "${{ matrix.job }}" == "lint" ]',
-            "then",
-            "  deno --version",
-            "fi",
-          ].join("\n"),
-        },
-        {
-          name: "Cache Cargo home",
-          uses: "actions/cache@v3",
-          with: {
-            // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-            path: [
-              "~/.cargo/registry/index",
-              "~/.cargo/registry/cache",
-              "~/.cargo/git/db",
+        ...[
+          submoduleStep("./test_util/std"),
+          {
+            ...submoduleStep("./test_util/wpt"),
+            if: "matrix.job == 'test'",
+          },
+          {
+            ...submoduleStep("./third_party"),
+            if: "matrix.job == 'lint' || matrix.job == 'bench'",
+          },
+          {
+            name: "Create source tarballs (release, linux)",
+            if: [
+              "startsWith(matrix.os, 'ubuntu') &&",
+              "matrix.profile == 'release' &&",
+              "matrix.job == 'test' &&",
+              "github.repository == 'denoland/deno' &&",
+              "startsWith(github.ref, 'refs/tags/')",
             ].join("\n"),
-            key:
-              "18-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}",
-          },
-        },
-        {
-          // In main branch, always creates fresh cache
-          name: "Cache build output (main)",
-          uses: "actions/cache/save@v3",
-          if:
-            "(matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'",
-          with: {
-            path: [
-              "./target",
-              "!./target/*/gn_out",
-              "!./target/*/*.zip",
-              "!./target/*/*.tar.gz",
+            run: [
+              "mkdir -p target/release",
+              'tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \\',
+              "    -czvf target/release/deno_src.tar.gz -C .. deno",
             ].join("\n"),
-            key:
-              "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}",
           },
-        },
-        {
-          // Restore cache from the latest 'main' branch build.
-          name: "Cache build output (PR)",
-          uses: "actions/cache/restore@v3",
-          if:
-            "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-          with: {
-            path: [
-              "./target",
-              "!./target/*/gn_out",
-              "!./target/*/*.zip",
-              "!./target/*/*.tar.gz",
+          installRustStep,
+          {
+            if: "matrix.job == 'lint' || matrix.job == 'test'",
+            ...installDenoStep,
+          },
+          ...installPythonSteps,
+          installNodeStep,
+          {
+            name: "Setup gcloud (unix)",
+            if: [
+              "runner.os != 'Windows' &&",
+              "matrix.profile == 'release' &&",
+              "matrix.job == 'test' &&",
+              "github.repository == 'denoland/deno' &&",
+              "(github.ref == 'refs/heads/main' ||",
+              "startsWith(github.ref, 'refs/tags/'))",
             ].join("\n"),
-            key: "never_saved",
-            "restore-keys":
-              "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-",
+            uses: "google-github-actions/setup-gcloud@v0",
+            with: {
+              project_id: "denoland",
+              service_account_key: "${{ secrets.GCP_SA_KEY }}",
+              export_default_credentials: true,
+            },
           },
-        },
-        {
-          name: "Apply and update mtime cache",
-          if: "matrix.profile == 'release'",
-          uses: "./.github/mtime_cache",
-          with: { "cache-path": "./target" },
-        },
-        {
-          // Shallow the cloning the crates.io index makes CI faster because it
-          // obviates the need for Cargo to clone the index. If we don't do this
-          // Cargo will `git clone` the github repository that contains the entire
-          // history of the crates.io index from github. We don't believe the
-          // identifier '1ecc6299db9ec823' will ever change, but if it does then this
-          // command must be updated.
-          name: "Shallow clone crates.io index",
-          shell: "bash",
-          run: [
-            "if [ ! -d ~/.cargo/registry/index/github.com-1ecc6299db9ec823/.git ]",
-            "then",
-            "  git clone --depth 1 --no-checkout                      \\",
-            "            https://github.com/rust-lang/crates.io-index \\",
-            "            ~/.cargo/registry/index/github.com-1ecc6299db9ec823",
-            "fi",
-          ].join("\n"),
-        },
-        {
-          name: "test_format.js",
-          if: "matrix.job == 'lint'",
-          run:
-            "deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check",
-        },
-        {
-          name: "lint.js",
-          if: "matrix.job == 'lint'",
-          run:
-            "deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js",
-        },
-        {
-          name: "Build debug",
-          if: [
-            "(matrix.job == 'test' || matrix.job == 'bench') &&",
-            "matrix.profile == 'debug'",
-          ].join("\n"),
-          run: "cargo build --locked --all-targets",
-        },
-        {
-          name: "Build fastci",
-          if: "(matrix.job == 'test' && matrix.profile == 'fastci')",
-          run: "cargo build --locked --all-targets",
-          env: { CARGO_PROFILE_DEV_DEBUG: 0 },
-        },
-        {
-          name: "Build release",
-          if: [
-            "(matrix.job == 'test' || matrix.job == 'bench') &&",
-            "matrix.profile == 'release' && (matrix.use_sysroot ||",
-            "(github.repository == 'denoland/deno' &&",
-            "(github.ref == 'refs/heads/main' ||",
-            "startsWith(github.ref, 'refs/tags/'))))",
-          ].join("\n"),
-          run: "cargo build --release --locked --all-targets",
-        },
-        {
-          name: "Upload PR artifact (linux)",
-          if: [
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' && (matrix.use_sysroot ||",
-            "(github.repository == 'denoland/deno' &&",
-            "(github.ref == 'refs/heads/main' ||",
-            "startsWith(github.ref, 'refs/tags/'))))",
-          ].join("\n"),
-          uses: "actions/upload-artifact@v3",
-          with: {
-            name: "deno-${{ github.event.number }}",
-            path: "target/release/deno",
-          },
-        },
-        {
-          name: "Pre-release (linux)",
-          if: [
-            "startsWith(matrix.os, 'ubuntu') &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno'",
-          ].join("\n"),
-          run: [
-            "cd target/release",
-            "zip -r deno-x86_64-unknown-linux-gnu.zip deno",
-            "./deno types > lib.deno.d.ts",
-          ].join("\n"),
-        },
-        {
-          name: "Pre-release (mac)",
-          if: [
-            "startsWith(matrix.os, 'macOS') &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
-          ].join("\n"),
-          run: ["cd target/release", "zip -r deno-x86_64-apple-darwin.zip deno"]
-            .join("\n"),
-        },
-        {
-          name: "Pre-release (windows)",
-          if: [
-            "startsWith(matrix.os, 'windows') &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
-          ].join("\n"),
-          run:
-            "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip",
-        },
-        {
-          name: "Upload canary to dl.deno.land (unix)",
-          if: [
-            "runner.os != 'Windows' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main'",
-          ].join("\n"),
-          run:
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-        },
-        {
-          name: "Upload canary to dl.deno.land (windows)",
-          if: [
-            "runner.os == 'Windows' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main'",
-          ].join("\n"),
-          env: {
-            CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-          },
-          shell: "bash",
-          run:
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-        },
-        {
-          name: "Test debug",
-          if: [
-            "matrix.job == 'test' && matrix.profile == 'debug' &&",
-            "!startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          run: ["cargo test --locked --doc", "cargo test --locked"].join("\n"),
-        },
-        {
-          name: "Test fastci",
-          if: "(matrix.job == 'test' && matrix.profile == 'fastci')",
-          run: "cargo test --locked",
-          env: {
-            CARGO_PROFILE_DEV_DEBUG: 0,
-          },
-        },
-        {
-          name: "Test release",
-          if: [
-            "matrix.job == 'test' && matrix.profile == 'release' &&",
-            "(matrix.use_sysroot || (",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))",
-          ].join("\n"),
-          run: "cargo test --release --locked",
-        },
-        {
-          // Since all tests are skipped when we're building a tagged commit
-          // this is a minimal check to ensure that binary is not corrupted
-          name: "Check deno binary",
-          if:
-            "matrix.profile == 'release' && startsWith(github.ref, 'refs/tags/')",
-          shell: "bash",
-          run: 'target/release/deno eval "console.log(1+2)" | grep 3',
-          env: {
-            NO_COLOR: 1,
-          },
-        },
-        {
-          // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
-          name: "Check deno binary (in sysroot)",
-          if: "matrix.profile == 'release' && matrix.use_sysroot",
-          run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',
-        },
-        {
-          // TODO(ry): Because CI is so slow on for OSX and Windows, we currently
-          //           run the Web Platform tests only on Linux.
-          name: "Configure hosts file for WPT",
-          if: "startsWith(matrix.os, 'ubuntu') && matrix.job == 'test'",
-          run: "./wpt make-hosts-file | sudo tee -a /etc/hosts",
-          "working-directory": "test_util/wpt/",
-        },
-        {
-          name: "Run web platform tests (debug)",
-          if: [
-            "startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&",
-            "matrix.profile == 'debug' &&",
-            "github.ref == 'refs/heads/main'",
-          ].join("\n"),
-          env: {
-            DENO_BIN: "./target/debug/deno",
-          },
-          run: [
-            "deno run --allow-env --allow-net --allow-read --allow-run \\",
-            "        --allow-write --unstable                         \\",
-            "        --lock=tools/deno.lock.json                      \\",
-            "        ./tools/wpt.ts setup",
-            "deno run --allow-env --allow-net --allow-read --allow-run \\",
-            "         --allow-write --unstable                         \\",
-            "         --lock=tools/deno.lock.json              \\",
-            '         ./tools/wpt.ts run --quiet --binary="$DENO_BIN"',
-          ].join("\n"),
-        },
-        {
-          name: "Run web platform tests (release)",
-          if: [
-            "startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&",
-            "matrix.profile == 'release' && !startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          env: {
-            DENO_BIN: "./target/release/deno",
-          },
-          run: [
-            "deno run --allow-env --allow-net --allow-read --allow-run \\",
-            "         --allow-write --unstable                         \\",
-            "         --lock=tools/deno.lock.json                      \\",
-            "         ./tools/wpt.ts setup",
-            "deno run --allow-env --allow-net --allow-read --allow-run \\",
-            "         --allow-write --unstable                         \\",
-            "         --lock=tools/deno.lock.json                      \\",
-            "         ./tools/wpt.ts run --quiet --release             \\",
-            '                            --binary="$DENO_BIN"          \\',
-            "                            --json=wpt.json               \\",
-            "                            --wptreport=wptreport.json",
-          ].join("\n"),
-        },
-        {
-          name: "Upload wpt results to dl.deno.land",
-          "continue-on-error": true,
-          if: [
-            "runner.os == 'Linux' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          run: [
-            "gzip ./wptreport.json",
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json',
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./wptreport.json.gz gs://dl.deno.land/wpt/$(git rev-parse HEAD)-wptreport.json.gz',
-            "echo $(git rev-parse HEAD) > wpt-latest.txt",
-            'gsutil -h "Cache-Control: no-cache" cp wpt-latest.txt gs://dl.deno.land/wpt-latest.txt',
-          ].join("\n"),
-        },
-        {
-          name: "Upload wpt results to wpt.fyi",
-          "continue-on-error": true,
-          if: [
-            "runner.os == 'Linux' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          env: {
-            WPT_FYI_USER: "deno",
-            WPT_FYI_PW: "${{ secrets.WPT_FYI_PW }}",
-            GITHUB_TOKEN: "${{ secrets.DENOBOT_PAT }}",
-          },
-          run: [
-            "./target/release/deno run --allow-all --lock=tools/deno.lock.json \\",
-            "    ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus",
-          ].join("\n"),
-        },
-        {
-          name: "Run benchmarks",
-          if: "matrix.job == 'bench' && !startsWith(github.ref, 'refs/tags/')",
-          run: "cargo bench --locked",
-        },
-        {
-          name: "Post Benchmarks",
-          if: [
-            "matrix.job == 'bench' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          env: {
-            DENOBOT_PAT: "${{ secrets.DENOBOT_PAT }}",
-          },
-          run: [
-            "git clone --depth 1 --branch gh-pages                             \\",
-            "    https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git \\",
-            "    gh-pages",
-            "./target/release/deno run --allow-all --unstable \\",
-            "    ./tools/build_benchmark_jsons.js --release",
-            "cd gh-pages",
-            'git config user.email "propelml@gmail.com"',
-            'git config user.name "denobot"',
-            "git add .",
-            'git commit --message "Update benchmarks"',
-            "git push origin gh-pages",
-          ].join("\n"),
-        },
-        {
-          name: "Build product size info",
-          if:
-            "matrix.job != 'lint' && matrix.profile != 'fastci' && github.repository == 'denoland/deno' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
-          run: [
-            'du -hd1 "./target/${{ matrix.profile }}"',
-            'du -ha  "./target/${{ matrix.profile }}/deno"',
-          ].join("\n"),
-        },
-        {
-          name: "Worker info",
-          if: "matrix.job == 'bench'",
-          run: [
-            "cat /proc/cpuinfo",
-            "cat /proc/meminfo",
-          ].join("\n"),
-        },
-        {
-          name: "Upload release to dl.deno.land (unix)",
-          if: [
-            "runner.os != 'Windows' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          run:
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
-        },
-        {
-          name: "Upload release to dl.deno.land (windows)",
-          if: [
-            "runner.os == 'Windows' &&",
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          env: {
-            CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-          },
-          shell: "bash",
-          run:
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
-        },
-        {
-          name: "Create release notes",
-          shell: "bash",
-          if: [
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          run: [
-            "export PATH=$PATH:$(pwd)/target/release",
-            "./tools/release/05_create_release_notes.ts",
-          ].join("\n"),
-        },
-        {
-          name: "Upload release to GitHub",
-          uses: "softprops/action-gh-release@v0.1.15",
-          if: [
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno' &&",
-            "startsWith(github.ref, 'refs/tags/')",
-          ].join("\n"),
-          env: {
-            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
-          },
-          with: {
-            files: [
-              "target/release/deno-x86_64-pc-windows-msvc.zip",
-              "target/release/deno-x86_64-unknown-linux-gnu.zip",
-              "target/release/deno-x86_64-apple-darwin.zip",
-              "target/release/deno_src.tar.gz",
-              "target/release/lib.deno.d.ts",
+          {
+            name: "Setup gcloud (windows)",
+            if: [
+              "runner.os == 'Windows' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "(github.ref == 'refs/heads/main' ||",
+              "startsWith(github.ref, 'refs/tags/'))",
             ].join("\n"),
-            body_path: "target/release/release-notes.md",
-            draft: true,
+            uses: "google-github-actions/setup-gcloud@v0",
+            env: {
+              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
+            },
+            with: {
+              project_id: "denoland",
+              service_account_key: "${{ secrets.GCP_SA_KEY }}",
+              export_default_credentials: true,
+            },
           },
-        },
+          {
+            name: "Configure canary build",
+            if: [
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main'",
+            ].join("\n"),
+            shell: "bash",
+            run: 'echo "DENO_CANARY=true" >> $GITHUB_ENV',
+          },
+          {
+            if: "matrix.use_sysroot",
+            ...sysRootStep,
+          },
+          {
+            name: "Log versions",
+            shell: "bash",
+            run: [
+              "node -v",
+              "python --version",
+              "rustc --version",
+              "cargo --version",
+              "# Deno is installed when linting.",
+              'if [ "${{ matrix.job }}" == "lint" ]',
+              "then",
+              "  deno --version",
+              "fi",
+            ].join("\n"),
+          },
+          {
+            name: "Cache Cargo home",
+            uses: "actions/cache@v3",
+            with: {
+              // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+              path: [
+                "~/.cargo/registry/index",
+                "~/.cargo/registry/cache",
+                "~/.cargo/git/db",
+              ].join("\n"),
+              key:
+                "18-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}",
+            },
+          },
+          {
+            // In main branch, always creates fresh cache
+            name: "Cache build output (main)",
+            uses: "actions/cache/save@v3",
+            if:
+              "(matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'",
+            with: {
+              path: [
+                "./target",
+                "!./target/*/gn_out",
+                "!./target/*/*.zip",
+                "!./target/*/*.tar.gz",
+              ].join("\n"),
+              key:
+                "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}",
+            },
+          },
+          {
+            // Restore cache from the latest 'main' branch build.
+            name: "Cache build output (PR)",
+            uses: "actions/cache/restore@v3",
+            if:
+              "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+            with: {
+              path: [
+                "./target",
+                "!./target/*/gn_out",
+                "!./target/*/*.zip",
+                "!./target/*/*.tar.gz",
+              ].join("\n"),
+              key: "never_saved",
+              "restore-keys":
+                "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-",
+            },
+          },
+          {
+            name: "Apply and update mtime cache",
+            if: "matrix.profile == 'release'",
+            uses: "./.github/mtime_cache",
+            with: { "cache-path": "./target" },
+          },
+          {
+            // Shallow the cloning the crates.io index makes CI faster because it
+            // obviates the need for Cargo to clone the index. If we don't do this
+            // Cargo will `git clone` the github repository that contains the entire
+            // history of the crates.io index from github. We don't believe the
+            // identifier '1ecc6299db9ec823' will ever change, but if it does then this
+            // command must be updated.
+            name: "Shallow clone crates.io index",
+            shell: "bash",
+            run: [
+              "if [ ! -d ~/.cargo/registry/index/github.com-1ecc6299db9ec823/.git ]",
+              "then",
+              "  git clone --depth 1 --no-checkout                      \\",
+              "            https://github.com/rust-lang/crates.io-index \\",
+              "            ~/.cargo/registry/index/github.com-1ecc6299db9ec823",
+              "fi",
+            ].join("\n"),
+          },
+          {
+            name: "test_format.js",
+            if: "matrix.job == 'lint'",
+            run:
+              "deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check",
+          },
+          {
+            name: "lint.js",
+            if: "matrix.job == 'lint'",
+            run:
+              "deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js",
+          },
+          {
+            name: "Build debug",
+            if: [
+              "(matrix.job == 'test' || matrix.job == 'bench') &&",
+              "matrix.profile == 'debug'",
+            ].join("\n"),
+            run: "cargo build --locked --all-targets",
+          },
+          {
+            name: "Build fastci",
+            if: "(matrix.job == 'test' && matrix.profile == 'fastci')",
+            run: "cargo build --locked --all-targets",
+            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
+          },
+          {
+            name: "Build release",
+            if: [
+              "(matrix.job == 'test' || matrix.job == 'bench') &&",
+              "matrix.profile == 'release' && (matrix.use_sysroot ||",
+              "(github.repository == 'denoland/deno' &&",
+              "(github.ref == 'refs/heads/main' ||",
+              "startsWith(github.ref, 'refs/tags/'))))",
+            ].join("\n"),
+            run: "cargo build --release --locked --all-targets",
+          },
+          {
+            name: "Upload PR artifact (linux)",
+            if: [
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' && (matrix.use_sysroot ||",
+              "(github.repository == 'denoland/deno' &&",
+              "(github.ref == 'refs/heads/main' ||",
+              "startsWith(github.ref, 'refs/tags/'))))",
+            ].join("\n"),
+            uses: "actions/upload-artifact@v3",
+            with: {
+              name: "deno-${{ github.event.number }}",
+              path: "target/release/deno",
+            },
+          },
+          {
+            name: "Pre-release (linux)",
+            if: [
+              "startsWith(matrix.os, 'ubuntu') &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno'",
+            ].join("\n"),
+            run: [
+              "cd target/release",
+              "zip -r deno-x86_64-unknown-linux-gnu.zip deno",
+              "./deno types > lib.deno.d.ts",
+            ].join("\n"),
+          },
+          {
+            name: "Pre-release (mac)",
+            if: [
+              "startsWith(matrix.os, 'macOS') &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+            ].join("\n"),
+            run: [
+              "cd target/release",
+              "zip -r deno-x86_64-apple-darwin.zip deno",
+            ]
+              .join("\n"),
+          },
+          {
+            name: "Pre-release (windows)",
+            if: [
+              "startsWith(matrix.os, 'windows') &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+            ].join("\n"),
+            run:
+              "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip",
+          },
+          {
+            name: "Upload canary to dl.deno.land (unix)",
+            if: [
+              "runner.os != 'Windows' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main'",
+            ].join("\n"),
+            run:
+              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
+          },
+          {
+            name: "Upload canary to dl.deno.land (windows)",
+            if: [
+              "runner.os == 'Windows' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main'",
+            ].join("\n"),
+            env: {
+              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
+            },
+            shell: "bash",
+            run:
+              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
+          },
+          {
+            name: "Test debug",
+            if: [
+              "matrix.job == 'test' && matrix.profile == 'debug' &&",
+              "!startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            run: ["cargo test --locked --doc", "cargo test --locked"].join(
+              "\n",
+            ),
+          },
+          {
+            name: "Test fastci",
+            if: "(matrix.job == 'test' && matrix.profile == 'fastci')",
+            run: "cargo test --locked",
+            env: {
+              CARGO_PROFILE_DEV_DEBUG: 0,
+            },
+          },
+          {
+            name: "Test release",
+            if: [
+              "matrix.job == 'test' && matrix.profile == 'release' &&",
+              "(matrix.use_sysroot || (",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))",
+            ].join("\n"),
+            run: "cargo test --release --locked",
+          },
+          {
+            // Since all tests are skipped when we're building a tagged commit
+            // this is a minimal check to ensure that binary is not corrupted
+            name: "Check deno binary",
+            if:
+              "matrix.profile == 'release' && startsWith(github.ref, 'refs/tags/')",
+            shell: "bash",
+            run: 'target/release/deno eval "console.log(1+2)" | grep 3',
+            env: {
+              NO_COLOR: 1,
+            },
+          },
+          {
+            // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
+            name: "Check deno binary (in sysroot)",
+            if: "matrix.profile == 'release' && matrix.use_sysroot",
+            run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',
+          },
+          {
+            // TODO(ry): Because CI is so slow on for OSX and Windows, we currently
+            //           run the Web Platform tests only on Linux.
+            name: "Configure hosts file for WPT",
+            if: "startsWith(matrix.os, 'ubuntu') && matrix.job == 'test'",
+            run: "./wpt make-hosts-file | sudo tee -a /etc/hosts",
+            "working-directory": "test_util/wpt/",
+          },
+          {
+            name: "Run web platform tests (debug)",
+            if: [
+              "startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&",
+              "matrix.profile == 'debug' &&",
+              "github.ref == 'refs/heads/main'",
+            ].join("\n"),
+            env: {
+              DENO_BIN: "./target/debug/deno",
+            },
+            run: [
+              "deno run --allow-env --allow-net --allow-read --allow-run \\",
+              "        --allow-write --unstable                         \\",
+              "        --lock=tools/deno.lock.json                      \\",
+              "        ./tools/wpt.ts setup",
+              "deno run --allow-env --allow-net --allow-read --allow-run \\",
+              "         --allow-write --unstable                         \\",
+              "         --lock=tools/deno.lock.json              \\",
+              '         ./tools/wpt.ts run --quiet --binary="$DENO_BIN"',
+            ].join("\n"),
+          },
+          {
+            name: "Run web platform tests (release)",
+            if: [
+              "startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&",
+              "matrix.profile == 'release' && !startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            env: {
+              DENO_BIN: "./target/release/deno",
+            },
+            run: [
+              "deno run --allow-env --allow-net --allow-read --allow-run \\",
+              "         --allow-write --unstable                         \\",
+              "         --lock=tools/deno.lock.json                      \\",
+              "         ./tools/wpt.ts setup",
+              "deno run --allow-env --allow-net --allow-read --allow-run \\",
+              "         --allow-write --unstable                         \\",
+              "         --lock=tools/deno.lock.json                      \\",
+              "         ./tools/wpt.ts run --quiet --release             \\",
+              '                            --binary="$DENO_BIN"          \\',
+              "                            --json=wpt.json               \\",
+              "                            --wptreport=wptreport.json",
+            ].join("\n"),
+          },
+          {
+            name: "Upload wpt results to dl.deno.land",
+            "continue-on-error": true,
+            if: [
+              "runner.os == 'Linux' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            run: [
+              "gzip ./wptreport.json",
+              'gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json',
+              'gsutil -h "Cache-Control: public, max-age=3600" cp ./wptreport.json.gz gs://dl.deno.land/wpt/$(git rev-parse HEAD)-wptreport.json.gz',
+              "echo $(git rev-parse HEAD) > wpt-latest.txt",
+              'gsutil -h "Cache-Control: no-cache" cp wpt-latest.txt gs://dl.deno.land/wpt-latest.txt',
+            ].join("\n"),
+          },
+          {
+            name: "Upload wpt results to wpt.fyi",
+            "continue-on-error": true,
+            if: [
+              "runner.os == 'Linux' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            env: {
+              WPT_FYI_USER: "deno",
+              WPT_FYI_PW: "${{ secrets.WPT_FYI_PW }}",
+              GITHUB_TOKEN: "${{ secrets.DENOBOT_PAT }}",
+            },
+            run: [
+              "./target/release/deno run --allow-all --lock=tools/deno.lock.json \\",
+              "    ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus",
+            ].join("\n"),
+          },
+          {
+            name: "Run benchmarks",
+            if:
+              "matrix.job == 'bench' && !startsWith(github.ref, 'refs/tags/')",
+            run: "cargo bench --locked",
+          },
+          {
+            name: "Post Benchmarks",
+            if: [
+              "matrix.job == 'bench' &&",
+              "github.repository == 'denoland/deno' &&",
+              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            env: {
+              DENOBOT_PAT: "${{ secrets.DENOBOT_PAT }}",
+            },
+            run: [
+              "git clone --depth 1 --branch gh-pages                             \\",
+              "    https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git \\",
+              "    gh-pages",
+              "./target/release/deno run --allow-all --unstable \\",
+              "    ./tools/build_benchmark_jsons.js --release",
+              "cd gh-pages",
+              'git config user.email "propelml@gmail.com"',
+              'git config user.name "denobot"',
+              "git add .",
+              'git commit --message "Update benchmarks"',
+              "git push origin gh-pages",
+            ].join("\n"),
+          },
+          {
+            name: "Build product size info",
+            if:
+              "matrix.job != 'lint' && matrix.profile != 'fastci' && github.repository == 'denoland/deno' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+            run: [
+              'du -hd1 "./target/${{ matrix.profile }}"',
+              'du -ha  "./target/${{ matrix.profile }}/deno"',
+            ].join("\n"),
+          },
+          {
+            name: "Worker info",
+            if: "matrix.job == 'bench'",
+            run: [
+              "cat /proc/cpuinfo",
+              "cat /proc/meminfo",
+            ].join("\n"),
+          },
+          {
+            name: "Upload release to dl.deno.land (unix)",
+            if: [
+              "runner.os != 'Windows' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            run:
+              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
+          },
+          {
+            name: "Upload release to dl.deno.land (windows)",
+            if: [
+              "runner.os == 'Windows' &&",
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            env: {
+              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
+            },
+            shell: "bash",
+            run:
+              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
+          },
+          {
+            name: "Create release notes",
+            shell: "bash",
+            if: [
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            run: [
+              "export PATH=$PATH:$(pwd)/target/release",
+              "./tools/release/05_create_release_notes.ts",
+            ].join("\n"),
+          },
+          {
+            name: "Upload release to GitHub",
+            uses: "softprops/action-gh-release@v0.1.15",
+            if: [
+              "matrix.job == 'test' &&",
+              "matrix.profile == 'release' &&",
+              "github.repository == 'denoland/deno' &&",
+              "startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            env: {
+              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+            },
+            with: {
+              files: [
+                "target/release/deno-x86_64-pc-windows-msvc.zip",
+                "target/release/deno-x86_64-unknown-linux-gnu.zip",
+                "target/release/deno-x86_64-apple-darwin.zip",
+                "target/release/deno_src.tar.gz",
+                "target/release/lib.deno.d.ts",
+              ].join("\n"),
+              body_path: "target/release/release-notes.md",
+              draft: true,
+            },
+          },
+        ].map((step) => {
+          const condition =
+            "${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true'";
+          if ("if" in step) {
+            step.if = `${condition} && (${step.if})`;
+          } else {
+            (step as any).if = condition;
+          }
+          return step;
+        }),
       ],
     },
     "publish-canary": {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -117,8 +117,10 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       if: [
-        "github.event_name == 'push' ||",
-        "!startsWith(github.event.pull_request.head.label, 'denoland:')",
+        "(",
+        "  github.event_name == 'push' && ",
+        "  (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]')",
+        ") || !startsWith(github.event.pull_request.head.label, 'denoland:')",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -140,7 +140,10 @@ function cancelEarlyIfDraftPr(nextSteps: Record<string, unknown>[]): unknown[] {
 const ci = {
   name: "ci",
   on: {
-    push: true,
+    push: {
+      branches: ["main"],
+      tags: ["*"],
+    },
     pull_request: {
       types: [
         "opened",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -116,8 +116,7 @@ const ci = {
   jobs: {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
-      if:
-        "github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]')",
+      if: "contains(github.event.head_commit.message, '[ci]')",
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,
       strategy: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -117,7 +117,7 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       if: [
-        "github.event_name == 'push' && !startsWith(github.event.pull_request.head.label, 'denoland:') &&",
+        "github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:') &&",
         "(github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -120,7 +120,7 @@ function cancelEarlyIfDraftPr(steps: Record<string, unknown>[]): unknown[] {
       if: "github.event.pull_request.draft == true",
       shell: "bash",
       run:
-        "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT) || exit 0",
+        "git show -s --format=%s | grep -c '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT) || exit 0",
     },
     ...steps.map((step) => {
       const condition = "steps.exit_early.outputs.EXIT_EARLY != 'true'";

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -139,7 +139,19 @@ function cancelEarlyIfDraftPr(nextSteps: Record<string, unknown>[]): unknown[] {
 
 const ci = {
   name: "ci",
-  on: ["push", "pull_request"],
+  on: {
+    push: true,
+    pull_request: {
+      types: [
+        "opened",
+        "reopened",
+        "synchronize",
+        // need to re-run the action when converting from draft because
+        // draft PRs will not necessarily run all the PR steps
+        "ready_for_review",
+      ],
+    },
+  },
   concurrency: {
     group:
       "${{ github.workflow }}-${{ !contains(github.event.pull_request.labels.*.name, 'test-flaky-ci') && github.head_ref || github.run_id }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -117,10 +117,8 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       if: [
-        "(",
-        "  github.event_name == 'push' &&",
-        "  !startsWith(github.event.pull_request.head.label, 'denoland:')",
-        ") && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
+        "github.event_name == 'push' && !startsWith(github.event.pull_request.head.label, 'denoland:') &&",
+        "(github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -119,7 +119,7 @@ const ci = {
       if: [
         "(",
         "  github.event_name == 'push' &&",
-        "  || !startsWith(github.event.pull_request.head.label, 'denoland:')",
+        "  !startsWith(github.event.pull_request.head.label, 'denoland:')",
         ") && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))",
       ].join("\n"),
       "runs-on": "${{ matrix.os }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -120,7 +120,7 @@ function cancelEarlyIfDraftPr(steps: Record<string, unknown>[]): unknown[] {
       if: "github.event.pull_request.draft == true",
       shell: "bash",
       run:
-        "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_STATE) || exit 0",
+        "git show -s --format=%s | grep '[ci]' && (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT) || exit 0",
     },
     {
       name: "TEMP - Check output",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@
 
 name: ci
 on:
-  push: true
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: contains(github.event.head_commit.message, '[ci]')
+    if: contains(github.event.head_commit.message, 'ci')
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
         id: exit_early
         if: github.event.pull_request.draft == true
         shell: bash
-        run: 'git show -s --format=%s | grep -c ''[ci]'' || (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT)'
+        run: |-
+          GIT_MESSAGE=$(git show -s --format=%s)
+          echo Commit message: $GIT_MESSAGE
+          echo $GIT_MESSAGE | grep -c '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     if: |-
-      github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:') &&
+      (github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:')) &&
       (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     if: |-
       (
-        github.event_name == 'push' && 
-        (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
-      ) || !startsWith(github.event.pull_request.head.label, 'denoland:')
+        github.event_name == 'push' &&
+        || !startsWith(github.event.pull_request.head.label, 'denoland:')
+      ) && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
         id: exit_early
         if: github.event.pull_request.draft == true
         shell: bash
-        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo "EXIT_EARLY=true" >> $GITHUB_STATE) || exit 0'
+        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_STATE) || exit 0'
+      - name: TEMP - Check output
+        run: 'echo ${{ steps.exit_early.outputs.EXIT_EARLY }}'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: |-
-      (github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:')) &&
-      (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
+    if: 'github.event_name == ''push'' && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, ''[ci]''))'
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     if: |-
       (
         github.event_name == 'push' &&
-        || !startsWith(github.event.pull_request.head.label, 'denoland:')
+        !startsWith(github.event.pull_request.head.label, 'denoland:')
       ) && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     if: |-
-      github.event_name == 'push' && !startsWith(github.event.pull_request.head.label, 'denoland:') &&
+      github.event_name == 'push' || !startsWith(github.event.pull_request.head.label, 'denoland:') &&
       (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         id: exit_early
         if: github.event.pull_request.draft == true
         shell: bash
-        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_STATE) || exit 0'
+        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT) || exit 0'
       - name: TEMP - Check output
         run: 'echo ${{ steps.exit_early.outputs.EXIT_EARLY }}'
       - name: Clone submodule ./test_util/std

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         id: exit_early
         if: github.event.pull_request.draft == true
         shell: bash
-        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo "::set-output name=EXIT_EARLY::true") || exit 0'
+        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo "EXIT_EARLY=true" >> $GITHUB_STATE) || exit 0'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
@@ -98,6 +98,7 @@ jobs:
         if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: Remove unused versions of Python
         if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (startsWith(matrix.os, ''windows''))'
+        shell: pwsh
         run: |-
           $env:PATH -split ";" |
             Where-Object { Test-Path "$_\python.exe" } |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         id: exit_early
         if: github.event.pull_request.draft == true
         shell: bash
-        run: 'git show -s --format=%s | grep -c ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT) || exit 0'
+        run: 'git show -s --format=%s | grep -c ''[ci]'' || (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT)'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
         if: github.event.pull_request.draft == true
         shell: bash
         run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT) || exit 0'
-      - name: TEMP - Check output
-        run: 'echo ${{ steps.exit_early.outputs.EXIT_EARLY }}'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
         if: github.event.pull_request.draft == true
         shell: bash
         run: |-
-          GIT_MESSAGE=$(git show -s --format=%s)
+          GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})
           echo Commit message: $GIT_MESSAGE
-          echo $GIT_MESSAGE | grep -c '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)
+          echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     if: |-
       (
         github.event_name == 'push' && 
-        (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]')
+        (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
       ) || !startsWith(github.event.pull_request.head.label, 'denoland:')
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: 'github.event_name == ''push'' && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, ''[ci]''))'
+    if: 'github.event.pull_request.draft == false || contains(github.event.head_commit.message, ''[ci]'')'
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,8 @@ jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     if: |-
-      (
-        github.event_name == 'push' &&
-        !startsWith(github.event.pull_request.head.label, 'denoland:')
-      ) && (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
+      github.event_name == 'push' && !startsWith(github.event.pull_request.head.label, 'denoland:') &&
+      (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]'))
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,16 +66,16 @@ jobs:
         run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo "EXIT_EARLY=true" >> $GITHUB_STATE) || exit 0'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''test'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test')
       - name: Clone submodule ./third_party
         run: git submodule update --init --recursive --depth=1 -- ./third_party
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'' || matrix.job == ''bench'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'lint' || matrix.job == 'bench')
       - name: 'Create source tarballs (release, linux)'
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
@@ -85,8 +85,8 @@ jobs:
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
       - uses: dtolnay/rust-toolchain@stable
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
-      - if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'' || matrix.job == ''test'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
+      - if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'lint' || matrix.job == 'test')
         name: Install Deno
         uses: denoland/setup-deno@v1
         with:
@@ -95,9 +95,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: Remove unused versions of Python
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (startsWith(matrix.os, ''windows''))'
+        if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (startsWith(matrix.os, ''windows''))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |
@@ -108,10 +108,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 17
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: Setup gcloud (unix)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os != 'Windows' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
@@ -124,7 +124,7 @@ jobs:
           export_default_credentials: true
       - name: Setup gcloud (windows)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Windows' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -139,13 +139,13 @@ jobs:
           export_default_credentials: true
       - name: Configure canary build
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main')
         shell: bash
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
-      - if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.use_sysroot)'
+      - if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.use_sysroot)
         name: Set up incremental LTO and sysroot build
         run: |-
           # Avoid running man-db triggers, which sometimes takes several minutes
@@ -218,7 +218,7 @@ jobs:
           then
             deno --version
           fi
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: Cache Cargo home
         uses: actions/cache@v3
         with:
@@ -227,10 +227,10 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: '18-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: Cache build output (main)
         uses: actions/cache/save@v3
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && ((matrix.profile == ''release'' || matrix.profile == ''fastci'') && github.ref == ''refs/heads/main'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main')
         with:
           path: |-
             ./target
@@ -240,7 +240,7 @@ jobs:
           key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}'
       - name: Cache build output (PR)
         uses: actions/cache/restore@v3
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
+        if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
         with:
           path: |-
             ./target
@@ -250,7 +250,7 @@ jobs:
           key: never_saved
           restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-'
       - name: Apply and update mtime cache
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.profile == ''release'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.profile == 'release')
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target
@@ -263,26 +263,26 @@ jobs:
                       https://github.com/rust-lang/crates.io-index \
                       ~/.cargo/registry/index/github.com-1ecc6299db9ec823
           fi
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: test_format.js
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'lint')
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
       - name: lint.js
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'lint')
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
       - name: Build debug
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'debug')
         run: cargo build --locked --all-targets
       - name: Build fastci
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci''))'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.job == 'test' && matrix.profile == 'fastci'))
         run: cargo build --locked --all-targets
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build release
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
@@ -290,7 +290,7 @@ jobs:
         run: cargo build --release --locked --all-targets
       - name: Upload PR artifact (linux)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
@@ -301,7 +301,7 @@ jobs:
           path: target/release/deno
       - name: Pre-release (linux)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
@@ -311,7 +311,7 @@ jobs:
           ./deno types > lib.deno.d.ts
       - name: Pre-release (mac)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'macOS') &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'macOS') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -321,7 +321,7 @@ jobs:
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (windows)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'windows') &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'windows') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -329,7 +329,7 @@ jobs:
         run: Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
       - name: Upload canary to dl.deno.land (unix)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os != 'Windows' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -337,7 +337,7 @@ jobs:
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Upload canary to dl.deno.land (windows)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Windows' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -348,39 +348,39 @@ jobs:
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Test debug
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
           !startsWith(github.ref, 'refs/tags/'))
         run: |-
           cargo test --locked --doc
           cargo test --locked
       - name: Test fastci
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci''))'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.job == 'test' && matrix.profile == 'fastci'))
         run: cargo test --locked
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test release
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' && matrix.profile == 'release' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'release' &&
           (matrix.use_sysroot || (
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))))
         run: cargo test --release --locked
       - name: Check deno binary
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/''))'
+        if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/''))'
         shell: bash
         run: target/release/deno eval "console.log(1+2)" | grep 3
         env:
           NO_COLOR: 1
       - name: Check deno binary (in sysroot)
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.profile == ''release'' && matrix.use_sysroot)'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.profile == 'release' && matrix.use_sysroot)
         run: sudo chroot /sysroot "$(pwd)/target/release/deno" --version
       - name: Configure hosts file for WPT
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (startsWith(matrix.os, ''ubuntu'') && matrix.job == ''test'')'
+        if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (startsWith(matrix.os, ''ubuntu'') && matrix.job == ''test'')'
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: test_util/wpt/
       - name: Run web platform tests (debug)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
           matrix.profile == 'debug' &&
           github.ref == 'refs/heads/main')
         env:
@@ -396,7 +396,7 @@ jobs:
                    ./tools/wpt.ts run --quiet --binary="$DENO_BIN"
       - name: Run web platform tests (release)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
           matrix.profile == 'release' && !startsWith(github.ref, 'refs/tags/'))
         env:
           DENO_BIN: ./target/release/deno
@@ -415,7 +415,7 @@ jobs:
       - name: Upload wpt results to dl.deno.land
         continue-on-error: true
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Linux' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Linux' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -429,7 +429,7 @@ jobs:
       - name: Upload wpt results to wpt.fyi
         continue-on-error: true
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Linux' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Linux' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -442,11 +442,11 @@ jobs:
           ./target/release/deno run --allow-all --lock=tools/deno.lock.json \
               ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus
       - name: Run benchmarks
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/''))'
+        if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/''))'
         run: cargo bench --locked
       - name: Post Benchmarks
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'bench' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'bench' &&
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         env:
@@ -464,18 +464,18 @@ jobs:
           git commit --message "Update benchmarks"
           git push origin gh-pages
       - name: Build product size info
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job != ''lint'' && matrix.profile != ''fastci'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')))'
+        if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint'' && matrix.profile != ''fastci'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')))'
         run: |-
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"
       - name: Worker info
-        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''bench'')'
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'bench')
         run: |-
           cat /proc/cpuinfo
           cat /proc/meminfo
       - name: Upload release to dl.deno.land (unix)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os != 'Windows' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -483,7 +483,7 @@ jobs:
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Upload release to dl.deno.land (windows)
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Windows' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -495,7 +495,7 @@ jobs:
       - name: Create release notes
         shell: bash
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           startsWith(github.ref, 'refs/tags/'))
@@ -505,7 +505,7 @@ jobs:
       - name: Upload release to GitHub
         uses: softprops/action-gh-release@v0.1.15
         if: |-
-          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
+          steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: 'github.event.pull_request.draft == false || contains(github.event.head_commit.message, ''[ci]'')'
+    if: 'contains(github.event.head_commit.message, ''[ci]'')'
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@
 
 name: ci
 on:
-  - push
-  - pull_request
+  push: true
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 concurrency:
   group: '${{ github.workflow }}-${{ !contains(github.event.pull_request.labels.*.name, ''test-flaky-ci'') && github.head_ref || github.run_id }}'
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         id: exit_early
         if: github.event.pull_request.draft == true
         shell: bash
-        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT) || exit 0'
+        run: 'git show -s --format=%s | grep -c ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo ''EXIT_EARLY=true'' >> $GITHUB_OUTPUT) || exit 0'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: 'contains(github.event.head_commit.message, ''[ci]'')'
+    if: contains(github.event.head_commit.message, '[ci]')
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     if: |-
-      github.event_name == 'push' ||
-      !startsWith(github.event.pull_request.head.label, 'denoland:')
+      (
+        github.event_name == 'push' && 
+        (github.event.pull_request.draft == false || contains(github.event.head_commit.message, '[ci]')
+      ) || !startsWith(github.event.pull_request.head.label, 'denoland:')
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: contains(github.event.head_commit.message, 'ci')
+    if: |-
+      github.event_name == 'push' ||
+      !startsWith(github.event.pull_request.head.label, 'denoland:')
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:
@@ -57,27 +59,34 @@ jobs:
         with:
           fetch-depth: 5
           submodules: false
+      - name: Cancel if draft PR
+        id: exit_early
+        if: github.event.pull_request.draft == true
+        shell: bash
+        run: 'git show -s --format=%s | grep ''[ci]'' && (echo ''Exiting due to draft PR. Commit with [ci] to bypass.'' ; echo "::set-output name=EXIT_EARLY::true") || exit 0'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt
-        if: matrix.job == 'test'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''test'')'
       - name: Clone submodule ./third_party
         run: git submodule update --init --recursive --depth=1 -- ./third_party
-        if: matrix.job == 'lint' || matrix.job == 'bench'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'' || matrix.job == ''bench'')'
       - name: 'Create source tarballs (release, linux)'
         if: |-
-          startsWith(matrix.os, 'ubuntu') &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         run: |-
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
       - uses: dtolnay/rust-toolchain@stable
-      - if: matrix.job == 'lint' || matrix.job == 'test'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
+      - if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'' || matrix.job == ''test'')'
         name: Install Deno
         uses: denoland/setup-deno@v1
         with:
@@ -86,8 +95,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: Remove unused versions of Python
-        if: 'startsWith(matrix.os, ''windows'')'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (startsWith(matrix.os, ''windows''))'
         run: |-
           $env:PATH -split ";" |
             Where-Object { Test-Path "$_\python.exe" } |
@@ -97,14 +107,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 17
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: Setup gcloud (unix)
         if: |-
-          runner.os != 'Windows' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os != 'Windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))
+          startsWith(github.ref, 'refs/tags/')))
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: denoland
@@ -112,12 +123,12 @@ jobs:
           export_default_credentials: true
       - name: Setup gcloud (windows)
         if: |-
-          runner.os == 'Windows' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))
+          startsWith(github.ref, 'refs/tags/')))
         uses: google-github-actions/setup-gcloud@v0
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
@@ -127,13 +138,13 @@ jobs:
           export_default_credentials: true
       - name: Configure canary build
         if: |-
-          matrix.job == 'test' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         shell: bash
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
-      - if: matrix.use_sysroot
+      - if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.use_sysroot)'
         name: Set up incremental LTO and sysroot build
         run: |-
           # Avoid running man-db triggers, which sometimes takes several minutes
@@ -206,6 +217,7 @@ jobs:
           then
             deno --version
           fi
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: Cache Cargo home
         uses: actions/cache@v3
         with:
@@ -214,9 +226,10 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: '18-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: Cache build output (main)
         uses: actions/cache/save@v3
-        if: (matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && ((matrix.profile == ''release'' || matrix.profile == ''fastci'') && github.ref == ''refs/heads/main'')'
         with:
           path: |-
             ./target
@@ -226,7 +239,7 @@ jobs:
           key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}'
       - name: Cache build output (PR)
         uses: actions/cache/restore@v3
-        if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
         with:
           path: |-
             ./target
@@ -236,7 +249,7 @@ jobs:
           key: never_saved
           restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-'
       - name: Apply and update mtime cache
-        if: matrix.profile == 'release'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.profile == ''release'')'
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target
@@ -249,125 +262,126 @@ jobs:
                       https://github.com/rust-lang/crates.io-index \
                       ~/.cargo/registry/index/github.com-1ecc6299db9ec823
           fi
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'''
       - name: test_format.js
-        if: matrix.job == 'lint'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
       - name: lint.js
-        if: matrix.job == 'lint'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
       - name: Build debug
         if: |-
-          (matrix.job == 'test' || matrix.job == 'bench') &&
-          matrix.profile == 'debug'
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
+          matrix.profile == 'debug')
         run: cargo build --locked --all-targets
       - name: Build fastci
-        if: (matrix.job == 'test' && matrix.profile == 'fastci')
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci''))'
         run: cargo build --locked --all-targets
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build release
         if: |-
-          (matrix.job == 'test' || matrix.job == 'bench') &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/')))))
         run: cargo build --release --locked --all-targets
       - name: Upload PR artifact (linux)
         if: |-
-          matrix.job == 'test' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/')))))
         uses: actions/upload-artifact@v3
         with:
           name: 'deno-${{ github.event.number }}'
           path: target/release/deno
       - name: Pre-release (linux)
         if: |-
-          startsWith(matrix.os, 'ubuntu') &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
-          github.repository == 'denoland/deno'
+          github.repository == 'denoland/deno')
         run: |-
           cd target/release
           zip -r deno-x86_64-unknown-linux-gnu.zip deno
           ./deno types > lib.deno.d.ts
       - name: Pre-release (mac)
         if: |-
-          startsWith(matrix.os, 'macOS') &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'macOS') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
         run: |-
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (windows)
         if: |-
-          startsWith(matrix.os, 'windows') &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'windows') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
         run: Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
       - name: Upload canary to dl.deno.land (unix)
         if: |-
-          runner.os != 'Windows' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Upload canary to dl.deno.land (windows)
         if: |-
-          runner.os == 'Windows' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         shell: bash
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Test debug
         if: |-
-          matrix.job == 'test' && matrix.profile == 'debug' &&
-          !startsWith(github.ref, 'refs/tags/')
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
+          !startsWith(github.ref, 'refs/tags/'))
         run: |-
           cargo test --locked --doc
           cargo test --locked
       - name: Test fastci
-        if: (matrix.job == 'test' && matrix.profile == 'fastci')
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci''))'
         run: cargo test --locked
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test release
         if: |-
-          matrix.job == 'test' && matrix.profile == 'release' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' && matrix.profile == 'release' &&
           (matrix.use_sysroot || (
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))))
         run: cargo test --release --locked
       - name: Check deno binary
-        if: 'matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/'')'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/''))'
         shell: bash
         run: target/release/deno eval "console.log(1+2)" | grep 3
         env:
           NO_COLOR: 1
       - name: Check deno binary (in sysroot)
-        if: matrix.profile == 'release' && matrix.use_sysroot
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.profile == ''release'' && matrix.use_sysroot)'
         run: sudo chroot /sysroot "$(pwd)/target/release/deno" --version
       - name: Configure hosts file for WPT
-        if: 'startsWith(matrix.os, ''ubuntu'') && matrix.job == ''test'''
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (startsWith(matrix.os, ''ubuntu'') && matrix.job == ''test'')'
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: test_util/wpt/
       - name: Run web platform tests (debug)
         if: |-
-          startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
           matrix.profile == 'debug' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         env:
           DENO_BIN: ./target/debug/deno
         run: |-
@@ -381,8 +395,8 @@ jobs:
                    ./tools/wpt.ts run --quiet --binary="$DENO_BIN"
       - name: Run web platform tests (release)
         if: |-
-          startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
-          matrix.profile == 'release' && !startsWith(github.ref, 'refs/tags/')
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (startsWith(matrix.os, 'ubuntu') && matrix.job == 'test' &&
+          matrix.profile == 'release' && !startsWith(github.ref, 'refs/tags/'))
         env:
           DENO_BIN: ./target/release/deno
         run: |-
@@ -400,11 +414,11 @@ jobs:
       - name: Upload wpt results to dl.deno.land
         continue-on-error: true
         if: |-
-          runner.os == 'Linux' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Linux' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         run: |-
           gzip ./wptreport.json
           gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json
@@ -414,11 +428,11 @@ jobs:
       - name: Upload wpt results to wpt.fyi
         continue-on-error: true
         if: |-
-          runner.os == 'Linux' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Linux' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         env:
           WPT_FYI_USER: deno
           WPT_FYI_PW: '${{ secrets.WPT_FYI_PW }}'
@@ -427,13 +441,13 @@ jobs:
           ./target/release/deno run --allow-all --lock=tools/deno.lock.json \
               ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus
       - name: Run benchmarks
-        if: 'matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/''))'
         run: cargo bench --locked
       - name: Post Benchmarks
         if: |-
-          matrix.job == 'bench' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'bench' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         env:
           DENOBOT_PAT: '${{ secrets.DENOBOT_PAT }}'
         run: |-
@@ -449,30 +463,30 @@ jobs:
           git commit --message "Update benchmarks"
           git push origin gh-pages
       - name: Build product size info
-        if: 'matrix.job != ''lint'' && matrix.profile != ''fastci'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job != ''lint'' && matrix.profile != ''fastci'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')))'
         run: |-
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"
       - name: Worker info
-        if: matrix.job == 'bench'
+        if: '${{ steps.exit_early.outputs.EXIT_EARLY }} != ''true'' && (matrix.job == ''bench'')'
         run: |-
           cat /proc/cpuinfo
           cat /proc/meminfo
       - name: Upload release to dl.deno.land (unix)
         if: |-
-          runner.os != 'Windows' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Upload release to dl.deno.land (windows)
         if: |-
-          runner.os == 'Windows' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         shell: bash
@@ -480,20 +494,20 @@ jobs:
       - name: Create release notes
         shell: bash
         if: |-
-          matrix.job == 'test' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         run: |-
           export PATH=$PATH:$(pwd)/target/release
           ./tools/release/05_create_release_notes.ts
       - name: Upload release to GitHub
         uses: softprops/action-gh-release@v0.1.15
         if: |-
-          matrix.job == 'test' &&
+          ${{ steps.exit_early.outputs.EXIT_EARLY }} != 'true' && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:


### PR DESCRIPTION
Tested:

- [x] Running CI in draft PR without [ci] message (does not run).
- [x] Running CI in draft PR with [ci] message (runs).
- [x] Running CI in draft PR without [ci] message (does not run), then marking the PR as ready for review (runs).

This will help us reduce CI time during development. The CI can be explicitly run on draft PRs by adding `[ci]` to the commit message.