### PR TITLE
fix: remote modules should be allowed to import data urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.44.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03c7b4d4990cc1f09c09c6ae94ee0dc039c9fcf66a97f8e5954ee102ba0eedf"
+checksum = "75a9fd8abbf9fd7e79762232611c188762b495919e1e8920bfd3d74b323edae3"
 dependencies = [
  "anyhow",
  "data-url",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,7 +46,7 @@ deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_gra
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "0.57.0"
 deno_emit = "0.16.0"
-deno_graph = "0.44.0"
+deno_graph = "0.44.1"
 deno_lint = { version = "0.40.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }


### PR DESCRIPTION
This was a regression that has already been broken for some time, but that also became broken for when using an import map 1.31.

Tests are in deno_graph.

```
> ./target/debug/deno run https://deno.com/blog/v1.7/import_data_url.ts
a
{ "0": "A", "1": "B", "2": "C", A: 0, B: 1, C: 2 }
0
```

Closes #17914