### PR TITLE
fix(ext/ffi): disallow empty ffi structs

### DIFF
--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -278,7 +278,7 @@ where
     permissions.check(None)?;
   };
 
-  let symbol = PtrSymbol::new(pointer, &def);
+  let symbol = PtrSymbol::new(pointer, &def)?;
   let call_args = ffi_parse_args(scope, parameters, &def.parameters)?;
   let def_result = def.result.clone();
 
@@ -379,7 +379,7 @@ where
     permissions.check(None)?;
   };
 
-  let symbol = PtrSymbol::new(pointer, &def);
+  let symbol = PtrSymbol::new(pointer, &def)?;
   let call_args = ffi_parse_args(scope, parameters, &def.parameters)?;
 
   let out_buffer = out_buffer

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -166,8 +166,9 @@ where
             .parameters
             .clone()
             .into_iter()
-            .map(libffi::middle::Type::from),
-          foreign_fn.result.clone().into(),
+            .map(libffi::middle::Type::try_from)
+            .collect::<Result<Vec<_>, _>>()?,
+          foreign_fn.result.clone().try_into()?,
         );
 
         let func_key = v8::String::new(scope, &symbol_key).unwrap();

--- a/ext/ffi/symbol.rs
+++ b/ext/ffi/symbol.rs
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::error::type_error;
+use deno_core::error::AnyError;
+
 /// Defines the accepted types that can be used as
 /// parameters and return values in FFI.
 #[derive(Clone, Debug, serde::Deserialize, Eq, PartialEq)]
@@ -25,9 +28,11 @@ pub enum NativeType {
   Struct(Box<[NativeType]>),
 }
 
-impl From<NativeType> for libffi::middle::Type {
-  fn from(native_type: NativeType) -> Self {
-    match native_type {
+impl TryFrom<NativeType> for libffi::middle::Type {
+  type Error = AnyError;
+
+  fn try_from(native_type: NativeType) -> Result<Self, Self::Error> {
+    Ok(match native_type {
       NativeType::Void => libffi::middle::Type::void(),
       NativeType::U8 | NativeType::Bool => libffi::middle::Type::u8(),
       NativeType::I8 => libffi::middle::Type::i8(),
@@ -44,10 +49,18 @@ impl From<NativeType> for libffi::middle::Type {
       NativeType::Pointer | NativeType::Buffer | NativeType::Function => {
         libffi::middle::Type::pointer()
       }
-      NativeType::Struct(fields) => libffi::middle::Type::structure(
-        fields.iter().map(|field| field.clone().into()),
-      ),
-    }
+      NativeType::Struct(fields) => {
+        libffi::middle::Type::structure(match fields.len() > 0 {
+          true => fields
+            .iter()
+            .map(|field| field.clone().try_into())
+            .collect::<Result<Vec<_>, _>>()?,
+          false => {
+            return Err(type_error("Struct must have at least one field"))
+          }
+        })
+      }
+    })
   }
 }
 

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -59,6 +59,18 @@ assertThrows(() => {
   "Struct must have at least one field"
 });
 
+const Empty = { struct: [] }
+assertThrows(() => {
+  Deno.dlopen(libPath, {
+    print_something: {
+      parameters: [ { struct: [Empty] } ],
+      result: "void",
+    },
+  }),
+  TypeError,
+  "Struct must have at least one field"
+});
+
 const Point = ["f64", "f64"];
 const Size = ["f64", "f64"];
 const Rect = ["f64", "f64", "f64", "f64"];

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -37,6 +37,28 @@ assertThrows(
   "Failed to register symbol non_existent_symbol",
 );
 
+assertThrows(() => {
+  Deno.dlopen(libPath, {
+    print_something: {
+      parameters: [],
+      result: { struct: [] }
+    },
+  }),
+  TypeError,
+  "Struct must have at least one field"
+});
+
+assertThrows(() => {
+  Deno.dlopen(libPath, {
+    print_something: {
+      parameters: [ { struct: [] } ],
+      result: "void",
+    },
+  }),
+  TypeError,
+  "Struct must have at least one field"
+});
+
 const Point = ["f64", "f64"];
 const Size = ["f64", "f64"];
 const Rect = ["f64", "f64", "f64", "f64"];


### PR DESCRIPTION
This patch makes `NativeType` to `libffi::middle::Type` conversion failliable and w.t disallows struct with empty fields. libffi does not handle "empty" struct because they don't exist in C (or Rust). 

Fixes #17481