### PR TITLE
feat(runtime): add `WorkerLogLevel`

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -678,11 +678,7 @@ impl CliFactory {
   ) -> Result<CliMainWorkerOptions, AnyError> {
     Ok(CliMainWorkerOptions {
       argv: self.options.argv().clone(),
-      debug: self
-        .options
-        .log_level()
-        .map(|l| l == log::Level::Debug)
-        .unwrap_or(false),
+      log_level: self.options.log_level().unwrap_or(log::Level::Info).into(),
       coverage_dir: self.options.coverage_dir(),
       enable_testing_features: self.options.enable_testing_features(),
       has_node_modules_dir: self.options.has_node_modules_dir(),

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -46,6 +46,7 @@ use deno_runtime::deno_tls::RootCertStoreProvider;
 use deno_runtime::deno_web::BlobStore;
 use deno_runtime::permissions::Permissions;
 use deno_runtime::permissions::PermissionsContainer;
+use deno_runtime::WorkerLogLevel;
 use deno_semver::npm::NpmPackageReqReference;
 use import_map::parse_from_json;
 use std::pin::Pin;
@@ -423,7 +424,7 @@ pub async fn run(
     None,
     CliMainWorkerOptions {
       argv: metadata.argv,
-      debug: false,
+      log_level: WorkerLogLevel::Info,
       coverage_dir: None,
       enable_testing_features: false,
       has_node_modules_dir,

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -37,6 +37,7 @@ use deno_runtime::web_worker::WebWorkerOptions;
 use deno_runtime::worker::MainWorker;
 use deno_runtime::worker::WorkerOptions;
 use deno_runtime::BootstrapOptions;
+use deno_runtime::WorkerLogLevel;
 use deno_semver::npm::NpmPackageReqReference;
 
 use crate::args::StorageKeyResolver;
@@ -73,7 +74,7 @@ pub trait HasNodeSpecifierChecker: Send + Sync {
 #[derive(Clone)]
 pub struct CliMainWorkerOptions {
   pub argv: Vec<String>,
-  pub debug: bool,
+  pub log_level: WorkerLogLevel,
   pub coverage_dir: Option<String>,
   pub enable_testing_features: bool,
   pub has_node_modules_dir: bool,
@@ -434,7 +435,7 @@ impl CliMainWorkerFactory {
         cpu_count: std::thread::available_parallelism()
           .map(|p| p.get())
           .unwrap_or(1),
-        debug_flag: shared.options.debug,
+        log_level: shared.options.log_level,
         enable_testing_features: shared.options.enable_testing_features,
         locale: deno_core::v8::icu::get_language_tag(),
         location: shared.options.location.clone(),
@@ -562,7 +563,7 @@ fn create_web_worker_callback(
         cpu_count: std::thread::available_parallelism()
           .map(|p| p.get())
           .unwrap_or(1),
-        debug_flag: shared.options.debug,
+        log_level: shared.options.log_level,
         enable_testing_features: shared.options.enable_testing_features,
         locale: deno_core::v8::icu::get_language_tag(),
         location: Some(args.main_module.clone()),

--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -5,18 +5,27 @@ const {
   Promise,
   SafeArrayIterator,
 } = primordials;
-let logDebug = false;
+
+// WARNING: Keep this in sync with Rust (search for LogLevel)
+const LogLevel = {
+  Error: 1,
+  Warn: 2,
+  Info: 3,
+  Debug: 4,
+};
+
+let logLevel = 3;
 let logSource = "JS";
 
-function setLogDebug(debug, source) {
-  logDebug = debug;
+function setLogLevel(level, source) {
+  logLevel = level;
   if (source) {
     logSource = source;
   }
 }
 
 function log(...args) {
-  if (logDebug) {
+  if (logLevel >= LogLevel.Debug) {
     // if we destructure `console` off `globalThis` too early, we don't bind to
     // the right console, therefore we don't log anything out.
     globalThis.console.error(
@@ -80,6 +89,6 @@ export {
   log,
   nonEnumerable,
   readOnly,
-  setLogDebug,
+  setLogLevel,
   writable,
 };

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -299,7 +299,7 @@ function runtimeStart(
   v8Version,
   tsVersion,
   target,
-  debugFlag,
+  logLevel,
   noColor,
   isTty,
   source,
@@ -315,7 +315,7 @@ function runtimeStart(
     tsVersion,
   );
   core.setBuildInfo(target);
-  util.setLogDebug(debugFlag, source);
+  util.setLogLevel(logLevel, source);
   setNoColor(noColor || !isTty);
   // deno-lint-ignore prefer-primordials
   Error.prepareStackTrace = core.prepareStackTrace;
@@ -428,7 +428,7 @@ function bootstrapMainRuntime(runtimeOptions) {
   const {
     0: args,
     1: cpuCount,
-    2: debugFlag,
+    2: logLevel,
     3: denoVersion,
     4: locale,
     5: location_,
@@ -495,7 +495,7 @@ function bootstrapMainRuntime(runtimeOptions) {
     v8Version,
     tsVersion,
     target,
-    debugFlag,
+    logLevel,
     noColor,
     isTty,
   );
@@ -542,7 +542,7 @@ function bootstrapWorkerRuntime(
   const {
     0: args,
     1: cpuCount,
-    2: debugFlag,
+    2: logLevel,
     3: denoVersion,
     4: locale,
     5: location_,
@@ -610,7 +610,7 @@ function bootstrapWorkerRuntime(
     v8Version,
     tsVersion,
     target,
-    debugFlag,
+    logLevel,
     noColor,
     isTty,
     internalName ?? name,

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -35,3 +35,4 @@ pub mod worker;
 
 mod worker_bootstrap;
 pub use worker_bootstrap::BootstrapOptions;
+pub use worker_bootstrap::WorkerLogLevel;


### PR DESCRIPTION
This is not really used yet, but provides some infrastructure for doing more fine grained logging.