### PR TITLE
perf(ext/http): Migrate op_http_get_request_headers to v8::Array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "ring",
  "serde",
  "slab",
+ "smallvec",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -46,6 +46,7 @@ pin-project.workspace = true
 ring.workspace = true
 serde.workspace = true
 slab.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, features = ["io"] }


### PR DESCRIPTION
The second item from the https://github.com/denoland/deno/issues/19330 list, based on https://github.com/denoland/deno/pull/19336#issuecomment-1572156142

~It's failing right now due to `the trait bound 'deno_core::v8::Local<'_, deno_core::v8::Array>: _::_serde::Serialize' is not satisfied`, but it's quite hard to understand what exactly `op(v8)` macro attribute is doing, so I'd need some pointers for this @mmastrac. Thanks!~