### PR TITLE
chore(wpt): expose gc

### DIFF
--- a/tools/wpt/runner.ts
+++ b/tools/wpt/runner.ts
@@ -101,6 +101,7 @@ export async function runSingleTest(
       "run",
       "-A",
       "--unstable",
+      "--v8-flags=--expose-gc",
     ];
 
     if (inspectBrk) {


### PR DESCRIPTION
This PR exposes garbage collector for WPT

see: https://github.com/web-platform-tests/wpt/blob/3d80f7e87928e2d0da25d1c60a13dab001332139/common/gc.js#L34-L36


```
/streams/readable-streams/garbage-collection.any.html


test stderr:
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.


file result: ok. 4 passed; 0 failed; 0 expected failure; total 4 (255ms)

----------------------------------------
/streams/readable-streams/garbage-collection.any.worker.html


test stderr:
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.
Tests are running without the ability to do manual garbage collection. They will still work, but coverage will be suboptimal.


file result: ok. 4 passed; 0 failed; 0 expected failure; total 4 (277ms)
```

This PR removes that warning and improves coverage.