### PR TITLE
fix(ext/http): Catch errors in eager stream timeout to avoid uncaught promise rejections

### DIFF
--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -434,7 +434,10 @@ async function asyncResponse(responseBodies, req, status, stream) {
       //
       // To avoid this, we're going to swallow errors here and allow the code later in the
       // file to re-throw them in a way that doesn't appear to be an uncaught promise rejection.
-      timeoutPromise = core.writeAll(responseRid, value1).catch(() => null);
+      timeoutPromise = PromisePrototypeCatch(
+        core.writeAll(responseRid, value1),
+        () => null,
+      );
     }, 250);
     const { value: value2, done: done2 } = await reader.read();
 

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -427,7 +427,14 @@ async function asyncResponse(responseBodies, req, status, stream) {
       responseRid = op_http_set_response_body_stream(req);
       SetPrototypeAdd(responseBodies, responseRid);
       op_http_set_promise_complete(req, status);
-      timeoutPromise = core.writeAll(responseRid, value1);
+      // TODO(mmastrac): if this promise fails before we get to the await below, it crashes
+      // the process with an error:
+      //
+      // 'Uncaught (in promise) BadResource: failed to write'.
+      //
+      // To avoid this, we're going to swallow errors here and allow the code later in the
+      // file to re-throw them in a way that doesn't appear to be an uncaught promise rejection.
+      timeoutPromise = core.writeAll(responseRid, value1).catch(() => null);
     }, 250);
     const { value: value2, done: done2 } = await reader.read();
 


### PR DESCRIPTION
Fixes #19687 by adding a rejection handler to the write inside the setTimeout. There is a small window where the promise is actually not awaited and may reject without a handler.