### PR TITLE
chore(core): Split JsRuntimeForSnapshot from JsRuntime

### DIFF
--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -290,7 +290,7 @@ pub fn host_import_module_dynamically_callback<'s>(
 
   let resolver_handle = v8::Global::new(scope, resolver);
   {
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let module_map_rc = JsRuntime::module_map_from(scope);
 
     debug!(
@@ -490,7 +490,7 @@ pub extern "C" fn promise_reject_callback(message: v8::PromiseRejectMessage) {
       };
 
     if has_unhandled_rejection_handler {
-      let state_rc = JsRuntime::state(tc_scope);
+      let state_rc = JsRuntime::state_from(tc_scope);
       let mut state = state_rc.borrow_mut();
       if let Some(pending_mod_evaluate) = state.pending_mod_evaluate.as_mut() {
         if !pending_mod_evaluate.has_evaluated {

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -134,7 +134,7 @@ pub(crate) fn initialize_context<'s>(
     codegen,
     "Deno.__op__ = function(opFns, callConsole, console) {{"
   );
-  if bindings_mode != BindingsMode::New {
+  if bindings_mode == BindingsMode::New {
     _ = writeln!(codegen, "Deno.__op__console(callConsole, console);");
   }
   for op_ctx in op_ctxs {

--- a/core/bindings.rs
+++ b/core/bindings.rs
@@ -20,8 +20,11 @@ use crate::JsRuntime;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum BindingsMode {
+  /// We have no snapshot -- this is a pristine context.
   New,
+  /// We have initialized before, are reloading a snapshot, and will snapshot.
   Loaded,
+  /// We have initialized before, are reloading a snapshot, and will not snapshot again.
   LoadedFinal,
 }
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -209,7 +209,7 @@ impl JsStackFrame {
     let l = message.get_line_number(scope)? as i64;
     // V8's column numbers are 0-based, we want 1-based.
     let c = message.get_start_column() as i64 + 1;
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let (getter, cache) = {
       let state = state_rc.borrow();
       (
@@ -282,7 +282,7 @@ impl JsError {
       frames = vec![stack_frame];
     }
     {
-      let state_rc = JsRuntime::state(scope);
+      let state_rc = JsRuntime::state_from(scope);
       let (getter, cache) = {
         let state = state_rc.borrow();
         (
@@ -414,7 +414,7 @@ impl JsError {
         }
       }
       {
-        let state_rc = JsRuntime::state(scope);
+        let state_rc = JsRuntime::state_from(scope);
         let (getter, cache) = {
           let state = state_rc.borrow();
           (

--- a/core/examples/http_bench_json_ops/main.rs
+++ b/core/examples/http_bench_json_ops/main.rs
@@ -3,7 +3,7 @@ use deno_core::anyhow::Error;
 use deno_core::op;
 use deno_core::AsyncRefCell;
 use deno_core::AsyncResult;
-use deno_core::JsRuntime;
+use deno_core::JsRuntimeForSnapshot;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
@@ -103,7 +103,7 @@ fn create_js_runtime() -> JsRuntimeForSnapshot {
     ])
     .build();
 
-  JsRuntime::new_for_snapshot(
+  JsRuntimeForSnapshot::new(
     deno_core::RuntimeOptions {
       extensions: vec![ext],
       ..Default::default()

--- a/core/examples/http_bench_json_ops/main.rs
+++ b/core/examples/http_bench_json_ops/main.rs
@@ -93,7 +93,7 @@ impl From<tokio::net::TcpStream> for TcpStream {
   }
 }
 
-fn create_js_runtime() -> JsRuntime {
+fn create_js_runtime() -> JsRuntimeForSnapshot {
   let ext = deno_core::Extension::builder("my_ext")
     .ops(vec![
       op_listen::decl(),
@@ -103,11 +103,10 @@ fn create_js_runtime() -> JsRuntime {
     ])
     .build();
 
-  JsRuntime::new(deno_core::RuntimeOptions {
+  JsRuntime::new_for_snapshot(deno_core::RuntimeOptions {
     extensions: vec![ext],
-    will_snapshot: false,
     ..Default::default()
-  })
+  }, Default::default())
 }
 
 #[op]

--- a/core/examples/http_bench_json_ops/main.rs
+++ b/core/examples/http_bench_json_ops/main.rs
@@ -103,10 +103,13 @@ fn create_js_runtime() -> JsRuntimeForSnapshot {
     ])
     .build();
 
-  JsRuntime::new_for_snapshot(deno_core::RuntimeOptions {
-    extensions: vec![ext],
-    ..Default::default()
-  }, Default::default())
+  JsRuntime::new_for_snapshot(
+    deno_core::RuntimeOptions {
+      extensions: vec![ext],
+      ..Default::default()
+    },
+    Default::default(),
+  )
 }
 
 #[op]

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -349,6 +349,7 @@ macro_rules! extension {
 
 #[derive(Default)]
 pub struct Extension {
+  pub(crate) name: &'static str,
   js_files: Option<Vec<ExtensionFileSource>>,
   esm_files: Option<Vec<ExtensionFileSource>>,
   esm_entry_point: Option<&'static str>,
@@ -358,7 +359,6 @@ pub struct Extension {
   event_loop_middleware: Option<Box<OpEventLoopFn>>,
   initialized: bool,
   enabled: bool,
-  name: &'static str,
   deps: Option<&'static [&'static str]>,
   force_op_registration: bool,
   pub(crate) is_core: bool,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -113,6 +113,7 @@ pub use crate::runtime::CrossIsolateStore;
 pub use crate::runtime::GetErrorClassFn;
 pub use crate::runtime::JsErrorCreateFn;
 pub use crate::runtime::JsRuntime;
+pub use crate::runtime::JsRuntimeForSnapshot;
 pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::SharedArrayBufferStore;
 pub use crate::runtime::Snapshot;

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -1719,6 +1719,7 @@ mod tests {
   use super::*;
   use crate::ascii_str;
   use crate::JsRuntime;
+  use crate::JsRuntimeForSnapshot;
   use crate::RuntimeOptions;
   use crate::Snapshot;
   use deno_ops::op;
@@ -2889,7 +2890,7 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
       );
 
       let loader = MockLoader::new();
-      let mut runtime = JsRuntime::new_for_snapshot(
+      let mut runtime = JsRuntimeForSnapshot::new(
         RuntimeOptions {
           module_loader: Some(loader),
           ..Default::default()
@@ -2933,7 +2934,7 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
       );
 
       let loader = MockLoader::new();
-      let mut runtime = JsRuntime::new_for_snapshot(
+      let mut runtime = JsRuntimeForSnapshot::new(
         RuntimeOptions {
           module_loader: Some(loader),
           ..Default::default()

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -2889,10 +2889,13 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
       );
 
       let loader = MockLoader::new();
-      let mut runtime = JsRuntime::new_for_snapshot(RuntimeOptions {
-        module_loader: Some(loader),
-        ..Default::default()
-      }, Default::default());
+      let mut runtime = JsRuntime::new_for_snapshot(
+        RuntimeOptions {
+          module_loader: Some(loader),
+          ..Default::default()
+        },
+        Default::default(),
+      );
       // In default resolution code should be empty.
       // Instead we explicitly pass in our own code.
       // The behavior should be very similar to /a.js.
@@ -2930,10 +2933,13 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
       );
 
       let loader = MockLoader::new();
-      let mut runtime = JsRuntime::new_for_snapshot(RuntimeOptions {
-        module_loader: Some(loader),
-        ..Default::default()
-      }, Default::default());
+      let mut runtime = JsRuntime::new_for_snapshot(
+        RuntimeOptions {
+          module_loader: Some(loader),
+          ..Default::default()
+        },
+        Default::default(),
+      );
       // In default resolution code should be empty.
       // Instead we explicitly pass in our own code.
       // The behavior should be very similar to /a.js.

--- a/core/modules.rs
+++ b/core/modules.rs
@@ -2889,11 +2889,10 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
       );
 
       let loader = MockLoader::new();
-      let mut runtime = JsRuntime::new(RuntimeOptions {
+      let mut runtime = JsRuntime::new_for_snapshot(RuntimeOptions {
         module_loader: Some(loader),
-        will_snapshot: true,
         ..Default::default()
-      });
+      }, Default::default());
       // In default resolution code should be empty.
       // Instead we explicitly pass in our own code.
       // The behavior should be very similar to /a.js.
@@ -2931,11 +2930,10 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
       );
 
       let loader = MockLoader::new();
-      let mut runtime = JsRuntime::new(RuntimeOptions {
+      let mut runtime = JsRuntime::new_for_snapshot(RuntimeOptions {
         module_loader: Some(loader),
-        will_snapshot: true,
         ..Default::default()
-      });
+      }, Default::default());
       // In default resolution code should be empty.
       // Instead we explicitly pass in our own code.
       // The behavior should be very similar to /a.js.

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -196,6 +196,12 @@ impl OpState {
       tracker: OpsTracker::new(ops_count),
     }
   }
+
+  /// Clear all user-provided resources and state.
+  pub(crate) fn clear(&mut self) {
+    std::mem::take(&mut self.gotham_state);
+    std::mem::take(&mut self.resource_table);
+  }
 }
 
 impl Deref for OpState {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -183,7 +183,7 @@ pub struct OpState {
   pub get_error_class_fn: GetErrorClassFn,
   pub tracker: OpsTracker,
   pub last_fast_op_error: Option<AnyError>,
-  gotham_state: GothamState,
+  pub(crate) gotham_state: GothamState,
 }
 
 impl OpState {

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -72,14 +72,14 @@ fn op_run_microtasks(scope: &mut v8::HandleScope) {
 
 #[op(v8)]
 fn op_has_tick_scheduled(scope: &mut v8::HandleScope) -> bool {
-  let state_rc = JsRuntime::state(scope);
+  let state_rc = JsRuntime::state_from(scope);
   let state = state_rc.borrow();
   state.has_tick_scheduled
 }
 
 #[op(v8)]
 fn op_set_has_tick_scheduled(scope: &mut v8::HandleScope, v: bool) {
-  let state_rc = JsRuntime::state(scope);
+  let state_rc = JsRuntime::state_from(scope);
   state_rc.borrow_mut().has_tick_scheduled = v;
 }
 
@@ -242,7 +242,7 @@ impl<'a> v8::ValueSerializerImpl for SerializeDeserialize<'a> {
     if self.for_storage {
       return None;
     }
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow_mut();
     if let Some(shared_array_buffer_store) = &state.shared_array_buffer_store {
       let backing_store = shared_array_buffer.get_backing_store();
@@ -263,7 +263,7 @@ impl<'a> v8::ValueSerializerImpl for SerializeDeserialize<'a> {
       self.throw_data_clone_error(scope, message);
       return None;
     }
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow_mut();
     if let Some(compiled_wasm_module_store) = &state.compiled_wasm_module_store
     {
@@ -305,7 +305,7 @@ impl<'a> v8::ValueDeserializerImpl for SerializeDeserialize<'a> {
     if self.for_storage {
       return None;
     }
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow_mut();
     if let Some(shared_array_buffer_store) = &state.shared_array_buffer_store {
       let backing_store = shared_array_buffer_store.take(transfer_id)?;
@@ -325,7 +325,7 @@ impl<'a> v8::ValueDeserializerImpl for SerializeDeserialize<'a> {
     if self.for_storage {
       return None;
     }
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow_mut();
     if let Some(compiled_wasm_module_store) = &state.compiled_wasm_module_store
     {
@@ -409,7 +409,7 @@ fn op_serialize(
   value_serializer.write_header();
 
   if let Some(transferred_array_buffers) = transferred_array_buffers {
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow_mut();
     for index in 0..transferred_array_buffers.length() {
       let i = v8::Number::new(scope, index as f64).into();
@@ -494,7 +494,7 @@ fn op_deserialize<'a>(
   }
 
   if let Some(transferred_array_buffers) = transferred_array_buffers {
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow_mut();
     if let Some(shared_array_buffer_store) = &state.shared_array_buffer_store {
       for i in 0..transferred_array_buffers.length() {
@@ -724,7 +724,7 @@ fn op_set_wasm_streaming_callback(
         .as_ref()
         .unwrap()
         .clone();
-      let state_rc = JsRuntime::state(scope);
+      let state_rc = JsRuntime::state_from(scope);
       let streaming_rid = state_rc
         .borrow()
         .op_state
@@ -751,7 +751,7 @@ fn op_abort_wasm_streaming(
   error: serde_v8::Value,
 ) -> Result<(), Error> {
   let wasm_streaming = {
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow();
     let wsr = state
       .op_state
@@ -790,7 +790,7 @@ fn op_dispatch_exception(
   scope: &mut v8::HandleScope,
   exception: serde_v8::Value,
 ) {
-  let state_rc = JsRuntime::state(scope);
+  let state_rc = JsRuntime::state_from(scope);
   let mut state = state_rc.borrow_mut();
   if let Some(inspector) = &state.inspector {
     let inspector = inspector.borrow();
@@ -828,7 +828,7 @@ fn op_apply_source_map(
   scope: &mut v8::HandleScope,
   location: Location,
 ) -> Result<Location, Error> {
-  let state_rc = JsRuntime::state(scope);
+  let state_rc = JsRuntime::state_from(scope);
   let (getter, cache) = {
     let state = state_rc.borrow();
     (

--- a/core/realm.rs
+++ b/core/realm.rs
@@ -162,7 +162,7 @@ impl JsRealmInner {
     };
 
     let exception = v8::Local::new(scope, handle);
-    let state_rc = JsRuntime::state(scope);
+    let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow();
     if let Some(inspector) = &state.inspector {
       let inspector = inspector.borrow();

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -120,7 +120,7 @@ struct InnerIsolateState {
 
 impl InnerIsolateState {
   /// Clean out the opstate and take the inspector to prevent the inspector from getting destroyed
-  /// after we're torn down the contexts. If the inspect is not correctly torn down, random crashes
+  /// after we've torn down the contexts. If the inspector is not correctly torn down, random crashes
   /// happen in tests (and possibly for users using the inspector).
   pub fn prepare_for_cleanup(&mut self) {
     let mut state = self.state.borrow_mut();

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -457,15 +457,12 @@ trait JsRuntimeInternalTrait {
 }
 
 impl<const FOR_SNAPSHOT: bool> JsRuntimeImpl<FOR_SNAPSHOT> {
-  fn init_v8(
-    v8_platform: Option<v8::SharedRef<v8::Platform>>,
-    for_snapshotting: bool,
-  ) {
+  fn init_v8(v8_platform: Option<v8::SharedRef<v8::Platform>>) {
     static DENO_INIT: Once = Once::new();
     static DENO_PREDICTABLE: AtomicBool = AtomicBool::new(false);
     static DENO_PREDICTABLE_SET: AtomicBool = AtomicBool::new(false);
 
-    let predictable = for_snapshotting || cfg!(test);
+    let predictable = FOR_SNAPSHOT || cfg!(test);
     if DENO_PREDICTABLE_SET.load(Ordering::SeqCst) {
       let current = DENO_PREDICTABLE.load(Ordering::SeqCst);
       assert_eq!(current, predictable, "V8 may only be initialized once in either snapshotting or non-snapshotting mode. Either snapshotting or non-snapshotting mode may be used in a single process, not both.");
@@ -1478,7 +1475,7 @@ impl<const FOR_SNAPSHOT: bool> JsRuntimeImpl<FOR_SNAPSHOT> {
 impl JsRuntime {
   /// Only constructor, configuration is done through `options`.
   pub fn new(mut options: RuntimeOptions) -> JsRuntime {
-    JsRuntimeImpl::<false>::init_v8(options.v8_platform.take(), false);
+    JsRuntimeImpl::<false>::init_v8(options.v8_platform.take());
 
     let snapshot_options = snapshot_util::SnapshotOptions::new_from(
       options.startup_snapshot.take(),
@@ -1537,7 +1534,7 @@ impl JsRuntimeForSnapshot {
     mut options: RuntimeOptions,
     runtime_snapshot_options: RuntimeSnapshotOptions,
   ) -> JsRuntimeForSnapshot {
-    JsRuntimeImpl::<true>::init_v8(options.v8_platform.take(), true);
+    JsRuntimeImpl::<true>::init_v8(options.v8_platform.take());
 
     let snapshot_options = snapshot_util::SnapshotOptions::new_from(
       options.startup_snapshot.take(),

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -126,7 +126,7 @@ impl InnerIsolateState {
 
 impl Drop for InnerIsolateState {
   fn drop(&mut self) {
-    self.cleanup()
+    self.cleanup();
   }
 }
 
@@ -854,7 +854,7 @@ impl<const FOR_SNAPSHOT: bool> JsRuntimeImpl<FOR_SNAPSHOT> {
     options: &mut RuntimeOptions,
     snapshot_options: &SnapshotOptions,
   ) -> (OpState, Vec<OpDecl>) {
-    // Add builtins extension
+    // Add built-in extension
     if snapshot_options.loaded() {
       options
         .extensions

--- a/core/runtime.rs
+++ b/core/runtime.rs
@@ -637,6 +637,11 @@ impl<const FOR_SNAPSHOT: bool> JsRuntimeImpl<FOR_SNAPSHOT> {
     state.global_realm.clone().unwrap()
   }
 
+  /// Returns the extensions that this runtime is using (including internal ones).
+  pub fn extensions(&self) -> &Vec<Extension> {
+    &self.extensions
+  }
+
   /// Creates a new realm (V8 context) in this JS execution context,
   /// pre-initialized with all of the extensions that were passed in
   /// [`RuntimeOptions::extensions`] when the [`JsRuntimeImpl`] was
@@ -1434,23 +1439,6 @@ impl JsRuntimeImpl<true> {
       options.startup_snapshot.take(),
       true,
     );
-
-    // TODO(mmastrac): We should not be printing here
-    #[cfg(feature = "include_js_files_for_snapshotting")]
-    for source in options
-      .extensions
-      .iter()
-      .flat_map(|e| vec![e.get_esm_sources(), e.get_js_sources()])
-      .flatten()
-      .flatten()
-    {
-      use crate::ExtensionFileSourceCode;
-      if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) =
-        &source.code
-      {
-        println!("cargo:rerun-if-changed={}", path.display())
-      }
-    }
 
     JsRuntimeImpl::<true>::new_runtime(
       options,

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -174,6 +174,10 @@ impl SnapshotOptions {
     matches!(self, Self::Load(_) | Self::CreateFromExisting(_))
   }
 
+  pub fn will_snapshot(&self) -> bool {
+    matches!(self, Self::Create | Self::CreateFromExisting(_))
+  }
+
   pub fn snapshot(self) -> Option<Snapshot> {
     match self {
       Self::CreateFromExisting(snapshot) => Some(snapshot),

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use crate::runtime::RuntimeSnapshotOptions;
 use crate::ExtModuleLoaderCb;
 use crate::Extension;
-use crate::JsRuntime;
+use crate::JsRuntimeForSnapshot;
 use crate::RuntimeOptions;
 use crate::Snapshot;
 
@@ -25,7 +25,7 @@ pub struct CreateSnapshotOptions {
 pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
   let mut mark = Instant::now();
 
-  let js_runtime = JsRuntime::new_for_snapshot(
+  let js_runtime = JsRuntimeForSnapshot::new(
     RuntimeOptions {
       startup_snapshot: create_snapshot_options.startup_snapshot,
       extensions: create_snapshot_options.extensions,

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -141,6 +141,18 @@ impl SnapshotOptions {
       (None, false) => Self::None,
     }
   }
+
+  pub fn loaded(&self) -> bool {
+    matches!(self, Self::Load(_) | Self::CreateFromExisting(_))
+  }
+
+  pub fn snapshot(self) -> Option<Snapshot> {
+    match self {
+      Self::CreateFromExisting(snapshot) => Some(snapshot),
+      Self::Load(snapshot) => Some(snapshot),
+      _ => None,
+    }
+  }
 }
 
 pub(crate) struct SnapshottedData {
@@ -213,9 +225,9 @@ pub(crate) fn set_snapshotted_data(
 /// Returns an isolate set up for snapshotting.
 pub(crate) fn create_snapshot_creator(
   external_refs: &'static v8::ExternalReferences,
-  maybe_startup_snapshot: Option<Snapshot>,
+  maybe_startup_snapshot: SnapshotOptions,
 ) -> v8::OwnedIsolate {
-  if let Some(snapshot) = maybe_startup_snapshot {
+  if let Some(snapshot) = maybe_startup_snapshot.snapshot() {
     match snapshot {
       Snapshot::Static(data) => {
         v8::Isolate::snapshot_creator_from_existing_snapshot(

--- a/core/snapshot_util.rs
+++ b/core/snapshot_util.rs
@@ -4,12 +4,12 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
 
+use crate::runtime::RuntimeSnapshotOptions;
 use crate::ExtModuleLoaderCb;
 use crate::Extension;
 use crate::JsRuntime;
 use crate::RuntimeOptions;
 use crate::Snapshot;
-use crate::runtime::RuntimeSnapshotOptions;
 
 pub type CompressionCb = dyn Fn(&mut Vec<u8>, &[u8]);
 
@@ -25,13 +25,16 @@ pub struct CreateSnapshotOptions {
 pub fn create_snapshot(create_snapshot_options: CreateSnapshotOptions) {
   let mut mark = Instant::now();
 
-  let js_runtime = JsRuntime::new_for_snapshot(RuntimeOptions {
-    startup_snapshot: create_snapshot_options.startup_snapshot,
-    extensions: create_snapshot_options.extensions,
-    ..Default::default()
-  }, RuntimeSnapshotOptions {
-    snapshot_module_load_cb: create_snapshot_options.snapshot_module_load_cb,
-  });
+  let js_runtime = JsRuntime::new_for_snapshot(
+    RuntimeOptions {
+      startup_snapshot: create_snapshot_options.startup_snapshot,
+      extensions: create_snapshot_options.extensions,
+      ..Default::default()
+    },
+    RuntimeSnapshotOptions {
+      snapshot_module_load_cb: create_snapshot_options.snapshot_module_load_cb,
+    },
+  );
   println!(
     "JsRuntime for snapshot prepared, took {:#?} ({})",
     Instant::now().saturating_duration_since(mark),

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -337,7 +337,7 @@ mod startup_snapshot {
       runtime_main::init_ops_and_esm(),
     ];
 
-    create_snapshot(CreateSnapshotOptions {
+    let output = create_snapshot(CreateSnapshotOptions {
       cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
       snapshot_path,
       startup_snapshot: None,
@@ -345,6 +345,9 @@ mod startup_snapshot {
       compression_cb: None,
       snapshot_module_load_cb: Some(Box::new(transpile_ts_for_snapshotting)),
     });
+    for path in output.files_loaded_during_snapshot {
+      println!("cargo:rerun-if-changed={}", path.display());
+    }
   }
 }
 


### PR DESCRIPTION
This cleans up `JsRuntime` a bit more:

 * We no longer print cargo's rerun-if-changed messages in `JsRuntime` -- those are printed elsewhere
 * We no longer special case the OwnedIsolate for snapshots. Instead we make use of an inner object that has the `Drop` impl and allows us to `std::mem::forget` it if we need to extract the isolate for a snapshot
 * The `snapshot` method is only available on `JsRuntimeForSnapshot`, not `JsRuntime`.
 * `OpState` construction is slightly cleaner, though I'd still like to extract more
