### PR TITLE
fix(dts): make Deno.Command accept readonly prop in options.args

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1539,7 +1539,7 @@ declare namespace Deno {
    */
   export interface CommandOptions {
     /** Arguments to pass to the process. */
-    args?: string[];
+    args?: readonly string[];
     /**
      * The working directory of the process.
      *


### PR DESCRIPTION
There's no need for `readonly string[] | string[]` as TS can infere it just fine - https://www.typescriptlang.org/play?ssl=14&ssc=1&pln=15&pc=1#code/PQgECcFMEMBMHsB2AbAnqajakUgtFHEmgFAmQAeADvOAC6gCWidk4AZtAMaSgDyVOgGcAYvHigA3iVCyM4AOZCA-AC4IMBCnRC64ZgoDaAXVAAfULv2IjxkgF8y7AK6IudRklDtxoABTwgkLqAsJi8ACUUo4kPvB+kvJK6oYARPAAFqmm9hGx4glJwfwARgBWkO4AdOxQkABekH5pmdlRuWQgwBpE2mSUNPRMLGycPPxBAELQ4FIycjNKaj1aaJZ6BiYOTq7unoigJTP+gcIhUzNRkjFH4IWLxS1ZOXm394rFfOWVdDV1jc10s92nkSF0cPhCKtUP1qLQGMxWBxuLxQkJpvU5nIissrJs7DEXG4PF4jpiAkFzsIMVcbtB6u9kqAntlQB0yYzPt9qrVIA0mizjCCgA

Fixes https://github.com/denoland/deno/issues/17711