### PR TITLE
chore(ext/kv): add limits

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1862,7 +1862,7 @@ declare namespace Deno {
    * matches an expected versionstamp.
    *
    * Keys have a maximum length of 2048 bytes after serialization. Values have a
-   * maximum length of 16 KiB after serialization. Serialization of both keys
+   * maximum length of 64 KiB after serialization. Serialization of both keys
    * and values is somewhat opaque, but one can usually assume that the
    * serialization of any value is about the same length as the resulting string
    * of a JSON serialization of that same value.

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -155,7 +155,7 @@ class Kv {
 
     let batchSize = options.batchSize ?? (options.limit ?? 100);
     if (batchSize <= 0) throw new Error("batchSize must be positive");
-    if (batchSize > 500) batchSize = 500;
+    if (options.batchSize === undefined && batchSize > 500) batchSize = 500;
 
     return new KvListIterator({
       limit: options.limit,

--- a/ext/kv/interface.rs
+++ b/ext/kv/interface.rs
@@ -292,3 +292,15 @@ pub enum MutationKind {
   Min(Value),
   Max(Value),
 }
+
+impl MutationKind {
+  pub fn value(&self) -> Option<&Value> {
+    match self {
+      MutationKind::Set(value) => Some(value),
+      MutationKind::Sum(value) => Some(value),
+      MutationKind::Min(value) => Some(value),
+      MutationKind::Max(value) => Some(value),
+      MutationKind::Delete => None,
+    }
+  }
+}


### PR DESCRIPTION
- Max key size: 2 KiB
- Max value size: 64 KiB
- Max entries returned by `snapshot_read`: 1000
- Max ranges in a `snapshot_read`: 10
- Max mutations in an `atomic_write`: 10