### PR TITLE
chore(ci): use windows-2022 runners on PRs

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -7,7 +7,7 @@ const Runners = {
     "${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}",
   macos: "macos-12",
   windows:
-    "${{ github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022' }}",
+    "${{ github.repository == 'denoland/deno' && github.event_name != 'pull_request' && 'windows-2022-xl' || 'windows-2022' }}",
 };
 
 const installPkgsCommand =

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -7,7 +7,7 @@ const Runners = {
     "${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}",
   macos: "macos-12",
   windows:
-    "${{ github.repository == 'denoland/deno' && github.event_name != 'pull_request' && 'windows-2022-xl' || 'windows-2022' }}",
+    "${{ github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022' }}",
 };
 
 const installPkgsCommand =
@@ -204,7 +204,8 @@ const ci = {
         "github.event_name == 'push' ||",
         "!startsWith(github.event.pull_request.head.label, 'denoland:')",
       ].join("\n"),
-      "runs-on": "${{ matrix.os }}",
+      // temp for testing
+      "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       strategy: {
         matrix: {
@@ -222,6 +223,9 @@ const ci = {
             },
             {
               os: Runners.windows,
+              // this is temporary for testing
+              runner:
+                "${{ github.event_name != 'pull_request' && 'windows-2022-xl' || 'windows-2022' }}",
               job: "test",
               profile: "fastci",
             },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             job: test
             profile: release
             skip_pr: true
-          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+          - os: '${{ github.repository == ''denoland/deno'' && github.event_name != ''pull_request'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
             profile: fastci
-          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+          - os: '${{ github.repository == ''denoland/deno'' && github.event_name != ''pull_request'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
             profile: release
             skip_pr: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     if: |-
       github.event_name == 'push' ||
       !startsWith(github.event.pull_request.head.label, 'denoland:')
-    runs-on: '${{ matrix.os }}'
+    runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     strategy:
       matrix:
@@ -34,10 +34,11 @@ jobs:
             job: test
             profile: release
             skip_pr: true
-          - os: '${{ github.repository == ''denoland/deno'' && github.event_name != ''pull_request'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+            runner: '${{ github.event_name != ''pull_request'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
             profile: fastci
-          - os: '${{ github.repository == ''denoland/deno'' && github.event_name != ''pull_request'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
             profile: release
             skip_pr: true


### PR DESCRIPTION
Windows isn't the slowest so let's see how this affects PR times.

Closes #17103