### PR TITLE
fix(cli/graph_util): don't append referrer info for root module errors

### DIFF
--- a/cli/tests/testdata/run/error_005_missing_dynamic_import.ts.out
+++ b/cli/tests/testdata/run/error_005_missing_dynamic_import.ts.out
@@ -1,5 +1,4 @@
 error: Uncaught (in promise) TypeError: Module not found "[WILDCARD]/bad-module.ts".
-    at file:///[WILDCARD]/error_005_missing_dynamic_import.ts:2:35
   const _badModule = await import("./bad-module.ts");
                      ^
     at async file://[WILDCARD]/error_005_missing_dynamic_import.ts:2:22

--- a/cli/tests/testdata/run/error_015_dynamic_import_permissions.out
+++ b/cli/tests/testdata/run/error_015_dynamic_import_permissions.out
@@ -1,5 +1,4 @@
 error: Uncaught (in promise) TypeError: Requires net access to "localhost:4545", run again with the --allow-net flag
-    at file:///[WILDCARD]/error_015_dynamic_import_permissions.js:2:16
   await import("http://localhost:4545/subdir/mod4.js");
   ^
     at async file://[WILDCARD]/error_015_dynamic_import_permissions.js:2:3

--- a/cli/tests/testdata/workers/permissions_dynamic_remote.ts.out
+++ b/cli/tests/testdata/workers/permissions_dynamic_remote.ts.out
@@ -1,5 +1,4 @@
 error: Uncaught (in worker "") (in promise) TypeError: Requires net access to "example.com", run again with the --allow-net flag
-    at http://localhost:4545/workers/dynamic_remote.ts:2:14
 await import("https://example.com/some/file.ts");
 ^
     at async http://localhost:4545/workers/dynamic_remote.ts:2:1


### PR DESCRIPTION
cc @dsherret This prevents `graph_valid()` from writing specifier locations for dynamic import errors whose runtime error stacks will give a similar location, regression in #17692. But it will still be added if the missing module is an indirect import, for example.

More generally, there's no reason to append referrer info to a graph validation error when the erroring module is one of the queried roots.