### PR TITLE
refactor: use `pin!` macro from std

### DIFF
--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -14,7 +14,6 @@ use deno_core::futures::future::Pending;
 use deno_core::futures::future::RemoteHandle;
 use deno_core::futures::future::Shared;
 use deno_core::futures::never::Never;
-use deno_core::futures::pin_mut;
 use deno_core::futures::ready;
 use deno_core::futures::stream::Peekable;
 use deno_core::futures::FutureExt;
@@ -62,6 +61,7 @@ use std::io;
 use std::io::Write;
 use std::mem::replace;
 use std::mem::take;
+use std::pin::pin;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -156,8 +156,8 @@ impl HttpConnResource {
 
     // A local task that polls the hyper connection future to completion.
     let task_fut = async move {
-      pin_mut!(shutdown_fut);
-      pin_mut!(conn_fut);
+      let conn_fut = pin!(conn_fut);
+      let shutdown_fut = pin!(shutdown_fut);
       let result = match select(conn_fut, shutdown_fut).await {
         Either::Left((result, _)) => result,
         Either::Right((_, mut conn_fut)) => {

--- a/runtime/inspector_server.rs
+++ b/runtime/inspector_server.rs
@@ -8,7 +8,6 @@ use deno_core::futures::channel::mpsc::UnboundedSender;
 use deno_core::futures::channel::oneshot;
 use deno_core::futures::future;
 use deno_core::futures::future::Future;
-use deno_core::futures::pin_mut;
 use deno_core::futures::prelude::*;
 use deno_core::futures::select;
 use deno_core::futures::stream::StreamExt;
@@ -25,6 +24,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::pin::pin;
 use std::process;
 use std::rc::Rc;
 use std::thread;
@@ -226,7 +226,7 @@ async fn server(
     Rc::new(RefCell::new(HashMap::<Uuid, InspectorInfo>::new()));
 
   let inspector_map = Rc::clone(&inspector_map_);
-  let register_inspector_handler = register_inspector_rx
+  let mut register_inspector_handler = pin!(register_inspector_rx
     .map(|info| {
       eprintln!(
         "Debugger listening on {}",
@@ -240,16 +240,16 @@ async fn server(
         panic!("Inspector UUID already in map");
       }
     })
-    .collect::<()>();
+    .collect::<()>());
 
   let inspector_map = Rc::clone(&inspector_map_);
-  let deregister_inspector_handler = future::poll_fn(|cx| {
+  let mut deregister_inspector_handler = pin!(future::poll_fn(|cx| {
     inspector_map
       .borrow_mut()
       .retain(|_, info| info.deregister_rx.poll_unpin(cx) == Poll::Pending);
     Poll::<Never>::Pending
   })
-  .fuse();
+  .fuse());
 
   let json_version_response = json!({
     "Browser": name,
@@ -287,7 +287,7 @@ async fn server(
   });
 
   // Create the server manually so it can use the Local Executor
-  let server_handler = hyper::server::Builder::new(
+  let mut server_handler = pin!(hyper::server::Builder::new(
     hyper::server::conn::AddrIncoming::bind(&host).unwrap_or_else(|e| {
       eprintln!("Cannot start inspector server: {e}.");
       process::exit(1);
@@ -302,11 +302,7 @@ async fn server(
     eprintln!("Cannot start inspector server: {err}.");
     process::exit(1);
   })
-  .fuse();
-
-  pin_mut!(register_inspector_handler);
-  pin_mut!(deregister_inspector_handler);
-  pin_mut!(server_handler);
+  .fuse());
 
   select! {
     _ = register_inspector_handler => {},


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This commit replaces `pin_mut!` macro with `pin!` macro that has been provided from std since Rust 1.68.0. 
With the std version we can not only expect its stability but also pass an expression (rather than identifier) as an argument to the macro.
