### PR TITLE
fix(ext/compression): throw TypeError on corrupt input

### DIFF
--- a/ext/web/compression.rs
+++ b/ext/web/compression.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::op;
 use deno_core::OpState;
@@ -74,32 +75,32 @@ pub fn op_compression_write(
   let mut inner = resource.0.borrow_mut();
   let out: Vec<u8> = match &mut *inner {
     Inner::DeflateDecoder(d) => {
-      d.write_all(input)?;
+      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::DeflateEncoder(d) => {
-      d.write_all(input)?;
+      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::DeflateRawDecoder(d) => {
-      d.write_all(input)?;
+      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::DeflateRawEncoder(d) => {
-      d.write_all(input)?;
+      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::GzDecoder(d) => {
-      d.write_all(input)?;
+      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::GzEncoder(d) => {
-      d.write_all(input)?;
+      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
@@ -117,12 +118,20 @@ pub fn op_compression_finish(
   let resource = Rc::try_unwrap(resource).unwrap();
   let inner = resource.0.into_inner();
   let out: Vec<u8> = match inner {
-    Inner::DeflateDecoder(d) => d.finish()?,
-    Inner::DeflateEncoder(d) => d.finish()?,
-    Inner::DeflateRawDecoder(d) => d.finish()?,
-    Inner::DeflateRawEncoder(d) => d.finish()?,
-    Inner::GzDecoder(d) => d.finish()?,
-    Inner::GzEncoder(d) => d.finish()?,
+    Inner::DeflateDecoder(d) => {
+      d.finish().map_err(|e| type_error(e.to_string()))?
+    }
+    Inner::DeflateEncoder(d) => {
+      d.finish().map_err(|e| type_error(e.to_string()))?
+    }
+    Inner::DeflateRawDecoder(d) => {
+      d.finish().map_err(|e| type_error(e.to_string()))?
+    }
+    Inner::DeflateRawEncoder(d) => {
+      d.finish().map_err(|e| type_error(e.to_string()))?
+    }
+    Inner::GzDecoder(d) => d.finish().map_err(|e| type_error(e.to_string()))?,
+    Inner::GzEncoder(d) => d.finish().map_err(|e| type_error(e.to_string()))?,
   };
   Ok(out.into())
 }

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -7608,18 +7608,8 @@
     "decompression-constructor-error.tentative.any.worker.html": true,
     "decompression-correct-input.tentative.any.html": true,
     "decompression-correct-input.tentative.any.worker.html": true,
-    "decompression-corrupt-input.tentative.any.html": [
-      "truncating the input for 'deflate' should give an error",
-      "trailing junk for 'deflate' should give an error",
-      "format 'deflate' field DATA should be error for 5",
-      "trailing junk for 'gzip' should give an error"
-    ],
-    "decompression-corrupt-input.tentative.any.worker.html": [
-      "truncating the input for 'deflate' should give an error",
-      "trailing junk for 'deflate' should give an error",
-      "format 'deflate' field DATA should be error for 5",
-      "trailing junk for 'gzip' should give an error"
-    ],
+    "decompression-corrupt-input.tentative.any.html": true,
+    "decompression-corrupt-input.tentative.any.worker.html": true,
     "decompression-empty-input.tentative.any.html": true,
     "decompression-empty-input.tentative.any.worker.html": true,
     "decompression-split-chunk.tentative.any.html": true,


### PR DESCRIPTION
`TypeError` should be thrown when decompressing a corrupt input