### PR TITLE
Changing serde & serde_json dependencies to use semver minimums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,9 +105,9 @@ rusqlite = { version = "=0.28.0", features = ["unlock_notify", "bundled"] }
 rustls = "0.20.5"
 rustls-pemfile = "1.0.0"
 semver = "=1.0.14"
-serde = { version = "=1.0.149", features = ["derive"] }
+serde = { version = "1.0.149", features = ["derive"] }
 serde_bytes = "0.11"
-serde_json = "=1.0.85"
+serde_json = "1.0.85"
 serde_repr = "=0.1.9"
 sha2 = { version = "0.10.6", features = ["oid"] }
 smallvec = "1.8"


### PR DESCRIPTION
 Changing serde & serde_json dependencies to use semver minimums rather than exact crate version.

Fixes https://github.com/denoland/deno/issues/17609