### PR TITLE
fix(napi): remove wrong length check in napi_create_function

### DIFF
--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -607,10 +607,6 @@ fn napi_create_function(
   check_arg!(env, result);
   check_arg_option!(env, cb);
 
-  if length > INT_MAX as _ {
-    return Err(Error::InvalidArg);
-  }
-
   let name = name
     .as_ref()
     .map(|_| check_new_from_utf8_len(env, name, length))


### PR DESCRIPTION
This check is not needed. 

This PR + #17613 makes `npm:ref-napi` work with Deno.