### PR TITLE
Revert "feat(flash): add 2nd param to handler to get remote address"

### DIFF
--- a/cli/tests/unit/flash_test.ts
+++ b/cli/tests/unit/flash_test.ts
@@ -89,14 +89,12 @@ Deno.test({ permissions: { net: true } }, async function httpServerBasic() {
   const listeningPromise = deferred();
 
   const server = Deno.serve({
-    handler: async (request, getRemoteAddr) => {
+    handler: async (request) => {
       // FIXME(bartlomieju):
       // make sure that request can be inspected
       console.log(request);
       assertEquals(new URL(request.url).href, "http://127.0.0.1:4501/");
       assertEquals(await request.text(), "");
-      const addr = getRemoteAddr();
-      assertEquals(addr.hostname, "127.0.0.1");
       promise.resolve();
       return new Response("Hello World", { headers: { "foo": "bar" } });
     },

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1173,7 +1173,7 @@ declare namespace Deno {
    *
    * @category HTTP Server
    */
-  export type ServeHandler = (request: Request, getRemoteAddr: () => Deno.NetAddr) => Response | Promise<Response>;
+  export type ServeHandler = (request: Request) => Response | Promise<Response>;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -580,16 +580,7 @@ function createServe(opFn) {
 
             let resp;
             try {
-              resp = handler(req, () => {
-                const { 0: hostname, 1: port } = core.ops.op_flash_addr(
-                  serverId,
-                  i,
-                );
-                return {
-                  hostname,
-                  port,
-                };
-              });
+              resp = handler(req);
               if (ObjectPrototypeIsPrototypeOf(PromisePrototype, resp)) {
                 PromisePrototypeCatch(
                   PromisePrototypeThen(

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -665,26 +665,6 @@ fn op_flash_headers(
   )
 }
 
-#[op]
-fn op_flash_addr(
-  state: Rc<RefCell<OpState>>,
-  server_id: u32,
-  token: u32,
-) -> Result<(String, u16), AnyError> {
-  let mut op_state = state.borrow_mut();
-  let flash_ctx = op_state.borrow_mut::<FlashContext>();
-  let ctx = flash_ctx
-    .servers
-    .get_mut(&server_id)
-    .ok_or_else(|| type_error("server closed"))?;
-  let req = &ctx
-    .requests
-    .get(&token)
-    .ok_or_else(|| type_error("request closed"))?;
-  let socket = req.socket();
-  Ok((socket.addr.ip().to_string(), socket.addr.port()))
-}
-
 // Remember the first packet we read? It probably also has some body data. This op quickly copies it into
 // a buffer and sets up channels for streaming the rest.
 #[op]
@@ -954,7 +934,7 @@ fn run_server(
       match token {
         Token(0) => loop {
           match listener.accept() {
-            Ok((mut socket, addr)) => {
+            Ok((mut socket, _)) => {
               counter += 1;
               let token = Token(counter);
               poll
@@ -980,7 +960,6 @@ fn run_server(
                 read_lock: Arc::new(Mutex::new(())),
                 parse_done: ParseStatus::None,
                 buffer: UnsafeCell::new(vec![0_u8; 1024]),
-                addr,
               });
 
               trace!("New connection: {}", token.0);
@@ -1545,7 +1524,6 @@ pub fn init<P: FlashPermissions + 'static>(unstable: bool) -> Extension {
       op_flash_method::decl(),
       op_flash_path::decl(),
       op_flash_headers::decl(),
-      op_flash_addr::decl(),
       op_flash_next::decl(),
       op_flash_next_server::decl(),
       op_flash_next_async::decl(),

--- a/ext/flash/socket.rs
+++ b/ext/flash/socket.rs
@@ -29,7 +29,6 @@ pub struct Stream {
   pub parse_done: ParseStatus,
   pub buffer: UnsafeCell<Vec<u8>>,
   pub read_lock: Arc<Mutex<()>>,
-  pub addr: std::net::SocketAddr,
 }
 
 impl Stream {


### PR DESCRIPTION
Reverts denoland/deno#17633

This is a terribly unergonomic API that is completely inextensible for the future. Let's revert, and reland with an options bag that has a `remoteAddr` property, like `std/http`'s `ConnInfo`.

I know that this API is unstable, and we should move fast, but come on... this is like really not a good API at all. The http server is one of the most used APIs and should be incredibly ergonomic - we should spend significant time designing the API here. Landing public API changes to this API should require reviews from large chunks of our engineering team (same goes for common `Deno.*` APIs).