### PR TITLE
chore: pin enum-as-inner dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ version = "0.98.0"
 dependencies = [
  "deno_core",
  "deno_tls",
+ "enum-as-inner",
  "log",
  "pin-project",
  "serde",

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -16,6 +16,9 @@ path = "lib.rs"
 [dependencies]
 deno_core.workspace = true
 deno_tls.workspace = true
+# Pinning to 0.5.1, because 0.5.2 breaks "cargo publish"
+# https://github.com/bluejekyll/enum-as-inner/pull/91
+enum-as-inner = "=0.5.1"
 log.workspace = true
 pin-project.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Ref https://github.com/bluejekyll/enum-as-inner/issues/98

Had to pin it during the release to publish crates.