### PR TITLE
fix: loading built-in Node modules embedded in the binary

### DIFF
--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -534,6 +534,11 @@ impl ProcState {
       match maybe_resolved {
         Some((found_referrer, Resolution::Ok(resolved))) => {
           let specifier = &resolved.specifier;
+
+          if specifier.scheme() == "node" {
+            return node::resolve_builtin_node_module(specifier.path());
+          }
+
           if let Ok(reference) = NpmPackageReference::from_specifier(specifier)
           {
             if !self.options.unstable()

--- a/cli/tests/testdata/run/node_builtin_modules/mod.js
+++ b/cli/tests/testdata/run/node_builtin_modules/mod.js
@@ -1,2 +1,4 @@
+import { createRequire } from "node:module";
+console.log(createRequire);
 import process from "node:process";
 console.log(process.version);

--- a/cli/tests/testdata/run/node_builtin_modules/mod.js.out
+++ b/cli/tests/testdata/run/node_builtin_modules/mod.js.out
@@ -1,1 +1,2 @@
+[Function: createRequire]
 v[WILDCARD].[WILDCARD].[WILDCARD]

--- a/cli/tests/testdata/run/node_builtin_modules/mod.ts
+++ b/cli/tests/testdata/run/node_builtin_modules/mod.ts
@@ -1,2 +1,4 @@
+import { createRequire } from "node:module";
+console.log(createRequire);
 import process from "node:process";
 console.log(process.version);

--- a/cli/tests/testdata/run/node_builtin_modules/mod.ts.out
+++ b/cli/tests/testdata/run/node_builtin_modules/mod.ts.out
@@ -1,1 +1,2 @@
+[Function: createRequire]
 v[WILDCARD].[WILDCARD].[WILDCARD]


### PR DESCRIPTION
Fixes bug introduced in ed3a7ce2f719e64e59cfebb3d131a05a1694523b that caused errors
when loading built-in Node modules, when using "deno_graph".

Fixes https://github.com/denoland/deno/issues/17735