### PR TITLE
fix(node): add missing process.reallyExit method

### DIFF
--- a/cli/tests/unit_node/process_test.ts
+++ b/cli/tests/unit_node/process_test.ts
@@ -727,3 +727,22 @@ Deno.test({
     assertEquals(stripColor(decoder.decode(stdout).trim()), "exit");
   },
 });
+
+Deno.test({
+  name: "process.reallyExit",
+  async fn() {
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--quiet",
+        "--unstable",
+        "./testdata/process_really_exit.ts",
+      ],
+      cwd: testDir,
+    });
+    const { stdout } = await command.output();
+
+    const decoder = new TextDecoder();
+    assertEquals(stripColor(decoder.decode(stdout).trim()), "really exited");
+  },
+});

--- a/cli/tests/unit_node/testdata/process_really_exit.ts
+++ b/cli/tests/unit_node/testdata/process_really_exit.ts
@@ -1,0 +1,10 @@
+import process from "node:process";
+
+//deno-lint-ignore no-undef
+// @ts-ignore - Node typings don't even have this because it's
+// been deprecated for 4 years. But it's used in `signal-exit`,
+// which in turn is used in `node-tap`.
+process.reallyExit = function () {
+  console.info("really exited");
+};
+process.exit();

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -91,7 +91,7 @@ export const exit = (code?: number | string) => {
     process.emit("exit", process.exitCode || 0);
   }
 
-  Deno.exit(process.exitCode || 0);
+  process.reallyExit(process.exitCode || 0);
 };
 
 function addReadOnlyProcessAlias(
@@ -379,6 +379,13 @@ class Process extends EventEmitter {
 
   /** https://nodejs.org/api/process.html#process_process_exit_code */
   exit = exit;
+
+  // Undocumented Node API that is used by `signal-exit` which in turn
+  // is used by `node-tap`. It was marked for removal a couple of years
+  // ago. See https://github.com/nodejs/node/blob/6a6b3c54022104cc110ab09044a2a0cecb8988e7/lib/internal/bootstrap/node.js#L172
+  reallyExit = (code: number) => {
+    return Deno.exit(code || 0);
+  };
 
   _exiting = _exiting;
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
This PR adds the missing `process.reallyExit()` method to node's `process` object.

Was [pinged on twitter](https://twitter.com/biwanczuk/status/1663326659787862017) regarding running the `fastify` test suite in node. They use `node-tap` which has been around arguably the longest of the test frameworks and relies on a couple of old APIs. They have `signal-exit` as a dependency which in turn [makes use of `process.reallyExit()`](https://github.com/tapjs/signal-exit/blob/8fa7fc9a9c63f559af43d292b7eb727901775507/src/index.ts#L19). That function cannot be found anywhere in their documentation, but exists at runtime. See https://github.com/nodejs/node/blob/6a6b3c54022104cc110ab09044a2a0cecb8988e7/lib/internal/bootstrap/node.js#L172

This doesn't yet make `node-tap` work, but gets us one step closer.