### PR TITLE
Revert "refactor: don't expose Deno[Deno.internal].core namespace"

### DIFF
--- a/cli/tests/integration/bench_tests.rs
+++ b/cli/tests/integration/bench_tests.rs
@@ -198,7 +198,7 @@ fn recursive_permissions_pledge() {
   let context = TestContext::default();
   let output = context
     .new_command()
-    .args("bench --enable-testing-features-do-not-use bench/recursive_permissions_pledge.js")
+    .args("bench bench/recursive_permissions_pledge.js")
     .run();
   output.assert_exit_code(1);
   assert_contains!(

--- a/cli/tests/integration/inspector_tests.rs
+++ b/cli/tests/integration/inspector_tests.rs
@@ -307,7 +307,6 @@ async fn inspector_break_on_first_line() {
   let child = util::deno_cmd()
     .arg("run")
     .arg(inspect_flag_with_unique_port("--inspect-brk"))
-    .arg("--enable-testing-features-do-not-use")
     .arg(script)
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())

--- a/cli/tests/integration/js_unit_tests.rs
+++ b/cli/tests/integration/js_unit_tests.rs
@@ -28,7 +28,6 @@ fn js_unit_tests() {
     .arg("--unstable")
     .arg("--location=http://js-unit-tests/foo/bar")
     .arg("--no-prompt")
-    .arg("--enable-testing-features-do-not-use")
     .arg("-A")
     .arg(util::tests_path().join("unit"))
     .spawn()

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -118,7 +118,7 @@ itest!(dual_cjs_esm {
 });
 
 itest!(child_process_fork_test {
-  args: "run -A --quiet --enable-testing-features-do-not-use npm/child_process_fork_test/main.ts",
+  args: "run -A --quiet npm/child_process_fork_test/main.ts",
   output: "npm/child_process_fork_test/main.out",
   envs: env_vars_for_npm_tests(),
   http_server: true,

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -213,7 +213,7 @@ itest!(_038_checkjs {
 });
 
 itest!(_042_dyn_import_evalcontext {
-  args: "run --quiet --allow-read --reload --enable-testing-features-do-not-use run/042_dyn_import_evalcontext.ts",
+  args: "run --quiet --allow-read --reload run/042_dyn_import_evalcontext.ts",
   output: "run/042_dyn_import_evalcontext.ts.out",
 });
 
@@ -1161,25 +1161,25 @@ itest!(exit_error42 {
 });
 
 itest!(set_exit_code_0 {
-  args: "run --no-check --unstable --enable-testing-features-do-not-use run/set_exit_code_0.ts",
+  args: "run --no-check --unstable run/set_exit_code_0.ts",
   output_str: Some(""),
   exit_code: 0,
 });
 
 itest!(set_exit_code_1 {
-  args: "run --no-check --unstable --enable-testing-features-do-not-use run/set_exit_code_1.ts",
+  args: "run --no-check --unstable run/set_exit_code_1.ts",
   output_str: Some(""),
   exit_code: 42,
 });
 
 itest!(set_exit_code_2 {
-  args: "run --no-check --unstable --enable-testing-features-do-not-use run/set_exit_code_2.ts",
+  args: "run --no-check --unstable run/set_exit_code_2.ts",
   output_str: Some(""),
   exit_code: 42,
 });
 
 itest!(op_exit_op_set_exit_code_in_worker {
-  args: "run --no-check --unstable --allow-read --enable-testing-features-do-not-use run/op_exit_op_set_exit_code_in_worker.ts",
+  args: "run --no-check --unstable --allow-read run/op_exit_op_set_exit_code_in_worker.ts",
   exit_code: 21,
   output_str: Some(""),
 });
@@ -1197,7 +1197,7 @@ itest!(heapstats {
 
 itest!(finalization_registry {
   args:
-    "run --quiet --unstable --enable-testing-features-do-not-use --v8-flags=--expose-gc run/finalization_registry.js",
+    "run --quiet --unstable --v8-flags=--expose-gc run/finalization_registry.js",
   output: "run/finalization_registry.js.out",
 });
 
@@ -2760,7 +2760,7 @@ itest!(long_data_url_formatting {
 });
 
 itest!(eval_context_throw_dom_exception {
-  args: "run --enable-testing-features-do-not-use run/eval_context_throw_dom_exception.js",
+  args: "run run/eval_context_throw_dom_exception.js",
   output: "run/eval_context_throw_dom_exception.js.out",
 });
 
@@ -3122,115 +3122,115 @@ itest!(fetch_async_error_stack {
 });
 
 itest!(unstable_ffi_1 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_1.js",
+  args: "run run/ffi/unstable_ffi_1.js",
   output: "run/ffi/unstable_ffi_1.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_2 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_2.js",
+  args: "run run/ffi/unstable_ffi_2.js",
   output: "run/ffi/unstable_ffi_2.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_3 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_3.js",
+  args: "run run/ffi/unstable_ffi_3.js",
   output: "run/ffi/unstable_ffi_3.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_4 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_4.js",
+  args: "run run/ffi/unstable_ffi_4.js",
   output: "run/ffi/unstable_ffi_4.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_5 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_5.js",
+  args: "run run/ffi/unstable_ffi_5.js",
   output: "run/ffi/unstable_ffi_5.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_6 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_6.js",
+  args: "run run/ffi/unstable_ffi_6.js",
   output: "run/ffi/unstable_ffi_6.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_7 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_7.js",
+  args: "run run/ffi/unstable_ffi_7.js",
   output: "run/ffi/unstable_ffi_7.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_8 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_8.js",
+  args: "run run/ffi/unstable_ffi_8.js",
   output: "run/ffi/unstable_ffi_8.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_9 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_9.js",
+  args: "run run/ffi/unstable_ffi_9.js",
   output: "run/ffi/unstable_ffi_9.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_10 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_10.js",
+  args: "run run/ffi/unstable_ffi_10.js",
   output: "run/ffi/unstable_ffi_10.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_11 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_11.js",
+  args: "run run/ffi/unstable_ffi_11.js",
   output: "run/ffi/unstable_ffi_11.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_12 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_12.js",
+  args: "run run/ffi/unstable_ffi_12.js",
   output: "run/ffi/unstable_ffi_12.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_13 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_13.js",
+  args: "run run/ffi/unstable_ffi_13.js",
   output: "run/ffi/unstable_ffi_13.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_14 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_14.js",
+  args: "run run/ffi/unstable_ffi_14.js",
   output: "run/ffi/unstable_ffi_14.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_15 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_15.js",
+  args: "run run/ffi/unstable_ffi_15.js",
   output: "run/ffi/unstable_ffi_15.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_16 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_16.js",
+  args: "run run/ffi/unstable_ffi_16.js",
   output: "run/ffi/unstable_ffi_16.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_17 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_17.js",
+  args: "run run/ffi/unstable_ffi_17.js",
   output: "run/ffi/unstable_ffi_17.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_18 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_18.js",
+  args: "run run/ffi/unstable_ffi_18.js",
   output: "run/ffi/unstable_ffi_18.js.out",
   exit_code: 70,
 });
 
 itest!(unstable_ffi_19 {
-  args: "run --enable-testing-features-do-not-use run/ffi/unstable_ffi_19.js",
+  args: "run run/ffi/unstable_ffi_19.js",
   output: "run/ffi/unstable_ffi_19.js.out",
   exit_code: 70,
 });
@@ -3253,7 +3253,7 @@ itest!(event_listener_error_handled {
 
 // https://github.com/denoland/deno/pull/14159#issuecomment-1092285446
 itest!(event_listener_error_immediate_exit {
-  args: "run --quiet --enable-testing-features-do-not-use run/event_listener_error_immediate_exit.ts",
+  args: "run --quiet run/event_listener_error_immediate_exit.ts",
   output: "run/event_listener_error_immediate_exit.ts.out",
   exit_code: 1,
 });
@@ -3261,7 +3261,7 @@ itest!(event_listener_error_immediate_exit {
 // https://github.com/denoland/deno/pull/14159#issuecomment-1092285446
 itest!(event_listener_error_immediate_exit_worker {
   args:
-    "run --quiet --unstable -A --enable-testing-features-do-not-use run/event_listener_error_immediate_exit_worker.ts",
+    "run --quiet --unstable -A run/event_listener_error_immediate_exit_worker.ts",
   output: "run/event_listener_error_immediate_exit_worker.ts.out",
   exit_code: 1,
 });
@@ -4368,24 +4368,22 @@ fn permission_prompt_strips_ansi_codes_and_control_chars() {
     )
   });
 
-  util::with_pty(
-    &["repl", "--enable-testing-features-do-not-use"],
-    |mut console| {
-      console.write_line_raw(r#"const boldANSI = "\u001b[1m";"#);
-      console.expect("undefined");
-      console.write_line_raw(r#"const unboldANSI = "\u001b[22m";"#);
-      console.expect("undefined");
-      console.write_line_raw(r#"const prompt = `┌ ⚠️  ${boldANSI}Deno requests run access to "echo"${unboldANSI}\n ├ Requested by \`Deno.Command().output()`"#);
-      console.expect("undefined");
-      console.write_line_raw(r#"const moveANSIUp = "\u001b[1A";"#);
-      console.expect("undefined");
-      console.write_line_raw(r#"const clearANSI = "\u001b[2K";"#);
-      console.expect("undefined");
-      console.write_line_raw(r#"const moveANSIStart = "\u001b[1000D";"#);
-      console.expect("undefined");
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line_raw(r#"const boldANSI = "\u001b[1m";"#);
+    console.expect("undefined");
+    console.write_line_raw(r#"const unboldANSI = "\u001b[22m";"#);
+    console.expect("undefined");
+    console.write_line_raw(r#"const prompt = `┌ ⚠️  ${boldANSI}Deno requests run access to "echo"${unboldANSI}\n ├ Requested by \`Deno.Command().output()`"#);
+    console.expect("undefined");
+    console.write_line_raw(r#"const moveANSIUp = "\u001b[1A";"#);
+    console.expect("undefined");
+    console.write_line_raw(r#"const clearANSI = "\u001b[2K";"#);
+    console.expect("undefined");
+    console.write_line_raw(r#"const moveANSIStart = "\u001b[1000D";"#);
+    console.expect("undefined");
 
-      console.write_line_raw(
-        r#"Deno[Deno.internal].core.ops.op_spawn_child({
+    console.write_line_raw(
+      r#"Deno[Deno.internal].core.ops.op_spawn_child({
     cmd: "cat",
     args: ["file.txt"],
     clearEnv: false,
@@ -4399,11 +4397,10 @@ fn permission_prompt_strips_ansi_codes_and_control_chars() {
     signal: undefined,
     windowsRawArguments: false,
 }, moveANSIUp + clearANSI + moveANSIStart + prompt)"#,
-      );
+    );
 
-      console.expect(r#"┌ ⚠️  Deno requests run access to "cat""#);
-    },
-  );
+    console.expect(r#"┌ ⚠️  Deno requests run access to "cat""#);
+  });
 }
 
 itest!(node_builtin_modules_ts {

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -222,7 +222,7 @@ itest!(ops_sanitizer_timeout_failure {
 });
 
 itest!(ops_sanitizer_multiple_timeout_tests {
-  args: "test --trace-ops --enable-testing-features-do-not-use test/ops_sanitizer_multiple_timeout_tests.ts",
+  args: "test --trace-ops test/ops_sanitizer_multiple_timeout_tests.ts",
   exit_code: 1,
   output: "test/ops_sanitizer_multiple_timeout_tests.out",
 });
@@ -396,7 +396,7 @@ fn recursive_permissions_pledge() {
   let context = TestContext::default();
   let output = context
     .new_command()
-    .args("test --enable-testing-features-do-not-use test/recursive_permissions_pledge.js")
+    .args("test test/recursive_permissions_pledge.js")
     .run();
   output.assert_exit_code(1);
   assert_contains!(

--- a/cli/tests/unit/read_text_file_test.ts
+++ b/cli/tests/unit/read_text_file_test.ts
@@ -166,7 +166,7 @@ Deno.test(
 
     try {
       Deno.writeFileSync(filePath, bytes);
-    } catch (e) {
+    } catch {
       // NOTE(bartlomieju): writing a 0.5Gb file might be too much for CI,
       // so skip running if writing fails.
       return;
@@ -193,7 +193,7 @@ Deno.test(
 
     try {
       await Deno.writeFile(filePath, bytes);
-    } catch (e) {
+    } catch {
       // NOTE(bartlomieju): writing a 0.5Gb file might be too much for CI,
       // so skip running if writing fails.
       return;

--- a/cli/tests/unit/read_text_file_test.ts
+++ b/cli/tests/unit/read_text_file_test.ts
@@ -164,7 +164,13 @@ Deno.test(
     const bytes = new Uint8Array(kStringMaxLengthPlusOne);
     const filePath = "cli/tests/testdata/too_big_a_file.txt";
 
-    Deno.writeFileSync(filePath, bytes);
+    try {
+      Deno.writeFileSync(filePath, bytes);
+    } catch (e) {
+      // NOTE(bartlomieju): writing a 0.5Gb file might be too much for CI,
+      // so skip running if writing fails.
+      return;
+    }
 
     assertThrows(
       () => {
@@ -185,7 +191,13 @@ Deno.test(
     const bytes = new Uint8Array(kStringMaxLengthPlusOne);
     const filePath = "cli/tests/testdata/too_big_a_file_2.txt";
 
-    await Deno.writeFile(filePath, bytes);
+    try {
+      await Deno.writeFile(filePath, bytes);
+    } catch (e) {
+      // NOTE(bartlomieju): writing a 0.5Gb file might be too much for CI,
+      // so skip running if writing fails.
+      return;
+    }
 
     await assertRejects(
       async () => {

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -962,7 +962,7 @@ pub async fn test_specifier(
   if options.trace_ops {
     worker.js_runtime.execute_script_static(
       located_script_name!(),
-      "Deno[Deno.internal].enableOpCallTracing();",
+      "Deno[Deno.internal].core.enableOpCallTracing();",
     )?;
   }
   worker.dispatch_load_event(located_script_name!())?;

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -453,6 +453,7 @@
     BadResourcePrototype,
     Interrupted,
     InterruptedPrototype,
+    enableOpCallTracing,
     isOpCallTracingEnabled,
     opCallTraces,
     refOp,
@@ -506,11 +507,8 @@
   });
 
   ObjectAssign(globalThis.__bootstrap, { core });
-  ObjectAssign(globalThis.__bootstrap, {
-    internals: {
-      enableOpCallTracing,
-    },
-  });
+  const internals = {};
+  ObjectAssign(globalThis.__bootstrap, { internals });
   ObjectAssign(globalThis.Deno, { core });
 
   // Direct bindings on `globalThis`

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -478,26 +478,6 @@ impl JsRuntime {
           }
         }
       }
-      // Cache bust plain JS (non-ES modules as well)
-      #[cfg(feature = "include_js_files_for_snapshotting")]
-      if snapshot_options != snapshot_util::SnapshotOptions::None {
-        let js_sources = options
-          .extensions
-          .iter()
-          .flat_map(|ext| match ext.get_js_sources() {
-            Some(s) => s.to_owned(),
-            None => vec![],
-          })
-          .collect::<Vec<ExtensionFileSource>>();
-        for source in js_sources {
-          use crate::ExtensionFileSourceCode;
-          if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) =
-            &source.code
-          {
-            println!("cargo:rerun-if-changed={}", path.display())
-          }
-        }
-      }
 
       Rc::new(crate::modules::ExtModuleLoader::new(
         options.module_loader,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -391,6 +391,12 @@ function promiseRejectMacrotaskCallback() {
 let hasBootstrapped = false;
 // Set up global properties shared by main and worker runtime.
 ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
+// FIXME(bartlomieju): temporarily add whole `Deno.core` to
+// `Deno[Deno.internal]` namespace. It should be removed and only necessary
+// methods should be left there.
+ObjectAssign(internals, {
+  core,
+});
 const internalSymbol = Symbol("Deno.internal");
 const finalDenoNs = {
   internal: internalSymbol,
@@ -422,7 +428,7 @@ function bootstrapMainRuntime(runtimeOptions) {
     13: v8Version,
     14: userAgent,
     15: inspectFlag,
-    16: enableTestingFeaturesFlag,
+    // 16: enableTestingFeaturesFlag
   } = runtimeOptions;
 
   performance.setTimeOrigin(DateNow());
@@ -495,12 +501,6 @@ function bootstrapMainRuntime(runtimeOptions) {
 
   if (unstableFlag) {
     ObjectAssign(finalDenoNs, denoNsUnstable);
-  }
-
-  // Add `Deno[Deno.internal].core` namespace if
-  // `--enable-testing-features-do-not-use` flag is set.
-  if (enableTestingFeaturesFlag) {
-    ObjectAssign(internals, { core });
   }
 
   // Setup `Deno` global - we're actually overriding already existing global
@@ -612,11 +612,6 @@ function bootstrapWorkerRuntime(
     noColor: util.readOnly(noColor),
     args: util.readOnly(ObjectFreeze(args)),
   });
-  // Add `Deno[Deno.internal].core` namespace if
-  // `--enable-testing-features-do-not-use` flag is set.
-  if (enableTestingFeaturesFlag) {
-    ObjectAssign(internals, { core });
-  }
   // Setup `Deno` global - we're actually overriding already
   // existing global `Deno` with `Deno` namespace from "./deno.ts".
   ObjectDefineProperty(globalThis, "Deno", util.readOnly(finalDenoNs));

--- a/test_napi/cleanup_hook_test.js
+++ b/test_napi/cleanup_hook_test.js
@@ -12,7 +12,6 @@ if (import.meta.main) {
     const { stdout, stderr, code } = await new Deno.Command(Deno.execPath(), {
       args: [
         "run",
-        "--enable-testing-features-do-not-use",
         "--allow-read",
         "--allow-run",
         "--allow-ffi",

--- a/test_napi/tests/napi_tests.rs
+++ b/test_napi/tests/napi_tests.rs
@@ -31,7 +31,6 @@ fn napi_tests() {
     .arg("--allow-env")
     .arg("--allow-ffi")
     .arg("--allow-run")
-    .arg("--enable-testing-features-do-not-use")
     .spawn()
     .unwrap()
     .wait_with_output()


### PR DESCRIPTION
Also conditionally disabled one test if there's not enough space on device.