### PR TITLE
feat(task): introduce built-in `unset` command to `deno task`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7068bd49521a7b22dc6df8937097a7ac285ea320cbd78582b4155d31f0d5049"
+checksum = "15deca0c59b55353c4a26c0259dd271c21eb72af106271c6459fd551c5f7bdef"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -48,7 +48,7 @@ deno_graph = "=0.45.0"
 deno_lint = { version = "0.43.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }
-deno_task_shell = "0.10.0"
+deno_task_shell = "0.11.0"
 napi_sym.workspace = true
 
 async-trait.workspace = true


### PR DESCRIPTION
This introduces a new built-in `unset` command to `deno task` by bumping deno_task_shell to the latest version 0.11.0. Also this includes a fix on how `deno task` handles empty environment variables (see https://github.com/denoland/deno_task_shell/pull/80 for details).