### PR TITLE
Revert "fix(cli) Better error messages on corrupt databases that aren…

### DIFF
--- a/cli/cache/node.rs
+++ b/cli/cache/node.rs
@@ -106,16 +106,11 @@ impl NodeAnalysisCache {
         ) {
           Ok(cache) => Some(cache),
           Err(err) => {
-            let file = self
-              .db_file_path
-              .as_ref()
-              .map(|s| s.to_string_lossy().to_string())
-              .unwrap_or_default();
-            log::error!("Error creating node analysis cache, file '{file}' may be corrupt: {:#}", err);
             // should never error here, but if it ever does don't fail
             if cfg!(debug_assertions) {
-              panic!("Error creating node analysis cache, file '{file}' may be corrupt: {err:#}");
+              panic!("Error creating node analysis cache: {err:#}");
             } else {
+              log::debug!("Error creating node analysis cache: {:#}", err);
               None
             }
           }

--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -121,12 +121,7 @@ impl ParsedSourceCache {
     ) {
       Ok(analyzer) => Box::new(analyzer),
       Err(err) => {
-        let file = self
-          .db_cache_path
-          .as_ref()
-          .map(|s| s.to_string_lossy().to_string())
-          .unwrap_or_default();
-        log::error!("Could not create cached module analyzer, cache file '{file}' may be corrupt: {:#}", err);
+        log::debug!("Could not create cached module analyzer. {:#}", err);
         // fallback to not caching if it can't be created
         Box::new(deno_graph::CapturingModuleAnalyzer::new(
           None,


### PR DESCRIPTION
…'t automatically re-created (#18330)"

This reverts commit 2ef8269fdb395b0736153ff5fbb9696cbb976e42.

Printing these messages by default (instead of requiring `-L debug` flag) caused
various tests to start printing it and mismatch in output assertions.