### PR TITLE
fix(fmt/json): support formatting number with exponent and no sign

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -51,8 +51,8 @@
     "tools/wpt/manifest.json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.84.0.wasm",
-    "https://plugins.dprint.dev/json-0.17.0.wasm",
+    "https://plugins.dprint.dev/typescript-0.84.2.wasm",
+    "https://plugins.dprint.dev/json-0.17.2.wasm",
     "https://plugins.dprint.dev/markdown-0.15.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/exec-0.3.5.json@d687dda57be0fe9a0088ccdaefa5147649ff24127d8b3ea227536c68ee7abeab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-json"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6120aa5613816db2ef2ef539c229c24f4ee3dbba15317242bcf0de5f17a0060"
+checksum = "602d5b9cc4657bdf06d27fa6c22dfcfdb85a19ab555f2834cf7b01ba8001a1f6"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -2596,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1853e40333206f9a685358046d13ab200169e3ee573019bddf0ede0dc29307"
+checksum = "7b56a20e76235284255a09fcd1f45cf55d3c524ea657ebd3854735925c57743d"
 dependencies = [
  "serde_json",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,7 +65,7 @@ clap_complete_fig = "=4.1.2"
 console_static_text.workspace = true
 data-url.workspace = true
 dissimilar = "=1.0.4"
-dprint-plugin-json = "=0.17.0"
+dprint-plugin-json = "=0.17.2"
 dprint-plugin-markdown = "=0.15.2"
 dprint-plugin-typescript = "=0.84.2"
 encoding_rs.workspace = true
@@ -79,7 +79,7 @@ http.workspace = true
 hyper.workspace = true
 import_map = "=0.15.0"
 indexmap.workspace = true
-jsonc-parser = { version = "=0.21.0", features = ["serde"] }
+jsonc-parser = { version = "=0.21.1", features = ["serde"] }
 lazy-regex.workspace = true
 libc.workspace = true
 log = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
Numbers with an exponent and no sign (ex. `1e1`) would fail to parse.