### PR TITLE
refactor(ext/node): `NodeFs` - add back altered metadata method

### DIFF
--- a/ext/node/ops.rs
+++ b/ext/node/ops.rs
@@ -264,8 +264,8 @@ where
 {
   let path = PathBuf::from(path);
   ensure_read_permission::<Env::P>(state, &path)?;
-  if Env::Fs::exists(&path) {
-    if Env::Fs::is_file(&path) {
+  if let Ok(metadata) = Env::Fs::metadata(&path) {
+    if metadata.is_file {
       return Ok(0);
     } else {
       return Ok(1);


### PR DESCRIPTION
From https://github.com/denoland/deno/pull/18604/files#r1159992299

We should still have a `metadata` method because it's one system call instead of two on most platforms.