### PR TITLE
fix(lsp): better handling of `data:` urls

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2779,13 +2779,13 @@ fn op_resolve(
           .collect(),
       )
     }
-    None => Err(custom_error(
-      "NotFound",
-      format!(
+    None => {
+      lsp_warn!(
         "Error resolving. Referring specifier \"{}\" was not found.",
         args.base
-      ),
-    )),
+      );
+      Ok(vec![None; args.specifiers.len()])
+    }
   };
 
   state.performance.measure(mark);

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7417,3 +7417,79 @@ fn lsp_closed_file_find_references() {
 
   client.shutdown();
 }
+
+#[test]
+fn lsp_data_urls_with_jsx_compiler_option() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write(
+    "deno.json",
+    r#"{ "compilerOptions": { "jsx": "react-jsx" } }"#,
+  );
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize(|builder| {
+    builder.set_import_map("import-map.json");
+  });
+
+  let uri = Url::from_file_path(temp_dir.path().join("main.ts")).unwrap();
+
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": uri,
+      "languageId": "typescript",
+      "version": 1,
+      "text": "import a from \"data:application/typescript,export default 5;\";\na;"
+    }
+  })).viewed();
+
+  // there will be a diagnostic about not having cached the data url
+  assert_eq!(diagnostics.len(), 1);
+  assert_eq!(
+    diagnostics[0].code,
+    Some(lsp::NumberOrString::String("no-cache-data".to_string()))
+  );
+
+  // so cache it
+  client.write_request(
+    "deno/cache",
+    json!({
+      "referrer": {
+        "uri": uri,
+      },
+      "uris": [],
+    }),
+  );
+
+  let res = client.write_request(
+    "textDocument/references",
+    json!({
+      "textDocument": {
+        "uri": uri
+      },
+      "position": { "line": 1, "character": 1 },
+      "context": {
+        "includeDeclaration": false
+      }
+    }),
+  );
+
+  assert_eq!(
+    res,
+    json!([{
+      "uri": uri,
+      "range": {
+        "start": { "line": 0, "character": 7 },
+        "end": { "line": 0, "character": 8 }
+      }
+    }, {
+      "uri": uri,
+      "range": {
+        "start": { "line": 1, "character": 0 },
+        "end": { "line": 1, "character": 1 }
+      }
+    }])
+  );
+
+  client.shutdown();
+}

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7428,9 +7428,7 @@ fn lsp_data_urls_with_jsx_compiler_option() {
   );
 
   let mut client = context.new_lsp_command().build();
-  client.initialize(|builder| {
-    builder.set_import_map("import-map.json");
-  });
+  client.initialize_default();
 
   let uri = Url::from_file_path(temp_dir.path().join("main.ts")).unwrap();
 


### PR DESCRIPTION
1. Log instead of error when the referrer can't be found
2. Fixes typescript to resolve data urls correctly. Properly documented here: https://github.com/denoland/TypeScript/pull/4/files#diff-180da7c288743d11d8590d30f0c07c48e5dcf291aa671bbea0dd520a9a1359d2

Closes #18524 