### PR TITLE
refactor: remove old cjs_esm_translations in graph_util

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -66,7 +66,6 @@ pub struct GraphData {
   /// error messages.
   referrer_map: HashMap<ModuleSpecifier, Box<Range>>,
   graph_imports: Vec<GraphImport>,
-  cjs_esm_translations: HashMap<ModuleSpecifier, String>,
 }
 
 impl GraphData {
@@ -311,7 +310,6 @@ impl GraphData {
       npm_packages: self.npm_packages.clone(),
       referrer_map,
       graph_imports: self.graph_imports.to_vec(),
-      cjs_esm_translations: Default::default(),
     })
   }
 
@@ -464,13 +462,6 @@ impl GraphData {
       return Some(&graph_import.dependencies);
     }
     None
-  }
-
-  pub fn get_cjs_esm_translation<'a>(
-    &'a self,
-    specifier: &ModuleSpecifier,
-  ) -> Option<&'a String> {
-    self.cjs_esm_translations.get(specifier)
   }
 }
 

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -96,14 +96,7 @@ impl CliModuleLoader {
           | MediaType::Unknown
           | MediaType::Cjs
           | MediaType::Mjs
-          | MediaType::Json => {
-            if let Some(source) = graph_data.get_cjs_esm_translation(specifier)
-            {
-              source.to_owned()
-            } else {
-              code.to_string()
-            }
-          }
+          | MediaType::Json => code.to_string(),
           MediaType::Dts | MediaType::Dcts | MediaType::Dmts => "".to_string(),
           MediaType::TypeScript
           | MediaType::Mts


### PR DESCRIPTION
This isn't used.