### PR TITLE
fix(test): don't swallow sanitizer errors with permissions

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -481,7 +481,7 @@ function withPermissions(fn, permissions) {
     const token = pledgePermissions(permissions);
 
     try {
-      await fn(...new SafeArrayIterator(params));
+      return await fn(...new SafeArrayIterator(params));
     } finally {
       restorePermissions(token);
     }

--- a/cli/tests/testdata/test/ops_sanitizer_unstable.out
+++ b/cli/tests/testdata/test/ops_sanitizer_unstable.out
@@ -10,7 +10,7 @@ error: Leaking async ops:
   - 1 async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at setInterval ([WILDCARD])
-    at [WILDCARD]/testdata/test/ops_sanitizer_unstable.ts:3:3
+    at fn ([WILDCARD]/testdata/test/ops_sanitizer_unstable.ts:7:5)
     at [WILDCARD]
 
  FAILURES 

--- a/cli/tests/testdata/test/ops_sanitizer_unstable.ts
+++ b/cli/tests/testdata/test/ops_sanitizer_unstable.ts
@@ -1,4 +1,9 @@
 Deno.test("no-op", function () {});
-Deno.test("leak interval", function () {
-  setInterval(function () {}, 100000);
+Deno.test({
+  name: "leak interval",
+  // regression test for sanitizer errors being swallowed with permissions.
+  permissions: {},
+  fn() {
+    setInterval(function () {}, 100000);
+  },
 });


### PR DESCRIPTION
Missing `return` from #18246.