### PR TITLE
fix(ext/fetch): clone second branch chunks in Body.clone()

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -33,6 +33,7 @@ import {
   readableStreamCollectIntoUint8Array,
   readableStreamDisturb,
   ReadableStreamPrototype,
+  readableStreamTee,
   readableStreamThrowIfErrored,
 } from "ext:deno_web/06_streams.js";
 const primordials = globalThis.__bootstrap.primordials;
@@ -194,7 +195,7 @@ class InnerBody {
    * @returns {InnerBody}
    */
   clone() {
-    const { 0: out1, 1: out2 } = this.stream.tee();
+    const { 0: out1, 1: out2 } = readableStreamTee(this.stream, true);
     this.streamOrStatic = out1;
     const second = new InnerBody(out2);
     second.source = core.deserialize(core.serialize(this.source));

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -4378,36 +4378,8 @@
         "response-from-stream.any.worker.html": true,
         "response-cancel-stream.any.html": true,
         "response-cancel-stream.any.worker.html": true,
-        "response-clone.any.html": [
-          "Check response clone use structureClone for teed ReadableStreams (Int8Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Int16Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Int32Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (ArrayBufferchunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint8Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint8ClampedArraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint16Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint32Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (BigInt64Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (BigUint64Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Float32Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Float64Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (DataViewchunk)"
-        ],
-        "response-clone.any.worker.html": [
-          "Check response clone use structureClone for teed ReadableStreams (Int8Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Int16Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Int32Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (ArrayBufferchunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint8Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint8ClampedArraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint16Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Uint32Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (BigInt64Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (BigUint64Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Float32Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (Float64Arraychunk)",
-          "Check response clone use structureClone for teed ReadableStreams (DataViewchunk)"
-        ],
+        "response-clone.any.html": true,
+        "response-clone.any.worker.html": true,
         "response-consume-empty.any.html": [
           "Consume empty FormData response body as text"
         ],


### PR DESCRIPTION
This PR makes `Body.clone()` spec compliant: https://fetch.spec.whatwg.org/#concept-body-clone

> 1, Let « out1, out2 » be the result of [teeing](https://streams.spec.whatwg.org/#readablestream-tee) body’s [stream](https://fetch.spec.whatwg.org/#concept-body-stream).
> ...
> To tee a [ReadableStream](https://streams.spec.whatwg.org/#readablestream) stream, return ? [ReadableStreamTee](https://streams.spec.whatwg.org/#readable-stream-tee)(stream, true).

---
Closes #10994 
