### PR TITLE
fix: Allow for logging URL/URLPattern.prototype

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1885,6 +1885,11 @@ itest!(shebang_with_json_imports_swc {
   exit_code: 1,
 });
 
+itest!(prototype_logging {
+  args: "run run/prototype_logging.ts",
+  output: "run/prototype_logging.ts.out",
+});
+
 #[test]
 fn no_validate_asm() {
   let output = util::deno_cmd()

--- a/cli/tests/testdata/run/prototype_logging.ts
+++ b/cli/tests/testdata/run/prototype_logging.ts
@@ -1,0 +1,2 @@
+console.log(URL.prototype)
+console.log(URLPattern.prototype)

--- a/cli/tests/testdata/run/prototype_logging.ts
+++ b/cli/tests/testdata/run/prototype_logging.ts
@@ -1,2 +1,2 @@
-console.log(URL.prototype)
-console.log(URLPattern.prototype)
+console.log(URL.prototype);
+console.log(URLPattern.prototype);

--- a/cli/tests/testdata/run/prototype_logging.ts.out
+++ b/cli/tests/testdata/run/prototype_logging.ts.out
@@ -1,20 +1,17 @@
-Object [URL] {
-  hash: [Getter/Setter],
-  host: [Getter/Setter],
-  hostname: [Getter/Setter],
+URL {
   href: [Getter/Setter],
   origin: [Getter],
-  password: [Getter/Setter],
-  pathname: [Getter/Setter],
-  port: [Getter/Setter],
   protocol: [Getter/Setter],
-  search: [Getter/Setter],
   username: [Getter/Setter],
-  searchParams: [Getter],
-  toString: [Function: toString],
-  toJSON: [Function: toJSON]
+  password: [Getter/Setter],
+  host: [Getter/Setter],
+  hostname: [Getter/Setter],
+  port: [Getter/Setter],
+  pathname: [Getter/Setter],
+  hash: [Getter/Setter],
+  search: [Getter/Setter]
 }
-Object [URLPattern] {
+URLPattern {
   protocol: [Getter],
   username: [Getter],
   password: [Getter],
@@ -22,7 +19,5 @@ Object [URLPattern] {
   port: [Getter],
   pathname: [Getter],
   search: [Getter],
-  hash: [Getter],
-  test: [Function: test],
-  exec: [Function: exec]
+  hash: [Getter]
 }

--- a/cli/tests/testdata/run/prototype_logging.ts.out
+++ b/cli/tests/testdata/run/prototype_logging.ts.out
@@ -1,0 +1,28 @@
+Object [URL] {
+  hash: [Getter/Setter],
+  host: [Getter/Setter],
+  hostname: [Getter/Setter],
+  href: [Getter/Setter],
+  origin: [Getter],
+  password: [Getter/Setter],
+  pathname: [Getter/Setter],
+  port: [Getter/Setter],
+  protocol: [Getter/Setter],
+  search: [Getter/Setter],
+  username: [Getter/Setter],
+  searchParams: [Getter],
+  toString: [Function: toString],
+  toJSON: [Function: toJSON]
+}
+Object [URLPattern] {
+  protocol: [Getter],
+  username: [Getter],
+  password: [Getter],
+  hostname: [Getter],
+  port: [Getter],
+  pathname: [Getter],
+  search: [Getter],
+  hash: [Getter],
+  test: [Function: test],
+  exec: [Function: exec]
+}

--- a/cli/tests/unit/urlpattern_test.ts
+++ b/cli/tests/unit/urlpattern_test.ts
@@ -63,3 +63,20 @@ Deno.test(function urlPatternWithPrototypePollution() {
     RegExp.prototype.exec = originalExec;
   }
 });
+
+Deno.test(function customInspectFunction() {
+  const pattern = new URLPattern("https://deno.land/foo/:bar");
+  assertEquals(
+    Deno.inspect(pattern),
+    `URLPattern {
+  protocol: "https",
+  username: "",
+  password: "",
+  hostname: "deno.land",
+  port: "",
+  pathname: "/foo/:bar",
+  search: "",
+  hash: ""
+}`,
+  );
+});

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -388,22 +388,25 @@ class URL {
     } = componentsBuf);
   }
 
-  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-    const object = {
-      href: this.href,
-      origin: this.origin,
-      protocol: this.protocol,
-      username: this.username,
-      password: this.password,
-      host: this.host,
-      hostname: this.hostname,
-      port: this.port,
-      pathname: this.pathname,
-      hash: this.hash,
-      search: this.search,
-    };
-    return `${this.constructor.name} ${inspect(object, inspectOptions)}`;
-  }
+  [SymbolFor("Deno.privateCustomInspect")] = {
+    value: function (inspect, inspectOptions) {
+      return `${this.constructor.name} ${
+        inspect({
+          href: this.href,
+          origin: this.origin,
+          protocol: this.protocol,
+          username: this.username,
+          password: this.password,
+          host: this.host,
+          hostname: this.hostname,
+          port: this.port,
+          pathname: this.pathname,
+          hash: this.hash,
+          search: this.search,
+        }, inspectOptions)
+      }`;
+    },
+  };
 
   #updateSearchParams() {
     if (this.#queryObject !== null) {

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -7,6 +7,7 @@
 
 const core = globalThis.Deno.core;
 const ops = core.ops;
+import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
@@ -17,6 +18,7 @@ const {
   ArrayPrototypeSort,
   ArrayPrototypeSplice,
   ObjectKeys,
+  ObjectPrototypeIsPrototypeOf,
   SafeArrayIterator,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
@@ -388,25 +390,25 @@ class URL {
     } = componentsBuf);
   }
 
-  [SymbolFor("Deno.privateCustomInspect")] = {
-    value: function (inspect, inspectOptions) {
-      return `${this.constructor.name} ${
-        inspect({
-          href: this.href,
-          origin: this.origin,
-          protocol: this.protocol,
-          username: this.username,
-          password: this.password,
-          host: this.host,
-          hostname: this.hostname,
-          port: this.port,
-          pathname: this.pathname,
-          hash: this.hash,
-          search: this.search,
-        }, inspectOptions)
-      }`;
-    },
-  };
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    return inspect(createFilteredInspectProxy({
+      object: this,
+      evaluate: ObjectPrototypeIsPrototypeOf(URL.prototype, this),
+      keys: [
+        "href",
+        "origin",
+        "protocol",
+        "username",
+        "password",
+        "host",
+        "hostname",
+        "port",
+        "pathname",
+        "hash",
+        "search",
+      ],
+    }), inspectOptions);
+  }
 
   #updateSearchParams() {
     if (this.#queryObject !== null) {

--- a/ext/url/00_url.js
+++ b/ext/url/00_url.js
@@ -391,23 +391,26 @@ class URL {
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-    return inspect(createFilteredInspectProxy({
-      object: this,
-      evaluate: ObjectPrototypeIsPrototypeOf(URL.prototype, this),
-      keys: [
-        "href",
-        "origin",
-        "protocol",
-        "username",
-        "password",
-        "host",
-        "hostname",
-        "port",
-        "pathname",
-        "hash",
-        "search",
-      ],
-    }), inspectOptions);
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(URL.prototype, this),
+        keys: [
+          "href",
+          "origin",
+          "protocol",
+          "username",
+          "password",
+          "host",
+          "hostname",
+          "port",
+          "pathname",
+          "hash",
+          "search",
+        ],
+      }),
+      inspectOptions,
+    );
   }
 
   #updateSearchParams() {

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -212,20 +212,23 @@ class URLPattern {
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-    return inspect(createFilteredInspectProxy({
-      object: this,
-      evaluate: ObjectPrototypeIsPrototypeOf(URLPattern.prototype, this),
-      keys: [
-        "protocol",
-        "username",
-        "password",
-        "hostname",
-        "port",
-        "pathname",
-        "search",
-        "hash",
-      ],
-    }), inspectOptions);
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(URLPattern.prototype, this),
+        keys: [
+          "protocol",
+          "username",
+          "password",
+          "hostname",
+          "port",
+          "pathname",
+          "search",
+          "hash",
+        ],
+      }),
+      inspectOptions,
+    );
   }
 }
 

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -209,20 +209,22 @@ class URLPattern {
     return result;
   }
 
-  [SymbolFor("Deno.customInspect")](inspect) {
-    return `URLPattern ${
-      inspect({
-        protocol: this.protocol,
-        username: this.username,
-        password: this.password,
-        hostname: this.hostname,
-        port: this.port,
-        pathname: this.pathname,
-        search: this.search,
-        hash: this.hash,
-      })
-    }`;
-  }
+  [SymbolFor("Deno.privateCustomInspect")] = {
+    value: function (inspect, inspectOptions) {
+      return `${this.constructor.name} ${
+        inspect({
+          protocol: this.protocol,
+          username: this.username,
+          password: this.password,
+          hostname: this.hostname,
+          port: this.port,
+          pathname: this.pathname,
+          search: this.search,
+          hash: this.hash,
+        }, inspectOptions)
+      }`;
+    },
+  };
 }
 
 webidl.configurePrototype(URLPattern);

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -9,6 +9,7 @@
 
 const core = globalThis.Deno.core;
 const ops = core.ops;
+import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
@@ -16,6 +17,7 @@ const {
   ArrayPrototypePop,
   ObjectFromEntries,
   ObjectKeys,
+  ObjectPrototypeIsPrototypeOf,
   RegExpPrototypeExec,
   RegExpPrototypeTest,
   SafeRegExp,
@@ -209,22 +211,22 @@ class URLPattern {
     return result;
   }
 
-  [SymbolFor("Deno.privateCustomInspect")] = {
-    value: function (inspect, inspectOptions) {
-      return `${this.constructor.name} ${
-        inspect({
-          protocol: this.protocol,
-          username: this.username,
-          password: this.password,
-          hostname: this.hostname,
-          port: this.port,
-          pathname: this.pathname,
-          search: this.search,
-          hash: this.hash,
-        }, inspectOptions)
-      }`;
-    },
-  };
+  [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
+    return inspect(createFilteredInspectProxy({
+      object: this,
+      evaluate: ObjectPrototypeIsPrototypeOf(URLPattern.prototype, this),
+      keys: [
+        "protocol",
+        "username",
+        "password",
+        "hostname",
+        "port",
+        "pathname",
+        "search",
+        "hash",
+      ],
+    }), inspectOptions);
+  }
 }
 
 webidl.configurePrototype(URLPattern);


### PR DESCRIPTION
Instead of throwing, it now prints:

```
URL {
  href: [Getter/Setter],
  origin: [Getter],
  protocol: [Getter/Setter],
  username: [Getter/Setter],
  password: [Getter/Setter],
  host: [Getter/Setter],
  hostname: [Getter/Setter],
  port: [Getter/Setter],
  pathname: [Getter/Setter],
  hash: [Getter/Setter],
  search: [Getter/Setter
}
```

Fixes https://github.com/denoland/deno/issues/19140
Fixes https://github.com/denoland/deno/issues/19128