### PR TITLE
Revert "test(wpt): implement process timeout (#17872)"

### DIFF
--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1087,8 +1087,8 @@
       "EventTarget-constructible.any.html": true,
       "EventTarget-constructible.any.worker.html": true,
       "Event-constructors.any.html": [
-        "Event constructors 3",
-        "Event constructors 4"
+        "Untitled 3",
+        "Untitled 4"
       ],
       "Event-constructors.any.worker.html": [
         "Event constructors 3",

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -76,15 +76,12 @@ export async function runSingleTest(
   reporter: (result: TestCaseResult) => void,
   inspectBrk: boolean,
 ): Promise<TestResult> {
-  const timeout = _options.timeout === "long" ? 60_000 : 20_000;
-  const { title } = Object.fromEntries(_options.script_metadata || []);
   const bundle = await generateBundle(url);
   const tempFile = await Deno.makeTempFile({
     prefix: "wpt-bundle-",
     suffix: ".js",
   });
 
-  let interval;
   try {
     await Deno.writeTextFile(tempFile, bundle);
 
@@ -110,7 +107,6 @@ export async function runSingleTest(
       "[]",
     );
 
-    const start = performance.now();
     const proc = new Deno.Command(denoBinary(), {
       args,
       env: {
@@ -128,19 +124,10 @@ export async function runSingleTest(
     const lines = proc.stderr.pipeThrough(new TextDecoderStream()).pipeThrough(
       new TextLineStream(),
     );
-    interval = setInterval(() => {
-      const passedTime = performance.now() - start;
-      if (passedTime > timeout) {
-        proc.kill("SIGINT");
-      }
-    }, 1000);
     for await (const line of lines) {
       if (line.startsWith("{")) {
         const data = JSON.parse(line);
         const result = { ...data, passed: data.status == 0 };
-        if (title && /^Untitled( \d+)?$/.test(result.name)) {
-          result.name = `${title}${result.name.slice(8)}`;
-        }
         cases.push(result);
         reporter(result);
       } else if (line.startsWith("#$#$#{")) {
@@ -162,7 +149,6 @@ export async function runSingleTest(
       stderr,
     };
   } finally {
-    clearInterval(interval);
     await Deno.remove(tempFile);
   }
 }


### PR DESCRIPTION
This reverts commit 5fcbdd62285140353edbb28e67f7d72e3317e96e.

Since landing that PR we are getting following failures on CI:

```
file failures:

        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?1-1000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?1001-2000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?2001-3000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?3001-4000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?4001-5000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?5001-6000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?6001-7000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?7001-8000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?1-1000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?1001-2000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?2001-3000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?3001-4000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?4001-5000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?5001-6000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?6001-7000"
        "/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html?7001-8000"
```

I'm going to revert it for now to unblock the v1.31 release. I'll look into relanding it on Friday.

CC @lucacasonato @panva 