### PR TITLE
feat(vendor): support for npm specifiers

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1343,7 +1343,7 @@ TypeScript compiler cache: Subdirectory containing TS compiler output.",
     .arg(lock_arg())
     .arg(config_arg())
     .arg(import_map_arg())
-    .arg(local_npm_arg())
+    .arg(node_modules_dir_arg())
     .arg(
       Arg::new("json")
         .long("json")
@@ -1862,6 +1862,7 @@ Remote modules and multiple modules may also be specified:
     .arg(config_arg())
     .arg(import_map_arg())
     .arg(lock_arg())
+    .arg(node_modules_dir_arg())
     .arg(reload_arg())
     .arg(ca_file_arg())
 }
@@ -1875,7 +1876,7 @@ fn compile_args_without_check_args(app: Command) -> Command {
     .arg(import_map_arg())
     .arg(no_remote_arg())
     .arg(no_npm_arg())
-    .arg(local_npm_arg())
+    .arg(node_modules_dir_arg())
     .arg(config_arg())
     .arg(no_config_arg())
     .arg(reload_arg())
@@ -2424,7 +2425,7 @@ fn no_npm_arg() -> Arg {
     .help("Do not resolve npm modules")
 }
 
-fn local_npm_arg() -> Arg {
+fn node_modules_dir_arg() -> Arg {
   Arg::new("node-modules-dir")
     .long("node-modules-dir")
     .num_args(0..=1)
@@ -2719,7 +2720,7 @@ fn info_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   import_map_arg_parse(flags, matches);
   location_arg_parse(flags, matches);
   ca_file_arg_parse(flags, matches);
-  local_npm_args_parse(flags, matches);
+  node_modules_dir_arg_parse(flags, matches);
   lock_arg_parse(flags, matches);
   no_lock_arg_parse(flags, matches);
   no_remote_arg_parse(flags, matches);
@@ -2975,6 +2976,7 @@ fn vendor_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   config_args_parse(flags, matches);
   import_map_arg_parse(flags, matches);
   lock_arg_parse(flags, matches);
+  node_modules_dir_arg_parse(flags, matches);
   reload_arg_parse(flags, matches);
 
   flags.subcommand = DenoSubcommand::Vendor(VendorFlags {
@@ -3000,7 +3002,7 @@ fn compile_args_without_check_parse(
   import_map_arg_parse(flags, matches);
   no_remote_arg_parse(flags, matches);
   no_npm_arg_parse(flags, matches);
-  local_npm_args_parse(flags, matches);
+  node_modules_dir_arg_parse(flags, matches);
   config_args_parse(flags, matches);
   reload_arg_parse(flags, matches);
   lock_args_parse(flags, matches);
@@ -3254,7 +3256,7 @@ fn no_npm_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   }
 }
 
-fn local_npm_args_parse(flags: &mut Flags, matches: &mut ArgMatches) {
+fn node_modules_dir_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   flags.node_modules_dir = matches.remove_one::<bool>("node-modules-dir");
 }
 

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -881,6 +881,15 @@ impl CliOptions {
     self.maybe_node_modules_folder.clone()
   }
 
+  pub fn node_modules_dir_enablement(&self) -> Option<bool> {
+    self.flags.node_modules_dir.or_else(|| {
+      self
+        .maybe_config_file
+        .as_ref()
+        .and_then(|c| c.node_modules_dir())
+    })
+  }
+
   pub fn node_modules_dir_specifier(&self) -> Option<ModuleSpecifier> {
     self
       .maybe_node_modules_folder

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -29,6 +29,7 @@ use crate::npm::create_npm_fs_resolver;
 use crate::npm::CliNpmRegistryApi;
 use crate::npm::CliNpmResolver;
 use crate::npm::NpmCache;
+use crate::npm::NpmPackageFsResolver;
 use crate::npm::NpmResolution;
 use crate::npm::PackageJsonDepsInstaller;
 use crate::resolver::CliGraphResolver;
@@ -323,6 +324,23 @@ impl CliFactory {
         )))
       })
       .await
+  }
+
+  pub async fn create_node_modules_npm_fs_resolver(
+    &self,
+    node_modules_dir_path: PathBuf,
+  ) -> Result<Arc<dyn NpmPackageFsResolver>, AnyError> {
+    Ok(create_npm_fs_resolver(
+      self.fs().clone(),
+      self.npm_cache()?.clone(),
+      self.text_only_progress_bar(),
+      CliNpmRegistryApi::default_url().to_owned(),
+      self.npm_resolution().await?.clone(),
+      // when an explicit path is provided here, it will create the
+      // local node_modules variant of an npm fs resolver
+      Some(node_modules_dir_path),
+      self.options.npm_system_info(),
+    ))
   }
 
   pub fn package_json_deps_provider(&self) -> &Arc<PackageJsonDepsProvider> {

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -14,4 +14,5 @@ pub use registry::CliNpmRegistryApi;
 pub use resolution::NpmResolution;
 pub use resolvers::create_npm_fs_resolver;
 pub use resolvers::CliNpmResolver;
+pub use resolvers::NpmPackageFsResolver;
 pub use resolvers::NpmProcessState;

--- a/cli/npm/resolvers/mod.rs
+++ b/cli/npm/resolvers/mod.rs
@@ -36,10 +36,11 @@ use crate::args::Lockfile;
 use crate::util::fs::canonicalize_path_maybe_not_exists_with_fs;
 use crate::util::progress_bar::ProgressBar;
 
-use self::common::NpmPackageFsResolver;
 use self::local::LocalNpmPackageResolver;
 use super::resolution::NpmResolution;
 use super::NpmCache;
+
+pub use self::common::NpmPackageFsResolver;
 
 /// State provided to the process via an environment variable.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/cli/tests/integration/vendor_tests.rs
+++ b/cli/tests/integration/vendor_tests.rs
@@ -187,15 +187,13 @@ fn import_map_output_dir() {
     String::from_utf8_lossy(&output.stderr).trim(),
     format!(
       concat!(
-        "Ignoring import map. Specifying an import map file ({}) in the deno ",
-        "vendor output directory is not supported. If you wish to use an ",
-        "import map while vendoring, please specify one located outside this ",
-        "directory.\n",
+        "{}\n",
         "Download http://localhost:4545/vendor/logger.ts\n",
-        "{}",
+        "{}\n\n{}",
       ),
-      PathBuf::from("vendor").join("import_map.json").display(),
-      success_text_updated_deno_json("1 module", "vendor/"),
+      ignoring_import_map_text(),
+      vendored_text("1 module", "vendor/"),
+      success_text_updated_deno_json("vendor/"),
     )
   );
   assert!(output.status.success());
@@ -512,8 +510,9 @@ fn update_existing_config_test() {
   assert_eq!(
     String::from_utf8_lossy(&output.stderr).trim(),
     format!(
-      "Download http://localhost:4545/vendor/logger.ts\n{}",
-      success_text_updated_deno_json("1 module", "vendor2",)
+      "Download http://localhost:4545/vendor/logger.ts\n{}\n\n{}",
+      vendored_text("1 module", "vendor2"),
+      success_text_updated_deno_json("vendor2",)
     )
   );
   assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "");
@@ -560,61 +559,100 @@ fn vendor_npm_node_specifiers() {
         "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
         "Download http://localhost:4545/npm/registry/@denotest/esm-basic/1.0.0.tgz\n",
         "{}\n",
+        "Initialize @denotest/esm-basic@1.0.0\n",
+        "{}\n\n",
+        "{}\n",
       ),
-      success_text_updated_deno_json("1 module", "vendor/")
+      vendored_text("1 module", "vendor/"),
+      vendored_npm_package_text("1 npm package"),
+      success_text_updated_deno_json("vendor/")
     )
   );
   let output = context.new_command().args("run -A my_app.ts").run();
-  output.assert_matches_text("Initialize @denotest/esm-basic@1.0.0\ntrue 5\n");
+  output.assert_matches_text("true 5\n");
   assert!(temp_dir.path().join("node_modules").exists());
   assert!(temp_dir.path().join("deno.lock").exists());
 
   // now try re-vendoring with a lockfile
   let output = context.new_command().args("vendor --force my_app.ts").run();
   output.assert_matches_text(format!(
-    concat!(
-      "Ignoring import map. Specifying an import map file ({}) in the deno ",
-      "vendor output directory is not supported. If you wish to use an ",
-      "import map while vendoring, please specify one located outside this ",
-      "directory.\n{}\n",
-    ),
-    PathBuf::from("vendor").join("import_map.json").display(),
-    success_text_updated_deno_json("1 module", "vendor/"),
+    "{}\n{}\n\n{}\n",
+    ignoring_import_map_text(),
+    vendored_text("1 module", "vendor/"),
+    success_text_updated_deno_json("vendor/"),
+  ));
+
+  // delete the node_modules folder
+  temp_dir.remove_dir_all("node_modules");
+
+  // vendor with --node-modules-dir=false
+  let output = context
+    .new_command()
+    .args("vendor --node-modules-dir=false --force my_app.ts")
+    .run();
+  output.assert_matches_text(format!(
+    "{}\n{}\n\n{}\n",
+    ignoring_import_map_text(),
+    vendored_text("1 module", "vendor/"),
+    success_text_updated_deno_json("vendor/")
+  ));
+  assert!(!temp_dir.path().join("node_modules").exists());
+
+  // delete the deno.json
+  temp_dir.remove_file("deno.json");
+
+  // vendor with --node-modules-dir
+  let output = context
+    .new_command()
+    .args("vendor --node-modules-dir --force my_app.ts")
+    .run();
+  output.assert_matches_text(format!(
+    "Initialize @denotest/esm-basic@1.0.0\n{}\n\n{}\n",
+    vendored_text("1 module", "vendor/"),
+    use_import_map_text("vendor/")
   ));
 }
 
 fn success_text(module_count: &str, dir: &str, has_import_map: bool) -> String {
   let mut text = format!("Vendored {module_count} into {dir} directory.");
   if has_import_map {
-    let f = format!(
-      concat!(
-        "\n\nTo use vendored modules, specify the `--import-map {}import_map.json` flag when ",
-        r#"invoking Deno subcommands or add an `"importMap": "<path_to_vendored_import_map>"` "#,
-        "entry to a deno.json file.",
-      ),
-      if dir != "vendor/" {
-        format!("{}{}", dir.trim_end_matches('/'), if cfg!(windows) { '\\' } else {'/'})
-      } else {
-        dir.to_string()
-      }
-    );
-    write!(text, "{f}").unwrap();
+    write!(text, "\n\n{}", use_import_map_text(dir)).unwrap();
   }
   text
 }
 
-fn success_text_updated_deno_json(module_count: &str, dir: &str) -> String {
+fn use_import_map_text(dir: &str) -> String {
   format!(
     concat!(
-      "Vendored {} into {} directory.\n\n",
+      "To use vendored modules, specify the `--import-map {}import_map.json` flag when ",
+      r#"invoking Deno subcommands or add an `"importMap": "<path_to_vendored_import_map>"` "#,
+      "entry to a deno.json file.",
+    ),
+    if dir != "vendor/" {
+      format!("{}{}", dir.trim_end_matches('/'), if cfg!(windows) { '\\' } else {'/'})
+    } else {
+      dir.to_string()
+    }
+  )
+}
+
+fn vendored_text(module_count: &str, dir: &str) -> String {
+  format!("Vendored {} into {} directory.", module_count, dir)
+}
+
+fn vendored_npm_package_text(package_count: &str) -> String {
+  format!("Vendored {} into node_modules directory. Set `nodeModulesDir: false` to disable vendoring npm packages in the future.", package_count)
+}
+
+fn success_text_updated_deno_json(dir: &str) -> String {
+  format!(
+    concat!(
       "Updated your local Deno configuration file with a reference to the ",
       "new vendored import map at {}import_map.json. Invoking Deno subcommands will ",
       "now automatically resolve using the vendored modules. You may override ",
       "this by providing the `--import-map <other-import-map>` flag or by ",
       "manually editing your Deno configuration file.",
     ),
-    module_count,
-    dir,
     if dir != "vendor/" {
       format!(
         "{}{}",
@@ -624,5 +662,17 @@ fn success_text_updated_deno_json(module_count: &str, dir: &str) -> String {
     } else {
       dir.to_string()
     }
+  )
+}
+
+fn ignoring_import_map_text() -> String {
+  format!(
+    concat!(
+      "Ignoring import map. Specifying an import map file ({}) in the deno ",
+      "vendor output directory is not supported. If you wish to use an ",
+      "import map while vendoring, please specify one located outside this ",
+      "directory.",
+    ),
+    PathBuf::from("vendor").join("import_map.json").display(),
   )
 }

--- a/cli/tests/integration/vendor_tests.rs
+++ b/cli/tests/integration/vendor_tests.rs
@@ -569,7 +569,7 @@ fn vendor_npm_node_specifiers() {
   assert!(temp_dir.path().join("node_modules").exists());
   assert!(temp_dir.path().join("deno.lock").exists());
 
-  // now try re-vendoring
+  // now try re-vendoring with a lockfile
   let output = context.new_command().args("vendor --force my_app.ts").run();
   output.assert_matches_text(format!(
     concat!(

--- a/cli/tests/integration/vendor_tests.rs
+++ b/cli/tests/integration/vendor_tests.rs
@@ -671,7 +671,13 @@ fn vendored_text(module_count: &str, dir: &str) -> String {
 }
 
 fn vendored_npm_package_text(package_count: &str) -> String {
-  format!("Vendored {} into node_modules directory. Set `nodeModulesDir: false` to disable vendoring npm packages in the future.", package_count)
+  format!(
+    concat!(
+     "Vendored {} into node_modules directory. Set `nodeModulesDir: false` ",
+     "in the Deno configuration file to disable vendoring npm packages in the future.",
+    ),
+    package_count
+  )
 }
 
 fn success_text_updated_deno_json(dir: &str) -> String {

--- a/cli/tests/testdata/vendor/npm_and_node_specifier.ts
+++ b/cli/tests/testdata/vendor/npm_and_node_specifier.ts
@@ -1,0 +1,2 @@
+export { default as path } from "node:path";
+export { getValue, setValue } from "npm:@denotest/esm-basic";

--- a/cli/tools/vendor/import_map.rs
+++ b/cli/tools/vendor/import_map.rs
@@ -304,7 +304,7 @@ fn handle_dep_specifier(
       referrer,
       mappings,
     )
-  } else {
+  } else if specifier.scheme() == "file" {
     handle_local_dep_specifier(
       text,
       unresolved_specifier,

--- a/cli/tools/vendor/mod.rs
+++ b/cli/tools/vendor/mod.rs
@@ -101,7 +101,10 @@ pub async fn vendor(
         .await?;
     }
     log::info!(
-      concat!("Vendored {} npm {} into node_modules directory. Set `nodeModulesDir: false` to disable vendoring npm packages in the future."),
+      concat!(
+        "Vendored {} npm {} into node_modules directory. Set `nodeModulesDir: false` ",
+        "in the Deno configuration file to disable vendoring npm packages in the future.",
+      ),
       npm_package_count,
       if npm_package_count == 1 {
         "package"

--- a/cli/tools/vendor/mod.rs
+++ b/cli/tools/vendor/mod.rs
@@ -405,6 +405,30 @@ mod internal_test {
 }
 "#
     );
+
+    // trailing comma
+    let result = update_config_text(
+      r#"{
+  "tasks": {
+    "task1": "other"
+  },
+}
+"#,
+      &Default::default(),
+      Some("./vendor/import_map.json"),
+      false,
+    )
+    .unwrap();
+    assert_eq!(
+      result.new_text.unwrap(),
+      r#"{
+  "tasks": {
+    "task1": "other"
+  },
+  "importMap": "./vendor/import_map.json"
+}
+"#
+    );
   }
 
   #[test]

--- a/cli/tools/vendor/specifiers.rs
+++ b/cli/tools/vendor/specifiers.rs
@@ -65,7 +65,7 @@ pub fn make_url_relative(
 }
 
 pub fn is_remote_specifier(specifier: &ModuleSpecifier) -> bool {
-  specifier.scheme().to_lowercase().starts_with("http")
+  matches!(specifier.scheme().to_lowercase().as_str(), "http" | "https")
 }
 
 pub fn is_remote_specifier_text(text: &str) -> bool {

--- a/test_util/src/temp_dir.rs
+++ b/test_util/src/temp_dir.rs
@@ -58,6 +58,10 @@ impl TempDir {
     fs::create_dir_all(self.path().join(path)).unwrap();
   }
 
+  pub fn remove_file(&self, path: impl AsRef<Path>) {
+    fs::remove_file(self.path().join(path)).unwrap();
+  }
+
   pub fn remove_dir_all(&self, path: impl AsRef<Path>) {
     fs::remove_dir_all(self.path().join(path)).unwrap();
   }


### PR DESCRIPTION
We never properly added support for this. This fixes vendoring when it has npm or node specifiers. Vendoring occurs by adding a `"nodeModulesDir": true` property to deno.json then it uses a local node_modules directory. This can be opted out by setting `"nodeModulesDir": false` or running with `--node-modules-dir=false`.

Closes #18090
Closes #17210
Closes #17619
Closes #16778