### PR TITLE
fix: ensure no node_modules directory is created when a package.json exists and no npm dependencies are used

### DIFF
--- a/cli/npm/resolution/snapshot.rs
+++ b/cli/npm/resolution/snapshot.rs
@@ -127,6 +127,11 @@ mod map_to_vec {
 }
 
 impl NpmResolutionSnapshot {
+  /// Gets if this snapshot is empty.
+  pub fn is_empty(&self) -> bool {
+    self.packages.is_empty() && self.pending_unresolved_packages.is_empty()
+  }
+
   /// Resolve a package from a package requirement.
   pub fn resolve_pkg_from_pkg_req(
     &self,

--- a/cli/npm/resolvers/local.rs
+++ b/cli/npm/resolvers/local.rs
@@ -232,6 +232,10 @@ async fn sync_resolution_with_fs(
   registry_url: &Url,
   root_node_modules_dir_path: &Path,
 ) -> Result<(), AnyError> {
+  if snapshot.is_empty() {
+    return Ok(()); // don't create the directory
+  }
+
   let deno_local_registry_dir = root_node_modules_dir_path.join(".deno");
   fs::create_dir_all(&deno_local_registry_dir).with_context(|| {
     format!("Creating '{}'", deno_local_registry_dir.display())

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2886,7 +2886,7 @@ fn package_json_no_node_modules_dir_created() {
 }
 
 #[test]
-fn node_modules_dir_no_npm_specifiers_no_node_modules_dir_created() {
+fn node_modules_dir_no_npm_specifiers_no_dir_created() {
   // it should not create a node_modules directory
   let context = TestContextBuilder::new()
     .add_npm_env_vars()

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2867,6 +2867,24 @@ fn package_json_error_dep_value_test() {
     .assert_matches_file("package_json/invalid_value/task.out");
 }
 
+#[test]
+fn package_json_no_node_modules_dir_created() {
+  // it should not create a node_modules directory
+  let context = TestContextBuilder::new()
+    .add_npm_env_vars()
+    .use_temp_cwd()
+    .build();
+  let temp_dir = context.deno_dir();
+
+  temp_dir.write("deno.json", "{}");
+  temp_dir.write("package.json", "{}");
+  temp_dir.write("main.ts", "");
+
+  context.new_command().args("run main.ts").run();
+
+  assert!(!temp_dir.path().join("node_modules").exists());
+}
+
 itest!(wasm_streaming_panic_test {
   args: "run run/wasm_streaming_panic_test.js",
   output: "run/wasm_streaming_panic_test.js.out",

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2885,6 +2885,26 @@ fn package_json_no_node_modules_dir_created() {
   assert!(!temp_dir.path().join("node_modules").exists());
 }
 
+#[test]
+fn node_modules_dir_no_npm_specifiers_no_node_modules_dir_created() {
+  // it should not create a node_modules directory
+  let context = TestContextBuilder::new()
+    .add_npm_env_vars()
+    .use_temp_cwd()
+    .build();
+  let temp_dir = context.deno_dir();
+
+  temp_dir.write("deno.json", "{}");
+  temp_dir.write("main.ts", "");
+
+  context
+    .new_command()
+    .args("run --node-modules-dir main.ts")
+    .run();
+
+  assert!(!temp_dir.path().join("node_modules").exists());
+}
+
 itest!(wasm_streaming_panic_test {
   args: "run run/wasm_streaming_panic_test.js",
   output: "run/wasm_streaming_panic_test.js.out",


### PR DESCRIPTION
Closes #18133
Closes #18038