### PR TITLE
chore(ci): save a cargo cache specifically for linting

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -12,7 +12,7 @@ const Runners = {
 };
 // bump the number at the start when you want to purge the cache
 const prCacheKeyPrefix =
-  "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}";
+  "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-";
 
 const installPkgsCommand =
   "sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15";

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -844,7 +844,8 @@ const ci = {
             // In main branch, always create a fresh cache
             name: "Save cache build output (main)",
             uses: "actions/cache/save@v3",
-            if: "matrix.job == 'test' && github.ref == 'refs/heads/main'",
+            //if: "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
+            if: "matrix.job == 'test' || matrix.job == 'lint'", // todo: revert
             with: {
               path: [
                 "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -270,7 +270,6 @@ const ci = {
             {
               os: Runners.linux,
               job: "lint",
-              use_sysroot: true,
               profile: "debug",
             },
           ],
@@ -436,8 +435,12 @@ const ci = {
             // Restore cache from the latest 'main' branch build.
             name: "Restore cache build output (PR)",
             uses: "actions/cache/restore@v3",
-            if:
-              "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+            if: [
+              "github.ref != 'refs/heads/main' &&",
+              "!startsWith(github.ref, 'refs/tags/') && ",
+              // cargo clippy seems to do a rebuild, so skip fetching the cache
+              "matrix.job != 'lint'",
+            ].join("\n"),
             with: {
               path: [
                 "./target",
@@ -494,7 +497,6 @@ const ci = {
             if: "matrix.job == 'lint'",
             run:
               "deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js",
-            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
           },
           {
             name: "Build debug",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -844,8 +844,8 @@ const ci = {
             // In main branch, always create a fresh cache
             name: "Save cache build output (main)",
             uses: "actions/cache/save@v3",
-            //if: "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
-            if: "matrix.job == 'test' || matrix.job == 'lint'",
+            if:
+              "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
             with: {
               path: [
                 "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -845,7 +845,7 @@ const ci = {
             name: "Save cache build output (main)",
             uses: "actions/cache/save@v3",
             //if: "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
-            if: "matrix.job == 'test' || matrix.job == 'lint'", // todo: revert
+            if: "matrix.job == 'test' || matrix.job == 'lint'",
             with: {
               path: [
                 "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -493,6 +493,7 @@ const ci = {
             if: "matrix.job == 'lint'",
             run:
               "deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js",
+            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
           },
           {
             name: "Build debug",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -11,8 +11,8 @@ const Runners = {
   windows: `\${{ ${windowsRunnerCondition} }}`,
 };
 // bump the number at the start when you want to purge the cache
-const cacheKeyPrefix =
-  "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-";
+const prCacheKeyPrefix =
+  "18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}";
 
 const installPkgsCommand =
   "sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15";
@@ -435,12 +435,8 @@ const ci = {
             // Restore cache from the latest 'main' branch build.
             name: "Restore cache build output (PR)",
             uses: "actions/cache/restore@v3",
-            if: [
-              "github.ref != 'refs/heads/main' &&",
-              "!startsWith(github.ref, 'refs/tags/') && ",
-              // cargo clippy seems to do a rebuild, so skip fetching the cache
-              "matrix.job != 'lint'",
-            ].join("\n"),
+            if:
+              "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
             with: {
               path: [
                 "./target",
@@ -449,7 +445,7 @@ const ci = {
                 "!./target/*/*.tar.gz",
               ].join("\n"),
               key: "never_saved",
-              "restore-keys": cacheKeyPrefix,
+              "restore-keys": prCacheKeyPrefix,
             },
           },
           {
@@ -856,7 +852,7 @@ const ci = {
                 "!./target/*/*.zip",
                 "!./target/*/*.tar.gz",
               ].join("\n"),
-              key: cacheKeyPrefix + "${{ github.sha }}",
+              key: prCacheKeyPrefix + "${{ github.sha }}",
             },
           },
         ]),

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -270,6 +270,7 @@ const ci = {
             {
               os: Runners.linux,
               job: "lint",
+              use_sysroot: true,
               profile: "debug",
             },
           ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
             wpt: '${{ github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'') }}'
           - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: lint
+            use_sysroot: true
             profile: debug
       fail-fast: '${{ github.event_name == ''pull_request'' || (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')) }}'
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && github.ref == ''refs/heads/main''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' || matrix.job == ''lint''))'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}'
+          restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (!startsWith(github.ref, ''refs/tags/'')))'
         uses: ./.github/mtime_cache
@@ -554,7 +554,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}${{ github.sha }}'
+          key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' || matrix.job == ''lint''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main''))'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,8 @@ jobs:
       - name: lint.js
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint''))'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
+        env:
+          CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build debug
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''debug''))'
         run: cargo build --locked --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,10 +266,7 @@ jobs:
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
-        if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (github.ref != 'refs/heads/main' &&
-          !startsWith(github.ref, 'refs/tags/') && 
-          matrix.job != 'lint'))
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')))'
         with:
           path: |-
             ./target
@@ -277,7 +274,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-'
+          restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}'
       - name: Apply and update mtime cache
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (!startsWith(github.ref, ''refs/tags/'')))'
         uses: ./.github/mtime_cache
@@ -557,7 +554,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ github.sha }}'
+          key: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
             wpt: '${{ github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'') }}'
           - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: lint
-            use_sysroot: true
             profile: debug
       fail-fast: '${{ github.event_name == ''pull_request'' || (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')) }}'
     env:
@@ -267,7 +266,10 @@ jobs:
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')))'
+        if: |-
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (github.ref != 'refs/heads/main' &&
+          !startsWith(github.ref, 'refs/tags/') && 
+          matrix.job != 'lint'))
         with:
           path: |-
             ./target
@@ -302,8 +304,6 @@ jobs:
       - name: lint.js
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint''))'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
-        env:
-          CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build debug
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''debug''))'
         run: cargo build --locked --all-targets

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -138,7 +138,7 @@ function splitToChunks(paths, initCmdLen) {
 
 async function clippy() {
   const currentBuildMode = buildMode();
-  const cmd = ["clippy", "--all-targets", "--all-features", "--locked"];
+  const cmd = ["clippy", "--all-targets", "--locked"];
 
   if (currentBuildMode != "debug") {
     cmd.push("--release");

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -138,7 +138,7 @@ function splitToChunks(paths, initCmdLen) {
 
 async function clippy() {
   const currentBuildMode = buildMode();
-  const cmd = ["clippy", "--all-targets", "--locked"];
+  const cmd = ["clippy", "--all-targets", "--all-features", "--locked"];
 
   if (currentBuildMode != "debug") {
     cmd.push("--release");


### PR DESCRIPTION
#18216 made the linux debug really fast (6 minutes), but the lint step doesn't seem to be able to take advantage of the cache since `cargo clippy` seems to rebuild (or maybe reanalyze?) the project (maybe it's getting more information for linting purposes).

This brings linting down from 4 minutes to 1 minute, which is nice for very fast feedback.

![image](https://user-images.githubusercontent.com/1609021/225510483-fd68143c-8c65-4de2-9784-7439d9b7c74b.png)
