### PR TITLE
chore(ci): use windows-2022 runner on skipped release job on PRs

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -2,12 +2,13 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as yaml from "https://deno.land/std@0.171.0/encoding/yaml.ts";
 
+const windowsRunnerCondition =
+  "github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022'";
 const Runners = {
   linux:
     "${{ github.repository == 'denoland/deno' && 'ubuntu-20.04-xl' || 'ubuntu-20.04' }}",
   macos: "macos-12",
-  windows:
-    "${{ github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022' }}",
+  windows: `\${{ ${windowsRunnerCondition} }}`,
 };
 
 const installPkgsCommand =
@@ -204,7 +205,7 @@ const ci = {
         "github.event_name == 'push' ||",
         "!startsWith(github.event.pull_request.head.label, 'denoland:')",
       ].join("\n"),
-      "runs-on": "${{ matrix.os }}",
+      "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       strategy: {
         matrix: {
@@ -227,6 +228,9 @@ const ci = {
             },
             {
               os: Runners.windows,
+              // use a free runner on PRs since this will be skipped
+              runner:
+                `\${{ github.event_name == 'pull_request' && 'windows-2022' || (${windowsRunnerCondition}) }}`,
               job: "test",
               profile: "release",
               skip_pr: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     if: |-
       github.event_name == 'push' ||
       !startsWith(github.event.pull_request.head.label, 'denoland:')
-    runs-on: '${{ matrix.os }}'
+    runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     strategy:
       matrix:
@@ -38,6 +38,7 @@ jobs:
             job: test
             profile: fastci
           - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+            runner: '${{ github.event_name == ''pull_request'' && ''windows-2022'' || (github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'') }}'
             job: test
             profile: release
             skip_pr: true


### PR DESCRIPTION
Gets rid of the billable time here:

![image](https://user-images.githubusercontent.com/1609021/212382166-40cd2944-8ac2-439e-9ad5-ded9c6c6d48e.png)