### PR TITLE
fix: do not include jsx without `@ts-check` in tsc roots

### DIFF
--- a/cli/tests/integration/check_tests.rs
+++ b/cli/tests/integration/check_tests.rs
@@ -58,6 +58,14 @@ itest!(bundle_jsximportsource_importmap_config {
   output: "check/jsximportsource_importmap_config/main.bundle.js",
 });
 
+itest!(jsx_not_checked {
+  args: "check check/jsx_not_checked/main.jsx",
+  output: "check/jsx_not_checked/main.out",
+  envs: env_vars_for_npm_tests_no_sync_download(),
+  http_server: true,
+  exit_code: 1,
+});
+
 itest!(check_npm_install_diagnostics {
   args: "check --quiet check/npm_install_diagnostics/main.ts",
   output: "check/npm_install_diagnostics/main.out",

--- a/cli/tests/testdata/check/jsx_not_checked/main.jsx
+++ b/cli/tests/testdata/check/jsx_not_checked/main.jsx
@@ -1,0 +1,21 @@
+// should not error about jsx-runtime not being found in types here
+/** @jsxImportSource npm:react@18.2.0 */
+
+import "./other.ts";
+
+export default (
+  <>
+    <h1>Hello world</h1>
+    <p>This is a JSX page</p>
+  </>
+);
+
+/**
+ * @param {number} a
+ * @param {number} b
+ */
+function add(a, b) {
+  return a + b;
+}
+
+console.log(add("1", "2"));

--- a/cli/tests/testdata/check/jsx_not_checked/main.out
+++ b/cli/tests/testdata/check/jsx_not_checked/main.out
@@ -1,0 +1,11 @@
+Download http://localhost:4545/npm/registry/react
+Download http://localhost:4545/npm/registry/loose-envify
+Download http://localhost:4545/npm/registry/js-tokens
+Download http://localhost:4545/npm/registry/react/react-18.2.0.tgz
+Download http://localhost:4545/npm/registry/loose-envify/loose-envify-1.4.0.tgz
+Download http://localhost:4545/npm/registry/js-tokens/js-tokens-4.0.0.tgz
+Check file:///[WILDCARD]/jsx_not_checked/main.jsx
+error: TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'number'.
+console.log(add("1", "2"));
+                ~~~
+    at file:///[WILDCARD]/other.ts:5:17

--- a/cli/tests/testdata/check/jsx_not_checked/other.ts
+++ b/cli/tests/testdata/check/jsx_not_checked/other.ts
@@ -1,0 +1,5 @@
+function add(a: number, b: number) {
+  return a + b;
+}
+
+console.log(add("1", "2"));

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -308,9 +308,13 @@ fn get_tsc_roots(
         | MediaType::Cts
         | MediaType::Dts
         | MediaType::Dmts
-        | MediaType::Dcts
-        | MediaType::Jsx => Some((module.specifier.clone(), module.media_type)),
-        MediaType::JavaScript | MediaType::Mjs | MediaType::Cjs => {
+        | MediaType::Dcts => {
+          Some((module.specifier.clone(), module.media_type))
+        }
+        MediaType::JavaScript
+        | MediaType::Mjs
+        | MediaType::Cjs
+        | MediaType::Jsx => {
           if check_js || has_ts_check(module.media_type, &module.source) {
             Some((module.specifier.clone(), module.media_type))
           } else {


### PR DESCRIPTION
Closes #19928