### PR TITLE
fix(lint): revert no-deprecated-api for Deno.run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85201db46e6a8b4aeea4b5d574fd28e95477590ad08e128f2f043ec60442d550"
+checksum = "663d65cb008cddda1d705cd397d5d80fd37716e708b4182ca076244e18132ace"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"]
 deno_doc = "0.55.0"
 deno_emit = "0.15.0"
 deno_graph = "0.43.3"
-deno_lint = { version = "0.38.0", features = ["docs"] }
+deno_lint = { version = "0.40.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }
 deno_task_shell = "0.8.1"

--- a/cli/bench/http/deno_http_flash_ops_spawn.js
+++ b/cli/bench/http/deno_http_flash_ops_spawn.js
@@ -10,7 +10,6 @@ const path = new URL("./deno_http_flash_ops.js", import.meta.url).pathname;
 const cpus = navigator.hardwareConcurrency / 2;
 const processes = new Array(cpus);
 for (let i = 0; i < cpus; i++) {
-  // deno-lint-ignore no-deprecated-deno-api
   const proc = Deno.run({
     cmd: [executable, "run", "-A", "--unstable", path, Deno.args[0]],
   });

--- a/cli/bench/http/deno_http_flash_spawn.js
+++ b/cli/bench/http/deno_http_flash_spawn.js
@@ -10,7 +10,6 @@ const path = new URL("./deno_http_flash.js", import.meta.url).pathname;
 const cpus = navigator.hardwareConcurrency / 2;
 const processes = new Array(cpus);
 for (let i = 0; i < cpus; i++) {
-  // deno-lint-ignore no-deprecated-deno-api
   const proc = Deno.run({
     cmd: [executable, "run", "-A", "--unstable", path, Deno.args[0]],
   });

--- a/cli/tests/testdata/coverage/complex_test.ts
+++ b/cli/tests/testdata/coverage/complex_test.ts
@@ -7,7 +7,6 @@ Deno.test("complex", function () {
 Deno.test("sub process with stdin", async () => {
   // ensure launching deno run with stdin doesn't affect coverage
   const code = "console.log('5')";
-  // deno-lint-ignore no-deprecated-deno-api
   const p = await Deno.run({
     cmd: [Deno.execPath(), "run", "-"],
     stdin: "piped",
@@ -26,7 +25,6 @@ Deno.test("sub process with stdin", async () => {
 Deno.test("sub process with deno eval", async () => {
   // ensure launching deno eval doesn't affect coverage
   const code = "console.log('5')";
-  // deno-lint-ignore no-deprecated-deno-api
   const p = await Deno.run({
     cmd: [Deno.execPath(), "eval", code],
     stdout: "piped",

--- a/cli/tests/testdata/test/captured_output.ts
+++ b/cli/tests/testdata/test/captured_output.ts
@@ -1,5 +1,4 @@
 Deno.test("output", async () => {
-  // deno-lint-ignore no-deprecated-deno-api
   const p = Deno.run({
     cmd: [Deno.execPath(), "eval", "console.log(0); console.error(1);"],
   });

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -2085,7 +2085,6 @@ Deno.test({
         "--header",
         "Accept-Encoding: deflate, gzip",
       ];
-      // deno-lint-ignore no-deprecated-deno-api
       const proc = Deno.run({ cmd, stdout: "piped", stderr: "null" });
       const status = await proc.status();
       assert(status.success);
@@ -2148,7 +2147,6 @@ Deno.test({
         "--header",
         "Accept-Encoding: deflate, gzip",
       ];
-      // deno-lint-ignore no-deprecated-deno-api
       const proc = Deno.run({ cmd, stdout: "piped", stderr: "null" });
       const status = await proc.status();
       assert(status.success);

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -11,7 +11,6 @@ Deno.test(
   { permissions: { read: true, run: false } },
   function runPermissions() {
     assertThrows(() => {
-      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
       });
@@ -22,7 +21,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runSuccess() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       // freeze the array to ensure it's not modified
       cmd: Object.freeze([
@@ -45,7 +43,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runUrl() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         new URL(`file:///${Deno.execPath()}`),
@@ -69,7 +66,6 @@ Deno.test(
   async function runStdinRid0(): Promise<
     void
   > {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
       stdin: 0,
@@ -89,7 +85,6 @@ Deno.test(
   { permissions: { run: true, read: true } },
   function runInvalidStdio() {
     assertThrows(() =>
-      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
         // @ts-expect-error because Deno.run should throw on invalid stdin.
@@ -97,7 +92,6 @@ Deno.test(
       })
     );
     assertThrows(() =>
-      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
         // @ts-expect-error because Deno.run should throw on invalid stdout.
@@ -105,7 +99,6 @@ Deno.test(
       })
     );
     assertThrows(() =>
-      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
         // @ts-expect-error because Deno.run should throw on invalid stderr.
@@ -118,7 +111,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runCommandFailedWithCode() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "Deno.exit(41 + 1)"],
     });
@@ -135,7 +127,6 @@ Deno.test(
     permissions: { run: true, read: true },
   },
   async function runCommandFailedWithSignal() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -159,7 +150,6 @@ Deno.test(
 Deno.test({ permissions: { run: true } }, function runNotFound() {
   let error;
   try {
-    // deno-lint-ignore no-deprecated-deno-api
     Deno.run({ cmd: ["this file hopefully doesn't exist"] });
   } catch (e) {
     error = e;
@@ -191,7 +181,6 @@ tryExit();
 `;
 
     Deno.writeFileSync(`${cwd}/${programFile}`, enc.encode(program));
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cwd,
       cmd: [Deno.execPath(), "run", "--allow-read", programFile],
@@ -215,7 +204,6 @@ Deno.test(
   async function runStdinPiped(): Promise<
     void
   > {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -247,7 +235,6 @@ Deno.test(
   async function runStdoutPiped(): Promise<
     void
   > {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -284,7 +271,6 @@ Deno.test(
   async function runStderrPiped(): Promise<
     void
   > {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -319,7 +305,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runOutput() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -340,7 +325,6 @@ Deno.test(
   async function runStderrOutput(): Promise<
     void
   > {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -366,7 +350,6 @@ Deno.test(
       write: true,
     });
 
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -399,7 +382,6 @@ Deno.test(
     await Deno.writeFile(fileName, encoder.encode("hello"));
     const file = await Deno.open(fileName);
 
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -419,7 +401,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runEnv() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -442,7 +423,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runClose() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -466,7 +446,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runKillAfterStatus() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", 'console.log("hello")'],
     });
@@ -523,7 +502,6 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function killSuccess() {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "setTimeout(() => {}, 10000)"],
     });
@@ -547,7 +525,6 @@ Deno.test(
 );
 
 Deno.test({ permissions: { run: true, read: true } }, function killFailed() {
-  // deno-lint-ignore no-deprecated-deno-api
   const p = Deno.run({
     cmd: [Deno.execPath(), "eval", "setTimeout(() => {}, 10000)"],
   });
@@ -565,7 +542,6 @@ Deno.test({ permissions: { run: true, read: true } }, function killFailed() {
 Deno.test(
   { permissions: { run: true, read: true, env: true } },
   async function clearEnv(): Promise<void> {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -598,7 +574,6 @@ Deno.test(
     ignore: Deno.build.os === "windows",
   },
   async function uid(): Promise<void> {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         "id",
@@ -612,7 +587,6 @@ Deno.test(
 
     if (currentUid !== "0") {
       assertThrows(() => {
-        // deno-lint-ignore no-deprecated-deno-api
         Deno.run({
           cmd: [
             "echo",
@@ -631,7 +605,6 @@ Deno.test(
     ignore: Deno.build.os === "windows",
   },
   async function gid(): Promise<void> {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         "id",
@@ -645,7 +618,6 @@ Deno.test(
 
     if (currentGid !== "0") {
       assertThrows(() => {
-        // deno-lint-ignore no-deprecated-deno-api
         Deno.run({
           cmd: [
             "echo",
@@ -664,7 +636,6 @@ Deno.test(
     ignore: Deno.build.os === "windows",
   },
   async function non_existent_cwd(): Promise<void> {
-    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),


### PR DESCRIPTION
In favour of #17879 (I didn't notice this other PR until I went to open this)