### PR TITLE
feat(npm): support npm specifiers in remote modules without `--unstable`

### DIFF
--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -217,11 +217,11 @@ itest!(sub_paths {
 });
 
 itest!(remote_npm_specifier {
-  args: "run --quiet npm/remote_npm_specifier/main.ts",
+  args: "run --quiet -A npm/remote_npm_specifier/main.ts",
   output: "npm/remote_npm_specifier/main.out",
   envs: env_vars_for_npm_tests(),
   http_server: true,
-  exit_code: 1,
+  exit_code: 0,
 });
 
 itest!(tarball_with_global_header {

--- a/cli/tests/testdata/npm/remote_npm_specifier/main.out
+++ b/cli/tests/testdata/npm/remote_npm_specifier/main.out
@@ -1,1 +1,1 @@
-error: importing npm specifiers in remote modules requires the --unstable flag (referrer: http://localhost:4545/npm/remote_npm_specifier/remote.ts)
+test


### PR DESCRIPTION
Closes #17455