### PR TITLE
chore(cli) Ensure no signal on test exit

### DIFF
--- a/cli/tests/integration/js_unit_tests.rs
+++ b/cli/tests/integration/js_unit_tests.rs
@@ -34,6 +34,12 @@ fn js_unit_tests() {
     .expect("failed to spawn script");
 
   let status = deno.wait().expect("failed to wait for the child process");
-  assert_eq!(Some(0), status.code());
+  #[cfg(unix)]
+  assert_eq!(
+    std::os::unix::process::ExitStatusExt::signal(&status),
+    None,
+    "Deno should not have died with a signal"
+  );
+  assert_eq!(Some(0), status.code(), "Deno should have exited cleanly");
   assert!(status.success());
 }


### PR DESCRIPTION
If deno crashes on exit, we get a failure on the exit code (None instead of Some(0) but we never see the signal.