### PR TITLE
docs: remove duplicate copyright disclaimer

### DIFF
--- a/lockfile/lib.rs
+++ b/lockfile/lib.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use std::collections::BTreeMap;
 use std::io::Write;


### PR DESCRIPTION
Removes duplicate copyright disclaimer from `/lockfile/lib.rs`