### PR TITLE
fix(config): do not canonicalize config file path before loading

### DIFF
--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -763,14 +763,14 @@ impl ConfigFile {
   pub fn read(config_path: &Path) -> Result<Self, AnyError> {
     debug_assert!(config_path.is_absolute());
 
-    let config_specifier = ModuleSpecifier::from_file_path(config_path)
-      .map_err(|_| {
+    let specifier =
+      ModuleSpecifier::from_file_path(config_path).map_err(|_| {
         anyhow!(
           "Could not convert config file path to specifier. Path: {}",
           config_path.display()
         )
       })?;
-    Self::from_specifier(config_specifier)
+    Self::from_specifier_and_path(specifier, config_path)
   }
 
   pub fn from_specifier(specifier: ModuleSpecifier) -> Result<Self, AnyError> {
@@ -778,6 +778,13 @@ impl ConfigFile {
       specifier_to_file_path(&specifier).with_context(|| {
         format!("Invalid config file path for '{}'.", specifier)
       })?;
+    Self::from_specifier_and_path(specifier, &config_path)
+  }
+
+  fn from_specifier_and_path(
+    specifier: ModuleSpecifier,
+    config_path: &Path,
+  ) -> Result<Self, AnyError> {
     let text = std::fs::read_to_string(config_path)
       .with_context(|| format!("Error reading config file '{}'.", specifier))?;
     Self::new(&text, specifier)

--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -2,7 +2,6 @@
 
 use crate::args::ConfigFlag;
 use crate::args::Flags;
-use crate::util::fs::canonicalize_path;
 use crate::util::path::specifier_parent;
 use crate::util::path::specifier_to_file_path;
 
@@ -23,6 +22,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -755,30 +755,7 @@ impl ConfigFile {
   pub fn read(config_path: &Path) -> Result<Self, AnyError> {
     debug_assert!(config_path.is_absolute());
 
-    // perf: Check if the config file exists before canonicalizing path.
-    if !config_path.exists() {
-      return Err(
-        std::io::Error::new(
-          std::io::ErrorKind::InvalidInput,
-          format!(
-            "Could not find the config file: {}",
-            config_path.to_string_lossy()
-          ),
-        )
-        .into(),
-      );
-    }
-
-    let config_path = canonicalize_path(config_path).map_err(|_| {
-      std::io::Error::new(
-        std::io::ErrorKind::InvalidInput,
-        format!(
-          "Could not find the config file: {}",
-          config_path.to_string_lossy()
-        ),
-      )
-    })?;
-    let config_specifier = ModuleSpecifier::from_file_path(&config_path)
+    let config_specifier = ModuleSpecifier::from_file_path(config_path)
       .map_err(|_| {
         anyhow!(
           "Could not convert path to specifier. Path: {}",
@@ -790,15 +767,21 @@ impl ConfigFile {
 
   pub fn from_specifier(specifier: ModuleSpecifier) -> Result<Self, AnyError> {
     let config_path = specifier_to_file_path(&specifier)?;
-    let config_text = match std::fs::read_to_string(config_path) {
-      Ok(text) => text,
+    match std::fs::read_to_string(config_path) {
+      Ok(text) => Self::new(&text, specifier),
+      Err(err) if err.kind() == ErrorKind::NotFound => Err(
+        std::io::Error::new(
+          std::io::ErrorKind::NotFound,
+          format!("Could not find the config file: {}", specifier),
+        )
+        .into(),
+      ),
       Err(err) => bail!(
         "Error reading config file {}: {}",
         specifier,
         err.to_string()
       ),
-    };
-    Self::new(&config_text, specifier)
+    }
   }
 
   pub fn new(text: &str, specifier: ModuleSpecifier) -> Result<Self, AnyError> {

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -396,8 +396,6 @@ fn discover_package_json(
   // `package.json` is ignored in bundle/compile/etc.
 
   if let Some(package_json_dir) = flags.package_json_search_dir(current_dir) {
-    let package_json_dir =
-      canonicalize_path_maybe_not_exists(&package_json_dir)?;
     return package_json::discover_from(&package_json_dir, maybe_stop_at);
   }
 


### PR DESCRIPTION
I'm unsure why we canonicalize the config file path when loading and the canonicalization is causing issues in #19431 because everything in the lsp is not canonicalized except the config file (actually, the config file is only canonicalized when auto-discovered and not whens pecified). We also don't canonicalize module paths when loading them.

Canonicalization was added in https://github.com/denoland/deno/pull/7621