### PR TITLE
fix(ext/node): util.types.isSharedArrayBuffer

### DIFF
--- a/cli/tests/node_compat/config.json
+++ b/cli/tests/node_compat/config.json
@@ -746,7 +746,7 @@
       "test-util-isDeepStrictEqual.js",
       "test-util-promisify.js",
       "test-util-types-exists.js",
-      "TODO:test-util-types.js",
+      "test-util-types.js",
       "test-util.js",
       "test-vm-static-this.js",
       "TODO:test-webcrypto-sign-verify.js",

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -56,6 +56,9 @@ const _getArrayBufferByteLength = Object.getOwnPropertyDescriptor(
   "byteLength",
 )!.get!;
 
+// https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength
+let _getSharedArrayBufferByteLength;
+
 // https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
 const _getTypedArrayToStringTag = Object.getOwnPropertyDescriptor(
   Object.getPrototypeOf(Uint8Array).prototype,
@@ -277,7 +280,18 @@ export function isSetIterator(
 export function isSharedArrayBuffer(
   value: unknown,
 ): value is SharedArrayBuffer {
-  return value instanceof SharedArrayBuffer;
+  // TODO(kt3k): add SharedArrayBuffer to primordials
+  _getSharedArrayBufferByteLength ??= Object.getOwnPropertyDescriptor(
+    SharedArrayBuffer.prototype,
+    "byteLength",
+  )!.get!;
+
+  try {
+    _getSharedArrayBufferByteLength.call(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // deno-lint-ignore ban-types

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -56,14 +56,6 @@ const _getArrayBufferByteLength = Object.getOwnPropertyDescriptor(
   "byteLength",
 )!.get!;
 
-// https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength
-const _getSharedArrayBufferByteLength = globalThis.SharedArrayBuffer
-  ? Object.getOwnPropertyDescriptor(
-    SharedArrayBuffer.prototype,
-    "byteLength",
-  )!.get!
-  : undefined;
-
 // https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
 const _getTypedArrayToStringTag = Object.getOwnPropertyDescriptor(
   Object.getPrototypeOf(Uint8Array).prototype,
@@ -285,17 +277,7 @@ export function isSetIterator(
 export function isSharedArrayBuffer(
   value: unknown,
 ): value is SharedArrayBuffer {
-  // SharedArrayBuffer is not available on this runtime
-  if (_getSharedArrayBufferByteLength === undefined) {
-    return false;
-  }
-
-  try {
-    _getSharedArrayBufferByteLength.call(value);
-    return true;
-  } catch {
-    return false;
-  }
+  return value instanceof SharedArrayBuffer;
 }
 
 // deno-lint-ignore ban-types


### PR DESCRIPTION
part of #17779

This fixes node compat test case `cli/tests/node_compat/test/parallel/test-util-types.js`.

`util.types.isSharedArrayBuffer` was broken because `SharedArrayBuffer` is unavailable during snapshotting. This fixes it by avoiding caching `_getSharedArrayBufferByteLength` during snapshotting
