### PR TITLE
fix(deno/ext): Fix WebCrypto API's deriveKey

### DIFF
--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -1211,7 +1211,7 @@ class SubtleCrypto {
     const length = getKeyLength(normalizedDerivedKeyAlgorithmLength);
 
     // 14.
-    const secret = await this.deriveBits(
+    const secret = await deriveBits(
       normalizedAlgorithm,
       baseKey,
       length,


### PR DESCRIPTION
Fixes a bug I noticed when deriving a key based from `ECDH`. Similar issue is also mentioned in #14693, where they derive a key using `PBKDF2`

 - In the WebCrypto API, `deriveKey()` is equivalent to `deriveBits()` followed by `importKey()`
 - But, `deriveKey()` requires just `deriveKey` in the `usages` of the `baseKey` parameter. The `deriveBits` usage is not required to be allowed. This is the uniform behaviour in Node, Chrome and Firefox.
 - The impl currently has userland-accessible `SubtleCrypto.deriveKey()` and `SubtleCrypto.deriveBits()`, as well as an internal `deriveBits()` (this is the one that accesses the ffi).
 - Also, `SubtleCrypto.deriveKey()` checks if `deriveKey` is an allowed usage and `SubtleCrypto.deriveBits()` checks if `deriveBits` is an allowed usage, as required.
 - However, the impl currently calls the userland accessible `SubtleCrypto.deriveBits()` in `SubtleCrypto.deriveKey()`, leading to an error being thrown if the `deriveBits` usage isn't present.
 - I have fixed this by making it call the internal `deriveBits()` instead.