### PR TITLE
feat(task): glob expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,12 +1302,13 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15deca0c59b55353c4a26c0259dd271c21eb72af106271c6459fd551c5f7bdef"
+checksum = "5fc7ee9db8e2094ace8b1c318b6c83533bc923524f9a5425846fb0e2cd4731a7"
 dependencies = [
  "anyhow",
  "futures",
+ "glob",
  "monch",
  "os_pipe",
  "path-dedot",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,7 @@ deno_lockfile.workspace = true
 deno_npm.workspace = true
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }
 deno_semver.workspace = true
-deno_task_shell = "0.11.0"
+deno_task_shell = "0.12.0"
 napi_sym.workspace = true
 
 async-trait.workspace = true


### PR DESCRIPTION
This adds cross-platform glob expansion to deno task.

```jsonc
{
  "tasks": {
    // outputs all the typescript files found in the current
    // directory or any descendant directories
    "my_task": "echo **/*.ts"
  }
}
```

https://github.com/denoland/deno_task_shell/pull/85

Related #19030