### PR TITLE
fix(dts): move BroadcastChannel type to lib.deno.unstable.d.ts

### DIFF
--- a/cli/tests/integration/check_tests.rs
+++ b/cli/tests/integration/check_tests.rs
@@ -84,6 +84,17 @@ itest!(check_no_error_truncation {
     exit_code: 1,
   });
 
+itest!(check_broadcast_channel_stable {
+  args: "check --quiet check/broadcast_channel.ts",
+  output: "check/broadcast_channel.ts.error.out",
+  exit_code: 1,
+});
+
+itest!(check_broadcast_channel_unstable {
+  args: "check --quiet --unstable check/broadcast_channel.ts",
+  exit_code: 0,
+});
+
 #[test]
 fn cache_switching_config_then_no_config() {
   let context = TestContext::default();

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -4713,7 +4713,7 @@ fn lsp_completions_auto_import() {
         "source": "./b.ts",
         "data": {
           "exportName": "foo",
-          "exportMapKey": "foo|6845|file:///a/b",
+          "exportMapKey": "foo|6806|file:///a/b",
           "moduleSpecifier": "./b.ts",
           "fileName": "file:///a/b.ts"
         },

--- a/cli/tests/testdata/check/broadcast_channel.ts
+++ b/cli/tests/testdata/check/broadcast_channel.ts
@@ -1,0 +1,1 @@
+const channel = new BroadcastChannel("foo");

--- a/cli/tests/testdata/check/broadcast_channel.ts
+++ b/cli/tests/testdata/check/broadcast_channel.ts
@@ -1,1 +1,1 @@
-const channel = new BroadcastChannel("foo");
+const _channel = new BroadcastChannel("foo");

--- a/cli/tests/testdata/check/broadcast_channel.ts.error.out
+++ b/cli/tests/testdata/check/broadcast_channel.ts.error.out
@@ -1,0 +1,4 @@
+error: TS2304 [ERROR]: Cannot find name 'BroadcastChannel'.
+const channel = new BroadcastChannel("foo");
+                    ~~~~~~~~~~~~~~~~
+    at [WILDCARD]

--- a/cli/tests/testdata/check/broadcast_channel.ts.error.out
+++ b/cli/tests/testdata/check/broadcast_channel.ts.error.out
@@ -1,4 +1,4 @@
 error: TS2304 [ERROR]: Cannot find name 'BroadcastChannel'.
-const channel = new BroadcastChannel("foo");
-                    ~~~~~~~~~~~~~~~~
+const _channel = new BroadcastChannel("foo");
+                     ~~~~~~~~~~~~~~~~
     at [WILDCARD]

--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -11,7 +11,6 @@
 /// <reference lib="deno.fetch" />
 /// <reference lib="deno.websocket" />
 /// <reference lib="deno.crypto" />
-/// <reference lib="deno.broadcast_channel" />
 
 /** @category WebAssembly */
 declare namespace WebAssembly {

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -2,6 +2,7 @@
 
 /// <reference no-default-lib="true" />
 /// <reference lib="deno.ns" />
+/// <reference lib="deno.broadcast_channel" />
 
 declare namespace Deno {
   export {}; // stop default export type behavior


### PR DESCRIPTION
`BroadcastChannel` is unstable in runtime, but its type is available in stable. This PR moves `BroadcastChannel` to `lib.deno.unstable.d.ts` and causes type check error when `--unstable` is not specified.