### PR TITLE
chore(ext/web): align with whatwg/dom typo fix

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -516,7 +516,7 @@ function isShadowRoot(nodeImpl) {
   );
 }
 
-function isSlotable(
+function isSlottable(
   nodeImpl,
 ) {
   return Boolean(isNode(nodeImpl) && ReflectHas(nodeImpl, "assignedSlot"));
@@ -586,7 +586,7 @@ function dispatch(
     }
 
     let slotInClosedTree = false;
-    let slotable = isSlotable(targetImpl) && getAssignedSlot(targetImpl)
+    let slottable = isSlottable(targetImpl) && getAssignedSlot(targetImpl)
       ? targetImpl
       : null;
     let parent = getParent(targetImpl);
@@ -594,8 +594,8 @@ function dispatch(
     // Populate event path
     // https://dom.spec.whatwg.org/#event-path
     while (parent !== null) {
-      if (slotable !== null) {
-        slotable = null;
+      if (slottable !== null) {
+        slottable = null;
 
         const parentRoot = getRoot(parent);
         if (


### PR DESCRIPTION
The WHATWG DOM specification has corrected the spelling of "slotable" to "slottable".[1]  This commit aligns our implementation accordingly.

[1]: https://github.com/whatwg/dom/pull/845