### PR TITLE
perf(ext/web): fast path for ws events

### DIFF
--- a/cli/tests/testdata/run/event_listener_error_immediate_exit.ts.out
+++ b/cli/tests/testdata/run/event_listener_error_immediate_exit.ts.out
@@ -3,8 +3,4 @@ error: Uncaught Error: bar
   throw new Error("bar");
         ^
     at [WILDCARD]/event_listener_error_immediate_exit.ts:4:9[WILDCARD]
-    at innerInvokeEventListeners (ext:deno_web/02_event.js:785:7)
-    at invokeEventListeners (ext:deno_web/02_event.js:825:5)
-    at dispatch (ext:deno_web/02_event.js:694:9)
-    at dispatchEvent (ext:deno_web/02_event.js:1086:12)
     at [WILDCARD]/event_listener_error_immediate_exit.ts:11:1

--- a/cli/tests/testdata/run/event_listener_error_immediate_exit_worker.ts.out
+++ b/cli/tests/testdata/run/event_listener_error_immediate_exit_worker.ts.out
@@ -2,11 +2,7 @@
 error: Uncaught (in worker "") Error: bar
   throw new Error("bar");
         ^
-    at [WILDCARD]/event_listener_error_immediate_exit.ts:4:9
-    at innerInvokeEventListeners (ext:deno_web/02_event.js:785:7)
-    at invokeEventListeners (ext:deno_web/02_event.js:825:5)
-    at dispatch (ext:deno_web/02_event.js:694:9)
-    at dispatchEvent (ext:deno_web/02_event.js:1086:12)
+    at [WILDCARD]/event_listener_error_immediate_exit.ts:4:9[WILDCARD]
     at [WILDCARD]/event_listener_error_immediate_exit.ts:11:1
 error: Uncaught (in promise) Error: Unhandled error in child worker.
     at [WILDCARD]

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -482,7 +482,7 @@ function getRoot(eventTarget) {
 function isNode(
   eventTarget,
 ) {
-  return eventTarget && eventTarget.nodeType !== undefined;
+  return eventTarget?.nodeType !== undefined;
 }
 
 // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -1527,6 +1527,7 @@ export {
   CloseEvent,
   CustomEvent,
   defineEventHandler,
+  dispatch,
   ErrorEvent,
   Event,
   EventTarget,

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -482,7 +482,7 @@ function getRoot(eventTarget) {
 function isNode(
   eventTarget,
 ) {
-  return Boolean(eventTarget && ReflectHas(eventTarget, "nodeType"));
+  return eventTarget && eventTarget.nodeType !== undefined;
 }
 
 // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor
@@ -734,8 +734,12 @@ function innerInvokeEventListeners(
     return found;
   }
 
+  let handlers = targetListeners[type];
+
   // Copy event listeners before iterating since the list can be modified during the iteration.
-  const handlers = ArrayPrototypeSlice(targetListeners[type]);
+  if (handlers.length > 1) {
+    handlers = ArrayPrototypeSlice(targetListeners[type]);
+  }
 
   for (let i = 0; i < handlers.length; i++) {
     const listener = handlers[i];
@@ -804,12 +808,19 @@ function innerInvokeEventListeners(
  * Ref: https://dom.spec.whatwg.org/#concept-event-listener-invoke */
 function invokeEventListeners(tuple, eventImpl) {
   const path = getPath(eventImpl);
-  const tupleIndex = ArrayPrototypeIndexOf(path, tuple);
-  for (let i = tupleIndex; i >= 0; i--) {
-    const t = path[i];
+  if (path.length === 1) {
+    const t = path[0];
     if (t.target) {
       setTarget(eventImpl, t.target);
-      break;
+    }
+  } else {
+    const tupleIndex = ArrayPrototypeIndexOf(path, tuple);
+    for (let i = tupleIndex; i >= 0; i--) {
+      const t = path[i];
+      if (t.target) {
+        setTarget(eventImpl, t.target);
+        break;
+      }
     }
   }
 

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -15,6 +15,7 @@ import {
   _skipInternalInit,
   CloseEvent,
   defineEventHandler,
+  dispatch,
   ErrorEvent,
   Event,
   EventTarget,
@@ -451,7 +452,7 @@ class WebSocket extends EventTarget {
             data: value,
             origin: this[_url],
           });
-          this.dispatchEvent(event);
+          dispatch(this, event);
           break;
         }
         case 1: {
@@ -470,7 +471,7 @@ class WebSocket extends EventTarget {
             origin: this[_url],
             [_skipInternalInit]: true,
           });
-          this.dispatchEvent(event);
+          dispatch(this, event);
           break;
         }
         case 2: {


### PR DESCRIPTION
- Do not use `ReflectHas` in `isNode`.
- Avoid copying handler array when handlers.length == 1
- Avoid searching for path target when path.length == 1

```
Linux divy-2 5.19.0-1022-gcp #24~22.04.1-Ubuntu SMP Sun Apr 23 09:51:08 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
32GiB System memory
Intel(R) Xeon(R) CPU @ 3.10GHz

# main + https://github.com/denoland/deno/pull/18904
Msg/sec: 89326.750000
Msg/sec: 90320.000000
Msg/sec: 89576.250000

# this patch
Msg/sec: 97250.000000
Msg/sec: 97125.500000
Msg/sec: 97964.500000
```
