### PR TITLE
fix: child process crash on closed stdout

### DIFF
--- a/cli/tests/testdata/run/console_boom.js
+++ b/cli/tests/testdata/run/console_boom.js
@@ -1,0 +1,5 @@
+console.log("ready");
+
+setTimeout(() => {
+  console.log("boom"); // This line caused it
+}, 100);

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -734,13 +734,12 @@ impl crate::fs::File for StdFileResourceInner {
 
 // override op_print to use the stdout and stderr in the resource table
 #[op]
-pub fn op_print(
-  state: &mut OpState,
-  msg: &str,
-  is_err: bool,
-) -> Result<(), AnyError> {
+pub fn op_print(state: &mut OpState, msg: &str, is_err: bool) {
   let rid = if is_err { 2 } else { 1 };
-  FileResource::with_file(state, rid, move |file| {
-    Ok(file.write_all_sync(msg.as_bytes())?)
-  })
+  let _ = FileResource::with_file(state, rid, move |file| {
+    // The stdio pipes can be closed if we're inside a child process and
+    // it's piped to a Web Stream. See #19401 .
+    let _ = file.write_all_sync(msg.as_bytes());
+    Ok(())
+  });
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
Calling `console.log` inside a child process should never crash it. This PR addresses that.

Fixes #19401