### PR TITLE
perf(core, runtime): Further improve startup time

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -974,18 +974,11 @@ impl JsRuntime {
   where
     v8::Local<'s, T>: TryFrom<v8::Local<'s, v8::Value>, Error = v8::DataError>,
   {
-    let start = std::time::Instant::now();
     let scope = &mut v8::EscapableHandleScope::new(scope);
     let source = v8::String::new(scope, code).unwrap();
     let script = v8::Script::compile(scope, source, None).unwrap();
     let v = script.run(scope)?;
-    let r = scope.escape(v).try_into().ok();
-    eprintln!(
-      "eval called on \"{}\", took {}ns",
-      code,
-      start.elapsed().as_nanos()
-    );
-    r
+    scope.escape(v).try_into().ok()
   }
 
   /// Grabs a reference to core.js' opresolve & syncOpsCache()

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -231,6 +231,69 @@ function formatException(error) {
   }
 }
 
+core.registerErrorClass("NotFound", errors.NotFound);
+core.registerErrorClass("PermissionDenied", errors.PermissionDenied);
+core.registerErrorClass("ConnectionRefused", errors.ConnectionRefused);
+core.registerErrorClass("ConnectionReset", errors.ConnectionReset);
+core.registerErrorClass("ConnectionAborted", errors.ConnectionAborted);
+core.registerErrorClass("NotConnected", errors.NotConnected);
+core.registerErrorClass("AddrInUse", errors.AddrInUse);
+core.registerErrorClass("AddrNotAvailable", errors.AddrNotAvailable);
+core.registerErrorClass("BrokenPipe", errors.BrokenPipe);
+core.registerErrorClass("AlreadyExists", errors.AlreadyExists);
+core.registerErrorClass("InvalidData", errors.InvalidData);
+core.registerErrorClass("TimedOut", errors.TimedOut);
+core.registerErrorClass("Interrupted", errors.Interrupted);
+core.registerErrorClass("WouldBlock", errors.WouldBlock);
+core.registerErrorClass("WriteZero", errors.WriteZero);
+core.registerErrorClass("UnexpectedEof", errors.UnexpectedEof);
+core.registerErrorClass("BadResource", errors.BadResource);
+core.registerErrorClass("Http", errors.Http);
+core.registerErrorClass("Busy", errors.Busy);
+core.registerErrorClass("NotSupported", errors.NotSupported);
+core.registerErrorBuilder(
+  "DOMExceptionOperationError",
+  function DOMExceptionOperationError(msg) {
+    return new DOMException(msg, "OperationError");
+  },
+);
+core.registerErrorBuilder(
+  "DOMExceptionQuotaExceededError",
+  function DOMExceptionQuotaExceededError(msg) {
+    return new DOMException(msg, "QuotaExceededError");
+  },
+);
+core.registerErrorBuilder(
+  "DOMExceptionNotSupportedError",
+  function DOMExceptionNotSupportedError(msg) {
+    return new DOMException(msg, "NotSupported");
+  },
+);
+core.registerErrorBuilder(
+  "DOMExceptionNetworkError",
+  function DOMExceptionNetworkError(msg) {
+    return new DOMException(msg, "NetworkError");
+  },
+);
+core.registerErrorBuilder(
+  "DOMExceptionAbortError",
+  function DOMExceptionAbortError(msg) {
+    return new DOMException(msg, "AbortError");
+  },
+);
+core.registerErrorBuilder(
+  "DOMExceptionInvalidCharacterError",
+  function DOMExceptionInvalidCharacterError(msg) {
+    return new DOMException(msg, "InvalidCharacterError");
+  },
+);
+core.registerErrorBuilder(
+  "DOMExceptionDataError",
+  function DOMExceptionDataError(msg) {
+    return new DOMException(msg, "DataError");
+  },
+);
+
 function runtimeStart(runtimeOptions, source) {
   core.setMacrotaskCallback(timers.handleTimerMacrotask);
   core.setMacrotaskCallback(promiseRejectMacrotaskCallback);
@@ -247,72 +310,6 @@ function runtimeStart(runtimeOptions, source) {
   colors.setNoColor(runtimeOptions.noColor || !runtimeOptions.isTty);
   // deno-lint-ignore prefer-primordials
   Error.prepareStackTrace = core.prepareStackTrace;
-  registerErrors();
-}
-
-function registerErrors() {
-  core.registerErrorClass("NotFound", errors.NotFound);
-  core.registerErrorClass("PermissionDenied", errors.PermissionDenied);
-  core.registerErrorClass("ConnectionRefused", errors.ConnectionRefused);
-  core.registerErrorClass("ConnectionReset", errors.ConnectionReset);
-  core.registerErrorClass("ConnectionAborted", errors.ConnectionAborted);
-  core.registerErrorClass("NotConnected", errors.NotConnected);
-  core.registerErrorClass("AddrInUse", errors.AddrInUse);
-  core.registerErrorClass("AddrNotAvailable", errors.AddrNotAvailable);
-  core.registerErrorClass("BrokenPipe", errors.BrokenPipe);
-  core.registerErrorClass("AlreadyExists", errors.AlreadyExists);
-  core.registerErrorClass("InvalidData", errors.InvalidData);
-  core.registerErrorClass("TimedOut", errors.TimedOut);
-  core.registerErrorClass("Interrupted", errors.Interrupted);
-  core.registerErrorClass("WouldBlock", errors.WouldBlock);
-  core.registerErrorClass("WriteZero", errors.WriteZero);
-  core.registerErrorClass("UnexpectedEof", errors.UnexpectedEof);
-  core.registerErrorClass("BadResource", errors.BadResource);
-  core.registerErrorClass("Http", errors.Http);
-  core.registerErrorClass("Busy", errors.Busy);
-  core.registerErrorClass("NotSupported", errors.NotSupported);
-  core.registerErrorBuilder(
-    "DOMExceptionOperationError",
-    function DOMExceptionOperationError(msg) {
-      return new DOMException(msg, "OperationError");
-    },
-  );
-  core.registerErrorBuilder(
-    "DOMExceptionQuotaExceededError",
-    function DOMExceptionQuotaExceededError(msg) {
-      return new DOMException(msg, "QuotaExceededError");
-    },
-  );
-  core.registerErrorBuilder(
-    "DOMExceptionNotSupportedError",
-    function DOMExceptionNotSupportedError(msg) {
-      return new DOMException(msg, "NotSupported");
-    },
-  );
-  core.registerErrorBuilder(
-    "DOMExceptionNetworkError",
-    function DOMExceptionNetworkError(msg) {
-      return new DOMException(msg, "NetworkError");
-    },
-  );
-  core.registerErrorBuilder(
-    "DOMExceptionAbortError",
-    function DOMExceptionAbortError(msg) {
-      return new DOMException(msg, "AbortError");
-    },
-  );
-  core.registerErrorBuilder(
-    "DOMExceptionInvalidCharacterError",
-    function DOMExceptionInvalidCharacterError(msg) {
-      return new DOMException(msg, "InvalidCharacterError");
-    },
-  );
-  core.registerErrorBuilder(
-    "DOMExceptionDataError",
-    function DOMExceptionDataError(msg) {
-      return new DOMException(msg, "DataError");
-    },
-  );
 }
 
 const pendingRejections = [];

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -318,6 +318,7 @@ pub struct WebWorker {
   pub worker_type: WebWorkerType,
   pub main_module: ModuleSpecifier,
   poll_for_messages_fn: Option<v8::Global<v8::Value>>,
+  bootstrap_fn_global: Option<v8::Global<v8::Function>>,
 }
 
 pub struct WebWorkerOptions {
@@ -496,6 +497,25 @@ impl WebWorker {
       (internal_handle, external_handle)
     };
 
+    let bootstrap_fn_global = {
+      let context = js_runtime.global_context();
+      let scope = &mut js_runtime.handle_scope();
+      let context_local = v8::Local::new(scope, context);
+      let global_obj = context_local.global(scope);
+      let bootstrap_str = v8::String::new(scope, "bootstrap").unwrap();
+      let bootstrap_ns: v8::Local<v8::Object> = global_obj
+        .get(scope, bootstrap_str.into())
+        .unwrap()
+        .try_into()
+        .unwrap();
+      let main_runtime_str = v8::String::new(scope, "mainRuntime").unwrap();
+      let bootstrap_fn =
+        bootstrap_ns.get(scope, main_runtime_str.into()).unwrap();
+      let bootstrap_fn =
+        v8::Local::<v8::Function>::try_from(bootstrap_fn).unwrap();
+      v8::Global::new(scope, bootstrap_fn)
+    };
+
     (
       Self {
         id: worker_id,
@@ -505,6 +525,7 @@ impl WebWorker {
         worker_type: options.worker_type,
         main_module,
         poll_for_messages_fn: None,
+        bootstrap_fn_global: Some(bootstrap_fn_global),
       },
       external_handle,
     )
@@ -513,15 +534,24 @@ impl WebWorker {
   pub fn bootstrap(&mut self, options: &BootstrapOptions) {
     // Instead of using name for log we use `worker-${id}` because
     // WebWorkers can have empty string as name.
-    let script = format!(
-      "bootstrap.workerRuntime({}, \"{}\", \"{}\")",
-      options.as_json(),
-      self.name,
-      self.id
-    );
-    self
-      .execute_script(&located_script_name!(), &script)
-      .expect("Failed to execute worker bootstrap script");
+    {
+      let scope = &mut self.js_runtime.handle_scope();
+      let options_v8 =
+        deno_core::serde_v8::to_v8(scope, options.as_json()).unwrap();
+      let bootstrap_fn = self.bootstrap_fn_global.take().unwrap();
+      let bootstrap_fn = v8::Local::new(scope, bootstrap_fn);
+      let undefined = v8::undefined(scope);
+      let name_str: v8::Local<v8::Value> =
+        v8::String::new(scope, &self.name).unwrap().into();
+      let id_str: v8::Local<v8::Value> =
+        v8::String::new(scope, &format!("{}", self.id))
+          .unwrap()
+          .into();
+      bootstrap_fn
+        .call(scope, undefined.into(), &[options_v8, name_str, id_str])
+        .unwrap();
+    }
+    // TODO(bartlomieju): this could be done using V8 API, without calling `execute_script`.
     // Save a reference to function that will start polling for messages
     // from a worker host; it will be called after the user code is loaded.
     let script = r#"

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -508,7 +508,7 @@ impl WebWorker {
         .unwrap()
         .try_into()
         .unwrap();
-      let main_runtime_str = v8::String::new(scope, "mainRuntime").unwrap();
+      let main_runtime_str = v8::String::new(scope, "workerRuntime").unwrap();
       let bootstrap_fn =
         bootstrap_ns.get(scope, main_runtime_str.into()).unwrap();
       let bootstrap_fn =

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -58,8 +58,8 @@ impl Default for BootstrapOptions {
 }
 
 impl BootstrapOptions {
-  pub fn as_json(&self) -> String {
-    let payload = json!({
+  pub fn as_json(&self) -> serde_json::Value {
+    json!({
       // Shared bootstrap args
       "args": self.args,
       "cpuCount": self.cpu_count,
@@ -80,7 +80,6 @@ impl BootstrapOptions {
       "v8Version": deno_core::v8_version(),
       "userAgent": self.user_agent,
       "inspectFlag": self.inspect,
-    });
-    serde_json::to_string_pretty(&payload).unwrap()
+    })
   }
 }


### PR DESCRIPTION
This commit further improves startup time by:

- no relying on "JsRuntime::execute_script" for runtime bootstrapping,
this is instead done using V8 APIs directly
- registering error classes during the snapshot time, instead of on
startup

Further improvements can be made, mainly around removing 
"core.initializeAsyncOps()" which takes around 2ms.

This commit should result in ~1ms startup time improvement.