### PR TITLE
chore: upgrade base64-simd to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,11 +239,12 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64-simd"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
- "simd-abstraction",
+ "outref",
+ "vsimd",
 ]
 
 [[package]]
@@ -3021,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "outref"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "p256"
@@ -4008,15 +4009,6 @@ checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
 dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "simd-abstraction"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d3f0728c33eb35102d2489a6a13dbbb510b07864b854e961b9e4b9cd011c61"
-dependencies = [
- "outref",
 ]
 
 [[package]]
@@ -5350,6 +5342,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 async-trait.workspace = true
-base64-simd = "0.7"
+base64-simd = "0.8"
 deno_core.workspace = true
 encoding_rs.workspace = true
 flate2.workspace = true

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -130,25 +130,27 @@ pub fn init<P: TimersPermission + 'static>(
 #[op]
 fn op_base64_decode(input: String) -> Result<ZeroCopyBuf, AnyError> {
   let mut s = input.into_bytes();
-  let decoded_len = forgiving_base64_decode(&mut s)?;
+  let decoded_len = forgiving_base64_decode_inplace(&mut s)?;
   s.truncate(decoded_len);
   Ok(s.into())
 }
 
 #[op]
 fn op_base64_atob(mut s: ByteString) -> Result<ByteString, AnyError> {
-  let decoded_len = forgiving_base64_decode(&mut s)?;
+  let decoded_len = forgiving_base64_decode_inplace(&mut s)?;
   s.truncate(decoded_len);
   Ok(s)
 }
 
 /// See <https://infra.spec.whatwg.org/#forgiving-base64>
 #[inline]
-fn forgiving_base64_decode(input: &mut [u8]) -> Result<usize, AnyError> {
+fn forgiving_base64_decode_inplace(
+  input: &mut [u8],
+) -> Result<usize, AnyError> {
   let error: _ =
     || DomExceptionInvalidCharacterError::new("Failed to decode base64");
-  let decoded = base64_simd::Base64::forgiving_decode_inplace(input)
-    .map_err(|_| error())?;
+  let decoded =
+    base64_simd::forgiving_decode_inplace(input).map_err(|_| error())?;
   Ok(decoded.len())
 }
 
@@ -165,8 +167,7 @@ fn op_base64_btoa(s: ByteString) -> String {
 /// See <https://infra.spec.whatwg.org/#forgiving-base64>
 #[inline]
 fn forgiving_base64_encode(s: &[u8]) -> String {
-  const BASE64_STANDARD: base64_simd::Base64 = base64_simd::Base64::STANDARD;
-  BASE64_STANDARD.encode_to_boxed_str(s).into_string()
+  base64_simd::STANDARD.encode_to_string(s)
 }
 
 #[op]


### PR DESCRIPTION
This PR upgrades the `base64-simd` dependency of `deno_web`.

base64-simd v0.8 supports `forgiving_decode` in ["copy" mode](https://docs.rs/base64-simd/0.8.0/base64_simd/fn.forgiving_decode.html), ["inplace" mode](https://docs.rs/base64-simd/0.8.0/base64_simd/fn.forgiving_decode_inplace.html) or ["alloc" mode](https://docs.rs/base64-simd/0.8.0/base64_simd/fn.forgiving_decode_to_vec.html). 
When #17159 resolves, they can be used to reduce unnecessary allocations and copies.
