### PR TITLE
chore: upgrade tokio to 1.24.2 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,9 +4812,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.0"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125661431c26622a80ca5051a2f936c9a678318e0351007b0cc313143024e5c"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ sha2 = { version = "0.10.6", features = ["oid"] }
 smallvec = "1.8"
 socket2 = "0.4.7"
 tar = "=0.4.38"
-tokio = { version = "=1.24.0", features = ["full"] }
+tokio = { version = "=1.24.2", features = ["full"] }
 tokio-rustls = "0.23.3"
 tokio-tungstenite = "0.16.1"
 tokio-util = "=0.7.4"


### PR DESCRIPTION
Tokio 1.24.2 fixed an unsoundness issue https://github.com/tokio-rs/tokio/pull/5375 so I guess it is worthy to upgrade