### PR TITLE
perf(core) Reduce copying and cloning in extension initialization

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -126,9 +126,9 @@ mod ts {
       path_dts: PathBuf,
     },
     state = |state, options| {
-      state.put(cfg.op_crate_libs);
-      state.put(cfg.build_libs);
-      state.put(cfg.path_dts);
+      state.put(options.op_crate_libs);
+      state.put(options.build_libs);
+      state.put(options.path_dts);
     },
   );
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,9 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use std::cell::RefCell;
 use std::env;
 use std::path::PathBuf;
-use std::rc::Rc;
 
 use deno_core::snapshot_util::*;
 use deno_core::Extension;
@@ -127,10 +125,10 @@ mod ts {
       build_libs: Vec<&'static str>,
       path_dts: PathBuf,
     },
-    state = |state, op_crate_libs, build_libs, path_dts| {
-      state.put(op_crate_libs);
-      state.put(build_libs);
-      state.put(path_dts);
+    state = |state, cfg| {
+      state.put(cfg.op_crate_libs);
+      state.put(cfg.build_libs);
+      state.put(cfg.path_dts);
     },
   );
 
@@ -362,7 +360,7 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
     deno_tls::deno_tls::init_ops(),
     deno_napi::deno_napi::init_ops::<PermissionsContainer>(),
     deno_http::deno_http::init_ops(),
-    deno_io::deno_io::init_ops(Rc::new(RefCell::new(Some(Default::default())))),
+    deno_io::deno_io::init_ops(Default::default()),
     deno_fs::deno_fs::init_ops::<PermissionsContainer>(false),
     deno_flash::deno_flash::init_ops::<PermissionsContainer>(false), // No --unstable
     deno_node::deno_node_loading::init_ops::<PermissionsContainer>(None), // No --unstable.

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -125,7 +125,7 @@ mod ts {
       build_libs: Vec<&'static str>,
       path_dts: PathBuf,
     },
-    state = |state, cfg| {
+    state = |state, options| {
       state.put(cfg.op_crate_libs);
       state.put(cfg.build_libs);
       state.put(cfg.path_dts);

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -120,7 +120,7 @@ mod ts {
       "00_typescript.js",
       "99_main_compiler.js",
     ],
-    config = {
+    options = {
       op_crate_libs: HashMap<&'static str, PathBuf>,
       build_libs: Vec<&'static str>,
       path_dts: PathBuf,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2834,7 +2834,7 @@ deno_core::extension!(deno_tsc,
     op_script_names,
     op_script_version,
   ],
-  config = {
+  options = {
     performance: Arc<Performance>
   },
   state = |state, options| {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2840,7 +2840,7 @@ deno_core::extension!(deno_tsc,
   state = |state, options| {
     state.put(State::new(
       Arc::new(StateSnapshot::default()),
-      cfg.performance,
+      options.performance,
     ));
   },
 );

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2837,7 +2837,7 @@ deno_core::extension!(deno_tsc,
   config = {
     performance: Arc<Performance>
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put(State::new(
       Arc::new(StateSnapshot::default()),
       cfg.performance,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2837,10 +2837,10 @@ deno_core::extension!(deno_tsc,
   config = {
     performance: Arc<Performance>
   },
-  state = |state, performance| {
+  state = |state, cfg| {
     state.put(State::new(
       Arc::new(StateSnapshot::default()),
-      performance,
+      cfg.performance,
     ));
   },
 );

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -35,8 +35,8 @@ deno_core::extension!(deno_bench,
     filter: TestFilter,
   },
   state = |state, options| {
-    state.put(cfg.sender);
-    state.put(cfg.filter);
+    state.put(options.sender);
+    state.put(options.filter);
   },
 );
 

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -30,7 +30,7 @@ deno_core::extension!(deno_bench,
     op_dispatch_bench_event,
     op_bench_now,
   ],
-  config = {
+  options = {
     sender: UnboundedSender<BenchEvent>,
     filter: TestFilter,
   },

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -34,9 +34,9 @@ deno_core::extension!(deno_bench,
     sender: UnboundedSender<BenchEvent>,
     filter: TestFilter,
   },
-  state = |state, sender, filter| {
-    state.put(sender);
-    state.put(filter);
+  state = |state, cfg| {
+    state.put(cfg.sender);
+    state.put(cfg.filter);
   },
 );
 

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -34,7 +34,7 @@ deno_core::extension!(deno_bench,
     sender: UnboundedSender<BenchEvent>,
     filter: TestFilter,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put(cfg.sender);
     state.put(cfg.filter);
   },

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -18,8 +18,8 @@ deno_core::extension!(deno_cli,
   config = {
     ps: ProcState,
   },
-  state = |state, ps| {
-    state.put(ps);
+  state = |state, cfg| {
+    state.put(cfg.ps);
   },
 );
 

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -15,7 +15,7 @@ pub fn cli_exts(ps: ProcState) -> Vec<Extension> {
 
 deno_core::extension!(deno_cli,
   ops = [op_npm_process_state],
-  config = {
+  options = {
     ps: ProcState,
   },
   state = |state, options| {

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -18,7 +18,7 @@ deno_core::extension!(deno_cli,
   config = {
     ps: ProcState,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put(cfg.ps);
   },
 );

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -19,7 +19,7 @@ deno_core::extension!(deno_cli,
     ps: ProcState,
   },
   state = |state, options| {
-    state.put(cfg.ps);
+    state.put(options.ps);
   },
 );
 

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -39,10 +39,10 @@ deno_core::extension!(deno_test,
     fail_fast_tracker: FailFastTracker,
     filter: TestFilter,
   },
-  state = |state, sender, fail_fast_tracker, filter| {
-    state.put(sender);
-    state.put(fail_fast_tracker);
-    state.put(filter);
+  state = |state, cfg| {
+    state.put(cfg.sender);
+    state.put(cfg.fail_fast_tracker);
+    state.put(cfg.filter);
   },
 );
 

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -34,7 +34,7 @@ deno_core::extension!(deno_test,
     op_dispatch_test_event,
     op_tests_should_stop,
   ],
-  config = {
+  options = {
     sender: TestEventSender,
     fail_fast_tracker: FailFastTracker,
     filter: TestFilter,

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -40,9 +40,9 @@ deno_core::extension!(deno_test,
     filter: TestFilter,
   },
   state = |state, options| {
-    state.put(cfg.sender);
-    state.put(cfg.fail_fast_tracker);
-    state.put(cfg.filter);
+    state.put(options.sender);
+    state.put(options.fail_fast_tracker);
+    state.put(options.filter);
   },
 );
 

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -39,7 +39,7 @@ deno_core::extension!(deno_test,
     fail_fast_tracker: FailFastTracker,
     filter: TestFilter,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put(cfg.sender);
     state.put(cfg.fail_fast_tracker);
     state.put(cfg.filter);

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -41,7 +41,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::sync::Arc;
 
 mod diagnostics;
@@ -830,18 +829,18 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
   deno_core::extension!(deno_cli_tsc,
     ops_fn = deno_ops,
     config = {
-      request: Rc<Request>,
+      request: Request,
       root_map: HashMap<String, Url>,
       remapped_specifiers: HashMap<String, Url>,
     },
-    state = |state, request, root_map, remapped_specifiers| {
+    state = |state, cfg| {
       state.put(State::new(
-        request.graph.clone(),
-        request.hash_data.clone(),
-        request.maybe_npm_resolver.clone(),
-        request.maybe_tsbuildinfo.clone(),
-        root_map,
-        remapped_specifiers,
+        cfg.request.graph,
+        cfg.request.hash_data,
+        cfg.request.maybe_npm_resolver,
+        cfg.request.maybe_tsbuildinfo,
+        cfg.root_map,
+        cfg.remapped_specifiers,
         std::env::current_dir()
           .context("Unable to get CWD")
           .unwrap(),
@@ -861,7 +860,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(compiler_snapshot()),
     extensions: vec![deno_cli_tsc::init_ops(
-      Rc::new(request),
+      request,
       root_map,
       remapped_specifiers,
     )],

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -828,7 +828,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
 
   deno_core::extension!(deno_cli_tsc,
     ops_fn = deno_ops,
-    config = {
+    options = {
       request: Request,
       root_map: HashMap<String, Url>,
       remapped_specifiers: HashMap<String, Url>,

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -833,7 +833,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
       root_map: HashMap<String, Url>,
       remapped_specifiers: HashMap<String, Url>,
     },
-    state = |state, cfg| {
+    state = |state, options| {
       state.put(State::new(
         cfg.request.graph,
         cfg.request.hash_data,

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -835,12 +835,12 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
     },
     state = |state, options| {
       state.put(State::new(
-        cfg.request.graph,
-        cfg.request.hash_data,
-        cfg.request.maybe_npm_resolver,
-        cfg.request.maybe_tsbuildinfo,
-        cfg.root_map,
-        cfg.remapped_specifiers,
+        options.request.graph,
+        options.request.hash_data,
+        options.request.maybe_npm_resolver,
+        options.request.maybe_tsbuildinfo,
+        options.root_map,
+        options.remapped_specifiers,
         std::env::current_dir()
           .context("Unable to get CWD")
           .unwrap(),

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -164,7 +164,7 @@ macro_rules! extension {
     $(, esm = [ $( dir $dir_esm:literal , )? $( $esm:literal ),* $(,)? ] )?
     $(, esm_setup_script = $esm_setup_script:expr )?
     $(, js = [ $( dir $dir_js:literal , )? $( $js:literal ),* $(,)? ] )?
-    $(, config = { $( $config_id:ident : $config_type:ty ),* $(,)? } )?
+    $(, options = { $( $options_id:ident : $options_type:ty ),* $(,)? } )?
     $(, middleware = $middleware_fn:expr )?
     $(, state = $state_fn:expr )?
     $(, event_loop_middleware = $event_loop_middleware_fn:ident )?
@@ -227,9 +227,9 @@ macro_rules! extension {
       // Includes the state and middleware functions, if defined.
       #[inline(always)]
       #[allow(unused_variables)]
-      fn with_state_and_middleware$( <  $( $param : $type + Clone + 'static ),+ > )?(ext: &mut $crate::ExtensionBuilder, $( $( $config_id : $config_type ),* )? ) {
+      fn with_state_and_middleware$( <  $( $param : $type + Clone + 'static ),+ > )?(ext: &mut $crate::ExtensionBuilder, $( $( $options_id : $options_type ),* )? ) {
         #[allow(unused_variables)]
-        let config = $crate::extension!(! __config__ $( parameters = [ $( $param : $type ),* ] )? $( config = { $( $config_id : $config_type ),* } )? );
+        let config = $crate::extension!(! __config__ $( parameters = [ $( $param : $type ),* ] )? $( config = { $( $options_id : $options_type ),* } )? );
 
         $(
           ext.state(move |state: &mut $crate::OpState| {
@@ -263,21 +263,21 @@ macro_rules! extension {
       }
 
       #[allow(dead_code)]
-      pub fn init_ops_and_esm $( <  $( $param : $type + Clone + 'static ),+ > )? ( $( $( $config_id : $config_type ),* )? ) -> $crate::Extension {
+      pub fn init_ops_and_esm $( <  $( $param : $type + Clone + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension {
         let mut ext = Self::ext();
         // If esm or JS was specified, add JS files
         Self::with_js(&mut ext);
         Self::with_ops $( ::<($( $param ),+)> )?(&mut ext);
-        Self::with_state_and_middleware $( ::<($( $param ),+)> )?(&mut ext, $( $( $config_id , )* )? );
+        Self::with_state_and_middleware $( ::<($( $param ),+)> )?(&mut ext, $( $( $options_id , )* )? );
         Self::with_customizer(&mut ext);
         ext.take()
       }
 
       #[allow(dead_code)]
-      pub fn init_ops $( <  $( $param : $type + Clone + 'static ),+ > )? ( $( $( $config_id : $config_type ),* )? ) -> $crate::Extension {
+      pub fn init_ops $( <  $( $param : $type + Clone + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension {
         let mut ext = Self::ext();
         Self::with_ops $( ::<($( $param ),+)> )?(&mut ext);
-        Self::with_state_and_middleware $( ::<($( $param ),+)> )?(&mut ext, $( $( $config_id , )* )? );
+        Self::with_state_and_middleware $( ::<($( $param ),+)> )?(&mut ext, $( $( $options_id , )* )? );
         Self::with_customizer(&mut ext);
         ext.take()
       }
@@ -285,11 +285,11 @@ macro_rules! extension {
   };
 
   // This branch of the macro generates a config object that calls the state function with itself.
-  (! __config__ $( parameters = [ $( $param:ident : $type:ident ),+ ] )? config = { $( $config_id:ident : $config_type:ty ),* } ) => {
+  (! __config__ $( parameters = [ $( $param:ident : $type:ident ),+ ] )? config = { $( $options_id:ident : $options_type:ty ),* } ) => {
     {
       #[doc(hidden)]
       struct Config $( <  $( $param : $type + Clone + 'static ),+ > )? {
-        $( pub $config_id : $config_type , )*
+        $( pub $options_id : $options_type , )*
         $( __phantom_data: ::std::marker::PhantomData<($( $param ),+)>, )?
       }
 
@@ -304,7 +304,7 @@ macro_rules! extension {
       }
 
       Config {
-        $( $config_id , )*
+        $( $options_id , )*
         $( __phantom_data: ::std::marker::PhantomData::<($( $param ),+)>::default() )?
       }
     }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2735,10 +2735,10 @@ pub mod tests {
         mode: Mode,
         dispatch_count: Arc<AtomicUsize>,
       },
-      state = |state, mode, dispatch_count| {
+      state = |state, cfg| {
         state.put(TestState {
-          mode,
-          dispatch_count
+          mode: cfg.mode,
+          dispatch_count: cfg.dispatch_count
         })
       }
     );

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2735,10 +2735,10 @@ pub mod tests {
         mode: Mode,
         dispatch_count: Arc<AtomicUsize>,
       },
-      state = |state, cfg| {
+      state = |state, options| {
         state.put(TestState {
-          mode: cfg.mode,
-          dispatch_count: cfg.dispatch_count
+          mode: options.mode,
+          dispatch_count: options.dispatch_count
         })
       }
     );

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2731,7 +2731,7 @@ pub mod tests {
     deno_core::extension!(
       test_ext,
       ops = [op_test],
-      config = {
+      options = {
         mode: Mode,
         dispatch_count: Arc<AtomicUsize>,
       },

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -118,9 +118,9 @@ deno_core::extension!(deno_broadcast_channel,
     bc: BC,
     unstable: bool,
   },
-  state = |state, bc, unstable| {
-    state.put(bc);
-    state.put(Unstable(unstable));
+  state = |state, cfg| {
+    state.put(cfg.bc);
+    state.put(Unstable(cfg.unstable));
   },
 );
 

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -114,7 +114,7 @@ deno_core::extension!(deno_broadcast_channel,
     op_broadcast_recv<BC>,
   ],
   esm = [ "01_broadcast_channel.js" ],
-  config = {
+  options = {
     bc: BC,
     unstable: bool,
   },

--- a/ext/broadcast_channel/lib.rs
+++ b/ext/broadcast_channel/lib.rs
@@ -118,9 +118,9 @@ deno_core::extension!(deno_broadcast_channel,
     bc: BC,
     unstable: bool,
   },
-  state = |state, cfg| {
-    state.put(cfg.bc);
-    state.put(Unstable(cfg.unstable));
+  state = |state, options| {
+    state.put(options.bc);
+    state.put(Unstable(options.unstable));
   },
 );
 

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -35,8 +35,8 @@ deno_core::extension!(deno_cache,
   config = {
     maybe_create_cache: Option<CreateCache<CA>>,
   },
-  state = |state, cfg| {
-    if let Some(create_cache) = cfg.maybe_create_cache {
+  state = |state, options| {
+    if let Some(create_cache) = options.maybe_create_cache {
       state.put(create_cache);
     }
   },

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -35,8 +35,8 @@ deno_core::extension!(deno_cache,
   config = {
     maybe_create_cache: Option<CreateCache<CA>>,
   },
-  state = |state, maybe_create_cache| {
-    if let Some(create_cache) = maybe_create_cache {
+  state = |state, cfg| {
+    if let Some(create_cache) = cfg.maybe_create_cache {
       state.put(create_cache);
     }
   },

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -32,7 +32,7 @@ deno_core::extension!(deno_cache,
     op_cache_delete<CA>,
   ],
   esm = [ "01_cache.js" ],
-  config = {
+  options = {
     maybe_create_cache: Option<CreateCache<CA>>,
   },
   state = |state, options| {

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -107,8 +107,8 @@ deno_core::extension!(deno_crypto,
   config = {
     maybe_seed: Option<u64>,
   },
-  state = |state, cfg| {
-    if let Some(seed) = cfg.maybe_seed {
+  state = |state, options| {
+    if let Some(seed) = options.maybe_seed {
       state.put(StdRng::seed_from_u64(seed));
     }
   },

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -104,7 +104,7 @@ deno_core::extension!(deno_crypto,
     x25519::op_export_pkcs8_x25519,
   ],
   esm = [ "00_crypto.js", "01_webidl.js" ],
-  config = {
+  options = {
     maybe_seed: Option<u64>,
   },
   state = |state, options| {

--- a/ext/crypto/lib.rs
+++ b/ext/crypto/lib.rs
@@ -107,8 +107,8 @@ deno_core::extension!(deno_crypto,
   config = {
     maybe_seed: Option<u64>,
   },
-  state = |state, maybe_seed| {
-    if let Some(seed) = maybe_seed {
+  state = |state, cfg| {
+    if let Some(seed) = cfg.maybe_seed {
       state.put(StdRng::seed_from_u64(seed));
     }
   },

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -110,16 +110,16 @@ deno_core::extension!(deno_fetch,
   config = {
     options: Options,
   },
-  state = |state, options| {
-    state.put::<Options>(options.clone());
+  state = |state, cfg| {
+    state.put::<Options>(cfg.options.clone());
     state.put::<reqwest::Client>({
       create_http_client(
-        options.user_agent,
-        options.root_cert_store,
+        cfg.options.user_agent,
+        cfg.options.root_cert_store,
         vec![],
-        options.proxy,
-        options.unsafely_ignore_certificate_errors,
-        options.client_cert_chain_and_key
+        cfg.options.proxy,
+        cfg.options.unsafely_ignore_certificate_errors,
+        cfg.options.client_cert_chain_and_key
       )
       .unwrap()
     });

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -107,7 +107,7 @@ deno_core::extension!(deno_fetch,
     "23_response.js",
     "26_fetch.js"
   ],
-  config = {
+  options = {
     options: Options,
   },
   state = |state, options| {

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -110,16 +110,16 @@ deno_core::extension!(deno_fetch,
   config = {
     options: Options,
   },
-  state = |state, cfg| {
-    state.put::<Options>(cfg.options.clone());
+  state = |state, options| {
+    state.put::<Options>(options.options.clone());
     state.put::<reqwest::Client>({
       create_http_client(
-        cfg.options.user_agent,
-        cfg.options.root_cert_store,
+        options.options.user_agent,
+        options.options.root_cert_store,
         vec![],
-        cfg.options.proxy,
-        cfg.options.unsafely_ignore_certificate_errors,
-        cfg.options.client_cert_chain_and_key
+        options.options.proxy,
+        options.options.unsafely_ignore_certificate_errors,
+        options.options.client_cert_chain_and_key
       )
       .unwrap()
     });

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -112,7 +112,7 @@ deno_core::extension!(deno_ffi,
     op_ffi_unsafe_callback_ref,
   ],
   esm = [ "00_ffi.js" ],
-  config = {
+  options = {
     unstable: bool,
   },
   state = |state, options| {

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -115,9 +115,9 @@ deno_core::extension!(deno_ffi,
   config = {
     unstable: bool,
   },
-  state = |state, unstable| {
+  state = |state, cfg| {
     // Stolen from deno_webgpu, is there a better option?
-    state.put(Unstable(unstable));
+    state.put(Unstable(cfg.unstable));
 
     let (async_work_sender, async_work_receiver) =
       mpsc::unbounded::<PendingFfiAsyncWork>();

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -115,9 +115,9 @@ deno_core::extension!(deno_ffi,
   config = {
     unstable: bool,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     // Stolen from deno_webgpu, is there a better option?
-    state.put(Unstable(cfg.unstable));
+    state.put(Unstable(options.unstable));
 
     let (async_work_sender, async_work_receiver) =
       mpsc::unbounded::<PendingFfiAsyncWork>();

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1559,7 +1559,7 @@ deno_core::extension!(deno_flash,
     op_try_flash_respond_chunked,
   ],
   esm = [ "01_http.js" ],
-  config = {
+  options = {
     unstable: bool,
   },
   state = |state, options| {

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1562,8 +1562,8 @@ deno_core::extension!(deno_flash,
   config = {
     unstable: bool,
   },
-  state = |state, unstable| {
-    state.put(Unstable(unstable));
+  state = |state, cfg| {
+    state.put(Unstable(cfg.unstable));
     state.put(FlashContext {
       next_server_id: 0,
       join_handles: HashMap::default(),

--- a/ext/flash/lib.rs
+++ b/ext/flash/lib.rs
@@ -1562,8 +1562,8 @@ deno_core::extension!(deno_flash,
   config = {
     unstable: bool,
   },
-  state = |state, cfg| {
-    state.put(Unstable(cfg.unstable));
+  state = |state, options| {
+    state.put(Unstable(options.unstable));
     state.put(FlashContext {
       next_server_id: 0,
       join_handles: HashMap::default(),

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -183,8 +183,8 @@ deno_core::extension!(deno_fs,
   config = {
     unstable: bool
   },
-  state = |state, unstable| {
-    state.put(UnstableChecker { unstable });
+  state = |state, cfg| {
+    state.put(UnstableChecker { unstable: cfg.unstable });
   },
 );
 

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -183,8 +183,8 @@ deno_core::extension!(deno_fs,
   config = {
     unstable: bool
   },
-  state = |state, cfg| {
-    state.put(UnstableChecker { unstable: cfg.unstable });
+  state = |state, options| {
+    state.put(UnstableChecker { unstable: options.unstable });
   },
 );
 

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -180,7 +180,7 @@ deno_core::extension!(deno_fs,
     op_readfile_text_async<P>,
   ],
   esm = [ "30_fs.js" ],
-  config = {
+  options = {
     unstable: bool
   },
   state = |state, options| {

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -80,7 +80,7 @@ deno_core::extension!(deno_io,
   deps = [ deno_web ],
   ops = [op_read_sync, op_write_sync],
   esm = [ "12_io.js" ],
-  config = {
+  options = {
     stdio: Option<Stdio>,
   },
   middleware = |op| match op.name {

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -87,8 +87,8 @@ deno_core::extension!(deno_io,
     "op_print" => op_print::decl(),
     _ => op,
   },
-  state = |state, cfg| {
-    if let Some(stdio) = cfg.stdio {
+  state = |state, options| {
+    if let Some(stdio) = options.stdio {
       let t = &mut state.resource_table;
 
       let rid = t.add(StdFileResource::stdio(

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -81,54 +81,52 @@ deno_core::extension!(deno_io,
   ops = [op_read_sync, op_write_sync],
   esm = [ "12_io.js" ],
   config = {
-    stdio: Rc<RefCell<Option<Stdio>>>,
+    stdio: Option<Stdio>,
   },
   middleware = |op| match op.name {
     "op_print" => op_print::decl(),
     _ => op,
   },
-  state = |state, stdio| {
-    let stdio = stdio
-      .borrow_mut()
-      .take()
-      .expect("Extension only supports being used once.");
-    let t = &mut state.resource_table;
+  state = |state, cfg| {
+    if let Some(stdio) = cfg.stdio {
+      let t = &mut state.resource_table;
 
-    let rid = t.add(StdFileResource::stdio(
-      match stdio.stdin {
-        StdioPipe::Inherit => StdFileResourceInner {
-          kind: StdFileResourceKind::Stdin,
-          file: STDIN_HANDLE.try_clone().unwrap(),
+      let rid = t.add(StdFileResource::stdio(
+        match stdio.stdin {
+          StdioPipe::Inherit => StdFileResourceInner {
+            kind: StdFileResourceKind::Stdin,
+            file: STDIN_HANDLE.try_clone().unwrap(),
+          },
+          StdioPipe::File(pipe) => StdFileResourceInner::file(pipe),
         },
-        StdioPipe::File(pipe) => StdFileResourceInner::file(pipe),
-      },
-      "stdin",
-    ));
-    assert_eq!(rid, 0, "stdin must have ResourceId 0");
+        "stdin",
+      ));
+      assert_eq!(rid, 0, "stdin must have ResourceId 0");
 
-    let rid = t.add(StdFileResource::stdio(
-      match stdio.stdout {
-        StdioPipe::Inherit => StdFileResourceInner {
-          kind: StdFileResourceKind::Stdout,
-          file: STDOUT_HANDLE.try_clone().unwrap(),
+      let rid = t.add(StdFileResource::stdio(
+        match stdio.stdout {
+          StdioPipe::Inherit => StdFileResourceInner {
+            kind: StdFileResourceKind::Stdout,
+            file: STDOUT_HANDLE.try_clone().unwrap(),
+          },
+          StdioPipe::File(pipe) => StdFileResourceInner::file(pipe),
         },
-        StdioPipe::File(pipe) => StdFileResourceInner::file(pipe),
-      },
-      "stdout",
-    ));
-    assert_eq!(rid, 1, "stdout must have ResourceId 1");
+        "stdout",
+      ));
+      assert_eq!(rid, 1, "stdout must have ResourceId 1");
 
-    let rid = t.add(StdFileResource::stdio(
-      match stdio.stderr {
-        StdioPipe::Inherit => StdFileResourceInner {
-          kind: StdFileResourceKind::Stderr,
-          file: STDERR_HANDLE.try_clone().unwrap(),
+      let rid = t.add(StdFileResource::stdio(
+        match stdio.stderr {
+          StdioPipe::Inherit => StdFileResourceInner {
+            kind: StdFileResourceKind::Stderr,
+            file: STDERR_HANDLE.try_clone().unwrap(),
+          },
+          StdioPipe::File(pipe) => StdFileResourceInner::file(pipe),
         },
-        StdioPipe::File(pipe) => StdFileResourceInner::file(pipe),
-      },
-      "stderr",
-    ));
-    assert_eq!(rid, 2, "stderr must have ResourceId 2");
+        "stderr",
+      ));
+      assert_eq!(rid, 2, "stderr must have ResourceId 2");
+    }
   },
 );
 

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -105,7 +105,7 @@ deno_core::extension!(deno_net,
     #[cfg(unix)] ops_unix::op_net_send_unixpacket<P>,
   ],
   esm = [ "01_net.js", "02_tls.js" ],
-  config = {
+  options = {
     root_cert_store: Option<RootCertStore>,
     unstable: bool,
     unsafely_ignore_certificate_errors: Option<Vec<String>>,

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -110,13 +110,13 @@ deno_core::extension!(deno_net,
     unstable: bool,
     unsafely_ignore_certificate_errors: Option<Vec<String>>,
   },
-  state = |state, root_cert_store, unstable, unsafely_ignore_certificate_errors| {
+  state = |state, cfg| {
     state.put(DefaultTlsOptions {
-      root_cert_store,
+      root_cert_store: cfg.root_cert_store,
     });
-    state.put(UnstableChecker { unstable });
+    state.put(UnstableChecker { unstable: cfg.unstable });
     state.put(UnsafelyIgnoreCertificateErrors(
-      unsafely_ignore_certificate_errors,
+      cfg.unsafely_ignore_certificate_errors,
     ));
   },
 );

--- a/ext/net/lib.rs
+++ b/ext/net/lib.rs
@@ -110,13 +110,13 @@ deno_core::extension!(deno_net,
     unstable: bool,
     unsafely_ignore_certificate_errors: Option<Vec<String>>,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put(DefaultTlsOptions {
-      root_cert_store: cfg.root_cert_store,
+      root_cert_store: options.root_cert_store,
     });
-    state.put(UnstableChecker { unstable: cfg.unstable });
+    state.put(UnstableChecker { unstable: options.unstable });
     state.put(UnsafelyIgnoreCertificateErrors(
-      cfg.unsafely_ignore_certificate_errors,
+      options.unsafely_ignore_certificate_errors,
     ));
   },
 );

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -370,7 +370,7 @@ deno_core::extension!(deno_node_loading,
     ops::op_require_break_on_next_statement,
   ],
   esm = ["01_node.js", "02_require.js", "module_es_shim.js"],
-  config = {
+  options = {
     maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
   },
   state = |state, options| {

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -373,8 +373,8 @@ deno_core::extension!(deno_node_loading,
   config = {
     maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
   },
-  state = |state, cfg| {
-    if let Some(npm_resolver) = cfg.maybe_npm_resolver {
+  state = |state, options| {
+    if let Some(npm_resolver) = options.maybe_npm_resolver {
       state.put(npm_resolver);
     }
   },

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -373,8 +373,8 @@ deno_core::extension!(deno_node_loading,
   config = {
     maybe_npm_resolver: Option<Rc<dyn RequireNpmResolver>>,
   },
-  state = |state, maybe_npm_resolver| {
-    if let Some(npm_resolver) = maybe_npm_resolver.clone() {
+  state = |state, cfg| {
+    if let Some(npm_resolver) = cfg.maybe_npm_resolver {
       state.put(npm_resolver);
     }
   },

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -113,9 +113,9 @@ deno_core::extension!(deno_web,
     blob_store: BlobStore,
     maybe_location: Option<Url>,
   },
-  state = |state, blob_store, maybe_location| {
-    state.put(blob_store);
-    if let Some(location) = maybe_location {
+  state = |state, cfg| {
+    state.put(cfg.blob_store);
+    if let Some(location) = cfg.maybe_location {
       state.put(Location(location));
     }
     state.put(StartTime::now());

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -109,7 +109,7 @@ deno_core::extension!(deno_web,
     "14_compression.js",
     "15_performance.js",
   ],
-  config = {
+  options = {
     blob_store: BlobStore,
     maybe_location: Option<Url>,
   },

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -113,9 +113,9 @@ deno_core::extension!(deno_web,
     blob_store: BlobStore,
     maybe_location: Option<Url>,
   },
-  state = |state, cfg| {
-    state.put(cfg.blob_store);
-    if let Some(location) = cfg.maybe_location {
+  state = |state, options| {
+    state.put(options.blob_store);
+    if let Some(location) = options.maybe_location {
       state.put(Location(location));
     }
     state.put(StartTime::now());

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -511,12 +511,12 @@ deno_core::extension!(deno_websocket,
     root_cert_store: Option<RootCertStore>,
     unsafely_ignore_certificate_errors: Option<Vec<String>>
   },
-  state = |state, cfg| {
-    state.put::<WsUserAgent>(WsUserAgent(cfg.user_agent));
+  state = |state, options| {
+    state.put::<WsUserAgent>(WsUserAgent(options.user_agent));
     state.put(UnsafelyIgnoreCertificateErrors(
-      cfg.unsafely_ignore_certificate_errors,
+      options.unsafely_ignore_certificate_errors,
     ));
-    state.put::<WsRootStore>(WsRootStore(cfg.root_cert_store));
+    state.put::<WsRootStore>(WsRootStore(options.root_cert_store));
   },
 );
 

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -511,12 +511,12 @@ deno_core::extension!(deno_websocket,
     root_cert_store: Option<RootCertStore>,
     unsafely_ignore_certificate_errors: Option<Vec<String>>
   },
-  state = |state, user_agent, root_cert_store, unsafely_ignore_certificate_errors| {
-    state.put::<WsUserAgent>(WsUserAgent(user_agent));
+  state = |state, cfg| {
+    state.put::<WsUserAgent>(WsUserAgent(cfg.user_agent));
     state.put(UnsafelyIgnoreCertificateErrors(
-      unsafely_ignore_certificate_errors,
+      cfg.unsafely_ignore_certificate_errors,
     ));
-    state.put::<WsRootStore>(WsRootStore(root_cert_store));
+    state.put::<WsRootStore>(WsRootStore(cfg.root_cert_store));
   },
 );
 

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -506,7 +506,7 @@ deno_core::extension!(deno_websocket,
     op_ws_next_event,
   ],
   esm = [ "01_websocket.js", "02_websocketstream.js" ],
-  config = {
+  options = {
     user_agent: String,
     root_cert_store: Option<RootCertStore>,
     unsafely_ignore_certificate_errors: Option<Vec<String>>

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -31,7 +31,7 @@ deno_core::extension!(deno_webstorage,
     op_webstorage_iterate_keys,
   ],
   esm = [ "01_webstorage.js" ],
-  config = {
+  options = {
     origin_storage_dir: Option<PathBuf>
   },
   state = |state, options| {

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -34,8 +34,8 @@ deno_core::extension!(deno_webstorage,
   config = {
     origin_storage_dir: Option<PathBuf>
   },
-  state = |state, origin_storage_dir| {
-    if let Some(origin_storage_dir) = origin_storage_dir {
+  state = |state, cfg| {
+    if let Some(origin_storage_dir) = cfg.origin_storage_dir {
       state.put(OriginStorageDir(origin_storage_dir));
     }
   },

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -34,8 +34,8 @@ deno_core::extension!(deno_webstorage,
   config = {
     origin_storage_dir: Option<PathBuf>
   },
-  state = |state, cfg| {
-    if let Some(origin_storage_dir) = cfg.origin_storage_dir {
+  state = |state, options| {
+    if let Some(origin_storage_dir) = options.origin_storage_dir {
       state.put(OriginStorageDir(origin_storage_dir));
     }
   },

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -17,9 +17,7 @@ mod startup_snapshot {
   use deno_core::snapshot_util::*;
   use deno_core::Extension;
   use deno_core::ExtensionFileSource;
-  use std::cell::RefCell;
   use std::path::Path;
-  use std::rc::Rc;
 
   fn transpile_ts_for_snapshotting(
     file_source: &ExtensionFileSource,
@@ -292,9 +290,7 @@ mod startup_snapshot {
       deno_tls::deno_tls::init_ops_and_esm(),
       deno_napi::deno_napi::init_ops_and_esm::<Permissions>(),
       deno_http::deno_http::init_ops_and_esm(),
-      deno_io::deno_io::init_ops_and_esm(Rc::new(RefCell::new(Some(
-        Default::default(),
-      )))),
+      deno_io::deno_io::init_ops_and_esm(Default::default()),
       deno_fs::deno_fs::init_ops_and_esm::<Permissions>(false),
       deno_flash::deno_flash::init_ops_and_esm::<Permissions>(false), // No --unstable
       runtime::init_ops_and_esm(),

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -46,7 +46,7 @@ deno_core::extension!(
     exit_code: ExitCode,
   },
   state = |state, options| {
-    state.put::<ExitCode>(cfg.exit_code);
+    state.put::<ExitCode>(options.exit_code);
   },
 );
 

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -42,7 +42,7 @@ deno_core::ops!(
 deno_core::extension!(
   deno_os,
   ops_fn = deno_ops,
-  config = {
+  options = {
     exit_code: ExitCode,
   },
   state = |state, options| {

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -45,7 +45,7 @@ deno_core::extension!(
   config = {
     exit_code: ExitCode,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put::<ExitCode>(cfg.exit_code);
   },
 );

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -45,8 +45,8 @@ deno_core::extension!(
   config = {
     exit_code: ExitCode,
   },
-  state = |state, exit_code| {
-    state.put::<ExitCode>(exit_code);
+  state = |state, cfg| {
+    state.put::<ExitCode>(cfg.exit_code);
   },
 );
 

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -10,8 +10,8 @@ deno_core::extension!(
   deno_runtime,
   ops = [op_main_module],
   config = { main_module: ModuleSpecifier },
-  state = |state, main_module| {
-    state.put::<ModuleSpecifier>(main_module);
+  state = |state, cfg| {
+    state.put::<ModuleSpecifier>(cfg.main_module);
   }
 );
 

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -9,7 +9,7 @@ use deno_core::OpState;
 deno_core::extension!(
   deno_runtime,
   ops = [op_main_module],
-  config = { main_module: ModuleSpecifier },
+  options = { main_module: ModuleSpecifier },
   state = |state, options| {
     state.put::<ModuleSpecifier>(options.main_module);
   }

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -10,7 +10,7 @@ deno_core::extension!(
   deno_runtime,
   ops = [op_main_module],
   config = { main_module: ModuleSpecifier },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put::<ModuleSpecifier>(cfg.main_module);
   }
 );

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -11,7 +11,7 @@ deno_core::extension!(
   ops = [op_main_module],
   config = { main_module: ModuleSpecifier },
   state = |state, options| {
-    state.put::<ModuleSpecifier>(cfg.main_module);
+    state.put::<ModuleSpecifier>(options.main_module);
   }
 );
 

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -102,21 +102,21 @@ deno_core::extension!(
     pre_execute_module_cb: Arc<WorkerEventCb>,
     format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
   },
-  state = |state, create_web_worker_cb, preload_module_cb, pre_execute_module_cb, format_js_error_fn| {
+  state = |state, cfg| {
     state.put::<WorkersTable>(WorkersTable::default());
     state.put::<WorkerId>(WorkerId::default());
 
     let create_web_worker_cb_holder =
-      CreateWebWorkerCbHolder(create_web_worker_cb.clone());
+      CreateWebWorkerCbHolder(cfg.create_web_worker_cb);
     state.put::<CreateWebWorkerCbHolder>(create_web_worker_cb_holder);
     let preload_module_cb_holder =
-      PreloadModuleCbHolder(preload_module_cb.clone());
+      PreloadModuleCbHolder(cfg.preload_module_cb);
     state.put::<PreloadModuleCbHolder>(preload_module_cb_holder);
     let pre_execute_module_cb_holder =
-      PreExecuteModuleCbHolder(pre_execute_module_cb.clone());
+      PreExecuteModuleCbHolder(cfg.pre_execute_module_cb);
     state.put::<PreExecuteModuleCbHolder>(pre_execute_module_cb_holder);
     let format_js_error_fn_holder =
-      FormatJsErrorFnHolder(format_js_error_fn.clone());
+      FormatJsErrorFnHolder(cfg.format_js_error_fn);
     state.put::<FormatJsErrorFnHolder>(format_js_error_fn_holder);
   }
 );

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -96,7 +96,7 @@ deno_core::extension!(
     op_host_recv_ctrl,
     op_host_recv_message,
   ],
-  config = {
+  options = {
     create_web_worker_cb: Arc<CreateWebWorkerCb>,
     preload_module_cb: Arc<WorkerEventCb>,
     pre_execute_module_cb: Arc<WorkerEventCb>,

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -107,16 +107,16 @@ deno_core::extension!(
     state.put::<WorkerId>(WorkerId::default());
 
     let create_web_worker_cb_holder =
-      CreateWebWorkerCbHolder(cfg.create_web_worker_cb);
+      CreateWebWorkerCbHolder(options.create_web_worker_cb);
     state.put::<CreateWebWorkerCbHolder>(create_web_worker_cb_holder);
     let preload_module_cb_holder =
-      PreloadModuleCbHolder(cfg.preload_module_cb);
+      PreloadModuleCbHolder(options.preload_module_cb);
     state.put::<PreloadModuleCbHolder>(preload_module_cb_holder);
     let pre_execute_module_cb_holder =
-      PreExecuteModuleCbHolder(cfg.pre_execute_module_cb);
+      PreExecuteModuleCbHolder(options.pre_execute_module_cb);
     state.put::<PreExecuteModuleCbHolder>(pre_execute_module_cb_holder);
     let format_js_error_fn_holder =
-      FormatJsErrorFnHolder(cfg.format_js_error_fn);
+      FormatJsErrorFnHolder(options.format_js_error_fn);
     state.put::<FormatJsErrorFnHolder>(format_js_error_fn_holder);
   }
 );

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -102,7 +102,7 @@ deno_core::extension!(
     pre_execute_module_cb: Arc<WorkerEventCb>,
     format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
   },
-  state = |state, cfg| {
+  state = |state, options| {
     state.put::<WorkersTable>(WorkersTable::default());
     state.put::<WorkerId>(WorkerId::default());
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -374,7 +374,7 @@ impl WebWorker {
         unstable: bool,
         enable_testing_features: bool,
       },
-      state = |state, cfg| {
+      state = |state, options| {
         state.put::<PermissionsContainer>(cfg.permissions);
         state.put(ops::UnstableChecker { unstable: cfg.unstable });
         state.put(ops::TestingFeaturesEnabled(cfg.enable_testing_features));

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -369,7 +369,7 @@ impl WebWorker {
     mut options: WebWorkerOptions,
   ) -> (Self, SendableWebWorkerHandle) {
     deno_core::extension!(deno_permissions_web_worker,
-      config = {
+      options = {
         permissions: PermissionsContainer,
         unstable: bool,
         enable_testing_features: bool,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -375,9 +375,9 @@ impl WebWorker {
         enable_testing_features: bool,
       },
       state = |state, options| {
-        state.put::<PermissionsContainer>(cfg.permissions);
-        state.put(ops::UnstableChecker { unstable: cfg.unstable });
-        state.put(ops::TestingFeaturesEnabled(cfg.enable_testing_features));
+        state.put::<PermissionsContainer>(options.permissions);
+        state.put(ops::UnstableChecker { unstable: options.unstable });
+        state.put(ops::TestingFeaturesEnabled(options.enable_testing_features));
       },
     );
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -374,10 +374,10 @@ impl WebWorker {
         unstable: bool,
         enable_testing_features: bool,
       },
-      state = |state, permissions, unstable, enable_testing_features| {
-        state.put::<PermissionsContainer>(permissions);
-        state.put(ops::UnstableChecker { unstable });
-        state.put(ops::TestingFeaturesEnabled(enable_testing_features));
+      state = |state, cfg| {
+        state.put::<PermissionsContainer>(cfg.permissions);
+        state.put(ops::UnstableChecker { unstable: cfg.unstable });
+        state.put(ops::TestingFeaturesEnabled(cfg.enable_testing_features));
       },
     );
 
@@ -432,7 +432,7 @@ impl WebWorker {
       deno_tls::deno_tls::init_ops(),
       deno_napi::deno_napi::init_ops::<PermissionsContainer>(),
       deno_http::deno_http::init_ops(),
-      deno_io::deno_io::init_ops(Rc::new(RefCell::new(Some(options.stdio)))),
+      deno_io::deno_io::init_ops(Some(options.stdio)),
       deno_fs::deno_fs::init_ops::<PermissionsContainer>(unstable),
       deno_flash::deno_flash::init_ops::<PermissionsContainer>(unstable),
       deno_node::deno_node_loading::init_ops::<PermissionsContainer>(

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -188,7 +188,7 @@ impl MainWorker {
     mut options: WorkerOptions,
   ) -> Self {
     deno_core::extension!(deno_permissions_worker,
-      config = {
+      options = {
         permissions: PermissionsContainer,
         unstable: bool,
         enable_testing_features: bool,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -193,7 +193,7 @@ impl MainWorker {
         unstable: bool,
         enable_testing_features: bool,
       },
-      state = |state, cfg| {
+      state = |state, options| {
         state.put::<PermissionsContainer>(cfg.permissions);
         state.put(ops::UnstableChecker { unstable: cfg.unstable });
         state.put(ops::TestingFeaturesEnabled(cfg.enable_testing_features));

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::atomic::AtomicI32;
@@ -194,10 +193,10 @@ impl MainWorker {
         unstable: bool,
         enable_testing_features: bool,
       },
-      state = |state, permissions, unstable, enable_testing_features| {
-        state.put::<PermissionsContainer>(permissions);
-        state.put(ops::UnstableChecker { unstable });
-        state.put(ops::TestingFeaturesEnabled(enable_testing_features));
+      state = |state, cfg| {
+        state.put::<PermissionsContainer>(cfg.permissions);
+        state.put(ops::UnstableChecker { unstable: cfg.unstable });
+        state.put(ops::TestingFeaturesEnabled(cfg.enable_testing_features));
       },
     );
 
@@ -255,7 +254,7 @@ impl MainWorker {
       deno_tls::deno_tls::init_ops(),
       deno_napi::deno_napi::init_ops::<PermissionsContainer>(),
       deno_http::deno_http::init_ops(),
-      deno_io::deno_io::init_ops(Rc::new(RefCell::new(Some(options.stdio)))),
+      deno_io::deno_io::init_ops(Some(options.stdio)),
       deno_fs::deno_fs::init_ops::<PermissionsContainer>(unstable),
       deno_flash::deno_flash::init_ops::<PermissionsContainer>(unstable),
       deno_node::deno_node_loading::init_ops::<PermissionsContainer>(

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -194,9 +194,9 @@ impl MainWorker {
         enable_testing_features: bool,
       },
       state = |state, options| {
-        state.put::<PermissionsContainer>(cfg.permissions);
-        state.put(ops::UnstableChecker { unstable: cfg.unstable });
-        state.put(ops::TestingFeaturesEnabled(cfg.enable_testing_features));
+        state.put::<PermissionsContainer>(options.permissions);
+        state.put(ops::UnstableChecker { unstable: options.unstable });
+        state.put(ops::TestingFeaturesEnabled(options.enable_testing_features));
       },
     );
 


### PR DESCRIPTION
Follow-up to #18210:

 * we are passing the generated `cfg` object into the state function rather than passing individual config fields
 * reduce cloning dramatically by making the state_fn `FnOnce`
 * `take` for `ExtensionBuilder` to avoid more unnecessary copies
