### PR TITLE
fix(node): support passing parent stdio streams

### DIFF
--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -577,3 +577,25 @@ Deno.test(
     assertStringIncludes(output, "typescript");
   },
 );
+
+Deno.test(
+  "[node/child_process spawn] supports stdio array option",
+  async () => {
+    const cmdFinished = deferred();
+    let output = "";
+    const script = path.join(
+      path.dirname(path.fromFileUrl(import.meta.url)),
+      "testdata",
+      "child_process_stdio.js",
+    );
+    const cp = spawn(Deno.execPath(), ["run", "-A", script]);
+    cp.stdout?.on("data", (data) => {
+      output += data;
+    });
+    cp.on("close", () => cmdFinished.resolve());
+    await cmdFinished;
+
+    assertStringIncludes(output, "foo");
+    assertStringIncludes(output, "close");
+  },
+);

--- a/cli/tests/unit_node/testdata/child_process_stdio.js
+++ b/cli/tests/unit_node/testdata/child_process_stdio.js
@@ -1,0 +1,15 @@
+import childProcess from "node:child_process";
+import process from "node:process";
+import * as path from "node:path";
+
+const script = path.join(
+  path.dirname(path.fromFileUrl(import.meta.url)),
+  "node_modules",
+  "foo",
+  "index.js",
+);
+
+const child = childProcess.spawn(process.execPath, [script], {
+  stdio: [process.stdin, process.stdout, process.stderr],
+});
+child.on("close", () => console.log("close"));

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -177,9 +177,9 @@ export class ChildProcess extends EventEmitter {
         args: cmdArgs,
         cwd,
         env: stringEnv,
-        stdin: toDenoStdio(stdin as NodeStdio | number),
-        stdout: toDenoStdio(stdout as NodeStdio | number),
-        stderr: toDenoStdio(stderr as NodeStdio | number),
+        stdin: toDenoStdio(stdin),
+        stdout: toDenoStdio(stdout),
+        stderr: toDenoStdio(stderr),
         windowsRawArguments: windowsVerbatimArguments,
       }).spawn();
       this.pid = this.#process.pid;
@@ -187,6 +187,16 @@ export class ChildProcess extends EventEmitter {
       if (stdin === "pipe") {
         assert(this.#process.stdin);
         this.stdin = Writable.fromWeb(this.#process.stdin);
+      }
+
+      if (stdin instanceof Stream) {
+        this.stdin = stdin;
+      }
+      if (stdout instanceof Stream) {
+        this.stdout = stdout;
+      }
+      if (stderr instanceof Stream) {
+        this.stderr = stderr;
       }
 
       if (stdout === "pipe") {
@@ -285,15 +295,22 @@ export class ChildProcess extends EventEmitter {
 
   async #_waitForChildStreamsToClose() {
     const promises = [] as Array<Promise<void>>;
-    if (this.stdin && !this.stdin.destroyed) {
+    // Don't close parent process stdin if that's passed through
+    if (this.stdin && !this.stdin.destroyed && this.stdin !== process.stdin) {
       assert(this.stdin);
       this.stdin.destroy();
       promises.push(waitForStreamToClose(this.stdin));
     }
-    if (this.stdout && !this.stdout.destroyed) {
+    // Only readable streams need to be closed
+    if (
+      this.stdout && !this.stdout.destroyed && this.stdout instanceof Readable
+    ) {
       promises.push(waitForReadableToClose(this.stdout));
     }
-    if (this.stderr && !this.stderr.destroyed) {
+    // Only readable streams need to be closed
+    if (
+      this.stderr && !this.stderr.destroyed && this.stderr instanceof Readable
+    ) {
       promises.push(waitForReadableToClose(this.stderr));
     }
     await Promise.all(promises);
@@ -317,9 +334,13 @@ const supportedNodeStdioTypes: NodeStdio[] = ["pipe", "ignore", "inherit"];
 function toDenoStdio(
   pipe: NodeStdio | number | Stream | null | undefined,
 ): DenoStdio {
+  if (pipe instanceof Stream) {
+    return "inherit";
+  }
+
   if (
     !supportedNodeStdioTypes.includes(pipe as NodeStdio) ||
-    typeof pipe === "number" || pipe instanceof Stream
+    typeof pipe === "number"
   ) {
     notImplemented(`toDenoStdio pipe=${typeof pipe} (${pipe})`);
   }
@@ -441,8 +462,17 @@ function normalizeStdioOption(
     "pipe",
     "pipe",
   ],
-) {
+): [
+  Stream | NodeStdio | number,
+  Stream | NodeStdio | number,
+  Stream | NodeStdio | number,
+  ...Array<Stream | NodeStdio | number>,
+] {
   if (Array.isArray(stdio)) {
+    // At least 3 stdio must be created to match node
+    while (stdio.length < 3) {
+      ArrayPrototypePush(stdio, undefined);
+    }
     return stdio;
   } else {
     switch (stdio) {
@@ -796,8 +826,8 @@ export function spawnSync(
       args,
       cwd,
       env,
-      stdout: toDenoStdio(normalizedStdio[1] as NodeStdio | number),
-      stderr: toDenoStdio(normalizedStdio[2] as NodeStdio | number),
+      stdout: toDenoStdio(normalizedStdio[1]),
+      stderr: toDenoStdio(normalizedStdio[2]),
       uid,
       gid,
       windowsRawArguments: windowsVerbatimArguments,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This is a bit bare bones but gets `npm-run-all` working. For full stdio compatibility with node more work is needed which is probably better done in follow up PRs.

Fixes #19159

Proof that it works

Before:

<img width="701" alt="Screenshot 2023-05-18 at 11 28 03" src="https://github.com/denoland/deno/assets/1062408/b6ba17cc-d804-4d94-929c-cd30e527563a">

After:

<img width="934" alt="Screenshot 2023-05-18 at 11 14 10" src="https://github.com/denoland/deno/assets/1062408/67e243da-6811-4aa5-ac3d-f2b30fe8957a">



