### PR TITLE
bench: fix json ops benchmark

### DIFF
--- a/core/examples/http_bench_json_ops/http_bench_json_ops.js
+++ b/core/examples/http_bench_json_ops/http_bench_json_ops.js
@@ -5,7 +5,7 @@
 
 // deno-lint-ignore-file camelcase
 
-const { op_listen } = Deno.core.ops;
+const { op_listen } = Deno[Deno.internal].core.ops;
 const {
   op_accept,
   op_read_socket,


### PR DESCRIPTION
I broke them on `main` by mistake