### PR TITLE
fix(core): allow esm extensions not included in snapshot

### DIFF
--- a/bench_util/js_runtime.rs
+++ b/bench_util/js_runtime.rs
@@ -10,7 +10,7 @@ use crate::profiling::is_profiling;
 pub fn create_js_runtime(setup: impl FnOnce() -> Vec<Extension>) -> JsRuntime {
   JsRuntime::new(RuntimeOptions {
     extensions: setup(),
-    module_loader: Some(std::rc::Rc::new(deno_core::NoopModuleLoader)),
+    module_loader: None,
     ..Default::default()
   })
 }

--- a/bench_util/js_runtime.rs
+++ b/bench_util/js_runtime.rs
@@ -10,9 +10,7 @@ use crate::profiling::is_profiling;
 pub fn create_js_runtime(setup: impl FnOnce() -> Vec<Extension>) -> JsRuntime {
   JsRuntime::new(RuntimeOptions {
     extensions: setup(),
-    module_loader: Some(
-      std::rc::Rc::new(deno_core::ExtModuleLoader::default()),
-    ),
+    module_loader: Some(std::rc::Rc::new(deno_core::NoopModuleLoader)),
     ..Default::default()
   })
 }

--- a/cli/tests/testdata/run/extension_dynamic_import.ts.out
+++ b/cli/tests/testdata/run/extension_dynamic_import.ts.out
@@ -1,4 +1,4 @@
-error: Uncaught TypeError: Cannot load extension module from external code
+error: Uncaught (in promise) TypeError: Cannot load extension module from external code
 await import("ext:runtime/01_errors.js");
 ^
     at [WILDCARD]/extension_dynamic_import.ts:1:1

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -471,6 +471,16 @@ impl Extension {
   pub fn disable(self) -> Self {
     self.enabled(false)
   }
+
+  pub(crate) fn find_esm(
+    &self,
+    specifier: &str,
+  ) -> Option<&ExtensionFileSource> {
+    self
+      .get_esm_sources()?
+      .iter()
+      .find(|s| s.specifier == specifier)
+  }
 }
 
 // Provides a convenient builder pattern to declare Extensions

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -2997,6 +2997,12 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
     loader
       .resolve("ext:core.js", ".", ResolutionKind::Import)
       .unwrap();
+  }
+
+  #[test]
+  fn ext_resolution_failure() {
+    let loader = ExtModuleLoader::default();
+    loader.allow_ext_resolution();
     assert_eq!(
       loader
         .resolve("ext:core.js", "file://bar", ResolutionKind::Import,)

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -132,7 +132,7 @@ pub struct JsRuntime {
   v8_isolate: Option<v8::OwnedIsolate>,
   snapshot_options: snapshot_util::SnapshotOptions,
   allocations: IsolateAllocations,
-  extensions: Vec<Extension>,
+  extensions: Rc<RefCell<Vec<Extension>>>,
   event_loop_middlewares: Vec<Box<OpEventLoopFn>>,
   // Marks if this is considered the top-level runtime. Used only be inspector.
   is_main: bool,
@@ -416,7 +416,7 @@ impl JsRuntime {
     let global_context;
     let mut maybe_snapshotted_data = None;
 
-    let (mut isolate, snapshot_options) = if snapshot_options.will_snapshot() {
+    let mut isolate = if snapshot_options.will_snapshot() {
       let snapshot_creator =
         snapshot_util::create_snapshot_creator(refs, options.startup_snapshot);
       let mut isolate = JsRuntime::setup_isolate(snapshot_creator);
@@ -433,7 +433,7 @@ impl JsRuntime {
 
         global_context = v8::Global::new(scope, context);
       }
-      (isolate, snapshot_options)
+      isolate
     } else {
       #[cfg(not(target_env = "msvc"))]
       let vtable: &'static v8::RustAllocatorVtable<
@@ -492,7 +492,7 @@ impl JsRuntime {
         global_context = v8::Global::new(scope, context);
       }
 
-      (isolate, snapshot_options)
+      isolate
     };
 
     // SAFETY: this is first use of `isolate_ptr` so we are sure we're
@@ -521,61 +521,33 @@ impl JsRuntime {
       None
     };
 
-    let loader = if snapshot_options != snapshot_util::SnapshotOptions::Load {
-      let esm_sources = options
+    let loader = options
+      .module_loader
+      .unwrap_or_else(|| Rc::new(NoopModuleLoader));
+    #[cfg(feature = "include_js_files_for_snapshotting")]
+    if snapshot_options.will_snapshot() {
+      for source in options
         .extensions
         .iter()
-        .flat_map(|ext| match ext.get_esm_sources() {
-          Some(s) => s.to_owned(),
-          None => vec![],
-        })
-        .collect::<Vec<ExtensionFileSource>>();
-
-      #[cfg(feature = "include_js_files_for_snapshotting")]
-      if snapshot_options != snapshot_util::SnapshotOptions::None {
-        for source in &esm_sources {
-          use crate::ExtensionFileSourceCode;
-          if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) =
-            &source.code
-          {
-            println!("cargo:rerun-if-changed={}", path.display())
-          }
-        }
-      }
-
-      #[cfg(feature = "include_js_files_for_snapshotting")]
+        .flat_map(|e| vec![e.get_esm_sources(), e.get_js_sources()])
+        .flatten()
+        .flatten()
       {
-        let js_sources = options
-          .extensions
-          .iter()
-          .flat_map(|ext| match ext.get_js_sources() {
-            Some(s) => s.to_owned(),
-            None => vec![],
-          })
-          .collect::<Vec<ExtensionFileSource>>();
-
-        if snapshot_options != snapshot_util::SnapshotOptions::None {
-          for source in &js_sources {
-            use crate::ExtensionFileSourceCode;
-            if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) =
-              &source.code
-            {
-              println!("cargo:rerun-if-changed={}", path.display())
-            }
-          }
+        use crate::ExtensionFileSourceCode;
+        if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) =
+          &source.code
+        {
+          println!("cargo:rerun-if-changed={}", path.display())
         }
       }
-
-      Rc::new(crate::modules::ExtModuleLoader::new(
-        options.module_loader,
-        esm_sources,
-        options.snapshot_module_load_cb,
-      ))
-    } else {
-      options
-        .module_loader
-        .unwrap_or_else(|| Rc::new(NoopModuleLoader))
-    };
+    }
+    let num_extensions = options.extensions.len();
+    let extensions = Rc::new(RefCell::new(options.extensions));
+    let ext_loader = Rc::new(crate::modules::ExtModuleLoader::new(
+      Some(loader.clone()),
+      extensions.clone(),
+      options.snapshot_module_load_cb,
+    ));
 
     {
       let mut state = state_rc.borrow_mut();
@@ -589,11 +561,11 @@ impl JsRuntime {
       Self::STATE_DATA_OFFSET,
       Rc::into_raw(state_rc.clone()) as *mut c_void,
     );
-
+    let loaded_extensions = Rc::new(RefCell::new(false));
     let module_map_rc = Rc::new(RefCell::new(ModuleMap::new(
-      loader,
+      ext_loader,
       op_state,
-      snapshot_options == snapshot_util::SnapshotOptions::Load,
+      loaded_extensions.clone(),
     )));
     if let Some(snapshotted_data) = maybe_snapshotted_data {
       let scope =
@@ -610,8 +582,8 @@ impl JsRuntime {
       v8_isolate: Some(isolate),
       snapshot_options,
       allocations: IsolateAllocations::default(),
-      event_loop_middlewares: Vec::with_capacity(options.extensions.len()),
-      extensions: options.extensions,
+      event_loop_middlewares: Vec::with_capacity(num_extensions),
+      extensions,
       state: state_rc,
       module_map: Some(module_map_rc),
       is_main: options.is_main,
@@ -622,6 +594,8 @@ impl JsRuntime {
     js_runtime.init_extension_ops().unwrap();
     let realm = js_runtime.global_realm();
     js_runtime.init_extension_js(&realm).unwrap();
+    *loaded_extensions.borrow_mut() = true;
+    js_runtime.module_map.as_ref().unwrap().borrow_mut().loader = loader;
 
     js_runtime
   }
@@ -790,7 +764,7 @@ impl JsRuntime {
 
     // Take extensions to avoid double-borrow
     let extensions = std::mem::take(&mut self.extensions);
-    for ext in &extensions {
+    for ext in extensions.borrow().iter() {
       {
         if let Some(esm_files) = ext.get_esm_sources() {
           if let Some(entry_point) = ext.get_esm_entry_point() {
@@ -863,23 +837,15 @@ impl JsRuntime {
   /// Initializes ops of provided Extensions
   fn init_extension_ops(&mut self) -> Result<(), Error> {
     let op_state = self.op_state();
-    // Take extensions to avoid double-borrow
-    {
-      let mut extensions: Vec<Extension> = std::mem::take(&mut self.extensions);
+    // Setup state
+    for e in self.extensions.borrow_mut().iter_mut() {
+      // ops are already registered during in bindings::initialize_context();
+      e.init_state(&mut op_state.borrow_mut());
 
-      // Setup state
-      for e in extensions.iter_mut() {
-        // ops are already registered during in bindings::initialize_context();
-        e.init_state(&mut op_state.borrow_mut());
-
-        // Setup event-loop middleware
-        if let Some(middleware) = e.init_event_loop_middleware() {
-          self.event_loop_middlewares.push(middleware);
-        }
+      // Setup event-loop middleware
+      if let Some(middleware) = e.init_event_loop_middleware() {
+        self.event_loop_middlewares.push(middleware);
       }
-
-      // Restore extensions
-      self.extensions = extensions;
     }
     Ok(())
   }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -692,15 +692,13 @@ impl JsRuntime {
       JsRealm::new(v8::Global::new(scope, context))
     };
 
-    self
-      .module_map
-      .as_ref()
-      .map(|m| m.borrow().loader.allow_ext_resolution());
+    if let Some(m) = self.module_map.as_ref() {
+      m.borrow().loader.allow_ext_resolution();
+    }
     self.init_extension_js(&realm)?;
-    self
-      .module_map
-      .as_ref()
-      .map(|m| m.borrow().loader.disallow_ext_resolution());
+    if let Some(m) = self.module_map.as_ref() {
+      m.borrow().loader.disallow_ext_resolution();
+    }
     Ok(realm)
   }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -692,13 +692,21 @@ impl JsRuntime {
       JsRealm::new(v8::Global::new(scope, context))
     };
 
-    if let Some(m) = self.module_map.as_ref() {
-      m.borrow().loader.allow_ext_resolution();
-    }
+    self
+      .module_map
+      .as_ref()
+      .unwrap()
+      .borrow()
+      .loader
+      .allow_ext_resolution();
     self.init_extension_js(&realm)?;
-    if let Some(m) = self.module_map.as_ref() {
-      m.borrow().loader.disallow_ext_resolution();
-    }
+    self
+      .module_map
+      .as_ref()
+      .unwrap()
+      .borrow()
+      .loader
+      .disallow_ext_resolution();
     Ok(realm)
   }
 

--- a/runtime/examples/hello_runtime.js
+++ b/runtime/examples/hello_runtime.js
@@ -1,3 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 console.log("Hello world!");
 console.log(Deno);
+Extension.hello();

--- a/runtime/examples/hello_runtime.rs
+++ b/runtime/examples/hello_runtime.rs
@@ -1,72 +1,31 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
 use deno_core::FsModuleLoader;
-use deno_runtime::deno_broadcast_channel::InMemoryBroadcastChannel;
-use deno_runtime::deno_web::BlobStore;
 use deno_runtime::permissions::PermissionsContainer;
 use deno_runtime::worker::MainWorker;
 use deno_runtime::worker::WorkerOptions;
-use deno_runtime::BootstrapOptions;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::Arc;
 
-fn get_error_class_name(e: &AnyError) -> &'static str {
-  deno_runtime::errors::get_error_class_name(e).unwrap_or("Error")
-}
+deno_core::extension!(hello_runtime, esm = ["hello_runtime_bootstrap.js"]);
 
 #[tokio::main]
 async fn main() -> Result<(), AnyError> {
-  let module_loader = Rc::new(FsModuleLoader);
-  let create_web_worker_cb = Arc::new(|_| {
-    todo!("Web workers are not supported in the example");
-  });
-  let web_worker_event_cb = Arc::new(|_| {
-    todo!("Web workers are not supported in the example");
-  });
-
-  let options = WorkerOptions {
-    bootstrap: BootstrapOptions::default(),
-    extensions: vec![],
-    startup_snapshot: None,
-    unsafely_ignore_certificate_errors: None,
-    root_cert_store_provider: None,
-    seed: None,
-    source_map_getter: None,
-    format_js_error_fn: None,
-    web_worker_preload_module_cb: web_worker_event_cb.clone(),
-    web_worker_pre_execute_module_cb: web_worker_event_cb,
-    create_web_worker_cb,
-    maybe_inspector_server: None,
-    should_break_on_first_statement: false,
-    should_wait_for_inspector_session: false,
-    module_loader,
-    node_fs: None,
-    npm_resolver: None,
-    get_error_class_fn: Some(&get_error_class_name),
-    cache_storage_dir: None,
-    origin_storage_dir: None,
-    blob_store: BlobStore::default(),
-    broadcast_channel: InMemoryBroadcastChannel::default(),
-    shared_array_buffer_store: None,
-    compiled_wasm_module_store: None,
-    stdio: Default::default(),
-  };
-
   let js_path =
     Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/hello_runtime.js");
   let main_module = deno_core::resolve_path(
     &js_path.to_string_lossy(),
-    &std::env::current_dir().context("Unable to get CWD")?,
+    &std::env::current_dir()?,
   )?;
-  let permissions = PermissionsContainer::allow_all();
-
   let mut worker = MainWorker::bootstrap_from_options(
     main_module.clone(),
-    permissions,
-    options,
+    PermissionsContainer::allow_all(),
+    WorkerOptions {
+      module_loader: Rc::new(FsModuleLoader),
+      extensions: vec![hello_runtime::init_ops_and_esm()],
+      ..Default::default()
+    },
   );
   worker.execute_main_module(&main_module).await?;
   worker.run_event_loop(false).await?;

--- a/runtime/examples/hello_runtime_bootstrap.js
+++ b/runtime/examples/hello_runtime_bootstrap.js
@@ -1,0 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+function hello() {
+  console.log("Hello from extension!");
+}
+globalThis.Extension = { hello };


### PR DESCRIPTION
Fixes #18979.

This changes the predicate for allowing `ext:` specifier resolution from `snapshot_loaded_and_not_snapshotting` to `ext_resolution_allowed` which is only set to true during the extension module loading phase. Module loaders as used in core
are now declared as `ExtModuleLoader` rather than `dyn ModuleLoader`.