### PR TITLE
fix(ext/ffi): crash when same reference struct is used in two fields

### DIFF
--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -313,8 +313,9 @@ function getTypeSizeAndAlignment(type, cache = new SafeMap()) {
       size += fieldSize;
     }
     size = MathCeil(size / alignment) * alignment;
-    cache.set(type, size);
-    return [size, alignment];
+    const result = [size, alignment];
+    cache.set(type, result);
+    return result;
   }
 
   switch (type) {

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -78,6 +78,7 @@ const Point = ["f64", "f64"];
 const Size = ["f64", "f64"];
 const Rect = ["f64", "f64", "f64", "f64"];
 const RectNested = [{ struct: Point }, { struct: Size }];
+const RectNestedCached = [{ struct: Size }, { struct: Size }];
 const Mixed = ["u8", "f32", { struct: Rect }, "usize", { struct: ["u32", "u32"] }];
 
 const dylib = Deno.dlopen(libPath, {
@@ -264,7 +265,7 @@ const dylib = Deno.dlopen(libPath, {
     result: { struct: RectNested },
   },
   print_rect: {
-    parameters: [{ struct: Rect }],
+    parameters: [{ struct: RectNestedCached }],
     result: "void",
   },
   print_rect_async: {


### PR DESCRIPTION
fix #17482
