### PR TITLE
chore(ext/node): suppress node compat tests stdout by default

### DIFF
--- a/cli/tests/node_compat/test.ts
+++ b/cli/tests/node_compat/test.ts
@@ -79,9 +79,10 @@ for await (const path of testPaths) {
       });
       const { code, stdout, stderr } = await command.output();
 
-      if (stdout.length && hasFilters) console.log(decoder.decode(stdout));
-
       if (code !== 0) {
+        // If the test case failed, show the stdout, stderr, and instruction
+        // for repeating the single test case.
+        if (stdout.length) console.log(decoder.decode(stdout));
         console.log(`Error: "${path}" failed`);
         console.log(
           "You can repeat only this test with the command:",
@@ -90,6 +91,11 @@ for await (const path of testPaths) {
           ),
         );
         fail(decoder.decode(stderr));
+      } else if (hasFilters) {
+        // Even if the test case is successful, shows the stdout and stderr
+        // when test case filtering is specified.
+        if (stdout.length) console.log(decoder.decode(stdout));
+        if (stderr.length) console.log(decoder.decode(stderr));
       }
     },
   });

--- a/cli/tests/node_compat/test.ts
+++ b/cli/tests/node_compat/test.ts
@@ -8,6 +8,7 @@ import { config, getPathsFromTestSuites } from "./common.ts";
 // deno test -A cli/tests/node_compat/test.ts -- <test-names>
 // Use the test-names as filters
 const filters = Deno.args;
+const hasFilters = filters.length > 0;
 
 /**
  * This script will run the test files specified in the configuration file
@@ -78,7 +79,7 @@ for await (const path of testPaths) {
       });
       const { code, stdout, stderr } = await command.output();
 
-      if (stdout.length) console.log(decoder.decode(stdout));
+      if (stdout.length && hasFilters) console.log(decoder.decode(stdout));
 
       if (code !== 0) {
         console.log(`Error: "${path}" failed`);
@@ -107,7 +108,7 @@ function checkConfigTestFilesOrder(testFileLists: Array<string[]>) {
   }
 }
 
-if (filters.length === 0) {
+if (!hasFilters) {
   Deno.test("checkConfigTestFilesOrder", function () {
     checkConfigTestFilesOrder([
       ...Object.keys(config.ignore).map((suite) => config.ignore[suite]),


### PR DESCRIPTION
This PR suppresses the stdout of Node.js compat test cases when they are executed without any filter. (The console output of node.js compat testing is large and they are not useful when running the entire test cases.)

The stdout is still displayed when the developer specifies any test case filter.