### PR TITLE
chore(flags): add short option for `--no-prompt` flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1984,6 +1984,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("no-prompt")
+        .short('N')
         .long("no-prompt")
         .action(ArgAction::SetTrue)
         .help("Always throw if required permission wasn't passed"),


### PR DESCRIPTION
Now it's possible to run `deno repl -N`.

From `--help`:
```
  -A, --allow-all
          Allow all permissions

  -N, --no-prompt
          Always throw if required permission wasn't passed
```

- Closes #18761