### PR TITLE
chore(ext/node): copy internal/crypto/types.ts from std

### DIFF
--- a/ext/node/polyfills/internal/crypto/types.ts
+++ b/ext/node/polyfills/internal/crypto/types.ts
@@ -1,0 +1,46 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
+
+import { Buffer } from "../../buffer.ts";
+
+export type HASH_DATA = string | ArrayBufferView | Buffer;
+
+export type BinaryToTextEncoding = "base64" | "base64url" | "hex" | "binary";
+
+export type CharacterEncoding = "utf8" | "utf-8" | "utf16le" | "latin1";
+
+export type LegacyCharacterEncoding = "ascii" | "binary" | "ucs2" | "ucs-2";
+
+export type Encoding =
+  | BinaryToTextEncoding
+  | CharacterEncoding
+  | LegacyCharacterEncoding;
+
+export type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
+
+export type BinaryLike = string | ArrayBufferView;
+
+export type KeyFormat = "pem" | "der";
+
+export type KeyType =
+  | "rsa"
+  | "rsa-pss"
+  | "dsa"
+  | "ec"
+  | "ed25519"
+  | "ed448"
+  | "x25519"
+  | "x448";
+
+export interface PrivateKeyInput {
+  key: string | Buffer;
+  format?: KeyFormat | undefined;
+  type?: "pkcs1" | "pkcs8" | "sec1" | undefined;
+  passphrase?: string | Buffer | undefined;
+}
+
+export interface PublicKeyInput {
+  key: string | Buffer;
+  format?: KeyFormat | undefined;
+  type?: "pkcs1" | "spki" | undefined;
+}


### PR DESCRIPTION
This file seems missed in std/node -> ext/node migration. ref https://github.com/denoland/deno_std/blob/0.177.0/node/internal/crypto/types.ts

This file seems unnecessary for building (probably because it only includes types), but the modules still reference the types in this file.