### PR TITLE
chore(core): Fully adopt the "main realm/context" terminology

### DIFF
--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -149,7 +149,7 @@ impl JsRuntimeInspector {
   pub fn new(
     scope: &mut v8::HandleScope,
     context: v8::Local<v8::Context>,
-    is_main: bool,
+    is_main_runtime: bool,
   ) -> Rc<RefCell<Self>> {
     let (new_session_tx, new_session_rx) =
       mpsc::unbounded::<InspectorSessionProxy>();
@@ -179,12 +179,12 @@ impl JsRuntimeInspector {
       new_session_rx,
     ));
 
-    // Tell the inspector about the global context.
-    let context_name = v8::inspector::StringView::from(&b"global context"[..]);
+    // Tell the inspector about the main realm.
+    let context_name = v8::inspector::StringView::from(&b"main realm"[..]);
     // NOTE(bartlomieju): this is what Node.js does and it turns out some
     // debuggers (like VSCode) rely on this information to disconnect after
     // program completes
-    let aux_data = if is_main {
+    let aux_data = if is_main_runtime {
       r#"{"isDefault": true}"#
     } else {
       r#"{"isDefault": false}"#

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -111,7 +111,7 @@ pub(crate) struct JsRealmInner {
   context_state: Rc<RefCell<ContextState>>,
   context: Rc<v8::Global<v8::Context>>,
   runtime_state: Rc<RefCell<JsRuntimeState>>,
-  is_global: bool,
+  is_main_realm: bool,
 }
 
 impl JsRealmInner {
@@ -119,13 +119,13 @@ impl JsRealmInner {
     context_state: Rc<RefCell<ContextState>>,
     context: v8::Global<v8::Context>,
     runtime_state: Rc<RefCell<JsRuntimeState>>,
-    is_global: bool,
+    is_main_realm: bool,
   ) -> Self {
     Self {
       context_state,
       context: context.into(),
       runtime_state,
-      is_global,
+      is_main_realm,
     }
   }
 
@@ -347,8 +347,8 @@ impl JsRealm {
 
 impl Drop for JsRealm {
   fn drop(&mut self) {
-    // Don't do anything special with the global realm
-    if self.0.is_global {
+    // Don't do anything special with the main realm
+    if self.0.is_main_realm {
       return;
     }
 

--- a/core/runtime/tests.rs
+++ b/core/runtime/tests.rs
@@ -138,7 +138,7 @@ async fn test_ref_unref_ops() {
     )
     .unwrap();
   {
-    let realm = runtime.global_realm();
+    let realm = runtime.main_realm();
     assert_eq!(realm.num_pending_ops(), 2);
     assert_eq!(realm.num_unrefed_ops(), 0);
   }
@@ -152,7 +152,7 @@ async fn test_ref_unref_ops() {
     )
     .unwrap();
   {
-    let realm = runtime.global_realm();
+    let realm = runtime.main_realm();
     assert_eq!(realm.num_pending_ops(), 2);
     assert_eq!(realm.num_unrefed_ops(), 2);
   }
@@ -166,7 +166,7 @@ async fn test_ref_unref_ops() {
     )
     .unwrap();
   {
-    let realm = runtime.global_realm();
+    let realm = runtime.main_realm();
     assert_eq!(realm.num_pending_ops(), 2);
     assert_eq!(realm.num_unrefed_ops(), 0);
   }
@@ -1626,12 +1626,12 @@ async fn test_set_promise_reject_callback() {
 #[tokio::test]
 async fn test_set_promise_reject_callback_realms() {
   let mut runtime = JsRuntime::new(RuntimeOptions::default());
-  let global_realm = runtime.global_realm();
+  let main_realm = runtime.main_realm();
   let realm1 = runtime.create_realm().unwrap();
   let realm2 = runtime.create_realm().unwrap();
 
   let realm_expectations = &[
-    (&global_realm, "global_realm", 42),
+    (&main_realm, "main_realm", 42),
     (&realm1, "realm1", 140),
     (&realm2, "realm2", 720),
   ];
@@ -1907,7 +1907,7 @@ fn test_op_unstable_disabling() {
 #[test]
 fn js_realm_simple() {
   let mut runtime = JsRuntime::new(Default::default());
-  let main_context = runtime.global_context();
+  let main_context = runtime.main_context();
   let main_global = {
     let scope = &mut runtime.handle_scope();
     let local_global = main_context.open(scope).global(scope);
@@ -2002,7 +2002,7 @@ fn js_realm_sync_ops() {
   let new_realm = runtime.create_realm().unwrap();
 
   // Test in both realms
-  for realm in [runtime.global_realm(), new_realm].into_iter() {
+  for realm in [runtime.main_realm(), new_realm].into_iter() {
     let ret = realm
       .execute_script_static(
         runtime.v8_isolate(),
@@ -2048,13 +2048,13 @@ async fn js_realm_async_ops() {
     ..Default::default()
   });
 
-  let global_realm = runtime.global_realm();
+  let main_realm = runtime.main_realm();
   let new_realm = runtime.create_realm().unwrap();
 
   let mut rets = vec![];
 
   // Test in both realms
-  for realm in [global_realm, new_realm].into_iter() {
+  for realm in [main_realm, new_realm].into_iter() {
     let ret = realm
       .execute_script_static(
         runtime.v8_isolate(),
@@ -2170,7 +2170,7 @@ async fn js_realm_ref_unref_ops() {
   });
 
   poll_fn(move |cx| {
-    let main_realm = runtime.global_realm();
+    let main_realm = runtime.main_realm();
     let other_realm = runtime.create_realm().unwrap();
 
     main_realm

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -531,7 +531,7 @@ impl WebWorker {
     };
 
     let bootstrap_fn_global = {
-      let context = js_runtime.global_context();
+      let context = js_runtime.main_context();
       let scope = &mut js_runtime.handle_scope();
       let context_local = v8::Local::new(scope, context);
       let global_obj = context_local.global(scope);

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -353,7 +353,7 @@ impl MainWorker {
     }
 
     let bootstrap_fn_global = {
-      let context = js_runtime.global_context();
+      let context = js_runtime.main_context();
       let scope = &mut js_runtime.handle_scope();
       let context_local = v8::Local::new(scope, context);
       let global_obj = context_local.global(scope);


### PR DESCRIPTION
It used to be that the realm/context created at the beginning of an isolate was sometimes called "global context" and sometimes "main context/realm". This seems to go back to the days before `JsRealm`, when the `JsRuntime::global_context` method returned the only `v8::Global<v8::Context>` that existed in the isolate. Nowadays that is no longer the case, and we should call it the main realm.

This change by itself would also result in the property/variable name `is_main` used to refer to either the main `JsRuntime`/isolate in a process, or to the main realm in an isolate. Those property names are renamed to `is_main_runtime` or `is_main_realm` to disambiguate.

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
