### PR TITLE
feat(ext/http): Automatic compression for Deno.serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project",
+ "rand",
  "ring",
  "serde",
  "slab",

--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -1993,7 +1993,22 @@ async function makeTempFile(size: number) {
 
 const compressionTestCases = [
   { name: "Empty", length: 0, in: {}, out: {}, expect: null },
-  // { name: "EmptyAcceptGzip", length: 0, in: { "Accept-Encoding": "gzip" }, out: {}, expect: null },
+  {
+    name: "EmptyAcceptGzip",
+    length: 0,
+    in: { "Accept-Encoding": "gzip" },
+    out: {},
+    expect: null,
+  },
+  // This technically would be compressible if not for the size, however the size_hint is not implemented
+  // for FileResource and we don't currently peek ahead on resources.
+  // {
+  //   name: "EmptyAcceptGzip2",
+  //   length: 0,
+  //   in: { "Accept-Encoding": "gzip" },
+  //   out: { "Content-Type": "text/plain" },
+  //   expect: null,
+  // },
   { name: "Uncompressible", length: 1024, in: {}, out: {}, expect: null },
   {
     name: "UncompressibleAcceptGzip",

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -50,3 +50,4 @@ tokio-util = { workspace = true, features = ["io"] }
 
 [dev-dependencies]
 bencher.workspace = true
+rand.workspace = true

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -500,11 +500,12 @@ fn is_request_compressible(headers: &HeaderMap) -> Compression {
   let accepted = fly_accept_encoding::encodings_iter(headers).filter(|r| {
     matches!(r, Ok((Some(Encoding::Identity | Encoding::Gzip), _)))
   });
+  #[allow(clippy::single_match)]
   match fly_accept_encoding::preferred(accepted) {
     Ok(Some(fly_accept_encoding::Encoding::Gzip)) => return Compression::GZip,
     _ => {}
   }
-  return Compression::None;
+  Compression::None
 }
 
 fn is_response_compressible(headers: &HeaderMap) -> bool {
@@ -530,7 +531,7 @@ fn is_response_compressible(headers: &HeaderMap) -> bool {
       }
     }
   }
-  return true;
+  true
 }
 
 fn modify_compressibility_from_response(
@@ -555,7 +556,7 @@ fn modify_compressibility_from_response(
   weaken_etag(headers);
   headers.remove(CONTENT_LENGTH);
   headers.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
-  return compression;
+  compression
 }
 
 /// If the user provided a ETag header for uncompressed data, we need to ensure it is a

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -492,11 +492,11 @@ pub fn op_set_response_body_resource(
   };
 
   with_resp_mut(index, move |response| {
-    response.as_mut().unwrap().body_mut().initialize(
-      ResponseBytesInner::Resource(ResourceBodyAdapter::new(
-        resource, auto_close,
-      )),
-    )
+    response
+      .as_mut()
+      .unwrap()
+      .body_mut()
+      .initialize(ResponseBytesInner::from_resource(resource, auto_close))
   });
 
   Ok(())
@@ -511,7 +511,7 @@ pub fn op_set_response_body_stream(
   let (tx, rx) = tokio::sync::mpsc::channel(1);
   let (tx, rx) = (
     V8StreamHttpResponseBody::new(tx),
-    ResponseBytesInner::V8Stream(rx),
+    ResponseBytesInner::from_v8(rx),
   );
 
   with_resp_mut(index, move |response| {

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -624,9 +624,13 @@ pub fn op_set_response_body_resource(
     state.resource_table.get_any(stream_rid)?
   };
 
-  set_response(index, None, move |compression| {
-    ResponseBytesInner::from_resource(compression, resource, auto_close)
-  });
+  set_response(
+    index,
+    resource.size_hint().1.map(|s| s as usize),
+    move |compression| {
+      ResponseBytesInner::from_resource(compression, resource, auto_close)
+    },
+  );
 
   Ok(())
 }

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -7,7 +7,6 @@ use crate::request_properties::HttpConnectionProperties;
 use crate::request_properties::HttpListenProperties;
 use crate::request_properties::HttpPropertyExtractor;
 use crate::response_body::CompletionHandle;
-use crate::response_body::ResourceBodyAdapter;
 use crate::response_body::ResponseBytes;
 use crate::response_body::ResponseBytesInner;
 use crate::response_body::V8StreamHttpResponseBody;
@@ -18,7 +17,6 @@ use deno_core::futures::TryFutureExt;
 use deno_core::op;
 use deno_core::AsyncRefCell;
 use deno_core::AsyncResult;
-use deno_core::BufView;
 use deno_core::ByteString;
 use deno_core::CancelFuture;
 use deno_core::CancelHandle;
@@ -33,7 +31,6 @@ use deno_net::raw::put_network_stream_resource;
 use deno_net::raw::NetworkStream;
 use deno_net::raw::NetworkStreamAddress;
 use http::request::Parts;
-use http::response;
 use hyper1::body::Incoming;
 use hyper1::header::COOKIE;
 use hyper1::http::HeaderName;
@@ -529,7 +526,7 @@ pub fn op_set_response_body_text(index: u32, text: String) {
         .as_mut()
         .unwrap()
         .body_mut()
-        .initialize(ResponseBytesInner::Bytes(BufView::from(text.into_bytes())))
+        .initialize(ResponseBytesInner::from_vec(text.into_bytes()))
     });
   }
 }
@@ -542,7 +539,7 @@ pub fn op_set_response_body_bytes(index: u32, buffer: &[u8]) {
         .as_mut()
         .unwrap()
         .body_mut()
-        .initialize(ResponseBytesInner::Bytes(BufView::from(buffer.to_vec())))
+        .initialize(ResponseBytesInner::from_slice(buffer))
     });
   };
 }

--- a/ext/http/response_body.rs
+++ b/ext/http/response_body.rs
@@ -6,8 +6,11 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Waker;
 
+use bytes::Bytes;
+use bytes::BytesMut;
 use deno_core::error::bad_resource;
 use deno_core::error::AnyError;
+use deno_core::futures::ready;
 use deno_core::futures::FutureExt;
 use deno_core::AsyncRefCell;
 use deno_core::AsyncResult;
@@ -17,9 +20,41 @@ use deno_core::CancelTryFuture;
 use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::WriteOutcome;
+use http::HeaderMap;
 use hyper1::body::Body;
 use hyper1::body::Frame;
 use hyper1::body::SizeHint;
+use pin_project::pin_project;
+
+/// Simplification for nested types we use for our streams. We provide a way to convert from
+/// this type into Hyper's body [`Frame`].
+enum ResponseStreamResult {
+  /// Stream is over.
+  EOS,
+  /// Stream provided non-empty data.
+  NonEmptyBuf(BufView),
+  /// Stream is ready, but provided no data. Retry. This is a result that is like Pending, but does
+  /// not register a waker and should be called again at the lowest level of this code. Generally this
+  /// will only be returned from compression streams that require additional buffering.
+  NoData,
+  /// Stream provided trailers.
+  Trailers(HeaderMap),
+  /// Stream failed.
+  Error(AnyError),
+}
+
+impl From<ResponseStreamResult> for Option<Result<Frame<BufView>, AnyError>> {
+  fn from(value: ResponseStreamResult) -> Self {
+    match value {
+      ResponseStreamResult::EOS => None,
+      ResponseStreamResult::NonEmptyBuf(buf) => Some(Ok(Frame::data(buf))),
+      ResponseStreamResult::Error(err) => Some(Err(err)),
+      ResponseStreamResult::Trailers(map) => Some(Ok(Frame::trailers(map))),
+      // This result should be handled by retrying
+      ResponseStreamResult::NoData => unimplemented!(),
+    }
+  }
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct CompletionHandle {
@@ -66,7 +101,7 @@ trait PollFrame: Unpin {
   fn poll_frame(
     self: Pin<&mut Self>,
     cx: &mut std::task::Context<'_>,
-  ) -> std::task::Poll<Option<Result<Frame<BufView>, AnyError>>>;
+  ) -> std::task::Poll<ResponseStreamResult>;
 
   fn size_hint(&self) -> SizeHint;
 }
@@ -146,15 +181,22 @@ impl ResponseBytesInner {
       Self::Empty => SizeHint::with_exact(0),
       Self::Bytes(bytes) => SizeHint::with_exact(bytes.len() as u64),
       Self::UncompressedStream(res) => res.size_hint(),
-      // Self::GZipStream(res) => SizeHint::
+      Self::GZipStream(res) => SizeHint::default(),
     }
   }
 
-  pub fn from_v8(compression: Compression, rx: tokio::sync::mpsc::Receiver<BufView>) -> Self {
+  pub fn from_v8(
+    compression: Compression,
+    rx: tokio::sync::mpsc::Receiver<BufView>,
+  ) -> Self {
     Self::UncompressedStream(ResponseStream::V8Stream(rx))
   }
 
-  pub fn from_resource(compression: Compression, stm: Rc<dyn Resource>, auto_close: bool) -> Self {
+  pub fn from_resource(
+    compression: Compression,
+    stm: Rc<dyn Resource>,
+    auto_close: bool,
+  ) -> Self {
     Self::UncompressedStream(ResponseStream::Resource(
       ResourceBodyAdapter::new(stm, auto_close),
     ))
@@ -177,30 +219,33 @@ impl Body for ResponseBytes {
     mut self: Pin<&mut Self>,
     cx: &mut std::task::Context<'_>,
   ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-    match &mut self.0 {
-      ResponseBytesInner::Done | ResponseBytesInner::Empty => {
-        unreachable!()
-      }
-      ResponseBytesInner::Bytes(..) => {
-        if let ResponseBytesInner::Bytes(data) = self.complete(true) {
-          std::task::Poll::Ready(Some(Ok(Frame::data(data))))
-        } else {
+    let res = loop {
+      let res = match &mut self.0 {
+        ResponseBytesInner::Done | ResponseBytesInner::Empty => {
           unreachable!()
         }
-      }
-      ResponseBytesInner::UncompressedStream(stm) => {
-        match Pin::new(stm).poll_frame(cx) {
-          x @ std::task::Poll::Ready(None) => {
-            self.complete(true);
-            x
-          }
-          x @ _ => x,
+        ResponseBytesInner::Bytes(..) => {
+          let ResponseBytesInner::Bytes(data) = self.complete(true) else { unreachable!(); };
+          return std::task::Poll::Ready(Some(Ok(Frame::data(data))));
         }
-      },
-      ResponseBytesInner::GZipStream(stm) => {
-
+        ResponseBytesInner::UncompressedStream(stm) => {
+          ready!(Pin::new(stm).poll_frame(cx))
+        }
+        ResponseBytesInner::GZipStream(stm) => {
+          ready!(Pin::new(stm).poll_frame(cx))
+        }
+      };
+      // This is where we retry the NoData response
+      if matches!(res, ResponseStreamResult::NoData) {
+        continue;
       }
+      break res;
+    };
+
+    if matches!(res, ResponseStreamResult::EOS) {
+      self.complete(true);
     }
+    std::task::Poll::Ready(res.into())
   }
 
   fn is_end_stream(&self) -> bool {
@@ -242,7 +287,7 @@ impl PollFrame for ResponseStream {
   fn poll_frame(
     mut self: Pin<&mut Self>,
     cx: &mut std::task::Context<'_>,
-  ) -> std::task::Poll<Option<Result<Frame<BufView>, AnyError>>> {
+  ) -> std::task::Poll<ResponseStreamResult> {
     match &mut *self {
       ResponseStream::Resource(res) => Pin::new(res).poll_frame(cx),
       ResponseStream::V8Stream(res) => Pin::new(res).poll_frame(cx),
@@ -261,24 +306,23 @@ impl PollFrame for ResourceBodyAdapter {
   fn poll_frame(
     mut self: Pin<&mut Self>,
     cx: &mut std::task::Context<'_>,
-  ) -> std::task::Poll<Option<Result<Frame<BufView>, AnyError>>> {
-    match self.future.poll_unpin(cx) {
-      std::task::Poll::Pending => std::task::Poll::Pending,
-      std::task::Poll::Ready(Err(err)) => {
-        std::task::Poll::Ready(Some(Err(err)))
-      }
-      std::task::Poll::Ready(Ok(buf)) => {
+  ) -> std::task::Poll<ResponseStreamResult> {
+    let res = match ready!(self.future.poll_unpin(cx)) {
+      Err(err) => ResponseStreamResult::Error(err),
+      Ok(buf) => {
         if buf.is_empty() {
           if self.auto_close {
             self.stm.clone().close();
           }
-          return std::task::Poll::Ready(None);
+          ResponseStreamResult::EOS
+        } else {
+          // Re-arm the future
+          self.future = self.stm.clone().read(64 * 1024);
+          ResponseStreamResult::NonEmptyBuf(buf)
         }
-        // Re-arm the future
-        self.future = self.stm.clone().read(64 * 1024);
-        std::task::Poll::Ready(Some(Ok(Frame::data(buf))))
       }
-    }
+    };
+    std::task::Poll::Ready(res)
   }
 
   fn size_hint(&self) -> SizeHint {
@@ -296,14 +340,12 @@ impl PollFrame for tokio::sync::mpsc::Receiver<BufView> {
   fn poll_frame(
     mut self: Pin<&mut Self>,
     cx: &mut std::task::Context<'_>,
-  ) -> std::task::Poll<Option<Result<Frame<BufView>, AnyError>>> {
-    match self.poll_recv(cx) {
-      std::task::Poll::Pending => std::task::Poll::Pending,
-      std::task::Poll::Ready(Some(buf)) => {
-        std::task::Poll::Ready(Some(Ok(Frame::data(buf))))
-      }
-      std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-    }
+  ) -> std::task::Poll<ResponseStreamResult> {
+    let res = match ready!(self.poll_recv(cx)) {
+      Some(buf) => ResponseStreamResult::NonEmptyBuf(buf),
+      None => ResponseStreamResult::EOS,
+    };
+    std::task::Poll::Ready(res)
   }
 
   fn size_hint(&self) -> SizeHint {
@@ -311,8 +353,154 @@ impl PollFrame for tokio::sync::mpsc::Receiver<BufView> {
   }
 }
 
-struct GZipResponseStream {
-  stm: async_compression::tokio::bufread::GzipEncoder<ResponseStream>,
+#[derive(Copy, Clone, Debug)]
+enum GZipState {
+  Header,
+  Streaming,
+  Flushing,
+  Trailer,
+  EOS,
+}
+
+#[pin_project]
+pub struct GZipResponseStream {
+  stm: flate2::Compress,
+  crc: flate2::Crc,
+  next_buf: Option<BytesMut>,
+  partial: Option<BufView>,
+  #[pin]
+  underlying: ResponseStream,
+  state: GZipState,
+}
+
+impl GZipResponseStream {
+  pub fn new(underlying: ResponseStream) -> Self {
+    Self {
+      stm: flate2::Compress::new(flate2::Compression::fast(), false),
+      crc: flate2::Crc::new(),
+      next_buf: None,
+      partial: None,
+      state: GZipState::Header,
+      underlying,
+    }
+  }
+}
+
+/// This is a minimal GZip header suitable for serving data from a webserver. We don't need to provide
+/// most of the information. We're skipping header name, CRC, etc, and providing a null timestamp.
+///
+/// We're using compression level 1, as higher levels don't produce significant size differences. This
+/// is probably the reason why nginx's default gzip compression level is also 1:
+///
+/// https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_comp_level
+static GZIP_HEADER: Bytes =
+  Bytes::from_static(&[0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0, 0x01, 0xff]);
+
+impl PollFrame for GZipResponseStream {
+  fn poll_frame(
+    self: Pin<&mut Self>,
+    cx: &mut std::task::Context<'_>,
+  ) -> std::task::Poll<ResponseStreamResult> {
+    let this = self.get_mut();
+    let state = &mut this.state;
+    let orig_state = *state;
+    let frame = match *state {
+      GZipState::EOS => {
+        return std::task::Poll::Ready(ResponseStreamResult::EOS)
+      }
+      GZipState::Header => {
+        *state = GZipState::Streaming;
+        return std::task::Poll::Ready(ResponseStreamResult::NonEmptyBuf(
+          BufView::from(GZIP_HEADER.clone()),
+        ));
+      }
+      GZipState::Trailer => {
+        *state = GZipState::EOS;
+        let mut v = Vec::with_capacity(8);
+        v.extend(&this.crc.sum().to_le_bytes());
+        v.extend(&this.crc.amount().to_le_bytes());
+        return std::task::Poll::Ready(ResponseStreamResult::NonEmptyBuf(
+          BufView::from(v),
+        ));
+      }
+      GZipState::Streaming => {
+        if let Some(partial) = this.partial.take() {
+          ResponseStreamResult::NonEmptyBuf(partial)
+        } else {
+          ready!(Pin::new(&mut this.underlying).poll_frame(cx))
+        }
+      }
+      GZipState::Flushing => ResponseStreamResult::EOS,
+    };
+
+    let stm = &mut this.stm;
+
+    // Ideally we could use MaybeUninit here, but flate2 requires &[u8]. We should also try
+    // to dynamically adjust this buffer.
+    let mut buf = this
+      .next_buf
+      .take()
+      .unwrap_or_else(|| BytesMut::zeroed(64 * 1024));
+
+    let start_in = stm.total_in();
+    let start_out = stm.total_out();
+    let res = match frame {
+      // Short-circuit these and just return
+      x @ (ResponseStreamResult::NoData
+      | ResponseStreamResult::Error(..)
+      | ResponseStreamResult::Trailers(..)) => {
+        return std::task::Poll::Ready(x)
+      }
+      ResponseStreamResult::EOS => {
+        *state = GZipState::Flushing;
+        stm.compress(&[], &mut buf, flate2::FlushCompress::Finish)
+      }
+      ResponseStreamResult::NonEmptyBuf(mut input) => {
+        let res = stm.compress(&*input, &mut *buf, flate2::FlushCompress::None);
+        let len_in = (stm.total_in() - start_in) as usize;
+        debug_assert!(len_in <= input.len());
+        this.crc.update(&input[..len_in]);
+        if len_in < input.len() {
+          input.advance_cursor(len_in);
+          this.partial = Some(input);
+        }
+        res
+      }
+    };
+    let len = stm.total_out() - start_out;
+    let res = match res {
+      Err(err) => ResponseStreamResult::Error(err.into()),
+      Ok(flate2::Status::BufError) => {
+        // This should not happen
+        unreachable!("old={orig_state:?} new={state:?} buf_len={}", buf.len());
+      }
+      Ok(flate2::Status::Ok) => {
+        if len == 0 {
+          this.next_buf = Some(buf);
+          ResponseStreamResult::NoData
+        } else {
+          buf.truncate(len as usize);
+          ResponseStreamResult::NonEmptyBuf(BufView::from(buf.freeze()))
+        }
+      }
+      Ok(flate2::Status::StreamEnd) => {
+        *state = GZipState::Trailer;
+        if len == 0 {
+          this.next_buf = Some(buf);
+          ResponseStreamResult::NoData
+        } else {
+          buf.truncate(len as usize);
+          ResponseStreamResult::NonEmptyBuf(BufView::from(buf.freeze()))
+        }
+      }
+    };
+
+    std::task::Poll::Ready(res)
+  }
+
+  fn size_hint(&self) -> SizeHint {
+    SizeHint::default()
+  }
 }
 
 /// A response body object that can be passed to V8. This body will feed byte buffers to a channel which
@@ -359,4 +547,185 @@ impl Resource for V8StreamHttpResponseBody {
   fn close(self: Rc<Self>) {
     self.1.cancel();
   }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use deno_core::futures::future::poll_fn;
+  use std::hash::Hasher;
+  use std::io::Read;
+  use std::io::Write;
+
+  fn zeros() -> Vec<u8> {
+    vec![0; 1024 * 1024]
+  }
+
+  fn hard_to_gzip_data() -> Vec<u8> {
+    const SIZE: usize = 1024 * 1024;
+    let mut v = Vec::with_capacity(SIZE);
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for i in 0..SIZE {
+      hasher.write_usize(i);
+      v.push(hasher.finish() as u8);
+    }
+    v
+  }
+
+  fn already_gzipped_data() -> Vec<u8> {
+    let mut v = Vec::with_capacity(1024 * 1024);
+    let mut gz =
+      flate2::GzBuilder::new().write(&mut v, flate2::Compression::best());
+    gz.write_all(&hard_to_gzip_data()).unwrap();
+    _ = gz.finish().unwrap();
+    v
+  }
+
+  fn empty() -> impl Iterator<Item = Vec<u8>> {
+    vec![].into_iter()
+  }
+
+  fn chunk(mut v: Vec<u8>) -> impl Iterator<Item = Vec<u8>> {
+    // Chunk the data into 10k
+    let mut out = vec![];
+    for v in v.chunks(10 * 1024) {
+      out.push(v.to_vec());
+    }
+    out.into_iter()
+  }
+
+  fn random(mut v: Vec<u8>) -> impl Iterator<Item = Vec<u8>> {
+    let mut out = vec![];
+    loop {
+      if v.is_empty() {
+        break;
+      }
+      let rand = (rand::random::<usize>() % v.len()) + 1;
+      let new = v.split_off(rand);
+      out.push(v);
+      v = new;
+    }
+    // Print the lengths of the vectors if we actually fail this test at some point
+    let lengths = out.iter().map(|v| v.len()).collect::<Vec<_>>();
+    eprintln!("Lengths = {:?}", lengths);
+    out.into_iter()
+  }
+
+  fn front_load(mut v: Vec<u8>) -> impl Iterator<Item = Vec<u8>> {
+    // Chunk the data at 90%
+    let offset = (v.len() * 90) / 100;
+    let v2 = v.split_off(offset);
+    vec![v, v2].into_iter()
+  }
+
+  fn front_load_but_one(mut v: Vec<u8>) -> impl Iterator<Item = Vec<u8>> {
+    // Chunk the data at 90%
+    let offset = v.len() - 1;
+    let v2 = v.split_off(offset);
+    vec![v, v2].into_iter()
+  }
+
+  fn back_load(mut v: Vec<u8>) -> impl Iterator<Item = Vec<u8>> {
+    // Chunk the data at 10%
+    let offset = (v.len() * 10) / 100;
+    let v2 = v.split_off(offset);
+    vec![v, v2].into_iter()
+  }
+
+  async fn test(i: impl Iterator<Item = Vec<u8>> + Send + 'static) {
+    let v = i.collect::<Vec<_>>();
+    let mut expected: Vec<u8> = vec![];
+    for v in &v {
+      expected.extend(v);
+    }
+    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let underlying = ResponseStream::V8Stream(rx);
+    let mut resp = GZipResponseStream::new(underlying);
+    let handle = tokio::task::spawn(async move {
+      for chunk in v {
+        tx.send(chunk.into()).await.ok().unwrap();
+      }
+    });
+    // Limit how many times we'll loop
+    const LIMIT: usize = 1000;
+    let mut v: Vec<u8> = vec![];
+    for i in 0..=LIMIT {
+      assert_ne!(i, LIMIT);
+      let frame = poll_fn(|cx| Pin::new(&mut resp).poll_frame(cx)).await;
+      if matches!(frame, ResponseStreamResult::EOS) {
+        break;
+      }
+      if matches!(frame, ResponseStreamResult::NoData) {
+        continue;
+      }
+      let ResponseStreamResult::NonEmptyBuf(buf) = frame else {
+        panic!("Unexpected stream type");
+      };
+      assert_ne!(buf.len(), 0);
+      v.extend(&*buf);
+    }
+
+    let mut gz = flate2::read::GzDecoder::new(&*v);
+    let mut v = vec![];
+    gz.read_to_end(&mut v).unwrap();
+
+    assert_eq!(v, expected);
+
+    handle.await.unwrap();
+  }
+
+  #[tokio::test]
+  async fn test_simple() {
+    test(vec![b"hello world".to_vec()].into_iter()).await
+  }
+
+  #[tokio::test]
+  async fn test_empty() {
+    test(vec![].into_iter()).await
+  }
+
+  #[tokio::test]
+  async fn test_simple_zeros() {
+    test(vec![vec![0; 0x10000]].into_iter()).await
+  }
+
+  macro_rules! test {
+    ($vec:ident) => {
+      mod $vec {
+        #[tokio::test]
+        async fn chunk() {
+          let iter = super::chunk(super::$vec());
+          super::test(iter).await;
+        }
+
+        #[tokio::test]
+        async fn front_load() {
+          let iter = super::front_load(super::$vec());
+          super::test(iter).await;
+        }
+
+        #[tokio::test]
+        async fn front_load_but_one() {
+          let iter = super::front_load_but_one(super::$vec());
+          super::test(iter).await;
+        }
+
+        #[tokio::test]
+        async fn back_load() {
+          let iter = super::back_load(super::$vec());
+          super::test(iter).await;
+        }
+
+        #[tokio::test]
+        async fn random() {
+          let iter = super::random(super::$vec());
+          super::test(iter).await;
+        }
+      }
+    };
+  }
+
+  test!(zeros);
+  test!(hard_to_gzip_data);
+  test!(already_gzipped_data);
 }

--- a/ext/http/response_body.rs
+++ b/ext/http/response_body.rs
@@ -639,7 +639,6 @@ mod tests {
   }
 
   fn front_load_but_one(mut v: Vec<u8>) -> impl Iterator<Item = Vec<u8>> {
-    // Chunk the data at 90%
     let offset = v.len() - 1;
     let v2 = v.split_off(offset);
     vec![v, v2].into_iter()

--- a/ext/http/response_body.rs
+++ b/ext/http/response_body.rs
@@ -7,7 +7,6 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Waker;
 
-use bytes::Buf;
 use bytes::Bytes;
 use bytes::BytesMut;
 use deno_core::error::bad_resource;
@@ -41,6 +40,8 @@ enum ResponseStreamResult {
   /// will only be returned from compression streams that require additional buffering.
   NoData,
   /// Stream provided trailers.
+  // TODO(mmastrac): We are threading trailers through the response system to eventually support Grpc.
+  #[allow(unused)]
   Trailers(HeaderMap),
   /// Stream failed.
   Error(AnyError),


### PR DESCRIPTION
`Content-Encoding: gzip` support for `Deno.serve`. This doesn't support Brotli (`br`) yet, however it should not be difficult to add. Heuristics for compression are modelled after those in `Deno.serveHttp`.

Tests are provided to ensure that the gzip compression is correct. We chunk a number of different streams (zeros, hard-to-compress data, already-gzipped data) in a number of different ways (regular, random, large/small, small/large).