### PR TITLE
fix: move `Deno.serve` to stable namespace

### DIFF
--- a/cli/tests/integration/watcher_tests.rs
+++ b/cli/tests/integration/watcher_tests.rs
@@ -1494,7 +1494,6 @@ async fn test_watch_serve() {
     .current_dir(util::testdata_path())
     .arg("run")
     .arg("--watch")
-    .arg("--unstable")
     .arg("--allow-net")
     .arg("-L")
     .arg("debug")

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -129,6 +129,7 @@ const denoNs = {
   PermissionStatus: permissions.PermissionStatus,
   // TODO(bartlomieju): why is this not in one of extensions?
   serveHttp: httpRuntime.serveHttp,
+  serve: http.serve,
   resolveDns: net.resolveDns,
   upgradeWebSocket: http.upgradeWebSocket,
   utime: fs.utime,
@@ -171,7 +172,6 @@ const denoNsUnstable = {
   funlock: fs.funlock,
   funlockSync: fs.funlockSync,
   upgradeHttp: http.upgradeHttp,
-  serve: http.serve,
   openKv: kv.openKv,
   AtomicOperation: kv.AtomicOperation,
   Kv: kv.Kv,


### PR DESCRIPTION
This was missed in #19141