### PR TITLE
fix(lockfile): emit trailing newline

### DIFF
--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -1306,7 +1306,8 @@ fn lock_file_lock_write() {
       }
     }
   }
-}"#;
+}
+"#;
   temp_dir.write("deno.lock", lock_file_content);
 
   let deno = util::deno_cmd_with_deno_dir(&deno_dir)

--- a/lockfile/lib.rs
+++ b/lockfile/lib.rs
@@ -187,7 +187,8 @@ impl Lockfile {
       return Ok(());
     }
 
-    let json_string = serde_json::to_string_pretty(&self.content).unwrap();
+    let mut json_string = serde_json::to_string_pretty(&self.content).unwrap();
+    json_string.push('\n'); // trailing newline in file
     let mut f = std::fs::OpenOptions::new()
       .write(true)
       .create(true)


### PR DESCRIPTION
The recent lockfile refactor seems to have caused the lockfile to not emit a trailing newline. It's not so nice because it causes this symbol to appear in github diffs

![image](https://user-images.githubusercontent.com/1609021/216154187-6d92889b-b9d2-4d9d-bf52-3b5bcd683bdd.png)
