### PR TITLE
fix(tsc): deno diagnostic - clarify where to put triple-slash directive

### DIFF
--- a/cli/tests/testdata/check/deno_not_found/main.out
+++ b/cli/tests/testdata/check/deno_not_found/main.out
@@ -1,4 +1,4 @@
-error: TS2304 [ERROR]: Cannot find name 'Deno'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'deno.ns' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.ns" />
+error: TS2304 [ERROR]: Cannot find name 'Deno'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'deno.ns' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib="deno.ns" />
 Deno;
 ~~~~
     at file:///[WILDCARD]/check/deno_not_found/main.ts:4:1

--- a/cli/tests/testdata/check/deno_unstable_not_found/main.out
+++ b/cli/tests/testdata/check/deno_unstable_not_found/main.out
@@ -1,4 +1,4 @@
-error: TS2551 [ERROR]: Property 'openKv' does not exist on type 'typeof Deno'. Did you mean 'open'? 'Deno.openKv' is an unstable API. Did you forget to run with the '--unstable' flag, or did you mean 'open'? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />
+error: TS2551 [ERROR]: Property 'openKv' does not exist on type 'typeof Deno'. Did you mean 'open'? 'Deno.openKv' is an unstable API. Did you forget to run with the '--unstable' flag, or did you mean 'open'? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib="deno.unstable" />
 Deno.openKv;
      ~~~~~~
     at file:///[WILDCARD]/deno_unstable_not_found/main.ts:1:6
@@ -8,7 +8,7 @@ Deno.openKv;
                       ~~~~
         at asset:///lib.deno.ns.d.ts:[WILDCARD]:19
 
-TS2339 [ERROR]: Property 'createHttpClient' does not exist on type 'typeof Deno'. 'Deno.createHttpClient' is an unstable API. Did you forget to run with the '--unstable' flag? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />
+TS2339 [ERROR]: Property 'createHttpClient' does not exist on type 'typeof Deno'. 'Deno.createHttpClient' is an unstable API. Did you forget to run with the '--unstable' flag? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib="deno.unstable" />
 Deno.createHttpClient;
      ~~~~~~~~~~~~~~~~
     at file:///[WILDCARD]/deno_unstable_not_found/main.ts:2:6

--- a/cli/tests/testdata/run/unstable_disabled.out
+++ b/cli/tests/testdata/run/unstable_disabled.out
@@ -1,5 +1,5 @@
 [WILDCARD]
-error: TS2339 [ERROR]: Property 'umask' does not exist on type 'typeof Deno'. 'Deno.umask' is an unstable API. Did you forget to run with the '--unstable' flag? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />
+error: TS2339 [ERROR]: Property 'umask' does not exist on type 'typeof Deno'. 'Deno.umask' is an unstable API. Did you forget to run with the '--unstable' flag? If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib="deno.unstable" />
 console.log(Deno.umask);
                  ~~~~~
     at [WILDCARD]/unstable.ts:1:18

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -58,7 +58,8 @@ delete Object.prototype.__proto__;
   ]);
   const unstableMsgSuggestion =
     "If not, try changing the 'lib' compiler option to include 'deno.unstable' " +
-    'or add a triple-slash directive to your entrypoint: /// <reference lib="deno.unstable" />';
+    "or add a triple-slash directive to the top of your entrypoint (main file): " +
+    '/// <reference lib="deno.unstable" />';
 
   /**
    * @param {unknown} value
@@ -344,7 +345,8 @@ delete Object.prototype.__proto__;
         if (msg === "Cannot find name 'Deno'.") {
           msg += " Do you need to change your target library? " +
             "Try changing the 'lib' compiler option to include 'deno.ns' " +
-            'or add a triple-slash directive to your entrypoint: /// <reference lib="deno.ns" />';
+            "or add a triple-slash directive to the top of your entrypoint " +
+            '(main file): /// <reference lib="deno.ns" />';
         }
         return msg;
       }


### PR DESCRIPTION
Some people might not know what "entrypoint" means or where to put the triple-slash directive.

https://github.com/denoland/vscode_deno/issues/841#issuecomment-1644640248