### PR TITLE
fix: Split extension registration and snapshotting

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -322,40 +322,36 @@ mod ts {
 
 fn create_cli_snapshot(snapshot_path: PathBuf) {
   let extensions: Vec<Extension> = vec![
-    deno_webidl::init_esm(),
-    deno_console::init_esm(),
-    deno_url::init_ops_and_esm(),
-    deno_tls::init(),
-    deno_web::init_ops_and_esm::<PermissionsContainer>(
+    deno_webidl::init(),
+    deno_console::init(),
+    deno_url::init_ops(),
+    deno_tls::init_ops(),
+    deno_web::init_ops::<PermissionsContainer>(
       deno_web::BlobStore::default(),
       Default::default(),
     ),
-    deno_fetch::init_ops_and_esm::<PermissionsContainer>(Default::default()),
-    deno_cache::init_ops_and_esm::<SqliteBackedCache>(None),
-    deno_websocket::init_ops_and_esm::<PermissionsContainer>(
-      "".to_owned(),
-      None,
-      None,
-    ),
-    deno_webstorage::init_ops_and_esm(None),
-    deno_crypto::init_ops_and_esm(None),
-    deno_webgpu::init_ops_and_esm(false),
-    deno_broadcast_channel::init_ops_and_esm(
+    deno_fetch::init_ops::<PermissionsContainer>(Default::default()),
+    deno_cache::init_ops::<SqliteBackedCache>(None),
+    deno_websocket::init_ops::<PermissionsContainer>("".to_owned(), None, None),
+    deno_webstorage::init_ops(None),
+    deno_crypto::init_ops(None),
+    deno_webgpu::init_ops(false),
+    deno_broadcast_channel::init_ops(
       deno_broadcast_channel::InMemoryBroadcastChannel::default(),
       false, // No --unstable.
     ),
-    deno_io::init_ops_and_esm(Default::default()),
-    deno_fs::init_ops_and_esm::<PermissionsContainer>(false),
-    deno_node::init_ops_and_esm::<PermissionsContainer>(None), // No --unstable.
-    deno_node::init_polyfill_ops_and_esm(),
-    deno_ffi::init_ops_and_esm::<PermissionsContainer>(false),
-    deno_net::init_ops_and_esm::<PermissionsContainer>(
+    deno_io::init_ops(Default::default()),
+    deno_fs::init_ops::<PermissionsContainer>(false),
+    deno_node::init_ops::<PermissionsContainer>(None), // No --unstable.
+    deno_node::init_polyfill_ops(),
+    deno_ffi::init_ops::<PermissionsContainer>(false),
+    deno_net::init_ops::<PermissionsContainer>(
       None, false, // No --unstable.
       None,
     ),
-    deno_napi::init::<PermissionsContainer>(),
-    deno_http::init_ops_and_esm(),
-    deno_flash::init_ops_and_esm::<PermissionsContainer>(false), // No --unstable
+    deno_napi::init_ops::<PermissionsContainer>(),
+    deno_http::init_ops(),
+    deno_flash::init_ops::<PermissionsContainer>(false), // No --unstable
   ];
 
   let mut esm_files = include_js_files!(

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -514,7 +514,7 @@ impl Env {
   }
 }
 
-pub fn init<P: NapiPermissions + 'static>() -> Extension {
+pub fn init_ops<P: NapiPermissions + 'static>() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME"))
     .ops(vec![op_napi_open::decl::<P>()])
     .event_loop_middleware(|op_state_rc, cx| {

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 /// This extension has no runtime apis, it only exports some shared native functions.
-pub fn init() -> Extension {
+pub fn init_ops() -> Extension {
   Extension::builder(env!("CARGO_PKG_NAME")).build()
 }
 

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -254,7 +254,7 @@ mod startup_snapshot {
       deno_webidl::init_esm(),
       deno_console::init_esm(),
       deno_url::init_ops_and_esm(),
-      deno_tls::init(),
+      deno_tls::init_ops(),
       deno_web::init_ops_and_esm::<Permissions>(
         deno_web::BlobStore::default(),
         Default::default(),
@@ -278,7 +278,7 @@ mod startup_snapshot {
         None, false, // No --unstable.
         None,
       ),
-      deno_napi::init::<Permissions>(),
+      deno_napi::init_ops::<Permissions>(),
       deno_http::init_ops_and_esm(),
       deno_io::init_ops_and_esm(Default::default()),
       deno_fs::init_ops_and_esm::<Permissions>(false),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -346,168 +346,6 @@ pub struct WebWorkerOptions {
   pub stdio: Stdio,
 }
 
-#[cfg(feature = "dont_create_runtime_snapshot")]
-fn get_extensions(
-  options: &mut WebWorkerOptions,
-  unstable: bool,
-  main_module: ModuleSpecifier,
-) -> Vec<Extension> {
-  let create_cache = options.cache_storage_dir.take().map(|storage_dir| {
-    let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
-    CreateCache(Arc::new(create_cache_fn))
-  });
-
-  vec![
-    // Web APIs
-    deno_webidl::init(),
-    deno_console::init(),
-    deno_url::init_ops(),
-    deno_web::init_ops::<PermissionsContainer>(
-      options.blob_store.clone(),
-      Some(main_module.clone()),
-    ),
-    deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
-      user_agent: options.bootstrap.user_agent.clone(),
-      root_cert_store: options.root_cert_store.clone(),
-      unsafely_ignore_certificate_errors: options
-        .unsafely_ignore_certificate_errors
-        .clone(),
-      file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
-      ..Default::default()
-    }),
-    deno_cache::init_ops::<SqliteBackedCache>(create_cache),
-    deno_websocket::init_ops::<PermissionsContainer>(
-      options.bootstrap.user_agent.clone(),
-      options.root_cert_store.clone(),
-      options.unsafely_ignore_certificate_errors.clone(),
-    ),
-    deno_webstorage::init_ops(None).disable(),
-    deno_broadcast_channel::init_ops(
-      options.broadcast_channel.clone(),
-      unstable,
-    ),
-    deno_crypto::init_ops(options.seed),
-    deno_webgpu::init_ops(unstable),
-    // ffi
-    deno_ffi::init_ops::<PermissionsContainer>(unstable),
-    // Runtime ops that are always initialized for WebWorkers
-    ops::web_worker::init(),
-    ops::runtime::init(main_module),
-    ops::worker_host::init(
-      options.create_web_worker_cb.clone(),
-      options.preload_module_cb.clone(),
-      options.pre_execute_module_cb.clone(),
-      options.format_js_error_fn.clone(),
-    ),
-    // Extensions providing Deno.* features
-    ops::fs_events::init(),
-    deno_fs::init_ops::<PermissionsContainer>(unstable),
-    deno_io::init_ops(std::mem::take(&mut options.stdio)),
-    deno_tls::init(),
-    deno_net::init_ops::<PermissionsContainer>(
-      options.root_cert_store.clone(),
-      unstable,
-      options.unsafely_ignore_certificate_errors.clone(),
-    ),
-    deno_napi::init::<PermissionsContainer>(),
-    // TODO(bartlomieju): thes two should be conditional on `dont_create_runtime_snapshot`
-    // cargo feature and should use `init_polyfill_ops` or `init_polyfill_ops_and_esm`
-    // if the feature is enabled
-    deno_node::init_polyfill_ops(),
-    deno_node::init_ops::<PermissionsContainer>(options.npm_resolver.take()),
-    ops::os::init_for_worker(),
-    ops::permissions::init(),
-    ops::process::init_ops(),
-    ops::signal::init(),
-    ops::tty::init(),
-    deno_http::init_ops(),
-    deno_flash::init_ops::<PermissionsContainer>(unstable),
-    ops::http::init(),
-  ]
-}
-
-#[cfg(not(feature = "dont_create_runtime_snapshot"))]
-fn get_extensions(
-  options: &mut WebWorkerOptions,
-  unstable: bool,
-  main_module: ModuleSpecifier,
-) -> Vec<Extension> {
-  let create_cache = options.cache_storage_dir.take().map(|storage_dir| {
-    let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
-    CreateCache(Arc::new(create_cache_fn))
-  });
-
-  vec![
-    // Web APIs
-    deno_webidl::init_esm(),
-    deno_console::init_esm(),
-    deno_url::init_ops_and_esm(),
-    deno_web::init_ops_and_esm::<PermissionsContainer>(
-      options.blob_store.clone(),
-      Some(main_module.clone()),
-    ),
-    deno_fetch::init_ops_and_esm::<PermissionsContainer>(deno_fetch::Options {
-      user_agent: options.bootstrap.user_agent.clone(),
-      root_cert_store: options.root_cert_store.clone(),
-      unsafely_ignore_certificate_errors: options
-        .unsafely_ignore_certificate_errors
-        .clone(),
-      file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
-      ..Default::default()
-    }),
-    deno_cache::init_ops_and_esm::<SqliteBackedCache>(create_cache),
-    deno_websocket::init_ops_and_esm::<PermissionsContainer>(
-      options.bootstrap.user_agent.clone(),
-      options.root_cert_store.clone(),
-      options.unsafely_ignore_certificate_errors.clone(),
-    ),
-    deno_webstorage::init_ops_and_esm(None).disable(),
-    deno_broadcast_channel::init_ops_and_esm(
-      options.broadcast_channel.clone(),
-      unstable,
-    ),
-    deno_crypto::init_ops_and_esm(options.seed),
-    deno_webgpu::init_ops_and_esm(unstable),
-    // ffi
-    deno_ffi::init_ops_and_esm::<PermissionsContainer>(unstable),
-    // Runtime ops that are always initialized for WebWorkers
-    ops::web_worker::init(),
-    ops::runtime::init(main_module),
-    ops::worker_host::init(
-      options.create_web_worker_cb.clone(),
-      options.preload_module_cb.clone(),
-      options.pre_execute_module_cb.clone(),
-      options.format_js_error_fn.clone(),
-    ),
-    // Extensions providing Deno.* features
-    ops::fs_events::init(),
-    deno_fs::init_ops_and_esm::<PermissionsContainer>(unstable),
-    deno_io::init_ops_and_esm(std::mem::take(&mut options.stdio)),
-    deno_tls::init(),
-    deno_net::init_ops_and_esm::<PermissionsContainer>(
-      options.root_cert_store.clone(),
-      unstable,
-      options.unsafely_ignore_certificate_errors.clone(),
-    ),
-    deno_napi::init::<PermissionsContainer>(),
-    // TODO(bartlomieju): thes two should be conditional on `dont_create_runtime_snapshot`
-    // cargo feature and should use `init_polyfill_ops` or `init_polyfill_ops_and_esm`
-    // if the feature is enabled
-    deno_node::init_polyfill_ops_and_esm(),
-    deno_node::init_ops_and_esm::<PermissionsContainer>(
-      options.npm_resolver.take(),
-    ),
-    ops::os::init_for_worker(),
-    ops::permissions::init(),
-    ops::process::init_ops(),
-    ops::signal::init(),
-    ops::tty::init(),
-    deno_http::init_ops_and_esm(),
-    deno_flash::init_ops_and_esm::<PermissionsContainer>(unstable),
-    ops::http::init(),
-  ]
-}
-
 impl WebWorker {
   pub fn bootstrap_from_options(
     name: String,
@@ -540,10 +378,77 @@ impl WebWorker {
         state.put(ops::TestingFeaturesEnabled(enable_testing_features));
       })
       .build();
+    let create_cache = options.cache_storage_dir.map(|storage_dir| {
+      let create_cache_fn = move || SqliteBackedCache::new(storage_dir.clone());
+      CreateCache(Arc::new(create_cache_fn))
+    });
 
-    let mut extensions =
-      get_extensions(&mut options, unstable, main_module.clone());
-    extensions.push(perm_ext);
+    let mut extensions: Vec<Extension> = vec![
+      // Web APIs
+      deno_webidl::init(),
+      deno_console::init(),
+      deno_url::init_ops(),
+      deno_web::init_ops::<PermissionsContainer>(
+        options.blob_store.clone(),
+        Some(main_module.clone()),
+      ),
+      deno_fetch::init_ops::<PermissionsContainer>(deno_fetch::Options {
+        user_agent: options.bootstrap.user_agent.clone(),
+        root_cert_store: options.root_cert_store.clone(),
+        unsafely_ignore_certificate_errors: options
+          .unsafely_ignore_certificate_errors
+          .clone(),
+        file_fetch_handler: Rc::new(deno_fetch::FsFetchHandler),
+        ..Default::default()
+      }),
+      deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+      deno_websocket::init_ops::<PermissionsContainer>(
+        options.bootstrap.user_agent.clone(),
+        options.root_cert_store.clone(),
+        options.unsafely_ignore_certificate_errors.clone(),
+      ),
+      deno_webstorage::init_ops(None).disable(),
+      deno_broadcast_channel::init_ops(
+        options.broadcast_channel.clone(),
+        unstable,
+      ),
+      deno_crypto::init_ops(options.seed),
+      deno_webgpu::init_ops(unstable),
+      // ffi
+      deno_ffi::init_ops::<PermissionsContainer>(unstable),
+      // Runtime ops that are always initialized for WebWorkers
+      ops::web_worker::init(),
+      ops::runtime::init(main_module.clone()),
+      ops::worker_host::init(
+        options.create_web_worker_cb.clone(),
+        options.preload_module_cb.clone(),
+        options.pre_execute_module_cb.clone(),
+        options.format_js_error_fn.clone(),
+      ),
+      // Extensions providing Deno.* features
+      ops::fs_events::init(),
+      deno_fs::init_ops::<PermissionsContainer>(unstable),
+      deno_io::init_ops(options.stdio),
+      deno_tls::init_ops(),
+      deno_net::init_ops::<PermissionsContainer>(
+        options.root_cert_store.clone(),
+        unstable,
+        options.unsafely_ignore_certificate_errors.clone(),
+      ),
+      deno_napi::init_ops::<PermissionsContainer>(),
+      deno_node::init_polyfill_ops(),
+      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
+      ops::os::init_for_worker(),
+      ops::permissions::init(),
+      ops::process::init_ops(),
+      ops::signal::init(),
+      ops::tty::init(),
+      deno_http::init_ops(),
+      deno_flash::init_ops::<PermissionsContainer>(unstable),
+      ops::http::init(),
+      // Permissions ext (worker specific state)
+      perm_ext,
+    ];
 
     // Append exts
     extensions.extend(std::mem::take(&mut options.extensions));


### PR DESCRIPTION
This commit partially reverts changes from https://github.com/denoland/deno/pull/18095.

Turns out I made a mistake that became apparent when working
on removing "RuntimeOptions::extensions_with_js" in a follow up.