### PR TITLE
feat: Deprecate Deno.run API in favor of Deno.Command (#17630)

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3691,9 +3691,9 @@ declare namespace Deno {
     options?: { recursive: boolean },
   ): FsWatcher;
 
-  /** 
+  /**
    * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
+   *
    * Options which can be used with {@linkcode Deno.run}.
    *
    * @category Sub Process */
@@ -3752,9 +3752,9 @@ declare namespace Deno {
     stdin?: "inherit" | "piped" | "null" | number;
   }
 
-  /** 
+  /**
    * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
+   *
    * The status resolved from the `.status()` method of a
    * {@linkcode Deno.Process} instance.
    *
@@ -3776,7 +3776,7 @@ declare namespace Deno {
 
   /**
    * * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
+   *
    * Represents an instance of a sub process that is returned from
    * {@linkcode Deno.run} which can be used to manage the sub-process.
    *
@@ -3933,9 +3933,9 @@ declare namespace Deno {
     handler: () => void,
   ): void;
 
-  /** 
+  /**
    * @deprecated Use {@linkcode Deno.Command} instead.
-   * 
+   *
    * Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
    * an array of program arguments, the first of which is the binary.
    *

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3691,7 +3691,10 @@ declare namespace Deno {
     options?: { recursive: boolean },
   ): FsWatcher;
 
-  /** Options which can be used with {@linkcode Deno.run}.
+  /** 
+   * @deprecated Use {@linkcode Deno.Command} instead.
+   * 
+   * Options which can be used with {@linkcode Deno.run}.
    *
    * @category Sub Process */
   export interface RunOptions {
@@ -3749,7 +3752,10 @@ declare namespace Deno {
     stdin?: "inherit" | "piped" | "null" | number;
   }
 
-  /** The status resolved from the `.status()` method of a
+  /** 
+   * @deprecated Use {@linkcode Deno.Command} instead.
+   * 
+   * The status resolved from the `.status()` method of a
    * {@linkcode Deno.Process} instance.
    *
    * If `success` is `true`, then `code` will be `0`, but if `success` is
@@ -3769,6 +3775,8 @@ declare namespace Deno {
     };
 
   /**
+   * * @deprecated Use {@linkcode Deno.Command} instead.
+   * 
    * Represents an instance of a sub process that is returned from
    * {@linkcode Deno.run} which can be used to manage the sub-process.
    *
@@ -3925,7 +3933,10 @@ declare namespace Deno {
     handler: () => void,
   ): void;
 
-  /** Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
+  /** 
+   * @deprecated Use {@linkcode Deno.Command} instead.
+   * 
+   * Spawns new subprocess. RunOptions must contain at a minimum the `opt.cmd`,
    * an array of program arguments, the first of which is the binary.
    *
    * ```ts


### PR DESCRIPTION
This commit adds `@deprecated` comments to `Deno.run` API declarations.
Since stabilization of `Deno.Command` API in [Deno v1.31](https://deno.com/blog/v1.31#api-stabilizations), `Deno.Command` is the preferred (more reliable) API to interact with subprocesses.
This is the preparation for the removal of `Deno.run` API in Deno 2.0.