### PR TITLE
experiment: faster dev iterations with ext plugins

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,7 +11,7 @@ rustflags = [
 ]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "metadata=12345678"]
 
 [target.'cfg(all())']
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5712,8 +5712,6 @@ dependencies = [
 [[package]]
 name = "v8"
 version = "0.71.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4bbfd886a9c2f87170438c0cdb6b1ddbfe80412ab591c83d24c7e48e487313"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot 0.12.1",
+ "paste",
  "pin-project",
  "serde",
  "serde_json",
@@ -3325,6 +3326,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "path-clean"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
-v8 = { version = "0.71.2", default-features = false }
+# v8 = { version = "0.71.2", default-features = false }
+v8 = { path = "../rusty_v8", default-features = false }
 deno_ast = { version = "0.26.0", features = ["transpiling"] }
 
 deno_core = { version = "0.186.0", path = "./core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ atty = "=0.2.14"
 base64 = "=0.13.1"
 bencher = "0.1"
 bytes = "1.4.0"
+paste = "1.0.12"
 cache_control = "=0.2.0"
 cbc = { version = "=0.1.2", features = ["alloc"] }
 console_static_text = "=0.8.1"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -340,7 +340,7 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
     ),
     deno_fetch::deno_fetch::init_ops::<PermissionsContainer>(Default::default()),
     deno_cache::deno_cache::init_ops::<SqliteBackedCache>(None),
-    deno_websocket::deno_websocket::init_ops::<PermissionsContainer>(
+    deno_websocket::deno_websocket::init_ops(
       "".to_owned(),
       None,
       None,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -26,13 +26,6 @@ mod version;
 mod watcher;
 mod worker;
 
-#[cfg(not(target_env = "msvc"))]
-use tikv_jemallocator::Jemalloc;
-
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
-
 use crate::args::flags_from_vec;
 use crate::args::DenoSubcommand;
 use crate::args::Flags;

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -760,7 +760,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
     })
     .collect();
 
-  deno_core::extension!(deno_cli_tsc,
+  deno_core::extension!(deno_cli_tsc2,
     ops_fn = deno_ops,
     options = {
       request: Request,
@@ -796,7 +796,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(compiler_snapshot()),
-    extensions: vec![deno_cli_tsc::init_ops(
+    extensions: vec![deno_cli_tsc2::init_ops(
       request,
       root_map,
       remapped_specifiers,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 serde_v8.workspace = true
 smallvec.workspace = true
 sourcemap = "6.1"
+paste.workspace = true
 tokio.workspace = true
 url.workspace = true
 v8.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,9 +14,10 @@ description = "A modern JavaScript/TypeScript runtime built with V8, Rust, and T
 path = "lib.rs"
 
 [features]
-default = ["v8_use_custom_libcxx"]
+default = ["v8_use_custom_libcxx", "unstable_type_name"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]
 include_js_files_for_snapshotting = []
+unstable_type_name = ["v8/unstable_type_name"]
 
 [dependencies]
 anyhow.workspace = true

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -309,6 +309,14 @@ macro_rules! extension {
         ext.take()
       }
     }
+
+    $crate::paste::paste! {
+      #[allow(dead_code)]
+      #[no_mangle]
+      pub fn [<init_ $name>] $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension {
+        $name::init_ops $( ::< $( $param ),+ > )? ( $( $( $options_id , )* )? )
+      }
+    }
   };
 
   // This branch of the macro generates a config object that calls the state function with itself.

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -193,6 +193,7 @@ macro_rules! extension {
     $(, state = $state_fn:expr )?
     $(, event_loop_middleware = $event_loop_middleware_fn:ident )?
     $(, customizer = $customizer_fn:expr )?
+    $(, dynamic = $symbol:ident )?
     $(,)?
   ) => {
     /// Extension struct for
@@ -320,7 +321,22 @@ macro_rules! extension {
         ext.take()
       }
     }
+
+    $crate::extension!(! __dyn__ $ ( $symbol )? $ ( config = { $( $options_id : $options_type ),* } )? );
   };
+
+  (! __dyn__ $name: ident $sym:ident config = { $( $options_id:ident : $options_type:ty ),* } ) => {
+    #[allow(dead_core)]
+      #[no_mangle]
+      pub fn $sym ( $( $options_id : $options_type ),* ) -> $crate::Extension {
+        $name::init_ops ( $( $options_id , )* )
+      }
+  };
+
+  (! __dyn__ config = { $( $options_id:ident : $options_type:ty ),* } ) => {
+  };
+
+  (! __dyn__ ) => {};
 
   // This branch of the macro generates a config object that calls the state function with itself.
   (! __config__ $ext:ident $( parameters = [ $( $param:ident : $type:ident ),+ ] )? config = { $( $options_id:ident : $options_type:ty ),* } $( state_fn = $state_fn:expr )? ) => {

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -308,13 +308,16 @@ macro_rules! extension {
         Self::with_customizer(&mut ext);
         ext.take()
       }
-    }
 
-    $crate::paste::paste! {
       #[allow(dead_code)]
-      #[no_mangle]
-      pub fn [<init_ $name>] $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension {
-        $name::init_ops $( ::< $( $param ),+ > )? ( $( $( $options_id , )* )? )
+      pub fn init_ops_self $( <  $( $param : $type + 'static ),+ > )? ( &self, $( $( $options_id : $options_type ),* )? ) -> $crate::Extension 
+      $( where $( $bound : $bound_type ),+ )?
+      {
+        let mut ext = Self::ext();
+        Self::with_ops $( ::< $( $param ),+ > )?(&mut ext);
+        Self::with_state_and_middleware $( ::< $( $param ),+ > )?(&mut ext, $( $( $options_id , )* )? );
+        Self::with_customizer(&mut ext);
+        ext.take()
       }
     }
   };

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -322,10 +322,10 @@ macro_rules! extension {
       }
     }
 
-    $crate::extension!(! __dyn__ $ ( $symbol )? $ ( config = { $( $options_id : $options_type ),* } )? );
+    $crate::extension!(! __dyn__ $name $ ( $symbol )? $ ( config = { $( $options_id : $options_type ),* } )? );
   };
 
-  (! __dyn__ $name: ident $sym:ident config = { $( $options_id:ident : $options_type:ty ),* } ) => {
+  (! __dyn__ $name:ident $sym:ident config = { $( $options_id:ident : $options_type:ty ),* } ) => {
     #[allow(dead_core)]
       #[no_mangle]
       pub fn $sym ( $( $options_id : $options_type ),* ) -> $crate::Extension {
@@ -333,10 +333,10 @@ macro_rules! extension {
       }
   };
 
-  (! __dyn__ config = { $( $options_id:ident : $options_type:ty ),* } ) => {
+  (! __dyn__ $name:ident config = { $( $options_id:ident : $options_type:ty ),* } ) => {
   };
 
-  (! __dyn__ ) => {};
+  (! __dyn__ $name:ident ) => {};
 
   // This branch of the macro generates a config object that calls the state function with itself.
   (! __config__ $ext:ident $( parameters = [ $( $param:ident : $type:ident ),+ ] )? config = { $( $options_id:ident : $options_type:ty ),* } $( state_fn = $state_fn:expr )? ) => {

--- a/core/gotham_state.rs
+++ b/core/gotham_state.rs
@@ -3,6 +3,7 @@
 // https://github.com/gotham-rs/gotham/blob/bcbbf8923789e341b7a0e62c59909428ca4e22e2/gotham/src/state/mod.rs
 // Copyright 2017 Gotham Project Developers. MIT license.
 
+
 use log::trace;
 use std::any::type_name;
 use std::any::Any;
@@ -11,7 +12,20 @@ use std::collections::BTreeMap;
 
 #[derive(Default)]
 pub struct GothamState {
+  #[cfg(not(feature = "unstable_type_name"))]
   data: BTreeMap<TypeId, Box<dyn Any>>,
+  #[cfg(feature = "unstable_type_name")]
+  data: BTreeMap<&'static str, Box<dyn Any>>,
+}
+
+#[cfg(not(feature = "unstable_type_name"))]
+fn type_id<T: 'static>() -> TypeId {
+  TypeId::of::<T>()
+}
+
+#[cfg(feature = "unstable_type_name")]
+const fn type_id<T: 'static>() -> &'static str {
+  std::any::type_name::<T>()
 }
 
 impl GothamState {
@@ -19,20 +33,20 @@ impl GothamState {
   /// Successive calls to `put` will overwrite the existing value of the same
   /// type.
   pub fn put<T: 'static>(&mut self, t: T) {
-    let type_id = TypeId::of::<T>();
+    let type_id = type_id::<T>();
     trace!(" inserting record to state for type_id `{:?}`", type_id);
     self.data.insert(type_id, Box::new(t));
   }
 
   /// Determines if the current value exists in `GothamState` storage.
   pub fn has<T: 'static>(&self) -> bool {
-    let type_id = TypeId::of::<T>();
+    let type_id = type_id::<T>();
     self.data.get(&type_id).is_some()
   }
 
   /// Tries to borrow a value from the `GothamState` storage.
   pub fn try_borrow<T: 'static>(&self) -> Option<&T> {
-    let type_id = TypeId::of::<T>();
+    let type_id = type_id::<T>();
     trace!(" borrowing state data for type_id `{:?}`", type_id);
     self.data.get(&type_id).and_then(|b| b.downcast_ref())
   }
@@ -44,7 +58,7 @@ impl GothamState {
 
   /// Tries to mutably borrow a value from the `GothamState` storage.
   pub fn try_borrow_mut<T: 'static>(&mut self) -> Option<&mut T> {
-    let type_id = TypeId::of::<T>();
+    let type_id = type_id::<T>();
     trace!(" mutably borrowing state data for type_id `{:?}`", type_id);
     self.data.get_mut(&type_id).and_then(|b| b.downcast_mut())
   }
@@ -56,7 +70,7 @@ impl GothamState {
 
   /// Tries to move a value out of the `GothamState` storage and return ownership.
   pub fn try_take<T: 'static>(&mut self) -> Option<T> {
-    let type_id = TypeId::of::<T>();
+    let type_id = type_id::<T>();
     trace!(
       " taking ownership from state data for type_id `{:?}`",
       type_id

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,4 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#![cfg_attr(feature = "unstable_type_name", feature(const_type_name))]
+
 mod async_cancel;
 mod async_cell;
 mod bindings;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -33,6 +33,7 @@ pub use parking_lot;
 pub use serde;
 pub use serde_json;
 pub use serde_v8;
+pub use paste;
 pub use serde_v8::ByteString;
 pub use serde_v8::DetachedBuffer;
 pub use serde_v8::StringOrBuffer;

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -79,6 +79,10 @@ pub trait Resource: Any + 'static {
     type_name::<Self>().into()
   }
 
+  fn type_name(&self) -> &'static str {
+    type_name::<Self>()
+  }
+
   /// Read a single chunk of data from the resource. This operation returns a
   /// `BufView` that represents the data that was read. If a zero length buffer
   /// is returned, it indicates that the resource has reached EOF.
@@ -202,7 +206,11 @@ pub trait Resource: Any + 'static {
 impl dyn Resource {
   #[inline(always)]
   fn is<T: Resource>(&self) -> bool {
-    self.type_id() == TypeId::of::<T>()
+    #[cfg(not(feature = "unstable_type_name"))]
+    return self.type_id() == TypeId::of::<T>();
+
+    #[cfg(feature = "unstable_type_name")]
+    return self.type_name() == type_name::<T>();
   }
 
   #[inline(always)]

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -373,7 +373,6 @@ impl JsRuntime {
     let refs: &'static v8::ExternalReferences = Box::leak(Box::new(refs));
     let global_context;
     let mut maybe_snapshotted_data = None;
-
     let mut isolate = if snapshot_options.will_snapshot() {
       let snapshot_creator =
         snapshot_util::create_snapshot_creator(refs, options.startup_snapshot);

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -12,7 +12,6 @@ description = "Implementation of WebSocket API for Deno"
 
 [lib]
 path = "lib.rs"
-crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bytes.workspace = true

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -12,6 +12,7 @@ description = "Implementation of WebSocket API for Deno"
 
 [lib]
 path = "lib.rs"
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bytes.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,6 +23,7 @@ snapshot_from_snapshot = []
 include_js_files_for_snapshotting = [
   "deno_core/include_js_files_for_snapshotting",
 ]
+dynamic = []
 
 [lib]
 name = "deno_runtime"

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -298,7 +298,7 @@ mod startup_snapshot {
         Default::default(),
       ),
       deno_cache::deno_cache::init_ops_and_esm::<SqliteBackedCache>(None),
-      deno_websocket::deno_websocket::init_ops_and_esm::<Permissions>(
+      deno_websocket::deno_websocket::init_ops_and_esm(
         "".to_owned(),
         None,
         None,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -417,7 +417,7 @@ impl WebWorker {
         },
       ),
       deno_cache::deno_cache::init_ops::<SqliteBackedCache>(create_cache),
-      deno_websocket::deno_websocket::init_ops::<PermissionsContainer>(
+      deno_websocket::deno_websocket::init_ops(
         options.bootstrap.user_agent.clone(),
         options.root_cert_store_provider.clone(),
         options.unsafely_ignore_certificate_errors.clone(),


### PR DESCRIPTION
~6min release build times are excruciating. This patch aims to bring down build times for quick dev iteration cycles when dealing with extensions. 

With this patch, dev release builds take ~15s (for deno_websocket)

Inspired by my bevy game with live reload - the idea is that you don't need to rebuilt `deno (bin)` crate for changes made only in ext crates.

```shell
# Build deno (bin) once
$ cargo +nightly build
  -p deno
  --features "core/unstable_type_name"
  --release

$ touch ext/websocket/lib.rs

# Build the plugin with your changes
$ cargo +nightly rustc
  -p deno_websocket
  --features "core/unstable_type_name"
  --crate-type cdylib
  --release
```

mode | deno | deno_websocket (dylib)
-- | -- | --
release | 9m 53s | 38s
release (incremental) | 5m 31s | 15s
debug (incremental) | 20s | 1s
build units (fresh) | 1027 | 219

### Changes

- To safely use the rusty_v8 context annex, OpState, and serde_v8 across dylib boundaries, we cannot rely on TypeId, as it differs across builds.
- The `unstable_type_name` feature in deno_core and rusty_v8 uses `type_name` for keys in Context annex and Gotham state instead of TypeId.
- The nightly toolchain is needed to use `const fn type_name`.
- The `ext` crate must be built as a dylib manually instead of using the crate-type in Cargo.toml.
- The `init` for the extension cannot have generics because it is called across the dylib boundary. Most of the generics being used are for Permissions, which have to be disabled using a feature flag.

Depends on https://github.com/denoland/rusty_v8/pull/1231