### PR TITLE
fix(wpt): set META_TITLE on global for the testharness

### DIFF
--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -180,8 +180,14 @@ async function generateBundle(location: URL): Promise<string> {
   const doc = new DOMParser().parseFromString(body, "text/html");
   assert(doc, "document should have been parsed");
   const scripts = doc.getElementsByTagName("script");
+  const title = doc.getElementsByTagName("title")[0]?.childNodes[0].nodeValue;
   const scriptContents = [];
   let inlineScriptCount = 0;
+  if (title) {
+    const url = new URL(`#${inlineScriptCount}`, location);
+    inlineScriptCount++;
+    scriptContents.push([url.href, `globalThis.META_TITLE="${title}"`]);
+  }
   for (const script of scripts) {
     const src = script.getAttribute("src");
     if (src === "/resources/testharnessreport.js") {


### PR DESCRIPTION
Fixes hopefully the last mismatch of reported test titles.

- [redirect-schemes.any.html](https://wpt.fyi/results/fetch/api/redirect/redirect-schemes.any.html?run_id=5139017526411264&run_id=5093839906275328)
- [redirect-schemes.any.worker.html](https://wpt.fyi/results/fetch/api/redirect/redirect-schemes.any.worker.html?run_id=5139017526411264&run_id=5093839906275328)
- https://github.com/web-platform-tests/wpt/blob/ebf6814ebdf36a551563a34a4396f4f2b3b1f617/resources/testharness.js#L4754-L4756

cc @bartlomieju 