### PR TITLE
perf: disable WAL for transpiled source cache

### DIFF
--- a/cli/cache/common.rs
+++ b/cli/cache/common.rs
@@ -49,10 +49,10 @@ impl FastInsecureHasher {
 
 /// Runs the common sqlite pragma.
 pub fn run_sqlite_pragma(conn: &Connection) -> Result<(), AnyError> {
-  // Enable write-ahead-logging and tweak some other stuff
+  // Disable write-ahead-logging and tweak some other stuff
   let initial_pragmas = "
-    -- enable write-ahead-logging mode
-    PRAGMA journal_mode=WAL;
+    -- Disable write-ahead-logging mode
+    PRAGMA journal_mode=Off;
     PRAGMA synchronous=NORMAL;
     PRAGMA temp_store=memory;
     PRAGMA page_size=4096;


### PR DESCRIPTION
Disable Write-Ahead Log for the cached module source database.

This brings SQLite connection cost on startup from 2.5% to 0.5%.

I'm still hesitant about it as disabling WAL might have negavitve
impact on multiple Deno processes running in parallel (ie. it may
cause module cache to become out of sync between processes
leading to strange transpilation bugs).