### PR TITLE
test(ext/node): add querystring_test.ts and readline_test.ts

### DIFF
--- a/cli/tests/unit_node/querystring_test.ts
+++ b/cli/tests/unit_node/querystring_test.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
+import { parse, stringify } from "node:querystring";
+
+Deno.test({
+  name: "stringify",
+  fn() {
+    assertEquals(
+      stringify({
+        a: "hello",
+        b: 5,
+        c: true,
+        d: ["foo", "bar"],
+      }),
+      "a=hello&b=5&c=true&d=foo&d=bar",
+    );
+  },
+});
+
+Deno.test({
+  name: "parse",
+  fn() {
+    assertEquals(parse("a=hello&b=5&c=true&d=foo&d=bar"), {
+      a: "hello",
+      b: "5",
+      c: "true",
+      d: ["foo", "bar"],
+    });
+  },
+});

--- a/cli/tests/unit_node/readline_test.ts
+++ b/cli/tests/unit_node/readline_test.ts
@@ -1,0 +1,14 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { createInterface, Interface } from "node:readline";
+import { assertInstanceOf } from "../../../test_util/std/testing/asserts.ts";
+import { Readable, Writable } from "node:stream";
+
+Deno.test("[node/readline] createInstance", () => {
+  const rl = createInterface({
+    input: new Readable({ read() {} }),
+    output: new Writable(),
+  });
+
+  // deno-lint-ignore no-explicit-any
+  assertInstanceOf(rl, Interface as any);
+});


### PR DESCRIPTION
This PR ports `querystring_test.ts` and `readline_test.ts` from `std/node`.

part of #17840
