### PR TITLE
chore(docs): Fixed manual link

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4173,8 +4173,8 @@ declare namespace Deno {
   }
 
   /**
-   * The interface returned from calling {@linkcode Command.output} or
-   * {@linkcode Command.outputSync} which represents the result of spawning the
+   * The interface returned from calling {@linkcode Deno.Command.output} or
+   * {@linkcode Deno.Command.outputSync} which represents the result of spawning the
    * child process.
    *
    * @category Sub Process


### PR DESCRIPTION
The `Deno.CommandOutput` link is currently disabled, so I fixed it.

![image](https://user-images.githubusercontent.com/40050810/223380260-3235d206-2b34-4dfc-8756-072d2aceb7d7.png)

https://deno.land/api@v1.31.1?s=Deno.CommandOutput