### PR TITLE
fix(repl): print unhandled rejections and event errors

### DIFF
--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::args::CliOptions;
@@ -128,12 +130,9 @@ pub struct ReplSession {
   session: LocalInspectorSession,
   pub context_id: u64,
   pub language_server: ReplLanguageServer,
+  pub notifications: Rc<RefCell<UnboundedReceiver<Value>>>,
   has_initialized_node_runtime: bool,
   referrer: ModuleSpecifier,
-  // FIXME(bartlomieju): this field should be used to listen
-  // for "exceptionThrown" notifications
-  #[allow(dead_code)]
-  notification_rx: UnboundedReceiver<Value>,
 }
 
 impl ReplSession {
@@ -193,7 +192,7 @@ impl ReplSession {
       language_server,
       has_initialized_node_runtime: false,
       referrer,
-      notification_rx,
+      notifications: Rc::new(RefCell::new(notification_rx)),
     };
 
     // inject prelude

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -715,8 +715,7 @@ fn op_dispatch_exception(
   let mut state = state_rc.borrow_mut();
   if let Some(inspector) = &state.inspector {
     let inspector = inspector.borrow();
-    // TODO(nayeemrmn): Send exception message to inspector sessions here.
-
+    inspector.exception_thrown(scope, exception.v8_value, false);
     // This indicates that the op is being called from a REPL. Skip termination.
     if inspector.is_dispatching_message() {
       return;


### PR DESCRIPTION
Fixes #8858.
Fixes #8869.

```
$ target/debug/deno
Deno 1.32.5
exit using ctrl+d, ctrl+c, or close()
REPL is running with all permissions allowed.
To specify permissions, run `deno repl` with allow flags.
> Promise.reject(new Error("bar"));
Promise { <rejected> Error: bar
    at <anonymous>:2:16 }
Uncaught (in promise) Error: bar
    at <anonymous>:2:16
> reportError(new Error("baz"));
undefined
Uncaught Error: baz
    at <anonymous>:2:13
>