### PR TITLE
fix: regression remapping remote specifier to local file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,9 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a9fd8abbf9fd7e79762232611c188762b495919e1e8920bfd3d74b323edae3"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "data-url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,8 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.44.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2cb8c414852294d5fb23d265725bbf1fab9608296e04301440dba14fef71e5"
 dependencies = [
  "anyhow",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,3 +303,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.base64-simd]
 opt-level = 3
+
+[patch.crates-io]
+deno_graph = { path = '../deno_graph' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.base64-simd]
 opt-level = 3
-
-[patch.crates-io]
-deno_graph = { path = '../deno_graph' }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,7 +46,7 @@ deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_gra
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "0.57.0"
 deno_emit = "0.16.0"
-deno_graph = "0.44.1"
+deno_graph = "=0.44.2"
 deno_lint = { version = "0.40.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -446,6 +446,7 @@ mod test {
         specifier: input.to_string(),
         range: Range {
           specifier,
+          text: "".to_string(),
           start: Position::zeroed(),
           end: Position::zeroed(),
         },
@@ -462,6 +463,7 @@ mod test {
       let err = ResolutionError::InvalidSpecifier {
         range: Range {
           specifier,
+          text: "".to_string(),
           start: Position::zeroed(),
           end: Position::zeroed(),
         },

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -681,6 +681,7 @@ mod tests {
       &text_info,
       &Range {
         specifier: ModuleSpecifier::parse("https://deno.land").unwrap(),
+        text: "".to_string(),
         start: deno_graph::Position {
           line: 0,
           character: 0,
@@ -705,6 +706,7 @@ mod tests {
       &text_info,
       &Range {
         specifier: ModuleSpecifier::parse("https://deno.land").unwrap(),
+        text: "".to_string(),
         start: deno_graph::Position {
           line: 0,
           character: 0,


### PR DESCRIPTION
Tests added to deno_graph, which were previously not there.

Closes #17932