### PR TITLE
feat(bench): add `--no-run` flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -59,6 +59,7 @@ pub struct BenchFlags {
   pub files: FileFlags,
   pub filter: Option<String>,
   pub json: bool,
+  pub no_run: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -799,6 +800,12 @@ fn bench_subcommand<'a>() -> Command<'a> {
         .takes_value(true)
         .multiple_values(true)
         .multiple_occurrences(true),
+    )
+    .arg(
+      Arg::new("no-run")
+        .long("no-run")
+        .help("Cache bench modules, but don't run benchmarks")
+        .takes_value(false),
     )
     .arg(watch_arg(false))
     .arg(no_clear_screen_arg())
@@ -2442,11 +2449,14 @@ fn bench_parse(flags: &mut Flags, matches: &clap::ArgMatches) {
     Vec::new()
   };
 
+  let no_run = matches.is_present("no-run");
+
   watch_arg_parse(flags, matches, false);
   flags.subcommand = DenoSubcommand::Bench(BenchFlags {
     files: FileFlags { include, ignore },
     filter,
     json,
+    no_run,
   });
 }
 
@@ -6684,6 +6694,7 @@ mod tests {
       "--unstable",
       "--no-npm",
       "--no-remote",
+      "--no-run",
       "--filter",
       "- foo",
       "--location",
@@ -6701,6 +6712,7 @@ mod tests {
         subcommand: DenoSubcommand::Bench(BenchFlags {
           filter: Some("- foo".to_string()),
           json: true,
+          no_run: true,
           files: FileFlags {
             include: vec![PathBuf::from("dir1/"), PathBuf::from("dir2/")],
             ignore: vec![],
@@ -6728,6 +6740,7 @@ mod tests {
         subcommand: DenoSubcommand::Bench(BenchFlags {
           filter: None,
           json: false,
+          no_run: false,
           files: FileFlags {
             include: vec![],
             ignore: vec![],

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -809,7 +809,7 @@ fn bench_subcommand() -> Command {
       Arg::new("no-run")
         .long("no-run")
         .help("Cache bench modules, but don't run benchmarks")
-        .takes_value(false),
+        .action(ArgAction::SetTrue),
     )
     .arg(watch_arg(false))
     .arg(no_clear_screen_arg())
@@ -2375,7 +2375,7 @@ fn bench_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     Vec::new()
   };
 
-  let no_run = matches.is_present("no-run");
+  let no_run = matches.get_flag("no-run");
 
   watch_arg_parse(flags, matches, false);
   flags.subcommand = DenoSubcommand::Bench(BenchFlags {

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -119,6 +119,7 @@ pub struct BenchOptions {
   pub files: FilesConfig,
   pub filter: Option<String>,
   pub json: bool,
+  pub no_run: bool,
 }
 
 impl BenchOptions {
@@ -134,6 +135,7 @@ impl BenchOptions {
       ),
       filter: bench_flags.filter,
       json: bench_flags.json,
+      no_run: bench_flags.no_run,
     })
   }
 }

--- a/cli/tests/integration/bench_tests.rs
+++ b/cli/tests/integration/bench_tests.rs
@@ -138,6 +138,12 @@ itest!(filter {
   output: "bench/filter.out",
 });
 
+itest!(no_run {
+  args: "bench --no-run bench/no_run.ts",
+  output: "bench/no_run.out",
+  exit_code: 1,
+});
+
 itest!(no_prompt_by_default {
   args: "bench --quiet bench/no_prompt_by_default.ts",
   exit_code: 1,

--- a/cli/tests/testdata/bench/no_run.out
+++ b/cli/tests/testdata/bench/no_run.out
@@ -1,0 +1,5 @@
+Check [WILDCARD]/bench/no_run.ts
+error: TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
+const _value: string = 1;
+      ~~~~~~
+    at [WILDCARD]/bench/no_run.ts:1:7

--- a/cli/tests/testdata/bench/no_run.ts
+++ b/cli/tests/testdata/bench/no_run.ts
@@ -1,0 +1,1 @@
+const _value: string = 1;

--- a/cli/tests/testdata/bench/no_run.ts
+++ b/cli/tests/testdata/bench/no_run.ts
@@ -1,1 +1,2 @@
 const _value: string = 1;
+console.log("this should not be run");

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -590,6 +590,10 @@ pub async fn run_benchmarks(
 
   check_specifiers(&ps, permissions.clone(), specifiers.clone()).await?;
 
+  if bench_options.no_run {
+    return Ok(());
+  }
+
   bench_specifiers(
     &ps,
     &permissions,
@@ -741,6 +745,10 @@ pub async fn run_benchmarks_with_watch(
           .collect::<Vec<ModuleSpecifier>>();
 
       check_specifiers(&ps, permissions.clone(), specifiers.clone()).await?;
+
+      if bench_options.no_run {
+        return Ok(());
+      }
 
       bench_specifiers(
         &ps,


### PR DESCRIPTION
This PR adds a flag to `deno bench` to cache and type-check specifiers only, similar to `deno test --no-run`

Closes https://github.com/denoland/deno/issues/18429