### PR TITLE
Revert "fix(cli): deno upgrade file permission (#18427)"

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -265,15 +265,13 @@ pub async fn upgrade(
 ) -> Result<(), AnyError> {
   let ps = ProcState::build(flags).await?;
   let current_exe_path = std::env::current_exe()?;
-  let output_exe_path =
-    upgrade_flags.output.as_ref().unwrap_or(&current_exe_path);
-  let metadata = fs::metadata(output_exe_path)?;
+  let metadata = fs::metadata(&current_exe_path)?;
   let permissions = metadata.permissions();
 
   if permissions.readonly() {
     bail!(
       "You do not have write permission to {}",
-      output_exe_path.display()
+      current_exe_path.display()
     );
   }
   #[cfg(unix)]
@@ -284,7 +282,7 @@ pub async fn upgrade(
       "You don't have write permission to {} because it's owned by root.\n",
       "Consider updating deno through your package manager if its installed from it.\n",
       "Otherwise run `deno upgrade` as root.",
-    ), output_exe_path.display());
+    ), current_exe_path.display());
   }
 
   let client = &ps.http_client;


### PR DESCRIPTION
This reverts commit 0742ea1170239b7d010e219b3349b2f9edaaefe5.

Closes https://github.com/denoland/deno/issues/18466

CC @rottenpen 