### PR TITLE
fix(ext/node): add crypto.sign|verify methods

### DIFF
--- a/cli/tests/unit_node/crypto_sign_test.ts
+++ b/cli/tests/unit_node/crypto_sign_test.ts
@@ -4,7 +4,7 @@ import {
   assert,
   assertEquals,
 } from "../../../test_util/std/testing/asserts.ts";
-import { createSign, createVerify } from "node:crypto";
+import { createSign, createVerify, sign, verify } from "node:crypto";
 import { Buffer } from "node:buffer";
 
 const rsaPrivatePem = Buffer.from(
@@ -41,30 +41,47 @@ const table = [
   },
 ];
 
+const data = Buffer.from("some data to sign");
+
 Deno.test({
-  name: "crypto.Sign - RSA PEM with SHA224, SHA256, SHA384, SHA512 digests",
+  name:
+    "crypto.Sign|sign - RSA PEM with SHA224, SHA256, SHA384, SHA512 digests",
   fn() {
     for (const testCase of table) {
       for (const algorithm of testCase.algorithms) {
-        const signature = createSign(algorithm)
-          .update("some data to sign")
-          .sign(rsaPrivatePem, "hex");
-        assertEquals(signature, testCase.signature);
+        assertEquals(
+          createSign(algorithm)
+            .update(data)
+            .sign(rsaPrivatePem, "hex"),
+          testCase.signature,
+        );
+        assertEquals(
+          sign(algorithm, data, rsaPrivatePem),
+          Buffer.from(testCase.signature, "hex"),
+        );
       }
     }
   },
 });
 
 Deno.test({
-  name: "crypto.Verify - RSA PEM with SHA224, SHA256, SHA384, SHA512 digests",
+  name: "crypto.Verify|verify - RSA PEM with SHA224, SHA256, SHA384, SHA512 digests",
   fn() {
     for (const testCase of table) {
       for (const algorithm of testCase.algorithms) {
         assert(
-          createVerify(algorithm).update("some data to sign").verify(
+          createVerify(algorithm).update(data).verify(
             rsaPublicPem,
             testCase.signature,
             "hex",
+          ),
+        );
+        assert(
+          verify(
+            algorithm,
+            data,
+            rsaPublicPem,
+            Buffer.from(testCase.signature, "hex"),
           ),
         );
       }

--- a/cli/tests/unit_node/crypto_sign_test.ts
+++ b/cli/tests/unit_node/crypto_sign_test.ts
@@ -65,7 +65,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "crypto.Verify|verify - RSA PEM with SHA224, SHA256, SHA384, SHA512 digests",
+  name:
+    "crypto.Verify|verify - RSA PEM with SHA224, SHA256, SHA384, SHA512 digests",
   fn() {
     for (const testCase of table) {
       for (const algorithm of testCase.algorithms) {

--- a/ext/node/polyfills/internal/crypto/sig.ts
+++ b/ext/node/polyfills/internal/crypto/sig.ts
@@ -46,7 +46,7 @@ export interface VerifyKeyObjectInput extends SigningOptions {
 
 export type KeyLike = string | Buffer | KeyObject;
 
-export class Sign extends Writable {
+export class SignImpl extends Writable {
   hash: Hash;
   #digestType: string;
 
@@ -107,7 +107,13 @@ export class Sign extends Writable {
   }
 }
 
-export class Verify extends Writable {
+export function Sign(algorithm: string, options?: WritableOptions) {
+  return new SignImpl(algorithm, options);
+}
+
+Sign.prototype = SignImpl.prototype;
+
+export class VerifyImpl extends Writable {
   hash: Hash;
   #digestType: string;
 
@@ -169,6 +175,12 @@ export class Verify extends Writable {
   }
 }
 
+export function Verify(algorithm: string, options?: WritableOptions) {
+  return new VerifyImpl(algorithm, options);
+}
+
+Verify.prototype = VerifyImpl.prototype;
+
 export function signOneShot(
   algorithm: string | null | undefined,
   data: ArrayBufferView,
@@ -187,7 +199,7 @@ export function signOneShot(
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
   }
 
-  const result = new Sign(algorithm!).update(data).sign(key);
+  const result = Sign(algorithm!).update(data).sign(key);
 
   if (callback) {
     setTimeout(() => callback(null, result));
@@ -215,7 +227,7 @@ export function verifyOneShot(
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
   }
 
-  const result = new Verify(algorithm!).update(data).verify(key, signature);
+  const result = Verify(algorithm!).update(data).verify(key, signature);
 
   if (callback) {
     setTimeout(() => callback(null, result));


### PR DESCRIPTION
This PR adds `crypto.sign` and `crypto.verify` methods. (These are shorthands of `createSign().update().sign()` or `createVerify().update().verify()`)

This PR also changes the Sign and Verify class callable with/without `new` operator. (This behavior will be necessary when we enable `test/parallel/test-crypto-sign-verify.js`)

part of #18455 