### PR TITLE
fix(fmt): better handling of link reference definitions when formatting markdown

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -45,7 +45,7 @@
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.80.2.wasm",
     "https://plugins.dprint.dev/json-0.17.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.15.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/exec-0.3.5.json@d687dda57be0fe9a0088ccdaefa5147649ff24127d8b3ea227536c68ee7abeab"
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-markdown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aec6d8d6d9a3a4c1a260893677d24c8feb03ce5f4ee5f6522c9da5e00e5597d"
+checksum = "5095e6471bc71892fd4fe3f74205a6d2e22bd3be9b09758fd23bff67b5ec15fd"
 dependencies = [
  "anyhow",
  "dprint-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -64,7 +64,7 @@ console_static_text = "=0.3.4"
 data-url.workspace = true
 dissimilar = "=1.0.4"
 dprint-plugin-json = "=0.17.0"
-dprint-plugin-markdown = "=0.15.1"
+dprint-plugin-markdown = "=0.15.2"
 dprint-plugin-typescript = "=0.80.2"
 encoding_rs.workspace = true
 env_logger = "=0.9.0"


### PR DESCRIPTION
Two fixes:

- https://github.com/dprint/dprint-plugin-markdown/pull/75
- https://github.com/dprint/dprint-plugin-markdown/pull/73