### PR TITLE
chore: reconfigure windows builder storage

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -114,7 +114,7 @@ const reconfigureWindowsStorage = {
   shell: "pwsh",
   run: `
 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
+New-Item -ItemType SymbolicLink -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
 `.trim(),
 };
 

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -109,13 +109,15 @@ __0`,
 const reconfigureWindowsStorage = {
   name: "Reconfigure Windows Storage",
   if: [
-    "startsWith(matrix.os, 'windows')"
+    "startsWith(matrix.os, 'windows')",
   ],
   shell: "pwsh",
   run: [
-    `New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-    New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"`
-  ]
+    `
+New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
+`.trim(),
+  ],
 };
 
 const cloneRepoStep = [{

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -115,7 +115,10 @@ const reconfigureWindowsStorage = {
   run: [
     `
     New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-    New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/target"
+    New-Item -ItemType "directory" -Path "D:/a"
+    New-Item -ItemType "directory" -Path "D:/a/deno"
+    New-Item -ItemType "directory" -Path "D:/a/deno/deno"
+    New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
     `
   ]
 };

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -114,7 +114,7 @@ const reconfigureWindowsStorage = {
   shell: "pwsh",
   run: `
 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno"
+New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno"
 `.trim(),
 };
 

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -113,13 +113,8 @@ const reconfigureWindowsStorage = {
   ],
   shell: "pwsh",
   run: [
-    `
-    New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-    New-Item -ItemType "directory" -Path "D:/a"
-    New-Item -ItemType "directory" -Path "D:/a/deno"
-    New-Item -ItemType "directory" -Path "D:/a/deno/deno"
-    New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
-    `
+    `New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+    New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"`
   ]
 };
 
@@ -387,8 +382,8 @@ const ci = {
         RUST_BACKTRACE: "full",
       },
       steps: skipJobsIfPrAndMarkedSkip([
-        reconfigureWindowsStorage,
         ...cloneRepoStep,
+        reconfigureWindowsStorage,
         submoduleStep("./test_util/std"),
         submoduleStep("./third_party"),
         {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -114,7 +114,7 @@ const reconfigureWindowsStorage = {
   shell: "pwsh",
   run: `
 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-New-Item -ItemType SymbolicLink -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
+New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
 `.trim(),
 };
 

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -114,7 +114,7 @@ const reconfigureWindowsStorage = {
   shell: "pwsh",
   run: `
 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
+New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno"
 `.trim(),
 };
 
@@ -382,8 +382,8 @@ const ci = {
         RUST_BACKTRACE: "full",
       },
       steps: skipJobsIfPrAndMarkedSkip([
-        ...cloneRepoStep,
         reconfigureWindowsStorage,
+        ...cloneRepoStep,
         submoduleStep("./test_util/std"),
         submoduleStep("./third_party"),
         {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -112,12 +112,10 @@ const reconfigureWindowsStorage = {
     "startsWith(matrix.os, 'windows')",
   ],
   shell: "pwsh",
-  run: [
-    `
+  run: `
 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
 New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
 `.trim(),
-  ],
 };
 
 const cloneRepoStep = [{

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -104,6 +104,22 @@ CFLAGS=-flto=thin --sysroot=/sysroot
 __0`,
 };
 
+// The Windows builder is a little strange -- there's lots of room on C: and not so much on D:
+// We'll check out to D:, but then all of our builds should happen on a C:-mapped drive
+const reconfigureWindowsStorage = {
+  name: "Reconfigure Windows Storage",
+  if: [
+    "startsWith(matrix.os, 'windows')"
+  ],
+  shell: "pwsh",
+  run: [
+    `
+    New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+    New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/target"
+    `
+  ]
+};
+
 const cloneRepoStep = [{
   name: "Configure git",
   run: [
@@ -368,6 +384,7 @@ const ci = {
         RUST_BACKTRACE: "full",
       },
       steps: skipJobsIfPrAndMarkedSkip([
+        reconfigureWindowsStorage,
         ...cloneRepoStep,
         submoduleStep("./test_util/std"),
         submoduleStep("./third_party"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run:
           - |-
             New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-                New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
+            New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         shell: pwsh
         run: |-
           New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-          New-Item -ItemType SymbolicLink -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
+          New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,9 @@ jobs:
       - name: Reconfigure Windows Storage
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (startsWith(matrix.os, ''windows''))'
         shell: pwsh
-        run:
-          - |-
-            New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-            New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
+        run: |-
+          New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+          New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,12 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
     steps:
+      - name: Reconfigure Windows Storage
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (startsWith(matrix.os, ''windows''))'
+        shell: pwsh
+        run: |-
+          New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+          New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno"
       - name: Configure git
         run: |-
           git config --global core.symlinks true
@@ -111,12 +117,6 @@ jobs:
           fetch-depth: 5
           submodules: false
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
-      - name: Reconfigure Windows Storage
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (startsWith(matrix.os, ''windows''))'
-        shell: pwsh
-        run: |-
-          New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-          New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,18 +100,6 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
     steps:
-      - name: Reconfigure Windows Storage
-        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (startsWith(matrix.os, ''windows''))'
-        shell: pwsh
-        run:
-          - |2-
-
-                New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-                New-Item -ItemType "directory" -Path "D:/a"
-                New-Item -ItemType "directory" -Path "D:/a/deno"
-                New-Item -ItemType "directory" -Path "D:/a/deno/deno"
-                New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
-                
       - name: Configure git
         run: |-
           git config --global core.symlinks true
@@ -123,6 +111,13 @@ jobs:
           fetch-depth: 5
           submodules: false
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
+      - name: Reconfigure Windows Storage
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (startsWith(matrix.os, ''windows''))'
+        shell: pwsh
+        run:
+          - |-
+            New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+                New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         shell: pwsh
         run: |-
           New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-          New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
+          New-Item -ItemType SymbolicLink -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno/target"
       - name: Clone submodule ./test_util/std
         run: git submodule update --init --recursive --depth=1 -- ./test_util/std
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,10 @@ jobs:
           - |2-
 
                 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-                New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/target"
+                New-Item -ItemType "directory" -Path "D:/a"
+                New-Item -ItemType "directory" -Path "D:/a/deno"
+                New-Item -ItemType "directory" -Path "D:/a/deno/deno"
+                New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/deno/deno/target"
                 
       - name: Configure git
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,15 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
     steps:
+      - name: Reconfigure Windows Storage
+        if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (startsWith(matrix.os, ''windows''))'
+        shell: pwsh
+        run:
+          - |2-
+
+                New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
+                New-Item -ItemType SymbolicLink -Path "$env:TEMP/__target__" -Target "D:/a/target"
+                
       - name: Configure git
         run: |-
           git config --global core.symlinks true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         shell: pwsh
         run: |-
           New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-          New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno"
+          New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno"
       - name: Configure git
         run: |-
           git config --global core.symlinks true

--- a/cli/tests/testdata/lockfile/basic/test.nolock.out
+++ b/cli/tests/testdata/lockfile/basic/test.nolock.out
@@ -1,4 +1,4 @@
 Download http://localhost:4545/lockfile/basic/mod.ts
 Check file:///[WILDCARD]/main.test.ts
-running 1 test from ./main.test.ts
+running 1 test from [WILDCARD]/main.test.ts
 [WILDCARD]

--- a/cli/tests/testdata/test/collect.deprecated.out
+++ b/cli/tests/testdata/test/collect.deprecated.out
@@ -2,9 +2,9 @@ Warning: "files" configuration is deprecated. Please use "include" and "exclude"
 Check [WILDCARD]/test/collect/include/2_test.ts
 Check [WILDCARD]/test/collect/include/test.ts
 Check [WILDCARD]/test/collect/test.ts
-running 0 tests from ./test/collect/include/2_test.ts
-running 0 tests from ./test/collect/include/test.ts
-running 0 tests from ./test/collect/test.ts
+running 0 tests from [WILDCARD]/test/collect/include/2_test.ts
+running 0 tests from [WILDCARD]/test/collect/include/test.ts
+running 0 tests from [WILDCARD]/test/collect/test.ts
 
 ok | 0 passed | 0 failed ([WILDCARD])
 

--- a/cli/tests/testdata/test/collect.out
+++ b/cli/tests/testdata/test/collect.out
@@ -1,9 +1,9 @@
 Check [WILDCARD]/test/collect/include/2_test.ts
 Check [WILDCARD]/test/collect/include/test.ts
 Check [WILDCARD]/test/collect/test.ts
-running 0 tests from ./test/collect/include/2_test.ts
-running 0 tests from ./test/collect/include/test.ts
-running 0 tests from ./test/collect/test.ts
+running 0 tests from [WILDCARD]/test/collect/include/2_test.ts
+running 0 tests from [WILDCARD]/test/collect/include/test.ts
+running 0 tests from [WILDCARD]/test/collect/test.ts
 
 ok | 0 passed | 0 failed ([WILDCARD])
 

--- a/cli/tests/testdata/test/collect2.out
+++ b/cli/tests/testdata/test/collect2.out
@@ -1,7 +1,7 @@
 Check [WILDCARD]/test/collect/include/test.ts
 Check [WILDCARD]/test/collect/test.ts
-running 0 tests from ./test/collect/include/test.ts
-running 0 tests from ./test/collect/test.ts
+running 0 tests from [WILDCARD]/test/collect/include/test.ts
+running 0 tests from [WILDCARD]/test/collect/test.ts
 
 ok | 0 passed | 0 failed ([WILDCARD])
 

--- a/cli/tests/testdata/test/filter.out
+++ b/cli/tests/testdata/test/filter.out
@@ -1,11 +1,11 @@
 Check [WILDCARD]/test/filter/a_test.ts
 Check [WILDCARD]/test/filter/b_test.ts
 Check [WILDCARD]/test/filter/c_test.ts
-running 1 test from ./test/filter/a_test.ts
+running 1 test from [WILDCARD]/test/filter/a_test.ts
 foo ... ok ([WILDCARD])
-running 1 test from ./test/filter/b_test.ts
+running 1 test from [WILDCARD]/test/filter/b_test.ts
 foo ... ok ([WILDCARD])
-running 1 test from ./test/filter/c_test.ts
+running 1 test from [WILDCARD]/test/filter/c_test.ts
 foo ... ok ([WILDCARD])
 
 ok | 3 passed | 0 failed | 6 filtered out ([WILDCARD])

--- a/cli/tests/testdata/test/shuffle.out
+++ b/cli/tests/testdata/test/shuffle.out
@@ -1,7 +1,7 @@
 Check [WILDCARD]/test/shuffle/bar_test.ts
 Check [WILDCARD]/test/shuffle/baz_test.ts
 Check [WILDCARD]/test/shuffle/foo_test.ts
-running 10 tests from ./test/shuffle/foo_test.ts
+running 10 tests from [WILDCARD]/test/shuffle/foo_test.ts
 test 3 ... ok ([WILDCARD])
 test 2 ... ok ([WILDCARD])
 test 7 ... ok ([WILDCARD])
@@ -12,7 +12,7 @@ test 9 ... ok ([WILDCARD])
 test 4 ... ok ([WILDCARD])
 test 6 ... ok ([WILDCARD])
 test 1 ... ok ([WILDCARD])
-running 10 tests from ./test/shuffle/baz_test.ts
+running 10 tests from [WILDCARD]/test/shuffle/baz_test.ts
 test 3 ... ok ([WILDCARD])
 test 2 ... ok ([WILDCARD])
 test 7 ... ok ([WILDCARD])
@@ -23,7 +23,7 @@ test 9 ... ok ([WILDCARD])
 test 4 ... ok ([WILDCARD])
 test 6 ... ok ([WILDCARD])
 test 1 ... ok ([WILDCARD])
-running 10 tests from ./test/shuffle/bar_test.ts
+running 10 tests from [WILDCARD]/test/shuffle/bar_test.ts
 test 3 ... ok ([WILDCARD])
 test 2 ... ok ([WILDCARD])
 test 7 ... ok ([WILDCARD])


### PR DESCRIPTION
Use `C:` drive to build on Windows, as `D:` is too limited.