### PR TITLE
chore(ci): save cache on main at end of workflow

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -362,23 +362,6 @@ const ci = {
             },
           },
           {
-            // In main branch, always creates fresh cache
-            name: "Cache build output (main)",
-            uses: "actions/cache/save@v3",
-            if:
-              "(matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'",
-            with: {
-              path: [
-                "./target",
-                "!./target/*/gn_out",
-                "!./target/*/*.zip",
-                "!./target/*/*.tar.gz",
-              ].join("\n"),
-              key:
-                "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}",
-            },
-          },
-          {
             // Restore cache from the latest 'main' branch build.
             name: "Cache build output (PR)",
             uses: "actions/cache/restore@v3",
@@ -788,6 +771,23 @@ const ci = {
               ].join("\n"),
               body_path: "target/release/release-notes.md",
               draft: true,
+            },
+          },
+          {
+            // In main branch, always creates fresh cache
+            name: "Cache build output (main)",
+            uses: "actions/cache/save@v3",
+            if:
+              "(matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'",
+            with: {
+              path: [
+                "./target",
+                "!./target/*/gn_out",
+                "!./target/*/*.zip",
+                "!./target/*/*.tar.gz",
+              ].join("\n"),
+              key:
+                "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}",
             },
           },
         ]),

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -363,7 +363,7 @@ const ci = {
           },
           {
             // Restore cache from the latest 'main' branch build.
-            name: "Cache build output (PR)",
+            name: "Restore cache build output (PR)",
             uses: "actions/cache/restore@v3",
             if:
               "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
@@ -775,7 +775,7 @@ const ci = {
           },
           {
             // In main branch, always creates fresh cache
-            name: "Cache build output (main)",
+            name: "Save cache build output (main)",
             uses: "actions/cache/save@v3",
             if:
               "(matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
             ~/.cargo/git/db
           key: '18-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'
-      - name: Cache build output (PR)
+      - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
         if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
         with:
@@ -522,7 +522,7 @@ jobs:
             target/release/lib.deno.d.ts
           body_path: target/release/release-notes.md
           draft: true
-      - name: Cache build output (main)
+      - name: Save cache build output (main)
         uses: actions/cache/save@v3
         if: steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main')
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,16 +240,6 @@ jobs:
             ~/.cargo/git/db
           key: '18-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'
-      - name: Cache build output (main)
-        uses: actions/cache/save@v3
-        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main')
-        with:
-          path: |-
-            ./target
-            !./target/*/gn_out
-            !./target/*/*.zip
-            !./target/*/*.tar.gz
-          key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}'
       - name: Cache build output (PR)
         uses: actions/cache/restore@v3
         if: 'steps.exit_early.outputs.EXIT_EARLY != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
@@ -532,6 +522,16 @@ jobs:
             target/release/lib.deno.d.ts
           body_path: target/release/release-notes.md
           draft: true
+      - name: Cache build output (main)
+        uses: actions/cache/save@v3
+        if: steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main')
+        with:
+          path: |-
+            ./target
+            !./target/*/gn_out
+            !./target/*/*.zip
+            !./target/*/*.tar.gz
+          key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Seems like our caching was totally broken. We need to save the cache after building and not before.

On main:

```
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
Warning: Cache save failed.
```

On PRs:

```
Cache not found for input keys: never_saved, 18-cargo-target-windows-2019-xl-release-
```