### PR TITLE
feat(lsp): ability to configure document pre-load limit

### DIFF
--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -26,13 +26,6 @@ pub enum TestingNotification {
   Progress(testing_lsp_custom::TestRunProgressParams),
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub enum LspClientKind {
-  #[default]
-  CodeEditor,
-  Repl,
-}
-
 #[derive(Clone)]
 pub struct Client(Arc<dyn ClientTrait>);
 
@@ -49,10 +42,6 @@ impl Client {
 
   pub fn new_for_repl() -> Self {
     Self(Arc::new(ReplClient))
-  }
-
-  pub fn kind(&self) -> LspClientKind {
-    self.0.kind()
   }
 
   /// Gets additional methods that should only be called outside
@@ -160,7 +149,6 @@ impl OutsideLockClient {
 
 #[async_trait]
 trait ClientTrait: Send + Sync {
-  fn kind(&self) -> LspClientKind;
   async fn publish_diagnostics(
     &self,
     uri: lsp::Url,
@@ -189,10 +177,6 @@ struct TowerClient(tower_lsp::Client);
 
 #[async_trait]
 impl ClientTrait for TowerClient {
-  fn kind(&self) -> LspClientKind {
-    LspClientKind::CodeEditor
-  }
-
   async fn publish_diagnostics(
     &self,
     uri: lsp::Url,
@@ -312,10 +296,6 @@ struct ReplClient;
 
 #[async_trait]
 impl ClientTrait for ReplClient {
-  fn kind(&self) -> LspClientKind {
-    LspClientKind::Repl
-  }
-
   async fn publish_diagnostics(
     &self,
     _uri: lsp::Url,

--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -391,7 +391,7 @@ pub async fn collect(
   code_lenses.extend(
     collect_tsc(
       specifier,
-      &config.get_workspace_settings(),
+      config.workspace_settings(),
       line_index,
       navigation_tree,
     )

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -519,7 +519,7 @@ mod tests {
     source_fixtures: &[(&str, &str)],
     location: &Path,
   ) -> Documents {
-    let mut documents = Documents::new(location, Default::default());
+    let mut documents = Documents::new(location);
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -265,7 +265,7 @@ fn default_to_true() -> bool {
   true
 }
 
-fn default_preload_limit() -> usize {
+fn default_document_preload_limit() -> usize {
   1000
 }
 
@@ -323,8 +323,8 @@ pub struct WorkspaceSettings {
   pub lint: bool,
 
   /// Limits the number of files that can be preloaded by the language server.
-  #[serde(default = "default_preload_limit")]
-  pub preload_limit: usize,
+  #[serde(default = "default_document_preload_limit")]
+  pub document_preload_limit: usize,
 
   /// A flag that indicates if Dene should validate code against the unstable
   /// APIs for the workspace.
@@ -362,7 +362,7 @@ impl Default for WorkspaceSettings {
       inlay_hints: Default::default(),
       internal_debug: false,
       lint: true,
-      preload_limit: default_preload_limit(),
+      document_preload_limit: default_document_preload_limit(),
       suggest: Default::default(),
       testing: Default::default(),
       tls_certificate: None,
@@ -759,7 +759,7 @@ mod tests {
         },
         internal_debug: false,
         lint: true,
-        preload_limit: 1_000,
+        document_preload_limit: 1_000,
         suggest: CompletionSettings {
           complete_function_calls: false,
           names: true,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -265,6 +265,10 @@ fn default_to_true() -> bool {
   true
 }
 
+fn default_preload_limit() -> usize {
+  1000
+}
+
 fn empty_string_none<'de, D: serde::Deserializer<'de>>(
   d: D,
 ) -> Result<Option<String>, D::Error> {
@@ -318,6 +322,10 @@ pub struct WorkspaceSettings {
   #[serde(default = "default_to_true")]
   pub lint: bool,
 
+  /// Limits the number of files that can be preloaded by the language server.
+  #[serde(default = "default_preload_limit")]
+  pub preload_limit: usize,
+
   /// A flag that indicates if Dene should validate code against the unstable
   /// APIs for the workspace.
   #[serde(default)]
@@ -354,6 +362,7 @@ impl Default for WorkspaceSettings {
       inlay_hints: Default::default(),
       internal_debug: false,
       lint: true,
+      preload_limit: default_preload_limit(),
       suggest: Default::default(),
       testing: Default::default(),
       tls_certificate: None,
@@ -439,8 +448,8 @@ impl Config {
     }
   }
 
-  pub fn get_workspace_settings(&self) -> WorkspaceSettings {
-    self.settings.workspace.clone()
+  pub fn workspace_settings(&self) -> &WorkspaceSettings {
+    &self.settings.workspace
   }
 
   /// Set the workspace settings directly, which occurs during initialization
@@ -714,7 +723,7 @@ mod tests {
       .set_workspace_settings(json!({}))
       .expect("could not update");
     assert_eq!(
-      config.get_workspace_settings(),
+      config.workspace_settings().clone(),
       WorkspaceSettings {
         enable: false,
         enable_paths: Vec::new(),
@@ -750,6 +759,7 @@ mod tests {
         },
         internal_debug: false,
         lint: true,
+        preload_limit: 1_000,
         suggest: CompletionSettings {
           complete_function_calls: false,
           names: true,
@@ -778,7 +788,7 @@ mod tests {
       .set_workspace_settings(json!({ "cache": "" }))
       .expect("could not update");
     assert_eq!(
-      config.get_workspace_settings(),
+      config.workspace_settings().clone(),
       WorkspaceSettings::default()
     );
   }
@@ -790,7 +800,7 @@ mod tests {
       .set_workspace_settings(json!({ "import_map": "" }))
       .expect("could not update");
     assert_eq!(
-      config.get_workspace_settings(),
+      config.workspace_settings().clone(),
       WorkspaceSettings::default()
     );
   }
@@ -802,7 +812,7 @@ mod tests {
       .set_workspace_settings(json!({ "tls_certificate": "" }))
       .expect("could not update");
     assert_eq!(
-      config.get_workspace_settings(),
+      config.workspace_settings().clone(),
       WorkspaceSettings::default()
     );
   }
@@ -814,7 +824,7 @@ mod tests {
       .set_workspace_settings(json!({ "config": "" }))
       .expect("could not update");
     assert_eq!(
-      config.get_workspace_settings(),
+      config.workspace_settings().clone(),
       WorkspaceSettings::default()
     );
   }

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1096,7 +1096,7 @@ mod tests {
     location: &Path,
     maybe_import_map: Option<(&str, &str)>,
   ) -> StateSnapshot {
-    let mut documents = Documents::new(location, Default::default());
+    let mut documents = Documents::new(location);
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use super::cache::calculate_fs_version;
-use super::client::LspClientKind;
 use super::text::LineIndex;
 use super::tsc;
 use super::tsc::AssetDocument;
@@ -793,6 +792,16 @@ fn get_document_path(
   }
 }
 
+pub struct UpdateDocumentConfigOptions<'a> {
+  pub enabled_urls: Vec<Url>,
+  pub document_preload_limit: usize,
+  pub maybe_import_map: Option<Arc<import_map::ImportMap>>,
+  pub maybe_config_file: Option<&'a ConfigFile>,
+  pub maybe_package_json: Option<&'a PackageJson>,
+  pub npm_registry_api: Arc<CliNpmRegistryApi>,
+  pub npm_resolution: Arc<NpmResolution>,
+}
+
 /// Specify the documents to include on a `documents.documents(...)` call.
 #[derive(Debug, Clone, Copy)]
 pub enum DocumentsFilter {
@@ -818,8 +827,6 @@ pub struct Documents {
   open_docs: HashMap<ModuleSpecifier, Document>,
   /// Documents stored on the file system.
   file_system_docs: Arc<Mutex<FileSystemDocuments>>,
-  /// Kind of the client that is using the documents.
-  lsp_client_kind: LspClientKind,
   /// Hash of the config used for resolution. When the hash changes we update
   /// dependencies.
   resolver_config_hash: u64,
@@ -839,14 +846,13 @@ pub struct Documents {
 }
 
 impl Documents {
-  pub fn new(location: &Path, lsp_client_kind: LspClientKind) -> Self {
+  pub fn new(location: &Path) -> Self {
     Self {
       cache: HttpCache::new(location),
       dirty: true,
       dependents_map: Default::default(),
       open_docs: HashMap::default(),
       file_system_docs: Default::default(),
-      lsp_client_kind,
       resolver_config_hash: 0,
       imports: Default::default(),
       resolver: Default::default(),
@@ -1161,15 +1167,7 @@ impl Documents {
     Ok(())
   }
 
-  pub fn update_config(
-    &mut self,
-    enabled_urls: Vec<Url>,
-    maybe_import_map: Option<Arc<import_map::ImportMap>>,
-    maybe_config_file: Option<&ConfigFile>,
-    maybe_package_json: Option<&PackageJson>,
-    npm_registry_api: Arc<CliNpmRegistryApi>,
-    npm_resolution: Arc<NpmResolution>,
-  ) {
+  pub fn update_config(&mut self, options: UpdateDocumentConfigOptions) {
     fn calculate_resolver_config_hash(
       enabled_urls: &[Url],
       maybe_import_map: Option<&import_map::ImportMap>,
@@ -1208,14 +1206,16 @@ impl Documents {
       hasher.finish()
     }
 
-    let maybe_package_json_deps = maybe_package_json.map(|package_json| {
-      package_json::get_local_package_json_version_reqs(package_json)
-    });
-    let maybe_jsx_config =
-      maybe_config_file.and_then(|cf| cf.to_maybe_jsx_import_source_config());
+    let maybe_package_json_deps =
+      options.maybe_package_json.map(|package_json| {
+        package_json::get_local_package_json_version_reqs(package_json)
+      });
+    let maybe_jsx_config = options
+      .maybe_config_file
+      .and_then(|cf| cf.to_maybe_jsx_import_source_config());
     let new_resolver_config_hash = calculate_resolver_config_hash(
-      &enabled_urls,
-      maybe_import_map.as_deref(),
+      &options.enabled_urls,
+      options.maybe_import_map.as_deref(),
       maybe_jsx_config.as_ref(),
       maybe_package_json_deps.as_ref(),
     );
@@ -1223,21 +1223,21 @@ impl Documents {
       Arc::new(PackageJsonDepsProvider::new(maybe_package_json_deps));
     let deps_installer = Arc::new(PackageJsonDepsInstaller::new(
       deps_provider.clone(),
-      npm_registry_api.clone(),
-      npm_resolution.clone(),
+      options.npm_registry_api.clone(),
+      options.npm_resolution.clone(),
     ));
     self.resolver = Arc::new(CliGraphResolver::new(
       maybe_jsx_config,
-      maybe_import_map,
+      options.maybe_import_map,
       false,
-      npm_registry_api,
-      npm_resolution,
+      options.npm_registry_api,
+      options.npm_resolution,
       deps_provider,
       deps_installer,
     ));
     self.imports = Arc::new(
       if let Some(Ok(imports)) =
-        maybe_config_file.map(|cf| cf.to_maybe_imports())
+        options.maybe_config_file.map(|cf| cf.to_maybe_imports())
       {
         imports
           .into_iter()
@@ -1257,14 +1257,21 @@ impl Documents {
 
     // only refresh the dependencies if the underlying configuration has changed
     if self.resolver_config_hash != new_resolver_config_hash {
-      self.refresh_dependencies(enabled_urls);
+      self.refresh_dependencies(
+        options.enabled_urls,
+        options.document_preload_limit,
+      );
       self.resolver_config_hash = new_resolver_config_hash;
     }
 
     self.dirty = true;
   }
 
-  fn refresh_dependencies(&mut self, enabled_urls: Vec<Url>) {
+  fn refresh_dependencies(
+    &mut self,
+    enabled_urls: Vec<Url>,
+    document_preload_limit: usize,
+  ) {
     let resolver = self.resolver.as_graph_resolver();
     for doc in self.open_docs.values_mut() {
       if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {
@@ -1274,51 +1281,72 @@ impl Documents {
 
     // update the file system documents
     let mut fs_docs = self.file_system_docs.lock();
-    match self.lsp_client_kind {
-      LspClientKind::CodeEditor => {
-        let mut not_found_docs =
-          fs_docs.docs.keys().cloned().collect::<HashSet<_>>();
-        let open_docs = &mut self.open_docs;
+    if document_preload_limit > 0 {
+      let mut not_found_docs =
+        fs_docs.docs.keys().cloned().collect::<HashSet<_>>();
+      let open_docs = &mut self.open_docs;
 
-        log::debug!("Preloading documents from enabled urls...");
-        for specifier in PreloadDocumentFinder::from_enabled_urls(&enabled_urls)
+      log::debug!("Preloading documents from enabled urls...");
+      let mut finder = PreloadDocumentFinder::from_enabled_urls_with_limit(
+        &enabled_urls,
+        document_preload_limit,
+      );
+      for specifier in finder.by_ref() {
+        // mark this document as having been found
+        not_found_docs.remove(&specifier);
+
+        if !open_docs.contains_key(&specifier)
+          && !fs_docs.docs.contains_key(&specifier)
         {
-          // mark this document as having been found
-          not_found_docs.remove(&specifier);
-
-          if !open_docs.contains_key(&specifier)
-            && !fs_docs.docs.contains_key(&specifier)
-          {
-            fs_docs.refresh_document(&self.cache, resolver, &specifier);
-          } else {
-            // update the existing entry to have the new resolver
-            if let Some(doc) = fs_docs.docs.get_mut(&specifier) {
-              if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {
-                *doc = new_doc;
-              }
+          fs_docs.refresh_document(&self.cache, resolver, &specifier);
+        } else {
+          // update the existing entry to have the new resolver
+          if let Some(doc) = fs_docs.docs.get_mut(&specifier) {
+            if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {
+              *doc = new_doc;
             }
           }
         }
+      }
 
+      if finder.hit_limit() {
+        lsp_warn!(
+            concat!(
+              "Hit the language server document preload limit of {} file system entries. ",
+              "You may want to use the \"deno.enablePaths\" configuration setting to only have Deno ",
+              "partially enable a workspace or increase the limit via \"deno.preloadLimit\"."
+            ),
+            document_preload_limit,
+          );
+
+        // since we hit the limit, just update everything to use the new resolver
+        for uri in not_found_docs {
+          if let Some(doc) = fs_docs.docs.get_mut(&uri) {
+            if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {
+              *doc = new_doc;
+            }
+          }
+        }
+      } else {
         // clean up and remove any documents that weren't found
         for uri in not_found_docs {
           fs_docs.docs.remove(&uri);
         }
       }
-      LspClientKind::Repl => {
-        // This log statement is used in the tests to ensure preloading doesn't
-        // happen, which is not useful in the repl and could be very expensive
-        // if the repl is launched from a directory with a lot of descendants.
-        log::debug!("Skipping document preload for repl.");
+    } else {
+      // This log statement is used in the tests to ensure preloading doesn't
+      // happen, which is not useful in the repl and could be very expensive
+      // if the repl is launched from a directory with a lot of descendants.
+      log::debug!("Skipping document preload.");
 
-        // for the repl, just update to use the new resolver
-        for doc in fs_docs.docs.values_mut() {
-          if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {
-            *doc = new_doc;
-          }
+      // just update to use the new resolver
+      for doc in fs_docs.docs.values_mut() {
+        if let Some(new_doc) = doc.maybe_with_new_resolver(resolver) {
+          *doc = new_doc;
         }
       }
     }
+
     fs_docs.dirty = true;
   }
 
@@ -1558,19 +1586,15 @@ enum PendingEntry {
 /// Iterator that finds documents that can be preloaded into
 /// the LSP on startup.
 struct PreloadDocumentFinder {
-  limit: u16,
-  entry_count: u16,
+  limit: usize,
+  entry_count: usize,
   pending_entries: VecDeque<PendingEntry>,
 }
 
 impl PreloadDocumentFinder {
-  pub fn from_enabled_urls(enabled_urls: &Vec<Url>) -> Self {
-    Self::from_enabled_urls_with_limit(enabled_urls, 1_000)
-  }
-
   pub fn from_enabled_urls_with_limit(
     enabled_urls: &Vec<Url>,
-    limit: u16,
+    limit: usize,
   ) -> Self {
     fn is_allowed_root_dir(dir_path: &Path) -> bool {
       if dir_path.parent().is_none() {
@@ -1603,6 +1627,10 @@ impl PreloadDocumentFinder {
       finder.pending_entries.push_back(PendingEntry::Dir(dir));
     }
     finder
+  }
+
+  pub fn hit_limit(&self) -> bool {
+    self.entry_count >= self.limit
   }
 
   fn get_valid_specifier(path: &Path) -> Option<ModuleSpecifier> {
@@ -1699,15 +1727,7 @@ impl Iterator for PreloadDocumentFinder {
           while let Some(entry) = entries.next() {
             self.entry_count += 1;
 
-            if self.entry_count >= self.limit {
-              lsp_warn!(
-                concat!(
-                  "Hit the language server document preload limit of {} file system entries. ",
-                  "You may want to use the \"deno.enablePaths\" configuration setting to only have Deno ",
-                  "partially enable a workspace."
-                ),
-                self.limit,
-              );
+            if self.hit_limit() {
               self.pending_entries.clear(); // stop searching
               return None;
             }
@@ -1769,7 +1789,7 @@ mod tests {
 
   fn setup(temp_dir: &TempDir) -> (Documents, PathBuf) {
     let location = temp_dir.path().join("deps");
-    let documents = Documents::new(&location, Default::default());
+    let documents = Documents::new(&location);
     (documents, location)
   }
 
@@ -1899,14 +1919,15 @@ console.log(b, "hello deno");
         .append("test".to_string(), "./file2.ts".to_string())
         .unwrap();
 
-      documents.update_config(
-        vec![],
-        Some(Arc::new(import_map)),
-        None,
-        None,
-        npm_registry_api.clone(),
-        npm_resolution.clone(),
-      );
+      documents.update_config(UpdateDocumentConfigOptions {
+        enabled_urls: vec![],
+        document_preload_limit: 1_000,
+        maybe_import_map: Some(Arc::new(import_map)),
+        maybe_config_file: None,
+        maybe_package_json: None,
+        npm_registry_api: npm_registry_api.clone(),
+        npm_resolution: npm_resolution.clone(),
+      });
 
       // open the document
       let document = documents.open(
@@ -1939,14 +1960,15 @@ console.log(b, "hello deno");
         .append("test".to_string(), "./file3.ts".to_string())
         .unwrap();
 
-      documents.update_config(
-        vec![],
-        Some(Arc::new(import_map)),
-        None,
-        None,
+      documents.update_config(UpdateDocumentConfigOptions {
+        enabled_urls: vec![],
+        document_preload_limit: 1_000,
+        maybe_import_map: Some(Arc::new(import_map)),
+        maybe_config_file: None,
+        maybe_package_json: None,
         npm_registry_api,
         npm_resolution,
-      );
+      });
 
       // check the document's dependencies
       let document = documents.get(&file1_specifier).unwrap();
@@ -2001,12 +2023,15 @@ console.log(b, "hello deno");
     temp_dir.create_dir_all("root3/");
     temp_dir.write("root3/mod.ts", ""); // no, not provided
 
-    let mut urls = PreloadDocumentFinder::from_enabled_urls(&vec![
-      temp_dir.uri().join("root1/").unwrap(),
-      temp_dir.uri().join("root2/file1.ts").unwrap(),
-      temp_dir.uri().join("root2/main.min.ts").unwrap(),
-      temp_dir.uri().join("root2/folder/").unwrap(),
-    ])
+    let mut urls = PreloadDocumentFinder::from_enabled_urls_with_limit(
+      &vec![
+        temp_dir.uri().join("root1/").unwrap(),
+        temp_dir.uri().join("root2/file1.ts").unwrap(),
+        temp_dir.uri().join("root2/main.min.ts").unwrap(),
+        temp_dir.uri().join("root2/folder/").unwrap(),
+      ],
+      1_000,
+    )
     .collect::<Vec<_>>();
 
     // Ideally we would test for order here, which should be BFS, but
@@ -2048,18 +2073,18 @@ console.log(b, "hello deno");
   #[test]
   pub fn test_pre_load_document_finder_disallowed_dirs() {
     if cfg!(windows) {
-      let paths = PreloadDocumentFinder::from_enabled_urls(&vec![Url::parse(
-        "file:///c:/",
+      let paths = PreloadDocumentFinder::from_enabled_urls_with_limit(
+        &vec![Url::parse("file:///c:/").unwrap()],
+        1_000,
       )
-      .unwrap()])
       .collect::<Vec<_>>();
       assert_eq!(paths, vec![]);
     } else {
-      let paths =
-        PreloadDocumentFinder::from_enabled_urls(&vec![
-          Url::parse("file:///").unwrap()
-        ])
-        .collect::<Vec<_>>();
+      let paths = PreloadDocumentFinder::from_enabled_urls_with_limit(
+        &vec![Url::parse("file:///").unwrap()],
+        1_000,
+      )
+      .collect::<Vec<_>>();
       assert_eq!(paths, vec![]);
     }
   }

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1314,7 +1314,8 @@ impl Documents {
             concat!(
               "Hit the language server document preload limit of {} file system entries. ",
               "You may want to use the \"deno.enablePaths\" configuration setting to only have Deno ",
-              "partially enable a workspace or increase the limit via \"deno.preloadLimit\"."
+              "partially enable a workspace or increase the limit via \"deno.documentPreloadLimit\". ",
+              "In cases where Deno ends up using too much memory, you may want to lower the limit."
             ),
             document_preload_limit,
           );

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1175,7 +1175,10 @@ impl Inner {
   fn refresh_documents_config(&mut self) {
     self.documents.update_config(UpdateDocumentConfigOptions {
       enabled_urls: self.config.enabled_urls(),
-      document_preload_limit: self.config.workspace_settings().preload_limit,
+      document_preload_limit: self
+        .config
+        .workspace_settings()
+        .document_preload_limit,
       maybe_import_map: self.maybe_import_map.clone(),
       maybe_config_file: self.maybe_config_file.as_ref(),
       maybe_package_json: self.maybe_package_json.as_ref(),

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -294,7 +294,7 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
     inlay_hints: Default::default(),
     internal_debug: false,
     lint: false,
-    preload_limit: 0, // don't pre-load any modules as it's expensive and not useful for the repl
+    document_preload_limit: 0, // don't pre-load any modules as it's expensive and not useful for the repl
     tls_certificate: None,
     unsafely_ignore_certificate_errors: None,
     unstable: false,

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -294,6 +294,7 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
     inlay_hints: Default::default(),
     internal_debug: false,
     lint: false,
+    preload_limit: 0, // don't pre-load any modules as it's expensive and not useful for the repl
     tls_certificate: None,
     unsafely_ignore_certificate_errors: None,
     unstable: false,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3525,7 +3525,7 @@ mod tests {
     fixtures: &[(&str, &str, i32, LanguageId)],
     location: &Path,
   ) -> StateSnapshot {
-    let mut documents = Documents::new(location, Default::default());
+    let mut documents = Documents::new(location);
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -1014,9 +1014,6 @@ fn closed_file_pre_load_does_not_occur() {
     .new_command()
     .args_vec(["repl", "-A", "--log-level=debug"])
     .with_pty(|console| {
-      assert_contains!(
-        console.all_output(),
-        "Skipping document preload for repl.",
-      );
+      assert_contains!(console.all_output(), "Skipping document preload.",);
     });
 }

--- a/test_util/src/lsp.rs
+++ b/test_util/src/lsp.rs
@@ -380,7 +380,7 @@ impl InitializeParamsBuilder {
 
   pub fn set_preload_limit(&mut self, arg: usize) -> &mut Self {
     let options = self.initialization_options_mut();
-    options.insert("preloadLimit".to_string(), arg.into());
+    options.insert("documentPreloadLimit".to_string(), arg.into());
     self
   }
 

--- a/test_util/src/lsp.rs
+++ b/test_util/src/lsp.rs
@@ -378,6 +378,12 @@ impl InitializeParamsBuilder {
     self
   }
 
+  pub fn set_preload_limit(&mut self, arg: usize) -> &mut Self {
+    let options = self.initialization_options_mut();
+    options.insert("preloadLimit".to_string(), arg.into());
+    self
+  }
+
   pub fn set_tls_certificate(&mut self, value: impl AsRef<str>) -> &mut Self {
     let options = self.initialization_options_mut();
     options.insert(


### PR DESCRIPTION
Adds a `deno.preloadLimit` option (ex. `"deno.preloadLimit": 2000`) which specifies how many file entries to traverse on the file system when the lsp loads or its configuration changes.

Closes #18955