### PR TITLE
refactor(init): remove CURRENT_STD_URL

### DIFF
--- a/cli/deno_std.rs
+++ b/cli/deno_std.rs
@@ -2,4 +2,4 @@
 
 // WARNING: Ensure this is the only deno_std version reference as this
 // is automatically updated by the version bump workflow.
-pub static CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.181.0/";
+pub const CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.181.0/";

--- a/cli/deno_std.rs
+++ b/cli/deno_std.rs
@@ -1,11 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::url::Url;
-use once_cell::sync::Lazy;
-
 // WARNING: Ensure this is the only deno_std version reference as this
 // is automatically updated by the version bump workflow.
-static CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.181.0/";
-
-pub static CURRENT_STD_URL: Lazy<Url> =
-  Lazy::new(|| Url::parse(CURRENT_STD_URL_STR).expect("invalid std url"));
+pub static CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.181.0/";

--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -38,7 +38,7 @@ pub async fn init_project(init_flags: InitFlags) -> Result<(), AnyError> {
   create_file(&dir, "main.ts", main_ts)?;
 
   let main_test_ts = include_str!("./templates/main_test.ts")
-    .replace("{CURRENT_STD_URL}", deno_std::CURRENT_STD_URL.as_str());
+    .replace("{CURRENT_STD_URL}", deno_std::CURRENT_STD_URL_STR);
   create_file(&dir, "main_test.ts", &main_test_ts)?;
   let main_bench_ts = include_str!("./templates/main_bench.ts");
   create_file(&dir, "main_bench.ts", main_bench_ts)?;


### PR DESCRIPTION
There's no point in having `Lazy<Url>`, since the only use case 
is string substitution in the "deno init" subcommand.
