### PR TITLE
refactor: simplify to string calls

### DIFF
--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -988,7 +988,7 @@ impl ModuleRegistry {
       .origins
       .keys()
       .filter_map(|k| {
-        let mut origin = k.as_str().to_string();
+        let mut origin = k.to_string();
         if origin.ends_with('/') {
           origin.pop();
         }

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -832,7 +832,7 @@ fn extract_files_from_source_comments(
   media_type: MediaType,
 ) -> Result<Vec<File>, AnyError> {
   let parsed_source = deno_ast::parse_module(deno_ast::ParseParams {
-    specifier: specifier.as_str().to_string(),
+    specifier: specifier.to_string(),
     text_info: deno_ast::SourceTextInfo::new(source),
     media_type,
     capture_tokens: false,

--- a/ext/node/resolution.rs
+++ b/ext/node/resolution.rs
@@ -291,7 +291,7 @@ fn throw_invalid_package_target(
     subpath,
     target,
     internal,
-    Some(referrer.as_str().to_string()),
+    Some(referrer.to_string()),
   )
 }
 


### PR DESCRIPTION
This PR updates `as_str().to_string()` to `to_string` when possible
