### PR TITLE
refactor(ext/node): Disable prefer-primordials on a per-file basis

### DIFF
--- a/ext/node/polyfills/_brotli.js
+++ b/ext/node/polyfills/_brotli.js
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { zlib as constants } from "ext:deno_node/internal_binding/constants.ts";
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { Transform } from "ext:deno_node/stream.ts";

--- a/ext/node/polyfills/_events.mjs
+++ b/ext/node/polyfills/_events.mjs
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 "use strict";
 
 const kRejection = Symbol.for("nodejs.rejection");

--- a/ext/node/polyfills/_fs/_fs_access.ts
+++ b/ext/node/polyfills/_fs/_fs_access.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   type CallbackWithError,
   makeCallback,

--- a/ext/node/polyfills/_fs/_fs_appendFile.ts
+++ b/ext/node/polyfills/_fs/_fs_appendFile.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   CallbackWithError,
   isFd,

--- a/ext/node/polyfills/_fs/_fs_chmod.ts
+++ b/ext/node/polyfills/_fs/_fs_chmod.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { getValidatedPath } from "ext:deno_node/internal/fs/utils.mjs";
 import * as pathModule from "ext:deno_node/path.ts";

--- a/ext/node/polyfills/_fs/_fs_chown.ts
+++ b/ext/node/polyfills/_fs/_fs_chown.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   type CallbackWithError,
   makeCallback,

--- a/ext/node/polyfills/_fs/_fs_close.ts
+++ b/ext/node/polyfills/_fs/_fs_close.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { getValidatedFd } from "ext:deno_node/internal/fs/utils.mjs";
 

--- a/ext/node/polyfills/_fs/_fs_common.ts
+++ b/ext/node/polyfills/_fs/_fs_common.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   O_APPEND,
   O_CREAT,

--- a/ext/node/polyfills/_fs/_fs_copy.ts
+++ b/ext/node/polyfills/_fs/_fs_copy.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { makeCallback } from "ext:deno_node/_fs/_fs_common.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";

--- a/ext/node/polyfills/_fs/_fs_dir.ts
+++ b/ext/node/polyfills/_fs/_fs_dir.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import Dirent from "ext:deno_node/_fs/_fs_dirent.ts";
 import { assert } from "ext:deno_node/_util/asserts.ts";
 import { ERR_MISSING_ARGS } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/_fs/_fs_exists.ts
+++ b/ext/node/polyfills/_fs/_fs_exists.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 
 type ExistsCallback = (exists: boolean) => void;

--- a/ext/node/polyfills/_fs/_fs_fdatasync.ts
+++ b/ext/node/polyfills/_fs/_fs_fdatasync.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 
 export function fdatasync(

--- a/ext/node/polyfills/_fs/_fs_fstat.ts
+++ b/ext/node/polyfills/_fs/_fs_fstat.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   BigIntStats,
   CFISBIS,

--- a/ext/node/polyfills/_fs/_fs_fsync.ts
+++ b/ext/node/polyfills/_fs/_fs_fsync.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 
 export function fsync(

--- a/ext/node/polyfills/_fs/_fs_ftruncate.ts
+++ b/ext/node/polyfills/_fs/_fs_ftruncate.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 
 export function ftruncate(

--- a/ext/node/polyfills/_fs/_fs_futimes.ts
+++ b/ext/node/polyfills/_fs/_fs_futimes.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 
 function getValidTime(

--- a/ext/node/polyfills/_fs/_fs_link.ts
+++ b/ext/node/polyfills/_fs/_fs_link.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";

--- a/ext/node/polyfills/_fs/_fs_lstat.ts
+++ b/ext/node/polyfills/_fs/_fs_lstat.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   BigIntStats,
   CFISBIS,

--- a/ext/node/polyfills/_fs/_fs_mkdir.ts
+++ b/ext/node/polyfills/_fs/_fs_mkdir.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { promisify } from "ext:deno_node/internal/util.mjs";
 import { denoErrorToNodeError } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/_fs/_fs_mkdtemp.ts
+++ b/ext/node/polyfills/_fs/_fs_mkdtemp.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Node.js contributors. All rights reserved. MIT License.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextDecoder, TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { existsSync } from "ext:deno_node/_fs/_fs_exists.ts";
 import { mkdir, mkdirSync } from "ext:deno_node/_fs/_fs_mkdir.ts";

--- a/ext/node/polyfills/_fs/_fs_open.ts
+++ b/ext/node/polyfills/_fs/_fs_open.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   O_APPEND,
   O_CREAT,

--- a/ext/node/polyfills/_fs/_fs_opendir.ts
+++ b/ext/node/polyfills/_fs/_fs_opendir.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import Dir from "ext:deno_node/_fs/_fs_dir.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import {

--- a/ext/node/polyfills/_fs/_fs_read.ts
+++ b/ext/node/polyfills/_fs/_fs_read.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";
 import * as io from "ext:deno_io/12_io.js";

--- a/ext/node/polyfills/_fs/_fs_readFile.ts
+++ b/ext/node/polyfills/_fs/_fs_readFile.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   BinaryOptionsArgument,
   FileOptionsArgument,

--- a/ext/node/polyfills/_fs/_fs_readdir.ts
+++ b/ext/node/polyfills/_fs/_fs_readdir.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextDecoder, TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { asyncIterableToCallback } from "ext:deno_node/_fs/_fs_watch.ts";
 import Dirent from "ext:deno_node/_fs/_fs_dirent.ts";

--- a/ext/node/polyfills/_fs/_fs_readlink.ts
+++ b/ext/node/polyfills/_fs/_fs_readlink.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import {
   intoCallbackAPIWithIntercept,

--- a/ext/node/polyfills/_fs/_fs_realpath.ts
+++ b/ext/node/polyfills/_fs/_fs_realpath.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { promisify } from "ext:deno_node/internal/util.mjs";
 
 type Options = { encoding: string };

--- a/ext/node/polyfills/_fs/_fs_rename.ts
+++ b/ext/node/polyfills/_fs/_fs_rename.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";
 

--- a/ext/node/polyfills/_fs/_fs_rm.ts
+++ b/ext/node/polyfills/_fs/_fs_rm.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   validateRmOptions,
   validateRmOptionsSync,

--- a/ext/node/polyfills/_fs/_fs_rmdir.ts
+++ b/ext/node/polyfills/_fs/_fs_rmdir.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   emitRecursiveRmdirWarning,
   getValidatedPath,

--- a/ext/node/polyfills/_fs/_fs_stat.ts
+++ b/ext/node/polyfills/_fs/_fs_stat.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { denoErrorToNodeError } from "ext:deno_node/internal/errors.ts";
 import { promisify } from "ext:deno_node/internal/util.mjs";
 

--- a/ext/node/polyfills/_fs/_fs_symlink.ts
+++ b/ext/node/polyfills/_fs/_fs_symlink.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";

--- a/ext/node/polyfills/_fs/_fs_truncate.ts
+++ b/ext/node/polyfills/_fs/_fs_truncate.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";

--- a/ext/node/polyfills/_fs/_fs_unlink.ts
+++ b/ext/node/polyfills/_fs/_fs_unlink.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { promisify } from "ext:deno_node/internal/util.mjs";
 
 export function unlink(path: string | URL, callback: (err?: Error) => void) {

--- a/ext/node/polyfills/_fs/_fs_utimes.ts
+++ b/ext/node/polyfills/_fs/_fs_utimes.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";

--- a/ext/node/polyfills/_fs/_fs_watch.ts
+++ b/ext/node/polyfills/_fs/_fs_watch.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { basename } from "ext:deno_node/path.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";

--- a/ext/node/polyfills/_fs/_fs_write.mjs
+++ b/ext/node/polyfills/_fs/_fs_write.mjs
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { validateEncoding, validateInteger } from "ext:deno_node/internal/validators.mjs";
 import * as io from "ext:deno_io/12_io.js";

--- a/ext/node/polyfills/_fs/_fs_writeFile.ts
+++ b/ext/node/polyfills/_fs/_fs_writeFile.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Encodings } from "ext:deno_node/_utils.ts";
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { Buffer } from "ext:deno_node/buffer.ts";

--- a/ext/node/polyfills/_fs/_fs_writev.mjs
+++ b/ext/node/polyfills/_fs/_fs_writev.mjs
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { validateBufferArray } from "ext:deno_node/internal/fs/utils.mjs";
 import { getValidatedFd } from "ext:deno_node/internal/fs/utils.mjs";

--- a/ext/node/polyfills/_http_agent.mjs
+++ b/ext/node/polyfills/_http_agent.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import * as net from "ext:deno_node/net.ts";
 import EventEmitter from "ext:deno_node/events.ts";
 import { debuglog } from "ext:deno_node/internal/util/debuglog.ts";

--- a/ext/node/polyfills/_http_common.ts
+++ b/ext/node/polyfills/_http_common.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
 /**
  * Verifies that the given val is a valid HTTP token

--- a/ext/node/polyfills/_http_outgoing.ts
+++ b/ext/node/polyfills/_http_outgoing.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const core = globalThis.__bootstrap.core;
 import { getDefaultHighWaterMark } from "ext:deno_node/internal/streams/state.mjs";
 import assert from "ext:deno_node/internal/assert.mjs";

--- a/ext/node/polyfills/_next_tick.ts
+++ b/ext/node/polyfills/_next_tick.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and other Node contributors.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import { _exiting } from "ext:deno_node/_process/exiting.ts";
 import { FixedQueue } from "ext:deno_node/internal/fixed_queue.ts";

--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // The following are all the process APIs that don't depend on the stream module
 // They have to be split this way to prevent a circular dependency
 

--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import {
   clearLine,

--- a/ext/node/polyfills/_readline.mjs
+++ b/ext/node/polyfills/_readline.mjs
@@ -20,6 +20,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
 // deno-lint-ignore-file camelcase
 
 import {

--- a/ext/node/polyfills/_tls_wrap.ts
+++ b/ext/node/polyfills/_tls_wrap.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
-// deno-lint-ignore-file no-explicit-any
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file no-explicit-any prefer-primordials
 
 import {
   ObjectAssign,

--- a/ext/node/polyfills/_util/_util_callbackify.ts
+++ b/ext/node/polyfills/_util/_util_callbackify.ts
@@ -21,6 +21,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // These are simplified versions of the "real" errors in Node.
 
 import { nextTick } from "ext:deno_node/_next_tick.ts";

--- a/ext/node/polyfills/_util/asserts.ts
+++ b/ext/node/polyfills/_util/asserts.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 /** Assertion error class for node compat layer's internal code. */
 export class NodeCompatAssertionError extends Error {
   constructor(message: string) {

--- a/ext/node/polyfills/_util/async.ts
+++ b/ext/node/polyfills/_util/async.ts
@@ -2,6 +2,9 @@
 // This module is vendored from std/async/deferred.ts and std/async/delay.ts
 // (with some modifications)
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export interface Deferred<T> extends Promise<T> {
   readonly state: "pending" | "fulfilled" | "rejected";
   resolve(value?: T | PromiseLike<T>): void;

--- a/ext/node/polyfills/_util/std_asserts.ts
+++ b/ext/node/polyfills/_util/std_asserts.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // vendored from std/testing/asserts.ts
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { red } from "ext:deno_node/_util/std_fmt_colors.ts";
 import {
   buildMessage,

--- a/ext/node/polyfills/_util/std_fmt_colors.ts
+++ b/ext/node/polyfills/_util/std_fmt_colors.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This file is vendored from std/fmt/colors.ts
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // TODO(kt3k): Initialize this at the start of runtime
 // based on Deno.noColor
 const noColor = false;

--- a/ext/node/polyfills/_util/std_testing_diff.ts
+++ b/ext/node/polyfills/_util/std_testing_diff.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This file was vendored from std/testing/_diff.ts
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   bgGreen,
   bgRed,

--- a/ext/node/polyfills/_utils.ts
+++ b/ext/node/polyfills/_utils.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextDecoder, TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { errorMap } from "ext:deno_node/internal_binding/uv.ts";
 import { codes } from "ext:deno_node/internal/error_codes.ts";

--- a/ext/node/polyfills/assert.ts
+++ b/ext/node/polyfills/assert.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// deno-lint-ignore-file ban-types
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file ban-types prefer-primordials
+
 import {
   AssertionError,
   AssertionErrorConstructorOptions,

--- a/ext/node/polyfills/assertion_error.ts
+++ b/ext/node/polyfills/assertion_error.ts
@@ -21,6 +21,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { inspect } from "ext:deno_node/util.ts";
 import { stripColor as removeColors } from "ext:deno_node/_util/std_fmt_colors.ts";
 import * as io from "ext:deno_io/12_io.js";

--- a/ext/node/polyfills/async_hooks.ts
+++ b/ext/node/polyfills/async_hooks.ts
@@ -4,6 +4,9 @@
 // This implementation is inspired by "workerd" AsyncLocalStorage implementation:
 // https://github.com/cloudflare/workerd/blob/77fd0ed6ddba184414f0216508fc62b06e716cab/src/workerd/api/node/async-hooks.c++#L9
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 
 const { core } = globalThis.__bootstrap;

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -2,6 +2,10 @@
 
 // This module implements 'child_process' module of Node.JS API.
 // ref: https://nodejs.org/api/child_process.html
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   ChildProcess,
   ChildProcessOptions,

--- a/ext/node/polyfills/console.ts
+++ b/ext/node/polyfills/console.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Console } from "ext:deno_node/internal/console/constructor.mjs";
 import { windowOrWorkerGlobalScope } from "ext:runtime/98_global_scope.js";
 // Don't rely on global `console` because during bootstrapping, it is pointing

--- a/ext/node/polyfills/crypto.ts
+++ b/ext/node/polyfills/crypto.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ERR_CRYPTO_FIPS_FORCED } from "ext:deno_node/internal/errors.ts";
 import { crypto as constants } from "ext:deno_node/internal_binding/constants.ts";
 import { getOptionValue } from "ext:deno_node/internal/options.ts";

--- a/ext/node/polyfills/dgram.ts
+++ b/ext/node/polyfills/dgram.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
 import { lookup as defaultLookup } from "ext:deno_node/dns.ts";

--- a/ext/node/polyfills/diagnostics_channel.ts
+++ b/ext/node/polyfills/diagnostics_channel.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";
 import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import { nextTick } from "ext:deno_node/process.ts";

--- a/ext/node/polyfills/dns.ts
+++ b/ext/node/polyfills/dns.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { nextTick } from "ext:deno_node/_next_tick.ts";
 import { customPromisifyArgs } from "ext:deno_node/internal/util.mjs";
 import {

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // import { ReadableStreamPrototype } from "ext:deno_web/06_streams.js";
 
 const core = globalThis.__bootstrap.core;

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented, warnNotImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";

--- a/ext/node/polyfills/https.ts
+++ b/ext/node/polyfills/https.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { urlToHttpOptions } from "ext:deno_node/internal/url.ts";
 import {

--- a/ext/node/polyfills/inspector.ts
+++ b/ext/node/polyfills/inspector.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { EventEmitter } from "ext:deno_node/events.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 

--- a/ext/node/polyfills/internal/async_hooks.ts
+++ b/ext/node/polyfills/internal/async_hooks.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // deno-lint-ignore camelcase
 import * as async_wrap from "ext:deno_node/internal_binding/async_wrap.ts";
 import { ERR_ASYNC_CALLBACK } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -2,6 +2,9 @@
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 // Copyright Feross Aboukhadijeh, and other contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextDecoder, TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { codes } from "ext:deno_node/internal/error_codes.ts";
 import { encodings } from "ext:deno_node/internal_binding/string_decoder.ts";

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -2,6 +2,10 @@
 
 // This module implements 'child_process' module of Node.JS API.
 // ref: https://nodejs.org/api/child_process.html
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { assert } from "ext:deno_node/_util/asserts.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
 import { os } from "ext:deno_node/internal_binding/constants.ts";

--- a/ext/node/polyfills/internal/cli_table.ts
+++ b/ext/node/polyfills/internal/cli_table.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { getStringWidth } from "ext:deno_node/internal/util/inspect.mjs";
 
 const tableChars = {

--- a/ext/node/polyfills/internal/console/constructor.mjs
+++ b/ext/node/polyfills/internal/console/constructor.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // Mock trace for now
 const trace = () => {};
 import {

--- a/ext/node/polyfills/internal/crypto/_keys.ts
+++ b/ext/node/polyfills/internal/crypto/_keys.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { kKeyObject } from "ext:deno_node/internal/crypto/constants.ts";
 
 export const kKeyType = Symbol("kKeyType");

--- a/ext/node/polyfills/internal/crypto/_randomBytes.ts
+++ b/ext/node/polyfills/internal/crypto/_randomBytes.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 
 export const MAX_RANDOM_VALUES = 65536;

--- a/ext/node/polyfills/internal/crypto/_randomFill.ts
+++ b/ext/node/polyfills/internal/crypto/_randomFill.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   MAX_SIZE as kMaxUint32,
 } from "ext:deno_node/internal/crypto/_randomBytes.ts";

--- a/ext/node/polyfills/internal/crypto/_randomInt.ts
+++ b/ext/node/polyfills/internal/crypto/_randomInt.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const ops = globalThis.Deno.core.ops;
 
 export default function randomInt(max: number): number;

--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";
 import {
   validateInt32,

--- a/ext/node/polyfills/internal/crypto/constants.ts
+++ b/ext/node/polyfills/internal/crypto/constants.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export const kHandle = Symbol("kHandle");
 export const kKeyObject = Symbol("kKeyObject");

--- a/ext/node/polyfills/internal/crypto/diffiehellman.ts
+++ b/ext/node/polyfills/internal/crypto/diffiehellman.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import {
   isAnyArrayBuffer,

--- a/ext/node/polyfills/internal/crypto/hash.ts
+++ b/ext/node/polyfills/internal/crypto/hash.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { Transform } from "ext:deno_node/stream.ts";

--- a/ext/node/polyfills/internal/crypto/hkdf.ts
+++ b/ext/node/polyfills/internal/crypto/hkdf.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   validateFunction,
   validateInteger,

--- a/ext/node/polyfills/internal/crypto/keygen.ts
+++ b/ext/node/polyfills/internal/crypto/keygen.ts
@@ -1,7 +1,8 @@
-// deno-lint-ignore-file no-explicit-any
-
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file no-explicit-any prefer-primordials
 
 import { KeyObject } from "ext:deno_node/internal/crypto/keys.ts";
 import { kAesKeyLengths } from "ext:deno_node/internal/crypto/util.ts";

--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   kHandle,
   kKeyObject,

--- a/ext/node/polyfills/internal/crypto/pbkdf2.ts
+++ b/ext/node/polyfills/internal/crypto/pbkdf2.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { HASH_DATA } from "ext:deno_node/internal/crypto/types.ts";
 

--- a/ext/node/polyfills/internal/crypto/random.ts
+++ b/ext/node/polyfills/internal/crypto/random.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
-// deno-lint-ignore-file camelcase
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file camelcase prefer-primordials
 
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import randomBytes from "ext:deno_node/internal/crypto/_randomBytes.ts";

--- a/ext/node/polyfills/internal/crypto/scrypt.ts
+++ b/ext/node/polyfills/internal/crypto/scrypt.ts
@@ -21,7 +21,10 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
- */
+*/
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
 
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { HASH_DATA } from "ext:deno_node/internal/crypto/types.ts";

--- a/ext/node/polyfills/internal/crypto/sig.ts
+++ b/ext/node/polyfills/internal/crypto/sig.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import {
   validateFunction,

--- a/ext/node/polyfills/internal/crypto/util.ts
+++ b/ext/node/polyfills/internal/crypto/util.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import {

--- a/ext/node/polyfills/internal/crypto/x509.ts
+++ b/ext/node/polyfills/internal/crypto/x509.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { KeyObject } from "ext:deno_node/internal/crypto/keys.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/internal/dgram.ts
+++ b/ext/node/polyfills/internal/dgram.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { lookup as defaultLookup } from "ext:deno_node/dns.ts";
 import {
   isInt32,

--- a/ext/node/polyfills/internal/dns/promises.ts
+++ b/ext/node/polyfills/internal/dns/promises.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   validateBoolean,
   validateNumber,

--- a/ext/node/polyfills/internal/dns/utils.ts
+++ b/ext/node/polyfills/internal/dns/utils.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { getOptionValue } from "ext:deno_node/internal/options.ts";
 import { emitWarning } from "ext:deno_node/process.ts";
 import {

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Node.js contributors. All rights reserved. MIT License.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 /** NOT IMPLEMENTED
  * ERR_MANIFEST_ASSERT_INTEGRITY
  * ERR_QUICSESSION_VERSION_NEGOTIATION

--- a/ext/node/polyfills/internal/event_target.mjs
+++ b/ext/node/polyfills/internal/event_target.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Node.js contributors. All rights reserved. MIT License.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   ERR_EVENT_RECURSION,
   ERR_INVALID_ARG_TYPE,

--- a/ext/node/polyfills/internal/fixed_queue.ts
+++ b/ext/node/polyfills/internal/fixed_queue.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and other Node contributors.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // Currently optimal queue size, tested on V8 6.0 - 6.6. Must be power of two.
 const kSize = 2048;
 const kMask = kSize - 1;

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { EventEmitter } from "ext:deno_node/events.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { promises, read, write } from "ext:deno_node/fs.ts";

--- a/ext/node/polyfills/internal/fs/streams.mjs
+++ b/ext/node/polyfills/internal/fs/streams.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ERR_INVALID_ARG_TYPE, ERR_OUT_OF_RANGE } from "ext:deno_node/internal/errors.ts";
 import { kEmptyObject } from "ext:deno_node/internal/util.mjs";
 import { deprecate } from "ext:deno_node/util.ts";

--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 "use strict";
 
 import { Buffer } from "ext:deno_node/buffer.ts";

--- a/ext/node/polyfills/internal/hide_stack_frames.ts
+++ b/ext/node/polyfills/internal/hide_stack_frames.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // deno-lint-ignore no-explicit-any
 type GenericFunction = (...args: any[]) => any;
 

--- a/ext/node/polyfills/internal/http.ts
+++ b/ext/node/polyfills/internal/http.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { setUnrefTimeout } from "ext:deno_node/timers.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 

--- a/ext/node/polyfills/internal/idna.ts
+++ b/ext/node/polyfills/internal/idna.ts
@@ -43,6 +43,9 @@
 
 // Adapted from https://github.com/mathiasbynens/punycode.js
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // TODO(cmorten): migrate punycode logic to "icu" internal binding and/or "url"
 // internal module so there can be re-use within the "url" module etc.
 

--- a/ext/node/polyfills/internal/net.ts
+++ b/ext/node/polyfills/internal/net.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { uvException } from "ext:deno_node/internal/errors.ts";
 import { writeBuffer } from "ext:deno_node/internal_binding/node_file.ts";

--- a/ext/node/polyfills/internal/normalize_encoding.mjs
+++ b/ext/node/polyfills/internal/normalize_encoding.mjs
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export function normalizeEncoding(enc) {
   if (enc == null || enc === "utf8" || enc === "utf-8") return "utf8";
   return slowCases(enc);

--- a/ext/node/polyfills/internal/options.ts
+++ b/ext/node/polyfills/internal/options.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { getOptions } from "ext:deno_node/internal_binding/node_options.ts";
 
 let optionsMap: Map<string, { value: string }>;

--- a/ext/node/polyfills/internal/primordials.mjs
+++ b/ext/node/polyfills/internal/primordials.mjs
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file prefer-primordials
+
 export const ArrayIsArray = Array.isArray;
 export const ArrayPrototypeFilter = (that, ...args) => that.filter(...args);
 export const ArrayPrototypeForEach = (that, ...args) => that.forEach(...args);

--- a/ext/node/polyfills/internal/process/per_thread.mjs
+++ b/ext/node/polyfills/internal/process/per_thread.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const kInternal = Symbol("internal properties");
 
 const replaceUnderscoresRegex = /_/g;

--- a/ext/node/polyfills/internal/querystring.ts
+++ b/ext/node/polyfills/internal/querystring.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ERR_INVALID_URI } from "ext:deno_node/internal/errors.ts";
 
 export const hexTable = new Array(256);

--- a/ext/node/polyfills/internal/readline/callbacks.mjs
+++ b/ext/node/polyfills/internal/readline/callbacks.mjs
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 "use strict";
 
 import { ERR_INVALID_ARG_VALUE, ERR_INVALID_CURSOR_POS } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/internal/readline/emitKeypressEvents.mjs
+++ b/ext/node/polyfills/internal/readline/emitKeypressEvents.mjs
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { charLengthAt, CSI, emitKeys } from "ext:deno_node/internal/readline/utils.mjs";
 import { kSawKeyPress } from "ext:deno_node/internal/readline/symbols.mjs";
 import { clearTimeout, setTimeout } from "ext:deno_node/timers.ts";

--- a/ext/node/polyfills/internal/readline/interface.mjs
+++ b/ext/node/polyfills/internal/readline/interface.mjs
@@ -20,6 +20,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
 // deno-lint-ignore-file camelcase no-inner-declarations no-this-alias
 
 import { ERR_INVALID_ARG_VALUE, ERR_USE_AFTER_CLOSE } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/internal/readline/promises.mjs
+++ b/ext/node/polyfills/internal/readline/promises.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and other Node contributors.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ArrayPrototypeJoin, ArrayPrototypePush } from "ext:deno_node/internal/primordials.mjs";
 
 import { CSI } from "ext:deno_node/internal/readline/utils.mjs";

--- a/ext/node/polyfills/internal/readline/symbols.mjs
+++ b/ext/node/polyfills/internal/readline/symbols.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export const kAddHistory = Symbol("_addHistory");
 export const kDecoder = Symbol("_decoder");
 export const kDeleteLeft = Symbol("_deleteLeft");

--- a/ext/node/polyfills/internal/readline/utils.mjs
+++ b/ext/node/polyfills/internal/readline/utils.mjs
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 "use strict";
 
 const kUTF16SurrogateThreshold = 0x10000; // 2 ** 16

--- a/ext/node/polyfills/internal/stream_base_commons.ts
+++ b/ext/node/polyfills/internal/stream_base_commons.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { ownerSymbol } from "ext:deno_node/internal/async_hooks.ts";
 import {
   kArrayBufferOffset,

--- a/ext/node/polyfills/internal/timers.mjs
+++ b/ext/node/polyfills/internal/timers.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { inspect } from "ext:deno_node/internal/util/inspect.mjs";
 import { validateFunction, validateNumber } from "ext:deno_node/internal/validators.mjs";
 import { ERR_OUT_OF_RANGE } from "ext:deno_node/internal/errors.ts";

--- a/ext/node/polyfills/internal/url.ts
+++ b/ext/node/polyfills/internal/url.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { fileURLToPath } from "ext:deno_node/url.ts";
 import { Buffer } from "ext:deno_node/buffer.ts";
 

--- a/ext/node/polyfills/internal/util.mjs
+++ b/ext/node/polyfills/internal/util.mjs
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import { normalizeEncoding, slowCases } from "ext:deno_node/internal/normalize_encoding.mjs";
 export { normalizeEncoding, slowCases };

--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { inspect } from "ext:deno_node/internal/util/inspect.mjs";
 
 // `debugImpls` and `testEnabled` are deliberately not initialized so any call

--- a/ext/node/polyfills/internal/util/inspect.mjs
+++ b/ext/node/polyfills/internal/util/inspect.mjs
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { validateObject, validateString } from "ext:deno_node/internal/validators.mjs";
 import { codes } from "ext:deno_node/internal/error_codes.ts";
 import { createStylizeWithColor, formatValue, formatNumber, formatBigInt, styles, colors } from "ext:deno_console/01_console.js";

--- a/ext/node/polyfills/internal/util/types.ts
+++ b/ext/node/polyfills/internal/util/types.ts
@@ -21,6 +21,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import * as bindingTypes from "ext:deno_node/internal_binding/types.ts";
 export {
   isCryptoKey,

--- a/ext/node/polyfills/internal/validators.mjs
+++ b/ext/node/polyfills/internal/validators.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { codes } from "ext:deno_node/internal/error_codes.ts";
 import { hideStackFrames } from "ext:deno_node/internal/hide_stack_frames.ts";
 import { isArrayBufferView } from "ext:deno_node/internal/util/types.ts";

--- a/ext/node/polyfills/internal_binding/_listen.ts
+++ b/ext/node/polyfills/internal_binding/_listen.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 /**
  * @param n Number to act on.
  * @return The number rounded up to the nearest power of 2.

--- a/ext/node/polyfills/internal_binding/_timingSafeEqual.ts
+++ b/ext/node/polyfills/internal_binding/_timingSafeEqual.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 
 function assert(cond) {

--- a/ext/node/polyfills/internal_binding/_utils.ts
+++ b/ext/node/polyfills/internal_binding/_utils.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   forgivingBase64Decode,
   forgivingBase64UrlEncode,

--- a/ext/node/polyfills/internal_binding/async_wrap.ts
+++ b/ext/node/polyfills/internal_binding/async_wrap.ts
@@ -25,6 +25,9 @@
 // - https://github.com/nodejs/node/blob/master/src/async_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/async_wrap.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export function registerDestroyHook(
   // deno-lint-ignore no-explicit-any
   _target: any,

--- a/ext/node/polyfills/internal_binding/buffer.ts
+++ b/ext/node/polyfills/internal_binding/buffer.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Encodings } from "ext:deno_node/internal_binding/_node.ts";
 
 export function indexOfNeedle(

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -24,6 +24,9 @@
 // - https://github.com/nodejs/node/blob/master/src/cares_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/cares_wrap.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { ErrnoException } from "ext:deno_node/internal/errors.ts";
 import { isIPv4 } from "ext:deno_node/internal/net.ts";
 import { codeMap } from "ext:deno_node/internal_binding/uv.ts";

--- a/ext/node/polyfills/internal_binding/connection_wrap.ts
+++ b/ext/node/polyfills/internal_binding/connection_wrap.ts
@@ -24,6 +24,9 @@
 // - https://github.com/nodejs/node/blob/master/src/connection_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/connection_wrap.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { LibuvStreamWrap } from "ext:deno_node/internal_binding/stream_wrap.ts";
 import {
   AsyncWrap,

--- a/ext/node/polyfills/internal_binding/handle_wrap.ts
+++ b/ext/node/polyfills/internal_binding/handle_wrap.ts
@@ -1,3 +1,6 @@
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -23,6 +26,9 @@
 // This module ports:
 // - https://github.com/nodejs/node/blob/master/src/handle_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/handle_wrap.h
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
 
 import { unreachable } from "ext:deno_node/_util/asserts.ts";
 import {

--- a/ext/node/polyfills/internal_binding/mod.ts
+++ b/ext/node/polyfills/internal_binding/mod.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import * as asyncWrap from "ext:deno_node/internal_binding/async_wrap.ts";
 import * as buffer from "ext:deno_node/internal_binding/buffer.ts";
 import * as caresWrap from "ext:deno_node/internal_binding/cares_wrap.ts";

--- a/ext/node/polyfills/internal_binding/node_file.ts
+++ b/ext/node/polyfills/internal_binding/node_file.ts
@@ -25,6 +25,9 @@
 // - https://github.com/nodejs/node/blob/master/src/node_file.cc
 // - https://github.com/nodejs/node/blob/master/src/node_file.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { assert } from "ext:deno_node/_util/asserts.ts";
 import * as io from "ext:deno_io/12_io.js";
 import * as fs from "ext:deno_fs/30_fs.js";

--- a/ext/node/polyfills/internal_binding/node_options.ts
+++ b/ext/node/polyfills/internal_binding/node_options.ts
@@ -25,6 +25,9 @@
 // - https://github.com/nodejs/node/blob/master/src/node_options.cc
 // - https://github.com/nodejs/node/blob/master/src/node_options.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export function getOptions() {
   // TODO(kt3k): Return option arguments as parsed object
   return { options: new Map() };

--- a/ext/node/polyfills/internal_binding/pipe_wrap.ts
+++ b/ext/node/polyfills/internal_binding/pipe_wrap.ts
@@ -24,6 +24,9 @@
 // - https://github.com/nodejs/node/blob/master/src/pipe_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/pipe_wrap.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { unreachable } from "ext:deno_node/_util/asserts.ts";
 import { ConnectionWrap } from "ext:deno_node/internal_binding/connection_wrap.ts";

--- a/ext/node/polyfills/internal_binding/stream_wrap.ts
+++ b/ext/node/polyfills/internal_binding/stream_wrap.ts
@@ -27,6 +27,9 @@
 // - https://github.com/nodejs/node/blob/master/src/stream_wrap.h
 // - https://github.com/nodejs/node/blob/master/src/stream_wrap.cc
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";

--- a/ext/node/polyfills/internal_binding/symbols.ts
+++ b/ext/node/polyfills/internal_binding/symbols.ts
@@ -23,5 +23,8 @@
 // This module ports:
 // - https://github.com/nodejs/node/blob/master/src/node_symbols.cc
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 export const asyncIdSymbol: unique symbol = Symbol("asyncIdSymbol");
 export const ownerSymbol: unique symbol = Symbol("ownerSymbol");

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -24,6 +24,9 @@
 // - https://github.com/nodejs/node/blob/master/src/tcp_wrap.cc
 // - https://github.com/nodejs/node/blob/master/src/tcp_wrap.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { unreachable } from "ext:deno_node/_util/asserts.ts";
 import { ConnectionWrap } from "ext:deno_node/internal_binding/connection_wrap.ts";

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -21,6 +21,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const { core } = globalThis.__bootstrap;
 
 // https://tc39.es/ecma262/#sec-object.prototype.tostring

--- a/ext/node/polyfills/internal_binding/udp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/udp_wrap.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const core = globalThis.Deno.core;
 const ops = core.ops;
 import {

--- a/ext/node/polyfills/internal_binding/util.ts
+++ b/ext/node/polyfills/internal_binding/util.ts
@@ -25,6 +25,9 @@
 // - https://github.com/nodejs/node/blob/master/src/util.cc
 // - https://github.com/nodejs/node/blob/master/src/util.h
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 
 export function guessHandleType(_fd: number): string {

--- a/ext/node/polyfills/internal_binding/uv.ts
+++ b/ext/node/polyfills/internal_binding/uv.ts
@@ -26,6 +26,9 @@
 //
 // See also: http://docs.libuv.org/en/v1.x/errors.html#error-constants
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { unreachable } from "ext:deno_node/_util/asserts.ts";
 import { osType } from "ext:deno_node/_util/os.ts";
 import { uvTranslateSysError } from "ext:deno_node/internal_binding/_libuv_winerror.ts";

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter } from "ext:deno_node/events.ts";
 import {

--- a/ext/node/polyfills/os.ts
+++ b/ext/node/polyfills/os.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { validateIntegerRange } from "ext:deno_node/_utils.ts";
 import process from "ext:deno_node/process.ts";

--- a/ext/node/polyfills/path/_posix.ts
+++ b/ext/node/polyfills/path/_posix.ts
@@ -2,6 +2,9 @@
 // Ported from https://github.com/browserify/path-browserify/
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type {
   FormatInputPathObject,
   ParsedPath,

--- a/ext/node/polyfills/path/_util.ts
+++ b/ext/node/polyfills/path/_util.ts
@@ -2,6 +2,9 @@
 // Ported from https://github.com/browserify/path-browserify/
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type { FormatInputPathObject } from "ext:deno_node/path/_interface.ts";
 import {
   CHAR_BACKWARD_SLASH,

--- a/ext/node/polyfills/path/_win32.ts
+++ b/ext/node/polyfills/path/_win32.ts
@@ -2,6 +2,9 @@
 // Ported from https://github.com/browserify/path-browserify/
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import type {
   FormatInputPathObject,
   ParsedPath,

--- a/ext/node/polyfills/path/common.ts
+++ b/ext/node/polyfills/path/common.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { SEP } from "ext:deno_node/path/separator.ts";
 
 /** Determines the common path from a set of paths, using an optional separator,

--- a/ext/node/polyfills/path/separator.ts
+++ b/ext/node/polyfills/path/separator.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { isWindows } from "ext:deno_node/_util/os.ts";
 
 export const SEP = isWindows ? "\\" : "/";

--- a/ext/node/polyfills/perf_hooks.ts
+++ b/ext/node/polyfills/perf_hooks.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import {
   performance as shimPerformance,

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent, Inc. and Node.js contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 const internals = globalThis.__bootstrap.internals;
 const { core } = globalThis.__bootstrap;
 import { notImplemented, warnNotImplemented } from "ext:deno_node/_utils.ts";

--- a/ext/node/polyfills/querystring.ts
+++ b/ext/node/polyfills/querystring.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import { encodeStr, hexTable } from "ext:deno_node/internal/querystring.ts";
 

--- a/ext/node/polyfills/readline/promises.ts
+++ b/ext/node/polyfills/readline/promises.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Readline } from "ext:deno_node/internal/readline/promises.mjs";
 
 import {

--- a/ext/node/polyfills/stream/consumers.mjs
+++ b/ext/node/polyfills/stream/consumers.mjs
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { TextDecoder } from "ext:deno_web/08_text_encoding.js";
 import { Buffer } from "ext:deno_node/buffer.ts";
 

--- a/ext/node/polyfills/string_decoder.ts
+++ b/ext/node/polyfills/string_decoder.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { Buffer } from "ext:deno_node/buffer.ts";
 import {
   normalizeEncoding as castEncoding,

--- a/ext/node/polyfills/timers.ts
+++ b/ext/node/polyfills/timers.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { setUnrefTimeout, Timeout } from "ext:deno_node/internal/timers.mjs";
 import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import { promisify } from "ext:deno_node/internal/util.mjs";

--- a/ext/node/polyfills/tls.ts
+++ b/ext/node/polyfills/tls.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import tlsCommon from "ext:deno_node/_tls_common.ts";
 import tlsWrap from "ext:deno_node/_tls_wrap.ts";

--- a/ext/node/polyfills/url.ts
+++ b/ext/node/polyfills/url.ts
@@ -20,6 +20,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,

--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -1,4 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { promisify } from "ext:deno_node/internal/util.mjs";
 import { callbackify } from "ext:deno_node/_util/_util_callbackify.ts";
 import { debuglog } from "ext:deno_node/internal/util/debuglog.ts";

--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { notImplemented } from "ext:deno_node/_utils.ts";
 
 const { ops } = globalThis.__bootstrap.core;

--- a/ext/node/polyfills/vm.ts
+++ b/ext/node/polyfills/vm.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-// deno-lint-ignore-file no-explicit-any
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file no-explicit-any prefer-primordials
 
 import { notImplemented } from "ext:deno_node/_utils.ts";
 

--- a/ext/node/polyfills/wasi.ts
+++ b/ext/node/polyfills/wasi.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 class Context {
   constructor() {
     throw new Error("Context is currently not supported");

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials
+
 import { resolve, toFileUrl } from "ext:deno_node/path.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter, once } from "ext:deno_node/events.ts";

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -96,11 +96,9 @@ async function dlintPreferPrimordials() {
   const sourceFiles = await getSources(ROOT_PATH, [
     "runtime/**/*.js",
     "ext/**/*.js",
-    // TODO(petamoriken): enable for node polyfills
-    // "ext/node/polyfills/*.mjs",
-    // "ext/node/polyfills/*.ts",
-    // ":!:ext/node/polyfills/*.d.ts",
-    ":!:ext/node/polyfills/_brotli.js",
+    "ext/node/polyfills/*.mjs",
+    "ext/node/polyfills/*.ts",
+    ":!:ext/node/polyfills/*.d.ts",
     "core/*.js",
     ":!:core/*_test.js",
     ":!:core/examples/**",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

For the moment, I disabled prefer-primordials on a per-file basis so that newly created files would comply with prefer-primordials.