### PR TITLE
Revert "perf: disable snapshot compression (#18061)"

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -378,7 +378,14 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
     startup_snapshot: Some(deno_runtime::js::deno_isolate_init()),
     extensions,
     extensions_with_js,
-    compression_cb: None,
+    compression_cb: Some(Box::new(|vec, snapshot_slice| {
+      lzzzz::lz4_hc::compress_to_vec(
+        snapshot_slice,
+        vec,
+        lzzzz::lz4_hc::CLEVEL_MAX,
+      )
+      .expect("snapshot compression failed");
+    })),
     snapshot_module_load_cb: None,
   })
 }

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -1,12 +1,37 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::Snapshot;
+use log::debug;
+use once_cell::sync::Lazy;
 
-static CLI_SNAPSHOT: &[u8] =
-  include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
+pub static CLI_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
+  #[allow(clippy::uninit_vec)]
+  #[cold]
+  #[inline(never)]
+  || {
+    static COMPRESSED_CLI_SNAPSHOT: &[u8] =
+      include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
+
+    let size =
+      u32::from_le_bytes(COMPRESSED_CLI_SNAPSHOT[0..4].try_into().unwrap())
+        as usize;
+    let mut vec = Vec::with_capacity(size);
+
+    // SAFETY: vec is allocated with exact snapshot size (+ alignment)
+    // SAFETY: non zeroed bytes are overwritten with decompressed snapshot
+    unsafe {
+      vec.set_len(size);
+    }
+
+    lzzzz::lz4::decompress(&COMPRESSED_CLI_SNAPSHOT[4..], &mut vec).unwrap();
+
+    vec.into_boxed_slice()
+  },
+);
 
 pub fn deno_isolate_init() -> Snapshot {
-  Snapshot::Static(CLI_SNAPSHOT)
+  debug!("Deno isolate init with snapshots.");
+  Snapshot::Static(&CLI_SNAPSHOT)
 }
 
 #[cfg(test)]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -294,7 +294,14 @@ mod startup_snapshot {
       startup_snapshot: None,
       extensions: vec![],
       extensions_with_js,
-      compression_cb: None,
+      compression_cb: Some(Box::new(|vec, snapshot_slice| {
+        lzzzz::lz4_hc::compress_to_vec(
+          snapshot_slice,
+          vec,
+          lzzzz::lz4_hc::CLEVEL_MAX,
+        )
+        .expect("snapshot compression failed");
+      })),
       snapshot_module_load_cb: Some(Box::new(transpile_ts_for_snapshotting)),
     });
   }

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -1,14 +1,43 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 #[cfg(not(feature = "dont_create_runtime_snapshot"))]
 use deno_core::Snapshot;
+#[cfg(not(feature = "dont_create_runtime_snapshot"))]
+use log::debug;
+#[cfg(not(feature = "dont_create_runtime_snapshot"))]
+use once_cell::sync::Lazy;
 
 #[cfg(not(feature = "dont_create_runtime_snapshot"))]
-static RUNTIME_SNAPSHOT: &[u8] =
+static COMPRESSED_RUNTIME_SNAPSHOT: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/RUNTIME_SNAPSHOT.bin"));
 
 #[cfg(not(feature = "dont_create_runtime_snapshot"))]
+pub static RUNTIME_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
+  #[allow(clippy::uninit_vec)]
+  #[cold]
+  #[inline(never)]
+  || {
+    let size =
+      u32::from_le_bytes(COMPRESSED_RUNTIME_SNAPSHOT[0..4].try_into().unwrap())
+        as usize;
+    let mut vec = Vec::with_capacity(size);
+
+    // SAFETY: vec is allocated with exact snapshot size (+ alignment)
+    // SAFETY: non zeroed bytes are overwritten with decompressed snapshot
+    unsafe {
+      vec.set_len(size);
+    }
+
+    lzzzz::lz4::decompress(&COMPRESSED_RUNTIME_SNAPSHOT[4..], &mut vec)
+      .unwrap();
+
+    vec.into_boxed_slice()
+  },
+);
+
+#[cfg(not(feature = "dont_create_runtime_snapshot"))]
 pub fn deno_isolate_init() -> Snapshot {
-  Snapshot::Static(RUNTIME_SNAPSHOT)
+  debug!("Deno isolate init with snapshots.");
+  Snapshot::Static(&RUNTIME_SNAPSHOT)
 }
 
 #[cfg(not(feature = "include_js_files_for_snapshotting"))]


### PR DESCRIPTION
This reverts commit d12b039e1ad601622c6135e13f00fd14cb09bce1.

It was landed as an experiment and it confirms much faster startup
if not compression is applied.
