### PR TITLE
perf(ext/websocket): improve server websocket perf

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -200,7 +200,7 @@ class Event {
         currentTarget: null,
         eventPhase: Event.NONE,
         target: null,
-        timeStamp: DateNow(),
+        timeStamp: 0,
       };
       // TODO(@littledivy): Not spec compliant but performance is hurt badly
       // for users of `_skipInternalInit`.

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -52,9 +52,7 @@ const {
   op_ws_close,
   op_ws_send_binary,
   op_ws_send_text,
-  op_ws_next_event,
   op_ws_loop,
-  op_ws_get_buffer,
   op_ws_get_buffer_as_string,
   op_ws_get_error,
   op_ws_send_ping,
@@ -411,7 +409,7 @@ class WebSocket extends EventTarget {
     }
   }
 
-  async [_eventLoop]() {
+  [_eventLoop]() {
     const rid = this[_rid];
     op_ws_loop(rid, (kind, buffer) => {
       if (this[_readyState] !== CLOSED) {

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -326,6 +326,7 @@ class WebSocket extends EventTarget {
     if (ArrayBufferIsView(data)) {
       op_ws_send_binary(this[_rid], data);
     } else if (ObjectPrototypeIsPrototypeOf(ArrayBufferPrototype, data)) {
+      // deno-lint-ignore prefer-primordials
       op_ws_send_binary(this[_rid], new Uint8Array(data));
     } else if (ObjectPrototypeIsPrototypeOf(BlobPrototype, data)) {
       PromisePrototypeThen(
@@ -428,7 +429,6 @@ class WebSocket extends EventTarget {
           case 1: {
             /* binary */
             this[_serverHandleIdleTimeout]();
-            // deno-lint-ignore prefer-primordials
             let data;
             if (this.binaryType === "blob") {
               data = new Blob([buffer]);


### PR DESCRIPTION
- timestamp set to `0` for server websocket events.
- take fast call path with `op_ws_send_binary`.
- use callback instead of pull-based `op_ws_next_event`.

on Linux:

```
# deno (main)

$ ./load_test 100 0.0.0.0 8080 0 0
Using message size of 20 bytes
Running benchmark now...
Msg/sec: 208268.500000

# deno (this pr)

$ ./load_test 100 0.0.0.0 8080 0 0
Using message size of 20 bytes
Running benchmark now...
Msg/sec: 262141.000000
```