### PR TITLE
fix(ext/node): polyfill response._implicitHeader method

### DIFF
--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -1,9 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import http from "node:http";
-import {
-  assertEquals,
-} from "../../../test_util/std/testing/asserts.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 import { assertSpyCalls, spy } from "../../../test_util/std/testing/mock.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
 

--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -1,0 +1,33 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import http from "node:http";
+import {
+  assert,
+  assertEquals,
+  assertFalse,
+} from "../../../test_util/std/testing/asserts.ts";
+import { assertSpyCalls, spy } from "../../../test_util/std/testing/mock.ts";
+import { deferred } from "../../../test_util/std/async/deferred.ts";
+
+Deno.test("[node/http] ServerResponse _implicitHeader", async () => {
+  const d = deferred<void>();
+  const server = http.createServer((_req, res) => {
+    const writeHeadSpy = spy(res, "writeHead");
+    // deno-lint-ignore no-implicit-any
+    (res as any)._implicitHeader();
+    assertSpyCalls(writeHeadSpy, 1);
+    writeHeadSpy.restore();
+    res.end("Hello World");
+  });
+
+  server.listen(async () => {
+    const { port } = server.address() as { port: number };
+    const res = await fetch(`http://localhost:${port}`);
+    assertEquals(await res.text(), "Hello World");
+    server.close(() => {
+      d.resolve();
+    });
+  });
+
+  await d;
+});

--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -2,9 +2,7 @@
 
 import http from "node:http";
 import {
-  assert,
   assertEquals,
-  assertFalse,
 } from "../../../test_util/std/testing/asserts.ts";
 import { assertSpyCalls, spy } from "../../../test_util/std/testing/mock.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
@@ -13,7 +11,7 @@ Deno.test("[node/http] ServerResponse _implicitHeader", async () => {
   const d = deferred<void>();
   const server = http.createServer((_req, res) => {
     const writeHeadSpy = spy(res, "writeHead");
-    // deno-lint-ignore no-implicit-any
+    // deno-lint-ignore no-explicit-any
     (res as any)._implicitHeader();
     assertSpyCalls(writeHeadSpy, 1);
     writeHeadSpy.restore();

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -485,7 +485,7 @@ export class ServerResponse extends NodeWritable {
     return this.#headers.has(name);
   }
 
-  writeHead(status: number, headers: Record<string, string>) {
+  writeHead(status: number, headers: Record<string, string> = {}) {
     this.statusCode = status;
     for (const k in headers) {
       if (Object.hasOwn(headers, k)) {
@@ -539,6 +539,11 @@ export class ServerResponse extends NodeWritable {
 
     // @ts-expect-error The signature for cb is stricter than the one implemented here
     return super.end(chunk, encoding, cb);
+  }
+
+  // Undocumented API used by `npm:compression`.
+  _implicitHeader() {
+    this.writeHead(this.statusCode);
   }
 }
 


### PR DESCRIPTION
This PR polyfills `ServerResponse.prototype._implicitHeader` private API of Node.js, which is used by `npm:compression` (ref: [source](https://github.com/expressjs/compression/blob/ad5113b98cafe1382a0ece30bb4673707ac59ce7/index.js#L84)), which is a dependency of `npm:json-server`.

closes #18325