### PR TITLE
fix(npm): package.json auto-discovery should respect `--no-config` and `--no-npm`

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -568,7 +568,7 @@ impl CliOptions {
     let maybe_config_file = ConfigFile::discover(&flags, &initial_cwd)?;
 
     let mut maybe_package_json = None;
-    if flags.config_flag == ConfigFlag::Disabled {
+    if flags.config_flag == ConfigFlag::Disabled || flags.no_npm {
       log::debug!("package.json auto-discovery is disabled")
     } else if let Some(config_file) = &maybe_config_file {
       let specifier = config_file.specifier.clone();

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -568,7 +568,9 @@ impl CliOptions {
     let maybe_config_file = ConfigFile::discover(&flags, &initial_cwd)?;
 
     let mut maybe_package_json = None;
-    if let Some(config_file) = &maybe_config_file {
+    if flags.config_flag == ConfigFlag::Disabled {
+      log::debug!("package.json auto-discovery is disabled")
+    } else if let Some(config_file) = &maybe_config_file {
       let specifier = config_file.specifier.clone();
       if specifier.scheme() == "file" {
         let maybe_stop_at = specifier
@@ -582,6 +584,7 @@ impl CliOptions {
     } else {
       maybe_package_json = discover_package_json(&flags, None)?;
     }
+
     let maybe_lock_file =
       lockfile::discover(&flags, maybe_config_file.as_ref())?;
     Self::new(

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2749,9 +2749,10 @@ itest!(config_not_auto_discovered_for_remote_script {
   http_server: true,
 });
 
-itest!(package_json_auto_discovered_for_local_script_log {
+itest!(package_json_auto_discovered_for_local_script_arg {
   args: "run -L debug -A no_deno_json/main.ts",
   output: "run/with_package_json/no_deno_json/main.out",
+  // notice this is not in no_deno_json
   cwd: Some("run/with_package_json/"),
   // prevent creating a node_modules dir in the code directory
   copy_temp_dir: Some("run/with_package_json/"),
@@ -2762,7 +2763,7 @@ itest!(package_json_auto_discovered_for_local_script_log {
 // In this case we shouldn't discover `package.json` file, because it's in a
 // directory that is above the directory containing `deno.json` file.
 itest!(
-  package_json_auto_discovered_for_local_script_log_with_stop {
+  package_json_auto_discovered_for_local_script_arg_with_stop {
     args: "run -L debug with_stop/some/nested/dir/main.ts",
     output: "run/with_package_json/with_stop/main.out",
     cwd: Some("run/with_package_json/"),
@@ -2772,6 +2773,12 @@ itest!(
     exit_code: 1,
   }
 );
+
+itest!(package_json_not_auto_discovered_no_config {
+  args: "run -L debug -A --no-config noconfig.ts",
+  output: "run/with_package_json/no_deno_json/noconfig.out",
+  cwd: Some("run/with_package_json/no_deno_json/"),
+});
 
 itest!(
   package_json_auto_discovered_node_modules_relative_package_json {

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2780,6 +2780,12 @@ itest!(package_json_not_auto_discovered_no_config {
   cwd: Some("run/with_package_json/no_deno_json/"),
 });
 
+itest!(package_json_not_auto_discovered_no_npm {
+  args: "run -L debug -A --no-npm noconfig.ts",
+  output: "run/with_package_json/no_deno_json/noconfig.out",
+  cwd: Some("run/with_package_json/no_deno_json/"),
+});
+
 itest!(
   package_json_auto_discovered_node_modules_relative_package_json {
     args: "run -A main.js",

--- a/cli/tests/testdata/run/with_package_json/no_deno_json/noconfig.out
+++ b/cli/tests/testdata/run/with_package_json/no_deno_json/noconfig.out
@@ -1,0 +1,3 @@
+[WILDCARD]package.json auto-discovery is disabled
+[WILDCARD]
+success

--- a/cli/tests/testdata/run/with_package_json/no_deno_json/noconfig.ts
+++ b/cli/tests/testdata/run/with_package_json/no_deno_json/noconfig.ts
@@ -1,0 +1,8 @@
+// ensure the cwd is this directory
+const cwd = Deno.cwd();
+if (!cwd.endsWith("no_deno_json")) {
+  console.log(cwd);
+  throw "FAIL";
+} else {
+  console.log("success");
+}


### PR DESCRIPTION
Part of #17916