### PR TITLE
perf(ext/node): optimize net streams

### DIFF
--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -11,6 +11,7 @@ use deno_core::op;
 use deno_core::serde_json;
 use deno_core::serde_v8;
 use deno_core::url::Url;
+#[allow(unused_imports)]
 use deno_core::v8;
 use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -9,7 +9,9 @@ use deno_core::error::AnyError;
 use deno_core::located_script_name;
 use deno_core::op;
 use deno_core::serde_json;
+use deno_core::serde_v8;
 use deno_core::url::Url;
+use deno_core::v8;
 use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;
 use deno_fs::sync::MaybeSend;
@@ -138,8 +140,8 @@ fn op_node_build_os() -> String {
 }
 
 #[op(fast)]
-fn op_is_any_arraybuffer(value: v8::Local<v8::Value>) -> bool {
-  value.is_array_buffer() || value.is_shared_array_buffer()
+fn op_is_any_arraybuffer(value: serde_v8::Value) -> bool {
+  value.v8_value.is_array_buffer() || value.v8_value.is_shared_array_buffer()
 }
 
 deno_core::extension!(deno_node,

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -137,6 +137,11 @@ fn op_node_build_os() -> String {
     .to_string()
 }
 
+#[op(fast)]
+fn op_is_any_arraybuffer(value: v8::Local<v8::Value>) -> bool {
+  value.is_array_buffer() || value.is_shared_array_buffer()
+}
+
 deno_core::extension!(deno_node,
   deps = [ deno_io, deno_fs ],
   parameters = [P: NodePermissions],
@@ -220,6 +225,7 @@ deno_core::extension!(deno_node,
     ops::zlib::op_zlib_reset,
     ops::http::op_node_http_request<P>,
     op_node_build_os,
+    op_is_any_arraybuffer,
     ops::require::op_require_init_paths,
     ops::require::op_require_node_module_paths<P>,
     ops::require::op_require_proxy_path,

--- a/ext/node/polyfills/internal_binding/stream_wrap.ts
+++ b/ext/node/polyfills/internal_binding/stream_wrap.ts
@@ -276,7 +276,7 @@ export class LibuvStreamWrap extends HandleWrap {
 
   /** Internal method for reading from the attached stream. */
   async #read() {
-    let buf = new Uint8Array(SUGGESTED_SIZE);
+    let buf = BUF;
 
     let nread: number | null;
     try {
@@ -372,3 +372,5 @@ export class LibuvStreamWrap extends HandleWrap {
     return;
   }
 }
+
+const BUF = new Uint8Array(SUGGESTED_SIZE);

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -98,12 +98,7 @@ export function isArgumentsObject(value: unknown): value is IArguments {
 }
 
 export function isArrayBuffer(value: unknown): value is ArrayBuffer {
-  try {
-    _getArrayBufferByteLength.call(value);
-    return true;
-  } catch {
-    return false;
-  }
+  return value instanceof ArrayBuffer;
 }
 
 export function isAsyncFunction(
@@ -280,18 +275,7 @@ export function isSetIterator(
 export function isSharedArrayBuffer(
   value: unknown,
 ): value is SharedArrayBuffer {
-  // TODO(kt3k): add SharedArrayBuffer to primordials
-  _getSharedArrayBufferByteLength ??= Object.getOwnPropertyDescriptor(
-    SharedArrayBuffer.prototype,
-    "byteLength",
-  )!.get!;
-
-  try {
-    _getSharedArrayBufferByteLength.call(value);
-    return true;
-  } catch {
-    return false;
-  }
+  value instanceof SharedArrayBuffer;
 }
 
 // deno-lint-ignore ban-types

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -87,7 +87,7 @@ function isObjectLike(
 export function isAnyArrayBuffer(
   value: unknown,
 ): value is ArrayBuffer | SharedArrayBuffer {
-  return op_is_any_arraybuffer(value);
+  return ops.op_is_any_arraybuffer(value);
 }
 
 export function isArgumentsObject(value: unknown): value is IArguments {

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -22,6 +22,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const { core } = globalThis.__bootstrap;
+const { ops } = core;
 
 // https://tc39.es/ecma262/#sec-object.prototype.tostring
 const _toString = Object.prototype.toString;
@@ -86,7 +87,7 @@ function isObjectLike(
 export function isAnyArrayBuffer(
   value: unknown,
 ): value is ArrayBuffer | SharedArrayBuffer {
-  return isArrayBuffer(value) || isSharedArrayBuffer(value);
+  return op_is_any_arraybuffer(value);
 }
 
 export function isArgumentsObject(value: unknown): value is IArguments {
@@ -98,7 +99,12 @@ export function isArgumentsObject(value: unknown): value is IArguments {
 }
 
 export function isArrayBuffer(value: unknown): value is ArrayBuffer {
-  return value instanceof ArrayBuffer;
+  try {
+    _getArrayBufferByteLength.call(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function isAsyncFunction(
@@ -275,7 +281,18 @@ export function isSetIterator(
 export function isSharedArrayBuffer(
   value: unknown,
 ): value is SharedArrayBuffer {
-  value instanceof SharedArrayBuffer;
+  // TODO(kt3k): add SharedArrayBuffer to primordials
+  _getSharedArrayBufferByteLength ??= Object.getOwnPropertyDescriptor(
+    SharedArrayBuffer.prototype,
+    "byteLength",
+  )!.get!;
+
+  try {
+    _getSharedArrayBufferByteLength.call(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // deno-lint-ignore ban-types


### PR DESCRIPTION
~4.5x improvement in `npm:ws` echo benchmark:

```
$ ./load_test 10 0.0.0.0 8080 0 0
Using message size of 20 bytes
Running benchmark now...
Msg/sec: 101083.750000
Msg/sec: 103606.000000
^C

$ ./load_test 10 0.0.0.0 8080 0 0
Using message size of 20 bytes
Running benchmark now...
Msg/sec: 24906.750000
Msg/sec: 28478.000000
^C
```
