### PR TITLE
chore: disable rustls logging

### DIFF
--- a/cli/util/logger.rs
+++ b/cli/util/logger.rs
@@ -44,6 +44,7 @@ pub fn init(maybe_level: Option<log::Level>) {
   // used to make available the lsp_debug which is then filtered out at runtime
   // in the cli logger
   .filter_module("deno::lsp::performance", log::LevelFilter::Debug)
+  .filter_module("rustls", log::LevelFilter::Off)
   .format(|buf, record| {
     let mut target = record.target().to_string();
     if let Some(line_no) = record.line() {


### PR DESCRIPTION
This commit disables internal logging coming from `rustls` crate.

So messages like:
```
TLS alert received: AlertMessagePayload {
    level: Fatal,
    description: UnknownCA,
}
```
will no longer appear unconditionally.