### PR TITLE
fix: make `serde_v8::V8Slice` sound

### DIFF
--- a/serde_v8/de.rs
+++ b/serde_v8/de.rs
@@ -144,7 +144,7 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
       // e.g: for untagged enums or StringOrBuffer
       ValueType::ArrayBufferView | ValueType::ArrayBuffer => {
         magic::v8slice::V8Slice::from_v8(&mut *self.scope, self.input)
-          .and_then(|zb| visitor.visit_byte_buf(Vec::from(&*zb)))
+          .and_then(|zb| visitor.visit_byte_buf(zb.to_vec()))
       }
     }
   }
@@ -449,8 +449,7 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
   where
     V: Visitor<'de>,
   {
-    magic::buffer::ZeroCopyBuf::from_v8(self.scope, self.input)
-      .and_then(|zb| visitor.visit_bytes(&zb))
+    self.deserialize_byte_buf(visitor)
   }
 
   fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
@@ -458,7 +457,7 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
     V: Visitor<'de>,
   {
     magic::buffer::ZeroCopyBuf::from_v8(self.scope, self.input)
-      .and_then(|zb| visitor.visit_byte_buf(Vec::from(&*zb)))
+      .and_then(|zb| visitor.visit_byte_buf(zb.to_vec()))
   }
 }
 

--- a/serde_v8/magic/buffer.rs
+++ b/serde_v8/magic/buffer.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use std::fmt::Debug;
-use std::ops::Deref;
-use std::ops::DerefMut;
 
 use super::transl8::FromV8;
 use super::transl8::ToV8;
@@ -14,16 +12,13 @@ use crate::magic::transl8::impl_magic;
 pub enum ZeroCopyBuf {
   FromV8(V8Slice),
   ToV8(Option<Box<[u8]>>),
-  // Variant of the ZeroCopyBuf than is never exposed to the JS.
-  // Generally used to pass Vec<u8> backed buffers to resource methods.
-  Temp(Vec<u8>),
 }
 
 impl_magic!(ZeroCopyBuf);
 
 impl Debug for ZeroCopyBuf {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_list().entries(self.as_ref().iter()).finish()
+    self.open(|bytes| f.debug_list().entries(bytes.iter()).finish())
   }
 }
 
@@ -32,58 +27,67 @@ impl ZeroCopyBuf {
     ZeroCopyBuf::ToV8(Some(vec![0_u8; 0].into_boxed_slice()))
   }
 
-  pub fn new_temp(vec: Vec<u8>) -> Self {
-    ZeroCopyBuf::Temp(vec)
+  /// View the contents of the underlying byte slice.
+  ///
+  /// ### Safety
+  ///
+  /// V8 must never be invoked or the underlying [v8::BackingStore] accessed or
+  /// resized for the duration of the callback `cb`'s execution.
+  pub fn open<'s, F, R>(&'s self, cb: F) -> R
+  where
+    F: FnOnce(&[u8]) -> R,
+  {
+    match self {
+      Self::FromV8(v8slice) => v8slice.open(cb),
+      Self::ToV8(Some(data)) => cb(&data),
+      Self::ToV8(_) => {
+        panic!("tried to read a V8Slice already sent to V8")
+      }
+    }
   }
 
-  // TODO(@littledivy): Temporary, this needs a refactor.
-  pub fn to_temp(self) -> Vec<u8> {
+  /// Access a mutable slice the contents of the underlying byte slice.
+  ///
+  /// ### Panics
+  ///
+  /// Must not be called on a V8Slice destined for V8.
+  ///
+  /// ### Safety
+  ///
+  /// V8 must never be invoked or the underlying [v8::BackingStore] accessed or
+  /// resized for the duration of the callback `cb`'s execution.
+  pub fn open_mut<'s, F, R>(&'s mut self, cb: F) -> R
+  where
+    F: FnOnce(&mut [u8]) -> R,
+  {
     match self {
-      ZeroCopyBuf::Temp(vec) => vec,
-      _ => unreachable!(),
+      Self::FromV8(v8slice) => v8slice.open_mut(cb),
+      Self::ToV8(Some(data)) => cb(&mut *data),
+      Self::ToV8(_) => {
+        panic!("tried to read a V8Slice already sent to V8")
+      }
     }
+  }
+
+  /// Copy the contents of the underlying byte slice into a new [Vec].
+  pub fn to_vec(&self) -> Vec<u8> {
+    self.open(|bytes| bytes.to_vec())
   }
 }
 
 impl Clone for ZeroCopyBuf {
+  /// Clone a ZeroCopyBuf. This creates a new reference to the underlying data,
+  /// and does not clone the data.
+  ///
+  /// ### Panics
+  ///
+  /// Must not be called on a V8Slice destined for V8.
   fn clone(&self) -> Self {
     match self {
       Self::FromV8(zbuf) => Self::FromV8(zbuf.clone()),
-      Self::Temp(vec) => Self::Temp(vec.clone()),
-      Self::ToV8(_) => panic!("Don't Clone a ZeroCopyBuf sent to v8"),
-    }
-  }
-}
-
-impl AsRef<[u8]> for ZeroCopyBuf {
-  fn as_ref(&self) -> &[u8] {
-    self
-  }
-}
-
-impl AsMut<[u8]> for ZeroCopyBuf {
-  fn as_mut(&mut self) -> &mut [u8] {
-    &mut *self
-  }
-}
-
-impl Deref for ZeroCopyBuf {
-  type Target = [u8];
-  fn deref(&self) -> &[u8] {
-    match self {
-      Self::FromV8(buf) => buf,
-      Self::Temp(vec) => vec,
-      Self::ToV8(_) => panic!("Don't Deref a ZeroCopyBuf sent to v8"),
-    }
-  }
-}
-
-impl DerefMut for ZeroCopyBuf {
-  fn deref_mut(&mut self) -> &mut [u8] {
-    match self {
-      Self::FromV8(buf) => &mut *buf,
-      Self::Temp(vec) => &mut *vec,
-      Self::ToV8(_) => panic!("Don't Deref a ZeroCopyBuf sent to v8"),
+      Self::ToV8(_) => {
+        panic!("ZeroCopyBufs that will be sent to v8 can not be cloned")
+      }
     }
   }
 }
@@ -105,31 +109,21 @@ impl ToV8 for ZeroCopyBuf {
     &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
-    let buf: Box<[u8]> = match self {
-      Self::FromV8(buf) => {
-        let value: &[u8] = buf;
-        value.into()
-      }
-      Self::Temp(_) => unreachable!(),
-      Self::ToV8(ref mut x) => x.take().expect("ZeroCopyBuf was empty"),
+    let data: Box<[u8]> = match self {
+      Self::FromV8(buf) => buf.to_vec().into(),
+      Self::ToV8(ref mut x) => x
+        .take()
+        .expect("tried to serialize a V8Slice already sent to V8"),
     };
 
-    if buf.is_empty() {
-      let ab = v8::ArrayBuffer::new(scope, 0);
-      return Ok(
-        v8::Uint8Array::new(scope, ab, 0, 0)
-          .expect("Failed to create Uint8Array")
-          .into(),
-      );
-    }
-    let buf_len = buf.len();
+    let len = data.len();
     let backing_store =
-      v8::ArrayBuffer::new_backing_store_from_boxed_slice(buf);
-    let backing_store_shared = backing_store.make_shared();
-    let ab = v8::ArrayBuffer::with_backing_store(scope, &backing_store_shared);
+      v8::ArrayBuffer::new_backing_store_from_boxed_slice(data).make_shared();
+    let array_buffer =
+      v8::ArrayBuffer::with_backing_store(scope, &backing_store);
     Ok(
-      v8::Uint8Array::new(scope, ab, 0, buf_len)
-        .expect("Failed to create Uint8Array")
+      v8::Uint8Array::new(scope, array_buffer, 0, len)
+        .expect("Uint8Array creation to succeed")
         .into(),
     )
   }
@@ -141,17 +135,5 @@ impl FromV8 for ZeroCopyBuf {
     value: v8::Local<v8::Value>,
   ) -> Result<Self, crate::Error> {
     Ok(Self::FromV8(V8Slice::from_v8(scope, value)?))
-  }
-}
-
-impl From<ZeroCopyBuf> for bytes::Bytes {
-  fn from(zbuf: ZeroCopyBuf) -> bytes::Bytes {
-    match zbuf {
-      ZeroCopyBuf::FromV8(v) => v.into(),
-      ZeroCopyBuf::ToV8(mut v) => {
-        v.take().expect("ZeroCopyBuf was empty").into()
-      }
-      ZeroCopyBuf::Temp(v) => v.into(),
-    }
   }
 }

--- a/serde_v8/magic/detached_buffer.rs
+++ b/serde_v8/magic/detached_buffer.rs
@@ -1,12 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use core::ops::Range;
-use std::ops::Deref;
-use std::ops::DerefMut;
-
 use super::transl8::FromV8;
 use super::transl8::ToV8;
-use super::v8slice::to_ranged_buffer;
+use super::v8slice::value_to_array_buffer;
 use super::v8slice::V8Slice;
 use crate::magic::transl8::impl_magic;
 
@@ -14,28 +10,40 @@ use crate::magic::transl8::impl_magic;
 pub struct DetachedBuffer(V8Slice);
 impl_magic!(DetachedBuffer);
 
-impl AsRef<[u8]> for DetachedBuffer {
-  fn as_ref(&self) -> &[u8] {
-    self.0.as_ref()
+impl DetachedBuffer {
+  /// View the contents of the underlying byte slice.
+  ///
+  /// ### Safety
+  ///
+  /// V8 must never be invoked or the underlying [v8::BackingStore] accessed or
+  /// resized for the duration of the callback `cb`'s execution.
+  pub fn open<'s, F, R>(&'s self, cb: F) -> R
+  where
+    F: FnOnce(&[u8]) -> R,
+  {
+    self.0.open(cb)
   }
-}
 
-impl AsMut<[u8]> for DetachedBuffer {
-  fn as_mut(&mut self) -> &mut [u8] {
-    self.0.as_mut()
+  /// Access a mutable slice the contents of the underlying byte slice.
+  ///
+  /// ### Panics
+  ///
+  /// Must not be called on a V8Slice destined for V8.
+  ///
+  /// ### Safety
+  ///
+  /// V8 must never be invoked or the underlying [v8::BackingStore] accessed or
+  /// resized for the duration of the callback `cb`'s execution.
+  pub fn open_mut<'s, F, R>(&'s mut self, cb: F) -> R
+  where
+    F: FnOnce(&mut [u8]) -> R,
+  {
+    self.0.open_mut(cb)
   }
-}
 
-impl Deref for DetachedBuffer {
-  type Target = [u8];
-  fn deref(&self) -> &[u8] {
-    self.0.deref()
-  }
-}
-
-impl DerefMut for DetachedBuffer {
-  fn deref_mut(&mut self) -> &mut [u8] {
-    self.0.deref_mut()
+  /// Copy the contents of the underlying byte slice into a new [Vec].
+  pub fn to_vec(&self) -> Vec<u8> {
+    self.open(|bytes| bytes.to_vec())
   }
 }
 
@@ -44,11 +52,17 @@ impl ToV8 for DetachedBuffer {
     &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
-    let buffer = v8::ArrayBuffer::with_backing_store(scope, &self.0.store);
-    let Range { start, end } = self.0.range;
-    let (off, len) = (start, end - start);
-    let v = v8::Uint8Array::new(scope, buffer, off, len).unwrap();
-    Ok(v.into())
+    let data: Box<[u8]> = self.0.to_vec().into();
+    let len = data.len();
+    let backing_store =
+      v8::ArrayBuffer::new_backing_store_from_boxed_slice(data).make_shared();
+    let array_buffer =
+      v8::ArrayBuffer::with_backing_store(scope, &backing_store);
+    Ok(
+      v8::Uint8Array::new(scope, array_buffer, 0, len)
+        .expect("Uint8Array creation to succeed")
+        .into(),
+    )
   }
 }
 
@@ -57,13 +71,14 @@ impl FromV8 for DetachedBuffer {
     scope: &mut v8::HandleScope,
     value: v8::Local<v8::Value>,
   ) -> Result<Self, crate::Error> {
-    let (b, range) =
-      to_ranged_buffer(scope, value).or(Err(crate::Error::ExpectedBuffer))?;
-    if !b.is_detachable() {
+    let (buffer, range) = value_to_array_buffer(scope, value)
+      .map_err(|_| crate::Error::ExpectedBuffer)?;
+    if !buffer.is_detachable() {
       return Err(crate::Error::ExpectedDetachable);
     }
-    let store = b.get_backing_store();
-    b.detach(None); // Detach
-    Ok(Self(V8Slice { store, range }))
+    let v8slice = V8Slice::from_array_buffer(buffer, range)
+      .map_err(|_| crate::Error::ExpectedBuffer)?;
+    buffer.detach(None); // Detach
+    Ok(DetachedBuffer(v8slice))
   }
 }

--- a/serde_v8/magic/rawbytes.rs
+++ b/serde_v8/magic/rawbytes.rs
@@ -1,122 +1,122 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-pub(crate) type AtomicPtr<T> = *mut T;
-#[allow(unused)]
-pub(crate) struct RawBytes {
-  ptr: *const u8,
-  len: usize,
-  // inlined "trait object"
-  data: AtomicPtr<()>,
-  vtable: &'static Vtable,
-}
+// // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// pub(crate) type AtomicPtr<T> = *mut T;
+// #[allow(unused)]
+// pub(crate) struct RawBytes {
+//   ptr: *const u8,
+//   len: usize,
+//   // inlined "trait object"
+//   data: AtomicPtr<()>,
+//   vtable: &'static Vtable,
+// }
 
-impl RawBytes {
-  pub fn new_raw(
-    ptr: *const u8,
-    len: usize,
-    data: AtomicPtr<()>,
-    vtable: &'static Vtable,
-  ) -> bytes::Bytes {
-    RawBytes {
-      ptr,
-      len,
-      data,
-      vtable,
-    }
-    .into()
-  }
-}
+// impl RawBytes {
+//   pub fn new_raw(
+//     ptr: *const u8,
+//     len: usize,
+//     data: AtomicPtr<()>,
+//     vtable: &'static Vtable,
+//   ) -> bytes::Bytes {
+//     RawBytes {
+//       ptr,
+//       len,
+//       data,
+//       vtable,
+//     }
+//     .into()
+//   }
+// }
 
-// Validate some bytes::Bytes layout assumptions at compile time.
-const _: () = {
-  assert!(
-    core::mem::size_of::<RawBytes>() == core::mem::size_of::<bytes::Bytes>(),
-  );
-  assert!(
-    core::mem::align_of::<RawBytes>() == core::mem::align_of::<bytes::Bytes>(),
-  );
-};
+// // Validate some bytes::Bytes layout assumptions at compile time.
+// const _: () = {
+//   assert!(
+//     core::mem::size_of::<RawBytes>() == core::mem::size_of::<bytes::Bytes>(),
+//   );
+//   assert!(
+//     core::mem::align_of::<RawBytes>() == core::mem::align_of::<bytes::Bytes>(),
+//   );
+// };
 
-#[allow(unused)]
-pub(crate) struct Vtable {
-  /// fn(data, ptr, len)
-  pub clone: unsafe fn(&AtomicPtr<()>, *const u8, usize) -> bytes::Bytes,
-  /// fn(data, ptr, len)
-  ///
-  /// takes `Bytes` to value
-  pub to_vec: unsafe fn(&AtomicPtr<()>, *const u8, usize) -> Vec<u8>,
-  /// fn(data, ptr, len)
-  pub drop: unsafe fn(&mut AtomicPtr<()>, *const u8, usize),
-}
+// #[allow(unused)]
+// pub(crate) struct Vtable {
+//   /// fn(data, ptr, len)
+//   pub clone: unsafe fn(&AtomicPtr<()>, *const u8, usize) -> bytes::Bytes,
+//   /// fn(data, ptr, len)
+//   ///
+//   /// takes `Bytes` to value
+//   pub to_vec: unsafe fn(&AtomicPtr<()>, *const u8, usize) -> Vec<u8>,
+//   /// fn(data, ptr, len)
+//   pub drop: unsafe fn(&mut AtomicPtr<()>, *const u8, usize),
+// }
 
-impl From<RawBytes> for bytes::Bytes {
-  fn from(b: RawBytes) -> Self {
-    // SAFETY: RawBytes has the same layout as bytes::Bytes
-    // this is tested below, both are composed of usize-d ptrs/values
-    // thus aren't currently subject to rust's field re-ordering to minimize padding
-    unsafe { std::mem::transmute(b) }
-  }
-}
+// impl From<RawBytes> for bytes::Bytes {
+//   fn from(b: RawBytes) -> Self {
+//     // SAFETY: RawBytes has the same layout as bytes::Bytes
+//     // this is tested below, both are composed of usize-d ptrs/values
+//     // thus aren't currently subject to rust's field re-ordering to minimize padding
+//     unsafe { std::mem::transmute(b) }
+//   }
+// }
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use std::mem;
+// #[cfg(test)]
+// mod tests {
+//   use super::*;
+//   use std::mem;
 
-  const HELLO: &str = "hello";
+//   const HELLO: &str = "hello";
 
-  // ===== impl StaticVtable =====
+//   // ===== impl StaticVtable =====
 
-  const STATIC_VTABLE: Vtable = Vtable {
-    clone: static_clone,
-    drop: static_drop,
-    to_vec: static_to_vec,
-  };
+//   const STATIC_VTABLE: Vtable = Vtable {
+//     clone: static_clone,
+//     drop: static_drop,
+//     to_vec: static_to_vec,
+//   };
 
-  unsafe fn static_clone(
-    _: &AtomicPtr<()>,
-    ptr: *const u8,
-    len: usize,
-  ) -> bytes::Bytes {
-    from_static(std::slice::from_raw_parts(ptr, len)).into()
-  }
+//   unsafe fn static_clone(
+//     _: &AtomicPtr<()>,
+//     ptr: *const u8,
+//     len: usize,
+//   ) -> bytes::Bytes {
+//     from_static(std::slice::from_raw_parts(ptr, len)).into()
+//   }
 
-  unsafe fn static_to_vec(
-    _: &AtomicPtr<()>,
-    ptr: *const u8,
-    len: usize,
-  ) -> Vec<u8> {
-    let slice = std::slice::from_raw_parts(ptr, len);
-    slice.to_vec()
-  }
+//   unsafe fn static_to_vec(
+//     _: &AtomicPtr<()>,
+//     ptr: *const u8,
+//     len: usize,
+//   ) -> Vec<u8> {
+//     let slice = std::slice::from_raw_parts(ptr, len);
+//     slice.to_vec()
+//   }
 
-  unsafe fn static_drop(_: &mut AtomicPtr<()>, _: *const u8, _: usize) {
-    // nothing to drop for &'static [u8]
-  }
+//   unsafe fn static_drop(_: &mut AtomicPtr<()>, _: *const u8, _: usize) {
+//     // nothing to drop for &'static [u8]
+//   }
 
-  fn from_static(bytes: &'static [u8]) -> RawBytes {
-    RawBytes {
-      ptr: bytes.as_ptr(),
-      len: bytes.len(),
-      data: std::ptr::null_mut(),
-      vtable: &STATIC_VTABLE,
-    }
-  }
+//   fn from_static(bytes: &'static [u8]) -> RawBytes {
+//     RawBytes {
+//       ptr: bytes.as_ptr(),
+//       len: bytes.len(),
+//       data: std::ptr::null_mut(),
+//       vtable: &STATIC_VTABLE,
+//     }
+//   }
 
-  #[test]
-  fn bytes_identity() {
-    let b1: bytes::Bytes = from_static(HELLO.as_bytes()).into();
-    let b2 = bytes::Bytes::from_static(HELLO.as_bytes());
-    assert_eq!(b1, b2); // Values are equal
-  }
+//   #[test]
+//   fn bytes_identity() {
+//     let b1: bytes::Bytes = from_static(HELLO.as_bytes()).into();
+//     let b2 = bytes::Bytes::from_static(HELLO.as_bytes());
+//     assert_eq!(b1, b2); // Values are equal
+//   }
 
-  #[test]
-  fn bytes_layout() {
-    let u1: [usize; 4] =
-      // SAFETY: ensuring layout is the same
-      unsafe { mem::transmute(from_static(HELLO.as_bytes())) };
-    let u2: [usize; 4] =
-      // SAFETY: ensuring layout is the same
-      unsafe { mem::transmute(bytes::Bytes::from_static(HELLO.as_bytes())) };
-    assert_eq!(u1[..3], u2[..3]); // Struct bytes are equal besides Vtables
-  }
-}
+//   #[test]
+//   fn bytes_layout() {
+//     let u1: [usize; 4] =
+//       // SAFETY: ensuring layout is the same
+//       unsafe { mem::transmute(from_static(HELLO.as_bytes())) };
+//     let u2: [usize; 4] =
+//       // SAFETY: ensuring layout is the same
+//       unsafe { mem::transmute(bytes::Bytes::from_static(HELLO.as_bytes())) };
+//     assert_eq!(u1[..3], u2[..3]); // Struct bytes are equal besides Vtables
+//   }
+// }

--- a/serde_v8/magic/v8slice.rs
+++ b/serde_v8/magic/v8slice.rs
@@ -1,37 +1,91 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use std::ops::Deref;
-use std::ops::DerefMut;
+use std::marker::PhantomData;
 use std::ops::Range;
-use std::rc::Rc;
 
-use super::rawbytes;
 use super::transl8::FromV8;
 
-/// A V8Slice encapsulates a slice that's been borrowed from a JavaScript
-/// ArrayBuffer object. JavaScript objects can normally be garbage collected,
-/// but the existence of a V8Slice inhibits this until it is dropped. It
-/// behaves much like an Arc<[u8]>.
+pub type PhantomUnsync = PhantomData<std::cell::Cell<()>>;
+pub type PhantomUnsend = PhantomData<std::sync::MutexGuard<'static, ()>>;
+
+/// [V8Slice] encapsulates a borrowed byte slice from V8, in the form of a
+/// [v8::BackingStore]. The allocation backing the [v8::BackingStore] is safe
+/// from garbage collection until the [V8Slice] is collected.
 ///
-/// # Cloning
-/// Cloning a V8Slice does not clone the contents of the buffer,
-/// it creates a new reference to that buffer.
+/// If the underlying [v8::BackingStore] comes from a [v8::ArrayBuffer] wrapped
+/// in a [v8::ArrayBufferView], the current start and end range of the view is
+/// captured upon creation of the [V8Slice]. The [V8Slice] only exposes the data
+/// contained within this range. The [v8::BackingStore] must not come from a
+/// [v8::SharedArrayBuffer].
 ///
-/// To actually clone the contents of the buffer do
-/// `let copy = Vec::from(&*zero_copy_buf);`
+/// To access the data backing a [V8Slice], one can call [V8Slice::to_vec] to
+/// fully copy the data into a [Vec<u8>], or [V8Slice::open] with a synchronous
+/// callback to get access to a `&mut [u8]` representing the data.
+///
+/// ### Cloning
+///
+/// Cloning a V8Slice does not clone the contents of the underlying backing
+/// store. Rather it clones the underlying smart-pointer.
+///
+/// To actually clone the contents of the buffer, use [V8Slice::to_vec].
+///
+/// ### Growing and shrinking ArrayBuffers
+///
+/// Since V8 11.2, ArrayBuffer is both growable and shrinkable. Both ArrayBuffer
+/// growth and shrinkage are implemented in V8 without re-alloc. The maximum
+/// length of the buffer must be specifed up-front and is reserved in virtual
+/// address space by [v8::BackingStore]. When the [v8::BackingStore] is grown,
+/// the underlying buffer is grown to the specified size by allocating physical
+/// pages for the relevant exisiting virtual address space. When a buffer is
+/// shrunk, the physical pages storing the excess bytes are de-allocated. In
+/// both cases the length of the reserved virtual address space stays fixed.
+///
+/// [V8Slice] can safely handle resizable buffers (safety is explained below).
+/// When the underlying [v8::BackingStore] is shrunk below the `range` of this
+/// [V8Slice], the length of any exposed byte slices is truncated to fit within
+/// the new bounds.
+///
+/// ### Safety
+///
+/// To make [V8Slice] fit within Rust's safety guaruantees, the following two
+/// constraints must always be upheld (especially in light of buffer resizing):
+///
+/// - There MUST never exist a mutable reference and a read-only reference to
+///   a byte slice at the same time (this is Rust's memory model).
+/// - While a `&[u8]` or `&mut [u8]` pointing to an underlying allocation exists
+///   that allocation MUST NEVER be deallocated (doing so may result in a
+///   use-after-free).
+///
+/// JavaScript execution has the ability to get a `&mut [u8]` for the underlying
+/// bytes at any time. JavaScript execution can also resize the allocation at
+/// any time. As such, it is never safe to expose a `&[u8]` or `&mut [u8]` while
+/// JavaScript is executing, as this would violate the above constraints.
+///
+/// To ensure that these constraints can not be violated, this type never
+/// exposes `&[u8]` or `&mut [u8]` pointing to the underlying bytes while
+/// JavaScript is executing. This is done through two mechanisms:
+///
+/// - [V8Slice] is not [Send] or [Sync]: it can not be sent to a different
+///   thread. This means that no `&[u8]` or `&mut [u8]` can be created from a
+///   different thread, out of the purview of the JavaScript executing thread
+///   which would possibly cause a constraint violation.
+/// - [V8Slice] never exposes a `&[u8]` or `&mut [u8]` that can be held
+///   asynchronously across a point causing JavaScript execution. This is
+///   enforced through the API design for asynchronous Rust. Users MUST take
+///   care to not execute JavaScript within a [V8Slice::open] or
+///   [V8Slice::open_mut] callback.
 #[derive(Clone)]
 pub struct V8Slice {
   pub(crate) store: v8::SharedRef<v8::BackingStore>,
-  pub(crate) range: Range<usize>,
+  pub(crate) range: Option<Range<usize>>,
+  _no_sync: PhantomUnsync,
+  _no_send: PhantomUnsend,
 }
 
-// SAFETY: unsafe trait must have unsafe implementation
-unsafe impl Send for V8Slice {}
-
 impl V8Slice {
-  pub fn from_buffer(
+  pub fn from_array_buffer(
     buffer: v8::Local<v8::ArrayBuffer>,
-    range: Range<usize>,
+    range: Option<Range<usize>>,
   ) -> Result<Self, v8::DataError> {
     let store = buffer.get_backing_store();
     if store.is_shared() {
@@ -40,48 +94,89 @@ impl V8Slice {
         expected: "non-shared ArrayBufferView",
       });
     }
-    Ok(Self { store, range })
+    Ok(Self {
+      store,
+      range,
+      _no_send: Default::default(),
+      _no_sync: Default::default(),
+    })
   }
 
-  fn as_slice(&self) -> &[u8] {
-    // SAFETY: v8::SharedRef<v8::BackingStore> is similar to Arc<[u8]>,
-    // it points to a fixed continuous slice of bytes on the heap.
-    // We assume it's initialized and thus safe to read (though may not contain meaningful data)
-    unsafe { &*(&self.store[self.range.clone()] as *const _ as *const [u8]) }
+  pub fn from_array_buffer_view(
+    scope: &mut v8::HandleScope,
+    view: v8::Local<v8::ArrayBufferView>,
+  ) -> Result<Self, v8::DataError> {
+    let (buffer, range) = array_buffer_view_to_array_buffer(scope, view)?;
+    Self::from_array_buffer(buffer, range)
   }
 
-  fn as_slice_mut(&mut self) -> &mut [u8] {
-    #[allow(clippy::cast_ref_to_mut)]
-    // SAFETY: v8::SharedRef<v8::BackingStore> is similar to Arc<[u8]>,
-    // it points to a fixed continuous slice of bytes on the heap.
-    // It's safe-ish to mutate concurrently because it can not be
-    // shrunk/grown/moved/reallocated, thus avoiding dangling refs (unlike a Vec).
-    // Concurrent writes can't lead to meaningful structural invalidation
-    // since we treat them as opaque buffers / "bags of bytes",
-    // concurrent mutation is simply an accepted fact of life.
-    // And in practice V8Slices also do not have overallping read/write phases.
-    // TLDR: permissive interior mutability on slices of bytes is "fine"
-    unsafe {
-      &mut *(&self.store[self.range.clone()] as *const _ as *mut [u8])
+  pub fn from_value(
+    scope: &mut v8::HandleScope,
+    value: v8::Local<v8::Value>,
+  ) -> Result<Self, v8::DataError> {
+    let (buffer, range) = value_to_array_buffer(scope, value)?;
+    Self::from_array_buffer(buffer, range)
+  }
+
+  // The truncated range of the backing store.
+  fn truncated_range(&self) -> Range<usize> {
+    let actual_length = self.store.byte_length();
+    if let Some(range) = &self.range {
+      let start = range.start.min(actual_length);
+      let end = range.end.min(actual_length);
+      start..end
+    } else {
+      0..actual_length
     }
   }
-}
 
-pub(crate) fn to_ranged_buffer<'s>(
-  scope: &mut v8::HandleScope<'s>,
-  value: v8::Local<v8::Value>,
-) -> Result<(v8::Local<'s, v8::ArrayBuffer>, Range<usize>), v8::DataError> {
-  if let Ok(view) = v8::Local::<v8::ArrayBufferView>::try_from(value) {
-    let (offset, len) = (view.byte_offset(), view.byte_length());
-    let buffer = view.buffer(scope).ok_or(v8::DataError::NoData {
-      expected: "view to have a buffer",
-    })?;
-    let buffer = v8::Local::new(scope, buffer); // recreate handle to avoid lifetime issues
-    return Ok((buffer, offset..offset + len));
+  /// View the contents of the underlying byte slice.
+  ///
+  /// ### Safety
+  ///
+  /// V8 must never be invoked or the underlying [v8::BackingStore] accessed or
+  /// resized for the duration of the callback `cb`'s execution.
+  pub fn open<'s, F, R>(&'s self, cb: F) -> R
+  where
+    F: FnOnce(&[u8]) -> R,
+  {
+    let range = self.truncated_range();
+    let bytes_celled = &self.store[range];
+    // SAFETY: v8::BackingStore points to a fixed continous slice of bytes on
+    // the heap. Constraints on the V8Slice type ensure that the bytes
+    // represented by the v8::BackingStore can not be deallocated or modified
+    // for the duration of the callback `cb`'s execution. The reasoning for this
+    // is elaborated on the safety comment for V8Slice.
+    let bytes: &[u8] = unsafe { &*(bytes_celled as *const _ as *mut [u8]) };
+    cb(bytes)
   }
-  let b: v8::Local<v8::ArrayBuffer> = value.try_into()?;
-  let b = v8::Local::new(scope, b); // recreate handle to avoid lifetime issues
-  Ok((b, 0..b.byte_length()))
+
+  /// Access a mutable slice the contents of the underlying byte slice.
+  ///
+  /// ### Safety
+  ///
+  /// V8 must never be invoked or the underlying [v8::BackingStore] accessed or
+  /// resized for the duration of the callback `cb`'s execution.
+  pub fn open_mut<'s, F, R>(&'s mut self, cb: F) -> R
+  where
+    F: FnOnce(&mut [u8]) -> R,
+  {
+    let range = self.truncated_range();
+    let bytes_celled = &self.store[range];
+    // SAFETY: v8::BackingStore points to a fixed continous slice of bytes on
+    // the heap. Constraints on the V8Slice type ensure that the bytes
+    // represented by the v8::BackingStore can not be deallocated or modified
+    // for the duration of the callback `cb`'s execution. The reasoning for this
+    // is elaborated on the safety comment for V8Slice.
+    let bytes: &mut [u8] =
+      unsafe { &mut *(bytes_celled as *const _ as *mut [u8]) };
+    cb(bytes)
+  }
+
+  /// Copy the contents of the underlying byte slice into a new [Vec].
+  pub fn to_vec(&self) -> Vec<u8> {
+    self.open(|bytes| bytes.to_vec())
+  }
 }
 
 impl FromV8 for V8Slice {
@@ -89,95 +184,97 @@ impl FromV8 for V8Slice {
     scope: &mut v8::HandleScope,
     value: v8::Local<v8::Value>,
   ) -> Result<Self, crate::Error> {
-    to_ranged_buffer(scope, value)
-      .and_then(|(b, r)| Self::from_buffer(b, r))
-      .map_err(|_| crate::Error::ExpectedBuffer)
+    Self::from_value(scope, value).map_err(|_| crate::Error::ExpectedBuffer)
   }
 }
 
-impl Deref for V8Slice {
-  type Target = [u8];
-  fn deref(&self) -> &[u8] {
-    self.as_slice()
+pub(crate) fn value_to_array_buffer<'a>(
+  scope: &mut v8::HandleScope<'a>,
+  value: v8::Local<v8::Value>,
+) -> Result<(v8::Local<'a, v8::ArrayBuffer>, Option<Range<usize>>), v8::DataError>
+{
+  if let Ok(view) = v8::Local::<v8::ArrayBufferView>::try_from(value) {
+    array_buffer_view_to_array_buffer(scope, view)
+  } else if let Ok(buffer) = v8::Local::<v8::ArrayBuffer>::try_from(value) {
+    Ok((v8::Local::new(scope, buffer), None))
+  } else {
+    Err(v8::DataError::BadType {
+      actual: "non-ArrayBuffer and non-ArrayBufferView",
+      expected: "ArrayBuffer or ArrayBufferView",
+    })
   }
 }
 
-impl DerefMut for V8Slice {
-  fn deref_mut(&mut self) -> &mut [u8] {
-    self.as_slice_mut()
-  }
+pub(crate) fn array_buffer_view_to_array_buffer<'a>(
+  scope: &mut v8::HandleScope<'a>,
+  view: v8::Local<v8::ArrayBufferView>,
+) -> Result<(v8::Local<'a, v8::ArrayBuffer>, Option<Range<usize>>), v8::DataError>
+{
+  let range = view.byte_offset()..view.byte_length();
+  let buffer = view.buffer(scope).ok_or(v8::DataError::NoData {
+    expected: "view to have a buffer",
+  })?;
+  Ok((buffer, Some(range)))
 }
 
-impl AsRef<[u8]> for V8Slice {
-  fn as_ref(&self) -> &[u8] {
-    self.as_slice()
-  }
-}
+// // Implement V8Slice -> bytes::Bytes
+// impl V8Slice {
+//   fn rc_into_byte_parts(self: Rc<Self>) -> (*const u8, usize, *mut V8Slice) {
+//     let (ptr, len) = {
+//       let slice = self.as_ref();
+//       (slice.as_ptr(), slice.len())
+//     };
+//     let rc_raw = Rc::into_raw(self);
+//     let data = rc_raw as *mut V8Slice;
+//     (ptr, len, data)
+//   }
+// }
 
-impl AsMut<[u8]> for V8Slice {
-  fn as_mut(&mut self) -> &mut [u8] {
-    self.as_slice_mut()
-  }
-}
+// impl From<V8Slice> for bytes::Bytes {
+//   fn from(v8slice: V8Slice) -> Self {
+//     let (ptr, len, data) = Rc::new(v8slice).rc_into_byte_parts();
+//     rawbytes::RawBytes::new_raw(ptr, len, data.cast(), &V8SLICE_VTABLE)
+//   }
+// }
 
-// Implement V8Slice -> bytes::Bytes
-impl V8Slice {
-  fn rc_into_byte_parts(self: Rc<Self>) -> (*const u8, usize, *mut V8Slice) {
-    let (ptr, len) = {
-      let slice = self.as_ref();
-      (slice.as_ptr(), slice.len())
-    };
-    let rc_raw = Rc::into_raw(self);
-    let data = rc_raw as *mut V8Slice;
-    (ptr, len, data)
-  }
-}
+// // NOTE: in the limit we could avoid extra-indirection and use the C++ shared_ptr
+// // but we can't store both the underlying data ptr & ctrl ptr ... so instead we
+// // use a shared rust ptr (Rc/Arc) that itself controls the C++ shared_ptr
+// const V8SLICE_VTABLE: rawbytes::Vtable = rawbytes::Vtable {
+//   clone: v8slice_clone,
+//   drop: v8slice_drop,
+//   to_vec: v8slice_to_vec,
+// };
 
-impl From<V8Slice> for bytes::Bytes {
-  fn from(v8slice: V8Slice) -> Self {
-    let (ptr, len, data) = Rc::new(v8slice).rc_into_byte_parts();
-    rawbytes::RawBytes::new_raw(ptr, len, data.cast(), &V8SLICE_VTABLE)
-  }
-}
+// unsafe fn v8slice_clone(
+//   data: &rawbytes::AtomicPtr<()>,
+//   ptr: *const u8,
+//   len: usize,
+// ) -> bytes::Bytes {
+//   let rc = Rc::from_raw(*data as *const V8Slice);
+//   let (_, _, data) = rc.clone().rc_into_byte_parts();
+//   std::mem::forget(rc);
+//   // NOTE: `bytes::Bytes` does bounds checking so we trust its ptr, len inputs
+//   // and must use them to allow cloning Bytes it has sliced
+//   rawbytes::RawBytes::new_raw(ptr, len, data.cast(), &V8SLICE_VTABLE)
+// }
 
-// NOTE: in the limit we could avoid extra-indirection and use the C++ shared_ptr
-// but we can't store both the underlying data ptr & ctrl ptr ... so instead we
-// use a shared rust ptr (Rc/Arc) that itself controls the C++ shared_ptr
-const V8SLICE_VTABLE: rawbytes::Vtable = rawbytes::Vtable {
-  clone: v8slice_clone,
-  drop: v8slice_drop,
-  to_vec: v8slice_to_vec,
-};
+// unsafe fn v8slice_to_vec(
+//   data: &rawbytes::AtomicPtr<()>,
+//   ptr: *const u8,
+//   len: usize,
+// ) -> Vec<u8> {
+//   let rc = Rc::from_raw(*data as *const V8Slice);
+//   std::mem::forget(rc);
+//   // NOTE: `bytes::Bytes` does bounds checking so we trust its ptr, len inputs
+//   // and must use them to allow cloning Bytes it has sliced
+//   Vec::from_raw_parts(ptr as _, len, len)
+// }
 
-unsafe fn v8slice_clone(
-  data: &rawbytes::AtomicPtr<()>,
-  ptr: *const u8,
-  len: usize,
-) -> bytes::Bytes {
-  let rc = Rc::from_raw(*data as *const V8Slice);
-  let (_, _, data) = rc.clone().rc_into_byte_parts();
-  std::mem::forget(rc);
-  // NOTE: `bytes::Bytes` does bounds checking so we trust its ptr, len inputs
-  // and must use them to allow cloning Bytes it has sliced
-  rawbytes::RawBytes::new_raw(ptr, len, data.cast(), &V8SLICE_VTABLE)
-}
-
-unsafe fn v8slice_to_vec(
-  data: &rawbytes::AtomicPtr<()>,
-  ptr: *const u8,
-  len: usize,
-) -> Vec<u8> {
-  let rc = Rc::from_raw(*data as *const V8Slice);
-  std::mem::forget(rc);
-  // NOTE: `bytes::Bytes` does bounds checking so we trust its ptr, len inputs
-  // and must use them to allow cloning Bytes it has sliced
-  Vec::from_raw_parts(ptr as _, len, len)
-}
-
-unsafe fn v8slice_drop(
-  data: &mut rawbytes::AtomicPtr<()>,
-  _: *const u8,
-  _: usize,
-) {
-  drop(Rc::from_raw(*data as *const V8Slice))
-}
+// unsafe fn v8slice_drop(
+//   data: &mut rawbytes::AtomicPtr<()>,
+//   _: *const u8,
+//   _: usize,
+// ) {
+//   drop(Rc::from_raw(*data as *const V8Slice))
+// }


### PR DESCRIPTION
Note: this PR is not complete - it requires more changes to `deno_core` and many code-paths touching `V8Slice` / `ZeroCopyBuf` in ext/ and runtime/.

This commit attempts to make `serde_v8::V8Slice` properly sound, according to Rust memory model (never both &mut and & a given value). This soundness fix will also enable using resizable `ArrayBuffer`s in ops.

There is however a catch - as part of this fix, the patch prevents callers from holding the byte slices represented by the `V8Slice` across await points. This means that all async ops will now require copying data out/in prior/post suspending. This may or may not be a performance problem. It is to be noted, that in practice this copying already happens for FS ops and TLS sockets, but for TCP sockets.

This leaves us in a precarious position with two options:
1. maybe fine, but not safe according to rust, and no RAB
   - we disable resizable ArrayBuffer as an argument to all async ops forever
   - we ignore Rust's memory model (never both &mut and & a given value). _note: this is what we do now_
   - leaves the possibility of very weird bugs in other code that explicitly relies on the assumption that `&[u8]` can never be modified. this may result in very undefined behaviour that could result in crashes, especially in crypto code. _note: we are currently susceptible to this, just no-one has made a POC for it yet_
   - fast, because we can directly let the kernel / other libs write into the V8Slice asynchronously
2. safe, RAB, but possibly slower
   - we prevent V8Slice access from other threads
   - we prevent JS execution while a & or &mut is held to the byte slice represented by the `V8Slice`
   - requires copying data prior/post passing it to async operations
   - completely within Rust's memory model. & and &mut are never held at the same time

The safety constraints for full soundness are described in the V8Slice rustdoc comment in this PR. 

I'd like to go with option 2, but I want feedback from the rest of the team. cc @littledivy @piscisaureus @bartlomieju. Additionally @andreubotella is likely interested.

Fixes #16756