### PR TITLE
fix(npm): only include top level packages in top level node_modules directory

### DIFF
--- a/cli/npm/resolvers/local.rs
+++ b/cli/npm/resolvers/local.rs
@@ -370,7 +370,7 @@ async fn sync_resolution_with_fs(
   // node_modules/.deno/<package_id>/node_modules/<package_name>
   let mut found_names = HashSet::new();
   let mut ids = snapshot.top_level_packages().collect::<Vec<_>>();
-  ids.sort_by(|a, b| b.cmp(&a)); // create determinism and only include the latest version
+  ids.sort_by(|a, b| b.cmp(a)); // create determinism and only include the latest version
   for id in ids {
     let root_folder_name = if found_names.insert(id.nv.name.clone()) {
       id.nv.name.clone()

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -563,12 +563,22 @@ Module._findPath = function (request, paths, isMain, parentPath) {
     const isRelative = ops.op_require_is_request_relative(
       request,
     );
+    console.log(
+      "pre basePath",
+      curPath,
+      request,
+      packageSpecifierSubPath(request),
+      isDenoDirPackage,
+      isRelative,
+    );
     const basePath = (isDenoDirPackage && !isRelative)
       ? pathResolve(curPath, packageSpecifierSubPath(request))
       : pathResolve(curPath, request);
+    console.log("basePath", basePath);
     let filename;
 
     const rc = stat(basePath);
+    // console.log("stat result", rc);
     if (!trailingSlash) {
       if (rc === 0) { // File.
         filename = toRealPath(basePath);
@@ -805,6 +815,9 @@ Module._resolveFilename = function (
     return selfResolved;
   }
 
+  // if (request.startsWith("node-releases/")) {
+  //   console.log("req", request, paths, parentPath);
+  // }
   // Look up the filename first, since that's the cache key.
   const filename = Module._findPath(
     request,

--- a/foo.js
+++ b/foo.js
@@ -1,0 +1,2 @@
+import fraction from "npm:autoprefixer";
+console.log(typeof fraction);

--- a/foo.js
+++ b/foo.js
@@ -1,2 +1,0 @@
-import fraction from "npm:autoprefixer";
-console.log(typeof fraction);


### PR DESCRIPTION
We were indeterministically including packages in the top level `node_modules/` folder when using a local node_modules directory. This change aligns with pnpm and only includes top level packages in this folder. This should be faster for initializing the folder, but may expose issues in packages that reference other packages not defined in their dependencies. That said, the behaviour previously was previously broken.

This has exposed a bug in the require implementation where it doesn't find a package (which is the main underlying issue here). There is a failing test already for this in the test suite after this change.

Closes #18822