### PR TITLE
feat: Deno.createHttpClient defaultHeaders

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1569,6 +1569,20 @@ Deno.test(
   },
 );
 
+Deno.test(
+  { permissions: { net: true, read: true } },
+  async function createHttpClientDefaultHeaders() {
+    const client = Deno.createHttpClient({
+      defaultHeaders: { "host": "example.com" },
+    });
+    const res = await fetch("http://localhost:4545/echo_server", { client });
+    assert(res.ok);
+    assertEquals(res.headers.get("host"), "example.com");
+    await res.body?.cancel();
+    client.close();
+  },
+);
+
 Deno.test({ permissions: { read: false } }, async function fetchFilePerm() {
   await assertRejects(async () => {
     await fetch(import.meta.resolve("../testdata/subdir/json_1.json"));

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -837,6 +837,10 @@ declare namespace Deno {
      * @default {true}
      */
     http2?: boolean;
+    /**
+     * Default set of headers to use for every request.
+     */
+    defaultHeaders?: HeadersInit;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -10,6 +10,8 @@
 /// <reference path="./lib.deno_fetch.d.ts" />
 /// <reference lib="esnext" />
 
+import { headerListFromHeaders, Headers } from "ext:deno_fetch/20_headers.js";
+
 const core = globalThis.Deno.core;
 const ops = core.ops;
 
@@ -19,9 +21,13 @@ const ops = core.ops;
  */
 function createHttpClient(options) {
   options.caCerts ??= [];
+  let defaultHeaders = [];
+  if (options.defaultHeaders) {
+    defaultHeaders = headerListFromHeaders(new Headers(options.defaultHeaders));
+  }
   return new HttpClient(
     ops.op_fetch_custom_client(
-      options,
+      { ...options, defaultHeaders },
     ),
   );
 }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -728,10 +728,7 @@ async fn main_server(
   req: Request<Body>,
 ) -> Result<Response<Body>, hyper::http::Error> {
   return match (req.method(), req.uri().path()) {
-    (
-      &hyper::Method::POST | &hyper::Method::PATCH | &hyper::Method::PUT,
-      "/echo_server",
-    ) => {
+    (_, "/echo_server") => {
       let (parts, body) = req.into_parts();
       let mut response = Response::new(body);
 


### PR DESCRIPTION
This adds an option to specify headers in createHttpClient, without any filters.
This is useful for setting forbidden headers (ie host header).
Closes #16840
Ref #11017