### PR TITLE
Implement node:path dirname, join, and basename in Rust

### DIFF
--- a/cli/bench/node/path/op_node_path_posix_dirname.js
+++ b/cli/bench/node/path/op_node_path_posix_dirname.js
@@ -1,0 +1,22 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { posix } from "node:path";
+
+const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
+let [total, count] = typeof Deno !== "undefined"
+  ? Deno.args
+  : [process.argv[2], process.argv[3]];
+
+total = total ? parseInt(total, 0) : 50;
+count = count ? parseInt(count, 10) : 10000000;
+
+function bench(fun) {
+  const start = Date.now();
+  for (let i = 0; i < count; i++) fun();
+  const elapsed = Date.now() - start;
+  const rate = Math.floor(count / (elapsed / 1000));
+  console.log(`time ${elapsed} ms rate ${rate}`);
+  if (--total) queueMicrotask(() => bench(fun));
+}
+
+bench(() => posix.dirname("/a/b"));

--- a/cli/bench/node/path/op_node_path_win32_dirname.js
+++ b/cli/bench/node/path/op_node_path_win32_dirname.js
@@ -1,0 +1,22 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { win32 } from "node:path";
+
+const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
+let [total, count] = typeof Deno !== "undefined"
+  ? Deno.args
+  : [process.argv[2], process.argv[3]];
+
+total = total ? parseInt(total, 0) : 50;
+count = count ? parseInt(count, 10) : 10000000;
+
+function bench(fun) {
+  const start = Date.now();
+  for (let i = 0; i < count; i++) fun();
+  const elapsed = Date.now() - start;
+  const rate = Math.floor(count / (elapsed / 1000));
+  console.log(`time ${elapsed} ms rate ${rate}`);
+  if (--total) queueMicrotask(() => bench(fun));
+}
+
+bench(() => win32.dirname("c:\\foo\\bar\\"));

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -334,6 +334,8 @@ pub fn init_polyfill() -> Extension {
       crypto::op_node_private_encrypt::decl(),
       crypto::op_node_private_decrypt::decl(),
       crypto::op_node_public_encrypt::decl(),
+      path::posix::op_node_path_posix_dirname::decl(),
+      path::win32::op_node_path_win32_dirname::decl(),
       winerror::op_node_sys_to_uv_error::decl(),
       v8::op_v8_cached_data_version_tag::decl(),
       v8::op_v8_get_heap_statistics::decl(),

--- a/ext/node/path/constants.rs
+++ b/ext/node/path/constants.rs
@@ -1,0 +1,50 @@
+// Copyright the Browserify authors. MIT License.
+// Ported from https://github.com/browserify/path-browserify/
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#![allow(unused)]
+
+// Alphabet chars.
+pub const CHAR_UPPERCASE_A: u32 = 65; /* A */
+pub const CHAR_LOWERCASE_A: u32 = 97; /* a */
+pub const CHAR_UPPERCASE_Z: u32 = 90; /* Z */
+pub const CHAR_LOWERCASE_Z: u32 = 122; /* z */
+
+// Non-alphabetic chars.
+pub const CHAR_DOT: u32 = 46; /* . */
+pub const CHAR_FORWARD_SLASH: u32 = 47; /* / */
+pub const CHAR_BACKWARD_SLASH: u32 = 92; /* \ */
+pub const CHAR_VERTICAL_LINE: u32 = 124; /* | */
+pub const CHAR_COLON: u32 = 58; /* : */
+pub const CHAR_QUESTION_MARK: u32 = 63; /* ? */
+pub const CHAR_UNDERSCORE: u32 = 95; /* _ */
+pub const CHAR_LINE_FEED: u32 = 10; /* \n */
+pub const CHAR_CARRIAGE_RETURN: u32 = 13; /* \r */
+pub const CHAR_TAB: u32 = 9; /* \t */
+pub const CHAR_FORM_FEED: u32 = 12; /* \f */
+pub const CHAR_EXCLAMATION_MARK: u32 = 33; /* ! */
+pub const CHAR_HASH: u32 = 35; /* # */
+pub const CHAR_SPACE: u32 = 32; /*   */
+pub const CHAR_NO_BREAK_SPACE: u32 = 160; /* \u00A0 */
+pub const CHAR_ZERO_WIDTH_NOBREAK_SPACE: u32 = 65279; /* \uFEFF */
+pub const CHAR_LEFT_SQUARE_BRACKET: u32 = 91; /* [ */
+pub const CHAR_RIGHT_SQUARE_BRACKET: u32 = 93; /* ] */
+pub const CHAR_LEFT_ANGLE_BRACKET: u32 = 60; /* < */
+pub const CHAR_RIGHT_ANGLE_BRACKET: u32 = 62; /* > */
+pub const CHAR_LEFT_CURLY_BRACKET: u32 = 123; /* { */
+pub const CHAR_RIGHT_CURLY_BRACKET: u32 = 125; /* } */
+pub const CHAR_HYPHEN_MINUS: u32 = 45; /* - */
+pub const CHAR_PLUS: u32 = 43; /* + */
+pub const CHAR_DOUBLE_QUOTE: u32 = 34; /* " */
+pub const CHAR_SINGLE_QUOTE: u32 = 39; /* ' */
+pub const CHAR_PERCENT: u32 = 37; /* % */
+pub const CHAR_SEMICOLON: u32 = 59; /* ; */
+pub const CHAR_CIRCUMFLEX_ACCENT: u32 = 94; /* ^ */
+pub const CHAR_GRAVE_ACCENT: u32 = 96; /* ` */
+pub const CHAR_AT: u32 = 64; /* @ */
+pub const CHAR_AMPERSAND: u32 = 38; /* & */
+pub const CHAR_EQUAL: u32 = 61; /* = */
+
+// Digits
+pub const CHAR_0: u32 = 48; /* 0 */
+pub const CHAR_9: u32 = 57; /* 9 */

--- a/ext/node/path/mod.rs
+++ b/ext/node/path/mod.rs
@@ -3,6 +3,10 @@
 use std::path::Component;
 use std::path::PathBuf;
 
+pub mod constants;
+pub mod posix;
+pub mod win32;
+
 /// Extension to path_clean::PathClean
 pub trait PathClean<T> {
   fn clean(&self) -> T;
@@ -37,4 +41,22 @@ impl PathClean<PathBuf> for PathBuf {
       path
     }
   }
+}
+
+pub fn is_windows_device_root(code: u32) -> bool {
+  (constants::CHAR_LOWERCASE_A..=constants::CHAR_LOWERCASE_Z).contains(&code)
+    || (constants::CHAR_UPPERCASE_A..=constants::CHAR_UPPERCASE_Z)
+      .contains(&code)
+}
+
+pub fn is_posix_path_separator(code: u32) -> bool {
+  code == constants::CHAR_FORWARD_SLASH
+}
+
+pub fn is_path_separator(code: u32) -> bool {
+  is_posix_path_separator(code) || code == constants::CHAR_BACKWARD_SLASH
+}
+
+pub fn char_at_index(path: &str, index: usize) -> Option<char> {
+  path.chars().nth(index)
 }

--- a/ext/node/path/posix.rs
+++ b/ext/node/path/posix.rs
@@ -1,0 +1,44 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::error::AnyError;
+use deno_core::op;
+
+use super::char_at_index;
+use super::constants;
+
+#[op]
+pub fn op_node_path_posix_dirname(path: &str) -> Result<String, AnyError> {
+  if path.chars().count() == 0 {
+    return Ok(String::from("."));
+  }
+
+  let has_root =
+    char_at_index(path, 0).unwrap() as u32 == constants::CHAR_FORWARD_SLASH;
+  let mut end: Option<usize> = None;
+  let mut matched_slash = true;
+
+  for (i, c) in path.char_indices().rev() {
+    if i < 1 {
+      break;
+    }
+    match c as u32 {
+      constants::CHAR_FORWARD_SLASH if !matched_slash => {
+        end = Some(i);
+        break;
+      }
+      constants::CHAR_FORWARD_SLASH => {
+        // noop
+      }
+      _ => matched_slash = false,
+    }
+  }
+
+  let dirname = match (end, has_root) {
+    (None, true) => String::from("/"),
+    (None, false) => String::from("."),
+    (Some(1), true) => String::from("//"),
+    (Some(ending), _) => path.chars().take(ending).collect(),
+  };
+
+  Ok(dirname)
+}

--- a/ext/node/path/posix.rs
+++ b/ext/node/path/posix.rs
@@ -8,36 +8,24 @@ use super::constants;
 
 #[op]
 pub fn op_node_path_posix_dirname(path: &str) -> Result<String, AnyError> {
-  if path.chars().count() == 0 {
-    return Ok(String::from("."));
-  }
+  let has_root = match char_at_index(path, 0) {
+    Some(char) => char as u32 == constants::CHAR_FORWARD_SLASH,
+    None => return Ok(String::from(".")),
+  };
 
-  let has_root =
-    char_at_index(path, 0).unwrap() as u32 == constants::CHAR_FORWARD_SLASH;
-  let mut end: Option<usize> = None;
-  let mut matched_slash = true;
+  let end = match path.rfind('/') {
+    Some(0) => None,
+    Some(n) => Some(n),
+    _ => None,
+  };
 
-  for (i, c) in path.char_indices().rev() {
-    if i < 1 {
-      break;
-    }
-    match c as u32 {
-      constants::CHAR_FORWARD_SLASH if !matched_slash => {
-        end = Some(i);
-        break;
-      }
-      constants::CHAR_FORWARD_SLASH => {
-        // noop
-      }
-      _ => matched_slash = false,
-    }
-  }
+  let mut dirname = String::with_capacity(path.len());
 
-  let dirname = match (end, has_root) {
-    (None, true) => String::from("/"),
-    (None, false) => String::from("."),
-    (Some(1), true) => String::from("//"),
-    (Some(ending), _) => path.chars().take(ending).collect(),
+  match (end, has_root) {
+    (None, true) => dirname.push('/'),
+    (None, false) => dirname.push('.'),
+    (Some(1), true) => dirname.push_str("//"),
+    (Some(ending), _) => dirname.extend(path.chars().take(ending)),
   };
 
   Ok(dirname)

--- a/ext/node/path/win32.rs
+++ b/ext/node/path/win32.rs
@@ -1,0 +1,130 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::error::AnyError;
+use deno_core::op;
+
+use super::char_at_index;
+use super::constants;
+use super::is_path_separator;
+use super::is_windows_device_root;
+
+#[op]
+pub fn op_node_path_win32_dirname(path: &str) -> Result<String, AnyError> {
+  let char_count = path.chars().count();
+  if char_count == 0 {
+    return Ok(String::from("."));
+  }
+
+  let mut root_end: Option<usize> = None;
+  let mut end: Option<usize> = None;
+  let mut matched_slash = true;
+  let mut offset = 0;
+
+  let code = char_at_index(path, 0).unwrap() as u32;
+
+  if char_count > 1 {
+    if is_path_separator(code) {
+      // Possible UNC root
+
+      root_end = Some(1);
+      offset = 1;
+
+      if is_path_separator(char_at_index(path, 1).unwrap() as u32) {
+        // Matched double path separator at beginning
+        let mut j = 2;
+        let mut last = j;
+        // Match 1 or more non-path separators
+        for ch in path.chars().skip(2) {
+          if is_path_separator(ch as u32) {
+            break;
+          }
+          j += 1;
+        }
+        if j < char_count && j != last {
+          // Matched!
+          last = j;
+          // Match 1 or more path separators
+          for ch in path.chars().skip(j) {
+            if !is_path_separator(ch as u32) {
+              break;
+            }
+            j += 1;
+          }
+
+          if j < char_count && j != last {
+            // Matched!
+            last = j;
+            // Match 1 or more non-path separators
+            for ch in path.chars().skip(j) {
+              if is_path_separator(ch as u32) {
+                break;
+              }
+              j += 1;
+            }
+            if j == char_count {
+              // We matched UNC root only
+              return Ok(path.to_string());
+            }
+            if j != last {
+              // We matched a UNC root with leftovers
+
+              // Offset by 1 to include the separator after the UNC root to
+              // treat it as a "normal root" on top of a (UNC) root
+              offset = j + 1;
+              root_end = Some(offset);
+            }
+          }
+        }
+      }
+    } else if is_windows_device_root(code) {
+      // Possible device root
+
+      if char_at_index(path, 1).unwrap() as u32 == constants::CHAR_COLON {
+        root_end = Some(2);
+        offset = 2;
+
+        if char_count > 2
+          && is_path_separator(char_at_index(path, 2).unwrap() as u32)
+        {
+          root_end = Some(3);
+          offset = 3;
+        }
+      }
+    }
+  } else if is_path_separator(code) {
+    // `path` contains just a path separator, exit early to avoid
+    // unnecessary work
+    return Ok(path.to_string());
+  }
+
+  for (i, ch) in path.char_indices().rev() {
+    if i <= offset {
+      break;
+    }
+    if is_path_separator(ch as u32) {
+      if !matched_slash {
+        end = Some(i);
+        break;
+      }
+    } else {
+      // We saw the first non-path separator
+      matched_slash = false;
+    }
+  }
+
+  if end.is_none() {
+    if root_end.is_none() {
+      return Ok(String::from("."));
+    } else {
+      end = root_end;
+    }
+  }
+
+  let dirname = match (end, root_end) {
+    (None, None) => String::from("."),
+    (None, Some(e)) => path.chars().take(e).collect(),
+    (Some(e), _) => path.chars().take(e).collect(),
+  };
+
+  Ok(dirname)
+}

--- a/ext/node/polyfills/path/posix.ts
+++ b/ext/node/polyfills/path/posix.ts
@@ -20,6 +20,8 @@ import {
   normalizeString,
 } from "internal:deno_node/path/_util.ts";
 
+const { ops } = globalThis.__bootstrap.core;
+
 export const sep = "/";
 export const delimiter = ":";
 
@@ -226,26 +228,14 @@ export function toNamespacedPath(path: string): string {
  * @param path to determine name for
  */
 export function dirname(path: string): string {
-  assertPath(path);
-  if (path.length === 0) return ".";
-  const hasRoot = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
-  let end = -1;
-  let matchedSlash = true;
-  for (let i = path.length - 1; i >= 1; --i) {
-    if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
-      if (!matchedSlash) {
-        end = i;
-        break;
-      }
-    } else {
-      // We saw the first non-path separator
-      matchedSlash = false;
+  try {
+    return ops.op_node_path_posix_dirname(path);
+  } catch (e) {
+    if (e.message.startsWith("Expected string")) {
+      throw new ERR_INVALID_ARG_TYPE("path", ["string"], path);
     }
+    throw e;
   }
-
-  if (end === -1) return hasRoot ? "/" : ".";
-  if (hasRoot && end === 1) return "//";
-  return path.slice(0, end);
 }
 
 /**

--- a/ext/node/polyfills/path/win32.ts
+++ b/ext/node/polyfills/path/win32.ts
@@ -24,6 +24,8 @@ import {
 } from "internal:deno_node/path/_util.ts";
 import { assert } from "internal:deno_node/_util/asserts.ts";
 
+const { ops } = globalThis.__bootstrap.core;
+
 export const sep = "\\";
 export const delimiter = ";";
 
@@ -542,91 +544,14 @@ export function toNamespacedPath(path: string): string {
  * @param path to determine name for
  */
 export function dirname(path: string): string {
-  assertPath(path);
-  const len = path.length;
-  if (len === 0) return ".";
-  let rootEnd = -1;
-  let end = -1;
-  let matchedSlash = true;
-  let offset = 0;
-  const code = path.charCodeAt(0);
-
-  // Try to match a root
-  if (len > 1) {
-    if (isPathSeparator(code)) {
-      // Possible UNC root
-
-      rootEnd = offset = 1;
-
-      if (isPathSeparator(path.charCodeAt(1))) {
-        // Matched double path separator at beginning
-        let j = 2;
-        let last = j;
-        // Match 1 or more non-path separators
-        for (; j < len; ++j) {
-          if (isPathSeparator(path.charCodeAt(j))) break;
-        }
-        if (j < len && j !== last) {
-          // Matched!
-          last = j;
-          // Match 1 or more path separators
-          for (; j < len; ++j) {
-            if (!isPathSeparator(path.charCodeAt(j))) break;
-          }
-          if (j < len && j !== last) {
-            // Matched!
-            last = j;
-            // Match 1 or more non-path separators
-            for (; j < len; ++j) {
-              if (isPathSeparator(path.charCodeAt(j))) break;
-            }
-            if (j === len) {
-              // We matched a UNC root only
-              return path;
-            }
-            if (j !== last) {
-              // We matched a UNC root with leftovers
-
-              // Offset by 1 to include the separator after the UNC root to
-              // treat it as a "normal root" on top of a (UNC) root
-              rootEnd = offset = j + 1;
-            }
-          }
-        }
-      }
-    } else if (isWindowsDeviceRoot(code)) {
-      // Possible device root
-
-      if (path.charCodeAt(1) === CHAR_COLON) {
-        rootEnd = offset = 2;
-        if (len > 2) {
-          if (isPathSeparator(path.charCodeAt(2))) rootEnd = offset = 3;
-        }
-      }
+  try {
+    return ops.op_node_path_win32_dirname(path);
+  } catch (e) {
+    if (e.message.startsWith("Expected string")) {
+      throw new ERR_INVALID_ARG_TYPE("path", ["string"], path);
     }
-  } else if (isPathSeparator(code)) {
-    // `path` contains just a path separator, exit early to avoid
-    // unnecessary work
-    return path;
+    throw e;
   }
-
-  for (let i = len - 1; i >= offset; --i) {
-    if (isPathSeparator(path.charCodeAt(i))) {
-      if (!matchedSlash) {
-        end = i;
-        break;
-      }
-    } else {
-      // We saw the first non-path separator
-      matchedSlash = false;
-    }
-  }
-
-  if (end === -1) {
-    if (rootEnd === -1) return ".";
-    else end = rootEnd;
-  }
-  return path.slice(0, end);
 }
 
 /**


### PR DESCRIPTION
Towards #17976 

Posting as a draft while still adding other implementations to get feedback early.

Includes new benchmarks in `cli/bench/node/path` folder.

completed in this PR:
- [x] dirname
- [ ] join
- [ ] basename
