### PR TITLE
fix(node): expose channels in worker_threads

### DIFF
--- a/cli/tests/node_compat/config.jsonc
+++ b/cli/tests/node_compat/config.jsonc
@@ -655,6 +655,7 @@
       "test-whatwg-url-override-hostname.js",
       "test-whatwg-url-properties.js",
       "test-whatwg-url-toascii.js",
+      "test-worker-threads-message-channel.js",
       "test-zlib-close-after-error.js",
       "test-zlib-close-after-write.js",
       "test-zlib-convenience-methods.js",

--- a/cli/tests/node_compat/config.jsonc
+++ b/cli/tests/node_compat/config.jsonc
@@ -655,6 +655,7 @@
       "test-whatwg-url-override-hostname.js",
       "test-whatwg-url-properties.js",
       "test-whatwg-url-toascii.js",
+      "test-worker-threads-broadcast-channel.js",
       "test-worker-threads-message-channel.js",
       "test-zlib-close-after-error.js",
       "test-zlib-close-after-write.js",

--- a/cli/tests/node_compat/test/parallel/test-worker-threads-broadcast-channel.js
+++ b/cli/tests/node_compat/test/parallel/test-worker-threads-broadcast-channel.js
@@ -1,0 +1,9 @@
+// deno-fmt-ignore-file
+// deno-lint-ignore-file
+
+"use strict";
+
+const assert = require("assert/strict");
+const worker_threads = require("worker_threads");
+
+assert.equal(BroadcastChannel, worker_threads.BroadcastChannel);

--- a/cli/tests/node_compat/test/parallel/test-worker-threads-message-channel.js
+++ b/cli/tests/node_compat/test/parallel/test-worker-threads-message-channel.js
@@ -1,0 +1,10 @@
+// deno-fmt-ignore-file
+// deno-lint-ignore-file
+
+"use strict";
+
+const assert = require("assert/strict");
+const worker_threads = require("worker_threads");
+
+assert.equal(MessageChannel, worker_threads.MessageChannel);
+assert.equal(MessagePort, worker_threads.MessagePort);

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -4,6 +4,7 @@
 import { resolve, toFileUrl } from "ext:deno_node/path.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
+import { BroadcastChannel } from "ext:deno_broadcast_channel/01_broadcast_channel.js";
 import { MessageChannel, MessagePort } from "ext:deno_web/13_message_port.js";
 
 const environmentData = new Map();
@@ -205,7 +206,6 @@ export function setEnvironmentData(key: unknown, value?: unknown) {
   }
 }
 
-export const BroadcastChannel = globalThis.BroadcastChannel;
 export const SHARE_ENV = Symbol.for("nodejs.worker_threads.SHARE_ENV");
 export function markAsUntransferable() {
   notImplemented("markAsUntransferable");
@@ -217,9 +217,10 @@ export function receiveMessageOnPort() {
   notImplemented("receiveMessageOnPort");
 }
 export {
+  _Worker as Worker,
+  BroadcastChannel,
   MessageChannel,
   MessagePort,
-  _Worker as Worker,
   parentPort,
   threadId,
   workerData,

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -4,6 +4,7 @@
 import { resolve, toFileUrl } from "ext:deno_node/path.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
+import { MessageChannel, MessagePort } from "ext:deno_web/13_message_port.js";
 
 const environmentData = new Map();
 let threads = 0;
@@ -204,11 +205,6 @@ export function setEnvironmentData(key: unknown, value?: unknown) {
   }
 }
 
-// deno-lint-ignore no-explicit-any
-const _MessagePort: typeof MessagePort = (globalThis as any).MessagePort;
-const _MessageChannel: typeof MessageChannel =
-  // deno-lint-ignore no-explicit-any
-  (globalThis as any).MessageChannel;
 export const BroadcastChannel = globalThis.BroadcastChannel;
 export const SHARE_ENV = Symbol.for("nodejs.worker_threads.SHARE_ENV");
 export function markAsUntransferable() {
@@ -221,8 +217,8 @@ export function receiveMessageOnPort() {
   notImplemented("receiveMessageOnPort");
 }
 export {
-  _MessageChannel as MessageChannel,
-  _MessagePort as MessagePort,
+  MessageChannel,
+  MessagePort,
   _Worker as Worker,
   parentPort,
   threadId,
@@ -233,8 +229,8 @@ export default {
   markAsUntransferable,
   moveMessagePortToContext,
   receiveMessageOnPort,
-  MessagePort: _MessagePort,
-  MessageChannel: _MessageChannel,
+  MessagePort,
+  MessageChannel,
   BroadcastChannel,
   Worker: _Worker,
   getEnvironmentData,


### PR DESCRIPTION
<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This PR ensures that node's `worker_threads` module exports `MessageChannel`, `MessagePort` and the `BroadcastChannel` API. Fixing these won't make `esbuild` work, but brings us one step closer 🎉 

Fixes #19028 .