### PR TITLE
Improve error message in module loader example

### DIFF
--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -47,7 +47,7 @@ impl ModuleLoader for TypescriptModuleLoader {
     async move {
       let path = module_specifier
         .to_file_path()
-        .map_err(|_| anyhow!("Only file: URLs are supported."))?;
+        .map_err(|_| anyhow!("Only file:// URLs are supported."))?;
 
       let media_type = MediaType::from(&path);
       let (module_type, should_transpile) = match MediaType::from(&path) {


### PR DESCRIPTION
Just a small tweak to the error message to avoid confusion, as recently came up in Discord:

![Screenshot from 2023-02-05_05-41-22](https://user-images.githubusercontent.com/478237/216803893-17e2abc0-df79-4218-ac37-a5622cf43b2c.png)

/cc @andreubotella