### PR TITLE
perf(ext/websocket): make `op_server_ws_next_event` deferred

### DIFF
--- a/ext/websocket/server.rs
+++ b/ext/websocket/server.rs
@@ -136,7 +136,7 @@ pub async fn op_server_ws_close(
   Ok(())
 }
 
-#[op]
+#[op(deferred)]
 pub async fn op_server_ws_next_event(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,


### PR DESCRIPTION
Avoid attempting to read immediately, wasting time polling the future. 2% throughput improvement on Linux.