### PR TITLE
feat: resolve entrypoint using import map

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -30,7 +30,6 @@ use deno_core::futures::future::FutureExt;
 use deno_core::futures::Future;
 use deno_core::parking_lot::Mutex;
 use deno_core::resolve_url;
-use deno_core::resolve_url_or_path;
 use deno_core::ModuleCode;
 use deno_core::ModuleLoader;
 use deno_core::ModuleSource;
@@ -194,14 +193,10 @@ impl ModuleLoadPreparer {
   /// the provided files.
   pub async fn load_and_type_check_files(
     &self,
-    files: &[String],
+    specifiers: Vec<ModuleSpecifier>,
   ) -> Result<(), AnyError> {
     let lib = self.options.ts_type_lib_window();
 
-    let specifiers = files
-      .iter()
-      .map(|file| resolve_url_or_path(file, self.options.initial_cwd()))
-      .collect::<Result<Vec<_>, _>>()?;
     self
       .prepare_module_load(
         specifiers,

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -14,7 +14,6 @@ use deno_ast::MediaType;
 use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_core::resolve_path;
-use deno_core::resolve_url_or_path;
 use deno_doc as doc;
 use deno_graph::GraphKind;
 use deno_graph::ModuleSpecifier;
@@ -66,9 +65,13 @@ pub async fn print_docs(
       let module_graph_builder = factory.module_graph_builder().await?;
       let maybe_lockfile = factory.maybe_lockfile();
       let parsed_source_cache = factory.parsed_source_cache()?;
+      let maybe_import_map = factory.maybe_import_map().await?;
 
-      let module_specifier =
-        resolve_url_or_path(&source_file, cli_options.initial_cwd())?;
+      let module_specifier = cli_options
+        .resolve_using_import_map_or_default_resolve(
+          &source_file,
+          maybe_import_map,
+        )?;
 
       // If the root module has external types, the module graph won't redirect it,
       // so instead create a dummy file which exports everything from the actual file being documented.

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -233,11 +233,17 @@ pub async fn install_command(
   install_flags: InstallFlags,
 ) -> Result<(), AnyError> {
   // ensure the module is cached
-  CliFactory::from_flags(flags.clone())
-    .await?
-    .module_load_preparer()
-    .await?
-    .load_and_type_check_files(&[install_flags.module_url.clone()])
+  let factory = CliFactory::from_flags(flags.clone()).await?;
+
+  let module_load_preparer = factory.module_load_preparer().await?;
+  let specifier = resolve_url_or_path(
+    &install_flags.module_url,
+    factory.cli_options().initial_cwd(),
+  )
+  .map_err(AnyError::from)?;
+
+  module_load_preparer
+    .load_and_type_check_files(vec![specifier])
     .await?;
 
   // create the install shim

--- a/cli/tools/run.rs
+++ b/cli/tools/run.rs
@@ -41,6 +41,7 @@ To grant permissions, set them before the script argument. For example:
   let deno_dir = factory.deno_dir()?;
   let http_client = factory.http_client();
   let cli_options = factory.cli_options();
+  let maybe_import_map = factory.maybe_import_map().await?;
 
   // Run a background task that checks for available upgrades. If an earlier
   // run of this background task found a new version of Deno.
@@ -49,7 +50,8 @@ To grant permissions, set them before the script argument. For example:
     deno_dir.upgrade_check_file_path(),
   );
 
-  let main_module = cli_options.resolve_main_module()?;
+  let main_module =
+    cli_options.resolve_main_module_with_import_map(maybe_import_map)?;
 
   maybe_npm_install(&factory).await?;
 
@@ -117,7 +119,9 @@ async fn run_with_watch(
           .build_from_flags(flags)
           .await?;
         let cli_options = factory.cli_options();
-        let main_module = cli_options.resolve_main_module()?;
+        let maybe_import_map = factory.maybe_import_map().await?;
+        let main_module =
+          cli_options.resolve_main_module_with_import_map(maybe_import_map)?;
 
         maybe_npm_install(&factory).await?;
 


### PR DESCRIPTION
This commit changes resolution of "entrypoint" to use import map
if one is provided for the following subcommands:
- "deno run"
- "deno doc"
- "deno check"
- "deno cache"

Closes https://github.com/denoland/deno/issues/14066
Closes https://github.com/denoland/deno/issues/19955