### PR TITLE
refactor(cache): fewer string allocations

### DIFF
--- a/cli/cache/check.rs
+++ b/cli/cache/check.rs
@@ -192,7 +192,7 @@ fn create_tables(
       |row| row.get(0),
     )
     .ok();
-  if data_cli_version != Some(cli_version.to_string()) {
+  if data_cli_version.as_deref() != Some(&cli_version) {
     conn.execute("DELETE FROM checkcache", params![])?;
     conn.execute("DELETE FROM tsbuildinfo", params![])?;
     let mut stmt = conn

--- a/cli/cache/incremental.rs
+++ b/cli/cache/incremental.rs
@@ -232,7 +232,7 @@ impl SqlIncrementalCache {
     stmt.execute(params![
       path.to_string_lossy(),
       &self.state_hash.to_string(),
-      &source_hash.to_string(),
+      &source_hash,
     ])?;
     Ok(())
   }
@@ -267,7 +267,7 @@ fn create_tables(
       |row| row.get(0),
     )
     .ok();
-  if data_cli_version != Some(cli_version.to_string()) {
+  if data_cli_version.as_deref() != Some(&cli_version) {
     conn.execute("DELETE FROM incrementalcache", params![])?;
     let mut stmt = conn
       .prepare("INSERT OR REPLACE INTO info (key, value) VALUES (?1, ?2)")?;

--- a/cli/cache/node.rs
+++ b/cli/cache/node.rs
@@ -253,7 +253,7 @@ impl NodeAnalysisCacheInner {
     let mut stmt = self.conn.prepare_cached(sql)?;
     stmt.execute(params![
       specifier,
-      &source_hash.to_string(),
+      &source_hash,
       &serde_json::to_string(top_level_decls)?,
     ])?;
     Ok(())
@@ -304,7 +304,7 @@ fn create_tables(conn: &Connection, cli_version: &str) -> Result<(), AnyError> {
       |row| row.get(0),
     )
     .ok();
-  if data_cli_version != Some(cli_version.to_string()) {
+  if data_cli_version.as_deref() != Some(cli_version) {
     conn.execute("DELETE FROM cjsanalysiscache", params![])?;
     conn.execute("DELETE FROM esmglobalscache", params![])?;
     let mut stmt = conn

--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -219,7 +219,7 @@ impl ParsedSourceCacheModuleAnalyzer {
     stmt.execute(params![
       specifier.as_str(),
       &media_type.to_string(),
-      &source_hash.to_string(),
+      &source_hash,
       &serde_json::to_string(&module_info)?,
     ])?;
     Ok(())
@@ -298,7 +298,7 @@ fn create_tables(
       |row| row.get(0),
     )
     .ok();
-  if data_cli_version != Some(cli_version.to_string()) {
+  if data_cli_version.as_deref() != Some(&cli_version) {
     conn.execute("DELETE FROM moduleinfocache", params![])?;
     let mut stmt = conn
       .prepare("INSERT OR REPLACE INTO info (key, value) VALUES (?1, ?2)")?;


### PR DESCRIPTION
This PR reduces some allocations (I think) by not calling `to_string`.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
