### PR TITLE
perf(core): over-allocate in ModuleMap when running from snapshot

### DIFF
--- a/core/modules.rs
+++ b/core/modules.rs
@@ -1129,7 +1129,8 @@ impl ModuleMap {
 
       let info_arr: v8::Local<v8::Array> = info_val.try_into().unwrap();
       let len = info_arr.length() as usize;
-      let mut info = Vec::with_capacity(len);
+      // Over allocate so executing a few scripts doesn't have to resize this vec.
+      let mut info = Vec::with_capacity(len + 16);
 
       for i in 0..len {
         let module_info_arr: v8::Local<v8::Array> = info_arr

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -463,7 +463,6 @@ impl JsRuntime {
         }
       }
 
-      let mut module_handles = vec![];
       let mut scope = v8::ContextScope::new(scope, context);
       // The 0th element is the module map itself, followed by X number of module
       // handles. We need to deserialize the "next_module_id" field from the
@@ -476,6 +475,9 @@ impl JsRuntime {
             info_data.length()
           };
 
+          // Over allocate so executing a few scripts doesn't have to resize this vec.
+          let mut module_handles =
+            Vec::with_capacity(next_module_id as usize + 16);
           for i in 1..=next_module_id {
             match scope
               .get_context_data_from_snapshot_once::<v8::Module>(i as usize)


### PR DESCRIPTION
This commit changes "ModuleMap" initialization to over-allocate by 16
for vectors storing module information and module V8 handles. In 99%
cases there's gonna be at least one additional module loaded, so it's
very wasteful to have to reallocate when the module is executed (IIRC
Rust will double the size of the vector) and move all of the elements.

This change removes any allocations to `ModuleMap` from the
produced flamegraph.