### PR TITLE
refactor(core): don't use Result in ExtensionBuilder::state

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -269,8 +269,6 @@ mod ts {
         state.put(op_crate_libs.clone());
         state.put(build_libs.clone());
         state.put(path_dts.clone());
-
-        Ok(())
       })
       .build();
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2826,7 +2826,6 @@ fn init_extension(performance: Arc<Performance>) -> Extension {
         Arc::new(StateSnapshot::default()),
         performance.clone(),
       ));
-      Ok(())
     })
     .build()
 }

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -38,7 +38,6 @@ pub fn init(
     .state(move |state| {
       state.put(sender.clone());
       state.put(filter.clone());
-      Ok(())
     })
     .build()
 }

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -18,7 +18,6 @@ fn init_proc_state(ps: ProcState) -> Extension {
     .ops(vec![op_npm_process_state::decl()])
     .state(move |state| {
       state.put(ps.clone());
-      Ok(())
     })
     .build()
 }

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -44,7 +44,6 @@ pub fn init(
       state.put(sender.clone());
       state.put(fail_fast_tracker.clone());
       state.put(filter.clone());
-      Ok(())
     })
     .build()
 }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -872,7 +872,6 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
           root_map.clone(),
           remapped_specifiers.clone(),
         ));
-        Ok(())
       })
       .build()],
     ..Default::default()

--- a/core/examples/schedule_task.rs
+++ b/core/examples/schedule_task.rs
@@ -34,8 +34,6 @@ fn main() {
       let (tx, rx) = mpsc::unbounded::<Task>();
       state.put(tx);
       state.put(rx);
-
-      Ok(())
     })
     .build();
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -939,7 +939,7 @@ impl JsRuntime {
       // Setup state
       for e in extensions.iter_mut() {
         // ops are already registered during in bindings::initialize_context();
-        e.init_state(&mut op_state.borrow_mut())?;
+        e.init_state(&mut op_state.borrow_mut());
 
         // Setup event-loop middleware
         if let Some(middleware) = e.init_event_loop_middleware() {
@@ -957,7 +957,7 @@ impl JsRuntime {
       // Setup state
       for e in extensions.iter_mut() {
         // ops are already registered during in bindings::initialize_context();
-        e.init_state(&mut op_state.borrow_mut())?;
+        e.init_state(&mut op_state.borrow_mut());
 
         // Setup event-loop middleware
         if let Some(middleware) = e.init_event_loop_middleware() {
@@ -2887,7 +2887,6 @@ pub mod tests {
           mode,
           dispatch_count: dispatch_count2.clone(),
         });
-        Ok(())
       })
       .build();
     let mut runtime = JsRuntime::new(RuntimeOptions {
@@ -4045,7 +4044,6 @@ assertEquals(1, notify_return_value);
       .ops(vec![op_async_borrow::decl()])
       .state(|state| {
         state.put(InnerState(42));
-        Ok(())
       })
       .build();
 

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -122,7 +122,6 @@ pub fn init<BC: BroadcastChannel + 'static>(
     .state(move |state| {
       state.put(bc.clone());
       state.put(Unstable(unstable));
-      Ok(())
     })
     .build()
 }

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -40,7 +40,6 @@ pub fn init<CA: Cache + 'static>(
       if let Some(create_cache) = maybe_create_cache.clone() {
         state.put(create_cache);
       }
-      Ok(())
     })
     .build()
 }

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -111,7 +111,6 @@ pub fn init(maybe_seed: Option<u64>) -> Extension {
       if let Some(seed) = maybe_seed {
         state.put(StdRng::seed_from_u64(seed));
       }
-      Ok(())
     })
     .build()
 }

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -124,7 +124,6 @@ where
         )
         .unwrap()
       });
-      Ok(())
     })
     .build()
 }

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -151,8 +151,6 @@ pub fn init<P: FfiPermissions + 'static>(unstable: bool) -> Extension {
         async_work_receiver,
         async_work_sender,
       });
-
-      Ok(())
     })
     .build()
 }

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1567,7 +1567,6 @@ pub fn init<P: FlashPermissions + 'static>(unstable: bool) -> Extension {
         join_handles: HashMap::default(),
         servers: HashMap::default(),
       });
-      Ok(())
     })
     .build()
 }

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -122,7 +122,6 @@ pub fn init<P: FsPermissions + 'static>(unstable: bool) -> Extension {
     .esm(include_js_files!("30_fs.js",))
     .state(move |state| {
       state.put(UnstableChecker { unstable });
-      Ok(())
     })
     .ops(vec![
       op_open_sync::decl::<P>(),

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -132,7 +132,6 @@ pub fn init(stdio: Stdio) -> Extension {
         "stderr",
       ));
       assert_eq!(rid, 2, "stderr must have ResourceId 2");
-      Ok(())
     })
     .build()
 }

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -578,7 +578,6 @@ pub fn init<P: NapiPermissions + 'static>() -> Extension {
         env_cleanup_hooks: Rc::new(RefCell::new(vec![])),
         tsfn_ref_counters: Arc::new(Mutex::new(vec![])),
       });
-      Ok(())
     })
     .build()
 }

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -96,7 +96,6 @@ pub fn init<P: NetPermissions + 'static>(
       state.put(UnsafelyIgnoreCertificateErrors(
         unsafely_ignore_certificate_errors.clone(),
       ));
-      Ok(())
     })
     .build()
 }

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -910,7 +910,6 @@ mod tests {
       .state(move |state| {
         state.put(TestPermission {});
         state.put(UnstableChecker { unstable: true });
-        Ok(())
       })
       .build();
 

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -383,7 +383,6 @@ pub fn init<P: NodePermissions + 'static>(
       if let Some(npm_resolver) = maybe_npm_resolver.clone() {
         state.put(npm_resolver);
       }
-      Ok(())
     })
     .build()
 }

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -40,7 +40,6 @@ fn setup() -> Vec<Extension> {
       }])
       .state(|state| {
         state.put(Permissions {});
-        Ok(())
       })
       .build(),
   ]

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -38,7 +38,6 @@ fn setup() -> Vec<Extension> {
     ])
     .state(|state| {
       state.put(Permissions{});
-      Ok(())
     })
     .build()
   ]

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -121,7 +121,6 @@ pub fn init<P: TimersPermission + 'static>(
         state.put(Location(location));
       }
       state.put(StartTime::now());
-      Ok(())
     })
     .build()
 }

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -127,7 +127,6 @@ pub fn init(unstable: bool) -> Extension {
       // let unstable_checker = state.borrow::<super::UnstableChecker>();
       // let unstable = unstable_checker.unstable;
       state.put(Unstable(unstable));
-      Ok(())
     })
     .build()
 }

--- a/ext/webgpu/surface.rs
+++ b/ext/webgpu/surface.rs
@@ -30,7 +30,6 @@ pub fn init_surface(unstable: bool) -> Extension {
       // let unstable_checker = state.borrow::<super::UnstableChecker>();
       // let unstable = unstable_checker.unstable;
       state.put(super::Unstable(unstable));
-      Ok(())
     })
     .build()
 }

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -521,7 +521,6 @@ pub fn init<P: WebSocketPermissions + 'static>(
         unsafely_ignore_certificate_errors.clone(),
       ));
       state.put::<WsRootStore>(WsRootStore(root_cert_store.clone()));
-      Ok(())
     })
     .build()
 }

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -38,7 +38,6 @@ pub fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
       if let Some(origin_storage_dir) = &origin_storage_dir {
         state.put(OriginStorageDir(origin_storage_dir.clone()));
       }
-      Ok(())
     })
     .build()
 }

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -45,7 +45,6 @@ pub fn init(exit_code: ExitCode) -> Extension {
   init_ops(&mut builder)
     .state(move |state| {
       state.put::<ExitCode>(exit_code.clone());
-      Ok(())
     })
     .build()
 }

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -12,7 +12,6 @@ pub fn init(main_module: ModuleSpecifier) -> Extension {
     .ops(vec![op_main_module::decl()])
     .state(move |state| {
       state.put::<ModuleSpecifier>(main_module.clone());
-      Ok(())
     })
     .build()
 }

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -111,8 +111,6 @@ pub fn init(
       let format_js_error_fn_holder =
         FormatJsErrorFnHolder(format_js_error_fn.clone());
       state.put::<FormatJsErrorFnHolder>(format_js_error_fn_holder);
-
-      Ok(())
     })
     .ops(vec![
       op_create_worker::decl(),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -376,7 +376,6 @@ impl WebWorker {
         state.put::<PermissionsContainer>(permissions.clone());
         state.put(ops::UnstableChecker { unstable });
         state.put(ops::TestingFeaturesEnabled(enable_testing_features));
-        Ok(())
       })
       .build();
     let create_cache = options.cache_storage_dir.map(|storage_dir| {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -206,7 +206,6 @@ impl MainWorker {
         state.put::<PermissionsContainer>(permissions.clone());
         state.put(ops::UnstableChecker { unstable });
         state.put(ops::TestingFeaturesEnabled(enable_testing_features));
-        Ok(())
       })
       .build();
     let exit_code = ExitCode(Arc::new(AtomicI32::new(0)));


### PR DESCRIPTION
There's no point for this API to expect result. If something fails it should
result in a panic during build time to signal to embedder that setup is wrong.