### PR TITLE
fix(ext/http): ensure that multiple upgrades and multiple simultaneous requests cannot cause a panic

### DIFF
--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -108,6 +108,10 @@ class InnerRequest {
   }
 
   _wantsUpgrade(upgradeType, ...originalArgs) {
+    if (this.#upgraded) {
+      throw new Deno.errors.Http("already upgraded");
+    }
+
     // upgradeHttp is async
     // TODO(mmastrac)
     if (upgradeType == "upgradeHttp") {

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -111,6 +111,9 @@ class InnerRequest {
     if (this.#upgraded) {
       throw new Deno.errors.Http("already upgraded");
     }
+    if (this.#slabId === undefined) {
+      throw new Deno.errors.Http("already closed");
+    }
 
     // upgradeHttp is async
     // TODO(mmastrac)
@@ -129,6 +132,8 @@ class InnerRequest {
       const response = originalArgs[0];
       const ws = originalArgs[1];
 
+      const slabId = this.#slabId;
+
       this.url();
       this.headerList;
       this.close();
@@ -144,7 +149,7 @@ class InnerRequest {
           // Returns the connection and extra bytes, which we can pass directly to op_ws_server_create
           const upgrade = await core.opAsync2(
             "op_upgrade",
-            this.#slabId,
+            slabId,
             response.headerList,
           );
           const wsRid = core.ops.op_ws_server_create(upgrade[0], upgrade[1]);

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -112,7 +112,14 @@ macro_rules! with {
       SLAB.with(|slab| {
         let mut borrow = slab.borrow_mut();
         #[allow(unused_mut)] // TODO(mmastrac): compiler issue?
-        let mut $http = borrow.get_mut(key).unwrap();
+        let mut $http = match borrow.get_mut(key) {
+          Some(http) => http,
+          None => panic!(
+            "Attemped to access invalid request {} ({} in total available)",
+            key,
+            borrow.len()
+          ),
+        };
         #[cfg(__zombie_http_tracking)]
         if !$http.alive {
           panic!("Attempted to access a dead HTTP object")


### PR DESCRIPTION
Fix a bug where we weren't saving `slabId` in #18619, plus add some robustness checks around multiple upgrades (w/test).