### PR TITLE
fix(repl): don't panic on undefined exception

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -825,6 +825,20 @@ fn repl_report_error() {
 }
 
 #[test]
+fn repl_error_undefined() {
+  util::with_pty(&["repl"], |mut console| {
+    console.write_line(r#"throw undefined;"#);
+    console.expect("Uncaught undefined");
+    console.write_line(r#"Promise.reject();"#);
+    console.expect("Promise { <rejected> undefined }");
+    console.expect("Uncaught (in promise) undefined");
+    console.write_line(r#"reportError(undefined);"#);
+    console.expect("undefined");
+    console.expect("Uncaught undefined");
+  });
+}
+
+#[test]
 fn pty_aggregate_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("await Promise.any([])");

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -70,7 +70,7 @@ async fn read_line_and_poll(
             let exception_details = params.get("exceptionDetails").unwrap().as_object().unwrap();
             let text = exception_details.get("text").unwrap().as_str().unwrap();
             let exception = exception_details.get("exception").unwrap().as_object().unwrap();
-            let description = exception.get("description").unwrap().as_str().unwrap();
+            let description = exception.get("description").and_then(|d| d.as_str()).unwrap_or("undefined");
             println!("{text} {description}");
           }
         }

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -260,7 +260,7 @@ impl ReplSession {
             let description = match exception_details.exception {
               Some(exception) => exception
                 .description
-                .unwrap_or_else(|| "Unknown exception".to_string()),
+                .unwrap_or_else(|| "undefined".to_string()),
               None => "Unknown exception".to_string(),
             };
             EvaluationOutput::Error(format!(


### PR DESCRIPTION
Fixes regression from #18878 where `Promise.reject()`, `Promise.reject(undefined)` and `reportError(undefined)` panic in the REPL.
Fixes `throw undefined` printing `Uncaught Unknown exception` instead of `Uncaught undefined`.