### PR TITLE
refactor(ops): op2 support for generics

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -239,7 +239,7 @@ macro_rules! extension {
           ext.ops(vec![
             $(
               $( #[ $m ] )*
-              $( $op )::+ :: decl $( :: < $($op_param),* > )? ()
+              $( $op )::+ $( :: < $($op_param),* > )? :: decl ()
             ),+
           ]);
         )?

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -65,6 +65,12 @@ pub type OpMiddlewareFn = dyn Fn(OpDecl) -> OpDecl;
 pub type OpStateFn = dyn FnOnce(&mut OpState);
 pub type OpEventLoopFn = dyn Fn(Rc<RefCell<OpState>>, &mut Context) -> bool;
 
+/// Trait implemented by all generated ops.
+pub trait Op {
+  const NAME: &'static str;
+  const DECL: OpDecl;
+}
+
 pub struct OpDecl {
   pub name: &'static str,
   pub v8_fn_ptr: OpFnRef,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -131,6 +131,7 @@ pub fn v8_version() -> &'static str {
 pub mod _ops {
   pub use super::error::throw_type_error;
   pub use super::error_codes::get_error_code;
+  pub use super::extensions::Op;
   pub use super::extensions::OpDecl;
   pub use super::ops::to_op_result;
   pub use super::ops::OpCtx;

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -227,7 +227,8 @@ mod tests {
       op_test_result_void_ok,
       op_test_result_void_err,
       op_test_result_primitive_ok,
-      op_test_result_primitive_err
+      op_test_result_primitive_err,
+      op_test_generics<String>,
     ]
   );
 
@@ -413,4 +414,8 @@ mod tests {
     )?;
     Ok(())
   }
+
+  // We don't actually test this one -- we just want it to compile
+  #[op2(core, fast)]
+  pub fn op_test_generics<T: Clone>() {}
 }

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -1047,7 +1047,7 @@ mod tests {
     };
 
     let mut connect_fut =
-      op_net_connect_tcp::call::<TestPermission>(conn_state, ip_addr)
+      op_net_connect_tcp::<TestPermission>::call(conn_state, ip_addr)
         .boxed_local();
     let mut rid = None;
 

--- a/ops/fast_call.rs
+++ b/ops/fast_call.rs
@@ -282,14 +282,16 @@ pub(crate) fn generate(
   let fast_fn = q!(
     Vars { core, pre_transforms, op_name_fast: &fast_fn_ident, op_name: &ident, fast_fn_inputs, generics, call_generics: &caller_generics, where_clause, idents, transforms, output_transforms, output: &output },
     {
-      #[allow(clippy::too_many_arguments)]
-      fn op_name_fast generics (_: core::v8::Local<core::v8::Object>, fast_fn_inputs) -> output where_clause {
-        use core::v8;
-        use core::_ops;
-        pre_transforms
-        transforms
-        let result = op_name::call call_generics (idents);
-        output_transforms
+      impl generics op_name generics where_clause {
+        #[allow(clippy::too_many_arguments)]
+        fn op_name_fast (_: core::v8::Local<core::v8::Object>, fast_fn_inputs) -> output {
+          use core::v8;
+          use core::_ops;
+          pre_transforms
+          transforms
+          let result = Self::call (idents);
+          output_transforms
+        }
       }
     }
   );
@@ -307,7 +309,7 @@ pub(crate) fn generate(
       Some(core::v8::fast_api::FastFunction::new(
         &[ inputs ],
         CType :: output,
-        fast_fn_ident generics as *const ::std::ffi::c_void
+        Self::fast_fn_ident as *const ::std::ffi::c_void
       ))
     }}
   ).dump();

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -978,8 +978,10 @@ mod tests {
     let expected = std::fs::read_to_string(input.with_extension("out"))
       .expect("Failed to read expected output file");
 
+    // Print the raw tokens in case we fail to parse
     let actual = op.gen();
-    println!("{}", actual);
+    println!("-----Raw tokens-----\n{}----------\n", actual);
+
     // Validate syntax tree.
     let tree = syn::parse2(actual).unwrap();
     let actual = prettyplease::unparse(&tree);

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -130,6 +130,21 @@ impl Op {
           _phantom_data: ::std::marker::PhantomData<(#(#params),*)>
         }
 
+        impl #generics #core::_ops::Op for #name #generics #where_clause {
+          const NAME: &'static str = stringify!(#name);
+          const DECL: #core::OpDecl = #core::OpDecl {
+            name: Self::name(),
+            v8_fn_ptr: #v8_fn::v8_fn_ptr as _,
+            enabled: true,
+            fast_fn: #decl,
+            is_async: #is_async,
+            is_unstable: #is_unstable,
+            is_v8: #is_v8,
+            // TODO(mmastrac)
+            arg_count: 0,
+          };
+        }
+
         #[doc(hidden)]
         impl #generics #name #generics #where_clause {
           pub const fn name() -> &'static str {
@@ -184,6 +199,21 @@ impl Op {
       #[doc="you can include in a `deno_core::Extension`."]
       pub struct #name #generics {
         _phantom_data: ::std::marker::PhantomData<(#(#params),*)>
+      }
+
+      impl #generics #core::_ops::Op for #name #generics #where_clause {
+        const NAME: &'static str = stringify!(#name);
+        const DECL: #core::OpDecl = #core::OpDecl {
+          name: Self::name(),
+          v8_fn_ptr: Self::v8_fn_ptr as _,
+          enabled: true,
+          fast_fn: #decl,
+          is_async: #is_async,
+          is_unstable: #is_unstable,
+          is_v8: #is_v8,
+          // TODO(mmastrac)
+          arg_count: 0,
+        };
       }
 
       #[doc(hidden)]

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -74,7 +74,7 @@ pub(crate) fn generate_dispatch_slow(
   } = &generator_state;
 
   Ok(quote! {
-    pub extern "C" fn #slow_function(#info: *const #deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn #slow_function(#info: *const #deno_core::v8::FunctionCallbackInfo) {
     #with_scope
     #with_retval
     #with_args

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -135,8 +135,8 @@ fn generate_op2(
   let scope = Ident::new("scope", Span::call_site());
   let info = Ident::new("info", Span::call_site());
   let opctx = Ident::new("opctx", Span::call_site());
-  let slow_function = Ident::new("slow_function", Span::call_site());
-  let fast_function = Ident::new("fast_function", Span::call_site());
+  let slow_function = Ident::new("v8_fn_ptr", Span::call_site());
+  let fast_function = Ident::new("v8_fn_ptr_fast", Span::call_site());
   let fast_api_callback_options =
     Ident::new("fast_api_callback_options", Span::call_site());
 
@@ -216,6 +216,20 @@ fn generate_op2(
       _unconstructable: ::std::marker::PhantomData<(#(#generic),*)>
     }
 
+    impl <#(#generic : #bound),*> #deno_core::_ops::Op for #name <#(#generic),*> {
+      const NAME: &'static str = stringify!(#name);
+      const DECL: #deno_core::_ops::OpDecl = #deno_core::_ops::OpDecl {
+        name: stringify!(#name),
+        v8_fn_ptr: Self::#slow_function as _,
+        enabled: true,
+        fast_fn: #fast_definition,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: #arg_count as u8,
+      };
+    }
+
     impl <#(#generic : #bound),*> #name <#(#generic),*> {
       pub const fn name() -> &'static str {
         stringify!(#name)
@@ -234,8 +248,8 @@ fn generate_op2(
         }
       }
 
-      #slow_fn
       #fast_fn
+      #slow_fn
 
       #[inline(always)]
       #op_fn

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -699,6 +699,11 @@ mod tests {
 
   expect_fail!(op_with_two_lifetimes, TooManyLifetimes, fn f<'a, 'b>() {});
   expect_fail!(
+    op_with_lifetime_bounds,
+    LifetimesMayNotHaveBounds("'a"),
+    fn f<'a: 'b, 'b>() {}
+  );
+  expect_fail!(
     op_with_missing_bounds,
     GenericBoundCardinality("B"),
     fn f<'a, B>() {}

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -4,12 +4,15 @@ use proc_macro2::Ident;
 use proc_macro2::Span;
 use quote::quote;
 use quote::ToTokens;
+use std::collections::BTreeMap;
 use strum::IntoEnumIterator;
 use strum::IntoStaticStr;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
 use syn2::Attribute;
 use syn2::FnArg;
+use syn2::GenericParam;
+use syn2::Generics;
 use syn2::Pat;
 use syn2::ReturnType;
 use syn2::Signature;
@@ -136,9 +139,16 @@ pub enum RetVal {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParsedSignature {
+  // The parsed arguments
   pub args: Vec<Arg>,
+  // The argument names
   pub names: Vec<String>,
+  // The parsed return value
   pub ret_val: RetVal,
+  // One and only one lifetime allowed
+  pub lifetime: Option<String>,
+  // Generic bounds: each generic must have one and only simple trait bound
+  pub generic_bounds: BTreeMap<String, String>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -153,10 +163,24 @@ enum AttributeModifier {
 
 #[derive(Error, Debug)]
 pub enum SignatureError {
-  #[error("Invalid argument: {0}")]
+  #[error("Invalid argument: '{0}'")]
   ArgError(String, #[source] ArgError),
   #[error("Invalid return type")]
   RetError(#[from] ArgError),
+  #[error("Only one lifetime is permitted")]
+  TooManyLifetimes,
+  #[error("Generic '{0}' must have one and only bound (either <T> and 'where T: Trait', or <T: Trait>)")]
+  GenericBoundCardinality(String),
+  #[error("Where clause predicate '{0}' (eg: where T: Trait) must appear in generics list (eg: <T>)")]
+  WherePredicateMustAppearInGenerics(String),
+  #[error("All generics must appear only once in the generics parameter list or where clause")]
+  DuplicateGeneric(String),
+  #[error("Generic lifetime '{0}' may not have bounds (eg: <'a: 'b>)")]
+  LifetimesMayNotHaveBounds(String),
+  #[error("Invalid generic: '{0}' Only simple generics bounds are allowed (eg: T: Trait)")]
+  InvalidGeneric(String),
+  #[error("Invalid predicate: '{0}' Only simple where predicates are allowed (eg: T: Trait)")]
+  InvalidWherePredicate(String),
 }
 
 #[derive(Error, Debug)]
@@ -216,11 +240,113 @@ pub fn parse_signature(
       parse_arg(input).map_err(|err| SignatureError::ArgError(name, err))?,
     );
   }
+  let ret_val =
+    parse_return(parse_attributes(&attributes)?, &signature.output)?;
+  let lifetime = parse_lifetime(&signature.generics)?;
+  let generic_bounds = parse_generics(&signature.generics)?;
   Ok(ParsedSignature {
     args,
     names,
-    ret_val: parse_return(parse_attributes(&attributes)?, &signature.output)?,
+    ret_val,
+    lifetime,
+    generic_bounds,
   })
+}
+
+/// Extract one lifetime from the [`syn2::Generics`], ensuring that the lifetime is valid
+/// and has no bounds.
+fn parse_lifetime(
+  generics: &Generics,
+) -> Result<Option<String>, SignatureError> {
+  let mut res = None;
+  for param in &generics.params {
+    match param {
+      GenericParam::Lifetime(lt) => {
+        if !lt.bounds.is_empty() {
+          return Err(SignatureError::LifetimesMayNotHaveBounds(
+            lt.lifetime.to_string(),
+          ));
+        }
+        if res.is_some() {
+          return Err(SignatureError::TooManyLifetimes);
+        }
+        res = Some(lt.lifetime.ident.to_string());
+      }
+      _ => {}
+    }
+  }
+  Ok(res)
+}
+
+/// Parse and validate generics. We require one and only one trait bound for each generic
+/// parameter. Tries to sanity check and return reasonable errors for possible signature errors.
+fn parse_generics(
+  generics: &Generics,
+) -> Result<BTreeMap<String, String>, SignatureError> {
+  let mut where_clauses = BTreeMap::new();
+
+  // First, extract the where clause so we can detect duplicated predicates
+  if let Some(where_clause) = &generics.where_clause {
+    for predicate in &where_clause.predicates {
+      let predicate = predicate.to_token_stream();
+      let (generic_name, bound) = std::panic::catch_unwind(|| {
+        use syn2 as syn;
+        rules!(predicate => {
+          ($t:ident : $bound:path) => (t.to_string(), stringify_token(bound)),
+        })
+      })
+      .map_err(|_| {
+        SignatureError::InvalidWherePredicate(predicate.to_string())
+      })?;
+      if where_clauses.insert(generic_name.clone(), bound).is_some() {
+        return Err(SignatureError::DuplicateGeneric(generic_name));
+      }
+    }
+  }
+
+  let mut res = BTreeMap::new();
+  for param in &generics.params {
+    match param {
+      GenericParam::Type(ty) => {
+        let ty = ty.to_token_stream();
+        let (name, bound) = std::panic::catch_unwind(|| {
+          use syn2 as syn;
+          rules!(ty => {
+            ($t:ident : $bound:path) => (t.to_string(), Some(stringify_token(bound))),
+            ($t:ident) => (t.to_string(), None),
+          })
+        }).map_err(|_| SignatureError::InvalidGeneric(ty.to_string()))?;
+        match bound {
+          Some(bound) => {
+            if where_clauses.contains_key(&name) {
+              return Err(SignatureError::GenericBoundCardinality(name));
+            }
+            if res.contains_key(&name) {
+              return Err(SignatureError::DuplicateGeneric(name));
+            }
+            res.insert(name, bound);
+          }
+          None => {
+            let Some(bound) = where_clauses.remove(&name) else {
+              return Err(SignatureError::GenericBoundCardinality(name));
+            };
+            if res.contains_key(&name) {
+              return Err(SignatureError::DuplicateGeneric(name));
+            }
+            res.insert(name, bound);
+          }
+        }
+      }
+      _ => {}
+    }
+  }
+  if !where_clauses.is_empty() {
+    return Err(SignatureError::WherePredicateMustAppearInGenerics(
+      where_clauses.into_keys().next().unwrap().clone(),
+    ));
+  }
+
+  Ok(res)
 }
 
 fn parse_attributes(attributes: &[Attribute]) -> Result<Attributes, ArgError> {
@@ -447,11 +573,27 @@ mod tests {
   // We can't test pattern args :/
   // https://github.com/rust-lang/rfcs/issues/2688
   macro_rules! test {
-    ( $(# [ $fn_attr:ident ])? fn $name:ident ( $( $(# [ $attr:ident ])? $ident:ident : $ty:ty ),* ) $(-> $(# [ $ret_attr:ident ])? $ret:ty)?, ( $( $arg_res:expr ),* ) -> $ret_res:expr ) => {
+    (
+      // Function attributes
+      $(# [ $fn_attr:ident ])?
+      // fn name < 'scope, GENERIC1, GENERIC2, ... >
+      fn $name:ident $( < $scope:lifetime $( , $generic:ident)* >)?
+      (
+        // Argument attribute, argument
+        $( $(# [ $attr:ident ])? $ident:ident : $ty:ty ),*
+      )
+      // Return value
+      $(-> $(# [ $ret_attr:ident ])? $ret:ty)?
+      // Where clause
+      $( where $($trait:ident : $bounds:path),* )?
+      ;
+      // Expected return value
+      $( < $( $lifetime_res:lifetime )? $(, $generic_res:ident : $bounds_res:path )* >)? ( $( $arg_res:expr ),* ) -> $ret_res:expr ) => {
       #[test]
       fn $name() {
         test(
-          stringify!($( #[$fn_attr] )? fn op( $( $( #[$attr] )? $ident : $ty ),* ) $(-> $( #[$ret_attr] )? $ret)? {}),
+          stringify!($( #[$fn_attr] )? fn op $( < $scope $( , $generic)* >)? ( $( $( #[$attr] )? $ident : $ty ),* ) $(-> $( #[$ret_attr] )? $ret)? $( where $($trait : $bounds),* )? {}),
+          stringify!($( < $( $lifetime_res )? $(, $generic_res : $bounds_res)* > )?),
           stringify!($($arg_res),*),
           stringify!($ret_res)
         );
@@ -459,14 +601,35 @@ mod tests {
     };
   }
 
-  fn test(op: &str, args_expected: &str, return_expected: &str) {
+  fn test(
+    op: &str,
+    generics_expected: &str,
+    args_expected: &str,
+    return_expected: &str,
+  ) {
+    // Parse the provided macro input as an ItemFn
     let item_fn = parse_str::<ItemFn>(op)
       .unwrap_or_else(|_| panic!("Failed to parse {op} as a ItemFn"));
-    let attrs = item_fn.attrs;
-    let sig = parse_signature(attrs, item_fn.sig).unwrap_or_else(|_| {
-      panic!("Failed to successfully parse signature from {op}")
-    });
 
+    let attrs = item_fn.attrs;
+    let sig = parse_signature(attrs, item_fn.sig).unwrap_or_else(|err| {
+      panic!("Failed to successfully parse signature from {op} ({err:?})")
+    });
+    println!("Raw parsed signatures = {sig:?}");
+
+    let mut generics_res = vec![];
+    if let Some(lifetime) = sig.lifetime {
+      generics_res.push(format!("'{lifetime}"));
+    }
+    for (name, bounds) in sig.generic_bounds {
+      generics_res.push(format!("{name} : {bounds}"));
+    }
+    if !generics_res.is_empty() {
+      assert_eq!(
+        generics_expected,
+        format!("< {} >", generics_res.join(", "))
+      );
+    }
     assert_eq!(
       args_expected,
       format!("{:?}", sig.args).trim_matches(|c| c == '[' || c == ']')
@@ -474,37 +637,90 @@ mod tests {
     assert_eq!(return_expected, format!("{:?}", sig.ret_val));
   }
 
+  macro_rules! expect_fail {
+    ($name:ident, $error:expr, $f:item) => {
+      #[test]
+      pub fn $name() {
+        expect_fail(stringify!($f), stringify!($error));
+      }
+    };
+  }
+
+  fn expect_fail(op: &str, error: &str) {
+    // Parse the provided macro input as an ItemFn
+    let item_fn = parse_str::<ItemFn>(op)
+      .unwrap_or_else(|_| panic!("Failed to parse {op} as a ItemFn"));
+    let attrs = item_fn.attrs;
+    let err = parse_signature(attrs, item_fn.sig)
+      .expect_err("Expected function to fail to parse");
+    assert_eq!(format!("{err:?}"), error.to_owned());
+  }
+
   test!(
-    fn op_state_and_number(opstate: &mut OpState, a: u32) -> (),
+    fn op_state_and_number(opstate: &mut OpState, a: u32) -> ();
     (Ref(Mut, OpState), Numeric(u32)) -> Infallible(Void)
   );
   test!(
-    fn op_slices(r#in: &[u8], out: &mut [u8]),
+    fn op_slices(r#in: &[u8], out: &mut [u8]);
     (Slice(Ref, u8), Slice(Mut, u8)) -> Infallible(Void)
   );
   test!(
-    #[serde] fn op_serde(#[serde] input: package::SerdeInputType) -> Result<package::SerdeReturnType, Error>,
+    #[serde] fn op_serde(#[serde] input: package::SerdeInputType) -> Result<package::SerdeReturnType, Error>;
     (SerdeV8("package::SerdeInputType")) -> Result(SerdeV8("package::SerdeReturnType"))
   );
   test!(
-    fn op_local(input: v8::Local<v8::String>) -> Result<v8::Local<v8::String>, Error>,
+    fn op_local(input: v8::Local<v8::String>) -> Result<v8::Local<v8::String>, Error>;
     (V8Local(String)) -> Result(V8Local(String))
   );
   test!(
-    fn op_resource(#[smi] rid: ResourceId, buffer: &[u8]),
+    fn op_resource(#[smi] rid: ResourceId, buffer: &[u8]);
     (Numeric(__SMI__), Slice(Ref, u8)) ->  Infallible(Void)
   );
   test!(
-    fn op_option_numeric_result(state: &mut OpState) -> Result<Option<u32>, AnyError>,
+    fn op_option_numeric_result(state: &mut OpState) -> Result<Option<u32>, AnyError>;
     (Ref(Mut, OpState)) -> Result(OptionNumeric(u32))
   );
   test!(
-    fn op_ffi_read_f64(state: &mut OpState, ptr: * mut c_void, offset: isize) -> Result <f64, AnyError>,
+    fn op_ffi_read_f64(state: &mut OpState, ptr: * mut c_void, offset: isize) -> Result <f64, AnyError>;
     (Ref(Mut, OpState), Ptr(Mut, __VOID__), Numeric(isize)) -> Result(Numeric(f64))
   );
   test!(
-    fn op_print(#[string] msg: &str, is_err: bool) -> Result<(), Error>,
+    fn op_print(#[string] msg: &str, is_err: bool) -> Result<(), Error>;
     (Special(RefStr), Numeric(bool)) -> Result(Void)
+  );
+  test!(
+    fn op_scope<'s>(#[string] msg: &'s str);
+    <'s> (Special(RefStr)) -> Infallible(Void)
+  );
+  test!(
+    fn op_scope_and_generics<'s, AB, BC>(#[string] msg: &'s str) where AB: some::Trait, BC: OtherTrait;
+    <'s, AB: some::Trait, BC: OtherTrait> (Special(RefStr)) -> Infallible(Void)
+  );
+
+  expect_fail!(op_with_two_lifetimes, TooManyLifetimes, fn f<'a, 'b>() {});
+  expect_fail!(
+    op_with_missing_bounds,
+    GenericBoundCardinality("B"),
+    fn f<'a, B>() {}
+  );
+  expect_fail!(
+    op_with_duplicate_bounds,
+    GenericBoundCardinality("B"),
+    fn f<'a, B: Trait>()
+    where
+      B: Trait,
+    {
+    }
+  );
+  expect_fail!(
+    op_with_extra_bounds,
+    WherePredicateMustAppearInGenerics("C"),
+    fn f<'a, B>()
+    where
+      B: Trait,
+      C: Trait,
+    {
+    }
   );
 
   #[test]

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -312,26 +312,24 @@ fn parse_generics(
           ($t:ident) => (t.to_string(), None),
         })
       }).map_err(|_| SignatureError::InvalidGeneric(ty.to_string()))?;
-      match bound {
+      let bound = match bound {
         Some(bound) => {
           if where_clauses.contains_key(&name) {
             return Err(SignatureError::GenericBoundCardinality(name));
           }
-          if res.contains_key(&name) {
-            return Err(SignatureError::DuplicateGeneric(name));
-          }
-          res.insert(name, bound);
+          bound
         }
         None => {
           let Some(bound) = where_clauses.remove(&name) else {
             return Err(SignatureError::GenericBoundCardinality(name));
           };
-          if res.contains_key(&name) {
-            return Err(SignatureError::DuplicateGeneric(name));
-          }
-          res.insert(name, bound);
+          bound
         }
+      };
+      if res.contains_key(&name) {
+        return Err(SignatureError::DuplicateGeneric(name));
       }
+      res.insert(name, bound);
     }
   }
   if !where_clauses.is_empty() {

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -2,6 +2,27 @@
 struct op_add {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_add {
+    const NAME: &'static str = stringify!(op_add);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_add),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[Type::V8Value, Type::Uint32, Type::Uint32],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 2usize as u8,
+    };
+}
 impl op_add {
     pub const fn name() -> &'static str {
         stringify!(op_add)
@@ -9,7 +30,7 @@ impl op_add {
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
             name: stringify!(op_add),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
                 use deno_core::v8::fast_api::Type;
@@ -17,7 +38,7 @@ impl op_add {
                 deno_core::v8::fast_api::FastFunction::new(
                     &[Type::V8Value, Type::Uint32, Type::Uint32],
                     CType::Uint32,
-                    Self::fast_function as *const ::std::ffi::c_void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
             }),
             is_async: false,
@@ -26,7 +47,15 @@ impl op_add {
             arg_count: 2usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const deno_core::v8::FunctionCallbackInfo) {
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: u32,
+        arg1: u32,
+    ) -> u32 {
+        let result = Self::call(arg0 as _, arg1 as _);
+        result
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
@@ -39,14 +68,6 @@ impl op_add {
         let arg1 = deno_core::_ops::to_u32(&arg1) as _;
         let result = Self::call(arg0, arg1);
         rv.set_uint32(result as u32);
-    }
-    fn fast_function(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-    ) -> u32 {
-        let result = Self::call(arg0 as _, arg1 as _);
-        result
     }
     #[inline(always)]
     fn call(a: u32, b: u32) -> u32 {

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -1,5 +1,7 @@
 #[allow(non_camel_case_types)]
-struct op_add {}
+struct op_add {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
 impl op_add {
     pub const fn name() -> &'static str {
         stringify!(op_add)

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -1,5 +1,7 @@
 #[allow(non_camel_case_types)]
-pub struct op_test_add_option {}
+pub struct op_test_add_option {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
 impl op_test_add_option {
     pub const fn name() -> &'static str {
         stringify!(op_test_add_option)

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -2,6 +2,19 @@
 pub struct op_test_add_option {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
+impl crate::_ops::Op for op_test_add_option {
+    const NAME: &'static str = stringify!(op_test_add_option);
+    const DECL: crate::_ops::OpDecl = crate::_ops::OpDecl {
+        name: stringify!(op_test_add_option),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 2usize as u8,
+    };
+}
 impl op_test_add_option {
     pub const fn name() -> &'static str {
         stringify!(op_test_add_option)
@@ -9,7 +22,7 @@ impl op_test_add_option {
     pub const fn decl() -> crate::_ops::OpDecl {
         crate::_ops::OpDecl {
             name: stringify!(op_test_add_option),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: None,
             is_async: false,
@@ -18,7 +31,7 @@ impl op_test_add_option {
             arg_count: 2usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const crate::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const crate::v8::FunctionCallbackInfo) {
         let mut rv = crate::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -2,6 +2,27 @@
 pub struct op_has_doc_comment {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_has_doc_comment {
+    const NAME: &'static str = stringify!(op_has_doc_comment);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_has_doc_comment),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0usize as u8,
+    };
+}
 impl op_has_doc_comment {
     pub const fn name() -> &'static str {
         stringify!(op_has_doc_comment)
@@ -9,7 +30,7 @@ impl op_has_doc_comment {
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
             name: stringify!(op_has_doc_comment),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
                 use deno_core::v8::fast_api::Type;
@@ -17,7 +38,7 @@ impl op_has_doc_comment {
                 deno_core::v8::fast_api::FastFunction::new(
                     &[Type::V8Value],
                     CType::Void,
-                    Self::fast_function as *const ::std::ffi::c_void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
             }),
             is_async: false,
@@ -26,12 +47,12 @@ impl op_has_doc_comment {
             arg_count: 0usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let result = Self::call();
-    }
-    fn fast_function(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = Self::call();
         result
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let result = Self::call();
     }
     #[inline(always)]
     pub fn call() -> () {}

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -1,14 +1,14 @@
 #[allow(non_camel_case_types)]
-pub struct op_has_doc_comment {
-    _unconstructable: ::std::marker::PhantomData<()>,
+pub struct op_generics<T> {
+    _unconstructable: ::std::marker::PhantomData<(T)>,
 }
-impl op_has_doc_comment {
+impl<T: Trait> op_generics<T> {
     pub const fn name() -> &'static str {
-        stringify!(op_has_doc_comment)
+        stringify!(op_generics)
     }
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
-            name: stringify!(op_has_doc_comment),
+            name: stringify!(op_generics),
             v8_fn_ptr: Self::slow_function as _,
             enabled: true,
             fast_fn: Some({
@@ -34,5 +34,5 @@ impl op_has_doc_comment {
         result
     }
     #[inline(always)]
-    pub fn call() -> () {}
+    pub fn call() {}
 }

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -2,6 +2,27 @@
 pub struct op_generics<T> {
     _unconstructable: ::std::marker::PhantomData<(T)>,
 }
+impl<T: Trait> deno_core::_ops::Op for op_generics<T> {
+    const NAME: &'static str = stringify!(op_generics);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_generics),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0usize as u8,
+    };
+}
 impl<T: Trait> op_generics<T> {
     pub const fn name() -> &'static str {
         stringify!(op_generics)
@@ -9,7 +30,7 @@ impl<T: Trait> op_generics<T> {
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
             name: stringify!(op_generics),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
                 use deno_core::v8::fast_api::Type;
@@ -17,7 +38,7 @@ impl<T: Trait> op_generics<T> {
                 deno_core::v8::fast_api::FastFunction::new(
                     &[Type::V8Value],
                     CType::Void,
-                    Self::fast_function as *const ::std::ffi::c_void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
             }),
             is_async: false,
@@ -26,12 +47,12 @@ impl<T: Trait> op_generics<T> {
             arg_count: 0usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let result = Self::call();
-    }
-    fn fast_function(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = Self::call();
         result
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let result = Self::call();
     }
     #[inline(always)]
     pub fn call() {}

--- a/ops/op2/test_cases/sync/generics.rs
+++ b/ops/op2/test_cases/sync/generics.rs
@@ -1,0 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#[op2(fast)]
+pub fn op_generics<T: Trait>() {}

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -1,5 +1,7 @@
 #[allow(non_camel_case_types)]
-pub struct op_u32_with_result {}
+pub struct op_u32_with_result {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
 impl op_u32_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_u32_with_result)

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -2,6 +2,27 @@
 pub struct op_u32_with_result {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_u32_with_result {
+    const NAME: &'static str = stringify!(op_u32_with_result);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_u32_with_result),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0usize as u8,
+    };
+}
 impl op_u32_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_u32_with_result)
@@ -9,7 +30,7 @@ impl op_u32_with_result {
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
             name: stringify!(op_u32_with_result),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
                 use deno_core::v8::fast_api::Type;
@@ -17,7 +38,7 @@ impl op_u32_with_result {
                 deno_core::v8::fast_api::FastFunction::new(
                     &[Type::V8Value, Type::CallbackOptions],
                     CType::Uint32,
-                    Self::fast_function as *const ::std::ffi::c_void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
             }),
             is_async: false,
@@ -26,7 +47,31 @@ impl op_u32_with_result {
             arg_count: 0usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const deno_core::v8::FunctionCallbackInfo) {
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        let result = Self::call();
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                unsafe {
+                    opctx.unsafely_set_last_error_for_ops_only(err);
+                }
+                fast_api_callback_options.fallback = true;
+                return ::std::default::Default::default();
+            }
+        };
+        result
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
@@ -71,30 +116,6 @@ impl op_u32_with_result {
                 return;
             }
         };
-    }
-    fn fast_function(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = Self::call();
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                unsafe {
-                    opctx.unsafely_set_last_error_for_ops_only(err);
-                }
-                fast_api_callback_options.fallback = true;
-                return ::std::default::Default::default();
-            }
-        };
-        result
     }
     #[inline(always)]
     pub fn call() -> Result<u32, AnyError> {}

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -2,6 +2,27 @@
 pub struct op_void_with_result {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_void_with_result {
+    const NAME: &'static str = stringify!(op_void_with_result);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_void_with_result),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0usize as u8,
+    };
+}
 impl op_void_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_void_with_result)
@@ -9,7 +30,7 @@ impl op_void_with_result {
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
             name: stringify!(op_void_with_result),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
                 use deno_core::v8::fast_api::Type;
@@ -17,7 +38,7 @@ impl op_void_with_result {
                 deno_core::v8::fast_api::FastFunction::new(
                     &[Type::V8Value, Type::CallbackOptions],
                     CType::Void,
-                    Self::fast_function as *const ::std::ffi::c_void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
             }),
             is_async: false,
@@ -26,7 +47,31 @@ impl op_void_with_result {
             arg_count: 0usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const deno_core::v8::FunctionCallbackInfo) {
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        let result = Self::call();
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                unsafe {
+                    opctx.unsafely_set_last_error_for_ops_only(err);
+                }
+                fast_api_callback_options.fallback = true;
+                return ::std::default::Default::default();
+            }
+        };
+        result
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
@@ -66,30 +111,6 @@ impl op_void_with_result {
                 return;
             }
         };
-    }
-    fn fast_function(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = Self::call();
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                unsafe {
-                    opctx.unsafely_set_last_error_for_ops_only(err);
-                }
-                fast_api_callback_options.fallback = true;
-                return ::std::default::Default::default();
-            }
-        };
-        result
     }
     #[inline(always)]
     pub fn call() -> Result<(), AnyError> {}

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -1,5 +1,7 @@
 #[allow(non_camel_case_types)]
-pub struct op_void_with_result {}
+pub struct op_void_with_result {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
 impl op_void_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_void_with_result)

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -2,6 +2,27 @@
 struct op_add {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_add {
+    const NAME: &'static str = stringify!(op_add);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_add),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[Type::V8Value, Type::Int32, Type::Uint32],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 2usize as u8,
+    };
+}
 impl op_add {
     pub const fn name() -> &'static str {
         stringify!(op_add)
@@ -9,7 +30,7 @@ impl op_add {
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
             name: stringify!(op_add),
-            v8_fn_ptr: Self::slow_function as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
                 use deno_core::v8::fast_api::Type;
@@ -17,7 +38,7 @@ impl op_add {
                 deno_core::v8::fast_api::FastFunction::new(
                     &[Type::V8Value, Type::Int32, Type::Uint32],
                     CType::Uint32,
-                    Self::fast_function as *const ::std::ffi::c_void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
             }),
             is_async: false,
@@ -26,7 +47,15 @@ impl op_add {
             arg_count: 2usize as u8,
         }
     }
-    pub extern "C" fn slow_function(info: *const deno_core::v8::FunctionCallbackInfo) {
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: i32,
+        arg1: u32,
+    ) -> u32 {
+        let result = Self::call(arg0 as _, arg1 as _);
+        result
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
@@ -39,14 +68,6 @@ impl op_add {
         let arg1 = deno_core::_ops::to_u32(&arg1) as _;
         let result = Self::call(arg0, arg1);
         rv.set_uint32(result as u32);
-    }
-    fn fast_function(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: i32,
-        arg1: u32,
-    ) -> u32 {
-        let result = Self::call(arg0 as _, arg1 as _);
-        result
     }
     #[inline(always)]
     fn call(id: ResourceId, extra: u16) -> u32 {}

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -1,5 +1,7 @@
 #[allow(non_camel_case_types)]
-struct op_add {}
+struct op_add {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
 impl op_add {
     pub const fn name() -> &'static str {
         stringify!(op_add)

--- a/ops/optimizer_tests/async_nop.out
+++ b/ops/optimizer_tests/async_nop.out
@@ -27,8 +27,8 @@ impl op_void_async {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Int32, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_void_async {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     async fn call<'scope>() {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/async_nop.out
+++ b/ops/optimizer_tests/async_nop.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_void_async::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_void_async;
+pub struct op_void_async {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_void_async {
     pub const fn name() -> &'static str {
         stringify!(op_void_async)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_void_async {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_void_async {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Int32, CallbackOptions],
                         CType::Void,
-                        op_void_async_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_void_async_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_void_async {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    async fn call() {}
+    async fn call<'scope>() {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -85,27 +85,29 @@ impl op_void_async {
         }
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_void_async_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    __promise_id: i32,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let op_state = __ctx.state.clone();
-    let result = op_void_async::call();
-    let result = _ops::queue_fast_async_op(
-        __ctx,
-        __promise_id,
-        async move { Ok(result.await) },
-    );
-    result
+impl op_void_async {
+    #[allow(clippy::too_many_arguments)]
+    fn op_void_async_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        __promise_id: i32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let op_state = __ctx.state.clone();
+        let result = Self::call();
+        let result = _ops::queue_fast_async_op(
+            __ctx,
+            __promise_id,
+            async move { Ok(result.await) },
+        );
+        result
+    }
 }

--- a/ops/optimizer_tests/async_nop.out
+++ b/ops/optimizer_tests/async_nop.out
@@ -6,6 +6,29 @@
 pub struct op_void_async {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_void_async {
+    const NAME: &'static str = stringify!(op_void_async);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Int32, CallbackOptions],
+                    CType::Void,
+                    Self::op_void_async_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: true,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_void_async {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/async_result.out
+++ b/ops/optimizer_tests/async_result.out
@@ -27,8 +27,8 @@ impl op_async_result {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Int32, Uint32, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_async_result {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     async fn call<'scope>(
         state: Rc<RefCell<OpState>>,
         rid: ResourceId,

--- a/ops/optimizer_tests/async_result.out
+++ b/ops/optimizer_tests/async_result.out
@@ -6,6 +6,29 @@
 pub struct op_async_result {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_async_result {
+    const NAME: &'static str = stringify!(op_async_result);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Int32, Uint32, CallbackOptions],
+                    CType::Void,
+                    Self::op_async_result_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: true,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_async_result {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/async_result.out
+++ b/ops/optimizer_tests/async_result.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_async_result::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_async_result;
+pub struct op_async_result {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_async_result {
     pub const fn name() -> &'static str {
         stringify!(op_async_result)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_async_result {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_async_result {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Int32, Uint32, CallbackOptions],
                         CType::Void,
-                        op_async_result_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_async_result_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,10 @@ impl op_async_result {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    async fn call(state: Rc<RefCell<OpState>>, rid: ResourceId) -> Result<u32, Error> {}
+    async fn call<'scope>(
+        state: Rc<RefCell<OpState>>,
+        rid: ResourceId,
+    ) -> Result<u32, Error> {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -99,23 +102,25 @@ impl op_async_result {
         }
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_async_result_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    __promise_id: i32,
-    rid: ResourceId,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = __ctx.state.clone();
-    let result = op_async_result::call(state, rid);
-    let result = _ops::queue_fast_async_op(__ctx, __promise_id, result);
+impl op_async_result {
+    #[allow(clippy::too_many_arguments)]
+    fn op_async_result_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        __promise_id: i32,
+        rid: ResourceId,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = __ctx.state.clone();
+        let result = Self::call(state, rid);
+        let result = _ops::queue_fast_async_op(__ctx, __promise_id, result);
+    }
 }

--- a/ops/optimizer_tests/callback_options.out
+++ b/ops/optimizer_tests/callback_options.out
@@ -6,6 +6,29 @@
 pub struct op_fallback {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_fallback {
+    const NAME: &'static str = stringify!(op_fallback);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, CallbackOptions],
+                    CType::Void,
+                    Self::op_fallback_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_fallback {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/callback_options.out
+++ b/ops/optimizer_tests/callback_options.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_fallback::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_fallback;
+pub struct op_fallback {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_fallback {
     pub const fn name() -> &'static str {
         stringify!(op_fallback)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_fallback {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_fallback {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
                         CType::Void,
-                        op_fallback_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_fallback_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_fallback {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(options: Option<&mut FastApiCallbackOptions>) {
+    fn call<'scope>(options: Option<&mut FastApiCallbackOptions>) {
         if let Some(options) = options {
             options.fallback = true;
         }
@@ -65,16 +65,18 @@ impl op_fallback {
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_fallback_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let result = op_fallback::call(options);
-    result
+impl op_fallback {
+    #[allow(clippy::too_many_arguments)]
+    fn op_fallback_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let result = Self::call(options);
+        result
+    }
 }

--- a/ops/optimizer_tests/callback_options.out
+++ b/ops/optimizer_tests/callback_options.out
@@ -27,8 +27,8 @@ impl op_fallback {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_fallback {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(options: Option<&mut FastApiCallbackOptions>) {
         if let Some(options) = options {
             options.fallback = true;

--- a/ops/optimizer_tests/cow_str.out
+++ b/ops/optimizer_tests/cow_str.out
@@ -6,6 +6,29 @@
 pub struct op_cow_str {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_cow_str {
+    const NAME: &'static str = stringify!(op_cow_str);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, SeqOneByteString, CallbackOptions],
+                    CType::Void,
+                    Self::op_cow_str_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_cow_str {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/cow_str.out
+++ b/ops/optimizer_tests/cow_str.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_cow_str::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_cow_str;
+pub struct op_cow_str {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_cow_str {
     pub const fn name() -> &'static str {
         stringify!(op_cow_str)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_cow_str {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_cow_str {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, SeqOneByteString, CallbackOptions],
                         CType::Void,
-                        op_cow_str_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_cow_str_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_cow_str {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(c: Cow<'_, str>) {}
+    fn call<'scope>(c: Cow<'_, str>) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -73,23 +73,25 @@ impl op_cow_str {
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_cow_str_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    c: *const deno_core::v8::fast_api::FastApiOneByteString,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let c = ::std::borrow::Cow::Borrowed(
-        match ::std::str::from_utf8(unsafe { &*c }.as_bytes()) {
-            Ok(v) => v,
-            Err(_) => {
-                unsafe { &mut *fast_api_callback_options }.fallback = true;
-                return Default::default();
-            }
-        },
-    );
-    let result = op_cow_str::call(c);
-    result
+impl op_cow_str {
+    #[allow(clippy::too_many_arguments)]
+    fn op_cow_str_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        c: *const deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let c = ::std::borrow::Cow::Borrowed(
+            match ::std::str::from_utf8(unsafe { &*c }.as_bytes()) {
+                Ok(v) => v,
+                Err(_) => {
+                    unsafe { &mut *fast_api_callback_options }.fallback = true;
+                    return Default::default();
+                }
+            },
+        );
+        let result = Self::call(c);
+        result
+    }
 }

--- a/ops/optimizer_tests/cow_str.out
+++ b/ops/optimizer_tests/cow_str.out
@@ -27,8 +27,8 @@ impl op_cow_str {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, SeqOneByteString, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_cow_str {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(c: Cow<'_, str>) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/f64_slice.out
+++ b/ops/optimizer_tests/f64_slice.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_f64_buf::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_f64_buf;
+pub struct op_f64_buf {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_f64_buf {
     pub const fn name() -> &'static str {
         stringify!(op_f64_buf)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_f64_buf {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_f64_buf {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, TypedArray(CType::Float64), CallbackOptions],
                         CType::Void,
-                        op_f64_buf_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_f64_buf_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_f64_buf {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(buffer: &mut [f64]) {}
+    fn call<'scope>(buffer: &mut [f64]) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -91,21 +91,23 @@ impl op_f64_buf {
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_f64_buf_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    buffer: *const deno_core::v8::fast_api::FastApiTypedArray<f64>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let buffer = match unsafe { &*buffer }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
-    let result = op_f64_buf::call(buffer);
-    result
+impl op_f64_buf {
+    #[allow(clippy::too_many_arguments)]
+    fn op_f64_buf_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        buffer: *const deno_core::v8::fast_api::FastApiTypedArray<f64>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let buffer = match unsafe { &*buffer }.get_storage_if_aligned() {
+            Some(v) => v,
+            None => {
+                unsafe { &mut *fast_api_callback_options }.fallback = true;
+                return Default::default();
+            }
+        };
+        let result = Self::call(buffer);
+        result
+    }
 }

--- a/ops/optimizer_tests/f64_slice.out
+++ b/ops/optimizer_tests/f64_slice.out
@@ -27,8 +27,8 @@ impl op_f64_buf {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, TypedArray(CType::Float64), CallbackOptions],
@@ -45,6 +45,7 @@ impl op_f64_buf {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(buffer: &mut [f64]) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/f64_slice.out
+++ b/ops/optimizer_tests/f64_slice.out
@@ -6,6 +6,29 @@
 pub struct op_f64_buf {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_f64_buf {
+    const NAME: &'static str = stringify!(op_f64_buf);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, TypedArray(CType::Float64), CallbackOptions],
+                    CType::Void,
+                    Self::op_f64_buf_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_f64_buf {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/incompatible_1.out
+++ b/ops/optimizer_tests/incompatible_1.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_sync_serialize_object_with_numbers_as_keys::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_sync_serialize_object_with_numbers_as_keys;
+pub struct op_sync_serialize_object_with_numbers_as_keys {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_sync_serialize_object_with_numbers_as_keys {
     pub const fn name() -> &'static str {
         stringify!(op_sync_serialize_object_with_numbers_as_keys)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_sync_serialize_object_with_numbers_as_keys {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,7 @@ impl op_sync_serialize_object_with_numbers_as_keys {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(value: serde_json::Value) -> Result<(), Error> {
+    fn call<'scope>(value: serde_json::Value) -> Result<(), Error> {
         assert_eq!(
             value.to_string(), r#"{"lines":{"100":{"unit":"m"},"200":{"unit":"cm"}}}"#
         );

--- a/ops/optimizer_tests/incompatible_1.out
+++ b/ops/optimizer_tests/incompatible_1.out
@@ -6,6 +6,19 @@
 pub struct op_sync_serialize_object_with_numbers_as_keys {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_sync_serialize_object_with_numbers_as_keys {
+    const NAME: &'static str = stringify!(op_sync_serialize_object_with_numbers_as_keys);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_sync_serialize_object_with_numbers_as_keys {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/incompatible_1.out
+++ b/ops/optimizer_tests/incompatible_1.out
@@ -35,6 +35,7 @@ impl op_sync_serialize_object_with_numbers_as_keys {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(value: serde_json::Value) -> Result<(), Error> {
         assert_eq!(
             value.to_string(), r#"{"lines":{"100":{"unit":"m"},"200":{"unit":"cm"}}}"#

--- a/ops/optimizer_tests/issue16934.out
+++ b/ops/optimizer_tests/issue16934.out
@@ -6,6 +6,19 @@
 pub struct send_stdin {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for send_stdin {
+    const NAME: &'static str = stringify!(send_stdin);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: true,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl send_stdin {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/issue16934.out
+++ b/ops/optimizer_tests/issue16934.out
@@ -3,16 +3,16 @@
 ///
 ///Use `send_stdin::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct send_stdin;
+pub struct send_stdin {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl send_stdin {
     pub const fn name() -> &'static str {
         stringify!(send_stdin)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl send_stdin {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,10 @@ impl send_stdin {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    async fn call(state: &mut OpState, cmd: String) -> Result<(), anyhow::Error> {
+    async fn call<'scope>(
+        state: &mut OpState,
+        cmd: String,
+    ) -> Result<(), anyhow::Error> {
         let instance = state.borrow::<MinecraftInstance>().clone();
         instance.send_command(&cmd, CausedBy::Unknown).await?;
         Ok(())

--- a/ops/optimizer_tests/issue16934.out
+++ b/ops/optimizer_tests/issue16934.out
@@ -35,6 +35,7 @@ impl send_stdin {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     async fn call<'scope>(
         state: &mut OpState,
         cmd: String,

--- a/ops/optimizer_tests/issue16934_fast.out
+++ b/ops/optimizer_tests/issue16934_fast.out
@@ -6,6 +6,19 @@
 pub struct send_stdin {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for send_stdin {
+    const NAME: &'static str = stringify!(send_stdin);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: true,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl send_stdin {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/issue16934_fast.out
+++ b/ops/optimizer_tests/issue16934_fast.out
@@ -35,6 +35,7 @@ impl send_stdin {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     async fn call<'scope>(state: &mut OpState, v: i32) -> Result<(), anyhow::Error> {
         Ok(())
     }

--- a/ops/optimizer_tests/issue16934_fast.out
+++ b/ops/optimizer_tests/issue16934_fast.out
@@ -3,16 +3,16 @@
 ///
 ///Use `send_stdin::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct send_stdin;
+pub struct send_stdin {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl send_stdin {
     pub const fn name() -> &'static str {
         stringify!(send_stdin)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl send_stdin {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,7 @@ impl send_stdin {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    async fn call(state: &mut OpState, v: i32) -> Result<(), anyhow::Error> {
+    async fn call<'scope>(state: &mut OpState, v: i32) -> Result<(), anyhow::Error> {
         Ok(())
     }
     pub fn v8_func<'scope>(

--- a/ops/optimizer_tests/op_blob_revoke_object_url.out
+++ b/ops/optimizer_tests/op_blob_revoke_object_url.out
@@ -35,6 +35,7 @@ impl op_blob_revoke_object_url {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(state: &mut OpState, url: String) -> Result<(), AnyError> {
         let url = Url::parse(&url)?;
         let blob_store = state.borrow::<BlobStore>();

--- a/ops/optimizer_tests/op_blob_revoke_object_url.out
+++ b/ops/optimizer_tests/op_blob_revoke_object_url.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_blob_revoke_object_url::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_blob_revoke_object_url;
+pub struct op_blob_revoke_object_url {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_blob_revoke_object_url {
     pub const fn name() -> &'static str {
         stringify!(op_blob_revoke_object_url)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_blob_revoke_object_url {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,7 @@ impl op_blob_revoke_object_url {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call(state: &mut OpState, url: String) -> Result<(), AnyError> {
+    pub fn call<'scope>(state: &mut OpState, url: String) -> Result<(), AnyError> {
         let url = Url::parse(&url)?;
         let blob_store = state.borrow::<BlobStore>();
         blob_store.remove_object_url(&url);

--- a/ops/optimizer_tests/op_blob_revoke_object_url.out
+++ b/ops/optimizer_tests/op_blob_revoke_object_url.out
@@ -6,6 +6,19 @@
 pub struct op_blob_revoke_object_url {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_blob_revoke_object_url {
+    const NAME: &'static str = stringify!(op_blob_revoke_object_url);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_blob_revoke_object_url {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_ffi_ptr_value.out
+++ b/ops/optimizer_tests/op_ffi_ptr_value.out
@@ -27,8 +27,8 @@ impl op_ffi_ptr_value {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Pointer, TypedArray(CType::Uint32), CallbackOptions],
@@ -45,6 +45,7 @@ impl op_ffi_ptr_value {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(ptr: *mut c_void, out: &mut [u32]) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/op_ffi_ptr_value.out
+++ b/ops/optimizer_tests/op_ffi_ptr_value.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_ffi_ptr_value::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_ffi_ptr_value;
+pub struct op_ffi_ptr_value {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_ffi_ptr_value {
     pub const fn name() -> &'static str {
         stringify!(op_ffi_ptr_value)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_ffi_ptr_value {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_ffi_ptr_value {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Pointer, TypedArray(CType::Uint32), CallbackOptions],
                         CType::Void,
-                        op_ffi_ptr_value_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_ffi_ptr_value_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_ffi_ptr_value {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call(ptr: *mut c_void, out: &mut [u32]) {}
+    pub fn call<'scope>(ptr: *mut c_void, out: &mut [u32]) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -105,22 +105,24 @@ impl op_ffi_ptr_value {
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_ffi_ptr_value_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    ptr: *mut ::std::ffi::c_void,
-    out: *const deno_core::v8::fast_api::FastApiTypedArray<u32>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let out = match unsafe { &*out }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
-    let result = op_ffi_ptr_value::call(ptr, out);
-    result
+impl op_ffi_ptr_value {
+    #[allow(clippy::too_many_arguments)]
+    fn op_ffi_ptr_value_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        ptr: *mut ::std::ffi::c_void,
+        out: *const deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let out = match unsafe { &*out }.get_storage_if_aligned() {
+            Some(v) => v,
+            None => {
+                unsafe { &mut *fast_api_callback_options }.fallback = true;
+                return Default::default();
+            }
+        };
+        let result = Self::call(ptr, out);
+        result
+    }
 }

--- a/ops/optimizer_tests/op_ffi_ptr_value.out
+++ b/ops/optimizer_tests/op_ffi_ptr_value.out
@@ -6,6 +6,29 @@
 pub struct op_ffi_ptr_value {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_ffi_ptr_value {
+    const NAME: &'static str = stringify!(op_ffi_ptr_value);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Pointer, TypedArray(CType::Uint32), CallbackOptions],
+                    CType::Void,
+                    Self::op_ffi_ptr_value_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_ffi_ptr_value {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_print.out
+++ b/ops/optimizer_tests/op_print.out
@@ -6,6 +6,19 @@
 pub struct op_print {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_print {
+    const NAME: &'static str = stringify!(op_print);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_print {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_print.out
+++ b/ops/optimizer_tests/op_print.out
@@ -35,6 +35,7 @@ impl op_print {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(
         state: &mut OpState,
         msg: &str,

--- a/ops/optimizer_tests/op_print.out
+++ b/ops/optimizer_tests/op_print.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_print::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_print;
+pub struct op_print {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_print {
     pub const fn name() -> &'static str {
         stringify!(op_print)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_print {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,11 @@ impl op_print {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(state: &mut OpState, msg: &str, is_err: bool) -> Result<(), AnyError> {}
+    fn call<'scope>(
+        state: &mut OpState,
+        msg: &str,
+        is_err: bool,
+    ) -> Result<(), AnyError> {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,

--- a/ops/optimizer_tests/op_state.out
+++ b/ops/optimizer_tests/op_state.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_set_exit_code::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_set_exit_code;
+pub struct op_set_exit_code {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_set_exit_code {
     pub const fn name() -> &'static str {
         stringify!(op_set_exit_code)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_set_exit_code {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_set_exit_code {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Int32, CallbackOptions],
                         CType::Void,
-                        op_set_exit_code_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_set_exit_code_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_set_exit_code {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(state: &mut OpState, code: i32) {
+    fn call<'scope>(state: &mut OpState, code: i32) {
         state.borrow_mut::<ExitCode>().set(code);
     }
     pub fn v8_func<'scope>(
@@ -73,22 +73,24 @@ impl op_set_exit_code {
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_set_exit_code_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    code: i32,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = op_set_exit_code::call(state, code);
-    result
+impl op_set_exit_code {
+    #[allow(clippy::too_many_arguments)]
+    fn op_set_exit_code_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        code: i32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(state, code);
+        result
+    }
 }

--- a/ops/optimizer_tests/op_state.out
+++ b/ops/optimizer_tests/op_state.out
@@ -6,6 +6,29 @@
 pub struct op_set_exit_code {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_set_exit_code {
+    const NAME: &'static str = stringify!(op_set_exit_code);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Int32, CallbackOptions],
+                    CType::Void,
+                    Self::op_set_exit_code_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_set_exit_code {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_state.out
+++ b/ops/optimizer_tests/op_state.out
@@ -27,8 +27,8 @@ impl op_set_exit_code {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Int32, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_set_exit_code {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(state: &mut OpState, code: i32) {
         state.borrow_mut::<ExitCode>().set(code);
     }

--- a/ops/optimizer_tests/op_state_basic1.out
+++ b/ops/optimizer_tests/op_state_basic1.out
@@ -3,16 +3,16 @@
 ///
 ///Use `foo::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct foo;
+pub struct foo {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl foo {
     pub const fn name() -> &'static str {
         stringify!(foo)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl foo {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl foo {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Uint32, CallbackOptions],
                         CType::Uint32,
-                        foo_fast_fn as *const ::std::ffi::c_void,
+                        Self::foo_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl foo {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(state: &mut OpState, a: u32, b: u32) -> u32 {
+    fn call<'scope>(state: &mut OpState, a: u32, b: u32) -> u32 {
         a + b
     }
     pub fn v8_func<'scope>(
@@ -100,23 +100,25 @@ impl foo {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn foo_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    a: u32,
-    b: u32,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> u32 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = foo::call(state, a, b);
-    result
+impl foo {
+    #[allow(clippy::too_many_arguments)]
+    fn foo_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        a: u32,
+        b: u32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(state, a, b);
+        result
+    }
 }

--- a/ops/optimizer_tests/op_state_basic1.out
+++ b/ops/optimizer_tests/op_state_basic1.out
@@ -6,6 +6,29 @@
 pub struct foo {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for foo {
+    const NAME: &'static str = stringify!(foo);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Uint32, Uint32, CallbackOptions],
+                    CType::Uint32,
+                    Self::foo_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl foo {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_state_basic1.out
+++ b/ops/optimizer_tests/op_state_basic1.out
@@ -27,8 +27,8 @@ impl foo {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Uint32, CallbackOptions],
@@ -45,6 +45,7 @@ impl foo {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(state: &mut OpState, a: u32, b: u32) -> u32 {
         a + b
     }

--- a/ops/optimizer_tests/op_state_generics.out
+++ b/ops/optimizer_tests/op_state_generics.out
@@ -6,6 +6,32 @@
 pub struct op_foo<SP> {
     _phantom_data: ::std::marker::PhantomData<(SP)>,
 }
+impl<SP> deno_core::_ops::Op for op_foo<SP>
+where
+    SP: SomePermission + 'static,
+{
+    const NAME: &'static str = stringify!(op_foo);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, CallbackOptions],
+                    CType::Void,
+                    Self::op_foo_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl<SP> op_foo<SP>
 where

--- a/ops/optimizer_tests/op_state_generics.out
+++ b/ops/optimizer_tests/op_state_generics.out
@@ -3,34 +3,31 @@
 ///
 ///Use `op_foo::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_foo;
+pub struct op_foo<SP> {
+    _phantom_data: ::std::marker::PhantomData<(SP)>,
+}
 #[doc(hidden)]
-impl op_foo {
+impl<SP> op_foo<SP>
+where
+    SP: SomePermission + 'static,
+{
     pub const fn name() -> &'static str {
         stringify!(op_foo)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope, SP>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    )
-    where
-        SP: SomePermission + 'static,
-    {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
             info,
         );
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
-        Self::v8_func::<SP>(scope, args, rv);
+        Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope, SP>() -> deno_core::OpDecl
-    where
-        SP: SomePermission + 'static,
-    {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr::<SP> as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
                 use deno_core::v8::fast_api::Type::*;
@@ -39,7 +36,7 @@ impl op_foo {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
                         CType::Void,
-                        op_foo_fast_fn::<SP> as *const ::std::ffi::c_void,
+                        Self::op_foo_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -51,45 +48,41 @@ impl op_foo {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call<SP>(state: &mut OpState)
-    where
-        SP: SomePermission + 'static,
-    {}
-    pub fn v8_func<'scope, SP>(
+    pub fn call<'scope>(state: &mut OpState) {}
+    pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
         mut rv: deno_core::v8::ReturnValue,
-    )
-    where
-        SP: SomePermission + 'static,
-    {
+    ) {
         let ctx = unsafe {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call::<SP>(&mut std::cell::RefCell::borrow_mut(&ctx.state));
+        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state));
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_foo_fast_fn<'scope, SP>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> ()
+impl<SP> op_foo<SP>
 where
     SP: SomePermission + 'static,
 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = op_foo::call::<SP>(state);
-    result
+    #[allow(clippy::too_many_arguments)]
+    fn op_foo_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(state);
+        result
+    }
 }

--- a/ops/optimizer_tests/op_state_generics.out
+++ b/ops/optimizer_tests/op_state_generics.out
@@ -30,8 +30,8 @@ where
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
@@ -48,6 +48,7 @@ where
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(state: &mut OpState) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/op_state_result.out
+++ b/ops/optimizer_tests/op_state_result.out
@@ -27,8 +27,8 @@ impl foo {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Uint32, CallbackOptions],
@@ -45,6 +45,7 @@ impl foo {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(state: &mut OpState, a: u32, b: u32) -> Result<u32, AnyError> {
         Ok(a + b)
     }

--- a/ops/optimizer_tests/op_state_result.out
+++ b/ops/optimizer_tests/op_state_result.out
@@ -6,6 +6,29 @@
 pub struct foo {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for foo {
+    const NAME: &'static str = stringify!(foo);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Uint32, Uint32, CallbackOptions],
+                    CType::Uint32,
+                    Self::foo_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl foo {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_state_result.out
+++ b/ops/optimizer_tests/op_state_result.out
@@ -3,16 +3,16 @@
 ///
 ///Use `foo::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct foo;
+pub struct foo {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl foo {
     pub const fn name() -> &'static str {
         stringify!(foo)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl foo {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl foo {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Uint32, CallbackOptions],
                         CType::Uint32,
-                        foo_fast_fn as *const ::std::ffi::c_void,
+                        Self::foo_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl foo {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(state: &mut OpState, a: u32, b: u32) -> Result<u32, AnyError> {
+    fn call<'scope>(state: &mut OpState, a: u32, b: u32) -> Result<u32, AnyError> {
         Ok(a + b)
     }
     pub fn v8_func<'scope>(
@@ -113,30 +113,32 @@ impl foo {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn foo_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    a: u32,
-    b: u32,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> u32 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = foo::call(state, a, b);
-    match result {
-        Ok(result) => result,
-        Err(err) => {
-            state.last_fast_op_error.replace(err);
-            __opts.fallback = true;
-            Default::default()
+impl foo {
+    #[allow(clippy::too_many_arguments)]
+    fn foo_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        a: u32,
+        b: u32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(state, a, b);
+        match result {
+            Ok(result) => result,
+            Err(err) => {
+                state.last_fast_op_error.replace(err);
+                __opts.fallback = true;
+                Default::default()
+            }
         }
     }
 }

--- a/ops/optimizer_tests/op_state_warning.out
+++ b/ops/optimizer_tests/op_state_warning.out
@@ -27,8 +27,8 @@ impl op_listen {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_listen {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(state: &mut OpState) -> Result<ResourceId, Error> {
         log::debug!("listen");
         let addr = "127.0.0.1:4570".parse::<SocketAddr>().unwrap();

--- a/ops/optimizer_tests/op_state_warning.out
+++ b/ops/optimizer_tests/op_state_warning.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_listen::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_listen;
+pub struct op_listen {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_listen {
     pub const fn name() -> &'static str {
         stringify!(op_listen)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_listen {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_listen {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
                         CType::Uint32,
-                        op_listen_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_listen_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_listen {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(state: &mut OpState) -> Result<ResourceId, Error> {
+    fn call<'scope>(state: &mut OpState) -> Result<ResourceId, Error> {
         log::debug!("listen");
         let addr = "127.0.0.1:4570".parse::<SocketAddr>().unwrap();
         let std_listener = std::net::TcpListener::bind(&addr)?;
@@ -104,28 +104,30 @@ impl op_listen {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_listen_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> u32 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = op_listen::call(state);
-    match result {
-        Ok(result) => result,
-        Err(err) => {
-            state.last_fast_op_error.replace(err);
-            __opts.fallback = true;
-            Default::default()
+impl op_listen {
+    #[allow(clippy::too_many_arguments)]
+    fn op_listen_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(state);
+        match result {
+            Ok(result) => result,
+            Err(err) => {
+                state.last_fast_op_error.replace(err);
+                __opts.fallback = true;
+                Default::default()
+            }
         }
     }
 }

--- a/ops/optimizer_tests/op_state_warning.out
+++ b/ops/optimizer_tests/op_state_warning.out
@@ -6,6 +6,29 @@
 pub struct op_listen {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_listen {
+    const NAME: &'static str = stringify!(op_listen);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, CallbackOptions],
+                    CType::Uint32,
+                    Self::op_listen_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_listen {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/op_state_with_transforms.out
+++ b/ops/optimizer_tests/op_state_with_transforms.out
@@ -3,34 +3,31 @@
 ///
 ///Use `op_now::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_now;
+pub struct op_now<TP> {
+    _phantom_data: ::std::marker::PhantomData<(TP)>,
+}
 #[doc(hidden)]
-impl op_now {
+impl<TP> op_now<TP>
+where
+    TP: TimersPermission + 'static,
+{
     pub const fn name() -> &'static str {
         stringify!(op_now)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope, TP>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    )
-    where
-        TP: TimersPermission + 'static,
-    {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
             info,
         );
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
-        Self::v8_func::<TP>(scope, args, rv);
+        Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope, TP>() -> deno_core::OpDecl
-    where
-        TP: TimersPermission + 'static,
-    {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr::<TP> as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
                 use deno_core::v8::fast_api::Type::*;
@@ -39,7 +36,7 @@ impl op_now {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, TypedArray(CType::Uint8), CallbackOptions],
                         CType::Void,
-                        op_now_fast_fn::<TP> as *const ::std::ffi::c_void,
+                        Self::op_now_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -51,18 +48,12 @@ impl op_now {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call<TP>(state: &mut OpState, buf: &mut [u8])
-    where
-        TP: TimersPermission + 'static,
-    {}
-    pub fn v8_func<'scope, TP>(
+    pub fn call<'scope>(state: &mut OpState, buf: &mut [u8]) {}
+    pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
         mut rv: deno_core::v8::ReturnValue,
-    )
-    where
-        TP: TimersPermission + 'static,
-    {
+    ) {
         let ctx = unsafe {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
@@ -112,33 +103,33 @@ impl op_now {
                 }
             }
         };
-        let result = Self::call::<
-            TP,
-        >(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0);
+        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0);
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_now_fast_fn<'scope, TP>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    buf: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> ()
+impl<TP> op_now<TP>
 where
     TP: TimersPermission + 'static,
 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let buf = unsafe { (&*buf).get_storage_if_aligned().unwrap_unchecked() };
-    let result = op_now::call::<TP>(state, buf);
-    result
+    #[allow(clippy::too_many_arguments)]
+    fn op_now_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        buf: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let buf = unsafe { (&*buf).get_storage_if_aligned().unwrap_unchecked() };
+        let result = Self::call(state, buf);
+        result
+    }
 }

--- a/ops/optimizer_tests/op_state_with_transforms.out
+++ b/ops/optimizer_tests/op_state_with_transforms.out
@@ -30,8 +30,8 @@ where
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, TypedArray(CType::Uint8), CallbackOptions],
@@ -48,6 +48,7 @@ where
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(state: &mut OpState, buf: &mut [u8]) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/op_state_with_transforms.out
+++ b/ops/optimizer_tests/op_state_with_transforms.out
@@ -6,6 +6,32 @@
 pub struct op_now<TP> {
     _phantom_data: ::std::marker::PhantomData<(TP)>,
 }
+impl<TP> deno_core::_ops::Op for op_now<TP>
+where
+    TP: TimersPermission + 'static,
+{
+    const NAME: &'static str = stringify!(op_now);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, TypedArray(CType::Uint8), CallbackOptions],
+                    CType::Void,
+                    Self::op_now_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl<TP> op_now<TP>
 where

--- a/ops/optimizer_tests/opstate_with_arity.out
+++ b/ops/optimizer_tests/opstate_with_arity.out
@@ -6,6 +6,29 @@
 pub struct op_add_4 {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_add_4 {
+    const NAME: &'static str = stringify!(op_add_4);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Uint32, Uint32, Uint32, Uint32, CallbackOptions],
+                    CType::Uint32,
+                    Self::op_add_4_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_add_4 {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/opstate_with_arity.out
+++ b/ops/optimizer_tests/opstate_with_arity.out
@@ -27,8 +27,8 @@ impl op_add_4 {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Uint32, Uint32, Uint32, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_add_4 {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(x1: u32, x2: u32, x3: u32, x4: u32) -> Result<u32, anyhow::Error> {
         Ok(x1 + x2 + x3 + x4)
     }

--- a/ops/optimizer_tests/opstate_with_arity.out
+++ b/ops/optimizer_tests/opstate_with_arity.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_add_4::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_add_4;
+pub struct op_add_4 {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_add_4 {
     pub const fn name() -> &'static str {
         stringify!(op_add_4)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_add_4 {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_add_4 {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Uint32, Uint32, Uint32, CallbackOptions],
                         CType::Uint32,
-                        op_add_4_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_add_4_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_add_4 {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(x1: u32, x2: u32, x3: u32, x4: u32) -> Result<u32, anyhow::Error> {
+    fn call<'scope>(x1: u32, x2: u32, x3: u32, x4: u32) -> Result<u32, anyhow::Error> {
         Ok(x1 + x2 + x3 + x4)
     }
     pub fn v8_func<'scope>(
@@ -131,32 +131,34 @@ impl op_add_4 {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_add_4_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    x1: u32,
-    x2: u32,
-    x3: u32,
-    x4: u32,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> u32 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let op_state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = op_add_4::call(x1, x2, x3, x4);
-    match result {
-        Ok(result) => result,
-        Err(err) => {
-            op_state.last_fast_op_error.replace(err);
-            __opts.fallback = true;
-            Default::default()
+impl op_add_4 {
+    #[allow(clippy::too_many_arguments)]
+    fn op_add_4_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        x1: u32,
+        x2: u32,
+        x3: u32,
+        x4: u32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let op_state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(x1, x2, x3, x4);
+        match result {
+            Ok(result) => result,
+            Err(err) => {
+                op_state.last_fast_op_error.replace(err);
+                __opts.fallback = true;
+                Default::default()
+            }
         }
     }
 }

--- a/ops/optimizer_tests/option_arg.out
+++ b/ops/optimizer_tests/option_arg.out
@@ -35,6 +35,7 @@ impl op_try_close {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(
         state: &mut OpState,
         rid: Option<ResourceId>,

--- a/ops/optimizer_tests/option_arg.out
+++ b/ops/optimizer_tests/option_arg.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_try_close::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_try_close;
+pub struct op_try_close {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_try_close {
     pub const fn name() -> &'static str {
         stringify!(op_try_close)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_try_close {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,10 @@ impl op_try_close {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call(state: &mut OpState, rid: Option<ResourceId>) -> Result<(), Error> {}
+    pub fn call<'scope>(
+        state: &mut OpState,
+        rid: Option<ResourceId>,
+    ) -> Result<(), Error> {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,

--- a/ops/optimizer_tests/option_arg.out
+++ b/ops/optimizer_tests/option_arg.out
@@ -6,6 +6,19 @@
 pub struct op_try_close {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_try_close {
+    const NAME: &'static str = stringify!(op_try_close);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_try_close {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/owned_string.out
+++ b/ops/optimizer_tests/owned_string.out
@@ -27,8 +27,8 @@ impl op_string_length {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, SeqOneByteString, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_string_length {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(string: String) -> u32 {
         string.len() as u32
     }

--- a/ops/optimizer_tests/owned_string.out
+++ b/ops/optimizer_tests/owned_string.out
@@ -6,6 +6,29 @@
 pub struct op_string_length {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_string_length {
+    const NAME: &'static str = stringify!(op_string_length);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, SeqOneByteString, CallbackOptions],
+                    CType::Uint32,
+                    Self::op_string_length_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_string_length {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/owned_string.out
+++ b/ops/optimizer_tests/owned_string.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_string_length::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_string_length;
+pub struct op_string_length {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_string_length {
     pub const fn name() -> &'static str {
         stringify!(op_string_length)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_string_length {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_string_length {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, SeqOneByteString, CallbackOptions],
                         CType::Uint32,
-                        op_string_length_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_string_length_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_string_length {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(string: String) -> u32 {
+    fn call<'scope>(string: String) -> u32 {
         string.len() as u32
     }
     pub fn v8_func<'scope>(
@@ -85,21 +85,23 @@ impl op_string_length {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_string_length_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    string: *const deno_core::v8::fast_api::FastApiOneByteString,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> u32 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let string = match ::std::str::from_utf8(unsafe { &*string }.as_bytes()) {
-        Ok(v) => v.to_owned(),
-        Err(_) => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
-    let result = op_string_length::call(string);
-    result
+impl op_string_length {
+    #[allow(clippy::too_many_arguments)]
+    fn op_string_length_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        string: *const deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let string = match ::std::str::from_utf8(unsafe { &*string }.as_bytes()) {
+            Ok(v) => v.to_owned(),
+            Err(_) => {
+                unsafe { &mut *fast_api_callback_options }.fallback = true;
+                return Default::default();
+            }
+        };
+        let result = Self::call(string);
+        result
+    }
 }

--- a/ops/optimizer_tests/param_mut_binding_warning.out
+++ b/ops/optimizer_tests/param_mut_binding_warning.out
@@ -35,6 +35,7 @@ impl op_read_sync {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(
         state: &mut OpState,
         rid: ResourceId,

--- a/ops/optimizer_tests/param_mut_binding_warning.out
+++ b/ops/optimizer_tests/param_mut_binding_warning.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_read_sync::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_read_sync;
+pub struct op_read_sync {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_read_sync {
     pub const fn name() -> &'static str {
         stringify!(op_read_sync)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_read_sync {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,7 @@ impl op_read_sync {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(
+    fn call<'scope>(
         state: &mut OpState,
         rid: ResourceId,
         mut buf: ZeroCopyBuf,

--- a/ops/optimizer_tests/param_mut_binding_warning.out
+++ b/ops/optimizer_tests/param_mut_binding_warning.out
@@ -6,6 +6,19 @@
 pub struct op_read_sync {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_read_sync {
+    const NAME: &'static str = stringify!(op_read_sync);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_read_sync {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/raw_ptr.out
+++ b/ops/optimizer_tests/raw_ptr.out
@@ -6,6 +6,37 @@
 pub struct op_ffi_ptr_of<FP> {
     _phantom_data: ::std::marker::PhantomData<(FP)>,
 }
+impl<FP> deno_core::_ops::Op for op_ffi_ptr_of<FP>
+where
+    FP: FfiPermissions + 'static,
+{
+    const NAME: &'static str = stringify!(op_ffi_ptr_of);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[
+                        V8Value,
+                        TypedArray(CType::Uint8),
+                        TypedArray(CType::Uint32),
+                        CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::op_ffi_ptr_of_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl<FP> op_ffi_ptr_of<FP>
 where

--- a/ops/optimizer_tests/raw_ptr.out
+++ b/ops/optimizer_tests/raw_ptr.out
@@ -30,8 +30,8 @@ where
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[
@@ -53,6 +53,7 @@ where
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(state: &mut OpState, buf: *const u8, out: &mut [u32]) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/raw_ptr.out
+++ b/ops/optimizer_tests/raw_ptr.out
@@ -3,34 +3,31 @@
 ///
 ///Use `op_ffi_ptr_of::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_ffi_ptr_of;
+pub struct op_ffi_ptr_of<FP> {
+    _phantom_data: ::std::marker::PhantomData<(FP)>,
+}
 #[doc(hidden)]
-impl op_ffi_ptr_of {
+impl<FP> op_ffi_ptr_of<FP>
+where
+    FP: FfiPermissions + 'static,
+{
     pub const fn name() -> &'static str {
         stringify!(op_ffi_ptr_of)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope, FP>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    )
-    where
-        FP: FfiPermissions + 'static,
-    {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
             info,
         );
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
-        Self::v8_func::<FP>(scope, args, rv);
+        Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope, FP>() -> deno_core::OpDecl
-    where
-        FP: FfiPermissions + 'static,
-    {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr::<FP> as _,
+            v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
                 use deno_core::v8::fast_api::Type::*;
@@ -44,7 +41,7 @@ impl op_ffi_ptr_of {
                             CallbackOptions,
                         ],
                         CType::Void,
-                        op_ffi_ptr_of_fast_fn::<FP> as *const ::std::ffi::c_void,
+                        Self::op_ffi_ptr_of_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -56,18 +53,12 @@ impl op_ffi_ptr_of {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call<FP>(state: &mut OpState, buf: *const u8, out: &mut [u32])
-    where
-        FP: FfiPermissions + 'static,
-    {}
-    pub fn v8_func<'scope, FP>(
+    fn call<'scope>(state: &mut OpState, buf: *const u8, out: &mut [u32]) {}
+    pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
         mut rv: deno_core::v8::ReturnValue,
-    )
-    where
-        FP: FfiPermissions + 'static,
-    {
+    ) {
         let ctx = unsafe {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
@@ -143,41 +134,46 @@ impl op_ffi_ptr_of {
                 format!("Expected Uint32Array at position {}", 1usize),
             );
         };
-        let result = Self::call::<
-            FP,
-        >(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0, arg_1);
+        let result = Self::call(
+            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            arg_0,
+            arg_1,
+        );
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_ffi_ptr_of_fast_fn<'scope, FP>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    buf: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
-    out: *const deno_core::v8::fast_api::FastApiTypedArray<u32>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> ()
+impl<FP> op_ffi_ptr_of<FP>
 where
     FP: FfiPermissions + 'static,
 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let buf = unsafe { (&*buf).get_storage_if_aligned().unwrap_unchecked() }.as_ptr();
-    let out = match unsafe { &*out }.get_storage_if_aligned() {
-        Some(v) => v,
-        None => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
-    let result = op_ffi_ptr_of::call::<FP>(state, buf, out);
-    result
+    #[allow(clippy::too_many_arguments)]
+    fn op_ffi_ptr_of_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        buf: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        out: *const deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let buf = unsafe { (&*buf).get_storage_if_aligned().unwrap_unchecked() }
+            .as_ptr();
+        let out = match unsafe { &*out }.get_storage_if_aligned() {
+            Some(v) => v,
+            None => {
+                unsafe { &mut *fast_api_callback_options }.fallback = true;
+                return Default::default();
+            }
+        };
+        let result = Self::call(state, buf, out);
+        result
+    }
 }

--- a/ops/optimizer_tests/serde_v8_value.out
+++ b/ops/optimizer_tests/serde_v8_value.out
@@ -6,6 +6,29 @@
 pub struct op_is_proxy {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_is_proxy {
+    const NAME: &'static str = stringify!(op_is_proxy);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, V8Value],
+                    CType::Bool,
+                    Self::op_is_proxy_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_is_proxy {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/serde_v8_value.out
+++ b/ops/optimizer_tests/serde_v8_value.out
@@ -27,8 +27,8 @@ impl op_is_proxy {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, V8Value],
@@ -45,6 +45,7 @@ impl op_is_proxy {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(value: serde_v8::Value) -> bool {
         value.v8_value.is_proxy()
     }

--- a/ops/optimizer_tests/serde_v8_value.out
+++ b/ops/optimizer_tests/serde_v8_value.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_is_proxy::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_is_proxy;
+pub struct op_is_proxy {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_is_proxy {
     pub const fn name() -> &'static str {
         stringify!(op_is_proxy)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_is_proxy {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_is_proxy {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, V8Value],
                         CType::Bool,
-                        op_is_proxy_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_is_proxy_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_is_proxy {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(value: serde_v8::Value) -> bool {
+    fn call<'scope>(value: serde_v8::Value) -> bool {
         value.v8_value.is_proxy()
     }
     pub fn v8_func<'scope>(
@@ -85,14 +85,16 @@ impl op_is_proxy {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_is_proxy_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    value: deno_core::v8::Local<deno_core::v8::Value>,
-) -> bool {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let value = serde_v8::Value { v8_value: value };
-    let result = op_is_proxy::call(value);
-    result
+impl op_is_proxy {
+    #[allow(clippy::too_many_arguments)]
+    fn op_is_proxy_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        value: deno_core::v8::Local<deno_core::v8::Value>,
+    ) -> bool {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let value = serde_v8::Value { v8_value: value };
+        let result = Self::call(value);
+        result
+    }
 }

--- a/ops/optimizer_tests/strings.out
+++ b/ops/optimizer_tests/strings.out
@@ -6,6 +6,29 @@
 pub struct op_string_length {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_string_length {
+    const NAME: &'static str = stringify!(op_string_length);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, SeqOneByteString, CallbackOptions],
+                    CType::Uint32,
+                    Self::op_string_length_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_string_length {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/strings.out
+++ b/ops/optimizer_tests/strings.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_string_length::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_string_length;
+pub struct op_string_length {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_string_length {
     pub const fn name() -> &'static str {
         stringify!(op_string_length)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_string_length {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_string_length {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, SeqOneByteString, CallbackOptions],
                         CType::Uint32,
-                        op_string_length_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_string_length_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_string_length {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(string: &str) -> u32 {
+    fn call<'scope>(string: &str) -> u32 {
         string.len() as u32
     }
     pub fn v8_func<'scope>(
@@ -86,21 +86,23 @@ impl op_string_length {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_string_length_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    string: *const deno_core::v8::fast_api::FastApiOneByteString,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> u32 {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let string = match ::std::str::from_utf8(unsafe { &*string }.as_bytes()) {
-        Ok(v) => v,
-        Err(_) => {
-            unsafe { &mut *fast_api_callback_options }.fallback = true;
-            return Default::default();
-        }
-    };
-    let result = op_string_length::call(string);
-    result
+impl op_string_length {
+    #[allow(clippy::too_many_arguments)]
+    fn op_string_length_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        string: *const deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let string = match ::std::str::from_utf8(unsafe { &*string }.as_bytes()) {
+            Ok(v) => v,
+            Err(_) => {
+                unsafe { &mut *fast_api_callback_options }.fallback = true;
+                return Default::default();
+            }
+        };
+        let result = Self::call(string);
+        result
+    }
 }

--- a/ops/optimizer_tests/strings.out
+++ b/ops/optimizer_tests/strings.out
@@ -27,8 +27,8 @@ impl op_string_length {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, SeqOneByteString, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_string_length {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(string: &str) -> u32 {
         string.len() as u32
     }

--- a/ops/optimizer_tests/strings_result.out
+++ b/ops/optimizer_tests/strings_result.out
@@ -6,6 +6,19 @@
 pub struct op_string_length {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_string_length {
+    const NAME: &'static str = stringify!(op_string_length);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_string_length {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/strings_result.out
+++ b/ops/optimizer_tests/strings_result.out
@@ -35,6 +35,7 @@ impl op_string_length {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(string: &str) -> Result<u32, AnyError> {
         Ok(string.len() as u32)
     }

--- a/ops/optimizer_tests/strings_result.out
+++ b/ops/optimizer_tests/strings_result.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_string_length::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_string_length;
+pub struct op_string_length {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_string_length {
     pub const fn name() -> &'static str {
         stringify!(op_string_length)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_string_length {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,7 @@ impl op_string_length {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(string: &str) -> Result<u32, AnyError> {
+    fn call<'scope>(string: &str) -> Result<u32, AnyError> {
         Ok(string.len() as u32)
     }
     pub fn v8_func<'scope>(

--- a/ops/optimizer_tests/u64_result.out
+++ b/ops/optimizer_tests/u64_result.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_bench_now::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_bench_now;
+pub struct op_bench_now {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_bench_now {
     pub const fn name() -> &'static str {
         stringify!(op_bench_now)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_bench_now {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -35,7 +35,7 @@ impl op_bench_now {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(state: &mut OpState) -> Result<u64, AnyError> {
+    fn call<'scope>(state: &mut OpState) -> Result<u64, AnyError> {
         let ns = state.borrow::<time::Instant>().elapsed().as_nanos();
         let ns_u64 = u64::try_from(ns)?;
         Ok(ns_u64)

--- a/ops/optimizer_tests/u64_result.out
+++ b/ops/optimizer_tests/u64_result.out
@@ -6,6 +6,19 @@
 pub struct op_bench_now {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_bench_now {
+    const NAME: &'static str = stringify!(op_bench_now);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_bench_now {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/u64_result.out
+++ b/ops/optimizer_tests/u64_result.out
@@ -35,6 +35,7 @@ impl op_bench_now {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(state: &mut OpState) -> Result<u64, AnyError> {
         let ns = state.borrow::<time::Instant>().elapsed().as_nanos();
         let ns_u64 = u64::try_from(ns)?;

--- a/ops/optimizer_tests/uint8array.out
+++ b/ops/optimizer_tests/uint8array.out
@@ -27,8 +27,8 @@ impl op_import_spki_x25519 {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, TypedArray(CType::Uint8), TypedArray(CType::Uint8)],
@@ -45,6 +45,7 @@ impl op_import_spki_x25519 {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(key_data: &[u8], out: &mut [u8]) -> bool {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/uint8array.out
+++ b/ops/optimizer_tests/uint8array.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_import_spki_x25519::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_import_spki_x25519;
+pub struct op_import_spki_x25519 {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_import_spki_x25519 {
     pub const fn name() -> &'static str {
         stringify!(op_import_spki_x25519)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_import_spki_x25519 {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_import_spki_x25519 {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, TypedArray(CType::Uint8), TypedArray(CType::Uint8)],
                         CType::Bool,
-                        op_import_spki_x25519_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_import_spki_x25519_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_import_spki_x25519 {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call(key_data: &[u8], out: &mut [u8]) -> bool {}
+    pub fn call<'scope>(key_data: &[u8], out: &mut [u8]) -> bool {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -162,16 +162,20 @@ impl op_import_spki_x25519 {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_import_spki_x25519_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    key_data: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
-    out: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
-) -> bool {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let key_data = unsafe { (&*key_data).get_storage_if_aligned().unwrap_unchecked() };
-    let out = unsafe { (&*out).get_storage_if_aligned().unwrap_unchecked() };
-    let result = op_import_spki_x25519::call(key_data, out);
-    result
+impl op_import_spki_x25519 {
+    #[allow(clippy::too_many_arguments)]
+    fn op_import_spki_x25519_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        key_data: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        out: *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
+    ) -> bool {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let key_data = unsafe {
+            (&*key_data).get_storage_if_aligned().unwrap_unchecked()
+        };
+        let out = unsafe { (&*out).get_storage_if_aligned().unwrap_unchecked() };
+        let result = Self::call(key_data, out);
+        result
+    }
 }

--- a/ops/optimizer_tests/uint8array.out
+++ b/ops/optimizer_tests/uint8array.out
@@ -6,6 +6,29 @@
 pub struct op_import_spki_x25519 {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_import_spki_x25519 {
+    const NAME: &'static str = stringify!(op_import_spki_x25519);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, TypedArray(CType::Uint8), TypedArray(CType::Uint8)],
+                    CType::Bool,
+                    Self::op_import_spki_x25519_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_import_spki_x25519 {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -6,6 +6,29 @@
 pub struct op_unit_result {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_unit_result {
+    const NAME: &'static str = stringify!(op_unit_result);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, CallbackOptions],
+                    CType::Void,
+                    Self::op_unit_result_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_unit_result {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -27,8 +27,8 @@ impl op_unit_result {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_unit_result {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>() -> Result<(), AnyError> {
         Ok(())
     }

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_unit_result::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_unit_result;
+pub struct op_unit_result {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_unit_result {
     pub const fn name() -> &'static str {
         stringify!(op_unit_result)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_unit_result {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_unit_result {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
                         CType::Void,
-                        op_unit_result_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_unit_result_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_unit_result {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call() -> Result<(), AnyError> {
+    fn call<'scope>() -> Result<(), AnyError> {
         Ok(())
     }
     pub fn v8_func<'scope>(
@@ -85,27 +85,29 @@ impl op_unit_result {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_unit_result_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let op_state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = op_unit_result::call();
-    match result {
-        Ok(result) => result,
-        Err(err) => {
-            op_state.last_fast_op_error.replace(err);
-            __opts.fallback = true;
+impl op_unit_result {
+    #[allow(clippy::too_many_arguments)]
+    fn op_unit_result_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let op_state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call();
+        match result {
+            Ok(result) => result,
+            Err(err) => {
+                op_state.last_fast_op_error.replace(err);
+                __opts.fallback = true;
+            }
         }
     }
 }

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -27,8 +27,8 @@ impl op_set_nodelay {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Bool, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_set_nodelay {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     pub fn call<'scope>(
         state: &mut OpState,
         rid: ResourceId,

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_set_nodelay::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_set_nodelay;
+pub struct op_set_nodelay {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_set_nodelay {
     pub const fn name() -> &'static str {
         stringify!(op_set_nodelay)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_set_nodelay {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_set_nodelay {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, Uint32, Bool, CallbackOptions],
                         CType::Void,
-                        op_set_nodelay_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_set_nodelay_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_set_nodelay {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    pub fn call(
+    pub fn call<'scope>(
         state: &mut OpState,
         rid: ResourceId,
         nodelay: bool,
@@ -118,29 +118,31 @@ impl op_set_nodelay {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_set_nodelay_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    rid: ResourceId,
-    nodelay: bool,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let __ctx = unsafe {
-        &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
-            as *const _ops::OpCtx)
-    };
-    let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
-    let result = op_set_nodelay::call(state, rid, nodelay);
-    match result {
-        Ok(result) => result,
-        Err(err) => {
-            state.last_fast_op_error.replace(err);
-            __opts.fallback = true;
+impl op_set_nodelay {
+    #[allow(clippy::too_many_arguments)]
+    fn op_set_nodelay_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        rid: ResourceId,
+        nodelay: bool,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let __ctx = unsafe {
+            &*(v8::Local::<v8::External>::cast(unsafe { __opts.data.data }).value()
+                as *const _ops::OpCtx)
+        };
+        let state = &mut ::std::cell::RefCell::borrow_mut(&__ctx.state);
+        let result = Self::call(state, rid, nodelay);
+        match result {
+            Ok(result) => result,
+            Err(err) => {
+                state.last_fast_op_error.replace(err);
+                __opts.fallback = true;
+            }
         }
     }
 }

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -6,6 +6,29 @@
 pub struct op_set_nodelay {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_set_nodelay {
+    const NAME: &'static str = stringify!(op_set_nodelay);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, Uint32, Bool, CallbackOptions],
+                    CType::Void,
+                    Self::op_set_nodelay_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_set_nodelay {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/unit_ret.out
+++ b/ops/optimizer_tests/unit_ret.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_unit::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_unit;
+pub struct op_unit {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_unit {
     pub const fn name() -> &'static str {
         stringify!(op_unit)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_unit {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_unit {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value],
                         CType::Void,
-                        op_unit_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_unit_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_unit {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call() -> () {
+    fn call<'scope>() -> () {
         ()
     }
     pub fn v8_func<'scope>(
@@ -74,10 +74,12 @@ impl op_unit {
         };
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_unit_fast_fn<'scope>(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let result = op_unit::call();
-    result
+impl op_unit {
+    #[allow(clippy::too_many_arguments)]
+    fn op_unit_fast_fn(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let result = Self::call();
+        result
+    }
 }

--- a/ops/optimizer_tests/unit_ret.out
+++ b/ops/optimizer_tests/unit_ret.out
@@ -6,6 +6,29 @@
 pub struct op_unit {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_unit {
+    const NAME: &'static str = stringify!(op_unit);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value],
+                    CType::Void,
+                    Self::op_unit_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_unit {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/unit_ret.out
+++ b/ops/optimizer_tests/unit_ret.out
@@ -27,8 +27,8 @@ impl op_unit {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value],
@@ -45,6 +45,7 @@ impl op_unit {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>() -> () {
         ()
     }

--- a/ops/optimizer_tests/wasm_op.out
+++ b/ops/optimizer_tests/wasm_op.out
@@ -27,8 +27,8 @@ impl op_wasm {
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: {
-                use deno_core::v8::fast_api::Type::*;
                 use deno_core::v8::fast_api::CType;
+                use deno_core::v8::fast_api::Type::*;
                 Some(
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
@@ -45,6 +45,7 @@ impl op_wasm {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::extra_unused_lifetimes)]
     fn call<'scope>(memory: Option<&mut [u8]>) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,

--- a/ops/optimizer_tests/wasm_op.out
+++ b/ops/optimizer_tests/wasm_op.out
@@ -6,6 +6,29 @@
 pub struct op_wasm {
     _phantom_data: ::std::marker::PhantomData<()>,
 }
+impl deno_core::_ops::Op for op_wasm {
+    const NAME: &'static str = stringify!(op_wasm);
+    const DECL: deno_core::OpDecl = deno_core::OpDecl {
+        name: Self::name(),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: {
+            use deno_core::v8::fast_api::CType;
+            use deno_core::v8::fast_api::Type::*;
+            Some(
+                deno_core::v8::fast_api::FastFunction::new(
+                    &[V8Value, CallbackOptions],
+                    CType::Void,
+                    Self::op_wasm_fast_fn as *const ::std::ffi::c_void,
+                ),
+            )
+        },
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 0,
+    };
+}
 #[doc(hidden)]
 impl op_wasm {
     pub const fn name() -> &'static str {

--- a/ops/optimizer_tests/wasm_op.out
+++ b/ops/optimizer_tests/wasm_op.out
@@ -3,16 +3,16 @@
 ///
 ///Use `op_wasm::decl()` to get an op-declaration
 ///you can include in a `deno_core::Extension`.
-pub struct op_wasm;
+pub struct op_wasm {
+    _phantom_data: ::std::marker::PhantomData<()>,
+}
 #[doc(hidden)]
 impl op_wasm {
     pub const fn name() -> &'static str {
         stringify!(op_wasm)
     }
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub extern "C" fn v8_fn_ptr<'scope>(
-        info: *const deno_core::v8::FunctionCallbackInfo,
-    ) {
+    pub extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let info = unsafe { &*info };
         let scope = &mut unsafe { deno_core::v8::CallbackScope::new(info) };
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
@@ -21,7 +21,7 @@ impl op_wasm {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl<'scope>() -> deno_core::OpDecl {
+    pub const fn decl() -> deno_core::OpDecl {
         deno_core::OpDecl {
             name: Self::name(),
             v8_fn_ptr: Self::v8_fn_ptr as _,
@@ -33,7 +33,7 @@ impl op_wasm {
                     deno_core::v8::fast_api::FastFunction::new(
                         &[V8Value, CallbackOptions],
                         CType::Void,
-                        op_wasm_fast_fn as *const ::std::ffi::c_void,
+                        Self::op_wasm_fast_fn as *const ::std::ffi::c_void,
                     ),
                 )
             },
@@ -45,7 +45,7 @@ impl op_wasm {
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]
-    fn call(memory: Option<&mut [u8]>) {}
+    fn call<'scope>(memory: Option<&mut [u8]>) {}
     pub fn v8_func<'scope>(
         scope: &mut deno_core::v8::HandleScope<'scope>,
         args: deno_core::v8::FunctionCallbackArguments,
@@ -61,20 +61,23 @@ impl op_wasm {
         op_state.tracker.track_sync(ctx.id);
     }
 }
-#[allow(clippy::too_many_arguments)]
-fn op_wasm_fast_fn<'scope>(
-    _: deno_core::v8::Local<deno_core::v8::Object>,
-    fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-) -> () {
-    use deno_core::v8;
-    use deno_core::_ops;
-    let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
-        &mut *fast_api_callback_options
-    };
-    let memory = unsafe {
-        &*(__opts.wasm_memory as *const deno_core::v8::fast_api::FastApiTypedArray<u8>)
+impl op_wasm {
+    #[allow(clippy::too_many_arguments)]
+    fn op_wasm_fast_fn(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        use deno_core::v8;
+        use deno_core::_ops;
+        let __opts: &mut v8::fast_api::FastApiCallbackOptions = unsafe {
+            &mut *fast_api_callback_options
+        };
+        let memory = unsafe {
+            &*(__opts.wasm_memory
+                as *const deno_core::v8::fast_api::FastApiTypedArray<u8>)
+        }
+            .get_storage_if_aligned();
+        let result = Self::call(memory);
+        result
     }
-        .get_storage_if_aligned();
-    let result = op_wasm::call(memory);
-    result
 }


### PR DESCRIPTION
Implementation of generics for `#[op2]`, along with some refactoring to improve the ergonomics of ops with generics parameters:

 - The ops have generics on the struct rather than the associated methods, which allows us to trait-ify ops (impossible when they are on the methods)
 - The decl() method can become a trait-associated const field which unlocks future optimizations

Callers of ops need to switch from: `op_net_connect_tcp::call::<TestPermission>(conn_state, ip_addr)` to `op_net_connect_tcp::<TestPermission>::call(conn_state, ip_addr)`.


