### PR TITLE
fix(ext/node): Define performance.timeOrigin as getter property

### DIFF
--- a/cli/tests/unit_node/perf_hooks_test.ts
+++ b/cli/tests/unit_node/perf_hooks_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as perfHooks from "node:perf_hooks";
 import { performance } from "node:perf_hooks";
-import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
+import {
+  assertEquals,
+  assertThrows,
+} from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test({
   name: "[perf_hooks] performance",
@@ -37,5 +40,16 @@ Deno.test({
   name: "[perf_hooks] PerformanceEntry",
   fn() {
     assertEquals<unknown>(perfHooks.PerformanceEntry, PerformanceEntry);
+  },
+});
+
+Deno.test({
+  name: "[perf_hooks] performance.timeOrigin",
+  fn() {
+    assertEquals(typeof performance.timeOrigin, "number");
+    assertThrows(() => {
+      // @ts-expect-error: Cannot assign to 'timeOrigin' because it is a read-only property
+      performance.timeOrigin = 1;
+    });
   },
 });

--- a/ext/node/polyfills/perf_hooks.ts
+++ b/ext/node/polyfills/perf_hooks.ts
@@ -54,8 +54,10 @@ const performance:
     nodeTiming: {},
     now: () => shimPerformance.now(),
     timerify: () => notImplemented("timerify from performance"),
-    // deno-lint-ignore no-explicit-any
-    timeOrigin: (shimPerformance as any).timeOrigin,
+    get timeOrigin() {
+      // deno-lint-ignore no-explicit-any
+      return (shimPerformance as any).timeOrigin;
+    },
     markResourceTiming: () => {},
     // @ts-ignore waiting on update in `deno`, but currently this is
     // a circular dependency


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
fix #19708