### PR TITLE
chore(cli): update deno_lint to 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663d65cb008cddda1d705cd397d5d80fd37716e708b4182ca076244e18132ace"
+checksum = "bb65a10eb9bbff2c0e475958ea4a1f7db1f1e92d4a78a07853867049b7dfee8f"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"]
 deno_doc = "0.57.0"
 deno_emit = "0.16.0"
 deno_graph = "=0.44.2"
-deno_lint = { version = "0.40.0", features = ["docs"] }
+deno_lint = { version = "0.41.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }
 deno_task_shell = "0.10.0"

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -21,7 +21,6 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tower_lsp::lsp_types as lsp;
 use tower_lsp::lsp_types::Position;
 use tower_lsp::lsp_types::Range;
@@ -121,7 +120,7 @@ fn as_lsp_range(range: &deno_lint::diagnostic::Range) -> Range {
 
 pub fn get_lint_references(
   parsed_source: &deno_ast::ParsedSource,
-  lint_rules: Vec<Arc<dyn LintRule>>,
+  lint_rules: Vec<&'static dyn LintRule>,
 ) -> Result<Vec<Reference>, AnyError> {
   let linter = create_linter(parsed_source.media_type(), lint_rules);
   let lint_diagnostics = linter.lint_with_ast(parsed_source);

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -490,7 +490,7 @@ async fn generate_lint_diagnostics(
 fn generate_document_lint_diagnostics(
   config: &ConfigSnapshot,
   lint_options: &LintOptions,
-  lint_rules: Vec<Arc<dyn LintRule>>,
+  lint_rules: Vec<&'static dyn LintRule>,
   document: &Document,
 ) -> Vec<lsp::Diagnostic> {
   if !config.specifier_enabled(document.specifier()) {

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -234,7 +234,7 @@ pub fn print_rules_list(json: bool) {
 
 pub fn create_linter(
   media_type: MediaType,
-  rules: Vec<Arc<dyn LintRule>>,
+  rules: Vec<&'static dyn LintRule>,
 ) -> Linter {
   LinterBuilder::default()
     .ignore_file_directive("deno-lint-ignore-file")
@@ -247,7 +247,7 @@ pub fn create_linter(
 fn lint_file(
   file_path: &PathBuf,
   source_code: String,
-  lint_rules: Vec<Arc<dyn LintRule>>,
+  lint_rules: Vec<&'static dyn LintRule>,
 ) -> Result<(Vec<LintDiagnostic>, String), AnyError> {
   let file_name = file_path.to_string_lossy().to_string();
   let media_type = MediaType::from(file_path);
@@ -263,7 +263,7 @@ fn lint_file(
 /// Treats input as TypeScript.
 /// Compatible with `--json` flag.
 fn lint_stdin(
-  lint_rules: Vec<Arc<dyn LintRule>>,
+  lint_rules: Vec<&'static dyn LintRule>,
 ) -> Result<(Vec<LintDiagnostic>, String), AnyError> {
   let mut source_code = String::new();
   if stdin().read_to_string(&mut source_code).is_err() {
@@ -530,7 +530,9 @@ fn sort_diagnostics(diagnostics: &mut [LintDiagnostic]) {
   });
 }
 
-pub fn get_configured_rules(rules: LintRulesConfig) -> Vec<Arc<dyn LintRule>> {
+pub fn get_configured_rules(
+  rules: LintRulesConfig,
+) -> Vec<&'static dyn LintRule> {
   if rules.tags.is_none() && rules.include.is_none() && rules.exclude.is_none()
   {
     rules::get_recommended_rules()


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This commit updates deno_lint crate to 0.41.0. The new version contains a braking change that requries a minor code fix here, which is also addressed in this commit.

