### PR TITLE
fix(test): use only a single timeout for op sanitizers

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -152,7 +152,7 @@ function assertOps(fn) {
       // cleared can actually be removed from resource table, otherwise
       // false positives may occur (https://github.com/denoland/deno/issues/4591)
       await opSanitizerDelay();
-      await opSanitizerDelay();
+      // await opSanitizerDelay();
     }
     const post = core.metrics();
     const postTraces = new Map(core.opCallTraces);

--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -152,7 +152,6 @@ function assertOps(fn) {
       // cleared can actually be removed from resource table, otherwise
       // false positives may occur (https://github.com/denoland/deno/issues/4591)
       await opSanitizerDelay();
-      // await opSanitizerDelay();
     }
     const post = core.metrics();
     const postTraces = new Map(core.opCallTraces);


### PR DESCRIPTION
Chipping away at making tests faster. Appears we don't need double timeout
before sanitizing ops. This should cut baseline cost of running a test by half.