### PR TITLE
fix(node_compat): Worker constructor doesn't check type: module of package.json

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -53,7 +53,8 @@ class _Worker extends EventEmitter {
       specifier = `data:text/javascript,${specifier}`;
     } else if (typeof specifier === "string") {
       specifier = resolve(specifier);
-      if (!specifier.toString().endsWith(".mjs")) {
+      const pkg = Deno[Deno.internal].core.ops.op_require_read_closest_package_json(specifier);
+      if (!(specifier.toString().endsWith(".mjs") || (pkg && pkg.exists && pkg.typ == "module"))) {
         const cwdFileUrl = toFileUrl(Deno.cwd());
         specifier =
           `data:text/javascript,(async function() {const { createRequire } = await import("node:module");const require = createRequire("${cwdFileUrl}");require("${specifier}");})();`;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
Worker while building sveltekit app seems to not recognize `type: module` in package.json
[Ref issue](https://github.com/denoland/deno/issues/19440)