### PR TITLE
fix(cli): restore `deno run -` to handle stdin as typescript

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -696,7 +696,8 @@ impl CliOptions {
           std::env::current_dir()
             .context("Unable to get CWD")
             .and_then(|cwd| {
-              resolve_url_or_path("./$deno$stdin", &cwd).map_err(AnyError::from)
+              resolve_url_or_path("./$deno$stdin.ts", &cwd)
+                .map_err(AnyError::from)
             })
         } else if self.flags.watch.is_some() {
           resolve_url_or_path(&run_flags.script, self.initial_cwd())

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1824,6 +1824,56 @@ fn exec_path() {
   assert_eq!(expected, actual);
 }
 
+#[test]
+fn run_from_stdin_defaults_to_ts() {
+  let source_code = r#"
+interface Lollipop {
+  _: number;
+}
+console.log("executing typescript");
+"#;
+
+  let mut p = util::deno_cmd()
+    .arg("run")
+    .arg("--check")
+    .arg("-")
+    .stdin(std::process::Stdio::piped())
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap();
+  let stdin = p.stdin.as_mut().unwrap();
+  stdin.write_all(source_code.as_bytes()).unwrap();
+  let result = p.wait_with_output().unwrap();
+  assert!(result.status.success());
+  let stdout_str = std::str::from_utf8(&result.stdout).unwrap().trim();
+  assert_eq!(stdout_str, "executing typescript");
+}
+
+#[test]
+fn run_from_stdin_ext() {
+  let source_code = r#"
+let i = 123;
+i = "hello"
+console.log("executing javascript");
+"#;
+
+  let mut p = util::deno_cmd()
+    .arg("run")
+    .args(["--ext", "js"])
+    .arg("--check")
+    .arg("-")
+    .stdin(std::process::Stdio::piped())
+    .stdout(std::process::Stdio::piped())
+    .spawn()
+    .unwrap();
+  let stdin = p.stdin.as_mut().unwrap();
+  stdin.write_all(source_code.as_bytes()).unwrap();
+  let result = p.wait_with_output().unwrap();
+  assert!(result.status.success());
+  let stdout_str = std::str::from_utf8(&result.stdout).unwrap().trim();
+  assert_eq!(stdout_str, "executing javascript");
+}
+
 #[cfg(windows)]
 // Clippy suggests to remove the `NoStd` prefix from all variants. I disagree.
 #[allow(clippy::enum_variant_names)]
@@ -3836,14 +3886,14 @@ itest!(js_without_extension {
 });
 
 itest!(ts_without_extension {
-  args: "run --ext ts file_extensions/ts_without_extension",
+  args: "run --ext ts --check file_extensions/ts_without_extension",
   output: "file_extensions/ts_without_extension.out",
   exit_code: 0,
 });
 
 itest!(ext_flag_takes_precedence_over_extension {
-  args: "run --ext ts file_extensions/ts_with_js_extension.js",
-  output: "file_extensions/ts_with_extension.out",
+  args: "run --ext ts --check file_extensions/ts_with_js_extension.js",
+  output: "file_extensions/ts_with_js_extension.out",
   exit_code: 0,
 });
 

--- a/cli/tests/testdata/file_extensions/ts_with_js_extension.out
+++ b/cli/tests/testdata/file_extensions/ts_with_js_extension.out
@@ -1,0 +1,2 @@
+Check [WILDCARD]/file_extensions/ts_with_js_extension.js
+executing typescript with extension

--- a/cli/tests/testdata/file_extensions/ts_without_extension.out
+++ b/cli/tests/testdata/file_extensions/ts_without_extension.out
@@ -1,1 +1,2 @@
+Check [WILDCARD]/file_extensions/ts_without_extension
 executing typescript with no extension


### PR DESCRIPTION
Bug reported here shortly after merging `--ext` changes https://github.com/denoland/deno/pull/17172#issuecomment-1480898098

Also found a missing `--check` in integration tests for `--ext` that would have missed a bug if there was one.

Fixes #18392