### PR TITLE
test(ext/ffi): Increase timeout value in event loop integration test callback

### DIFF
--- a/test_ffi/tests/event_loop_integration.ts
+++ b/test_ffi/tests/event_loop_integration.ts
@@ -44,7 +44,7 @@ const tripleLogCallback = () => {
       callback.ref();
       dylib.symbols.call_stored_function_thread_safe_and_log();
     }
-  }, 10);
+  }, 100);
 };
 
 const callback = Deno.UnsafeCallback.threadSafe(
@@ -60,11 +60,12 @@ dylib.symbols.store_function(callback.pointer);
 
 // Synchronous callback logging
 console.log("SYNCHRONOUS");
+// This function only calls the callback, and does not log.
 dylib.symbols.call_stored_function();
 console.log("STORED_FUNCTION called");
 
 // Wait to make sure synch logging and async logging
-await new Promise((res) => setTimeout(res, 100));
+await new Promise((res) => setTimeout(res, 200));
 
 // Ref once to make sure both `queueMicrotask()` and `setTimeout()`
 // must resolve and unref before isolate exists.
@@ -73,4 +74,5 @@ callback.ref();
 
 console.log("THREAD SAFE");
 retry = true;
+// This function calls the callback and logs 'STORED_FUNCTION called'
 dylib.symbols.call_stored_function_thread_safe_and_log();


### PR DESCRIPTION
The test has flakes for essentially the same reason as what it is trying to test: How asynchronous work started from FFI callbacks gets resolved.

Due to Deno using the `v8::MicrotasksPolicy::kAuto` for handling microtasks, the microtask queue is drained synchronously when the script call depth decrements to zero. FFI callbacks coming from foreign threads get called one at a time from an empty scope created expressly for the purpose of calling that particular callback. As a result, each FFI callback immediately drains the microtask queue upon its completion.

The test uses two calls, `queueMicrotask` and `setTimeout` to respectively push one microtask into the queue and push one macrotask into their separate queue. However, `setTimeout` isn't exactly guaranteed to create a macrotask. A short enough timeout can cause the task to become a microtask instead. The 10 ms timeout had been chosen as a safe bound but apparently it is not quite safe enough. The flake occurs when the `setTimeout` manages to inch itself into the microtask queue:

The test expects that first the "Sync" will be logged from the callback directly, then "Async" from the `queueMicrotask` microtask. Then, the Rust code calling the callback will log its "STORED_FUNCTION called", after which finally the `setTimeout` task logs "Timeout". When `setTimeout` gets into the microtask queue, it instead logs before the Rust code is returned to.

From a JS point of view this would look like this to:
```ts
(() => {
  console.log("Sync");
  queueMicrotask(() => console.log("Async"));
  setTimeout(() => console.log("Timeout"), 10);
})();
console.log("Done");
```