### PR TITLE
chore: upgrade rusty_v8 to 0.60.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5328,9 +5328,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5867543c19b87c45ed3f2bc49eb6135474ed6a1803cac40c278620b53e9865ef"
+checksum = "07fd5b3ed559897ff02c0f62bc0a5f300bfe79bb4c77a50031b8df771701c628"
 dependencies = [
  "bitflags",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
-v8 = { version = "0.60.0", default-features = false }
+v8 = { version = "0.60.1", default-features = false }
 deno_ast = { version = "0.23.2", features = ["transpiling"] }
 
 deno_core = { version = "0.166.0", path = "./core" }


### PR DESCRIPTION
Required for https://github.com/denoland/deno/pull/17306