### PR TITLE
fix(npm): `process` not defined in readline

### DIFF
--- a/cli/tests/unit_node/readline_test.ts
+++ b/cli/tests/unit_node/readline_test.ts
@@ -12,3 +12,16 @@ Deno.test("[node/readline] createInstance", () => {
   // deno-lint-ignore no-explicit-any
   assertInstanceOf(rl, Interface as any);
 });
+
+// Test for https://github.com/denoland/deno/issues/19183
+Deno.test("[node/readline] don't throw on rl.question()", () => {
+  const rli = createInterface({
+    input: new Readable({ read() {} }),
+    output: new Writable({ write() {} }),
+    terminal: true,
+  });
+
+  // Calling this would throw
+  rli.question("foo", () => rli.close());
+  rli.close();
+});

--- a/ext/node/polyfills/internal/readline/interface.mjs
+++ b/ext/node/polyfills/internal/readline/interface.mjs
@@ -44,6 +44,7 @@ import {
 } from "ext:deno_node/internal/readline/utils.mjs";
 import { clearScreenDown, cursorTo, moveCursor } from "ext:deno_node/internal/readline/callbacks.mjs";
 import { Readable } from "ext:deno_node/_stream.mjs";
+import process from "ext:deno_node/process.ts";
 
 import { StringDecoder } from "ext:deno_node/string_decoder.ts";
 import {


### PR DESCRIPTION
Issue was that we create node globals much later, so pulling `process` via a module import is the way to go.

Fixes #19183