### PR TITLE
test(cli): add test for default export type check bug

### DIFF
--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -332,6 +332,18 @@ itest!(types_general {
   exit_code: 1,
 });
 
+// This test currently asserts wrong behavior to verify
+// https://github.com/denoland/deno/issues/19096.
+// Once that bug has been fixed the content of main.out
+// should be deleted and the test renamed accordingly.
+itest!(types_export_default_should_actually_fail {
+  args: "check --quiet npm/types_export_default/main.ts",
+  output: "npm/types_export_default/main.out",
+  envs: env_vars_for_npm_tests(),
+  http_server: true,
+  exit_code: 1,
+});
+
 itest!(types_ambient_module {
   args: "check --quiet npm/types_ambient_module/main.ts",
   output: "npm/types_ambient_module/main.out",

--- a/cli/tests/testdata/npm/registry/@denotest/types-export-default/1.0.0/index.d.ts
+++ b/cli/tests/testdata/npm/registry/@denotest/types-export-default/1.0.0/index.d.ts
@@ -1,0 +1,2 @@
+function foo() {}
+export default foo;

--- a/cli/tests/testdata/npm/registry/@denotest/types-export-default/1.0.0/package.json
+++ b/cli/tests/testdata/npm/registry/@denotest/types-export-default/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/types-export-default",
+  "version": "1.0.0",
+  "types": "./index.d.ts"
+}

--- a/cli/tests/testdata/npm/types_export_default/main.out
+++ b/cli/tests/testdata/npm/types_export_default/main.out
@@ -1,0 +1,5 @@
+error: TS2349 [ERROR]: This expression is not callable.
+  Type 'typeof import("file:///[WILDCARD]/@denotest/types-export-default/1.0.0/index.d.ts")' has no call signatures.
+foo();
+~~~
+    at file:///[WILDCARD]/types_export_default/main.ts:2:1

--- a/cli/tests/testdata/npm/types_export_default/main.ts
+++ b/cli/tests/testdata/npm/types_export_default/main.ts
@@ -1,0 +1,2 @@
+import foo from "npm:@denotest/types-export-default";
+foo();


### PR DESCRIPTION
This commit adds a test to verify the bug described by #19096.

Once the bug has been fixed the test should be updated accordingly.

CC: @dsherret 