### PR TITLE
refactor(core): Overwrite `ArrayPrototypeToString` in primordials

### DIFF
--- a/core/00_primordials.js
+++ b/core/00_primordials.js
@@ -292,6 +292,7 @@
 
   const {
     ArrayPrototypeForEach,
+    ArrayPrototypeJoin,
     ArrayPrototypeMap,
     FunctionPrototypeCall,
     ObjectDefineProperty,
@@ -302,6 +303,7 @@
     PromisePrototype,
     PromisePrototypeThen,
     SymbolIterator,
+    TypedArrayPrototypeJoin,
   } = primordials;
 
   // Because these functions are used by `makeSafe`, which is exposed
@@ -456,6 +458,12 @@
       }
     },
   );
+
+  primordials.ArrayPrototypeToString = (thisArray) =>
+    ArrayPrototypeJoin(thisArray);
+
+  primordials.TypedArrayPrototypeToString = (thisArray) =>
+    TypedArrayPrototypeJoin(thisArray);
 
   primordials.PromisePrototypeCatch = (thisPromise, onRejected) =>
     PromisePrototypeThen(thisPromise, undefined, onRejected);


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Since `ArrayPrototypeToString` (and `TypedArrayPrototypeToString`) is [designed to call the `"join"` method](https://tc39.es/ecma262/#sec-array.prototype.tostring), it is affected when `Array.prototype.join` is rewritten.

```js
const ArrayPrototypeToString = Function.call.bind(Array.prototype.toString);

// prototype pollution
const originalJoin = Array.prototype.join;
Array.prototype.join = function (sep) { console.log("bang!"); return originalJoin.call(this, sep) };

ArrayPrototypeToString([1, 2, 3]); // bang!
```

This change makes it safe to call `ArrayPrototypeToString`.