### PR TITLE
chore(cli): Fix test that locks up on some M2 macs

### DIFF
--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -626,12 +626,12 @@ Deno.test({
   name: "[node/child_process spawn] supports SIGIOT signal",
   ignore: Deno.build.os === "windows",
   async fn() {
-    const script = path.join(
-      path.dirname(path.fromFileUrl(import.meta.url)),
-      "testdata",
-      "child_process_stdin.js",
-    );
-    const cp = spawn(Deno.execPath(), ["run", "-A", script]);
+    // Note: attempting to kill Deno with SIGABRT causes the process to zombify on certain OSX builds
+    // eg: 22.5.0 Darwin Kernel Version 22.5.0: Mon Apr 24 20:53:19 PDT 2023; root:xnu-8796.121.2~5/RELEASE_ARM64_T6020 arm64
+    // M2 Pro running Ventura 13.4
+
+    // Spawn an infinite cat
+    const cp = spawn("cat", ["-"]);
     const p = withTimeout();
     cp.on("exit", () => p.resolve());
     cp.kill("SIGIOT");


### PR DESCRIPTION
I'm not sure why, but sending SIGABRT to Deno on my machine as part of this test causes it to lock up very badly, leaving it in an unkillable `UE+` state.

This showed up after #19333, but was not caused by it.
