### PR TITLE
fix(check): include dts files in tsc roots

### DIFF
--- a/cli/tests/integration/check_tests.rs
+++ b/cli/tests/integration/check_tests.rs
@@ -232,6 +232,12 @@ fn ts_no_recheck_on_redirect() {
   assert!(std::str::from_utf8(&output.stderr).unwrap().is_empty());
 }
 
+itest!(check_dts {
+  args: "check --quiet check/check_dts.d.ts",
+  output: "check/check_dts.out",
+  exit_code: 1,
+});
+
 itest!(package_json_basic {
   args: "check main.ts",
   output: "package_json/basic/main.check.out",

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -1021,7 +1021,7 @@ fn lsp_hover() {
           "language": "typescript",
           "value": "const Deno.args: string[]"
         },
-        "Returns the script arguments to the program.\n\nGive the following command line invocation of Deno:\n\n```sh\ndeno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd\n```\n\nThen `Deno.args` will contain:\n\n```\n[ \"/etc/passwd\" ]\n```\n\nIf you are looking for a structured way to parse arguments, there is the\n[`std/flags`](https://deno.land/std/flags) module as part of the Deno\nstandard library.",
+        "Returns the script arguments to the program.\n\nGive the following command line invocation of Deno:\n\n```sh\ndeno run --allow-read https://deno.land/std/examples/cat.ts /etc/passwd\n```\n\nThen `Deno.args` will contain:\n\n```ts\n[ \"/etc/passwd\" ]\n```\n\nIf you are looking for a structured way to parse arguments, there is the\n[`std/flags`](https://deno.land/std/flags) module as part of the Deno\nstandard library.",
         "\n\n*@category* - Runtime Environment",
       ],
       "range": {

--- a/cli/tests/testdata/check/check_dts.d.ts
+++ b/cli/tests/testdata/check/check_dts.d.ts
@@ -1,0 +1,2 @@
+// TS1039 [ERROR]: Initializers are not allowed in ambient contexts.
+export const a: string = Deno.version.deno;

--- a/cli/tests/testdata/check/check_dts.out
+++ b/cli/tests/testdata/check/check_dts.out
@@ -1,0 +1,4 @@
+error: TS1039 [ERROR]: Initializers are not allowed in ambient contexts.
+export const a: string = Deno.version.deno;
+                         ~~~~~~~~~~~~~~~~~
+    at file:///[WILDCARD]/check_dts.d.ts:2:26

--- a/cli/tests/testdata/test/doc.out
+++ b/cli/tests/testdata/test/doc.out
@@ -1,4 +1,3 @@
-Check [WILDCARD]/doc.ts$2-5.ts
 Check [WILDCARD]/doc.ts$6-9.js
 Check [WILDCARD]/doc.ts$10-13.jsx
 Check [WILDCARD]/doc.ts$14-17.ts

--- a/cli/tests/testdata/test/doc.ts
+++ b/cli/tests/testdata/test/doc.ts
@@ -27,7 +27,7 @@
  */
 
 /**
- * ```
+ * ```ts
  * import { check } from "./doc.ts";
  *
  * console.assert(check() == 42);

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -244,6 +244,9 @@ fn get_tsc_roots(
       | MediaType::Tsx
       | MediaType::Mts
       | MediaType::Cts
+      | MediaType::Dts
+      | MediaType::Dmts
+      | MediaType::Dcts
       | MediaType::Jsx => Some((module.specifier.clone(), module.media_type)),
       MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs => {
         if check_js || has_ts_check(module.media_type, &module.source) {
@@ -253,9 +256,6 @@ fn get_tsc_roots(
         }
       }
       MediaType::Json
-      | MediaType::Dts
-      | MediaType::Dmts
-      | MediaType::Dcts
       | MediaType::Wasm
       | MediaType::TsBuildInfo
       | MediaType::SourceMap

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -775,7 +775,6 @@ fn extract_files_from_regex_blocks(
           Some(&"mts") => MediaType::Mts,
           Some(&"cts") => MediaType::Cts,
           Some(&"tsx") => MediaType::Tsx,
-          Some(&"") => media_type,
           _ => MediaType::Unknown,
         }
       } else {

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -332,7 +332,7 @@ declare namespace Deno {
    * ```
    *
    * Requires `allow-sys` permission.
-   * 
+   *
    * On Windows there is no API available to retrieve this information and this method returns `[ 0, 0, 0 ]`.
    *
    * @tags allow-sys
@@ -3481,7 +3481,7 @@ declare namespace Deno {
    *
    * ### Truncate part of the file
    *
-   * ```
+   * ```ts
    * const file = await Deno.makeTempFile();
    * await Deno.writeFile(file, new TextEncoder().encode("Hello World"));
    * await Deno.truncate(file, 7);
@@ -4095,7 +4095,7 @@ declare namespace Deno {
     unref(): void;
   }
 
-  /** 
+  /**
    * Options which can be set when calling {@linkcode Deno.Command}.
    *
    * @category Sub Process
@@ -4159,7 +4159,7 @@ declare namespace Deno {
     windowsRawArguments?: boolean;
   }
 
-  /** 
+  /**
    * @category Sub Process
    */
   export interface CommandStatus {
@@ -4172,7 +4172,7 @@ declare namespace Deno {
     signal: Signal | null;
   }
 
-  /** 
+  /**
    * The interface returned from calling {@linkcode Command.output} or
    * {@linkcode Command.outputSync} which represents the result of spawning the
    * child process.
@@ -4720,7 +4720,7 @@ declare namespace Deno {
    *
    * Then `Deno.args` will contain:
    *
-   * ```
+   * ```ts
    * [ "/etc/passwd" ]
    * ```
    *


### PR DESCRIPTION
Currently declaration files aren't included in type checking unless as a dependency of a module. This affects entrypoint `.d.ts` modules, the `X-TypeScript-Types`/`<reference types="./foo.d.ts" />` of a JS entrypoint module and doc tests of untagged code blocks within a `.d.ts` module.

The last one exposed that there were some untagged code blocks in `lib.deno.ns.d.ts` which would be wrongly checked in ambient mode due to the inherited virtual file extension being `.d.ts`. I've added those tags and also removed the unsafe default which causes that to happen.