### PR TITLE
perf: use sendto syscalls

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -73,13 +73,13 @@ type Request = hyper1::Request<Incoming>;
 type Response = hyper1::Response<ResponseBytes>;
 
 static USE_WRITEV: Lazy<bool> = Lazy::new(|| {
-  let disable_writev = std::env::var("DENO_HYPER_USE_WRITEV").ok();
+  let enable = std::env::var("DENO_USE_WRITEV").ok();
 
-  if let Some(val) = disable_writev {
-    return val != "0";
+  if let Some(val) = enable {
+    return !val.is_empty();
   }
 
-  true
+  false
 });
 
 /// All HTTP/2 connections start with this byte string.

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -53,6 +53,16 @@ use fastwebsockets::WebSocket;
 
 mod stream;
 
+static USE_WRITEV: Lazy<bool> = Lazy::new(|| {
+  let enable = std::env::var("DENO_USE_WRITEV").ok();
+
+  if let Some(val) = enable {
+    return !val.is_empty();
+  }
+
+  false
+});
+
 #[derive(Clone)]
 pub struct WsRootStoreProvider(Option<Arc<dyn RootCertStoreProvider>>);
 
@@ -360,7 +370,7 @@ pub fn ws_create_server_stream(
     ),
     Role::Server,
   );
-  ws.set_writev(true);
+  ws.set_writev(USE_WRITEV);
   ws.set_auto_close(true);
   ws.set_auto_pong(true);
 


### PR DESCRIPTION
This switches syscall used in HTTP and WS server from "writev"
to "sendto".

"DENO_USE_WRITEV=1" can be used to enable using "writev" syscall.
Doing this for easier testing of various setups.