### PR TITLE
ci: don't use shell with hyperfine

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -182,6 +182,9 @@ fn run_exec_time(
     benchmark_file,
     "--warmup",
     "3",
+    // don't use shell
+    "-S",
+    "none",
   ]
   .iter()
   .map(|s| s.to_string())


### PR DESCRIPTION
According to @mmastrac this should give less noisy results.