### PR TITLE
feat(core): sync io ops in core

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -412,6 +412,8 @@
     readAll: opAsync.bind(null, "op_read_all"),
     write: opAsync.bind(null, "op_write"),
     writeAll: opAsync.bind(null, "op_write_all"),
+    readSync: (rid, buffer) => ops.op_read_sync(rid, buffer),
+    writeSync: (rid, buffer) => ops.op_write_sync(rid, buffer),
     shutdown: opAsync.bind(null, "op_shutdown"),
     print: (msg, isErr) => ops.op_print(msg, isErr),
     setMacrotaskCallback: (fn) => ops.op_set_macrotask_callback(fn),

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -61,6 +61,16 @@ declare namespace Deno {
     function writeAll(rid: number, buf: Uint8Array): Promise<void>;
 
     /**
+     * Synchronously read from a (stream) resource that implements readSync().
+     */
+    function readSync(rid: number, buf: Uint8Array): number;
+
+    /**
+     * Synchronously write to a (stream) resource that implements writeSync().
+     */
+    function writeSync(rid: number, buf: Uint8Array): number;
+
+    /**
      * Print a message to stdout or stderr
      */
     function print(message: string, is_err?: boolean): void;

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -154,6 +154,18 @@ pub trait Resource: Any + 'static {
     })
   }
 
+  /// The same as [`read_byob()`][Resource::read_byob], but synchronous.
+  fn read_byob_sync(&self, data: &mut [u8]) -> Result<usize, Error> {
+    _ = data;
+    Err(not_supported())
+  }
+
+  /// The same as [`write()`][Resource::write], but synchronous.
+  fn write_sync(&self, data: &[u8]) -> Result<usize, Error> {
+    _ = data;
+    Err(not_supported())
+  }
+
   /// The shutdown method can be used to asynchronously close the resource. It
   /// is not automatically called when the resource is dropped or closed.
   ///

--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -93,27 +93,19 @@ function* iterSync(
 }
 
 function readSync(rid, buffer) {
-  if (buffer.length === 0) {
-    return 0;
-  }
-
-  const nread = ops.op_read_sync(rid, buffer);
-
+  if (buffer.length === 0) return 0;
+  const nread = core.readSync(rid, buffer);
   return nread === 0 ? null : nread;
 }
 
 async function read(rid, buffer) {
-  if (buffer.length === 0) {
-    return 0;
-  }
-
+  if (buffer.length === 0) return 0;
   const nread = await core.read(rid, buffer);
-
   return nread === 0 ? null : nread;
 }
 
 function writeSync(rid, data) {
-  return ops.op_write_sync(rid, data);
+  return core.writeSync(rid, data);
 }
 
 function write(rid, data) {


### PR DESCRIPTION
This commit adds op_read_sync and op_write_sync to core. These ops are similar
to op_read and op_write, but they are synchronous. Just like the async ops, they
operate on generic `deno_core::Resource` objects. These now have new
`read_byob_sync` and `write_sync` methods, with default implementations throwing
"NotSupported" errors, just like the async counterparts.

There are no `write_all` or `read` equivalents, because the optimizations they
unlock are not useful in synchronous contexts.
