### PR TITLE
feat(ext/http): h2c for http/2

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -59,10 +59,18 @@ type Request = hyper1::Request<Incoming>;
 type Response = hyper1::Response<ResponseBytes>;
 
 /// All HTTP/2 connections start with this byte string.
-const HTTP2_PREFIX: &[u8] = &[
-  0x50, 0x52, 0x49, 0x20, 0x2a, 0x20, 0x48, 0x54, 0x54, 0x50, 0x2f, 0x32, 0x2e,
-  0x30, 0x0d, 0x0a,
-];
+///
+/// In HTTP/2, each endpoint is required to send a connection preface as a final confirmation
+/// of the protocol in use and to establish the initial settings for the HTTP/2 connection. The
+/// client and server each send a different connection preface.
+///
+/// The client connection preface starts with a sequence of 24 octets, which in hex notation is:
+///
+/// 0x505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
+///
+/// That is, the connection preface starts with the string PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n). This sequence
+/// MUST be followed by a SETTINGS frame (Section 6.5), which MAY be empty.
+const HTTP2_PREFIX: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 /// ALPN negotation for "h2"
 const TLS_ALPN_HTTP_2: &[u8] = b"h2";

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -1279,7 +1279,7 @@ fn maybe_extract_network_stream<
           Bytes::from(v)
         }
       };
-      return Ok((io.into(), bytes));
+      Ok((io.into(), bytes))
     }
     Err(x) => Err(x),
   }

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -78,6 +78,7 @@ use crate::reader_stream::ShutdownHandle;
 
 pub mod compressible;
 mod http_next;
+mod network_buffered_stream;
 mod reader_stream;
 mod request_body;
 mod request_properties;

--- a/ext/http/network_buffered_stream.rs
+++ b/ext/http/network_buffered_stream.rs
@@ -1,0 +1,235 @@
+use std::io;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::task::Poll;
+
+use deno_core::futures::future::poll_fn;
+use deno_core::futures::ready;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+
+const MAX_PREFIX_SIZE: usize = 256;
+
+struct NetworkStreamPrefixCheck<S: AsyncRead + Unpin> {
+  io: S,
+  prefix: &'static [u8],
+  buffer: [MaybeUninit<u8>; MAX_PREFIX_SIZE * 2],
+}
+
+impl <S: AsyncRead + Unpin> NetworkStreamPrefixCheck<S> {
+  pub fn new(io: S, prefix: &'static [u8]) -> Self {
+    debug_assert!(prefix.len() < MAX_PREFIX_SIZE);
+    Self {
+      io,
+      prefix,
+      buffer: [MaybeUninit::<u8>::uninit(); MAX_PREFIX_SIZE * 2],
+    }
+  }
+
+  // Returns a [`NetworkBufferedStream`], rewound with the bytes we read to determine what
+  // type of stream this is.
+  pub async fn match_prefix(self) -> io::Result<(bool, NetworkBufferedStream<S>)> {
+    let mut buffer = self.buffer;
+    let mut readbuf = ReadBuf::uninit(&mut buffer);
+    let mut io = self.io;
+    let prefix = self.prefix;
+    loop {
+      enum State {
+        Unknown,
+        Matched,
+        NotMatched,
+      }
+
+      let state = poll_fn(|cx| {
+        let filled_len = readbuf.filled().len();
+        let res = ready!(Pin::new(&mut io).poll_read(cx, &mut readbuf));
+        if let Err(e) = res {
+          return Poll::Ready(Err(e));
+        }
+        let filled = readbuf.filled();
+        let new_len = filled.len();
+        if new_len == filled_len {
+          // Empty read, no match
+          return Poll::Ready(Ok(State::NotMatched));
+        } else if new_len < prefix.len() {
+          // Read less than prefix, make sure we're still matching the prefix (early exit)
+          if !prefix.starts_with(filled) {
+            return Poll::Ready(Ok(State::NotMatched));
+          }
+        } else if new_len >= prefix.len() {
+          // We have enough to determine
+          if filled.starts_with(prefix) {
+            return Poll::Ready(Ok(State::Matched));
+          } else {
+            return Poll::Ready(Ok(State::NotMatched));
+          }
+        }
+
+        Poll::Ready(Ok(State::Unknown))
+      })
+      .await?;
+
+      match state {
+        State::Unknown => continue,
+        State::Matched => {
+          let initialized_len = readbuf.filled().len();
+          return Ok((
+            true,
+            NetworkBufferedStream::new(io, buffer, initialized_len),
+          ))
+        }
+        State::NotMatched => {
+          let initialized_len = readbuf.filled().len();
+          return Ok((
+            false,
+            NetworkBufferedStream::new(io, buffer, initialized_len),
+          ))
+        }
+      }
+    }
+  }
+}
+
+struct NetworkBufferedStream<S: AsyncRead + Unpin> {
+  io: S,
+  initialized_len: usize,
+  prefix_offset: usize,
+  prefix: [MaybeUninit<u8>; MAX_PREFIX_SIZE * 2],
+  prefix_read: bool,
+}
+
+impl <S: AsyncRead + Unpin> NetworkBufferedStream<S> {
+  fn new(
+    io: S,
+    prefix: [MaybeUninit<u8>; MAX_PREFIX_SIZE * 2],
+    initialized_len: usize,
+  ) -> Self {
+    Self {
+      io,
+      initialized_len,
+      prefix_offset: 0,
+      prefix,
+      prefix_read: false,
+    }
+  }
+}
+
+impl <S: AsyncRead + Unpin> AsyncRead for NetworkBufferedStream<S> {
+  // From hyper's Rewind (https://github.com/hyperium/hyper), MIT License, Copyright (c) Sean McArthur
+  fn poll_read(
+    mut self: Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+    buf: &mut ReadBuf<'_>,
+  ) -> Poll<std::io::Result<()>> {
+    if !self.prefix_read {
+      // We trust that these bytes are initialized properly
+      let slice = &self.prefix[self.prefix_offset..self.initialized_len];
+
+      // This guarantee comes from slice_assume_init_ref (we can't use that until it's stable)
+      // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
+      // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
+      // The pointer obtained is valid since it refers to memory owned by `slice` which is a
+      // reference and thus guaranteed to be valid for reads.
+      let prefix = unsafe { &*(slice as *const [_] as *const [u8]) };
+
+      // If there are no remaining bytes, let the bytes get dropped.
+      if !prefix.is_empty() {
+        let copy_len = std::cmp::min(prefix.len(), buf.remaining());
+        buf.put_slice(&prefix[..copy_len]);
+        self.prefix_offset += copy_len;
+
+        return Poll::Ready(Ok(()));
+      } else {
+        self.prefix_read = true;
+      }
+    }
+    Pin::new(&mut self.io).poll_read(cx, buf)
+  }
+}
+
+impl <S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for NetworkBufferedStream<S> {
+  fn poll_write(
+    mut self: Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+    buf: &[u8],
+  ) -> std::task::Poll<Result<usize, std::io::Error>> {
+    Pin::new(&mut self.io).poll_write(cx, buf)
+  }
+
+  fn poll_flush(
+    mut self: Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+  ) -> std::task::Poll<Result<(), std::io::Error>> {
+    Pin::new(&mut self.io).poll_flush(cx)
+  }
+
+  fn poll_shutdown(
+    mut self: Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+  ) -> std::task::Poll<Result<(), std::io::Error>> {
+    Pin::new(&mut self.io).poll_shutdown(cx)
+  }
+
+  fn is_write_vectored(&self) -> bool {
+    self.io.is_write_vectored()
+  }
+
+  fn poll_write_vectored(
+    mut self: Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+    bufs: &[std::io::IoSlice<'_>],
+  ) -> std::task::Poll<Result<usize, std::io::Error>> {
+    Pin::new(&mut self.io).poll_write_vectored(cx, bufs)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use tokio::io::AsyncReadExt;
+  use super::*;
+
+  #[tokio::test]
+  async fn matches_prefix_simple() -> io::Result<()> {
+    let buf = b"prefix match".as_slice();
+    let (matches, mut io) = NetworkStreamPrefixCheck::new(buf, b"prefix").match_prefix().await?;
+    assert!(matches);
+    let mut s = String::new();
+    Pin::new(&mut io).read_to_string(&mut s).await?;
+    assert_eq!(s, "prefix match");
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn matches_prefix_exact() -> io::Result<()> {
+    let buf = b"prefix".as_slice();
+    let (matches, mut io) = NetworkStreamPrefixCheck::new(buf, b"prefix").match_prefix().await?;
+    assert!(matches);
+    let mut s = String::new();
+    Pin::new(&mut io).read_to_string(&mut s).await?;
+    assert_eq!(s, "prefix");
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn not_matches_prefix_simple() -> io::Result<()> {
+    let buf = b"prefill match".as_slice();
+    let (matches, mut io) = NetworkStreamPrefixCheck::new(buf, b"prefix").match_prefix().await?;
+    assert!(!matches);
+    let mut s = String::new();
+    Pin::new(&mut io).read_to_string(&mut s).await?;
+    assert_eq!(s, "prefill match");
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn not_matches_prefix_empty() -> io::Result<()> {
+    let buf = b"".as_slice();
+    let (matches, mut io) = NetworkStreamPrefixCheck::new(buf, b"prefix").match_prefix().await?;
+    assert!(!matches);
+    let mut s = String::new();
+    Pin::new(&mut io).read_to_string(&mut s).await?;
+    assert_eq!(s, "");
+    Ok(())
+  }
+}

--- a/ext/http/network_buffered_stream.rs
+++ b/ext/http/network_buffered_stream.rs
@@ -128,8 +128,8 @@ impl<S: AsyncRead + Unpin> NetworkBufferedStream<S> {
     // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
     // The pointer obtained is valid since it refers to memory owned by `slice` which is a
     // reference and thus guaranteed to be valid for reads.
-    let prefix = unsafe { &*(slice as *const [_] as *const [u8]) };
-    prefix
+
+    unsafe { &*(slice as *const [_] as *const [u8]) as _ }
   }
 
   pub fn into_inner(self) -> (S, Bytes) {

--- a/ext/net/raw.rs
+++ b/ext/net/raw.rs
@@ -30,6 +30,25 @@ pub enum NetworkStream {
   Unix(#[pin] UnixStream),
 }
 
+impl From<TcpStream> for NetworkStream {
+  fn from(value: TcpStream) -> Self {
+    NetworkStream::Tcp(value)
+  }
+}
+
+impl From<TlsStream> for NetworkStream {
+  fn from(value: TlsStream) -> Self {
+    NetworkStream::Tls(value)
+  }
+}
+
+#[cfg(unix)]
+impl From<UnixStream> for NetworkStream {
+  fn from(value: UnixStream) -> Self {
+    NetworkStream::Unix(value)
+  }
+}
+
 /// A raw stream of one of the types handled by this extension.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum NetworkStreamType {


### PR DESCRIPTION
This implements HTTP/2 prior-knowledge connections, allowing clients to request HTTP/2 over plaintext or TLS-without-ALPN connections. If a client requests a specific protocol via ALPN (`h2` or `http/1.1`), however, the protocol is forced and must be used.

