### PR TITLE
perf(fmt): faster formatting for minified object literals

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -54,7 +54,7 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.84.2.wasm",
+    "https://plugins.dprint.dev/typescript-0.84.4.wasm",
     "https://plugins.dprint.dev/json-0.17.2.wasm",
     "https://plugins.dprint.dev/markdown-0.15.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.84.2"
+version = "0.84.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8979688409764dd95b356c0d278023cad45fbb24cf788eab8c972ae069a7a3f8"
+checksum = "9945b1fae98529bd905d66b3c5efd45408b928cd10b7a3e0764049cf9aaf2167"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -67,7 +67,7 @@ data-url.workspace = true
 dissimilar = "=1.0.4"
 dprint-plugin-json = "=0.17.2"
 dprint-plugin-markdown = "=0.15.2"
-dprint-plugin-typescript = "=0.84.2"
+dprint-plugin-typescript = "=0.84.4"
 encoding_rs.workspace = true
 env_logger = "=0.9.0"
 eszip = "=0.41.0"

--- a/ext/node/polyfills/_stream.d.ts
+++ b/ext/node/polyfills/_stream.d.ts
@@ -1190,7 +1190,7 @@ type PipelineDestinationPromiseFunction<T, P> = (
   source: AsyncIterable<T>,
 ) => Promise<P>;
 type PipelineDestination<S extends PipelineTransformSource<any>, P> = S extends
-  PipelineTransformSource<infer ST> ? 
+  PipelineTransformSource<infer ST> ?
     | WritableStream
     | PipelineDestinationIterableFunction<ST>
     | PipelineDestinationPromiseFunction<ST, P>


### PR DESCRIPTION
Has fix for https://github.com/dprint/dprint-plugin-typescript/issues/520