### PR TITLE
feat(cli): shorthands for --allow-* flags

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2054,6 +2054,7 @@ fn permission_args(app: Command) -> Command {
   app
     .arg(
       Arg::new("allow-read")
+        .short('R')
         .long("allow-read")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2065,6 +2066,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("allow-write")
+        .short('W')
         .long("allow-write")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2076,6 +2078,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("allow-net")
+        .short('N')
         .long("allow-net")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2087,6 +2090,7 @@ fn permission_args(app: Command) -> Command {
     .arg(unsafely_ignore_certificate_errors_arg())
     .arg(
       Arg::new("allow-env")
+        .short('E')
         .long("allow-env")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2107,6 +2111,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("allow-sys")
+        .short('S')
         .long("allow-sys")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2117,6 +2122,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("allow-run")
+        .short('X')
         .long("allow-run")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2126,6 +2132,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("allow-ffi")
+        .short('F')
         .long("allow-ffi")
         .num_args(0..)
         .use_value_delimiter(true)
@@ -2137,6 +2144,7 @@ fn permission_args(app: Command) -> Command {
     )
     .arg(
       Arg::new("allow-hrtime")
+        .short('T')
         .long("allow-hrtime")
         .action(ArgAction::SetTrue)
         .help(ALLOW_HRTIME_HELP),


### PR DESCRIPTION
As per #19530, adds the following short flags:
| short | long |
|--------|--------|
| -E | --allow-env |
| -F | --allow-ffi |
| -T | --allow-hrtime |
| -N | --allow-net | 
| -R | --allow-read | 
| -X | --allow-run | 
| -S | --allow-sys | 
| -W | --allow-write | 

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
