### PR TITLE
perf: module info cache - avoid MediaType.to_string() allocation

### DIFF
--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -191,7 +191,7 @@ impl ParsedSourceCacheModuleAnalyzer {
     let mut stmt = self.conn.prepare_cached(query)?;
     let mut rows = stmt.query(params![
       &specifier.as_str(),
-      &media_type.to_string(),
+      serialize_media_type(media_type),
       &expected_source_hash,
     ])?;
     if let Some(row) = rows.next()? {
@@ -218,11 +218,35 @@ impl ParsedSourceCacheModuleAnalyzer {
     let mut stmt = self.conn.prepare_cached(sql)?;
     stmt.execute(params![
       specifier.as_str(),
-      &media_type.to_string(),
+      serialize_media_type(media_type),
       &source_hash,
       &serde_json::to_string(&module_info)?,
     ])?;
     Ok(())
+  }
+}
+
+// todo(dsherret): change this to be stored as an integer next time
+// the cache version is bumped
+fn serialize_media_type(media_type: MediaType) -> &'static str {
+  use MediaType::*;
+  match media_type {
+    JavaScript => "1",
+    Jsx => "2",
+    Mjs => "3",
+    Cjs => "4",
+    TypeScript => "5",
+    Mts => "6",
+    Cts => "7",
+    Dts => "8",
+    Dmts => "9",
+    Dcts => "10",
+    Tsx => "11",
+    Json => "12",
+    Wasm => "13",
+    TsBuildInfo => "14",
+    SourceMap => "15",
+    Unknown => "16",
   }
 }
 


### PR DESCRIPTION
Micro optimization because these allocations were coming up on a flame graph I was looking at (only 0.28% of total).