### PR TITLE
fix(node/path): Remove toFileUrl

### DIFF
--- a/cli/tests/node_compat/test/parallel/test-path.js
+++ b/cli/tests/node_compat/test/parallel/test-path.js
@@ -30,6 +30,8 @@
 const common = require('../common');
 const assert = require('assert');
 const path = require('path');
+const posix = require('path/posix');
+const win32 = require('path/win32');
 
 // Test thrown TypeErrors
 const typeErrorTests = [true, false, 7, null, {}, undefined, [], NaN];
@@ -74,8 +76,15 @@ assert.strictEqual(path.win32.delimiter, ';');
 // posix
 assert.strictEqual(path.posix.delimiter, ':');
 
-// TODO(wafuwafu13): Enable this
-// if (common.isWindows)
-//   assert.strictEqual(path, path.win32);
-// else
-//   assert.strictEqual(path, path.posix);
+if (common.isWindows)
+  assert.strictEqual(path, path.win32);
+else
+  assert.strictEqual(path, path.posix);
+
+// referential invariants
+assert.strictEqual(path.posix, posix);
+assert.strictEqual(path.win32, win32);
+assert.strictEqual(path.posix, path.posix.posix);
+assert.strictEqual(path.win32, path.posix.win32);
+assert.strictEqual(path.posix, path.win32.posix);
+assert.strictEqual(path.win32, path.win32.win32);

--- a/ext/node/polyfills/path/_posix.ts
+++ b/ext/node/polyfills/path/_posix.ts
@@ -12,7 +12,6 @@ import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";
 import {
   _format,
   assertPath,
-  encodeWhitespace,
   isPosixPathSeparator,
   normalizeString,
 } from "ext:deno_node/path/_util.ts";
@@ -476,25 +475,6 @@ export function parse(path: string): ParsedPath {
 
   return ret;
 }
-
-/**
- * Converts a path string to a file URL.
- *
- * ```ts
- *      toFileUrl("/home/foo"); // new URL("file:///home/foo")
- * ```
- * @param path to convert to file URL
- */
-export function toFileUrl(path: string): URL {
-  if (!isAbsolute(path)) {
-    throw new TypeError("Must be an absolute path.");
-  }
-  const url = new URL("file:///");
-  url.pathname = encodeWhitespace(
-    path.replace(/%/g, "%25").replace(/\\/g, "%5C"),
-  );
-  return url;
-}
 export default {
   basename,
   delimiter,
@@ -508,6 +488,5 @@ export default {
   relative,
   resolve,
   sep,
-  toFileUrl,
   toNamespacedPath,
 };

--- a/ext/node/polyfills/path/_util.ts
+++ b/ext/node/polyfills/path/_util.ts
@@ -114,18 +114,3 @@ export function _format(
   if (dir === pathObject.root) return dir + base;
   return dir + sep + base;
 }
-
-const WHITESPACE_ENCODINGS: Record<string, string> = {
-  "\u0009": "%09",
-  "\u000A": "%0A",
-  "\u000B": "%0B",
-  "\u000C": "%0C",
-  "\u000D": "%0D",
-  "\u0020": "%20",
-};
-
-export function encodeWhitespace(string: string): string {
-  return string.replaceAll(/[\s]/g, (c) => {
-    return WHITESPACE_ENCODINGS[c] ?? c;
-  });
-}

--- a/ext/node/polyfills/path/_win32.ts
+++ b/ext/node/polyfills/path/_win32.ts
@@ -17,7 +17,6 @@ import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";
 import {
   _format,
   assertPath,
-  encodeWhitespace,
   isPathSeparator,
   isWindowsDeviceRoot,
   normalizeString,
@@ -951,34 +950,6 @@ export function parse(path: string): ParsedPath {
   return ret;
 }
 
-/**
- * Converts a path string to a file URL.
- *
- * ```ts
- *      toFileUrl("\\home\\foo"); // new URL("file:///home/foo")
- *      toFileUrl("C:\\Users\\foo"); // new URL("file:///C:/Users/foo")
- *      toFileUrl("\\\\127.0.0.1\\home\\foo"); // new URL("file://127.0.0.1/home/foo")
- * ```
- * @param path to convert to file URL
- */
-export function toFileUrl(path: string): URL {
-  if (!isAbsolute(path)) {
-    throw new TypeError("Must be an absolute path.");
-  }
-  const [, hostname, pathname] = path.match(
-    /^(?:[/\\]{2}([^/\\]+)(?=[/\\](?:[^/\\]|$)))?(.*)/,
-  )!;
-  const url = new URL("file:///");
-  url.pathname = encodeWhitespace(pathname.replace(/%/g, "%25"));
-  if (hostname != null && hostname != "localhost") {
-    url.hostname = hostname;
-    if (!url.hostname) {
-      throw new TypeError("Invalid hostname.");
-    }
-  }
-  return url;
-}
-
 export default {
   basename,
   delimiter,
@@ -992,6 +963,5 @@ export default {
   relative,
   resolve,
   sep,
-  toFileUrl,
   toNamespacedPath,
 };

--- a/ext/node/polyfills/path/mod.ts
+++ b/ext/node/polyfills/path/mod.ts
@@ -35,7 +35,6 @@ export const {
   relative,
   resolve,
   sep,
-  toFileUrl,
   toNamespacedPath,
 } = path;
 export default path;

--- a/ext/node/polyfills/path/posix.ts
+++ b/ext/node/polyfills/path/posix.ts
@@ -17,7 +17,6 @@ export const {
   relative,
   resolve,
   sep,
-  toFileUrl,
   toNamespacedPath,
 } = path.posix;
 

--- a/ext/node/polyfills/path/win32.ts
+++ b/ext/node/polyfills/path/win32.ts
@@ -17,7 +17,6 @@ export const {
   relative,
   resolve,
   sep,
-  toFileUrl,
   toNamespacedPath,
 } = path.win32;
 

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
-import { resolve, toFileUrl } from "ext:deno_node/path.ts";
+import { isAbsolute, resolve } from "ext:deno_node/path.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter, once } from "ext:deno_node/events.ts";
 import { BroadcastChannel } from "ext:deno_broadcast_channel/01_broadcast_channel.js";
@@ -30,6 +30,67 @@ export interface WorkerOptions {
   eval?: boolean;
   transferList?: Transferable[];
   workerData?: unknown;
+}
+
+const WHITESPACE_ENCODINGS: Record<string, string> = {
+  "\u0009": "%09",
+  "\u000A": "%0A",
+  "\u000B": "%0B",
+  "\u000C": "%0C",
+  "\u000D": "%0D",
+  "\u0020": "%20",
+};
+
+function encodeWhitespace(string: string): string {
+  return string.replaceAll(/[\s]/g, (c) => {
+    return WHITESPACE_ENCODINGS[c] ?? c;
+  });
+}
+
+function toFileUrlPosix(path: string): URL {
+  if (!isAbsolute(path)) {
+    throw new TypeError("Must be an absolute path.");
+  }
+  const url = new URL("file:///");
+  url.pathname = encodeWhitespace(
+    path.replace(/%/g, "%25").replace(/\\/g, "%5C"),
+  );
+  return url;
+}
+
+function toFileUrlWin32(path: string): URL {
+  if (!isAbsolute(path)) {
+    throw new TypeError("Must be an absolute path.");
+  }
+  const [, hostname, pathname] = path.match(
+    /^(?:[/\\]{2}([^/\\]+)(?=[/\\](?:[^/\\]|$)))?(.*)/,
+  )!;
+  const url = new URL("file:///");
+  url.pathname = encodeWhitespace(pathname.replace(/%/g, "%25"));
+  if (hostname != null && hostname != "localhost") {
+    url.hostname = hostname;
+    if (!url.hostname) {
+      throw new TypeError("Invalid hostname.");
+    }
+  }
+  return url;
+}
+
+/**
+ * Converts a path string to a file URL.
+ *
+ * ```ts
+ *      toFileUrl("/home/foo"); // new URL("file:///home/foo")
+ *      toFileUrl("\\home\\foo"); // new URL("file:///home/foo")
+ *      toFileUrl("C:\\Users\\foo"); // new URL("file:///C:/Users/foo")
+ *      toFileUrl("\\\\127.0.0.1\\home\\foo"); // new URL("file://127.0.0.1/home/foo")
+ * ```
+ * @param path to convert to file URL
+ */
+function toFileUrl(path: string): URL {
+  return core.build.os == "windows"
+    ? toFileUrlWin32(path)
+    : toFileUrlPosix(path);
 }
 
 const kHandle = Symbol("kHandle");
@@ -68,7 +129,7 @@ class _Worker extends EventEmitter {
         specifier =
           `data:text/javascript,(async function() {const { createRequire } = await import("node:module");const require = createRequire("${cwdFileUrl}");require("${specifier}");})();`;
       } else {
-        specifier = toFileUrl(specifier);
+        specifier = toFileUrl(specifier as string);
       }
     }
     const handle = this[kHandle] = new Worker(


### PR DESCRIPTION
- Remove the toFileUrl function from node/path since it doesn't exist there
- Add more assertions against referential invariants of the path export of node
- Fixes #18177

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
