### PR TITLE
test(wpt): implement process timeout

### DIFF
--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1087,8 +1087,8 @@
       "EventTarget-constructible.any.html": true,
       "EventTarget-constructible.any.worker.html": true,
       "Event-constructors.any.html": [
-        "Untitled 3",
-        "Untitled 4"
+        "Event constructors 3",
+        "Event constructors 4"
       ],
       "Event-constructors.any.worker.html": [
         "Event constructors 3",

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -76,12 +76,15 @@ export async function runSingleTest(
   reporter: (result: TestCaseResult) => void,
   inspectBrk: boolean,
 ): Promise<TestResult> {
+  const timeout = _options.timeout === "long" ? 60_000 : 20_000;
+  const { title } = Object.fromEntries(_options.script_metadata || []);
   const bundle = await generateBundle(url);
   const tempFile = await Deno.makeTempFile({
     prefix: "wpt-bundle-",
     suffix: ".js",
   });
 
+  let interval;
   try {
     await Deno.writeTextFile(tempFile, bundle);
 
@@ -107,6 +110,7 @@ export async function runSingleTest(
       "[]",
     );
 
+    const start = performance.now();
     const proc = new Deno.Command(denoBinary(), {
       args,
       env: {
@@ -124,10 +128,19 @@ export async function runSingleTest(
     const lines = proc.stderr.pipeThrough(new TextDecoderStream()).pipeThrough(
       new TextLineStream(),
     );
+    interval = setInterval(() => {
+      const passedTime = performance.now() - start;
+      if (passedTime > timeout) {
+        proc.kill("SIGINT");
+      }
+    }, 1000);
     for await (const line of lines) {
       if (line.startsWith("{")) {
         const data = JSON.parse(line);
         const result = { ...data, passed: data.status == 0 };
+        if (title && /^Untitled( \d+)?$/.test(result.name)) {
+          result.name = `${title}${result.name.slice(8)}`;
+        }
         cases.push(result);
         reporter(result);
       } else if (line.startsWith("#$#$#{")) {
@@ -149,6 +162,7 @@ export async function runSingleTest(
       stderr,
     };
   } finally {
+    clearInterval(interval);
     await Deno.remove(tempFile);
   }
 }


### PR DESCRIPTION
```
response-consume-stream.any.js
Blob-stream.any.js
```

These tests just hang whenever they get to use byob mode. This PR adds a timeout to the spawned process so that the WPTs finish running.

This first broke the daily run due to https://github.com/web-platform-tests/wpt/commit/7b49c547d4b7bcc17e6308f741b080f4207d1e8a

closes #17682

Also fixes "Untitled" test names in https://wpt.fyi/results/dom/events/Event-constructors.any.html?label=experimental&label=master&product=deno&product=chrome&aligned&view=subtest