### PR TITLE
test(wpt): implement process timeout, fix expectations update, and more...

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -72,7 +72,7 @@ jobs:
           deno run --unstable --allow-write --allow-read --allow-net           \
             --allow-env --allow-run --lock=tools/deno.lock.json                \
             ./tools/wpt.ts run                                                 \
-            --binary=$(which deno) --quiet --release --json=wpt.json --wptreport=wptreport.json || true
+            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json || true
 
       - name: Upload wpt results to wpt.fyi
         env:

--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -25,6 +25,7 @@ import {
   ManifestFolder,
   ManifestTestOptions,
   ManifestTestVariation,
+  noIgnore,
   quiet,
   rest,
   runPy,
@@ -703,7 +704,7 @@ function discoverTestsToRun(
                 typeof expectation.ignore === "boolean",
                 "test entry's `ignore` key must be a boolean",
               );
-              if (expectation.ignore === true) continue;
+              if (expectation.ignore === true && !noIgnore) continue;
             }
           }
 

--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -173,6 +173,9 @@ async function run() {
           test.options,
           inParallel ? () => {} : createReportTestCase(test.expectation),
           inspectBrk,
+          Deno.env.get("CI")
+            ? { long: 4 * 60_000, default: 4 * 60_000 }
+            : { long: 60_000, default: 10_000 },
         );
         results.push({ test, result });
         if (inParallel) {
@@ -332,6 +335,7 @@ async function update() {
         test.options,
         json ? () => {} : createReportTestCase(test.expectation),
         inspectBrk,
+        { long: 60_000, default: 10_000 },
       );
       results.push({ test, result });
       reportVariation(result, test.expectation);
@@ -367,7 +371,7 @@ async function update() {
 
   const currentExpectation = getExpectation();
 
-  for (const result of Object.values(resultTests)) {
+  for (const [path, result] of Object.entries(resultTests)) {
     const { passed, failed, testSucceeded } = result;
     let finalExpectation: boolean | string[];
     if (failed.length == 0 && testSucceeded) {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -1087,8 +1087,8 @@
       "EventTarget-constructible.any.html": true,
       "EventTarget-constructible.any.worker.html": true,
       "Event-constructors.any.html": [
-        "Untitled 3",
-        "Untitled 4"
+        "Event constructors 3",
+        "Event constructors 4"
       ],
       "Event-constructors.any.worker.html": [
         "Event constructors 3",

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -80,6 +80,10 @@ export async function runSingleTest(
   const timeout = _options.timeout === "long"
     ? timeouts.long
     : timeouts.default;
+  const filename = url.pathname.substring(
+    url.pathname.lastIndexOf("/") + 1,
+    url.pathname.indexOf("."),
+  );
   const { title } = Object.fromEntries(_options.script_metadata || []);
   const bundle = await generateBundle(url);
   const tempFile = await Deno.makeTempFile({
@@ -141,8 +145,8 @@ export async function runSingleTest(
       if (line.startsWith("{")) {
         const data = JSON.parse(line);
         const result = { ...data, passed: data.status == 0 };
-        if (title && /^Untitled( \d+)?$/.test(result.name)) {
-          result.name = `${title}${result.name.slice(8)}`;
+        if (/^Untitled( \d+)?$/.test(result.name)) {
+          result.name = `${title || filename}${result.name.slice(8)}`;
         }
         cases.push(result);
         reporter(result);

--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -75,8 +75,11 @@ export async function runSingleTest(
   _options: ManifestTestOptions,
   reporter: (result: TestCaseResult) => void,
   inspectBrk: boolean,
+  timeouts: { long: number; default: number },
 ): Promise<TestResult> {
-  const timeout = (_options.timeout === "long" ? 4 : 2) * 60 * 1000;
+  const timeout = _options.timeout === "long"
+    ? timeouts.long
+    : timeouts.default;
   const { title } = Object.fromEntries(_options.script_metadata || []);
   const bundle = await generateBundle(url);
   const tempFile = await Deno.makeTempFile({

--- a/tools/wpt/utils.ts
+++ b/tools/wpt/utils.ts
@@ -13,10 +13,11 @@ export const {
   ["--"]: rest,
   ["auto-config"]: autoConfig,
   ["inspect-brk"]: inspectBrk,
+  ["no-ignore"]: noIgnore,
   binary,
 } = parse(Deno.args, {
   "--": true,
-  boolean: ["quiet", "release", "no-interactive", "inspect-brk"],
+  boolean: ["quiet", "release", "no-interactive", "inspect-brk", "no-ignore"],
   string: ["json", "wptreport", "binary"],
 });
 


### PR DESCRIPTION
- relands #17872
- updates the timeouts to be re-configurable just for CI
- fixes `./tools/wpt.ts update`
- adds option not "ignore" during, applied to wpt epoch runs only

cc @bartlomieju @lucacasonato 