### PR TITLE
chore(ext/ffi): Use queueMicrotask in tests

### DIFF
--- a/test_ffi/tests/event_loop_integration.ts
+++ b/test_ffi/tests/event_loop_integration.ts
@@ -29,7 +29,7 @@ const dylib = Deno.dlopen(
 let retry = false;
 const tripleLogCallback = () => {
   console.log("Sync");
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     console.log("Async");
     callback.unref();
   });
@@ -66,7 +66,7 @@ console.log("STORED_FUNCTION called");
 // Wait to make sure synch logging and async logging
 await new Promise((res) => setTimeout(res, 100));
 
-// Ref once to make sure both `Promise.resolve().then()` and `setTimeout()`
+// Ref once to make sure both `queueMicrotask()` and `setTimeout()`
 // must resolve and unref before isolate exists.
 // One ref'ing has been done by `threadSafe` constructor.
 callback.ref();

--- a/test_ffi/tests/thread_safe_test.js
+++ b/test_ffi/tests/thread_safe_test.js
@@ -82,7 +82,7 @@ const cleanupCallback = new Deno.UnsafeCallback(
   { parameters: [], result: "void" },
   () => {
     console.log("Callback being called");
-    Promise.resolve().then(() => cleanup());
+    queueMicrotask(() => cleanup());
   },
 );
 


### PR DESCRIPTION
Absolutely nothingburger of a PR: I just hadn't realized `queueMicrotask()` is a thing and wrote tests using `Promise.resolve().then()` in its stead.