### PR TITLE
ci: do not run build job on draft prs

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -206,7 +206,7 @@ const ci = {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       needs: ["pre_build"],
       if:
-        "${{ needs.pre_build.outputs.skip_build == 'true' && false || always() }}",
+        "${{ needs.pre_build.outputs.skip_build == 'true' && false || true }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       defaults: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -172,14 +172,14 @@ const ci = {
       outputs: {
         skip_build: "${{ steps.check.outputs.skip_build == 'true' }}",
       },
-      steps: {
+      steps: [{
         id: "check",
         run: [
           "GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})",
           "echo Commit message: $GIT_MESSAGE",
           "echo $GIT_MESSAGE | grep '\\[ci\\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)",
         ].join("\n"),
-      },
+      }],
     },
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -188,7 +188,7 @@ const ci = {
       "runs-on": "ubuntu-latest",
       if: "github.event.pull_request.draft == true",
       outputs: {
-        skip_build: "${{ steps.check.outputs.skip_build == 'true' }}",
+        skip_build: "${{ steps.check.outputs.skip_build }}",
       },
       steps: [
         ...cloneRepoStep,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -219,7 +219,8 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       needs: ["pre_build"],
-      if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
+      if:
+        "${{ !(needs.pre_build.outputs.skip_build == 'true') || (needs.pre_build.result == 'skipped') }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       defaults: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -208,8 +208,10 @@ const ci = {
     "cancel-in-progress": true,
   },
   jobs: {
+    // The pre_build step is used to skip running the CI on draft PRs and to not even
+    // start the build job. This can be overridden by adding [ci] to the commit title
     pre_build: {
-      name: "pre_build",
+      name: "pre-build",
       "runs-on": "ubuntu-latest",
       outputs: {
         skip_build: "${{ steps.check.outputs.skip_build }}",
@@ -234,7 +236,8 @@ const ci = {
       "timeout-minutes": 120,
       defaults: {
         run: {
-          // GH actions doesn't use `set -e` by default unless you specify bash
+          // GH actions does not fail fast by default on
+          // Windows, so we set bash as the default shell
           shell: "bash",
         },
       },

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -183,7 +183,7 @@ const ci = {
     },
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
-      needs: "pre_build",
+      needs: ["pre_build"],
       if: "${{ pre_build.outputs.skip_build == 'true' && false || always() }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -219,8 +219,7 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       needs: ["pre_build"],
-      if:
-        "${{ needs.pre_build.outputs.skip_build == 'true' && false || true }}",
+      if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       defaults: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -131,50 +131,6 @@ const authenticateWithGoogleCloud = {
   },
 };
 
-function cancelEarlyIfDraftPr(
-  nextSteps: Record<string, unknown>[],
-): Record<string, unknown>[] {
-  // Couple issues with GH Actions:
-  //
-  // 1. The pull_request event type does not include the commit message, so
-  //    there's no way to override this with a commit message without running
-  //    the workflow.
-  // 2. Currently no way to early exit in GH Actions, so we need to do all these
-  //    if conditions. Waiting on: https://github.com/actions/runner/issues/662
-  //
-  // The solution below will only occur on draft PRs and only run the CI if the
-  // commit message contains [ci].
-  return [
-    {
-      name: "Cancel if draft PR",
-      id: "exit_early",
-      if: "github.event.pull_request.draft == true",
-      run: [
-        "GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})",
-        "echo Commit message: $GIT_MESSAGE",
-        "echo $GIT_MESSAGE | grep '\\[ci\\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)",
-      ].join("\n"),
-    },
-    ...nextSteps.map((step) =>
-      withCondition(step, "steps.exit_early.outputs.EXIT_EARLY != 'true'")
-    ),
-  ];
-}
-
-function skipJobsIfPrAndMarkedSkip(
-  steps: Record<string, unknown>[],
-): Record<string, unknown>[] {
-  // GitHub does not make skipping a specific matrix element easy
-  // so just apply this condition to all the steps.
-  // https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
-  return steps.map((s) =>
-    withCondition(
-      s,
-      "!(github.event_name == 'pull_request' && matrix.skip_pr)",
-    )
-  );
-}
-
 function withCondition(
   step: Record<string, unknown>,
   condition: string,
@@ -209,8 +165,26 @@ const ci = {
     "cancel-in-progress": true,
   },
   jobs: {
+    pre_build: {
+      name: "pre_build",
+      "runs-on": "ubuntu-latest",
+      if: "github.event.pull_request.draft == true",
+      outputs: {
+        skip_build: "${{ steps.check.outputs.skip_build == 'true' }}",
+      },
+      steps: {
+        id: "check",
+        run: [
+          "GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})",
+          "echo Commit message: $GIT_MESSAGE",
+          "echo $GIT_MESSAGE | grep '\\[ci\\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)",
+        ].join("\n"),
+      },
+    },
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
+      needs: "pre_build",
+      if: "${{ pre_build.outputs.skip_build == 'true' && false || always() }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       defaults: {
@@ -291,7 +265,7 @@ const ci = {
         CARGO_TERM_COLOR: "always",
         RUST_BACKTRACE: "full",
       },
-      steps: skipJobsIfPrAndMarkedSkip([
+      steps: [
         {
           name: "Configure git",
           run: [
@@ -310,553 +284,551 @@ const ci = {
             submodules: false,
           },
         },
-        ...cancelEarlyIfDraftPr([
-          submoduleStep("./test_util/std"),
-          submoduleStep("./third_party"),
-          {
-            ...submoduleStep("./test_util/wpt"),
-            if: "matrix.wpt",
+
+        submoduleStep("./test_util/std"),
+        submoduleStep("./third_party"),
+        {
+          ...submoduleStep("./test_util/wpt"),
+          if: "matrix.wpt",
+        },
+        {
+          name: "Create source tarballs (release, linux)",
+          if: [
+            "startsWith(matrix.os, 'ubuntu') &&",
+            "matrix.profile == 'release' &&",
+            "matrix.job == 'test' &&",
+            "github.repository == 'denoland/deno' &&",
+            "startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          run: [
+            "mkdir -p target/release",
+            'tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \\',
+            "    -czvf target/release/deno_src.tar.gz -C .. deno",
+          ].join("\n"),
+        },
+        installRustStep,
+        {
+          if: "matrix.job == 'lint' || matrix.job == 'test'",
+          ...installDenoStep,
+        },
+        ...installPythonSteps.map((s) =>
+          withCondition(s, "matrix.job != 'lint'")
+        ),
+        {
+          // only necessary for benchmarks
+          if: "matrix.job == 'bench'",
+          ...installNodeStep,
+        },
+        {
+          if: [
+            "matrix.profile == 'release' &&",
+            "matrix.job == 'test' &&",
+            "github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' ||",
+            "startsWith(github.ref, 'refs/tags/'))",
+          ].join("\n"),
+          ...authenticateWithGoogleCloud,
+        },
+        {
+          name: "Setup gcloud (unix)",
+          if: [
+            "runner.os != 'Windows' &&",
+            "matrix.profile == 'release' &&",
+            "matrix.job == 'test' &&",
+            "github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' ||",
+            "startsWith(github.ref, 'refs/tags/'))",
+          ].join("\n"),
+          uses: "google-github-actions/setup-gcloud@v1",
+          with: {
+            project_id: "denoland",
           },
-          {
-            name: "Create source tarballs (release, linux)",
-            if: [
-              "startsWith(matrix.os, 'ubuntu') &&",
-              "matrix.profile == 'release' &&",
-              "matrix.job == 'test' &&",
-              "github.repository == 'denoland/deno' &&",
-              "startsWith(github.ref, 'refs/tags/')",
+        },
+        {
+          name: "Setup gcloud (windows)",
+          if: [
+            "runner.os == 'Windows' &&",
+            "matrix.profile == 'release' &&",
+            "matrix.job == 'test' &&",
+            "github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' ||",
+            "startsWith(github.ref, 'refs/tags/'))",
+          ].join("\n"),
+          uses: "google-github-actions/setup-gcloud@v1",
+          env: {
+            CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
+          },
+          with: {
+            project_id: "denoland",
+          },
+        },
+        {
+          name: "Configure canary build",
+          if: [
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main'",
+          ].join("\n"),
+          run: 'echo "DENO_CANARY=true" >> $GITHUB_ENV',
+        },
+        {
+          if: "matrix.use_sysroot",
+          ...sysRootStep,
+        },
+        {
+          name: "Log versions",
+          run: [
+            "python --version",
+            "rustc --version",
+            "cargo --version",
+            // Deno is installed when linting.
+            'if [ "${{ matrix.job }}" == "lint" ]',
+            "then",
+            "  deno --version",
+            "fi",
+            // Node is installed for benchmarks.
+            'if [ "${{ matrix.job }}" == "bench" ]',
+            "then",
+            "  node -v",
+            "fi",
+          ].join("\n"),
+        },
+        {
+          name: "Cache Cargo home",
+          uses: "actions/cache@v3",
+          with: {
+            // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+            path: [
+              "~/.cargo/registry/index",
+              "~/.cargo/registry/cache",
+              "~/.cargo/git/db",
             ].join("\n"),
-            run: [
-              "mkdir -p target/release",
-              'tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \\',
-              "    -czvf target/release/deno_src.tar.gz -C .. deno",
+            key:
+              "20-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}",
+          },
+        },
+        {
+          // Restore cache from the latest 'main' branch build.
+          name: "Restore cache build output (PR)",
+          uses: "actions/cache/restore@v3",
+          if:
+            "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+          with: {
+            path: [
+              "./target",
+              "!./target/*/gn_out",
+              "!./target/*/*.zip",
+              "!./target/*/*.tar.gz",
             ].join("\n"),
+            key: "never_saved",
+            "restore-keys": prCacheKeyPrefix,
           },
-          installRustStep,
-          {
-            if: "matrix.job == 'lint' || matrix.job == 'test'",
-            ...installDenoStep,
+        },
+        {
+          name: "Apply and update mtime cache",
+          if: "!startsWith(github.ref, 'refs/tags/')",
+          uses: "./.github/mtime_cache",
+          with: {
+            "cache-path": "./target",
           },
-          ...installPythonSteps.map((s) =>
-            withCondition(s, "matrix.job != 'lint'")
-          ),
-          {
-            // only necessary for benchmarks
-            if: "matrix.job == 'bench'",
-            ...installNodeStep,
+        },
+        {
+          // Shallow the cloning the crates.io index makes CI faster because it
+          // obviates the need for Cargo to clone the index. If we don't do this
+          // Cargo will `git clone` the github repository that contains the entire
+          // history of the crates.io index from github. We don't believe the
+          // identifier '1ecc6299db9ec823' will ever change, but if it does then this
+          // command must be updated.
+          name: "Shallow clone crates.io index",
+          run: [
+            "if [ ! -d ~/.cargo/registry/index/github.com-1ecc6299db9ec823/.git ]",
+            "then",
+            "  git clone --depth 1 --no-checkout                      \\",
+            "            https://github.com/rust-lang/crates.io-index \\",
+            "            ~/.cargo/registry/index/github.com-1ecc6299db9ec823",
+            "fi",
+          ].join("\n"),
+        },
+        {
+          name: "test_format.js",
+          if: "matrix.job == 'lint'",
+          run:
+            "deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check",
+        },
+        {
+          name: "Lint PR title",
+          if: "matrix.job == 'lint' && github.event_name == 'pull_request'",
+          env: {
+            PR_TITLE: "${{ github.event.pull_request.title }}",
           },
-          {
-            if: [
-              "matrix.profile == 'release' &&",
-              "matrix.job == 'test' &&",
-              "github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' ||",
-              "startsWith(github.ref, 'refs/tags/'))",
+          run: 'deno run ./tools/verify_pr_title.js "$PR_TITLE"',
+        },
+        {
+          name: "lint.js",
+          if: "matrix.job == 'lint'",
+          run:
+            "deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js",
+        },
+        {
+          name: "Build debug",
+          if: "matrix.job == 'test' && matrix.profile == 'debug'",
+          run: "cargo build --locked --all-targets",
+          env: { CARGO_PROFILE_DEV_DEBUG: 0 },
+        },
+        {
+          name: "Build release",
+          if: [
+            "(matrix.job == 'test' || matrix.job == 'bench') &&",
+            "matrix.profile == 'release' && (matrix.use_sysroot ||",
+            "(github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' ||",
+            "startsWith(github.ref, 'refs/tags/'))))",
+          ].join("\n"),
+          run: "cargo build --release --locked --all-targets",
+        },
+        {
+          name: "Upload PR artifact (linux)",
+          if: [
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' && (matrix.use_sysroot ||",
+            "(github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' ||",
+            "startsWith(github.ref, 'refs/tags/'))))",
+          ].join("\n"),
+          uses: "actions/upload-artifact@v3",
+          with: {
+            name: "deno-${{ github.event.number }}",
+            path: "target/release/deno",
+          },
+        },
+        {
+          name: "Pre-release (linux)",
+          if: [
+            "startsWith(matrix.os, 'ubuntu') &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno'",
+          ].join("\n"),
+          run: [
+            "cd target/release",
+            "zip -r deno-x86_64-unknown-linux-gnu.zip deno",
+            "./deno types > lib.deno.d.ts",
+          ].join("\n"),
+        },
+        {
+          name: "Pre-release (mac)",
+          if: [
+            "startsWith(matrix.os, 'macOS') &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+          ].join("\n"),
+          run: [
+            "cd target/release",
+            "zip -r deno-x86_64-apple-darwin.zip deno",
+          ]
+            .join("\n"),
+        },
+        {
+          name: "Pre-release (windows)",
+          if: [
+            "startsWith(matrix.os, 'windows') &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+          ].join("\n"),
+          shell: "pwsh",
+          run:
+            "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip",
+        },
+        {
+          name: "Upload canary to dl.deno.land (unix)",
+          if: [
+            "runner.os != 'Windows' &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main'",
+          ].join("\n"),
+          run:
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
+        },
+        {
+          name: "Upload canary to dl.deno.land (windows)",
+          if: [
+            "runner.os == 'Windows' &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main'",
+          ].join("\n"),
+          env: {
+            CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
+          },
+          run:
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
+        },
+        {
+          name: "Test debug",
+          if: [
+            "matrix.job == 'test' && matrix.profile == 'debug' &&",
+            "!startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')",
+          ].join("\n"),
+          run: "cargo test --locked",
+          env: { CARGO_PROFILE_DEV_DEBUG: 0 },
+        },
+        {
+          name: "Test debug (fast)",
+          if: [
+            "matrix.job == 'test' && matrix.profile == 'debug' && ",
+            "!startsWith(matrix.os, 'ubuntu')",
+          ].join("\n"),
+          run: [
+            // Run unit then integration tests. Skip doc tests here
+            // since they are sometimes very slow on Mac.
+            "cargo test --locked --lib",
+            "cargo test --locked --test '*'",
+          ].join("\n"),
+          env: { CARGO_PROFILE_DEV_DEBUG: 0 },
+        },
+        {
+          name: "Test release",
+          if: [
+            "matrix.job == 'test' && matrix.profile == 'release' &&",
+            "(matrix.use_sysroot || (",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))",
+          ].join("\n"),
+          run: "cargo test --release --locked",
+        },
+        {
+          // Since all tests are skipped when we're building a tagged commit
+          // this is a minimal check to ensure that binary is not corrupted
+          name: "Check deno binary",
+          if:
+            "matrix.profile == 'release' && startsWith(github.ref, 'refs/tags/')",
+          run: 'target/release/deno eval "console.log(1+2)" | grep 3',
+          env: {
+            NO_COLOR: 1,
+          },
+        },
+        {
+          // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
+          name: "Check deno binary (in sysroot)",
+          if: "matrix.profile == 'release' && matrix.use_sysroot",
+          run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',
+        },
+        {
+          name: "Configure hosts file for WPT",
+          if: "matrix.wpt",
+          run: "./wpt make-hosts-file | sudo tee -a /etc/hosts",
+          "working-directory": "test_util/wpt/",
+        },
+        {
+          name: "Run web platform tests (debug)",
+          if: "matrix.wpt && matrix.profile == 'debug'",
+          env: {
+            DENO_BIN: "./target/debug/deno",
+          },
+          run: [
+            "deno run --allow-env --allow-net --allow-read --allow-run \\",
+            "        --allow-write --unstable                         \\",
+            "        --lock=tools/deno.lock.json                      \\",
+            "        ./tools/wpt.ts setup",
+            "deno run --allow-env --allow-net --allow-read --allow-run \\",
+            "         --allow-write --unstable                         \\",
+            "         --lock=tools/deno.lock.json              \\",
+            '         ./tools/wpt.ts run --quiet --binary="$DENO_BIN"',
+          ].join("\n"),
+        },
+        {
+          name: "Run web platform tests (release)",
+          if: "matrix.wpt && matrix.profile == 'release'",
+          env: {
+            DENO_BIN: "./target/release/deno",
+          },
+          run: [
+            "deno run --allow-env --allow-net --allow-read --allow-run \\",
+            "         --allow-write --unstable                         \\",
+            "         --lock=tools/deno.lock.json                      \\",
+            "         ./tools/wpt.ts setup",
+            "deno run --allow-env --allow-net --allow-read --allow-run \\",
+            "         --allow-write --unstable                         \\",
+            "         --lock=tools/deno.lock.json                      \\",
+            "         ./tools/wpt.ts run --quiet --release             \\",
+            '                            --binary="$DENO_BIN"          \\',
+            "                            --json=wpt.json               \\",
+            "                            --wptreport=wptreport.json",
+          ].join("\n"),
+        },
+        {
+          name: "Upload wpt results to dl.deno.land",
+          "continue-on-error": true,
+          if: [
+            "matrix.wpt &&",
+            "runner.os == 'Linux' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          run: [
+            "gzip ./wptreport.json",
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json',
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./wptreport.json.gz gs://dl.deno.land/wpt/$(git rev-parse HEAD)-wptreport.json.gz',
+            "echo $(git rev-parse HEAD) > wpt-latest.txt",
+            'gsutil -h "Cache-Control: no-cache" cp wpt-latest.txt gs://dl.deno.land/wpt-latest.txt',
+          ].join("\n"),
+        },
+        {
+          name: "Upload wpt results to wpt.fyi",
+          "continue-on-error": true,
+          if: [
+            "matrix.wpt &&",
+            "runner.os == 'Linux' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          env: {
+            WPT_FYI_USER: "deno",
+            WPT_FYI_PW: "${{ secrets.WPT_FYI_PW }}",
+            GITHUB_TOKEN: "${{ secrets.DENOBOT_PAT }}",
+          },
+          run: [
+            "./target/release/deno run --allow-all --lock=tools/deno.lock.json \\",
+            "    ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus",
+          ].join("\n"),
+        },
+        {
+          name: "Run benchmarks",
+          if: "matrix.job == 'bench' && !startsWith(github.ref, 'refs/tags/')",
+          run: "cargo bench --locked",
+        },
+        {
+          name: "Post Benchmarks",
+          if: [
+            "matrix.job == 'bench' &&",
+            "github.repository == 'denoland/deno' &&",
+            "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          env: {
+            DENOBOT_PAT: "${{ secrets.DENOBOT_PAT }}",
+          },
+          run: [
+            "git clone --depth 1 --branch gh-pages                             \\",
+            "    https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git \\",
+            "    gh-pages",
+            "./target/release/deno run --allow-all --unstable \\",
+            "    ./tools/build_benchmark_jsons.js --release",
+            "cd gh-pages",
+            'git config user.email "propelml@gmail.com"',
+            'git config user.name "denobot"',
+            "git add .",
+            'git commit --message "Update benchmarks"',
+            "git push origin gh-pages",
+          ].join("\n"),
+        },
+        {
+          name: "Build product size info",
+          if:
+            "matrix.job != 'lint' && matrix.profile != 'debug' && github.repository == 'denoland/deno' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
+          run: [
+            'du -hd1 "./target/${{ matrix.profile }}"',
+            'du -ha  "./target/${{ matrix.profile }}/deno"',
+          ].join("\n"),
+        },
+        {
+          name: "Worker info",
+          if: "matrix.job == 'bench'",
+          run: [
+            "cat /proc/cpuinfo",
+            "cat /proc/meminfo",
+          ].join("\n"),
+        },
+        {
+          name: "Upload release to dl.deno.land (unix)",
+          if: [
+            "runner.os != 'Windows' &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          run:
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
+        },
+        {
+          name: "Upload release to dl.deno.land (windows)",
+          if: [
+            "runner.os == 'Windows' &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          env: {
+            CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
+          },
+          run:
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
+        },
+        {
+          name: "Create release notes",
+          if: [
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          run: [
+            "export PATH=$PATH:$(pwd)/target/release",
+            "./tools/release/05_create_release_notes.ts",
+          ].join("\n"),
+        },
+        {
+          name: "Upload release to GitHub",
+          uses: "softprops/action-gh-release@v0.1.15",
+          if: [
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "github.repository == 'denoland/deno' &&",
+            "startsWith(github.ref, 'refs/tags/')",
+          ].join("\n"),
+          env: {
+            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+          },
+          with: {
+            files: [
+              "target/release/deno-x86_64-pc-windows-msvc.zip",
+              "target/release/deno-x86_64-unknown-linux-gnu.zip",
+              "target/release/deno-x86_64-apple-darwin.zip",
+              "target/release/deno_src.tar.gz",
+              "target/release/lib.deno.d.ts",
             ].join("\n"),
-            ...authenticateWithGoogleCloud,
+            body_path: "target/release/release-notes.md",
+            draft: true,
           },
-          {
-            name: "Setup gcloud (unix)",
-            if: [
-              "runner.os != 'Windows' &&",
-              "matrix.profile == 'release' &&",
-              "matrix.job == 'test' &&",
-              "github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' ||",
-              "startsWith(github.ref, 'refs/tags/'))",
+        },
+        {
+          // In main branch, always create a fresh cache
+          name: "Save cache build output (main)",
+          uses: "actions/cache/save@v3",
+          if:
+            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
+          with: {
+            path: [
+              "./target",
+              "!./target/*/gn_out",
+              "!./target/*/*.zip",
+              "!./target/*/*.tar.gz",
             ].join("\n"),
-            uses: "google-github-actions/setup-gcloud@v1",
-            with: {
-              project_id: "denoland",
-            },
+            key: prCacheKeyPrefix + "${{ github.sha }}",
           },
-          {
-            name: "Setup gcloud (windows)",
-            if: [
-              "runner.os == 'Windows' &&",
-              "matrix.profile == 'release' &&",
-              "matrix.job == 'test' &&",
-              "github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' ||",
-              "startsWith(github.ref, 'refs/tags/'))",
-            ].join("\n"),
-            uses: "google-github-actions/setup-gcloud@v1",
-            env: {
-              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-            },
-            with: {
-              project_id: "denoland",
-            },
-          },
-          {
-            name: "Configure canary build",
-            if: [
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main'",
-            ].join("\n"),
-            run: 'echo "DENO_CANARY=true" >> $GITHUB_ENV',
-          },
-          {
-            if: "matrix.use_sysroot",
-            ...sysRootStep,
-          },
-          {
-            name: "Log versions",
-            run: [
-              "python --version",
-              "rustc --version",
-              "cargo --version",
-              // Deno is installed when linting.
-              'if [ "${{ matrix.job }}" == "lint" ]',
-              "then",
-              "  deno --version",
-              "fi",
-              // Node is installed for benchmarks.
-              'if [ "${{ matrix.job }}" == "bench" ]',
-              "then",
-              "  node -v",
-              "fi",
-            ].join("\n"),
-          },
-          {
-            name: "Cache Cargo home",
-            uses: "actions/cache@v3",
-            with: {
-              // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-              path: [
-                "~/.cargo/registry/index",
-                "~/.cargo/registry/cache",
-                "~/.cargo/git/db",
-              ].join("\n"),
-              key:
-                "20-cargo-home-${{ matrix.os }}-${{ hashFiles('Cargo.lock') }}",
-            },
-          },
-          {
-            // Restore cache from the latest 'main' branch build.
-            name: "Restore cache build output (PR)",
-            uses: "actions/cache/restore@v3",
-            if:
-              "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-            with: {
-              path: [
-                "./target",
-                "!./target/*/gn_out",
-                "!./target/*/*.zip",
-                "!./target/*/*.tar.gz",
-              ].join("\n"),
-              key: "never_saved",
-              "restore-keys": prCacheKeyPrefix,
-            },
-          },
-          {
-            name: "Apply and update mtime cache",
-            if: "!startsWith(github.ref, 'refs/tags/')",
-            uses: "./.github/mtime_cache",
-            with: {
-              "cache-path": "./target",
-            },
-          },
-          {
-            // Shallow the cloning the crates.io index makes CI faster because it
-            // obviates the need for Cargo to clone the index. If we don't do this
-            // Cargo will `git clone` the github repository that contains the entire
-            // history of the crates.io index from github. We don't believe the
-            // identifier '1ecc6299db9ec823' will ever change, but if it does then this
-            // command must be updated.
-            name: "Shallow clone crates.io index",
-            run: [
-              "if [ ! -d ~/.cargo/registry/index/github.com-1ecc6299db9ec823/.git ]",
-              "then",
-              "  git clone --depth 1 --no-checkout                      \\",
-              "            https://github.com/rust-lang/crates.io-index \\",
-              "            ~/.cargo/registry/index/github.com-1ecc6299db9ec823",
-              "fi",
-            ].join("\n"),
-          },
-          {
-            name: "test_format.js",
-            if: "matrix.job == 'lint'",
-            run:
-              "deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check",
-          },
-          {
-            name: "Lint PR title",
-            if: "matrix.job == 'lint' && github.event_name == 'pull_request'",
-            env: {
-              PR_TITLE: "${{ github.event.pull_request.title }}",
-            },
-            run: 'deno run ./tools/verify_pr_title.js "$PR_TITLE"',
-          },
-          {
-            name: "lint.js",
-            if: "matrix.job == 'lint'",
-            run:
-              "deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js",
-          },
-          {
-            name: "Build debug",
-            if: "matrix.job == 'test' && matrix.profile == 'debug'",
-            run: "cargo build --locked --all-targets",
-            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
-          },
-          {
-            name: "Build release",
-            if: [
-              "(matrix.job == 'test' || matrix.job == 'bench') &&",
-              "matrix.profile == 'release' && (matrix.use_sysroot ||",
-              "(github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' ||",
-              "startsWith(github.ref, 'refs/tags/'))))",
-            ].join("\n"),
-            run: "cargo build --release --locked --all-targets",
-          },
-          {
-            name: "Upload PR artifact (linux)",
-            if: [
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' && (matrix.use_sysroot ||",
-              "(github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' ||",
-              "startsWith(github.ref, 'refs/tags/'))))",
-            ].join("\n"),
-            uses: "actions/upload-artifact@v3",
-            with: {
-              name: "deno-${{ github.event.number }}",
-              path: "target/release/deno",
-            },
-          },
-          {
-            name: "Pre-release (linux)",
-            if: [
-              "startsWith(matrix.os, 'ubuntu') &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno'",
-            ].join("\n"),
-            run: [
-              "cd target/release",
-              "zip -r deno-x86_64-unknown-linux-gnu.zip deno",
-              "./deno types > lib.deno.d.ts",
-            ].join("\n"),
-          },
-          {
-            name: "Pre-release (mac)",
-            if: [
-              "startsWith(matrix.os, 'macOS') &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
-            ].join("\n"),
-            run: [
-              "cd target/release",
-              "zip -r deno-x86_64-apple-darwin.zip deno",
-            ]
-              .join("\n"),
-          },
-          {
-            name: "Pre-release (windows)",
-            if: [
-              "startsWith(matrix.os, 'windows') &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
-            ].join("\n"),
-            shell: "pwsh",
-            run:
-              "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip",
-          },
-          {
-            name: "Upload canary to dl.deno.land (unix)",
-            if: [
-              "runner.os != 'Windows' &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main'",
-            ].join("\n"),
-            run:
-              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-          },
-          {
-            name: "Upload canary to dl.deno.land (windows)",
-            if: [
-              "runner.os == 'Windows' &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main'",
-            ].join("\n"),
-            env: {
-              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-            },
-            run:
-              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-          },
-          {
-            name: "Test debug",
-            if: [
-              "matrix.job == 'test' && matrix.profile == 'debug' &&",
-              "!startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')",
-            ].join("\n"),
-            run: "cargo test --locked",
-            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
-          },
-          {
-            name: "Test debug (fast)",
-            if: [
-              "matrix.job == 'test' && matrix.profile == 'debug' && ",
-              "!startsWith(matrix.os, 'ubuntu')",
-            ].join("\n"),
-            run: [
-              // Run unit then integration tests. Skip doc tests here
-              // since they are sometimes very slow on Mac.
-              "cargo test --locked --lib",
-              "cargo test --locked --test '*'",
-            ].join("\n"),
-            env: { CARGO_PROFILE_DEV_DEBUG: 0 },
-          },
-          {
-            name: "Test release",
-            if: [
-              "matrix.job == 'test' && matrix.profile == 'release' &&",
-              "(matrix.use_sysroot || (",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))",
-            ].join("\n"),
-            run: "cargo test --release --locked",
-          },
-          {
-            // Since all tests are skipped when we're building a tagged commit
-            // this is a minimal check to ensure that binary is not corrupted
-            name: "Check deno binary",
-            if:
-              "matrix.profile == 'release' && startsWith(github.ref, 'refs/tags/')",
-            run: 'target/release/deno eval "console.log(1+2)" | grep 3',
-            env: {
-              NO_COLOR: 1,
-            },
-          },
-          {
-            // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
-            name: "Check deno binary (in sysroot)",
-            if: "matrix.profile == 'release' && matrix.use_sysroot",
-            run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',
-          },
-          {
-            name: "Configure hosts file for WPT",
-            if: "matrix.wpt",
-            run: "./wpt make-hosts-file | sudo tee -a /etc/hosts",
-            "working-directory": "test_util/wpt/",
-          },
-          {
-            name: "Run web platform tests (debug)",
-            if: "matrix.wpt && matrix.profile == 'debug'",
-            env: {
-              DENO_BIN: "./target/debug/deno",
-            },
-            run: [
-              "deno run --allow-env --allow-net --allow-read --allow-run \\",
-              "        --allow-write --unstable                         \\",
-              "        --lock=tools/deno.lock.json                      \\",
-              "        ./tools/wpt.ts setup",
-              "deno run --allow-env --allow-net --allow-read --allow-run \\",
-              "         --allow-write --unstable                         \\",
-              "         --lock=tools/deno.lock.json              \\",
-              '         ./tools/wpt.ts run --quiet --binary="$DENO_BIN"',
-            ].join("\n"),
-          },
-          {
-            name: "Run web platform tests (release)",
-            if: "matrix.wpt && matrix.profile == 'release'",
-            env: {
-              DENO_BIN: "./target/release/deno",
-            },
-            run: [
-              "deno run --allow-env --allow-net --allow-read --allow-run \\",
-              "         --allow-write --unstable                         \\",
-              "         --lock=tools/deno.lock.json                      \\",
-              "         ./tools/wpt.ts setup",
-              "deno run --allow-env --allow-net --allow-read --allow-run \\",
-              "         --allow-write --unstable                         \\",
-              "         --lock=tools/deno.lock.json                      \\",
-              "         ./tools/wpt.ts run --quiet --release             \\",
-              '                            --binary="$DENO_BIN"          \\',
-              "                            --json=wpt.json               \\",
-              "                            --wptreport=wptreport.json",
-            ].join("\n"),
-          },
-          {
-            name: "Upload wpt results to dl.deno.land",
-            "continue-on-error": true,
-            if: [
-              "matrix.wpt &&",
-              "runner.os == 'Linux' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            run: [
-              "gzip ./wptreport.json",
-              'gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json',
-              'gsutil -h "Cache-Control: public, max-age=3600" cp ./wptreport.json.gz gs://dl.deno.land/wpt/$(git rev-parse HEAD)-wptreport.json.gz',
-              "echo $(git rev-parse HEAD) > wpt-latest.txt",
-              'gsutil -h "Cache-Control: no-cache" cp wpt-latest.txt gs://dl.deno.land/wpt-latest.txt',
-            ].join("\n"),
-          },
-          {
-            name: "Upload wpt results to wpt.fyi",
-            "continue-on-error": true,
-            if: [
-              "matrix.wpt &&",
-              "runner.os == 'Linux' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            env: {
-              WPT_FYI_USER: "deno",
-              WPT_FYI_PW: "${{ secrets.WPT_FYI_PW }}",
-              GITHUB_TOKEN: "${{ secrets.DENOBOT_PAT }}",
-            },
-            run: [
-              "./target/release/deno run --allow-all --lock=tools/deno.lock.json \\",
-              "    ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus",
-            ].join("\n"),
-          },
-          {
-            name: "Run benchmarks",
-            if:
-              "matrix.job == 'bench' && !startsWith(github.ref, 'refs/tags/')",
-            run: "cargo bench --locked",
-          },
-          {
-            name: "Post Benchmarks",
-            if: [
-              "matrix.job == 'bench' &&",
-              "github.repository == 'denoland/deno' &&",
-              "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            env: {
-              DENOBOT_PAT: "${{ secrets.DENOBOT_PAT }}",
-            },
-            run: [
-              "git clone --depth 1 --branch gh-pages                             \\",
-              "    https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git \\",
-              "    gh-pages",
-              "./target/release/deno run --allow-all --unstable \\",
-              "    ./tools/build_benchmark_jsons.js --release",
-              "cd gh-pages",
-              'git config user.email "propelml@gmail.com"',
-              'git config user.name "denobot"',
-              "git add .",
-              'git commit --message "Update benchmarks"',
-              "git push origin gh-pages",
-            ].join("\n"),
-          },
-          {
-            name: "Build product size info",
-            if:
-              "matrix.job != 'lint' && matrix.profile != 'debug' && github.repository == 'denoland/deno' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
-            run: [
-              'du -hd1 "./target/${{ matrix.profile }}"',
-              'du -ha  "./target/${{ matrix.profile }}/deno"',
-            ].join("\n"),
-          },
-          {
-            name: "Worker info",
-            if: "matrix.job == 'bench'",
-            run: [
-              "cat /proc/cpuinfo",
-              "cat /proc/meminfo",
-            ].join("\n"),
-          },
-          {
-            name: "Upload release to dl.deno.land (unix)",
-            if: [
-              "runner.os != 'Windows' &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            run:
-              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
-          },
-          {
-            name: "Upload release to dl.deno.land (windows)",
-            if: [
-              "runner.os == 'Windows' &&",
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            env: {
-              CLOUDSDK_PYTHON: "${{env.pythonLocation}}\\python.exe",
-            },
-            run:
-              'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
-          },
-          {
-            name: "Create release notes",
-            if: [
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            run: [
-              "export PATH=$PATH:$(pwd)/target/release",
-              "./tools/release/05_create_release_notes.ts",
-            ].join("\n"),
-          },
-          {
-            name: "Upload release to GitHub",
-            uses: "softprops/action-gh-release@v0.1.15",
-            if: [
-              "matrix.job == 'test' &&",
-              "matrix.profile == 'release' &&",
-              "github.repository == 'denoland/deno' &&",
-              "startsWith(github.ref, 'refs/tags/')",
-            ].join("\n"),
-            env: {
-              GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
-            },
-            with: {
-              files: [
-                "target/release/deno-x86_64-pc-windows-msvc.zip",
-                "target/release/deno-x86_64-unknown-linux-gnu.zip",
-                "target/release/deno-x86_64-apple-darwin.zip",
-                "target/release/deno_src.tar.gz",
-                "target/release/lib.deno.d.ts",
-              ].join("\n"),
-              body_path: "target/release/release-notes.md",
-              draft: true,
-            },
-          },
-          {
-            // In main branch, always create a fresh cache
-            name: "Save cache build output (main)",
-            uses: "actions/cache/save@v3",
-            if:
-              "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
-            with: {
-              path: [
-                "./target",
-                "!./target/*/gn_out",
-                "!./target/*/*.zip",
-                "!./target/*/*.tar.gz",
-              ].join("\n"),
-              key: prCacheKeyPrefix + "${{ github.sha }}",
-            },
-          },
-        ]),
-      ]),
+        },
+      ],
     },
     "publish-canary": {
       name: "publish canary",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -184,7 +184,8 @@ const ci = {
     build: {
       name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
       needs: ["pre_build"],
-      if: "${{ pre_build.outputs.skip_build == 'true' && false || always() }}",
+      if:
+        "${{ needs.pre_build.outputs.skip_build == 'true' && false || always() }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",
       "timeout-minutes": 120,
       defaults: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,15 @@ jobs:
     outputs:
       skip_build: '${{ steps.check.outputs.skip_build == ''true'' }}'
     steps:
+      - name: Configure git
+        run: |-
+          git config --global core.symlinks true
+          git config --global fetch.parallel 32
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          submodules: false
       - id: check
         run: |-
           GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     outputs:
       skip_build: '${{ steps.check.outputs.skip_build == ''true'' }}'
     steps:
-      id: check
-      run: |-
-        GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})
-        echo Commit message: $GIT_MESSAGE
-        echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
+      - id: check
+        run: |-
+          GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})
+          echo Commit message: $GIT_MESSAGE
+          echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
   pre_build:
     name: pre_build
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == true
     outputs:
       skip_build: '${{ steps.check.outputs.skip_build }}'
     steps:
@@ -28,21 +27,24 @@ jobs:
         run: |-
           git config --global core.symlinks true
           git config --global fetch.parallel 32
+        if: github.event.pull_request.draft == true
       - name: Clone repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: false
+        if: github.event.pull_request.draft == true
       - id: check
         run: |-
           GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})
           echo Commit message: $GIT_MESSAGE
           echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
+        if: github.event.pull_request.draft == true
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:
       - pre_build
-    if: '${{ !(needs.pre_build.outputs.skip_build == ''true'') || (needs.pre_build.result == ''skipped'') }}'
+    if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pre_build:
-    name: pre_build
+    name: pre-build
     runs-on: ubuntu-latest
     outputs:
       skip_build: '${{ steps.check.outputs.skip_build }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == true
     outputs:
-      skip_build: '${{ steps.check.outputs.skip_build == ''true'' }}'
+      skip_build: '${{ steps.check.outputs.skip_build }}'
     steps:
       - name: Configure git
         run: |-
@@ -42,7 +42,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:
       - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build == ''true'' && false || always() }}'
+    if: '${{ needs.pre_build.outputs.skip_build == ''true'' && false || true }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
         echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
-    needs: pre_build
+    needs:
+      - pre_build
     if: '${{ pre_build.outputs.skip_build == ''true'' && false || always() }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:
       - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
+    if: '${{ !(needs.pre_build.outputs.skip_build == ''true'') || (needs.pre_build.result == ''skipped'') }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:
       - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build == ''true'' && false || true }}'
+    if: '${{ needs.pre_build.outputs.skip_build == ''true'' ? false : true }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:
@@ -397,7 +397,7 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test debug (fast)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'debug' && 
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'debug' &&
           !startsWith(matrix.os, 'ubuntu'))
         run: |-
           cargo test --locked --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:
       - pre_build
-    if: '${{ pre_build.outputs.skip_build == ''true'' && false || always() }}'
+    if: '${{ needs.pre_build.outputs.skip_build == ''true'' && false || always() }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,22 @@ concurrency:
   group: '${{ github.workflow }}-${{ !contains(github.event.pull_request.labels.*.name, ''ci-test-flaky'') && github.head_ref || github.run_id }}'
   cancel-in-progress: true
 jobs:
+  pre_build:
+    name: pre_build
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == true
+    outputs:
+      skip_build: '${{ steps.check.outputs.skip_build == ''true'' }}'
+    steps:
+      id: check
+      run: |-
+        GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})
+        echo Commit message: $GIT_MESSAGE
+        echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
   build:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
+    needs: pre_build
+    if: '${{ pre_build.outputs.skip_build == ''true'' && false || always() }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:
@@ -69,43 +83,31 @@ jobs:
         run: |-
           git config --global core.symlinks true
           git config --global fetch.parallel 32
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Clone repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: false
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
-      - name: Cancel if draft PR
-        id: exit_early
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (github.event.pull_request.draft == true)'
-        run: |-
-          GIT_MESSAGE=$(git log --format=%s -n 1 ${{github.event.after}})
-          echo Commit message: $GIT_MESSAGE
-          echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'EXIT_EARLY=true' >> $GITHUB_OUTPUT)
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Clone submodule ./third_party
         run: git submodule update --init --recursive --depth=1 -- ./third_party
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.wpt))'
+        if: matrix.wpt
       - name: 'Create source tarballs (release, linux)'
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') &&
+          startsWith(matrix.os, 'ubuntu') &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')))
+          startsWith(github.ref, 'refs/tags/')
         run: |-
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
       - uses: dsherret/rust-toolchain-file@v1
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
-      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint'' || matrix.job == ''test''))'
+      - if: matrix.job == 'lint' || matrix.job == 'test'
         name: Install Deno
         uses: denoland/setup-deno@v1
         with:
@@ -114,26 +116,26 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint''))'
+        if: matrix.job != 'lint'
       - name: Remove unused versions of Python
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint'' && (startsWith(matrix.os, ''windows''))))'
+        if: 'matrix.job != ''lint'' && (startsWith(matrix.os, ''windows''))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |
             Where-Object { Test-Path "$_\python.exe" } |
             Select-Object -Skip 1 |
             ForEach-Object { Move-Item "$_" "$_.disabled" }
-      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench''))'
+      - if: matrix.job == 'bench'
         name: Install Node
         uses: actions/setup-node@v3
         with:
           node-version: 18
       - if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.profile == 'release' &&
+          matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/'))
         name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v1
         with:
@@ -143,23 +145,23 @@ jobs:
           create_credentials_file: true
       - name: Setup gcloud (unix)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
+          runner.os != 'Windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/'))
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: denoland
       - name: Setup gcloud (windows)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Windows' &&
+          runner.os == 'Windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/'))
         uses: google-github-actions/setup-gcloud@v1
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
@@ -167,12 +169,12 @@ jobs:
           project_id: denoland
       - name: Configure canary build
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
+          matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'))
+          github.ref == 'refs/heads/main'
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
-      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.use_sysroot))'
+      - if: matrix.use_sysroot
         name: Set up incremental LTO and sysroot build
         run: |-
           # Avoid running man-db triggers, which sometimes takes several minutes
@@ -254,7 +256,6 @@ jobs:
           then
             node -v
           fi
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Cache Cargo home
         uses: actions/cache@v3
         with:
@@ -263,10 +264,9 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: '20-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')))'
+        if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
             ./target
@@ -276,7 +276,7 @@ jobs:
           key: never_saved
           restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (!startsWith(github.ref, ''refs/tags/'')))'
+        if: '!startsWith(github.ref, ''refs/tags/'')'
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target
@@ -288,100 +288,99 @@ jobs:
                       https://github.com/rust-lang/crates.io-index \
                       ~/.cargo/registry/index/github.com-1ecc6299db9ec823
           fi
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'')'
       - name: test_format.js
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint''))'
+        if: matrix.job == 'lint'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
       - name: Lint PR title
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint'' && github.event_name == ''pull_request''))'
+        if: matrix.job == 'lint' && github.event_name == 'pull_request'
         env:
           PR_TITLE: '${{ github.event.pull_request.title }}'
         run: deno run ./tools/verify_pr_title.js "$PR_TITLE"
       - name: lint.js
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''lint''))'
+        if: matrix.job == 'lint'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
       - name: Build debug
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''test'' && matrix.profile == ''debug''))'
+        if: matrix.job == 'test' && matrix.profile == 'debug'
         run: cargo build --locked --all-targets
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build release
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && ((matrix.job == 'test' || matrix.job == 'bench') &&
+          (matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))))
+          startsWith(github.ref, 'refs/tags/'))))
         run: cargo build --release --locked --all-targets
       - name: Upload PR artifact (linux)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
+          matrix.job == 'test' &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))))
+          startsWith(github.ref, 'refs/tags/'))))
         uses: actions/upload-artifact@v3
         with:
           name: 'deno-${{ github.event.number }}'
           path: target/release/deno
       - name: Pre-release (linux)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'ubuntu') &&
+          startsWith(matrix.os, 'ubuntu') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
-          github.repository == 'denoland/deno'))
+          github.repository == 'denoland/deno'
         run: |-
           cd target/release
           zip -r deno-x86_64-unknown-linux-gnu.zip deno
           ./deno types > lib.deno.d.ts
       - name: Pre-release (mac)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'macOS') &&
+          startsWith(matrix.os, 'macOS') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))))
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |-
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (windows)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (startsWith(matrix.os, 'windows') &&
+          startsWith(matrix.os, 'windows') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))))
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         shell: pwsh
         run: Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
       - name: Upload canary to dl.deno.land (unix)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
+          runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'))
+          github.ref == 'refs/heads/main'
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Upload canary to dl.deno.land (windows)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Windows' &&
+          runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'))
+          github.ref == 'refs/heads/main'
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Test debug
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' &&
-          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')))
+          matrix.job == 'test' && matrix.profile == 'debug' &&
+          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')
         run: cargo test --locked
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test debug (fast)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'debug' && 
-          !startsWith(matrix.os, 'ubuntu')))
+          matrix.job == 'test' && matrix.profile == 'debug' && 
+          !startsWith(matrix.os, 'ubuntu')
         run: |-
           cargo test --locked --lib
           cargo test --locked --test '*'
@@ -389,25 +388,25 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test release
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' && matrix.profile == 'release' &&
+          matrix.job == 'test' && matrix.profile == 'release' &&
           (matrix.use_sysroot || (
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))))
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))
         run: cargo test --release --locked
       - name: Check deno binary
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/'')))'
+        if: 'matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/'')'
         run: target/release/deno eval "console.log(1+2)" | grep 3
         env:
           NO_COLOR: 1
       - name: Check deno binary (in sysroot)
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.profile == ''release'' && matrix.use_sysroot))'
+        if: matrix.profile == 'release' && matrix.use_sysroot
         run: sudo chroot /sysroot "$(pwd)/target/release/deno" --version
       - name: Configure hosts file for WPT
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.wpt))'
+        if: matrix.wpt
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: test_util/wpt/
       - name: Run web platform tests (debug)
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.wpt && matrix.profile == ''debug''))'
+        if: matrix.wpt && matrix.profile == 'debug'
         env:
           DENO_BIN: ./target/debug/deno
         run: |-
@@ -420,7 +419,7 @@ jobs:
                    --lock=tools/deno.lock.json              \
                    ./tools/wpt.ts run --quiet --binary="$DENO_BIN"
       - name: Run web platform tests (release)
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.wpt && matrix.profile == ''release''))'
+        if: matrix.wpt && matrix.profile == 'release'
         env:
           DENO_BIN: ./target/release/deno
         run: |-
@@ -438,11 +437,11 @@ jobs:
       - name: Upload wpt results to dl.deno.land
         continue-on-error: true
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.wpt &&
+          matrix.wpt &&
           runner.os == 'Linux' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         run: |-
           gzip ./wptreport.json
           gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json
@@ -452,11 +451,11 @@ jobs:
       - name: Upload wpt results to wpt.fyi
         continue-on-error: true
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.wpt &&
+          matrix.wpt &&
           runner.os == 'Linux' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         env:
           WPT_FYI_USER: deno
           WPT_FYI_PW: '${{ secrets.WPT_FYI_PW }}'
@@ -465,13 +464,13 @@ jobs:
           ./target/release/deno run --allow-all --lock=tools/deno.lock.json \
               ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus
       - name: Run benchmarks
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/'')))'
+        if: 'matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/'')'
         run: cargo bench --locked
       - name: Post Benchmarks
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'bench' &&
+          matrix.job == 'bench' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
         env:
           DENOBOT_PAT: '${{ secrets.DENOBOT_PAT }}'
         run: |-
@@ -487,49 +486,49 @@ jobs:
           git commit --message "Update benchmarks"
           git push origin gh-pages
       - name: Build product size info
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job != ''lint'' && matrix.profile != ''debug'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))))'
+        if: 'matrix.job != ''lint'' && matrix.profile != ''debug'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"
       - name: Worker info
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && (matrix.job == ''bench''))'
+        if: matrix.job == 'bench'
         run: |-
           cat /proc/cpuinfo
           cat /proc/meminfo
       - name: Upload release to dl.deno.land (unix)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os != 'Windows' &&
+          runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')))
+          startsWith(github.ref, 'refs/tags/')
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Upload release to dl.deno.land (windows)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (runner.os == 'Windows' &&
+          runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')))
+          startsWith(github.ref, 'refs/tags/')
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Create release notes
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
+          matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')))
+          startsWith(github.ref, 'refs/tags/')
         run: |-
           export PATH=$PATH:$(pwd)/target/release
           ./tools/release/05_create_release_notes.ts
       - name: Upload release to GitHub
         uses: softprops/action-gh-release@v0.1.15
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != 'true' && (matrix.job == 'test' &&
+          matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')))
+          startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
@@ -543,7 +542,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (steps.exit_early.outputs.EXIT_EARLY != ''true'' && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main''))'
+        if: (matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
     needs:
       - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build == ''true'' ? false : true }}'
+    if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
     runs-on: '${{ matrix.runner || matrix.os }}'
     timeout-minutes: 120
     defaults:
@@ -397,7 +397,7 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test debug (fast)
         if: |-
-          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'debug' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'debug' && 
           !startsWith(matrix.os, 'ubuntu'))
         run: |-
           cargo test --locked --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,31 +93,36 @@ jobs:
         run: |-
           git config --global core.symlinks true
           git config --global fetch.parallel 32
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Clone repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 5
           submodules: false
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Clone submodule ./third_party
         run: git submodule update --init --recursive --depth=1 -- ./third_party
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt
-        if: matrix.wpt
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.wpt)'
       - name: 'Create source tarballs (release, linux)'
         if: |-
-          startsWith(matrix.os, 'ubuntu') &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (startsWith(matrix.os, 'ubuntu') &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         run: |-
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
       - uses: dsherret/rust-toolchain-file@v1
-      - if: matrix.job == 'lint' || matrix.job == 'test'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
+      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''lint'' || matrix.job == ''test'')'
         name: Install Deno
         uses: denoland/setup-deno@v1
         with:
@@ -126,26 +131,26 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-        if: matrix.job != 'lint'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job != ''lint'')'
       - name: Remove unused versions of Python
-        if: 'matrix.job != ''lint'' && (startsWith(matrix.os, ''windows''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job != ''lint'' && (startsWith(matrix.os, ''windows'')))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |
             Where-Object { Test-Path "$_\python.exe" } |
             Select-Object -Skip 1 |
             ForEach-Object { Move-Item "$_" "$_.disabled" }
-      - if: matrix.job == 'bench'
+      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''bench'')'
         name: Install Node
         uses: actions/setup-node@v3
         with:
           node-version: 18
       - if: |-
-          matrix.profile == 'release' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))
+          startsWith(github.ref, 'refs/tags/')))
         name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v1
         with:
@@ -155,23 +160,23 @@ jobs:
           create_credentials_file: true
       - name: Setup gcloud (unix)
         if: |-
-          runner.os != 'Windows' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (runner.os != 'Windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))
+          startsWith(github.ref, 'refs/tags/')))
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: denoland
       - name: Setup gcloud (windows)
         if: |-
-          runner.os == 'Windows' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (runner.os == 'Windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))
+          startsWith(github.ref, 'refs/tags/')))
         uses: google-github-actions/setup-gcloud@v1
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
@@ -179,12 +184,12 @@ jobs:
           project_id: denoland
       - name: Configure canary build
         if: |-
-          matrix.job == 'test' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         run: echo "DENO_CANARY=true" >> $GITHUB_ENV
-      - if: matrix.use_sysroot
+      - if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.use_sysroot)'
         name: Set up incremental LTO and sysroot build
         run: |-
           # Avoid running man-db triggers, which sometimes takes several minutes
@@ -266,6 +271,7 @@ jobs:
           then
             node -v
           fi
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Cache Cargo home
         uses: actions/cache@v3
         with:
@@ -274,9 +280,10 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: '20-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
-        if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
         with:
           path: |-
             ./target
@@ -286,7 +293,7 @@ jobs:
           key: never_saved
           restore-keys: '18-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
-        if: '!startsWith(github.ref, ''refs/tags/'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target
@@ -298,99 +305,100 @@ jobs:
                       https://github.com/rust-lang/crates.io-index \
                       ~/.cargo/registry/index/github.com-1ecc6299db9ec823
           fi
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: test_format.js
-        if: matrix.job == 'lint'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check
       - name: Lint PR title
-        if: matrix.job == 'lint' && github.event_name == 'pull_request'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''lint'' && github.event_name == ''pull_request'')'
         env:
           PR_TITLE: '${{ github.event.pull_request.title }}'
         run: deno run ./tools/verify_pr_title.js "$PR_TITLE"
       - name: lint.js
-        if: matrix.job == 'lint'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/lint.js
       - name: Build debug
-        if: matrix.job == 'test' && matrix.profile == 'debug'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''test'' && matrix.profile == ''debug'')'
         run: cargo build --locked --all-targets
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build release
         if: |-
-          (matrix.job == 'test' || matrix.job == 'bench') &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && ((matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/')))))
         run: cargo build --release --locked --all-targets
       - name: Upload PR artifact (linux)
         if: |-
-          matrix.job == 'test' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' &&
           matrix.profile == 'release' && (matrix.use_sysroot ||
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/tags/'))))
+          startsWith(github.ref, 'refs/tags/')))))
         uses: actions/upload-artifact@v3
         with:
           name: 'deno-${{ github.event.number }}'
           path: target/release/deno
       - name: Pre-release (linux)
         if: |-
-          startsWith(matrix.os, 'ubuntu') &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (startsWith(matrix.os, 'ubuntu') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
-          github.repository == 'denoland/deno'
+          github.repository == 'denoland/deno')
         run: |-
           cd target/release
           zip -r deno-x86_64-unknown-linux-gnu.zip deno
           ./deno types > lib.deno.d.ts
       - name: Pre-release (mac)
         if: |-
-          startsWith(matrix.os, 'macOS') &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (startsWith(matrix.os, 'macOS') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
         run: |-
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (windows)
         if: |-
-          startsWith(matrix.os, 'windows') &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (startsWith(matrix.os, 'windows') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
         shell: pwsh
         run: Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
       - name: Upload canary to dl.deno.land (unix)
         if: |-
-          runner.os != 'Windows' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Upload canary to dl.deno.land (windows)
         if: |-
-          runner.os == 'Windows' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main')
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/'
       - name: Test debug
         if: |-
-          matrix.job == 'test' && matrix.profile == 'debug' &&
-          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'debug' &&
+          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu'))
         run: cargo test --locked
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test debug (fast)
         if: |-
-          matrix.job == 'test' && matrix.profile == 'debug' && 
-          !startsWith(matrix.os, 'ubuntu')
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'debug' && 
+          !startsWith(matrix.os, 'ubuntu'))
         run: |-
           cargo test --locked --lib
           cargo test --locked --test '*'
@@ -398,25 +406,25 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Test release
         if: |-
-          matrix.job == 'test' && matrix.profile == 'release' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' && matrix.profile == 'release' &&
           (matrix.use_sysroot || (
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')))
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))))
         run: cargo test --release --locked
       - name: Check deno binary
-        if: 'matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.profile == ''release'' && startsWith(github.ref, ''refs/tags/''))'
         run: target/release/deno eval "console.log(1+2)" | grep 3
         env:
           NO_COLOR: 1
       - name: Check deno binary (in sysroot)
-        if: matrix.profile == 'release' && matrix.use_sysroot
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.profile == ''release'' && matrix.use_sysroot)'
         run: sudo chroot /sysroot "$(pwd)/target/release/deno" --version
       - name: Configure hosts file for WPT
-        if: matrix.wpt
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.wpt)'
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: test_util/wpt/
       - name: Run web platform tests (debug)
-        if: matrix.wpt && matrix.profile == 'debug'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.wpt && matrix.profile == ''debug'')'
         env:
           DENO_BIN: ./target/debug/deno
         run: |-
@@ -429,7 +437,7 @@ jobs:
                    --lock=tools/deno.lock.json              \
                    ./tools/wpt.ts run --quiet --binary="$DENO_BIN"
       - name: Run web platform tests (release)
-        if: matrix.wpt && matrix.profile == 'release'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.wpt && matrix.profile == ''release'')'
         env:
           DENO_BIN: ./target/release/deno
         run: |-
@@ -447,11 +455,11 @@ jobs:
       - name: Upload wpt results to dl.deno.land
         continue-on-error: true
         if: |-
-          matrix.wpt &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.wpt &&
           runner.os == 'Linux' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         run: |-
           gzip ./wptreport.json
           gsutil -h "Cache-Control: public, max-age=3600" cp ./wpt.json gs://dl.deno.land/wpt/$(git rev-parse HEAD).json
@@ -461,11 +469,11 @@ jobs:
       - name: Upload wpt results to wpt.fyi
         continue-on-error: true
         if: |-
-          matrix.wpt &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.wpt &&
           runner.os == 'Linux' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         env:
           WPT_FYI_USER: deno
           WPT_FYI_PW: '${{ secrets.WPT_FYI_PW }}'
@@ -474,13 +482,13 @@ jobs:
           ./target/release/deno run --allow-all --lock=tools/deno.lock.json \
               ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus
       - name: Run benchmarks
-        if: 'matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''bench'' && !startsWith(github.ref, ''refs/tags/''))'
         run: cargo bench --locked
       - name: Post Benchmarks
         if: |-
-          matrix.job == 'bench' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'bench' &&
           github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')
+          github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
         env:
           DENOBOT_PAT: '${{ secrets.DENOBOT_PAT }}'
         run: |-
@@ -496,49 +504,49 @@ jobs:
           git commit --message "Update benchmarks"
           git push origin gh-pages
       - name: Build product size info
-        if: 'matrix.job != ''lint'' && matrix.profile != ''debug'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job != ''lint'' && matrix.profile != ''debug'' && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')))'
         run: |-
           du -hd1 "./target/${{ matrix.profile }}"
           du -ha  "./target/${{ matrix.profile }}/deno"
       - name: Worker info
-        if: matrix.job == 'bench'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''bench'')'
         run: |-
           cat /proc/cpuinfo
           cat /proc/meminfo
       - name: Upload release to dl.deno.land (unix)
         if: |-
-          runner.os != 'Windows' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (runner.os != 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Upload release to dl.deno.land (windows)
         if: |-
-          runner.os == 'Windows' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (runner.os == 'Windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         env:
           CLOUDSDK_PYTHON: '${{env.pythonLocation}}\python.exe'
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Create release notes
         if: |-
-          matrix.job == 'test' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         run: |-
           export PATH=$PATH:$(pwd)/target/release
           ./tools/release/05_create_release_notes.ts
       - name: Upload release to GitHub
         uses: softprops/action-gh-release@v0.1.15
         if: |-
-          matrix.job == 'test' &&
+          !(github.event_name == 'pull_request' && matrix.skip_pr) && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
-          startsWith(github.ref, 'refs/tags/')
+          startsWith(github.ref, 'refs/tags/'))
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
@@ -552,7 +560,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: (matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'')'
         with:
           path: |-
             ./target

--- a/ext/node/crypto/x509.rs
+++ b/ext/node/crypto/x509.rs
@@ -1,3 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
 use deno_core::error::bad_resource_id;
 use deno_core::error::AnyError;
 use deno_core::op;

--- a/ext/node/crypto/x509.rs
+++ b/ext/node/crypto/x509.rs
@@ -88,7 +88,7 @@ pub fn op_node_x509_ca(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(cert.is_ca())
 }
 
@@ -101,7 +101,7 @@ pub fn op_node_x509_check_email(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
 
   let subject = cert.subject();
   if subject
@@ -142,7 +142,7 @@ pub fn op_node_x509_fingerprint(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(cert.fingerprint::<sha1::Sha1>())
 }
 
@@ -154,7 +154,7 @@ pub fn op_node_x509_fingerprint256(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(cert.fingerprint::<sha2::Sha256>())
 }
 
@@ -166,7 +166,7 @@ pub fn op_node_x509_fingerprint512(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(cert.fingerprint::<sha2::Sha512>())
 }
 
@@ -178,7 +178,7 @@ pub fn op_node_x509_get_issuer(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(x509name_to_string(cert.issuer(), oid_registry())?)
 }
 
@@ -190,7 +190,7 @@ pub fn op_node_x509_get_subject(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(x509name_to_string(cert.subject(), oid_registry())?)
 }
 
@@ -264,7 +264,7 @@ pub fn op_node_x509_get_valid_from(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(cert.validity().not_before.to_string())
 }
 
@@ -276,7 +276,7 @@ pub fn op_node_x509_get_valid_to(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   Ok(cert.validity().not_after.to_string())
 }
 
@@ -288,7 +288,7 @@ pub fn op_node_x509_get_serial_number(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
   let mut s = cert.serial.to_str_radix(16);
   s.make_ascii_uppercase();
   Ok(s)
@@ -302,7 +302,7 @@ pub fn op_node_x509_key_usage(
   let cert = state
     .resource_table
     .get::<Certificate>(rid)
-    .or_else(|_| Err(bad_resource_id()))?;
+    .map_err(|_| bad_resource_id())?;
 
   let key_usage = cert
     .extensions()


### PR DESCRIPTION
We had a PR land that didn't actually pass the steps because it passed on a draft pr. This prevents running the "build" job on draft prs.