### PR TITLE
chore(ci): only run doc tests on linux

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -587,14 +587,22 @@ const ci = {
               'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
           },
           {
+            name: "Test debug (doc)",
+            if: [
+              // only bother running on linux CI
+              "startsWith(matrix.os, 'ubuntu') &&",
+              "matrix.job == 'test' && matrix.profile == 'debug' &&",
+              "!startsWith(github.ref, 'refs/tags/')",
+            ].join("\n"),
+            run: "cargo test --locked --doc",
+          },
+          {
             name: "Test debug",
             if: [
               "matrix.job == 'test' && matrix.profile == 'debug' &&",
               "!startsWith(github.ref, 'refs/tags/')",
             ].join("\n"),
-            run: ["cargo test --locked --doc", "cargo test --locked"].join(
-              "\n",
-            ),
+            run: "cargo test --locked",
           },
           {
             name: "Test fastci",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -601,7 +601,7 @@ const ci = {
               // Run unit then integration tests. Skip doc tests here
               // since they are sometimes very slow on Mac.
               "cargo test --locked --lib",
-              "cargo test --locked --tests '*'",
+              "cargo test --locked --test '*'",
             ].join("\n"),
             env: {
               CARGO_PROFILE_DEV_DEBUG: 0,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -587,16 +587,6 @@ const ci = {
               'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
           },
           {
-            name: "Test debug (doc)",
-            if: [
-              // only bother running on linux CI
-              "startsWith(matrix.os, 'ubuntu') &&",
-              "matrix.job == 'test' && matrix.profile == 'debug' &&",
-              "!startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            run: "cargo test --locked --doc",
-          },
-          {
             name: "Test debug",
             if: [
               "matrix.job == 'test' && matrix.profile == 'debug' &&",
@@ -606,8 +596,13 @@ const ci = {
           },
           {
             name: "Test fastci",
-            if: "(matrix.job == 'test' && matrix.profile == 'fastci')",
-            run: "cargo test --locked",
+            if: "matrix.job == 'test' && matrix.profile == 'fastci'",
+            run: [
+              // Run unit then integration tests. Skip doc tests here
+              // since they are sometimes very slow on Mac.
+              "cargo test --locked --lib",
+              "cargo test --locked --tests '*'",
+            ].join("\n"),
             env: {
               CARGO_PROFILE_DEV_DEBUG: 0,
             },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,20 +366,16 @@ jobs:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         shell: bash
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
-      - name: Test debug (doc)
-        if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') &&
-          matrix.job == 'test' && matrix.profile == 'debug' &&
-          !startsWith(github.ref, 'refs/tags/')))
-        run: cargo test --locked --doc
       - name: Test debug
         if: |-
           !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
           !startsWith(github.ref, 'refs/tags/')))
         run: cargo test --locked
       - name: Test fastci
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci'')))'
-        run: cargo test --locked
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''fastci''))'
+        run: |-
+          cargo test --locked --lib
+          cargo test --locked --tests '*'
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''fastci''))'
         run: |-
           cargo test --locked --lib
-          cargo test --locked --tests '*'
+          cargo test --locked --test '*'
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,13 +366,17 @@ jobs:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         shell: bash
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
+      - name: Test debug (doc)
+        if: |-
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') &&
+          matrix.job == 'test' && matrix.profile == 'debug' &&
+          !startsWith(github.ref, 'refs/tags/')))
+        run: cargo test --locked --doc
       - name: Test debug
         if: |-
           !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
           !startsWith(github.ref, 'refs/tags/')))
-        run: |-
-          cargo test --locked --doc
-          cargo test --locked
+        run: cargo test --locked
       - name: Test fastci
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci'')))'
         run: cargo test --locked


### PR DESCRIPTION
Doc tests were observed to take over 100s on the Mac CI in one instance. We might as well only run this on the Linux CI because our docs seem to be cross platform. Any cross platform issues can be caught locally by developers contributing to the project.

```
2023-01-12T22:02:30.6140250Z [0m[0m[1m[32m   Doc-tests[0m deno_core
2023-01-12T22:02:32.6324310Z 
2023-01-12T22:02:32.6346910Z running 4 tests
2023-01-12T22:02:32.6347950Z test bindings.rs - bindings::call_console (line 523) ... ignored
2023-01-12T22:02:32.6354860Z test extensions.rs - extensions::include_js_files (line 215) ... ignored
2023-01-12T22:03:32.7603850Z test async_cell.rs - async_cell::RcRef (line 125) has been running for over 60 seconds
2023-01-12T22:03:32.7604710Z test resources.rs - resources::ResourceTable::names (line 342) has been running for over 60 seconds
2023-01-12T22:04:26.6187450Z test async_cell.rs - async_cell::RcRef (line 125) ... ok
2023-01-12T22:04:27.0016040Z test resources.rs - resources::ResourceTable::names (line 342) ... ok
2023-01-12T22:04:27.0016310Z 
2023-01-12T22:04:27.0016520Z test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 114.37s
```