### PR TITLE
refactor(core): More efficient serde for ES modules in snapshot

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -1051,12 +1051,13 @@ impl ModuleMap {
       for (i, elem) in self.by_name.iter().enumerate() {
         let arr = v8::Array::new(scope, 3);
 
-        let specifier = v8::String::new(scope, &elem.0 .0).unwrap();
+        let (specifier, asserted_module_type) = &elem.0;
+        let specifier = v8::String::new(scope, specifier).unwrap();
         arr.set_index(scope, 0, specifier.into());
 
         let asserted_module_type = v8::Integer::new(
           scope,
-          match elem.0 .1 {
+          match asserted_module_type {
             AssertedModuleType::JavaScriptOrWasm => 0,
             AssertedModuleType::Json => 1,
           },

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -438,7 +438,7 @@ impl JsRuntime {
     fn get_context_data(
       scope: &mut v8::HandleScope<()>,
       context: v8::Local<v8::Context>,
-    ) -> (Vec<v8::Global<v8::Module>>, v8::Global<v8::Object>) {
+    ) -> (Vec<v8::Global<v8::Module>>, v8::Global<v8::Array>) {
       fn data_error_to_panic(err: v8::DataError) -> ! {
         match err {
           v8::DataError::BadType { actual, expected } => {
@@ -457,15 +457,11 @@ impl JsRuntime {
       // The 0th element is the module map itself, followed by X number of module
       // handles. We need to deserialize the "next_module_id" field from the
       // map to see how many module handles we expect.
-      match scope.get_context_data_from_snapshot_once::<v8::Object>(0) {
+      match scope.get_context_data_from_snapshot_once::<v8::Array>(0) {
         Ok(val) => {
           let next_module_id = {
-            let info_str = v8::String::new(&mut scope, "info").unwrap();
-            let info_data: v8::Local<v8::Array> = val
-              .get(&mut scope, info_str.into())
-              .unwrap()
-              .try_into()
-              .unwrap();
+            let info_data: v8::Local<v8::Array> =
+              val.get_index(&mut scope, 1).unwrap().try_into().unwrap();
             info_data.length()
           };
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -3644,7 +3644,7 @@ pub mod tests {
         main,
         name: specifier.to_string(),
         requests: vec![crate::modules::ModuleRequest {
-          specifier: crate::resolve_url(&format!("file:///{prev}.js")).unwrap(),
+          specifier: format!("file:///{prev}.js"),
           asserted_module_type: AssertedModuleType::JavaScriptOrWasm,
         }],
         module_type: ModuleType::JavaScript,


### PR DESCRIPTION
Instead of relying on "serde_v8" which is very inefficient in serializing enums, I'm
hand rolling serde for "ModuleMap" data that is stored in the V8 snapshot to make
ES modules snapshottable.

Will post number comparison later, but I don't expect more than 5-10% improvement in
startup time.

EDIT: Benchmark results:
```
// this branch
Benchmark #2: ./target/release/deno run empty.js

  Time (mean ± σ):      21.4 ms ±   0.9 ms    [User: 15.6 ms, System: 6.4 ms]

  Range (min … max):    20.2 ms …  24.4 ms

// main branch
Benchmark #2: ./target/release/deno run empty.js

  Time (mean ± σ):      23.1 ms ±   1.2 ms    [User: 17.0 ms, System: 6.2 ms]

  Range (min … max):    21.0 ms …  26.0 ms

```