### PR TITLE
build: remove redundant rerun-if-changed for compiler snapshot

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -224,18 +224,6 @@ mod ts {
         path_dts.join(format!("lib.{name}.d.ts")).display()
       );
     }
-    println!(
-      "cargo:rerun-if-changed={}",
-      cwd.join("tsc").join("00_typescript.js").display()
-    );
-    println!(
-      "cargo:rerun-if-changed={}",
-      cwd.join("tsc").join("99_main_compiler.js").display()
-    );
-    println!(
-      "cargo:rerun-if-changed={}",
-      cwd.join("js").join("40_testing.js").display()
-    );
 
     // create a copy of the vector that includes any op crate libs to be passed
     // to the JavaScript compiler to build into the snapshot


### PR DESCRIPTION
Not sure why `40_testing.js` is there. The other two `00_typescript.js` and `99_main_compiler.js` should be covered by `files_loaded_during_snapshot` at the end.

This helps with `__runtime_js_sources` wrt changing `40_testing.js`.