### PR TITLE
feat: start caching npm package version's "bin" entry from npm registry

### DIFF
--- a/cli/npm/registry.rs
+++ b/cli/npm/registry.rs
@@ -89,19 +89,25 @@ impl Ord for NpmDependencyEntry {
   }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct NpmPeerDependencyMeta {
   #[serde(default)]
   optional: bool,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum NpmPackageVersionBinEntry {
+  String(String),
+  Map(HashMap<String, String>),
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NpmPackageVersionInfo {
   pub version: String,
   pub dist: NpmPackageVersionDistInfo,
-  #[serde(default)]
-  pub bin: HashMap<String, String>,
+  pub bin: Option<NpmPackageVersionBinEntry>,
   // Bare specifier to version (ex. `"typescript": "^3.0.1") or possibly
   // package and version (ex. `"typescript-3.0.1": "npm:typescript@3.0.1"`).
   #[serde(default)]
@@ -639,5 +645,60 @@ impl NpmRegistryApiInner for TestNpmRegistryApiInner {
 
   fn base_url(&self) -> &Url {
     NpmRegistryApi::default_url()
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use std::collections::HashMap;
+
+  use deno_core::serde_json;
+
+  use crate::npm::registry::NpmPackageVersionBinEntry;
+  use crate::npm::NpmPackageVersionDistInfo;
+
+  use super::NpmPackageVersionInfo;
+
+  #[test]
+  fn deserializes_minimal_pkg_info() {
+    let text = r#"{ "version": "1.0.0", "dist": { "tarball": "value", "shasum": "test" } }"#;
+    let info: NpmPackageVersionInfo = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+      info,
+      NpmPackageVersionInfo {
+        version: "1.0.0".to_string(),
+        dist: NpmPackageVersionDistInfo {
+          tarball: "value".to_string(),
+          shasum: "test".to_string(),
+          integrity: None,
+        },
+        bin: None,
+        dependencies: Default::default(),
+        peer_dependencies: Default::default(),
+        peer_dependencies_meta: Default::default()
+      }
+    );
+  }
+
+  #[test]
+  fn deserializes_bin_entry() {
+    // string
+    let text = r#"{ "version": "1.0.0", "bin": "bin-value", "dist": { "tarball": "value", "shasum": "test" } }"#;
+    let info: NpmPackageVersionInfo = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+      info.bin,
+      Some(NpmPackageVersionBinEntry::String("bin-value".to_string()))
+    );
+
+    // map
+    let text = r#"{ "version": "1.0.0", "bin": { "a": "a-value", "b": "b-value" }, "dist": { "tarball": "value", "shasum": "test" } }"#;
+    let info: NpmPackageVersionInfo = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+      info.bin,
+      Some(NpmPackageVersionBinEntry::Map(HashMap::from([
+        ("a".to_string(), "a-value".to_string()),
+        ("b".to_string(), "b-value".to_string()),
+      ])))
+    );
   }
 }

--- a/cli/npm/registry.rs
+++ b/cli/npm/registry.rs
@@ -100,6 +100,8 @@ pub struct NpmPeerDependencyMeta {
 pub struct NpmPackageVersionInfo {
   pub version: String,
   pub dist: NpmPackageVersionDistInfo,
+  #[serde(default)]
+  pub bin: HashMap<String, String>,
   // Bare specifier to version (ex. `"typescript": "^3.0.1") or possibly
   // package and version (ex. `"typescript-3.0.1": "npm:typescript@3.0.1"`).
   #[serde(default)]

--- a/cli/npm/registry.rs
+++ b/cli/npm/registry.rs
@@ -662,7 +662,7 @@ mod test {
   #[test]
   fn deserializes_minimal_pkg_info() {
     let text = r#"{ "version": "1.0.0", "dist": { "tarball": "value", "shasum": "test" } }"#;
-    let info: NpmPackageVersionInfo = serde_json::from_str(&text).unwrap();
+    let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
     assert_eq!(
       info,
       NpmPackageVersionInfo {
@@ -684,7 +684,7 @@ mod test {
   fn deserializes_bin_entry() {
     // string
     let text = r#"{ "version": "1.0.0", "bin": "bin-value", "dist": { "tarball": "value", "shasum": "test" } }"#;
-    let info: NpmPackageVersionInfo = serde_json::from_str(&text).unwrap();
+    let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
     assert_eq!(
       info.bin,
       Some(NpmPackageVersionBinEntry::String("bin-value".to_string()))
@@ -692,7 +692,7 @@ mod test {
 
     // map
     let text = r#"{ "version": "1.0.0", "bin": { "a": "a-value", "b": "b-value" }, "dist": { "tarball": "value", "shasum": "test" } }"#;
-    let info: NpmPackageVersionInfo = serde_json::from_str(&text).unwrap();
+    let info: NpmPackageVersionInfo = serde_json::from_str(text).unwrap();
     assert_eq!(
       info.bin,
       Some(NpmPackageVersionBinEntry::Map(HashMap::from([


### PR DESCRIPTION
This is to start saving this entry in people's cache directory.