### PR TITLE
chore: add Deno version information to new 1.34 deno.json properties

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -225,7 +225,7 @@
     },
     "exclude": {
       "type": "array",
-      "description": "List of files or directories that will be ignored by all other configurations. (Requires Deno 1.34 or later)",
+      "description": "List of files or directories that will be ignored by all other configurations. Requires Deno 1.34 or later.",
       "items": {
         "type": "string"
       }
@@ -423,7 +423,7 @@
       }
     },
     "nodeModulesDir": {
-      "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` or `--node-modules-dir=false` flag. (requires Deno 1.34 or later)",
+      "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` or `--node-modules-dir=false` flag. Requires Deno 1.34 or later.",
       "type": "boolean"
     },
     "tasks": {

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -225,7 +225,7 @@
     },
     "exclude": {
       "type": "array",
-      "description": "List of files or directories that will be ignored by all other configurations.",
+      "description": "List of files or directories that will be ignored by all other configurations. (Requires Deno 1.34 or later)",
       "items": {
         "type": "string"
       }
@@ -423,7 +423,7 @@
       }
     },
     "nodeModulesDir": {
-      "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` or `--node-modules-dir=false` flag.",
+      "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` or `--node-modules-dir=false` flag. (requires Deno 1.34 or later)",
       "type": "boolean"
     },
     "tasks": {


### PR DESCRIPTION
These already come up in the auto-complete, so let's let users know what versions these are available in.