### PR TITLE
Revert "feat: Deprecate Deno.run API in favor of Deno.Command (#17630)"

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3688,10 +3688,7 @@ declare namespace Deno {
     options?: { recursive: boolean },
   ): FsWatcher;
 
-  /** 
-   * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
-   * Options which can be used with {@linkcode Deno.run}.
+  /** Options which can be used with {@linkcode Deno.run}.
    *
    * @category Sub Process */
   export interface RunOptions {
@@ -3749,10 +3746,7 @@ declare namespace Deno {
     stdin?: "inherit" | "piped" | "null" | number;
   }
 
-  /** 
-   * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
-   * The status resolved from the `.status()` method of a
+  /** The status resolved from the `.status()` method of a
    * {@linkcode Deno.Process} instance.
    *
    * If `success` is `true`, then `code` will be `0`, but if `success` is
@@ -3772,8 +3766,6 @@ declare namespace Deno {
     };
 
   /**
-   * * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
    * Represents an instance of a sub process that is returned from
    * {@linkcode Deno.run} which can be used to manage the sub-process.
    *
@@ -3930,10 +3922,7 @@ declare namespace Deno {
     handler: () => void,
   ): void;
 
-  /** 
-   * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
-   * Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
+  /** Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
    * an array of program arguments, the first of which is the binary.
    *
    * ```ts


### PR DESCRIPTION
Deno.Command needs to be stabilized first and allow people to upgrade to it before we can deprecate Deno.run. Otherwise lint will suddenly fail with deprecated errors without giving people a chance to update.