### PR TITLE
chore: Ensure copyright line is the first in the file

### DIFF
--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1,4 +1,3 @@
-use super::MacroConfig;
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use super::generator_state::GeneratorState;
 use super::signature::Arg;
@@ -6,6 +5,7 @@ use super::signature::NumericArg;
 use super::signature::ParsedSignature;
 use super::signature::RetVal;
 use super::signature::Special;
+use super::MacroConfig;
 use super::V8MappingError;
 use proc_macro2::TokenStream;
 use quote::quote;

--- a/serde_v8/magic/any_value.rs
+++ b/serde_v8/magic/any_value.rs
@@ -1,5 +1,3 @@
-use num_bigint::BigInt;
-
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use super::buffer::JsBuffer;
 use super::transl8::FromV8;
@@ -7,6 +5,7 @@ use super::transl8::ToV8;
 use crate::magic::transl8::impl_magic;
 use crate::Error;
 use crate::ToJsBuffer;
+use num_bigint::BigInt;
 
 /// An untagged enum type that can be any of number, string, bool, bigint, or
 /// buffer.

--- a/test_util/src/factory.rs
+++ b/test_util/src/factory.rs
@@ -1,8 +1,7 @@
-use std::collections::HashSet;
-use std::path::PathBuf;
-
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use glob::glob;
+use std::collections::HashSet;
+use std::path::PathBuf;
 
 /// Generate a unit test factory verified and backed by a glob.
 #[macro_export]

--- a/tools/copyright_checker.js
+++ b/tools/copyright_checker.js
@@ -42,29 +42,47 @@ export async function checkCopyright() {
 
   const errors = [];
   const sourceFilesSet = new Set(sourceFiles);
+  const ERROR_MSG = "Copyright header is missing: ";
+
+  // Acceptable content before the copyright line
+  const ACCEPTABLE_LINES =
+    /^(\/\/ deno-lint-.*|\/\/ Copyright.*|\/\/ Ported.*|\s*|#!\/.*)\n/;
+  const COPYRIGHT_LINE =
+    "Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.";
+  const TOML_COPYRIGHT_LINE = "# " + COPYRIGHT_LINE;
+  const C_STYLE_COPYRIGHT_LINE = "// " + COPYRIGHT_LINE;
 
   for (const file of sourceFilesSet) {
-    const ERROR_MSG = "Copyright header is missing: ";
-
     const fileText = await readFirstPartOfFile(file);
     if (file.endsWith("Cargo.toml")) {
       if (
-        !fileText.startsWith(
-          "# Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.",
-        )
+        !fileText.startsWith(TOML_COPYRIGHT_LINE)
       ) {
         errors.push(ERROR_MSG + file);
       }
       continue;
     }
 
-    // use .includes(...) because the first line might be a shebang
     if (
-      !fileText.includes(
-        "// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.",
-      )
+      !fileText.startsWith(C_STYLE_COPYRIGHT_LINE)
     ) {
-      errors.push(ERROR_MSG + file);
+      let trimmedText = fileText;
+      // Attempt to trim accceptable lines
+      while (
+        ACCEPTABLE_LINES.test(trimmedText) &&
+        !trimmedText.startsWith(C_STYLE_COPYRIGHT_LINE)
+      ) {
+        trimmedText = trimmedText.split("\n").slice(1).join("\n");
+      }
+      if (
+        !trimmedText.startsWith(C_STYLE_COPYRIGHT_LINE)
+      ) {
+        errors.push(
+          `${ERROR_MSG}${file} (incorrect line is '${
+            trimmedText.split("\n", 1)
+          }')`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
The copyright checker was allowing files with code above the copyright line in a few places, mainly as a result of IDEs ordering imports improperly.

This makes the check more robust, and adds a whitelist of valid lines that may appear before the copyright line.