### PR TITLE
fix(ext/flash): Fix request object returning uri property correctly after websocket upgrade

### DIFF
--- a/cli/tests/unit/websocket_request_test.ts
+++ b/cli/tests/unit/websocket_request_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, Deferred, deferred } from "./test_util.ts";
 
 function onListen<T>(
-  p: Deferred<T>
+  p: Deferred<T>,
 ): ({ hostname, port }: { hostname: string; port: number }) => void {
   return () => {
     p.resolve();
@@ -41,7 +41,7 @@ Deno.test(
         });
 
         return response;
-      }
+      },
     );
 
     const ws = new WebSocket("ws://127.0.0.1:4501/test");
@@ -49,5 +49,5 @@ Deno.test(
     ws.close();
     assertEquals(url, "http://localhost:4501/test");
     await closedPromise;
-  }
+  },
 );

--- a/cli/tests/unit/websocket_request_test.ts
+++ b/cli/tests/unit/websocket_request_test.ts
@@ -1,11 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import {
-  assertEquals,
-  assertThrows,
-  Deferred,
-  deferred,
-  fail,
-} from "./test_util.ts";
+import { assertEquals, Deferred, deferred } from "./test_util.ts";
 
 function onListen<T>(
   p: Deferred<T>,

--- a/cli/tests/unit/websocket_request_test.ts
+++ b/cli/tests/unit/websocket_request_test.ts
@@ -1,0 +1,53 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import {
+  assertEquals,
+  assertThrows,
+  Deferred,
+  deferred,
+  fail,
+} from "./test_util.ts";
+
+function onListen<T>(
+  p: Deferred<T>,
+): ({ hostname, port }: { hostname: string; port: number }) => void {
+  return () => {
+    p.resolve();
+  };
+}
+
+Deno.test(
+  "should correctly return url property after websocket upgrade",
+  async () => {
+    const listeningPromise = deferred();
+    const ac = new AbortController();
+    let url;
+
+    const server = Deno.serve(
+      {
+        hostname: "localhost",
+        port: 4501,
+        onListen: onListen(listeningPromise),
+        signal: ac.signal,
+      },
+      (request) => {
+        if (request.headers.get("upgrade") != "websocket") {
+          return new Response(null, { status: 501 });
+        }
+        const { socket, response } = Deno.upgradeWebSocket(request);
+
+        socket.addEventListener("open", () => {
+          url = request.url;
+          socket.close();
+          ac.abort();
+        });
+
+        return response;
+      },
+    );
+
+    new WebSocket("ws://127.0.0.1:4501/test");
+    await listeningPromise;
+    await server;
+    assertEquals(url, "http://localhost:4501/test");
+  },
+);

--- a/cli/tests/unit/websocket_request_test.ts
+++ b/cli/tests/unit/websocket_request_test.ts
@@ -2,7 +2,7 @@
 import { assertEquals, Deferred, deferred } from "./test_util.ts";
 
 function onListen<T>(
-  p: Deferred<T>,
+  p: Deferred<T>
 ): ({ hostname, port }: { hostname: string; port: number }) => void {
   return () => {
     p.resolve();
@@ -41,14 +41,13 @@ Deno.test(
         });
 
         return response;
-      },
+      }
     );
 
     const ws = new WebSocket("ws://127.0.0.1:4501/test");
-    await listeningPromise;
     await server;
     ws.close();
     assertEquals(url, "http://localhost:4501/test");
     await closedPromise;
-  },
+  }
 );

--- a/ext/flash/01_http.js
+++ b/ext/flash/01_http.js
@@ -562,6 +562,7 @@ function createServe(opFn) {
               }
             }
 
+            const path = ops.op_flash_path(serverId, i);
             const req = fromFlashRequest(
               serverId,
               /* streamRid */
@@ -571,7 +572,6 @@ function createServe(opFn) {
               () => methods[method],
               /* urlCb */
               () => {
-                const path = ops.op_flash_path(serverId, i);
                 return `${server.transport}://${server.hostname}:${server.port}${path}`;
               },
               /* headersCb */


### PR DESCRIPTION
Currently this is what's happening using the example from #18490

1. When websocket connection established, the following function executes and adds the request with token 0 in context https://github.com/denoland/deno/blame/main/ext/flash/lib.rs#L1377
2. After that websocket is upgraded (https://github.com/denoland/deno/blob/main/ext/flash/01_http.js#L425) which removes the request with token 0 from the context https://github.com/denoland/deno/blame/main/ext/flash/lib.rs#L1456
3. `open` event is emitted after websocket upgraded is executed https://github.com/denoland/deno/blob/main/ext/flash/01_http.js#L435, therefore on `open` callbacks are executed later
4. If we request `request.uri` option inside `open` callback, it is lazy loaded via this function https://github.com/denoland/deno/blob/main/ext/flash/01_http.js#L574 which requires request with token 0 in the server context which was removed on step 2. Thus panic.

This PR fixes this issue by preloading path before executing flash request.

Closes #18490

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

5. Ensure there is a related issue and it is referenced in the PR text.
6. Ensure there are tests that cover the changes.
7. Ensure `cargo test` passes.
8. Ensure `./tools/format.js` passes without changing files.
9. Ensure `./tools/lint.js` passes.
10. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
11. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
