### PR TITLE
perf(ext/ffi): Revert UTF-8 validity check from getCString

### DIFF
--- a/ext/ffi/repr.rs
+++ b/ext/ffi/repr.rs
@@ -145,14 +145,13 @@ where
   let ptr = unsafe { ptr.add(offset) };
 
   // SAFETY: Pointer is user provided.
-  let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }
-    .to_str()
-    .map_err(|_| type_error("Invalid CString pointer, not valid UTF-8"))?;
-  let value: v8::Local<v8::Value> = v8::String::new(scope, cstr)
-    .ok_or_else(|| {
-      type_error("Invalid CString pointer, string exceeds max length")
-    })?
-    .into();
+  let cstr = unsafe { CStr::from_ptr(ptr as *const c_char) }.to_bytes();
+  let value: v8::Local<v8::Value> =
+    v8::String::new_from_utf8(scope, cstr, v8::NewStringType::Normal)
+      .ok_or_else(|| {
+        type_error("Invalid CString pointer, string exceeds max length")
+      })?
+      .into();
   Ok(value.into())
 }
 

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -699,10 +699,26 @@ assertEquals([...uint8Array], [
   0x00
 ]);
 
-try {
-  assertThrows(() => charView.getCString(), TypeError, "Invalid CString pointer, not valid UTF-8");
-} catch (_err) {
-  console.log("Invalid UTF-8 characters to `v8::String`:", charView.getCString());
+// Check that `getCString` works equally to `TextDecoder`
+assertEquals(charView.getCString(), new TextDecoder().decode(uint8Array.subarray(0, uint8Array.length - 1)));
+
+// Check a selection of various invalid UTF-8 sequences in C strings and verify
+// that the `getCString` API does not cause unexpected behaviour.
+for (const charBuffer of [
+  Uint8Array.from([0xA0, 0xA1, 0x00]),
+  Uint8Array.from([0xE2, 0x28, 0xA1, 0x00]),
+  Uint8Array.from([0xE2, 0x82, 0x28, 0x00]),
+  Uint8Array.from([0xF0, 0x28, 0x8C, 0xBC, 0x00]),
+  Uint8Array.from([0xF0, 0x90, 0x28, 0xBC, 0x00]),
+  Uint8Array.from([0xF0, 0x28, 0x8C, 0x28, 0x00]),
+  Uint8Array.from([0xF8, 0xA1, 0xA1, 0xA1, 0xA1, 0x00]),
+  Uint8Array.from([0xFC, 0xA1, 0xA1, 0xA1, 0xA1, 0xA1, 0x00]),
+]) {
+  const charBufferPointer = Deno.UnsafePointer.of(charBuffer);
+  const charString = Deno.UnsafePointerView.getCString(charBufferPointer);
+  const charBufferPointerArrayBuffer = new Uint8Array(Deno.UnsafePointerView.getArrayBuffer(charBufferPointer, charBuffer.length - 1));
+  assertEquals(charString, new TextDecoder().decode(charBufferPointerArrayBuffer));
+  assertEquals([...charBuffer.subarray(0, charBuffer.length - 1)], [...charBufferPointerArrayBuffer]);
 }
 
 


### PR DESCRIPTION
I previously added a UTF-8 validity check to the `getCString` FFI API thinking that it was essentially a fluke or at least poorly thought out to pass in possibly invalid UTF-8 into the `NewFromUtf8` V8 String API.

It seems this is not the case. I've added tests to rusty_v8 (https://github.com/denoland/rusty_v8/pull/1190) to check that the API handles invalid UTF-8 sequences and also added similar or equal tests to FFI tests here locally. The local tests verify that not only does the API work, it also produces the equivalent result as using `TextDecoder` would.

The performance difference in our bench case is about 5-15 nanoseconds out of roughly 150ns. 2 ** 28 byte string shows a similar difference, going from 115 ms to 104 ms.