### PR TITLE
perf: cache node resolution when accesing a global

### DIFF
--- a/cli/tests/testdata/run/with_package_json/npm_binary/main.out
+++ b/cli/tests/testdata/run/with_package_json/npm_binary/main.out
@@ -1,9 +1,6 @@
 [WILDCARD]package.json file found at '[WILDCARD]with_package_json[WILDCARD]npm_binary[WILDCARD]package.json'
 [WILDCARD]
 this
-[WILDCARD]
 is
-[WILDCARD]
 a
-[WILDCARD]
 test

--- a/ext/fs/sync.rs
+++ b/ext/fs/sync.rs
@@ -5,10 +5,42 @@ pub use inner::*;
 #[cfg(feature = "sync_fs")]
 mod inner {
   #![allow(clippy::disallowed_types)]
+
+  use std::ops::Deref;
+  use std::ops::DerefMut;
   pub use std::sync::Arc as MaybeArc;
 
   pub use core::marker::Send as MaybeSend;
   pub use core::marker::Sync as MaybeSync;
+
+  pub struct MaybeArcMutexGuard<'lock, T>(std::sync::MutexGuard<'lock, T>);
+
+  impl<'lock, T> Deref for MaybeArcMutexGuard<'lock, T> {
+    type Target = std::sync::MutexGuard<'lock, T>;
+    fn deref(&self) -> &std::sync::MutexGuard<'lock, T> {
+      &self.0
+    }
+  }
+
+  impl<'lock, T> DerefMut for MaybeArcMutexGuard<'lock, T> {
+    fn deref_mut(&mut self) -> &mut std::sync::MutexGuard<'lock, T> {
+      &mut self.0
+    }
+  }
+
+  #[derive(Debug)]
+  pub struct MaybeArcMutex<T>(std::sync::Arc<std::sync::Mutex<T>>);
+  impl<T> MaybeArcMutex<T> {
+    pub fn new(val: T) -> Self {
+      Self(std::sync::Arc::new(std::sync::Mutex::new(val)))
+    }
+  }
+
+  impl<'lock, T> MaybeArcMutex<T> {
+    pub fn lock(&'lock self) -> MaybeArcMutexGuard<'lock, T> {
+      MaybeArcMutexGuard(self.0.lock().unwrap())
+    }
+  }
 }
 
 #[cfg(not(feature = "sync_fs"))]
@@ -19,4 +51,33 @@ mod inner {
   impl<T> MaybeSync for T where T: ?Sized {}
   pub trait MaybeSend {}
   impl<T> MaybeSend for T where T: ?Sized {}
+
+  pub struct MaybeArcMutexGuard<'lock, T>(std::cell::RefMut<'lock, T>);
+
+  impl<'lock, T> Deref for MaybeArcMutexGuard<'lock, T> {
+    type Target = std::cell::RefMut<'lock, T>;
+    fn deref(&self) -> &std::cell::RefMut<'lock, T> {
+      &self.0
+    }
+  }
+
+  impl<'lock, T> DerefMut for MaybeArcMutexGuard<'lock, T> {
+    fn deref_mut(&mut self) -> &mut std::cell::RefMut<'lock, T> {
+      &mut self.0
+    }
+  }
+
+  #[derive(Debug)]
+  pub struct MaybeArcMutex<T>(std::rc::Rc<std::cell::RefCell<T>>);
+  impl<T> MaybeArcMutex<T> {
+    pub fn new(val: T) -> Self {
+      Self(std::rc::Rc::new(std::cell::RefCell::new(val)))
+    }
+  }
+
+  impl<'lock, T> MaybeArcMutex<T> {
+    pub fn lock(&'lock self) -> MaybeArcMutexGuard<'lock, T> {
+      MaybeArcMutexGuard(self.0.borrow_mut())
+    }
+  }
 }

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -267,16 +267,12 @@ fn current_mode(scope: &mut v8::HandleScope) -> Mode {
     return Mode::Deno;
   };
   let string = v8_string.to_rust_string_lossy(scope);
-  // TODO: don't require parsing the specifier
-  let Ok(specifier) = deno_core::ModuleSpecifier::parse(&string) else {
-    return Mode::Deno;
-  };
   let op_state = deno_core::JsRuntime::op_state_from(scope);
   let op_state = op_state.borrow();
   let Some(node_resolver) = op_state.try_borrow::<Rc<NodeResolver>>() else {
     return Mode::Deno;
   };
-  if node_resolver.in_npm_package(&specifier) {
+  if node_resolver.in_npm_package_with_cache(string) {
     Mode::Node
   } else {
     Mode::Deno

--- a/ext/node/resolution.rs
+++ b/ext/node/resolution.rs
@@ -1,12 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-#![allow(clippy::disallowed_types)]
-
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::Mutex;
 
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
@@ -116,8 +112,7 @@ pub type NodeResolverRc = deno_fs::sync::MaybeArc<NodeResolver>;
 pub struct NodeResolver {
   fs: FileSystemRc,
   npm_resolver: NpmResolverRc,
-  #[allow(clippy::disallowed_types)]
-  in_npm_package_cache: Arc<Mutex<HashMap<String, bool>>>,
+  in_npm_package_cache: deno_fs::sync::MaybeArcMutex<HashMap<String, bool>>,
 }
 
 impl NodeResolver {
@@ -125,8 +120,7 @@ impl NodeResolver {
     Self {
       fs,
       npm_resolver,
-      #[allow(clippy::disallowed_types)]
-      in_npm_package_cache: Arc::new(Mutex::new(HashMap::new())),
+      in_npm_package_cache: deno_fs::sync::MaybeArcMutex::new(HashMap::new()),
     }
   }
 
@@ -135,7 +129,7 @@ impl NodeResolver {
   }
 
   pub fn in_npm_package_with_cache(&self, specifier: String) -> bool {
-    let mut cache = self.in_npm_package_cache.lock().unwrap();
+    let mut cache = self.in_npm_package_cache.lock();
 
     if let Some(result) = cache.get(&specifier) {
       return *result;


### PR DESCRIPTION
Reclaims some of the performance hit introduced by https://github.com/denoland/deno/pull/19307.

Express

`v1.35.1`

```
Running 10s test @ http://localhost:7001
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   366.00us  280.04us  10.70ms   96.05%
    Req/Sec    14.33k     1.16k   15.79k    89.11%
  Latency Distribution
     50%  317.00us
     75%  345.00us
     90%  408.00us
     99%    1.50ms
  288027 requests in 10.10s, 58.78MB read
Requests/sec:  28513.16
Transfer/sec:      5.82MB
```

`v1.35.2`

```
Running 10s test @ http://localhost:7001
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   730.26us  267.97us  10.78ms   95.44%
    Req/Sec     6.91k   413.47     7.25k    90.59%
  Latency Distribution
     50%  686.00us
     75%  703.00us
     90%  771.00us
     99%    1.58ms
  138852 requests in 10.10s, 28.34MB read
Requests/sec:  13747.35
Transfer/sec:      2.81MB
```

this PR
```
Running 10s test @ http://localhost:7001
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   393.91us  268.28us   9.46ms   95.53%
    Req/Sec    13.23k     1.07k   14.64k    83.17%
  Latency Distribution
     50%  343.00us
     75%  372.00us
     90%  445.00us
     99%    1.51ms
  265928 requests in 10.10s, 54.27MB read
Requests/sec:  26326.57
Transfer/sec:      5.37MB
```

`npm:ws` 

`v1.35.1`

```
./third_party/prebuilt/mac/load_test 10 0.0.0.0 8080 0 0
Running benchmark now...
Msg/sec: 118798.250000
```

`v1.35.2`

```
./third_party/prebuilt/mac/load_test 10 0.0.0.0 8080 0 0
Running benchmark now...
Msg/sec: 11843.500000
Msg/sec: 12015.750000
```

this PR
```
./third_party/prebuilt/mac/load_test 10 0.0.0.0 8080 0 0
Running benchmark now...
Msg/sec: 95359.000000
Msg/sec: 97625.000000
```