### PR TITLE
fix: add `exactOptionalPropertyTypes` for configuration file JSON schema

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -34,6 +34,12 @@
           "default": false,
           "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
         },
+        "exactOptionalPropertyTypes": {
+          "description": "Differentiate between undefined and not present when type checking",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Differentiate between undefined and not present when type checking\n\nSee more: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes"
+        },
         "experimentalDecorators": {
           "description": "Enable experimental support for TC39 stage 2 draft decorators.",
           "type": "boolean",


### PR DESCRIPTION
- fixes #19646 

lines copied from: https://github.com/SchemaStore/schemastore/blob/8513fdcc29f89a3b864bd712e6fdd78a6691884f/src/schemas/json/tsconfig.json#L281-L286
