### PR TITLE
refactor: Split extension registration for runtime and snapshotting

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -322,36 +322,40 @@ mod ts {
 
 fn create_cli_snapshot(snapshot_path: PathBuf) {
   let extensions: Vec<Extension> = vec![
-    deno_webidl::init(),
-    deno_console::init(),
-    deno_url::init(),
+    deno_webidl::init_esm(),
+    deno_console::init_esm(),
+    deno_url::init_ops_and_esm(),
     deno_tls::init(),
-    deno_web::init::<PermissionsContainer>(
+    deno_web::init_ops_and_esm::<PermissionsContainer>(
       deno_web::BlobStore::default(),
       Default::default(),
     ),
-    deno_fetch::init::<PermissionsContainer>(Default::default()),
-    deno_cache::init::<SqliteBackedCache>(None),
-    deno_websocket::init::<PermissionsContainer>("".to_owned(), None, None),
-    deno_webstorage::init(None),
-    deno_crypto::init(None),
-    deno_webgpu::init(false),
-    deno_broadcast_channel::init(
+    deno_fetch::init_ops_and_esm::<PermissionsContainer>(Default::default()),
+    deno_cache::init_ops_and_esm::<SqliteBackedCache>(None),
+    deno_websocket::init_ops_and_esm::<PermissionsContainer>(
+      "".to_owned(),
+      None,
+      None,
+    ),
+    deno_webstorage::init_ops_and_esm(None),
+    deno_crypto::init_ops_and_esm(None),
+    deno_webgpu::init_ops_and_esm(false),
+    deno_broadcast_channel::init_ops_and_esm(
       deno_broadcast_channel::InMemoryBroadcastChannel::default(),
       false, // No --unstable.
     ),
-    deno_io::init(Default::default()),
-    deno_fs::init::<PermissionsContainer>(false),
+    deno_io::init_ops_and_esm(Default::default()),
+    deno_fs::init_ops_and_esm::<PermissionsContainer>(false),
     deno_node::init_ops_and_esm::<PermissionsContainer>(None), // No --unstable.
     deno_node::init_polyfill_ops_and_esm(),
-    deno_ffi::init::<PermissionsContainer>(false),
-    deno_net::init::<PermissionsContainer>(
+    deno_ffi::init_ops_and_esm::<PermissionsContainer>(false),
+    deno_net::init_ops_and_esm::<PermissionsContainer>(
       None, false, // No --unstable.
       None,
     ),
     deno_napi::init::<PermissionsContainer>(),
-    deno_http::init(),
-    deno_flash::init::<PermissionsContainer>(false), // No --unstable
+    deno_http::init_ops_and_esm(),
+    deno_flash::init_ops_and_esm::<PermissionsContainer>(false), // No --unstable
   ];
 
   let mut esm_files = include_js_files!(

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -342,7 +342,7 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
     ),
     deno_io::init(Default::default()),
     deno_fs::init::<PermissionsContainer>(false),
-    deno_node::init::<PermissionsContainer>(None), // No --unstable.
+    deno_node::init_ops_and_esm::<PermissionsContainer>(None), // No --unstable.
     deno_node::init_polyfill_ops_and_esm(),
     deno_ffi::init::<PermissionsContainer>(false),
     deno_net::init::<PermissionsContainer>(

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -13,6 +13,7 @@ use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use deno_core::ByteString;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
@@ -22,28 +23,45 @@ pub use sqlite::SqliteBackedCache;
 #[derive(Clone)]
 pub struct CreateCache<C: Cache + 'static>(pub Arc<dyn Fn() -> C>);
 
-pub fn init<CA: Cache + 'static>(
-  maybe_create_cache: Option<CreateCache<CA>>,
-) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(
     env!("CARGO_PKG_NAME"),
     &["deno_webidl", "deno_web", "deno_url", "deno_fetch"],
   )
-  .esm(include_js_files!("01_cache.js",))
-  .ops(vec![
-    op_cache_storage_open::decl::<CA>(),
-    op_cache_storage_has::decl::<CA>(),
-    op_cache_storage_delete::decl::<CA>(),
-    op_cache_put::decl::<CA>(),
-    op_cache_match::decl::<CA>(),
-    op_cache_delete::decl::<CA>(),
-  ])
-  .state(move |state| {
-    if let Some(create_cache) = maybe_create_cache.clone() {
-      state.put(create_cache);
-    }
-  })
-  .build()
+}
+
+fn ops<CA: Cache + 'static>(
+  ext: &mut ExtensionBuilder,
+  maybe_create_cache: Option<CreateCache<CA>>,
+) -> &mut ExtensionBuilder {
+  ext
+    .ops(vec![
+      op_cache_storage_open::decl::<CA>(),
+      op_cache_storage_has::decl::<CA>(),
+      op_cache_storage_delete::decl::<CA>(),
+      op_cache_put::decl::<CA>(),
+      op_cache_match::decl::<CA>(),
+      op_cache_delete::decl::<CA>(),
+    ])
+    .state(move |state| {
+      if let Some(create_cache) = maybe_create_cache.clone() {
+        state.put(create_cache);
+      }
+    })
+}
+
+pub fn init_ops_and_esm<CA: Cache + 'static>(
+  maybe_create_cache: Option<CreateCache<CA>>,
+) -> Extension {
+  ops::<CA>(&mut ext(), maybe_create_cache)
+    .esm(include_js_files!("01_cache.js",))
+    .build()
+}
+
+pub fn init_ops<CA: Cache + 'static>(
+  maybe_create_cache: Option<CreateCache<CA>>,
+) -> Extension {
+  ops::<CA>(&mut ext(), maybe_create_cache).build()
 }
 
 pub fn get_declaration() -> PathBuf {

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -2,10 +2,18 @@
 
 use deno_core::include_js_files;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use std::path::PathBuf;
 
-pub fn init() -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder(env!("CARGO_PKG_NAME"))
+}
+pub fn init() -> Extension {
+  ext().build()
+}
+
+pub fn init_esm() -> Extension {
+  ext()
     .esm(include_js_files!("01_colors.js", "02_console.js",))
     .build()
 }

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -10,6 +10,7 @@ use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::op;
+use deno_core::ExtensionBuilder;
 
 use deno_core::Extension;
 use deno_core::OpState;
@@ -72,49 +73,64 @@ use crate::key::CryptoNamedCurve;
 use crate::key::HkdfOutput;
 use crate::shared::RawKeyData;
 
-pub fn init(maybe_seed: Option<u64>) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(
     env!("CARGO_PKG_NAME"),
     &["deno_webidl", "deno_web"],
   )
-  .esm(include_js_files!("00_crypto.js", "01_webidl.js",))
-  .ops(vec![
-    op_crypto_get_random_values::decl(),
-    op_crypto_generate_key::decl(),
-    op_crypto_sign_key::decl(),
-    op_crypto_verify_key::decl(),
-    op_crypto_derive_bits::decl(),
-    op_crypto_import_key::decl(),
-    op_crypto_export_key::decl(),
-    op_crypto_encrypt::decl(),
-    op_crypto_decrypt::decl(),
-    op_crypto_subtle_digest::decl(),
-    op_crypto_random_uuid::decl(),
-    op_crypto_wrap_key::decl(),
-    op_crypto_unwrap_key::decl(),
-    op_crypto_base64url_decode::decl(),
-    op_crypto_base64url_encode::decl(),
-    x25519::op_generate_x25519_keypair::decl(),
-    x25519::op_derive_bits_x25519::decl(),
-    x25519::op_import_spki_x25519::decl(),
-    x25519::op_import_pkcs8_x25519::decl(),
-    ed25519::op_generate_ed25519_keypair::decl(),
-    ed25519::op_import_spki_ed25519::decl(),
-    ed25519::op_import_pkcs8_ed25519::decl(),
-    ed25519::op_sign_ed25519::decl(),
-    ed25519::op_verify_ed25519::decl(),
-    ed25519::op_export_spki_ed25519::decl(),
-    ed25519::op_export_pkcs8_ed25519::decl(),
-    ed25519::op_jwk_x_ed25519::decl(),
-    x25519::op_export_spki_x25519::decl(),
-    x25519::op_export_pkcs8_x25519::decl(),
-  ])
-  .state(move |state| {
-    if let Some(seed) = maybe_seed {
-      state.put(StdRng::seed_from_u64(seed));
-    }
-  })
-  .build()
+}
+
+fn ops(
+  ext: &mut ExtensionBuilder,
+  maybe_seed: Option<u64>,
+) -> &mut ExtensionBuilder {
+  ext
+    .ops(vec![
+      op_crypto_get_random_values::decl(),
+      op_crypto_generate_key::decl(),
+      op_crypto_sign_key::decl(),
+      op_crypto_verify_key::decl(),
+      op_crypto_derive_bits::decl(),
+      op_crypto_import_key::decl(),
+      op_crypto_export_key::decl(),
+      op_crypto_encrypt::decl(),
+      op_crypto_decrypt::decl(),
+      op_crypto_subtle_digest::decl(),
+      op_crypto_random_uuid::decl(),
+      op_crypto_wrap_key::decl(),
+      op_crypto_unwrap_key::decl(),
+      op_crypto_base64url_decode::decl(),
+      op_crypto_base64url_encode::decl(),
+      x25519::op_generate_x25519_keypair::decl(),
+      x25519::op_derive_bits_x25519::decl(),
+      x25519::op_import_spki_x25519::decl(),
+      x25519::op_import_pkcs8_x25519::decl(),
+      ed25519::op_generate_ed25519_keypair::decl(),
+      ed25519::op_import_spki_ed25519::decl(),
+      ed25519::op_import_pkcs8_ed25519::decl(),
+      ed25519::op_sign_ed25519::decl(),
+      ed25519::op_verify_ed25519::decl(),
+      ed25519::op_export_spki_ed25519::decl(),
+      ed25519::op_export_pkcs8_ed25519::decl(),
+      ed25519::op_jwk_x_ed25519::decl(),
+      x25519::op_export_spki_x25519::decl(),
+      x25519::op_export_pkcs8_x25519::decl(),
+    ])
+    .state(move |state| {
+      if let Some(seed) = maybe_seed {
+        state.put(StdRng::seed_from_u64(seed));
+      }
+    })
+}
+
+pub fn init_ops_and_esm(maybe_seed: Option<u64>) -> Extension {
+  ops(&mut ext(), maybe_seed)
+    .esm(include_js_files!("00_crypto.js", "01_webidl.js",))
+    .build()
+}
+
+pub fn init_ops(maybe_seed: Option<u64>) -> Extension {
+  ops(&mut ext(), maybe_seed).build()
 }
 
 #[op]

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -5,6 +5,7 @@ use deno_core::futures::channel::mpsc;
 use deno_core::include_js_files;
 use deno_core::v8;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 
 use std::cell::RefCell;
@@ -81,9 +82,15 @@ pub(crate) struct FfiState {
   pub(crate) async_work_receiver: mpsc::UnboundedReceiver<PendingFfiAsyncWork>,
 }
 
-pub fn init<P: FfiPermissions + 'static>(unstable: bool) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_web"])
-    .esm(include_js_files!("00_ffi.js",))
+}
+
+fn ops<P: FfiPermissions + 'static>(
+  ext: &mut ExtensionBuilder,
+  unstable: bool,
+) -> &mut ExtensionBuilder {
+  ext
     .ops(vec![
       op_ffi_load::decl::<P>(),
       op_ffi_get_static::decl(),
@@ -151,5 +158,18 @@ pub fn init<P: FfiPermissions + 'static>(unstable: bool) -> Extension {
         async_work_sender,
       });
     })
+}
+
+pub fn init_ops_and_esm<P: FfiPermissions + 'static>(
+  unstable: bool,
+) -> Extension {
+  ops::<P>(&mut ext(), unstable)
+    .esm(include_js_files!("00_ffi.js",))
+    .build()
+}
+
+pub fn init_ops<P: FfiPermissions + 'static>(unstable: bool) -> Extension {
+  ops::<P>(&mut ext(), unstable)
+    .esm(include_js_files!("00_ffi.js",))
     .build()
 }

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -9,6 +9,7 @@ use deno_core::op;
 use deno_core::CancelFuture;
 use deno_core::CancelHandle;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::ResourceId;
 use deno_core::ZeroCopyBuf;
@@ -117,9 +118,15 @@ use deno_core::error::generic_error;
 #[cfg(not(unix))]
 use deno_core::error::not_supported;
 
-pub fn init<P: FsPermissions + 'static>(unstable: bool) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder("deno_fs")
-    .esm(include_js_files!("30_fs.js",))
+}
+
+fn ops<P: FsPermissions + 'static>(
+  ext: &mut ExtensionBuilder,
+  unstable: bool,
+) -> &mut ExtensionBuilder {
+  ext
     .state(move |state| {
       state.put(UnstableChecker { unstable });
     })
@@ -184,6 +191,19 @@ pub fn init<P: FsPermissions + 'static>(unstable: bool) -> Extension {
       op_readfile_async::decl::<P>(),
       op_readfile_text_async::decl::<P>(),
     ])
+}
+
+pub fn init_ops_and_esm<P: FsPermissions + 'static>(
+  unstable: bool,
+) -> Extension {
+  ops::<P>(&mut ext(), unstable)
+    .esm(include_js_files!("30_fs.js",))
+    .build()
+}
+
+pub fn init_ops<P: FsPermissions + 'static>(unstable: bool) -> Extension {
+  ops::<P>(&mut ext(), unstable)
+    .esm(include_js_files!("30_fs.js",))
     .build()
 }
 

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -30,6 +30,7 @@ use deno_core::CancelFuture;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -77,13 +78,15 @@ use crate::reader_stream::ShutdownHandle;
 pub mod compressible;
 mod reader_stream;
 
-pub fn init() -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(
     env!("CARGO_PKG_NAME"),
     &["deno_web", "deno_net", "deno_fetch", "deno_websocket"],
   )
-  .esm(include_js_files!("01_http.js",))
-  .ops(vec![
+}
+
+fn ops(ext: &mut ExtensionBuilder) -> &mut ExtensionBuilder {
+  ext.ops(vec![
     op_http_accept::decl(),
     op_http_write_headers::decl(),
     op_http_headers::decl(),
@@ -93,7 +96,16 @@ pub fn init() -> Extension {
     op_http_websocket_accept_header::decl(),
     op_http_upgrade_websocket::decl(),
   ])
-  .build()
+}
+
+pub fn init_ops_and_esm() -> Extension {
+  ops(&mut ext())
+    .esm(include_js_files!("01_http.js",))
+    .build()
+}
+
+pub fn init_ops() -> Extension {
+  ops(&mut ext()).build()
 }
 
 pub enum HttpSocketAddr {

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -13,6 +13,7 @@ use deno_core::BufView;
 use deno_core::CancelHandle;
 use deno_core::CancelTryFuture;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
@@ -78,13 +79,16 @@ pub static STDERR_HANDLE: Lazy<StdFile> = Lazy::new(|| {
   unsafe { StdFile::from_raw_handle(GetStdHandle(winbase::STD_ERROR_HANDLE)) }
 });
 
-pub fn init(stdio: Stdio) -> Extension {
-  // todo(dsheret): don't do this? Taking out the writers was necessary to prevent invalid handle panics
-  let stdio = Rc::new(RefCell::new(Some(stdio)));
-
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps("deno_io", &["deno_web"])
+}
+
+fn ops(
+  ext: &mut ExtensionBuilder,
+  stdio: Rc<RefCell<Option<Stdio>>>,
+) -> &mut ExtensionBuilder {
+  ext
     .ops(vec![op_read_sync::decl(), op_write_sync::decl()])
-    .esm(include_js_files!("12_io.js",))
     .middleware(|op| match op.name {
       "op_print" => op_print::decl(),
       _ => op,
@@ -132,7 +136,22 @@ pub fn init(stdio: Stdio) -> Extension {
       ));
       assert_eq!(rid, 2, "stderr must have ResourceId 2");
     })
+}
+
+pub fn init_ops_and_esm(stdio: Stdio) -> Extension {
+  // todo(dsheret): don't do this? Taking out the writers was necessary to prevent invalid handle panics
+  let stdio = Rc::new(RefCell::new(Some(stdio)));
+
+  ops(&mut ext(), stdio)
+    .esm(include_js_files!("12_io.js",))
     .build()
+}
+
+pub fn init_ops(stdio: Stdio) -> Extension {
+  // todo(dsheret): don't do this? Taking out the writers was necessary to prevent invalid handle panics
+  let stdio = Rc::new(RefCell::new(Some(stdio)));
+
+  ops(&mut ext(), stdio).build()
 }
 
 pub enum StdioPipe {

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -10,6 +10,7 @@ pub mod resolve_addr;
 use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_tls::rustls::RootCertStore;
 use std::cell::RefCell;
@@ -77,24 +78,55 @@ pub struct DefaultTlsOptions {
 /// would override previously used alias.
 pub struct UnsafelyIgnoreCertificateErrors(pub Option<Vec<String>>);
 
-pub fn init<P: NetPermissions + 'static>(
+fn ext() -> ExtensionBuilder {
+  Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_web"])
+}
+
+fn ops<P: NetPermissions + 'static>(
+  ext: &mut ExtensionBuilder,
+  root_cert_store: Option<RootCertStore>,
+  unstable: bool,
+  unsafely_ignore_certificate_errors: Option<Vec<String>>,
+) -> &mut ExtensionBuilder {
+  let mut ops = ops::init::<P>();
+  ops.extend(ops_tls::init::<P>());
+
+  ext.ops(ops).state(move |state| {
+    state.put(DefaultTlsOptions {
+      root_cert_store: root_cert_store.clone(),
+    });
+    state.put(UnstableChecker { unstable });
+    state.put(UnsafelyIgnoreCertificateErrors(
+      unsafely_ignore_certificate_errors.clone(),
+    ));
+  })
+}
+
+pub fn init_ops_and_esm<P: NetPermissions + 'static>(
   root_cert_store: Option<RootCertStore>,
   unstable: bool,
   unsafely_ignore_certificate_errors: Option<Vec<String>>,
 ) -> Extension {
-  let mut ops = ops::init::<P>();
-  ops.extend(ops_tls::init::<P>());
-  Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_web"])
-    .esm(include_js_files!("01_net.js", "02_tls.js",))
-    .ops(ops)
-    .state(move |state| {
-      state.put(DefaultTlsOptions {
-        root_cert_store: root_cert_store.clone(),
-      });
-      state.put(UnstableChecker { unstable });
-      state.put(UnsafelyIgnoreCertificateErrors(
-        unsafely_ignore_certificate_errors.clone(),
-      ));
-    })
-    .build()
+  ops::<P>(
+    &mut ext(),
+    root_cert_store,
+    unstable,
+    unsafely_ignore_certificate_errors,
+  )
+  .esm(include_js_files!("01_net.js", "02_tls.js",))
+  .build()
+}
+
+pub fn init_ops<P: NetPermissions + 'static>(
+  root_cert_store: Option<RootCertStore>,
+  unstable: bool,
+  unsafely_ignore_certificate_errors: Option<Vec<String>>,
+) -> Extension {
+  ops::<P>(
+    &mut ext(),
+    root_cert_store,
+    unstable,
+    unsafely_ignore_certificate_errors,
+  )
+  .build()
 }

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -5,6 +5,7 @@ use deno_core::include_js_files;
 use deno_core::located_script_name;
 use deno_core::op;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::JsRuntime;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
@@ -95,16 +96,34 @@ fn op_node_build_os() -> String {
     .to_string()
 }
 
+fn ext_polyfill() -> ExtensionBuilder {
+  Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_io", "deno_fs"])
+}
+
+fn ops_polyfill(ext: &mut ExtensionBuilder) -> &mut ExtensionBuilder {
+  ext.ops(vec![
+    crypto::op_node_create_hash::decl(),
+    crypto::op_node_hash_update::decl(),
+    crypto::op_node_hash_update_str::decl(),
+    crypto::op_node_hash_digest::decl(),
+    crypto::op_node_hash_digest_hex::decl(),
+    crypto::op_node_hash_clone::decl(),
+    crypto::op_node_private_encrypt::decl(),
+    crypto::op_node_private_decrypt::decl(),
+    crypto::op_node_public_encrypt::decl(),
+    winerror::op_node_sys_to_uv_error::decl(),
+    v8::op_v8_cached_data_version_tag::decl(),
+    v8::op_v8_get_heap_statistics::decl(),
+    idna::op_node_idna_domain_to_ascii::decl(),
+    idna::op_node_idna_domain_to_unicode::decl(),
+    idna::op_node_idna_punycode_decode::decl(),
+    idna::op_node_idna_punycode_encode::decl(),
+    op_node_build_os::decl(),
+  ])
+}
+
 pub fn init_polyfill_ops() -> Extension {
-  Extension::builder(env!("CARGO_PKG_NAME"))
-    .ops(vec![
-      crypto::op_node_create_hash::decl(),
-      crypto::op_node_hash_update::decl(),
-      crypto::op_node_hash_digest::decl(),
-      crypto::op_node_hash_clone::decl(),
-      op_node_build_os::decl(),
-    ])
-    .build()
+  ops_polyfill(&mut ext_polyfill()).build()
 }
 
 pub fn init_polyfill_ops_and_esm() -> Extension {
@@ -332,40 +351,21 @@ pub fn init_polyfill_ops_and_esm() -> Extension {
     "zlib.ts",
   );
 
-  Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_io", "deno_fs"])
+  ops_polyfill(&mut ext_polyfill())
     .esm(esm_files)
     .esm_entry_point("ext:deno_node/module_all.ts")
-    .ops(vec![
-      crypto::op_node_create_hash::decl(),
-      crypto::op_node_hash_update::decl(),
-      crypto::op_node_hash_update_str::decl(),
-      crypto::op_node_hash_digest::decl(),
-      crypto::op_node_hash_digest_hex::decl(),
-      crypto::op_node_hash_clone::decl(),
-      crypto::op_node_private_encrypt::decl(),
-      crypto::op_node_private_decrypt::decl(),
-      crypto::op_node_public_encrypt::decl(),
-      winerror::op_node_sys_to_uv_error::decl(),
-      v8::op_v8_cached_data_version_tag::decl(),
-      v8::op_v8_get_heap_statistics::decl(),
-      idna::op_node_idna_domain_to_ascii::decl(),
-      idna::op_node_idna_domain_to_unicode::decl(),
-      idna::op_node_idna_punycode_decode::decl(),
-      idna::op_node_idna_punycode_encode::decl(),
-      op_node_build_os::decl(),
-    ])
     .build()
 }
 
-pub fn init<P: NodePermissions + 'static>(
-  maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
-) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder("deno_node_loading")
-    .esm(include_js_files!(
-      "01_node.js",
-      "02_require.js",
-      "module_es_shim.js",
-    ))
+}
+
+fn ops<P: NodePermissions + 'static>(
+  ext: &mut ExtensionBuilder,
+  maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
+) -> &mut ExtensionBuilder {
+  ext
     .ops(vec![
       ops::op_require_init_paths::decl(),
       ops::op_require_node_module_paths::decl::<P>(),
@@ -395,7 +395,24 @@ pub fn init<P: NodePermissions + 'static>(
         state.put(npm_resolver);
       }
     })
+}
+
+pub fn init_ops_and_esm<P: NodePermissions + 'static>(
+  maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
+) -> Extension {
+  ops::<P>(&mut ext(), maybe_npm_resolver)
+    .esm(include_js_files!(
+      "01_node.js",
+      "02_require.js",
+      "module_es_shim.js",
+    ))
     .build()
+}
+
+pub fn init_ops<P: NodePermissions + 'static>(
+  maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
+) -> Extension {
+  ops::<P>(&mut ext(), maybe_npm_resolver).build()
 }
 
 pub async fn initialize_runtime(

--- a/ext/url/benches/url_ops.rs
+++ b/ext/url/benches/url_ops.rs
@@ -11,8 +11,8 @@ use deno_core::ExtensionFileSourceCode;
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::init(),
-    deno_url::init(),
+    deno_webidl::init_esm(),
+    deno_url::init_ops_and_esm(),
     Extension::builder("bench_setup")
       .esm(vec![ExtensionFileSource {
         specifier: "ext:setup".to_string(),

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -10,6 +10,7 @@ use deno_core::url::form_urlencoded;
 use deno_core::url::quirks;
 use deno_core::url::Url;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::ZeroCopyBuf;
 use std::path::PathBuf;
@@ -17,20 +18,31 @@ use std::path::PathBuf;
 use crate::urlpattern::op_urlpattern_parse;
 use crate::urlpattern::op_urlpattern_process_match_input;
 
-pub fn init() -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_webidl"])
+}
+
+fn ops(ext: &mut ExtensionBuilder) -> &mut ExtensionBuilder {
+  ext.ops(vec![
+    op_url_reparse::decl(),
+    op_url_parse::decl(),
+    op_url_get_serialization::decl(),
+    op_url_parse_with_base::decl(),
+    op_url_parse_search_params::decl(),
+    op_url_stringify_search_params::decl(),
+    op_urlpattern_parse::decl(),
+    op_urlpattern_process_match_input::decl(),
+  ])
+}
+
+pub fn init_ops_and_esm() -> Extension {
+  ops(&mut ext())
     .esm(include_js_files!("00_url.js", "01_urlpattern.js",))
-    .ops(vec![
-      op_url_reparse::decl(),
-      op_url_parse::decl(),
-      op_url_get_serialization::decl(),
-      op_url_parse_with_base::decl(),
-      op_url_parse_search_params::decl(),
-      op_url_stringify_search_params::decl(),
-      op_urlpattern_parse::decl(),
-      op_urlpattern_process_match_input::decl(),
-    ])
     .build()
+}
+
+pub fn init_ops() -> Extension {
+  ops(&mut ext()).build()
 }
 
 /// Parse `href` with a `base_href`. Fills the out `buf` with URL components.

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -23,10 +23,10 @@ impl deno_web::TimersPermission for Permissions {
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::init(),
-    deno_url::init(),
-    deno_console::init(),
-    deno_web::init::<Permissions>(BlobStore::default(), None),
+    deno_webidl::init_esm(),
+    deno_url::init_ops_and_esm(),
+    deno_console::init_esm(),
+    deno_web::init_ops_and_esm::<Permissions>(BlobStore::default(), None),
     Extension::builder("bench_setup")
       .esm(vec![ExtensionFileSource {
         specifier: "ext:setup".to_string(),

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -21,10 +21,10 @@ impl deno_web::TimersPermission for Permissions {
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::init(),
-    deno_url::init(),
-    deno_console::init(),
-    deno_web::init::<Permissions>(BlobStore::default(), None),
+    deno_webidl::init_esm(),
+    deno_url::init_ops_and_esm(),
+    deno_console::init_esm(),
+    deno_web::init_ops_and_esm::<Permissions>(BlobStore::default(), None),
     Extension::builder("bench_setup")
     .esm(vec![
       ExtensionFileSource {

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -16,6 +16,7 @@ use deno_core::v8;
 use deno_core::ByteString;
 use deno_core::CancelHandle;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
@@ -57,74 +58,92 @@ use crate::timers::op_timer_handle;
 use crate::timers::StartTime;
 pub use crate::timers::TimersPermission;
 
-/// Load and execute the javascript code.
-pub fn init<P: TimersPermission + 'static>(
-  blob_store: BlobStore,
-  maybe_location: Option<Url>,
-) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(
     env!("CARGO_PKG_NAME"),
     &["deno_webidl", "deno_console", "deno_url"],
   )
-  .esm(include_js_files!(
-    "00_infra.js",
-    "01_dom_exception.js",
-    "01_mimesniff.js",
-    "02_event.js",
-    "02_structured_clone.js",
-    "02_timers.js",
-    "03_abort_signal.js",
-    "04_global_interfaces.js",
-    "05_base64.js",
-    "06_streams.js",
-    "08_text_encoding.js",
-    "09_file.js",
-    "10_filereader.js",
-    "11_blob_url.js",
-    "12_location.js",
-    "13_message_port.js",
-    "14_compression.js",
-    "15_performance.js",
-  ))
-  .ops(vec![
-    op_base64_decode::decl(),
-    op_base64_encode::decl(),
-    op_base64_atob::decl(),
-    op_base64_btoa::decl(),
-    op_encoding_normalize_label::decl(),
-    op_encoding_decode_single::decl(),
-    op_encoding_decode_utf8::decl(),
-    op_encoding_new_decoder::decl(),
-    op_encoding_decode::decl(),
-    op_encoding_encode_into::decl(),
-    op_encode_binary_string::decl(),
-    op_blob_create_part::decl(),
-    op_blob_slice_part::decl(),
-    op_blob_read_part::decl(),
-    op_blob_remove_part::decl(),
-    op_blob_create_object_url::decl(),
-    op_blob_revoke_object_url::decl(),
-    op_blob_from_object_url::decl(),
-    op_message_port_create_entangled::decl(),
-    op_message_port_post_message::decl(),
-    op_message_port_recv_message::decl(),
-    compression::op_compression_new::decl(),
-    compression::op_compression_write::decl(),
-    compression::op_compression_finish::decl(),
-    op_now::decl::<P>(),
-    op_timer_handle::decl(),
-    op_cancel_handle::decl(),
-    op_sleep::decl(),
-    op_transfer_arraybuffer::decl(),
-  ])
-  .state(move |state| {
-    state.put(blob_store.clone());
-    if let Some(location) = maybe_location.clone() {
-      state.put(Location(location));
-    }
-    state.put(StartTime::now());
-  })
-  .build()
+}
+
+fn ops<P: TimersPermission + 'static>(
+  ext: &mut ExtensionBuilder,
+  blob_store: BlobStore,
+  maybe_location: Option<Url>,
+) -> &mut ExtensionBuilder {
+  ext
+    .ops(vec![
+      op_base64_decode::decl(),
+      op_base64_encode::decl(),
+      op_base64_atob::decl(),
+      op_base64_btoa::decl(),
+      op_encoding_normalize_label::decl(),
+      op_encoding_decode_single::decl(),
+      op_encoding_decode_utf8::decl(),
+      op_encoding_new_decoder::decl(),
+      op_encoding_decode::decl(),
+      op_encoding_encode_into::decl(),
+      op_encode_binary_string::decl(),
+      op_blob_create_part::decl(),
+      op_blob_slice_part::decl(),
+      op_blob_read_part::decl(),
+      op_blob_remove_part::decl(),
+      op_blob_create_object_url::decl(),
+      op_blob_revoke_object_url::decl(),
+      op_blob_from_object_url::decl(),
+      op_message_port_create_entangled::decl(),
+      op_message_port_post_message::decl(),
+      op_message_port_recv_message::decl(),
+      compression::op_compression_new::decl(),
+      compression::op_compression_write::decl(),
+      compression::op_compression_finish::decl(),
+      op_now::decl::<P>(),
+      op_timer_handle::decl(),
+      op_cancel_handle::decl(),
+      op_sleep::decl(),
+      op_transfer_arraybuffer::decl(),
+    ])
+    .state(move |state| {
+      state.put(blob_store.clone());
+      if let Some(location) = maybe_location.clone() {
+        state.put(Location(location));
+      }
+      state.put(StartTime::now());
+    })
+}
+
+pub fn init_ops_and_esm<P: TimersPermission + 'static>(
+  blob_store: BlobStore,
+  maybe_location: Option<Url>,
+) -> Extension {
+  ops::<P>(&mut ext(), blob_store, maybe_location)
+    .esm(include_js_files!(
+      "00_infra.js",
+      "01_dom_exception.js",
+      "01_mimesniff.js",
+      "02_event.js",
+      "02_structured_clone.js",
+      "02_timers.js",
+      "03_abort_signal.js",
+      "04_global_interfaces.js",
+      "05_base64.js",
+      "06_streams.js",
+      "08_text_encoding.js",
+      "09_file.js",
+      "10_filereader.js",
+      "11_blob_url.js",
+      "12_location.js",
+      "13_message_port.js",
+      "14_compression.js",
+      "15_performance.js",
+    ))
+    .build()
+}
+
+pub fn init_ops<P: TimersPermission + 'static>(
+  blob_store: BlobStore,
+  maybe_location: Option<Url>,
+) -> Extension {
+  ops::<P>(&mut ext(), blob_store, maybe_location).build()
 }
 
 #[op]

--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -6,6 +6,7 @@ use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::op;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
@@ -116,21 +117,31 @@ impl Resource for WebGpuQuerySet {
   }
 }
 
-pub fn init(unstable: bool) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(
     env!("CARGO_PKG_NAME"),
     &["deno_webidl", "deno_web"],
   )
-  .esm(include_js_files!("01_webgpu.js", "02_idl_types.js",))
-  .ops(declare_webgpu_ops())
-  .state(move |state| {
+}
+
+fn ops(ext: &mut ExtensionBuilder, unstable: bool) -> &mut ExtensionBuilder {
+  ext.ops(declare_webgpu_ops()).state(move |state| {
     // TODO: check & possibly streamline this
     // Unstable might be able to be OpMiddleware
     // let unstable_checker = state.borrow::<super::UnstableChecker>();
     // let unstable = unstable_checker.unstable;
     state.put(Unstable(unstable));
   })
-  .build()
+}
+
+pub fn init_ops_and_esm(unstable: bool) -> Extension {
+  ops(&mut ext(), unstable)
+    .esm(include_js_files!("01_webgpu.js", "02_idl_types.js",))
+    .build()
+}
+
+pub fn init_ops(unstable: bool) -> Extension {
+  ops(&mut ext(), unstable).build()
 }
 
 fn deserialize_features(features: &wgpu_types::Features) -> Vec<&'static str> {

--- a/ext/webidl/benches/dict.rs
+++ b/ext/webidl/benches/dict.rs
@@ -11,7 +11,7 @@ use deno_core::ExtensionFileSourceCode;
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::init(),
+    deno_webidl::init_esm(),
     Extension::builder("deno_webidl_bench")
       .esm(vec![ExtensionFileSource {
         specifier: "ext:setup".to_string(),

--- a/ext/webidl/lib.rs
+++ b/ext/webidl/lib.rs
@@ -3,8 +3,11 @@
 use deno_core::include_js_files;
 use deno_core::Extension;
 
-/// Load and execute the javascript code.
 pub fn init() -> Extension {
+  Extension::builder(env!("CARGO_PKG_NAME")).build()
+}
+
+pub fn init_esm() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .esm(include_js_files!("00_webidl.js",))
     .build()

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -9,6 +9,7 @@ use deno_core::error::AnyError;
 use deno_core::include_js_files;
 use deno_core::op;
 use deno_core::Extension;
+use deno_core::ExtensionBuilder;
 use deno_core::OpState;
 use rusqlite::params;
 use rusqlite::Connection;
@@ -21,9 +22,15 @@ struct OriginStorageDir(PathBuf);
 
 const MAX_STORAGE_BYTES: usize = 10 * 1024 * 1024;
 
-pub fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
+fn ext() -> ExtensionBuilder {
   Extension::builder_with_deps(env!("CARGO_PKG_NAME"), &["deno_webidl"])
-    .esm(include_js_files!("01_webstorage.js",))
+}
+
+fn ops(
+  ext: &mut ExtensionBuilder,
+  origin_storage_dir: Option<PathBuf>,
+) -> &mut ExtensionBuilder {
+  ext
     .ops(vec![
       op_webstorage_length::decl(),
       op_webstorage_key::decl(),
@@ -38,7 +45,16 @@ pub fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
         state.put(OriginStorageDir(origin_storage_dir.clone()));
       }
     })
+}
+
+pub fn init_ops_and_esm(origin_storage_dir: Option<PathBuf>) -> Extension {
+  ops(&mut ext(), origin_storage_dir)
+    .esm(include_js_files!("01_webstorage.js",))
     .build()
+}
+
+pub fn init_ops(origin_storage_dir: Option<PathBuf>) -> Extension {
+  ops(&mut ext(), origin_storage_dir).build()
 }
 
 pub fn get_declaration() -> PathBuf {

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -251,34 +251,38 @@ mod startup_snapshot {
     .build();
 
     let mut extensions_with_js: Vec<Extension> = vec![
-      deno_webidl::init(),
-      deno_console::init(),
-      deno_url::init(),
+      deno_webidl::init_esm(),
+      deno_console::init_esm(),
+      deno_url::init_ops_and_esm(),
       deno_tls::init(),
-      deno_web::init::<Permissions>(
+      deno_web::init_ops_and_esm::<Permissions>(
         deno_web::BlobStore::default(),
         Default::default(),
       ),
-      deno_fetch::init::<Permissions>(Default::default()),
-      deno_cache::init::<SqliteBackedCache>(None),
-      deno_websocket::init::<Permissions>("".to_owned(), None, None),
-      deno_webstorage::init(None),
-      deno_crypto::init(None),
-      deno_webgpu::init(false),
-      deno_broadcast_channel::init(
+      deno_fetch::init_ops_and_esm::<Permissions>(Default::default()),
+      deno_cache::init_ops_and_esm::<SqliteBackedCache>(None),
+      deno_websocket::init_ops_and_esm::<Permissions>(
+        "".to_owned(),
+        None,
+        None,
+      ),
+      deno_webstorage::init_ops_and_esm(None),
+      deno_crypto::init_ops_and_esm(None),
+      deno_webgpu::init_ops_and_esm(false),
+      deno_broadcast_channel::init_ops_and_esm(
         deno_broadcast_channel::InMemoryBroadcastChannel::default(),
         false, // No --unstable.
       ),
-      deno_ffi::init::<Permissions>(false),
-      deno_net::init::<Permissions>(
+      deno_ffi::init_ops_and_esm::<Permissions>(false),
+      deno_net::init_ops_and_esm::<Permissions>(
         None, false, // No --unstable.
         None,
       ),
       deno_napi::init::<Permissions>(),
-      deno_http::init(),
-      deno_io::init(Default::default()),
-      deno_fs::init::<Permissions>(false),
-      deno_flash::init::<Permissions>(false), // No --unstable
+      deno_http::init_ops_and_esm(),
+      deno_io::init_ops_and_esm(Default::default()),
+      deno_fs::init_ops_and_esm::<Permissions>(false),
+      deno_flash::init_ops_and_esm::<Permissions>(false), // No --unstable
       runtime_extension,
       // FIXME(bartlomieju): these extensions are specified last, because they
       // depend on `runtime`, even though it should be other way around

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -282,7 +282,7 @@ mod startup_snapshot {
       runtime_extension,
       // FIXME(bartlomieju): these extensions are specified last, because they
       // depend on `runtime`, even though it should be other way around
-      deno_node::init::<Permissions>(None),
+      deno_node::init_ops_and_esm::<Permissions>(None),
       deno_node::init_polyfill_ops_and_esm(),
     ];
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -387,12 +387,12 @@ impl WebWorker {
       // Web APIs
       deno_webidl::init(),
       deno_console::init(),
-      deno_url::init(),
-      deno_web::init::<PermissionsContainer>(
+      deno_url::init_ops(),
+      deno_web::init_ops::<PermissionsContainer>(
         options.blob_store.clone(),
         Some(main_module.clone()),
       ),
-      deno_fetch::init::<PermissionsContainer>(deno_fetch::Options {
+      deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
         user_agent: options.bootstrap.user_agent.clone(),
         root_cert_store: options.root_cert_store.clone(),
         unsafely_ignore_certificate_errors: options
@@ -401,18 +401,21 @@ impl WebWorker {
         file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
         ..Default::default()
       }),
-      deno_cache::init::<SqliteBackedCache>(create_cache),
-      deno_websocket::init::<PermissionsContainer>(
+      deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+      deno_websocket::init_ops::<PermissionsContainer>(
         options.bootstrap.user_agent.clone(),
         options.root_cert_store.clone(),
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_webstorage::init(None).disable(),
-      deno_broadcast_channel::init(options.broadcast_channel.clone(), unstable),
-      deno_crypto::init(options.seed),
-      deno_webgpu::init(unstable),
+      deno_webstorage::init_ops(None).disable(),
+      deno_broadcast_channel::init_ops(
+        options.broadcast_channel.clone(),
+        unstable,
+      ),
+      deno_crypto::init_ops(options.seed),
+      deno_webgpu::init_ops(unstable),
       // ffi
-      deno_ffi::init::<PermissionsContainer>(unstable),
+      deno_ffi::init_ops::<PermissionsContainer>(unstable),
       // Runtime ops that are always initialized for WebWorkers
       ops::web_worker::init(),
       ops::runtime::init(main_module.clone()),
@@ -424,10 +427,10 @@ impl WebWorker {
       ),
       // Extensions providing Deno.* features
       ops::fs_events::init(),
-      deno_fs::init::<PermissionsContainer>(unstable),
-      deno_io::init(options.stdio),
+      deno_fs::init_ops::<PermissionsContainer>(unstable),
+      deno_io::init_ops(options.stdio),
       deno_tls::init(),
-      deno_net::init::<PermissionsContainer>(
+      deno_net::init_ops::<PermissionsContainer>(
         options.root_cert_store.clone(),
         unstable,
         options.unsafely_ignore_certificate_errors.clone(),
@@ -443,8 +446,8 @@ impl WebWorker {
       ops::process::init_ops(),
       ops::signal::init(),
       ops::tty::init(),
-      deno_http::init(),
-      deno_flash::init::<PermissionsContainer>(unstable),
+      deno_http::init_ops(),
+      deno_flash::init_ops::<PermissionsContainer>(unstable),
       ops::http::init(),
       // Permissions ext (worker specific state)
       perm_ext,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -346,6 +346,168 @@ pub struct WebWorkerOptions {
   pub stdio: Stdio,
 }
 
+#[cfg(feature = "dont_create_runtime_snapshot")]
+fn get_extensions(
+  options: &mut WebWorkerOptions,
+  unstable: bool,
+  main_module: ModuleSpecifier,
+) -> Vec<Extension> {
+  let create_cache = options.cache_storage_dir.take().map(|storage_dir| {
+    let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
+    CreateCache(Arc::new(create_cache_fn))
+  });
+
+  vec![
+    // Web APIs
+    deno_webidl::init(),
+    deno_console::init(),
+    deno_url::init_ops(),
+    deno_web::init_ops::<PermissionsContainer>(
+      options.blob_store.clone(),
+      Some(main_module.clone()),
+    ),
+    deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
+      user_agent: options.bootstrap.user_agent.clone(),
+      root_cert_store: options.root_cert_store.clone(),
+      unsafely_ignore_certificate_errors: options
+        .unsafely_ignore_certificate_errors
+        .clone(),
+      file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
+      ..Default::default()
+    }),
+    deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+    deno_websocket::init_ops::<PermissionsContainer>(
+      options.bootstrap.user_agent.clone(),
+      options.root_cert_store.clone(),
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_webstorage::init_ops(None).disable(),
+    deno_broadcast_channel::init_ops(
+      options.broadcast_channel.clone(),
+      unstable,
+    ),
+    deno_crypto::init_ops(options.seed),
+    deno_webgpu::init_ops(unstable),
+    // ffi
+    deno_ffi::init_ops::<PermissionsContainer>(unstable),
+    // Runtime ops that are always initialized for WebWorkers
+    ops::web_worker::init(),
+    ops::runtime::init(main_module),
+    ops::worker_host::init(
+      options.create_web_worker_cb.clone(),
+      options.preload_module_cb.clone(),
+      options.pre_execute_module_cb.clone(),
+      options.format_js_error_fn.clone(),
+    ),
+    // Extensions providing Deno.* features
+    ops::fs_events::init(),
+    deno_fs::init_ops::<PermissionsContainer>(unstable),
+    deno_io::init_ops(std::mem::take(&mut options.stdio)),
+    deno_tls::init(),
+    deno_net::init_ops::<PermissionsContainer>(
+      options.root_cert_store.clone(),
+      unstable,
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_napi::init::<PermissionsContainer>(),
+    // TODO(bartlomieju): thes two should be conditional on `dont_create_runtime_snapshot`
+    // cargo feature and should use `init_polyfill_ops` or `init_polyfill_ops_and_esm`
+    // if the feature is enabled
+    deno_node::init_polyfill_ops(),
+    deno_node::init_ops::<PermissionsContainer>(options.npm_resolver.take()),
+    ops::os::init_for_worker(),
+    ops::permissions::init(),
+    ops::process::init_ops(),
+    ops::signal::init(),
+    ops::tty::init(),
+    deno_http::init_ops(),
+    deno_flash::init_ops::<PermissionsContainer>(unstable),
+    ops::http::init(),
+  ]
+}
+
+#[cfg(not(feature = "dont_create_runtime_snapshot"))]
+fn get_extensions(
+  options: &mut WebWorkerOptions,
+  unstable: bool,
+  main_module: ModuleSpecifier,
+) -> Vec<Extension> {
+  let create_cache = options.cache_storage_dir.take().map(|storage_dir| {
+    let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
+    CreateCache(Arc::new(create_cache_fn))
+  });
+
+  vec![
+    // Web APIs
+    deno_webidl::init_esm(),
+    deno_console::init_esm(),
+    deno_url::init_ops_and_esm(),
+    deno_web::init_ops_and_esm::<PermissionsContainer>(
+      options.blob_store.clone(),
+      Some(main_module.clone()),
+    ),
+    deno_fetch::init_ops_and_esm::<PermissionsContainer>(deno_fetch::Options {
+      user_agent: options.bootstrap.user_agent.clone(),
+      root_cert_store: options.root_cert_store.clone(),
+      unsafely_ignore_certificate_errors: options
+        .unsafely_ignore_certificate_errors
+        .clone(),
+      file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
+      ..Default::default()
+    }),
+    deno_cache::init_ops_and_esm::<SqliteBackedCache>(create_cache),
+    deno_websocket::init_ops_and_esm::<PermissionsContainer>(
+      options.bootstrap.user_agent.clone(),
+      options.root_cert_store.clone(),
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_webstorage::init_ops_and_esm(None).disable(),
+    deno_broadcast_channel::init_ops_and_esm(
+      options.broadcast_channel.clone(),
+      unstable,
+    ),
+    deno_crypto::init_ops_and_esm(options.seed),
+    deno_webgpu::init_ops_and_esm(unstable),
+    // ffi
+    deno_ffi::init_ops_and_esm::<PermissionsContainer>(unstable),
+    // Runtime ops that are always initialized for WebWorkers
+    ops::web_worker::init(),
+    ops::runtime::init(main_module),
+    ops::worker_host::init(
+      options.create_web_worker_cb.clone(),
+      options.preload_module_cb.clone(),
+      options.pre_execute_module_cb.clone(),
+      options.format_js_error_fn.clone(),
+    ),
+    // Extensions providing Deno.* features
+    ops::fs_events::init(),
+    deno_fs::init_ops_and_esm::<PermissionsContainer>(unstable),
+    deno_io::init_ops_and_esm(std::mem::take(&mut options.stdio)),
+    deno_tls::init(),
+    deno_net::init_ops_and_esm::<PermissionsContainer>(
+      options.root_cert_store.clone(),
+      unstable,
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_napi::init::<PermissionsContainer>(),
+    // TODO(bartlomieju): thes two should be conditional on `dont_create_runtime_snapshot`
+    // cargo feature and should use `init_polyfill_ops` or `init_polyfill_ops_and_esm`
+    // if the feature is enabled
+    deno_node::init_polyfill_ops_and_esm(),
+    deno_node::init_ops_and_esm::<PermissionsContainer>(
+      options.npm_resolver.take(),
+    ),
+    ops::os::init_for_worker(),
+    ops::permissions::init(),
+    ops::process::init_ops(),
+    ops::signal::init(),
+    ops::tty::init(),
+    deno_http::init_ops_and_esm(),
+    deno_flash::init_ops_and_esm::<PermissionsContainer>(unstable),
+    ops::http::init(),
+  ]
+}
+
 impl WebWorker {
   pub fn bootstrap_from_options(
     name: String,
@@ -378,80 +540,10 @@ impl WebWorker {
         state.put(ops::TestingFeaturesEnabled(enable_testing_features));
       })
       .build();
-    let create_cache = options.cache_storage_dir.map(|storage_dir| {
-      let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
-      CreateCache(Arc::new(create_cache_fn))
-    });
 
-    let mut extensions: Vec<Extension> = vec![
-      // Web APIs
-      deno_webidl::init(),
-      deno_console::init(),
-      deno_url::init_ops(),
-      deno_web::init_ops::<PermissionsContainer>(
-        options.blob_store.clone(),
-        Some(main_module.clone()),
-      ),
-      deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
-        user_agent: options.bootstrap.user_agent.clone(),
-        root_cert_store: options.root_cert_store.clone(),
-        unsafely_ignore_certificate_errors: options
-          .unsafely_ignore_certificate_errors
-          .clone(),
-        file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
-        ..Default::default()
-      }),
-      deno_cache::init_ops::<SqliteBackedCache>(create_cache),
-      deno_websocket::init_ops::<PermissionsContainer>(
-        options.bootstrap.user_agent.clone(),
-        options.root_cert_store.clone(),
-        options.unsafely_ignore_certificate_errors.clone(),
-      ),
-      deno_webstorage::init_ops(None).disable(),
-      deno_broadcast_channel::init_ops(
-        options.broadcast_channel.clone(),
-        unstable,
-      ),
-      deno_crypto::init_ops(options.seed),
-      deno_webgpu::init_ops(unstable),
-      // ffi
-      deno_ffi::init_ops::<PermissionsContainer>(unstable),
-      // Runtime ops that are always initialized for WebWorkers
-      ops::web_worker::init(),
-      ops::runtime::init(main_module.clone()),
-      ops::worker_host::init(
-        options.create_web_worker_cb.clone(),
-        options.preload_module_cb.clone(),
-        options.pre_execute_module_cb.clone(),
-        options.format_js_error_fn.clone(),
-      ),
-      // Extensions providing Deno.* features
-      ops::fs_events::init(),
-      deno_fs::init_ops::<PermissionsContainer>(unstable),
-      deno_io::init_ops(options.stdio),
-      deno_tls::init(),
-      deno_net::init_ops::<PermissionsContainer>(
-        options.root_cert_store.clone(),
-        unstable,
-        options.unsafely_ignore_certificate_errors.clone(),
-      ),
-      deno_napi::init::<PermissionsContainer>(),
-      // TODO(bartlomieju): thes two should be conditional on `dont_create_runtime_snapshot`
-      // cargo feature and should use `init_polyfill_ops` or `init_polyfill_ops_and_esm`
-      // if the feature is enabled
-      deno_node::init_polyfill_ops(),
-      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
-      ops::os::init_for_worker(),
-      ops::permissions::init(),
-      ops::process::init_ops(),
-      ops::signal::init(),
-      ops::tty::init(),
-      deno_http::init_ops(),
-      deno_flash::init_ops::<PermissionsContainer>(unstable),
-      ops::http::init(),
-      // Permissions ext (worker specific state)
-      perm_ext,
-    ];
+    let mut extensions =
+      get_extensions(&mut options, unstable, main_module.clone());
+    extensions.push(perm_ext);
 
     // Append exts
     extensions.extend(std::mem::take(&mut options.extensions));

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -433,11 +433,11 @@ impl WebWorker {
         options.unsafely_ignore_certificate_errors.clone(),
       ),
       deno_napi::init::<PermissionsContainer>(),
-      // TODO(bartlomieju): this should be conditional on `dont_create_runtime_snapshot`
+      // TODO(bartlomieju): thes two should be conditional on `dont_create_runtime_snapshot`
       // cargo feature and should use `init_polyfill_ops` or `init_polyfill_ops_and_esm`
       // if the feature is enabled
       deno_node::init_polyfill_ops(),
-      deno_node::init::<PermissionsContainer>(options.npm_resolver),
+      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
       ops::os::init_for_worker(),
       ops::permissions::init(),
       ops::process::init_ops(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -264,7 +264,7 @@ impl MainWorker {
         options.unsafely_ignore_certificate_errors.clone(),
       ),
       deno_napi::init::<PermissionsContainer>(),
-      deno_node::init::<PermissionsContainer>(options.npm_resolver),
+      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
       ops::os::init(exit_code.clone()),
       ops::permissions::init(),
       ops::process::init_ops(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -183,6 +183,160 @@ impl Default for WorkerOptions {
   }
 }
 
+#[cfg(not(feature = "dont_create_runtime_snapshot"))]
+fn get_extensions(
+  options: &mut WorkerOptions,
+  unstable: bool,
+  exit_code: ExitCode,
+  main_module: ModuleSpecifier,
+) -> Vec<Extension> {
+  let create_cache = options.cache_storage_dir.take().map(|storage_dir| {
+    let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
+    CreateCache(Arc::new(create_cache_fn))
+  });
+
+  vec![
+    // Web APIs
+    deno_webidl::init(),
+    deno_console::init(),
+    deno_url::init_ops(),
+    deno_web::init_ops::<PermissionsContainer>(
+      options.blob_store.clone(),
+      options.bootstrap.location.clone(),
+    ),
+    deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
+      user_agent: options.bootstrap.user_agent.clone(),
+      root_cert_store: options.root_cert_store.clone(),
+      unsafely_ignore_certificate_errors: options
+        .unsafely_ignore_certificate_errors
+        .clone(),
+      file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
+      ..Default::default()
+    }),
+    deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+    deno_websocket::init_ops::<PermissionsContainer>(
+      options.bootstrap.user_agent.clone(),
+      options.root_cert_store.clone(),
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_webstorage::init_ops(options.origin_storage_dir.clone()),
+    deno_broadcast_channel::init_ops(
+      options.broadcast_channel.clone(),
+      unstable,
+    ),
+    deno_crypto::init_ops(options.seed),
+    deno_webgpu::init_ops(unstable),
+    // ffi
+    deno_ffi::init_ops::<PermissionsContainer>(unstable),
+    // Runtime ops
+    ops::runtime::init(main_module),
+    ops::worker_host::init(
+      options.create_web_worker_cb.clone(),
+      options.web_worker_preload_module_cb.clone(),
+      options.web_worker_pre_execute_module_cb.clone(),
+      options.format_js_error_fn.clone(),
+    ),
+    ops::fs_events::init(),
+    deno_fs::init_ops::<PermissionsContainer>(unstable),
+    deno_io::init_ops(std::mem::take(&mut options.stdio)),
+    deno_tls::init(),
+    deno_net::init_ops::<PermissionsContainer>(
+      options.root_cert_store.clone(),
+      unstable,
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_napi::init::<PermissionsContainer>(),
+    deno_node::init_ops::<PermissionsContainer>(options.npm_resolver.take()),
+    ops::os::init(exit_code),
+    ops::permissions::init(),
+    ops::process::init_ops(),
+    ops::signal::init(),
+    ops::tty::init(),
+    deno_http::init_ops(),
+    deno_flash::init_ops::<PermissionsContainer>(unstable),
+    ops::http::init(),
+    deno_node::init_polyfill_ops(),
+  ]
+}
+
+#[cfg(feature = "dont_create_runtime_snapshot")]
+fn get_extensions(
+  options: &mut WorkerOptions,
+  unstable: bool,
+  exit_code: ExitCode,
+  main_module: ModuleSpecifier,
+) -> Vec<Extension> {
+  let create_cache = options.cache_storage_dir.take().map(|storage_dir| {
+    let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
+    CreateCache(Arc::new(create_cache_fn))
+  });
+
+  vec![
+    // Web APIs
+    deno_webidl::init_esm(),
+    deno_console::init_esm(),
+    deno_url::init_ops_and_esm(),
+    deno_web::init_ops_and_esm::<PermissionsContainer>(
+      options.blob_store.clone(),
+      options.bootstrap.location.clone(),
+    ),
+    deno_fetch::init_ops_and_esm::<PermissionsContainer>(deno_fetch::Options {
+      user_agent: options.bootstrap.user_agent.clone(),
+      root_cert_store: options.root_cert_store.clone(),
+      unsafely_ignore_certificate_errors: options
+        .unsafely_ignore_certificate_errors
+        .clone(),
+      file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
+      ..Default::default()
+    }),
+    deno_cache::init_ops_and_esm::<SqliteBackedCache>(create_cache),
+    deno_websocket::init_ops_and_esm::<PermissionsContainer>(
+      options.bootstrap.user_agent.clone(),
+      options.root_cert_store.clone(),
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_webstorage::init_ops_and_esm(options.origin_storage_dir.clone()),
+    deno_broadcast_channel::init_ops_and_esm(
+      options.broadcast_channel.clone(),
+      unstable,
+    ),
+    deno_crypto::init_ops_and_esm(options.seed),
+    deno_webgpu::init_ops_and_esm(unstable),
+    // ffi
+    deno_ffi::init_ops_and_esm::<PermissionsContainer>(unstable),
+    // Runtime ops
+    ops::runtime::init(main_module),
+    ops::worker_host::init(
+      options.create_web_worker_cb.clone(),
+      options.web_worker_preload_module_cb.clone(),
+      options.web_worker_pre_execute_module_cb.clone(),
+      options.format_js_error_fn.clone(),
+    ),
+    ops::fs_events::init(),
+    deno_fs::init_ops_and_esm::<PermissionsContainer>(unstable),
+    deno_io::init_ops_and_esm(std::mem::take(&mut options.stdio)),
+    deno_tls::init(),
+    deno_net::init_ops_and_esm::<PermissionsContainer>(
+      options.root_cert_store.clone(),
+      unstable,
+      options.unsafely_ignore_certificate_errors.clone(),
+    ),
+    deno_napi::init::<PermissionsContainer>(),
+    deno_node::init_ops_and_esm::<PermissionsContainer>(
+      options.npm_resolver.take(),
+    ),
+    ops::os::init(exit_code),
+    ops::permissions::init(),
+    ops::process::init_ops(),
+    ops::signal::init(),
+    ops::tty::init(),
+    deno_http::init_ops_and_esm(),
+    deno_flash::init_ops_and_esm::<PermissionsContainer>(unstable),
+    ops::http::init(),
+    deno_node::init_polyfill_ops_and_esm(),
+  ]
+}
+
 impl MainWorker {
   pub fn bootstrap_from_options(
     main_module: ModuleSpecifier,
@@ -211,80 +365,13 @@ impl MainWorker {
       })
       .build();
     let exit_code = ExitCode(Arc::new(AtomicI32::new(0)));
-    let create_cache = options.cache_storage_dir.map(|storage_dir| {
-      let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
-      CreateCache(Arc::new(create_cache_fn))
-    });
 
-    let mut extensions = vec![
-      // Web APIs
-      deno_webidl::init(),
-      deno_console::init(),
-      deno_url::init_ops(),
-      deno_web::init_ops::<PermissionsContainer>(
-        options.blob_store.clone(),
-        options.bootstrap.location.clone(),
-      ),
-      deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
-        user_agent: options.bootstrap.user_agent.clone(),
-        root_cert_store: options.root_cert_store.clone(),
-        unsafely_ignore_certificate_errors: options
-          .unsafely_ignore_certificate_errors
-          .clone(),
-        file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
-        ..Default::default()
-      }),
-      deno_cache::init_ops::<SqliteBackedCache>(create_cache),
-      deno_websocket::init_ops::<PermissionsContainer>(
-        options.bootstrap.user_agent.clone(),
-        options.root_cert_store.clone(),
-        options.unsafely_ignore_certificate_errors.clone(),
-      ),
-      deno_webstorage::init_ops(options.origin_storage_dir.clone()),
-      deno_broadcast_channel::init_ops(
-        options.broadcast_channel.clone(),
-        unstable,
-      ),
-      deno_crypto::init_ops(options.seed),
-      deno_webgpu::init_ops(unstable),
-      // ffi
-      deno_ffi::init_ops::<PermissionsContainer>(unstable),
-      // Runtime ops
-      ops::runtime::init(main_module.clone()),
-      ops::worker_host::init(
-        options.create_web_worker_cb.clone(),
-        options.web_worker_preload_module_cb.clone(),
-        options.web_worker_pre_execute_module_cb.clone(),
-        options.format_js_error_fn.clone(),
-      ),
-      ops::fs_events::init(),
-      deno_fs::init_ops::<PermissionsContainer>(unstable),
-      deno_io::init_ops(options.stdio),
-      deno_tls::init(),
-      deno_net::init_ops::<PermissionsContainer>(
-        options.root_cert_store.clone(),
-        unstable,
-        options.unsafely_ignore_certificate_errors.clone(),
-      ),
-      deno_napi::init::<PermissionsContainer>(),
-      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
-      ops::os::init(exit_code.clone()),
-      ops::permissions::init(),
-      ops::process::init_ops(),
-      ops::signal::init(),
-      ops::tty::init(),
-      deno_http::init_ops(),
-      deno_flash::init_ops::<PermissionsContainer>(unstable),
-      ops::http::init(),
-    ];
-
-    // TODO(bartlomieju): finish this work, currently only `deno_node` is different
-    // as it has the most files
-    #[cfg(feature = "dont_create_runtime_snapshot")]
-    extensions.push(deno_node::init_polyfill_ops_and_esm());
-
-    #[cfg(not(feature = "dont_create_runtime_snapshot"))]
-    extensions.push(deno_node::init_polyfill_ops());
+    let mut extensions = get_extensions(
+      &mut options,
+      unstable,
+      exit_code.clone(),
+      main_module.clone(),
+    );
 
     extensions.push(perm_ext);
 

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -220,12 +220,12 @@ impl MainWorker {
       // Web APIs
       deno_webidl::init(),
       deno_console::init(),
-      deno_url::init(),
-      deno_web::init::<PermissionsContainer>(
+      deno_url::init_ops(),
+      deno_web::init_ops::<PermissionsContainer>(
         options.blob_store.clone(),
         options.bootstrap.location.clone(),
       ),
-      deno_fetch::init::<PermissionsContainer>(deno_fetch::Options {
+      deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
         user_agent: options.bootstrap.user_agent.clone(),
         root_cert_store: options.root_cert_store.clone(),
         unsafely_ignore_certificate_errors: options
@@ -234,18 +234,21 @@ impl MainWorker {
         file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
         ..Default::default()
       }),
-      deno_cache::init::<SqliteBackedCache>(create_cache),
-      deno_websocket::init::<PermissionsContainer>(
+      deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+      deno_websocket::init_ops::<PermissionsContainer>(
         options.bootstrap.user_agent.clone(),
         options.root_cert_store.clone(),
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_webstorage::init(options.origin_storage_dir.clone()),
-      deno_broadcast_channel::init(options.broadcast_channel.clone(), unstable),
-      deno_crypto::init(options.seed),
-      deno_webgpu::init(unstable),
+      deno_webstorage::init_ops(options.origin_storage_dir.clone()),
+      deno_broadcast_channel::init_ops(
+        options.broadcast_channel.clone(),
+        unstable,
+      ),
+      deno_crypto::init_ops(options.seed),
+      deno_webgpu::init_ops(unstable),
       // ffi
-      deno_ffi::init::<PermissionsContainer>(unstable),
+      deno_ffi::init_ops::<PermissionsContainer>(unstable),
       // Runtime ops
       ops::runtime::init(main_module.clone()),
       ops::worker_host::init(
@@ -255,10 +258,10 @@ impl MainWorker {
         options.format_js_error_fn.clone(),
       ),
       ops::fs_events::init(),
-      deno_fs::init::<PermissionsContainer>(unstable),
-      deno_io::init(options.stdio),
+      deno_fs::init_ops::<PermissionsContainer>(unstable),
+      deno_io::init_ops(options.stdio),
       deno_tls::init(),
-      deno_net::init::<PermissionsContainer>(
+      deno_net::init_ops::<PermissionsContainer>(
         options.root_cert_store.clone(),
         unstable,
         options.unsafely_ignore_certificate_errors.clone(),
@@ -270,8 +273,8 @@ impl MainWorker {
       ops::process::init_ops(),
       ops::signal::init(),
       ops::tty::init(),
-      deno_http::init(),
-      deno_flash::init::<PermissionsContainer>(unstable),
+      deno_http::init_ops(),
+      deno_flash::init_ops::<PermissionsContainer>(unstable),
       ops::http::init(),
     ];
 


### PR DESCRIPTION
This commit splits "<ext_name>::init" functions into "init_ops" and
"init_ops_and_esm". That way we don't have to construct list of
ESM sources on each startup if we're running with a snapshot.

In a follow up commit "deno_core" will be changed to not have a split
between "extensions" and "extensions_with_js" - it will be embedders'
responsibility to pass appropriately configured extensions.

Prerequisite for https://github.com/denoland/deno/pull/18080