### PR TITLE
fix(core): Wrap safe collections' argument of primordials

### DIFF
--- a/core/00_primordials.js
+++ b/core/00_primordials.js
@@ -405,7 +405,11 @@
     Map,
     class SafeMap extends Map {
       constructor(i) {
-        super(i);
+        if (i == null) {
+          super();
+          return;
+        }
+        super(new SafeArrayIterator(i));
       }
     },
   );
@@ -413,7 +417,11 @@
     WeakMap,
     class SafeWeakMap extends WeakMap {
       constructor(i) {
-        super(i);
+        if (i == null) {
+          super();
+          return;
+        }
+        super(new SafeArrayIterator(i));
       }
     },
   );
@@ -422,7 +430,11 @@
     Set,
     class SafeSet extends Set {
       constructor(i) {
-        super(i);
+        if (i == null) {
+          super();
+          return;
+        }
+        super(new SafeArrayIterator(i));
       }
     },
   );
@@ -430,7 +442,11 @@
     WeakSet,
     class SafeWeakSet extends WeakSet {
       constructor(i) {
-        super(i);
+        if (i == null) {
+          super();
+          return;
+        }
+        super(new SafeArrayIterator(i));
       }
     },
   );

--- a/ext/console/02_console.js
+++ b/ext/console/02_console.js
@@ -56,7 +56,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   SafeStringIterator,
-  SafeSet,
+  SafeSetIterator,
   SafeRegExp,
   SetPrototype,
   SetPrototypeEntries,
@@ -2158,7 +2158,7 @@ class Console {
     const indexKey = isSet || isMap ? "(iter idx)" : "(idx)";
 
     if (isSet) {
-      resultData = [...new SafeSet(data)];
+      resultData = [...new SafeSetIterator(data)];
     } else if (isMap) {
       let idx = 0;
       resultData = {};


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Collections such as `Set` cause prototype pollution by [treating argument as a iterable](https://tc39.es/ecma262/#sec-set-iterable).

```js
// prototype pollution
const original = Array.prototype[Symbol.iterator];
Array.prototype[Symbol.iterator] = function (...args) { console.log("bang!"); return original.apply(this, args); }

// current primordials
new SafeSet([1, 2, 3]); // bang!
```

This PR fix that situation. It affects performance, but the scope should be quite limited.