### PR TITLE
perf(ext/websocket): monomorphize code

### DIFF
--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -126,7 +126,6 @@ class WebSocket extends EventTarget {
     this[_protocol] = "";
     this[_url] = "";
     this[_binaryType] = "blob";
-    this[_serverHandleIdleTimeout] = undefined;
     this[_idleTimeoutDuration] = 0;
     this[_idleTimeoutTimeout] = undefined;
     const prefix = "Failed to construct 'WebSocket'";

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -116,78 +116,19 @@ const _idleTimeoutDuration = Symbol("[[idleTimeout]]");
 const _idleTimeoutTimeout = Symbol("[[idleTimeoutTimeout]]");
 const _serverHandleIdleTimeout = Symbol("[[serverHandleIdleTimeout]]");
 class WebSocket extends EventTarget {
-  [_rid];
-  [_role];
-
-  [_readyState] = CONNECTING;
-  get readyState() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return this[_readyState];
-  }
-
-  get CONNECTING() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return CONNECTING;
-  }
-  get OPEN() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return OPEN;
-  }
-  get CLOSING() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return CLOSING;
-  }
-  get CLOSED() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return CLOSED;
-  }
-
-  [_extensions] = "";
-  get extensions() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return this[_extensions];
-  }
-
-  [_protocol] = "";
-  get protocol() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return this[_protocol];
-  }
-
-  [_url] = "";
-  get url() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return this[_url];
-  }
-
-  [_binaryType] = "blob";
-  get binaryType() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    return this[_binaryType];
-  }
-  set binaryType(value) {
-    webidl.assertBranded(this, WebSocketPrototype);
-    value = webidl.converters.DOMString(
-      value,
-      "Failed to set 'binaryType' on 'WebSocket'",
-    );
-    if (value === "blob" || value === "arraybuffer") {
-      this[_binaryType] = value;
-    }
-  }
-
-  get bufferedAmount() {
-    webidl.assertBranded(this, WebSocketPrototype);
-    if (this[_readyState] === OPEN) {
-      return op_ws_get_buffered_amount(this[_rid]);
-    } else {
-      return 0;
-    }
-  }
-
   constructor(url, protocols = []) {
     super();
     this[webidl.brand] = webidl.brand;
+    this[_rid] = undefined;
+    this[_role] = undefined;
+    this[_readyState] = CONNECTING;
+    this[_extensions] = "";
+    this[_protocol] = "";
+    this[_url] = "";
+    this[_binaryType] = "blob";
+    this[_serverHandleIdleTimeout] = undefined;
+    this[_idleTimeoutDuration] = 0;
+    this[_idleTimeoutTimeout] = undefined;
     const prefix = "Failed to construct 'WebSocket'";
     webidl.requiredArguments(arguments.length, 1, prefix);
     url = webidl.converters.USVString(url, prefix, "Argument 1");
@@ -305,6 +246,67 @@ class WebSocket extends EventTarget {
         this.dispatchEvent(closeEv);
       },
     );
+  }
+
+  get readyState() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return this[_readyState];
+  }
+
+  get CONNECTING() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return CONNECTING;
+  }
+  get OPEN() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return OPEN;
+  }
+  get CLOSING() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return CLOSING;
+  }
+  get CLOSED() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return CLOSED;
+  }
+
+  get extensions() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return this[_extensions];
+  }
+
+  get protocol() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return this[_protocol];
+  }
+
+  get url() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return this[_url];
+  }
+
+  get binaryType() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    return this[_binaryType];
+  }
+  set binaryType(value) {
+    webidl.assertBranded(this, WebSocketPrototype);
+    value = webidl.converters.DOMString(
+      value,
+      "Failed to set 'binaryType' on 'WebSocket'",
+    );
+    if (value === "blob" || value === "arraybuffer") {
+      this[_binaryType] = value;
+    }
+  }
+
+  get bufferedAmount() {
+    webidl.assertBranded(this, WebSocketPrototype);
+    if (this[_readyState] === OPEN) {
+      return op_ws_get_buffered_amount(this[_rid]);
+    } else {
+      return 0;
+    }
   }
 
   send(data) {


### PR DESCRIPTION
Using `deopt-explorer` I found that a bunch of fields on `WebSocket` class
were polymorphic. Fortunately it was enough to initialize them to `undefined`
to fix the problem.