### PR TITLE
refactor: cleanup ModuleMap

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -3568,7 +3568,7 @@ pub mod tests {
         )
         .unwrap()
       };
-      assert_eq!(i, id as usize);
+      assert_eq!(i, id);
 
       let _ = runtime.mod_evaluate(id);
       futures::executor::block_on(runtime.run_event_loop(false)).unwrap();


### PR DESCRIPTION
- changes module id to be usize & 0 based instead of 1 based
- merges `ids_by_handle` & `handles_by_id` to be a single `handles` vector
- removes `next_module_id`, as vector is used
- turns `info` into a vector