### PR TITLE
fix: Add missing `processenv` winapi feature to deno_io

### DIFF
--- a/ext/io/Cargo.toml
+++ b/ext/io/Cargo.toml
@@ -22,4 +22,4 @@ tokio.workspace = true
 nix.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["winbase"] }
+winapi = { workspace = true, features = ["winbase", "processenv"] }


### PR DESCRIPTION
Currently the `processenv` feature is not explicitly requested by `deno_io`, however it is using the `processenv` module. This will prevent downstream users from building on Windows.

I'd assume that this doesn't popup in Deno itself since another crate is enabling this feature.