### PR TITLE
fix(log): handle objects with err in constructor

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -1202,7 +1202,22 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
   let firstProto;
   const tmp = obj;
   while (obj || isUndetectableObject(obj)) {
-    const descriptor = ObjectGetOwnPropertyDescriptor(obj, "constructor");
+    //NOTE: in addPrototypeProperties function we look for the prototype first
+    // ```js
+    //  obj = ObjectGetPrototypeOf(obj);
+    //  // Stop as soon as a null prototype is encountered.
+    //  if (obj === null) {
+    //    return;
+    //  }
+    //  ``
+    // should it be the same here ?
+    let descriptor = undefined
+    try {
+      descriptor = ObjectGetOwnPropertyDescriptor(obj, "constructor");
+    } catch {
+      // obj might not have a constructor
+    }
+
     if (
       descriptor !== undefined &&
       typeof descriptor.value === "function" &&


### PR DESCRIPTION
fix https://github.com/denoland/deno/issues/19785

This PR fixes the issue but have a regression

```a.js
const target = {
  a: 5
};

const handler = {
  getOwnPropertyDescriptor(target, property) {
    throw "nope";
  },
};

const proxy = new Proxy(target, handler);

console.log(proxy);
```

in master this outputs `error: Uncaught "nope"` but with this pr I get an error
```
nope
error: Uncaught ReferenceError: AssertionError is not defined
console.log(proxy);
        ^
    at assert (ext:deno_console/01_console.js:152:5)
    at getKeys (ext:deno_console/01_console.js:1386:7)
    at formatRaw (ext:deno_console/01_console.js:920:14)
    at formatValue (ext:deno_console/01_console.js:721:10)
    at inspectArgs (ext:deno_console/01_console.js:3167:17)
    at console.log (ext:deno_console/01_console.js:3236:7)
    at file:///workspace/deno/b.js:14:9
```
I'm not sure what is wrong