### PR TITLE
fix(repl): disable language server document preloading in the repl

### DIFF
--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -26,6 +26,13 @@ pub enum TestingNotification {
   Progress(testing_lsp_custom::TestRunProgressParams),
 }
 
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub enum LspClientKind {
+  #[default]
+  CodeEditor,
+  Repl,
+}
+
 #[derive(Clone)]
 pub struct Client(Arc<dyn ClientTrait>);
 
@@ -42,6 +49,10 @@ impl Client {
 
   pub fn new_for_repl() -> Self {
     Self(Arc::new(ReplClient))
+  }
+
+  pub fn kind(&self) -> LspClientKind {
+    self.0.kind()
   }
 
   /// Gets additional methods that should only be called outside
@@ -149,6 +160,7 @@ impl OutsideLockClient {
 
 #[async_trait]
 trait ClientTrait: Send + Sync {
+  fn kind(&self) -> LspClientKind;
   async fn publish_diagnostics(
     &self,
     uri: lsp::Url,
@@ -177,6 +189,10 @@ struct TowerClient(tower_lsp::Client);
 
 #[async_trait]
 impl ClientTrait for TowerClient {
+  fn kind(&self) -> LspClientKind {
+    LspClientKind::CodeEditor
+  }
+
   async fn publish_diagnostics(
     &self,
     uri: lsp::Url,
@@ -296,6 +312,10 @@ struct ReplClient;
 
 #[async_trait]
 impl ClientTrait for ReplClient {
+  fn kind(&self) -> LspClientKind {
+    LspClientKind::Repl
+  }
+
   async fn publish_diagnostics(
     &self,
     _uri: lsp::Url,

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -519,7 +519,7 @@ mod tests {
     source_fixtures: &[(&str, &str)],
     location: &Path,
   ) -> Documents {
-    let mut documents = Documents::new(location);
+    let mut documents = Documents::new(location, Default::default());
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1079,7 +1079,7 @@ mod tests {
     location: &Path,
     maybe_import_map: Option<(&str, &str)>,
   ) -> StateSnapshot {
-    let mut documents = Documents::new(location);
+    let mut documents = Documents::new(location, Default::default());
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -16,7 +16,6 @@ use crate::cache::HttpCache;
 use crate::file_fetcher::get_source_from_bytes;
 use crate::file_fetcher::map_content_type;
 use crate::file_fetcher::SUPPORTED_SCHEMES;
-use crate::lsp::logging::lsp_debug;
 use crate::node;
 use crate::node::node_resolve_npm_reference;
 use crate::node::NodeResolution;
@@ -1259,7 +1258,7 @@ impl Documents {
           fs_docs.docs.keys().cloned().collect::<HashSet<_>>();
         let open_docs = &mut self.open_docs;
 
-        lsp_debug!("Preloading documents from root urls...");
+        log::debug!("Preloading documents from root urls...");
         for specifier in PreloadDocumentFinder::from_root_urls(&root_urls) {
           // mark this document as having been found
           not_found_docs.remove(&specifier);
@@ -1287,7 +1286,7 @@ impl Documents {
         // This log statement is used in the tests to ensure preloading doesn't
         // happen, which is not useful in the repl and could be very expensive
         // if the repl is launched from a directory with a lot of descendants.
-        lsp_debug!("Skipping document preload for repl.");
+        log::debug!("Skipping document preload for repl.");
 
         // for the repl, just update to use the new resolver
         for doc in fs_docs.docs.values_mut() {

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -16,6 +16,7 @@ use crate::cache::HttpCache;
 use crate::file_fetcher::get_source_from_bytes;
 use crate::file_fetcher::map_content_type;
 use crate::file_fetcher::SUPPORTED_SCHEMES;
+use crate::lsp::logging::lsp_debug;
 use crate::node;
 use crate::node::node_resolve_npm_reference;
 use crate::node::NodeResolution;
@@ -1258,6 +1259,7 @@ impl Documents {
           fs_docs.docs.keys().cloned().collect::<HashSet<_>>();
         let open_docs = &mut self.open_docs;
 
+        lsp_debug!("Preloading documents from root urls...");
         for specifier in PreloadDocumentFinder::from_root_urls(&root_urls) {
           // mark this document as having been found
           not_found_docs.remove(&specifier);
@@ -1282,6 +1284,11 @@ impl Documents {
         }
       }
       LspClientKind::Repl => {
+        // This log statement is used in the tests to ensure preloading doesn't
+        // happen, which is not useful in the repl and could be very expensive
+        // if the repl is launched from a directory with a lot of descendants.
+        lsp_debug!("Skipping document preload for repl.");
+
         // for the repl, just update to use the new resolver
         for doc in fs_docs.docs.values_mut() {
           if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -463,7 +463,7 @@ impl Inner {
       ModuleRegistry::new(&module_registries_location, http_client.clone())
         .unwrap();
     let location = dir.deps_folder_path();
-    let documents = Documents::new(&location);
+    let documents = Documents::new(&location, client.kind());
     let deps_http_cache = HttpCache::new(&location);
     let cache_metadata = cache::CacheMetadata::new(deps_http_cache.clone());
     let performance = Arc::new(Performance::default());

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3530,7 +3530,7 @@ mod tests {
     fixtures: &[(&str, &str, i32, LanguageId)],
     location: &Path,
   ) -> StateSnapshot {
-    let mut documents = Documents::new(location);
+    let mut documents = Documents::new(location, Default::default());
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -5,6 +5,7 @@ use test_util::assert_contains;
 use test_util::assert_ends_with;
 use test_util::assert_not_contains;
 use util::TempDir;
+use util::TestContext;
 use util::TestContextBuilder;
 
 #[test]
@@ -956,4 +957,17 @@ fn package_json_uncached_no_error() {
     console.write_line("getValue()");
     console.expect("42")
   });
+}
+
+#[test]
+fn closed_file_pre_load_does_not_occur() {
+  TestContext::default()
+    .new_command()
+    .args_vec(["repl", "-A", "--log-level=debug"])
+    .with_pty(|console| {
+      assert_contains!(
+        console.all_output(),
+        "Skipping document preload for repl.",
+      );
+    });
 }


### PR DESCRIPTION
This was an oversight because the repl uses the language server under the hood. Also, never preloads from a root directory.

Part of #18538