### PR TITLE
fix(cli): build script panics on musl due to glibc_version check

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -437,11 +437,13 @@ fn main() {
 
   #[cfg(target_os = "linux")]
   {
-    let ver = glibc_version::get_version().unwrap();
-
     // If a custom compiler is set, the glibc version is not reliable.
     // Here, we assume that if a custom compiler is used, that it will be modern enough to support a dynamic symbol list.
-    if env::var("CC").is_err() && ver.major <= 2 && ver.minor < 35 {
+    if env::var("CC").is_err()
+      && glibc_version::get_version()
+        .map(|ver| ver.major <= 2 && ver.minor < 35)
+        .unwrap_or(false)
+    {
       println!("cargo:warning=Compiling with all symbols exported, this will result in a larger binary. Please use glibc 2.35 or later for an optimised build.");
       println!("cargo:rustc-link-arg-bin=deno=-rdynamic");
     } else {


### PR DESCRIPTION
musl supports dynamic list.

This patch comes from https://github.com/12101111/overlay/blob/cb58b125ada1d11c0309da144309628c5670af46/dev-lang/deno/files/glibc.patch.

Resolves #17739

Note: This patch is already used in Alpine Linux’s [deno](https://pkgs.alpinelinux.org/packages?name=deno) package.