### PR TITLE
refactor(core): set function names for ops in JavaScript

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -563,7 +563,7 @@ for (let i = 0; i < 10; i++) {
         );
     }
     ObjectDefineProperty(fn, "name", {
-      value: `${opName}_wrapped`,
+      value: opName,
       configurable: false,
       writable: false,
     });

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -14,6 +14,7 @@
     MapPrototypeHas,
     MapPrototypeSet,
     ObjectAssign,
+    ObjectDefineProperty,
     ObjectFreeze,
     ObjectFromEntries,
     ObjectKeys,
@@ -561,6 +562,11 @@ for (let i = 0; i < 10; i++) {
           })`,
         );
     }
+    ObjectDefineProperty(fn, "name", {
+      value: opName,
+      configurable: false,
+      writable: false,
+    });
     return (ops[opName] = fn);
   }
 

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -563,7 +563,7 @@ for (let i = 0; i < 10; i++) {
         );
     }
     ObjectDefineProperty(fn, "name", {
-      value: opName,
+      value: `${opName}_wrapped`,
       configurable: false,
       writable: false,
     });

--- a/core/bindings.js
+++ b/core/bindings.js
@@ -20,7 +20,7 @@ Deno.__op__registerOp = function (isAsync, op, opName) {
       return;
     }
     core.asyncOps[opName] = op;
-    core.ops[opName] = function (...args) {
+    const fn = function (...args) {
       if (this !== core.ops) {
         // deno-lint-ignore prefer-primordials
         throw new Error(
@@ -29,6 +29,8 @@ Deno.__op__registerOp = function (isAsync, op, opName) {
       }
       return core.asyncStub(opName, args);
     };
+    fn.name = opName;
+    core.ops[opName] = fn;
   } else {
     core.ops[opName] = op;
   }

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -206,6 +206,9 @@ fn op_ctx_function<'s>(
 ) -> v8::Local<'s, v8::Function> {
   let op_ctx_ptr = op_ctx as *const OpCtx as *const c_void;
   let external = v8::External::new(scope, op_ctx_ptr as *mut c_void);
+  let v8name =
+    v8::String::new_external_onebyte_static(scope, op_ctx.decl.name.as_bytes())
+      .unwrap();
   let builder: v8::FunctionBuilder<v8::FunctionTemplate> =
     v8::FunctionTemplate::builder_raw(op_ctx.decl.v8_fn_ptr)
       .data(external.into())
@@ -222,7 +225,10 @@ fn op_ctx_function<'s>(
   } else {
     builder.build(scope)
   };
-  templ.get_function(scope).unwrap()
+
+  let v8fn = templ.get_function(scope).unwrap();
+  v8fn.set_name(v8name);
+  v8fn
 }
 
 pub extern "C" fn wasm_async_resolve_promise_callback(

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -214,7 +214,7 @@ fn op_ctx_function<'s>(
       .data(external.into())
       .length(op_ctx.decl.arg_count as i32);
 
-  let templ = if let Some(fast_function) = &op_ctx.decl.fast_fn {
+  let template = if let Some(fast_function) = &op_ctx.decl.fast_fn {
     builder.build_fast(
       scope,
       fast_function,
@@ -226,7 +226,7 @@ fn op_ctx_function<'s>(
     builder.build(scope)
   };
 
-  let v8fn = templ.get_function(scope).unwrap();
+  let v8fn = template.get_function(scope).unwrap();
   v8fn.set_name(v8name);
   v8fn
 }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -4904,6 +4904,6 @@ Deno.core.opAsync("op_async_serialize_object_with_numbers_as_keys", {
       throw new Error();
     }
     "#;
-    runtime.execute_script_static("test", src.into()).unwrap();
+    runtime.execute_script_static("test", src).unwrap();
   }
 }

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -4871,4 +4871,39 @@ Deno.core.opAsync("op_async_serialize_object_with_numbers_as_keys", {
       ..Default::default()
     });
   }
+
+  #[test]
+  fn ops_in_js_have_proper_names() {
+    #[op]
+    fn op_test_sync() -> Result<String, Error> {
+      Ok(String::from("Test"))
+    }
+
+    #[op]
+    async fn op_test_async() -> Result<String, Error> {
+      Ok(String::from("Test"))
+    }
+
+    deno_core::extension!(test_ext, ops = [op_test_sync, op_test_async]);
+    let mut runtime = JsRuntime::new(RuntimeOptions {
+      extensions: vec![test_ext::init_ops()],
+      ..Default::default()
+    });
+
+    let src = r#"
+    if (Deno.core.ops.op_test_sync.name !== "op_test_sync") {
+      throw new Error();
+    }
+
+    if (Deno.core.ops.op_test_async.name !== "op_test_async") {
+      throw new Error();
+    }
+
+    const { op_test_async } = Deno.core.generateAsyncOpHandler("op_test_async");
+    if (op_test_async.name !== "op_test_async") {
+      throw new Error();
+    }
+    "#;
+    runtime.execute_script_static("test", src.into()).unwrap();
+  }
 }


### PR DESCRIPTION
This commit ensures that JavaScript functions generated for registered ops
have proper names set up - the function name matches the name of the op.
A test was added in `core/runtime.rs` that verifies this.

Closes https://github.com/denoland/deno/issues/19206