### PR TITLE
fix(ext/node): fix process.uptime

### DIFF
--- a/cli/tests/node_compat/config.json
+++ b/cli/tests/node_compat/config.json
@@ -540,7 +540,7 @@
       "test-process-exit-recursive.js",
       "test-process-exit.js",
       "test-process-kill-pid.js",
-      "TODO:test-process-uptime.js",
+      "test-process-uptime.js",
       "test-promise-unhandled-silent.js",
       "test-promise-unhandled-throw-handler.js",
       "TODO:test-punycode.js",

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -767,7 +767,7 @@ internals.__bootstrapNodeProcess = function (
   );
 
   process.setStartTime(Date.now());
-  // @ts-ignore
+  // @ts-ignore Remove setStartTime and #startTime is not modifiable
   delete process.setStartTime;
   delete internals.__bootstrapNodeProcess;
 };

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -647,7 +647,11 @@ class Process extends EventEmitter {
     execPath = path;
   }
 
-  #startTime = Date.now();
+  setStartTime(t: number) {
+    this.#startTime = t;
+  }
+
+  #startTime = 0;
   /** https://nodejs.org/api/process.html#processuptime */
   uptime() {
     return (Date.now() - this.#startTime) / 1000;
@@ -762,6 +766,9 @@ internals.__bootstrapNodeProcess = function (
     "stdout",
   );
 
+  process.setStartTime(Date.now());
+  // @ts-ignore
+  delete process.setStartTime;
   delete internals.__bootstrapNodeProcess;
 };
 


### PR DESCRIPTION
This fixes process.uptime. Sets #startTime at bootstrap time instead of snapshotting time.

ref #17779 