### PR TITLE
fix(serde_v8): Do not coerce values in serde_v8

### DIFF
--- a/cli/tests/testdata/run/ffi/unstable_ffi_18.js
+++ b/cli/tests/testdata/run/ffi/unstable_ffi_18.js
@@ -1,1 +1,1 @@
-Deno[Deno.internal].core.ops.op_ffi_ptr_create(null);
+Deno[Deno.internal].core.ops.op_ffi_ptr_create(1);

--- a/core/runtime/tests.rs
+++ b/core/runtime/tests.rs
@@ -217,7 +217,7 @@ fn test_dispatch_no_zero_copy_buf() {
       "filename.js",
       r#"
 
-      Deno.core.opAsync("op_test");
+      Deno.core.opAsync("op_test", 0);
       "#,
     )
     .unwrap();
@@ -233,7 +233,7 @@ fn test_dispatch_stack_zero_copy_bufs() {
       r#"
       const { op_test } = Deno.core.ensureFastOps();
       let zero_copy_a = new Uint8Array([0]);
-      op_test(null, zero_copy_a);
+      op_test(0, zero_copy_a);
       "#,
     )
     .unwrap();

--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -4417,7 +4417,7 @@ async function deriveBits(normalizedAlgorithm, baseKey, length) {
           publicKey: publicKeyData,
           algorithm: "ECDH",
           namedCurve: publicKey[_algorithm].namedCurve,
-          length,
+          length: length ?? 0,
         });
 
         // 8.

--- a/ext/node/polyfills/internal/crypto/diffiehellman.ts
+++ b/ext/node/polyfills/internal/crypto/diffiehellman.ts
@@ -189,7 +189,7 @@ export class DiffieHellman {
     const generator = this.#checkGenerator();
     const [privateKey, publicKey] = ops.op_node_dh_generate2(
       this.#prime,
-      this.#primeLength,
+      this.#primeLength ?? 0,
       generator,
     );
 

--- a/serde_v8/de.rs
+++ b/serde_v8/de.rs
@@ -80,10 +80,6 @@ macro_rules! deserialize_signed {
           x.value() as $t
         } else if let Ok(x) = v8::Local::<v8::BigInt>::try_from(self.input) {
           x.i64_value().0 as $t
-        } else if let Some(x) = self.input.number_value(self.scope) {
-          x as $t
-        } else if let Some(x) = self.input.to_big_int(self.scope) {
-          x.i64_value().0 as $t
         } else {
           return Err(Error::ExpectedInteger(value_to_type_str(self.input)));
         },
@@ -102,10 +98,6 @@ macro_rules! deserialize_unsigned {
         if let Ok(x) = v8::Local::<v8::Number>::try_from(self.input) {
           x.value() as $t
         } else if let Ok(x) = v8::Local::<v8::BigInt>::try_from(self.input) {
-          x.u64_value().0 as $t
-        } else if let Some(x) = self.input.number_value(self.scope) {
-          x as $t
-        } else if let Some(x) = self.input.to_big_int(self.scope) {
           x.u64_value().0 as $t
         } else {
           return Err(Error::ExpectedInteger(value_to_type_str(self.input)));
@@ -183,10 +175,6 @@ impl<'de, 'a, 'b, 's, 'x> de::Deserializer<'de>
       if let Ok(x) = v8::Local::<v8::Number>::try_from(self.input) {
         x.value()
       } else if let Ok(x) = v8::Local::<v8::BigInt>::try_from(self.input) {
-        bigint_to_f64(x)
-      } else if let Some(x) = self.input.number_value(self.scope) {
-        x
-      } else if let Some(x) = self.input.to_big_int(self.scope) {
         bigint_to_f64(x)
       } else {
         return Err(Error::ExpectedNumber(value_to_type_str(self.input)));

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -508,34 +508,6 @@ detest!(de_neg_inf_i64, i64, "-Infinity", i64::MIN);
 detest!(de_neg_inf_f32, f32, "-Infinity", f32::NEG_INFINITY);
 detest!(de_neg_inf_f64, f64, "-Infinity", f64::NEG_INFINITY);
 
-// valueOf Number
-detest!(de_valof_u8, u8, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_u16, u16, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_u32, u32, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_u64, u64, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_i8, i8, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_i16, i16, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_i32, i32, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_i64, i64, "({ valueOf: () => 123 })", 123);
-detest!(de_valof_f32, f32, "({ valueOf: () => 123 })", 123.0);
-detest!(de_valof_f64, f64, "({ valueOf: () => 123 })", 123.0);
-
-// valueOf BigInt
-detest!(de_valof_bigint_u8, u8, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_u16, u16, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_u32, u32, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_u64, u64, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_i8, i8, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_i16, i16, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_i32, i32, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_i64, i64, "({ valueOf: () => 123n })", 123);
-detest!(de_valof_bigint_f32, f32, "({ valueOf: () => 123n })", 123.0);
-detest!(de_valof_bigint_f64, f64, "({ valueOf: () => 123n })", 123.0);
-
-// bool
-detest!(de_num_true, u8, "true", 1);
-detest!(de_num_false, u8, "false", 0);
-
 // BigInt to f32/f64 max/min
 detest!(
   de_bigint_f64_max,


### PR DESCRIPTION
Fixes #19568 

Values are not coerced to the desired type during deserialisation. This makes serde_v8 stricter.