### PR TITLE
fix(node): duplicate node_module suffixes

### DIFF
--- a/cli/tests/unit_node/module_test.ts
+++ b/cli/tests/unit_node/module_test.ts
@@ -1,8 +1,12 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import { Module } from "node:module";
-import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../test_util/std/testing/asserts.ts";
 import process from "node:process";
+import * as path from "node:path";
 
 Deno.test("[node/module _preloadModules] has internal require hook", () => {
   // Check if it's there
@@ -24,4 +28,32 @@ Deno.test("[node/module runMain] loads module using the current process.argv", (
   (Module as any).runMain();
   // deno-lint-ignore no-explicit-any
   assertEquals((globalThis as any).calledViaRunMain, true);
+});
+
+Deno.test("[node/module _nodeModulePaths] prevents duplicate /node_modules/node_modules suffix", () => {
+  // deno-lint-ignore no-explicit-any
+  const actual: string[] = (Module as any)._nodeModulePaths(
+    path.join(process.cwd(), "testdata", "node_modules", "foo"),
+  );
+
+  assert(
+    !actual.some((dir) => /node_modules[/\\]node_modules/g.test(dir)),
+    "Duplicate 'node_modules/node_modules' suffix found",
+  );
+});
+
+Deno.test("[node/module _nodeModulePaths] prevents duplicate root /node_modules", () => {
+  // deno-lint-ignore no-explicit-any
+  const actual: string[] = (Module as any)._nodeModulePaths(
+    path.join(process.cwd(), "testdata", "node_modules", "foo"),
+  );
+
+  assert(
+    new Set(actual).size === actual.length,
+    "Duplicate path entries found",
+  );
+  assert(
+    actual.includes("/node_modules"),
+    "Missing root '/node_modules' directory",
+  );
 });

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -128,16 +128,11 @@ where
   let mut current_path = from.as_path();
   let mut maybe_parent = Some(current_path);
   while let Some(parent) = maybe_parent {
-    if !parent.ends_with("/node_modules") {
+    if !parent.ends_with("node_modules") {
       paths.push(parent.join("node_modules").to_string_lossy().to_string());
-      current_path = parent;
-      maybe_parent = current_path.parent();
     }
-  }
-
-  if !cfg!(windows) {
-    // Append /node_modules to handle root paths.
-    paths.push("/node_modules".to_string());
+    current_path = parent;
+    maybe_parent = current_path.parent();
   }
 
   Ok(paths)

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -607,6 +607,11 @@ Module._findPath = function (request, paths, isMain, parentPath) {
   return false;
 };
 
+/**
+ * Get a list of potential module directories
+ * @param {string} fromPath The directory name of the module
+ * @returns {string[]} List of module directories
+ */
 Module._nodeModulePaths = function (fromPath) {
   return ops.op_require_node_module_paths(fromPath);
 };


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
Noticed that we're checking more module paths than necessary. In particular the module path array contains a couple of entries with a duplicated `node_modules/node_modules` suffix.

```js
[
    // ... more entries before here
    "/Users/marvinhagemeister/dev/preact-render-to-string/node_modules/.deno/node_modules",
    "/Users/marvinhagemeister/dev/preact-render-to-string/node_modules/node_modules", // <-- duplicate suffix
    "/Users/marvinhagemeister/dev/preact-render-to-string/node_modules",
    "/Users/marvinhagemeister/dev/node_modules",
    "/Users/marvinhagemeister/node_modules",
    "/Users/node_modules",
    "/node_modules",
    "/node_modules"  // <-- duplicate entry
]
```

This was caused by a misunderstanding in how Rust's [`Path::ends_with()`] works. It's designed to match on whole path segments and the suffix `/node_modules` is not that, except for the root entry. This meant that our check for if the path already ended with `node_module` always returned `false`. Removing the leading slash fixes that.

While we're at it, we can remove the last condition where we explicitly added the root `/node_modules` entry since the while loop prior to that takes care of that already.