### PR TITLE
fix(console): correct the parseCssColor algorithm

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1152,9 +1152,12 @@ Deno.test(function consoleParseCssColor() {
   assertEquals(parseCssColor("darkmagenta"), [139, 0, 139]);
   assertEquals(parseCssColor("slateblue"), [106, 90, 205]);
   assertEquals(parseCssColor("#ffaa00"), [255, 170, 0]);
-  assertEquals(parseCssColor("#ffaa00"), [255, 170, 0]);
-  assertEquals(parseCssColor("#18d"), [16, 128, 208]);
-  assertEquals(parseCssColor("#18D"), [16, 128, 208]);
+  assertEquals(parseCssColor("#ffAA00"), [255, 170, 0]);
+  assertEquals(parseCssColor("#fa0"), [255, 170, 0]);
+  assertEquals(parseCssColor("#FA0"), [255, 170, 0]);
+  assertEquals(parseCssColor("#18d"), [17, 136, 221]);
+  assertEquals(parseCssColor("#18D"), [17, 136, 221]);
+  assertEquals(parseCssColor("#1188DD"), [17, 136, 221]);
   assertEquals(parseCssColor("rgb(100, 200, 50)"), [100, 200, 50]);
   assertEquals(parseCssColor("rgb(+100.3, -200, .5)"), [100, 0, 1]);
   assertEquals(parseCssColor("hsl(75, 60%, 40%)"), [133, 163, 41]);

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -2541,7 +2541,7 @@ function replaceEscapeSequences(string) {
       ESCAPE_PATTERN,
       (c) => ESCAPE_MAP[c],
     ),
-    new SafeRegExp(ESCAPE_PATTERN2),
+    ESCAPE_PATTERN2,
     (c) =>
       "\\x" +
       StringPrototypePadStart(
@@ -2753,9 +2753,9 @@ function parseCssColor(colorString) {
   const smallHashMatch = StringPrototypeMatch(colorString, SMALL_HASH_PATTERN);
   if (smallHashMatch != null) {
     return [
-      Number(`0x${smallHashMatch[1]}0`),
-      Number(`0x${smallHashMatch[2]}0`),
-      Number(`0x${smallHashMatch[3]}0`),
+      Number(`0x${smallHashMatch[1]}${smallHashMatch[1]}`),
+      Number(`0x${smallHashMatch[2]}${smallHashMatch[2]}`),
+      Number(`0x${smallHashMatch[3]}${smallHashMatch[3]}`),
     ];
   }
   // deno-fmt-ignore
@@ -3329,7 +3329,7 @@ class Console {
     if (properties !== undefined && !ArrayIsArray(properties)) {
       throw new Error(
         "The 'properties' argument must be of type Array. " +
-          "Received type string",
+          "Received type " + typeof properties,
       );
     }
 
@@ -3436,7 +3436,7 @@ class Console {
     label = String(label);
 
     if (!MapPrototypeHas(timerMap, label)) {
-      this.warn(`Timer '${label}' does not exists`);
+      this.warn(`Timer '${label}' does not exist`);
       return;
     }
 


### PR DESCRIPTION
This is a fix for issue #19644, concerning the `parseCssColor` function in the file `ext/console/01_console.js`. Changes made on lines 2756-2758. To sum it up:

> The internal `parseCssColor` function currently parses 3/4-digit hex colors incorrectly. For example, it parses the string `#FFFFFF` as `[255, 255, 255]` (as expected), but returns `[240, 240, 240]` for `#FFF`, when it should return the same triplet as the former. 

While it's not going to cause a fatal runtime error, it did bug me enough to fix it real quick.

#### Additional Changes

- [x] removed an unnecessary call to `SafeRegExp` on L2544
- [x] changed an error message's hard-coded type to `typeof x` on L3332
- [x] updated the grammar for the error message on L3439

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
