### PR TITLE
docs(lib): document `Deno.Command` requires the `allow-run` permission

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4047,6 +4047,7 @@ declare namespace Deno {
    * console.assert("world\n" === new TextDecoder().decode(stderr));
    * ```
    *
+   * @tags allow-run
    * @category Sub Process
    */
   export class Command {


### PR DESCRIPTION
Adds the `allow-run` tag to `Deno.Command`