### PR TITLE
fix(ext/ffi): UnsafeCallback can hang with 'deno test'

### DIFF
--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -426,7 +426,7 @@ class UnsafeCallback {
 
   close() {
     this.#refcount = 0;
-    core.close(this.#rid);
+    ops.op_ffi_unsafe_callback_close(this.#rid);
   }
 }
 

--- a/ext/ffi/callback.rs
+++ b/ext/ffi/callback.rs
@@ -80,6 +80,10 @@ impl Resource for UnsafeCallbackResource {
   fn name(&self) -> Cow<str> {
     "unsafecallback".into()
   }
+
+  fn close(self: Rc<Self>) {
+    self.cancel.cancel();
+  }
 }
 
 struct CallbackInfo {
@@ -616,10 +620,10 @@ pub fn op_ffi_unsafe_callback_close(
   unsafe {
     let callback_resource =
       state.resource_table.take::<UnsafeCallbackResource>(rid)?;
-    callback_resource.cancel.cancel();
     let info = Box::from_raw(callback_resource.info);
     let _ = v8::Global::from_raw(scope, info.callback);
     let _ = v8::Global::from_raw(scope, info.context);
+    callback_resource.close();
   }
   Ok(())
 }

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -10,7 +10,6 @@ use std::os::raw::c_char;
 use std::os::raw::c_short;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::atomic::AtomicU32;
 
 mod call;
 mod callback;
@@ -42,12 +41,6 @@ const _: () = {
   assert!(size_of::<c_short>() == 2);
   assert!(size_of::<*const ()>() == 8);
 };
-
-static ISOLATE_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
-
-thread_local! {
-  static LOCAL_ISOLATE_ID: RefCell<u32> = RefCell::new(0);
-}
 
 pub(crate) const MAX_SAFE_INTEGER: isize = 9007199254740991;
 pub(crate) const MIN_SAFE_INTEGER: isize = -9007199254740991;

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -2,7 +2,6 @@
 
 use deno_core::error::AnyError;
 use deno_core::futures::channel::mpsc;
-use deno_core::v8;
 use deno_core::OpState;
 
 use std::cell::RefCell;
@@ -10,8 +9,8 @@ use std::mem::size_of;
 use std::os::raw::c_char;
 use std::os::raw::c_short;
 use std::path::Path;
-use std::ptr;
 use std::rc::Rc;
+use std::sync::atomic::AtomicU32;
 
 mod call;
 mod callback;
@@ -25,6 +24,7 @@ mod turbocall;
 use call::op_ffi_call_nonblocking;
 use call::op_ffi_call_ptr;
 use call::op_ffi_call_ptr_nonblocking;
+use callback::op_ffi_unsafe_callback_close;
 use callback::op_ffi_unsafe_callback_create;
 use callback::op_ffi_unsafe_callback_ref;
 use dlfcn::op_ffi_load;
@@ -43,8 +43,10 @@ const _: () = {
   assert!(size_of::<*const ()>() == 8);
 };
 
+static ISOLATE_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
+
 thread_local! {
-  static LOCAL_ISOLATE_POINTER: RefCell<*const v8::Isolate> = RefCell::new(ptr::null());
+  static LOCAL_ISOLATE_ID: RefCell<u32> = RefCell::new(0);
 }
 
 pub(crate) const MAX_SAFE_INTEGER: isize = 9007199254740991;
@@ -109,6 +111,7 @@ deno_core::extension!(deno_ffi,
     op_ffi_read_f64<P>,
     op_ffi_read_ptr<P>,
     op_ffi_unsafe_callback_create<P>,
+    op_ffi_unsafe_callback_close,
     op_ffi_unsafe_callback_ref,
   ],
   esm = [ "00_ffi.js" ],


### PR DESCRIPTION
fixes https://github.com/denoland/deno/issues/18898

The way `UnsafeCallback` detected its "own thread" was based on the isolate pointer value saved into a thread-local. It turns out that it _is_ possible for the isolate to be moved around, meaning that the isolate pointer is not stable. This would happen regularly with `deno test` running multiple files.

To fix this issue, this PR changes `UnsafeCallback` to not require an isolate pointer internally and to instead use an arbitrary isolate ID to detect its "own thread". The callbacks thus no longer need to know their own isolate specifically for any reason.