### PR TITLE
refactor: `ProcState::build` -> `ProcState::from_flags`

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -182,7 +182,7 @@ impl LanguageServer {
         .into_iter()
         .map(|d| (d.specifier().clone(), d))
         .collect::<HashMap<_, _>>();
-      let ps = ProcState::from_options(Arc::new(cli_options)).await?;
+      let ps = ProcState::from_cli_options(Arc::new(cli_options)).await?;
       let mut inner_loader = ps.create_graph_loader();
       let mut loader = crate::lsp::documents::OpenDocumentsGraphLoader {
         inner_loader: &mut inner_loader,

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -259,7 +259,7 @@ impl TestRun {
     let args = self.get_args();
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
     let flags = flags_from_vec(args.into_iter().map(String::from).collect())?;
-    let ps = proc_state::ProcState::build(flags).await?;
+    let ps = proc_state::ProcState::from_flags(flags).await?;
     // Various test files should not share the same permissions in terms of
     // `PermissionsContainer` - otherwise granting/revoking permissions in one
     // file would have impact on other files, which is undesirable.

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -69,13 +69,13 @@ async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
       tools::run::eval_command(flags, eval_flags).await
     }
     DenoSubcommand::Cache(cache_flags) => {
-      let ps = ProcState::build(flags).await?;
+      let ps = ProcState::from_flags(flags).await?;
       ps.load_and_type_check_files(&cache_flags.files).await?;
       ps.cache_module_emits()?;
       Ok(0)
     }
     DenoSubcommand::Check(check_flags) => {
-      let ps = ProcState::build(flags).await?;
+      let ps = ProcState::from_flags(flags).await?;
       ps.load_and_type_check_files(&check_flags.files).await?;
       Ok(0)
     }

--- a/cli/proc_state.rs
+++ b/cli/proc_state.rs
@@ -112,17 +112,17 @@ impl Deref for ProcState {
 }
 
 impl ProcState {
-  pub async fn build(flags: Flags) -> Result<Self, AnyError> {
-    Self::from_options(Arc::new(CliOptions::from_flags(flags)?)).await
-  }
-
-  pub async fn from_options(
+  pub async fn from_cli_options(
     options: Arc<CliOptions>,
   ) -> Result<Self, AnyError> {
     Self::build_with_sender(options, None).await
   }
 
-  pub async fn build_for_file_watcher(
+  pub async fn from_flags(flags: Flags) -> Result<Self, AnyError> {
+    Self::from_cli_options(Arc::new(CliOptions::from_flags(flags)?)).await
+  }
+
+  pub async fn from_flags_for_file_watcher(
     flags: Flags,
     files_to_watch_sender: tokio::sync::mpsc::UnboundedSender<Vec<PathBuf>>,
   ) -> Result<Self, AnyError> {

--- a/cli/standalone.rs
+++ b/cli/standalone.rs
@@ -307,7 +307,7 @@ pub async fn run(
 ) -> Result<(), AnyError> {
   let flags = metadata_to_flags(&metadata);
   let main_module = &metadata.entrypoint;
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   let permissions = PermissionsContainer::new(Permissions::from_options(
     &metadata.permissions,
   )?);

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -574,7 +574,7 @@ pub async fn run_benchmarks(
   cli_options: CliOptions,
   bench_options: BenchOptions,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::from_options(Arc::new(cli_options)).await?;
+  let ps = ProcState::from_cli_options(Arc::new(cli_options)).await?;
   // Various bench files should not share the same permissions in terms of
   // `PermissionsContainer` - otherwise granting/revoking permissions in one
   // file would have impact on other files, which is undesirable.
@@ -613,7 +613,7 @@ pub async fn run_benchmarks_with_watch(
   cli_options: CliOptions,
   bench_options: BenchOptions,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::from_options(Arc::new(cli_options)).await?;
+  let ps = ProcState::from_cli_options(Arc::new(cli_options)).await?;
   // Various bench files should not share the same permissions in terms of
   // `PermissionsContainer` - otherwise granting/revoking permissions in one
   // file would have impact on other files, which is undesirable.

--- a/cli/tools/bundle.rs
+++ b/cli/tools/bundle.rs
@@ -41,7 +41,7 @@ pub async fn bundle(
     let module_specifier = &module_specifier;
     async move {
       log::debug!(">>>>> bundle START");
-      let ps = ProcState::from_options(cli_options).await?;
+      let ps = ProcState::from_cli_options(cli_options).await?;
       let graph =
         create_graph_and_maybe_check(vec![module_specifier.clone()], &ps)
           .await?;

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -621,7 +621,7 @@ pub async fn cover_files(
     return Err(generic_error("No matching coverage profiles found"));
   }
 
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   let root_dir_url = ps.npm_resolver.root_dir_url();
 
   let script_coverages = collect_coverages(coverage_flags.files)?;

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -23,7 +23,7 @@ pub async fn print_docs(
   flags: Flags,
   doc_flags: DocFlags,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
 
   let mut doc_nodes = match doc_flags.source_file {
     DocSourceFileFlag::Builtin => {

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -33,7 +33,7 @@ use crate::proc_state::ProcState;
 use crate::util::checksum;
 
 pub async fn info(flags: Flags, info_flags: InfoFlags) -> Result<(), AnyError> {
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   if let Some(specifier) = info_flags.file {
     let specifier = resolve_url_or_path(&specifier, ps.options.initial_cwd())?;
     let mut loader = ps.create_graph_loader();

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -233,7 +233,7 @@ pub async fn install_command(
   install_flags: InstallFlags,
 ) -> Result<(), AnyError> {
   // ensure the module is cached
-  ProcState::build(flags.clone())
+  ProcState::from_flags(flags.clone())
     .await?
     .load_and_type_check_files(&[install_flags.module_url.clone()])
     .await?;

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -80,7 +80,7 @@ async fn read_eval_file(
 }
 
 pub async fn run(flags: Flags, repl_flags: ReplFlags) -> Result<i32, AnyError> {
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   let main_module = ps.options.resolve_main_module()?;
   let mut worker = create_main_worker(
     &ps,

--- a/cli/tools/standalone.rs
+++ b/cli/tools/standalone.rs
@@ -38,7 +38,7 @@ pub async fn compile(
   flags: Flags,
   compile_flags: CompileFlags,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   let module_specifier = ps.options.resolve_main_module()?;
   let module_roots = {
     let mut vec = Vec::with_capacity(compile_flags.include.len() + 1);

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -23,7 +23,7 @@ pub async fn execute_script(
   flags: Flags,
   task_flags: TaskFlags,
 ) -> Result<i32, AnyError> {
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   let tasks_config = ps.options.resolve_tasks_config()?;
   let maybe_package_json = ps.options.maybe_package_json();
   let package_json_scripts = maybe_package_json

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1531,7 +1531,7 @@ pub async fn run_tests(
   cli_options: CliOptions,
   test_options: TestOptions,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::from_options(Arc::new(cli_options)).await?;
+  let ps = ProcState::from_cli_options(Arc::new(cli_options)).await?;
   // Various test files should not share the same permissions in terms of
   // `PermissionsContainer` - otherwise granting/revoking permissions in one
   // file would have impact on other files, which is undesirable.
@@ -1575,7 +1575,7 @@ pub async fn run_tests_with_watch(
   cli_options: CliOptions,
   test_options: TestOptions,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::from_options(Arc::new(cli_options)).await?;
+  let ps = ProcState::from_cli_options(Arc::new(cli_options)).await?;
   // Various test files should not share the same permissions in terms of
   // `PermissionsContainer` - otherwise granting/revoking permissions in one
   // file would have impact on other files, which is undesirable.

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -263,7 +263,7 @@ pub async fn upgrade(
   flags: Flags,
   upgrade_flags: UpgradeFlags,
 ) -> Result<(), AnyError> {
-  let ps = ProcState::build(flags).await?;
+  let ps = ProcState::from_flags(flags).await?;
   let current_exe_path = std::env::current_exe()?;
   let metadata = fs::metadata(&current_exe_path)?;
   let permissions = metadata.permissions();

--- a/cli/tools/vendor/mod.rs
+++ b/cli/tools/vendor/mod.rs
@@ -42,7 +42,7 @@ pub async fn vendor(
   let output_dir = resolve_from_cwd(&raw_output_dir)?;
   validate_output_dir(&output_dir, &vendor_flags)?;
   validate_options(&mut cli_options, &output_dir)?;
-  let ps = ProcState::from_options(Arc::new(cli_options)).await?;
+  let ps = ProcState::from_cli_options(Arc::new(cli_options)).await?;
   let graph = create_graph(&ps, &vendor_flags).await?;
   let vendored_count = build::build(
     graph,


### PR DESCRIPTION
Makes it more discoverable to have all the methods show up in auto-complete when doing `ProcState::from_` now that we have multiple ways of creating this. I saw someone incorrectly use `ProcState::build` when they should have used `ProcState::from_cli_options`.