### PR TITLE
BREAKING(unstable): change return type of Deno.serve() API

### DIFF
--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -50,7 +50,7 @@ Deno.test(async function httpServerShutsDownPortBeforeResolving() {
   assertThrows(() => Deno.listen({ port: 4501 }));
 
   ac.abort();
-  await server;
+  await server.finished;
 
   const listener = Deno.listen({ port: 4501 });
   listener!.close();
@@ -93,7 +93,7 @@ Deno.test(async function httpServerRejectsOnAddrInUse() {
   });
   await listeningPromise;
 
-  await assertRejects(
+  assertThrows(
     () =>
       Deno.serve({
         handler: (_req) => new Response("ok"),
@@ -286,16 +286,16 @@ Deno.test(
   { permissions: { net: true } },
   async function httpServerErrorOverloadMissingHandler() {
     // @ts-ignore - testing invalid overload
-    await assertRejects(() => Deno.serve(), TypeError, "handler");
+    assertThrows(() => Deno.serve(), TypeError, "handler");
     // @ts-ignore - testing invalid overload
-    await assertRejects(() => Deno.serve({}), TypeError, "handler");
-    await assertRejects(
+    assertThrows(() => Deno.serve({}), TypeError, "handler");
+    assertThrows(
       // @ts-ignore - testing invalid overload
       () => Deno.serve({ handler: undefined }),
       TypeError,
       "handler",
     );
-    await assertRejects(
+    assertThrows(
       // @ts-ignore - testing invalid overload
       () => Deno.serve(undefined, { handler: () => {} }),
       TypeError,

--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -6,7 +6,6 @@ import { TextProtoReader } from "../testdata/run/textproto.ts";
 import {
   assert,
   assertEquals,
-  assertRejects,
   assertStringIncludes,
   assertThrows,
   Deferred,
@@ -284,7 +283,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerOverload2() {
 
 Deno.test(
   { permissions: { net: true } },
-  async function httpServerErrorOverloadMissingHandler() {
+  function httpServerErrorOverloadMissingHandler() {
     // @ts-ignore - testing invalid overload
     assertThrows(() => Deno.serve(), TypeError, "handler");
     // @ts-ignore - testing invalid overload

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1341,8 +1341,11 @@ declare namespace Deno {
    * ```ts
    * const ac = new AbortController();
    *
-   * Deno.serve({ signal: ac.signal }, (_req) => new Response("Hello, world"))
-   *  .then(() => console.log("Server closed"));
+   * const server = Deno.serve(
+   *   { signal: ac.signal },
+   *   (_req) => new Response("Hello, world")
+   * );
+   * server.finished.then(() => console.log("Server closed"));
    *
    * console.log("Closing server...");
    * ac.abort();
@@ -1401,8 +1404,11 @@ declare namespace Deno {
    * ```ts
    * const ac = new AbortController();
    *
-   * Deno.serve({ signal: ac.signal }, (_req) => new Response("Hello, world"))
-   *  .then(() => console.log("Server closed"));
+   * const server = Deno.serve(
+   *   { signal: ac.signal },
+   *   (_req) => new Response("Hello, world")
+   * );
+   * server.finished.then(() => console.log("Server closed"));
    *
    * console.log("Closing server...");
    * ac.abort();
@@ -1464,8 +1470,11 @@ declare namespace Deno {
    * ```ts
    * const ac = new AbortController();
    *
-   * Deno.serve({ signal: ac.signal }, (_req) => new Response("Hello, world"))
-   *  .then(() => console.log("Server closed"));
+   * const server = Deno.serve(
+   *   { signal: ac.signal },
+   *   (_req) => new Response("Hello, world")
+   * );
+   * server.finished.then(() => console.log("Server closed"));
    *
    * console.log("Closing server...");
    * ac.abort();

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1305,6 +1305,16 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
+   * @category HTTP Server
+   */
+  export interface Server {
+    /** A promise that resolves once server finishes - eg. when aborted using
+     * the signal passed to {@linkcode ServeOptions.signal}.
+     */
+    finished: Promise<void>;
+  }
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
    * Serves HTTP requests with the given handler.
    *
    * You can specify an object with a port and hostname option, which is the
@@ -1362,7 +1372,7 @@ declare namespace Deno {
    *
    * @category HTTP Server
    */
-  export function serve(handler: ServeHandler): Promise<void>;
+  export function serve(handler: ServeHandler): Server;
   /** **UNSTABLE**: New API, yet to be vetted.
    *
    * Serves HTTP requests with the given handler.
@@ -1425,7 +1435,7 @@ declare namespace Deno {
   export function serve(
     options: ServeOptions | ServeTlsOptions,
     handler: ServeHandler,
-  ): Promise<void>;
+  ): Server;
   /** **UNSTABLE**: New API, yet to be vetted.
    *
    * Serves HTTP requests with the given handler.
@@ -1487,7 +1497,7 @@ declare namespace Deno {
    */
   export function serve(
     options: ServeInit & (ServeOptions | ServeTlsOptions),
-  ): Promise<void>;
+  ): Server;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -682,8 +682,6 @@ function serve(arg1, arg2) {
     for (const streamRid of new SafeSetIterator(responseBodies)) {
       core.tryClose(streamRid);
     }
-
-    serverPromise.resolve();
   })();
 
   return { finished };

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -653,14 +653,8 @@ function serve(arg1, arg2) {
 
   onListen({ port: listenOpts.port });
 
-  const serverPromise = new Deferred();
-
-  const server = {
-    finished: serverPromise.promise,
-  };
-
   // Run the server
-  (async () => {
+  const finished = (async () => {
     while (true) {
       const rid = context.serverRid;
       let req;
@@ -692,7 +686,7 @@ function serve(arg1, arg2) {
     serverPromise.resolve();
   })();
 
-  return server;
+  return { finished };
 }
 
 internals.upgradeHttpRaw = upgradeHttpRaw;

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1577,7 +1577,7 @@ class ServerImpl extends EventEmitter {
           this.emit("listening");
         },
       },
-    ).then(() => this.#servePromise!.resolve());
+    ).finished.then(() => this.#servePromise!.resolve());
   }
 
   setTimeout() {


### PR DESCRIPTION
This commit changes the return type of an unstable `Deno.serve()` API
to instead return a `Deno.Server` object that has a `finished` field.

This change is done in preparation to be able to ref/unref the HTTP server.