### PR TITLE
Added partial support for node:os > userInfo function

### DIFF
--- a/cli/tests/unit_node/os_test.ts
+++ b/cli/tests/unit_node/os_test.ts
@@ -252,6 +252,18 @@ Deno.test({
 });
 
 Deno.test({
+  name: "os.userInfo()",
+  fn() {
+    const info = os.userInfo()
+    assertEquals(info.uid, -1);
+    assertEquals(info.gid, -1);
+    assertEquals(typeof info.homedir, "string");
+    assertEquals(info.shell, null);
+    assertEquals(typeof info.username, "string");
+  },
+});
+
+Deno.test({
   name: "APIs not yet implemented",
   fn() {
     assertThrows(
@@ -264,13 +276,6 @@ Deno.test({
     assertThrows(
       () => {
         os.setPriority(0);
-      },
-      Error,
-      "Not implemented",
-    );
-    assertThrows(
-      () => {
-        os.userInfo();
       },
       Error,
       "Not implemented",

--- a/ext/node/polyfills/os.ts
+++ b/ext/node/polyfills/os.ts
@@ -24,6 +24,7 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { notImplemented } from "ext:deno_node/_utils.ts";
+import { codes } from "ext:deno_node/internal/error_codes.ts";
 import { validateIntegerRange } from "ext:deno_node/_utils.ts";
 import process from "node:process";
 import { isWindows, osType } from "ext:deno_node/_util/os.ts";
@@ -315,12 +316,28 @@ export function uptime(): number {
   return osUptime();
 }
 
-/** Not yet implemented */
+/** partially implemented
+ * https://nodejs.org/api/os.html#osuserinfooptions
+ * missing gid, uid
+ */
 export function userInfo(
-  // deno-lint-ignore no-unused-vars
   options: UserInfoOptions = { encoding: "utf-8" },
 ): UserInfo {
-  notImplemented(SEE_GITHUB_ISSUE);
+  if (options.encoding !== "utf-8") notImplemented(SEE_GITHUB_ISSUE);
+
+  const username = Deno.env.get("USER");
+  const homedir = Deno.env.get("HOME");
+  const shell = Deno.env.get("SHELL") || null;
+
+  if (!username || !homedir) throw codes.SYSERR;
+
+  return {
+    uid: -1,
+    gid: -1,
+    username,
+    shell,
+    homedir,
+  };
 }
 
 export const EOL = isWindows ? "\r\n" : "\n";


### PR DESCRIPTION
Most packages in node uses os.userInfo to read username, shell or homedir. this changes still causes an exception on trying to read `uid` and `gid` and supports only `utf-8` option for now but that's a start.

# impact
While this isn't an accurate implementation, some npm packages such as https://www.npmjs.com/package/atomically (which is used by remix and many other projects) depends on it and would make a large chunk of the npm ecosystem workable, making deno more adoptable

this is linked to https://github.com/denoland/deno/issues/17850

This feels like a "poorman solution" but if any insights on integrating [gu]id is provided I would gladly try my best to address it.

propositions:
- maybe we could put that behind an unstable flag while it's a temp / partial implementation?
something like `deno run --unstable-os-user-info npm:<package>`

<img width="655" alt="image" src="https://github.com/denoland/deno/assets/1691052/aac02f90-8e17-452d-861a-36616565974f">


<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
