### PR TITLE
fix(core): Re-export RuntimeSnapshotOptions

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -115,6 +115,7 @@ pub use crate::runtime::JsRealm;
 pub use crate::runtime::JsRuntime;
 pub use crate::runtime::JsRuntimeForSnapshot;
 pub use crate::runtime::RuntimeOptions;
+pub use crate::runtime::RuntimeSnapshotOptions;
 pub use crate::runtime::SharedArrayBufferStore;
 pub use crate::runtime::Snapshot;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;


### PR DESCRIPTION
It seems like `JsRuntimeForSnapshot` cannot be created from outside of deno-core because `RuntimeSnapshotOptions` isn't publicly exported.