### PR TITLE
feat(ext/console): Only right-align integers in console.table()

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1395,7 +1395,8 @@ Deno.test(function consoleTable() {
     console.table({ a: "test", b: 1 });
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬────────┐
+      `\
+┌───────┬────────┐
 │ (idx) │ Values │
 ├───────┼────────┤
 │ a     │ "test" │
@@ -1408,7 +1409,8 @@ Deno.test(function consoleTable() {
     console.table({ a: { b: 10 }, b: { b: 20, c: 30 } }, ["c"]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬────┐
+      `\
+┌───────┬────┐
 │ (idx) │ c  │
 ├───────┼────┤
 │ a     │    │
@@ -1421,7 +1423,8 @@ Deno.test(function consoleTable() {
     console.table([1, 2, [3, [4]], [5, 6], [[7], [8]]]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬───────┬───────┬────────┐
+      `\
+┌───────┬───────┬───────┬────────┐
 │ (idx) │ 0     │ 1     │ Values │
 ├───────┼───────┼───────┼────────┤
 │     0 │       │       │      1 │
@@ -1437,7 +1440,8 @@ Deno.test(function consoleTable() {
     console.table(new Set([1, 2, 3, "test"]));
     assertEquals(
       stripColor(out.toString()),
-      `┌────────────┬────────┐
+      `\
+┌────────────┬────────┐
 │ (iter idx) │ Values │
 ├────────────┼────────┤
 │          0 │ 1      │
@@ -1457,7 +1461,8 @@ Deno.test(function consoleTable() {
     );
     assertEquals(
       stripColor(out.toString()),
-      `┌────────────┬─────┬────────┐
+      `\
+┌────────────┬─────┬────────┐
 │ (iter idx) │ Key │ Values │
 ├────────────┼─────┼────────┤
 │          0 │   1 │ "one"  │
@@ -1476,7 +1481,8 @@ Deno.test(function consoleTable() {
     });
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬───────────┬───────────────────┬────────┐
+      `\
+┌───────┬───────────┬───────────────────┬────────┐
 │ (idx) │ c         │ e                 │ Values │
 ├───────┼───────────┼───────────────────┼────────┤
 │ a     │           │                   │ true   │
@@ -1498,7 +1504,8 @@ Deno.test(function consoleTable() {
     ]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬────────┬──────────────────────┬────┬────────┐
+      `\
+┌───────┬────────┬──────────────────────┬────┬────────┐
 │ (idx) │ 0      │ 1                    │ a  │ Values │
 ├───────┼────────┼──────────────────────┼────┼────────┤
 │     0 │        │                      │    │ 1      │
@@ -1514,7 +1521,8 @@ Deno.test(function consoleTable() {
     console.table([]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┐
+      `\
+┌───────┐
 │ (idx) │
 ├───────┤
 └───────┘
@@ -1525,7 +1533,8 @@ Deno.test(function consoleTable() {
     console.table({});
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┐
+      `\
+┌───────┐
 │ (idx) │
 ├───────┤
 └───────┘
@@ -1536,7 +1545,8 @@ Deno.test(function consoleTable() {
     console.table(new Set());
     assertEquals(
       stripColor(out.toString()),
-      `┌────────────┐
+      `\
+┌────────────┐
 │ (iter idx) │
 ├────────────┤
 └────────────┘
@@ -1547,7 +1557,8 @@ Deno.test(function consoleTable() {
     console.table(new Map());
     assertEquals(
       stripColor(out.toString()),
-      `┌────────────┐
+      `\
+┌────────────┐
 │ (iter idx) │
 ├────────────┤
 └────────────┘
@@ -1562,7 +1573,8 @@ Deno.test(function consoleTable() {
     console.table(["Hello", "你好", "Amapá"]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬─────────┐
+      `\
+┌───────┬─────────┐
 │ (idx) │ Values  │
 ├───────┼─────────┤
 │     0 │ "Hello" │
@@ -1579,7 +1591,8 @@ Deno.test(function consoleTable() {
     ]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬───┬───┐
+      `\
+┌───────┬───┬───┐
 │ (idx) │ 0 │ 1 │
 ├───────┼───┼───┤
 │     0 │ 1 │ 2 │
@@ -1592,7 +1605,8 @@ Deno.test(function consoleTable() {
     console.table({ 1: { a: 4, b: 5 }, 2: null, 3: { b: 6, c: 7 } }, ["b"]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬───┐
+      `\
+┌───────┬───┐
 │ (idx) │ b │
 ├───────┼───┤
 │     1 │ 5 │
@@ -1606,7 +1620,8 @@ Deno.test(function consoleTable() {
     console.table([{ a: 0 }, { a: 1, b: 1 }, { a: 2 }, { a: 3, b: 3 }]);
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬───┬───┐
+      `\
+┌───────┬───┬───┐
 │ (idx) │ a │ b │
 ├───────┼───┼───┤
 │     0 │ 0 │   │
@@ -1624,7 +1639,8 @@ Deno.test(function consoleTable() {
     );
     assertEquals(
       stripColor(out.toString()),
-      `┌───────┬───┬───┬───┐
+      `\
+┌───────┬───┬───┬───┐
 │ (idx) │ a │ b │ c │
 ├───────┼───┼───┼───┤
 │     0 │ 0 │   │   │

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1420,6 +1420,21 @@ Deno.test(function consoleTable() {
     );
   });
   mockConsole((console, out) => {
+    console.table([[1, 1], [234, 2.34], [56789, 56.789]]);
+    assertEquals(
+      stripColor(out.toString()),
+      `\
+┌───────┬───────┬────────┐
+│ (idx) │ 0     │ 1      │
+├───────┼───────┼────────┤
+│     0 │     1 │ 1      │
+│     1 │   234 │ 2.34   │
+│     2 │ 56789 │ 56.789 │
+└───────┴───────┴────────┘
+`,
+    );
+  });
+  mockConsole((console, out) => {
     console.table([1, 2, [3, [4]], [5, 6], [[7], [8]]]);
     assertEquals(
       stripColor(out.toString()),

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -253,7 +253,7 @@ function cliTable(head, columns) {
       const width = columnWidths[i] || 0;
       const counted = getStringWidth(value);
       columnWidths[i] = MathMax(width, counted);
-      columnRightAlign[i] &= NumberIsInteger(value);
+      columnRightAlign[i] &= NumberIsInteger(+value);
     }
   }
 

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -232,11 +232,6 @@ function renderRow(row, columnWidths, columnRightAlign) {
   return out;
 }
 
-function canRightAlign(value) {
-  const isNumber = !isNaN(value);
-  return isNumber;
-}
-
 function cliTable(head, columns) {
   const rows = [];
   const columnWidths = ArrayPrototypeMap(head, (h) => getStringWidth(h));
@@ -257,7 +252,7 @@ function cliTable(head, columns) {
       const width = columnWidths[i] || 0;
       const counted = getStringWidth(value);
       columnWidths[i] = MathMax(width, counted);
-      columnRightAlign[i] &= canRightAlign(value);
+      columnRightAlign[i] &= Number.isInteger(value);
     }
   }
 

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -47,6 +47,7 @@ const {
   StringPrototypeIncludes,
   StringPrototypeStartsWith,
   TypeError,
+  NumberIsInteger,
   NumberParseInt,
   RegExp,
   RegExpPrototype,
@@ -252,7 +253,7 @@ function cliTable(head, columns) {
       const width = columnWidths[i] || 0;
       const counted = getStringWidth(value);
       columnWidths[i] = MathMax(width, counted);
-      columnRightAlign[i] &= Number.isInteger(value);
+      columnRightAlign[i] &= NumberIsInteger(value);
     }
   }
 


### PR DESCRIPTION
This PR changes `console.table()` to only right-align columns when their contents are integers (rather than any numbers, as is currently the case). This was proposed in [this comment on #11294](https://github.com/denoland/deno/issues/11294#issuecomment-904759464). A new test is added to validate this behavior.

The goal is to change from this: 

```
┌───────┬───────┬────────┐
│ (idx) │ foo   │ bar    │
├───────┼───────┼────────┤
│     0 │   456 │    1.1 │
│     1 │    32 │      2 │
│     2 │       │ 3.1415 │
└───────┴───────┴────────┘
```

to this:

```
┌───────┬───────┬────────┐
│ (idx) │ foo   │ bar    │
├───────┼───────┼────────┤
│     0 │   456 │ 123.45 │
│     1 │    32 │ 2      │
│     2 │       │ 3.1415 │
└───────┴───────┴────────┘
```

(Of course, the ideal would be to align numbers regardless of how many decimal places they have, i.e.:

```
┌───────┬───────┬──────────┐
│ (idx) │ foo   │ bar      │
├───────┼───────┼──────────┤
│     0 │   456 │ 123.45   │
│     1 │    32 │   2      │
│     2 │       │   3.1415 │
└───────┴───────┴──────────┘
```

...but I don't know how to go about doing that :sweat_smile:)

Follow-up of #11295 and #11748.

I also tweaked formatting of `console.table()` tests (in a separate commit), to make the table format more evident in the source code of the tests.

**Note:** I'm opening as draft because I can't get the tests to pass — something in the logic to detect whether an entire column consists only of integers seems to be failing, but I'm not sure what. Any assistance would greatly appreciated!
