### PR TITLE
chore: forward 1.29.3 release back to main

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -200,10 +200,6 @@ const ci = {
   jobs: {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
-      if: [
-        "github.event_name == 'push' ||",
-        "!startsWith(github.event.pull_request.head.label, 'denoland:')",
-      ].join("\n"),
       "runs-on": "${{ matrix.os }}",
       "timeout-minutes": 120,
       strategy: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ concurrency:
 jobs:
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    if: |-
-      github.event_name == 'push' ||
-      !startsWith(github.event.pull_request.head.label, 'denoland:')
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 120
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "deno"
-version = "1.29.2"
+version = "1.29.3"
 dependencies = [
  "atty",
  "base32",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "deno_bench_util"
-version = "0.77.0"
+version = "0.78.0"
 dependencies = [
  "bencher",
  "deno_core",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.77.0"
+version = "0.78.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -903,14 +903,14 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.165.0"
+version = "0.166.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.107.0"
+version = "0.108.0"
 dependencies = [
  "bytes",
  "data-url",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ffi"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "deno_core",
  "dlopen",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "deno_flash"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "async-compression",
  "base64",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "deno_core",
  "libloading",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.75.0"
+version = "0.76.0"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "once_cell",
  "pmutil",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.91.0"
+version = "0.92.0"
 dependencies = [
  "atty",
  "deno_broadcast_channel",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "deno_bench_util",
  "deno_core",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "deno_core",
  "serde",
@@ -1282,14 +1282,14 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "napi_sym"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.76.0"
+version = "0.77.0"
 dependencies = [
  "bencher",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,33 +43,33 @@ repository = "https://github.com/denoland/deno"
 v8 = { version = "0.60.0", default-features = false }
 deno_ast = { version = "0.23.2", features = ["transpiling"] }
 
-deno_core = { version = "0.165.0", path = "./core" }
-deno_ops = { version = "0.43.0", path = "./ops" }
-serde_v8 = { version = "0.76.0", path = "./serde_v8" }
-deno_runtime = { version = "0.91.0", path = "./runtime" }
-napi_sym = { version = "0.13.0", path = "./cli/napi/sym" }
-deno_bench_util = { version = "0.77.0", path = "./bench_util" }
+deno_core = { version = "0.166.0", path = "./core" }
+deno_ops = { version = "0.44.0", path = "./ops" }
+serde_v8 = { version = "0.77.0", path = "./serde_v8" }
+deno_runtime = { version = "0.92.0", path = "./runtime" }
+napi_sym = { version = "0.14.0", path = "./cli/napi/sym" }
+deno_bench_util = { version = "0.78.0", path = "./bench_util" }
 test_util = { path = "./test_util" }
 
 # exts
-deno_broadcast_channel = { version = "0.77.0", path = "./ext/broadcast_channel" }
-deno_cache = { version = "0.15.0", path = "./ext/cache" }
-deno_console = { version = "0.83.0", path = "./ext/console" }
-deno_crypto = { version = "0.97.0", path = "./ext/crypto" }
-deno_fetch = { version = "0.107.0", path = "./ext/fetch" }
-deno_ffi = { version = "0.70.0", path = "./ext/ffi" }
-deno_flash = { version = "0.19.0", path = "./ext/flash" }
-deno_http = { version = "0.78.0", path = "./ext/http" }
-deno_net = { version = "0.75.0", path = "./ext/net" }
-deno_node = { version = "0.20.0", path = "./ext/node" }
-deno_tls = { version = "0.70.0", path = "./ext/tls" }
-deno_url = { version = "0.83.0", path = "./ext/url" }
-deno_web = { version = "0.114.0", path = "./ext/web" }
-deno_webgpu = { version = "0.84.0", path = "./ext/webgpu" }
-deno_webidl = { version = "0.83.0", path = "./ext/webidl" }
-deno_websocket = { version = "0.88.0", path = "./ext/websocket" }
-deno_webstorage = { version = "0.78.0", path = "./ext/webstorage" }
-deno_napi = { version = "0.13.0", path = "./ext/napi" }
+deno_broadcast_channel = { version = "0.78.0", path = "./ext/broadcast_channel" }
+deno_cache = { version = "0.16.0", path = "./ext/cache" }
+deno_console = { version = "0.84.0", path = "./ext/console" }
+deno_crypto = { version = "0.98.0", path = "./ext/crypto" }
+deno_fetch = { version = "0.108.0", path = "./ext/fetch" }
+deno_ffi = { version = "0.71.0", path = "./ext/ffi" }
+deno_flash = { version = "0.20.0", path = "./ext/flash" }
+deno_http = { version = "0.79.0", path = "./ext/http" }
+deno_net = { version = "0.76.0", path = "./ext/net" }
+deno_node = { version = "0.21.0", path = "./ext/node" }
+deno_tls = { version = "0.71.0", path = "./ext/tls" }
+deno_url = { version = "0.84.0", path = "./ext/url" }
+deno_web = { version = "0.115.0", path = "./ext/web" }
+deno_webgpu = { version = "0.85.0", path = "./ext/webgpu" }
+deno_webidl = { version = "0.84.0", path = "./ext/webidl" }
+deno_websocket = { version = "0.89.0", path = "./ext/websocket" }
+deno_webstorage = { version = "0.79.0", path = "./ext/webstorage" }
+deno_napi = { version = "0.14.0", path = "./ext/napi" }
 
 anyhow = "1.0.57"
 async-trait = "0.1.51"

--- a/Releases.md
+++ b/Releases.md
@@ -6,6 +6,42 @@ https://github.com/denoland/deno/releases
 We also have one-line install commands at:
 https://github.com/denoland/deno_install
 
+### 1.29.3 / 2023.01.13
+
+- feat(core): allow specifying name and dependencies of an Extension (#17301)
+- feat(ext/ffi): structs by value (#15060)
+- fix(cli): uninstall command accept short flags (#17259)
+- fix(cli/args): update value_name of inspect args to resolve broken completions
+  (#17287)
+- fix(core): get v8 console from context extra bindings (#17243)
+- fix(ext/web/streams): fix ReadableStream asyncIterator (#16276)
+- fix(fmt): better handling of link reference definitions when formatting
+  markdown (#17352)
+- fix(install): should always include `--no-config` in shim unless `--config` is
+  specified (#17300)
+- fix(napi): Implement `napi_threadsafe_function` ref and unref (#17304)
+- fix(napi): date and unwrap handling (#17369)
+- fix(napi): handle static properties in classes (#17320)
+- fix(napi): support for env cleanup hooks (#17324)
+- fix(npm): allow to read package.json if permissions are granted (#17209)
+- fix(npm): handle declaration file resolution where packages incorrectly define
+  "types" last in "exports" (#17290)
+- fix(npm): panic resolving some dependencies with dist tags (#17278)
+- fix(npm): reduce copy packages when resolving optional peer dependencies
+  (#17280)
+- fix(npm): support old packages and registries with no integrity, but with a
+  sha1sum (#17289)
+- fix(permissions): lock stdio streams when prompt is shown (#17392)
+- fix(watch): preserve `ProcState::file_fetcher` between restarts (#15466)
+- fix(webidl): properly implement setlike (#17363)
+- fix: check if BroadcastChannel is open before sending (#17366)
+- fix: don't panic on resolveDns if unsupported record type is specified
+  (#17336)
+- fix: don't unwrap in test pipe handling logic (#17341)
+- fix: make self and window getters only & make getterOnly ignore setting
+  (#17362)
+- perf(ext,runtime): remove using `SafeArrayIterator` from `for-of` (#17255)
+
 ### 1.29.2 / 2023.01.05
 
 - feat(unstable): Add "Deno.osUptime()" API (#17179)

--- a/bench_util/Cargo.toml
+++ b/bench_util/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_bench_util"
-version = "0.77.0"
+version = "0.78.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "1.29.2"
+version = "1.29.3"
 authors.workspace = true
 default-run = "deno"
 edition.workspace = true

--- a/cli/deno_std.rs
+++ b/cli/deno_std.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 
 // WARNING: Ensure this is the only deno_std version reference as this
 // is automatically updated by the version bump workflow.
-static CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.171.0/";
+static CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.172.0/";
 
 pub static CURRENT_STD_URL: Lazy<Url> =
   Lazy::new(|| Url::parse(CURRENT_STD_URL_STR).unwrap());

--- a/cli/napi/sym/Cargo.toml
+++ b/cli/napi/sym/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "napi_sym"
-version = "0.13.0"
+version = "0.14.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_core"
-version = "0.165.0"
+version = "0.166.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/broadcast_channel/Cargo.toml
+++ b/ext/broadcast_channel/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_broadcast_channel"
-version = "0.77.0"
+version = "0.78.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/cache/Cargo.toml
+++ b/ext/cache/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_cache"
-version = "0.15.0"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/console/Cargo.toml
+++ b/ext/console/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_console"
-version = "0.83.0"
+version = "0.84.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_crypto"
-version = "0.97.0"
+version = "0.98.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_fetch"
-version = "0.107.0"
+version = "0.108.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_ffi"
-version = "0.70.0"
+version = "0.71.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/flash/Cargo.toml
+++ b/ext/flash/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_flash"
-version = "0.19.0"
+version = "0.20.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_http"
-version = "0.78.0"
+version = "0.79.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_napi"
-version = "0.13.0"
+version = "0.14.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_net"
-version = "0.75.0"
+version = "0.76.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_node"
-version = "0.20.0"
+version = "0.21.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/tls/Cargo.toml
+++ b/ext/tls/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_tls"
-version = "0.70.0"
+version = "0.71.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/url/Cargo.toml
+++ b/ext/url/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_url"
-version = "0.83.0"
+version = "0.84.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_web"
-version = "0.114.0"
+version = "0.115.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webgpu/Cargo.toml
+++ b/ext/webgpu/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webgpu"
-version = "0.84.0"
+version = "0.85.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webidl/Cargo.toml
+++ b/ext/webidl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webidl"
-version = "0.83.0"
+version = "0.84.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_websocket"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webstorage/Cargo.toml
+++ b/ext/webstorage/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webstorage"
-version = "0.78.0"
+version = "0.79.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_ops"
-version = "0.43.0"
+version = "0.44.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_runtime"
-version = "0.91.0"
+version = "0.92.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_v8"
-version = "0.76.0"
+version = "0.77.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
We need to fix https://github.com/denoland/deno/pull/17400 someday.