### PR TITLE
refactor(core): move setting up snapshot context to JsRuntime::snapshot

### DIFF
--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -411,7 +411,6 @@ impl JsRuntime {
         }
 
         global_context = v8::Global::new(scope, context);
-        scope.set_default_context(context);
       }
       (isolate, snapshot_options)
     } else {
@@ -930,6 +929,14 @@ impl JsRuntime {
   /// `Error` can usually be downcast to `JsError`.
   pub fn snapshot(mut self) -> v8::StartupData {
     self.state.borrow_mut().inspector.take();
+
+    // Set the context to be snapshot's default context
+    {
+      let context = self.global_context();
+      let mut scope = self.handle_scope();
+      let local_context = v8::Local::new(&mut scope, context);
+      scope.set_default_context(local_context);
+    }
 
     // Serialize the module map and store its data in the snapshot.
     {


### PR DESCRIPTION
Need this change to be able to warm up snapshot.