### PR TITLE
fix(node/worker_threads): `pkg.type` typo in Worker class constructor

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -126,7 +126,7 @@ class _Worker extends EventEmitter {
       }
       if (
         !(specifier.toString().endsWith(".mjs") ||
-          (pkg && pkg.exists && pkg.typ == "module"))
+          (pkg && pkg.exists && pkg.type == "module"))
       ) {
         const cwdFileUrl = toFileUrl(Deno.cwd());
         specifier =

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -126,7 +126,7 @@ class _Worker extends EventEmitter {
       }
       if (
         !(specifier.toString().endsWith(".mjs") ||
-          (pkg && pkg.exists && pkg.type == "module"))
+          (pkg && pkg.exists && pkg.typ == "module")) // `pkg.typ` is not a typo
       ) {
         const cwdFileUrl = toFileUrl(Deno.cwd());
         specifier =


### PR DESCRIPTION
Fixes a very small typo (with potential to be bigly problematic) in the Worker constructor from `node:worker_threads`. `pkg.typ` isn't a recognized field in the package.json spec, and in this context it's obvious that it was meant to be `pkg.type`, so I just added an `e`. 

I hope you don't mind that I didn't bother creating an issue for this PR, it felt a bit silly for something this small.

Thank you :)