### PR TITLE
chore(ci): try some wpt parallelism

### DIFF
--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -31,6 +31,7 @@ import {
   updateManifest,
   wptreport,
 } from "./wpt/utils.ts";
+import { pooledMap } from "../test_util/std/async/pool.ts";
 import { blue, bold, green, red, yellow } from "../test_util/std/fmt/colors.ts";
 import { writeAll, writeAllSync } from "../test_util/std/streams/conversion.ts";
 import { saveExpectation } from "./wpt/utils.ts";
@@ -155,18 +156,29 @@ async function run() {
   console.log(`Going to run ${tests.length} test files.`);
 
   const results = await runWithTestUtil(false, async () => {
-    const results = [];
+    const results: { test: TestToRun; result: TestResult }[] = [];
+    const cores = Deno.systemCpuInfo().cores ?? 4;
+    const inParallel = !(cores === 1 || tests.length === 1);
+    const partitionedTests = partitionTests(tests);
 
-    for (const test of tests) {
-      console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
-      const result = await runSingleTest(
-        test.url,
-        test.options,
-        createReportTestCase(test.expectation),
-        inspectBrk,
-      );
-      results.push({ test, result });
-      reportVariation(result, test.expectation);
+    const iter = pooledMap(cores, partitionedTests, async (tests) => {
+      for (const test of tests) {
+        if (!inParallel) {
+          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
+        }
+        const result = await runSingleTest(
+          test.url,
+          test.options,
+          inParallel ? () => {} : createReportTestCase(test.expectation),
+          inspectBrk,
+        );
+        results.push({ test, result });
+        reportVariation(result, test.expectation);
+      }
+    });
+
+    for await (const _ of iter) {
+      // do nothing
     }
 
     return results;
@@ -722,4 +734,16 @@ function discoverTestsToRun(
   walk(manifestFolder, expectation, "");
 
   return testsToRun;
+}
+
+function partitionTests(tests: TestToRun[]): TestToRun[][] {
+  const testsByKey: { [key: string]: TestToRun[] } = {};
+  for (const test of tests) {
+    const key = test.path.split("/")[1];
+    if (!(key in testsByKey)) {
+      testsByKey[key] = [];
+    }
+    testsByKey[key].push(test);
+  }
+  return Object.values(testsByKey);
 }

--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -175,6 +175,9 @@ async function run() {
           inspectBrk,
         );
         results.push({ test, result });
+        if (inParallel) {
+          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
+        }
         reportVariation(result, test.expectation);
       }
     });

--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -157,7 +157,7 @@ async function run() {
 
   const results = await runWithTestUtil(false, async () => {
     const results: { test: TestToRun; result: TestResult }[] = [];
-    const cores = Deno.systemCpuInfo().cores ?? 4;
+    const cores = navigator.hardwareConcurrency;
     const inParallel = !(cores === 1 || tests.length === 1);
     const partitionedTests = partitionTests(tests);
 


### PR DESCRIPTION
WPT tests seem to make the ubuntu runner go for the longest on the PR CI now (in some cases). Previously we tried parallelizing all tests individually (https://github.com/denoland/deno/pull/11321), but got some flakiness... maybe it's ok to parallelize into groups instead?

Ported over some of the code from https://github.com/denoland/deno/pull/11306

**Results**
Before: 9m 27s
After: 4m 48s

https://github.com/denoland/deno/actions/runs/3905209199