### PR TITLE
perf(ext/headers): use .push loop instead of spread operator

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -28,7 +28,6 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeSplice,
   ArrayPrototypeFilter,
-  ArrayPrototypeConcat,
   ObjectEntries,
   ObjectHasOwn,
   RegExpPrototypeExec,
@@ -262,8 +261,13 @@ class Headers {
       }
     }
 
+    const entries = ObjectEntries(headers);
+    for (let i = 0; i < cookies.length; ++i) {
+      ArrayPrototypePush(entries, cookies[i]);
+    }
+
     return ArrayPrototypeSort(
-      ArrayPrototypeConcat(ObjectEntries(headers), cookies),
+      entries,
       (a, b) => {
         const akey = a[0];
         const bkey = b[0];

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -28,10 +28,10 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeSplice,
   ArrayPrototypeFilter,
+  ArrayPrototypeConcat,
   ObjectEntries,
   ObjectHasOwn,
   RegExpPrototypeExec,
-  SafeArrayIterator,
   SafeMap,
   MapPrototypeGet,
   MapPrototypeHas,
@@ -263,10 +263,7 @@ class Headers {
     }
 
     return ArrayPrototypeSort(
-      [
-        ...new SafeArrayIterator(ObjectEntries(headers)),
-        ...new SafeArrayIterator(cookies),
-      ],
+      ArrayPrototypeConcat(ObjectEntries(headers), cookies),
       (a, b) => {
         const akey = a[0];
         const bkey = b[0];


### PR DESCRIPTION
This PR slightly improves performance of `Header` iterator by using `.concat` instead of spread operator.

**This patch**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.0 (x86_64-unknown-linux-gnu)

benchmark             time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------------- -----------------------------
Headers iterator       1.49 µs/iter     669,569.7     (1.48 µs … 1.56 µs)    1.5 µs   1.56 µs   1.56 µs
```

**Main**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.0 (x86_64-unknown-linux-gnu)

benchmark             time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------------- -----------------------------
Headers iterator       1.62 µs/iter     617,624.9     (1.59 µs … 1.66 µs)   1.63 µs   1.66 µs   1.66 µs
```

```js
const headers = new Headers({
  "Content-Type": "application/json",
  "Date": "Wed, 09 Aug 2023 11:37:57 GMT",
});

Deno.bench("Headers iterator", () => {
  const i = [...headers];
});
