### PR TITLE
chore: Use relative paths for assert imports to avoid test flakes

### DIFF
--- a/cli/tests/testdata/compile/dynamic_imports/main_unanalyzable.ts
+++ b/cli/tests/testdata/compile/dynamic_imports/main_unanalyzable.ts
@@ -1,4 +1,4 @@
-import { join } from "https://deno.land/std@0.178.0/path/mod.ts";
+import { join } from "../../../../../test_util/std/path/mod.ts";
 
 console.log("Starting the main module");
 

--- a/cli/tests/testdata/compile/standalone_follow_redirects_2.js
+++ b/cli/tests/testdata/compile/standalone_follow_redirects_2.js
@@ -2,4 +2,4 @@
 import {
   assertNotEquals as _a,
   assertStrictEquals as _b,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "../../../../test_util/std/testing/asserts.ts";

--- a/cli/tests/testdata/coverage/no_tests_included/foo.test.js
+++ b/cli/tests/testdata/coverage/no_tests_included/foo.test.js
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "https://deno.land/std@0.183.0/testing/asserts.ts";
+import { assertEquals } from "../../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/cli/tests/testdata/coverage/no_tests_included/foo.test.mts
+++ b/cli/tests/testdata/coverage/no_tests_included/foo.test.mts
@@ -1,5 +1,5 @@
 import { addNumbers } from './foo.ts';
-import { assertEquals } from "https://deno.land/std@0.183.0/testing/asserts.ts";
+import { assertEquals } from "../../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/cli/tests/testdata/coverage/no_tests_included/foo.test.ts
+++ b/cli/tests/testdata/coverage/no_tests_included/foo.test.ts
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "https://deno.land/std@0.183.0/testing/asserts.ts";
+import { assertEquals } from "../../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/cli/tests/unit/opcall_test.ts
+++ b/cli/tests/unit/opcall_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 import { assert, assertStringIncludes, unreachable } from "./test_util.ts";
 
 Deno.test(async function sendAsyncStackTrace() {

--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assertMatch } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
+import { assertMatch } from "../../../test_util/std/testing/asserts.ts";
 import { Buffer, BufReader, BufWriter } from "../../../test_util/std/io/mod.ts";
 import { TextProtoReader } from "../testdata/run/textproto.ts";
 import {

--- a/cli/tests/unit_node/http2_test.ts
+++ b/cli/tests/unit_node/http2_test.ts
@@ -3,7 +3,7 @@
 import * as http2 from "node:http2";
 import * as net from "node:net";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
-import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 
 const {
   HTTP2_HEADER_AUTHORITY,


### PR DESCRIPTION
Tests occasionally fail if we get a bad gateway attempting to fetch the assertion module