### PR TITLE
fix(ext/ffi): Remove deno_core::OpState qualifiers, fix ops returning pointer defaults

### DIFF
--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -16,6 +16,7 @@ use deno_core::serde_json::Value;
 use deno_core::serde_v8;
 use deno_core::serde_v8::ExternalPointer;
 use deno_core::v8;
+use deno_core::OpState;
 use deno_core::ResourceId;
 use libffi::middle::Arg;
 use serde::Serialize;
@@ -274,7 +275,7 @@ fn ffi_call(
 #[op(v8)]
 pub fn op_ffi_call_ptr_nonblocking<'scope, FP>(
   scope: &mut v8::HandleScope<'scope>,
-  state: Rc<RefCell<deno_core::OpState>>,
+  state: Rc<RefCell<OpState>>,
   pointer: *mut c_void,
   def: ForeignFunction,
   parameters: serde_v8::Value<'scope>,
@@ -322,7 +323,7 @@ where
 #[op(v8)]
 pub fn op_ffi_call_nonblocking<'scope>(
   scope: &mut v8::HandleScope<'scope>,
-  state: Rc<RefCell<deno_core::OpState>>,
+  state: Rc<RefCell<OpState>>,
   rid: ResourceId,
   symbol: String,
   parameters: serde_v8::Value<'scope>,
@@ -374,7 +375,7 @@ pub fn op_ffi_call_nonblocking<'scope>(
 #[op(v8)]
 pub fn op_ffi_call_ptr<FP, 'scope>(
   scope: &mut v8::HandleScope<'scope>,
-  state: Rc<RefCell<deno_core::OpState>>,
+  state: Rc<RefCell<OpState>>,
   pointer: *mut c_void,
   def: ForeignFunction,
   parameters: serde_v8::Value<'scope>,

--- a/ext/ffi/callback.rs
+++ b/ext/ffi/callback.rs
@@ -540,7 +540,7 @@ pub struct RegisterCallbackArgs {
 
 #[op(v8)]
 pub fn op_ffi_unsafe_callback_create<FP, 'scope>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   scope: &mut v8::HandleScope<'scope>,
   args: RegisterCallbackArgs,
   cb: serde_v8::Value<'scope>,

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -11,6 +11,7 @@ use deno_core::error::AnyError;
 use deno_core::op;
 use deno_core::serde_v8;
 use deno_core::v8;
+use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
 use dlopen::raw::Library;
@@ -126,7 +127,7 @@ pub struct FfiLoadArgs {
 #[op(v8)]
 pub fn op_ffi_load<FP, 'scope>(
   scope: &mut v8::HandleScope<'scope>,
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   args: FfiLoadArgs,
 ) -> Result<(ResourceId, serde_v8::Value<'scope>), AnyError>
 where

--- a/ext/ffi/repr.rs
+++ b/ext/ffi/repr.rs
@@ -8,6 +8,7 @@ use deno_core::error::AnyError;
 use deno_core::op;
 use deno_core::serde_v8;
 use deno_core::v8;
+use deno_core::OpState;
 use std::ffi::c_char;
 use std::ffi::c_void;
 use std::ffi::CStr;
@@ -15,7 +16,7 @@ use std::ptr;
 
 #[op(fast)]
 fn op_ffi_ptr_create<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr_number: usize,
 ) -> Result<*mut c_void, AnyError>
 where
@@ -30,7 +31,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_ptr_equals<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   a: *const c_void,
   b: *const c_void,
 ) -> Result<bool, AnyError>
@@ -46,7 +47,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_ptr_of<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   buf: *const u8,
 ) -> Result<*mut c_void, AnyError>
 where
@@ -61,7 +62,7 @@ where
 
 #[op(fast)]
 fn op_ffi_ptr_offset<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<*mut c_void, AnyError>
@@ -89,7 +90,7 @@ unsafe extern "C" fn noop_deleter_callback(
 
 #[op(fast)]
 fn op_ffi_ptr_value<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   out: &mut [u32],
 ) -> Result<(), AnyError>
@@ -117,7 +118,7 @@ where
 #[op(v8)]
 pub fn op_ffi_get_buf<FP, 'scope>(
   scope: &mut v8::HandleScope<'scope>,
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
   len: usize,
@@ -151,7 +152,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_buf_copy_into<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   src: *mut c_void,
   offset: isize,
   dst: &mut [u8],
@@ -186,7 +187,7 @@ where
 #[op(v8)]
 pub fn op_ffi_cstr_read<FP, 'scope>(
   scope: &mut v8::HandleScope<'scope>,
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<serde_v8::Value<'scope>, AnyError>
@@ -216,7 +217,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_bool<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<bool, AnyError>
@@ -238,7 +239,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_u8<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<u32, AnyError>
@@ -262,7 +263,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_i8<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<i32, AnyError>
@@ -286,7 +287,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_u16<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<u32, AnyError>
@@ -310,7 +311,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_i16<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<i32, AnyError>
@@ -334,7 +335,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_u32<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<u32, AnyError>
@@ -356,7 +357,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_i32<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<i32, AnyError>
@@ -378,7 +379,7 @@ where
 
 #[op]
 pub fn op_ffi_read_u64<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
   out: &mut [u32],
@@ -413,7 +414,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_i64<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
   out: &mut [u32],
@@ -447,7 +448,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_f32<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<f32, AnyError>
@@ -469,7 +470,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_f64<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<f64, AnyError>
@@ -491,7 +492,7 @@ where
 
 #[op(fast)]
 pub fn op_ffi_read_ptr<FP>(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   ptr: *mut c_void,
   offset: isize,
 ) -> Result<*mut c_void, AnyError>

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -7,6 +7,7 @@ use deno_bench_util::bencher::Bencher;
 use deno_core::Extension;
 use deno_core::ExtensionFileSource;
 use deno_core::ExtensionFileSourceCode;
+use deno_core::OpState;
 use deno_web::BlobStore;
 
 struct Permissions;
@@ -15,11 +16,7 @@ impl deno_web::TimersPermission for Permissions {
   fn allow_hrtime(&mut self) -> bool {
     false
   }
-  fn check_unstable(
-    &self,
-    _state: &deno_core::OpState,
-    _api_name: &'static str,
-  ) {
+  fn check_unstable(&self, _state: &OpState, _api_name: &'static str) {
     unreachable!()
   }
 }

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -7,6 +7,7 @@ use deno_bench_util::bencher::Bencher;
 use deno_core::Extension;
 use deno_core::ExtensionFileSource;
 use deno_core::ExtensionFileSourceCode;
+use deno_core::OpState;
 use deno_web::BlobStore;
 
 struct Permissions;
@@ -15,12 +16,7 @@ impl deno_web::TimersPermission for Permissions {
   fn allow_hrtime(&mut self) -> bool {
     true
   }
-  fn check_unstable(
-    &self,
-    _state: &deno_core::OpState,
-    _api_name: &'static str,
-  ) {
-  }
+  fn check_unstable(&self, _state: &OpState, _api_name: &'static str) {}
 }
 
 fn setup() -> Vec<Extension> {

--- a/ext/web/blob.rs
+++ b/ext/web/blob.rs
@@ -12,6 +12,7 @@ use deno_core::error::AnyError;
 use deno_core::op;
 use deno_core::parking_lot::Mutex;
 use deno_core::url::Url;
+use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use serde::Deserialize;
 use serde::Serialize;
@@ -159,10 +160,7 @@ impl BlobPart for SlicedBlobPart {
 }
 
 #[op]
-pub fn op_blob_create_part(
-  state: &mut deno_core::OpState,
-  data: ZeroCopyBuf,
-) -> Uuid {
+pub fn op_blob_create_part(state: &mut OpState, data: ZeroCopyBuf) -> Uuid {
   let blob_store = state.borrow::<BlobStore>();
   let part = InMemoryBlobPart(data.to_vec());
   blob_store.insert_part(Arc::new(part))
@@ -177,7 +175,7 @@ pub struct SliceOptions {
 
 #[op]
 pub fn op_blob_slice_part(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   id: Uuid,
   options: SliceOptions,
 ) -> Result<Uuid, AnyError> {
@@ -203,7 +201,7 @@ pub fn op_blob_slice_part(
 
 #[op]
 pub async fn op_blob_read_part(
-  state: Rc<RefCell<deno_core::OpState>>,
+  state: Rc<RefCell<OpState>>,
   id: Uuid,
 ) -> Result<ZeroCopyBuf, AnyError> {
   let part = {
@@ -217,14 +215,14 @@ pub async fn op_blob_read_part(
 }
 
 #[op]
-pub fn op_blob_remove_part(state: &mut deno_core::OpState, id: Uuid) {
+pub fn op_blob_remove_part(state: &mut OpState, id: Uuid) {
   let blob_store = state.borrow::<BlobStore>();
   blob_store.remove_part(&id);
 }
 
 #[op]
 pub fn op_blob_create_object_url(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   media_type: String,
   part_ids: Vec<Uuid>,
 ) -> Result<String, AnyError> {
@@ -250,7 +248,7 @@ pub fn op_blob_create_object_url(
 
 #[op]
 pub fn op_blob_revoke_object_url(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   url: String,
 ) -> Result<(), AnyError> {
   let url = Url::parse(&url)?;
@@ -273,7 +271,7 @@ pub struct ReturnBlobPart {
 
 #[op]
 pub fn op_blob_from_object_url(
-  state: &mut deno_core::OpState,
+  state: &mut OpState,
   url: String,
 ) -> Result<Option<ReturnBlob>, AnyError> {
   let url = Url::parse(&url)?;

--- a/ops/fast_call.rs
+++ b/ops/fast_call.rs
@@ -250,13 +250,19 @@ pub(crate) fn generate(
       //
       // V8 calls the slow path so we can take the slot
       // value and throw.
-      let result_wrap = q!(Vars { op_state }, {
+      let default = if optimizer.fast_result == Some(FastValue::Pointer) {
+        // Pointers do not have default value.
+        q!({ ::std::ptr::null_mut() })
+      } else {
+        q!({ Default::default() })
+      };
+      let result_wrap = q!(Vars { op_state, default }, {
         match result {
           Ok(result) => result,
           Err(err) => {
             op_state.last_fast_op_error.replace(err);
             __opts.fallback = true;
-            Default::default()
+            default
           }
         }
       });

--- a/ops/fast_call.rs
+++ b/ops/fast_call.rs
@@ -250,12 +250,7 @@ pub(crate) fn generate(
       //
       // V8 calls the slow path so we can take the slot
       // value and throw.
-      let default = if optimizer.fast_result == Some(FastValue::Pointer) {
-        // Pointers do not have default value.
-        q!({ ::std::ptr::null_mut() })
-      } else {
-        q!({ Default::default() })
-      };
+      let default = optimizer.fast_result.as_ref().unwrap().default_value();
       let result_wrap = q!(Vars { op_state, default }, {
         match result {
           Ok(result) => result,

--- a/ops/optimizer.rs
+++ b/ops/optimizer.rs
@@ -217,10 +217,8 @@ fn get_fast_scalar(s: &str) -> Option<FastValue> {
     "bool" => Some(FastValue::Bool),
     "u32" => Some(FastValue::U32),
     "i32" => Some(FastValue::I32),
-    "u64" => Some(FastValue::U64),
-    "i64" => Some(FastValue::I64),
-    "usize" => Some(FastValue::U64),
-    "isize" => Some(FastValue::I64),
+    "u64" | "usize" => Some(FastValue::U64),
+    "i64" | "isize" => Some(FastValue::I64),
     "f32" => Some(FastValue::F32),
     "f64" => Some(FastValue::F64),
     "* const c_void" | "* mut c_void" => Some(FastValue::Pointer),
@@ -254,6 +252,16 @@ pub(crate) enum FastValue {
   Uint8Array,
   Uint32Array,
   Float64Array,
+}
+
+impl FastValue {
+  pub fn default_value(&self) -> Quote {
+    match self {
+      FastValue::Pointer => q!({ ::std::ptr::null_mut() }),
+      FastValue::Void => q!({}),
+      _ => q!({ Default::default() }),
+    }
+  }
 }
 
 impl Default for FastValue {

--- a/ops/optimizer.rs
+++ b/ops/optimizer.rs
@@ -219,6 +219,8 @@ fn get_fast_scalar(s: &str) -> Option<FastValue> {
     "i32" => Some(FastValue::I32),
     "u64" => Some(FastValue::U64),
     "i64" => Some(FastValue::I64),
+    "usize" => Some(FastValue::U64),
+    "isize" => Some(FastValue::I64),
     "f32" => Some(FastValue::F32),
     "f64" => Some(FastValue::F64),
     "* const c_void" | "* mut c_void" => Some(FastValue::Pointer),

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -107,7 +107,6 @@ fn op_unit_result_fast_fn<'scope>(
         Err(err) => {
             op_state.last_fast_op_error.replace(err);
             __opts.fallback = true;
-            Default::default()
         }
     }
 }

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -142,7 +142,6 @@ fn op_set_nodelay_fast_fn<'scope>(
         Err(err) => {
             state.last_fast_op_error.replace(err);
             __opts.fallback = true;
-            Default::default()
         }
     }
 }


### PR DESCRIPTION
`#[op(fast)]` is currently not properly asserting the fastness of an op. Thus, the FFI pointer read ops had under the radar been avoiding the Fast API. The reason was that the ops macro does not understand `deno_core::OpState` as an alias of `OpState`.

Once this was fixed, another error was unearthed as `Result<*mut c_void>` returning ops would try to return `Default::default()` on the fast path from an error result which is not implemented for `*mut c_void`.