### PR TITLE
fix(lsp): remove quotes and period surrounding specifier in uncached messages

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -931,9 +931,9 @@ impl DenoDiagnostic {
       Self::ImportMapRemap { from, to } => (lsp::DiagnosticSeverity::HINT, format!("The import specifier can be remapped to \"{to}\" which will resolve it via the active import map."), Some(json!({ "from": from, "to": to }))),
       Self::InvalidAssertType(assert_type) => (lsp::DiagnosticSeverity::ERROR, format!("The module is a JSON module and expected an assertion type of \"json\". Instead got \"{assert_type}\"."), None),
       Self::NoAssertType => (lsp::DiagnosticSeverity::ERROR, "The module is a JSON module and not being imported with an import assertion. Consider adding `assert { type: \"json\" }` to the import statement.".to_string(), None),
-      Self::NoCache(specifier) => (lsp::DiagnosticSeverity::ERROR, format!("Uncached or missing remote URL: \"{specifier}\"."), Some(json!({ "specifier": specifier }))),
-      Self::NoCacheNpm(pkg_ref, specifier) => (lsp::DiagnosticSeverity::ERROR, format!("Uncached or missing npm package: \"{}\".", pkg_ref.req), Some(json!({ "specifier": specifier }))),
-      Self::NoLocal(specifier) => (lsp::DiagnosticSeverity::ERROR, format!("Unable to load a local module: \"{specifier}\".\n  Please check the file path."), None),
+      Self::NoCache(specifier) => (lsp::DiagnosticSeverity::ERROR, format!("Uncached or missing remote URL: {specifier}"), Some(json!({ "specifier": specifier }))),
+      Self::NoCacheNpm(pkg_ref, specifier) => (lsp::DiagnosticSeverity::ERROR, format!("Uncached or missing npm package: {}", pkg_ref.req), Some(json!({ "specifier": specifier }))),
+      Self::NoLocal(specifier) => (lsp::DiagnosticSeverity::ERROR, format!("Unable to load a local module: {specifier}\n  Please check the file path."), None),
       Self::Redirect { from, to} => (lsp::DiagnosticSeverity::INFORMATION, format!("The import of \"{from}\" was redirected to \"{to}\"."), Some(json!({ "specifier": from, "redirect": to }))),
       Self::ResolutionError(err) => (
         lsp::DiagnosticSeverity::ERROR,

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -3907,7 +3907,7 @@ fn lsp_code_actions_deno_cache() {
         "severity": 1,
         "code": "no-cache",
         "source": "deno",
-        "message": "Uncached or missing remote URL: \"https://deno.land/x/a/mod.ts\".",
+        "message": "Uncached or missing remote URL: https://deno.land/x/a/mod.ts",
         "data": { "specifier": "https://deno.land/x/a/mod.ts" }
       }],
       "version": 1
@@ -3997,7 +3997,7 @@ fn lsp_code_actions_deno_cache_npm() {
         "severity": 1,
         "code": "no-cache-npm",
         "source": "deno",
-        "message": "Uncached or missing npm package: \"chalk\".",
+        "message": "Uncached or missing npm package: chalk",
         "data": { "specifier": "npm:chalk" }
       }],
       "version": 1
@@ -4024,7 +4024,7 @@ fn lsp_code_actions_deno_cache_npm() {
           "severity": 1,
           "code": "no-cache-npm",
           "source": "deno",
-          "message": "Uncached or missing npm package: \"chalk\".",
+          "message": "Uncached or missing npm package: chalk",
           "data": { "specifier": "npm:chalk" }
         }],
         "only": ["quickfix"]
@@ -4044,7 +4044,7 @@ fn lsp_code_actions_deno_cache_npm() {
         "severity": 1,
         "code": "no-cache-npm",
         "source": "deno",
-        "message": "Uncached or missing npm package: \"chalk\".",
+        "message": "Uncached or missing npm package: chalk",
         "data": { "specifier": "npm:chalk" }
       }],
       "command": {
@@ -6125,7 +6125,7 @@ fn lsp_completions_node_specifier() {
         "severity": 1,
         "code": "no-cache-npm",
         "source": "deno",
-        "message": "Uncached or missing npm package: \"@types/node\"."
+        "message": "Uncached or missing npm package: @types/node"
       }
     ])
   );

--- a/cli/tests/testdata/lsp/diagnostics_deno_types.json
+++ b/cli/tests/testdata/lsp/diagnostics_deno_types.json
@@ -15,7 +15,7 @@
       "severity": 1,
       "code": "no-cache",
       "source": "deno",
-      "message": "Uncached or missing remote URL: \"https://example.com/a/b.d.ts\".",
+      "message": "Uncached or missing remote URL: https://example.com/a/b.d.ts",
       "data": {
         "specifier": "https://example.com/a/b.d.ts"
       }
@@ -34,7 +34,7 @@
       "severity": 1,
       "code": "no-cache",
       "source": "deno",
-      "message": "Uncached or missing remote URL: \"https://example.com/a/e.js\".",
+      "message": "Uncached or missing remote URL: https://example.com/a/e.js",
       "data": {
         "specifier": "https://example.com/a/e.js"
       }
@@ -53,7 +53,7 @@
       "severity": 1,
       "code": "no-cache",
       "source": "deno",
-      "message": "Uncached or missing remote URL: \"https://example.com/a/e.d.ts\".",
+      "message": "Uncached or missing remote URL: https://example.com/a/e.d.ts",
       "data": {
         "specifier": "https://example.com/a/e.d.ts"
       }
@@ -72,7 +72,7 @@
       "severity": 1,
       "code": "no-cache",
       "source": "deno",
-      "message": "Uncached or missing remote URL: \"https://example.com/a/d.js\".",
+      "message": "Uncached or missing remote URL: https://example.com/a/d.js",
       "data": {
         "specifier": "https://example.com/a/d.js"
       }
@@ -91,7 +91,7 @@
       "severity": 1,
       "code": "no-cache",
       "source": "deno",
-      "message": "Uncached or missing remote URL: \"https://example.com/a/d.d.ts\".",
+      "message": "Uncached or missing remote URL: https://example.com/a/d.d.ts",
       "data": {
         "specifier": "https://example.com/a/d.d.ts"
       }


### PR DESCRIPTION
Changes:

```
Uncached or missing npm package: "@dprint/node-plugin-base".
```

To:

```
Uncached or missing npm package: @dprint/node-plugin-base
```

I think it's a bit cleaner and easier to copy and paste. This was copied from the `Uncached or missing remote URL: "{specifier}".` message, which was also updated in this PR.