### PR TITLE
fix: make "suggest.autoImports" to switch completions from external modules

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2305,10 +2305,10 @@ impl Inner {
                 tsc::ImportModuleSpecifierEnding::Index,
               ),
               include_automatic_optional_chain_completions: Some(true),
-              include_completions_for_import_statements: Some(
+              include_completions_for_import_statements: Some(true),
+              include_completions_for_module_exports: Some(
                 self.config.workspace_settings().suggest.auto_imports,
               ),
-              include_completions_for_module_exports: Some(true),
               include_completions_with_object_literal_method_snippets: Some(
                 use_snippets,
               ),


### PR DESCRIPTION
## What's the bug?

The `suggest.auto_imports` should suppress autocomplete suggestions for symbols that is not imported.
But now it is passed to `include_completions_for_import_statements`, that tells tsc to do autocomplete for the `import` statement or not.

It causes the bug described in #15488.

## What's fix in this PR?

I make the `suggest.auto_imports` be passed to the right option `include_completions_for_module_exports` that tells tsc to not take suggestions for symbols from modules that is not imported.

Fix #15488

<details><summary>Screenshots (after this PR)</summary>

I'm using denols with nvim-lspconfig.

If the `suggest.autoImports` is true (default),
<img src="https://github.com/denoland/deno/assets/5582459/cb75d75b-69d3-4563-b307-ca7056603d12" width="302">
deno ls returns suggestions from modules that is not imported.
<img src="https://github.com/denoland/deno/assets/5582459/89a55860-08bf-41ee-8b51-ed41454153db" width="686">

If the `suggest.autoImports` is false,
<img src="https://github.com/denoland/deno/assets/5582459/1f435a29-92f5-48d9-935a-23cdb9b2ca08" width="304">
deno ls returns only suggestions from modules that has already imported.
<img src="https://github.com/denoland/deno/assets/5582459/eaf02f30-d883-4e2c-961a-be3ad59f9549" width="686">
</details>