### PR TITLE
fix(repl): correctly print string exception

### DIFF
--- a/cli/tests/integration/repl_tests.rs
+++ b/cli/tests/integration/repl_tests.rs
@@ -814,6 +814,10 @@ fn repl_reject() {
     console.expect("    at <anonymous>");
     console.write_line("console.log(2);");
     console.expect("2");
+    console.write_line(r#"throw "hello";"#);
+    console.expect(r#"Uncaught "hello""#);
+    console.write_line(r#"throw `hello ${"world"}`;"#);
+    console.expect(r#"Uncaught "hello world""#);
   });
 }
 

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -258,9 +258,15 @@ impl ReplSession {
           Ok(if let Some(exception_details) = exception_details {
             session.set_last_thrown_error(&result).await?;
             let description = match exception_details.exception {
-              Some(exception) => exception
-                .description
-                .unwrap_or_else(|| "undefined".to_string()),
+              Some(exception) => {
+                if let Some(description) = exception.description {
+                  description
+                } else if let Some(value) = exception.value {
+                  value.to_string()
+                } else {
+                  "undefined".to_string()
+                }
+              }
               None => "Unknown exception".to_string(),
             };
             EvaluationOutput::Error(format!(


### PR DESCRIPTION
Fixes a recent regression where `throw "hello"` in the repl prints `Uncaught undefined` instead of `throw "hello"`