### PR TITLE
refactor: use default implementation of BootstrapOptions

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -742,21 +742,7 @@ mod tests {
     let permissions = PermissionsContainer::new(Permissions::default());
 
     let options = WorkerOptions {
-      bootstrap: BootstrapOptions {
-        args: vec![],
-        cpu_count: 1,
-        debug_flag: false,
-        enable_testing_features: false,
-        locale: deno_core::v8::icu::get_language_tag(),
-        location: None,
-        no_color: true,
-        is_tty: false,
-        runtime_version: "x".to_string(),
-        ts_version: "x".to_string(),
-        unstable: false,
-        user_agent: "x".to_string(),
-        inspect: false,
-      },
+      bootstrap: BootstrapOptions::default(),
       extensions: vec![],
       startup_snapshot: Some(crate::js::deno_isolate_init()),
       unsafely_ignore_certificate_errors: None,

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -28,21 +28,7 @@ async fn main() -> Result<(), AnyError> {
   });
 
   let options = WorkerOptions {
-    bootstrap: BootstrapOptions {
-      args: vec![],
-      cpu_count: 1,
-      debug_flag: false,
-      enable_testing_features: false,
-      locale: deno_core::v8::icu::get_language_tag(),
-      location: None,
-      no_color: false,
-      is_tty: false,
-      runtime_version: "x".to_string(),
-      ts_version: "x".to_string(),
-      unstable: false,
-      user_agent: "hello_runtime".to_string(),
-      inspect: false,
-    },
+    bootstrap: BootstrapOptions::default(),
     extensions: vec![],
     startup_snapshot: None,
     unsafely_ignore_certificate_errors: None,


### PR DESCRIPTION
Drive-by cleanup while I was looking into serialization of BootstrapOptions.
There's no need to use non-default implementation in these places.