### PR TITLE
fix(napi): don't hold on to borrow during iteration

### DIFF
--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -533,7 +533,8 @@ pub fn init<P: NapiPermissions + 'static>(unstable: bool) -> Extension {
           maybe_scheduling = true;
         }
 
-        for (_id, counter) in napi_state.tsfn_ref_counters.borrow().iter() {
+        let tsfn_ref_counters = napi_state.tsfn_ref_counters.borrow().clone();
+        for (_id, counter) in tsfn_ref_counters.iter() {
           if counter.load(std::sync::atomic::Ordering::SeqCst) > 0 {
             maybe_scheduling = true;
             break;


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/17457

I mistakenly held on to a RefCell's borrow for the whole time of iteration,
but since these counters can be refed/unrefed from any thread that is a mistake.