### PR TITLE
fix(runtime): JS debug log to stderr

### DIFF
--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -19,7 +19,7 @@ function log(...args) {
   if (logDebug) {
     // if we destructure `console` off `globalThis` too early, we don't bind to
     // the right console, therefore we don't log anything out.
-    globalThis.console.log(
+    globalThis.console.error(
       `DEBUG ${logSource} -`,
       ...new SafeArrayIterator(args),
     );


### PR DESCRIPTION
Debug logs should all go to stderr.