### PR TITLE
fix(napi) use c_char instead of hardcoding i8 to avoid incompatibility with aarch64

### DIFF
--- a/test_napi/src/typedarray.rs
+++ b/test_napi/src/typedarray.rs
@@ -9,6 +9,7 @@ use napi_sys::TypedarrayType;
 use napi_sys::ValueType::napi_number;
 use napi_sys::ValueType::napi_object;
 use napi_sys::*;
+use std::os::raw::c_char;
 use std::ptr;
 
 extern "C" fn test_multiply(
@@ -103,7 +104,8 @@ extern "C" fn test_multiply(
     assert_napi_ok!(napi_throw_error(
       env,
       ptr::null(),
-      "Typed array was of a type not expected by test.".as_ptr() as *const i8,
+      "Typed array was of a type not expected by test.".as_ptr()
+        as *const c_char,
     ));
     return ptr::null_mut();
   }


### PR DESCRIPTION
Quick one, compatibility fix for [aarch64 builds](https://github.com/LukeChannings/deno-arm64).