### PR TITLE
perf(test): lower base overhead to <1ms

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -5,7 +5,7 @@ const ops = core.ops;
 import { setExitHandler } from "ext:runtime/30_os.js";
 import { Console } from "ext:deno_console/01_console.js";
 import { serializePermissions } from "ext:runtime/10_permissions.js";
-import { setTimeout } from "ext:deno_web/02_timers.js";
+import { setTimeoutUnclamped } from "ext:deno_web/02_timers.js";
 import { assert } from "ext:deno_web/00_infra.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
@@ -50,7 +50,7 @@ function opSanitizerDelay() {
     hasSetOpSanitizerDelayMacrotask = true;
   }
   return new Promise((resolve) => {
-    setTimeout(() => {
+    setTimeoutUnclamped(() => {
       ArrayPrototypePush(opSanitizerDelayResolveQueue, resolve);
     }, 1);
   });

--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -5,7 +5,6 @@ const ops = core.ops;
 import { setExitHandler } from "ext:runtime/30_os.js";
 import { Console } from "ext:deno_console/01_console.js";
 import { serializePermissions } from "ext:runtime/10_permissions.js";
-import { setTimeoutUnclamped } from "ext:deno_web/02_timers.js";
 import { assert } from "ext:deno_web/00_infra.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
@@ -55,9 +54,7 @@ async function opSanitizerDelay() {
     await core.opAsync("op_void_async_deferred");
   }
   return new Promise((resolve) => {
-    ArrayPrototypePush(opSanitizerDelayResolveQueue, () => {
-      resolve();
-    });
+    ArrayPrototypePush(opSanitizerDelayResolveQueue, resolve);
   });
 }
 


### PR DESCRIPTION
This PR changes how op sanitizer is run to only wait for an event loop tick
if there are unresolved ops. In most cases tests are finishing okay and don't
have leaky ops (unless there are workers or timers) involved. In such case
we can skip waiting for the macrotask callback and lower the base overhead
from ~3ms to ~1ms.