### PR TITLE
fix: support import map specified as data uri

### DIFF
--- a/cli/args/import_map.rs
+++ b/cli/args/import_map.rs
@@ -3,11 +3,40 @@
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::url::Url;
+use deno_runtime::permissions::PermissionsContainer;
 use import_map::ImportMap;
 use import_map::ImportMapDiagnostic;
 use log::warn;
 
-pub fn import_map_from_value(
+use super::ConfigFile;
+use crate::file_fetcher::get_source_from_data_url;
+use crate::file_fetcher::FileFetcher;
+
+pub async fn resolve_import_map_from_specifier(
+  specifier: &Url,
+  maybe_config_file: Option<&ConfigFile>,
+  file_fetcher: &FileFetcher,
+) -> Result<ImportMap, AnyError> {
+  let value: serde_json::Value = if specifier.scheme() == "data" {
+    serde_json::from_str(&get_source_from_data_url(specifier)?.0)?
+  } else {
+    let import_map_config = maybe_config_file
+      .as_ref()
+      .filter(|c| c.specifier == *specifier);
+    match import_map_config {
+      Some(config) => config.to_import_map_value(),
+      None => {
+        let file = file_fetcher
+          .fetch(specifier, PermissionsContainer::allow_all())
+          .await?;
+        serde_json::from_str(&file.source)?
+      }
+    }
+  };
+  import_map_from_value(specifier, value)
+}
+
+fn import_map_from_value(
   specifier: &Url,
   json_value: serde_json::Value,
 ) -> Result<ImportMap, AnyError> {

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -193,8 +193,8 @@ impl FileFetcher {
     http_client: HttpClient,
     blob_store: BlobStore,
     progress_bar: Option<ProgressBar>,
-  ) -> Result<Self, AnyError> {
-    Ok(Self {
+  ) -> Self {
+    Self {
       auth_tokens: AuthTokens::new(env::var("DENO_AUTH_TOKENS").ok()),
       allow_remote,
       cache: Default::default(),
@@ -204,7 +204,7 @@ impl FileFetcher {
       blob_store,
       download_log_level: log::Level::Info,
       progress_bar,
-    })
+    }
   }
 
   /// Sets the log level to use when outputting the download message.
@@ -778,8 +778,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       blob_store.clone(),
       None,
-    )
-    .unwrap();
+    );
     (file_fetcher, temp_dir, blob_store)
   }
 
@@ -1215,8 +1214,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let result = file_fetcher
       .fetch(&specifier, PermissionsContainer::allow_all())
       .await;
@@ -1241,8 +1239,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let specifier =
       resolve_url("http://localhost:4545/subdir/mismatch_ext.ts").unwrap();
     let cache_filename = file_fetcher_01
@@ -1267,8 +1264,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let result = file_fetcher_02
       .fetch(&specifier, PermissionsContainer::allow_all())
       .await;
@@ -1409,8 +1405,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let specifier =
       resolve_url("http://localhost:4548/subdir/mismatch_ext.ts").unwrap();
     let redirected_specifier =
@@ -1438,8 +1433,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let result = file_fetcher_02
       .fetch(&redirected_specifier, PermissionsContainer::allow_all())
       .await;
@@ -1538,8 +1532,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let specifier =
       resolve_url("http://localhost:4545/run/002_hello.ts").unwrap();
 
@@ -1564,8 +1557,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let file_fetcher_02 = FileFetcher::new(
       HttpCache::new(&location),
       CacheSetting::Use,
@@ -1573,8 +1565,7 @@ mod tests {
       HttpClient::new(None, None).unwrap(),
       BlobStore::default(),
       None,
-    )
-    .unwrap();
+    );
     let specifier =
       resolve_url("http://localhost:4545/run/002_hello.ts").unwrap();
 

--- a/cli/lsp/cache.rs
+++ b/cli/lsp/cache.rs
@@ -55,9 +55,9 @@ pub struct CacheMetadata {
 }
 
 impl CacheMetadata {
-  pub fn new(location: &Path) -> Self {
+  pub fn new(cache: HttpCache) -> Self {
     Self {
-      cache: HttpCache::new(location),
+      cache,
       metadata: Default::default(),
     }
   }

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -442,7 +442,7 @@ impl ModuleRegistry {
       http_client,
       BlobStore::default(),
       None,
-    )?;
+    );
     file_fetcher.set_download_log_level(super::logging::lsp_log_level());
 
     Ok(Self {

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -202,7 +202,7 @@ impl ProcState {
       http_client.clone(),
       blob_store.clone(),
       Some(progress_bar.clone()),
-    )?;
+    );
 
     let lockfile = cli_options.maybe_lock_file();
 

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -182,6 +182,13 @@ itest!(_033_import_map_remote {
   http_server: true,
 });
 
+itest!(_033_import_map_data_uri {
+  args:
+    "run --quiet --reload --import-map=data:application/json;charset=utf-8;base64,ewogICJpbXBvcnRzIjogewogICAgInRlc3Rfc2VydmVyLyI6ICJodHRwOi8vbG9jYWxob3N0OjQ1NDUvIgogIH0KfQ== run/import_maps/test_data.ts",
+  output: "run/import_maps/test_data.ts.out",
+  http_server: true,
+});
+
 itest!(onload {
   args: "run --quiet --reload run/onload/main.ts",
   output: "run/onload/main.out",

--- a/cli/tests/testdata/run/import_maps/test_data.ts
+++ b/cli/tests/testdata/run/import_maps/test_data.ts
@@ -1,0 +1,1 @@
+import "test_server/import_maps/lodash/lodash.ts";

--- a/cli/tests/testdata/run/import_maps/test_data.ts.out
+++ b/cli/tests/testdata/run/import_maps/test_data.ts.out
@@ -1,0 +1,1 @@
+Hello from remapped lodash!


### PR DESCRIPTION
Consolidates the import map uri -> import map resolution between the lsp and cli options. While doing this, I noticed the LSP supports a data uri, but the cli flags do not, so the consolidation fixed this issue.