### PR TITLE
fix: do not show cache initialization errors if stderr is piped

### DIFF
--- a/cli/cache/cache_db.rs
+++ b/cli/cache/cache_db.rs
@@ -261,7 +261,9 @@ impl CacheDB {
     };
 
     // Failed, try deleting it
-    log::warn!(
+    let is_tty = atty::is(atty::Stream::Stderr);
+    log::log!(
+      if is_tty { log::Level::Warn } else { log::Level::Trace },
       "Could not initialize cache database '{}', deleting and retrying... ({err:?})",
       path.to_string_lossy()
     );
@@ -275,7 +277,12 @@ impl CacheDB {
 
     match self.config.on_failure {
       CacheFailure::InMemory => {
-        log::error!(
+        log::log!(
+          if is_tty {
+            log::Level::Error
+          } else {
+            log::Level::Trace
+          },
           "Failed to open cache file '{}', opening in-memory cache.",
           path.to_string_lossy()
         );
@@ -284,7 +291,12 @@ impl CacheDB {
         ))
       }
       CacheFailure::Blackhole => {
-        log::error!(
+        log::log!(
+          if is_tty {
+            log::Level::Error
+          } else {
+            log::Level::Trace
+          },
           "Failed to open cache file '{}', performance may be degraded.",
           path.to_string_lossy()
         );


### PR DESCRIPTION
Maybe? These don't seem worth surfacing all the time.

Closes #18918