### PR TITLE
perf(ext/http): Add a sync phase to http serving

### DIFF
--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -120,6 +120,7 @@ deno_core::extension!(
     http_next::op_http_track,
     http_next::op_http_upgrade_websocket_next,
     http_next::op_http_upgrade_raw,
+    http_next::op_http_try_wait,
     http_next::op_http_wait,
   ],
   esm = ["00_serve.js", "01_http.js"],


### PR DESCRIPTION
Under heavy load, we often have requests queued up that don't need an async call to retrieve. We can use a fast path sync op to drain this set of ready requests, and then fall back to the async op once we run out of work. 

This is a .5-1% bump in req/s on an M2 mac. About 90% of the handlers go through this sync phase (based on a simple instrumentation that is not included in this PR) and skip the async machinery entirely.


