### PR TITLE
wpt: unlock nightly with --no-ignore

### DIFF
--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -249,8 +249,10 @@ async function generateWptReport(
         if (!case_.passed) {
           if (typeof test.expectation === "boolean") {
             expected = test.expectation ? "PASS" : "FAIL";
-          } else {
+          } else if (Array.isArray(test.expectation)) {
             expected = test.expectation.includes(case_.name) ? "FAIL" : "PASS";
+          } else {
+            expected = "PASS";
           }
         }
 
@@ -708,10 +710,12 @@ function discoverTestsToRun(
             }
           }
 
-          assert(
-            Array.isArray(expectation) || typeof expectation == "boolean",
-            "test entry must not have a folder expectation",
-          );
+          if (!noIgnore) {
+            assert(
+              Array.isArray(expectation) || typeof expectation == "boolean",
+              "test entry must not have a folder expectation",
+            );
+          }
 
           if (
             filter &&

--- a/tools/wpt/utils.ts
+++ b/tools/wpt/utils.ts
@@ -98,6 +98,7 @@ export function getExpectFailForCase(
   expectation: boolean | string[],
   caseName: string,
 ): boolean {
+  if (noIgnore) return false;
   if (typeof expectation == "boolean") {
     return !expectation;
   }


### PR DESCRIPTION
When I was testing the code in #17892 I had updated expectations and didn't catch this.

This PR fixes the the expectation file format to not be checked when --no-ignore is passed during [nightly](https://github.com/denoland/deno/actions/runs/4319520368/jobs/7538796572#step:9:46) runs.