### PR TITLE
chore: remove base64 encoding code from typescript snapshot

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -93,43 +93,6 @@ delete Object.prototype.__proto__;
     }
   }
 
-  // deno-fmt-ignore
-  const base64abc = [
-    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
-    "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d",
-    "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s",
-    "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7",
-    "8", "9", "+", "/",
-  ];
-
-  /** Taken from https://deno.land/std/encoding/base64.ts */
-  function convertToBase64(data) {
-    const uint8 = core.encode(data);
-    let result = "",
-      i;
-    const l = uint8.length;
-    for (i = 2; i < l; i += 3) {
-      result += base64abc[uint8[i - 2] >> 2];
-      result += base64abc[((uint8[i - 2] & 0x03) << 4) | (uint8[i - 1] >> 4)];
-      result += base64abc[((uint8[i - 1] & 0x0f) << 2) | (uint8[i] >> 6)];
-      result += base64abc[uint8[i] & 0x3f];
-    }
-    if (i === l + 1) {
-      // 1 octet yet to write
-      result += base64abc[uint8[i - 2] >> 2];
-      result += base64abc[(uint8[i - 2] & 0x03) << 4];
-      result += "==";
-    }
-    if (i === l) {
-      // 2 octets yet to write
-      result += base64abc[uint8[i - 2] >> 2];
-      result += base64abc[((uint8[i - 2] & 0x03) << 4) | (uint8[i - 1] >> 4)];
-      result += base64abc[(uint8[i - 1] & 0x0f) << 2];
-      result += "=";
-    }
-    return result;
-  }
-
   class SpecifierIsCjsCache {
     /** @type {Set<string>} */
     #cache = new Set();
@@ -818,14 +781,6 @@ delete Object.prototype.__proto__;
    * @param {Request} request
    */
   function exec({ config, debug: debugFlag, rootNames }) {
-    // https://github.com/microsoft/TypeScript/issues/49150
-    ts.base64encode = function (host, input) {
-      if (host && host.base64encode) {
-        return host.base64encode(input);
-      }
-      return convertToBase64(input);
-    };
-
     setLogDebug(debugFlag, "TS");
     performanceStart();
     if (logDebug) {


### PR DESCRIPTION
This code is no longer used because we use swc for this now.