### PR TITLE
wpt: only tag daily runs as master

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -79,4 +79,4 @@ jobs:
           WPT_FYI_USER: deno
           WPT_FYI_PW: ${{ secrets.WPT_FYI_PW }}
         run: |
-          deno run -A --lock=tools/deno.lock.json ./tools/upload_wptfyi.js wptreport.json --from-raw-file
+          deno run -A --lock=tools/deno.lock.json ./tools/upload_wptfyi.js wptreport.json --from-raw-file --daily-run

--- a/tools/upload_wptfyi.js
+++ b/tools/upload_wptfyi.js
@@ -10,9 +10,14 @@ const user = Deno.env.get("WPT_FYI_USER");
 const password = Deno.env.get("WPT_FYI_PW");
 
 const fromRawFile = Deno.args.includes("--from-raw-file");
+const dailyRun = Deno.args.includes("--daily-run");
 
 const form = new FormData();
-form.set("labels", "master,actions");
+if (dailyRun) {
+  form.set("labels", "master,actions");
+} else {
+  form.set("labels", "actions");
+}
 
 if (fromRawFile) {
   const file = Deno.args[0];


### PR DESCRIPTION
This PR updates the WPT upload script so that it only labels runs that come from the daily WPT job as "master".

This is so that only the daily synchronized runs get selected when viewing dashboards such as [this](https://wpt.fyi/results/?label=master&label=experimental&product=deno&product=node.js&product=chrome&product=edge&product=firefox&product=safari&aligned&view=subtest&q=deno%3A%21missing).