### PR TITLE
chore(tools): Copyright checker had a bad interpolation

### DIFF
--- a/tools/copyright_checker.js
+++ b/tools/copyright_checker.js
@@ -72,7 +72,7 @@ export async function checkCopyright() {
     // show all the errors at the same time to prevent overlap with
     // other running scripts that may be outputting
     console.error(errors.join("\n"));
-    throw new Error(`Copyright checker had ${totalCount} errors.`);
+    throw new Error(`Copyright checker had ${errors.length} errors.`);
   }
 }
 


### PR DESCRIPTION
The copyright checker was erroring out with a bad interpolation if errors existed.