### PR TITLE
refactor(ext/websocket): use specialized ops

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -128,7 +128,10 @@ const OP_DETAILS = {
   "op_ws_close": ["close a WebSocket", "awaiting until the `close` event is emitted on a `WebSocket`, or the `WebSocketStream#closed` promise resolves"],
   "op_ws_create": ["create a WebSocket", "awaiting until the `open` event is emitted on a `WebSocket`, or the result of a `WebSocketStream#connection` promise"],
   "op_ws_next_event": ["receive the next message on a WebSocket", "closing a `WebSocket` or `WebSocketStream`"],
-  "op_ws_send": ["send a message on a WebSocket", "closing a `WebSocket` or `WebSocketStream`"],
+  "op_ws_send_text": ["send a message on a WebSocket", "closing a `WebSocket` or `WebSocketStream`"],
+  "op_ws_send_binary": ["send a message on a WebSocket", "closing a `WebSocket` or `WebSocketStream`"],
+  "op_ws_send_ping": ["send a message on a WebSocket", "closing a `WebSocket` or `WebSocketStream`"],
+  "op_ws_send_pong": ["send a message on a WebSocket", "closing a `WebSocket` or `WebSocketStream`"],
 };
 
 // Wrap test function in additional assertion that makes sure

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -534,13 +534,7 @@ class WebSocket extends EventTarget {
       clearTimeout(this[_idleTimeoutTimeout]);
       this[_idleTimeoutTimeout] = setTimeout(async () => {
         if (this[_readyState] === OPEN) {
-          await core.opAsync(
-            "op_ws_send",
-            this[_rid],
-            {
-              kind: "ping",
-            },
-          );
+          await core.opAsync("op_ws_send_ping", this[_rid]);
           this[_idleTimeoutTimeout] = setTimeout(async () => {
             if (this[_readyState] === OPEN) {
               this[_readyState] = CLOSING;

--- a/ext/websocket/02_websocketstream.js
+++ b/ext/websocket/02_websocketstream.js
@@ -207,17 +207,11 @@ class WebSocketStream {
             const writable = new WritableStream({
               write: async (chunk) => {
                 if (typeof chunk === "string") {
-                  await core.opAsync("op_ws_send", this[_rid], {
-                    kind: "text",
-                    value: chunk,
-                  });
+                  await core.opAsync("op_ws_send_text", this[_rid], chunk);
                 } else if (
                   ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, chunk)
                 ) {
-                  await core.opAsync("op_ws_send", this[_rid], {
-                    kind: "binary",
-                    value: chunk,
-                  }, chunk);
+                  await core.opAsync("op_ws_send_binary", this[_rid], chunk);
                 } else {
                   throw new TypeError(
                     "A chunk may only be either a string or an Uint8Array",
@@ -265,9 +259,7 @@ class WebSocketStream {
                 }
                 case 3: {
                   /* ping */
-                  await core.opAsync("op_ws_send", this[_rid], {
-                    kind: "pong",
-                  });
+                  await core.opAsync("op_ws_send_pong", this[_rid]);
                   await pull(controller);
                   break;
                 }

--- a/ext/websocket/02_websocketstream.js
+++ b/ext/websocket/02_websocketstream.js
@@ -207,11 +207,11 @@ class WebSocketStream {
             const writable = new WritableStream({
               write: async (chunk) => {
                 if (typeof chunk === "string") {
-                  await core.opAsync("op_ws_send_text", this[_rid], chunk);
+                  await core.opAsync2("op_ws_send_text", this[_rid], chunk);
                 } else if (
                   ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, chunk)
                 ) {
-                  await core.opAsync("op_ws_send_binary", this[_rid], chunk);
+                  await core.opAsync2("op_ws_send_binary", this[_rid], chunk);
                 } else {
                   throw new TypeError(
                     "A chunk may only be either a string or an Uint8Array",


### PR DESCRIPTION
Instead of relying on `op_ws_send` to send different kinds of messages,
use specialized ops everywhere.