### PR TITLE
feat: suggest adding a "node:" prefix for bare specifiers that look like built-in Node modules

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -630,18 +630,16 @@ fn handle_check_error(
 
   let mut message = format!("{}", error);
 
-  if let Some(error) = error.downcast_ref::<ResolutionError>() {
-    if let ResolutionError::InvalidSpecifier {
-      error: SpecifierError::ImportPrefixMissing(specifier, _),
-      ..
-    } = error
-    {
-      if crate::node::resolve_builtin_node_module(specifier).is_ok() {
-        message.push_str(&format!(
-          "\nIf you want to use a built-in Node module, add a \"node:\" prefix (ex. \"node:{}\").",
-          specifier
-        ));
-      }
+  if let Some(ResolutionError::InvalidSpecifier {
+    error: SpecifierError::ImportPrefixMissing(specifier, _),
+    ..
+  }) = error.downcast_ref::<ResolutionError>()
+  {
+    if crate::node::resolve_builtin_node_module(specifier).is_ok() {
+      message.push_str(&format!(
+        "\nIf you want to use a built-in Node module, add a \"node:\" prefix (ex. \"node:{}\").",
+        specifier
+      ));
     }
   }
 

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -346,13 +346,10 @@ impl GraphData {
           if check_types {
             if let Some(Resolved::Err(error)) = maybe_types {
               let range = error.range();
-              if !range.specifier.as_str().contains("$deno") {
-                return Some(Err(custom_error(
-                  get_error_class_name(&error.clone().into()),
-                  format!("{}\n    at {}", error, range),
-                )));
-              }
-              return Some(Err(error.clone().into()));
+              return Some(handle_check_error(
+                error.clone().into(),
+                Some(range),
+              ));
             }
           }
           for (_, dep) in dependencies.iter() {
@@ -365,31 +362,25 @@ impl GraphData {
               for resolved in resolutions {
                 if let Resolved::Err(error) = resolved {
                   let range = error.range();
-                  if !range.specifier.as_str().contains("$deno") {
-                    return Some(Err(custom_error(
-                      get_error_class_name(&error.clone().into()),
-                      format!("{}\n    at {}", error, range),
-                    )));
-                  }
-                  return Some(Err(error.clone().into()));
+                  return Some(handle_check_error(
+                    error.clone().into(),
+                    Some(range),
+                  ));
                 }
               }
             }
           }
         }
         ModuleEntry::Error(error) => {
-          if !roots.contains(specifier) {
-            if let Some(range) = self.referrer_map.get(specifier) {
-              if !range.specifier.as_str().contains("$deno") {
-                let message = error.to_string();
-                return Some(Err(custom_error(
-                  get_error_class_name(&error.clone().into()),
-                  format!("{}\n    at {}", message, range),
-                )));
-              }
-            }
-          }
-          return Some(Err(error.clone().into()));
+          let maybe_range = if roots.contains(specifier) {
+            None
+          } else {
+            self.referrer_map.get(specifier)
+          };
+          return Some(handle_check_error(
+            error.clone().into(),
+            maybe_range.map(|r| &**r),
+          ));
         }
         _ => {}
       }
@@ -628,4 +619,37 @@ pub fn error_for_any_npm_specifier(
   } else {
     Ok(())
   }
+}
+
+fn handle_check_error(
+  error: AnyError,
+  maybe_range: Option<&deno_graph::Range>,
+) -> Result<(), AnyError> {
+  use deno_graph::ResolutionError;
+  use deno_graph::SpecifierError;
+
+  let mut message = format!("{}", error);
+
+  if let Some(error) = error.downcast_ref::<ResolutionError>() {
+    if let ResolutionError::InvalidSpecifier {
+      error: SpecifierError::ImportPrefixMissing(specifier, _),
+      ..
+    } = error
+    {
+      if crate::node::resolve_builtin_node_module(specifier).is_ok() {
+        message.push_str(&format!(
+          "\nIf you want to use a built-in Node module, add a \"node:\" prefix (ex. \"node:{}\").",
+          specifier
+        ));
+      }
+    }
+  }
+
+  if let Some(range) = maybe_range {
+    if !range.specifier.as_str().contains("$deno") {
+      message.push_str(&format!("\n    at {}", range));
+    }
+  }
+
+  Err(custom_error(get_error_class_name(&error), message))
 }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1368,7 +1368,7 @@ impl Inner {
             _ => false,
           },
           "deno-lint" => matches!(&d.code, Some(_)),
-          "deno" => diagnostics::DenoDiagnostic::is_fixable(&d.code),
+          "deno" => diagnostics::DenoDiagnostic::is_fixable(d),
           _ => false,
         },
         None => false,

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -41,7 +41,7 @@ fn load_fixture_str(path: &str) -> String {
 
 fn init(init_path: &str) -> LspClient {
   let deno_exe = deno_exe_path();
-  let mut client = LspClient::new(&deno_exe, false).unwrap();
+  let mut client = LspClient::new(&deno_exe, true).unwrap(); // todo: REVVVERRRT
   client
     .write_request::<_, _, Value>("initialize", load_fixture(init_path))
     .unwrap();
@@ -4436,14 +4436,8 @@ fn lsp_completions_node_specifier() {
     json!([
       {
         "range": {
-          "start": {
-            "line": 0,
-            "character": 15
-          },
-          "end": {
-            "line": 0,
-            "character": 34
-          }
+          "start": { "line": 0, "character": 15 },
+          "end": { "line": 0, "character": 34 },
         },
         "severity": 1,
         "code": "resolver-error",
@@ -4453,7 +4447,7 @@ fn lsp_completions_node_specifier() {
     ])
   );
 
-  // update to have node:fs import
+  // update to have fs import
   client
     .write_notification(
       "textDocument/didChange",
@@ -4465,21 +4459,108 @@ fn lsp_completions_node_specifier() {
         "contentChanges": [
           {
             "range": {
-              "start": {
-                "line": 0,
-                "character": 16
-              },
-              "end": {
-                "line": 0,
-                "character": 33
-              }
+              "start": { "line": 0, "character": 16 },
+              "end": { "line": 0, "character": 33 },
             },
-            "text": "node:fs"
+            "text": "fs"
           }
         ]
       }),
     )
     .unwrap();
+  let diagnostics = read_diagnostics(&mut client);
+  let diagnostics = diagnostics
+    .with_file_and_source("file:///a/file.ts", "deno")
+    .diagnostics
+    .into_iter()
+    .filter(|d| {
+      d.code
+        == Some(lsp::NumberOrString::String(
+          "import-prefix-missing".to_string(),
+        ))
+    })
+    .collect::<Vec<_>>();
+
+  // get the quick fixes
+  let (maybe_res, maybe_err) = client
+    .write_request(
+      "textDocument/codeAction",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.ts"
+        },
+        "range": {
+          "start": { "line": 0, "character": 16 },
+          "end": { "line": 0, "character": 18 },
+        },
+        "context": {
+          "diagnostics": json!(diagnostics),
+          "only": [
+            "quickfix"
+          ]
+        }
+      }),
+    )
+    .unwrap();
+  assert!(maybe_err.is_none());
+  assert_eq!(
+    maybe_res,
+    Some(json!([{
+      "title": "Update specifier to node:fs",
+      "kind": "quickfix",
+      "diagnostics": [
+        {
+          "range": {
+            "start": { "line": 0, "character": 15 },
+            "end": { "line": 0, "character": 19 }
+          },
+          "severity": 1,
+          "code": "import-prefix-missing",
+          "source": "deno",
+          "message": "Relative import path \"fs\" not prefixed with / or ./ or ../",
+          "data": {
+            "specifier": "fs"
+          },
+        }
+      ],
+      "edit": {
+        "changes": {
+          "file:///a/file.ts": [
+            {
+              "range": {
+                "start": { "line": 0, "character": 15 },
+                "end": { "line": 0, "character": 19 }
+              },
+              "newText": "\"node:fs\""
+            }
+          ]
+        }
+      }
+    }]))
+  );
+
+  // update to have node:fs import
+  client
+    .write_notification(
+      "textDocument/didChange",
+      json!({
+        "textDocument": {
+          "uri": "file:///a/file.ts",
+          "version": 3,
+        },
+        "contentChanges": [
+          {
+            "range": {
+              "start": { "line": 0, "character": 15 },
+              "end": { "line": 0, "character": 19 },
+            },
+            "text": "\"node:fs\"",
+          }
+        ]
+      }),
+    )
+    .unwrap();
+
   let diagnostics = read_diagnostics(&mut client);
   let cache_diagnostics = diagnostics
     .with_file_and_source("file:///a/file.ts", "deno")
@@ -4495,14 +4576,8 @@ fn lsp_completions_node_specifier() {
     json!([
       {
         "range": {
-          "start": {
-            "line": 0,
-            "character": 15
-          },
-          "end": {
-            "line": 0,
-            "character": 24
-          }
+          "start": { "line": 0, "character": 15 },
+          "end": { "line": 0, "character": 24 }
         },
         "data": {
           "specifier": "npm:@types/node",
@@ -4539,19 +4614,13 @@ fn lsp_completions_node_specifier() {
       json!({
         "textDocument": {
           "uri": "file:///a/file.ts",
-          "version": 2
+          "version": 4
         },
         "contentChanges": [
           {
             "range": {
-              "start": {
-                "line": 2,
-                "character": 0
-              },
-              "end": {
-                "line": 2,
-                "character": 0
-              }
+              "start": { "line": 2, "character": 0 },
+              "end": { "line": 2, "character": 0 }
             },
             "text": "fs."
           }
@@ -4568,10 +4637,7 @@ fn lsp_completions_node_specifier() {
         "textDocument": {
           "uri": "file:///a/file.ts"
         },
-        "position": {
-          "line": 2,
-          "character": 3
-        },
+        "position": { "line": 2, "character": 3 },
         "context": {
           "triggerKind": 2,
           "triggerCharacter": "."

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -41,7 +41,7 @@ fn load_fixture_str(path: &str) -> String {
 
 fn init(init_path: &str) -> LspClient {
   let deno_exe = deno_exe_path();
-  let mut client = LspClient::new(&deno_exe, true).unwrap(); // todo: REVVVERRRT
+  let mut client = LspClient::new(&deno_exe, false).unwrap();
   client
     .write_request::<_, _, Value>("initialize", load_fixture(init_path))
     .unwrap();

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -4517,7 +4517,7 @@ fn lsp_completions_node_specifier() {
           "severity": 1,
           "code": "import-prefix-missing",
           "source": "deno",
-          "message": "Relative import path \"fs\" not prefixed with / or ./ or ../",
+          "message": "Relative import path \"fs\" not prefixed with / or ./ or ../\nIf you want to use a built-in Node module, add a \"node:\" prefix (ex. \"node:fs\").",
           "data": {
             "specifier": "fs"
           },

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -12,6 +12,7 @@ use tokio::task::LocalSet;
 use trust_dns_client::serialize::txt::Lexer;
 use trust_dns_client::serialize::txt::Parser;
 use util::assert_contains;
+use util::env_vars_for_npm_tests_no_sync_download;
 
 itest!(stdout_write_all {
   args: "run --quiet run/stdout_write_all.ts",
@@ -3749,22 +3750,23 @@ fn stdio_streams_are_locked_in_permission_prompt() {
   });
 }
 
-itest!(run_node_builtin_modules_ts {
+itest!(node_builtin_modules_ts {
   args: "run --quiet run/node_builtin_modules/mod.ts",
   output: "run/node_builtin_modules/mod.ts.out",
-  envs: vec![(
-    "DENO_NODE_COMPAT_URL".to_string(),
-    test_util::std_file_url()
-  )],
+  envs: env_vars_for_npm_tests_no_sync_download(),
   exit_code: 0,
 });
 
-itest!(run_node_builtin_modules_js {
+itest!(node_builtin_modules_js {
   args: "run --quiet run/node_builtin_modules/mod.js",
   output: "run/node_builtin_modules/mod.js.out",
-  envs: vec![(
-    "DENO_NODE_COMPAT_URL".to_string(),
-    test_util::std_file_url()
-  )],
+  envs: env_vars_for_npm_tests_no_sync_download(),
   exit_code: 0,
+});
+
+itest!(node_prefix_missing {
+  args: "run --quiet run/node_prefix_missing/main.ts",
+  output: "run/node_prefix_missing/main.ts.out",
+  envs: env_vars_for_npm_tests_no_sync_download(),
+  exit_code: 1,
 });

--- a/cli/tests/testdata/jsx/deno.lock
+++ b/cli/tests/testdata/jsx/deno.lock
@@ -1,0 +1,6 @@
+{
+  "version": "2",
+  "remote": {
+    "http://localhost:4545/jsx/jsx-dev-runtime/index.ts": "183c5bf1cfb82b15fc1e8cca15593d4816035759532d851abd4476df378c8412"
+  }
+}

--- a/cli/tests/testdata/run/035_cached_only_flag.out
+++ b/cli/tests/testdata/run/035_cached_only_flag.out
@@ -1,4 +1,1 @@
 error: Specifier not found in cache: "http://127.0.0.1:4545/run/019_media_types.ts", --cached-only is specified.
-
-Caused by:
-    Specifier not found in cache: "http://127.0.0.1:4545/run/019_media_types.ts", --cached-only is specified.

--- a/cli/tests/testdata/run/052_no_remote_flag.out
+++ b/cli/tests/testdata/run/052_no_remote_flag.out
@@ -1,4 +1,1 @@
 error: A remote specifier was requested: "http://127.0.0.1:4545/run/019_media_types.ts", but --no-remote is specified.
-
-Caused by:
-    A remote specifier was requested: "http://127.0.0.1:4545/run/019_media_types.ts", but --no-remote is specified.

--- a/cli/tests/testdata/run/node_prefix_missing/main.ts
+++ b/cli/tests/testdata/run/node_prefix_missing/main.ts
@@ -1,0 +1,3 @@
+import fs from "fs";
+
+console.log(fs.writeFile);

--- a/cli/tests/testdata/run/node_prefix_missing/main.ts.out
+++ b/cli/tests/testdata/run/node_prefix_missing/main.ts.out
@@ -1,0 +1,3 @@
+error: Relative import path "fs" not prefixed with / or ./ or ../
+If you want to use a built-in Node module, add a "node:" prefix (ex. "node:fs").
+    at file:///[WILDCARD]/main.ts:1:16


### PR DESCRIPTION
Adds a better message on the CLI and quick fix in the LSP:

![image](https://user-images.githubusercontent.com/1609021/214381807-557942db-fd42-4bfd-8e42-a5af47c7e102.png)

![image](https://user-images.githubusercontent.com/1609021/214378930-ccfdccaa-3d99-4041-9479-4a2ba7d5ff8f.png)

Closes https://github.com/denoland/deno/issues/17493