### PR TITLE
 refactor: rename `deno` specifiers to `internal`

### DIFF
--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -925,7 +925,7 @@ pub fn get_ts_config_for_emit(
       "sourceMap": false,
       "strict": true,
       "target": "esnext",
-      "tsBuildInfoFile": "deno:///.tsbuildinfo",
+      "tsBuildInfoFile": "internal:///.tsbuildinfo",
       "useDefineForClassFields": true,
       // TODO(@kitsonk) remove for Deno 2.0
       "useUnknownInCatchVariables": false,

--- a/cli/args/flags_allow_net.rs
+++ b/cli/args/flags_allow_net.rs
@@ -27,7 +27,7 @@ impl FromStr for BarePort {
 }
 
 pub fn validator(host_and_port: &str) -> Result<(), String> {
-  if Url::parse(&format!("deno://{host_and_port}")).is_ok()
+  if Url::parse(&format!("internal://{host_and_port}")).is_ok()
     || host_and_port.parse::<IpAddr>().is_ok()
     || host_and_port.parse::<BarePort>().is_ok()
   {
@@ -43,7 +43,7 @@ pub fn validator(host_and_port: &str) -> Result<(), String> {
 pub fn parse(paths: Vec<String>) -> clap::Result<Vec<String>> {
   let mut out: Vec<String> = vec![];
   for host_and_port in paths.iter() {
-    if Url::parse(&format!("deno://{host_and_port}")).is_ok()
+    if Url::parse(&format!("internal://{host_and_port}")).is_ok()
       || host_and_port.parse::<IpAddr>().is_ok()
     {
       out.push(host_and_port.to_owned())

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1050,7 +1050,7 @@ impl Inner {
 
   async fn did_close(&mut self, params: DidCloseTextDocumentParams) {
     let mark = self.performance.mark("did_close", Some(&params));
-    if params.text_document.uri.scheme() == "deno" {
+    if params.text_document.uri.scheme() == "internal" {
       // we can ignore virtual text documents closing, as they don't need to
       // be tracked in memory, as they are static assets that won't change
       // already managed by the language service
@@ -2609,7 +2609,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
   }
 
   async fn did_open(&self, params: DidOpenTextDocumentParams) {
-    if params.text_document.uri.scheme() == "deno" {
+    if params.text_document.uri.scheme() == "internal" {
       // we can ignore virtual text documents opening, as they don't need to
       // be tracked in memory, as they are static assets that won't change
       // already managed by the language service
@@ -3121,7 +3121,7 @@ impl Inner {
       .performance
       .mark("virtual_text_document", Some(&params));
     let specifier = self.url_map.normalize_url(&params.text_document.uri);
-    let contents = if specifier.as_str() == "deno:/status.md" {
+    let contents = if specifier.as_str() == "internal:/status.md" {
       let mut contents = String::new();
       let mut documents_specifiers = self
         .documents

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1154,11 +1154,15 @@ impl ImplementationLocation {
     language_server: &language_server::Inner,
   ) -> lsp::Location {
     let specifier = normalize_specifier(&self.document_span.file_name)
-      .unwrap_or_else(|_| ModuleSpecifier::parse("internal://invalid").unwrap());
+      .unwrap_or_else(|_| {
+        ModuleSpecifier::parse("internal://invalid").unwrap()
+      });
     let uri = language_server
       .url_map
       .normalize_specifier(&specifier)
-      .unwrap_or_else(|_| ModuleSpecifier::parse("internal://invalid").unwrap());
+      .unwrap_or_else(|_| {
+        ModuleSpecifier::parse("internal://invalid").unwrap()
+      });
     lsp::Location {
       uri,
       range: self.document_span.text_span.to_range(line_index),

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1154,11 +1154,11 @@ impl ImplementationLocation {
     language_server: &language_server::Inner,
   ) -> lsp::Location {
     let specifier = normalize_specifier(&self.document_span.file_name)
-      .unwrap_or_else(|_| ModuleSpecifier::parse("deno://invalid").unwrap());
+      .unwrap_or_else(|_| ModuleSpecifier::parse("internal://invalid").unwrap());
     let uri = language_server
       .url_map
       .normalize_specifier(&specifier)
-      .unwrap_or_else(|_| ModuleSpecifier::parse("deno://invalid").unwrap());
+      .unwrap_or_else(|_| ModuleSpecifier::parse("internal://invalid").unwrap());
     lsp::Location {
       uri,
       range: self.document_span.text_span.to_range(line_index),

--- a/cli/node/mod.rs
+++ b/cli/node/mod.rs
@@ -101,7 +101,7 @@ impl NodeResolution {
       }
       Some(resolution) => (resolution.into_url(), MediaType::Dts),
       None => (
-        ModuleSpecifier::parse("deno:///missing_dependency.d.ts").unwrap(),
+        ModuleSpecifier::parse("internal:///missing_dependency.d.ts").unwrap(),
         MediaType::Dts,
       ),
     }

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -1073,7 +1073,7 @@ fn lsp_hover_asset() {
       "deno/virtualTextDocument",
       json!({
         "textDocument": {
-          "uri": "deno:/asset/lib.deno.shared_globals.d.ts"
+          "uri": "internal:/asset/lib.deno.shared_globals.d.ts"
         }
       }),
     )
@@ -1084,7 +1084,7 @@ fn lsp_hover_asset() {
       "textDocument/hover",
       json!({
         "textDocument": {
-          "uri": "deno:/asset/lib.es2015.symbol.wellknown.d.ts"
+          "uri": "internal:/asset/lib.es2015.symbol.wellknown.d.ts"
         },
         "position": {
           "line": 109,
@@ -3103,7 +3103,7 @@ fn lsp_code_lens_non_doc_nav_tree() {
       "deno/virtualTextDocument",
       json!({
         "textDocument": {
-          "uri": "deno:/asset/lib.deno.shared_globals.d.ts"
+          "uri": "internal:/asset/lib.deno.shared_globals.d.ts"
         }
       }),
     )
@@ -3115,7 +3115,7 @@ fn lsp_code_lens_non_doc_nav_tree() {
       "textDocument/codeLens",
       json!({
         "textDocument": {
-          "uri": "deno:/asset/lib.deno.shared_globals.d.ts"
+          "uri": "internal:/asset/lib.deno.shared_globals.d.ts"
         }
       }),
     )

--- a/cli/tests/testdata/run/error_009_extensions_error.js.out
+++ b/cli/tests/testdata/run/error_009_extensions_error.js.out
@@ -2,5 +2,5 @@
 new Event();
 ^
     at [WILDCARD]
-    at new Event (deno:ext/web/[WILDCARD])
+    at new Event (internal:ext/web/[WILDCARD])
     at [WILDCARD]

--- a/cli/tests/testdata/run/fetch_async_error_stack.ts.out
+++ b/cli/tests/testdata/run/fetch_async_error_stack.ts.out
@@ -1,5 +1,5 @@
 error: Uncaught (in promise) TypeError: error sending request for url[WILDCARD]
 await fetch("https://nonexistent.deno.land/");
 ^[WILDCARD]
-    at async fetch (deno:[WILDCARD])
+    at async fetch (internal:[WILDCARD])
     at async file:///[WILDCARD]/fetch_async_error_stack.ts:1:1

--- a/cli/tests/testdata/run/queue_microtask_error.ts.out
+++ b/cli/tests/testdata/run/queue_microtask_error.ts.out
@@ -3,4 +3,4 @@ error: Uncaught Error: foo
   throw new Error("foo");
         ^
     at [WILDCARD]/queue_microtask_error.ts:2:9
-    at deno:core/[WILDCARD]
+    at internal:core/[WILDCARD]

--- a/cli/tests/testdata/run/queue_microtask_error_handled.ts.out
+++ b/cli/tests/testdata/run/queue_microtask_error_handled.ts.out
@@ -7,9 +7,9 @@
   colno: 9,
   error: Error: foo
     at [WILDCARD]/queue_microtask_error_handled.ts:18:9
-    at deno:core/[WILDCARD]
+    at internal:core/[WILDCARD]
 }
 onerror() called Error: foo
     at [WILDCARD]/queue_microtask_error_handled.ts:18:9
-    at deno:core/[WILDCARD]
+    at internal:core/[WILDCARD]
 2

--- a/cli/tests/testdata/run/wasm_streaming_panic_test.js.out
+++ b/cli/tests/testdata/run/wasm_streaming_panic_test.js.out
@@ -1,2 +1,2 @@
 error: Uncaught (in promise) TypeError: Invalid WebAssembly content type.
-    at handleWasmStreaming (deno:ext/fetch/26_fetch.js:[WILDCARD])
+    at handleWasmStreaming (internal:ext/fetch/26_fetch.js:[WILDCARD])

--- a/cli/tests/testdata/run/worker_drop_handle_race.js.out
+++ b/cli/tests/testdata/run/worker_drop_handle_race.js.out
@@ -2,7 +2,7 @@ error: Uncaught (in worker "") Error
   throw new Error();
         ^
     at [WILDCARD]/workers/drop_handle_race.js:2:9
-    at Object.action (deno:ext/web/02_timers.js:[WILDCARD])
-    at handleTimerMacrotask (deno:ext/web/02_timers.js:[WILDCARD])
+    at Object.action (internal:ext/web/02_timers.js:[WILDCARD])
+    at handleTimerMacrotask (internal:ext/web/02_timers.js:[WILDCARD])
 error: Uncaught (in promise) Error: Unhandled error in child worker.
-    at Worker.#pollControl (deno:runtime/js/11_workers.js:[WILDCARD])
+    at Worker.#pollControl (internal:runtime/js/11_workers.js:[WILDCARD])

--- a/cli/tests/testdata/test/steps/failing_steps.out
+++ b/cli/tests/testdata/test/steps/failing_steps.out
@@ -37,13 +37,13 @@ failing step in failing test ... FAILED ([WILDCARD])
 
 nested failure => ./test/steps/failing_steps.ts:[WILDCARD]
 error: Error: 1 test step failed.
-    at runTest (deno:cli/js/40_testing.js:[WILDCARD])
-    at async runTests (deno:cli/js/40_testing.js:[WILDCARD])
+    at runTest (internal:cli/js/40_testing.js:[WILDCARD])
+    at async runTests (internal:cli/js/40_testing.js:[WILDCARD])
 
 multiple test step failures => ./test/steps/failing_steps.ts:[WILDCARD]
 error: Error: 2 test steps failed.
-    at runTest (deno:cli/js/40_testing.js:[WILDCARD])
-    at async runTests (deno:cli/js/40_testing.js:[WILDCARD])
+    at runTest (internal:cli/js/40_testing.js:[WILDCARD])
+    at async runTests (internal:cli/js/40_testing.js:[WILDCARD])
 
 failing step in failing test => ./test/steps/failing_steps.ts:[WILDCARD]
 error: Error: Fail test.

--- a/cli/tests/unit/opcall_test.ts
+++ b/cli/tests/unit/opcall_test.ts
@@ -16,8 +16,8 @@ Deno.test(async function sendAsyncStackTrace() {
     assertStringIncludes(s, "opcall_test.ts");
     assertStringIncludes(s, "read");
     assert(
-      !s.includes("deno:core"),
-      "opcall stack traces should NOT include deno:core internals such as unwrapOpResult",
+      !s.includes("internal:core"),
+      "opcall stack traces should NOT include internal:core internals such as unwrapOpResult",
     );
   }
 });

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -594,7 +594,7 @@ fn filter_coverages(
   coverages
     .into_iter()
     .filter(|e| {
-      let is_internal = e.url.starts_with("deno:")
+      let is_internal = e.url.starts_with("internal:")
         || e.url.ends_with("__anonymous__")
         || e.url.ends_with("$deno$test.js")
         || e.url.ends_with(".snap");

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -26,7 +26,7 @@ pub async fn print_docs(
   let mut doc_nodes = match doc_flags.source_file {
     DocSourceFileFlag::Builtin => {
       let source_file_specifier =
-        ModuleSpecifier::parse("deno://lib.deno.d.ts").unwrap();
+        ModuleSpecifier::parse("internal://lib.deno.d.ts").unwrap();
       let content = get_types_declaration_file_text(ps.options.unstable());
       let mut loader = deno_graph::source::MemoryLoader::new(
         vec![(

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -655,7 +655,8 @@ fn abbreviate_test_error(js_error: &JsError) -> JsError {
   // check if there are any stack frames coming from user code
   let should_filter = frames.iter().any(|f| {
     if let Some(file_name) = &f.file_name {
-      !(file_name.starts_with("[internal:") || file_name.starts_with("internal:"))
+      !(file_name.starts_with("[internal:")
+        || file_name.starts_with("internal:"))
     } else {
       true
     }
@@ -667,7 +668,8 @@ fn abbreviate_test_error(js_error: &JsError) -> JsError {
       .rev()
       .skip_while(|f| {
         if let Some(file_name) = &f.file_name {
-          file_name.starts_with("[internal:") || file_name.starts_with("internal:")
+          file_name.starts_with("[internal:")
+            || file_name.starts_with("internal:")
         } else {
           false
         }

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -655,7 +655,7 @@ fn abbreviate_test_error(js_error: &JsError) -> JsError {
   // check if there are any stack frames coming from user code
   let should_filter = frames.iter().any(|f| {
     if let Some(file_name) = &f.file_name {
-      !(file_name.starts_with("[deno:") || file_name.starts_with("deno:"))
+      !(file_name.starts_with("[internal:") || file_name.starts_with("internal:"))
     } else {
       true
     }
@@ -667,7 +667,7 @@ fn abbreviate_test_error(js_error: &JsError) -> JsError {
       .rev()
       .skip_while(|f| {
         if let Some(file_name) = &f.file_name {
-          file_name.starts_with("[deno:") || file_name.starts_with("deno:")
+          file_name.starts_with("[internal:") || file_name.starts_with("internal:")
         } else {
           false
         }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1146,9 +1146,11 @@ mod tests {
       Some("some content".to_string()),
     )
     .await;
-    let actual =
-      op_load::call(&mut state, json!({ "specifier": "internal:///.tsbuildinfo"}))
-        .expect("should have invoked op");
+    let actual = op_load::call(
+      &mut state,
+      json!({ "specifier": "internal:///.tsbuildinfo"}),
+    )
+    .expect("should have invoked op");
     assert_eq!(
       actual,
       json!({

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -446,7 +446,7 @@ struct EmitArgs {
 fn op_emit(state: &mut OpState, args: EmitArgs) -> bool {
   let state = state.borrow_mut::<State>();
   match args.file_name.as_ref() {
-    "deno:///.tsbuildinfo" => state.maybe_tsbuildinfo = Some(args.data),
+    "internal:///.tsbuildinfo" => state.maybe_tsbuildinfo = Some(args.data),
     _ => {
       if cfg!(debug_assertions) {
         panic!("Unhandled emit write: {}", args.file_name);
@@ -518,11 +518,11 @@ fn op_load(state: &mut OpState, args: Value) -> Result<Value, AnyError> {
   let mut hash: Option<String> = None;
   let mut media_type = MediaType::Unknown;
   let graph_data = state.graph_data.read();
-  let data = if &v.specifier == "deno:///.tsbuildinfo" {
+  let data = if &v.specifier == "internal:///.tsbuildinfo" {
     state.maybe_tsbuildinfo.as_deref().map(Cow::Borrowed)
   // in certain situations we return a "blank" module to tsc and we need to
   // handle the request for that module here.
-  } else if &v.specifier == "deno:///missing_dependency.d.ts" {
+  } else if &v.specifier == "internal:///missing_dependency.d.ts" {
     hash = Some("1".to_string());
     media_type = MediaType::Dts;
     Some(Cow::Borrowed("declare const __: any;\nexport = __;\n"))
@@ -726,7 +726,7 @@ fn op_resolve(
         (specifier_str, media_type.as_ts_extension().into())
       }
       None => (
-        "deno:///missing_dependency.d.ts".to_string(),
+        "internal:///missing_dependency.d.ts".to_string(),
         ".d.ts".to_string(),
       ),
     };
@@ -983,10 +983,10 @@ mod tests {
       "lib": ["deno.window"],
       "module": "esnext",
       "noEmit": true,
-      "outDir": "deno:///",
+      "outDir": "internal:///",
       "strict": true,
       "target": "esnext",
-      "tsBuildInfoFile": "deno:///.tsbuildinfo",
+      "tsBuildInfoFile": "internal:///.tsbuildinfo",
     }));
     let request = Request {
       config,
@@ -1075,7 +1075,7 @@ mod tests {
       &mut state,
       EmitArgs {
         data: "some file content".to_string(),
-        file_name: "deno:///.tsbuildinfo".to_string(),
+        file_name: "internal:///.tsbuildinfo".to_string(),
       },
     );
     assert!(actual);
@@ -1147,7 +1147,7 @@ mod tests {
     )
     .await;
     let actual =
-      op_load::call(&mut state, json!({ "specifier": "deno:///.tsbuildinfo"}))
+      op_load::call(&mut state, json!({ "specifier": "internal:///.tsbuildinfo"}))
         .expect("should have invoked op");
     assert_eq!(
       actual,
@@ -1217,7 +1217,7 @@ mod tests {
     .expect("should have not errored");
     assert_eq!(
       actual,
-      vec![("deno:///missing_dependency.d.ts".into(), ".d.ts".into())]
+      vec![("internal:///missing_dependency.d.ts".into(), ".d.ts".into())]
     );
   }
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -272,7 +272,7 @@ impl JsError {
           if let (Some(file_name), Some(line_number)) =
             (&frame.file_name, frame.line_number)
           {
-            if !file_name.trim_start_matches('[').starts_with("deno:") {
+            if !file_name.trim_start_matches('[').starts_with("internal:") {
               source_line = get_source_line(
                 file_name,
                 line_number,
@@ -424,7 +424,7 @@ impl JsError {
             if let (Some(file_name), Some(line_number)) =
               (&frame.file_name, frame.line_number)
             {
-              if !file_name.trim_start_matches('[').starts_with("deno:") {
+              if !file_name.trim_start_matches('[').starts_with("internal:") {
                 source_line = get_source_line(
                   file_name,
                   line_number,
@@ -438,7 +438,7 @@ impl JsError {
           }
         } else if let Some(frame) = frames.first() {
           if let Some(file_name) = &frame.file_name {
-            if !file_name.trim_start_matches('[').starts_with("deno:") {
+            if !file_name.trim_start_matches('[').starts_with("internal:") {
               source_line = msg
                 .get_source_line(scope)
                 .map(|v| v.to_rust_string_lossy(scope));

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -216,7 +216,7 @@ impl ExtensionBuilder {
 /// Example:
 /// ```ignore
 /// include_js_files!(
-///   prefix "deno:extensions/hello",
+///   prefix "internal:extensions/hello",
 ///   "01_hello.js",
 ///   "02_goodbye.js",
 /// )

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -134,12 +134,12 @@ pub mod _ops {
 /// A helper macro that will return a call site in Rust code. Should be
 /// used when executing internal one-line scripts for JsRuntime lifecycle.
 ///
-/// Returns a string in form of: "`[deno:<filename>:<line>:<column>]`"
+/// Returns a string in form of: "`[internal:<filename>:<line>:<column>]`"
 #[macro_export]
 macro_rules! located_script_name {
   () => {
     format!(
-      "[deno:{}:{}:{}]",
+      "[internal:{}:{}:{}]",
       std::file!(),
       std::line!(),
       std::column!()

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 pub(crate) fn init_builtins() -> Extension {
   Extension::builder("deno_builtins")
     .js(include_js_files!(
-      prefix "deno:core",
+      prefix "internal:core",
       "00_primordials.js",
       "01_core.js",
       "02_error.js",

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -3887,8 +3887,8 @@ assertEquals(1, notify_return_value);
       )
       .unwrap_err();
     let error_string = error.to_string();
-    // Test that the script specifier is a URL: `deno:<repo-relative path>`.
-    assert!(error_string.contains("deno:core/01_core.js"));
+    // Test that the script specifier is a URL: `internal:<repo-relative path>`.
+    assert!(error_string.contains("internal:core/01_core.js"));
   }
 
   #[test]

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -39,7 +39,7 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
     let display_path_str = display_path.display().to_string();
     js_runtime
       .execute_script(
-        &("deno:".to_string() + &display_path_str.replace('\\', "/")),
+        &("internal:".to_string() + &display_path_str.replace('\\', "/")),
         &std::fs::read_to_string(&file).unwrap(),
       )
       .unwrap();

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -113,7 +113,7 @@ pub fn init<BC: BroadcastChannel + 'static>(
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl", "deno_web"])
     .js(include_js_files!(
-      prefix "deno:ext/broadcast_channel",
+      prefix "internal:ext/broadcast_channel",
       "01_broadcast_channel.js",
     ))
     .ops(vec![

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -28,7 +28,7 @@ pub fn init<CA: Cache + 'static>(
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl", "deno_web", "deno_url", "deno_fetch"])
     .js(include_js_files!(
-      prefix "deno:ext/cache",
+      prefix "internal:ext/cache",
       "01_cache.js",
     ))
     .ops(vec![

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 pub fn init() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
-      prefix "deno:ext/console",
+      prefix "internal:ext/console",
       "01_colors.js",
       "02_console.js",
     ))

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -76,7 +76,7 @@ pub fn init(maybe_seed: Option<u64>) -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl", "deno_web"])
     .js(include_js_files!(
-      prefix "deno:ext/crypto",
+      prefix "internal:ext/crypto",
       "00_crypto.js",
       "01_webidl.js",
     ))

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -98,7 +98,7 @@ where
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl", "deno_web", "deno_url", "deno_console"])
     .js(include_js_files!(
-      prefix "deno:ext/fetch",
+      prefix "internal:ext/fetch",
       "01_fetch_util.js",
       "20_headers.js",
       "21_formdata.js",

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -85,7 +85,7 @@ pub(crate) struct FfiState {
 pub fn init<P: FfiPermissions + 'static>(unstable: bool) -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
-      prefix "deno:ext/ffi",
+      prefix "internal:ext/ffi",
       "00_ffi.js",
     ))
     .ops(vec![

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1515,7 +1515,7 @@ pub fn init<P: FlashPermissions + 'static>(unstable: bool) -> Extension {
       "deno_http",
     ])
     .js(deno_core::include_js_files!(
-      prefix "deno:ext/flash",
+      prefix "internal:ext/flash",
       "01_http.js",
     ))
     .ops(vec![

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -81,7 +81,7 @@ pub fn init() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_web", "deno_net", "deno_fetch", "deno_websocket"])
     .js(include_js_files!(
-      prefix "deno:ext/http",
+      prefix "internal:ext/http",
       "01_http.js",
     ))
     .ops(vec![

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -87,7 +87,7 @@ pub fn init<P: NetPermissions + 'static>(
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_web"])
     .js(include_js_files!(
-      prefix "deno:ext/net",
+      prefix "internal:ext/net",
       "01_net.js",
       "02_tls.js",
     ))

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -86,7 +86,7 @@ pub fn init<P: NodePermissions + 'static>(
 ) -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
-      prefix "deno:ext/node",
+      prefix "internal:ext/node",
       "01_node.js",
       "02_require.js",
     ))

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -21,7 +21,7 @@ pub fn init() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl"])
     .js(include_js_files!(
-      prefix "deno:ext/url",
+      prefix "internal:ext/url",
       "00_url.js",
       "01_urlpattern.js",
     ))

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -1462,7 +1462,7 @@
         const frame = frames[i];
         if (
           typeof frame.fileName == "string" &&
-          !StringPrototypeStartsWith(frame.fileName, "deno:")
+          !StringPrototypeStartsWith(frame.fileName, "internal:")
         ) {
           filename = frame.fileName;
           lineno = frame.lineNumber;

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -65,7 +65,7 @@ pub fn init<P: TimersPermission + 'static>(
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl", "deno_console", "deno_url"])
     .js(include_js_files!(
-      prefix "deno:ext/web",
+      prefix "internal:ext/web",
       "00_infra.js",
       "01_dom_exception.js",
       "01_mimesniff.js",

--- a/ext/webgpu/src/lib.rs
+++ b/ext/webgpu/src/lib.rs
@@ -120,7 +120,7 @@ pub fn init(unstable: bool) -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl", "deno_web"])
     .js(include_js_files!(
-      prefix "deno:ext/webgpu",
+      prefix "internal:ext/webgpu",
       "01_webgpu.js",
       "02_idl_types.js",
     ))

--- a/ext/webgpu/src/surface.rs
+++ b/ext/webgpu/src/surface.rs
@@ -16,7 +16,7 @@ pub fn init_surface(unstable: bool) -> Extension {
   Extension::builder("deno_webgpu_surface")
     .dependencies(vec!["deno_webidl", "deno_web", "deno_webgpu"])
     .js(include_js_files!(
-      prefix "deno:deno_webgpu",
+      prefix "internal:deno_webgpu",
       "03_surface.js",
       "04_surface_idl_types.js",
     ))

--- a/ext/webidl/lib.rs
+++ b/ext/webidl/lib.rs
@@ -7,7 +7,7 @@ use deno_core::Extension;
 pub fn init() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .js(include_js_files!(
-      prefix "deno:ext/webidl",
+      prefix "internal:ext/webidl",
       "00_webidl.js",
     ))
     .build()

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -505,7 +505,7 @@ pub fn init<P: WebSocketPermissions + 'static>(
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_url", "deno_webidl"])
     .js(include_js_files!(
-      prefix "deno:ext/websocket",
+      prefix "internal:ext/websocket",
       "01_websocket.js",
       "02_websocketstream.js",
     ))

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -25,7 +25,7 @@ pub fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .dependencies(vec!["deno_webidl"])
     .js(include_js_files!(
-      prefix "deno:ext/webstorage",
+      prefix "internal:ext/webstorage",
       "01_webstorage.js",
     ))
     .ops(vec![

--- a/runtime/fmt_errors.rs
+++ b/runtime/fmt_errors.rs
@@ -45,7 +45,7 @@ pub fn format_location(frame: &JsStackFrame) -> String {
   let _internal = frame
     .file_name
     .as_ref()
-    .map_or(false, |f| f.starts_with("deno:"));
+    .map_or(false, |f| f.starts_with("internal:"));
   if frame.is_native {
     return cyan("native").to_string();
   }
@@ -73,7 +73,7 @@ fn format_frame(frame: &JsStackFrame) -> String {
   let _internal = frame
     .file_name
     .as_ref()
-    .map_or(false, |f| f.starts_with("deno:"));
+    .map_or(false, |f| f.starts_with("internal:"));
   let is_method_call =
     !(frame.is_top_level.unwrap_or_default() || frame.is_constructor);
   let mut result = String::new();

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -98,7 +98,7 @@ impl Serialize for WorkerControlEvent {
         let value = match error.downcast_ref::<JsError>() {
           Some(js_error) => {
             let frame = js_error.frames.iter().find(|f| match &f.file_name {
-              Some(s) => !s.trim_start_matches('[').starts_with("deno:"),
+              Some(s) => !s.trim_start_matches('[').starts_with("internal:"),
               None => false,
             });
             json!({

--- a/tools/wgpu_sync.js
+++ b/tools/wgpu_sync.js
@@ -85,7 +85,7 @@ async function patchSrcLib() {
   await patchFile(
     join(TARGET_DIR, "src", "lib.rs"),
     (data) =>
-      data.replace(`prefix "deno:deno_webgpu",`, `prefix "deno:ext/webgpu",`),
+      data.replace(`prefix "internal:deno_webgpu",`, `prefix "internal:ext/webgpu",`),
   );
 }
 

--- a/tools/wgpu_sync.js
+++ b/tools/wgpu_sync.js
@@ -85,7 +85,10 @@ async function patchSrcLib() {
   await patchFile(
     join(TARGET_DIR, "src", "lib.rs"),
     (data) =>
-      data.replace(`prefix "internal:deno_webgpu",`, `prefix "internal:ext/webgpu",`),
+      data.replace(
+        `prefix "internal:deno_webgpu",`,
+        `prefix "internal:ext/webgpu",`,
+      ),
   );
 }
 


### PR DESCRIPTION
Ahead of work of adding deno specifiers to prevent issues & confusion, and for #17648