### PR TITLE
chore(ci): try to make sysroot step more reliable

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -26,7 +26,7 @@ curl https://apt.llvm.org/llvm-snapshot.gpg.key |
 sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
 sudo apt-get update
 # this was unreliable sometimes, so try doing an update with no cache when it fails
-${installPkgsCommand} || echo 'Failed. Trying no cache.' && sudo apt-get update --no-cache && ${installPkgsCommand}
+${installPkgsCommand} || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && ${installPkgsCommand}
 
 # Create ubuntu-16.04 sysroot environment, which is used to avoid
 # depending on a very recent version of glibc.

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -10,6 +10,8 @@ const Runners = {
     "${{ github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022' }}",
 };
 
+const installPkgsCommand =
+  "sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15";
 const sysRootStep = {
   name: "Set up incremental LTO and sysroot build",
   run: `# Avoid running man-db triggers, which sometimes takes several minutes
@@ -23,8 +25,8 @@ curl https://apt.llvm.org/llvm-snapshot.gpg.key |
   gpg --dearmor                                 |
 sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
 sudo apt-get update
-sudo apt-get install --no-install-recommends debootstrap     \\
-                                             clang-15 lld-15
+# this was unreliable sometimes, so try doing an update with no cache when it fails
+${installPkgsCommand} || echo 'Failed. Trying no cache.' && sudo apt-get update --no-cache && ${installPkgsCommand}
 
 # Create ubuntu-16.04 sysroot environment, which is used to avoid
 # depending on a very recent version of glibc.

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -25,7 +25,7 @@ curl https://apt.llvm.org/llvm-snapshot.gpg.key |
   gpg --dearmor                                 |
 sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
 sudo apt-get update
-# this was unreliable sometimes, so try doing an update with no cache when it fails
+# this was unreliable sometimes, so try again if it fails
 ${installPkgsCommand} || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && ${installPkgsCommand}
 
 # Create ubuntu-16.04 sysroot environment, which is used to avoid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
             gpg --dearmor                                 |
           sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo apt-get update
-          sudo apt-get install --no-install-recommends debootstrap     \
-                                                       clang-15 lld-15
+          # this was unreliable sometimes, so try doing an update with no cache when it fails
+          sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15 || echo 'Failed. Trying no cache.' && sudo apt-get update --no-cache && sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15
 
           # Create ubuntu-16.04 sysroot environment, which is used to avoid
           # depending on a very recent version of glibc.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo apt-get update
           # this was unreliable sometimes, so try doing an update with no cache when it fails
-          sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15 || echo 'Failed. Trying no cache.' && sudo apt-get update --no-cache && sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15
+          sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15
 
           # Create ubuntu-16.04 sysroot environment, which is used to avoid
           # depending on a very recent version of glibc.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
             gpg --dearmor                                 |
           sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo apt-get update
-          # this was unreliable sometimes, so try doing an update with no cache when it fails
+          # this was unreliable sometimes, so try again if it fails
           sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15
 
           # Create ubuntu-16.04 sysroot environment, which is used to avoid


### PR DESCRIPTION
Main is failing a lot because of:

```
Err:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 debootstrap all 1.0.118ubuntu1.8
  Connection failed [IP: 40.81.13.82 80]
Fetched 44.1 MB in 60s (734 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.118ubuntu1.8_all.deb  Connection failed [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
