### PR TITLE
fix(runtime/os): use GetPerformanceInfo for swap info on Windows

### DIFF
--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -275,6 +275,8 @@ pub fn mem_info() -> Option<MemInfo> {
     use std::mem;
     use winapi::shared::minwindef;
     use winapi::um::sysinfoapi;
+    use winapi::um::psapi::PERFORMANCE_INFORMATION;
+    use winapi::um::psapi::GetPerformanceInfo;
 
     let mut mem_status =
       mem::MaybeUninit::<sysinfoapi::MEMORYSTATUSEX>::uninit();
@@ -297,13 +299,13 @@ pub fn mem_info() -> Option<MemInfo> {
       // and https://github.com/GuillaumeGomez/sysinfo/issues/534
 
       let mut perf_info =
-        mem::MaybeUninit::<sysinfoapi::PERFORMANCE_INFORMATION>::uninit();
-      let result = sysinfoapi::GetPerformanceInfo(
+        mem::MaybeUninit::<PERFORMANCE_INFORMATION>::uninit();
+      let result = GetPerformanceInfo(
         perf_info.as_mut_ptr(),
-        mem::size_of::<sysinfoapi::PERFORMANCE_INFORMATION>()
+        mem::size_of::<PERFORMANCE_INFORMATION>()
           as minwindef::DWORD,
       );
-      if result == winapi::shared::minwindef::TRUE {
+      if result == minwindef::TRUE {
         let perf_info = perf_info.assume_init();
         let swap_total = perf_info.PageSize
           * perf_info

--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -274,9 +274,9 @@ pub fn mem_info() -> Option<MemInfo> {
   unsafe {
     use std::mem;
     use winapi::shared::minwindef;
-    use winapi::um::sysinfoapi;
-    use winapi::um::psapi::PERFORMANCE_INFORMATION;
     use winapi::um::psapi::GetPerformanceInfo;
+    use winapi::um::psapi::PERFORMANCE_INFORMATION;
+    use winapi::um::sysinfoapi;
 
     let mut mem_status =
       mem::MaybeUninit::<sysinfoapi::MEMORYSTATUSEX>::uninit();
@@ -298,12 +298,10 @@ pub fn mem_info() -> Option<MemInfo> {
       // See https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
       // and https://github.com/GuillaumeGomez/sysinfo/issues/534
 
-      let mut perf_info =
-        mem::MaybeUninit::<PERFORMANCE_INFORMATION>::uninit();
+      let mut perf_info = mem::MaybeUninit::<PERFORMANCE_INFORMATION>::uninit();
       let result = GetPerformanceInfo(
         perf_info.as_mut_ptr(),
-        mem::size_of::<PERFORMANCE_INFORMATION>()
-          as minwindef::DWORD,
+        mem::size_of::<PERFORMANCE_INFORMATION>() as minwindef::DWORD,
       );
       if result == minwindef::TRUE {
         let perf_info = perf_info.assume_init();

--- a/runtime/ops/os/sys_info.rs
+++ b/runtime/ops/os/sys_info.rs
@@ -290,10 +290,32 @@ pub fn mem_info() -> Option<MemInfo> {
       mem_info.free = stat.ullAvailPhys / 1024;
       mem_info.cached = 0;
       mem_info.buffers = 0;
-      mem_info.swap_total = (stat.ullTotalPageFile - stat.ullTotalPhys) / 1024;
-      mem_info.swap_free = (stat.ullAvailPageFile - stat.ullAvailPhys) / 1024;
-      if mem_info.swap_free > mem_info.swap_total {
-        mem_info.swap_free = mem_info.swap_total;
+
+      // `stat.ullTotalPageFile` is reliable only from GetPerformanceInfo()
+      //
+      // See https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
+      // and https://github.com/GuillaumeGomez/sysinfo/issues/534
+
+      let mut perf_info =
+        mem::MaybeUninit::<sysinfoapi::PERFORMANCE_INFORMATION>::uninit();
+      let result = sysinfoapi::GetPerformanceInfo(
+        perf_info.as_mut_ptr(),
+        mem::size_of::<sysinfoapi::PERFORMANCE_INFORMATION>()
+          as minwindef::DWORD,
+      );
+      if result == winapi::shared::minwindef::TRUE {
+        let perf_info = perf_info.assume_init();
+        let swap_total = perf_info.PageSize
+          * perf_info
+            .CommitLimit
+            .saturating_sub(perf_info.PhysicalTotal);
+        let swap_free = perf_info.PageSize
+          * perf_info
+            .CommitLimit
+            .saturating_sub(perf_info.PhysicalTotal)
+            .saturating_sub(perf_info.PhysicalAvailable);
+        mem_info.swap_total = (swap_total / 1000) as u64;
+        mem_info.swap_free = (swap_free / 1000) as u64;
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/17417

According to https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex , `stat.ullTotalPageFile` value is reliable only from GetPerformanceInfo()

Also see https://github.com/GuillaumeGomez/sysinfo/issues/534