### PR TITLE
refactor(core): Reduce middleware cost in core of event loop

### DIFF
--- a/core/examples/schedule_task.rs
+++ b/core/examples/schedule_task.rs
@@ -20,8 +20,8 @@ type Task = Box<dyn FnOnce()>;
 fn main() {
   let my_ext = Extension::builder("my_ext")
     .ops(vec![op_schedule_task::decl()])
-    .event_loop_middleware(|state_rc, cx| {
-      let mut state = state_rc.borrow_mut();
+    .event_loop_middleware(|state, cx| {
+      let mut state = state.borrow_mut();
       let recv = state.borrow_mut::<mpsc::UnboundedReceiver<Task>>();
       let mut ref_loop = false;
       while let Poll::Ready(Some(call)) = recv.poll_next_unpin(cx) {

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -93,7 +93,7 @@ pub struct JsRuntime {
   snapshot_options: snapshot_util::SnapshotOptions,
   allocations: IsolateAllocations,
   extensions: Vec<Extension>,
-  event_loop_middlewares: Vec<Box<OpEventLoopFn>>,
+  event_loop_middlewares: Vec<OpEventLoopFn>,
   // Marks if this is considered the top-level runtime. Used only be inspector.
   is_main: bool,
 }
@@ -1242,11 +1242,10 @@ impl JsRuntime {
     // Event loop middlewares
     let mut maybe_scheduling = false;
     {
-      let op_state = self.state.borrow().op_state.clone();
+      let rc = self.state.borrow();
+      let refcell = &*rc.op_state;
       for f in &self.event_loop_middlewares {
-        if f(op_state.clone(), cx) {
-          maybe_scheduling = true;
-        }
+        maybe_scheduling |= f(refcell, cx);
       }
     }
 

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -131,7 +131,7 @@ deno_core::extension!(deno_ffi,
 );
 
 fn event_loop_middleware(
-  op_state_rc: Rc<RefCell<OpState>>,
+  op_state: &RefCell<OpState>,
   _cx: &mut std::task::Context,
 ) -> bool {
   // FFI callbacks coming in from other threads will call in and get queued.
@@ -140,7 +140,7 @@ fn event_loop_middleware(
   let mut work_items: Vec<PendingFfiAsyncWork> = vec![];
 
   {
-    let mut op_state = op_state_rc.borrow_mut();
+    let mut op_state = op_state.borrow_mut();
     let ffi_state = op_state.borrow_mut::<FfiState>();
 
     while let Ok(Some(async_work_fut)) =
@@ -150,8 +150,6 @@ fn event_loop_middleware(
       work_items.push(async_work_fut);
       maybe_scheduling = true;
     }
-
-    drop(op_state);
   }
   while let Some(async_work_fut) = work_items.pop() {
     async_work_fut();

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -538,7 +538,7 @@ deno_core::extension!(deno_napi,
 );
 
 fn event_loop_middleware(
-  op_state_rc: Rc<RefCell<OpState>>,
+  op_state: &RefCell<OpState>,
   cx: &mut std::task::Context,
 ) -> bool {
   // `work` can call back into the runtime. It can also schedule an async task
@@ -547,7 +547,7 @@ fn event_loop_middleware(
   let mut maybe_scheduling = false;
 
   {
-    let mut op_state = op_state_rc.borrow_mut();
+    let mut op_state = op_state.borrow_mut();
     let napi_state = op_state.borrow_mut::<NapiState>();
 
     while let Poll::Ready(Some(async_work_fut)) =
@@ -571,7 +571,7 @@ fn event_loop_middleware(
 
   loop {
     let maybe_work = {
-      let mut op_state = op_state_rc.borrow_mut();
+      let mut op_state = op_state.borrow_mut();
       let napi_state = op_state.borrow_mut::<NapiState>();
       napi_state.pending_async_work.pop()
     };


### PR DESCRIPTION
This removes a `Box` and a few `clone`s from the core of the event loop to help reduce the cost of the middleware.