### PR TITLE
fix(lsp): ensure `enablePaths` works when clients do not provide a trailing slash for workspace dir

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -377,7 +377,7 @@ impl LanguageServer {
       let mut ls = self.0.write().await;
       if let Ok(configs) = configs_result {
         for (value, internal_uri) in
-          configs.into_iter().zip(specifiers.into_iter().map(|s| s.1))
+          configs.into_iter().zip(specifiers.into_iter().map(|s| s.0))
         {
           match value {
             Ok(specifier_settings) => {


### PR DESCRIPTION
Closes https://github.com/denoland/vscode_deno/issues/827