### PR TITLE
perf(ext/websocket): use opAsync2 to avoid spread deopt

### DIFF
--- a/core/examples/http_bench_json_ops/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops/http_bench_json_ops.js
@@ -3,7 +3,7 @@
 // then write this fixed 'responseBuf'. The point of this benchmark is to
 // exercise the event loop in a simple yet semi-realistic way.
 
-const { ops, opAsync } = Deno.core;
+const { ops, opAsync, opAsync2 } = Deno.core;
 
 const requestBuf = new Uint8Array(64 * 1024);
 const responseBuf = new Uint8Array(
@@ -23,7 +23,7 @@ function accept(serverRid) {
 }
 
 function read(serverRid, buf) {
-  return opAsync("op_read_socket", serverRid, buf);
+  return opAsync2("op_read_socket", serverRid, buf);
 }
 
 async function serve(rid) {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2918,7 +2918,7 @@ pub mod tests {
         r#"
         
         let zero_copy_a = new Uint8Array([0]);
-        Deno.core.opAsync("op_test", null, zero_copy_a);
+        Deno.core.opAsync2("op_test", null, zero_copy_a);
         "#,
       )
       .unwrap();

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -31,7 +31,7 @@ function chmodSync(path, mode) {
 }
 
 async function chmod(path, mode) {
-  await core.opAsync("op_chmod_async", pathFromURL(path), mode);
+  await core.opAsync2("op_chmod_async", pathFromURL(path), mode);
 }
 
 function chownSync(
@@ -121,7 +121,7 @@ async function mkdir(
   path,
   options,
 ) {
-  await core.opAsync("op_mkdir_async", mkdirArgs(path, options));
+  await core.opAsync2("op_mkdir_async", mkdirArgs(path, options));
 }
 
 function readDirSync(path) {
@@ -349,7 +349,7 @@ function ftruncateSync(rid, len) {
 }
 
 async function ftruncate(rid, len) {
-  await core.opAsync("op_ftruncate_async", rid, coerceLen(len));
+  await core.opAsync2("op_ftruncate_async", rid, coerceLen(len));
 }
 
 function truncateSync(path, len) {
@@ -357,7 +357,7 @@ function truncateSync(path, len) {
 }
 
 async function truncate(path, len) {
-  await core.opAsync("op_truncate_async", path, coerceLen(len));
+  await core.opAsync2("op_truncate_async", path, coerceLen(len));
 }
 
 function umask(mask) {
@@ -369,7 +369,7 @@ function linkSync(oldpath, newpath) {
 }
 
 async function link(oldpath, newpath) {
-  await core.opAsync("op_link_async", oldpath, newpath);
+  await core.opAsync2("op_link_async", oldpath, newpath);
 }
 
 function toUnixTimeFromEpoch(value) {
@@ -499,7 +499,7 @@ function flockSync(rid, exclusive) {
 }
 
 async function flock(rid, exclusive) {
-  await core.opAsync("op_flock_async", rid, exclusive === true);
+  await core.opAsync2("op_flock_async", rid, exclusive === true);
 }
 
 function funlockSync(rid) {

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -316,7 +316,7 @@ function createRespondWith(
               break;
             }
             try {
-              await core.opAsync("op_http_write", streamRid, value);
+              await core.opAsync2("op_http_write", streamRid, value);
             } catch (error) {
               const connError = httpConn[connErrorSymbol];
               if (

--- a/ext/node/polyfills/internal/crypto/random.ts
+++ b/ext/node/polyfills/internal/crypto/random.ts
@@ -92,7 +92,7 @@ export function checkPrime(
     );
   }
 
-  core.opAsync(op, candidate, checks).then(
+  core.opAsync2(op, candidate, checks).then(
     (result) => {
       callback?.(null, result);
     },

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -215,7 +215,7 @@ const scheduledTimers = { head: null, tail: null };
  */
 function runAfterTimeout(cb, millis, timerInfo) {
   const cancelRid = timerInfo.cancelRid;
-  const sleepPromise = core.opAsync("op_sleep", millis, cancelRid);
+  const sleepPromise = core.opAsync2("op_sleep", millis, cancelRid);
   timerInfo.promiseId = sleepPromise[SymbolFor("Deno.core.internalPromiseId")];
   if (!timerInfo.isRef) {
     core.unrefOp(timerInfo.promiseId);

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -301,7 +301,7 @@ class WebSocket extends EventTarget {
     const sendTypedArray = (ta) => {
       this[_bufferedAmount] += ta.byteLength;
       PromisePrototypeThen(
-        core.opAsync("op_ws_send_binary", this[_rid], ta),
+        core.opAsync2("op_ws_send_binary", this[_rid], ta),
         () => {
           this[_bufferedAmount] -= ta.byteLength;
         },
@@ -322,7 +322,7 @@ class WebSocket extends EventTarget {
       const d = core.encode(string);
       this[_bufferedAmount] += d.byteLength;
       PromisePrototypeThen(
-        core.opAsync("op_ws_send_text", this[_rid], string),
+        core.opAsync2("op_ws_send_text", this[_rid], string),
         () => {
           this[_bufferedAmount] -= d.byteLength;
         },
@@ -394,7 +394,7 @@ class WebSocket extends EventTarget {
 
   async [_eventLoop]() {
     while (this[_readyState] !== CLOSED) {
-      const { 0: kind, 1: value } = await core.opAsync(
+      const { 0: kind, 1: value } = await core.opAsync2(
         "op_ws_next_event",
         this[_rid],
       );


### PR DESCRIPTION
This commit adds a new core API `opAsync2` to call an async op with atmost 2 arguments. Spread argument iterators has a pretty big perf hit when calling ops.

| name | avg msg/sec/core |
| --- | --- |
| 1.32.1 | `127820.750000` |
| #18506 | `140079.000000` |
| #18506 + #18509 | `150104.250000` |
| #18506 + #18509 + this | `157340.000000` |
