### PR TITLE
chore: upgrade rusty_v8 to 0.70.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5511,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687e14c2535fe5749098994fd67773962050abe64bcc6a8c92dbf7221b746f49"
+checksum = "ab13e022340b67561836bbb90ceeebbfca7e35fbc05471ceff5ce099e5a754a3"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
-v8 = { version = "0.69.0", default-features = false }
+v8 = { version = "0.70.0", default-features = false }
 deno_ast = { version = "0.26.0", features = ["transpiling"] }
 
 deno_core = { version = "0.181.0", path = "./core" }


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/18369
Supersedes https://github.com/denoland/deno/pull/18838