### PR TITLE
refactor(ext/webidl): remove object from 'requiredArguments'

### DIFF
--- a/ext/broadcast_channel/01_broadcast_channel.js
+++ b/ext/broadcast_channel/01_broadcast_channel.js
@@ -83,7 +83,7 @@ class BroadcastChannel extends EventTarget {
     super();
 
     const prefix = "Failed to construct 'BroadcastChannel'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     this[_name] = webidl.converters["DOMString"](name, {
       prefix,
@@ -106,7 +106,7 @@ class BroadcastChannel extends EventTarget {
     webidl.assertBranded(this, BroadcastChannelPrototype);
 
     const prefix = "Failed to execute 'postMessage' on 'BroadcastChannel'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     if (this[_closed]) {
       throw new DOMException("Already closed", "InvalidStateError");

--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -26,7 +26,7 @@ class CacheStorage {
   async open(cacheName) {
     webidl.assertBranded(this, CacheStoragePrototype);
     const prefix = "Failed to execute 'open' on 'CacheStorage'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     cacheName = webidl.converters["DOMString"](cacheName, {
       prefix,
       context: "Argument 1",
@@ -40,7 +40,7 @@ class CacheStorage {
   async has(cacheName) {
     webidl.assertBranded(this, CacheStoragePrototype);
     const prefix = "Failed to execute 'has' on 'CacheStorage'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     cacheName = webidl.converters["DOMString"](cacheName, {
       prefix,
       context: "Argument 1",
@@ -51,7 +51,7 @@ class CacheStorage {
   async delete(cacheName) {
     webidl.assertBranded(this, CacheStoragePrototype);
     const prefix = "Failed to execute 'delete' on 'CacheStorage'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     cacheName = webidl.converters["DOMString"](cacheName, {
       prefix,
       context: "Argument 1",
@@ -75,7 +75,7 @@ class Cache {
   async put(request, response) {
     webidl.assertBranded(this, CachePrototype);
     const prefix = "Failed to execute 'put' on 'Cache'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     request = webidl.converters["RequestInfo_DOMString"](request, {
       prefix,
       context: "Argument 1",
@@ -165,7 +165,7 @@ class Cache {
   async match(request, options) {
     webidl.assertBranded(this, CachePrototype);
     const prefix = "Failed to execute 'match' on 'Cache'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     request = webidl.converters["RequestInfo_DOMString"](request, {
       prefix,
       context: "Argument 1",
@@ -182,7 +182,7 @@ class Cache {
   async delete(request, _options) {
     webidl.assertBranded(this, CachePrototype);
     const prefix = "Failed to execute 'delete' on 'Cache'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     request = webidl.converters["RequestInfo_DOMString"](request, {
       prefix,
       context: "Argument 1",

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -468,7 +468,7 @@ class SubtleCrypto {
   async digest(algorithm, data) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'digest' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -500,7 +500,7 @@ class SubtleCrypto {
   async encrypt(algorithm, key, data) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'encrypt' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 3, { prefix });
+    webidl.requiredArguments(arguments.length, 3, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -548,7 +548,7 @@ class SubtleCrypto {
   async decrypt(algorithm, key, data) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'decrypt' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 3, { prefix });
+    webidl.requiredArguments(arguments.length, 3, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -756,7 +756,7 @@ class SubtleCrypto {
   async sign(algorithm, key, data) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'sign' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 3, { prefix });
+    webidl.requiredArguments(arguments.length, 3, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -920,7 +920,7 @@ class SubtleCrypto {
   async importKey(format, keyData, algorithm, extractable, keyUsages) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'importKey' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 4, { prefix });
+    webidl.requiredArguments(arguments.length, 4, prefix);
     format = webidl.converters.KeyFormat(format, {
       prefix,
       context: "Argument 1",
@@ -1054,7 +1054,7 @@ class SubtleCrypto {
   async exportKey(format, key) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'exportKey' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     format = webidl.converters.KeyFormat(format, {
       prefix,
       context: "Argument 1",
@@ -1126,7 +1126,7 @@ class SubtleCrypto {
   async deriveBits(algorithm, baseKey, length) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'deriveBits' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 3, { prefix });
+    webidl.requiredArguments(arguments.length, 3, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -1176,7 +1176,7 @@ class SubtleCrypto {
   ) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'deriveKey' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 5, { prefix });
+    webidl.requiredArguments(arguments.length, 5, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -1271,7 +1271,7 @@ class SubtleCrypto {
   async verify(algorithm, key, signature, data) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'verify' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 4, { prefix });
+    webidl.requiredArguments(arguments.length, 4, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -1411,7 +1411,7 @@ class SubtleCrypto {
   async wrapKey(format, key, wrappingKey, wrapAlgorithm) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'wrapKey' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 4, { prefix });
+    webidl.requiredArguments(arguments.length, 4, prefix);
     format = webidl.converters.KeyFormat(format, {
       prefix,
       context: "Argument 1",
@@ -1547,7 +1547,7 @@ class SubtleCrypto {
   ) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'unwrapKey' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 7, { prefix });
+    webidl.requiredArguments(arguments.length, 7, prefix);
     format = webidl.converters.KeyFormat(format, {
       prefix,
       context: "Argument 1",
@@ -1708,7 +1708,7 @@ class SubtleCrypto {
   async generateKey(algorithm, extractable, keyUsages) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'generateKey' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 3, { prefix });
+    webidl.requiredArguments(arguments.length, 3, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
       prefix,
       context: "Argument 1",
@@ -4715,7 +4715,7 @@ class Crypto {
   getRandomValues(typedArray) {
     webidl.assertBranded(this, CryptoPrototype);
     const prefix = "Failed to execute 'getRandomValues' on 'Crypto'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     // Fast path for Uint8Array
     const tag = TypedArrayPrototypeGetSymbolToStringTag(typedArray);
     if (tag === "Uint8Array") {

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -271,7 +271,7 @@ class Headers {
   append(name, value) {
     webidl.assertBranded(this, HeadersPrototype);
     const prefix = "Failed to execute 'append' on 'Headers'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     name = webidl.converters["ByteString"](name, {
       prefix,
       context: "Argument 1",
@@ -288,7 +288,7 @@ class Headers {
    */
   delete(name) {
     const prefix = "Failed to execute 'delete' on 'Headers'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters["ByteString"](name, {
       prefix,
       context: "Argument 1",
@@ -316,7 +316,7 @@ class Headers {
    */
   get(name) {
     const prefix = "Failed to execute 'get' on 'Headers'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters["ByteString"](name, {
       prefix,
       context: "Argument 1",
@@ -335,7 +335,7 @@ class Headers {
    */
   has(name) {
     const prefix = "Failed to execute 'has' on 'Headers'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters["ByteString"](name, {
       prefix,
       context: "Argument 1",
@@ -362,7 +362,7 @@ class Headers {
   set(name, value) {
     webidl.assertBranded(this, HeadersPrototype);
     const prefix = "Failed to execute 'set' on 'Headers'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     name = webidl.converters["ByteString"](name, {
       prefix,
       context: "Argument 1",

--- a/ext/fetch/21_formdata.js
+++ b/ext/fetch/21_formdata.js
@@ -101,7 +101,7 @@ class FormData {
   append(name, valueOrBlobValue, filename) {
     webidl.assertBranded(this, FormDataPrototype);
     const prefix = "Failed to execute 'append' on 'FormData'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
 
     name = webidl.converters["USVString"](name, {
       prefix,
@@ -137,7 +137,7 @@ class FormData {
   delete(name) {
     webidl.assertBranded(this, FormDataPrototype);
     const prefix = "Failed to execute 'name' on 'FormData'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     name = webidl.converters["USVString"](name, {
       prefix,
@@ -160,7 +160,7 @@ class FormData {
   get(name) {
     webidl.assertBranded(this, FormDataPrototype);
     const prefix = "Failed to execute 'get' on 'FormData'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     name = webidl.converters["USVString"](name, {
       prefix,
@@ -182,7 +182,7 @@ class FormData {
   getAll(name) {
     webidl.assertBranded(this, FormDataPrototype);
     const prefix = "Failed to execute 'getAll' on 'FormData'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     name = webidl.converters["USVString"](name, {
       prefix,
@@ -205,7 +205,7 @@ class FormData {
   has(name) {
     webidl.assertBranded(this, FormDataPrototype);
     const prefix = "Failed to execute 'has' on 'FormData'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     name = webidl.converters["USVString"](name, {
       prefix,
@@ -229,7 +229,7 @@ class FormData {
   set(name, valueOrBlobValue, filename) {
     webidl.assertBranded(this, FormDataPrototype);
     const prefix = "Failed to execute 'set' on 'FormData'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
 
     name = webidl.converters["USVString"](name, {
       prefix,

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -273,7 +273,7 @@ class Request {
    */
   constructor(input, init = {}) {
     const prefix = "Failed to construct 'Request'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     input = webidl.converters["RequestInfo_DOMString"](input, {
       prefix,
       context: "Argument 1",

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -413,7 +413,7 @@ function fetch(input, init = {}) {
   // 1.
   const result = new Promise((resolve, reject) => {
     const prefix = "Failed to call 'fetch'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     // 2.
     const requestObject = new Request(input, init);
     // 3.

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -157,7 +157,7 @@ class URLSearchParams {
   append(name, value) {
     webidl.assertBranded(this, URLSearchParamsPrototype);
     const prefix = "Failed to execute 'append' on 'URLSearchParams'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     name = webidl.converters.USVString(name, {
       prefix,
       context: "Argument 1",
@@ -176,7 +176,7 @@ class URLSearchParams {
   delete(name) {
     webidl.assertBranded(this, URLSearchParamsPrototype);
     const prefix = "Failed to execute 'append' on 'URLSearchParams'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters.USVString(name, {
       prefix,
       context: "Argument 1",
@@ -200,7 +200,7 @@ class URLSearchParams {
   getAll(name) {
     webidl.assertBranded(this, URLSearchParamsPrototype);
     const prefix = "Failed to execute 'getAll' on 'URLSearchParams'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters.USVString(name, {
       prefix,
       context: "Argument 1",
@@ -223,7 +223,7 @@ class URLSearchParams {
   get(name) {
     webidl.assertBranded(this, URLSearchParamsPrototype);
     const prefix = "Failed to execute 'get' on 'URLSearchParams'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters.USVString(name, {
       prefix,
       context: "Argument 1",
@@ -245,7 +245,7 @@ class URLSearchParams {
   has(name) {
     webidl.assertBranded(this, URLSearchParamsPrototype);
     const prefix = "Failed to execute 'has' on 'URLSearchParams'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters.USVString(name, {
       prefix,
       context: "Argument 1",
@@ -260,7 +260,7 @@ class URLSearchParams {
   set(name, value) {
     webidl.assertBranded(this, URLSearchParamsPrototype);
     const prefix = "Failed to execute 'set' on 'URLSearchParams'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     name = webidl.converters.USVString(name, {
       prefix,
       context: "Argument 1",
@@ -464,7 +464,7 @@ class URL {
   set hash(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'hash' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -492,7 +492,7 @@ class URL {
   set host(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'host' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -520,7 +520,7 @@ class URL {
   set hostname(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'hostname' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -547,7 +547,7 @@ class URL {
   set href(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'href' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -603,7 +603,7 @@ class URL {
   set password(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'password' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -636,7 +636,7 @@ class URL {
   set pathname(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'pathname' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -671,7 +671,7 @@ class URL {
   set port(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'port' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -699,7 +699,7 @@ class URL {
   set protocol(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'protocol' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -730,7 +730,7 @@ class URL {
   set search(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'search' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",
@@ -770,7 +770,7 @@ class URL {
   set username(value) {
     webidl.assertBranded(this, URLPrototype);
     const prefix = "Failed to set 'username' on 'URL'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     value = webidl.converters.DOMString(value, {
       prefix,
       context: "Argument 1",

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -55,7 +55,7 @@ class URLPattern {
   constructor(input, baseURL = undefined) {
     this[webidl.brand] = webidl.brand;
     const prefix = "Failed to construct 'URLPattern'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     input = webidl.converters.URLPatternInput(input, {
       prefix,
       context: "Argument 1",
@@ -133,7 +133,7 @@ class URLPattern {
   test(input, baseURL = undefined) {
     webidl.assertBranded(this, URLPatternPrototype);
     const prefix = "Failed to execute 'test' on 'URLPattern'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     input = webidl.converters.URLPatternInput(input, {
       prefix,
       context: "Argument 1",
@@ -174,7 +174,7 @@ class URLPattern {
   exec(input, baseURL = undefined) {
     webidl.assertBranded(this, URLPatternPrototype);
     const prefix = "Failed to execute 'exec' on 'URLPattern'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     input = webidl.converters.URLPatternInput(input, {
       prefix,
       context: "Argument 1",

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -162,9 +162,11 @@ class Event {
     this[_path] = [];
 
     if (!eventInitDict[_skipInternalInit]) {
-      webidl.requiredArguments(arguments.length, 1, {
-        prefix: "Failed to construct 'Event'",
-      });
+      webidl.requiredArguments(
+        arguments.length,
+        1,
+        "Failed to construct 'Event'",
+      );
       type = webidl.converters.DOMString(type, {
         prefix: "Failed to construct 'Event'",
         context: "Argument 1",
@@ -958,9 +960,7 @@ class EventTarget {
     webidl.assertBranded(self, EventTargetPrototype);
     const prefix = "Failed to execute 'addEventListener' on 'EventTarget'";
 
-    webidl.requiredArguments(arguments.length, 2, {
-      prefix,
-    });
+    webidl.requiredArguments(arguments.length, 2, prefix);
 
     options = webidl.converters.AddEventListenerOptions(options, {
       prefix,
@@ -1014,9 +1014,11 @@ class EventTarget {
   ) {
     const self = this ?? globalThis_;
     webidl.assertBranded(self, EventTargetPrototype);
-    webidl.requiredArguments(arguments.length, 2, {
-      prefix: "Failed to execute 'removeEventListener' on 'EventTarget'",
-    });
+    webidl.requiredArguments(
+      arguments.length,
+      2,
+      "Failed to execute 'removeEventListener' on 'EventTarget'",
+    );
 
     const { listeners } = self[eventTargetData];
     if (callback !== null && ReflectHas(listeners, type)) {
@@ -1052,9 +1054,11 @@ class EventTarget {
     // executed.
     const self = this ?? globalThis_;
     webidl.assertBranded(self, EventTargetPrototype);
-    webidl.requiredArguments(arguments.length, 1, {
-      prefix: "Failed to execute 'dispatchEvent' on 'EventTarget'",
-    });
+    webidl.requiredArguments(
+      arguments.length,
+      1,
+      "Failed to execute 'dispatchEvent' on 'EventTarget'",
+    );
 
     // This is an optimization to avoid creating an event listener
     // on each startup.
@@ -1261,9 +1265,11 @@ class CustomEvent extends Event {
 
   constructor(type, eventInitDict = {}) {
     super(type, eventInitDict);
-    webidl.requiredArguments(arguments.length, 1, {
-      prefix: "Failed to construct 'CustomEvent'",
-    });
+    webidl.requiredArguments(
+      arguments.length,
+      1,
+      "Failed to construct 'CustomEvent'",
+    );
     const { detail } = eventInitDict;
     this.#detail = detail;
   }
@@ -1512,7 +1518,7 @@ function checkThis(thisArg) {
 function reportError(error) {
   checkThis(this);
   const prefix = "Failed to call 'reportError'";
-  webidl.requiredArguments(arguments.length, 1, { prefix });
+  webidl.requiredArguments(arguments.length, 1, prefix);
   reportException(error);
 }
 

--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -45,7 +45,7 @@ class AbortSignal extends EventTarget {
 
   static timeout(millis) {
     const prefix = "Failed to call 'AbortSignal.timeout'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     millis = webidl.converters["unsigned long long"](millis, {
       enforceRange: true,
     });

--- a/ext/web/05_base64.js
+++ b/ext/web/05_base64.js
@@ -22,7 +22,7 @@ const {
  */
 function atob(data) {
   const prefix = "Failed to execute 'atob'";
-  webidl.requiredArguments(arguments.length, 1, { prefix });
+  webidl.requiredArguments(arguments.length, 1, prefix);
   data = webidl.converters.DOMString(data, {
     prefix,
     context: "Argument 1",
@@ -46,7 +46,7 @@ function atob(data) {
  */
 function btoa(data) {
   const prefix = "Failed to execute 'btoa'";
-  webidl.requiredArguments(arguments.length, 1, { prefix });
+  webidl.requiredArguments(arguments.length, 1, prefix);
   data = webidl.converters.DOMString(data, {
     prefix,
     context: "Argument 1",

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -4701,7 +4701,7 @@ class ByteLengthQueuingStrategy {
   /** @param {{ highWaterMark: number }} init */
   constructor(init) {
     const prefix = "Failed to construct 'ByteLengthQueuingStrategy'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     init = webidl.converters.QueuingStrategyInit(init, {
       prefix,
       context: "Argument 1",
@@ -4758,7 +4758,7 @@ class CountQueuingStrategy {
   /** @param {{ highWaterMark: number }} init */
   constructor(init) {
     const prefix = "Failed to construct 'CountQueuingStrategy'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     init = webidl.converters.QueuingStrategyInit(init, {
       prefix,
       context: "Argument 1",
@@ -4950,7 +4950,7 @@ class ReadableStream {
   pipeThrough(transform, options = {}) {
     webidl.assertBranded(this, ReadableStreamPrototype);
     const prefix = "Failed to execute 'pipeThrough' on 'ReadableStream'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     transform = webidl.converters.ReadableWritablePair(transform, {
       prefix,
       context: "Argument 1",
@@ -4988,7 +4988,7 @@ class ReadableStream {
     try {
       webidl.assertBranded(this, ReadableStreamPrototype);
       const prefix = "Failed to execute 'pipeTo' on 'ReadableStream'";
-      webidl.requiredArguments(arguments.length, 1, { prefix });
+      webidl.requiredArguments(arguments.length, 1, prefix);
       destination = webidl.converters.WritableStream(destination, {
         prefix,
         context: "Argument 1",
@@ -5079,7 +5079,7 @@ class ReadableStreamDefaultReader {
   /** @param {ReadableStream<R>} stream */
   constructor(stream) {
     const prefix = "Failed to construct 'ReadableStreamDefaultReader'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     stream = webidl.converters.ReadableStream(stream, {
       prefix,
       context: "Argument 1",
@@ -5179,7 +5179,7 @@ class ReadableStreamBYOBReader {
   /** @param {ReadableStream<R>} stream */
   constructor(stream) {
     const prefix = "Failed to construct 'ReadableStreamBYOBReader'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     stream = webidl.converters.ReadableStream(stream, {
       prefix,
       context: "Argument 1",
@@ -5321,7 +5321,7 @@ class ReadableStreamBYOBRequest {
   respond(bytesWritten) {
     webidl.assertBranded(this, ReadableStreamBYOBRequestPrototype);
     const prefix = "Failed to execute 'respond' on 'ReadableStreamBYOBRequest'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     bytesWritten = webidl.converters["unsigned long long"](bytesWritten, {
       enforceRange: true,
       prefix,
@@ -5354,7 +5354,7 @@ class ReadableStreamBYOBRequest {
     webidl.assertBranded(this, ReadableStreamBYOBRequestPrototype);
     const prefix =
       "Failed to execute 'respondWithNewView' on 'ReadableStreamBYOBRequest'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     view = webidl.converters.ArrayBufferView(view, {
       prefix,
       context: "Argument 1",
@@ -5448,7 +5448,7 @@ class ReadableByteStreamController {
     webidl.assertBranded(this, ReadableByteStreamControllerPrototype);
     const prefix =
       "Failed to execute 'enqueue' on 'ReadableByteStreamController'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     const arg1 = "Argument 1";
     chunk = webidl.converters.ArrayBufferView(chunk, {
       prefix,
@@ -6038,7 +6038,7 @@ class WritableStreamDefaultWriter {
    */
   constructor(stream) {
     const prefix = "Failed to construct 'WritableStreamDefaultWriter'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     stream = webidl.converters.WritableStream(stream, {
       prefix,
       context: "Argument 1",

--- a/ext/web/09_file.js
+++ b/ext/web/09_file.js
@@ -492,7 +492,7 @@ class File extends Blob {
    */
   constructor(fileBits, fileName, options = {}) {
     const prefix = "Failed to construct 'File'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
 
     fileBits = webidl.converters["sequence<BlobPart>"](fileBits, {
       context: "Argument 1",

--- a/ext/web/10_filereader.js
+++ b/ext/web/10_filereader.js
@@ -352,7 +352,7 @@ class FileReader extends EventTarget {
   readAsArrayBuffer(blob) {
     webidl.assertBranded(this, FileReaderPrototype);
     const prefix = "Failed to execute 'readAsArrayBuffer' on 'FileReader'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     this.#readOperation(blob, { kind: "ArrayBuffer" });
   }
 
@@ -360,7 +360,7 @@ class FileReader extends EventTarget {
   readAsBinaryString(blob) {
     webidl.assertBranded(this, FileReaderPrototype);
     const prefix = "Failed to execute 'readAsBinaryString' on 'FileReader'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     // alias for readAsArrayBuffer
     this.#readOperation(blob, { kind: "BinaryString" });
   }
@@ -369,7 +369,7 @@ class FileReader extends EventTarget {
   readAsDataURL(blob) {
     webidl.assertBranded(this, FileReaderPrototype);
     const prefix = "Failed to execute 'readAsDataURL' on 'FileReader'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     // alias for readAsArrayBuffer
     this.#readOperation(blob, { kind: "DataUrl" });
   }
@@ -381,7 +381,7 @@ class FileReader extends EventTarget {
   readAsText(blob, encoding = undefined) {
     webidl.assertBranded(this, FileReaderPrototype);
     const prefix = "Failed to execute 'readAsText' on 'FileReader'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     if (encoding !== undefined) {
       encoding = webidl.converters["DOMString"](encoding, {
         prefix,

--- a/ext/web/11_blob_url.js
+++ b/ext/web/11_blob_url.js
@@ -23,7 +23,7 @@ import { URL } from "ext:deno_url/00_url.js";
  */
 function createObjectURL(blob) {
   const prefix = "Failed to execute 'createObjectURL' on 'URL'";
-  webidl.requiredArguments(arguments.length, 1, { prefix });
+  webidl.requiredArguments(arguments.length, 1, prefix);
   blob = webidl.converters["Blob"](blob, {
     context: "Argument 1",
     prefix,
@@ -38,7 +38,7 @@ function createObjectURL(blob) {
  */
 function revokeObjectURL(url) {
   const prefix = "Failed to execute 'revokeObjectURL' on 'URL'";
-  webidl.requiredArguments(arguments.length, 1, { prefix });
+  webidl.requiredArguments(arguments.length, 1, prefix);
   url = webidl.converters["DOMString"](url, {
     context: "Argument 1",
     prefix,

--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -100,7 +100,7 @@ class MessagePort extends EventTarget {
   postMessage(message, transferOrOptions = {}) {
     webidl.assertBranded(this, MessagePortPrototype);
     const prefix = "Failed to execute 'postMessage' on 'MessagePort'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     message = webidl.converters.any(message);
     let options;
     if (
@@ -329,7 +329,7 @@ webidl.converters.StructuredSerializeOptions = webidl
 
 function structuredClone(value, options) {
   const prefix = "Failed to execute 'structuredClone'";
-  webidl.requiredArguments(arguments.length, 1, { prefix });
+  webidl.requiredArguments(arguments.length, 1, prefix);
   options = webidl.converters.StructuredSerializeOptions(options, {
     prefix,
     context: "Argument 2",

--- a/ext/web/14_compression.js
+++ b/ext/web/14_compression.js
@@ -28,7 +28,7 @@ class CompressionStream {
 
   constructor(format) {
     const prefix = "Failed to construct 'CompressionStream'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     format = webidl.converters.CompressionFormat(format, {
       prefix,
       context: "Argument 1",
@@ -76,7 +76,7 @@ class DecompressionStream {
 
   constructor(format) {
     const prefix = "Failed to construct 'DecompressionStream'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     format = webidl.converters.CompressionFormat(format, {
       prefix,
       context: "Argument 1",

--- a/ext/web/15_performance.js
+++ b/ext/web/15_performance.js
@@ -219,7 +219,7 @@ class PerformanceMark extends PerformanceEntry {
     options = {},
   ) {
     const prefix = "Failed to construct 'PerformanceMark'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     name = webidl.converters.DOMString(name, {
       prefix,
@@ -394,7 +394,7 @@ class Performance extends EventTarget {
   ) {
     webidl.assertBranded(this, PerformancePrototype);
     const prefix = "Failed to execute 'getEntriesByName' on 'Performance'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     name = webidl.converters.DOMString(name, {
       prefix,
@@ -414,7 +414,7 @@ class Performance extends EventTarget {
   getEntriesByType(type) {
     webidl.assertBranded(this, PerformancePrototype);
     const prefix = "Failed to execute 'getEntriesByName' on 'Performance'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     type = webidl.converters.DOMString(type, {
       prefix,
@@ -430,7 +430,7 @@ class Performance extends EventTarget {
   ) {
     webidl.assertBranded(this, PerformancePrototype);
     const prefix = "Failed to execute 'mark' on 'Performance'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     markName = webidl.converters.DOMString(markName, {
       prefix,
@@ -458,7 +458,7 @@ class Performance extends EventTarget {
   ) {
     webidl.assertBranded(this, PerformancePrototype);
     const prefix = "Failed to execute 'measure' on 'Performance'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
 
     measureName = webidl.converters.DOMString(measureName, {
       prefix,

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -642,11 +642,9 @@ converters["sequence<DOMString>"] = createSequenceConverter(
   converters.DOMString,
 );
 
-function requiredArguments(length, required, opts = {}) {
+function requiredArguments(length, required) {
   if (length < required) {
-    const errMsg = `${
-      opts.prefix ? opts.prefix + ": " : ""
-    }${required} argument${
+    const errMsg = `${prefix ? prefix + ": " : ""}${required} argument${
       required === 1 ? "" : "s"
     } required, but only ${length} present.`;
     throw new TypeError(errMsg);

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -642,7 +642,7 @@ converters["sequence<DOMString>"] = createSequenceConverter(
   converters.DOMString,
 );
 
-function requiredArguments(length, required) {
+function requiredArguments(length, required, prefix) {
   if (length < required) {
     const errMsg = `${prefix ? prefix + ": " : ""}${required} argument${
       required === 1 ? "" : "s"

--- a/ext/webidl/internal.d.ts
+++ b/ext/webidl/internal.d.ts
@@ -206,7 +206,7 @@ declare module "ext:deno_webidl/00_webidl.js" {
   function requiredArguments(
     length: number,
     required: number,
-    opts: ConverterOpts,
+    prefix: string,
   ): void;
   type Dictionary = DictionaryMember[];
   interface DictionaryMember {

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -172,9 +172,7 @@ class WebSocket extends EventTarget {
     super();
     this[webidl.brand] = webidl.brand;
     const prefix = "Failed to construct 'WebSocket'";
-    webidl.requiredArguments(arguments.length, 1, {
-      prefix,
-    });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     url = webidl.converters.USVString(url, {
       prefix,
       context: "Argument 1",
@@ -301,9 +299,7 @@ class WebSocket extends EventTarget {
     webidl.assertBranded(this, WebSocketPrototype);
     const prefix = "Failed to execute 'send' on 'WebSocket'";
 
-    webidl.requiredArguments(arguments.length, 1, {
-      prefix,
-    });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     data = webidl.converters.WebSocketSend(data, {
       prefix,
       context: "Argument 1",

--- a/ext/websocket/02_websocketstream.js
+++ b/ext/websocket/02_websocketstream.js
@@ -87,7 +87,7 @@ class WebSocketStream {
   constructor(url, options) {
     this[webidl.brand] = webidl.brand;
     const prefix = "Failed to construct 'WebSocketStream'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     url = webidl.converters.USVString(url, {
       prefix,
       context: "Argument 1",

--- a/ext/webstorage/01_webstorage.js
+++ b/ext/webstorage/01_webstorage.js
@@ -35,7 +35,7 @@ class Storage {
   key(index) {
     webidl.assertBranded(this, StoragePrototype);
     const prefix = "Failed to execute 'key' on 'Storage'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     index = webidl.converters["unsigned long"](index, {
       prefix,
       context: "Argument 1",
@@ -47,7 +47,7 @@ class Storage {
   setItem(key, value) {
     webidl.assertBranded(this, StoragePrototype);
     const prefix = "Failed to execute 'setItem' on 'Storage'";
-    webidl.requiredArguments(arguments.length, 2, { prefix });
+    webidl.requiredArguments(arguments.length, 2, prefix);
     key = webidl.converters.DOMString(key, {
       prefix,
       context: "Argument 1",
@@ -63,7 +63,7 @@ class Storage {
   getItem(key) {
     webidl.assertBranded(this, StoragePrototype);
     const prefix = "Failed to execute 'getItem' on 'Storage'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     key = webidl.converters.DOMString(key, {
       prefix,
       context: "Argument 1",
@@ -75,7 +75,7 @@ class Storage {
   removeItem(key) {
     webidl.assertBranded(this, StoragePrototype);
     const prefix = "Failed to execute 'removeItem' on 'Storage'";
-    webidl.requiredArguments(arguments.length, 1, { prefix });
+    webidl.requiredArguments(arguments.length, 1, prefix);
     key = webidl.converters.DOMString(key, {
       prefix,
       context: "Argument 1",


### PR DESCRIPTION
This should produce a little less garbage and using an object here wasn't
really required.