### PR TITLE
fix(test): make test runner work when global setTimeout is replaced

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -5,6 +5,7 @@ const ops = core.ops;
 import { setExitHandler } from "ext:runtime/30_os.js";
 import { Console } from "ext:deno_console/01_console.js";
 import { serializePermissions } from "ext:runtime/10_permissions.js";
+import { setTimeout } from "ext:deno_web/02_timers.js";
 import { assert } from "ext:deno_web/00_infra.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {

--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -529,6 +529,11 @@ itest!(test_no_lock {
   output: "lockfile/basic/test.nolock.out",
 });
 
+itest!(test_replace_timers {
+  args: "test test/replace_timers.js",
+  output: "test/replace_timers.js.out",
+});
+
 #[test]
 fn test_with_glob_config() {
   let context = TestContextBuilder::new().cwd("test").build();

--- a/cli/tests/testdata/test/replace_timers.js
+++ b/cli/tests/testdata/test/replace_timers.js
@@ -1,0 +1,7 @@
+Deno.test("foo", async (t) => {
+  globalThis.setTimeout = () => {};
+  globalThis.clearTimeout = () => {};
+  globalThis.setInterval = () => {};
+  globalThis.clearInterval = () => {};
+  await t.step("bar", () => {});
+});

--- a/cli/tests/testdata/test/replace_timers.js.out
+++ b/cli/tests/testdata/test/replace_timers.js.out
@@ -1,0 +1,7 @@
+running 1 test from ./test/replace_timers.js
+foo ...
+  bar ... ok ([WILDCARD])
+foo ... ok ([WILDCARD])
+
+ok | 1 passed (1 step) | 0 failed ([WILDCARD])
+


### PR DESCRIPTION
fixes #20051

`t.step` doesn't work when the global setTimeout is replaced by mock/stub implementation. This PR fixes it by using setTimeout from `ext:deno_web/02_timers.js`