### PR TITLE
chore: remove println in DenoCompileBinaryWriter

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -68,6 +68,15 @@ pub struct CompileFlags {
   pub include: Vec<String>,
 }
 
+impl CompileFlags {
+  pub fn resolve_target(&self) -> String {
+    self
+      .target
+      .clone()
+      .unwrap_or_else(|| env!("TARGET").to_string())
+  }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CompletionsFlags {
   pub buf: Box<[u8]>,

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -387,7 +387,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     let mut original_binary = self.get_base_binary(compile_flags).await?;
 
     if compile_flags.no_terminal {
-      let target = self.resolve_target(compile_flags);
+      let target = compile_flags.resolve_target();
       if !target.contains("windows") {
         bail!(
           "The `--no-terminal` flag is only available when targeting Windows (current: {})",
@@ -418,7 +418,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       return Ok(std::fs::read(path)?);
     }
 
-    let target = self.resolve_target(compile_flags);
+    let target = compile_flags.resolve_target();
     let binary_name = format!("deno-{target}.zip");
 
     let binary_path_suffix = if crate::version::is_canary() {
@@ -446,13 +446,6 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     let base_binary = std::fs::read(base_binary_path)?;
     drop(temp_dir); // delete the temp dir
     Ok(base_binary)
-  }
-
-  fn resolve_target(&self, compile_flags: &CompileFlags) -> String {
-    compile_flags
-      .target
-      .clone()
-      .unwrap_or_else(|| env!("TARGET").to_string())
   }
 
   async fn download_base_binary(


### PR DESCRIPTION
There was a println in an error case from #17991. Also consolidates some code that had different resolution.