### PR TITLE
fix(lsp): add a document preload file system entry limit

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -485,9 +485,12 @@ impl Config {
       .unwrap_or_else(|| self.settings.workspace.enable)
   }
 
-  /// Gets the root directories or specifically enabled file paths based on the
+  /// Gets the directories or specifically enabled file paths based on the
   /// workspace config.
-  pub fn enabled_root_urls(&self) -> Vec<Url> {
+  ///
+  /// WARNING: This may incorrectly have some directory urls as being
+  /// represented as file urls.
+  pub fn enabled_urls(&self) -> Vec<Url> {
     let mut urls: Vec<Url> = Vec::new();
 
     if !self.settings.workspace.enable && self.enabled_paths.is_empty() {
@@ -502,12 +505,16 @@ impl Config {
         urls.push(workspace.clone());
       }
     }
+
     if urls.is_empty() {
       if let Some(root_dir) = &self.root_uri {
         urls.push(root_dir.clone())
       }
     }
-    sort_and_remove_non_leaf_dir_urls(urls)
+
+    // sort for determinism
+    urls.sort();
+    urls
   }
 
   pub fn specifier_code_lens_test(&self, specifier: &ModuleSpecifier) -> bool {
@@ -644,30 +651,6 @@ impl Config {
     self.settings.specifiers.insert(specifier, settings);
     true
   }
-}
-
-/// Removes any directory URLs that are a descendant of another URL in the collection.
-fn sort_and_remove_non_leaf_dir_urls(urls: Vec<Url>) -> Vec<Url> {
-  if urls.is_empty() {
-    return urls;
-  }
-
-  let (mut dirs, files) = urls
-    .into_iter()
-    .partition::<Vec<_>, _>(|url| url.path().ends_with('/'));
-
-  dirs.sort();
-  for i in (0..dirs.len() - 1).rev() {
-    let prev = &dirs[i + 1];
-    if prev.as_str().starts_with(dirs[i].as_str()) {
-      dirs.remove(i + 1);
-    }
-  }
-
-  // add back the files and sort
-  dirs.extend(files);
-  dirs.sort();
-  dirs
 }
 
 #[cfg(test)]
@@ -837,47 +820,16 @@ mod tests {
   }
 
   #[test]
-  fn test_sort_and_remove_non_leaf_dir_urls() {
-    fn run_test(paths: Vec<&str>, expected_output: Vec<&str>) {
-      let paths = sort_and_remove_non_leaf_dir_urls(
-        paths
-          .into_iter()
-          .map(|dir| Url::parse(dir).unwrap())
-          .collect(),
-      );
-      let dirs: Vec<_> = paths.iter().map(|dir| dir.as_str()).collect();
-      assert_eq!(dirs, expected_output);
-    }
-
-    run_test(
-      vec![
-        "file:///test/asdf/test/asdf/",
-        "file:///test/asdf/test/asdf/test.ts",
-        "file:///test/asdf/",
-        "file:///test/asdf/",
-        "file:///testing/456/893/",
-        "file:///testing/456/893/test/",
-      ],
-      vec![
-        "file:///test/asdf/",
-        "file:///test/asdf/test/asdf/test.ts", // keeps this, because it's a specified file
-        "file:///testing/456/893/",
-      ],
-    );
-    run_test(vec![], vec![]);
-  }
-
-  #[test]
   fn config_enabled_root_urls() {
     let mut config = Config::new();
     let root_dir = Url::parse("file:///example/").unwrap();
     config.root_uri = Some(root_dir.clone());
     config.settings.workspace.enable = false;
     config.settings.workspace.enable_paths = Vec::new();
-    assert_eq!(config.enabled_root_urls(), vec![]);
+    assert_eq!(config.enabled_urls(), vec![]);
 
     config.settings.workspace.enable = true;
-    assert_eq!(config.enabled_root_urls(), vec![root_dir]);
+    assert_eq!(config.enabled_urls(), vec![root_dir]);
 
     config.settings.workspace.enable = false;
     let root_dir1 = Url::parse("file:///root1/").unwrap();
@@ -897,9 +849,10 @@ mod tests {
     ]);
 
     assert_eq!(
-      config.enabled_root_urls(),
+      config.enabled_urls(),
       vec![
         root_dir1.join("sub_dir/").unwrap(),
+        root_dir1.join("sub_dir/other/").unwrap(),
         root_dir1.join("test.ts").unwrap(),
         root_dir2.join("other.ts").unwrap(),
         root_dir3

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -899,7 +899,7 @@ mod tests {
     assert_eq!(
       config.enabled_root_urls(),
       vec![
-        root_dir1.join("sub_dir").unwrap(),
+        root_dir1.join("sub_dir/").unwrap(),
         root_dir1.join("test.ts").unwrap(),
         root_dir2.join("other.ts").unwrap(),
         root_dir3

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -675,6 +675,7 @@ mod tests {
   use super::*;
   use deno_core::resolve_url;
   use deno_core::serde_json::json;
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn test_config_specifier_enabled() {
@@ -886,8 +887,8 @@ mod tests {
       (
         root_dir1.clone(),
         vec![
-          root_dir1.join("sub_dir").unwrap(),
-          root_dir1.join("sub_dir/other").unwrap(),
+          root_dir1.join("sub_dir/").unwrap(),
+          root_dir1.join("sub_dir/other/").unwrap(),
           root_dir1.join("test.ts").unwrap(),
         ],
       ),

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -820,7 +820,7 @@ mod tests {
   }
 
   #[test]
-  fn config_enabled_root_urls() {
+  fn config_enabled_urls() {
     let mut config = Config::new();
     let root_dir = Url::parse("file:///example/").unwrap();
     config.root_uri = Some(root_dir.clone());

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1994,8 +1994,9 @@ console.log(b, "hello deno");
     .collect::<Vec<_>>();
 
     // since different file system have different iteration
-    // order, we only check the length
-    assert_eq!(urls.len(), 3);
+    // order, the number here may vary, so just assert it's below
+    // a certain amount
+    assert!(urls.len() < 5, "Actual length: {}", urls.len());
   }
 
   #[test]

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1955,7 +1955,7 @@ console.log(b, "hello deno");
     temp_dir.create_dir_all("root3/");
     temp_dir.write("root3/mod.ts", ""); // no, not provided
 
-    let urls = PreloadDocumentFinder::from_root_urls(&vec![
+    let mut urls = PreloadDocumentFinder::from_root_urls(&vec![
       temp_dir.uri().join("root1/").unwrap(),
       temp_dir.uri().join("root2/file1.ts").unwrap(),
       temp_dir.uri().join("root2/main.min.ts").unwrap(),
@@ -1963,11 +1963,14 @@ console.log(b, "hello deno");
     ])
     .collect::<Vec<_>>();
 
+    // Ideally we would test for order here, which should be BFS, but
+    // different file systems have different directory iteration
+    // so we sort the results
+    urls.sort();
+
     assert_eq!(
       urls,
       vec![
-        temp_dir.uri().join("root2/file1.ts").unwrap(),
-        temp_dir.uri().join("root2/main.min.ts").unwrap(),
         temp_dir.uri().join("root1/mod1.ts").unwrap(),
         temp_dir.uri().join("root1/mod2.js").unwrap(),
         temp_dir.uri().join("root1/mod3.tsx").unwrap(),
@@ -1976,8 +1979,10 @@ console.log(b, "hello deno");
         temp_dir.uri().join("root1/mod6.mjs").unwrap(),
         temp_dir.uri().join("root1/mod7.mts").unwrap(),
         temp_dir.uri().join("root1/mod8.d.mts").unwrap(),
-        temp_dir.uri().join("root2/folder/main.ts").unwrap(),
         temp_dir.uri().join("root1/sub_dir/mod.ts").unwrap(),
+        temp_dir.uri().join("root2/file1.ts").unwrap(),
+        temp_dir.uri().join("root2/folder/main.ts").unwrap(),
+        temp_dir.uri().join("root2/main.min.ts").unwrap(),
       ]
     );
 
@@ -1988,14 +1993,9 @@ console.log(b, "hello deno");
     )
     .collect::<Vec<_>>();
 
-    assert_eq!(
-      urls,
-      vec![
-        temp_dir.uri().join("root1/mod1.ts").unwrap(),
-        temp_dir.uri().join("root1/mod2.js").unwrap(),
-        temp_dir.uri().join("root1/mod3.tsx").unwrap(),
-      ]
-    );
+    // since different file system have different iteration
+    // order, we only check the length
+    assert_eq!(urls.len(), 3);
   }
 
   #[test]

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1176,7 +1176,7 @@ impl Documents {
     ) -> u64 {
       let mut hasher = FastInsecureHasher::default();
       hasher.write_hashable(&{
-        // ensure these are sorted so the hashing is more deterministic
+        // ensure these are sorted so the hashing is deterministic
         let mut enabled_urls = enabled_urls.to_vec();
         enabled_urls.sort_unstable();
         enabled_urls

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1925,6 +1925,7 @@ console.log(b, "hello deno");
 
     temp_dir.create_dir_all("root1/sub_dir");
     temp_dir.create_dir_all("root1/target");
+    temp_dir.create_dir_all("root1/node_modules");
     temp_dir.create_dir_all("root1/.git");
     temp_dir.create_dir_all("root1/file.ts"); // no, directory
     temp_dir.write("root1/mod1.ts", ""); // yes
@@ -1939,10 +1940,11 @@ console.log(b, "hello deno");
     temp_dir.write("root1/other.txt", ""); // no, text file
     temp_dir.write("root1/other.wasm", ""); // no, don't load wasm
     temp_dir.write("root1/Cargo.toml", ""); // no
-    temp_dir.write("root1/target/main.ts", ""); // no, because there is a Cargo.toml in the root directory
     temp_dir.write("root1/sub_dir/mod.ts", ""); // yes
     temp_dir.write("root1/sub_dir/data.min.ts", ""); // no, minified file
     temp_dir.write("root1/.git/main.ts", ""); // no, .git folder
+    temp_dir.write("root1/node_modules/main.ts", ""); // no, because it's in a node_modules folder
+    temp_dir.write("root1/target/main.ts", ""); // no, because there is a Cargo.toml in the root directory
 
     temp_dir.create_dir_all("root2/folder");
     temp_dir.write("root2/file1.ts", ""); // yes, provided

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1138,7 +1138,7 @@ impl Inner {
 
   fn refresh_documents_config(&mut self) {
     self.documents.update_config(
-      self.config.enabled_root_urls(),
+      self.config.enabled_urls(),
       self.maybe_import_map.clone(),
       self.maybe_config_file.as_ref(),
       self.maybe_package_json.as_ref(),


### PR DESCRIPTION
I was testing this out and it's badly needed. For now, it's not configurable and limited to 1,000 file system entries.

Related to #18538