### PR TITLE
refactor(flags): move watch flags into subcommand structs

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -38,12 +38,14 @@ pub struct BenchFlags {
   pub filter: Option<String>,
   pub json: bool,
   pub no_run: bool,
+  pub watch: Option<WatchFlags>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BundleFlags {
   pub source_file: String,
   pub out_file: Option<PathBuf>,
+  pub watch: Option<WatchFlags>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -115,6 +117,7 @@ pub struct FmtFlags {
   pub single_quote: Option<bool>,
   pub prose_wrap: Option<String>,
   pub no_semicolons: Option<bool>,
+  pub watch: Option<WatchFlags>,
 }
 
 impl FmtFlags {
@@ -159,6 +162,7 @@ pub struct LintFlags {
   pub maybe_rules_exclude: Option<Vec<String>>,
   pub json: bool,
   pub compact: bool,
+  pub watch: Option<WatchFlags>,
 }
 
 impl LintFlags {
@@ -178,12 +182,24 @@ pub struct ReplFlags {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RunFlags {
   pub script: String,
+  pub watch: Option<WatchFlagsWithPaths>,
 }
 
 impl RunFlags {
   pub fn is_stdin(&self) -> bool {
     self.script == "-"
   }
+}
+
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
+pub struct WatchFlags {
+  pub no_clear_screen: bool,
+}
+
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
+pub struct WatchFlagsWithPaths {
+  pub paths: Vec<PathBuf>,
+  pub no_clear_screen: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -196,6 +212,7 @@ pub struct TaskFlags {
 pub struct TestFlags {
   pub doc: bool,
   pub no_run: bool,
+  pub coverage_dir: Option<String>,
   pub fail_fast: Option<NonZeroUsize>,
   pub files: FileFlags,
   pub allow_none: bool,
@@ -203,6 +220,7 @@ pub struct TestFlags {
   pub shuffle: Option<u64>,
   pub concurrent_jobs: Option<NonZeroUsize>,
   pub trace_ops: bool,
+  pub watch: Option<WatchFlags>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -343,7 +361,6 @@ pub struct Flags {
   pub type_check_mode: TypeCheckMode,
   pub config_flag: ConfigFlag,
   pub node_modules_dir: Option<bool>,
-  pub coverage_dir: Option<String>,
   pub enable_testing_features: bool,
   pub ext: Option<String>,
   pub ignore: Vec<PathBuf>,
@@ -364,9 +381,6 @@ pub struct Flags {
   pub unstable: bool,
   pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
   pub v8_flags: Vec<String>,
-  pub version: bool,
-  pub watch: Option<Vec<PathBuf>>,
-  pub no_clear_screen: bool,
 }
 
 fn join_paths(allowlist: &[PathBuf], d: &str) -> String {
@@ -497,7 +511,7 @@ impl Flags {
     match &self.subcommand {
       Fmt(FmtFlags { files, .. }) => Some(files.include.clone()),
       Lint(LintFlags { files, .. }) => Some(files.include.clone()),
-      Run(RunFlags { script }) => {
+      Run(RunFlags { script, .. }) => {
         if let Ok(module_specifier) = resolve_url_or_path(script, current_dir) {
           if module_specifier.scheme() == "file"
             || module_specifier.scheme() == "npm"
@@ -539,7 +553,7 @@ impl Flags {
     use DenoSubcommand::*;
 
     match &self.subcommand {
-      Run(RunFlags { script }) => {
+      Run(RunFlags { script, .. }) => {
         let module_specifier = resolve_url_or_path(script, current_dir).ok()?;
         if module_specifier.scheme() == "file" {
           let p = module_specifier
@@ -2544,12 +2558,12 @@ fn bench_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 
   let no_run = matches.get_flag("no-run");
 
-  watch_arg_parse(flags, matches, false);
   flags.subcommand = DenoSubcommand::Bench(BenchFlags {
     files: FileFlags { include, ignore },
     filter,
     json,
     no_run,
+    watch: watch_arg_parse(matches),
   });
 }
 
@@ -2568,12 +2582,12 @@ fn bundle_parse(flags: &mut Flags, matches: &mut ArgMatches) {
       None
     };
 
-  watch_arg_parse(flags, matches, false);
   ext_arg_parse(flags, matches);
 
   flags.subcommand = DenoSubcommand::Bundle(BundleFlags {
     source_file,
     out_file,
+    watch: watch_arg_parse(matches),
   });
 }
 
@@ -2743,7 +2757,6 @@ fn eval_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 
 fn fmt_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   config_args_parse(flags, matches);
-  watch_arg_parse(flags, matches, false);
   ext_arg_parse(flags, matches);
 
   let include = match matches.remove_many::<PathBuf>("files") {
@@ -2771,6 +2784,7 @@ fn fmt_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     single_quote,
     prose_wrap,
     no_semicolons,
+    watch: watch_arg_parse(matches),
   });
 }
 
@@ -2832,7 +2846,6 @@ fn lsp_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
 
 fn lint_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   config_args_parse(flags, matches);
-  watch_arg_parse(flags, matches, false);
   let files = match matches.remove_many::<PathBuf>("files") {
     Some(f) => f.collect(),
     None => vec![],
@@ -2865,9 +2878,9 @@ fn lint_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     maybe_rules_tags,
     maybe_rules_include,
     maybe_rules_exclude,
-
     json,
     compact,
+    watch: watch_arg_parse(matches),
   });
 }
 
@@ -2899,8 +2912,10 @@ fn run_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 
   ext_arg_parse(flags, matches);
 
-  watch_arg_parse(flags, matches, true);
-  flags.subcommand = DenoSubcommand::Run(RunFlags { script });
+  flags.subcommand = DenoSubcommand::Run(RunFlags {
+    script,
+    watch: watch_arg_parse_with_paths(matches),
+  });
 }
 
 fn task_parse(flags: &mut Flags, matches: &mut ArgMatches) {
@@ -3001,11 +3016,10 @@ fn test_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     Vec::new()
   };
 
-  flags.coverage_dir = matches.remove_one::<String>("coverage");
-  watch_arg_parse(flags, matches, false);
   flags.subcommand = DenoSubcommand::Test(TestFlags {
     no_run,
     doc,
+    coverage_dir: matches.remove_one::<String>("coverage"),
     fail_fast,
     files: FileFlags { include, ignore },
     filter,
@@ -3013,6 +3027,7 @@ fn test_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     allow_none,
     concurrent_jobs,
     trace_ops,
+    watch: watch_arg_parse(matches),
   });
 }
 
@@ -3336,22 +3351,25 @@ fn reload_arg_validate(urlstr: &str) -> Result<String, String> {
   }
 }
 
-fn watch_arg_parse(
-  flags: &mut Flags,
-  matches: &mut ArgMatches,
-  allow_extra: bool,
-) {
-  if allow_extra {
-    if let Some(f) = matches.remove_many::<PathBuf>("watch") {
-      flags.watch = Some(f.collect());
-    }
-  } else if matches.get_flag("watch") {
-    flags.watch = Some(vec![]);
+fn watch_arg_parse(matches: &mut ArgMatches) -> Option<WatchFlags> {
+  if matches.get_flag("watch") {
+    Some(WatchFlags {
+      no_clear_screen: matches.get_flag("no-clear-screen"),
+    })
+  } else {
+    None
   }
+}
 
-  if matches.get_flag("no-clear-screen") {
-    flags.no_clear_screen = true;
-  }
+fn watch_arg_parse_with_paths(
+  matches: &mut ArgMatches,
+) -> Option<WatchFlagsWithPaths> {
+  matches
+    .remove_many::<PathBuf>("watch")
+    .map(|f| WatchFlagsWithPaths {
+      paths: f.collect(),
+      no_clear_screen: matches.get_flag("no-clear-screen"),
+    })
 }
 
 // TODO(ry) move this to utility module and add test.
@@ -3394,6 +3412,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         unstable: true,
         log_level: Some(Level::Error),
@@ -3448,6 +3467,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         reload: true,
         ..Flags::default()
@@ -3464,8 +3484,11 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Some(WatchFlagsWithPaths {
+            paths: vec![],
+            no_clear_screen: false,
+          }),
         }),
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -3481,8 +3504,11 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Some(WatchFlagsWithPaths {
+            paths: vec![PathBuf::from("file1"), PathBuf::from("file2")],
+            no_clear_screen: false,
+          }),
         }),
-        watch: Some(vec![PathBuf::from("file1"), PathBuf::from("file2")]),
         ..Flags::default()
       }
     );
@@ -3504,9 +3530,11 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Some(WatchFlagsWithPaths {
+            paths: vec![],
+            no_clear_screen: true,
+          })
         }),
-        watch: Some(vec![]),
-        no_clear_screen: true,
         ..Flags::default()
       }
     );
@@ -3522,6 +3550,7 @@ mod tests {
         reload: true,
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_write: Some(vec![]),
         ..Flags::default()
@@ -3537,6 +3566,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "_".to_string(),
+          watch: Default::default(),
         }),
         v8_flags: svec!["--help"],
         ..Flags::default()
@@ -3554,6 +3584,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         v8_flags: svec!["--expose-gc", "--gc-stats=1"],
         ..Flags::default()
@@ -3594,6 +3625,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "gist.ts".to_string(),
+          watch: Default::default(),
         }),
         argv: svec!["--title", "X"],
         allow_net: Some(vec![]),
@@ -3610,6 +3642,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "gist.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_all: true,
         allow_net: Some(vec![]),
@@ -3633,6 +3666,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "gist.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_read: Some(vec![]),
         ..Flags::default()
@@ -3648,6 +3682,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "gist.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_hrtime: true,
         ..Flags::default()
@@ -3674,6 +3709,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         argv: svec!["--", "-D", "--allow-net"],
         allow_write: Some(vec![]),
@@ -3703,6 +3739,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
         ..Flags::default()
@@ -3725,6 +3762,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
         ..Flags::default()
@@ -3747,6 +3785,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
         ..Flags::default()
@@ -3769,9 +3808,11 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          })
         }),
         ext: Some("ts".to_string()),
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -3793,10 +3834,11 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: true,
+          })
         }),
         ext: Some("ts".to_string()),
-        watch: Some(vec![]),
-        no_clear_screen: true,
         ..Flags::default()
       }
     );
@@ -3824,9 +3866,11 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          })
         }),
         ext: Some("ts".to_string()),
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -3847,6 +3891,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
@@ -3877,10 +3922,12 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          })
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ext: Some("ts".to_string()),
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -3913,6 +3960,7 @@ mod tests {
           single_quote: Some(true),
           prose_wrap: Some("never".to_string()),
           no_semicolons: Some(true),
+          watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
         ..Flags::default()
@@ -3942,6 +3990,7 @@ mod tests {
           single_quote: Some(false),
           prose_wrap: None,
           no_semicolons: Some(false),
+          watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
         ..Flags::default()
@@ -3969,6 +4018,7 @@ mod tests {
           maybe_rules_exclude: None,
           json: false,
           compact: false,
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -3998,8 +4048,10 @@ mod tests {
           maybe_rules_exclude: None,
           json: false,
           compact: false,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          })
         }),
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -4029,9 +4081,10 @@ mod tests {
           maybe_rules_exclude: None,
           json: false,
           compact: false,
+          watch: Some(WatchFlags {
+            no_clear_screen: true,
+          })
         }),
-        watch: Some(vec![]),
-        no_clear_screen: true,
         ..Flags::default()
       }
     );
@@ -4055,6 +4108,7 @@ mod tests {
           maybe_rules_exclude: None,
           json: false,
           compact: false,
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -4075,6 +4129,7 @@ mod tests {
           maybe_rules_exclude: None,
           json: false,
           compact: false,
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -4101,6 +4156,7 @@ mod tests {
           maybe_rules_exclude: Some(svec!["no-const-assign"]),
           json: false,
           compact: false,
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -4121,6 +4177,7 @@ mod tests {
           maybe_rules_exclude: None,
           json: true,
           compact: false,
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -4148,6 +4205,7 @@ mod tests {
           maybe_rules_exclude: None,
           json: true,
           compact: false,
+          watch: Default::default(),
         }),
         config_flag: ConfigFlag::Path("Deno.jsonc".to_string()),
         ..Flags::default()
@@ -4176,6 +4234,7 @@ mod tests {
           maybe_rules_exclude: None,
           json: false,
           compact: true,
+          watch: Default::default(),
         }),
         config_flag: ConfigFlag::Path("Deno.jsonc".to_string()),
         ..Flags::default()
@@ -4345,6 +4404,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         config_flag: ConfigFlag::Path("tsconfig.json".to_owned()),
         ..Flags::default()
@@ -4614,6 +4674,7 @@ mod tests {
         allow_read: Some(vec![PathBuf::from("."), temp_dir]),
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -4638,6 +4699,7 @@ mod tests {
         allow_write: Some(vec![PathBuf::from("."), temp_dir]),
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         ..Flags::default()
       }
@@ -4657,6 +4719,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_net: Some(svec!["127.0.0.1"]),
         ..Flags::default()
@@ -4673,6 +4736,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_env: Some(svec!["HOME"]),
         ..Flags::default()
@@ -4693,6 +4757,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_env: Some(svec!["HOME", "PATH"]),
         ..Flags::default()
@@ -4721,6 +4786,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_sys: Some(vec![]),
         ..Flags::default()
@@ -4737,6 +4803,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_sys: Some(svec!["hostname"]),
         ..Flags::default()
@@ -4757,6 +4824,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_sys: Some(svec!["hostname", "osRelease"]),
         ..Flags::default()
@@ -4869,6 +4937,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()
@@ -4893,6 +4962,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: Some(PathBuf::from("bundle.js")),
+          watch: Default::default(),
         }),
         allow_write: Some(vec![]),
         no_remote: true,
@@ -4912,6 +4982,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: Some(PathBuf::from("bundle.js")),
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         allow_write: Some(vec![]),
@@ -4935,6 +5006,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         lock_write: true,
@@ -4954,6 +5026,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()
@@ -4971,6 +5044,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "script.ts".to_string(),
           out_file: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::None,
         ..Flags::default()
@@ -4987,9 +5061,11 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          }),
         }),
         type_check_mode: TypeCheckMode::Local,
-        watch: Some(vec![]),
         ..Flags::default()
       }
     )
@@ -5010,10 +5086,11 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: true,
+          }),
         }),
         type_check_mode: TypeCheckMode::Local,
-        watch: Some(vec![]),
-        no_clear_screen: true,
         ..Flags::default()
       }
     )
@@ -5032,6 +5109,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         import_map_path: Some("import_map.json".to_owned()),
         ..Flags::default()
@@ -5126,6 +5204,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         seed: Some(250_u64),
         v8_flags: svec!["--random-seed=250"],
@@ -5149,6 +5228,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         seed: Some(250_u64),
         v8_flags: svec!["--expose-gc", "--random-seed=250"],
@@ -5243,6 +5323,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         log_level: Some(Level::Debug),
         ..Flags::default()
@@ -5258,6 +5339,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         log_level: Some(Level::Error),
         ..Flags::default()
@@ -5291,6 +5373,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         argv: svec!["--allow-read", "--allow-net"],
         ..Flags::default()
@@ -5314,6 +5397,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         location: Some(Url::parse("https://foo/").unwrap()),
         allow_read: Some(vec![]),
@@ -5328,6 +5412,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         argv: svec!["foo", "bar"],
         ..Flags::default()
@@ -5339,6 +5424,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         argv: svec!["-"],
         ..Flags::default()
@@ -5352,6 +5438,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         argv: svec!["-", "foo", "bar"],
         ..Flags::default()
@@ -5367,6 +5454,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::None,
         ..Flags::default()
@@ -5383,6 +5471,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()
@@ -5427,6 +5516,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         unsafely_ignore_certificate_errors: Some(vec![]),
         ..Flags::default()
@@ -5447,6 +5537,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         unsafely_ignore_certificate_errors: Some(svec![
           "deno.land",
@@ -5497,6 +5588,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         no_remote: true,
         ..Flags::default()
@@ -5512,6 +5604,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         no_npm: true,
         ..Flags::default()
@@ -5528,6 +5621,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         node_modules_dir: Some(true),
         ..Flags::default()
@@ -5545,6 +5639,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         node_modules_dir: Some(false),
         ..Flags::default()
@@ -5560,6 +5655,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         cached_only: true,
         ..Flags::default()
@@ -5580,6 +5676,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_net: Some(svec![
           "deno.land",
@@ -5608,6 +5705,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         allow_net: Some(svec![
           "deno.land",
@@ -5640,6 +5738,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         lock_write: true,
         lock: Some(PathBuf::from("lock.json")),
@@ -5653,6 +5752,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         no_lock: true,
         ..Flags::default()
@@ -5671,6 +5771,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         lock_write: true,
         lock: Some(PathBuf::from("./deno.lock")),
@@ -5691,6 +5792,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         lock_write: true,
         lock: Some(PathBuf::from("lock.json")),
@@ -5704,6 +5806,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         lock_write: true,
         ..Flags::default()
@@ -5761,12 +5864,13 @@ mod tests {
           shuffle: None,
           concurrent_jobs: None,
           trace_ops: true,
+          coverage_dir: Some("cov".to_string()),
+          watch: Default::default(),
         }),
         unstable: true,
         no_prompt: true,
         no_npm: true,
         no_remote: true,
-        coverage_dir: Some("cov".to_string()),
         location: Some(Url::parse("https://foo/").unwrap()),
         type_check_mode: TypeCheckMode::Local,
         allow_net: Some(vec![]),
@@ -5790,6 +5894,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         ca_data: Some(CaData::File("example.crt".to_owned())),
         ..Flags::default()
@@ -5810,6 +5915,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         enable_testing_features: true,
         ..Flags::default()
@@ -5836,6 +5942,8 @@ mod tests {
           },
           concurrent_jobs: Some(NonZeroUsize::new(4).unwrap()),
           trace_ops: false,
+          coverage_dir: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         no_prompt: true,
@@ -5866,6 +5974,8 @@ mod tests {
           },
           concurrent_jobs: None,
           trace_ops: false,
+          coverage_dir: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         no_prompt: true,
@@ -5900,6 +6010,8 @@ mod tests {
           },
           concurrent_jobs: None,
           trace_ops: false,
+          coverage_dir: None,
+          watch: Default::default(),
         }),
         no_prompt: true,
         type_check_mode: TypeCheckMode::Local,
@@ -5928,9 +6040,10 @@ mod tests {
           },
           concurrent_jobs: None,
           trace_ops: false,
+          coverage_dir: None,
+          watch: Default::default(),
         }),
         no_prompt: true,
-        watch: None,
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()
       }
@@ -5956,10 +6069,13 @@ mod tests {
           },
           concurrent_jobs: None,
           trace_ops: false,
+          coverage_dir: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          }),
         }),
         no_prompt: true,
         type_check_mode: TypeCheckMode::Local,
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -5983,10 +6099,13 @@ mod tests {
           },
           concurrent_jobs: None,
           trace_ops: false,
+          coverage_dir: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          }),
         }),
         no_prompt: true,
         type_check_mode: TypeCheckMode::Local,
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -6012,10 +6131,12 @@ mod tests {
           },
           concurrent_jobs: None,
           trace_ops: false,
+          coverage_dir: None,
+          watch: Some(WatchFlags {
+            no_clear_screen: true,
+          }),
         }),
-        watch: Some(vec![]),
         type_check_mode: TypeCheckMode::Local,
-        no_clear_screen: true,
         no_prompt: true,
         ..Flags::default()
       }
@@ -6037,6 +6158,7 @@ mod tests {
         subcommand: DenoSubcommand::Bundle(BundleFlags {
           source_file: "source.ts".to_string(),
           out_file: None,
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         ca_data: Some(CaData::File("example.crt".to_owned())),
@@ -6203,6 +6325,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "foo.js".to_string(),
+          watch: Default::default(),
         }),
         inspect: Some("127.0.0.1:9229".parse().unwrap()),
         ..Flags::default()
@@ -6218,6 +6341,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "foo.js".to_string(),
+          watch: Default::default(),
         }),
         inspect_wait: Some("127.0.0.1:9229".parse().unwrap()),
         ..Flags::default()
@@ -6235,6 +6359,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "foo.js".to_string(),
+          watch: Default::default(),
         }),
         inspect_wait: Some("127.0.0.1:3567".parse().unwrap()),
         ..Flags::default()
@@ -6684,6 +6809,7 @@ mod tests {
             include: vec![PathBuf::from("dir1/"), PathBuf::from("dir2/")],
             ignore: vec![],
           },
+          watch: Default::default(),
         }),
         unstable: true,
         no_npm: true,
@@ -6712,10 +6838,12 @@ mod tests {
             include: vec![],
             ignore: vec![],
           },
+          watch: Some(WatchFlags {
+            no_clear_screen: false,
+          }),
         }),
         no_prompt: true,
         type_check_mode: TypeCheckMode::Local,
-        watch: Some(vec![]),
         ..Flags::default()
       }
     );
@@ -6729,6 +6857,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()
@@ -6741,6 +6870,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::All,
         ..Flags::default()
@@ -6753,6 +6883,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         type_check_mode: TypeCheckMode::None,
         ..Flags::default()
@@ -6777,6 +6908,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Run(RunFlags {
           script: "script.ts".to_string(),
+          watch: Default::default(),
         }),
         config_flag: ConfigFlag::Disabled,
         ..Flags::default()

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -82,7 +82,7 @@ fn spawn_subcommand<F: Future<Output = T> + 'static, T: SubcommandOutput>(
 async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
   let handle = match flags.subcommand.clone() {
     DenoSubcommand::Bench(bench_flags) => spawn_subcommand(async {
-      if flags.watch.is_some() {
+      if bench_flags.watch.is_some() {
         tools::bench::run_benchmarks_with_watch(flags, bench_flags).await
       } else {
         tools::bench::run_benchmarks(flags, bench_flags).await
@@ -153,7 +153,7 @@ async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
       if run_flags.is_stdin() {
         tools::run::run_from_stdin(flags).await
       } else {
-        tools::run::run_script(flags).await
+        tools::run::run_script(flags, run_flags).await
       }
     }),
     DenoSubcommand::Task(task_flags) => spawn_subcommand(async {
@@ -161,7 +161,7 @@ async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
     }),
     DenoSubcommand::Test(test_flags) => {
       spawn_subcommand(async {
-        if let Some(ref coverage_dir) = flags.coverage_dir {
+        if let Some(ref coverage_dir) = test_flags.coverage_dir {
           std::fs::create_dir_all(coverage_dir)
             .with_context(|| format!("Failed creating: {coverage_dir}"))?;
           // this is set in order to ensure spawned processes use the same
@@ -172,7 +172,7 @@ async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
           );
         }
 
-        if flags.watch.is_some() {
+        if test_flags.watch.is_some() {
           tools::test::run_tests_with_watch(flags, test_flags).await
         } else {
           tools::test::run_tests(flags, test_flags).await

--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -385,6 +385,7 @@ async fn fmt_watch_test() {
     wait_contains("Checked", &mut stderr_lines).await,
     "Checked 1 file"
   );
+  wait_contains("Fmt finished", &mut stderr_lines).await;
 
   let expected = std::fs::read_to_string(fixed.clone()).unwrap();
   let actual = std::fs::read_to_string(badly_formatted.clone()).unwrap();
@@ -401,6 +402,7 @@ async fn fmt_watch_test() {
     wait_contains("Checked", &mut stderr_lines).await,
     "Checked 1 file"
   );
+  wait_contains("Fmt finished", &mut stderr_lines).await;
 
   // Check if file has been automatically formatted by watcher
   let expected = std::fs::read_to_string(fixed).unwrap();

--- a/cli/tools/bundle.rs
+++ b/cli/tools/bundle.rs
@@ -28,13 +28,12 @@ pub async fn bundle(
     "Use alternative bundlers like \"deno_emit\", \"esbuild\" or \"rollup\" instead."
   );
 
-  if flags.watch.is_some() {
-    let clear_screen = !flags.no_clear_screen;
+  if let Some(watch_flags) = &bundle_flags.watch {
     util::file_watcher::watch_func(
       flags,
       util::file_watcher::PrintConfig {
         job_name: "Bundle".to_string(),
-        clear_screen,
+        clear_screen: !watch_flags.no_clear_screen,
       },
       move |flags, sender, _changed_paths| {
         let bundle_flags = bundle_flags.clone();
@@ -44,11 +43,7 @@ pub async fn bundle(
             .build_from_flags(flags)
             .await?;
           let cli_options = factory.cli_options();
-
-          if let Some(watch_paths) = cli_options.watch_paths() {
-            let _ = sender.send(watch_paths);
-          }
-
+          let _ = sender.send(cli_options.watch_paths());
           bundle_action(factory, &bundle_flags).await?;
 
           Ok(())

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -61,13 +61,12 @@ pub async fn format(flags: Flags, fmt_flags: FmtFlags) -> Result<(), AnyError> {
     );
   }
 
-  if flags.watch.is_some() {
-    let clear_screen = !flags.no_clear_screen;
+  if let Some(watch_flags) = &fmt_flags.watch {
     file_watcher::watch_func(
       flags,
       file_watcher::PrintConfig {
         job_name: "Fmt".to_string(),
-        clear_screen,
+        clear_screen: !watch_flags.no_clear_screen,
       },
       move |flags, sender, changed_paths| {
         let fmt_flags = fmt_flags.clone();

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -51,18 +51,17 @@ fn create_reporter(kind: LintReporterKind) -> Box<dyn LintReporter + Send> {
 }
 
 pub async fn lint(flags: Flags, lint_flags: LintFlags) -> Result<(), AnyError> {
-  if flags.watch.is_some() {
+  if let Some(watch_flags) = &lint_flags.watch {
     if lint_flags.is_stdin() {
       return Err(generic_error(
         "Lint watch on standard input is not supported.",
       ));
     }
-    let clear_screen = !flags.no_clear_screen;
     file_watcher::watch_func(
       flags,
       file_watcher::PrintConfig {
         job_name: "Lint".to_string(),
-        clear_screen,
+        clear_screen: !watch_flags.no_clear_screen,
       },
       move |flags, sender, changed_paths| {
         let lint_flags = lint_flags.clone();

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1726,12 +1726,15 @@ pub async fn run_tests_with_watch(
     }
   });
 
-  let clear_screen = !flags.no_clear_screen;
   file_watcher::watch_func(
     flags,
     file_watcher::PrintConfig {
       job_name: "Test".to_string(),
-      clear_screen,
+      clear_screen: !test_flags
+        .watch
+        .as_ref()
+        .map(|w| !w.no_clear_screen)
+        .unwrap_or(true),
     },
     move |flags, sender, changed_paths| {
       let test_flags = test_flags.clone();
@@ -1743,9 +1746,7 @@ pub async fn run_tests_with_watch(
         let cli_options = factory.cli_options();
         let test_options = cli_options.resolve_test_options(test_flags)?;
 
-        if let Some(watch_paths) = cli_options.watch_paths() {
-          let _ = sender.send(watch_paths);
-        }
+        let _ = sender.send(cli_options.watch_paths());
         let _ = sender.send(test_options.files.include.clone());
 
         let graph_kind = cli_options.type_check_mode().as_graph_kind();


### PR DESCRIPTION
Moves the watch setting out of the `Flags` struct and into the individual subcommands