### PR TITLE
refactor(ext/fs): remove `interface::FileSystem::File`

### DIFF
--- a/core/resources.rs
+++ b/core/resources.rs
@@ -194,13 +194,15 @@ pub trait Resource: Any + 'static {
 
 impl dyn Resource {
   #[inline(always)]
-  fn is<T: Resource>(&self) -> bool {
+  fn is<T: Resource + ?Sized>(&self) -> bool {
     self.type_id() == TypeId::of::<T>()
   }
 
   #[inline(always)]
   #[allow(clippy::needless_lifetimes)]
-  pub fn downcast_rc<'a, T: Resource>(self: &'a Rc<Self>) -> Option<&'a Rc<T>> {
+  pub fn downcast_rc<'a, T: Resource + ?Sized>(
+    self: &'a Rc<Self>,
+  ) -> Option<&'a Rc<T>> {
     if self.is::<T>() {
       let ptr = self as *const Rc<_> as *const Rc<T>;
       // TODO(piscisaureus): safety comment
@@ -272,7 +274,10 @@ impl ResourceTable {
   /// Returns a reference counted pointer to the resource of type `T` with the
   /// given `rid`. If `rid` is not present or has a type different than `T`,
   /// this function returns `None`.
-  pub fn get<T: Resource>(&self, rid: ResourceId) -> Result<Rc<T>, Error> {
+  pub fn get<T: Resource + ?Sized>(
+    &self,
+    rid: ResourceId,
+  ) -> Result<Rc<T>, Error> {
     self
       .index
       .get(&rid)

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -18,7 +18,6 @@ pub use crate::std_fs::StdFs;
 
 use deno_core::error::AnyError;
 use deno_core::OpState;
-use deno_core::Resource;
 use std::cell::RefCell;
 use std::convert::From;
 use std::path::Path;
@@ -88,7 +87,6 @@ pub(crate) fn check_unstable2(state: &Rc<RefCell<OpState>>, api_name: &str) {
 deno_core::extension!(deno_fs,
   deps = [ deno_web ],
   parameters = [Fs: FileSystem, P: FsPermissions],
-  bounds = [Fs::File: Resource],
   ops = [
     op_cwd<Fs, P>,
     op_umask<Fs>,


### PR DESCRIPTION
Removed this in order to support boxing `FileSystem` in a future PR so it can easily be passed down as a worker option.