### PR TITLE
chore(ci): only install node for the benchmarks

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -305,7 +305,11 @@ const ci = {
             ...installDenoStep,
           },
           ...installPythonSteps,
-          installNodeStep,
+          {
+            // only necessary for benchmarks
+            if: "matrix.job == 'bench'",
+            ...installNodeStep,
+          },
           {
             name: "Setup gcloud (unix)",
             if: [
@@ -362,14 +366,18 @@ const ci = {
             name: "Log versions",
             shell: "bash",
             run: [
-              "node -v",
               "python --version",
               "rustc --version",
               "cargo --version",
-              "# Deno is installed when linting.",
+              // Deno is installed when linting.
               'if [ "${{ matrix.job }}" == "lint" ]',
               "then",
               "  deno --version",
+              "fi",
+              // Node is installed for benchmarks.
+              'if [ "${{ matrix.job }}" == "bench" ]',
+              "then",
+              "  node -v",
               "fi",
             ].join("\n"),
           },

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -323,12 +323,12 @@ const ci = {
             ...installDenoStep,
           },
           ...installPythonSteps,
-          authenticateWithGoogleCloud,
           {
             // only necessary for benchmarks
             if: "matrix.job == 'bench'",
             ...installNodeStep,
           },
+          authenticateWithGoogleCloud,
           {
             name: "Setup gcloud (unix)",
             if: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,11 @@ jobs:
             Where-Object { Test-Path "$_\python.exe" } |
             Select-Object -Skip 1 |
             ForEach-Object { Move-Item "$_" "$_.disabled" }
+      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench''))'
+        name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Authenticate with Google Cloud
         if: |-
           !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.profile == 'release' &&
@@ -133,11 +138,6 @@ jobs:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
           export_environment_variables: true
           create_credentials_file: true
-      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench''))'
-        name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
       - name: Setup gcloud (unix)
         if: |-
           !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,11 @@ jobs:
             Where-Object { Test-Path "$_\python.exe" } |
             Select-Object -Skip 1 |
             ForEach-Object { Move-Item "$_" "$_.disabled" }
-      - name: Install Node
+      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench''))'
+        name: Install Node
         uses: actions/setup-node@v3
         with:
           node-version: 18
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Setup gcloud (unix)
         if: |-
           !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
@@ -225,14 +225,16 @@ jobs:
       - name: Log versions
         shell: bash
         run: |-
-          node -v
           python --version
           rustc --version
           cargo --version
-          # Deno is installed when linting.
           if [ "${{ matrix.job }}" == "lint" ]
           then
             deno --version
+          fi
+          if [ "${{ matrix.job }}" == "bench" ]
+          then
+            node -v
           fi
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Cache Cargo home


### PR DESCRIPTION
The mtime_cache also uses this, but there's a `using: node16` defined in mtime_cache/action.yml

Installing Node can sometimes be slow and it seems to only be necessary for the benchmarks.

![image](https://user-images.githubusercontent.com/1609021/212107019-7e166912-05b8-485b-b52b-6b2c51c6307b.png)