### PR TITLE
perf(http): avoid flattening http headers

### DIFF
--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -37,7 +37,6 @@ import {
 import { listen, TcpConn } from "ext:deno_net/01_net.js";
 import { listenTls } from "ext:deno_net/02_tls.js";
 const {
-  ArrayPrototypeFlat,
   ArrayPrototypePush,
   ObjectPrototypeIsPrototypeOf,
   PromisePrototypeCatch,
@@ -559,7 +558,7 @@ function mapToCallback(context, callback, onError) {
       if (headers.length == 1) {
         op_http_set_response_header(req, headers[0][0], headers[0][1]);
       } else {
-        op_http_set_response_headers(req, ArrayPrototypeFlat(headers));
+        op_http_set_response_headers(req, headers);
       }
     }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
@bartlomieju and I noticed that we call `Array.prototype.flat()` when setting http headers. We can speed this up via a dedicated Rust op.

| Test | Requests/sec |
|---|--:|
| 1.34.1 | 83308.71 |
| this PR | 86764.46 |