### PR TITLE
refactor(core): rename pending_promise_exception to pending_promise_rejection

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -505,11 +505,11 @@ pub extern "C" fn promise_reject_callback(message: v8::PromiseRejectMessage) {
         let error = message.get_value().unwrap();
         let error_global = v8::Global::new(scope, error);
         state
-          .pending_promise_exceptions
+          .pending_promise_rejections
           .insert(promise_global, error_global);
       }
       PromiseHandlerAddedAfterReject => {
-        state.pending_promise_exceptions.remove(&promise_global);
+        state.pending_promise_rejections.remove(&promise_global);
       }
       PromiseRejectAfterResolved => {}
       PromiseResolveAfterResolved => {

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -50,9 +50,9 @@ pub(crate) fn init_builtins_v8() -> Vec<OpDecl> {
     op_apply_source_map::decl(),
     op_set_format_exception_callback::decl(),
     op_event_loop_has_more_work::decl(),
-    op_store_pending_promise_exception::decl(),
-    op_remove_pending_promise_exception::decl(),
-    op_has_pending_promise_exception::decl(),
+    op_store_pending_promise_rejection::decl(),
+    op_remove_pending_promise_rejection::decl(),
+    op_has_pending_promise_rejection::decl(),
     op_arraybuffer_was_detached::decl(),
   ]
 }
@@ -859,7 +859,7 @@ fn op_event_loop_has_more_work(scope: &mut v8::HandleScope) -> bool {
 }
 
 #[op(v8)]
-fn op_store_pending_promise_exception<'a>(
+fn op_store_pending_promise_rejection<'a>(
   scope: &mut v8::HandleScope<'a>,
   promise: serde_v8::Value<'a>,
   reason: serde_v8::Value<'a>,
@@ -871,12 +871,12 @@ fn op_store_pending_promise_exception<'a>(
   let promise_global = v8::Global::new(scope, promise_value);
   let error_global = v8::Global::new(scope, reason.v8_value);
   state
-    .pending_promise_exceptions
+    .pending_promise_rejections
     .insert(promise_global, error_global);
 }
 
 #[op(v8)]
-fn op_remove_pending_promise_exception<'a>(
+fn op_remove_pending_promise_rejection<'a>(
   scope: &mut v8::HandleScope<'a>,
   promise: serde_v8::Value<'a>,
 ) {
@@ -885,11 +885,11 @@ fn op_remove_pending_promise_exception<'a>(
   let promise_value =
     v8::Local::<v8::Promise>::try_from(promise.v8_value).unwrap();
   let promise_global = v8::Global::new(scope, promise_value);
-  state.pending_promise_exceptions.remove(&promise_global);
+  state.pending_promise_rejections.remove(&promise_global);
 }
 
 #[op(v8)]
-fn op_has_pending_promise_exception<'a>(
+fn op_has_pending_promise_rejection<'a>(
   scope: &mut v8::HandleScope<'a>,
   promise: serde_v8::Value<'a>,
 ) -> bool {
@@ -899,7 +899,7 @@ fn op_has_pending_promise_exception<'a>(
     v8::Local::<v8::Promise>::try_from(promise.v8_value).unwrap();
   let promise_global = v8::Global::new(scope, promise_value);
   state
-    .pending_promise_exceptions
+    .pending_promise_rejections
     .contains_key(&promise_global)
 }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -1169,7 +1169,7 @@ impl JsRuntime {
     // run in macrotasks callbacks so we need to let them run first).
     self.drain_nexttick()?;
     self.drain_macrotasks()?;
-    self.check_promise_exceptions()?;
+    self.check_promise_rejections()?;
 
     // Event loop middlewares
     let mut maybe_scheduling = false;
@@ -2126,7 +2126,7 @@ impl JsRuntime {
     Ok(root_id)
   }
 
-  fn check_promise_exceptions(&mut self) -> Result<(), Error> {
+  fn check_promise_rejections(&mut self) -> Result<(), Error> {
     let mut state = self.state.borrow_mut();
 
     if state.pending_promise_rejections.is_empty() {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -323,13 +323,13 @@ delete Intl.v8BreakIterator;
   function promiseRejectCallback(type, promise, reason) {
     switch (type) {
       case 0: {
-        ops.op_store_pending_promise_exception(promise, reason);
+        ops.op_store_pending_promise_rejection(promise, reason);
         ArrayPrototypePush(pendingRejections, promise);
         WeakMapPrototypeSet(pendingRejectionsReasons, promise, reason);
         break;
       }
       case 1: {
-        ops.op_remove_pending_promise_exception(promise);
+        ops.op_remove_pending_promise_rejection(promise);
         const index = ArrayPrototypeIndexOf(pendingRejections, promise);
         if (index > -1) {
           ArrayPrototypeSplice(pendingRejections, index, 1);
@@ -348,7 +348,7 @@ delete Intl.v8BreakIterator;
   function promiseRejectMacrotaskCallback() {
     while (pendingRejections.length > 0) {
       const promise = ArrayPrototypeShift(pendingRejections);
-      const hasPendingException = ops.op_has_pending_promise_exception(
+      const hasPendingException = ops.op_has_pending_promise_rejection(
         promise,
       );
       const reason = WeakMapPrototypeGet(pendingRejectionsReasons, promise);
@@ -369,7 +369,7 @@ delete Intl.v8BreakIterator;
 
       const errorEventCb = (event) => {
         if (event.error === reason) {
-          ops.op_remove_pending_promise_exception(promise);
+          ops.op_remove_pending_promise_rejection(promise);
         }
       };
       // Add a callback for "error" event - it will be dispatched
@@ -382,7 +382,7 @@ delete Intl.v8BreakIterator;
       // If event was not prevented (or "unhandledrejection" listeners didn't
       // throw) we will let Rust side handle it.
       if (rejectionEvent.defaultPrevented) {
-        ops.op_remove_pending_promise_exception(promise);
+        ops.op_remove_pending_promise_rejection(promise);
       }
     }
     return true;


### PR DESCRIPTION
These are technically rejections - a rejection can then raise an exception. Prompted by discussion with @andreubotella 