### PR TITLE
chore: No longer need a sparse checkout thanks to cargo sparse index

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -488,13 +488,12 @@ const ci = {
           uses: "actions/cache@v3",
           with: {
             // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+            // Note that with the new sparse registry format, we no longer have to cache a `.git` dir
             path: [
               "~/.cargo/registry/index",
               "~/.cargo/registry/cache",
-              "~/.cargo/git/db",
             ].join("\n"),
-            key:
-              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ hashFiles('Cargo.lock') }}`,
+            key: `${cacheVersion}-cargo-home-\${{ matrix.os }}`,
           },
         },
         {
@@ -521,23 +520,6 @@ const ci = {
           with: {
             "cache-path": "./target",
           },
-        },
-        {
-          // Shallow the cloning the crates.io index makes CI faster because it
-          // obviates the need for Cargo to clone the index. If we don't do this
-          // Cargo will `git clone` the github repository that contains the entire
-          // history of the crates.io index from github. We don't believe the
-          // identifier '1ecc6299db9ec823' will ever change, but if it does then this
-          // command must be updated.
-          name: "Shallow clone crates.io index",
-          run: [
-            "if [ ! -d ~/.cargo/registry/index/github.com-1ecc6299db9ec823/.git ]",
-            "then",
-            "  git clone --depth 1 --no-checkout                      \\",
-            "            https://github.com/rust-lang/crates.io-index \\",
-            "            ~/.cargo/registry/index/github.com-1ecc6299db9ec823",
-            "fi",
-          ].join("\n"),
         },
         {
           name: "test_format.js",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -493,7 +493,10 @@ const ci = {
               "~/.cargo/registry/index",
               "~/.cargo/registry/cache",
             ].join("\n"),
-            key: `${cacheVersion}-cargo-home-\${{ matrix.os }}`,
+            key:
+              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ hashFiles('Cargo.lock') }}`,
+            // We will try to restore from the closest cargo-home we can find
+            "restore-keys": `${cacheVersion}-cargo-home-\${{ matrix.os }}`,
           },
         },
         {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -5,7 +5,7 @@ import * as yaml from "https://deno.land/std@0.173.0/encoding/yaml.ts";
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 38;
+const cacheVersion = 39;
 
 const Runners = (() => {
   const ubuntuRunner = "ubuntu-22.04";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,8 +298,7 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: '38-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+          key: '38-cargo-home-${{ matrix.os }}'
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
@@ -317,15 +316,6 @@ jobs:
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target
-      - name: Shallow clone crates.io index
-        run: |-
-          if [ ! -d ~/.cargo/registry/index/github.com-1ecc6299db9ec823/.git ]
-          then
-            git clone --depth 1 --no-checkout                      \
-                      https://github.com/rust-lang/crates.io-index \
-                      ~/.cargo/registry/index/github.com-1ecc6299db9ec823
-          fi
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: test_format.js
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run ./tools/format.js --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,12 +298,8 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-<<<<<<< HEAD
-          key: '38-cargo-home-${{ matrix.os }}'
-=======
-          key: '36-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '36-cargo-home-${{ matrix.os }}'
->>>>>>> 52e8226ed (Use restore-keys)
+          key: '38-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '38-cargo-home-${{ matrix.os }}'
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,12 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
+<<<<<<< HEAD
           key: '38-cargo-home-${{ matrix.os }}'
+=======
+          key: '36-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '36-cargo-home-${{ matrix.os }}'
+>>>>>>> 52e8226ed (Use restore-keys)
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,8 +298,8 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-          key: '38-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '38-cargo-home-${{ matrix.os }}'
+          key: '39-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '39-cargo-home-${{ matrix.os }}'
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
@@ -311,7 +311,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '38-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '39-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
@@ -592,7 +592,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '38-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '39-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-22.04


### PR DESCRIPTION
`cargo`'s sparse index showed up in 1.68

(testing build times before we commit)