### PR TITLE
chore(build): don't compress TSC snapshot in debug build

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -281,9 +281,9 @@ mod ts {
       extensions: vec![],
       extensions_with_js: vec![tsc_extension],
 
-      // NOTE(bartlomieju): compressing the TSC snapshot during build time took
-      // ~45s on M1 MacBook Pro, so for debug build. When not using compression,
-      // it takes ~1s. Thus we're not not using compressed snapshot, trading off
+      // NOTE(bartlomieju): Compressing the TSC snapshot in debug build took
+      // ~45s on M1 MacBook Pro; without compression it took ~1s.
+      // Thus we're not not using compressed snapshot, trading off
       // a lot of build time for some startup time in debug build.
       #[cfg(debug_assertions)]
       compression_cb: None,

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -290,7 +290,7 @@ mod ts {
 
       #[cfg(not(debug_assertions))]
       compression_cb: Some(Box::new(|vec, snapshot_slice| {
-        eprintln!("hello from compression cb");
+        eprintln!("Compressing TSC snapshot...");
         vec.extend_from_slice(
           &zstd::bulk::compress(snapshot_slice, 22)
             .expect("snapshot compression failed"),

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -280,7 +280,17 @@ mod ts {
       startup_snapshot: None,
       extensions: vec![],
       extensions_with_js: vec![tsc_extension],
+
+      // NOTE(bartlomieju): compressing the TSC snapshot during build time took
+      // ~45s on M1 MacBook Pro, so for debug build. When not using compression,
+      // it takes ~1s. Thus we're not not using compressed snapshot, trading off
+      // a lot of build time for some startup time in debug build.
+      #[cfg(debug_assertions)]
+      compression_cb: None,
+
+      #[cfg(not(debug_assertions))]
       compression_cb: Some(Box::new(|vec, snapshot_slice| {
+        eprintln!("hello from compression cb");
         vec.extend_from_slice(
           &zstd::bulk::compress(snapshot_slice, 22)
             .expect("snapshot compression failed"),

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -56,6 +56,14 @@ pub static COMPILER_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
     static COMPRESSED_COMPILER_SNAPSHOT: &[u8] =
       include_bytes!(concat!(env!("OUT_DIR"), "/COMPILER_SNAPSHOT.bin"));
 
+    // NOTE(bartlomieju): compressing the TSC snapshot during build time took
+    // ~45s on M1 MacBook Pro, so for debug build. When not using compression,
+    // it takes ~1s. Thus we're not not using compressed snapshot, trading off
+    // a lot of build time for some startup time in debug build.
+    #[cfg(debug_assertions)]
+    return COMPRESSED_COMPILER_SNAPSHOT.to_vec().into_boxed_slice();
+
+    #[cfg(not(debug_assertions))]
     zstd::bulk::decompress(
       &COMPRESSED_COMPILER_SNAPSHOT[4..],
       u32::from_le_bytes(COMPRESSED_COMPILER_SNAPSHOT[0..4].try_into().unwrap())

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -56,9 +56,9 @@ pub static COMPILER_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
     static COMPRESSED_COMPILER_SNAPSHOT: &[u8] =
       include_bytes!(concat!(env!("OUT_DIR"), "/COMPILER_SNAPSHOT.bin"));
 
-    // NOTE(bartlomieju): compressing the TSC snapshot during build time took
-    // ~45s on M1 MacBook Pro, so for debug build. When not using compression,
-    // it takes ~1s. Thus we're not not using compressed snapshot, trading off
+    // NOTE(bartlomieju): Compressing the TSC snapshot in debug build took
+    // ~45s on M1 MacBook Pro; without compression it took ~1s.
+    // Thus we're not not using compressed snapshot, trading off
     // a lot of build time for some startup time in debug build.
     #[cfg(debug_assertions)]
     return COMPRESSED_COMPILER_SNAPSHOT.to_vec().into_boxed_slice();

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use crate::Extension;
 use crate::InternalModuleLoaderCb;
@@ -22,7 +23,8 @@ pub struct CreateSnapshotOptions {
 }
 
 pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
-  let start = std::time::Instant::now();
+  let mut mark = Instant::now();
+
   let js_runtime = JsRuntime::new(RuntimeOptions {
     will_snapshot: true,
     startup_snapshot: create_snapshot_options.startup_snapshot,
@@ -35,11 +37,12 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
   let snapshot = js_runtime.snapshot();
   let snapshot_slice: &[u8] = &snapshot;
   println!(
-    "Snapshot size: {}, took {}s ({})",
+    "Snapshot size: {}, took {:#?} ({})",
     snapshot_slice.len(),
-    start.elapsed().as_secs_f64(),
+    Instant::now().saturating_duration_since(mark),
     create_snapshot_options.snapshot_path.display()
   );
+  mark = Instant::now();
 
   let maybe_compressed_snapshot: Box<dyn AsRef<[u8]>> =
     if let Some(compression_cb) = create_snapshot_options.compression_cb {
@@ -54,11 +57,12 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
       (compression_cb)(&mut vec, snapshot_slice);
 
       println!(
-        "Snapshot compressed size: {}, took {}s ({})",
+        "Snapshot compressed size: {}, took {:#?} ({})",
         vec.len(),
-        start.elapsed().as_secs_f64(),
+        Instant::now().saturating_duration_since(mark),
         create_snapshot_options.snapshot_path.display()
       );
+      mark = std::time::Instant::now();
 
       Box::new(vec)
     } else {
@@ -71,9 +75,9 @@ pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
   )
   .unwrap();
   println!(
-    "Snapshot written to: {}, took: {}s",
+    "Snapshot written, took: {:#?} ({})",
+    Instant::now().saturating_duration_since(mark),
     create_snapshot_options.snapshot_path.display(),
-    start.elapsed().as_secs_f64()
   );
 }
 


### PR DESCRIPTION
Compressing the TSC snapshot in debug build took
~45s on M1 MacBook Pro; without compression it took ~1s.
Thus we're not not using compressed snapshot, trading off
a lot of build time for some startup time in debug build.