### PR TITLE
refactor(ext/fetch): Remove FetchRequestBodyResource from FetchHandler interface

### DIFF
--- a/ext/fetch/fs_fetch_handler.rs
+++ b/ext/fetch/fs_fetch_handler.rs
@@ -25,10 +25,7 @@ impl FetchHandler for FsFetchHandler {
     &self,
     _state: &mut OpState,
     url: Url,
-  ) -> (
-    CancelableResponseFuture,
-    Option<Rc<CancelHandle>>,
-  ) {
+  ) -> (CancelableResponseFuture, Option<Rc<CancelHandle>>) {
     let cancel_handle = CancelHandle::new_rc();
     let response_fut = async move {
       let path = url.to_file_path()?;

--- a/ext/fetch/fs_fetch_handler.rs
+++ b/ext/fetch/fs_fetch_handler.rs
@@ -27,7 +27,6 @@ impl FetchHandler for FsFetchHandler {
     url: Url,
   ) -> (
     CancelableResponseFuture,
-    Option<FetchRequestBodyResource>,
     Option<Rc<CancelHandle>>,
   ) {
     let cancel_handle = CancelHandle::new_rc();
@@ -49,6 +48,6 @@ impl FetchHandler for FsFetchHandler {
     .or_cancel(&cancel_handle)
     .boxed_local();
 
-    (response_fut, None, Some(cancel_handle))
+    (response_fut, Some(cancel_handle))
   }
 }

--- a/ext/fetch/fs_fetch_handler.rs
+++ b/ext/fetch/fs_fetch_handler.rs
@@ -3,7 +3,6 @@
 use crate::CancelHandle;
 use crate::CancelableResponseFuture;
 use crate::FetchHandler;
-use crate::FetchRequestBodyResource;
 
 use deno_core::error::type_error;
 use deno_core::futures::FutureExt;

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -142,10 +142,7 @@ pub trait FetchHandler: dyn_clone::DynClone {
     &self,
     state: &mut OpState,
     url: Url,
-  ) -> (
-    CancelableResponseFuture,
-    Option<Rc<CancelHandle>>,
-  );
+  ) -> (CancelableResponseFuture, Option<Rc<CancelHandle>>);
 }
 
 dyn_clone::clone_trait_object!(FetchHandler);
@@ -159,10 +156,7 @@ impl FetchHandler for DefaultFileFetchHandler {
     &self,
     _state: &mut OpState,
     _url: Url,
-  ) -> (
-    CancelableResponseFuture,
-    Option<Rc<CancelHandle>>,
-  ) {
+  ) -> (CancelableResponseFuture, Option<Rc<CancelHandle>>) {
     let fut = async move {
       Ok(Err(type_error(
         "NetworkError when attempting to fetch resource.",


### PR DESCRIPTION
This is unused and will allow us to remove `FetchRequestBodyResource` in a future PR.