### PR TITLE
refactor(runtime): manual serialization of bootstrap data

### DIFF
--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -556,8 +556,7 @@ impl WebWorker {
     // WebWorkers can have empty string as name.
     {
       let scope = &mut self.js_runtime.handle_scope();
-      let options_v8 =
-        deno_core::serde_v8::to_v8(scope, options.as_json()).unwrap();
+      let args = options.as_v8(scope);
       let bootstrap_fn = self.bootstrap_fn_global.take().unwrap();
       let bootstrap_fn = v8::Local::new(scope, bootstrap_fn);
       let undefined = v8::undefined(scope);
@@ -568,7 +567,7 @@ impl WebWorker {
           .unwrap()
           .into();
       bootstrap_fn
-        .call(scope, undefined.into(), &[options_v8, name_str, id_str])
+        .call(scope, undefined.into(), &[args.into(), name_str, id_str])
         .unwrap();
     }
     // TODO(bartlomieju): this could be done using V8 API, without calling `execute_script`.

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -361,13 +361,12 @@ impl MainWorker {
 
   pub fn bootstrap(&mut self, options: &BootstrapOptions) {
     let scope = &mut self.js_runtime.handle_scope();
-    let options_v8 =
-      deno_core::serde_v8::to_v8(scope, options.as_json()).unwrap();
+    let args = options.as_v8(scope);
     let bootstrap_fn = self.bootstrap_fn_global.take().unwrap();
     let bootstrap_fn = v8::Local::new(scope, bootstrap_fn);
     let undefined = v8::undefined(scope);
     bootstrap_fn
-      .call(scope, undefined.into(), &[options_v8])
+      .call(scope, undefined.into(), &[args.into()])
       .unwrap();
   }
 

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -86,7 +86,7 @@ impl BootstrapOptions {
       let val = v8::String::new_from_one_byte(
         scope,
         self.runtime_version.as_bytes(),
-        v8::NewStringType::Normal,
+        v8::NewStringType::Internalized,
       )
       .unwrap();
       array.set_index(scope, 3, val.into());
@@ -104,13 +104,7 @@ impl BootstrapOptions {
 
     {
       let val: v8::Local<v8::Value> = if let Some(location) = &self.location {
-        v8::String::new_from_one_byte(
-          scope,
-          location.as_str().as_bytes(),
-          v8::NewStringType::Normal,
-        )
-        .unwrap()
-        .into()
+        v8::String::new(scope, location.as_str()).unwrap().into()
       } else {
         v8::undefined(scope).into()
       };
@@ -154,10 +148,9 @@ impl BootstrapOptions {
     }
 
     {
-      let val = v8::String::new_from_one_byte(
+      let val = v8::String::new_external_onebyte_static(
         scope,
         env!("TARGET").as_bytes(),
-        v8::NewStringType::Normal,
       )
       .unwrap();
       array.set_index(scope, 12, val.into());

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -2,6 +2,7 @@
 
 use deno_core::serde_json;
 use deno_core::serde_json::json;
+use deno_core::v8;
 use deno_core::ModuleSpecifier;
 use std::thread;
 
@@ -58,6 +59,145 @@ impl Default for BootstrapOptions {
 }
 
 impl BootstrapOptions {
+  pub fn as_v8<'s>(
+    &self,
+    scope: &mut v8::HandleScope<'s>,
+  ) -> v8::Local<'s, v8::Array> {
+    let array = v8::Array::new(scope, 17);
+
+    {
+      let args = v8::Array::new(scope, self.args.len() as i32);
+      for (idx, arg) in self.args.iter().enumerate() {
+        let arg_str = v8::String::new(scope, &arg).unwrap();
+        args.set_index(scope, idx as u32, arg_str.into());
+      }
+      array.set_index(scope, 0, args.into());
+    }
+
+    {
+      let val = v8::Integer::new(scope, self.cpu_count as i32);
+      array.set_index(scope, 1, val.into());
+    }
+
+    {
+      let val = v8::Boolean::new(scope, self.debug_flag);
+      array.set_index(scope, 2, val.into());
+    }
+
+    {
+      let val = v8::String::new_from_one_byte(
+        scope,
+        self.runtime_version.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      array.set_index(scope, 3, val.into());
+    }
+
+    {
+      let val = v8::String::new_from_one_byte(
+        scope,
+        self.locale.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      array.set_index(scope, 4, val.into());
+    }
+
+    {
+      let val: v8::Local<v8::Value> = if let Some(location) = &self.location {
+        v8::String::new_from_one_byte(
+          scope,
+          location.as_str().as_bytes(),
+          v8::NewStringType::Normal,
+        )
+        .unwrap()
+        .into()
+      } else {
+        v8::undefined(scope).into()
+      };
+
+      array.set_index(scope, 5, val);
+    }
+
+    {
+      let val = v8::Boolean::new(scope, self.no_color);
+      array.set_index(scope, 6, val.into());
+    }
+
+    {
+      let val = v8::Boolean::new(scope, self.is_tty);
+      array.set_index(scope, 7, val.into());
+    }
+
+    {
+      let val = v8::String::new_from_one_byte(
+        scope,
+        self.ts_version.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      array.set_index(scope, 8, val.into());
+    }
+
+    {
+      let val = v8::Boolean::new(scope, self.unstable);
+      array.set_index(scope, 9, val.into());
+    }
+
+    {
+      let val = v8::Integer::new(scope, std::process::id() as i32);
+      array.set_index(scope, 10, val.into());
+    }
+
+    {
+      let val = v8::Integer::new(scope, ppid() as i32);
+      array.set_index(scope, 11, val.into());
+    }
+
+    {
+      let val = v8::String::new_from_one_byte(
+        scope,
+        env!("TARGET").as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      array.set_index(scope, 12, val.into());
+    }
+
+    {
+      let val = v8::String::new_from_one_byte(
+        scope,
+        deno_core::v8_version().as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      array.set_index(scope, 13, val.into());
+    }
+
+    {
+      let val = v8::String::new_from_one_byte(
+        scope,
+        self.user_agent.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
+      array.set_index(scope, 14, val.into());
+    }
+
+    {
+      let val = v8::Boolean::new(scope, self.unstable);
+      array.set_index(scope, 15, val.into());
+    }
+
+    {
+      let val = v8::Boolean::new(scope, self.unstable);
+      array.set_index(scope, 16, val.into());
+    }
+
+    array
+  }
+
   pub fn as_json(&self) -> serde_json::Value {
     json!({
       // Shared bootstrap args

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -184,7 +184,7 @@ impl BootstrapOptions {
     }
 
     {
-      let val = v8::Boolean::new(scope, self.unstable);
+      let val = v8::Boolean::new(scope, self.inspect);
       array.set_index(scope, 15, val.into());
     }
 

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -1,7 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::serde_json;
-use deno_core::serde_json::json;
 use deno_core::v8;
 use deno_core::ModuleSpecifier;
 use std::thread;
@@ -68,7 +66,7 @@ impl BootstrapOptions {
     {
       let args = v8::Array::new(scope, self.args.len() as i32);
       for (idx, arg) in self.args.iter().enumerate() {
-        let arg_str = v8::String::new(scope, &arg).unwrap();
+        let arg_str = v8::String::new(scope, arg).unwrap();
         args.set_index(scope, idx as u32, arg_str.into());
       }
       array.set_index(scope, 0, args.into());
@@ -191,35 +189,10 @@ impl BootstrapOptions {
     }
 
     {
-      let val = v8::Boolean::new(scope, self.unstable);
+      let val = v8::Boolean::new(scope, self.enable_testing_features);
       array.set_index(scope, 16, val.into());
     }
 
     array
-  }
-
-  pub fn as_json(&self) -> serde_json::Value {
-    json!({
-      // Shared bootstrap args
-      "args": self.args,
-      "cpuCount": self.cpu_count,
-      "debugFlag": self.debug_flag,
-      "denoVersion": self.runtime_version,
-      "locale": self.locale,
-      "location": self.location,
-      "noColor": self.no_color,
-      "isTty": self.is_tty,
-      "tsVersion": self.ts_version,
-      "unstableFlag": self.unstable,
-      // Web worker only
-      "enableTestingFeaturesFlag": self.enable_testing_features,
-      // Env values
-      "pid": std::process::id(),
-      "ppid": ppid(),
-      "target": env!("TARGET"),
-      "v8Version": deno_core::v8_version(),
-      "userAgent": self.user_agent,
-      "inspectFlag": self.inspect,
-    })
   }
 }


### PR DESCRIPTION
This commit changes how data required to bootstrap main and worker runtime
is serialized. Instead of relying on serde_v8 and using JSON object, we're doing
manual serialization to a "v8::Array". This limits number of V8 strings that need
to be serialized by 16. It also made it clear that some data could be obtained during
snapshotting instead of during bootstrap.