### PR TITLE
fix(cli/test): fix clear screen behavior when run `deno test --watch`

### DIFF
--- a/cli/tools/test.rs
+++ b/cli/tools/test.rs
@@ -1789,7 +1789,7 @@ pub async fn run_tests_with_watch(
     flags,
     file_watcher::PrintConfig {
       job_name: "Test".to_string(),
-      clear_screen: !test_flags
+      clear_screen: test_flags
         .watch
         .as_ref()
         .map(|w| !w.no_clear_screen)


### PR DESCRIPTION
fix #19725 