### PR TITLE
feat(ext/ffi): support marking symbols as optional

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -271,6 +271,11 @@ declare namespace Deno {
      *
      * @default {false} */
     callback?: boolean;
+    /** When `true`, dlopen will not fail if the symbol is not found.
+     * Instead, the symbol will be set to `null`.
+     *
+     * @default {false} */
+    optional?: boolean;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.
@@ -282,6 +287,11 @@ declare namespace Deno {
     name?: string;
     /** The type of the foreign static value. */
     type: Type;
+    /** When `true`, dlopen will not fail if the symbol is not found.
+     * Instead, the symbol will be set to `null`.
+     *
+     * @default {false} */
+    optional?: boolean;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.
@@ -336,7 +346,9 @@ declare namespace Deno {
    * @category FFI
    */
   type StaticForeignLibraryInterface<T extends ForeignLibraryInterface> = {
-    [K in keyof T]: StaticForeignSymbol<T[K]>;
+    [K in keyof T]: T[K]["optional"] extends true
+      ? StaticForeignSymbol<T[K]> | null
+      : StaticForeignSymbol<T[K]>;
   };
 
   const brand: unique symbol;

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -418,6 +418,12 @@ class DynamicLibrary {
         continue;
       }
 
+      // Symbol was marked as optional, and not found.
+      // In that case, we set its value to null in Rust-side.
+      if (symbols[symbol] === null) {
+        continue;
+      }
+
       if (ReflectHas(symbols[symbol], "type")) {
         const type = symbols[symbol].type;
         if (type === "void") {
@@ -431,6 +437,7 @@ class DynamicLibrary {
           this.#rid,
           name,
           type,
+          symbols[symbol].optional,
         );
         ObjectDefineProperty(
           this.symbols,

--- a/test_ffi/tests/ffi_types.ts
+++ b/test_ffi/tests/ffi_types.ts
@@ -46,6 +46,11 @@ const remote = Deno.dlopen(
       parameters: ["bool"],
       result: "bool",
     },
+    method25: {
+      parameters: [],
+      result: "void",
+      optional: true,
+    },
     static1: { type: "usize" },
     static2: { type: "pointer" },
     static3: { type: "usize" },
@@ -61,6 +66,10 @@ const remote = Deno.dlopen(
     static13: { type: "f32" },
     static14: { type: "f64" },
     static15: { type: "bool" },
+    static16: {
+      type: "bool",
+      optional: true,
+    },
   },
 );
 
@@ -277,6 +286,9 @@ let r24_0: true = remote.symbols.method24(true);
 let r42_1: number = remote.symbols.method24(true);
 <boolean> remote.symbols.method24(Math.random() > 0.5);
 
+// @ts-expect-error: Optional symbol; can be null.
+remote.symbols.method25();
+
 // @ts-expect-error: Invalid member type
 const static1_wrong: null = remote.symbols.static1;
 const static1_right: number | bigint = remote.symbols.static1;
@@ -322,6 +334,9 @@ const static14_right: number = remote.symbols.static14;
 // @ts-expect-error: Invalid member type
 const static15_wrong: number = remote.symbols.static15;
 const static15_right: boolean = remote.symbols.static15;
+// @ts-expect-error: Invalid member type
+const static16_wrong: boolean = remote.symbols.static16;
+const static16_right: boolean | null = remote.symbols.static16;
 
 // Adapted from https://stackoverflow.com/a/53808212/10873797
 type Equal<T, U> = (<G>() => G extends T ? 1 : 2) extends

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -251,6 +251,7 @@ const dylib = Deno.dlopen(libPath, {
    */
   "static_char": {
     type: "pointer",
+    optional: true,
   },
   "hash": { parameters: ["buffer", "u32"], result: "u32" },
   make_rect: {
@@ -280,6 +281,7 @@ const dylib = Deno.dlopen(libPath, {
   print_mixed: {
     parameters: [{ struct: Mixed }],
     result: "void",
+    optional: true,
   },
   non_existent_symbol: {
     parameters: [],

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -281,6 +281,21 @@ const dylib = Deno.dlopen(libPath, {
     parameters: [{ struct: Mixed }],
     result: "void",
   },
+  non_existent_symbol: {
+    parameters: [],
+    result: "void",
+    optional: true,
+  },
+  non_existent_nonblocking_symbol: {
+    parameters: [],
+    result: "void",
+    nonblocking: true,
+    optional: true,
+  },
+  non_existent_static: {
+    type: "u32",
+    optional: true,
+  },
 });
 const { symbols } = dylib;
 


### PR DESCRIPTION
Adds support for marking Foreign Library symbols as `optional`, which does not prevent the library from loading in case an optional symbol is not found.

For example, when loading Vulkan library, certain symbols related to extensions are not present on all machines, so we mark them as optional and allow the library to still load. It's also helpful in case certain symbols are OS-specific. Some system libraries like win32 (user32, etc) may have symbols that are only present on newer version of Windows, so it can also allow compatibility with older versions.
