### PR TITLE
fix(core): panic at build time if extension code contains anything other than 7-bit ASCII

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -23,23 +23,46 @@ pub enum ExtensionFileSourceCode {
   LoadedFromFsDuringSnapshot(PathBuf),
 }
 
-impl ExtensionFileSourceCode {
-  pub fn load(&self) -> Result<ModuleCode, Error> {
-    match self {
-      ExtensionFileSourceCode::IncludedInBinary(code) => Ok((*code).into()),
-      ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) => {
-        let msg = || format!("Failed to read \"{}\"", path.display());
-        Ok(std::fs::read_to_string(path).with_context(msg)?.into())
-      }
-    }
-  }
-}
-
 #[derive(Clone, Debug)]
 pub struct ExtensionFileSource {
   pub specifier: &'static str,
   pub code: ExtensionFileSourceCode,
 }
+
+impl ExtensionFileSource {
+  fn find_non_ascii(s: &str) -> String {
+    s
+      .chars()
+      .filter(|c| !c.is_ascii())
+      .collect::<String>()
+  }
+
+  pub fn load(&self) -> Result<ModuleCode, Error> {
+    match &self.code {
+      ExtensionFileSourceCode::IncludedInBinary(code) => {
+        debug_assert!(
+          code.is_ascii(),
+          "Extension code must be 7-bit ASCII: {} (found {})",
+          self.specifier,
+          Self::find_non_ascii(code)
+        );
+        Ok((*code).into())
+      }
+      ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) => {
+        let msg = || format!("Failed to read \"{}\"", path.display());
+        let s = std::fs::read_to_string(path).with_context(msg)?;
+        debug_assert!(
+          s.is_ascii(),
+          "Extension code must be 7-bit ASCII: {} (found {})",
+          self.specifier,
+          Self::find_non_ascii(&s)
+        );
+        Ok(s.into())
+      }
+    }
+  }
+}
+
 pub type OpFnRef = v8::FunctionCallback;
 pub type OpMiddlewareFn = dyn Fn(OpDecl) -> OpDecl;
 pub type OpStateFn = dyn FnOnce(&mut OpState);

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -31,10 +31,7 @@ pub struct ExtensionFileSource {
 
 impl ExtensionFileSource {
   fn find_non_ascii(s: &str) -> String {
-    s
-      .chars()
-      .filter(|c| !c.is_ascii())
-      .collect::<String>()
+    s.chars().filter(|c| !c.is_ascii()).collect::<String>()
   }
 
   pub fn load(&self) -> Result<ModuleCode, Error> {

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -309,7 +309,7 @@ impl From<Cow<'static, [u8]>> for ModuleCode {
 impl From<&'static str> for ModuleCode {
   #[inline(always)]
   fn from(value: &'static str) -> Self {
-    assert!(value.is_ascii());
+    debug_assert!(value.is_ascii());
     ModuleCode::Static(value.as_bytes())
   }
 }
@@ -331,7 +331,7 @@ impl From<Vec<u8>> for ModuleCode {
 impl From<&'static [u8]> for ModuleCode {
   #[inline(always)]
   fn from(value: &'static [u8]) -> Self {
-    assert!(value.is_ascii());
+    debug_assert!(value.is_ascii());
     ModuleCode::Static(value)
   }
 }
@@ -339,7 +339,7 @@ impl From<&'static [u8]> for ModuleCode {
 impl<const N: usize> From<&'static [u8; N]> for ModuleCode {
   #[inline(always)]
   fn from(value: &'static [u8; N]) -> Self {
-    assert!(value.is_ascii());
+    debug_assert!(value.is_ascii());
     ModuleCode::Static(value)
   }
 }
@@ -583,7 +583,7 @@ impl ModuleLoader for ExtModuleLoader {
       let result = if let Some(load_callback) = &self.maybe_load_callback {
         load_callback(file_source)
       } else {
-        match file_source.code.load() {
+        match file_source.load() {
           Ok(code) => Ok(code),
           Err(err) => return futures::future::err(err).boxed_local(),
         }
@@ -1517,7 +1517,7 @@ impl ModuleMap {
   ) -> Option<v8::Local<'a, v8::String>> {
     match name {
       ModuleName::Static(s) => {
-        assert!(s.is_ascii());
+        debug_assert!(s.is_ascii());
         v8::String::new_external_onebyte_static(scope, s.as_bytes())
       }
       ModuleName::NotStatic(s) => v8::String::new(scope, s),

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -751,7 +751,7 @@ impl JsRuntime {
             realm.execute_script(
               self.v8_isolate(),
               file_source.specifier,
-              file_source.code.load()?,
+              file_source.load()?,
             )?;
           }
         }
@@ -2536,7 +2536,7 @@ impl JsRealm {
     let scope = &mut self.handle_scope(isolate);
 
     let source = Self::string_from_code(scope, &source_code).unwrap();
-    assert!(name.is_ascii());
+    debug_assert!(name.is_ascii());
     let name =
       v8::String::new_external_onebyte_static(scope, name.as_bytes()).unwrap();
     let origin = bindings::script_origin(scope, name);

--- a/ext/node/polyfills/internal/cli_table.ts
+++ b/ext/node/polyfills/internal/cli_table.ts
@@ -3,11 +3,6 @@
 
 import { getStringWidth } from "ext:deno_node/internal/util/inspect.mjs";
 
-// The use of Unicode characters below is the only non-comment use of non-ASCII
-// Unicode characters in Node.js built-in modules. If they are ever removed or
-// rewritten with \u escapes, then a test will need to be (re-)added to Node.js
-// core to verify that Unicode characters work in built-ins.
-// Refs: https://github.com/nodejs/node/issues/10673
 const tableChars = {
   middleMiddle: "\u2500",
   rowMiddle: "\u253c",

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -34,7 +34,7 @@ mod startup_snapshot {
         file_source.specifier
       ),
     };
-    let code = file_source.code.load()?;
+    let code = file_source.load()?;
 
     if !should_transpile {
       return Ok(code);


### PR DESCRIPTION
This will improve diagnostics and catch any non-ASCII extension code early.

This will use `debug_assert!` rather than `assert!` to avoid runtime costs, and ensures (in debug_assert mode only) that all extension source files are ASCII as we load them.