### PR TITLE
fix(ext/node): add missing _preloadModules hook

### DIFF
--- a/cli/tests/unit_node/module_test.ts
+++ b/cli/tests/unit_node/module_test.ts
@@ -1,0 +1,14 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { Module } from "node:module";
+import { assertStrictEquals } from "../../../test_util/std/testing/asserts.ts";
+
+Deno.test("[node/module _preloadModules] has internal require hook", () => {
+  // Check if it's there
+  // deno-lint-ignore no-explicit-any
+  (Module as any)._preloadModules([
+    "./cli/tests/unit_node/testdata/add_global_property.js",
+  ]);
+  // deno-lint-ignore no-explicit-any
+  assertStrictEquals((globalThis as any).foo, "Hello");
+});

--- a/cli/tests/unit_node/testdata/add_global_property.js
+++ b/cli/tests/unit_node/testdata/add_global_property.js
@@ -1,0 +1,1 @@
+globalThis.foo = "Hello";


### PR DESCRIPTION
This internal node hook is used by libraries such as `ts-node` when used as a require hook `node -r ts-node/register`. That combination is often used with test frameworks like `mocha` or `jasmine`.

We had a reference to `Module._preloadModules` in our code, but the implementation was missing. While fixing this I also noticed that the `fakeParent` module that we create internally always threw because of the `pathDirname` check on the module id in the constructor of `Mdoule`. So this code path was probably broken for a while.

```txt
✖ ERROR: Error: Empty filepath.
    at pathDirname (ext:deno_node/01_require.js:245:11)
    at new Module (ext:deno_node/01_require.js:446:15)
    at Function.Module._resolveFilename (ext:deno_node/01_require.js:754:28)
    at Function.resolve (ext:deno_node/01_require.js:1015:19)
```

With the changes in this PR I'm now able to run `mocha` tests with `ts-node` in `deno`:

<img width="842" alt="Screenshot 2023-03-26 at 22 47 46" src="https://user-images.githubusercontent.com/1062408/227803830-f78c11aa-bd24-46d6-b221-0ebd778ab857.png">


<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
