### PR TITLE
Revert "chore(core): remove have_unpolled_ops on rt state (#17601)"

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -179,6 +179,7 @@ pub struct JsRuntimeState {
   pub(crate) source_map_getter: Option<Box<dyn SourceMapGetter>>,
   pub(crate) source_map_cache: SourceMapCache,
   pub(crate) pending_ops: FuturesUnordered<PendingOpFuture>,
+  pub(crate) have_unpolled_ops: bool,
   pub(crate) op_state: Rc<RefCell<OpState>>,
   pub(crate) shared_array_buffer_store: Option<SharedArrayBufferStore>,
   pub(crate) compiled_wasm_module_store: Option<CompiledWasmModuleStore>,
@@ -397,6 +398,7 @@ impl JsRuntime {
       compiled_wasm_module_store: options.compiled_wasm_module_store,
       op_state: op_state.clone(),
       waker: AtomicWaker::new(),
+      have_unpolled_ops: false,
       dispatched_exceptions: Default::default(),
       // Some fields are initialized later after isolate is created
       inspector: None,
@@ -1318,7 +1320,7 @@ impl JsRuntime {
     // TODO(andreubotella) The event loop will spin as long as there are pending
     // background tasks. We should look into having V8 notify us when a
     // background task is done.
-    if !state.pending_ops.is_empty()
+    if state.have_unpolled_ops
       || pending_state.has_pending_background_tasks
       || pending_state.has_tick_scheduled
       || maybe_scheduling
@@ -2257,6 +2259,7 @@ impl JsRuntime {
     // Now handle actual ops.
     {
       let mut state = self.state.borrow_mut();
+      state.have_unpolled_ops = false;
 
       while let Poll::Ready(Some(item)) = state.pending_ops.poll_next_unpin(cx)
       {
@@ -2352,6 +2355,7 @@ impl JsRuntime {
     // Now handle actual ops.
     {
       let mut state = self.state.borrow_mut();
+      state.have_unpolled_ops = false;
 
       let realm_state_rc = state.global_realm.as_ref().unwrap().state(scope);
       let mut realm_state = realm_state_rc.borrow_mut();
@@ -2629,10 +2633,9 @@ pub fn queue_fast_async_op(
     None => unreachable!(),
   };
 
-  runtime_state
-    .borrow_mut()
-    .pending_ops
-    .push(OpCall::lazy(op));
+  let mut state = runtime_state.borrow_mut();
+  state.pending_ops.push(OpCall::lazy(op));
+  state.have_unpolled_ops = true;
 }
 
 #[inline]
@@ -2686,10 +2689,14 @@ pub fn queue_async_op(
     }
     EagerPollResult::Ready(op) => {
       let ready = OpCall::ready(op);
-      runtime_state.borrow_mut().pending_ops.push(ready);
+      let mut state = runtime_state.borrow_mut();
+      state.pending_ops.push(ready);
+      state.have_unpolled_ops = true;
     }
     EagerPollResult::Pending(op) => {
-      runtime_state.borrow_mut().pending_ops.push(op);
+      let mut state = runtime_state.borrow_mut();
+      state.pending_ops.push(op);
+      state.have_unpolled_ops = true;
     }
   }
 }


### PR DESCRIPTION
This reverts commit e85ca8be0dafdab28e6283aed64c8ee0eb3a338d.

This commit caused a huge spike in various benchmarks we track at https://deno.land/benchmarks

Closes https://github.com/denoland/deno/issues/17629

CC @lucacasonato 