### PR TITLE
fix(ext/web): Copy EventTarget list before dispatch

### DIFF
--- a/cli/tests/unit/event_target_test.ts
+++ b/cli/tests/unit/event_target_test.ts
@@ -245,6 +245,20 @@ Deno.test(function eventTargetDispatchShouldSetTargetInListener() {
   assertEquals(called, true);
 });
 
+Deno.test(function eventTargetDispatchShouldFireCurrentListenersOnly() {
+  const target = new EventTarget();
+  const event = new Event("foo");
+  let callCount = 0;
+  target.addEventListener("foo", () => {
+    ++callCount;
+    target.addEventListener("foo", () => {
+      ++callCount;
+    });
+  });
+  target.dispatchEvent(event);
+  assertEquals(callCount, 1);
+});
+
 Deno.test(function eventTargetAddEventListenerGlobalAbort() {
   return new Promise((resolve) => {
     const c = new AbortController();

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -736,10 +736,15 @@ function innerInvokeEventListeners(
     return found;
   }
 
-  // Copy event listeners before iterating since the list can be modified during the iteration.
-  const handlers = ArrayPrototypeSlice(targetListeners[type]);
+  let handlers = targetListeners[type];
+  const handlersLength = handlers.length;
 
-  for (let i = 0; i < handlers.length; i++) {
+  // Copy event listeners before iterating since the list can be modified during the iteration.
+  if (handlersLength > 1) {
+    handlers = ArrayPrototypeSlice(targetListeners[type]);
+  }
+
+  for (let i = 0; i < handlersLength; i++) {
     const listener = handlers[i];
 
     let capture, once, passive;

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -736,10 +736,8 @@ function innerInvokeEventListeners(
     return found;
   }
 
-  let handlers = targetListeners[type];
-
   // Copy event listeners before iterating since the list can be modified during the iteration.
-  handlers = ArrayPrototypeSlice(targetListeners[type]);
+  const handlers = ArrayPrototypeSlice(targetListeners[type]);
 
   for (let i = 0; i < handlers.length; i++) {
     const listener = handlers[i];

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -739,9 +739,7 @@ function innerInvokeEventListeners(
   let handlers = targetListeners[type];
 
   // Copy event listeners before iterating since the list can be modified during the iteration.
-  if (handlers.length > 1) {
-    handlers = ArrayPrototypeSlice(targetListeners[type]);
-  }
+  handlers = ArrayPrototypeSlice(targetListeners[type]);
 
   for (let i = 0; i < handlers.length; i++) {
     const listener = handlers[i];


### PR DESCRIPTION
Related issue: https://github.com/denoland/deno/issues/19358.

This is a regression that seems to have been introduced in https://github.com/denoland/deno/pull/18905. It looks to have been a performance optimization.

The issue is probably easiest described with some code:
```ts
const target = new EventTarget();
const event = new Event("foo");
target.addEventListener("foo", () => {
  console.log('base');
  target.addEventListener("foo", () => {
    console.log('nested');
  });
});
target.dispatchEvent(event);
```
Essentially, the second event listener is being attached while the `foo` event is still being dispatched. It should then not fire that second event listener, but Deno currently does.


<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
