### PR TITLE
fix(cli): Set a maximum time to wait for `spawn_blocking` tasks

### DIFF
--- a/test_ffi/tests/integration_tests.rs
+++ b/test_ffi/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use std::process::{Command, Stdio};
+use std::process::Command;
 use test_util::deno_cmd;
 
 #[cfg(debug_assertions)]

--- a/test_ffi/tests/issue18131.js
+++ b/test_ffi/tests/issue18131.js
@@ -1,0 +1,25 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+const targetDir = Deno.execPath().replace(/[^\/\\]+$/, "");
+const [libPrefix, libSuffix] = {
+  darwin: ["lib", "dylib"],
+  linux: ["lib", "so"],
+  windows: ["", "dll"],
+}[Deno.build.os];
+const libPath = `${targetDir}/${libPrefix}test_ffi.${libSuffix}`;
+
+const lib = Deno.dlopen(libPath, {
+  sleep_nonblocking: {
+    name: "sleep_blocking",
+    parameters: ["u64"],
+    result: "void",
+    nonblocking: true,
+  },
+});
+
+const ONE_HOUR = 1000 * 60 * 60;
+lib.symbols.sleep_nonblocking(ONE_HOUR).then(() => {
+  console.log("WTF? We woke up!");
+});
+
+throw new Error("Error!");


### PR DESCRIPTION
Tokio's `spawn_blocking` allows running blocking operations, which in Deno include file I/O and "non-blocking" FFI, in a thread pool separate from the thread running the JS event loop. However, by default, when the tokio runtime is dropped, it will block on the main thread until all such blocking operations have completed.

This is a problem, since a non-blocking FFI call might never actually finish, which would keep the Deno process running forever, even if it would otherwise have finished earlier because of an uncaught exception. This change, therefore, sets a time limit of 0.5 seconds to wait for those blocking tasks to finish.

Closes #18131.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
