### PR TITLE
fix: better error message for malformed glob

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1345,7 +1345,7 @@ fn expand_globs(paths: &[PathBuf]) -> Result<Vec<PathBuf>, AnyError> {
         },
       )
       .with_context(|| {
-        format!("Failed to expand glob: \"{}\"", escaped_path_str)
+        format!("Failed to expand glob: \"{}\"", path_str)
       })?;
 
       for globbed_path_result in globbed_paths {

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1344,9 +1344,7 @@ fn expand_globs(paths: &[PathBuf]) -> Result<Vec<PathBuf>, AnyError> {
           require_literal_leading_dot: true,
         },
       )
-      .with_context(|| {
-        format!("Failed to expand glob: \"{}\"", path_str)
-      })?;
+      .with_context(|| format!("Failed to expand glob: \"{}\"", path_str))?;
 
       for globbed_path_result in globbed_paths {
         new_paths.push(globbed_path_result?);

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1343,7 +1343,10 @@ fn expand_globs(paths: &[PathBuf]) -> Result<Vec<PathBuf>, AnyError> {
           // true because it copies with sh does—these files are considered "hidden"
           require_literal_leading_dot: true,
         },
-      )?;
+      )
+      .with_context(|| {
+        format!("Failed to expand glob: \"{}\"", escaped_path_str)
+      })?;
 
       for globbed_path_result in globbed_paths {
         new_paths.push(globbed_path_result?);
@@ -1591,6 +1594,16 @@ mod test {
     temp_dir.write("nested/fizz/bazz.ts", "");
 
     temp_dir.write("pages/[id].ts", "");
+
+    let error = resolve_files(
+      Some(FilesConfig {
+        include: vec![temp_dir.path().join("data/**********.ts")],
+        exclude: vec![],
+      }),
+      None,
+    )
+    .unwrap_err();
+    assert!(error.to_string().starts_with("Failed to expand glob"));
 
     let resolved_files = resolve_files(
       Some(FilesConfig {


### PR DESCRIPTION
Before:
```
$ cargo run -- test "foo/*******/bar.ts"
error: Pattern syntax error near position 6: wildcards are either regular `*` or recursive `**`
```

After:
```
$ cargo run -- test "foo/*******/bar.ts"
error: Failed to expand glob: "foo/*******/bar.ts"

Caused by:
    Pattern syntax error near position 6: wildcards are either regular `*` or recursive `**`
```