### PR TITLE
bench: fix benchmarks with extensions

### DIFF
--- a/bench_util/benches/utf8.rs
+++ b/bench_util/benches/utf8.rs
@@ -24,7 +24,6 @@ fn setup() -> Vec<Extension> {
       "#,
       ),
     }])
-    .esm_entry_point("ext:bench_setup/setup.js")
     .build()]
 }
 

--- a/bench_util/benches/utf8.rs
+++ b/bench_util/benches/utf8.rs
@@ -24,6 +24,7 @@ fn setup() -> Vec<Extension> {
       "#,
       ),
     }])
+    .esm_entry_point("ext:bench_setup/setup.js")
     .build()]
 }
 

--- a/ext/url/benches/url_ops.rs
+++ b/ext/url/benches/url_ops.rs
@@ -22,6 +22,7 @@ fn setup() -> Vec<Extension> {
         "#,
         ),
       }])
+      .esm_entry_point("ext:bench_setup/setup")
       .build(),
   ]
 }

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -45,6 +45,7 @@ fn setup() -> Vec<Extension> {
       .state(|state| {
         state.put(Permissions {});
       })
+      .esm_entry_point("ext:bench_setup/setup")
       .build(),
   ]
 }

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -40,6 +40,7 @@ fn setup() -> Vec<Extension> {
     .state(|state| {
       state.put(Permissions{});
     })
+    .esm_entry_point("ext:bench_setup/setup")
     .build()
   ]
 }

--- a/ext/webidl/benches/dict.rs
+++ b/ext/webidl/benches/dict.rs
@@ -19,6 +19,7 @@ fn setup() -> Vec<Extension> {
           "dict.js"
         )),
       }])
+      .esm_entry_point("ext:deno_webidl_bench/setup.js")
       .build(),
   ]
 }


### PR DESCRIPTION
They broke in f34fcd16ea4d504c8a87c0873c65598d70bb1d07