### PR TITLE
refactor(ext/node): make initialization functions sync

### DIFF
--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -507,8 +507,7 @@ impl ReplSession {
         deno_node::initialize_runtime(
           &mut self.worker.js_runtime,
           self.proc_state.options.has_node_modules_dir(),
-        )
-        .await?;
+        )?;
         self.has_initialized_node_runtime = true;
       }
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -67,7 +67,7 @@ impl CliMainWorker {
     log::debug!("main_module {}", self.main_module);
 
     if self.is_main_cjs {
-      self.initialize_main_module_for_node().await?;
+      self.initialize_main_module_for_node()?;
       deno_node::load_cjs_module(
         &mut self.worker.js_runtime,
         &self.main_module.to_file_path().unwrap().to_string_lossy(),
@@ -295,17 +295,16 @@ impl CliMainWorker {
   ) -> Result<(), AnyError> {
     if self.ps.npm_resolver.has_packages() || self.ps.graph().has_node_specifier
     {
-      self.initialize_main_module_for_node().await?;
+      self.initialize_main_module_for_node()?;
     }
     self.worker.evaluate_module(id).await
   }
 
-  async fn initialize_main_module_for_node(&mut self) -> Result<(), AnyError> {
+  fn initialize_main_module_for_node(&mut self) -> Result<(), AnyError> {
     deno_node::initialize_runtime(
       &mut self.worker.js_runtime,
       self.ps.options.has_node_modules_dir(),
-    )
-    .await?;
+    )?;
     if let DenoSubcommand::Run(flags) = self.ps.options.sub_command() {
       if let Ok(pkg_ref) = NpmPackageReqReference::from_str(&flags.script) {
         // if the user ran a binary command, we'll need to set process.argv[0]
@@ -317,8 +316,7 @@ impl CliMainWorker {
         deno_node::initialize_binary_command(
           &mut self.worker.js_runtime,
           binary_name,
-        )
-        .await?;
+        )?;
       }
     }
     Ok(())
@@ -629,8 +627,7 @@ fn create_web_worker_pre_execute_module_callback(
         deno_node::initialize_runtime(
           &mut worker.js_runtime,
           ps.options.has_node_modules_dir(),
-        )
-        .await?;
+        )?;
       }
 
       Ok(worker)

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -383,12 +383,12 @@ deno_core::extension!(deno_node_loading,
   },
 );
 
-pub async fn initialize_runtime(
+pub fn initialize_runtime(
   js_runtime: &mut JsRuntime,
   uses_local_node_modules_dir: bool,
 ) -> Result<(), AnyError> {
   let source_code = &format!(
-    r#"(async function loadBuiltinNodeModules(nodeGlobalThisName, usesLocalNodeModulesDir) {{
+    r#"(function loadBuiltinNodeModules(nodeGlobalThisName, usesLocalNodeModulesDir) {{
       Deno[Deno.internal].node.initialize(Deno[Deno.internal].nodeModuleAll, nodeGlobalThisName);
       if (usesLocalNodeModulesDir) {{
         Deno[Deno.internal].require.setUsesLocalNodeModulesDir();
@@ -398,9 +398,7 @@ pub async fn initialize_runtime(
     uses_local_node_modules_dir,
   );
 
-  let value =
-    js_runtime.execute_script(&located_script_name!(), source_code)?;
-  js_runtime.resolve_value(value).await?;
+  js_runtime.execute_script(&located_script_name!(), source_code)?;
   Ok(())
 }
 
@@ -430,13 +428,13 @@ pub fn load_cjs_module(
   Ok(())
 }
 
-pub async fn initialize_binary_command(
+pub fn initialize_binary_command(
   js_runtime: &mut JsRuntime,
   binary_name: &str,
 ) -> Result<(), AnyError> {
   // overwrite what's done in deno_std in order to set the binary arg name
   let source_code = &format!(
-    r#"(async function initializeBinaryCommand(binaryName) {{
+    r#"(function initializeBinaryCommand(binaryName) {{
       const process = Deno[Deno.internal].node.globalThis.process;
       Object.defineProperty(process.argv, "0", {{
         get: () => binaryName,
@@ -444,8 +442,6 @@ pub async fn initialize_binary_command(
     }})('{binary_name}');"#,
   );
 
-  let value =
-    js_runtime.execute_script(&located_script_name!(), source_code)?;
-  js_runtime.resolve_value(value).await?;
+  js_runtime.execute_script(&located_script_name!(), source_code)?;
   Ok(())
 }


### PR DESCRIPTION
These functions don't need to be async, as they are only calling
synchronous JavaScript code. As a follow up, all 3 functions
should be merge together - this will reduce roundtrips for
calling V8 from Rust, which is somewhat expensive