### PR TITLE
chore: ignore permission_prompt_strips_ansi_codes_and_control_chars test

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -4066,6 +4066,7 @@ fn stdio_streams_are_locked_in_permission_prompt() {
 }
 
 #[test]
+#[ignore]
 fn permission_prompt_strips_ansi_codes_and_control_chars() {
   let _guard = util::http_server();
   util::with_pty(&["repl"], |mut console| {


### PR DESCRIPTION
This test hangs on all operating systems.

Opened https://github.com/denoland/deno/issues/18233 for the future