### PR TITLE
Revert "Reland "refactor(core): cleanup feature flags for js source i…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,6 @@ dependencies = [
  "anyhow",
  "bytes",
  "deno_ast",
- "deno_core",
  "deno_ops",
  "futures",
  "indexmap",

--- a/bench_util/benches/op_baseline.rs
+++ b/bench_util/benches/op_baseline.rs
@@ -19,7 +19,7 @@ deno_core::extension!(
 );
 
 fn setup() -> Vec<Extension> {
-  vec![bench_setup::init_ext()]
+  vec![bench_setup::init_ops()]
 }
 
 #[op]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,8 +27,8 @@ harness = false
 path = "./bench/lsp_bench_standalone.rs"
 
 [build-dependencies]
-deno_runtime = { workspace = true, features = ["exclude_js_main_from_snapshot"] }
-deno_core = { workspace = true, features = ["runtime_js_sources"] }
+deno_runtime = { workspace = true, features = ["snapshot_from_snapshot", "include_js_files_for_snapshotting"] }
+deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 lazy-regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -41,14 +41,14 @@ winres.workspace = true
 
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
-deno_core = { workspace = true, features = ["exclude_js_sources"] }
+deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "=0.63.1"
 deno_emit = "=0.24.0"
 deno_graph = "=0.49.0"
 deno_lint = { version = "=0.47.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm.workspace = true
-deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot"] }
+deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "include_js_files_for_snapshotting"] }
 deno_semver.workspace = true
 deno_task_shell = "=0.12.0"
 eszip = "=0.44.0"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -266,7 +266,11 @@ mod ts {
       cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
       snapshot_path,
       startup_snapshot: None,
-      extensions: vec![deno_tsc::init_ext(op_crate_libs, build_libs, path_dts)],
+      extensions: vec![deno_tsc::init_ops_and_esm(
+        op_crate_libs,
+        build_libs,
+        path_dts,
+      )],
 
       // NOTE(bartlomieju): Compressing the TSC snapshot in debug build took
       // ~45s on M1 MacBook Pro; without compression it took ~1s.
@@ -318,7 +322,7 @@ deno_core::extension!(
   customizer = |ext: &mut deno_core::ExtensionBuilder| {
     ext.esm(vec![ExtensionFileSource {
       specifier: "ext:cli/runtime/js/99_main.js",
-      code: ExtensionFileSourceCode::LoadAtRuntime(
+      code: ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(
         std::path::PathBuf::from(deno_runtime::js::PATH_FOR_99_MAIN_JS),
       ),
     }]);
@@ -331,42 +335,42 @@ fn create_cli_snapshot(snapshot_path: PathBuf) -> CreateSnapshotOutput {
   // `runtime/worker.rs`, `runtime/web_worker.rs` and `runtime/build.rs`!
   let fs = Arc::new(deno_fs::RealFs);
   let extensions: Vec<Extension> = vec![
-    deno_webidl::deno_webidl::init_ext(),
-    deno_console::deno_console::init_ext(),
-    deno_url::deno_url::init_ext(),
-    deno_web::deno_web::init_ext::<PermissionsContainer>(
+    deno_webidl::deno_webidl::init_ops(),
+    deno_console::deno_console::init_ops(),
+    deno_url::deno_url::init_ops(),
+    deno_web::deno_web::init_ops::<PermissionsContainer>(
       deno_web::BlobStore::default(),
       Default::default(),
     ),
-    deno_fetch::deno_fetch::init_ext::<PermissionsContainer>(Default::default()),
-    deno_cache::deno_cache::init_ext::<SqliteBackedCache>(None),
-    deno_websocket::deno_websocket::init_ext::<PermissionsContainer>(
+    deno_fetch::deno_fetch::init_ops::<PermissionsContainer>(Default::default()),
+    deno_cache::deno_cache::init_ops::<SqliteBackedCache>(None),
+    deno_websocket::deno_websocket::init_ops::<PermissionsContainer>(
       "".to_owned(),
       None,
       None,
     ),
-    deno_webstorage::deno_webstorage::init_ext(None),
-    deno_crypto::deno_crypto::init_ext(None),
-    deno_broadcast_channel::deno_broadcast_channel::init_ext(
+    deno_webstorage::deno_webstorage::init_ops(None),
+    deno_crypto::deno_crypto::init_ops(None),
+    deno_broadcast_channel::deno_broadcast_channel::init_ops(
       deno_broadcast_channel::InMemoryBroadcastChannel::default(),
       false, // No --unstable.
     ),
-    deno_ffi::deno_ffi::init_ext::<PermissionsContainer>(false),
-    deno_net::deno_net::init_ext::<PermissionsContainer>(
+    deno_ffi::deno_ffi::init_ops::<PermissionsContainer>(false),
+    deno_net::deno_net::init_ops::<PermissionsContainer>(
       None, false, // No --unstable.
       None,
     ),
-    deno_tls::deno_tls::init_ext(),
-    deno_kv::deno_kv::init_ext(
+    deno_tls::deno_tls::init_ops(),
+    deno_kv::deno_kv::init_ops(
       SqliteDbHandler::<PermissionsContainer>::new(None),
       false, // No --unstable.
     ),
-    deno_napi::deno_napi::init_ext::<PermissionsContainer>(),
-    deno_http::deno_http::init_ext::<DefaultHttpPropertyExtractor>(),
-    deno_io::deno_io::init_ext(Default::default()),
-    deno_fs::deno_fs::init_ext::<PermissionsContainer>(false, fs.clone()),
-    deno_node::deno_node::init_ext::<PermissionsContainer>(None, fs),
-    cli::init_ext(),
+    deno_napi::deno_napi::init_ops::<PermissionsContainer>(),
+    deno_http::deno_http::init_ops::<DefaultHttpPropertyExtractor>(),
+    deno_io::deno_io::init_ops(Default::default()),
+    deno_fs::deno_fs::init_ops::<PermissionsContainer>(false, fs.clone()),
+    deno_node::deno_node::init_ops::<PermissionsContainer>(None, fs),
+    cli::init_ops_and_esm(), // NOTE: This needs to be init_ops_and_esm!
   ];
 
   create_snapshot(CreateSnapshotOptions {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3236,7 +3236,7 @@ fn op_script_version(
 /// server.
 fn js_runtime(performance: Arc<Performance>) -> JsRuntime {
   JsRuntime::new(RuntimeOptions {
-    extensions: vec![deno_tsc::init_ext(performance)],
+    extensions: vec![deno_tsc::init_ops(performance)],
     startup_snapshot: Some(tsc::compiler_snapshot()),
     ..Default::default()
   })

--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -12,7 +12,7 @@ pub mod bench;
 pub mod testing;
 
 pub fn cli_exts(npm_resolver: Arc<CliNpmResolver>) -> Vec<Extension> {
-  vec![deno_cli::init_ext(npm_resolver)]
+  vec![deno_cli::init_ops(npm_resolver)]
 }
 
 deno_core::extension!(deno_cli,

--- a/cli/tools/bench.rs
+++ b/cli/tools/bench.rs
@@ -447,7 +447,7 @@ async fn bench_specifier(
     .create_custom_worker(
       specifier.clone(),
       PermissionsContainer::new(permissions),
-      vec![ops::bench::deno_bench::init_ext(sender.clone())],
+      vec![ops::bench::deno_bench::init_ops(sender.clone())],
       Default::default(),
     )
     .await?;

--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -936,7 +936,7 @@ pub async fn test_specifier(
     .create_custom_worker(
       specifier.clone(),
       PermissionsContainer::new(permissions),
-      vec![ops::testing::deno_test::init_ext(sender.clone())],
+      vec![ops::testing::deno_test::init_ops(sender.clone())],
       Stdio {
         stdin: StdioPipe::Inherit,
         stdout,

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -122,7 +122,7 @@ fn get_asset_texts_from_new_runtime() -> Result<Vec<AssetText>, AnyError> {
   // the assets are stored within the typescript isolate, so take them out of there
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(compiler_snapshot()),
-    extensions: vec![deno_cli_tsc::init_ext()],
+    extensions: vec![deno_cli_tsc::init_ops()],
     ..Default::default()
   });
   let global = runtime
@@ -787,7 +787,7 @@ pub fn exec(request: Request) -> Result<Response, AnyError> {
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(compiler_snapshot()),
-    extensions: vec![deno_cli_tsc::init_ext(
+    extensions: vec![deno_cli_tsc::init_ops(
       request,
       root_map,
       remapped_specifiers,

--- a/core/00_primordials.js
+++ b/core/00_primordials.js
@@ -34,14 +34,6 @@
 "use strict";
 
 (() => {
-  // Provide bootstrap namespace
-  globalThis.__bootstrap ??= {};
-  const key = Symbol.for("00_primordials.js");
-  if (globalThis.__bootstrap[key]) {
-    return;
-  }
-  globalThis.__bootstrap[key] = true;
-
   const primordials = {};
 
   const {
@@ -305,7 +297,6 @@
     ArrayPrototypeJoin,
     ArrayPrototypeMap,
     FunctionPrototypeCall,
-    ObjectAssign,
     ObjectDefineProperty,
     ObjectFreeze,
     ObjectPrototypeIsPrototypeOf,
@@ -619,5 +610,6 @@
   ObjectSetPrototypeOf(primordials, null);
   ObjectFreeze(primordials);
 
-  ObjectAssign(globalThis.__bootstrap, { primordials });
+  // Provide bootstrap namespace
+  globalThis.__bootstrap = { primordials };
 })();

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -38,13 +38,6 @@
     URIError,
     setQueueMicrotask,
   } = window.__bootstrap.primordials;
-
-  const key = SymbolFor("01_core.js");
-  if (globalThis.__bootstrap[key]) {
-    return;
-  }
-  globalThis.__bootstrap[key] = true;
-
   const { ops, asyncOps } = window.Deno.core;
 
   const build = {

--- a/core/02_error.js
+++ b/core/02_error.js
@@ -14,14 +14,7 @@
     ArrayPrototypePush,
     ArrayPrototypeMap,
     ArrayPrototypeJoin,
-    SymbolFor,
   } = window.__bootstrap.primordials;
-
-  const key = SymbolFor("02_error.js");
-  if (globalThis.__bootstrap[key]) {
-    return;
-  }
-  globalThis.__bootstrap[key] = true;
 
   // Keep in sync with `cli/fmt_errors.rs`.
   function formatLocation(cse) {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,12 +16,7 @@ path = "lib.rs"
 [features]
 default = ["v8_use_custom_libcxx"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]
-# Enable to exclude extension!() JS sources from the binary (e.g. if they are already snapshotted).
-exclude_js_sources = []
-# Read extension!() JS sources at 'runtime' instead of statically including them. They will be read
-# from their `CARGO_MANIFEST_DIR`-based paths, so it should only to be used in build and dev scripts
-# where these paths are available. Overrides `exclude_js_sources`.
-runtime_js_sources = ["exclude_js_sources"]
+include_js_files_for_snapshotting = []
 
 [dependencies]
 anyhow.workspace = true
@@ -49,8 +44,6 @@ v8.workspace = true
 name = "http_bench_json_ops"
 path = "examples/http_bench_json_ops/main.rs"
 
-[dev-dependencies]
-deno_core = { workspace = true, features = ["runtime_js_sources"] }
-
 # These dependencies are only used for the 'http_bench_*_ops' examples.
+[dev-dependencies]
 deno_ast.workspace = true

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -17,10 +17,10 @@ pub enum ExtensionFileSourceCode {
   /// snapshot, the other the static string in the `Extension`.
   IncludedInBinary(&'static str),
 
-  /// Source code is loaded from a file on disk at 'runtime'. It's meant to be
-  /// used in build and dev scripts using the `runtime_js_sources` feature,
-  /// likely to create snapshots.
-  LoadAtRuntime(PathBuf),
+  // Source code is loaded from a file on disk. It's meant to be used if the
+  // embedder is creating snapshots. Files will be loaded from the filesystem
+  // during the build time and they will only be present in the V8 snapshot.
+  LoadedFromFsDuringSnapshot(PathBuf),
 }
 
 #[derive(Clone, Debug)]
@@ -45,7 +45,7 @@ impl ExtensionFileSource {
         );
         Ok(ModuleCode::from_static(code))
       }
-      ExtensionFileSourceCode::LoadAtRuntime(path) => {
+      ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) => {
         let msg = || format!("Failed to read \"{}\"", path.display());
         let s = std::fs::read_to_string(path).with_context(msg)?;
         debug_assert!(
@@ -168,6 +168,7 @@ macro_rules! ops {
 ///  * bounds: a comma-separated list of additional type bounds, eg: `bounds = [ P::MyAssociatedType: MyTrait ]`
 ///  * ops: a comma-separated list of [`OpDecl`]s to provide, eg: `ops = [ op_foo, op_bar ]`
 ///  * esm: a comma-separated list of ESM module filenames (see [`include_js_files`]), eg: `esm = [ dir "dir", "my_file.js" ]`
+///  * esm_setup_script: see [`ExtensionBuilder::esm_setup_script`]
 ///  * js: a comma-separated list of JS filenames (see [`include_js_files`]), eg: `js = [ dir "dir", "my_file.js" ]`
 ///  * config: a structure-like definition for configuration parameters which will be required when initializing this extension, eg: `config = { my_param: Option<usize> }`
 ///  * middleware: an [`OpDecl`] middleware function with the signature `fn (OpDecl) -> OpDecl`
@@ -184,8 +185,8 @@ macro_rules! extension {
     $(, ops = [ $( $(#[$m:meta])* $( $op:ident )::+ $( < $( $op_param:ident ),* > )?  ),+ $(,)? ] )?
     $(, esm_entry_point = $esm_entry_point:literal )?
     $(, esm = [ $( dir $dir_esm:literal , )? $( $esm:literal ),* $(,)? ] )?
+    $(, esm_setup_script = $esm_setup_script:expr )?
     $(, js = [ $( dir $dir_js:literal , )? $( $js:literal ),* $(,)? ] )?
-    $(, force_include_js_sources $($force_include_js_sources:block)? )? // dummy variable
     $(, options = { $( $options_id:ident : $options_type:ty ),* $(,)? } )?
     $(, middleware = $middleware_fn:expr )?
     $(, state = $state_fn:expr )?
@@ -210,15 +211,21 @@ macro_rules! extension {
       #[inline(always)]
       #[allow(unused_variables)]
       fn with_js(ext: &mut $crate::ExtensionBuilder) {
-        ext.esm(
-          $crate::include_js_files!( $name $( force_include_js_sources $($force_include_js_sources)?, )? $( $( dir $dir_esm , )? $( $esm , )* )? )
-        );
+        $( ext.esm(
+          $crate::include_js_files!( $name $( dir $dir_esm , )? $( $esm , )* )
+        ); )?
+        $(
+          ext.esm(vec![ExtensionFileSource {
+            specifier: "ext:setup",
+            code: ExtensionFileSourceCode::IncludedInBinary($esm_setup_script),
+          }]);
+        )?
         $(
           ext.esm_entry_point($esm_entry_point);
         )?
-        ext.js(
-          $crate::include_js_files!( $name $( force_include_js_sources $($force_include_js_sources)?, )? $( $( dir $dir_js , )? $( $js , )* )? )
-        );
+        $( ext.js(
+          $crate::include_js_files!( $name $( dir $dir_js , )? $( $js , )* )
+        ); )?
       }
 
       // If ops were specified, add those ops to the extension.
@@ -278,12 +285,23 @@ macro_rules! extension {
       }
 
       #[allow(dead_code)]
-      pub fn init_ext $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension
+      pub fn init_ops_and_esm $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension
       $( where $( $bound : $bound_type ),+ )?
       {
         let mut ext = Self::ext();
         // If esm or JS was specified, add JS files
         Self::with_js(&mut ext);
+        Self::with_ops $( ::< $( $param ),+ > )?(&mut ext);
+        Self::with_state_and_middleware $( ::< $( $param ),+ > )?(&mut ext, $( $( $options_id , )* )? );
+        Self::with_customizer(&mut ext);
+        ext.take()
+      }
+
+      #[allow(dead_code)]
+      pub fn init_ops $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension
+      $( where $( $bound : $bound_type ),+ )?
+      {
+        let mut ext = Self::ext();
         Self::with_ops $( ::< $( $param ),+ > )?(&mut ext);
         Self::with_state_and_middleware $( ::< $( $param ),+ > )?(&mut ext, $( $( $options_id , )* )? );
         Self::with_customizer(&mut ext);
@@ -331,8 +349,8 @@ macro_rules! extension {
 #[derive(Default)]
 pub struct Extension {
   pub(crate) name: &'static str,
-  js_files: Vec<ExtensionFileSource>,
-  esm_files: Vec<ExtensionFileSource>,
+  js_files: Option<Vec<ExtensionFileSource>>,
+  esm_files: Option<Vec<ExtensionFileSource>>,
   esm_entry_point: Option<&'static str>,
   ops: Option<Vec<OpDecl>>,
   opstate_fn: Option<Box<OpStateFn>>,
@@ -388,12 +406,12 @@ impl Extension {
 
   /// returns JS source code to be loaded into the isolate (either at snapshotting,
   /// or at startup).  as a vector of a tuple of the file name, and the source code.
-  pub fn get_js_sources(&self) -> &Vec<ExtensionFileSource> {
-    &self.js_files
+  pub fn get_js_sources(&self) -> Option<&Vec<ExtensionFileSource>> {
+    self.js_files.as_ref()
   }
 
-  pub fn get_esm_sources(&self) -> &Vec<ExtensionFileSource> {
-    &self.esm_files
+  pub fn get_esm_sources(&self) -> Option<&Vec<ExtensionFileSource>> {
+    self.esm_files.as_ref()
   }
 
   pub fn get_esm_entry_point(&self) -> Option<&'static str> {
@@ -514,11 +532,13 @@ impl ExtensionBuilder {
 
   /// Consume the [`ExtensionBuilder`] and return an [`Extension`].
   pub fn take(self) -> Extension {
+    let js_files = Some(self.js);
+    let esm_files = Some(self.esm);
     let ops = Some(self.ops);
     let deps = Some(self.deps);
     Extension {
-      js_files: self.js,
-      esm_files: self.esm,
+      js_files,
+      esm_files,
       esm_entry_point: self.esm_entry_point,
       ops,
       opstate_fn: self.state,
@@ -533,11 +553,13 @@ impl ExtensionBuilder {
   }
 
   pub fn build(&mut self) -> Extension {
+    let js_files = Some(std::mem::take(&mut self.js));
+    let esm_files = Some(std::mem::take(&mut self.esm));
     let ops = Some(std::mem::take(&mut self.ops));
     let deps = Some(std::mem::take(&mut self.deps));
     Extension {
-      js_files: std::mem::take(&mut self.js),
-      esm_files: std::mem::take(&mut self.esm),
+      js_files,
+      esm_files,
       esm_entry_point: self.esm_entry_point.take(),
       ops,
       opstate_fn: self.state.take(),
@@ -586,58 +608,54 @@ impl ExtensionBuilder {
 /// - "ext:my_extension/js/01_hello.js"
 /// - "ext:my_extension/js/02_goodbye.js"
 /// ```
-#[cfg(all(
-  feature = "exclude_js_sources",
-  not(feature = "runtime_js_sources"),
-))]
+#[cfg(not(feature = "include_js_files_for_snapshotting"))]
 #[macro_export]
 macro_rules! include_js_files {
-  ($name:ident $(dir $dir:literal,)? $($file:literal,)*) => {
-    vec![]
+  ($name:ident dir $dir:literal, $($file:literal,)+) => {
+    vec![
+      $($crate::ExtensionFileSource {
+        specifier: concat!("ext:", stringify!($name), "/", $file),
+        code: $crate::ExtensionFileSourceCode::IncludedInBinary(
+          include_str!(concat!($dir, "/", $file)
+        )),
+      },)+
+    ]
   };
 
-  ($name:ident force_include_js_sources $($dummy:block)?, $($file:literal,)*) => {
-    vec![$($crate::include_js_file!($name $file)),*]
-  };
-
-  ($name:ident force_include_js_sources $($dummy:block)?, dir $dir:literal, $($file:literal,)*) => {
-    vec![$($crate::include_js_file!($name dir $dir, $file)),*]
+  ($name:ident $($file:literal,)+) => {
+    vec![
+      $($crate::ExtensionFileSource {
+        specifier: concat!("ext:", stringify!($name), "/", $file),
+        code: $crate::ExtensionFileSourceCode::IncludedInBinary(
+          include_str!($file)
+        ),
+      },)+
+    ]
   };
 }
 
-#[cfg(not(all(
-  feature = "exclude_js_sources",
-  not(feature = "runtime_js_sources"),
-)))]
+#[cfg(feature = "include_js_files_for_snapshotting")]
 #[macro_export]
 macro_rules! include_js_files {
-  ($name:ident $(force_include_js_sources $($dummy:block)?,)? $($file:literal,)*) => {
-    vec![$($crate::include_js_file!($name $file)),*]
+  ($name:ident dir $dir:literal, $($file:literal,)+) => {
+    vec![
+      $($crate::ExtensionFileSource {
+        specifier: concat!("ext:", stringify!($name), "/", $file),
+        code: $crate::ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(
+          std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join($dir).join($file)
+        ),
+      },)+
+    ]
   };
 
-  ($name:ident $(force_include_js_sources $($dummy:block)?,)? dir $dir:literal, $($file:literal,)*) => {
-    vec![$($crate::include_js_file!($name dir $dir, $file)),*]
-  };
-}
-
-#[cfg(not(feature = "runtime_js_sources"))]
-#[macro_export]
-macro_rules! include_js_file {
-  ($ext_name:ident $(dir $dir:literal,)? $file:literal) => {
-    $crate::ExtensionFileSource {
-      specifier: concat!("ext:", stringify!($ext_name), "/", $file),
-      code: $crate::ExtensionFileSourceCode::IncludedInBinary(include_str!(concat!($($dir, "/",)? $file))),
-    }
-  };
-}
-
-#[cfg(feature = "runtime_js_sources")]
-#[macro_export]
-macro_rules! include_js_file {
-  ($ext_name:ident $(dir $dir:literal,)? $file:literal) => {
-    $crate::ExtensionFileSource {
-      specifier: concat!("ext:", stringify!($ext_name), "/", $file),
-      code: $crate::ExtensionFileSourceCode::LoadAtRuntime(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))$(.join($dir))?.join($file)),
-    }
+  ($name:ident $($file:literal,)+) => {
+    vec![
+      $($crate::ExtensionFileSource {
+        specifier: concat!("ext:", stringify!($name), "/", $file),
+        code: $crate::ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(
+          std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join($file)
+        ),
+      },)+
+    ]
   };
 }

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -342,7 +342,7 @@ fn test_mods() {
   deno_core::extension!(test_ext, ops = [op_test]);
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     module_loader: Some(loader),
     ..Default::default()
   });

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -505,7 +505,7 @@ impl JsRuntime {
     maybe_load_callback: Option<ExtModuleLoaderCb>,
   ) -> JsRuntime {
     let init_mode = InitMode::from_options(&options);
-    let (op_state, ops) = Self::create_opstate(&mut options);
+    let (op_state, ops) = Self::create_opstate(&mut options, init_mode);
     let op_state = Rc::new(RefCell::new(op_state));
 
     // Collect event-loop middleware
@@ -844,25 +844,29 @@ impl JsRuntime {
       for extension in &extensions {
         let maybe_esm_entry_point = extension.get_esm_entry_point();
 
-        for file_source in extension.get_esm_sources() {
-          self
-            .load_side_module(
-              &ModuleSpecifier::parse(file_source.specifier)?,
-              None,
-            )
-            .await?;
+        if let Some(esm_files) = extension.get_esm_sources() {
+          for file_source in esm_files {
+            self
+              .load_side_module(
+                &ModuleSpecifier::parse(file_source.specifier)?,
+                None,
+              )
+              .await?;
+          }
         }
 
         if let Some(entry_point) = maybe_esm_entry_point {
           esm_entrypoints.push(entry_point);
         }
 
-        for file_source in extension.get_js_sources() {
-          realm.execute_script(
-            self.v8_isolate(),
-            file_source.specifier,
-            file_source.load()?,
-          )?;
+        if let Some(js_files) = extension.get_js_sources() {
+          for file_source in js_files {
+            realm.execute_script(
+              self.v8_isolate(),
+              file_source.specifier,
+              file_source.load()?,
+            )?;
+          }
         }
 
         if extension.is_core {
@@ -880,16 +884,6 @@ impl JsRuntime {
               panic!("{} not present in the module map", specifier)
             })
         };
-        {
-          let module_map_rc = self.module_map.clone();
-          let module_map = module_map_rc.borrow();
-          let handle = module_map.handles.get(mod_id).unwrap().clone();
-          let mut scope = realm.handle_scope(self.v8_isolate());
-          let handle = v8::Local::new(&mut scope, handle);
-          if handle.get_status() == v8::ModuleStatus::Evaluated {
-            continue;
-          }
-        }
         let receiver = self.mod_evaluate(mod_id);
         self.run_event_loop(false).await?;
         receiver
@@ -973,11 +967,20 @@ impl JsRuntime {
   }
 
   /// Initializes ops of provided Extensions
-  fn create_opstate(options: &mut RuntimeOptions) -> (OpState, Vec<OpDecl>) {
+  fn create_opstate(
+    options: &mut RuntimeOptions,
+    init_mode: InitMode,
+  ) -> (OpState, Vec<OpDecl>) {
     // Add built-in extension
-    options
-      .extensions
-      .insert(0, crate::ops_builtin::core::init_ext());
+    if init_mode == InitMode::FromSnapshot {
+      options
+        .extensions
+        .insert(0, crate::ops_builtin::core::init_ops());
+    } else {
+      options
+        .extensions
+        .insert(0, crate::ops_builtin::core::init_ops_and_esm());
+    }
 
     let ops = Self::collect_ops(&mut options.extensions);
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -235,7 +235,7 @@ mod tests {
     f: impl FnOnce(Result<&v8::Value, anyhow::Error>, &mut v8::HandleScope),
   ) {
     let mut runtime = JsRuntime::new(RuntimeOptions {
-      extensions: vec![testing::init_ext()],
+      extensions: vec![testing::init_ops_and_esm()],
       ..Default::default()
     });
     let value: Result<v8::Global<v8::Value>, anyhow::Error> = runtime

--- a/core/runtime/snapshot_util.rs
+++ b/core/runtime/snapshot_util.rs
@@ -57,9 +57,12 @@ pub fn create_snapshot(
     .iter()
     .flat_map(|e| vec![e.get_esm_sources(), e.get_js_sources()])
     .flatten()
+    .flatten()
   {
     use crate::ExtensionFileSourceCode;
-    if let ExtensionFileSourceCode::LoadAtRuntime(path) = &source.code {
+    if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) =
+      &source.code
+    {
       files_loaded_during_snapshot.push(path.clone());
     }
   }

--- a/core/runtime/tests.rs
+++ b/core/runtime/tests.rs
@@ -100,7 +100,7 @@ fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
     }
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext(mode, dispatch_count.clone())],
+    extensions: vec![test_ext::init_ops(mode, dispatch_count.clone())],
     get_error_class_fn: Some(&|error| {
       crate::error::get_custom_error_class(error).unwrap()
     }),
@@ -515,7 +515,7 @@ async fn test_error_builder() {
 
   deno_core::extension!(test_ext, ops = [op_err]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     get_error_class_fn: Some(&get_error_class_name),
     ..Default::default()
   });
@@ -1114,7 +1114,7 @@ async fn test_error_context() {
 
   deno_core::extension!(test_ext, ops = [op_err_sync, op_err_async]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1274,7 +1274,7 @@ async fn test_async_opstate_borrow() {
     state = |state| state.put(InnerState(42))
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1305,7 +1305,7 @@ async fn test_sync_op_serialize_object_with_numbers_as_keys() {
     ops = [op_sync_serialize_object_with_numbers_as_keys]
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1347,7 +1347,7 @@ async fn test_async_op_serialize_object_with_numbers_as_keys() {
     ops = [op_async_serialize_object_with_numbers_as_keys]
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1383,7 +1383,7 @@ async fn test_set_macrotask_callback_set_next_tick_callback() {
 
   deno_core::extension!(test_ext, ops = [op_async_sleep]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1438,7 +1438,7 @@ fn test_has_tick_scheduled() {
 
   deno_core::extension!(test_ext, ops = [op_macrotask, op_next_tick]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1578,7 +1578,7 @@ async fn test_set_promise_reject_callback() {
 
   deno_core::extension!(test_ext, ops = [op_promise_reject]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1717,7 +1717,7 @@ async fn test_set_promise_reject_callback_top_level_await() {
   }
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     module_loader: Some(Rc::new(ModsLoader)),
     ..Default::default()
   });
@@ -1742,7 +1742,7 @@ fn test_op_return_serde_v8_error() {
 
   deno_core::extension!(test_ext, ops = [op_err]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
   assert!(runtime
@@ -1767,7 +1767,7 @@ fn test_op_high_arity() {
 
   deno_core::extension!(test_ext, ops = [op_add_4]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
   let r = runtime
@@ -1790,7 +1790,7 @@ fn test_op_disabled() {
 
   deno_core::extension!(test_ext, ops_fn = ops);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
   let err = runtime
@@ -1817,7 +1817,7 @@ fn test_op_detached_buffer() {
 
   deno_core::extension!(test_ext, ops = [op_sum_take, op_boomerang]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -1886,7 +1886,7 @@ fn test_op_unstable_disabling() {
     middleware = |op| if op.is_unstable { op.disable() } else { op }
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
   runtime
@@ -1934,7 +1934,7 @@ fn js_realm_init() {
 
   deno_core::extension!(test_ext, ops = [op_test]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
   let realm = runtime.create_realm().unwrap();
@@ -1963,7 +1963,7 @@ fn js_realm_init_snapshot() {
   deno_core::extension!(test_ext, ops = [op_test]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(Snapshot::Boxed(snapshot)),
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
   let realm = runtime.create_realm().unwrap();
@@ -1993,7 +1993,7 @@ fn js_realm_sync_ops() {
 
   deno_core::extension!(test_ext, ops = [op_test]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     get_error_class_fn: Some(&|error| {
       crate::error::get_custom_error_class(error).unwrap()
     }),
@@ -2041,7 +2041,7 @@ async fn js_realm_async_ops() {
 
   deno_core::extension!(test_ext, ops = [op_test]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     get_error_class_fn: Some(&|error| {
       crate::error::get_custom_error_class(error).unwrap()
     }),
@@ -2118,7 +2118,7 @@ async fn js_realm_gc() {
 
   deno_core::extension!(test_ext, ops = [op_pending]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -2165,7 +2165,7 @@ async fn js_realm_ref_unref_ops() {
 
   deno_core::extension!(test_ext, ops = [op_pending]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 
@@ -2265,7 +2265,7 @@ fn duplicate_op_names() {
 
   deno_core::extension!(test_ext, ops = [a::op_test, op_test]);
   JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 }
@@ -2284,7 +2284,7 @@ fn ops_in_js_have_proper_names() {
 
   deno_core::extension!(test_ext, ops = [op_test_sync, op_test_async]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ext()],
+    extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
 

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -19,6 +19,7 @@ use crate::ops::*;
 use deno_core::error::AnyError;
 use deno_core::OpState;
 use std::cell::RefCell;
+use std::convert::From;
 use std::path::Path;
 use std::rc::Rc;
 

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -1034,7 +1034,7 @@ mod tests {
     );
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
-      extensions: vec![test_ext::init_ext()],
+      extensions: vec![test_ext::init_ops()],
       ..Default::default()
     });
 

--- a/ext/url/benches/url_ops.rs
+++ b/ext/url/benches/url_ops.rs
@@ -11,8 +11,8 @@ use deno_core::ExtensionFileSourceCode;
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::deno_webidl::init_ext(),
-    deno_url::deno_url::init_ext(),
+    deno_webidl::deno_webidl::init_ops_and_esm(),
+    deno_url::deno_url::init_ops_and_esm(),
     Extension::builder("bench_setup")
       .esm(vec![ExtensionFileSource {
         specifier: "ext:bench_setup/setup",

--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -24,10 +24,13 @@ impl deno_web::TimersPermission for Permissions {
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::deno_webidl::init_ext(),
-    deno_url::deno_url::init_ext(),
-    deno_console::deno_console::init_ext(),
-    deno_web::deno_web::init_ext::<Permissions>(BlobStore::default(), None),
+    deno_webidl::deno_webidl::init_ops_and_esm(),
+    deno_url::deno_url::init_ops_and_esm(),
+    deno_console::deno_console::init_ops_and_esm(),
+    deno_web::deno_web::init_ops_and_esm::<Permissions>(
+      BlobStore::default(),
+      None,
+    ),
     Extension::builder("bench_setup")
       .esm(vec![ExtensionFileSource {
         specifier: "ext:bench_setup/setup",

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -22,14 +22,14 @@ impl deno_web::TimersPermission for Permissions {
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::deno_webidl::init_ext(),
-    deno_url::deno_url::init_ext(),
-    deno_console::deno_console::init_ext(),
-    deno_web::deno_web::init_ext::<Permissions>(BlobStore::default(), None),
+    deno_webidl::deno_webidl::init_ops_and_esm(),
+    deno_url::deno_url::init_ops_and_esm(),
+    deno_console::deno_console::init_ops_and_esm(),
+    deno_web::deno_web::init_ops_and_esm::<Permissions>(BlobStore::default(), None),
     Extension::builder("bench_setup")
     .esm(vec![
       ExtensionFileSource {
-        specifier: "ext:bench_setup/setup",
+        specifier: "ext:bench_setup/setup", 
         code: ExtensionFileSourceCode::IncludedInBinary(r#"
       import { setTimeout, handleTimerMacrotask } from "ext:deno_web/02_timers.js";
       globalThis.setTimeout = setTimeout;

--- a/ext/webidl/benches/dict.rs
+++ b/ext/webidl/benches/dict.rs
@@ -11,7 +11,7 @@ use deno_core::ExtensionFileSourceCode;
 
 fn setup() -> Vec<Extension> {
   vec![
-    deno_webidl::deno_webidl::init_ext(),
+    deno_webidl::deno_webidl::init_ops_and_esm(),
     Extension::builder("deno_webidl_bench")
       .esm(vec![ExtensionFileSource {
         specifier: "ext:deno_webidl_bench/setup.js",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,8 +14,15 @@ description = "Provides the deno runtime library"
 docsrs = []
 # A feature that disables creation of startup snapshot during in the build script.
 dont_create_runtime_snapshot = []
-# Enable to exclude `js/99_main.js` from the generated snapshot.
-exclude_js_main_from_snapshot = []
+# A feature that changes how startup snapshot is generated, that allows
+# extending it in embedder crates.
+snapshot_from_snapshot = []
+# A feature that disables embedding of the JavaScript source files in the binary.
+# With this feature enabled, the sources must be consumed during build time,
+# by creating a startup snapshot.
+include_js_files_for_snapshotting = [
+  "deno_core/include_js_files_for_snapshotting",
+]
 
 [lib]
 name = "deno_runtime"
@@ -34,7 +41,7 @@ deno_ast.workspace = true
 deno_broadcast_channel.workspace = true
 deno_cache.workspace = true
 deno_console.workspace = true
-deno_core = { workspace = true, features = ["runtime_js_sources"] }
+deno_core.workspace = true
 deno_crypto.workspace = true
 deno_fetch.workspace = true
 deno_ffi.workspace = true

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -264,22 +264,22 @@ mod startup_snapshot {
     ],
   );
 
-  #[cfg(not(feature = "exclude_js_main_from_snapshot"))]
+  #[cfg(not(feature = "snapshot_from_snapshot"))]
   deno_core::extension!(
     runtime_main,
     deps = [runtime],
     customizer = |ext: &mut deno_core::ExtensionBuilder| {
       ext.esm(vec![ExtensionFileSource {
         specifier: "ext:runtime_main/js/99_main.js",
-        code: ExtensionFileSourceCode::LoadAtRuntime(PathBuf::from(
-          "js/99_main.js",
-        )),
+        code: deno_core::ExtensionFileSourceCode::IncludedInBinary(
+          include_str!("js/99_main.js"),
+        ),
       }]);
       ext.esm_entry_point("ext:runtime_main/js/99_main.js");
     }
   );
 
-  #[cfg(feature = "exclude_js_main_from_snapshot")]
+  #[cfg(feature = "snapshot_from_snapshot")]
   deno_core::extension!(
     runtime_main,
     deps = [runtime],
@@ -294,45 +294,47 @@ mod startup_snapshot {
     // `runtime/worker.rs`, `runtime/web_worker.rs` and `cli/build.rs`!
     let fs = std::sync::Arc::new(deno_fs::RealFs);
     let extensions: Vec<Extension> = vec![
-      deno_webidl::deno_webidl::init_ext(),
-      deno_console::deno_console::init_ext(),
-      deno_url::deno_url::init_ext(),
-      deno_web::deno_web::init_ext::<Permissions>(
+      deno_webidl::deno_webidl::init_ops_and_esm(),
+      deno_console::deno_console::init_ops_and_esm(),
+      deno_url::deno_url::init_ops_and_esm(),
+      deno_web::deno_web::init_ops_and_esm::<Permissions>(
         deno_web::BlobStore::default(),
         Default::default(),
       ),
-      deno_fetch::deno_fetch::init_ext::<Permissions>(Default::default()),
-      deno_cache::deno_cache::init_ext::<SqliteBackedCache>(None),
-      deno_websocket::deno_websocket::init_ext::<Permissions>(
+      deno_fetch::deno_fetch::init_ops_and_esm::<Permissions>(
+        Default::default(),
+      ),
+      deno_cache::deno_cache::init_ops_and_esm::<SqliteBackedCache>(None),
+      deno_websocket::deno_websocket::init_ops_and_esm::<Permissions>(
         "".to_owned(),
         None,
         None,
       ),
-      deno_webstorage::deno_webstorage::init_ext(None),
-      deno_crypto::deno_crypto::init_ext(None),
-      deno_broadcast_channel::deno_broadcast_channel::init_ext(
+      deno_webstorage::deno_webstorage::init_ops_and_esm(None),
+      deno_crypto::deno_crypto::init_ops_and_esm(None),
+      deno_broadcast_channel::deno_broadcast_channel::init_ops_and_esm(
         deno_broadcast_channel::InMemoryBroadcastChannel::default(),
         false, // No --unstable.
       ),
-      deno_ffi::deno_ffi::init_ext::<Permissions>(false),
-      deno_net::deno_net::init_ext::<Permissions>(
+      deno_ffi::deno_ffi::init_ops_and_esm::<Permissions>(false),
+      deno_net::deno_net::init_ops_and_esm::<Permissions>(
         None, false, // No --unstable.
         None,
       ),
-      deno_tls::deno_tls::init_ext(),
-      deno_kv::deno_kv::init_ext(
+      deno_tls::deno_tls::init_ops_and_esm(),
+      deno_kv::deno_kv::init_ops_and_esm(
         deno_kv::sqlite::SqliteDbHandler::<Permissions>::new(None),
         false, // No --unstable
       ),
-      deno_napi::deno_napi::init_ext::<Permissions>(),
-      deno_http::deno_http::init_ext::<DefaultHttpPropertyExtractor>(),
-      deno_io::deno_io::init_ext(Default::default()),
-      deno_fs::deno_fs::init_ext::<Permissions>(false, fs.clone()),
-      runtime::init_ext(),
+      deno_napi::deno_napi::init_ops_and_esm::<Permissions>(),
+      deno_http::deno_http::init_ops_and_esm::<DefaultHttpPropertyExtractor>(),
+      deno_io::deno_io::init_ops_and_esm(Default::default()),
+      deno_fs::deno_fs::init_ops_and_esm::<Permissions>(false, fs.clone()),
+      runtime::init_ops_and_esm(),
       // FIXME(bartlomieju): these extensions are specified last, because they
       // depend on `runtime`, even though it should be other way around
-      deno_node::deno_node::init_ext::<Permissions>(None, fs),
-      runtime_main::init_ext(),
+      deno_node::deno_node::init_ops_and_esm::<Permissions>(None, fs),
+      runtime_main::init_ops_and_esm(),
     ];
 
     let output = create_snapshot(CreateSnapshotOptions {

--- a/runtime/examples/extension_with_esm/main.rs
+++ b/runtime/examples/extension_with_esm/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), AnyError> {
     PermissionsContainer::allow_all(),
     WorkerOptions {
       module_loader: Rc::new(FsModuleLoader),
-      extensions: vec![hello_runtime::init_ext()],
+      extensions: vec![hello_runtime::init_ops_and_esm()],
       ..Default::default()
     },
   );

--- a/runtime/examples/extension_with_ops/main.rs
+++ b/runtime/examples/extension_with_ops/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), AnyError> {
     PermissionsContainer::allow_all(),
     WorkerOptions {
       module_loader: Rc::new(FsModuleLoader),
-      extensions: vec![hello_runtime::init_ext()],
+      extensions: vec![hello_runtime::init_ops()],
       ..Default::default()
     },
   );

--- a/runtime/js.rs
+++ b/runtime/js.rs
@@ -14,8 +14,9 @@ pub fn deno_isolate_init() -> Snapshot {
   Snapshot::Static(RUNTIME_SNAPSHOT)
 }
 
-/// Depends on LTO to be excluded from production binaries if unused.
+#[cfg(not(feature = "include_js_files_for_snapshotting"))]
 pub static SOURCE_CODE_FOR_99_MAIN_JS: &str = include_str!("js/99_main.js");
 
+#[cfg(feature = "include_js_files_for_snapshotting")]
 pub static PATH_FOR_99_MAIN_JS: &str =
   concat!(env!("CARGO_MANIFEST_DIR"), "/js/99_main.js");

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -398,14 +398,14 @@ impl WebWorker {
     // `runtime/build.rs`, `runtime/worker.rs` and `cli/build.rs`!
     let mut extensions: Vec<Extension> = vec![
       // Web APIs
-      deno_webidl::deno_webidl::init_ext(),
-      deno_console::deno_console::init_ext(),
-      deno_url::deno_url::init_ext(),
-      deno_web::deno_web::init_ext::<PermissionsContainer>(
+      deno_webidl::deno_webidl::init_ops(),
+      deno_console::deno_console::init_ops(),
+      deno_url::deno_url::init_ops(),
+      deno_web::deno_web::init_ops::<PermissionsContainer>(
         options.blob_store.clone(),
         Some(main_module.clone()),
       ),
-      deno_fetch::deno_fetch::init_ext::<PermissionsContainer>(
+      deno_fetch::deno_fetch::init_ops::<PermissionsContainer>(
         deno_fetch::Options {
           user_agent: options.bootstrap.user_agent.clone(),
           root_cert_store_provider: options.root_cert_store_provider.clone(),
@@ -416,57 +416,57 @@ impl WebWorker {
           ..Default::default()
         },
       ),
-      deno_cache::deno_cache::init_ext::<SqliteBackedCache>(create_cache),
-      deno_websocket::deno_websocket::init_ext::<PermissionsContainer>(
+      deno_cache::deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+      deno_websocket::deno_websocket::init_ops::<PermissionsContainer>(
         options.bootstrap.user_agent.clone(),
         options.root_cert_store_provider.clone(),
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_webstorage::deno_webstorage::init_ext(None).disable(),
-      deno_crypto::deno_crypto::init_ext(options.seed),
-      deno_broadcast_channel::deno_broadcast_channel::init_ext(
+      deno_webstorage::deno_webstorage::init_ops(None).disable(),
+      deno_crypto::deno_crypto::init_ops(options.seed),
+      deno_broadcast_channel::deno_broadcast_channel::init_ops(
         options.broadcast_channel.clone(),
         unstable,
       ),
-      deno_ffi::deno_ffi::init_ext::<PermissionsContainer>(unstable),
-      deno_net::deno_net::init_ext::<PermissionsContainer>(
+      deno_ffi::deno_ffi::init_ops::<PermissionsContainer>(unstable),
+      deno_net::deno_net::init_ops::<PermissionsContainer>(
         options.root_cert_store_provider.clone(),
         unstable,
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_tls::deno_tls::init_ext(),
-      deno_kv::deno_kv::init_ext(
+      deno_tls::deno_tls::init_ops(),
+      deno_kv::deno_kv::init_ops(
         SqliteDbHandler::<PermissionsContainer>::new(None),
         unstable,
       ),
-      deno_napi::deno_napi::init_ext::<PermissionsContainer>(),
-      deno_http::deno_http::init_ext::<DefaultHttpPropertyExtractor>(),
-      deno_io::deno_io::init_ext(Some(options.stdio)),
-      deno_fs::deno_fs::init_ext::<PermissionsContainer>(
+      deno_napi::deno_napi::init_ops::<PermissionsContainer>(),
+      deno_http::deno_http::init_ops::<DefaultHttpPropertyExtractor>(),
+      deno_io::deno_io::init_ops(Some(options.stdio)),
+      deno_fs::deno_fs::init_ops::<PermissionsContainer>(
         unstable,
         options.fs.clone(),
       ),
-      deno_node::deno_node::init_ext::<PermissionsContainer>(
+      deno_node::deno_node::init_ops::<PermissionsContainer>(
         options.npm_resolver,
         options.fs,
       ),
       // Runtime ops that are always initialized for WebWorkers
-      ops::web_worker::deno_web_worker::init_ext(),
-      ops::runtime::deno_runtime::init_ext(main_module.clone()),
-      ops::worker_host::deno_worker_host::init_ext(
+      ops::web_worker::deno_web_worker::init_ops(),
+      ops::runtime::deno_runtime::init_ops(main_module.clone()),
+      ops::worker_host::deno_worker_host::init_ops(
         options.create_web_worker_cb.clone(),
         options.preload_module_cb.clone(),
         options.pre_execute_module_cb.clone(),
         options.format_js_error_fn.clone(),
       ),
-      ops::fs_events::deno_fs_events::init_ext(),
-      ops::os::deno_os_worker::init_ext(),
-      ops::permissions::deno_permissions::init_ext(),
-      ops::process::deno_process::init_ext(),
-      ops::signal::deno_signal::init_ext(),
-      ops::tty::deno_tty::init_ext(),
-      ops::http::deno_http_runtime::init_ext(),
-      deno_permissions_web_worker::init_ext(
+      ops::fs_events::deno_fs_events::init_ops(),
+      ops::os::deno_os_worker::init_ops(),
+      ops::permissions::deno_permissions::init_ops(),
+      ops::process::deno_process::init_ops(),
+      ops::signal::deno_signal::init_ops(),
+      ops::tty::deno_tty::init_ops(),
+      ops::http::deno_http_runtime::init_ops(),
+      deno_permissions_web_worker::init_ops(
         permissions,
         unstable,
         enable_testing_features,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -225,14 +225,14 @@ impl MainWorker {
     // `runtime/build.rs`, `runtime/web_worker.rs` and `cli/build.rs`!
     let mut extensions = vec![
       // Web APIs
-      deno_webidl::deno_webidl::init_ext(),
-      deno_console::deno_console::init_ext(),
-      deno_url::deno_url::init_ext(),
-      deno_web::deno_web::init_ext::<PermissionsContainer>(
+      deno_webidl::deno_webidl::init_ops(),
+      deno_console::deno_console::init_ops(),
+      deno_url::deno_url::init_ops(),
+      deno_web::deno_web::init_ops::<PermissionsContainer>(
         options.blob_store.clone(),
         options.bootstrap.location.clone(),
       ),
-      deno_fetch::deno_fetch::init_ext::<PermissionsContainer>(
+      deno_fetch::deno_fetch::init_ops::<PermissionsContainer>(
         deno_fetch::Options {
           user_agent: options.bootstrap.user_agent.clone(),
           root_cert_store_provider: options.root_cert_store_provider.clone(),
@@ -243,60 +243,60 @@ impl MainWorker {
           ..Default::default()
         },
       ),
-      deno_cache::deno_cache::init_ext::<SqliteBackedCache>(create_cache),
-      deno_websocket::deno_websocket::init_ext::<PermissionsContainer>(
+      deno_cache::deno_cache::init_ops::<SqliteBackedCache>(create_cache),
+      deno_websocket::deno_websocket::init_ops::<PermissionsContainer>(
         options.bootstrap.user_agent.clone(),
         options.root_cert_store_provider.clone(),
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_webstorage::deno_webstorage::init_ext(
+      deno_webstorage::deno_webstorage::init_ops(
         options.origin_storage_dir.clone(),
       ),
-      deno_crypto::deno_crypto::init_ext(options.seed),
-      deno_broadcast_channel::deno_broadcast_channel::init_ext(
+      deno_crypto::deno_crypto::init_ops(options.seed),
+      deno_broadcast_channel::deno_broadcast_channel::init_ops(
         options.broadcast_channel.clone(),
         unstable,
       ),
-      deno_ffi::deno_ffi::init_ext::<PermissionsContainer>(unstable),
-      deno_net::deno_net::init_ext::<PermissionsContainer>(
+      deno_ffi::deno_ffi::init_ops::<PermissionsContainer>(unstable),
+      deno_net::deno_net::init_ops::<PermissionsContainer>(
         options.root_cert_store_provider.clone(),
         unstable,
         options.unsafely_ignore_certificate_errors.clone(),
       ),
-      deno_tls::deno_tls::init_ext(),
-      deno_kv::deno_kv::init_ext(
+      deno_tls::deno_tls::init_ops(),
+      deno_kv::deno_kv::init_ops(
         SqliteDbHandler::<PermissionsContainer>::new(
           options.origin_storage_dir.clone(),
         ),
         unstable,
       ),
-      deno_napi::deno_napi::init_ext::<PermissionsContainer>(),
-      deno_http::deno_http::init_ext::<DefaultHttpPropertyExtractor>(),
-      deno_io::deno_io::init_ext(Some(options.stdio)),
-      deno_fs::deno_fs::init_ext::<PermissionsContainer>(
+      deno_napi::deno_napi::init_ops::<PermissionsContainer>(),
+      deno_http::deno_http::init_ops::<DefaultHttpPropertyExtractor>(),
+      deno_io::deno_io::init_ops(Some(options.stdio)),
+      deno_fs::deno_fs::init_ops::<PermissionsContainer>(
         unstable,
         options.fs.clone(),
       ),
-      deno_node::deno_node::init_ext::<PermissionsContainer>(
+      deno_node::deno_node::init_ops::<PermissionsContainer>(
         options.npm_resolver,
         options.fs,
       ),
       // Ops from this crate
-      ops::runtime::deno_runtime::init_ext(main_module.clone()),
-      ops::worker_host::deno_worker_host::init_ext(
+      ops::runtime::deno_runtime::init_ops(main_module.clone()),
+      ops::worker_host::deno_worker_host::init_ops(
         options.create_web_worker_cb.clone(),
         options.web_worker_preload_module_cb.clone(),
         options.web_worker_pre_execute_module_cb.clone(),
         options.format_js_error_fn.clone(),
       ),
-      ops::fs_events::deno_fs_events::init_ext(),
-      ops::os::deno_os::init_ext(exit_code.clone()),
-      ops::permissions::deno_permissions::init_ext(),
-      ops::process::deno_process::init_ext(),
-      ops::signal::deno_signal::init_ext(),
-      ops::tty::deno_tty::init_ext(),
-      ops::http::deno_http_runtime::init_ext(),
-      deno_permissions_worker::init_ext(
+      ops::fs_events::deno_fs_events::init_ops(),
+      ops::os::deno_os::init_ops(exit_code.clone()),
+      ops::permissions::deno_permissions::init_ops(),
+      ops::process::deno_process::init_ops(),
+      ops::signal::deno_signal::init_ops(),
+      ops::tty::deno_tty::init_ops(),
+      ops::http::deno_http_runtime::init_ops(),
+      deno_permissions_worker::init_ops(
         permissions,
         unstable,
         enable_testing_features,


### PR DESCRIPTION
…nclusion" (#19519)"

This reverts commit 28a4f3d0f5383695b1d49ccdc8b0f799a715b2c2.

This change causes failures when used outside Deno repo:
```
============================================================
Deno has panicked. This is a bug in Deno. Please report this
at https://github.com/denoland/deno/issues/new.
If you can reliably reproduce this panic, include the
reproduction steps and re-run with the RUST_BACKTRACE=1 env
var set and include the backtrace in your report.

Platform: linux x86_64
Version: 1.34.3+b37b286
Args: ["/opt/hostedtoolcache/deno/0.0.0-b37b286f7fa68d5656f7c180f6127bdc38cf2cf5/x64/deno", "test", "--doc", "--unstable", "--allow-all", "--coverage=./cov"]

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Failed to read "/home/runner/work/deno/deno/core/00_primordials.js"

Caused by:
    No such file or directory (os error 2)', core/runtime/jsruntime.rs:699:8
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
https://github.com/denoland/deno_std/actions/runs/5374528073/jobs/9749992481

CC @nayeemrmn 