### PR TITLE
perf(ext/websocket): special op for sending binary data frames

### DIFF
--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -301,10 +301,7 @@ class WebSocket extends EventTarget {
     const sendTypedArray = (ta) => {
       this[_bufferedAmount] += ta.byteLength;
       PromisePrototypeThen(
-        core.opAsync("op_ws_send", this[_rid], {
-          kind: "binary",
-          value: ta,
-        }),
+        core.opAsync("op_ws_send_binary", this[_rid], ta),
         () => {
           this[_bufferedAmount] -= ta.byteLength;
         },

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -403,6 +403,20 @@ pub enum SendValue {
 }
 
 #[op]
+pub async fn op_ws_send_binary(
+  state: Rc<RefCell<OpState>>,
+  rid: ResourceId,
+  data: ZeroCopyBuf,
+) -> Result<(), AnyError> {
+  let resource = state
+    .borrow_mut()
+    .resource_table
+    .get::<WsStreamResource>(rid)?;
+  resource.send(Message::Binary(data.to_vec())).await?;
+  Ok(())
+}
+
+#[op]
 pub async fn op_ws_send(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
@@ -504,6 +518,7 @@ deno_core::extension!(deno_websocket,
     op_ws_send,
     op_ws_close,
     op_ws_next_event,
+    op_ws_send_binary,
   ],
   esm = [ "01_websocket.js", "02_websocketstream.js" ],
   options = {


### PR DESCRIPTION
Easy perf win by avoiding deserializing `SendValue` through serde_v8. 

| name | avg msg/sec/core |
| --- | --- |
| deno_main | `127820.750000` |
| deno_this | `140079.000000` |
