### PR TITLE
fix(unstable): vendor cache should support adding files to hashed directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63772a60d740a41d97fbffb4788fc3779e6df47289e01892c12be38f4a5beded"
+checksum = "001d69b833ed4d244b608bab9c07069bfb570f631b763b58e73f82a020bf84ef"
 dependencies = [
  "data-url",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ napi_sym = { version = "0.44.0", path = "./cli/napi/sym" }
 deno_bench_util = { version = "0.108.0", path = "./bench_util" }
 test_util = { path = "./test_util" }
 deno_lockfile = "0.14.1"
-deno_media_type = { version = "0.1.0", features = ["module_specifier"] }
+deno_media_type = { version = "0.1.1", features = ["module_specifier"] }
 deno_npm = "0.10.1"
 deno_semver = "0.3.0"
 

--- a/cli/cache/http_cache/local.rs
+++ b/cli/cache/http_cache/local.rs
@@ -696,12 +696,12 @@ mod manifest {
       default = "IndexMap::new",
       skip_serializing_if = "IndexMap::is_empty"
     )]
-    pub modules: IndexMap<Url, SerializedLocalCacheManifestDataModule>,
+    pub folders: IndexMap<Url, String>,
     #[serde(
       default = "IndexMap::new",
       skip_serializing_if = "IndexMap::is_empty"
     )]
-    pub directories: IndexMap<Url, String>,
+    pub modules: IndexMap<Url, SerializedLocalCacheManifestDataModule>,
   }
 
   #[derive(Debug, Default, Clone)]
@@ -742,7 +742,7 @@ mod manifest {
                   (path, url.clone())
                 })
             })
-            .chain(serialized.directories.iter().map(|(url, local_path)| {
+            .chain(serialized.folders.iter().map(|(url, local_path)| {
               let path = if cfg!(windows) {
                 PathBuf::from(local_path.replace('/', "\\"))
               } else {
@@ -778,7 +778,7 @@ mod manifest {
     }
 
     pub fn add_directory(&mut self, url: Url, local_path: String) -> bool {
-      if let Some(current) = self.serialized.directories.get(&url) {
+      if let Some(current) = self.serialized.folders.get(&url) {
         if *current == local_path {
           return false;
         }
@@ -795,7 +795,7 @@ mod manifest {
         );
       }
 
-      self.serialized.directories.insert(url, local_path);
+      self.serialized.folders.insert(url, local_path);
       true
     }
 
@@ -1200,7 +1200,7 @@ mod test {
             "https://deno.land/INVALID/Module.ts?dev": {
             }
           },
-          "directories": {
+          "folders": {
             "https://deno.land/INVALID/": "deno.land/#invalid_1ee01",
           }
         })

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -4565,7 +4565,7 @@ console.log(returnsHi());"#,
   assert_eq!(
     deno_modules_dir.join("manifest.json").read_json_value(),
     json!({
-      "directories": {
+      "folders": {
         "http://localhost:4545/subdir/CAPITALS/": "http_localhost_4545/subdir/#capitals_c75d7"
       }
     })

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::serde_json::json;
 use deno_core::url;
 use deno_runtime::deno_fetch::reqwest;
 use std::io::Read;
@@ -4553,4 +4554,29 @@ console.log(returnsHi());"#,
   // now it should run
   deno_run_cmd.run().assert_matches_text("bye bye bye\n");
   assert!(lockfile.exists());
+
+  // ensure we can add and execute files in directories that have a hash in them
+  test_context
+    .new_command()
+    // http_localhost_4545/subdir/#capitals_c75d7/main.js
+    .args("cache http://localhost:4545/subdir/CAPITALS/main.js")
+    .run()
+    .skip_output_check();
+  assert_eq!(
+    deno_modules_dir.join("manifest.json").read_json_value(),
+    json!({
+      "directories": {
+        "http://localhost:4545/subdir/CAPITALS/": "http_localhost_4545/subdir/#capitals_c75d7"
+      }
+    })
+  );
+  deno_modules_dir
+    .join("http_localhost_4545/subdir/#capitals_c75d7/hello_there.ts")
+    .write("console.log('hello there');");
+  test_context
+    .new_command()
+    // todo(dsherret): seems wrong that we don't auto-discover the config file to get the vendor directory for this
+    .args("run --deno-modules-dir http://localhost:4545/subdir/CAPITALS/hello_there.ts")
+    .run()
+    .assert_matches_text("hello there\n");
 }

--- a/cli/tests/testdata/subdir/CAPITALS/main.js
+++ b/cli/tests/testdata/subdir/CAPITALS/main.js
@@ -1,0 +1,3 @@
+export function returnsUppperHi() {
+  return "HI";
+}


### PR DESCRIPTION
This changes the design of the manifest.json file to have a separate "folders" map for mapping hashed directories. This allows, for example, to add files in a folder like `http_localhost_8000/#testing_5de71/` and have them be resolved automatically as long as their remaining components are identity-mappable to the file system (not hashed). It also saves space in the manifest.json file by only including the hashed directory instead of each descendant file.

```
// manifest.json
{
  "folders": {
    "https://localhost/NOT_MAPPABLE/": "localhost/#not_mappable_5cefgh"
  },
  "modules": {
    "https://localhost/folder/file": {
      "headers": {
        "content-type": "application/javascript"
      }
    },
  }
}

// folder structure
localhost
  - folder
    - #file_2defn (note: I've made up the hashes in these examples)
  - #not_mappable_5cefgh
    - mod.ts
    - etc.ts
    - more_files.ts
```