### PR TITLE
chore(ci): allow 'BREAKING' PR title prefix

### DIFF
--- a/tools/verify_pr_title.js
+++ b/tools/verify_pr_title.js
@@ -28,6 +28,8 @@ const validPrefixes = [
   // allow Revert PRs because it allows us to remove the landed
   // commit from the generated changelog
   "Revert ",
+  // Allow landing breaking changes that are properly marked
+  "BREAKING",
 ];
 
 if (validPrefixes.some((prefix) => prTitle.startsWith(prefix))) {


### PR DESCRIPTION
So that we can land PRs like https://github.com/denoland/deno/pull/18237 or https://github.com/denoland/deno/pull/18094