### PR TITLE
chore(cli): clean up unused number value

### DIFF
--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -185,7 +185,7 @@ Deno.test({
   },
 });
 
-/* Start of ported part */ 3;
+/* Start of ported part */
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 // Ported from Node 15.5.1
 


### PR DESCRIPTION
This PR removes an accidentally declared number value.
