### PR TITLE
chore: downgrade to Rust 1.69

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -5,7 +5,7 @@ import * as yaml from "https://deno.land/std@0.173.0/encoding/yaml.ts";
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 34;
+const cacheVersion = 35;
 
 const Runners = (() => {
   const ubuntuRunner = "ubuntu-22.04";
@@ -24,16 +24,16 @@ const prCacheKeyPrefix =
   `${cacheVersion}-cargo-target-\${{ matrix.os }}-\${{ matrix.profile }}-\${{ matrix.job }}-`;
 
 const installPkgsCommand =
-  "sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16";
+  "sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15";
 const sysRootStep = {
   name: "Set up incremental LTO and sysroot build",
   run: `# Avoid running man-db triggers, which sometimes takes several minutes
 # to complete.
 sudo apt-get remove --purge -y man-db
 
-# Install clang-16, lld-16, and debootstrap.
-echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" |
-  sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-16.list
+# Install clang-15, lld-15, and debootstrap.
+echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" |
+  sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-15.list
 curl https://apt.llvm.org/llvm-snapshot.gpg.key |
   gpg --dearmor                                 |
 sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
@@ -70,8 +70,8 @@ CARGO_PROFILE_RELEASE_INCREMENTAL=false
 CARGO_PROFILE_RELEASE_LTO=false
 RUSTFLAGS<<__1
   -C linker-plugin-lto=true
-  -C linker=clang-16
-  -C link-arg=-fuse-ld=lld-16
+  -C linker=clang-15
+  -C link-arg=-fuse-ld=lld-15
   -C link-arg=--sysroot=/sysroot
   -C link-arg=-ldl
   -C link-arg=-Wl,--allow-shlib-undefined
@@ -81,8 +81,8 @@ RUSTFLAGS<<__1
 __1
 RUSTDOCFLAGS<<__1
   -C linker-plugin-lto=true
-  -C linker=clang-16
-  -C link-arg=-fuse-ld=lld-16
+  -C linker=clang-15
+  -C link-arg=-fuse-ld=lld-15
   -C link-arg=--sysroot=/sysroot
   -C link-arg=-ldl
   -C link-arg=-Wl,--allow-shlib-undefined
@@ -90,7 +90,7 @@ RUSTDOCFLAGS<<__1
   -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
   \${{ env.RUSTFLAGS }}
 __1
-CC=clang-16
+CC=clang-15
 CFLAGS=-flto=thin --sysroot=/sysroot
 __0`,
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,15 +210,15 @@ jobs:
           # to complete.
           sudo apt-get remove --purge -y man-db
 
-          # Install clang-16, lld-16, and debootstrap.
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" |
-            sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-16.list
+          # Install clang-15, lld-15, and debootstrap.
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" |
+            sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-15.list
           curl https://apt.llvm.org/llvm-snapshot.gpg.key |
             gpg --dearmor                                 |
           sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo apt-get update
           # this was unreliable sometimes, so try again if it fails
-          sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16
+          sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-15 lld-15
 
           # Create ubuntu-16.04 sysroot environment, which is used to avoid
           # depending on a very recent version of glibc.
@@ -249,8 +249,8 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO=false
           RUSTFLAGS<<__1
             -C linker-plugin-lto=true
-            -C linker=clang-16
-            -C link-arg=-fuse-ld=lld-16
+            -C linker=clang-15
+            -C link-arg=-fuse-ld=lld-15
             -C link-arg=--sysroot=/sysroot
             -C link-arg=-ldl
             -C link-arg=-Wl,--allow-shlib-undefined
@@ -260,8 +260,8 @@ jobs:
           __1
           RUSTDOCFLAGS<<__1
             -C linker-plugin-lto=true
-            -C linker=clang-16
-            -C link-arg=-fuse-ld=lld-16
+            -C linker=clang-15
+            -C link-arg=-fuse-ld=lld-15
             -C link-arg=--sysroot=/sysroot
             -C link-arg=-ldl
             -C link-arg=-Wl,--allow-shlib-undefined
@@ -269,7 +269,7 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             ${{ env.RUSTFLAGS }}
           __1
-          CC=clang-16
+          CC=clang-15
           CFLAGS=-flto=thin --sysroot=/sysroot
           __0
       - name: Log versions
@@ -293,7 +293,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '34-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+          key: '35-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
@@ -305,7 +305,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '34-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '35-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
@@ -589,7 +589,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '34-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '35-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "dlopen",
  "dynasmrt",
  "libffi",
+ "libffi-sys",
  "serde",
  "serde-value",
  "serde_json",
@@ -2787,9 +2788,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libffi"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+checksum = "6cb06d5b4c428f3cd682943741c39ed4157ae989fffe1094a08eaf7c4014cf60"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -2797,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+checksum = "11c6f11e063a27ffe040a9d15f0b661bf41edc2383b7ae0e0ad5a7e7d53d9da3"
 dependencies = [
  "cc",
 ]

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -17,7 +17,8 @@ path = "lib.rs"
 deno_core.workspace = true
 dlopen.workspace = true
 dynasmrt = "1.2.3"
-libffi = "3.2.0"
+libffi = "=3.1.0"
+libffi-sys = "=2.1.0" # temporary pin for downgrade to Rust 1.69
 serde.workspace = true
 serde-value = "0.7"
 serde_json = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.69.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
We keep running out of disk space in Rust 1.70 on the CI and have issues with libsys-ffi. We're going to try temporarily downgrading Rust for now.

<details>
  <summary>libffi-sys error message</summary>

```
error: failed to run custom build command for `libffi-sys v2.3.0`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/home/runner/work/deno/deno/target/debug/build/libffi-sys-9af4a5008c5509de/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
  CC_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
  CC_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = Some("clang-16")
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = Some("-flto=thin --sysroot=/sysroot")
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  checking build system type... x86_64-pc-linux-gnu
  checking host system type... x86_64-pc-linux-gnu
  checking target system type... x86_64-pc-linux-gnu
  continue configure in default builddir "./x86_64-unknown-linux-gnu"
  ....exec /bin/bash .././configure "--srcdir=.." "--enable-builddir=x86_64-unknown-linux-gnu" "linux
  gnu"
  checking build system type... x86_64-pc-linux-gnu
  checking host system type... x86_64-pc-linux-gnu
  checking target system type... x86_64-pc-linux-gnu
  checking for gsed... sed
  checking for a BSD-compatible install... /usr/bin/install -c
  checking whether build environment is sane... yes
  checking for a race-free mkdir -p... /usr/bin/mkdir -p
  checking for gawk... gawk
  checking whether make sets $(MAKE)... yes
  checking whether make supports nested variables... yes
  checking for gcc... clang-16
  checking whether the C compiler works... yes
  checking for C compiler default output file name... a.out
  checking for suffix of executables... 
  checking whether we are cross compiling... no
  checking for suffix of object files... o
  checking whether the compiler supports GNU C... yes
  checking whether clang-16 accepts -g... yes
  checking for clang-16 option to enable C11 features... none needed
  checking whether clang-16 understands -c and -o together... yes
  checking whether make supports the include directive... yes (GNU style)
  checking dependency style of clang-16... gcc3
  checking for g++... g++
  checking whether the compiler supports GNU C++... yes
  checking whether g++ accepts -g... yes
  checking for g++ option to enable C++11 features... none needed
  checking dependency style of g++... gcc3
  checking dependency style of clang-16... gcc3
  checking for grep that handles long lines and -e... /usr/bin/grep
  checking for egrep... /usr/bin/grep -E
  checking how to print strings... printf
  checking for a sed that does not truncate output... /usr/bin/sed
  checking for fgrep... /usr/bin/grep -F
  checking for ld used by clang-16... /usr/bin/ld
  checking if the linker (/usr/bin/ld) is GNU ld... yes
  checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
  checking the name lister (/usr/bin/nm -B) interface... BSD nm
  checking whether ln -s works... yes
  checking the maximum length of command line arguments... 3145728
  checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
  checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
  checking for /usr/bin/ld option to reload object files... -r
  checking for file... file
  checking for objdump... objdump
  checking how to recognize dependent libraries... pass_all
  checking for dlltool... no
  checking how to associate runtime and link libraries... printf %s\n
  checking for ar... ar
  checking for archiver @FILE support... @
  checking for strip... strip
  checking for ranlib... ranlib
  checking command to parse /usr/bin/nm -B output from clang-16 object... failed
  checking for sysroot... no
  checking for a working dd... /usr/bin/dd
  checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
  checking for mt... mt
  checking if mt is a manifest tool... no
  checking for stdio.h... yes
  checking for stdlib.h... yes
  checking for string.h... yes
  checking for inttypes.h... yes
  checking for stdint.h... yes
  checking for strings.h... yes
  checking for sys/stat.h... yes
  checking for sys/types.h... yes
  checking for unistd.h... yes
  checking for dlfcn.h... yes
  checking for objdir... .libs
  checking if clang-16 supports -fno-rtti -fno-exceptions... yes
  checking for clang-16 option to produce PIC... -fPIC -DPIC
  checking if clang-16 PIC flag -fPIC -DPIC works... yes
  checking if clang-16 static flag -static works... no
  checking if clang-16 supports -c -o file.o... yes
  checking if clang-16 supports -c -o file.o... (cached) yes
  checking whether the clang-16 linker (/usr/bin/ld) supports shared libraries... yes
  checking dynamic linker characteristics... GNU/Linux ld.so
  checking how to hardcode library paths into programs... immediate
  checking whether stripping libraries is possible... yes
  checking if libtool supports shared libraries... yes
  checking whether to build shared libraries... no
  checking whether to build static libraries... yes
  checking how to run the C++ preprocessor... g++ -E
  checking for ld used by g++... /usr/bin/ld
  checking if the linker (/usr/bin/ld) is GNU ld... yes
  checking whether the g++ linker (/usr/bin/ld) supports shared libraries... yes
  checking for g++ option to produce PIC... -fPIC -DPIC
  checking if g++ PIC flag -fPIC -DPIC works... yes
  checking if g++ static flag -static works... yes
  checking if g++ supports -c -o file.o... yes
  checking if g++ supports -c -o file.o... (cached) yes
  checking whether the g++ linker (/usr/bin/ld) supports shared libraries... yes
  checking dynamic linker characteristics... (cached) GNU/Linux ld.so
  checking how to hardcode library paths into programs... immediate
  checking for readelf... readelf
  checking size of size_t... 8
  checking for C compiler vendor... clang
  checking CFLAGS for most reasonable warnings... -Wall
  checking whether to enable maintainer-specific portions of Makefiles... no
  checking for sys/memfd.h... no
  checking for memfd_create... no
  checking for sys/mman.h... yes
  checking for mmap... yes
  checking for mkostemp... yes
  checking for mkstemp... yes
  checking for sys/mman.h... (cached) yes
  checking for mmap... (cached) yes
  checking whether read-only mmap of a plain file works... yes
  checking whether mmap from /dev/zero works... yes
  checking for MAP_ANON(YMOUS)... yes
  checking whether mmap with MAP_ANON(YMOUS) works... yes
  checking for egrep... (cached) /usr/bin/grep -E
  checking for memcpy... yes
  checking for size_t... yes
  checking for working alloca.h... yes
  checking for alloca... yes
  checking size of double... 8
  checking size of long double... 16
  checking whether byte ordering is bigendian... no
  checking assembler .cfi pseudo-op support... yes
  checking assembler supports pc related relocs... yes
  checking whether compiler supports pointer authentication... no
  checking for _ prefix in compiled symbols... no
  checking toolchain supports unwind section type... yes
  checking whether C compiler accepts -fno-lto... yes
  checking whether .eh_frame section should be read-only... yes
  checking for __attribute__((visibility("hidden")))... yes
  configure: versioning on shared library symbols is no
  checking that generated files are newer than configure... done
  configure: creating ./config.status
  config.status: creating include/Makefile
  config.status: creating include/ffi.h
  config.status: creating Makefile
  config.status: creating testsuite/Makefile
  config.status: creating man/Makefile
  config.status: creating doc/Makefile
  config.status: creating libffi.pc
  config.status: creating fficonfig.h
  config.status: executing buildir commands
  config.status: create top_srcdir/Makefile guessed from local Makefile
  config.status: build in x86_64-unknown-linux-gnu (HOST=x86_64-unknown-linux-gnu)
  config.status: executing depfiles commands
  config.status: executing libtool commands
  config.status: executing include commands
  config.status: executing src commands
  MAKE x86_64-unknown-linux-gnu : 1 * install
  make[1]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu'
  Making install in include
  make[2]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/include'
  make[3]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/include'
  make[3]: Nothing to be done for 'install-exec-am'.
   /usr/bin/mkdir -p '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-root/include'
   /usr/bin/install -c -m 644 ffi.h ffitarget.h '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-root/include'
  make[3]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/include'
  make[2]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/include'
  Making install in testsuite
  make[2]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/testsuite'
  make[3]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/testsuite'
  make[3]: Nothing to be done for 'install-exec-am'.
  make[3]: Nothing to be done for 'install-data-am'.
  make[3]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/testsuite'
  make[2]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/testsuite'
  Making install in man
  make[2]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/man'
  make[3]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/man'
  make[3]: Nothing to be done for 'install-exec-am'.
   /usr/bin/mkdir -p '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-root/share/man/man3'
   /usr/bin/install -c -m 644 ../../man/ffi.3 ../../man/ffi_call.3 ../../man/ffi_prep_cif.3 ../../man/ffi_prep_cif_var.3 '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-root/share/man/man3'
  make[3]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/man'
  make[2]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu/man'
  make[2]: Entering directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu'
  depbase=`echo src/prep_cif.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/prep_cif.lo -MD -MP -MF $depbase.Tpo -c -o src/prep_cif.lo ../src/prep_cif.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/prep_cif.lo -MD -MP -MF src/.deps/prep_cif.Tpo -c ../src/prep_cif.c  -fPIC -DPIC -o src/prep_cif.o
  depbase=`echo src/types.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/types.lo -MD -MP -MF $depbase.Tpo -c -o src/types.lo ../src/types.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/types.lo -MD -MP -MF src/.deps/types.Tpo -c ../src/types.c  -fPIC -DPIC -o src/types.o
  depbase=`echo src/raw_api.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/raw_api.lo -MD -MP -MF $depbase.Tpo -c -o src/raw_api.lo ../src/raw_api.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/raw_api.lo -MD -MP -MF src/.deps/raw_api.Tpo -c ../src/raw_api.c  -fPIC -DPIC -o src/raw_api.o
  depbase=`echo src/java_raw_api.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/java_raw_api.lo -MD -MP -MF $depbase.Tpo -c -o src/java_raw_api.lo ../src/java_raw_api.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/java_raw_api.lo -MD -MP -MF src/.deps/java_raw_api.Tpo -c ../src/java_raw_api.c  -fPIC -DPIC -o src/java_raw_api.o
  depbase=`echo src/closures.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/closures.lo -MD -MP -MF $depbase.Tpo -c -o src/closures.lo ../src/closures.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/closures.lo -MD -MP -MF src/.deps/closures.Tpo -c ../src/closures.c  -fPIC -DPIC -o src/closures.o
  depbase=`echo src/tramp.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/tramp.lo -MD -MP -MF $depbase.Tpo -c -o src/tramp.lo ../src/tramp.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/tramp.lo -MD -MP -MF src/.deps/tramp.Tpo -c ../src/tramp.c  -fPIC -DPIC -o src/tramp.o
  depbase=`echo src/x86/ffi64.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/x86/ffi64.lo -MD -MP -MF $depbase.Tpo -c -o src/x86/ffi64.lo ../src/x86/ffi64.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/x86/ffi64.lo -MD -MP -MF src/x86/.deps/ffi64.Tpo -c ../src/x86/ffi64.c  -fPIC -DPIC -o src/x86/ffi64.o
  depbase=`echo src/x86/unix64.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src  -I. -I../include -Iinclude -I../src -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -MT src/x86/unix64.lo -MD -MP -MF $depbase.Tpo -c -o src/x86/unix64.lo ../src/x86/unix64.S &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -I. -I../include -Iinclude -I../src -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -MT src/x86/unix64.lo -MD -MP -MF src/x86/.deps/unix64.Tpo -c ../src/x86/unix64.S  -fPIC -DPIC -o src/x86/unix64.o
  depbase=`echo src/x86/ffiw64.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src   -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/x86/ffiw64.lo -MD -MP -MF $depbase.Tpo -c -o src/x86/ffiw64.lo ../src/x86/ffiw64.c &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions -MT src/x86/ffiw64.lo -MD -MP -MF src/x86/.deps/ffiw64.Tpo -c ../src/x86/ffiw64.c  -fPIC -DPIC -o src/x86/ffiw64.o
  depbase=`echo src/x86/win64.lo | sed 's|[^/]*$|.deps/&|;s|\.lo$||'`;\
  /bin/bash ./libtool  --tag=CC   --mode=compile clang-16 -DHAVE_CONFIG_H -I. -I..  -I. -I../include -Iinclude -I../src  -I. -I../include -Iinclude -I../src -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -MT src/x86/win64.lo -MD -MP -MF $depbase.Tpo -c -o src/x86/win64.lo ../src/x86/win64.S &&\
  mv -f $depbase.Tpo $depbase.Plo
  libtool: compile:  clang-16 -DHAVE_CONFIG_H -I. -I.. -I. -I../include -Iinclude -I../src -I. -I../include -Iinclude -I../src -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -MT src/x86/win64.lo -MD -MP -MF src/x86/.deps/win64.Tpo -c ../src/x86/win64.S  -fPIC -DPIC -o src/x86/win64.o
  /bin/bash ./libtool  --tag=CC   --mode=link clang-16  -Wall -O0 -ffunction-sections -fdata-sections -fPIC --target=x86_64-unknown-linux-gnu -flto=thin --sysroot=/sysroot -Wno-implicit-function-declaration -flto=thin --sysroot=/sysroot -fexceptions   -o libffi_convenience.la  src/prep_cif.lo src/types.lo src/raw_api.lo src/java_raw_api.lo src/closures.lo src/tramp.lo   src/x86/ffi64.lo src/x86/unix64.lo src/x86/ffiw64.lo src/x86/win64.lo 
  libtool: link: ar cr .libs/libffi_convenience.a  src/prep_cif.o src/types.o src/raw_api.o src/java_raw_api.o src/closures.o src/tramp.o src/x86/ffi64.o src/x86/unix64.o src/x86/ffiw64.o src/x86/win64.o
  make[2]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu'
  make[1]: Leaving directory '/home/runner/work/deno/deno/target/debug/build/libffi-sys-387c9c657c9961ac/out/libffi-build/x86_64-unknown-linux-gnu'

  --- stderr
  clang: error: unsupported option '-print-multi-os-directory'
  clang: error: no input files
  ../src/java_raw_api.c:328:46: warning: 'ffi_java_raw_size' is deprecated [-Wdeprecated-declarations]
    ffi_java_raw *raw = (ffi_java_raw*)alloca (ffi_java_raw_size (cif));
                                               ^
  include/ffi.h:326:56: note: 'ffi_java_raw_size' has been explicitly marked deprecated here
  size_t ffi_java_raw_size (ffi_cif *cif) __attribute__((deprecated));
                                                         ^
  ../src/java_raw_api.c:331:3: warning: 'ffi_java_ptrarray_to_raw' is deprecated [-Wdeprecated-declarations]
    ffi_java_ptrarray_to_raw (cif, avalue, raw);
    ^
  include/ffi.h:322:93: note: 'ffi_java_ptrarray_to_raw' has been explicitly marked deprecated here
  void ffi_java_ptrarray_to_raw (ffi_cif *cif, void **args, ffi_java_raw *raw) __attribute__((deprecated));
                                                                                              ^
  2 warnings generated.
  In file included from ../src/closures.c:570:
  ../src/dlmalloc.c:3390:7: warning: variable 'nfences' set but not used [-Wunused-but-set-variable]
    int nfences = 0;
        ^
  1 warning generated.
  LLVM ERROR: Type mismatch in constant table!
  ./libtool: line 1901: 30829 Aborted                 (core dumped) ar cr .libs/libffi_convenience.a src/prep_cif.o src/types.o src/raw_api.o src/java_raw_api.o src/closures.o src/tramp.o src/x86/ffi64.o src/x86/unix64.o src/x86/ffiw64.o src/x86/win64.o
  make[2]: *** [Makefile:1105: libffi_convenience.la] Error 134
  make[1]: *** [Makefile:1397: install-recursive] Error 1
  make: *** [Makefile:3158: install] Error 2
  thread 'main' panicked at 'Building libffi', /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libffi-sys-2.3.0/build/common.rs:8:5
  stack backtrace:
     0:     0x555a381d206a - std::backtrace_rs::backtrace::libunwind::trace::h9a6b80bbf328ba5d
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
     1:     0x555a381d206a - std::backtrace_rs::backtrace::trace_unsynchronized::hd162ec543a11886b
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
     2:     0x555a381d206a - std::sys_common::backtrace::_print_fmt::h78a5099be12f51a6
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/sys_common/backtrace.rs:65:5
     3:     0x555a381d206a - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::ha1c5390454d74f71
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/sys_common/backtrace.rs:44:22
     4:     0x555a381f3f2f - core::fmt::write::h9ffde816c577717b
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/fmt/mod.rs:1254:17
     5:     0x555a381ce785 - std::io::Write::write_fmt::h88186074961638e4
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/io/mod.rs:1698:15
     6:     0x555a381d1e35 - std::sys_common::backtrace::_print::h184198273ed08d59
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/sys_common/backtrace.rs:47:5
     7:     0x555a381d1e35 - std::sys_common::backtrace::print::h1b4d8e7add699453
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/sys_common/backtrace.rs:34:9
     8:     0x555a381d3d6e - std::panicking::default_hook::***closure***::h393bcea75423915a
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:269:22
     9:     0x555a381d3b15 - std::panicking::default_hook::h48c64f31d8b3fd03
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:288:9
    10:     0x555a381d[432](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:433)e - std::panicking::rust_panic_with_hook::hafdc493a79370062
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:691:13
    11:     0x555a381d4229 - std::panicking::begin_panic_handler::***closure***::h0a64bc82e36bedc7
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:582:13
    12:     0x555a381d24d6 - std::sys_common::backtrace::__rust_end_short_backtrace::hc203444fb7416a16
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/sys_common/backtrace.rs:150:18
    13:     0x555a381d3f82 - rust_begin_unwind
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
    14:     0x555a381f2bc3 - core::panicking::panic_fmt::h0f6ef0178afce4f2
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
    15:     0x555a381f9b0f - core::panicking::panic_display::h2659937d781317ae
    16:     0x555a381f9593 - build_script_build::common::run_command::hadd2ac2ab17ea387
    17:     0x555a381f8b6b - build_script_build::not_msvc::build_and_link::hbe18fbcea71b7ce4
    18:     0x555a381f9626 - build_script_build::main::h6db8757455681780
    19:     0x555a381f95c3 - core::ops::function::FnOnce::call_once::h2673aaa3477cd9b3
    20:     0x555a381f95a6 - std::sys_common::backtrace::__rust_begin_short_backtrace::h5dca0df55158f42c
    21:     0x555a381f9b49 - std::rt::lang_start::***closure***::h6de8a7a3465beb90
    22:     0x555a381cb2ee - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hb1327dc2ef3fecdf
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:287:13
    23:     0x555a381cb2ee - std::panicking::try::do_call::h40[441](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:442)73225fe83dd
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:485:40
    24:     0x555a381cb2ee - std::panicking::try::hd8a722c09d156a53
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:[449](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:450):19
    25:     0x555a381cb2ee - std::panic::catch_unwind::hd2ca07971cf0119b
                                 at /rustc/90c541806f23a127002de5b4038be731ba1[458](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:459)ca/library/std/src/panic.rs:140:14
    26:     0x555a381cb2ee - std::rt::lang_start_internal::***closure***::h26d89d595cf47b70
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/rt.rs:148:48
    27:     0x555a381cb2ee - std::panicking::try::do_call::hf47aa1aa005e5f1a
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:[485](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:486):40
    28:     0x555a381cb2ee - std::panicking::try::h73d246b2423eaf4e
                                 at /rustc/90c[541](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:542)806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:449:19
    29:     0x[555](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:556)a381cb2ee - std::panic::catch_unwind::hbaaeae8f1b2f9915
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panic.rs:140:14
    30:     0x555a381cb2ee - std::rt::lang_start_internal::h76f3e81e6b8f13f9
                                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/rt.rs:148:20
    31:     0x555a381f9b34 - std::rt::lang_start::h18ca6df76d65d895
    32:     0x555a381f9[645](https://github.com/denoland/deno/actions/runs/5201033494/jobs/9380608359#step:28:646) - main
    33:     0x7f4cd10fad90 - <unknown>
    34:     0x7f4cd10fae40 - __libc_start_main
    35:     0x555a381b0cf9 - _start
    36:                0x0 - <unknown>
warning: build failed, waiting for other jobs to finish...
```
</details>