### PR TITLE
fix(ext/fs): fix boolean checks in JS parser

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -316,9 +316,9 @@ function parseFileInfo(response) {
     isDirectory: response.isDirectory,
     isSymlink: response.isSymlink,
     size: response.size,
-    mtime: response.mtimeSet !== null ? new Date(response.mtime) : null,
-    atime: response.atimeSet !== null ? new Date(response.atime) : null,
-    birthtime: response.birthtimeSet !== null
+    mtime: response.mtimeSet === true ? new Date(response.mtime) : null,
+    atime: response.atimeSet === true ? new Date(response.atime) : null,
+    birthtime: response.birthtimeSet === true
       ? new Date(response.birthtime)
       : null,
     dev: response.dev,


### PR DESCRIPTION
This fixes a bug in file metadata parsing logic, which now properly evaluates boolean fields when forwarding for atime / mtime / birthtime values.

Ref: https://github.com/denoland/deploy_feedback/issues/409