### PR TITLE
fix(ci): use Node 18

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -98,7 +98,7 @@ const installPythonSteps = [{
 const installNodeStep = {
   name: "Install Node",
   uses: "actions/setup-node@v3",
-  with: { "node-version": 17 },
+  with: { "node-version": 18 },
 };
 const installDenoStep = {
   name: "Install Deno",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 18
         if: steps.exit_early.outputs.EXIT_EARLY != 'true'
       - name: Setup gcloud (unix)
         if: |-


### PR DESCRIPTION
Some caching steps are prefixed with `18-`, which I assume represents that Node 18 should be in use rather than Node 17. Node 18 is also the latest LTS version.