### PR TITLE
chore(core): remove have_unpolled_ops on rt state

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2629,7 +2629,10 @@ pub fn queue_fast_async_op(
     None => unreachable!(),
   };
 
-  runtime_state.borrow_mut().pending_ops.push(OpCall::lazy(op));
+  runtime_state
+    .borrow_mut()
+    .pending_ops
+    .push(OpCall::lazy(op));
 }
 
 #[inline]

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2629,8 +2629,7 @@ pub fn queue_fast_async_op(
     None => unreachable!(),
   };
 
-  let mut state = runtime_state.borrow_mut();
-  state.pending_ops.push(OpCall::lazy(op));
+  runtime_state.borrow_mut().pending_ops.push(OpCall::lazy(op));
 }
 
 #[inline]
@@ -2684,12 +2683,10 @@ pub fn queue_async_op(
     }
     EagerPollResult::Ready(op) => {
       let ready = OpCall::ready(op);
-      let mut state = runtime_state.borrow_mut();
-      state.pending_ops.push(ready);
+      runtime_state.borrow_mut().pending_ops.push(ready);
     }
     EagerPollResult::Pending(op) => {
-      let mut state = runtime_state.borrow_mut();
-      state.pending_ops.push(op);
+      runtime_state.borrow_mut().pending_ops.push(op);
     }
   }
 }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -179,7 +179,6 @@ pub struct JsRuntimeState {
   pub(crate) source_map_getter: Option<Box<dyn SourceMapGetter>>,
   pub(crate) source_map_cache: SourceMapCache,
   pub(crate) pending_ops: FuturesUnordered<PendingOpFuture>,
-  pub(crate) have_unpolled_ops: bool,
   pub(crate) op_state: Rc<RefCell<OpState>>,
   pub(crate) shared_array_buffer_store: Option<SharedArrayBufferStore>,
   pub(crate) compiled_wasm_module_store: Option<CompiledWasmModuleStore>,
@@ -398,7 +397,6 @@ impl JsRuntime {
       compiled_wasm_module_store: options.compiled_wasm_module_store,
       op_state: op_state.clone(),
       waker: AtomicWaker::new(),
-      have_unpolled_ops: false,
       dispatched_exceptions: Default::default(),
       // Some fields are initialized later after isolate is created
       inspector: None,
@@ -1320,7 +1318,7 @@ impl JsRuntime {
     // TODO(andreubotella) The event loop will spin as long as there are pending
     // background tasks. We should look into having V8 notify us when a
     // background task is done.
-    if state.have_unpolled_ops
+    if !state.pending_ops.is_empty()
       || pending_state.has_pending_background_tasks
       || pending_state.has_tick_scheduled
       || maybe_scheduling
@@ -2259,7 +2257,6 @@ impl JsRuntime {
     // Now handle actual ops.
     {
       let mut state = self.state.borrow_mut();
-      state.have_unpolled_ops = false;
 
       while let Poll::Ready(Some(item)) = state.pending_ops.poll_next_unpin(cx)
       {
@@ -2355,7 +2352,6 @@ impl JsRuntime {
     // Now handle actual ops.
     {
       let mut state = self.state.borrow_mut();
-      state.have_unpolled_ops = false;
 
       let realm_state_rc = state.global_realm.as_ref().unwrap().state(scope);
       let mut realm_state = realm_state_rc.borrow_mut();
@@ -2635,7 +2631,6 @@ pub fn queue_fast_async_op(
 
   let mut state = runtime_state.borrow_mut();
   state.pending_ops.push(OpCall::lazy(op));
-  state.have_unpolled_ops = true;
 }
 
 #[inline]
@@ -2691,12 +2686,10 @@ pub fn queue_async_op(
       let ready = OpCall::ready(op);
       let mut state = runtime_state.borrow_mut();
       state.pending_ops.push(ready);
-      state.have_unpolled_ops = true;
     }
     EagerPollResult::Pending(op) => {
       let mut state = runtime_state.borrow_mut();
       state.pending_ops.push(op);
-      state.have_unpolled_ops = true;
     }
   }
 }


### PR DESCRIPTION
It's not needed - `!state.have_unpolled_ops.is_empty()` does the same thing.