### PR TITLE
perf: don't add unload event listener

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -1056,6 +1056,15 @@ class EventTarget {
       prefix: "Failed to execute 'dispatchEvent' on 'EventTarget'",
     });
 
+    // This is an optimization to avoid creating an event listener
+    // on each startup.
+    // Stores the flag for checking whether unload is dispatched or not.
+    // This prevents the recursive dispatches of unload events.
+    // See https://github.com/denoland/deno/issues/9201.
+    if (event.type === "unload" && self === globalThis_) {
+      globalThis_[SymbolFor("isUnloadDispatched")] = true;
+    }
+
     const { listeners } = self[eventTargetData];
     if (!ReflectHas(listeners, event.type)) {
       setTarget(event, this);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -404,7 +404,6 @@ function bootstrapMainRuntime(runtimeOptions) {
   if (hasBootstrapped) {
     throw new Error("Worker runtime already bootstrapped");
   }
-
   performance.setTimeOrigin(DateNow());
   globalThis_ = globalThis;
 
@@ -450,15 +449,6 @@ function bootstrapMainRuntime(runtimeOptions) {
   event.defineEventHandler(globalThis, "unhandledrejection");
 
   core.setPromiseRejectCallback(promiseRejectCallback);
-
-  const isUnloadDispatched = SymbolFor("isUnloadDispatched");
-  // Stores the flag for checking whether unload is dispatched or not.
-  // This prevents the recursive dispatches of unload events.
-  // See https://github.com/denoland/deno/issues/9201.
-  globalThis[isUnloadDispatched] = false;
-  globalThis.addEventListener("unload", () => {
-    globalThis_[isUnloadDispatched] = true;
-  });
 
   runtimeStart(runtimeOptions);
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -30,7 +30,6 @@ const {
   ObjectSetPrototypeOf,
   PromiseResolve,
   Symbol,
-  SymbolFor,
   SymbolIterator,
   PromisePrototypeThen,
   SafeWeakMap,


### PR DESCRIPTION
This commit changes how "unload" event is handled - before
this commit an event listener was added unconditionally in
the runtime bootstrapping function, which for some reason was
very expensive (0.3ms). Instead of adding an event listener,
a check was added to "dispatchEvent" function that performs
the same action (so it's only called if there's an event dispatched).