### PR TITLE
perf(ext/websocket): Cut event dispatch/blob overhead as much as we can

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -551,6 +551,13 @@ function appendToEventPath(
   });
 }
 
+function dispatchFast(
+  targetImpl,
+  eventImpl,
+) {
+  innerInvokeEventListeners(eventImpl, getListeners(targetImpl));
+}
+
 function dispatch(
   targetImpl,
   eventImpl,
@@ -1543,6 +1550,7 @@ export {
   CustomEvent,
   defineEventHandler,
   dispatch,
+  dispatchFast,
   ErrorEvent,
   Event,
   EventTarget,

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -12,13 +12,13 @@ import {
   _skipInternalInit,
   CloseEvent,
   defineEventHandler,
-  dispatch,
+  dispatchFast,
   ErrorEvent,
   Event,
   EventTarget,
   MessageEvent,
 } from "ext:deno_web/02_event.js";
-import { Blob, BlobPrototype } from "ext:deno_web/09_file.js";
+import { blobFromBuffer, BlobPrototype } from "ext:deno_web/09_file.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
   ArrayBufferPrototype,
@@ -416,8 +416,9 @@ class WebSocket extends EventTarget {
           const event = new MessageEvent("message", {
             data: value,
             origin: this[_url],
+            [_skipInternalInit]: true,
           });
-          dispatch(this, event);
+          dispatchFast(this, event);
           break;
         }
         case 1: {
@@ -426,7 +427,7 @@ class WebSocket extends EventTarget {
           let data;
 
           if (this.binaryType === "blob") {
-            data = new Blob([value]);
+            data = blobFromBuffer(value);
           } else {
             data = value;
           }
@@ -436,7 +437,7 @@ class WebSocket extends EventTarget {
             origin: this[_url],
             [_skipInternalInit]: true,
           });
-          dispatch(this, event);
+          dispatchFast(this, event);
           break;
         }
         case 2: {

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -277,17 +277,17 @@ class WebSocket extends EventTarget {
               this[_readyState] = CLOSED;
 
               const errEvent = new ErrorEvent("error");
-              this.dispatchEvent(errEvent);
+              dispatchFast(this, errEvent);
 
               const event = new CloseEvent("close");
-              this.dispatchEvent(event);
+              dispatchFast(this, event);
               core.tryClose(this[_rid]);
             },
           );
         } else {
           this[_readyState] = OPEN;
           const event = new Event("open");
-          this.dispatchEvent(event);
+          dispatchFast(this, event);
 
           this[_eventLoop]();
         }
@@ -299,10 +299,10 @@ class WebSocket extends EventTarget {
           "error",
           { error: err, message: ErrorPrototypeToString(err) },
         );
-        this.dispatchEvent(errorEv);
+        dispatchFast(this, errorEv);
 
         const closeEv = new CloseEvent("close");
-        this.dispatchEvent(closeEv);
+        dispatchFast(this, closeEv);
       },
     );
   }
@@ -395,10 +395,10 @@ class WebSocket extends EventTarget {
             error: err,
             message: ErrorPrototypeToString(err),
           });
-          this.dispatchEvent(errorEv);
+          dispatchFast(this, errorEv);
 
           const closeEv = new CloseEvent("close");
-          this.dispatchEvent(closeEv);
+          dispatchFast(this, closeEv);
           core.tryClose(this[_rid]);
         },
       );
@@ -452,10 +452,10 @@ class WebSocket extends EventTarget {
           const errorEv = new ErrorEvent("error", {
             message: value,
           });
-          this.dispatchEvent(errorEv);
+          dispatchFast(this, errorEv);
 
           const closeEv = new CloseEvent("close");
-          this.dispatchEvent(closeEv);
+          dispatchFast(this, closeEv);
           core.tryClose(this[_rid]);
           break;
         }
@@ -483,7 +483,7 @@ class WebSocket extends EventTarget {
             code: code,
             reason: value,
           });
-          this.dispatchEvent(event);
+          dispatchFast(this, event);
           core.tryClose(this[_rid]);
           break;
         }
@@ -507,14 +507,14 @@ class WebSocket extends EventTarget {
               const errEvent = new ErrorEvent("error", {
                 message: reason,
               });
-              this.dispatchEvent(errEvent);
+              dispatchFast(this, errEvent);
 
               const event = new CloseEvent("close", {
                 wasClean: false,
                 code: 1001,
                 reason,
               });
-              this.dispatchEvent(event);
+              dispatchFast(this, event);
               core.tryClose(this[_rid]);
             } else {
               clearTimeout(this[_idleTimeoutTimeout]);


### PR DESCRIPTION
Small improvement, seems to reduce benchmark jitter a bit. I was not able to see any major differences with `--trace-gc`, but the results are consistently better (average is higher and std dev is much lower)

Before:

```
Msg/sec: 155174.750000
Msg/sec: 160164.250000
Msg/sec: 164021.750000
Msg/sec: 164089.750000
Msg/sec: 161876.000000
Msg/sec: 164591.750000
Msg/sec: 166381.000000
Msg/sec: 165368.500000
Msg/sec: 152099.000000
Msg/sec: 160498.000000
```

After:

```
Msg/sec: 165066.250000
Msg/sec: 163997.750000
Msg/sec: 166492.500000
Msg/sec: 167396.500000
Msg/sec: 167681.500000
Msg/sec: 164960.500000
Msg/sec: 165815.000000
Msg/sec: 166636.250000
Msg/sec: 166958.000000
Msg/sec: 166451.250000
Msg/sec: 166227.750000
Msg/sec: 165989.750000
```