### PR TITLE
chore: fix typos in HrtimePermissionDescriptor and performance.now docs

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4452,8 +4452,8 @@ declare namespace Deno {
 
   /** The permission descriptor for the `allow-hrtime` permission, which
    * controls if the runtime code has access to high resolution time. High
-   * resolution time is consider sensitive information, because it can be used
-   * by malicious code to gain information about the host that it might
+   * resolution time is considered sensitive information, because it can be used
+   * by malicious code to gain information about the host that it might not
    * otherwise have access to.
    *
    * @category Permissions */

--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -579,7 +579,7 @@ declare class Performance extends EventTarget {
 
   /** Returns a current time from Deno's start in milliseconds.
    *
-   * Use the permission flag `--allow-hrtime` return a precise value.
+   * Use the permission flag `--allow-hrtime` to return a precise value.
    *
    * ```ts
    * const t = performance.now();


### PR DESCRIPTION
Some typo fixes for HrtimePermissionDescriptor and performance.now documentation