### PR TITLE
fix(npm): reload an npm package's dependency's information when version not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b498f30dd6d0149e98b210ef7a01e54b2a8ba703b08a30fe4d87b3f36b93737c"
+checksum = "dfe101b42a94cd47522f91f490a647cd88a034996eff6806a14a59e672d80bbc"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ deno_emit = "0.18.0"
 deno_graph = "=0.46.0"
 deno_lint = { version = "0.43.0", features = ["docs"] }
 deno_lockfile.workspace = true
-deno_npm = "0.1.0"
+deno_npm = "0.2.0"
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }
 deno_semver = "0.2.0"
 deno_task_shell = "0.11.0"

--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -117,10 +117,11 @@ pub async fn snapshot_from_lockfile(
   let mut version_infos =
       FuturesOrdered::from_iter(packages.iter().map(|p| p.pkg_id.nv.clone()).map(
         |nv| async move {
-          match api.package_version_info(&nv).await? {
-            Some(version_info) => Ok(version_info),
-            None => {
-              bail!("could not find '{}' specified in the lockfile. Maybe try again with --reload", nv);
+          let package_info = api.package_info(&nv.name).await?;
+          match package_info.version_info(&nv) {
+            Ok(version_info) => Ok(version_info),
+            Err(err) => {
+              bail!("Could not find '{}' specified in the lockfile. Maybe try again with --reload", err.0);
             }
           }
         },

--- a/cli/npm/resolvers/global.rs
+++ b/cli/npm/resolvers/global.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
 use deno_core::url::Url;
+use deno_npm::resolution::PackageNotFoundFromReferrerError;
 use deno_npm::NpmPackageCacheFolderId;
 use deno_npm::NpmPackageId;
 use deno_npm::NpmResolutionPackage;
@@ -58,7 +59,7 @@ impl GlobalNpmPackageResolver {
     &self,
     package_name: &str,
     referrer_pkg_id: &NpmPackageCacheFolderId,
-  ) -> Result<NpmResolutionPackage, AnyError> {
+  ) -> Result<NpmResolutionPackage, Box<PackageNotFoundFromReferrerError>> {
     let types_name = types_package_name(package_name);
     self
       .resolution

--- a/cli/npm/resolvers/mod.rs
+++ b/cli/npm/resolvers/mod.rs
@@ -15,6 +15,7 @@ use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
 use deno_core::url::Url;
 use deno_npm::resolution::NpmResolutionSnapshot;
+use deno_npm::resolution::PackageReqNotFoundError;
 use deno_npm::NpmPackageId;
 use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
@@ -82,14 +83,14 @@ impl NpmPackageResolver {
   pub fn resolve_pkg_id_from_pkg_req(
     &self,
     req: &NpmPackageReq,
-  ) -> Result<NpmPackageId, AnyError> {
+  ) -> Result<NpmPackageId, PackageReqNotFoundError> {
     self.resolution.resolve_pkg_id_from_pkg_req(req)
   }
 
   pub fn pkg_req_ref_to_nv_ref(
     &self,
     req_ref: NpmPackageReqReference,
-  ) -> Result<NpmPackageNvReference, AnyError> {
+  ) -> Result<NpmPackageNvReference, PackageReqNotFoundError> {
     self.resolution.pkg_req_ref_to_nv_ref(req_ref)
   }
 
@@ -225,10 +226,8 @@ impl NpmPackageResolver {
     &self,
   ) -> Result<(), AnyError> {
     // add and ensure this isn't added to the lockfile
-    self
-      .resolution
-      .add_package_reqs(vec![NpmPackageReq::from_str("@types/node").unwrap()])
-      .await?;
+    let package_reqs = vec![NpmPackageReq::from_str("@types/node").unwrap()];
+    self.resolution.add_package_reqs(package_reqs).await?;
     self.fs_resolver.cache_packages().await?;
 
     Ok(())

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -237,9 +237,15 @@ impl NpmResolver for CliGraphResolver {
     if self.no_npm {
       bail!("npm specifiers were requested; but --no-npm is specified")
     }
-    self
+    match self
       .npm_resolution
       .resolve_package_req_as_pending(package_req)
+    {
+      Ok(nv) => Ok(nv),
+      Err(err) => {
+        bail!("{:#} Try retrieving the latest npm package information by running with --reload", err)
+      }
+    }
   }
 }
 

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -1661,6 +1661,7 @@ fn reload_info_not_found_cache_but_exists_remote() {
   ));
 
   // now try running without it, it currently will error, but this should work in the future
+  // todo(https://github.com/denoland/deno/issues/16901): fix this
   let output = test_context.new_command().args("run main.ts").run();
   output.assert_exit_code(1);
   output.assert_matches_text(concat!(

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::serde_json;
+use deno_core::serde_json::Value;
 use pretty_assertions::assert_eq;
 use std::process::Stdio;
 use test_util as util;
@@ -1546,3 +1548,123 @@ itest!(node_modules_import_check {
   copy_temp_dir: Some("npm/node_modules_import/"),
   exit_code: 1,
 });
+
+itest!(non_existent_dep {
+  args: "cache npm:@denotest/non-existent-dep",
+  envs: env_vars_for_npm_tests(),
+  http_server: true,
+  exit_code: 1,
+  output_str: Some(concat!(
+    "Download http://localhost:4545/npm/registry/@denotest/non-existent-dep\n",
+    "Download http://localhost:4545/npm/registry/@denotest/non-existent\n",
+    "error: npm package '@denotest/non-existent' does not exist.\n"
+  )),
+});
+
+itest!(non_existent_dep_version {
+  args: "cache npm:@denotest/non-existent-dep-version",
+  envs: env_vars_for_npm_tests(),
+  http_server: true,
+  exit_code: 1,
+  output_str: Some(concat!(
+    "Download http://localhost:4545/npm/registry/@denotest/non-existent-dep-version\n",
+    "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
+    // does two downloads because when failing once it max tries to
+    // get the latest version a second time
+    "Download http://localhost:4545/npm/registry/@denotest/non-existent-dep-version\n",
+    "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
+    "error: Could not find npm package '@denotest/esm-basic' matching '=99.99.99'.\n"
+  )),
+});
+
+#[test]
+fn reload_info_not_found_cache_but_exists_remote() {
+  fn remove_version(registry_json: &mut Value, version: &str) {
+    registry_json
+      .as_object_mut()
+      .unwrap()
+      .get_mut("versions")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
+      .remove(version);
+  }
+
+  // This tests that when a local machine doesn't have a version
+  // specified in a dependency that exists in the npm registry
+  let test_context = TestContextBuilder::for_npm()
+    .use_sync_npm_download()
+    .use_temp_cwd()
+    .build();
+  let deno_dir = test_context.deno_dir();
+  let temp_dir = test_context.temp_dir();
+  temp_dir.write(
+    "main.ts",
+    "import 'npm:@denotest/esm-import-cjs-default@1.0.0';",
+  );
+
+  // cache successfully to the deno_dir
+  let output = test_context.new_command().args("cache main.ts").run();
+  output.assert_matches_text(concat!(
+    "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
+    "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
+    "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export/1.0.0.tgz\n",
+    "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default/1.0.0.tgz\n",
+  ));
+
+  // modify the package information in the cache to remove the latest version
+  let registry_json_path = "npm/localhost_4545/npm/registry/@denotest/cjs-default-export/registry.json";
+  let mut registry_json: Value =
+    serde_json::from_str(&deno_dir.read_to_string(registry_json_path)).unwrap();
+  remove_version(&mut registry_json, "1.0.0");
+  deno_dir.write(
+    registry_json_path,
+    serde_json::to_string(&registry_json).unwrap(),
+  );
+
+  // should error when `--cache-only` is used now because the version is not in the cache
+  let output = test_context
+    .new_command()
+    .args("run --cached-only main.ts")
+    .run();
+  output.assert_exit_code(1);
+  output.assert_matches_text("error: Could not find npm package '@denotest/cjs-default-export' matching '^1.0.0'.\n");
+
+  // now try running without it, it should download the package now
+  let output = test_context.new_command().args("run main.ts").run();
+  output.assert_matches_text(concat!(
+    "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
+    "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
+    "Node esm importing node cjs\n[WILDCARD]",
+  ));
+  output.assert_exit_code(0);
+
+  // now remove the information for the top level package
+  let registry_json_path = "npm/localhost_4545/npm/registry/@denotest/esm-import-cjs-default/registry.json";
+  let mut registry_json: Value =
+    serde_json::from_str(&deno_dir.read_to_string(registry_json_path)).unwrap();
+  remove_version(&mut registry_json, "1.0.0");
+  deno_dir.write(
+    registry_json_path,
+    serde_json::to_string(&registry_json).unwrap(),
+  );
+
+  // should error again for --cached-only
+  let output = test_context
+    .new_command()
+    .args("run --cached-only main.ts")
+    .run();
+  output.assert_exit_code(1);
+  output.assert_matches_text(concat!(
+    "error: Could not find npm package '@denotest/esm-import-cjs-default' matching '1.0.0'. Try retrieving the latest npm package information by running with --reload\n",
+    "    at file:///[WILDCARD]/main.ts:1:8\n",
+  ));
+
+  // now try running without it, it currently will error, but this should work in the future
+  let output = test_context.new_command().args("run main.ts").run();
+  output.assert_exit_code(1);
+  output.assert_matches_text(concat!(
+    "error: Could not find npm package '@denotest/esm-import-cjs-default' matching '1.0.0'. Try retrieving the latest npm package information by running with --reload\n",
+    "    at file:///[WILDCARD]/main.ts:1:8\n",
+  ));
+}

--- a/cli/tests/testdata/npm/deno_run_non_existent.out
+++ b/cli/tests/testdata/npm/deno_run_non_existent.out
@@ -1,2 +1,3 @@
 Download http://localhost:4545/npm/registry/mkdirp
-error: Could not find npm package 'mkdirp' matching '0.5.125'. Try retrieving the latest npm package information by running with --reload
+Download http://localhost:4545/npm/registry/mkdirp
+error: Could not find npm package 'mkdirp' matching '0.5.125'.

--- a/cli/tests/testdata/npm/registry/@denotest/non-existent-dep-version/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/non-existent-dep-version/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = 5;

--- a/cli/tests/testdata/npm/registry/@denotest/non-existent-dep-version/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/non-existent-dep-version/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest/non-existent-dep-version",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/esm-basic": "=99.99.99"
+  }
+}

--- a/cli/tests/testdata/npm/registry/@denotest/non-existent-dep/1.0.0/index.js
+++ b/cli/tests/testdata/npm/registry/@denotest/non-existent-dep/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = 5;

--- a/cli/tests/testdata/npm/registry/@denotest/non-existent-dep/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/non-existent-dep/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest/non-existent-dep",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/non-existent": "1.0"
+  }
+}

--- a/test_util/src/builders.rs
+++ b/test_util/src/builders.rs
@@ -455,6 +455,7 @@ pub struct TestCommandOutput {
 }
 
 impl Drop for TestCommandOutput {
+  // assert the output and exit code was asserted
   fn drop(&mut self) {
     fn panic_unasserted_output(text: &str) {
       println!("OUTPUT\n{text}\nOUTPUT");
@@ -466,13 +467,6 @@ impl Drop for TestCommandOutput {
 
     if std::thread::panicking() {
       return;
-    }
-    // force the caller to assert these
-    if !*self.asserted_exit_code.borrow() && self.exit_code != Some(0) {
-      panic!(
-        "The non-zero exit code of the command was not asserted: {:?}",
-        self.exit_code,
-      )
     }
 
     // either the combined output needs to be asserted or both stdout and stderr
@@ -488,6 +482,14 @@ impl Drop for TestCommandOutput {
       if !*self.asserted_stderr.borrow() && !stderr.is_empty() {
         panic_unasserted_output(stderr);
       }
+    }
+
+    // now ensure the exit code was asserted
+    if !*self.asserted_exit_code.borrow() && self.exit_code != Some(0) {
+      panic!(
+        "The non-zero exit code of the command was not asserted: {:?}",
+        self.exit_code,
+      )
     }
   }
 }


### PR DESCRIPTION
This reloads an npm package's dependency's information when a version/version req/tag is not found.

This PR applies only to dependencies of npm packages. It does NOT yet cause npm specifiers to have their dependency information cache busted. That requires a different solution, but this should help cache bust in more scenarios.

Part of #16901, but doesn't close it yet