### PR TITLE
ci: use non-XL runners more

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -874,7 +874,7 @@ const ci = {
           name: "Save cache build output (main)",
           uses: "actions/cache/save@v3",
           if:
-            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main' || startsWith(matrix.os, 'ubuntu')", // todo(dsherret): revert
+            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
           with: {
             path: [
               "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -2,8 +2,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as yaml from "https://deno.land/std@0.173.0/encoding/yaml.ts";
 
-const windowsRunnerCondition =
-  "github.repository == 'denoland/deno' && 'windows-2022-xl' || 'windows-2022'";
+const windowsRunnerCondition = "'windows-2022'";
 const Runners = {
   linux:
     "${{ github.repository == 'denoland/deno' && 'ubuntu-22.04-xl' || 'ubuntu-22.04' }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -846,7 +846,7 @@ const ci = {
           name: "Save cache build output (main)",
           uses: "actions/cache/save@v3",
           if:
-            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
+            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main' || startsWith(matrix.os, 'windows')", // todo: revert
           with: {
             path: [
               "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -3,7 +3,6 @@
 import * as yaml from "https://deno.land/std@0.173.0/encoding/yaml.ts";
 
 const Runners = (() => {
-  const windowsRunner = "windows-2022";
   const ubuntuRunner = "ubuntu-22.04";
   const ubuntuXlRunner = "ubuntu-22.04-xl";
 
@@ -13,7 +12,7 @@ const Runners = (() => {
     ubuntu: ubuntuRunner,
     linux: ubuntuRunner,
     macos: "macos-12",
-    windows: windowsRunner,
+    windows: "windows-2022",
   };
 })();
 // bump the number at the start when you want to purge the cache
@@ -191,7 +190,11 @@ function withCondition(
 }
 
 function removeSurroundingExpression(text: string) {
-  return text.replace(/^${{/, "").replace(/}}$/, "");
+  if (text.startsWith("${{")) {
+    return text.replace(/^\${{/, "").replace(/}}$/, "").trim();
+  } else {
+    return `'${text}'`;
+  }
 }
 
 function handleMatrixItems(items: {
@@ -209,7 +212,9 @@ function handleMatrixItems(items: {
       if (typeof item.skip_pr === "string") {
         text += removeSurroundingExpression(item.skip_pr.toString()) + " && ";
       }
-      text += `'${Runners.ubuntu}' || '${item.os}' }}`;
+      text += `'${Runners.ubuntu}' || ${
+        removeSurroundingExpression(item.os)
+      } }}`;
       // deno-lint-ignore: no-explicit-any
       (item as any).runner = text;
     }

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -205,6 +205,18 @@ function handleMatrixItems(items: {
   use_sysroot?: boolean;
   wpt?: string;
 }[]) {
+  function getOsDisplayName(os: string) {
+    if (os.includes("ubuntu")) {
+      return "ubuntu-x86_64";
+    } else if (os.includes("windows")) {
+      return "windows-x86_64";
+    } else if (os.includes("macos")) {
+      return "macos-x86_64";
+    } else {
+      throw new Error(`Display name not found: ${os}`);
+    }
+  }
+
   return items.map((item) => {
     // use a free "ubuntu" runner on jobs that are skipped on pull requests
     if (item.skip_pr != null) {
@@ -219,7 +231,10 @@ function handleMatrixItems(items: {
       // deno-lint-ignore no-explicit-any
       (item as any).runner = text;
     }
-    return item;
+    return {
+      ...item,
+      os_display_name: getOsDisplayName(item.os),
+    };
   });
 }
 
@@ -268,7 +283,8 @@ const ci = {
       ]),
     },
     build: {
-      name: "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}",
+      name:
+        "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os_display_name }}",
       needs: ["pre_build"],
       if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
       "runs-on": "${{ matrix.runner || matrix.os }}",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -846,7 +846,7 @@ const ci = {
           name: "Save cache build output (main)",
           uses: "actions/cache/save@v3",
           if:
-            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main' || startsWith(matrix.os, 'windows')", // todo: revert
+            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main' || startsWith(matrix.os, 'windows')", // todo(dsherret): revert
           with: {
             path: [
               "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -215,7 +215,8 @@ function handleMatrixItems(items: {
       text += `'${Runners.ubuntu}' || ${
         removeSurroundingExpression(item.os)
       } }}`;
-      // deno-lint-ignore: no-explicit-any
+
+      // deno-lint-ignore no-explicit-any
       (item as any).runner = text;
     }
     return item;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,15 @@ jobs:
             job: test
             profile: release
             skip_pr: true
-          - os: '${{ ''windows-2022'' }}'
+            runner: '${{ github.event_name == ''pull_request'' && ''ubuntu-22.04'' || ''macos-12'' }}'
+          - os: windows-2022
             job: test
             profile: debug
-          - os: '${{ ''windows-2022'' }}'
-            runner: '${{ github.event_name == ''pull_request'' && ''windows-2022'' || (''windows-2022'') }}'
+          - os: windows-2022
             job: test
             profile: release
             skip_pr: true
+            runner: '${{ github.event_name == ''pull_request'' && ''ubuntu-22.04'' || ''windows-2022'' }}'
           - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: test
             profile: release
@@ -78,12 +79,13 @@ jobs:
             profile: release
             use_sysroot: true
             skip_pr: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-bench'') }}'
-          - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
+            runner: '${{ github.event_name == ''pull_request'' && ${{ !contains(github.event.pull_request.labels.*.name, ''ci-bench'')  && ''ubuntu-22.04'' || ''${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'' }}'
+          - os: ubuntu-22.04
             job: test
             profile: debug
             use_sysroot: true
             wpt: '${{ github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'') }}'
-          - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
+          - os: ubuntu-22.04
             job: lint
             profile: debug
       fail-fast: '${{ github.event_name == ''pull_request'' || (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')) }}'
@@ -562,7 +564,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'' || startsWith(matrix.os, ''windows''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'' || startsWith(matrix.os, ''ubuntu''))'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             profile: release
             use_sysroot: true
             skip_pr: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-bench'') }}'
-            runner: '${{ github.event_name == ''pull_request'' && ${{ !contains(github.event.pull_request.labels.*.name, ''ci-bench'')  && ''ubuntu-22.04'' || ''${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'' }}'
+            runner: '${{ github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench'') && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
           - os: ubuntu-22.04
             job: test
             profile: debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,7 +562,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'')'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'' || startsWith(matrix.os, ''windows''))'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'' || startsWith(matrix.os, ''ubuntu''))'
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'')'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
         if: github.event.pull_request.draft == true
   build:
-    name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}'
+    name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os_display_name }}'
     needs:
       - pre_build
     if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
@@ -56,38 +56,46 @@ jobs:
           - os: macos-12
             job: test
             profile: debug
+            os_display_name: macos-x86_64
           - os: macos-12
             job: test
             profile: release
             skip_pr: true
             runner: '${{ github.event_name == ''pull_request'' && ''ubuntu-22.04'' || ''macos-12'' }}'
+            os_display_name: macos-x86_64
           - os: windows-2022
             job: test
             profile: debug
+            os_display_name: windows-x86_64
           - os: windows-2022
             job: test
             profile: release
             skip_pr: true
             runner: '${{ github.event_name == ''pull_request'' && ''ubuntu-22.04'' || ''windows-2022'' }}'
+            os_display_name: windows-x86_64
           - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: test
             profile: release
             use_sysroot: true
             wpt: '${{ !startsWith(github.ref, ''refs/tags/'') }}'
+            os_display_name: ubuntu-x86_64
           - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: bench
             profile: release
             use_sysroot: true
             skip_pr: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-bench'') }}'
             runner: '${{ github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench'') && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
+            os_display_name: ubuntu-x86_64
           - os: ubuntu-22.04
             job: test
             profile: debug
             use_sysroot: true
             wpt: '${{ github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'') }}'
+            os_display_name: ubuntu-x86_64
           - os: ubuntu-22.04
             job: lint
             profile: debug
+            os_display_name: ubuntu-x86_64
       fail-fast: '${{ github.event_name == ''pull_request'' || (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')) }}'
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,11 @@ jobs:
             job: test
             profile: release
             skip_pr: true
-          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+          - os: '${{ ''windows-2022'' }}'
             job: test
             profile: debug
-          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
-            runner: '${{ github.event_name == ''pull_request'' && ''windows-2022'' || (github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'') }}'
+          - os: '${{ ''windows-2022'' }}'
+            runner: '${{ github.event_name == ''pull_request'' && ''windows-2022'' || (''windows-2022'') }}'
             job: test
             profile: release
             skip_pr: true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1609021/231593822-b9d7c9db-4416-4735-bd89-f28a260607f1.png)

Non-xl runners are faster than the linux xl job, so let's use them for now

Closes #17103