### PR TITLE
chore(ci): ensure Rust toolchain installation is based on rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -81,7 +81,7 @@ const submoduleStep = (submodule: string) => ({
 });
 
 const installRustStep = {
-  uses: "dtolnay/rust-toolchain@stable",
+  uses: "dsherret/rust-toolchain-file@v1",
 };
 const installPythonSteps = [{
   name: "Install Python",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dsherret/rust-toolchain-file@v1
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint'' || matrix.job == ''test''))'
         name: Install Deno


### PR DESCRIPTION
It seems like `dtolnay/rust-toolchain` does not want to support rust-toolchain.toml unfortunately and we had thought it did.