### PR TITLE
test(compile): Add a test for dynamic imports in `deno compile`

### DIFF
--- a/cli/tests/integration/compile_tests.rs
+++ b/cli/tests/integration/compile_tests.rs
@@ -564,3 +564,31 @@ fn check_local_by_default2() {
     r#"error: TS2322 [ERROR]: Type '12' is not assignable to type '"b"'."#
   ));
 }
+
+#[test]
+fn dynamic_import() {
+  let _guard = util::http_server();
+  let dir = TempDir::new();
+  let exe = if cfg!(windows) {
+    dir.path().join("dynamic_import.exe")
+  } else {
+    dir.path().join("dynamic_import")
+  };
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("compile")
+    .arg("--output")
+    .arg(&exe)
+    .arg(util::testdata_path().join("./compile/dynamic_imports/main.ts"))
+    .output()
+    .unwrap();
+  assert!(output.status.success());
+
+  let output = Command::new(&exe).env("NO_COLOR", "").output().unwrap();
+  assert!(output.status.success());
+  let expected = std::fs::read_to_string(
+    util::testdata_path().join("./compile/dynamic_imports/main.out"),
+  )
+  .unwrap();
+  assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+}

--- a/cli/tests/testdata/compile/dynamic_imports/import1.ts
+++ b/cli/tests/testdata/compile/dynamic_imports/import1.ts
@@ -1,0 +1,3 @@
+import "./import2.ts";
+
+console.log("import1.ts");

--- a/cli/tests/testdata/compile/dynamic_imports/import2.ts
+++ b/cli/tests/testdata/compile/dynamic_imports/import2.ts
@@ -1,0 +1,1 @@
+console.log("import2.ts");

--- a/cli/tests/testdata/compile/dynamic_imports/main.out
+++ b/cli/tests/testdata/compile/dynamic_imports/main.out
@@ -1,0 +1,5 @@
+Starting the main module
+Dynamic importing
+import2.ts
+import1.ts
+Dynamic import done.

--- a/cli/tests/testdata/compile/dynamic_imports/main.ts
+++ b/cli/tests/testdata/compile/dynamic_imports/main.ts
@@ -1,0 +1,6 @@
+console.log("Starting the main module");
+
+setTimeout(() => {
+  console.log("Dynamic importing");
+  import("./import1.ts").then(() => console.log("Dynamic import done."));
+}, 500);


### PR DESCRIPTION
denoland/eszip#115 added support for statically-analyzed dynamic imports in eszip, which made `deno compile` support dynamic imports starting from #17858. This PR adds a test for it.

----

This test is adapted from PR #17663.

Closes #17908