### PR TITLE
fix(ext/ffi): improve error messages in FFI module (denoland#16922)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,8 @@ dependencies = [
  "dynasmrt",
  "libffi",
  "serde",
+ "serde-value",
+ "serde_json",
  "tokio",
  "winapi",
 ]
@@ -3122,6 +3124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4010,6 +4021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -19,6 +19,8 @@ dlopen.workspace = true
 dynasmrt = "1.2.3"
 libffi = "3.1.0"
 serde.workspace = true
+serde-value = "0.7"
+serde_json = "1.0"
 tokio.workspace = true
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Fixes denoland#16922.

The error messages in the `ffi` module are somewhat cryptic when passing functions that have invalid `parameters` or `result` type strings. While the generated serializer for the `ForeignFunction` struct correctly outputs a correct and verbose message, the user sees a far less helpful `data did not match any variant` message instead.

The underlying cause appears to be the fallback message in the auto-derived deserializer for untagged enums [1] generated as a result of `ForeignSymbol` being marked as `#[serde(untagged)]` [2]. Passing an unexpected value for `NativeType` causes it to error out while attempting to deserialize both enum variants -- once because it's not a match for the `ForeignStatic` variant, and once because the `ForeignFunction` deserializer rejects the invalid type for the parameters/return type. This is currently open as [serde #773](https://github.com/serde-rs/serde/issues/773), and not a trivial exercise to fix generically.

[1] https://github.com/serde-rs/serde/blob/v0.9.7/serde_derive/src/de.rs#L730
[2] https://github.com/denoland/deno/blob/main/ext/ffi/dlfcn.rs#L102
[3] https://github.com/serde-rs/serde/issues/773

Note that the auto-generated deserializer for untagged enums uses a private API to buffer deserializer content that we don't have access to. Instead, we can make use of the `serde_value` crate to buffer the values. This can likely be removed once the official buffering API lands (see [4] and [5]). In addition, this crate pulls in `serde_json` as a cheap way to test that the deserializer works properly.

[4] https://github.com/serde-rs/serde/issues/741
[5] https://github.com/serde-rs/serde/pull/2348

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
