### PR TITLE
fix(console): handle error when inspecting promise-like

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -2235,6 +2235,13 @@ Deno.test(function inspectWithPrototypePollution() {
   }
 });
 
+Deno.test(function inspectPromiseLike() {
+  assertEquals(
+    Deno.inspect(Object.create(Promise.prototype)),
+    "Promise { <unknown> }",
+  );
+});
+
 Deno.test(function inspectorMethods() {
   console.timeStamp("test");
   console.profile("test");


### PR DESCRIPTION
Fixes https://discord.com/channels/684898665143206084/684911491035430919/1105900195406958672.

This was caused by: 
- A `TypeError` from `core.getPromiseDetails()` for promise-likes which also lead to that code path.
- Swallowing internal formatting errors by returning `undefined`. I've made it so that a special message is formatted in that case instead (note that this case is fixed now): 
![image](https://github.com/denoland/deno/assets/29990554/4e994bc1-dba0-41e7-bc4e-b71319763132)
