### PR TITLE
deps: bump `regexp` to `^1.7.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ percent-encoding = "=2.2.0"
 pin-project = "1.0.11" # don't pin because they yank crates from cargo
 pretty_assertions = "=1.3.0"
 rand = "=0.8.5"
-regex = "=1.6.0"
+regex = "^1.7.0"
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks"] }
 ring = "=0.16.20"
 rusqlite = { version = "=0.28.0", features = ["unlock_notify", "bundled"] }


### PR DESCRIPTION
forking and experimenting with [tauri-codegen](https://crates.io/crates/tauri-codegen) and [specta](https://crates.io/crates/specta) to codegen an ABI/SDK from rust `#[op]`'s to typescript functions for streamlining custom Deno runtimes for projects. `regexp` is currently `=1.6.0` conflicting `tauri-codegen` which requires `regexp = "^1.7.0"`. this pr would permit such use-case.

best