### PR TITLE
perf: disable fetching graph cache info except for `deno info`

### DIFF
--- a/cli/cache/mod.rs
+++ b/cli/cache/mod.rs
@@ -45,6 +45,7 @@ pub struct FetchCacher {
   dynamic_permissions: PermissionsContainer,
   file_fetcher: Arc<FileFetcher>,
   root_permissions: PermissionsContainer,
+  cache_info_enabled: bool,
 }
 
 impl FetchCacher {
@@ -59,12 +60,23 @@ impl FetchCacher {
       dynamic_permissions,
       file_fetcher,
       root_permissions,
+      cache_info_enabled: false,
     }
+  }
+
+  /// The cache information takes a bit of time to fetch and it's
+  /// not always necessary. It should only be enabled for deno info.
+  pub fn enable_loading_cache_info(&mut self) {
+    self.cache_info_enabled = true;
   }
 }
 
 impl Loader for FetchCacher {
   fn get_cache_info(&self, specifier: &ModuleSpecifier) -> Option<CacheInfo> {
+    if !self.cache_info_enabled {
+      return None;
+    }
+
     if matches!(specifier.scheme(), "npm" | "node") {
       return None;
     }

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -33,7 +33,11 @@ pub async fn info(flags: Flags, info_flags: InfoFlags) -> Result<(), AnyError> {
   let ps = ProcState::build(flags).await?;
   if let Some(specifier) = info_flags.file {
     let specifier = resolve_url_or_path(&specifier)?;
-    let graph = ps.create_graph(vec![specifier]).await?;
+    let mut loader = ps.create_graph_loader();
+    loader.enable_loading_cache_info(); // for displaying the cache information
+    let graph = ps
+      .create_graph_with_loader(vec![specifier], &mut loader)
+      .await?;
 
     if info_flags.json {
       let mut json_graph = json!(graph);


### PR DESCRIPTION
I did a CPU profile for the first time on Deno's codebase and noticed it was spending about 5% of the time fetching cache information for deno graph. This is not necessary except for `deno info`.

With a basic example that imports oak doing `deno run`:

Main: 272ms
This PR: 247ms

Profile from one of my other PRs that has a big deno graph refactor:

![image](https://user-images.githubusercontent.com/1609021/217681807-7924dabd-a984-44a7-85ff-7431b5054660.png)

