### PR TITLE
refactor(core): store pending ops per realm

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -29,7 +29,6 @@ pub type OpId = u16;
 
 #[pin_project]
 pub struct OpCall {
-  realm_idx: RealmIdx,
   promise_id: PromiseId,
   op_id: OpId,
   /// Future is not necessarily Unpin, so we need to pin_project.
@@ -45,7 +44,6 @@ impl OpCall {
     fut: Pin<Box<dyn Future<Output = OpResult> + 'static>>,
   ) -> Self {
     Self {
-      realm_idx: op_ctx.realm_idx,
       op_id: op_ctx.id,
       promise_id,
       fut: MaybeDone::Future(fut),
@@ -56,7 +54,6 @@ impl OpCall {
   /// `async { value }` or `futures::future::ready(value)`.
   pub fn ready(op_ctx: &OpCtx, promise_id: PromiseId, value: OpResult) -> Self {
     Self {
-      realm_idx: op_ctx.realm_idx,
       op_id: op_ctx.id,
       promise_id,
       fut: MaybeDone::Done(value),
@@ -65,13 +62,12 @@ impl OpCall {
 }
 
 impl Future for OpCall {
-  type Output = (RealmIdx, PromiseId, OpId, OpResult);
+  type Output = (PromiseId, OpId, OpResult);
 
   fn poll(
     self: std::pin::Pin<&mut Self>,
     cx: &mut std::task::Context<'_>,
   ) -> std::task::Poll<Self::Output> {
-    let realm_idx = self.realm_idx;
     let promise_id = self.promise_id;
     let op_id = self.op_id;
     let fut = &mut *self.project().fut;
@@ -88,7 +84,7 @@ impl Future for OpCall {
       MaybeDone::Future(f) => f.poll_unpin(cx),
       MaybeDone::Gone => std::task::Poll::Pending,
     }
-    .map(move |res| (realm_idx, promise_id, op_id, res))
+    .map(move |res| (promise_id, op_id, res))
   }
 }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -2,6 +2,7 @@
 
 use crate::error::AnyError;
 use crate::gotham_state::GothamState;
+use crate::realm::ContextState;
 use crate::resources::ResourceTable;
 use crate::runtime::GetErrorClassFn;
 use crate::runtime::JsRuntimeState;
@@ -23,7 +24,6 @@ use std::rc::Weak;
 use v8::fast_api::CFunctionInfo;
 use v8::fast_api::CTypeInfo;
 
-pub type RealmIdx = u16;
 pub type PromiseId = i32;
 pub type OpId = u16;
 
@@ -141,14 +141,13 @@ pub struct OpCtx {
   pub decl: Rc<OpDecl>,
   pub fast_fn_c_info: Option<NonNull<v8::fast_api::CFunctionInfo>>,
   pub runtime_state: Weak<RefCell<JsRuntimeState>>,
-  // Index of the current realm into `JsRuntimeState::known_realms`.
-  pub realm_idx: RealmIdx,
+  pub(crate) context_state: Rc<RefCell<ContextState>>,
 }
 
 impl OpCtx {
-  pub fn new(
+  pub(crate) fn new(
     id: OpId,
-    realm_idx: RealmIdx,
+    context_state: Rc<RefCell<ContextState>>,
     decl: Rc<OpDecl>,
     state: Rc<RefCell<OpState>>,
     runtime_state: Weak<RefCell<JsRuntimeState>>,
@@ -172,7 +171,7 @@ impl OpCtx {
       state,
       runtime_state,
       decl,
-      realm_idx,
+      context_state,
       fast_fn_c_info,
     }
   }

--- a/core/realm.rs
+++ b/core/realm.rs
@@ -206,9 +206,9 @@ impl JsRealmInner {
     // assert_eq!(Rc::strong_count(&self.1), 1);
 
     let state = self.state();
+    let raw_ptr = self.state().borrow().isolate.unwrap();
     // SAFETY: We know the isolate outlives the realm
-    let isolate =
-      unsafe { self.state().borrow().isolate.unwrap().as_mut().unwrap() };
+    let isolate = unsafe { raw_ptr.as_mut().unwrap() };
     let mut realm_state = state.borrow_mut();
     std::mem::take(&mut realm_state.js_event_loop_tick_cb);
     std::mem::take(&mut realm_state.js_build_custom_error_cb);

--- a/core/realm.rs
+++ b/core/realm.rs
@@ -150,20 +150,6 @@ impl JsRealmInner {
     &self.1
   }
 
-  // /// Attempt to destroy this realm, if there are no other clones of it alive.
-  // pub fn try_destroy(self, isolate: &mut v8::Isolate) -> Result<(), Self> {
-  //   // SAFETY: repr(transparent) allows us to take rc without triggering drop
-  //   let rc: Rc<v8::Global<v8::Context>> = unsafe { std::mem::transmute(self) };
-  //   match Rc::try_unwrap(rc) {
-  //     Ok(context) => {
-  //       // Force any circular references to clear
-  //       context.open(isolate).clear_all_slots(isolate);
-  //       Ok(())
-  //     }
-  //     Err(rc) => Err(Self(rc))
-  //   }
-  // }
-
   #[inline(always)]
   pub(crate) fn state(&self) -> Rc<RefCell<ContextState>> {
     self.0.clone()

--- a/core/realm.rs
+++ b/core/realm.rs
@@ -102,6 +102,7 @@ pub(crate) struct ContextState {
 /// keep the underlying V8 context alive even if it would have otherwise been
 /// garbage collected.
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct JsRealm(JsRealmInner);
 
 impl Deref for JsRealm {
@@ -224,6 +225,12 @@ impl JsRealmInner {
 impl JsRealm {
   pub(crate) fn new(inner: JsRealmInner) -> Self {
     Self(inner)
+  }
+
+  pub(crate) fn destroy(self) {
+    // SAFETY: #[repr(transparent)] allows this
+    let inner: JsRealmInner = unsafe { std::mem::transmute(self) };
+    inner.destroy()
   }
 
   #[inline(always)]

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -2666,7 +2666,7 @@ pub mod tests {
     {
       let realm = runtime.global_realm();
       assert_eq!(realm.num_pending_ops(), 2);
-      assert_eq!(realm.state().borrow().unrefed_ops.len(), 0);
+      assert_eq!(realm.num_unrefed_ops.len(), 0);
     }
   }
 

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -303,11 +303,11 @@ impl Drop for JsRuntime {
   fn drop(&mut self) {
     // Forcibly destroy all outstanding realms
     self.state.borrow_mut().destroy_all_realms();
-    // Ensure that we've correctly dropped all references
-    debug_assert_eq!(Rc::strong_count(&self.state), 1);
     if let Some(v8_isolate) = self.v8_isolate.as_mut() {
       Self::drop_state_and_module_map(v8_isolate);
     }
+    // Ensure that we've correctly dropped all references
+    debug_assert_eq!(Rc::strong_count(&self.state), 1);
   }
 }
 
@@ -2666,7 +2666,7 @@ pub mod tests {
     {
       let realm = runtime.global_realm();
       assert_eq!(realm.num_pending_ops(), 2);
-      assert_eq!(realm.num_unrefed_ops.len(), 0);
+      assert_eq!(realm.num_unrefed_ops(), 0);
     }
   }
 


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/19020#issuecomment-1539959897

This implementation is not complete - when the realm is garbage collected its "pending_ops" container is not removed. CC @andreubotella any pointers here?