### PR TITLE
chore: parallelize lint steps

### DIFF
--- a/tools/copyright_checker.js
+++ b/tools/copyright_checker.js
@@ -40,7 +40,7 @@ export async function checkCopyright() {
     "*Cargo.toml",
   ]);
 
-  let totalCount = 0;
+  const errors = [];
   const sourceFilesSet = new Set(sourceFiles);
 
   for (const file of sourceFilesSet) {
@@ -53,8 +53,7 @@ export async function checkCopyright() {
           "# Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.",
         )
       ) {
-        console.log(ERROR_MSG + file);
-        totalCount += 1;
+        errors.push(ERROR_MSG + file);
       }
       continue;
     }
@@ -65,12 +64,14 @@ export async function checkCopyright() {
         "// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.",
       )
     ) {
-      console.log(ERROR_MSG + file);
-      totalCount += 1;
+      errors.push(ERROR_MSG + file);
     }
   }
 
-  if (totalCount > 0) {
+  if (errors.length > 0) {
+    // show all the errors at the same time to prevent overlap with
+    // other running scripts that may be outputting
+    console.error(errors.join("\n"));
     throw new Error(`Copyright checker had ${totalCount} errors.`);
   }
 }

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -26,7 +26,7 @@ if (!didLint) {
   await Promise.all([
     dlint(),
     // todo(dsherret): re-enable
-    // dlintPreferPrimordials().then(() => console.log("Finished dlint prefer primoridals")),
+    // dlintPreferPrimordials(),
     checkCopyright(),
     clippy(),
   ]);

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -23,18 +23,18 @@ if (Deno.args.includes("--rs")) {
 }
 
 if (!didLint) {
-  await dlint();
-  // todo(dsherret): re-enable
-  // await dlintPreferPrimordials();
-  console.log("copyright checker");
-  await checkCopyright();
-  await clippy();
+  await Promise.all([
+    dlint(),
+    // todo(dsherret): re-enable
+    // dlintPreferPrimordials().then(() => console.log("Finished dlint prefer primoridals")),
+    checkCopyright(),
+    clippy(),
+  ]);
 }
 
 async function dlint() {
   const configFile = join(ROOT_PATH, ".dlint.json");
   const execPath = getPrebuiltToolPath("dlint");
-  console.log("dlint");
 
   const sourceFiles = await getSources(ROOT_PATH, [
     "*.js",
@@ -65,19 +65,26 @@ async function dlint() {
   }
 
   const chunks = splitToChunks(sourceFiles, `${execPath} run`.length);
+  const pending = [];
   for (const chunk of chunks) {
     const cmd = new Deno.Command(execPath, {
       cwd: ROOT_PATH,
       args: ["run", "--config=" + configFile, ...chunk],
-      stdout: "inherit",
-      stderr: "inherit",
+      // capture to not conflict with clippy output
+      stderr: "piped",
     });
-    const { code } = await cmd.output();
-
-    if (code > 0) {
-      throw new Error("dlint failed");
-    }
+    pending.push(
+      cmd.output().then(({ stderr, code }) => {
+        if (code > 0) {
+          const decoder = new TextDecoder();
+          console.log("\n------ dlint ------");
+          console.log(decoder.decode(stderr));
+          throw new Error("dlint failed");
+        }
+      }),
+    );
   }
+  await Promise.all(pending);
 }
 
 // `prefer-primordials` has to apply only to files related to bootstrapping,
@@ -85,8 +92,6 @@ async function dlint() {
 // is needed.
 async function dlintPreferPrimordials() {
   const execPath = getPrebuiltToolPath("dlint");
-  console.log("prefer-primordials");
-
   const sourceFiles = await getSources(ROOT_PATH, [
     "runtime/**/*.js",
     "ext/**/*.js",
@@ -132,8 +137,6 @@ function splitToChunks(paths, initCmdLen) {
 }
 
 async function clippy() {
-  console.log("clippy");
-
   const currentBuildMode = buildMode();
   const cmd = ["clippy", "--all-targets", "--all-features", "--locked"];
 


### PR DESCRIPTION
Before:

```
> Measure-Command { deno run -A ./tools/lint.js } | Select-Object -Property TotalMilliseconds
    Finished dev [unoptimized + debuginfo] target(s) in 0.78s

TotalMilliseconds
-----------------
        7404.1583
```

After:

```
> Measure-Command { deno run -A ./tools/lint.js } | Select-Object -Property TotalMilliseconds    
    Finished dev [unoptimized + debuginfo] target(s) in 0.80s

TotalMilliseconds
-----------------
        1981.9303
```