### PR TITLE
chore(ext/webidl): Add dictionary converter microbenchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,6 +1284,7 @@ dependencies = [
 name = "deno_webidl"
 version = "0.84.0"
 dependencies = [
+ "deno_bench_util",
  "deno_core",
 ]
 

--- a/ext/webidl/Cargo.toml
+++ b/ext/webidl/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 deno_core.workspace = true
 
 [dev-dependencies]
-deno_bench_util = { version = "0.70.0", path = "../../bench_util" }
+deno_bench_util.workspace = true
 
 [[bench]]
 name = "dict"

--- a/ext/webidl/Cargo.toml
+++ b/ext/webidl/Cargo.toml
@@ -15,3 +15,10 @@ path = "lib.rs"
 
 [dependencies]
 deno_core.workspace = true
+
+[dev-dependencies]
+deno_bench_util = { version = "0.70.0", path = "../../bench_util" }
+
+[[bench]]
+name = "dict"
+harness = false

--- a/ext/webidl/benches/dict.js
+++ b/ext/webidl/benches/dict.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 // deno-lint-ignore-file
 

--- a/ext/webidl/benches/dict.js
+++ b/ext/webidl/benches/dict.js
@@ -1,0 +1,33 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+const { createDictionaryConverter, converters } = globalThis.__bootstrap.webidl;
+
+const TextDecodeOptions = createDictionaryConverter(
+  "TextDecodeOptions",
+  [
+    {
+      key: "stream",
+      converter: converters.boolean,
+      defaultValue: false,
+    },
+  ],
+);
+
+// Sanity check
+{
+  const o = TextDecodeOptions(undefined);
+  if (o.stream !== false) {
+    throw new Error("Unexpected stream value");
+  }
+}
+
+function handwrittenConverter(V) {
+  const defaultValue = { stream: false };
+  if (V === undefined || V === null) {
+    return defaultValue;
+  }
+  if (V.stream !== undefined) {
+    defaultValue.stream = !!V.stream;
+  }
+  return defaultValue;
+}

--- a/ext/webidl/benches/dict.js
+++ b/ext/webidl/benches/dict.js
@@ -1,5 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file
+
 const { createDictionaryConverter, converters } = globalThis.__bootstrap.webidl;
 
 const TextDecodeOptions = createDictionaryConverter(

--- a/ext/webidl/benches/dict.rs
+++ b/ext/webidl/benches/dict.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+use deno_bench_util::bench_js_sync;
+use deno_bench_util::bench_or_profile;
+use deno_bench_util::bencher::benchmark_group;
+use deno_bench_util::bencher::Bencher;
+
+use deno_core::Extension;
+
+fn setup() -> Vec<Extension> {
+  vec![
+    deno_webidl::init(),
+    Extension::builder()
+      .js(vec![("setup", include_str!("dict.js"))])
+      .build(),
+  ]
+}
+
+fn converter_undefined(b: &mut Bencher) {
+  bench_js_sync(b, r#"TextDecodeOptions(undefined);"#, setup);
+}
+
+fn handwritten_baseline_undefined(b: &mut Bencher) {
+  bench_js_sync(b, r#"handwrittenConverter(undefined)"#, setup);
+}
+
+fn converter_object(b: &mut Bencher) {
+  bench_js_sync(b, r#"TextDecodeOptions({});"#, setup);
+}
+
+fn handwritten_baseline_object(b: &mut Bencher) {
+  bench_js_sync(b, r#"handwrittenConverter({})"#, setup);
+}
+
+benchmark_group!(
+  benches,
+  converter_undefined,
+  handwritten_baseline_undefined,
+  converter_object,
+  handwritten_baseline_object,
+);
+bench_or_profile!(benches);

--- a/ext/webidl/benches/dict.rs
+++ b/ext/webidl/benches/dict.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use deno_bench_util::bench_js_sync;
 use deno_bench_util::bench_or_profile;

--- a/ext/webidl/benches/dict.rs
+++ b/ext/webidl/benches/dict.rs
@@ -10,7 +10,7 @@ use deno_core::Extension;
 fn setup() -> Vec<Extension> {
   vec![
     deno_webidl::init(),
-    Extension::builder()
+    Extension::builder("deno_webidl_bench")
       .js(vec![("setup", include_str!("dict.js"))])
       .build(),
   ]


### PR DESCRIPTION
This commits add a `webidl.createDictionaryConverter` converter microbenchmark.

There are 2 PRs currently open that need a microbenchmark for webidl dictionary converter. See  https://github.com/denoland/deno/pull/16594 and https://github.com/denoland/deno/pull/16407

Closes https://github.com/denoland/deno/issues/17436