### PR TITLE
fix(cli): avoid crash on import of invalid module names

### DIFF
--- a/cli/npm/registry.rs
+++ b/cli/npm/registry.rs
@@ -363,7 +363,23 @@ impl CliNpmRegistryApiInner {
   }
 
   fn get_package_url(&self, name: &str) -> Url {
-    self.base_url.join(name).unwrap()
+    // list of all characters used in npm packages:
+    //  !, ', (, ), *, -, ., /, [0-9], @, [A-Za-z], _, ~
+    const ASCII_SET: percent_encoding::AsciiSet =
+      percent_encoding::NON_ALPHANUMERIC
+        .remove(b'!')
+        .remove(b'\'')
+        .remove(b'(')
+        .remove(b')')
+        .remove(b'*')
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'/')
+        .remove(b'@')
+        .remove(b'_')
+        .remove(b'~');
+    let name = percent_encoding::utf8_percent_encode(name, &ASCII_SET);
+    self.base_url.join(&name.to_string()).unwrap()
   }
 
   fn get_package_file_cache_path(&self, name: &str) -> PathBuf {

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -183,6 +183,13 @@ itest!(dynamic_import_reload_same_package {
   http_server: true,
 });
 
+itest!(dynamic_import_invalid_package_name {
+  args: "run -A --reload npm/dynamic_import_invalid_package_name/main.ts",
+  output: "npm/dynamic_import_invalid_package_name/main.out",
+  envs: env_vars_for_npm_tests(),
+  http_server: true,
+});
+
 itest!(env_var_re_export_dev {
   args: "run --allow-read --allow-env --quiet npm/env_var_re_export/main.js",
   output_str: Some("dev\n"),

--- a/cli/tests/testdata/npm/dynamic_import_invalid_package_name/main.out
+++ b/cli/tests/testdata/npm/dynamic_import_invalid_package_name/main.out
@@ -1,0 +1,6 @@
+Download http://localhost:4545/npm/registry/ws%3A
+FAILED
+TypeError: npm package 'ws:' does not exist.
+    at async file:///[WILDCARD]/dynamic_import_invalid_package_name/main.ts:2:3 {
+  code: "ERR_MODULE_NOT_FOUND"
+}

--- a/cli/tests/testdata/npm/dynamic_import_invalid_package_name/main.ts
+++ b/cli/tests/testdata/npm/dynamic_import_invalid_package_name/main.ts
@@ -1,0 +1,6 @@
+try {
+  await import(`npm:${"ws:"}`);
+} catch (err) {
+  console.log("FAILED");
+  console.log(err);
+}


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/17748
Closes #17770