### PR TITLE
feat(config_file): add config file option `npmRegistry`

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -655,6 +655,13 @@ impl CliOptions {
     &self.initial_cwd
   }
 
+  pub fn maybe_npm_registry(&self) -> Option<Url> {
+    self
+      .maybe_config_file
+      .as_ref()
+      .and_then(|f| f.to_npm_registry())
+  }
+
   pub fn maybe_config_file_specifier(&self) -> Option<ModuleSpecifier> {
     self.maybe_config_file.as_ref().map(|f| f.specifier.clone())
   }

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -426,6 +426,10 @@
       "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` or `--node-modules-dir=false` flag. Requires Deno 1.34 or later.",
       "type": "boolean"
     },
+    "npmRegistry": {
+      "description": "The npm registry to use for npm specifiers.",
+      "type": "string"
+    },
     "tasks": {
       "description": "Configuration for deno task",
       "type": "object",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
Adding Configuration file option `"npmRegistry"`, respected in the LSP and in the runtime. The `NPM_CONFIG_REGISTRY` env var takes precedence. Both `"npmRegistry"` and `NPM_CONFIG_REGISTRY` are treated the same in terms of trailing slash (added if not already present). 

Closes https://github.com/denoland/deno/issues/16105

In the issue there are calls for a per-scope configurable value, but perhaps this is a good enough first milestone (since it makes the LSP usable with a custom registry). The config value can also be expanded in the future to be either a string url or an object map from scope to registry url, building on top this behavior.

