### PR TITLE
fix(flash): Always send correct number of bytes when handling HEAD requests

### DIFF
--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -1701,7 +1701,7 @@ Deno.test(
     const server = Deno.serve({
       handler: () => {
         promise.resolve();
-        return new Response("foo bar baz");
+        return new Response("NaN".repeat(100));
       },
       port: 4503,
       signal: ac.signal,
@@ -1726,7 +1726,7 @@ Deno.test(
     assert(readResult);
     const msg = decoder.decode(buf.subarray(0, readResult));
 
-    assert(msg.endsWith("Content-Length: 11\r\n\r\n"));
+    assert(msg.endsWith("Content-Length: 300\r\n\r\n"));
 
     conn.close();
 

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -316,11 +316,13 @@ async function handleResponse(
       respBody,
       length,
     );
+    // A HEAD request always ignores body, but includes the correct content-length size.
+    const responseLen = method === 1 ? core.byteLength(responseStr) : length;
     writeFixedResponse(
       serverId,
       i,
       responseStr,
-      length,
+      responseLen,
       !ws, // Don't close socket if there is a deferred websocket upgrade.
       respondFast,
     );


### PR DESCRIPTION
This was not caught in the previous test case, as the response body was smaller than the size of `HEAD` response.
This made `nwritten < responseLen` check in `writeFixedResponse` to fail, and not trigger `op_flash_respond_async` as a result.

When the response body is larger than the `HEAD` though, as in the updated test case (`HEAD` i 120 bytes, where our response is 300 bytes), it would think that we still have something to send, and effectively panic, as `op_flash_respond` already removed the request from the pool.

This change, makes the `handleResponse` function always calculate the number of bytes to transmit when `HEAD` request is encountered. Effectively ignoring `Content-Length` of the body, but still setting it correctly in the request header itself.

Fixes https://github.com/denoland/deno/issues/17737