### PR TITLE
chore(ext/console): inspect anonymous function as `[Function (anonymous)]`

### DIFF
--- a/cli/tests/testdata/npm/esm_import_cjs_default/main.out
+++ b/cli/tests/testdata/npm/esm_import_cjs_default/main.out
@@ -1,28 +1,44 @@
 Node esm importing node cjs
 ===========================
-{ default: [Function], named: [Function], MyClass: [Class: MyClass] }
-{ default: [Function], named: [Function] }
+{
+  default: [Function (anonymous)],
+  named: [Function (anonymous)],
+  MyClass: [Class: MyClass]
+}
+{ default: [Function (anonymous)], named: [Function (anonymous)] }
 Module {
   MyClass: [Class: MyClass],
   __esModule: true,
-  default: { default: [Function], named: [Function], MyClass: [Class: MyClass] },
-  named: [Function]
+  default: {
+    default: [Function (anonymous)],
+    named: [Function (anonymous)],
+    MyClass: [Class: MyClass]
+  },
+  named: [Function (anonymous)]
 }
 Module {
   __esModule: true,
-  default: { default: [Function], named: [Function] },
-  named: [Function]
+  default: { default: [Function (anonymous)], named: [Function (anonymous)] },
+  named: [Function (anonymous)]
 }
 ===========================
 static method
 Deno esm importing node cjs
 ===========================
-{ default: [Function], named: [Function], MyClass: [Class: MyClass] }
+{
+  default: [Function (anonymous)],
+  named: [Function (anonymous)],
+  MyClass: [Class: MyClass]
+}
 Module {
   MyClass: [Class: MyClass],
   __esModule: true,
-  default: { default: [Function], named: [Function], MyClass: [Class: MyClass] },
-  named: [Function]
+  default: {
+    default: [Function (anonymous)],
+    named: [Function (anonymous)],
+    MyClass: [Class: MyClass]
+  },
+  named: [Function (anonymous)]
 }
 ===========================
 Deno esm importing node esm

--- a/cli/tests/testdata/run/fix_emittable_skipped.ts.out
+++ b/cli/tests/testdata/run/fix_emittable_skipped.ts.out
@@ -1,2 +1,2 @@
 [WILDCARD]
-[Function]
+[Function (anonymous)]

--- a/cli/tests/testdata/run/with_package_json/no_deno_json/main.out
+++ b/cli/tests/testdata/run/with_package_json/no_deno_json/main.out
@@ -5,7 +5,7 @@ ok
   constructor: [Function (anonymous)],
   Instance: [Class: ChalkClass],
   supportsColor: false,
-  stderr: [Chalk] {
+  stderr: [Chalk (anonymous)] {
     constructor: [Function (anonymous)],
     Instance: [Class: ChalkClass],
     supportsColor: false

--- a/cli/tests/testdata/run/with_package_json/no_deno_json/main.out
+++ b/cli/tests/testdata/run/with_package_json/no_deno_json/main.out
@@ -1,9 +1,13 @@
 [WILDCARD]package.json file found at '[WILDCARD]with_package_json[WILDCARD]package.json'
 [WILDCARD]
 ok
-[Chalk] {
-  constructor: [Function],
+[Chalk (anonymous)] {
+  constructor: [Function (anonymous)],
   Instance: [Class: ChalkClass],
   supportsColor: false,
-  stderr: [Chalk] { constructor: [Function], Instance: [Class: ChalkClass], supportsColor: false }
+  stderr: [Chalk] {
+    constructor: [Function (anonymous)],
+    Instance: [Class: ChalkClass],
+    supportsColor: false
+  }
 }

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -236,7 +236,7 @@ Deno.test(function consoleTestStringifyCircular() {
   nu: null,
   arrowFunc: [Function: arrowFunc],
   extendedClass: Extended { a: 1, b: 2 },
-  nFunc: [Function],
+  nFunc: [Function (anonymous)],
   extendedCstr: [Class: Extended],
   o: {
     num: 2,
@@ -395,7 +395,13 @@ Deno.test(function consoleTestStringifyFunctionWithProperties() {
   assertEquals(
     stringify({ f }),
     `{
-  f: [Function: f] { x: [Function], y: 3, z: [Function], b: [Function: bar], a: Map {} }
+  f: [Function: f] {
+    x: [Function (anonymous)],
+    y: 3,
+    z: [Function (anonymous)],
+    b: [Function: bar],
+    a: Map {}
+  }
 }`,
   );
 
@@ -407,9 +413,9 @@ Deno.test(function consoleTestStringifyFunctionWithProperties() {
     stringify({ f }),
     `{
   f: <ref *1> [Function: f] {
-    x: [Function],
+    x: [Function (anonymous)],
     y: 3,
-    z: [Function],
+    z: [Function (anonymous)],
     b: [Function: bar],
     a: Map {},
     s: [Circular *1],
@@ -2168,3 +2174,12 @@ Deno.test(function inspectQuotesOverride() {
     `"'foo'"`,
   );
 });
+
+Deno.test(function inspectAnonymousFunctions() {
+  assertEquals(Deno.inspect(() => {}), "[Function (anonymous)]");
+  assertEquals(Deno.inspect(function () {}), "[Function (anonymous)]");
+  assertEquals(Deno.inspect(async () => {}), "[AsyncFunction (anonymous)]");
+  assertEquals(Deno.inspect(async function () {}), "[AsyncFunction (anonymous)]");
+  assertEquals(Deno.inspect(function *() {}), "[GeneratorFunction (anonymous)]");
+  assertEquals(Deno.inspect(async function *() {}), "[AsyncGeneratorFunction (anonymous)]");
+})

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -2179,7 +2179,16 @@ Deno.test(function inspectAnonymousFunctions() {
   assertEquals(Deno.inspect(() => {}), "[Function (anonymous)]");
   assertEquals(Deno.inspect(function () {}), "[Function (anonymous)]");
   assertEquals(Deno.inspect(async () => {}), "[AsyncFunction (anonymous)]");
-  assertEquals(Deno.inspect(async function () {}), "[AsyncFunction (anonymous)]");
-  assertEquals(Deno.inspect(function *() {}), "[GeneratorFunction (anonymous)]");
-  assertEquals(Deno.inspect(async function *() {}), "[AsyncGeneratorFunction (anonymous)]");
-})
+  assertEquals(
+    Deno.inspect(async function () {}),
+    "[AsyncFunction (anonymous)]",
+  );
+  assertEquals(
+    Deno.inspect(function* () {}),
+    "[GeneratorFunction (anonymous)]",
+  );
+  assertEquals(
+    Deno.inspect(async function* () {}),
+    "[AsyncGeneratorFunction (anonymous)]",
+  );
+});

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -390,7 +390,7 @@ function inspectFunction(value, inspectOptions) {
     // from MDN spec
     return cyan(`${refStr}[${cstrName}: ${value.name}]`) + suffix;
   }
-  return cyan(`${refStr}[${cstrName}]`) + suffix;
+  return cyan(`${refStr}[${cstrName} (anonymous)]`) + suffix;
 }
 
 function inspectIterable(


### PR DESCRIPTION
This PR changes the inspect result of anonymous functions from `[Function]` to `[Function (anonymous)]`.

This behavior is aligned to `util.inspect` of Node.js and this change prepares for unifying `Deno.inspect` and `util.inspect`. ref https://github.com/denoland/deno/pull/17960