### PR TITLE
chore(test_util): Increate pty timeout to 15s to avoid flakes

### DIFF
--- a/test_util/src/pty.rs
+++ b/test_util/src/pty.rs
@@ -181,7 +181,7 @@ impl Pty {
     mut condition: impl FnMut(&mut Self) -> bool,
   ) {
     let timeout_time =
-      Instant::now().checked_add(Duration::from_secs(5)).unwrap();
+      Instant::now().checked_add(Duration::from_secs(15)).unwrap();
     while Instant::now() < timeout_time {
       self.fill_more_bytes();
       if condition(self) {


### PR DESCRIPTION
Mac builds are occasionally flaking out on these.