### PR TITLE
fix(ext/abort): trigger AbortSignal events in correct order

### DIFF
--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -86,15 +86,17 @@ class AbortSignal extends EventTarget {
       return;
     }
     this[abortReason] = reason;
-    if (this[abortAlgos] !== null) {
-      for (const algorithm of new SafeSetIterator(this[abortAlgos])) {
-        algorithm();
-      }
-      this[abortAlgos] = null;
-    }
+    const algos = this[abortAlgos];
+    this[abortAlgos] = null;
+
     const event = new Event("abort");
     setIsTrusted(event, true);
     this.dispatchEvent(event);
+    if (algos !== null) {
+      for (const algorithm of new SafeSetIterator(algos)) {
+        algorithm();
+      }
+    }
   }
 
   [remove](algorithm) {

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -4944,12 +4944,8 @@
       "abort": {
         "request.any.html": true,
         "request.any.worker.html": true,
-        "general.any.html": [
-          "Clone aborts with original controller"
-        ],
-        "general.any.worker.html": [
-          "Clone aborts with original controller"
-        ],
+        "general.any.html": true,
+        "general.any.worker.html": true,
         "cache.https.any.html": false,
         "cache.https.any.worker.html": false
       },


### PR DESCRIPTION
This PR ensures that the original signal event is fired before any dependent signal events.

---
The enabled tests fail on `main`:

```
assert_array_equals: Abort events fired in correct order expected property 0 to be 
"original-aborted" but got "clone-aborted" (expected array ["original-aborted", "clone-aborted"] 
got ["clone-aborted", "original-aborted"])
```