### PR TITLE
test(ext/node): add _fs_access_test.ts and _fs_watch_test.ts

### DIFF
--- a/cli/tests/unit_node/_fs/_fs_access_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_access_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as fs from "node:fs";
 import {
+  assertRejects,
   assertThrows,
-  assertRejects
 } from "../../../../test_util/std/testing/asserts.ts";
 
 Deno.test(

--- a/cli/tests/unit_node/_fs/_fs_access_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_access_test.ts
@@ -1,0 +1,70 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import * as fs from "node:fs";
+import {
+  assertThrows,
+  assertRejects
+} from "../../../../test_util/std/testing/asserts.ts";
+
+Deno.test(
+  "[node/fs.access] Uses the owner permission when the user is the owner",
+  { ignore: Deno.build.os === "windows" },
+  async () => {
+    const file = await Deno.makeTempFile();
+    try {
+      Deno.chmod(file, 0o600);
+      await fs.promises.access(file, fs.constants.R_OK);
+      await fs.promises.access(file, fs.constants.W_OK);
+      await assertRejects(async () => {
+        await fs.promises.access(file, fs.constants.X_OK);
+      });
+    } finally {
+      await Deno.remove(file);
+    }
+  },
+);
+
+Deno.test(
+  "[node/fs.access] doesn't reject on windows",
+  { ignore: Deno.build.os !== "windows" },
+  async () => {
+    const file = await Deno.makeTempFile();
+    try {
+      await fs.promises.access(file, fs.constants.R_OK);
+      await fs.promises.access(file, fs.constants.W_OK);
+    } finally {
+      await Deno.remove(file);
+    }
+  },
+);
+
+Deno.test(
+  "[node/fs.accessSync] Uses the owner permission when the user is the owner",
+  { ignore: Deno.build.os === "windows" },
+  () => {
+    const file = Deno.makeTempFileSync();
+    try {
+      Deno.chmod(file, 0o600);
+      fs.accessSync(file, fs.constants.R_OK);
+      fs.accessSync(file, fs.constants.W_OK);
+      assertThrows(() => {
+        fs.accessSync(file, fs.constants.X_OK);
+      });
+    } finally {
+      Deno.removeSync(file);
+    }
+  },
+);
+
+Deno.test(
+  "[node/fs.accessSync] doesn't throw on windows",
+  { ignore: Deno.build.os !== "windows" },
+  () => {
+    const file = Deno.makeTempFileSync();
+    try {
+      fs.accessSync(file, fs.constants.R_OK);
+      fs.accessSync(file, fs.constants.W_OK);
+    } finally {
+      Deno.removeSync(file);
+    }
+  },
+);

--- a/cli/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_watch_test.ts
@@ -1,0 +1,27 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { watch } from "node:fs";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
+
+function wait(time: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, time);
+  });
+}
+
+Deno.test({
+  name: "watching a file",
+  async fn() {
+    const file = Deno.makeTempFileSync();
+    const result: Array<[string, string]> = [];
+    const watcher = watch(
+      file,
+      (eventType, filename) => result.push([eventType, filename]),
+    );
+    await wait(100);
+    Deno.writeTextFileSync(file, "something");
+    await wait(100);
+    watcher.close();
+    await wait(100);
+    assertEquals(result.length >= 1, true);
+  },
+});


### PR DESCRIPTION
This PR ports `_fs/_fs_access_test.ts` and `_fs/_fs_watch_test.ts` from `std/node`.

part of https://github.com/denoland/deno/issues/17840