### PR TITLE
perf: disable TSC snapshot compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,9 +400,6 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -786,7 +783,6 @@ dependencies = [
  "walkdir",
  "winapi",
  "winres",
- "zstd",
 ]
 
 [[package]]
@@ -2341,15 +2337,6 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -5647,34 +5634,4 @@ dependencies = [
  "quote 1.0.23",
  "syn 1.0.109",
  "synstructure",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,6 @@ tokio-util = "0.7.4"
 tower-lsp = { version = "=0.17.0", features = ["proposed"] }
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
 uuid = { version = "1.3.0", features = ["v4"] }
-zstd = "=0.11.2"
 
 # crypto
 rsa = { version = "0.7.0", default-features = false, features = ["std", "pem"] }
@@ -229,10 +228,6 @@ opt-level = 3
 opt-level = 3
 [profile.bench.package.tokio]
 opt-level = 3
-[profile.bench.package.zstd]
-opt-level = 3
-[profile.bench.package.zstd-sys]
-opt-level = 3
 [profile.bench.package.base64-simd]
 opt-level = 3
 
@@ -300,10 +295,6 @@ opt-level = 3
 [profile.release.package.hyper]
 opt-level = 3
 [profile.release.package.tokio]
-opt-level = 3
-[profile.release.package.zstd]
-opt-level = 3
-[profile.release.package.zstd-sys]
 opt-level = 3
 [profile.release.package.base64-simd]
 opt-level = 3

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,7 +32,6 @@ deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"]
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-zstd.workspace = true
 glibc_version = "0.1.2"
 
 [target.'cfg(windows)'.build-dependencies]
@@ -106,7 +105,6 @@ twox-hash = "=1.6.3"
 typed-arena = "=2.0.1"
 uuid = { workspace = true, features = ["serde"] }
 walkdir = "=2.3.2"
-zstd.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 fwdansi.workspace = true

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -270,22 +270,7 @@ mod ts {
         build_libs,
         path_dts,
       )],
-
-      // NOTE(bartlomieju): Compressing the TSC snapshot in debug build took
-      // ~45s on M1 MacBook Pro; without compression it took ~1s.
-      // Thus we're not not using compressed snapshot, trading off
-      // a lot of build time for some startup time in debug build.
-      #[cfg(debug_assertions)]
       compression_cb: None,
-
-      #[cfg(not(debug_assertions))]
-      compression_cb: Some(Box::new(|vec, snapshot_slice| {
-        eprintln!("Compressing TSC snapshot...");
-        vec.extend_from_slice(
-          &zstd::bulk::compress(snapshot_slice, 22)
-            .expect("snapshot compression failed"),
-        );
-      })),
       snapshot_module_load_cb: None,
     });
   }


### PR DESCRIPTION
This commit disables compression of the TSC snapshot.
The compression only decreased the size of snapshot by 0.5Mb
and it took about 40s during release build to compress.

With recent gains in TS 5.0 upgrade in terms of size and performance
it makes sense to remove this compression.