### PR TITLE
feat: Add Deno.standalone API (#15996)

### DIFF
--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -288,6 +288,7 @@ fn create_web_worker_callback(
       compiled_wasm_module_store: Some(ps.compiled_wasm_module_store.clone()),
       cache_storage_dir: None,
       stdio: Default::default(),
+      standalone: true,
     };
 
     WebWorker::bootstrap_from_options(
@@ -367,6 +368,7 @@ pub async fn run(
     maybe_inspector_server: None,
     should_break_on_first_statement: false,
     should_wait_for_inspector_session: false,
+    standalone: true,
     module_loader,
     npm_resolver: None, // not currently supported
     get_error_class_fn: Some(&get_error_class_name),

--- a/cli/tests/integration/compile_tests.rs
+++ b/cli/tests/integration/compile_tests.rs
@@ -787,3 +787,43 @@ fn dynamic_import_unanalyzable() {
   .unwrap();
   assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
 }
+
+#[test]
+fn standalone_api() {
+  let _guard = util::http_server();
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("run")
+    .arg("--no-check")
+    .arg(util::testdata_path().join("./compile/standalone_api.ts"))
+    .output()
+    .unwrap();
+  assert!(output.status.success());
+
+  assert_eq!(output.stdout, "false\n".as_bytes());
+}
+
+#[test]
+fn standalone_api_compiled() {
+  let _guard = util::http_server();
+  let dir = TempDir::new();
+  let exe = if cfg!(windows) {
+    dir.path().join("standalone_api.exe")
+  } else {
+    dir.path().join("standalone_api")
+  };
+  let output = util::deno_cmd()
+    .current_dir(util::root_path())
+    .arg("compile")
+    .arg("--no-check")
+    .arg("--output")
+    .arg(&exe)
+    .arg(util::testdata_path().join("./compile/standalone_api.ts"))
+    .output()
+    .unwrap();
+  assert!(output.status.success());
+
+  let output = Command::new(&exe).output().unwrap();
+  assert!(output.status.success());
+  assert_eq!(output.stdout, "true\n".as_bytes());
+}

--- a/cli/tests/testdata/compile/standalone_api.ts
+++ b/cli/tests/testdata/compile/standalone_api.ts
@@ -1,0 +1,1 @@
+console.log(Deno.standalone);

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4758,6 +4758,13 @@ declare namespace Deno {
    */
   export const mainModule: string;
 
+  /** A flag that indicates if the current module is running in a self-contained executable.
+   *
+   * @tags allow-read
+   * @category Runtime Environment
+   */
+  export const standalone: boolean;
+
   /** Options that can be used with {@linkcode symlink} and
    * {@linkcode symlinkSync}.
    *

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -539,6 +539,7 @@ async fn create_main_worker_internal(
     maybe_inspector_server,
     should_break_on_first_statement: ps.options.inspect_brk().is_some(),
     should_wait_for_inspector_session: ps.options.inspect_wait().is_some(),
+    standalone: false,
     module_loader,
     npm_resolver: Some(Rc::new(ps.npm_resolver.clone())),
     get_error_class_fn: Some(&errors::get_error_class_name),
@@ -715,6 +716,7 @@ fn create_web_worker_callback(
       compiled_wasm_module_store: Some(ps.compiled_wasm_module_store.clone()),
       stdio: stdio.clone(),
       cache_storage_dir,
+      standalone: false,
     };
 
     WebWorker::bootstrap_from_options(
@@ -756,6 +758,7 @@ mod tests {
       maybe_inspector_server: None,
       should_break_on_first_statement: false,
       should_wait_for_inspector_session: false,
+      standalone: false,
       module_loader: Rc::new(FsModuleLoader),
       npm_resolver: None,
       get_error_class_fn: None,

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -42,6 +42,7 @@ async fn main() -> Result<(), AnyError> {
     maybe_inspector_server: None,
     should_break_on_first_statement: false,
     should_wait_for_inspector_session: false,
+    standalone: false,
     module_loader,
     npm_resolver: None,
     get_error_class_fn: Some(&get_error_class_name),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -213,6 +213,10 @@ function opMainModule() {
   return ops.op_main_module();
 }
 
+function opStandalone() {
+  return ops.op_standalone();
+}
+
 function formatException(error) {
   if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, error)) {
     return null;
@@ -459,6 +463,7 @@ function bootstrapMainRuntime(runtimeOptions) {
     noColor: util.readOnly(runtimeOptions.noColor),
     args: util.readOnly(ObjectFreeze(runtimeOptions.args)),
     mainModule: util.getterOnly(opMainModule),
+    standalone: util.getterOnly(opStandalone),
   });
 
   if (runtimeOptions.unstableFlag) {

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -8,10 +8,11 @@ use deno_core::OpState;
 
 deno_core::extension!(
   deno_runtime,
-  ops = [op_main_module],
-  options = { main_module: ModuleSpecifier },
+  ops = [op_main_module, op_standalone],
+  options = { main_module: ModuleSpecifier, standalone: bool },
   state = |state, options| {
     state.put::<ModuleSpecifier>(options.main_module);
+    state.put::<bool>(options.standalone);
   },
   customizer = |ext: &mut deno_core::ExtensionBuilder| {
     ext.force_op_registration();
@@ -29,6 +30,11 @@ fn op_main_module(state: &mut OpState) -> Result<String, AnyError> {
       .check_read_blind(&main_path, "main_module", "Deno.mainModule")?;
   }
   Ok(main_path)
+}
+
+#[op]
+fn op_standalone(state: &mut OpState) -> Result<bool, AnyError> {
+  Ok(*state.borrow::<bool>())
 }
 
 pub fn ppid() -> i64 {

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -346,6 +346,7 @@ pub struct WebWorkerOptions {
   pub compiled_wasm_module_store: Option<CompiledWasmModuleStore>,
   pub cache_storage_dir: Option<std::path::PathBuf>,
   pub stdio: Stdio,
+  pub standalone: bool,
 }
 
 impl WebWorker {
@@ -446,7 +447,10 @@ impl WebWorker {
       ),
       // Runtime ops that are always initialized for WebWorkers
       ops::web_worker::deno_web_worker::init_ops(),
-      ops::runtime::deno_runtime::init_ops(main_module.clone()),
+      ops::runtime::deno_runtime::init_ops(
+        main_module.clone(),
+        options.standalone,
+      ),
       ops::worker_host::deno_worker_host::init_ops(
         options.create_web_worker_cb.clone(),
         options.preload_module_cb.clone(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -110,6 +110,9 @@ pub struct WorkerOptions {
   // user code.
   pub should_wait_for_inspector_session: bool,
 
+  // If true, the worker is running in a self-contained executable
+  pub standalone: bool,
+
   /// Allows to map error type to a string "class" used to represent
   /// error in JavaScript.
   pub get_error_class_fn: Option<GetErrorClassFn>,
@@ -152,6 +155,7 @@ impl Default for WorkerOptions {
       unsafely_ignore_certificate_errors: Default::default(),
       should_break_on_first_statement: Default::default(),
       should_wait_for_inspector_session: Default::default(),
+      standalone: Default::default(),
       compiled_wasm_module_store: Default::default(),
       shared_array_buffer_store: Default::default(),
       maybe_inspector_server: Default::default(),
@@ -269,7 +273,10 @@ impl MainWorker {
         options.npm_resolver,
       ),
       // Ops from this crate
-      ops::runtime::deno_runtime::init_ops(main_module.clone()),
+      ops::runtime::deno_runtime::init_ops(
+        main_module.clone(),
+        options.standalone,
+      ),
       ops::worker_host::deno_worker_host::init_ops(
         options.create_web_worker_cb.clone(),
         options.web_worker_preload_module_cb.clone(),


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This PR fixes #15996 by _attempting_ to add a new runtime API (`Deno.standalone`) to check whether the current code is running inside a self-contained executable.

---

#15996 was my issue from half a year ago and since it got a few thumbs up and I stumbled upon a similar issue just a few days ago and therefore needed such an API for the second time now, I just thought _"well, why not implement it myself and see what happens"_. It would be absolutely understandable if this API were rejected due to lack of demand.


I apologize in advance, for code that is not in the right spot. This is just my first time contributing to Deno and the project is veeeeery huge. 😂 Just let me know what to change 🙃 


