### PR TITLE
test(unit_fs_dirent): added fs dirent unit test from std deno

### DIFF
--- a/cli/tests/integration/node_unit_tests.rs
+++ b/cli/tests/integration/node_unit_tests.rs
@@ -19,6 +19,7 @@ util::unit_test_factory!(
     _fs_close_test = _fs / _fs_close_test,
     _fs_copy_test = _fs / _fs_copy_test,
     _fs_dir_test = _fs / _fs_dir_test,
+    _fs_dirent_test = _fs / _fs_dirent_test,
     _fs_exists_test = _fs / _fs_exists_test,
     _fs_fdatasync_test = _fs / _fs_fdatasync_test,
     _fs_fstat_test = _fs / _fs_fstat_test,

--- a/cli/tests/unit_node/_fs/_fs_dirent_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_dirent_test.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, assertThrows } from "../../../../test_util/std/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+} from "../../../../test_util/std/testing/asserts.ts";
 import Dirent from "node:fs";
 
 class DirEntryMock implements Deno.DirEntry {

--- a/cli/tests/unit_node/_fs/_fs_dirent_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_dirent_test.ts
@@ -1,0 +1,79 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { assert, assertEquals, assertThrows } from "../../../../test_util/std/testing/asserts.ts";
+import Dirent from "node:fs";
+
+class DirEntryMock implements Deno.DirEntry {
+  name = "";
+  isFile = false;
+  isDirectory = false;
+  isSymlink = false;
+}
+
+Deno.test({
+  name: "Directories are correctly identified",
+  fn() {
+    const entry: DirEntryMock = new DirEntryMock();
+    entry.isDirectory = true;
+    entry.isFile = false;
+    entry.isSymlink = false;
+    assert(new Dirent(entry).isDirectory());
+    assert(!new Dirent(entry).isFile());
+    assert(!new Dirent(entry).isSymbolicLink());
+  },
+});
+
+Deno.test({
+  name: "Files are correctly identified",
+  fn() {
+    const entry: DirEntryMock = new DirEntryMock();
+    entry.isDirectory = false;
+    entry.isFile = true;
+    entry.isSymlink = false;
+    assert(!new Dirent(entry).isDirectory());
+    assert(new Dirent(entry).isFile());
+    assert(!new Dirent(entry).isSymbolicLink());
+  },
+});
+
+Deno.test({
+  name: "Symlinks are correctly identified",
+  fn() {
+    const entry: DirEntryMock = new DirEntryMock();
+    entry.isDirectory = false;
+    entry.isFile = false;
+    entry.isSymlink = true;
+    assert(!new Dirent(entry).isDirectory());
+    assert(!new Dirent(entry).isFile());
+    assert(new Dirent(entry).isSymbolicLink());
+  },
+});
+
+Deno.test({
+  name: "File name is correct",
+  fn() {
+    const entry: DirEntryMock = new DirEntryMock();
+    entry.name = "my_file";
+    assertEquals(new Dirent(entry).name, "my_file");
+  },
+});
+
+Deno.test({
+  name: "Socket and FIFO pipes aren't yet available",
+  fn() {
+    const entry: DirEntryMock = new DirEntryMock();
+    assertThrows(
+      () => {
+        new Dirent(entry).isFIFO();
+      },
+      Error,
+      "does not yet support",
+    );
+    assertThrows(
+      () => {
+        new Dirent(entry).isSocket();
+      },
+      Error,
+      "does not yet support",
+    );
+  },
+});

--- a/cli/tests/unit_node/_fs/_fs_dirent_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_dirent_test.ts
@@ -4,7 +4,10 @@ import {
   assertEquals,
   assertThrows,
 } from "../../../../test_util/std/testing/asserts.ts";
-import Dirent from "node:fs";
+import { Dirent as Dirent_ } from "node:fs";
+
+// deno-lint-ignore no-explicit-any
+const Dirent = Dirent_ as any;
 
 class DirEntryMock implements Deno.DirEntry {
   name = "";


### PR DESCRIPTION
added fs dirent unit test from std deno using correct calls

included a new files based on deno_std unit test for node fs
following previous additions on the issue related below
tests run well

https://github.com/denoland/deno/issues/17840
