### PR TITLE
perf(ext/node): improve createHash performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,7 @@ version = "0.28.0"
 dependencies = [
  "deno_core",
  "digest 0.10.6",
+ "hex",
  "idna 0.3.0",
  "indexmap",
  "md-5",
@@ -2240,6 +2241,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [dependencies]
 deno_core.workspace = true
 digest = { version = "0.10.5", features = ["core-api", "std"] }
+hex = "0.4.3"
 idna = "0.3.0"
 indexmap.workspace = true
 md-5 = "0.10.5"

--- a/ext/node/crypto/mod.rs
+++ b/ext/node/crypto/mod.rs
@@ -17,23 +17,38 @@ use rsa::RsaPublicKey;
 
 mod digest;
 
-#[op]
-pub fn op_node_create_hash(
-  state: &mut OpState,
-  algorithm: String,
-) -> Result<ResourceId, AnyError> {
-  Ok(state.resource_table.add(digest::Context::new(&algorithm)?))
+#[op(fast)]
+pub fn op_node_create_hash(state: &mut OpState, algorithm: &str) -> u32 {
+  state
+    .resource_table
+    .add(match digest::Context::new(algorithm) {
+      Ok(context) => context,
+      Err(_) => return 0,
+    })
 }
 
-#[op]
-pub fn op_node_hash_update(
-  state: &mut OpState,
-  rid: ResourceId,
-  data: &[u8],
-) -> Result<(), AnyError> {
-  let context = state.resource_table.get::<digest::Context>(rid)?;
+#[op(fast)]
+pub fn op_node_hash_update(state: &mut OpState, rid: u32, data: &[u8]) -> bool {
+  let context = match state.resource_table.get::<digest::Context>(rid) {
+    Ok(context) => context,
+    _ => return false,
+  };
   context.update(data);
-  Ok(())
+  true
+}
+
+#[op(fast)]
+pub fn op_node_hash_update_str(
+  state: &mut OpState,
+  rid: u32,
+  data: &str,
+) -> bool {
+  let context = match state.resource_table.get::<digest::Context>(rid) {
+    Ok(context) => context,
+    _ => return false,
+  };
+  context.update(data.as_bytes());
+  true
 }
 
 #[op]
@@ -45,6 +60,18 @@ pub fn op_node_hash_digest(
   let context = Rc::try_unwrap(context)
     .map_err(|_| type_error("Hash context is already in use"))?;
   Ok(context.digest()?.into())
+}
+
+#[op]
+pub fn op_node_hash_digest_hex(
+  state: &mut OpState,
+  rid: ResourceId,
+) -> Result<String, AnyError> {
+  let context = state.resource_table.take::<digest::Context>(rid)?;
+  let context = Rc::try_unwrap(context)
+    .map_err(|_| type_error("Hash context is already in use"))?;
+  let digest = context.digest()?;
+  Ok(hex::encode(digest))
 }
 
 #[op]

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -336,7 +336,9 @@ pub fn init_polyfill() -> Extension {
     .ops(vec![
       crypto::op_node_create_hash::decl(),
       crypto::op_node_hash_update::decl(),
+      crypto::op_node_hash_update_str::decl(),
       crypto::op_node_hash_digest::decl(),
+      crypto::op_node_hash_digest_hex::decl(),
       crypto::op_node_hash_clone::decl(),
       crypto::op_node_private_encrypt::decl(),
       crypto::op_node_private_decrypt::decl(),

--- a/ext/node/polyfills/internal/crypto/hash.ts
+++ b/ext/node/polyfills/internal/crypto/hash.ts
@@ -1,10 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
-import {
-  TextDecoder,
-  TextEncoder,
-} from "internal:deno_web/08_text_encoding.js";
+import { TextEncoder } from "internal:deno_web/08_text_encoding.js";
 import { Buffer } from "internal:deno_node/buffer.ts";
 import { Transform } from "internal:deno_node/stream.ts";
 import {

--- a/ext/node/polyfills/internal/crypto/hash.ts
+++ b/ext/node/polyfills/internal/crypto/hash.ts
@@ -7,7 +7,6 @@ import {
 } from "internal:deno_web/08_text_encoding.js";
 import { Buffer } from "internal:deno_node/buffer.ts";
 import { Transform } from "internal:deno_node/stream.ts";
-import { encode as encodeToHex } from "internal:deno_node/internal/crypto/_hex.ts";
 import {
   forgivingBase64Encode as encodeToBase64,
   forgivingBase64UrlEncode as encodeToBase64Url,
@@ -25,6 +24,14 @@ import {
 import { notImplemented } from "internal:deno_node/_utils.ts";
 
 const { ops } = globalThis.__bootstrap.core;
+
+// TODO(@littledivy): Use Result<T, E> instead of boolean when
+// https://bugs.chromium.org/p/v8/issues/detail?id=13600 is fixed.
+function unwrapErr(ok: boolean) {
+  if (!ok) {
+    throw new Error("Context is not initialized");
+  }
+}
 
 const coerceToBytes = (data: string | BufferSource): Uint8Array => {
   if (data instanceof Uint8Array) {
@@ -71,6 +78,9 @@ export class Hash extends Transform {
       this.#context = ops.op_node_create_hash(
         algorithm,
       );
+      if (this.#context === 0) {
+        throw new TypeError(`Unknown hash algorithm: ${algorithm}`);
+      }
     } else {
       this.#context = algorithm;
     }
@@ -86,15 +96,11 @@ export class Hash extends Transform {
    * Updates the hash content with the given data.
    */
   update(data: string | ArrayBuffer, _encoding?: string): this {
-    let bytes;
     if (typeof data === "string") {
-      data = new TextEncoder().encode(data);
-      bytes = coerceToBytes(data);
+      unwrapErr(ops.op_node_hash_update_str(this.#context, data));
     } else {
-      bytes = coerceToBytes(data);
+      unwrapErr(ops.op_node_hash_update(this.#context, coerceToBytes(data)));
     }
-
-    ops.op_node_hash_update(this.#context, bytes);
 
     return this;
   }
@@ -107,14 +113,17 @@ export class Hash extends Transform {
    * Supported encodings are currently 'hex', 'binary', 'base64', 'base64url'.
    */
   digest(encoding?: string): Buffer | string {
+    if (encoding === "hex") {
+      return ops.op_node_hash_digest_hex(this.#context);
+    }
+
     const digest = ops.op_node_hash_digest(this.#context);
     if (encoding === undefined) {
       return Buffer.from(digest);
     }
 
+    // TODO(@littedivy): Fast paths for below encodings.
     switch (encoding) {
-      case "hex":
-        return new TextDecoder().decode(encodeToHex(new Uint8Array(digest)));
       case "binary":
         return String.fromCharCode(...digest);
       case "base64":


### PR DESCRIPTION
```
> deno run -A ../test.mjs
cpu: unknown
runtime: deno 1.31.1 (aarch64-apple-darwin)

benchmark      time (avg)             (min … max)       p75       p99      p995
------------------------------------------------- -----------------------------
             2.22 µs/iter      (2.2 µs … 2.28 µs)   2.22 µs   2.28 µs   2.28 µs

> target/release/deno run -A test.mjs
cpu: unknown
runtime: deno 1.31.1 (aarch64-apple-darwin)

benchmark      time (avg)             (min … max)       p75       p99      p995
------------------------------------------------- -----------------------------
            864.9 ns/iter   (825.05 ns … 1.22 µs) 864.93 ns   1.22 µs   1.22 µs
```