### PR TITLE
chore(ci): cache test debug ubuntu-22.04-xl build

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -220,7 +220,7 @@ const ci = {
             {
               os: Runners.macos,
               job: "test",
-              profile: "fastci",
+              profile: "debug",
             },
             {
               os: Runners.macos,
@@ -231,7 +231,7 @@ const ci = {
             {
               os: Runners.windows,
               job: "test",
-              profile: "fastci",
+              profile: "debug",
             },
             {
               os: Runners.windows,
@@ -496,15 +496,7 @@ const ci = {
           },
           {
             name: "Build debug",
-            if: [
-              "(matrix.job == 'test' || matrix.job == 'bench') &&",
-              "matrix.profile == 'debug'",
-            ].join("\n"),
-            run: "cargo build --locked --all-targets",
-          },
-          {
-            name: "Build fastci",
-            if: "(matrix.job == 'test' && matrix.profile == 'fastci')",
+            if: "matrix.job == 'test' && matrix.profile == 'debug'",
             run: "cargo build --locked --all-targets",
             env: { CARGO_PROFILE_DEV_DEBUG: 0 },
           },
@@ -607,22 +599,24 @@ const ci = {
             name: "Test debug",
             if: [
               "matrix.job == 'test' && matrix.profile == 'debug' &&",
-              "!startsWith(github.ref, 'refs/tags/')",
+              "!startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')",
             ].join("\n"),
             run: "cargo test --locked",
+            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
           },
           {
-            name: "Test fastci",
-            if: "matrix.job == 'test' && matrix.profile == 'fastci'",
+            name: "Test debug (fast)",
+            if: [
+              "matrix.job == 'test' && matrix.profile == 'debug' && ",
+              "!startsWith(matrix.os, 'ubuntu')",
+            ].join("\n"),
             run: [
               // Run unit then integration tests. Skip doc tests here
               // since they are sometimes very slow on Mac.
               "cargo test --locked --lib",
               "cargo test --locked --test '*'",
             ].join("\n"),
-            env: {
-              CARGO_PROFILE_DEV_DEBUG: 0,
-            },
+            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
           },
           {
             name: "Test release",
@@ -766,7 +760,7 @@ const ci = {
           {
             name: "Build product size info",
             if:
-              "matrix.job != 'lint' && matrix.profile != 'fastci' && github.repository == 'denoland/deno' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+              "matrix.job != 'lint' && matrix.profile != 'debug' && github.repository == 'denoland/deno' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
             run: [
               'du -hd1 "./target/${{ matrix.profile }}"',
               'du -ha  "./target/${{ matrix.profile }}/deno"',
@@ -847,11 +841,10 @@ const ci = {
             },
           },
           {
-            // In main branch, always creates fresh cache
+            // In main branch, always create a fresh cache
             name: "Save cache build output (main)",
             uses: "actions/cache/save@v3",
-            if:
-              "(matrix.profile == 'release' || matrix.profile == 'fastci') && github.ref == 'refs/heads/main'",
+            if: "matrix.job == 'test' && github.ref == 'refs/heads/main'",
             with: {
               path: [
                 "./target",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
         include:
           - os: macos-12
             job: test
-            profile: fastci
+            profile: debug
           - os: macos-12
             job: test
             profile: release
             skip_pr: true
           - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
-            profile: fastci
+            profile: debug
           - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             runner: '${{ github.event_name == ''pull_request'' && ''windows-2022'' || (github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'') }}'
             job: test
@@ -302,12 +302,7 @@ jobs:
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint''))'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
       - name: Build debug
-        if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
-          matrix.profile == 'debug'))
-        run: cargo build --locked --all-targets
-      - name: Build fastci
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && ((matrix.job == ''test'' && matrix.profile == ''fastci'')))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''debug''))'
         run: cargo build --locked --all-targets
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
@@ -380,10 +375,14 @@ jobs:
       - name: Test debug
         if: |-
           !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
-          !startsWith(github.ref, 'refs/tags/')))
+          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')))
         run: cargo test --locked
-      - name: Test fastci
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''fastci''))'
+        env:
+          CARGO_PROFILE_DEV_DEBUG: 0
+      - name: Test debug (fast)
+        if: |-
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' && 
+          !startsWith(matrix.os, 'ubuntu')))
         run: |-
           cargo test --locked --lib
           cargo test --locked --test '*'
@@ -490,7 +489,7 @@ jobs:
           git commit --message "Update benchmarks"
           git push origin gh-pages
       - name: Build product size info
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint'' && matrix.profile != ''fastci'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint'' && matrix.profile != ''debug'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))))'
         run: |-
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"
@@ -548,7 +547,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && ((matrix.profile == ''release'' || matrix.profile == ''fastci'') && github.ref == ''refs/heads/main''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && github.ref == ''refs/heads/main''))'
         with:
           path: |-
             ./target


### PR DESCRIPTION
The "test debug ubuntu-22.04-xl build" is currently the longest running job. We should cache its output on main, which could then also be picked up for the "lint debug ubuntu-22.04-xl" step as well leading to faster feedback.

https://github.com/denoland/deno/actions/runs/4431215588/jobs/7773915734?pr=18215

The changes won't be evident in this PR since this will need to land on main first to create the cache.