### PR TITLE
refactor: allow to provide polyfills for Node modules from the snapshot

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -78,9 +78,11 @@ impl CliModuleLoader {
     specifier: &ModuleSpecifier,
     maybe_referrer: Option<ModuleSpecifier>,
   ) -> Result<ModuleCodeSource, AnyError> {
-    if specifier.scheme() == "node" {
-      unreachable!("Node built-in modules should be handled internally.");
-    }
+    // TODO(bartlomieju): uncomment, when all `node:` module have been
+    // snapshotted
+    // if specifier.scheme() == "node" {
+    //   unreachable!("Node built-in modules should be handled internally.");
+    // }
     let graph_data = self.ps.graph_data.read();
     let found_url = graph_data.follow_redirect(specifier);
     match graph_data.get(&found_url) {

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -78,12 +78,8 @@ impl CliModuleLoader {
     specifier: &ModuleSpecifier,
     maybe_referrer: Option<ModuleSpecifier>,
   ) -> Result<ModuleCodeSource, AnyError> {
-    if specifier.as_str() == "node:module" {
-      return Ok(ModuleCodeSource {
-        code: deno_runtime::deno_node::MODULE_ES_SHIM.to_string(),
-        found_url: specifier.to_owned(),
-        media_type: MediaType::JavaScript,
-      });
+    if specifier.scheme() == "node" {
+      unreachable!("Node built-in modules should be handled internally.");
     }
     let graph_data = self.ps.graph_data.read();
     let found_url = graph_data.follow_redirect(specifier);

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -677,15 +677,17 @@ fn op_require_break_on_next_statement(state: &mut OpState) {
 }
 
 pub enum NodeModulePolyfillSpecifier {
+  /// An internal module specifier, like "internal:deno_node/assert.ts". The
+  /// module must be either embedded in the binary or snapshotted.
   Embedded(&'static str),
+
+  /// Specifier relative to the root of `deno_std` repo, like "node/assert.ts"
   StdNode(&'static str),
 }
 
 pub struct NodeModulePolyfill {
   /// Name of the module like "assert" or "timers/promises"
   pub name: &'static str,
-
-  /// Specifier relative to the root of `deno_std` repo, like "node/assert.ts"
   pub specifier: NodeModulePolyfillSpecifier,
 }
 

--- a/ext/node/module_es_shim.js
+++ b/ext/node/module_es_shim.js
@@ -1,6 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-const m = Deno[Deno.internal].require.Module;
+const internals = globalThis.__bootstrap.internals;
+const m = internals.require.Module;
 export const _cache = m._cache;
 export const _extensions = m._extensions;
 export const _findPath = m._findPath;


### PR DESCRIPTION
This commit does preparatory work to allow snapshotting Node.js compatibility
layer, that currently lives in `std/node`. The logic was changed to allow loading
some modules from the snapshot and some from the remote URL.

Additionally "module_es_shim.js" that provides exports for "node:module" is now
snapshotted.