### PR TITLE
perf(core) Reduce script name and content copies

### DIFF
--- a/bench_util/js_runtime.rs
+++ b/bench_util/js_runtime.rs
@@ -103,7 +103,8 @@ pub fn bench_js_async_with(
     opts.benching_inner
   };
   let looped = loop_code(inner_iters, src);
-  let src = looped.as_ref();
+  // Get a &'static str by leaking -- this is fine because it's benchmarking code
+  let src = Box::leak(looped.into_boxed_str());
   if is_profiling() {
     for _ in 0..opts.profiling_outer {
       tokio_runtime.block_on(inner_async(src, &mut runtime));
@@ -115,7 +116,7 @@ pub fn bench_js_async_with(
   }
 }
 
-async fn inner_async(src: &str, runtime: &mut JsRuntime) {
+async fn inner_async(src: &'static str, runtime: &mut JsRuntime) {
   runtime.execute_script("inner_loop", src).unwrap();
   runtime.run_event_loop(false).await.unwrap();
 }

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -5,6 +5,7 @@ use crate::cache::FastInsecureHasher;
 use crate::cache::ParsedSourceCache;
 
 use deno_core::error::AnyError;
+use deno_core::ModuleCode;
 use deno_core::ModuleSpecifier;
 use deno_graph::MediaType;
 use std::sync::Arc;
@@ -27,11 +28,11 @@ pub fn emit_parsed_source(
   source: &Arc<str>,
   emit_options: &deno_ast::EmitOptions,
   emit_config_hash: u64,
-) -> Result<String, AnyError> {
+) -> Result<ModuleCode, AnyError> {
   let source_hash = get_source_hash(source, emit_config_hash);
 
   if let Some(emit_code) = emit_cache.get_emit_code(specifier, source_hash) {
-    Ok(emit_code)
+    Ok(emit_code.into())
   } else {
     // this will use a cached version if it exists
     let parsed_source = parsed_source_cache.get_or_parse_module(
@@ -42,6 +43,6 @@ pub fn emit_parsed_source(
     let transpiled_source = parsed_source.transpile(emit_options)?;
     debug_assert!(transpiled_source.source_map.is_none());
     emit_cache.set_emit_code(specifier, source_hash, &transpiled_source.text);
-    Ok(transpiled_source.text)
+    Ok(transpiled_source.text.into())
   }
 }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2854,7 +2854,7 @@ fn start(runtime: &mut JsRuntime, debug: bool) -> Result<(), AnyError> {
   let init_config = json!({ "debug": debug });
   let init_src = format!("globalThis.serverInit({init_config});");
 
-  runtime.execute_script(&located_script_name!(), &init_src)?;
+  runtime.execute_script(&located_script_name!(), init_src)?;
   Ok(())
 }
 
@@ -3442,7 +3442,7 @@ pub fn request(
   };
   let mark = performance.mark("request", Some(request_params.clone()));
   let request_src = format!("globalThis.serverRequest({request_params});");
-  runtime.execute_script(&located_script_name!(), &request_src)?;
+  runtime.execute_script(&located_script_name!(), request_src)?;
 
   let op_state = runtime.op_state();
   let mut op_state = op_state.borrow_mut();

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2854,7 +2854,7 @@ fn start(runtime: &mut JsRuntime, debug: bool) -> Result<(), AnyError> {
   let init_config = json!({ "debug": debug });
   let init_src = format!("globalThis.serverInit({init_config});");
 
-  runtime.execute_script(&located_script_name!(), init_src)?;
+  runtime.execute_script(located_script_name!(), init_src)?;
   Ok(())
 }
 
@@ -3442,7 +3442,7 @@ pub fn request(
   };
   let mark = performance.mark("request", Some(request_params.clone()));
   let request_src = format!("globalThis.serverRequest({request_params});");
-  runtime.execute_script(&located_script_name!(), request_src)?;
+  runtime.execute_script(located_script_name!(), request_src)?;
 
   let op_state = runtime.op_state();
   let mut op_state = op_state.borrow_mut();

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -136,7 +136,7 @@ impl CliModuleLoader {
         self.ps.parsed_source_cache.free(specifier);
 
         Ok(ModuleCodeSource {
-          code: code.into(),
+          code,
           found_url: specifier.clone(),
           media_type: *media_type,
         })

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -14,6 +14,7 @@ use deno_core::error::AnyError;
 use deno_core::futures::future::FutureExt;
 use deno_core::futures::Future;
 use deno_core::resolve_url;
+use deno_core::ModuleCode;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSource;
 use deno_core::ModuleSpecifier;
@@ -30,7 +31,7 @@ use std::rc::Rc;
 use std::str;
 
 struct ModuleCodeSource {
-  pub code: String,
+  pub code: ModuleCode,
   pub found_url: ModuleSpecifier,
   pub media_type: MediaType,
 }
@@ -91,7 +92,7 @@ impl CliModuleLoader {
         specifier,
         ..
       })) => Ok(ModuleCodeSource {
-        code: source.to_string(),
+        code: source.into(),
         found_url: specifier.clone(),
         media_type: *media_type,
       }),
@@ -101,13 +102,15 @@ impl CliModuleLoader {
         specifier,
         ..
       })) => {
-        let code = match media_type {
+        let code: ModuleCode = match media_type {
           MediaType::JavaScript
           | MediaType::Unknown
           | MediaType::Cjs
           | MediaType::Mjs
-          | MediaType::Json => source.to_string(),
-          MediaType::Dts | MediaType::Dcts | MediaType::Dmts => "".to_string(),
+          | MediaType::Json => source.into(),
+          MediaType::Dts | MediaType::Dcts | MediaType::Dmts => {
+            Default::default()
+          }
           MediaType::TypeScript
           | MediaType::Mts
           | MediaType::Cts
@@ -133,7 +136,7 @@ impl CliModuleLoader {
         self.ps.parsed_source_cache.free(specifier);
 
         Ok(ModuleCodeSource {
-          code,
+          code: code.into(),
           found_url: specifier.clone(),
           media_type: *media_type,
         })
@@ -191,7 +194,7 @@ impl CliModuleLoader {
         )?
       };
       ModuleCodeSource {
-        code,
+        code: code.into(),
         found_url: specifier.clone(),
         media_type: MediaType::from_specifier(specifier),
       }
@@ -208,7 +211,7 @@ impl CliModuleLoader {
       code_without_source_map(code_source.code)
     };
     Ok(ModuleSource {
-      code: code.into_bytes().into_boxed_slice(),
+      code,
       module_url_specified: specifier.to_string(),
       module_url_found: code_source.found_url.to_string(),
       module_type: match code_source.media_type {

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -178,7 +178,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
     async move {
       if let Some((source, _)) = is_data_uri {
         return Ok(deno_core::ModuleSource {
-          code: source.into_bytes().into_boxed_slice(),
+          code: source.into(),
           module_type: deno_core::ModuleType::JavaScript,
           module_url_specified: module_specifier.to_string(),
           module_url_found: module_specifier.to_string(),
@@ -192,7 +192,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
         .to_owned();
 
       Ok(deno_core::ModuleSource {
-        code: code.into_bytes().into_boxed_slice(),
+        code: code.into(),
         module_type: match module.kind {
           eszip::ModuleKind::JavaScript => deno_core::ModuleType::JavaScript,
           eszip::ModuleKind::Json => deno_core::ModuleType::Json,

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -384,16 +384,16 @@ pub async fn run(
     options,
   );
   worker.execute_main_module(main_module).await?;
-  worker.dispatch_load_event(&located_script_name!())?;
+  worker.dispatch_load_event(located_script_name!())?;
 
   loop {
     worker.run_event_loop(false).await?;
-    if !worker.dispatch_beforeunload_event(&located_script_name!())? {
+    if !worker.dispatch_beforeunload_event(located_script_name!())? {
       break;
     }
   }
 
-  worker.dispatch_unload_event(&located_script_name!())?;
+  worker.dispatch_unload_event(located_script_name!())?;
   std::process::exit(0);
 }
 

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -714,7 +714,7 @@ pub async fn cover_files(
     let source_map = source_map_from_code(&transpiled_code);
     let coverage_report = generate_coverage_report(
       &script_coverage,
-      transpiled_code.to_string(),
+      transpiled_code.take_as_string(),
       &source_map,
       &out_mode,
     );

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -20,6 +20,7 @@ use deno_core::serde_json;
 use deno_core::sourcemap::SourceMap;
 use deno_core::url::Url;
 use deno_core::LocalInspectorSession;
+use deno_core::ModuleCode;
 use regex::Regex;
 use std::fs;
 use std::fs::File;
@@ -170,16 +171,16 @@ struct CoverageReport {
 
 fn generate_coverage_report(
   script_coverage: &ScriptCoverage,
-  script_source: &str,
+  script_source: String,
   maybe_source_map: &Option<Vec<u8>>,
   output: &Option<PathBuf>,
 ) -> CoverageReport {
   let maybe_source_map = maybe_source_map
     .as_ref()
     .map(|source_map| SourceMap::from_slice(source_map).unwrap());
-  let text_lines = TextLines::new(script_source);
+  let text_lines = TextLines::new(&script_source);
 
-  let comment_ranges = deno_ast::lex(script_source, MediaType::JavaScript)
+  let comment_ranges = deno_ast::lex(&script_source, MediaType::JavaScript)
     .into_iter()
     .filter(|item| {
       matches!(item.inner, deno_ast::TokenOrComment::Comment { .. })
@@ -680,14 +681,14 @@ pub async fn cover_files(
     })?;
 
     // Check if file was transpiled
-    let original_source = &file.source;
-    let transpiled_code = match file.media_type {
+    let original_source = file.source.clone();
+    let transpiled_code: ModuleCode = match file.media_type {
       MediaType::JavaScript
       | MediaType::Unknown
       | MediaType::Cjs
       | MediaType::Mjs
-      | MediaType::Json => file.source.as_ref().to_string(),
-      MediaType::Dts | MediaType::Dmts | MediaType::Dcts => "".to_string(),
+      | MediaType::Json => file.source.into(),
+      MediaType::Dts | MediaType::Dmts | MediaType::Dcts => Default::default(),
       MediaType::TypeScript
       | MediaType::Jsx
       | MediaType::Mts
@@ -695,7 +696,7 @@ pub async fn cover_files(
       | MediaType::Tsx => {
         let source_hash = get_source_hash(&file.source, ps.emit_options_hash);
         match ps.emit_cache.get_emit_code(&file.specifier, source_hash) {
-          Some(code) => code,
+          Some(code) => code.into(),
           None => {
             return Err(anyhow!(
               "Missing transpiled source code for: \"{}\".
@@ -710,15 +711,16 @@ pub async fn cover_files(
       }
     };
 
+    let source_map = source_map_from_code(&transpiled_code);
     let coverage_report = generate_coverage_report(
       &script_coverage,
-      &transpiled_code,
-      &source_map_from_code(&transpiled_code),
+      transpiled_code.to_string(),
+      &source_map,
       &out_mode,
     );
 
     if !coverage_report.found_lines.is_empty() {
-      reporter.report(&coverage_report, original_source)?;
+      reporter.report(&coverage_report, &original_source)?;
     }
   }
 

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -823,7 +823,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
   runtime
     .execute_script(&located_script_name!(), startup_source)
     .context("Could not properly start the compiler runtime.")?;
-  runtime.execute_script(&located_script_name!(), &exec_source)?;
+  runtime.execute_script(&located_script_name!(), exec_source)?;
 
   let op_state = runtime.op_state();
   let mut op_state = op_state.borrow_mut();

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -821,9 +821,9 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
   });
 
   runtime
-    .execute_script(&located_script_name!(), startup_source)
+    .execute_script(located_script_name!(), startup_source)
     .context("Could not properly start the compiler runtime.")?;
-  runtime.execute_script(&located_script_name!(), exec_source)?;
+  runtime.execute_script(located_script_name!(), exec_source)?;
 
   let op_state = runtime.op_state();
   let mut op_state = op_state.borrow_mut();

--- a/cli/util/text_encoding.rs
+++ b/cli/util/text_encoding.rs
@@ -159,7 +159,7 @@ mod tests {
     );
 
     fn run_test(input: &'static str, output: &'static str) {
-      assert_eq!(code_without_source_map(input.into()).to_string(), output);
+      assert_eq!(code_without_source_map(input.into()).take_as_string(), output);
     }
   }
 }

--- a/cli/util/text_encoding.rs
+++ b/cli/util/text_encoding.rs
@@ -159,7 +159,10 @@ mod tests {
     );
 
     fn run_test(input: &'static str, output: &'static str) {
-      assert_eq!(code_without_source_map(input.into()).take_as_string(), output);
+      assert_eq!(
+        code_without_source_map(input.into()).take_as_string(),
+        output
+      );
     }
   }
 }

--- a/cli/util/text_encoding.rs
+++ b/cli/util/text_encoding.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::ModuleCode;
 use encoding_rs::*;
 use std::borrow::Cow;
 use std::io::Error;
@@ -53,11 +54,12 @@ pub fn strip_bom(text: &str) -> &str {
   }
 }
 
-static SOURCE_MAP_PREFIX: &str =
-  "//# sourceMappingURL=data:application/json;base64,";
+static SOURCE_MAP_PREFIX: &[u8] =
+  b"//# sourceMappingURL=data:application/json;base64,";
 
-pub fn source_map_from_code(code: &str) -> Option<Vec<u8>> {
-  let last_line = code.rsplit(|u| u == '\n').next()?;
+pub fn source_map_from_code(code: &ModuleCode) -> Option<Vec<u8>> {
+  let bytes = code.as_bytes();
+  let last_line = bytes.rsplit(|u| *u == b'\n').next()?;
   if last_line.starts_with(SOURCE_MAP_PREFIX) {
     let input = last_line.split_at(SOURCE_MAP_PREFIX.len()).1;
     let decoded_map = base64::decode(input)
@@ -68,17 +70,18 @@ pub fn source_map_from_code(code: &str) -> Option<Vec<u8>> {
   }
 }
 
-pub fn code_without_source_map(mut code: String) -> String {
-  if let Some(last_line_index) = code.rfind('\n') {
-    if code[last_line_index + 1..].starts_with(SOURCE_MAP_PREFIX) {
-      code.truncate(last_line_index + 1);
-      code
-    } else {
-      code
+/// Truncate the source code before the source map.
+pub fn code_without_source_map(mut code: ModuleCode) -> ModuleCode {
+  let bytes = code.as_bytes();
+  for i in (0..bytes.len()).rev() {
+    if bytes[i] == b'\n' {
+      if bytes[i + 1..].starts_with(SOURCE_MAP_PREFIX) {
+        code.truncate(i + 1);
+      }
+      return code;
     }
-  } else {
-    code
   }
+  code
 }
 
 #[cfg(test)]
@@ -155,8 +158,8 @@ mod tests {
       "\n",
     );
 
-    fn run_test(input: &str, output: &str) {
-      assert_eq!(code_without_source_map(input.to_string()), output);
+    fn run_test(input: &'static str, output: &'static str) {
+      assert_eq!(code_without_source_map(input.into()).to_string(), output);
     }
   }
 }

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -78,7 +78,7 @@ impl CliMainWorker {
       self.execute_main_module_possibly_with_npm().await?;
     }
 
-    self.worker.dispatch_load_event(&located_script_name!())?;
+    self.worker.dispatch_load_event(located_script_name!())?;
 
     loop {
       self
@@ -87,13 +87,13 @@ impl CliMainWorker {
         .await?;
       if !self
         .worker
-        .dispatch_beforeunload_event(&located_script_name!())?
+        .dispatch_beforeunload_event(located_script_name!())?
       {
         break;
       }
     }
 
-    self.worker.dispatch_unload_event(&located_script_name!())?;
+    self.worker.dispatch_unload_event(located_script_name!())?;
 
     if let Some(coverage_collector) = maybe_coverage_collector.as_mut() {
       self
@@ -129,7 +129,7 @@ impl CliMainWorker {
         self
           .inner
           .worker
-          .dispatch_load_event(&located_script_name!())?;
+          .dispatch_load_event(located_script_name!())?;
         self.pending_unload = true;
 
         let result = loop {
@@ -140,7 +140,7 @@ impl CliMainWorker {
           match self
             .inner
             .worker
-            .dispatch_beforeunload_event(&located_script_name!())
+            .dispatch_beforeunload_event(located_script_name!())
           {
             Ok(default_prevented) if default_prevented => {} // continue loop
             Ok(_) => break Ok(()),
@@ -154,7 +154,7 @@ impl CliMainWorker {
         self
           .inner
           .worker
-          .dispatch_unload_event(&located_script_name!())?;
+          .dispatch_unload_event(located_script_name!())?;
 
         Ok(())
       }
@@ -166,7 +166,7 @@ impl CliMainWorker {
           let _ = self
             .inner
             .worker
-            .dispatch_unload_event(&located_script_name!());
+            .dispatch_unload_event(located_script_name!());
         }
       }
     }
@@ -185,7 +185,7 @@ impl CliMainWorker {
     // failures.
     if self.ps.options.trace_ops() {
       self.worker.js_runtime.execute_script(
-        &located_script_name!(),
+        located_script_name!(),
         "Deno[Deno.internal].core.enableOpCallTracing();",
       )?;
     }
@@ -200,19 +200,19 @@ impl CliMainWorker {
       self.execute_side_module_possibly_with_npm().await?;
     }
 
-    self.worker.dispatch_load_event(&located_script_name!())?;
+    self.worker.dispatch_load_event(located_script_name!())?;
     self.run_tests(&self.ps.options.shuffle_tests()).await?;
     loop {
       if !self
         .worker
-        .dispatch_beforeunload_event(&located_script_name!())?
+        .dispatch_beforeunload_event(located_script_name!())?
       {
         break;
       }
       self.worker.run_event_loop(false).await?;
     }
 
-    self.worker.dispatch_unload_event(&located_script_name!())?;
+    self.worker.dispatch_unload_event(located_script_name!())?;
 
     if let Some(coverage_collector) = maybe_coverage_collector.as_mut() {
       self
@@ -230,7 +230,7 @@ impl CliMainWorker {
     self.enable_test();
 
     self.worker.execute_script(
-      &located_script_name!(),
+      located_script_name!(),
       "Deno[Deno.internal].core.enableOpCallTracing();",
     )?;
 
@@ -239,18 +239,18 @@ impl CliMainWorker {
       self.execute_side_module_possibly_with_npm().await?;
     }
 
-    self.worker.dispatch_load_event(&located_script_name!())?;
+    self.worker.dispatch_load_event(located_script_name!())?;
     self.run_tests(&None).await?;
     loop {
       if !self
         .worker
-        .dispatch_beforeunload_event(&located_script_name!())?
+        .dispatch_beforeunload_event(located_script_name!())?
       {
         break;
       }
       self.worker.run_event_loop(false).await?;
     }
-    self.worker.dispatch_unload_event(&located_script_name!())?;
+    self.worker.dispatch_unload_event(located_script_name!())?;
     Ok(())
   }
 
@@ -260,18 +260,18 @@ impl CliMainWorker {
     // We execute the module module as a side module so that import.meta.main is not set.
     self.execute_side_module_possibly_with_npm().await?;
 
-    self.worker.dispatch_load_event(&located_script_name!())?;
+    self.worker.dispatch_load_event(located_script_name!())?;
     self.run_benchmarks().await?;
     loop {
       if !self
         .worker
-        .dispatch_beforeunload_event(&located_script_name!())?
+        .dispatch_beforeunload_event(located_script_name!())?
       {
         break;
       }
       self.worker.run_event_loop(false).await?;
     }
-    self.worker.dispatch_unload_event(&located_script_name!())?;
+    self.worker.dispatch_unload_event(located_script_name!())?;
     Ok(())
   }
 

--- a/core/examples/eval_js_value.rs
+++ b/core/examples/eval_js_value.rs
@@ -26,7 +26,7 @@ fn main() {
 
 fn eval(
   context: &mut JsRuntime,
-  code: &str,
+  code: &'static str,
 ) -> Result<serde_json::Value, String> {
   let res = context.execute_script("<anon>", code);
   match res {

--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -82,7 +82,7 @@ impl ModuleLoader for TypescriptModuleLoader {
         code
       };
       let module = ModuleSource {
-        code: code.into_bytes().into_boxed_slice(),
+        code: code.into(),
         module_type,
         module_url_specified: module_specifier.to_string(),
         module_url_found: module_specifier.to_string(),

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use crate::modules::ModuleCode;
 use crate::OpState;
 use anyhow::Context as _;
 use anyhow::Error;
@@ -23,13 +24,12 @@ pub enum ExtensionFileSourceCode {
 }
 
 impl ExtensionFileSourceCode {
-  pub fn load(&self) -> Result<String, Error> {
+  pub fn load(&self) -> Result<ModuleCode, Error> {
     match self {
-      ExtensionFileSourceCode::IncludedInBinary(code) => Ok(code.to_string()),
+      ExtensionFileSourceCode::IncludedInBinary(code) => Ok((*code).into()),
       ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) => {
-        let msg = format!("Failed to read \"{}\"", path.display());
-        let code = std::fs::read_to_string(path).context(msg)?;
-        Ok(code)
+        let msg = || format!("Failed to read \"{}\"", path.display());
+        Ok(std::fs::read_to_string(path).with_context(msg)?.into())
       }
     }
   }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -77,6 +77,7 @@ pub use crate::module_specifier::ModuleSpecifier;
 pub use crate::modules::ExtModuleLoader;
 pub use crate::modules::ExtModuleLoaderCb;
 pub use crate::modules::FsModuleLoader;
+pub use crate::modules::ModuleCode;
 pub use crate::modules::ModuleId;
 pub use crate::modules::ModuleLoader;
 pub use crate::modules::ModuleSource;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -145,7 +145,7 @@ pub mod _ops {
 #[macro_export]
 macro_rules! located_script_name {
   () => {
-    format!("[ext:{}:{}:{}]", std::file!(), std::line!(), std::column!());
+    concat!("[ext:{}:{}:{}]", std::file!(), std::line!(), std::column!());
   };
 }
 

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -247,7 +247,7 @@ impl ModuleCode {
   }
 
   /// Takes a [`ModuleCode`] value as an owned [`String`]. May be slow.
-  pub fn to_string(self) -> String {
+  pub fn take_as_string(self) -> String {
     match self {
       Self::Static(b) => String::from_utf8(b.to_vec()).unwrap(),
       Self::Owned(b) => String::from_utf8(b).unwrap(),
@@ -584,7 +584,7 @@ impl ModuleLoader for ExtModuleLoader {
         load_callback(file_source)
       } else {
         match file_source.code.load() {
-          Ok(code) => Ok(code.into()),
+          Ok(code) => Ok(code),
           Err(err) => return futures::future::err(err).boxed_local(),
         }
       };
@@ -592,7 +592,7 @@ impl ModuleLoader for ExtModuleLoader {
       return async move {
         let code = result?;
         let source = ModuleSource {
-          code: code.into(),
+          code,
           module_type: ModuleType::JavaScript,
           module_url_specified: specifier.clone(),
           module_url_found: specifier.clone(),
@@ -3210,15 +3210,15 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
 
     let mut code: ModuleCode = "123456".into();
     code.truncate(3);
-    assert_eq!(s, code.to_string());
+    assert_eq!(s, code.take_as_string());
 
     let mut code: ModuleCode = "123456".to_owned().into();
     code.truncate(3);
-    assert_eq!(s, code.to_string());
+    assert_eq!(s, code.take_as_string());
 
     let arc_str: Arc<str> = "123456".into();
     let mut code: ModuleCode = arc_str.into();
     code.truncate(3);
-    assert_eq!(s, code.to_string());
+    assert_eq!(s, code.take_as_string());
   }
 }

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -1530,6 +1530,7 @@ impl ModuleMap {
     name: N,
     source: &ModuleCode,
   ) -> Result<ModuleId, ModuleError> {
+    // Manual monomorphization (TODO: replace w/momo)
     self.new_json_module_inner(scope, name.into(), source)
   }
 
@@ -1582,7 +1583,8 @@ impl ModuleMap {
     Ok(id)
   }
 
-  // Create and compile an ES module.
+  /// Create and compile an ES module. Generic interface that can receive either a `&'static str` or a string with a lifetime. Prefer
+  /// to pass `&'static str` as this allows us to use v8 external strings.
   pub(crate) fn new_es_module<'a, N: Into<ModuleName<'a>>>(
     &mut self,
     scope: &mut v8::HandleScope,
@@ -1591,6 +1593,7 @@ impl ModuleMap {
     source: &ModuleCode,
     is_dynamic_import: bool,
   ) -> Result<ModuleId, ModuleError> {
+    // Manual monomorphization (TODO: replace w/momo)
     self.new_es_module_inner(
       scope,
       main,
@@ -1600,7 +1603,6 @@ impl ModuleMap {
     )
   }
 
-  // Create and compile an ES module.
   fn new_es_module_inner(
     &mut self,
     scope: &mut v8::HandleScope,

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -914,12 +914,12 @@ impl JsRuntime {
   /// The same `name` value can be used for multiple executions.
   ///
   /// `Error` can usually be downcast to `JsError`.
-  #[inline(always)]
   pub fn execute_script<S: Into<ModuleCode>>(
     &mut self,
     name: &'static str,
     source_code: S,
   ) -> Result<v8::Global<v8::Value>, Error> {
+    // Manual monomorphization (TODO: replace w/momo)
     self.execute_module_code(name, source_code.into())
   }
 
@@ -2521,13 +2521,13 @@ impl JsRealm {
   /// The same `name` value can be used for multiple executions.
   ///
   /// `Error` can usually be downcast to `JsError`.
-  #[inline(always)]
   pub fn execute_script<S: Into<ModuleCode>>(
     &self,
     isolate: &mut v8::Isolate,
     name: &'static str,
     source_code: S,
   ) -> Result<v8::Global<v8::Value>, Error> {
+    // Manual monomorphization (TODO: replace w/momo)
     self.execute_module_code(isolate, name, source_code.into())
   }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2501,10 +2501,10 @@ impl JsRealm {
     source_code: S,
   ) -> Result<v8::Global<v8::Value>, Error> {
     // Manual monomorphization (TODO: replace w/momo)
-    self.execute_module_code(isolate, name, source_code.into())
+    self.execute_script_inner(isolate, name, source_code.into())
   }
 
-  fn execute_module_code(
+  fn execute_script_inner(
     &self,
     isolate: &mut v8::Isolate,
     name: &'static str,

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -390,7 +390,7 @@ pub fn initialize_runtime(
   } else {
     "undefined".to_string()
   };
-  let source_code = &format!(
+  let source_code = format!(
     r#"(function loadBuiltinNodeModules(nodeGlobalThisName, usesLocalNodeModulesDir, argv0) {{
       Deno[Deno.internal].node.initialize(
         nodeGlobalThisName, 
@@ -417,7 +417,7 @@ pub fn load_cjs_module(
     text.replace('\\', r"\\").replace('\'', r"\'")
   }
 
-  let source_code = &format!(
+  let source_code = format!(
     r#"(function loadCjsModule(moduleName, isMain, inspectBrk) {{
       Deno[Deno.internal].node.loadCjsModule(moduleName, isMain, inspectBrk);
     }})('{module}', {main}, {inspect_brk});"#,

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -403,7 +403,7 @@ pub fn initialize_runtime(
     argv0
   );
 
-  js_runtime.execute_script(&located_script_name!(), source_code)?;
+  js_runtime.execute_script(located_script_name!(), source_code)?;
   Ok(())
 }
 
@@ -426,6 +426,6 @@ pub fn load_cjs_module(
     inspect_brk = inspect_brk,
   );
 
-  js_runtime.execute_script(&located_script_name!(), source_code)?;
+  js_runtime.execute_script(located_script_name!(), source_code)?;
   Ok(())
 }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -37,7 +37,7 @@ mod startup_snapshot {
     let code = file_source.code.load()?;
 
     if !should_transpile {
-      return Ok(code.into());
+      return Ok(code);
     }
 
     let parsed = deno_ast::parse_module(ParseParams {

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -17,11 +17,12 @@ mod startup_snapshot {
   use deno_core::snapshot_util::*;
   use deno_core::Extension;
   use deno_core::ExtensionFileSource;
+  use deno_core::ModuleCode;
   use std::path::Path;
 
   fn transpile_ts_for_snapshotting(
     file_source: &ExtensionFileSource,
-  ) -> Result<String, AnyError> {
+  ) -> Result<ModuleCode, AnyError> {
     let media_type = MediaType::from_path(Path::new(&file_source.specifier));
 
     let should_transpile = match media_type {
@@ -36,12 +37,12 @@ mod startup_snapshot {
     let code = file_source.code.load()?;
 
     if !should_transpile {
-      return Ok(code);
+      return Ok(code.into());
     }
 
     let parsed = deno_ast::parse_module(ParseParams {
       specifier: file_source.specifier.to_string(),
-      text_info: SourceTextInfo::from_string(code),
+      text_info: SourceTextInfo::from_string(code.to_string()),
       media_type,
       capture_tokens: false,
       scope_analysis: false,
@@ -53,7 +54,7 @@ mod startup_snapshot {
       ..Default::default()
     })?;
 
-    Ok(transpiled_source.text)
+    Ok(transpiled_source.text.into())
   }
 
   #[derive(Clone)]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -42,7 +42,7 @@ mod startup_snapshot {
 
     let parsed = deno_ast::parse_module(ParseParams {
       specifier: file_source.specifier.to_string(),
-      text_info: SourceTextInfo::from_string(code.to_string()),
+      text_info: SourceTextInfo::from_string(code.take_as_string()),
       media_type,
       capture_tokens: false,
       scope_analysis: false,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -576,7 +576,7 @@ impl WebWorker {
     "#;
     let poll_for_messages_fn = self
       .js_runtime
-      .execute_script(&located_script_name!(), script)
+      .execute_script(located_script_name!(), script)
       .expect("Failed to execute worker bootstrap script");
     self.poll_for_messages_fn = Some(poll_for_messages_fn);
   }
@@ -774,7 +774,7 @@ pub fn run_web_worker(
 
     // Execute provided source code immediately
     let result = if let Some(source_code) = maybe_source_code.take() {
-      let r = worker.execute_script(&located_script_name!(), source_code);
+      let r = worker.execute_script(located_script_name!(), source_code);
       worker.start_polling_for_messages();
       r
     } else {

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -584,7 +584,7 @@ impl WebWorker {
   /// See [JsRuntime::execute_script](deno_core::JsRuntime::execute_script)
   pub fn execute_script<S: Into<ModuleCode>>(
     &mut self,
-    name: &str,
+    name: &'static str,
     source_code: S,
   ) -> Result<(), AnyError> {
     self.js_runtime.execute_script(name, source_code)?;

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -25,6 +25,7 @@ use deno_core::CompiledWasmModuleStore;
 use deno_core::Extension;
 use deno_core::GetErrorClassFn;
 use deno_core::JsRuntime;
+use deno_core::ModuleCode;
 use deno_core::ModuleId;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
@@ -581,10 +582,10 @@ impl WebWorker {
   }
 
   /// See [JsRuntime::execute_script](deno_core::JsRuntime::execute_script)
-  pub fn execute_script(
+  pub fn execute_script<S: Into<ModuleCode>>(
     &mut self,
     name: &str,
-    source_code: &str,
+    source_code: S,
   ) -> Result<(), AnyError> {
     self.js_runtime.execute_script(name, source_code)?;
     Ok(())
@@ -744,7 +745,7 @@ fn print_worker_error(
 pub fn run_web_worker(
   worker: WebWorker,
   specifier: ModuleSpecifier,
-  maybe_source_code: Option<String>,
+  mut maybe_source_code: Option<String>,
   preload_module_cb: Arc<ops::worker_host::WorkerEventCb>,
   pre_execute_module_cb: Arc<ops::worker_host::WorkerEventCb>,
   format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
@@ -772,8 +773,8 @@ pub fn run_web_worker(
     };
 
     // Execute provided source code immediately
-    let result = if let Some(source_code) = maybe_source_code {
-      let r = worker.execute_script(&located_script_name!(), &source_code);
+    let result = if let Some(source_code) = maybe_source_code.take() {
+      let r = worker.execute_script(&located_script_name!(), source_code);
       worker.start_polling_for_messages();
       r
     } else {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -367,7 +367,7 @@ impl MainWorker {
   /// See [JsRuntime::execute_script](deno_core::JsRuntime::execute_script)
   pub fn execute_script<S: Into<ModuleCode>>(
     &mut self,
-    script_name: &str,
+    script_name: &'static str,
     source_code: S,
   ) -> Result<v8::Global<v8::Value>, AnyError> {
     self.js_runtime.execute_script(script_name, source_code)
@@ -503,7 +503,7 @@ impl MainWorker {
   /// Does not poll event loop, and thus not await any of the "load" event handlers.
   pub fn dispatch_load_event(
     &mut self,
-    script_name: &str,
+    script_name: &'static str,
   ) -> Result<(), AnyError> {
     self.execute_script(
       script_name,
@@ -520,7 +520,7 @@ impl MainWorker {
   /// Does not poll event loop, and thus not await any of the "unload" event handlers.
   pub fn dispatch_unload_event(
     &mut self,
-    script_name: &str,
+    script_name: &'static str,
   ) -> Result<(), AnyError> {
     self.execute_script(
       script_name,
@@ -537,7 +537,7 @@ impl MainWorker {
   /// running.
   pub fn dispatch_beforeunload_event(
     &mut self,
-    script_name: &str,
+    script_name: &'static str,
   ) -> Result<bool, AnyError> {
     let value = self.js_runtime.execute_script(
       script_name,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -21,6 +21,7 @@ use deno_core::FsModuleLoader;
 use deno_core::GetErrorClassFn;
 use deno_core::JsRuntime;
 use deno_core::LocalInspectorSession;
+use deno_core::ModuleCode;
 use deno_core::ModuleId;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSpecifier;
@@ -364,10 +365,10 @@ impl MainWorker {
   }
 
   /// See [JsRuntime::execute_script](deno_core::JsRuntime::execute_script)
-  pub fn execute_script(
+  pub fn execute_script<S: Into<ModuleCode>>(
     &mut self,
     script_name: &str,
-    source_code: &str,
+    source_code: S,
   ) -> Result<v8::Global<v8::Value>, AnyError> {
     self.js_runtime.execute_script(script_name, source_code)
   }


### PR DESCRIPTION
Reduce the number of copies and allocations of script code by carrying around ownership/reference information from creation time. 

As an advantage, this allows us to maintain the identity of `&'static str`-based scripts and use v8's external 1-byte strings (to avoid incorrectly passing non-ASCII strings, debug `assert!`s gate all string reference paths).

Benchmark results:

Perf improvements -- ~0.1 - 0.2ms faster, but should reduce garbage w/external strings and reduces data copies overall. May also unlock some more interesting optimizations in the future.

This requires adding some generics to functions, but manual monomorphization has been applied (outer/inner function) to avoid code bloat.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
