### PR TITLE
fix(tsc): more informative diagnostic when `Deno` does not exist

### DIFF
--- a/cli/tests/integration/check_tests.rs
+++ b/cli/tests/integration/check_tests.rs
@@ -105,6 +105,18 @@ itest!(check_broadcast_channel_unstable {
   exit_code: 0,
 });
 
+itest!(check_deno_not_found {
+  args: "check --quiet check/deno_not_found/main.ts",
+  output: "check/deno_not_found/main.out",
+  exit_code: 1,
+});
+
+itest!(check_deno_unstable_not_found {
+  args: "check --quiet check/deno_unstable_not_found/main.ts",
+  output: "check/deno_unstable_not_found/main.out",
+  exit_code: 1,
+});
+
 #[test]
 fn cache_switching_config_then_no_config() {
   let context = TestContext::default();

--- a/cli/tests/testdata/check/deno_not_found/main.out
+++ b/cli/tests/testdata/check/deno_not_found/main.out
@@ -1,0 +1,4 @@
+error: TS2304 [ERROR]: Cannot find name 'Deno'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'deno.ns' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.ns" />
+Deno;
+~~~~
+    at file:///[WILDCARD]/check/deno_not_found/main.ts:4:1

--- a/cli/tests/testdata/check/deno_not_found/main.ts
+++ b/cli/tests/testdata/check/deno_not_found/main.ts
@@ -1,0 +1,4 @@
+/// <reference no-default-lib="true"/>
+/// <reference lib="es5" />
+
+Deno;

--- a/cli/tests/testdata/check/deno_unstable_not_found/main.out
+++ b/cli/tests/testdata/check/deno_unstable_not_found/main.out
@@ -1,0 +1,16 @@
+error: TS2551 [ERROR]: Property 'openKv' does not exist on type 'typeof Deno'. Did you mean 'open'? 'Deno.openKv' is an unstable API. Did you forget to run with the '--unstable' flag, or did you mean 'open'? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />
+Deno.openKv;
+     ~~~~~~
+    at file:///[WILDCARD]/deno_unstable_not_found/main.ts:1:6
+
+    'open' is declared here.
+      export function open(
+                      ~~~~
+        at asset:///lib.deno.ns.d.ts:1667:19
+
+TS2339 [ERROR]: Property 'createHttpClient' does not exist on type 'typeof Deno'. 'Deno.createHttpClient' is an unstable API. Did you forget to run with the '--unstable' flag? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />
+Deno.createHttpClient;
+     ~~~~~~~~~~~~~~~~
+    at file:///[WILDCARD]/deno_unstable_not_found/main.ts:2:6
+
+Found 2 errors.

--- a/cli/tests/testdata/check/deno_unstable_not_found/main.ts
+++ b/cli/tests/testdata/check/deno_unstable_not_found/main.ts
@@ -1,0 +1,2 @@
+Deno.openKv;
+Deno.createHttpClient;

--- a/cli/tests/testdata/run/unstable_disabled.out
+++ b/cli/tests/testdata/run/unstable_disabled.out
@@ -1,5 +1,5 @@
 [WILDCARD]
-error: TS2339 [ERROR]: Property 'umask' does not exist on type 'typeof Deno'. 'Deno.umask' is an unstable API. Did you forget to run with the '--unstable' flag?
+error: TS2339 [ERROR]: Property 'umask' does not exist on type 'typeof Deno'. 'Deno.umask' is an unstable API. Did you forget to run with the '--unstable' flag? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />
 console.log(Deno.umask);
                  ~~~~~
     at [WILDCARD]/unstable.ts:1:18

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -152,6 +152,7 @@ const denoNs = {
   ChildProcess: process.ChildProcess,
 };
 
+// when editing this list, also update unstableDenoProps in cli/tsc/99_main_compiler.js
 const denoNsUnstable = {
   listenDatagram: net.createListenDatagram(
     ops.op_net_listen_udp,


### PR DESCRIPTION
Also improved the diagnostic when using something like `Deno.openKv` and it doesn't exist.