### PR TITLE
feat(unstable): rename `deno_modules` to `vendor`

### DIFF
--- a/cli/args/config_file.rs
+++ b/cli/args/config_file.rs
@@ -673,7 +673,7 @@ pub struct ConfigFileJson {
   pub lock: Option<Value>,
   pub exclude: Option<Value>,
   pub node_modules_dir: Option<bool>,
-  pub deno_modules_dir: Option<bool>,
+  pub vendor: Option<bool>,
 }
 
 #[derive(Clone, Debug)]
@@ -855,16 +855,16 @@ impl ConfigFile {
     self.json.import_map.clone()
   }
 
-  pub fn node_modules_dir(&self) -> Option<bool> {
+  pub fn node_modules_dir_flag(&self) -> Option<bool> {
     self.json.node_modules_dir
   }
 
-  pub fn deno_modules_dir(&self) -> Option<bool> {
-    self.json.deno_modules_dir
+  pub fn vendor_dir_flag(&self) -> Option<bool> {
+    self.json.vendor
   }
 
-  pub fn deno_modules_dir_path(&self) -> Option<PathBuf> {
-    if self.json.deno_modules_dir == Some(true) {
+  pub fn vendor_dir_path(&self) -> Option<PathBuf> {
+    if self.json.vendor == Some(true) {
       Some(
         self
           .specifier
@@ -872,7 +872,7 @@ impl ConfigFile {
           .unwrap()
           .parent()
           .unwrap()
-          .join("deno_modules"),
+          .join("vendor"),
       )
     } else {
       None
@@ -903,8 +903,8 @@ impl ConfigFile {
         Vec::new()
       };
 
-    if self.deno_modules_dir() == Some(true) {
-      exclude.push("deno_modules".to_string());
+    if self.vendor_dir_flag() == Some(true) {
+      exclude.push("vendor".to_string());
     }
 
     let raw_files_config = SerializedFilesConfig {

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1186,7 +1186,7 @@ fn resolve_node_modules_folder(
   let use_node_modules_dir = flags
     .node_modules_dir
     .or_else(|| maybe_config_file.and_then(|c| c.node_modules_dir_flag()))
-    .or_else(|| flags.vendor)
+    .or(flags.vendor)
     .or_else(|| maybe_config_file.and_then(|c| c.vendor_dir_flag()));
   let path = if use_node_modules_dir == Some(false) {
     return Ok(None);

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -541,7 +541,7 @@ pub struct CliOptions {
   flags: Flags,
   initial_cwd: PathBuf,
   maybe_node_modules_folder: Option<PathBuf>,
-  maybe_deno_modules_folder: Option<PathBuf>,
+  maybe_vendor_folder: Option<PathBuf>,
   maybe_config_file: Option<ConfigFile>,
   maybe_package_json: Option<PackageJson>,
   maybe_lockfile: Option<Arc<Mutex<Lockfile>>>,
@@ -577,11 +577,8 @@ impl CliOptions {
       maybe_package_json.as_ref(),
     )
     .with_context(|| "Resolving node_modules folder.")?;
-    let maybe_deno_modules_folder = resolve_deno_modules_folder(
-      &initial_cwd,
-      &flags,
-      maybe_config_file.as_ref(),
-    );
+    let maybe_vendor_folder =
+      resolve_vendor_folder(&initial_cwd, &flags, maybe_config_file.as_ref());
 
     Ok(Self {
       flags,
@@ -590,7 +587,7 @@ impl CliOptions {
       maybe_lockfile,
       maybe_package_json,
       maybe_node_modules_folder,
-      maybe_deno_modules_folder,
+      maybe_vendor_folder,
       overrides: Default::default(),
     })
   }
@@ -863,7 +860,7 @@ impl CliOptions {
       self
         .maybe_config_file
         .as_ref()
-        .and_then(|c| c.node_modules_dir())
+        .and_then(|c| c.node_modules_dir_flag())
     })
   }
 
@@ -874,8 +871,8 @@ impl CliOptions {
       .map(|path| ModuleSpecifier::from_directory_path(path).unwrap())
   }
 
-  pub fn deno_modules_dir_path(&self) -> Option<&PathBuf> {
-    self.maybe_deno_modules_folder.as_ref()
+  pub fn vendor_dir_path(&self) -> Option<&PathBuf> {
+    self.maybe_vendor_folder.as_ref()
   }
 
   pub fn resolve_root_cert_store_provider(
@@ -1188,7 +1185,9 @@ fn resolve_node_modules_folder(
 ) -> Result<Option<PathBuf>, AnyError> {
   let use_node_modules_dir = flags
     .node_modules_dir
-    .or_else(|| maybe_config_file.and_then(|c| c.node_modules_dir()));
+    .or_else(|| maybe_config_file.and_then(|c| c.node_modules_dir_flag()))
+    .or_else(|| flags.vendor)
+    .or_else(|| maybe_config_file.and_then(|c| c.vendor_dir_flag()));
   let path = if use_node_modules_dir == Some(false) {
     return Ok(None);
   } else if let Some(state) = &*NPM_PROCESS_STATE {
@@ -1209,28 +1208,28 @@ fn resolve_node_modules_folder(
   Ok(Some(canonicalize_path_maybe_not_exists(&path)?))
 }
 
-fn resolve_deno_modules_folder(
+fn resolve_vendor_folder(
   cwd: &Path,
   flags: &Flags,
   maybe_config_file: Option<&ConfigFile>,
 ) -> Option<PathBuf> {
-  let use_deno_modules_dir = flags
-    .deno_modules_dir
-    .or_else(|| maybe_config_file.and_then(|c| c.deno_modules_dir()))
+  let use_vendor_dir = flags
+    .vendor
+    .or_else(|| maybe_config_file.and_then(|c| c.vendor_dir_flag()))
     .unwrap_or(false);
   // Unlike the node_modules directory, there is no need to canonicalize
   // this directory because it's just used as a cache and the resolved
   // specifier is not based on the canonicalized path (unlike the modules
   // in the node_modules folder).
-  if !use_deno_modules_dir {
+  if !use_vendor_dir {
     None
   } else if let Some(config_path) = maybe_config_file
     .as_ref()
     .and_then(|c| c.specifier.to_file_path().ok())
   {
-    Some(config_path.parent().unwrap().join("deno_modules"))
+    Some(config_path.parent().unwrap().join("vendor"))
   } else {
-    Some(cwd.join("deno_modules"))
+    Some(cwd.join("vendor"))
   }
 }
 

--- a/cli/cache/http_cache/local.rs
+++ b/cli/cache/http_cache/local.rs
@@ -28,7 +28,7 @@ use super::CachedUrlMetadata;
 use super::HttpCache;
 use super::HttpCacheItemKey;
 
-/// A deno_modules http cache for the lsp that provides functionality
+/// A vendor/ folder http cache for the lsp that provides functionality
 /// for doing a reverse mapping.
 #[derive(Debug)]
 pub struct LocalLspHttpCache {

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -248,7 +248,7 @@ impl CliFactory {
   pub fn http_cache(&self) -> Result<&Arc<dyn HttpCache>, AnyError> {
     self.services.http_cache.get_or_try_init(|| {
       let global_cache = self.global_http_cache()?.clone();
-      match self.options.deno_modules_dir_path() {
+      match self.options.vendor_dir_path() {
         Some(local_path) => {
           let local_cache =
             LocalHttpCache::new(local_path.clone(), global_cache);

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -475,10 +475,8 @@ impl Config {
       .and_then(|p| p.maybe_node_modules_dir.as_ref())
   }
 
-  pub fn maybe_deno_modules_dir_path(&self) -> Option<PathBuf> {
-    self
-      .maybe_config_file()
-      .and_then(|c| c.deno_modules_dir_path())
+  pub fn maybe_vendor_dir_path(&self) -> Option<PathBuf> {
+    self.maybe_config_file().and_then(|c| c.vendor_dir_path())
   }
 
   pub fn maybe_config_file(&self) -> Option<&ConfigFile> {
@@ -816,7 +814,13 @@ fn resolve_node_modules_dir(config_file: &ConfigFile) -> Option<PathBuf> {
   // `nodeModulesDir: true` setting in the deno.json file. This is to
   // reduce the chance of modifying someone's node_modules directory
   // without them having asked us to do so.
-  if config_file.node_modules_dir() != Some(true) {
+  let explicitly_disabled = config_file.node_modules_dir_flag() == Some(false);
+  if explicitly_disabled {
+    return None;
+  }
+  let enabled = config_file.node_modules_dir_flag() == Some(true)
+    || config_file.vendor_dir_flag() == Some(true);
+  if !enabled {
     return None;
   }
   if config_file.specifier.scheme() != "file" {

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1184,7 +1184,7 @@ impl Documents {
       document_preload_limit: usize,
       maybe_import_map: Option<&import_map::ImportMap>,
       maybe_jsx_config: Option<&JsxImportSourceConfig>,
-      maybe_deno_modules_dir: Option<bool>,
+      maybe_vendor_dir: Option<bool>,
       maybe_package_json_deps: Option<&PackageJsonDeps>,
     ) -> u64 {
       let mut hasher = FastInsecureHasher::default();
@@ -1199,7 +1199,7 @@ impl Documents {
         hasher.write_str(&import_map.to_json());
         hasher.write_str(import_map.base_url().as_str());
       }
-      hasher.write_hashable(maybe_deno_modules_dir);
+      hasher.write_hashable(maybe_vendor_dir);
       hasher.write_hashable(maybe_jsx_config);
       if let Some(package_json_deps) = &maybe_package_json_deps {
         // We need to ensure the hashing is deterministic so explicitly type
@@ -1234,7 +1234,7 @@ impl Documents {
       options.document_preload_limit,
       options.maybe_import_map.as_deref(),
       maybe_jsx_config.as_ref(),
-      options.maybe_config_file.and_then(|c| c.deno_modules_dir()),
+      options.maybe_config_file.and_then(|c| c.vendor_dir_flag()),
       maybe_package_json_deps.as_ref(),
     );
     let deps_provider =

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -906,7 +906,7 @@ impl Inner {
     // update the cache path
     let global_cache = Arc::new(GlobalHttpCache::new(dir.deps_folder_path()));
     let maybe_local_cache =
-      self.config.maybe_deno_modules_dir_path().map(|local_path| {
+      self.config.maybe_vendor_dir_path().map(|local_path| {
         Arc::new(LocalLspHttpCache::new(local_path, global_cache.clone()))
       });
     let cache: Arc<dyn HttpCache> = maybe_local_cache

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -429,11 +429,11 @@
       }
     },
     "nodeModulesDir": {
-      "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` or `--node-modules-dir=false` flag. Requires Deno 1.34 or later.",
+      "description": "Enables or disables the use of a local node_modules folder for npm packages. Alternatively, use the `--node-modules-dir` flag or override the config via `--node-modules-dir=false`. Requires Deno 1.34 or later.",
       "type": "boolean"
     },
-    "denoModulesDir": {
-      "description": "UNSTABLE: Enables or disables the use of a local deno_modules folder as a local cache for remote modules. Alternatively, use the `--deno-modules-dir` or `--deno-modules-dir=false` flag. Requires Deno 1.36 or later.",
+    "vendor": {
+      "description": "UNSTABLE: Enables or disables the use of a local vendor folder as a local cache for remote modules and node_modules folder for npm packages. Alternatively, use the `--vendor` flag or ovveride the config via `--vendor=false`. Requires Deno 1.36.1 or later.",
       "type": "boolean"
     },
     "tasks": {

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -433,7 +433,7 @@
       "type": "boolean"
     },
     "vendor": {
-      "description": "UNSTABLE: Enables or disables the use of a local vendor folder as a local cache for remote modules and node_modules folder for npm packages. Alternatively, use the `--vendor` flag or ovveride the config via `--vendor=false`. Requires Deno 1.36.1 or later.",
+      "description": "UNSTABLE: Enables or disables the use of a local vendor folder as a local cache for remote modules and node_modules folder for npm packages. Alternatively, use the `--vendor` flag or override the config via `--vendor=false`. Requires Deno 1.36.1 or later.",
       "type": "boolean"
     },
     "tasks": {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -8768,7 +8768,7 @@ fn lsp_node_modules_dir() {
 }
 
 #[test]
-fn lsp_deno_modules_dir() {
+fn lsp_vendor_dir() {
   let context = TestContextBuilder::new()
     .use_http_server()
     .use_temp_cwd()
@@ -8804,11 +8804,11 @@ fn lsp_deno_modules_dir() {
 
   cache(&mut client);
 
-  assert!(!temp_dir.path().join("deno_modules").exists());
+  assert!(!temp_dir.path().join("vendor").exists());
 
   temp_dir.write(
     temp_dir.path().join("deno.json"),
-    "{ \"denoModulesDir\": true, \"lock\": false }\n",
+    "{ \"vendor\": true, \"lock\": false }\n",
   );
   let refresh_config = |client: &mut LspClient| {
     client.write_notification(
@@ -8852,10 +8852,10 @@ fn lsp_deno_modules_dir() {
   // no caching necessary because it was already cached. It should exist now
   assert!(temp_dir
     .path()
-    .join("deno_modules/http_localhost_4545/subdir/mod1.ts")
+    .join("vendor/http_localhost_4545/subdir/mod1.ts")
     .exists());
 
-  // the declaration should be found in the deno_modules directory
+  // the declaration should be found in the vendor directory
   let res = client.write_request(
     "textDocument/references",
     json!({
@@ -8869,7 +8869,7 @@ fn lsp_deno_modules_dir() {
     }),
   );
 
-  // ensure that it's using the deno_modules directory
+  // ensure that it's using the vendor directory
   let references = res.as_array().unwrap();
   assert_eq!(references.len(), 2, "references: {:#?}", references);
   let uri = references[1]
@@ -8881,7 +8881,7 @@ fn lsp_deno_modules_dir() {
     .unwrap();
   let file_path = temp_dir
     .path()
-    .join("deno_modules/http_localhost_4545/subdir/mod1.ts");
+    .join("vendor/http_localhost_4545/subdir/mod1.ts");
   let remote_file_uri = file_path.uri_file();
   assert_eq!(uri, remote_file_uri.as_str());
 

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -2023,8 +2023,14 @@ pub fn node_modules_dir_config_file() {
 
   let deno_cache_cmd = test_context.new_command().args("cache --quiet main.ts");
   deno_cache_cmd.run();
-
   assert!(node_modules_dir.exists());
+
+  // now try adding a vendor flag, it should exist
+  rm_node_modules();
+  temp_dir.write("deno.json", r#"{ "vendor": true }"#);
+  deno_cache_cmd.run();
+  assert!(node_modules_dir.exists());
+
   rm_node_modules();
   temp_dir.write("deno.json", r#"{ "nodeModulesDir": false }"#);
 
@@ -2040,6 +2046,14 @@ pub fn node_modules_dir_config_file() {
     .args("cache --quiet --node-modules-dir main.ts")
     .run();
   assert!(node_modules_dir.exists());
+
+  // should override the `--vendor` flag
+  rm_node_modules();
+  test_context
+    .new_command()
+    .args("cache --quiet --node-modules-dir=false --vendor main.ts")
+    .run();
+  assert!(!node_modules_dir.exists());
 }
 
 #[test]

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -4564,20 +4564,20 @@ console.log(returnsHi());"#,
     .run()
     .skip_output_check();
   assert_eq!(
-    deno_modules_dir.join("manifest.json").read_json_value(),
+    vendor_dir.join("manifest.json").read_json_value(),
     json!({
       "folders": {
         "http://localhost:4545/subdir/CAPITALS/": "http_localhost_4545/subdir/#capitals_c75d7"
       }
     })
   );
-  deno_modules_dir
+  vendor_dir
     .join("http_localhost_4545/subdir/#capitals_c75d7/hello_there.ts")
     .write("console.log('hello there');");
   test_context
     .new_command()
     // todo(dsherret): seems wrong that we don't auto-discover the config file to get the vendor directory for this
-    .args("run --deno-modules-dir http://localhost:4545/subdir/CAPITALS/hello_there.ts")
+    .args("run --vendor http://localhost:4545/subdir/CAPITALS/hello_there.ts")
     .run()
     .assert_matches_text("hello there\n");
 }

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -101,8 +101,9 @@ itest!(_017_import_redirect_check {
   output: "run/017_import_redirect.ts.out",
 });
 
-itest!(_017_import_redirect_deno_modules_dir {
-  args: "run --quiet --reload --deno-modules-dir --check $TESTDATA/run/017_import_redirect.ts",
+itest!(_017_import_redirect_vendor_dir {
+  args:
+    "run --quiet --reload --vendor --check $TESTDATA/run/017_import_redirect.ts",
   output: "run/017_import_redirect.ts.out",
   temp_cwd: true,
 });
@@ -162,9 +163,9 @@ itest!(_027_redirect_typescript {
   http_server: true,
 });
 
-itest!(_027_redirect_typescript_deno_modules_dir {
+itest!(_027_redirect_typescript_vendor_dir {
   args:
-    "run --quiet --reload --deno-modules-dir $TESTDATA/run/027_redirect_typescript.ts",
+    "run --quiet --reload --vendor $TESTDATA/run/027_redirect_typescript.ts",
   output: "run/027_redirect_typescript.ts.out",
   http_server: true,
   temp_cwd: true,
@@ -200,9 +201,9 @@ itest!(_033_import_map_remote {
   http_server: true,
 });
 
-itest!(_033_import_map_deno_modules_dir_remote {
+itest!(_033_import_map_vendor_dir_remote {
   args:
-    "run --quiet --reload --import-map=http://127.0.0.1:4545/import_maps/import_map_remote.json --deno-modules-dir --unstable $TESTDATA/import_maps/test_remote.ts",
+    "run --quiet --reload --import-map=http://127.0.0.1:4545/import_maps/import_map_remote.json --vendor --unstable $TESTDATA/import_maps/test_remote.ts",
   output: "run/033_import_map_remote.out",
   http_server: true,
   temp_cwd: true,
@@ -1705,8 +1706,8 @@ itest!(jsx_import_source_pragma_with_config_no_check {
   http_server: true,
 });
 
-itest!(jsx_import_source_pragma_with_config_deno_modules_dir {
-  args: "run --reload --config jsx/deno-jsx.jsonc --no-lock --deno-modules-dir $TESTDATA/run/jsx_import_source_pragma.tsx",
+itest!(jsx_import_source_pragma_with_config_vendor_dir {
+  args: "run --reload --config jsx/deno-jsx.jsonc --no-lock --vendor $TESTDATA/run/jsx_import_source_pragma.tsx",
   output: "run/jsx_import_source.out",
   http_server: true,
   temp_cwd: true,
@@ -1766,9 +1767,9 @@ itest!(reference_types_error {
   exit_code: 1,
 });
 
-itest!(reference_types_error_deno_modules_dir {
+itest!(reference_types_error_vendor_dir {
   args:
-    "run --config run/checkjs.tsconfig.json --check --deno-modules-dir $TESTDATA/run/reference_types_error.js",
+    "run --config run/checkjs.tsconfig.json --check --vendor $TESTDATA/run/reference_types_error.js",
   output: "run/reference_types_error.js.out",
   exit_code: 1,
 });
@@ -4493,16 +4494,16 @@ itest!(extension_dynamic_import {
 });
 
 #[test]
-pub fn deno_modules_dir_config_file() {
+pub fn vendor_dir_config_file() {
   let test_context = TestContextBuilder::new()
     .use_http_server()
     .use_temp_cwd()
     .build();
   let temp_dir = test_context.temp_dir();
-  let deno_modules_dir = temp_dir.path().join("deno_modules");
-  let rm_deno_modules = || std::fs::remove_dir_all(&deno_modules_dir).unwrap();
+  let vendor_dir = temp_dir.path().join("vendor");
+  let rm_vendor_dir = || std::fs::remove_dir_all(&vendor_dir).unwrap();
 
-  temp_dir.write("deno.json", r#"{ "denoModulesDir": true }"#);
+  temp_dir.write("deno.json", r#"{ "vendor": true }"#);
   temp_dir.write(
     "main.ts",
     r#"import { returnsHi } from 'http://localhost:4545/subdir/mod1.ts';
@@ -4512,25 +4513,25 @@ console.log(returnsHi());"#,
   let deno_run_cmd = test_context.new_command().args("run --quiet main.ts");
   deno_run_cmd.run().assert_matches_text("Hi\n");
 
-  assert!(deno_modules_dir.exists());
-  rm_deno_modules();
-  temp_dir.write("deno.json", r#"{ "denoModulesDir": false }"#);
+  assert!(vendor_dir.exists());
+  rm_vendor_dir();
+  temp_dir.write("deno.json", r#"{ "vendor": false }"#);
 
   deno_run_cmd.run().assert_matches_text("Hi\n");
-  assert!(!deno_modules_dir.exists());
+  assert!(!vendor_dir.exists());
   test_context
     .new_command()
-    .args("cache --quiet --deno-modules-dir main.ts")
+    .args("cache --quiet --vendor main.ts")
     .run();
-  assert!(deno_modules_dir.exists());
-  rm_deno_modules();
+  assert!(vendor_dir.exists());
+  rm_vendor_dir();
 
-  temp_dir.write("deno.json", r#"{ "denoModulesDir": true }"#);
+  temp_dir.write("deno.json", r#"{ "vendor": true }"#);
   let cache_command = test_context.new_command().args("cache --quiet main.ts");
   cache_command.run();
 
-  assert!(deno_modules_dir.exists());
-  let mod1_file = deno_modules_dir
+  assert!(vendor_dir.exists());
+  let mod1_file = vendor_dir
     .join("http_localhost_4545")
     .join("subdir")
     .join("mod1.ts");

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -571,7 +571,7 @@ fn collect_coverages(
   })
   .ignore_git_folder()
   .ignore_node_modules()
-  .ignore_deno_modules()
+  .ignore_vendor_folder()
   .add_ignore_paths(&files.ignore)
   .collect_files(&files.include)?;
 

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -151,7 +151,7 @@ fn collect_fmt_files(files: &FilesConfig) -> Result<Vec<PathBuf>, AnyError> {
   FileCollector::new(is_supported_ext_fmt)
     .ignore_git_folder()
     .ignore_node_modules()
-    .ignore_deno_modules()
+    .ignore_vendor_folder()
     .add_ignore_paths(&files.exclude)
     .collect_files(&files.include)
 }

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -198,7 +198,7 @@ fn collect_lint_files(files: &FilesConfig) -> Result<Vec<PathBuf>, AnyError> {
   FileCollector::new(is_supported_ext)
     .ignore_git_folder()
     .ignore_node_modules()
-    .ignore_deno_modules()
+    .ignore_vendor_folder()
     .add_ignore_paths(&files.exclude)
     .collect_files(&files.include)
 }


### PR DESCRIPTION
Renames the unstable `deno_modules` directory and corresponding settings to `vendor` after feedback. Also causes the vendoring of the `node_modules` directory which can be disabled via `--node-modules-dir=false` or `"nodeModulesDir": false`.

Part of https://github.com/denoland/deno/issues/15633