### PR TITLE
fix(watch): restore env between runs

### DIFF
--- a/cli/tools/run.rs
+++ b/cli/tools/run.rs
@@ -123,7 +123,9 @@ async fn run_with_watch(flags: Flags) -> Result<i32, AnyError> {
       let worker = create_cli_main_worker_factory()
         .create_main_worker(main_module, permissions)
         .await?;
+      let reset_env = util::env::reset_env_func();
       worker.run_for_watcher().await?;
+      reset_env();
 
       Ok(())
     })

--- a/cli/util/env.rs
+++ b/cli/util/env.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use std::collections::BTreeMap;
+use std::env;
+
+type Snapshot = BTreeMap<String, String>;
+
+pub fn make_snapshot() -> Snapshot {
+  return env::vars().collect();
+}
+
+pub fn restore_snapshot(old: &Snapshot) {
+  env::vars()
+    .filter(|(k, _)| !old.contains_key(k))
+    .for_each(|(k, _)| env::remove_var(k));
+  old.iter().for_each(|(k, v)| env::set_var(k, v));
+}
+
+pub fn reset_env_func() -> impl Fn() {
+  let current_env = make_snapshot();
+  return move || restore_snapshot(&current_env);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_snapshots() {
+    env::set_var("DENO_HELLO_WORLD", "Hello World!");
+    env::set_var("DENO_FOOBAR", "foobar");
+    let reset_env = reset_env_func();
+
+    env::remove_var("DENO_HELLO_WORLD");
+    env::set_var("DENO_RUSTY_SPOONS", "there is no spoon");
+
+    reset_env();
+    assert!(env::var("DENO_HELLO_WORLD").unwrap() == "Hello World!");
+    assert!(env::var("DENO_FOOBAR").unwrap() == "foobar");
+    assert!(env::var("DENO_RUSTY_SPOONS").is_err());
+  }
+}

--- a/cli/util/mod.rs
+++ b/cli/util/mod.rs
@@ -6,6 +6,7 @@ pub mod console;
 pub mod diff;
 pub mod display;
 pub mod draw_thread;
+pub mod env;
 pub mod file_watcher;
 pub mod fs;
 pub mod logger;


### PR DESCRIPTION
Fixes #15883

Let me know what you think?

----

I wasn't able to run the linter because of some unrelated issues, not sure what that's about:

```
error: the borrowed expression implements the required traits
   --> ext/fs/std_fs.rs:437:44
    |
437 |         let mut from_file = fs::File::open(&from)?;
    |                                            ^^^^^ help: change this to: `from`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `-D clippy::needless-borrow` implied by `-D clippy::all`

error: the borrowed expression implements the required traits
   --> ext/fs/std_fs.rs:446:17
    |
446 |           .open(&to)?;
    |                 ^^^ help: change this to: `to`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: could not compile `deno_fs` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `deno_fs` due to 2 previous errors
error: could not compile `deno_fs` due to 2 previous errors
error: Uncaught (in promise) Error: clippy failed
    throw new Error("clippy failed");
          ^
    at clippy (file:///Users/deniz/Code/denoland/deno/tools/lint.js:165:11)
    at eventLoopTick (ext:core/01_core.js:181:11)
    at async file:///Users/deniz/Code/denoland/deno/tools/lint.js:21:3
```

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
