### PR TITLE
chore(ci): use mtime cache for fastci

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -150,7 +150,7 @@ function cancelEarlyIfDraftPr(
       ].join("\n"),
     },
     ...nextSteps.map((step) =>
-      skipForCondition(step, "steps.exit_early.outputs.EXIT_EARLY != 'true'")
+      withCondition(step, "steps.exit_early.outputs.EXIT_EARLY != 'true'")
     ),
   ];
 }
@@ -162,14 +162,14 @@ function skipJobsIfPrAndMarkedSkip(
   // so just apply this condition to all the steps.
   // https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
   return steps.map((s) =>
-    skipForCondition(
+    withCondition(
       s,
       "!(github.event_name == 'pull_request' && matrix.skip_pr)",
     )
   );
 }
 
-function skipForCondition(
+function withCondition(
   step: Record<string, unknown>,
   condition: string,
 ): Record<string, unknown> {
@@ -298,7 +298,10 @@ const ci = {
           },
         },
         ...cancelEarlyIfDraftPr([
-          submoduleStep("./test_util/std"),
+          {
+            ...submoduleStep("./test_util/std"),
+            if: "matrix.job != 'lint'",
+          },
           {
             ...submoduleStep("./test_util/wpt"),
             if: "matrix.wpt",
@@ -327,7 +330,9 @@ const ci = {
             if: "matrix.job == 'lint' || matrix.job == 'test'",
             ...installDenoStep,
           },
-          ...installPythonSteps,
+          ...installPythonSteps.map((s) =>
+            withCondition(s, "matrix.job != 'lint")
+          ),
           {
             // only necessary for benchmarks
             if: "matrix.job == 'bench'",
@@ -435,9 +440,11 @@ const ci = {
           },
           {
             name: "Apply and update mtime cache",
-            if: "matrix.profile == 'release'",
+            if: "!startsWith(github.ref, 'refs/tags/')",
             uses: "./.github/mtime_cache",
-            with: { "cache-path": "./target" },
+            with: {
+              "cache-path": "./target",
+            },
           },
           {
             // Shallow the cloning the crates.io index makes CI faster because it

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -298,10 +298,7 @@ const ci = {
           },
         },
         ...cancelEarlyIfDraftPr([
-          {
-            ...submoduleStep("./test_util/std"),
-            if: "matrix.job != 'lint'",
-          },
+          submoduleStep("./test_util/std"),
           {
             ...submoduleStep("./test_util/wpt"),
             if: "matrix.wpt",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -331,7 +331,7 @@ const ci = {
             ...installDenoStep,
           },
           ...installPythonSteps.map((s) =>
-            withCondition(s, "matrix.job != 'lint")
+            withCondition(s, "matrix.job != 'lint'")
           ),
           {
             // only necessary for benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.wpt))'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint''))'
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.wpt))'
@@ -113,9 +113,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint))'
       - name: Remove unused versions of Python
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (startsWith(matrix.os, ''windows'')))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint && (startsWith(matrix.os, ''windows''))))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |
@@ -269,7 +269,7 @@ jobs:
           key: never_saved
           restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-'
       - name: Apply and update mtime cache
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.profile == ''release''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (!startsWith(github.ref, ''refs/tags/'')))'
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint''))'
       - name: Remove unused versions of Python
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint && (startsWith(matrix.os, ''windows''))))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint'' && (startsWith(matrix.os, ''windows''))))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |


### PR DESCRIPTION
The mac fastci is taking about 7.5 mins to build and windows fastci about 4.5 mins. I believe this is because it is not using the mtime cache. Maybe let's try it out?

Seems to take about 2s to apply this to the PR. To see if this works I believe it requires the cache to take effect on main.