### PR TITLE
Revert "test: fix flaky deno_land_unsafe_ssl test (#17357)"

### DIFF
--- a/cli/tests/cert_tests.rs
+++ b/cli/tests/cert_tests.rs
@@ -58,9 +58,8 @@ mod cert {
 
   itest!(deno_land_unsafe_ssl {
     args:
-      "run --quiet --reload --allow-net --cert=tls/RootCA.pem --unsafely-ignore-certificate-errors=localhost cert/deno_land_unsafe_ssl.ts",
+      "run --quiet --reload --allow-net --unsafely-ignore-certificate-errors=deno.land cert/deno_land_unsafe_ssl.ts",
     output: "cert/deno_land_unsafe_ssl.ts.out",
-    http_server: true,
   });
 
   itest!(ip_address_unsafe_ssl {

--- a/cli/tests/testdata/cert/deno_land_unsafe_ssl.ts
+++ b/cli/tests/testdata/cert/deno_land_unsafe_ssl.ts
@@ -1,2 +1,2 @@
-const r = await fetch("https://localhost:5545/cert/cafile_info.ts");
+const r = await fetch("https://google.com");
 console.log(r.status);

--- a/cli/tests/testdata/cert/deno_land_unsafe_ssl.ts.out
+++ b/cli/tests/testdata/cert/deno_land_unsafe_ssl.ts.out
@@ -1,2 +1,2 @@
-DANGER: TLS certificate validation is disabled for: localhost
+DANGER: TLS certificate validation is disabled for: deno.land
 200


### PR DESCRIPTION
This reverts commit ee2c6cb04af232be672b31b81f7c377b2f571267.

Closes https://github.com/denoland/deno/issues/17359