### PR TITLE
fix(cli): add colors to "Module not found" error frame

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -96,7 +96,12 @@ pub fn graph_valid(
 
       if let Some(range) = error.maybe_range() {
         if !is_root && !range.specifier.as_str().contains("/$deno$eval") {
-          message.push_str(&format!("\n    at {range}"));
+          message.push_str(&format!(
+            "\n    at {}:{}:{}",
+            colors::cyan(range.specifier.as_str()),
+            colors::yellow(&(range.start.line + 1).to_string()),
+            colors::yellow(&(range.start.character + 1).to_string())
+          ));
         }
       }
 

--- a/cli/tools/vendor/build.rs
+++ b/cli/tools/vendor/build.rs
@@ -1117,7 +1117,7 @@ mod test {
       .unwrap();
 
     assert_eq!(
-      err.to_string(),
+      test_util::strip_ansi_codes(&err.to_string()),
       concat!(
         "500 Internal Server Error\n",
         "    at https://localhost/mod.ts:1:14"


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Noticed that `ReferenceError` and other errors get a colored stack frame, but missing module errors don't. This PR adds the colors back.

Example for a `ReferenceError`:

<img width="856" alt="Screenshot 2023-03-25 at 00 07 30" src="https://user-images.githubusercontent.com/1062408/227745290-742e4bfb-e797-4a09-9c48-f74404229b73.png">

Before:
<img width="1124" alt="Screenshot 2023-03-25 at 22 57 04" src="https://user-images.githubusercontent.com/1062408/227745255-cc7dad82-0a5b-4684-ba89-47a842e1301a.png">

After:

<img width="1141" alt="Screenshot 2023-03-25 at 22 57 52" src="https://user-images.githubusercontent.com/1062408/227745263-7e7eabff-d593-4114-a066-4c7405748580.png">