### PR TITLE
refactor: remove Deno[Deno.internal].nodeUnstable namespace

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+const core = globalThis.Deno.core;
+const ops = core.ops;
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { type Deferred, deferred } from "ext:deno_node/_util/async.ts";
 import { _normalizeArgs, ListenOptions, Socket } from "ext:deno_node/net.ts";
@@ -17,6 +19,7 @@ import { Agent } from "ext:deno_node/_http_agent.mjs";
 import { chunkExpression as RE_TE_CHUNKED } from "ext:deno_node/_http_common.ts";
 import { urlToHttpOptions } from "ext:deno_node/internal/url.ts";
 import { constants, TCP } from "ext:deno_node/internal_binding/tcp_wrap.ts";
+import * as flash from "ext:deno_flash/01_http.js";
 
 enum STATUS_CODES {
   /** RFC 7231, 6.2.1 */
@@ -188,11 +191,8 @@ const METHODS = [
 
 type Chunk = string | Buffer | Uint8Array;
 
-// @ts-ignore Deno[Deno.internal] is used on purpose here
-const DenoServe = Deno[Deno.internal]?.nodeUnstable?.serve || Deno.serve;
-// @ts-ignore Deno[Deno.internal] is used on purpose here
-const DenoUpgradeHttpRaw = Deno[Deno.internal]?.nodeUnstable?.upgradeHttpRaw ||
-  Deno.upgradeHttpRaw;
+const DenoServe = flash.createServe(ops.op_node_unstable_flash_server);
+const DenoUpgradeHttpRaw = flash.upgradeHttpRaw;
 
 const ENCODER = new TextEncoder();
 

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -191,7 +191,7 @@ const METHODS = [
 
 type Chunk = string | Buffer | Uint8Array;
 
-const DenoServe = flash.createServe(ops.op_node_unstable_flash_server);
+const DenoServe = flash.createServe(ops.op_node_unstable_flash_serve);
 const DenoUpgradeHttpRaw = flash.upgradeHttpRaw;
 
 const ENCODER = new TextEncoder();

--- a/ext/node/polyfills/internal_binding/udp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/udp_wrap.ts
@@ -20,6 +20,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+const core = globalThis.Deno.core;
+const ops = core.ops;
 import {
   AsyncWrap,
   providerType,
@@ -32,12 +34,13 @@ import { notImplemented } from "ext:deno_node/_utils.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import type { ErrnoException } from "ext:deno_node/internal/errors.ts";
 import { isIP } from "ext:deno_node/internal/net.ts";
-
+import * as net from "ext:deno_net/01_net.js";
 import { isLinux, isWindows } from "ext:deno_node/_util/os.ts";
 
-// @ts-ignore Deno[Deno.internal] is used on purpose here
-const DenoListenDatagram = Deno[Deno.internal]?.nodeUnstable?.listenDatagram ||
-  Deno.listenDatagram;
+const DenoListenDatagram = net.createListenDatagram(
+  ops.op_node_unstable_net_listen_udp,
+  ops.op_node_unstable_net_listen_unixpacket,
+);
 
 type MessageType = string | Uint8Array | Buffer | DataView;
 

--- a/ext/node/polyfills/os.ts
+++ b/ext/node/polyfills/os.ts
@@ -25,14 +25,10 @@ import { validateIntegerRange } from "ext:deno_node/_utils.ts";
 import process from "ext:deno_node/process.ts";
 import { isWindows, osType } from "ext:deno_node/_util/os.ts";
 import { os } from "ext:deno_node/internal_binding/constants.ts";
-
+import { osUptime } from "ext:runtime/30_os.js";
 export const constants = os;
 
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno_std/issues/1436";
-
-// @ts-ignore Deno[Deno.internal] is used on purpose here
-const DenoOsUptime = Deno[Deno.internal]?.nodeUnstable?.osUptime ||
-  Deno.osUptime;
 
 interface CPUTimes {
   /** The number of milliseconds the CPU has spent in user mode */
@@ -310,7 +306,7 @@ export function type(): string {
 
 /** Returns the Operating System uptime in number of seconds. */
 export function uptime(): number {
-  return DenoOsUptime();
+  return osUptime();
 }
 
 /** Not yet implemented */

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -170,6 +170,11 @@ const denoNsUnstable = {
   funlockSync: fs.funlockSync,
   upgradeHttp: http.upgradeHttp,
   upgradeHttpRaw: flash.upgradeHttpRaw,
+  serve: flash.createServe(ops.op_flash_serve),
+  listenDatagram: net.createListenDatagram(
+    ops.op_net_listen_udp,
+    ops.op_net_listen_unixpacket,
+  ),
   openKv: kv.openKv,
   Kv: kv.Kv,
   KvU64: kv.KvU64,

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -153,7 +153,10 @@ const denoNs = {
 };
 
 const denoNsUnstable = {
-  listenDatagram: net.listenDatagram,
+  listenDatagram: net.createListenDatagram(
+    ops.op_net_listen_udp,
+    ops.op_net_listen_unixpacket,
+  ),
   umask: fs.umask,
   HttpClient: httpClient.HttpClient,
   createHttpClient: httpClient.createHttpClient,
@@ -171,10 +174,6 @@ const denoNsUnstable = {
   upgradeHttp: http.upgradeHttp,
   upgradeHttpRaw: flash.upgradeHttpRaw,
   serve: flash.createServe(ops.op_flash_serve),
-  listenDatagram: net.createListenDatagram(
-    ops.op_net_listen_udp,
-    ops.op_net_listen_unixpacket,
-  ),
   openKv: kv.openKv,
   Kv: kv.Kv,
   KvU64: kv.KvU64,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -465,16 +465,6 @@ function bootstrapMainRuntime(runtimeOptions) {
 
   if (runtimeOptions.unstableFlag) {
     ObjectAssign(finalDenoNs, denoNsUnstable);
-    // These have to initialized here and not in `90_deno_ns.js` because
-    // the op function that needs to be passed will be invalidated by creating
-    // a snapshot
-    ObjectAssign(finalDenoNs, {
-      serve: flash.createServe(ops.op_flash_serve),
-      listenDatagram: net.createListenDatagram(
-        ops.op_net_listen_udp,
-        ops.op_net_listen_unixpacket,
-      ),
-    });
   }
 
   // Setup `Deno` global - we're actually overriding already existing global
@@ -554,16 +544,6 @@ function bootstrapWorkerRuntime(
 
   if (runtimeOptions.unstableFlag) {
     ObjectAssign(finalDenoNs, denoNsUnstable);
-    // These have to initialized here and not in `90_deno_ns.js` because
-    // the op function that needs to be passed will be invalidated by creating
-    // a snapshot
-    ObjectAssign(finalDenoNs, {
-      serve: flash.createServe(ops.op_flash_serve),
-      listenDatagram: net.createListenDatagram(
-        ops.op_net_listen_udp,
-        ops.op_net_listen_unixpacket,
-      ),
-    });
   }
   ObjectDefineProperties(finalDenoNs, {
     pid: util.readOnly(runtimeOptions.pid),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -455,27 +455,6 @@ function bootstrapMainRuntime(runtimeOptions) {
   setUserAgent(runtimeOptions.userAgent);
   setLanguage(runtimeOptions.locale);
 
-  // These have to initialized here and not in `90_deno_ns.js` because
-  // the op function that needs to be passed will be invalidated by creating
-  // a snapshot
-  ObjectAssign(internals, {
-    nodeUnstable: {
-      serve: flash.createServe(ops.op_node_unstable_flash_serve),
-      upgradeHttpRaw: flash.upgradeHttpRaw,
-      listenDatagram: net.createListenDatagram(
-        ops.op_node_unstable_net_listen_udp,
-        ops.op_node_unstable_net_listen_unixpacket,
-      ),
-    },
-  });
-
-  // FIXME(bartlomieju): temporarily add whole `Deno.core` to
-  // `Deno[Deno.internal]` namespace. It should be removed and only necessary
-  // methods should be left there.
-  ObjectAssign(internals, {
-    core,
-  });
-
   ObjectDefineProperties(finalDenoNs, {
     pid: util.readOnly(runtimeOptions.pid),
     ppid: util.readOnly(runtimeOptions.ppid),
@@ -572,27 +551,6 @@ function bootstrapWorkerRuntime(
   setLanguage(runtimeOptions.locale);
 
   globalThis.pollForMessages = pollForMessages;
-
-  // These have to initialized here and not in `90_deno_ns.js` because
-  // the op function that needs to be passed will be invalidated by creating
-  // a snapshot
-  ObjectAssign(internals, {
-    nodeUnstable: {
-      serve: flash.createServe(ops.op_node_unstable_flash_serve),
-      upgradeHttpRaw: flash.upgradeHttpRaw,
-      listenDatagram: net.createListenDatagram(
-        ops.op_node_unstable_net_listen_udp,
-        ops.op_node_unstable_net_listen_unixpacket,
-      ),
-    },
-  });
-
-  // FIXME(bartlomieju): temporarily add whole `Deno.core` to
-  // `Deno[Deno.internal]` namespace. It should be removed and only necessary
-  // methods should be left there.
-  ObjectAssign(internals, {
-    core,
-  });
 
   if (runtimeOptions.unstableFlag) {
     ObjectAssign(finalDenoNs, denoNsUnstable);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -45,7 +45,6 @@ import * as version from "ext:runtime/01_version.ts";
 import * as os from "ext:runtime/30_os.js";
 import * as timers from "ext:deno_web/02_timers.js";
 import * as colors from "ext:deno_console/01_colors.js";
-import * as net from "ext:deno_net/01_net.js";
 import {
   inspectArgs,
   quoteString,
@@ -59,7 +58,6 @@ import { denoNs, denoNsUnstable } from "ext:runtime/90_deno_ns.js";
 import { errors } from "ext:runtime/01_errors.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import DOMException from "ext:deno_web/01_dom_exception.js";
-import * as flash from "ext:deno_flash/01_http.js";
 import {
   mainRuntimeGlobalProperties,
   setLanguage,


### PR DESCRIPTION
Since we can preserve ops in the snapshot these days, we no longer
need to have "Deno[Deno.internal].nodeUnstable" namespace.

Instead, various built-in Node.js modules can use appropriate APIs
directly.