### PR TITLE
fix(lsp): auto-discover deno.json in more cases

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -773,7 +773,12 @@ fn resolve_lockfile_from_path(
   lockfile_path: PathBuf,
 ) -> Option<Arc<Mutex<Lockfile>>> {
   match Lockfile::new(lockfile_path, false) {
-    Ok(value) => Some(Arc::new(Mutex::new(value))),
+    Ok(value) => {
+      if let Ok(specifier) = ModuleSpecifier::from_file_path(&value.filename) {
+        lsp_log!("  Resolved lock file: \"{}\"", specifier);
+      }
+      Some(Arc::new(Mutex::new(value)))
+    }
     Err(err) => {
       lsp_warn!("Error loading lockfile: {:#}", err);
       None

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -433,6 +433,118 @@ fn lsp_import_map_embedded_in_config_file_after_initialize() {
 }
 
 #[test]
+fn lsp_import_map_config_file_auto_discovered() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.create_dir_all("lib");
+  temp_dir.write("lib/b.ts", r#"export const b = "b";"#);
+
+  let mut client = context.new_lsp_command().capture_stderr().build();
+  client.initialize_default();
+
+  // add the deno.json
+  temp_dir.write("deno.jsonc", r#"{ "imports": { "/~/": "./lib/" } }"#);
+  client.did_change_watched_files(json!({
+    "changes": [{
+      "uri": temp_dir.uri().join("deno.jsonc").unwrap(),
+      "type": 2
+    }]
+  }));
+  client.wait_until_stderr_line(|line| {
+    line.contains("Auto-resolved configuration file:")
+  });
+
+  let uri = temp_dir.uri().join("a.ts").unwrap();
+
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": uri,
+      "languageId": "typescript",
+      "version": 1,
+      "text": "import { b } from \"/~/b.ts\";\n\nconsole.log(b);\n"
+    }
+  }));
+
+  assert_eq!(diagnostics.all().len(), 0);
+
+  let res = client.write_request(
+    "textDocument/hover",
+    json!({
+      "textDocument": {
+        "uri": uri
+      },
+      "position": { "line": 2, "character": 12 }
+    }),
+  );
+  assert_eq!(
+    res,
+    json!({
+      "contents": [
+        {
+          "language": "typescript",
+          "value":"(alias) const b: \"b\"\nimport b"
+        },
+        ""
+      ],
+      "range": {
+        "start": { "line": 2, "character": 12 },
+        "end": { "line": 2, "character": 13 }
+      }
+    })
+  );
+
+  // now cause a syntax error
+  temp_dir.write("deno.jsonc", r#",,#,#,,"#);
+  client.did_change_watched_files(json!({
+    "changes": [{
+      "uri": temp_dir.uri().join("deno.jsonc").unwrap(),
+      "type": 2
+    }]
+  }));
+  assert_eq!(client.read_diagnostics().all().len(), 1);
+
+  // now fix it, and things should work again
+  temp_dir.write("deno.jsonc", r#"{ "imports": { "/~/": "./lib/" } }"#);
+  client.did_change_watched_files(json!({
+    "changes": [{
+      "uri": temp_dir.uri().join("deno.jsonc").unwrap(),
+      "type": 2
+    }]
+  }));
+  client.wait_until_stderr_line(|line| {
+    line.contains("Auto-resolved configuration file:")
+  });
+  let res = client.write_request(
+    "textDocument/hover",
+    json!({
+      "textDocument": {
+        "uri": uri
+      },
+      "position": { "line": 2, "character": 12 }
+    }),
+  );
+  assert_eq!(
+    res,
+    json!({
+      "contents": [
+        {
+          "language": "typescript",
+          "value":"(alias) const b: \"b\"\nimport b"
+        },
+        ""
+      ],
+      "range": {
+        "start": { "line": 2, "character": 12 },
+        "end": { "line": 2, "character": 13 }
+      }
+    })
+  );
+  assert_eq!(client.read_diagnostics().all().len(), 0);
+
+  client.shutdown();
+}
+
+#[test]
 fn lsp_deno_task() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir();


### PR DESCRIPTION
We weren't auto-discovering the deno.json in two cases:

1. A project that didn't have a deno.json and just added one.
2. After a syntax error in the deno.json.

This now rediscovers it in both these cases.

Closes https://github.com/denoland/vscode_deno/issues/867