### PR TITLE
fix(fs): support rename across filesystems

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -179,16 +179,14 @@ impl FileSystem for RealFs {
   }
 
   fn rename_sync(&self, oldpath: &Path, newpath: &Path) -> FsResult<()> {
-    fs::rename(oldpath, newpath).map_err(Into::into)
+    rename(oldpath, newpath)
   }
   async fn rename_async(
     &self,
     oldpath: PathBuf,
     newpath: PathBuf,
   ) -> FsResult<()> {
-    spawn_blocking(move || fs::rename(oldpath, newpath))
-      .await?
-      .map_err(Into::into)
+    spawn_blocking(move || rename(&oldpath, &newpath)).await?
   }
 
   fn link_sync(&self, oldpath: &Path, newpath: &Path) -> FsResult<()> {
@@ -596,6 +594,29 @@ fn read_dir(path: &Path) -> FsResult<Vec<FsDirEntry>> {
     .collect();
 
   Ok(entries)
+}
+
+fn rename(oldpath: &Path, newpath: &Path) -> FsResult<()> {
+  match fs::rename(oldpath, newpath) {
+    Ok(_) => Ok(()),
+    Err(err) => {
+      if err.raw_os_error() == Some(libc::EXDEV) {
+        // EXDEV: rename fails because oldpath and newpath are not on the same
+        // mounted filesystem. We need to do a copy and remove.
+        //
+        // This check can be replaced with the following once
+        // https://github.com/rust-lang/rust/issues/86442 stabilizes:
+        //
+        //    if err.kind() == io::ErrorKind::CrossDeviceLink
+        //
+        copy_file(oldpath, newpath)?;
+        fs::remove_file(oldpath)?;
+        Ok(())
+      } else {
+        Err(err.into())
+      }
+    }
+  }
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Rather than expect the user to know that they need to handle a special case when renaming across filesystems, we can just handle it for them.

I didn't add any tests for this because I could not see any other filesystem related tests. Please direct me if I am mistaken.

Fixes #3092

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
