### PR TITLE
chore(cli) Use with_context(|| format!(...)) rather than context(format!(...)) to avoid allocations in non-error path

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -669,9 +669,9 @@ impl CliOptions {
       file_fetcher,
     )
     .await
-    .with_context(|| format!(
-      "Unable to load '{import_map_specifier}' import map"
-    ))
+    .with_context(|| {
+      format!("Unable to load '{import_map_specifier}' import map")
+    })
     .map(Some)
   }
 
@@ -1091,7 +1091,9 @@ fn resolve_import_map_specifier(
     }
     let specifier =
       deno_core::resolve_url_or_path(import_map_path, current_dir)
-        .with_context(|| format!("Bad URL (\"{import_map_path}\") for import map."))?;
+        .with_context(|| {
+          format!("Bad URL (\"{import_map_path}\") for import map.")
+        })?;
     return Ok(Some(specifier));
   } else if let Some(config_file) = &maybe_config_file {
     // if the config file is an import map we prefer to use it, over `importMap`

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -669,7 +669,7 @@ impl CliOptions {
       file_fetcher,
     )
     .await
-    .context(format!(
+    .with_context(|| format!(
       "Unable to load '{import_map_specifier}' import map"
     ))
     .map(Some)
@@ -1091,7 +1091,7 @@ fn resolve_import_map_specifier(
     }
     let specifier =
       deno_core::resolve_url_or_path(import_map_path, current_dir)
-        .context(format!("Bad URL (\"{import_map_path}\") for import map."))?;
+        .with_context(|| format!("Bad URL (\"{import_map_path}\") for import map."))?;
     return Ok(Some(specifier));
   } else if let Some(config_file) = &maybe_config_file {
     // if the config file is an import map we prefer to use it, over `importMap`
@@ -1131,7 +1131,7 @@ fn resolve_import_map_specifier(
           // use "import resolution" with the config file as the base.
           } else {
             deno_core::resolve_import(&import_map_path, config_file.specifier.as_str())
-              .context(format!(
+              .with_context(|| format!(
                 "Bad URL (\"{import_map_path}\") for import map."
               ))?
           };


### PR DESCRIPTION
This won't move the needle on performance but it is generally better to avoid error allocations in the success path.