### PR TITLE
feat(lint): add `Deno.run` to `no-deprecated-deno-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8314e893e86e7f66cf06926d684a5d8708d737a28056472c9d7d78ef1c00691b"
+checksum = "3867178bfb6579aaf9ed79599d3181d134f13dfcd38fdd93cae7d53a37bece8d"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,7 +45,7 @@ deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"]
 deno_doc = "0.62.0"
 deno_emit = "0.20.0"
 deno_graph = "=0.48.1"
-deno_lint = { version = "0.44.0", features = ["docs"] }
+deno_lint = { version = "0.45.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }

--- a/cli/tests/testdata/coverage/complex_test.ts
+++ b/cli/tests/testdata/coverage/complex_test.ts
@@ -7,6 +7,7 @@ Deno.test("complex", function () {
 Deno.test("sub process with stdin", async () => {
   // ensure launching deno run with stdin doesn't affect coverage
   const code = "console.log('5')";
+  // deno-lint-ignore no-deprecated-deno-api
   const p = await Deno.run({
     cmd: [Deno.execPath(), "run", "-"],
     stdin: "piped",
@@ -25,6 +26,7 @@ Deno.test("sub process with stdin", async () => {
 Deno.test("sub process with deno eval", async () => {
   // ensure launching deno eval doesn't affect coverage
   const code = "console.log('5')";
+  // deno-lint-ignore no-deprecated-deno-api
   const p = await Deno.run({
     cmd: [Deno.execPath(), "eval", code],
     stdout: "piped",

--- a/cli/tests/testdata/test/captured_output.ts
+++ b/cli/tests/testdata/test/captured_output.ts
@@ -1,4 +1,5 @@
 Deno.test("output", async () => {
+  // deno-lint-ignore no-deprecated-deno-api
   const p = Deno.run({
     cmd: [Deno.execPath(), "eval", "console.log(0); console.error(1);"],
   });

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -2085,6 +2085,7 @@ Deno.test({
         "--header",
         "Accept-Encoding: deflate, gzip",
       ];
+      // deno-lint-ignore no-deprecated-deno-api
       const proc = Deno.run({ cmd, stdout: "piped", stderr: "null" });
       const status = await proc.status();
       assert(status.success);
@@ -2147,6 +2148,7 @@ Deno.test({
         "--header",
         "Accept-Encoding: deflate, gzip",
       ];
+      // deno-lint-ignore no-deprecated-deno-api
       const proc = Deno.run({ cmd, stdout: "piped", stderr: "null" });
       const status = await proc.status();
       assert(status.success);

--- a/cli/tests/unit/process_test.ts
+++ b/cli/tests/unit/process_test.ts
@@ -11,6 +11,7 @@ Deno.test(
   { permissions: { read: true, run: false } },
   function runPermissions() {
     assertThrows(() => {
+      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
       });
@@ -21,6 +22,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runSuccess() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       // freeze the array to ensure it's not modified
       cmd: Object.freeze([
@@ -43,6 +45,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runUrl() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         new URL(`file:///${Deno.execPath()}`),
@@ -66,6 +69,7 @@ Deno.test(
   async function runStdinRid0(): Promise<
     void
   > {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
       stdin: 0,
@@ -85,6 +89,7 @@ Deno.test(
   { permissions: { run: true, read: true } },
   function runInvalidStdio() {
     assertThrows(() =>
+      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
         // @ts-expect-error because Deno.run should throw on invalid stdin.
@@ -92,6 +97,7 @@ Deno.test(
       })
     );
     assertThrows(() =>
+      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
         // @ts-expect-error because Deno.run should throw on invalid stdout.
@@ -99,6 +105,7 @@ Deno.test(
       })
     );
     assertThrows(() =>
+      // deno-lint-ignore no-deprecated-deno-api
       Deno.run({
         cmd: [Deno.execPath(), "eval", "console.log('hello world')"],
         // @ts-expect-error because Deno.run should throw on invalid stderr.
@@ -111,6 +118,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runCommandFailedWithCode() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "Deno.exit(41 + 1)"],
     });
@@ -127,6 +135,7 @@ Deno.test(
     permissions: { run: true, read: true },
   },
   async function runCommandFailedWithSignal() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -150,6 +159,7 @@ Deno.test(
 Deno.test({ permissions: { run: true } }, function runNotFound() {
   let error;
   try {
+    // deno-lint-ignore no-deprecated-deno-api
     Deno.run({ cmd: ["this file hopefully doesn't exist"] });
   } catch (e) {
     error = e;
@@ -181,6 +191,7 @@ tryExit();
 `;
 
     Deno.writeFileSync(`${cwd}/${programFile}`, enc.encode(program));
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cwd,
       cmd: [Deno.execPath(), "run", "--allow-read", programFile],
@@ -204,6 +215,7 @@ Deno.test(
   async function runStdinPiped(): Promise<
     void
   > {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -235,6 +247,7 @@ Deno.test(
   async function runStdoutPiped(): Promise<
     void
   > {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -271,6 +284,7 @@ Deno.test(
   async function runStderrPiped(): Promise<
     void
   > {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -305,6 +319,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runOutput() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -325,6 +340,7 @@ Deno.test(
   async function runStderrOutput(): Promise<
     void
   > {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -350,6 +366,7 @@ Deno.test(
       write: true,
     });
 
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -382,6 +399,7 @@ Deno.test(
     await Deno.writeFile(fileName, encoder.encode("hello"));
     const file = await Deno.open(fileName);
 
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -401,6 +419,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runEnv() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -423,6 +442,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runClose() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -446,6 +466,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function runKillAfterStatus() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", 'console.log("hello")'],
     });
@@ -502,6 +523,7 @@ Deno.test(
 Deno.test(
   { permissions: { run: true, read: true } },
   async function killSuccess() {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [Deno.execPath(), "eval", "setTimeout(() => {}, 10000)"],
     });
@@ -525,6 +547,7 @@ Deno.test(
 );
 
 Deno.test({ permissions: { run: true, read: true } }, function killFailed() {
+  // deno-lint-ignore no-deprecated-deno-api
   const p = Deno.run({
     cmd: [Deno.execPath(), "eval", "setTimeout(() => {}, 10000)"],
   });
@@ -542,6 +565,7 @@ Deno.test({ permissions: { run: true, read: true } }, function killFailed() {
 Deno.test(
   { permissions: { run: true, read: true, env: true } },
   async function clearEnv(): Promise<void> {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),
@@ -574,6 +598,7 @@ Deno.test(
     ignore: Deno.build.os === "windows",
   },
   async function uid(): Promise<void> {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         "id",
@@ -587,6 +612,7 @@ Deno.test(
 
     if (currentUid !== "0") {
       assertThrows(() => {
+        // deno-lint-ignore no-deprecated-deno-api
         Deno.run({
           cmd: [
             "echo",
@@ -605,6 +631,7 @@ Deno.test(
     ignore: Deno.build.os === "windows",
   },
   async function gid(): Promise<void> {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         "id",
@@ -618,6 +645,7 @@ Deno.test(
 
     if (currentGid !== "0") {
       assertThrows(() => {
+        // deno-lint-ignore no-deprecated-deno-api
         Deno.run({
           cmd: [
             "echo",
@@ -636,6 +664,7 @@ Deno.test(
     ignore: Deno.build.os === "windows",
   },
   async function non_existent_cwd(): Promise<void> {
+    // deno-lint-ignore no-deprecated-deno-api
     const p = Deno.run({
       cmd: [
         Deno.execPath(),


### PR DESCRIPTION
This upgrade includes warning for deprecated "Deno.run()" API.
