### PR TITLE
fix(ext/net): fix string port number handling in listen

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -1237,3 +1237,12 @@ Deno.test({
   }, Deno.errors.AddrInUse);
   listener1.close();
 });
+
+Deno.test({
+  permissions: { net: true },
+}, function netTcpListenDoesNotThrowOnStringPort() {
+  // @ts-ignore String port is not allowed by typing, but it shouldn't throw
+  // for backwards compatibility.
+  const listener = Deno.listen({ hostname: "localhost", port: "0" });
+  listener.close();
+});

--- a/cli/tests/unit/tls_test.ts
+++ b/cli/tests/unit/tls_test.ts
@@ -1477,3 +1477,17 @@ Deno.test({
   }, Deno.errors.AddrInUse);
   listener1.close();
 });
+
+Deno.test({
+  permissions: { net: true },
+}, function listenTlsDoesNotThrowOnStringPort() {
+  const listener = Deno.listenTls({
+    hostname: "localhost",
+    // @ts-ignore String port is not allowed by typing, but it shouldn't throw
+    // for backwards compatibility.
+    port: "0",
+    cert,
+    key,
+  });
+  listener.close();
+});

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -15,6 +15,7 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypePush,
   Error,
+  Number,
   ObjectPrototypeIsPrototypeOf,
   PromiseResolve,
   SymbolAsyncIterator,

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -420,7 +420,7 @@ function listen(args) {
     case "tcp": {
       const { 0: rid, 1: addr } = ops.op_net_listen_tcp({
         hostname: args.hostname ?? "0.0.0.0",
-        port: args.port,
+        port: Number(args.port),
       }, args.reusePort);
       addr.transport = "tcp";
       return new Listener(rid, addr);

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -4,7 +4,7 @@ const core = globalThis.Deno.core;
 const ops = core.ops;
 import { Conn, Listener } from "ext:deno_net/01_net.js";
 const primordials = globalThis.__bootstrap.primordials;
-const { TypeError } = primordials;
+const { Number, TypeError } = primordials;
 
 function opStartTls(args) {
   return core.opAsync("op_tls_start", args);

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -70,7 +70,7 @@ function listenTls({
     throw new TypeError(`Unsupported transport: '${transport}'`);
   }
   const { 0: rid, 1: localAddr } = ops.op_net_listen_tls(
-    { hostname, port },
+    { hostname, port: Number(port) },
     { cert, certFile, key, keyFile, alpnProtocols, reusePort },
   );
   return new TlsListener(rid, localAddr);


### PR DESCRIPTION
While string `port` is not allowed in typing, it seems we used to support that and now it's broken. ref: https://github.com/denoland/deno/issues/10064#issuecomment-1637427260

This PR restores the support of string port number in `listen` and `listenTls`