### PR TITLE
fix(test): allow explicit undefined for boolean test options

### DIFF
--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -100,7 +100,9 @@ struct TestInfo<'s> {
   #[serde(rename = "fn")]
   function: serde_v8::Value<'s>,
   name: String,
+  #[serde(default)]
   ignore: bool,
+  #[serde(default)]
   only: bool,
   location: TestLocation,
 }

--- a/cli/tests/unit/testing_test.ts
+++ b/cli/tests/unit/testing_test.ts
@@ -147,3 +147,8 @@ Deno.test(async function parentOnTextContext(t1) {
     });
   });
 });
+
+Deno.test("explicit undefined for boolean options", {
+  ignore: undefined,
+  only: undefined,
+}, () => {});


### PR DESCRIPTION
Fixes #18784.