### PR TITLE
chore(cli): Don't assume deno is in path for spawn_kill_permissions

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -3434,8 +3434,9 @@ itest!(test_and_bench_are_noops_in_run {
   output_str: Some(""),
 });
 
+#[cfg(not(target_os = "windows"))]
 itest!(spawn_kill_permissions {
-  args: "run --quiet --unstable --allow-run=deno spawn_kill_permissions.ts",
+  args: "run --quiet --unstable --allow-run=cat spawn_kill_permissions.ts",
   output_str: Some(""),
 });
 

--- a/cli/tests/testdata/spawn_kill_permissions.ts
+++ b/cli/tests/testdata/spawn_kill_permissions.ts
@@ -1,5 +1,5 @@
-const child = new Deno.Command(Deno.execPath(), {
-  args: ["eval", "await new Promise(r => setTimeout(r, 2000))"],
+const child = new Deno.Command("cat", {
+  args: ["-"],
   stdout: "null",
   stderr: "null",
 }).spawn();

--- a/cli/tests/testdata/spawn_kill_permissions.ts
+++ b/cli/tests/testdata/spawn_kill_permissions.ts
@@ -1,4 +1,4 @@
-const child = new Deno.Command("deno", {
+const child = new Deno.Command(Deno.execPath(), {
   args: ["eval", "await new Promise(r => setTimeout(r, 2000))"],
   stdout: "null",
   stderr: "null",


### PR DESCRIPTION
We don't need to use the `deno` command here to test kill permissions and it's awkward to get right without passing `-A`. `cat` works, but for platforms other than windows. This test should have plenty of coverage on other platforms.