### PR TITLE
perf: add setup cache for node_modules folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +788,7 @@ dependencies = [
  "atty",
  "base32",
  "base64 0.13.1",
+ "bincode",
  "cache_control",
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,6 +58,7 @@ async-trait.workspace = true
 atty.workspace = true
 base32 = "=0.4.0"
 base64.workspace = true
+bincode = "=1.3.3"
 cache_control.workspace = true
 chrono = { version = "=0.4.22", default-features = false, features = ["std"] }
 clap = { version = "=4.3.3", features = ["string"] }

--- a/cli/npm/resolvers/local.rs
+++ b/cli/npm/resolvers/local.rs
@@ -780,7 +780,7 @@ mod test {
     assert!(cache.insert_root_symlink("package-b", "package-b@0.2.0"));
     assert!(cache.save());
 
-    let mut cache = SetupCache::load(cache_bin_path.clone());
+    let mut cache = SetupCache::load(cache_bin_path);
     cache.remove_dep("package-a");
     assert!(cache
       .with_dep("package-a")


### PR DESCRIPTION
Part of #19774. This makes it twice as fast on my machine.

Stores a file at `node_modules/.deno/setup-cache.bin`, which contains information about how the node_modules folder is currently setup. Obviously there is a risk that this information will get out of date with the current folder structure.