### PR TITLE
refactor: reorder op initialization

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -308,11 +308,12 @@ mod ts {
 }
 
 fn create_cli_snapshot(snapshot_path: PathBuf) {
+  // NOTE(bartlomieju): ordering is important here, keep it in sync with
+  // `runtime/worker.rs`, `runtime/web_worker.rs` and `runtime/build.rs`!
   let mut extensions: Vec<Extension> = vec![
     deno_webidl::init(),
     deno_console::init(),
     deno_url::init_ops(),
-    deno_tls::init_ops(),
     deno_web::init_ops::<PermissionsContainer>(
       deno_web::BlobStore::default(),
       Default::default(),
@@ -327,18 +328,19 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
       deno_broadcast_channel::InMemoryBroadcastChannel::default(),
       false, // No --unstable.
     ),
-    deno_io::init_ops(Default::default()),
-    deno_fs::init_ops::<PermissionsContainer>(false),
-    deno_node::init_ops::<PermissionsContainer>(None), // No --unstable.
-    deno_node::init_polyfill_ops(),
     deno_ffi::init_ops::<PermissionsContainer>(false),
     deno_net::init_ops::<PermissionsContainer>(
       None, false, // No --unstable.
       None,
     ),
+    deno_tls::init_ops(),
     deno_napi::init_ops::<PermissionsContainer>(),
     deno_http::init_ops(),
+    deno_io::init_ops(Default::default()),
+    deno_fs::init_ops::<PermissionsContainer>(false),
     deno_flash::init_ops::<PermissionsContainer>(false), // No --unstable
+    deno_node::init_ops::<PermissionsContainer>(None),   // No --unstable.
+    deno_node::init_polyfill_ops(),
   ];
 
   let mut esm_files = include_js_files!(

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -250,11 +250,12 @@ mod startup_snapshot {
     ))
     .build();
 
+    // NOTE(bartlomieju): ordering is important here, keep it in sync with
+    // `runtime/worker.rs`, `runtime/web_worker.rs` and `cli/build.rs`!
     let mut extensions: Vec<Extension> = vec![
       deno_webidl::init_esm(),
       deno_console::init_esm(),
       deno_url::init_ops_and_esm(),
-      deno_tls::init_ops(),
       deno_web::init_ops_and_esm::<Permissions>(
         deno_web::BlobStore::default(),
         Default::default(),
@@ -278,6 +279,7 @@ mod startup_snapshot {
         None, false, // No --unstable.
         None,
       ),
+      deno_tls::init_ops(),
       deno_napi::init_ops::<Permissions>(),
       deno_http::init_ops_and_esm(),
       deno_io::init_ops_and_esm(Default::default()),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -383,6 +383,8 @@ impl WebWorker {
       CreateCache(Arc::new(create_cache_fn))
     });
 
+    // NOTE(bartlomieju): ordering is important here, keep it in sync with
+    // `runtime/build.rs`, `runtime/worker.rs` and `cli/build.rs`!
     let mut extensions: Vec<Extension> = vec![
       // Web APIs
       deno_webidl::init(),
@@ -408,14 +410,26 @@ impl WebWorker {
         options.unsafely_ignore_certificate_errors.clone(),
       ),
       deno_webstorage::init_ops(None).disable(),
+      deno_crypto::init_ops(options.seed),
+      deno_webgpu::init_ops(unstable),
       deno_broadcast_channel::init_ops(
         options.broadcast_channel.clone(),
         unstable,
       ),
-      deno_crypto::init_ops(options.seed),
-      deno_webgpu::init_ops(unstable),
-      // ffi
       deno_ffi::init_ops::<PermissionsContainer>(unstable),
+      deno_net::init_ops::<PermissionsContainer>(
+        options.root_cert_store.clone(),
+        unstable,
+        options.unsafely_ignore_certificate_errors.clone(),
+      ),
+      deno_tls::init_ops(),
+      deno_napi::init_ops::<PermissionsContainer>(),
+      deno_http::init_ops(),
+      deno_io::init_ops(options.stdio),
+      deno_fs::init_ops::<PermissionsContainer>(unstable),
+      deno_flash::init_ops::<PermissionsContainer>(unstable),
+      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
+      deno_node::init_polyfill_ops(),
       // Runtime ops that are always initialized for WebWorkers
       ops::web_worker::init(),
       ops::runtime::init(main_module.clone()),
@@ -425,30 +439,16 @@ impl WebWorker {
         options.pre_execute_module_cb.clone(),
         options.format_js_error_fn.clone(),
       ),
-      // Extensions providing Deno.* features
       ops::fs_events::init(),
-      deno_fs::init_ops::<PermissionsContainer>(unstable),
-      deno_io::init_ops(options.stdio),
-      deno_tls::init_ops(),
-      deno_net::init_ops::<PermissionsContainer>(
-        options.root_cert_store.clone(),
-        unstable,
-        options.unsafely_ignore_certificate_errors.clone(),
-      ),
-      deno_napi::init_ops::<PermissionsContainer>(),
-      deno_node::init_polyfill_ops(),
-      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
       ops::os::init_for_worker(),
       ops::permissions::init(),
       ops::process::init_ops(),
       ops::signal::init(),
       ops::tty::init(),
-      deno_http::init_ops(),
-      deno_flash::init_ops::<PermissionsContainer>(unstable),
       ops::http::init(),
-      // Permissions ext (worker specific state)
-      perm_ext,
     ];
+
+    extensions.push(perm_ext);
 
     // Append exts
     extensions.extend(std::mem::take(&mut options.extensions));

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -203,6 +203,8 @@ impl MainWorker {
       CreateCache(Arc::new(create_cache_fn))
     });
 
+    // NOTE(bartlomieju): ordering is important here, keep it in sync with
+    // `runtime/build.rs`, `runtime/web_worker.rs` and `cli/build.rs`!
     let mut extensions = vec![
       // Web APIs
       deno_webidl::init(),
@@ -228,15 +230,27 @@ impl MainWorker {
         options.unsafely_ignore_certificate_errors.clone(),
       ),
       deno_webstorage::init_ops(options.origin_storage_dir.clone()),
+      deno_crypto::init_ops(options.seed),
+      deno_webgpu::init_ops(unstable),
       deno_broadcast_channel::init_ops(
         options.broadcast_channel.clone(),
         unstable,
       ),
-      deno_crypto::init_ops(options.seed),
-      deno_webgpu::init_ops(unstable),
-      // ffi
       deno_ffi::init_ops::<PermissionsContainer>(unstable),
-      // Runtime ops
+      deno_net::init_ops::<PermissionsContainer>(
+        options.root_cert_store.clone(),
+        unstable,
+        options.unsafely_ignore_certificate_errors.clone(),
+      ),
+      deno_tls::init_ops(),
+      deno_napi::init_ops::<PermissionsContainer>(),
+      deno_http::init_ops(),
+      deno_io::init_ops(options.stdio),
+      deno_fs::init_ops::<PermissionsContainer>(unstable),
+      deno_flash::init_ops::<PermissionsContainer>(unstable),
+      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
+      deno_node::init_polyfill_ops(),
+      // Ops from this crate
       ops::runtime::init(main_module.clone()),
       ops::worker_host::init(
         options.create_web_worker_cb.clone(),
@@ -245,24 +259,11 @@ impl MainWorker {
         options.format_js_error_fn.clone(),
       ),
       ops::fs_events::init(),
-      deno_fs::init_ops::<PermissionsContainer>(unstable),
-      deno_io::init_ops(options.stdio),
-      deno_tls::init_ops(),
-      deno_net::init_ops::<PermissionsContainer>(
-        options.root_cert_store.clone(),
-        unstable,
-        options.unsafely_ignore_certificate_errors.clone(),
-      ),
-      deno_napi::init_ops::<PermissionsContainer>(),
-      deno_node::init_ops::<PermissionsContainer>(options.npm_resolver),
-      deno_node::init_polyfill_ops(),
       ops::os::init(exit_code.clone()),
       ops::permissions::init(),
       ops::process::init_ops(),
       ops::signal::init(),
       ops::tty::init(),
-      deno_http::init_ops(),
-      deno_flash::init_ops::<PermissionsContainer>(unstable),
       ops::http::init(),
     ];
 


### PR DESCRIPTION
To be able to preserve "Deno.core.ops" we need to ensure that
ops are registered in the same order in various places, otherwise
we will get mismatch in external references ordering.

Prerequisite for https://github.com/denoland/deno/pull/18080