### PR TITLE
Revert "refactor: remove Deno[Deno.internal].nodeUnstable namespace (…

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-const core = globalThis.Deno.core;
-const ops = core.ops;
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { type Deferred, deferred } from "ext:deno_node/_util/async.ts";
 import { _normalizeArgs, ListenOptions, Socket } from "ext:deno_node/net.ts";
@@ -19,7 +17,6 @@ import { Agent } from "ext:deno_node/_http_agent.mjs";
 import { chunkExpression as RE_TE_CHUNKED } from "ext:deno_node/_http_common.ts";
 import { urlToHttpOptions } from "ext:deno_node/internal/url.ts";
 import { constants, TCP } from "ext:deno_node/internal_binding/tcp_wrap.ts";
-import * as flash from "ext:deno_flash/01_http.js";
 
 enum STATUS_CODES {
   /** RFC 7231, 6.2.1 */
@@ -191,8 +188,11 @@ const METHODS = [
 
 type Chunk = string | Buffer | Uint8Array;
 
-const DenoServe = flash.createServe(ops.op_node_unstable_flash_serve);
-const DenoUpgradeHttpRaw = flash.upgradeHttpRaw;
+// @ts-ignore Deno[Deno.internal] is used on purpose here
+const DenoServe = Deno[Deno.internal]?.nodeUnstable?.serve || Deno.serve;
+// @ts-ignore Deno[Deno.internal] is used on purpose here
+const DenoUpgradeHttpRaw = Deno[Deno.internal]?.nodeUnstable?.upgradeHttpRaw ||
+  Deno.upgradeHttpRaw;
 
 const ENCODER = new TextEncoder();
 

--- a/ext/node/polyfills/internal_binding/udp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/udp_wrap.ts
@@ -20,8 +20,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const core = globalThis.Deno.core;
-const ops = core.ops;
 import {
   AsyncWrap,
   providerType,
@@ -34,13 +32,12 @@ import { notImplemented } from "ext:deno_node/_utils.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import type { ErrnoException } from "ext:deno_node/internal/errors.ts";
 import { isIP } from "ext:deno_node/internal/net.ts";
-import * as net from "ext:deno_net/01_net.js";
+
 import { isLinux, isWindows } from "ext:deno_node/_util/os.ts";
 
-const DenoListenDatagram = net.createListenDatagram(
-  ops.op_node_unstable_net_listen_udp,
-  ops.op_node_unstable_net_listen_unixpacket,
-);
+// @ts-ignore Deno[Deno.internal] is used on purpose here
+const DenoListenDatagram = Deno[Deno.internal]?.nodeUnstable?.listenDatagram ||
+  Deno.listenDatagram;
 
 type MessageType = string | Uint8Array | Buffer | DataView;
 

--- a/ext/node/polyfills/os.ts
+++ b/ext/node/polyfills/os.ts
@@ -25,10 +25,14 @@ import { validateIntegerRange } from "ext:deno_node/_utils.ts";
 import process from "ext:deno_node/process.ts";
 import { isWindows, osType } from "ext:deno_node/_util/os.ts";
 import { os } from "ext:deno_node/internal_binding/constants.ts";
-import { osUptime } from "ext:runtime/30_os.js";
+
 export const constants = os;
 
 const SEE_GITHUB_ISSUE = "See https://github.com/denoland/deno_std/issues/1436";
+
+// @ts-ignore Deno[Deno.internal] is used on purpose here
+const DenoOsUptime = Deno[Deno.internal]?.nodeUnstable?.osUptime ||
+  Deno.osUptime;
 
 interface CPUTimes {
   /** The number of milliseconds the CPU has spent in user mode */
@@ -306,7 +310,7 @@ export function type(): string {
 
 /** Returns the Operating System uptime in number of seconds. */
 export function uptime(): number {
-  return osUptime();
+  return DenoOsUptime();
 }
 
 /** Not yet implemented */

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -153,10 +153,7 @@ const denoNs = {
 };
 
 const denoNsUnstable = {
-  listenDatagram: net.createListenDatagram(
-    ops.op_net_listen_udp,
-    ops.op_net_listen_unixpacket,
-  ),
+  listenDatagram: net.listenDatagram,
   umask: fs.umask,
   HttpClient: httpClient.HttpClient,
   createHttpClient: httpClient.createHttpClient,
@@ -173,7 +170,6 @@ const denoNsUnstable = {
   funlockSync: fs.funlockSync,
   upgradeHttp: http.upgradeHttp,
   upgradeHttpRaw: flash.upgradeHttpRaw,
-  serve: flash.createServe(ops.op_flash_serve),
   openKv: kv.openKv,
   Kv: kv.Kv,
   KvU64: kv.KvU64,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -45,6 +45,7 @@ import * as version from "ext:runtime/01_version.ts";
 import * as os from "ext:runtime/30_os.js";
 import * as timers from "ext:deno_web/02_timers.js";
 import * as colors from "ext:deno_console/01_colors.js";
+import * as net from "ext:deno_net/01_net.js";
 import {
   inspectArgs,
   quoteString,
@@ -58,6 +59,7 @@ import { denoNs, denoNsUnstable } from "ext:runtime/90_deno_ns.js";
 import { errors } from "ext:runtime/01_errors.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import DOMException from "ext:deno_web/01_dom_exception.js";
+import * as flash from "ext:deno_flash/01_http.js";
 import {
   mainRuntimeGlobalProperties,
   setLanguage,
@@ -453,6 +455,27 @@ function bootstrapMainRuntime(runtimeOptions) {
   setUserAgent(runtimeOptions.userAgent);
   setLanguage(runtimeOptions.locale);
 
+  // These have to initialized here and not in `90_deno_ns.js` because
+  // the op function that needs to be passed will be invalidated by creating
+  // a snapshot
+  ObjectAssign(internals, {
+    nodeUnstable: {
+      serve: flash.createServe(ops.op_node_unstable_flash_serve),
+      upgradeHttpRaw: flash.upgradeHttpRaw,
+      listenDatagram: net.createListenDatagram(
+        ops.op_node_unstable_net_listen_udp,
+        ops.op_node_unstable_net_listen_unixpacket,
+      ),
+    },
+  });
+
+  // FIXME(bartlomieju): temporarily add whole `Deno.core` to
+  // `Deno[Deno.internal]` namespace. It should be removed and only necessary
+  // methods should be left there.
+  ObjectAssign(internals, {
+    core,
+  });
+
   ObjectDefineProperties(finalDenoNs, {
     pid: util.readOnly(runtimeOptions.pid),
     ppid: util.readOnly(runtimeOptions.ppid),
@@ -463,6 +486,16 @@ function bootstrapMainRuntime(runtimeOptions) {
 
   if (runtimeOptions.unstableFlag) {
     ObjectAssign(finalDenoNs, denoNsUnstable);
+    // These have to initialized here and not in `90_deno_ns.js` because
+    // the op function that needs to be passed will be invalidated by creating
+    // a snapshot
+    ObjectAssign(finalDenoNs, {
+      serve: flash.createServe(ops.op_flash_serve),
+      listenDatagram: net.createListenDatagram(
+        ops.op_net_listen_udp,
+        ops.op_net_listen_unixpacket,
+      ),
+    });
   }
 
   // Setup `Deno` global - we're actually overriding already existing global
@@ -540,8 +573,39 @@ function bootstrapWorkerRuntime(
 
   globalThis.pollForMessages = pollForMessages;
 
+  // These have to initialized here and not in `90_deno_ns.js` because
+  // the op function that needs to be passed will be invalidated by creating
+  // a snapshot
+  ObjectAssign(internals, {
+    nodeUnstable: {
+      serve: flash.createServe(ops.op_node_unstable_flash_serve),
+      upgradeHttpRaw: flash.upgradeHttpRaw,
+      listenDatagram: net.createListenDatagram(
+        ops.op_node_unstable_net_listen_udp,
+        ops.op_node_unstable_net_listen_unixpacket,
+      ),
+    },
+  });
+
+  // FIXME(bartlomieju): temporarily add whole `Deno.core` to
+  // `Deno[Deno.internal]` namespace. It should be removed and only necessary
+  // methods should be left there.
+  ObjectAssign(internals, {
+    core,
+  });
+
   if (runtimeOptions.unstableFlag) {
     ObjectAssign(finalDenoNs, denoNsUnstable);
+    // These have to initialized here and not in `90_deno_ns.js` because
+    // the op function that needs to be passed will be invalidated by creating
+    // a snapshot
+    ObjectAssign(finalDenoNs, {
+      serve: flash.createServe(ops.op_flash_serve),
+      listenDatagram: net.createListenDatagram(
+        ops.op_net_listen_udp,
+        ops.op_net_listen_unixpacket,
+      ),
+    });
   }
   ObjectDefineProperties(finalDenoNs, {
     pid: util.readOnly(runtimeOptions.pid),


### PR DESCRIPTION
…#18449)"

This reverts commit d1a9c4cd7ce0c19ddf9c7c52c0d35d6124a7677d.

Appears this made CI very flaky on macOS, but I can't repeat it locally yet