### PR TITLE
fix(runtime/fs): preserve permissions in copyFileSync for macOS

### DIFF
--- a/cli/tests/unit/copy_file_test.ts
+++ b/cli/tests/unit/copy_file_test.ts
@@ -209,3 +209,27 @@ Deno.test(
     }, Deno.errors.PermissionDenied);
   },
 );
+
+function copyFileSyncMode(content: string): void {
+  const tempDir = Deno.makeTempDirSync();
+  const fromFilename = tempDir + "/from.txt";
+  const toFilename = tempDir + "/to.txt";
+  Deno.writeTextFileSync(fromFilename, content);
+  Deno.chmodSync(fromFilename, 0o100755);
+
+  Deno.copyFileSync(fromFilename, toFilename);
+  const toStat = Deno.statSync(toFilename);
+  assertEquals(toStat.mode!, 0o100755);
+}
+
+Deno.test(
+  { permissions: { read: true, write: true } },
+  function copyFileSyncChmod() {
+    // this Tests different optimization paths on MacOS:
+    //
+    // < 128 KB clonefile() w/ fallback to copyfile()
+    // > 128 KB
+    copyFileSyncMode("Hello world!");
+    copyFileSyncMode("Hello world!".repeat(128 * 1024));
+  },
+);

--- a/cli/tests/unit/copy_file_test.ts
+++ b/cli/tests/unit/copy_file_test.ts
@@ -223,7 +223,10 @@ function copyFileSyncMode(content: string): void {
 }
 
 Deno.test(
-  { permissions: { read: true, write: true } },
+  {
+    ignore: Deno.build.os === "windows",
+    permissions: { read: true, write: true },
+  },
   function copyFileSyncChmod() {
     // this Tests different optimization paths on MacOS:
     //


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/16921