### PR TITLE
perf: disable runtime snapshot compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,6 @@ dependencies = [
  "libc",
  "log",
  "lsp-types",
- "lzzzz",
  "mitata",
  "monch",
  "napi_sym",
@@ -1207,7 +1206,6 @@ dependencies = [
  "hyper",
  "libc",
  "log",
- "lzzzz",
  "netif",
  "nix",
  "notify",
@@ -2596,15 +2594,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
-]
-
-[[package]]
-name = "lzzzz"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8014d1362004776e6a91e4c15a3aa7830d1b6650a075b51a9969ebb6d6af13bc"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,6 @@ indexmap = { version = "1.9.2", features = ["serde"] }
 libc = "0.2.126"
 log = "=0.4.17"
 lsp-types = "=0.93.2" # used by tower-lsp and "proposed" feature is unstable in patch releases
-lzzzz = "1.0"
 notify = "=5.0.0"
 num-bigint = "0.4"
 once_cell = "1.17.1"
@@ -232,8 +231,6 @@ opt-level = 3
 opt-level = 3
 [profile.bench.package.zstd]
 opt-level = 3
-[profile.bench.package.lzzzz]
-opt-level = 3
 [profile.bench.package.zstd-sys]
 opt-level = 3
 [profile.bench.package.base64-simd]
@@ -305,8 +302,6 @@ opt-level = 3
 [profile.release.package.tokio]
 opt-level = 3
 [profile.release.package.zstd]
-opt-level = 3
-[profile.release.package.lzzzz]
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,8 +35,6 @@ serde_json.workspace = true
 zstd.workspace = true
 glibc_version = "0.1.2"
 
-lzzzz = '1.0'
-
 [target.'cfg(windows)'.build-dependencies]
 winapi.workspace = true
 winres.workspace = true
@@ -81,7 +79,6 @@ jsonc-parser = { version = "=0.21.0", features = ["serde"] }
 libc.workspace = true
 log = { workspace = true, features = ["serde"] }
 lsp-types.workspace = true
-lzzzz = '1.0'
 mitata = "=0.0.7"
 monch = "=0.4.1"
 notify.workspace = true

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -364,14 +364,7 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
     snapshot_path,
     startup_snapshot: Some(deno_runtime::js::deno_isolate_init()),
     extensions,
-    compression_cb: Some(Box::new(|vec, snapshot_slice| {
-      lzzzz::lz4_hc::compress_to_vec(
-        snapshot_slice,
-        vec,
-        lzzzz::lz4_hc::CLEVEL_MAX,
-      )
-      .expect("snapshot compression failed");
-    })),
+    compression_cb: None,
     snapshot_module_load_cb: None,
   })
 }

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -2,36 +2,13 @@
 
 use deno_core::Snapshot;
 use log::debug;
-use once_cell::sync::Lazy;
 
-pub static CLI_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
-  #[allow(clippy::uninit_vec)]
-  #[cold]
-  #[inline(never)]
-  || {
-    static COMPRESSED_CLI_SNAPSHOT: &[u8] =
-      include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
-
-    let size =
-      u32::from_le_bytes(COMPRESSED_CLI_SNAPSHOT[0..4].try_into().unwrap())
-        as usize;
-    let mut vec = Vec::with_capacity(size);
-
-    // SAFETY: vec is allocated with exact snapshot size (+ alignment)
-    // SAFETY: non zeroed bytes are overwritten with decompressed snapshot
-    unsafe {
-      vec.set_len(size);
-    }
-
-    lzzzz::lz4::decompress(&COMPRESSED_CLI_SNAPSHOT[4..], &mut vec).unwrap();
-
-    vec.into_boxed_slice()
-  },
-);
+static CLI_SNAPSHOT: &[u8] =
+  include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
 
 pub fn deno_isolate_init() -> Snapshot {
   debug!("Deno isolate init with snapshots.");
-  Snapshot::Static(&CLI_SNAPSHOT)
+  Snapshot::Static(CLI_SNAPSHOT)
 }
 
 #[cfg(test)]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -55,8 +55,6 @@ deno_websocket.workspace = true
 deno_webstorage.workspace = true
 deno_napi.workspace = true
 
-lzzzz.workspace = true
-
 [target.'cfg(windows)'.build-dependencies]
 winres.workspace = true
 winapi.workspace = true
@@ -93,7 +91,6 @@ http.workspace = true
 hyper = { workspace = true, features = ["server", "stream", "http1", "http2", "runtime"] }
 libc.workspace = true
 log.workspace = true
-lzzzz.workspace = true
 netif = "0.1.6"
 notify.workspace = true
 once_cell.workspace = true

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -299,14 +299,7 @@ mod startup_snapshot {
       snapshot_path,
       startup_snapshot: None,
       extensions,
-      compression_cb: Some(Box::new(|vec, snapshot_slice| {
-        lzzzz::lz4_hc::compress_to_vec(
-          snapshot_slice,
-          vec,
-          lzzzz::lz4_hc::CLEVEL_MAX,
-        )
-        .expect("snapshot compression failed");
-      })),
+      compression_cb: None,
       snapshot_module_load_cb: Some(Box::new(transpile_ts_for_snapshotting)),
     });
   }

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -3,41 +3,15 @@
 use deno_core::Snapshot;
 #[cfg(not(feature = "dont_create_runtime_snapshot"))]
 use log::debug;
-#[cfg(not(feature = "dont_create_runtime_snapshot"))]
-use once_cell::sync::Lazy;
 
 #[cfg(not(feature = "dont_create_runtime_snapshot"))]
-static COMPRESSED_RUNTIME_SNAPSHOT: &[u8] =
+static RUNTIME_SNAPSHOT: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/RUNTIME_SNAPSHOT.bin"));
-
-#[cfg(not(feature = "dont_create_runtime_snapshot"))]
-pub static RUNTIME_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(
-  #[allow(clippy::uninit_vec)]
-  #[cold]
-  #[inline(never)]
-  || {
-    let size =
-      u32::from_le_bytes(COMPRESSED_RUNTIME_SNAPSHOT[0..4].try_into().unwrap())
-        as usize;
-    let mut vec = Vec::with_capacity(size);
-
-    // SAFETY: vec is allocated with exact snapshot size (+ alignment)
-    // SAFETY: non zeroed bytes are overwritten with decompressed snapshot
-    unsafe {
-      vec.set_len(size);
-    }
-
-    lzzzz::lz4::decompress(&COMPRESSED_RUNTIME_SNAPSHOT[4..], &mut vec)
-      .unwrap();
-
-    vec.into_boxed_slice()
-  },
-);
 
 #[cfg(not(feature = "dont_create_runtime_snapshot"))]
 pub fn deno_isolate_init() -> Snapshot {
   debug!("Deno isolate init with snapshots.");
-  Snapshot::Static(&RUNTIME_SNAPSHOT)
+  Snapshot::Static(RUNTIME_SNAPSHOT)
 }
 
 #[cfg(not(feature = "include_js_files_for_snapshotting"))]


### PR DESCRIPTION
This commit removes compression for the runtime JS code.

It means that we will have a bigger binary, but faster startup. After
several discussion in the CLI team we decided it's worth to trade
about 3Mb of binary size for 2ms faster startup time. With WebGPU
removed in 35196eab279340376929dd75ed717ef4830e2fa9
it shouldn't have such a big impact on the binary size.