### PR TITLE
chore(core): Optimize polling for zero and one ready async op

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -194,6 +194,25 @@
     }
   }
 
+  // Fast event loop tick for a single promise and no nextTick.
+  function eventLoopTick1(promiseId, res) {
+    // Resolve the promise
+    getPromise(promiseId).resolve(res);
+    ops.op_run_microtasks();
+
+    // Finally drain macrotask queue.
+    for (let i = 0; i < macrotaskCallbacks.length; i++) {
+      const cb = macrotaskCallbacks[i];
+      while (true) {
+        const res = cb();
+        ops.op_run_microtasks();
+        if (res === true) {
+          break;
+        }
+      }
+    }
+  }
+
   function registerErrorClass(className, errorClass) {
     registerErrorBuilder(className, (msg) => new errorClass(msg));
   }
@@ -810,6 +829,7 @@ for (let i = 0; i < 10; i++) {
     registerErrorClass,
     buildCustomError,
     eventLoopTick,
+    eventLoopTick1,
     BadResource,
     BadResourcePrototype,
     Interrupted,

--- a/core/realm.rs
+++ b/core/realm.rs
@@ -38,6 +38,7 @@ impl Hasher for IdentityHasher {
 #[derive(Default)]
 pub(crate) struct ContextState {
   pub(crate) js_event_loop_tick_cb: Option<Rc<v8::Global<v8::Function>>>,
+  pub(crate) js_event_loop_tick1_cb: Option<Rc<v8::Global<v8::Function>>>,
   pub(crate) js_build_custom_error_cb: Option<Rc<v8::Global<v8::Function>>>,
   pub(crate) js_promise_reject_cb: Option<Rc<v8::Global<v8::Function>>>,
   pub(crate) js_format_exception_cb: Option<Rc<v8::Global<v8::Function>>>,


### PR DESCRIPTION
This is a small optimization for async op dispatch, ~1% for deferred ops, ~2% for non-deferred ops:

# Deferred async ops (count=10000000)

Before:

time 10223 ms rate 978186

After:

time 10120 ms rate 988142

# Non-deferred async ops (count=10000000)

Before:

time 1021 ms rate 9794319

After:

time 998 ms rate 10020040

