### PR TITLE
feat: ES module snapshotting

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -765,7 +765,7 @@ pub(crate) struct ModuleInfo {
 }
 
 /// A symbolic module entity.
-enum SymbolicModule {
+pub (crate) enum SymbolicModule {
   /// This module is an alias to another module.
   /// This is useful such that multiple names could point to
   /// the same underlying module (particularly due to redirects).
@@ -783,12 +783,12 @@ pub(crate) enum ModuleError {
 /// A collection of JS modules.
 pub(crate) struct ModuleMap {
   // Handling of specifiers and v8 objects
-  ids_by_handle: HashMap<v8::Global<v8::Module>, ModuleId>,
+  pub (crate) ids_by_handle: HashMap<v8::Global<v8::Module>, ModuleId>,
   pub handles_by_id: HashMap<ModuleId, v8::Global<v8::Module>>,
   pub info: HashMap<ModuleId, ModuleInfo>,
-  by_name: HashMap<(String, AssertedModuleType), SymbolicModule>,
-  next_module_id: ModuleId,
-  next_load_id: ModuleLoadId,
+  pub (crate) by_name: HashMap<(String, AssertedModuleType), SymbolicModule>,
+  pub (crate) next_module_id: ModuleId,
+  pub (crate) next_load_id: ModuleLoadId,
 
   // Handling of futures for loading module sources
   pub loader: Rc<dyn ModuleLoader>,

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -901,32 +901,29 @@ impl ModuleMap {
     }
 
     {
-      let mut by_name = HashMap::new();
       let by_name_str = v8::String::new(scope, "by_name").unwrap();
       let by_name_data = local_data.get(scope, by_name_str.into()).unwrap();
-      let by_name_deser_: Vec<(String, AssertedModuleType, SymbolicModule)> =
+      let by_name_deser: Vec<(String, AssertedModuleType, SymbolicModule)> =
         serde_v8::from_v8(scope, by_name_data).unwrap();
-      for (name, module_type, symbolic_module) in by_name_deser_ {
-        by_name.insert((name, module_type), symbolic_module);
-      }
-      self.by_name = by_name;
+      self.by_name = by_name_deser
+        .into_iter()
+        .map(|(name, module_type, symbolic_module)| {
+          ((name, module_type), symbolic_module)
+        })
+        .collect();
     }
 
-    {
-      let mut ids_by_handle = HashMap::new();
-      for (index, handle) in module_handles.iter().enumerate() {
-        ids_by_handle.insert(handle.clone(), (index + 1) as i32);
-      }
-      self.ids_by_handle = ids_by_handle;
+    self.ids_by_handle = module_handles
+      .iter()
+      .enumerate()
+      .map(|(index, handle)| (handle.clone(), (index + 1) as i32))
+      .collect();
 
-      {
-        let mut handles_by_id = HashMap::new();
-        for (index, handle) in module_handles.iter().enumerate() {
-          handles_by_id.insert((index + 1) as i32, handle.clone());
-        }
-        self.handles_by_id = handles_by_id;
-      }
-    }
+    self.handles_by_id = module_handles
+      .iter()
+      .enumerate()
+      .map(|(index, handle)| ((index + 1) as i32, handle.clone()))
+      .collect();
   }
 
   pub(crate) fn new(

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -842,7 +842,7 @@ impl ModuleMap {
         .collect();
     let by_name_array = serde_v8::to_v8(scope, by_name_triples).unwrap();
     let by_name_str = v8::String::new(scope, "by_name").unwrap();
-    obj.set(scope, by_name_str.into(), by_name_array.into());
+    obj.set(scope, by_name_str.into(), by_name_array);
 
     v8::Global::new(scope, obj)
   }

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -851,6 +851,7 @@ impl ModuleMap {
     &mut self,
     scope: &mut v8::HandleScope,
     data: v8::Global<v8::Object>,
+    module_handles: Vec<v8::Global<v8::Module>>,
   ) {
     let local_data: v8::Local<v8::Object> = v8::Local::new(scope, data);
 
@@ -909,6 +910,22 @@ impl ModuleMap {
         by_name.insert((name, module_type), symbolic_module);
       }
       self.by_name = by_name;
+    }
+
+    {
+      let mut ids_by_handle = HashMap::new();
+      for (index, handle) in module_handles.iter().enumerate() {
+        ids_by_handle.insert(handle.clone(), (index + 1) as i32);
+      }
+      self.ids_by_handle = ids_by_handle;
+
+      {
+        let mut handles_by_id = HashMap::new();
+        for (index, handle) in module_handles.iter().enumerate() {
+          handles_by_id.insert((index + 1) as i32, handle.clone());
+        }
+        self.handles_by_id = handles_by_id;
+      }
     }
   }
 

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -806,6 +806,38 @@ pub(crate) struct ModuleMap {
 }
 
 impl ModuleMap {
+  pub fn to_v8_object(&self, handle_scope: &mut v8::HandleScope) -> v8::Global<v8::Object> {
+    let obj = v8::Object::new(handle_scope);
+
+    let next_module_id_str = v8::String::new(handle_scope, "next_module_id").unwrap();
+    let next_module_id = v8::Integer::new(handle_scope, self.next_module_id);
+    obj.set(handle_scope, next_module_id_str.into(), next_module_id.into());
+
+    let next_load_id_str = v8::String::new(handle_scope, "next_load_id").unwrap();
+    let next_load_id = v8::Integer::new(handle_scope, self.next_load_id);
+    obj.set(handle_scope, next_load_id_str.into(), next_load_id.into());
+
+    v8::Global::new(handle_scope, obj)
+  }
+
+  pub fn from_v8_data(&mut self, handle_scope: &mut v8::HandleScope, data: v8::Global<v8::Object>) {
+    let local_data: v8::Local<v8::Object> = v8::Local::new(handle_scope, data);
+
+    let next_module_id_str = v8::String::new(handle_scope, "next_module_id").unwrap();
+    let next_module_id = local_data.get(handle_scope, next_module_id_str.into()).unwrap();
+    assert!(next_module_id.is_int32());
+    let integer = next_module_id.to_integer(handle_scope).unwrap();
+    let val = integer.int32_value(handle_scope).unwrap();
+    self.next_module_id = val;
+
+    let next_load_id_str = v8::String::new(handle_scope, "next_load_id").unwrap();
+    let next_load_id = local_data.get(handle_scope, next_load_id_str.into()).unwrap();
+    assert!(next_load_id.is_int32());
+    let integer = next_load_id.to_integer(handle_scope).unwrap();
+    let val = integer.int32_value(handle_scope).unwrap();
+    self.next_load_id = val;
+  }
+
   pub(crate) fn new(
     loader: Rc<dyn ModuleLoader>,
     op_state: Rc<RefCell<OpState>>,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -3621,7 +3621,7 @@ pub mod tests {
       ..Default::default()
     });
 
-    let specifier = crate::resolve_url(&format!("file:///0.js")).unwrap();
+    let specifier = crate::resolve_url("file:///0.js").unwrap();
     let source_code =
       r#"export function f0() { return "hello world" }"#.to_string();
     let id = futures::executor::block_on(

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2644,6 +2644,7 @@ pub mod tests {
   use super::*;
   use crate::error::custom_error;
   use crate::error::AnyError;
+  use crate::modules::ModuleInfo;
   use crate::modules::ModuleSource;
   use crate::modules::ModuleSourceFuture;
   use crate::modules::ModuleType;
@@ -3503,6 +3504,17 @@ pub mod tests {
       assert_eq!(module_map.handles_by_id.len(), 1);
       assert_eq!(module_map.handles_by_id.keys().next().unwrap(), &1);
       assert_eq!(module_map.info.len(), 1);
+      assert_eq!(module_map.info.keys().next().unwrap(), &1);
+      assert_eq!(
+        module_map.info.values().next().unwrap(),
+        &ModuleInfo {
+          id: 1,
+          main: true,
+          name: "file:///main.js".to_string(),
+          requests: vec![],
+          module_type: ModuleType::JavaScript,
+        }
+      );
       assert_eq!(module_map.by_name.len(), 1);
       assert_eq!(module_map.next_module_id, 2);
       assert_eq!(module_map.next_load_id, 2);
@@ -3519,12 +3531,23 @@ pub mod tests {
     {
       let module_map_rc = runtime2.get_module_map();
       let module_map = module_map_rc.borrow();
-      /*assert_eq!(module_map.ids_by_handle.len(), 1);
-      assert_eq!(module_map.ids_by_handle.values().next().unwrap(), &1);
-      assert_eq!(module_map.handles_by_id.len(), 1);
-      assert_eq!(module_map.handles_by_id.keys().next().unwrap(), &1);*/
+      // assert_eq!(module_map.ids_by_handle.len(), 1);
+      // assert_eq!(module_map.ids_by_handle.values().next().unwrap(), &1);
+      // assert_eq!(module_map.handles_by_id.len(), 1);
+      // assert_eq!(module_map.handles_by_id.keys().next().unwrap(), &1);
       assert_eq!(module_map.info.len(), 1);
-      /*assert_eq!(module_map.by_name.len(), 1);*/
+      assert_eq!(module_map.info.keys().next().unwrap(), &1);
+      assert_eq!(
+        module_map.info.values().next().unwrap(),
+        &ModuleInfo {
+          id: 1,
+          main: true,
+          name: "file:///main.js".to_string(),
+          requests: vec![],
+          module_type: ModuleType::JavaScript,
+        }
+      );
+      // assert_eq!(module_map.by_name.len(), 1);
       assert_eq!(module_map.next_module_id, 2);
       assert_eq!(module_map.next_load_id, 2);
     }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -3641,7 +3641,7 @@ pub mod tests {
       module_type: ModuleType::JavaScript,
     });
 
-    modules.extend((1..3).map(|i| create_module(&mut runtime, i, false)));
+    modules.extend((1..200).map(|i| create_module(&mut runtime, i, false)));
 
     assert_module_map(&mut runtime, &modules);
 
@@ -3656,8 +3656,8 @@ pub mod tests {
 
     assert_module_map(&mut runtime2, &modules);
 
-    modules.extend((3..5).map(|i| create_module(&mut runtime2, i, false)));
-    modules.push(create_module(&mut runtime2, 5, true));
+    modules.extend((200..400).map(|i| create_module(&mut runtime2, i, false)));
+    modules.push(create_module(&mut runtime2, 400, true));
 
     assert_module_map(&mut runtime2, &modules);
 
@@ -3672,8 +3672,8 @@ pub mod tests {
     assert_module_map(&mut runtime3, &modules);
 
     let source_code = r#"(async () => {
-      const mod = await import("file:///5.js");
-      return mod.f5();
+      const mod = await import("file:///400.js");
+      return mod.f400();
     })();"#
       .to_string();
     let val = runtime3.execute_script(".", &source_code).unwrap();

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2644,11 +2644,13 @@ pub mod tests {
   use super::*;
   use crate::error::custom_error;
   use crate::error::AnyError;
+  use crate::modules::AssertedModuleType;
   use crate::modules::ModuleInfo;
   use crate::modules::ModuleSource;
   use crate::modules::ModuleSourceFuture;
   use crate::modules::ModuleType;
   use crate::modules::ResolutionKind;
+  use crate::modules::SymbolicModule;
   use crate::ZeroCopyBuf;
   use deno_ops::op;
   use futures::future::lazy;
@@ -3516,6 +3518,17 @@ pub mod tests {
         }
       );
       assert_eq!(module_map.by_name.len(), 1);
+      assert_eq!(
+        module_map.by_name.keys().next().unwrap(),
+        &(
+          "file:///main.js".to_string(),
+          AssertedModuleType::JavaScriptOrWasm
+        )
+      );
+      assert_eq!(
+        module_map.by_name.values().next().unwrap(),
+        &SymbolicModule::Mod(1)
+      );
       assert_eq!(module_map.next_module_id, 2);
       assert_eq!(module_map.next_load_id, 2);
     }
@@ -3547,7 +3560,18 @@ pub mod tests {
           module_type: ModuleType::JavaScript,
         }
       );
-      // assert_eq!(module_map.by_name.len(), 1);
+      assert_eq!(module_map.by_name.len(), 1);
+      assert_eq!(
+        module_map.by_name.keys().next().unwrap(),
+        &(
+          "file:///main.js".to_string(),
+          AssertedModuleType::JavaScriptOrWasm
+        )
+      );
+      assert_eq!(
+        module_map.by_name.values().next().unwrap(),
+        &SymbolicModule::Mod(1)
+      );
       assert_eq!(module_map.next_module_id, 2);
       assert_eq!(module_map.next_load_id, 2);
     }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -616,7 +616,7 @@ impl JsRuntime {
       state.inspector = inspector;
       state
         .known_realms
-        .push(v8::Weak::new(&mut isolate, global_context.clone()));
+        .push(v8::Weak::new(&mut isolate, &global_context));
     }
     isolate.set_data(
       Self::STATE_DATA_OFFSET,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -351,7 +351,8 @@ impl JsRuntime {
     DENO_INIT.call_once(move || v8_init(v8_platform, options.will_snapshot));
 
     // Add builtins extension
-    if options.startup_snapshot.is_none() {
+    let has_startup_snapshot = options.startup_snapshot.is_some();
+    if !has_startup_snapshot {
       options
         .extensions_with_js
         .insert(0, crate::ops_builtin::init_builtins());
@@ -513,7 +514,7 @@ impl JsRuntime {
           bindings::initialize_context(scope, &op_ctxs, snapshot_options);
 
         // Get module map data from the snapshot
-        {
+        if has_startup_snapshot {
           fn data_error_to_panic(err: v8::DataError) {
             match err {
               v8::DataError::BadType { actual, expected } => {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -596,10 +596,8 @@ impl JsRuntime {
 
     let module_map_rc = Rc::new(RefCell::new(ModuleMap::new(loader, op_state)));
     if let Some(module_map_data) = module_map_data {
-      let scope = &mut v8::HandleScope::with_context(
-        &mut isolate,
-        global_context.clone(),
-      );
+      let scope =
+        &mut v8::HandleScope::with_context(&mut isolate, global_context);
       let mut module_map = module_map_rc.borrow_mut();
       module_map.with_v8_data(scope, module_map_data, module_handles);
     }


### PR DESCRIPTION
This commit adds support for snapshotting ES modules. This is done by
adding an ability to serialize and deserialize a "ModuleMap" and attach it
to the snapshot, using "add_context_data" API.

This has been tested with 400 modules and seems to not have a limit on
the number of modules that might be snapshotted. 