### PR TITLE
chore: add release checklist step to check the benchmarks page

### DIFF
--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -13,6 +13,8 @@
 release from) should be frozen and no commits should land until the release is
 cut.**
 
+- [ ] Check https://deno.land/benchmarks?-100 and ensure there's no recent
+      regressions.
 - [ ] Write a message in company's #cli channel:
       `:lock: deno and deno_std are now locked (<LINK TO THIS FORKED GIST GOES HERE>)`
 


### PR DESCRIPTION
The 1.30.1 release had a performance regression that would have been caught by looking at the benchmarks page. This adds a pre-flight step to the release checklist for the person doing the release to go to this page and look at the output.

This would have prevented #17629