### PR TITLE
refactor(core): derive equality traits for `ResolutionKind` enum

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -204,6 +204,7 @@ pub type ModuleSourceFuture = dyn Future<Output = Result<ModuleSource, Error>>;
 type ModuleLoadFuture =
   dyn Future<Output = Result<(ModuleRequest, ModuleSource), Error>>;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum ResolutionKind {
   /// This kind is used in only one situation: when a module is loaded via
   /// `JsRuntime::load_main_module` and is the top-level module, ie. the one


### PR DESCRIPTION
The commit derives Eq, PartialEq, and Debug traits for the `ResolutionKind` enum
to make it possible for external implementors to assert ResolutionKind.