### PR TITLE
Revert "refactor: rename Deno.openKv() to Deno.kv()"

### DIFF
--- a/cli/tests/unit/kv_test.ts
+++ b/cli/tests/unit/kv_test.ts
@@ -8,25 +8,25 @@ import {
 } from "./test_util.ts";
 
 Deno.test({
-  name: "kv :memory: no permissions",
+  name: "openKv :memory: no permissions",
   permissions: {},
   async fn() {
-    const db = await Deno.kv(":memory:");
+    const db = await Deno.openKv(":memory:");
     await db.close();
   },
 });
 
 Deno.test({
-  name: "kv invalid filenames",
+  name: "openKv invalid filenames",
   permissions: {},
   async fn() {
     await assertRejects(
-      async () => await Deno.kv(""),
+      async () => await Deno.openKv(""),
       TypeError,
       "Filename cannot be empty",
     );
     await assertRejects(
-      async () => await Deno.kv(":foo"),
+      async () => await Deno.openKv(":foo"),
       TypeError,
       "Filename cannot start with ':' unless prefixed with './'",
     );
@@ -37,7 +37,9 @@ function dbTest(name: string, fn: (db: Deno.Kv) => Promise<void>) {
   Deno.test({
     name,
     async fn() {
-      const db: Deno.Kv = await Deno.kv(":memory:");
+      const db: Deno.Kv = await Deno.openKv(
+        ":memory:",
+      );
       try {
         await fn(db);
       } finally {

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1535,7 +1535,7 @@ declare namespace Deno {
    * @tags allow-read, allow-write
    * @category KV
    */
-  export function kv(path?: string): Promise<Deno.Kv>;
+  export function openKv(path?: string): Promise<Deno.Kv>;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
@@ -1876,7 +1876,7 @@ declare namespace Deno {
      * the returned entry will have a `null` value and versionstamp.
      *
      * ```ts
-     * const db = await Deno.kv();
+     * const db = await Deno.openKv();
      * const result = await db.get(["foo"]);
      * result.key; // ["foo"]
      * result.value; // "bar"
@@ -1902,7 +1902,7 @@ declare namespace Deno {
      * entry will have a `null` value and versionstamp.
      *
      * ```ts
-     * const db = await Deno.kv();
+     * const db = await Deno.openKv();
      * const result = await db.getMany([["foo"], ["baz"]]);
      * result[0].key; // ["foo"]
      * result[0].value; // "bar"
@@ -1928,7 +1928,7 @@ declare namespace Deno {
      * exists for the key, it will be overwritten.
      *
      * ```ts
-     * const db = await Deno.kv();
+     * const db = await Deno.openKv();
      * await db.set(["foo"], "bar");
      * ```
      */
@@ -1939,7 +1939,7 @@ declare namespace Deno {
      * for the key, this operation is a no-op.
      *
      * ```ts
-     * const db = await Deno.kv();
+     * const db = await Deno.openKv();
      * await db.delete(["foo"]);
      * ```
      */
@@ -1971,7 +1971,7 @@ declare namespace Deno {
      *   not `["users", "noa"]` or `["users", "zoe"]`.
      *
      * ```ts
-     * const db = await Deno.kv();
+     * const db = await Deno.openKv();
      * const entries = db.list({ prefix: ["users"] });
      * for await (const entry of entries) {
      *   entry.key; // ["users", "alice"]

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -14,7 +14,7 @@ const encodeCursor: (
 ) => string = (selector, boundaryKey) =>
   ops.op_kv_encode_cursor(selector, boundaryKey);
 
-async function kv(path: string) {
+async function openKv(path: string) {
   const rid = await core.opAsync("op_kv_database_open", path);
   return new Kv(rid);
 }
@@ -466,4 +466,4 @@ class KvListIterator extends AsyncIterator
   }
 }
 
-export { Kv, kv, KvListIterator, KvU64 };
+export { Kv, KvListIterator, KvU64, openKv };

--- a/ext/kv/lib.rs
+++ b/ext/kv/lib.rs
@@ -84,7 +84,9 @@ where
 {
   let handler = {
     let state = state.borrow();
-    state.borrow::<UnstableChecker>().check_unstable("Deno.kv");
+    state
+      .borrow::<UnstableChecker>()
+      .check_unstable("Deno.openKv");
     state.borrow::<Rc<DBH>>().clone()
   };
   let db = handler.open(state.clone(), path).await?;

--- a/ext/kv/sqlite.rs
+++ b/ext/kv/sqlite.rs
@@ -128,8 +128,8 @@ impl<P: SqliteDbHandlerPermissions> DatabaseHandler for SqliteDbHandler<P> {
         {
           let mut state = state.borrow_mut();
           let permissions = state.borrow_mut::<P>();
-          permissions.check_read(path, "Deno.kv")?;
-          permissions.check_write(path, "Deno.kv")?;
+          permissions.check_read(path, "Deno.openKv")?;
+          permissions.check_write(path, "Deno.openKv")?;
         }
         let flags = OpenFlags::default().difference(OpenFlags::SQLITE_OPEN_URI);
         rusqlite::Connection::open_with_flags(path, flags)?

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -170,7 +170,7 @@ const denoNsUnstable = {
   funlockSync: fs.funlockSync,
   upgradeHttp: http.upgradeHttp,
   upgradeHttpRaw: flash.upgradeHttpRaw,
-  kv: kv.kv,
+  openKv: kv.openKv,
   Kv: kv.Kv,
   KvU64: kv.KvU64,
   KvListIterator: kv.KvListIterator,


### PR DESCRIPTION
Reverts denoland/deno#18349

The old name is clearer.