### PR TITLE
feat(http): improve http token validation perf

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -16,8 +16,8 @@ import {
   collectSequenceOfCodepoints,
   HTTP_TAB_OR_SPACE_PREFIX_RE,
   HTTP_TAB_OR_SPACE_SUFFIX_RE,
-  HTTP_TOKEN_CODE_POINT_RE,
   httpTrim,
+  isValidHTTPToken,
 } from "ext:deno_web/00_infra.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
@@ -102,7 +102,7 @@ function appendHeader(headers, name, value) {
   value = normalizeHeaderValue(value);
 
   // 2.
-  if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, name) === null) {
+  if (!isValidHTTPToken(name)) {
     throw new TypeError("Header name is not valid.");
   }
   if (RegExpPrototypeExec(ILLEGAL_VALUE_CHARS, value) !== null) {
@@ -282,7 +282,7 @@ class Headers {
     webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters["ByteString"](name, prefix, "Argument 1");
 
-    if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, name) === null) {
+    if (!isValidHTTPToken(name)) {
       throw new TypeError("Header name is not valid.");
     }
     if (this[_guard] == "immutable") {
@@ -307,7 +307,7 @@ class Headers {
     webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters["ByteString"](name, prefix, "Argument 1");
 
-    if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, name) === null) {
+    if (!isValidHTTPToken(name)) {
       throw new TypeError("Header name is not valid.");
     }
 
@@ -323,7 +323,7 @@ class Headers {
     webidl.requiredArguments(arguments.length, 1, prefix);
     name = webidl.converters["ByteString"](name, prefix, "Argument 1");
 
-    if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, name) === null) {
+    if (!isValidHTTPToken(name)) {
       throw new TypeError("Header name is not valid.");
     }
 
@@ -351,7 +351,7 @@ class Headers {
     value = normalizeHeaderValue(value);
 
     // 2.
-    if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, name) === null) {
+    if (!isValidHTTPToken(name)) {
       throw new TypeError("Header name is not valid.");
     }
     if (RegExpPrototypeExec(ILLEGAL_VALUE_CHARS, value) !== null) {

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -11,10 +11,7 @@
 
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
-import {
-  byteUpperCase,
-  HTTP_TOKEN_CODE_POINT_RE,
-} from "ext:deno_web/00_infra.js";
+import { byteUpperCase, isValidHTTPToken } from "ext:deno_web/00_infra.js";
 import { URL } from "ext:deno_url/00_url.js";
 import { extractBody, mixinBody } from "ext:deno_fetch/22_body.js";
 import { getLocationHref } from "ext:deno_web/12_location.js";
@@ -36,7 +33,6 @@ const {
   ArrayPrototypeSplice,
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
-  RegExpPrototypeExec,
   StringPrototypeStartsWith,
   Symbol,
   SymbolFor,
@@ -227,7 +223,7 @@ function validateAndNormalizeMethod(m) {
   }
 
   // Regular path
-  if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, m) === null) {
+  if (!isValidHTTPToken(m)) {
     throw new TypeError("Method is not valid.");
   }
   const upperCase = byteUpperCase(m);

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -36,18 +36,6 @@ const {
 } = primordials;
 import { URLPrototype } from "ext:deno_url/00_url.js";
 
-const ASCII_DIGIT = ["\u0030-\u0039"];
-const ASCII_UPPER_ALPHA = ["\u0041-\u005A"];
-const ASCII_LOWER_ALPHA = ["\u0061-\u007A"];
-const ASCII_ALPHA = [
-  ...new SafeArrayIterator(ASCII_UPPER_ALPHA),
-  ...new SafeArrayIterator(ASCII_LOWER_ALPHA),
-];
-const ASCII_ALPHANUMERIC = [
-  ...new SafeArrayIterator(ASCII_DIGIT),
-  ...new SafeArrayIterator(ASCII_ALPHA),
-];
-
 const HTTP_TAB_OR_SPACE = ["\u0009", "\u0020"];
 const HTTP_WHITESPACE = [
   "\u000A",
@@ -488,11 +476,6 @@ function pathFromURL(pathOrUrl) {
 internals.pathFromURL = pathFromURL;
 
 export {
-  ASCII_ALPHA,
-  ASCII_ALPHANUMERIC,
-  ASCII_DIGIT,
-  ASCII_LOWER_ALPHA,
-  ASCII_UPPER_ALPHA,
   assert,
   AssertionError,
   byteLowerCase,

--- a/ext/web/01_mimesniff.js
+++ b/ext/web/01_mimesniff.js
@@ -13,7 +13,6 @@ const {
   MapPrototypeHas,
   MapPrototypeSet,
   RegExpPrototypeTest,
-  RegExpPrototypeExec,
   SafeMap,
   SafeMapIterator,
   StringPrototypeReplaceAll,
@@ -23,10 +22,10 @@ import {
   collectHttpQuotedString,
   collectSequenceOfCodepoints,
   HTTP_QUOTED_STRING_TOKEN_POINT_RE,
-  HTTP_TOKEN_CODE_POINT_RE,
   HTTP_WHITESPACE,
   HTTP_WHITESPACE_PREFIX_RE,
   HTTP_WHITESPACE_SUFFIX_RE,
+  isValidHTTPToken,
 } from "ext:deno_web/00_infra.js";
 
 /**
@@ -59,7 +58,7 @@ function parseMimeType(input) {
   position = res1.position;
 
   // 4.
-  if (type === "" || !RegExpPrototypeTest(HTTP_TOKEN_CODE_POINT_RE, type)) {
+  if (type === "" || !isValidHTTPToken(type)) {
     return null;
   }
 
@@ -83,7 +82,7 @@ function parseMimeType(input) {
 
   // 9.
   if (
-    subtype === "" || !RegExpPrototypeTest(HTTP_TOKEN_CODE_POINT_RE, subtype)
+    subtype === "" || !isValidHTTPToken(subtype)
   ) {
     return null;
   }
@@ -166,7 +165,7 @@ function parseMimeType(input) {
     // 11.10.
     if (
       parameterName !== "" &&
-      RegExpPrototypeTest(HTTP_TOKEN_CODE_POINT_RE, parameterName) &&
+      isValidHTTPToken(parameterName) &&
       RegExpPrototypeTest(
         HTTP_QUOTED_STRING_TOKEN_POINT_RE,
         parameterValue,
@@ -198,7 +197,7 @@ function serializeMimeType(mimeType) {
   for (const param of new SafeMapIterator(mimeType.parameters)) {
     serialization += `;${param[0]}=`;
     let value = param[1];
-    if (RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, value) === null) {
+    if (!isValidHTTPToken(value)) {
       value = StringPrototypeReplaceAll(value, "\\", "\\\\");
       value = StringPrototypeReplaceAll(value, '"', '\\"');
       value = `"${value}"`;

--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -19,8 +19,6 @@ declare module "ext:deno_web/00_infra.js" {
   const ASCII_ALPHANUMERIC: string[];
   const HTTP_TAB_OR_SPACE: string[];
   const HTTP_WHITESPACE: string[];
-  const HTTP_TOKEN_CODE_POINT: string[];
-  const HTTP_TOKEN_CODE_POINT_RE: RegExp;
   const HTTP_QUOTED_STRING_TOKEN_POINT: string[];
   const HTTP_QUOTED_STRING_TOKEN_POINT_RE: RegExp;
   const HTTP_TAB_OR_SPACE_PREFIX_RE: RegExp;
@@ -28,6 +26,7 @@ declare module "ext:deno_web/00_infra.js" {
   const HTTP_WHITESPACE_PREFIX_RE: RegExp;
   const HTTP_WHITESPACE_SUFFIX_RE: RegExp;
   function httpTrim(s: string): string;
+  function isValidHTTPToken(s: string): boolean;
   function regexMatcher(chars: string[]): string;
   function byteUpperCase(s: string): string;
   function byteLowerCase(s: string): string;

--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -12,11 +12,6 @@ declare module "ext:deno_web/00_infra.js" {
     result: string;
     position: number;
   };
-  const ASCII_DIGIT: string[];
-  const ASCII_UPPER_ALPHA: string[];
-  const ASCII_LOWER_ALPHA: string[];
-  const ASCII_ALPHA: string[];
-  const ASCII_ALPHANUMERIC: string[];
   const HTTP_TAB_OR_SPACE: string[];
   const HTTP_WHITESPACE: string[];
   const HTTP_QUOTED_STRING_TOKEN_POINT: string[];

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -6,7 +6,7 @@
 const core = globalThis.Deno.core;
 import { URL } from "ext:deno_url/00_url.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
-import { HTTP_TOKEN_CODE_POINT_RE } from "ext:deno_web/00_infra.js";
+import { isValidHTTPToken } from "ext:deno_web/00_infra.js";
 import DOMException from "ext:deno_web/01_dom_exception.js";
 import {
   _skipInternalInit,
@@ -33,7 +33,6 @@ const {
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,
   PromisePrototypeThen,
-  RegExpPrototypeExec,
   SafeSet,
   SetPrototypeGetSize,
   // TODO(lucacasonato): add SharedArrayBuffer to primordials
@@ -256,8 +255,7 @@ class WebSocket extends EventTarget {
     if (
       ArrayPrototypeSome(
         protocols,
-        (protocol) =>
-          RegExpPrototypeExec(HTTP_TOKEN_CODE_POINT_RE, protocol) === null,
+        (protocol) => isValidHTTPToken(protocol),
       )
     ) {
       throw new DOMException(


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This PR replaces the regex-based matching logic to check if a string is a valid HTTP token with a plain for-loop. It's modelled after the one in [Chromium](https://github.com/chromium/chromium/blob/fd8a8914ca0183f0add65ae55f04e287543c7d4a/third_party/blink/renderer/platform/network/http_parsers.cc#L346-L355), which happens to be the same one as node. Main difference in the PR is that I wrote it to avoid string->number casting in JS. This allows us to get rid of a bunch of unused constants too.

Marking as draft, because I still need to benchmark this and verify if the results make sense. Don't know how we do benchmarking here though (haven't looked at that yet).