### PR TITLE
fix(node/async_hooks): don't pop async context frame if stack if empty

### DIFF
--- a/ext/node/polyfills/async_hooks.ts
+++ b/ext/node/polyfills/async_hooks.ts
@@ -48,7 +48,6 @@ function setPromiseHooks() {
     }
   };
   const before = (promise: Promise<unknown>) => {
-    console.log("promiseHook before");
     const maybeFrame = promise[asyncContext];
     if (maybeFrame) {
       pushAsyncFrame(maybeFrame);
@@ -57,7 +56,6 @@ function setPromiseHooks() {
     }
   };
   const after = (promise: Promise<unknown>) => {
-    console.log("promiseHook after", promise);
     popAsyncFrame();
     if (!ops.op_node_is_promise_rejected(promise)) {
       // @ts-ignore promise async context

--- a/ext/node/polyfills/async_hooks.ts
+++ b/ext/node/polyfills/async_hooks.ts
@@ -22,8 +22,9 @@ function pushAsyncFrame(frame: AsyncContextFrame) {
 }
 
 function popAsyncFrame() {
-  assert(asyncContextStack.length > 0);
-  asyncContextStack.pop();
+  if (asyncContextStack.length > 0) {
+    asyncContextStack.pop();
+  }
 }
 
 let rootAsyncFrame: AsyncContextFrame | undefined = undefined;
@@ -47,6 +48,7 @@ function setPromiseHooks() {
     }
   };
   const before = (promise: Promise<unknown>) => {
+    console.log("promiseHook before");
     const maybeFrame = promise[asyncContext];
     if (maybeFrame) {
       pushAsyncFrame(maybeFrame);
@@ -55,6 +57,7 @@ function setPromiseHooks() {
     }
   };
   const after = (promise: Promise<unknown>) => {
+    console.log("promiseHook after", promise);
     popAsyncFrame();
     if (!ops.op_node_is_promise_rejected(promise)) {
       // @ts-ignore promise async context


### PR DESCRIPTION
I couldn't come up with a test case that doesn't involve pulling
quite a bit of dependencies.

Closes https://github.com/denoland/deno/issues/20076