### PR TITLE
fix(ext/websocket): extra ws pongs sent

### DIFF
--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -433,12 +433,6 @@ class WebSocket extends EventTarget {
           this.dispatchEvent(event);
           break;
         }
-        case "ping": {
-          core.opAsync("op_ws_send", this[_rid], {
-            kind: "pong",
-          });
-          break;
-        }
         case "pong": {
           this[_serverHandleIdleTimeout]();
           break;


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/17761

Tugstenite already sends a pong for a recieved ping. This automatically happens when the socket read is being driven. From https://github.com/snapview/tokio-tungstenite/issues/88

> You need to read from the read-side of the socket so that it receives/handles pings, and on the next write it would then send the corresponding pong.

Here's the source:

https://github.com/snapview/tungstenite-rs/blob/e1033afd959bb7abfcbc181033b8326f8a40562b/src/protocol/mod.rs#L374-L380

```rust
// Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in
// response, unless it already received a Close frame. It SHOULD
// respond with Pong frame as soon as is practical. (RFC 6455)
if let Some(pong) = self.pong.take() {
  trace!("Sending pong reply");
  self.send_one_frame(stream, pong)?;
}
```

WIth this patch, all Autobahn tests from 1-8 pass. Fixed cases: 2.1, 2.2, 2.3, 2.4, 2.6, 2.9, 2.10, 2.11, 5.6, 5.7, 5.8, 5.19, 5.20

To run the test yourself, follow https://www.notion.so/denolandinc/Autobahn-WebSocket-testsuite-723a86f450ce4823b4ef9cb3dc4c7869?pvs=4