### PR TITLE
bench: add benchmark for deferred async ops

### DIFF
--- a/cli/bench/async_ops_deferred.js
+++ b/cli/bench/async_ops_deferred.js
@@ -1,0 +1,20 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
+let [total, count] = typeof Deno !== "undefined"
+  ? Deno.args
+  : [process.argv[2], process.argv[3]];
+
+total = total ? parseInt(total, 0) : 50;
+count = count ? parseInt(count, 10) : 1000000;
+
+async function bench(fun) {
+  const start = Date.now();
+  for (let i = 0; i < count; i++) await fun();
+  const elapsed = Date.now() - start;
+  const rate = Math.floor(count / (elapsed / 1000));
+  console.log(`time ${elapsed} ms rate ${rate}`);
+  if (--total) queueMicrotask(() => bench(fun));
+}
+
+const core = Deno[Deno.internal].core;
+bench(() => core.opAsync("op_void_async_deferred"));

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -28,6 +28,7 @@ crate::extension!(
     op_wasm_streaming_set_url,
     op_void_sync,
     op_void_async,
+    op_void_async_deferred,
     op_add,
     // TODO(@AaronO): track IO metrics for builtin streams
     op_read,
@@ -98,6 +99,9 @@ pub fn op_void_sync() {}
 
 #[op]
 pub async fn op_void_async() {}
+
+#[op(deferred)]
+pub async fn op_void_async_deferred() {}
 
 /// Remove a resource from the resource table.
 #[op]


### PR DESCRIPTION
```
./target/release/deno run cli/bench/async_ops_deferred.js
time 794 ms rate 1259445
time 786 ms rate 1272264
time 770 ms rate 1298701
time 784 ms rate 1275510
time 775 ms rate 1290322
time 786 ms rate 1272264
time 773 ms rate 1293661
time 771 ms rate 1297016
time 774 ms rate 1291989
time 767 ms rate 1303780
time 764 ms rate 1308900
time 768 ms rate 1302083
time 763 ms rate 1310615
time 761 ms rate 1314060
time 761 ms rate 1314060
time 762 ms rate 1312335
time 763 ms rate 1310615
time 759 ms rate 1317523
time 760 ms rate 1315789
time 761 ms rate 1314060
time 769 ms rate 1300390
time 763 ms rate 1310615
time 760 ms rate 1315789
time 763 ms rate 1310615
time 761 ms rate 1314060
time 759 ms rate 1317523
time 765 ms rate 1307189
time 760 ms rate 1315789
time 764 ms rate 1308900
time 763 ms rate 1310615
time 760 ms rate 1315789
time 757 ms rate 1321003
time 763 ms rate 1310615
time 759 ms rate 1317523
time 771 ms rate 1297016
time 759 ms rate 1317523
time 759 ms rate 1317523
time 763 ms rate 1310615
time 754 ms rate 1326259
time 755 ms rate 1324503
time 762 ms rate 1312335
time 752 ms rate 1329787
time 755 ms rate 1324503
time 754 ms rate 1326259
time 759 ms rate 1317523
time 754 ms rate 1326259
time 749 ms rate 1335113
time 753 ms rate 1328021
time 756 ms rate 1322751
time 753 ms rate 1328021
```

```
samply record -r 20000 target/release/deno run cli/bench/async_ops_deferred.js
```

https://share.firefox.dev/43Efvm6