### PR TITLE
feat(core): allow to specify entry point for snapshotted ES modules

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -43,6 +43,7 @@ impl OpDecl {
 pub struct Extension {
   js_files: Option<Vec<ExtensionFileSource>>,
   esm_files: Option<Vec<ExtensionFileSource>>,
+  esm_entry_point: Option<&'static str>,
   ops: Option<Vec<OpDecl>>,
   opstate_fn: Option<Box<OpStateFn>>,
   middleware_fn: Option<Box<OpMiddlewareFn>>,
@@ -98,6 +99,10 @@ impl Extension {
       Some(files) => files,
       None => &[],
     }
+  }
+
+  pub fn get_esm_entry_point(&self) -> Option<&'static str> {
+    self.esm_entry_point
   }
 
   /// Called at JsRuntime startup to initialize ops in the isolate.
@@ -158,6 +163,7 @@ impl Extension {
 pub struct ExtensionBuilder {
   js: Vec<ExtensionFileSource>,
   esm: Vec<ExtensionFileSource>,
+  esm_entry_point: Option<&'static str>,
   ops: Vec<OpDecl>,
   state: Option<Box<OpStateFn>>,
   middleware: Option<Box<OpMiddlewareFn>>,
@@ -194,6 +200,11 @@ impl ExtensionBuilder {
           code: file_source.code,
         });
     self.esm.extend(esm_files);
+    self
+  }
+
+  pub fn esm_entry_point(&mut self, entry_point: &'static str) -> &mut Self {
+    self.esm_entry_point = Some(entry_point);
     self
   }
 
@@ -234,6 +245,7 @@ impl ExtensionBuilder {
     Extension {
       js_files,
       esm_files,
+      esm_entry_point: self.esm_entry_point.take(),
       ops,
       opstate_fn: self.state.take(),
       middleware_fn: self.middleware.take(),

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -22,6 +22,7 @@ pub struct CreateSnapshotOptions {
 }
 
 pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
+  let start = std::time::Instant::now();
   let js_runtime = JsRuntime::new(RuntimeOptions {
     will_snapshot: true,
     startup_snapshot: create_snapshot_options.startup_snapshot,
@@ -33,7 +34,12 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
 
   let snapshot = js_runtime.snapshot();
   let snapshot_slice: &[u8] = &snapshot;
-  println!("Snapshot size: {}", snapshot_slice.len());
+  println!(
+    "Snapshot size: {}, took {}s ({})",
+    snapshot_slice.len(),
+    start.elapsed().as_secs_f64(),
+    create_snapshot_options.snapshot_path.display()
+  );
 
   let maybe_compressed_snapshot: Box<dyn AsRef<[u8]>> =
     if let Some(compression_cb) = create_snapshot_options.compression_cb {
@@ -47,7 +53,12 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
 
       (compression_cb)(&mut vec, snapshot_slice);
 
-      println!("Snapshot compressed size: {}", vec.len());
+      println!(
+        "Snapshot compressed size: {}, took {}s ({})",
+        vec.len(),
+        start.elapsed().as_secs_f64(),
+        create_snapshot_options.snapshot_path.display()
+      );
 
       Box::new(vec)
     } else {
@@ -60,8 +71,9 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
   )
   .unwrap();
   println!(
-    "Snapshot written to: {} ",
-    create_snapshot_options.snapshot_path.display()
+    "Snapshot written to: {}, took: {}s",
+    create_snapshot_options.snapshot_path.display(),
+    start.elapsed().as_secs_f64()
   );
 }
 


### PR DESCRIPTION
This commit adds "ExtensionBuilder::esm_entry_point()" function that
allows to specify which of the extension files should be treated as an entry
point. If the entry point is not provided all modules are loaded and evaluated,
but if it is provided then only the entry point is explicitly loaded and evaluated.

Prerequisite for https://github.com/denoland/deno/pull/17724
Closes https://github.com/denoland/deno/issues/17764