### PR TITLE
fix(ext/io) several sync fs fixes

### DIFF
--- a/core/resources.rs
+++ b/core/resources.rs
@@ -155,13 +155,13 @@ pub trait Resource: Any + 'static {
   }
 
   /// The same as [`read_byob()`][Resource::read_byob], but synchronous.
-  fn read_byob_sync(&self, data: &mut [u8]) -> Result<usize, Error> {
+  fn read_byob_sync(self: Rc<Self>, data: &mut [u8]) -> Result<usize, Error> {
     _ = data;
     Err(not_supported())
   }
 
   /// The same as [`write()`][Resource::write], but synchronous.
-  fn write_sync(&self, data: &[u8]) -> Result<usize, Error> {
+  fn write_sync(self: Rc<Self>, data: &[u8]) -> Result<usize, Error> {
     _ = data;
     Err(not_supported())
   }


### PR DESCRIPTION
2 fixes related to sync fs:
* update the 2 sync methods on `Resource` trait to take `Rc<Self>` (consistent with other methods)
* fix a bug in `StdFileResource::with_inner_and_metadata`, which currently can trigger a panic if a sync method is called on a file with a pending async operation. This could happen in the code path where `File::try_clone` [fails](https://github.com/denoland/deno/blob/39ece1fe0ddacc2cbf182403c9e7085bc01df5a6/ext/io/lib.rs#L485-L489).