### PR TITLE
fix(node): don't print warning on process.dlopen.flags

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -292,11 +292,10 @@ function _kill(pid: number, sig: number): number {
   }
 }
 
-// TODO(bartlomieju): flags is currently not supported.
-export function dlopen(module, filename, flags) {
-  if (typeof flags !== "undefined") {
-    warnNotImplemented("process.dlopen doesn't support 'flags' argument");
-  }
+export function dlopen(module, filename, _flags) {
+  // NOTE(bartlomieju): _flags is currently ignored, but we don't warn for it
+  // as it makes DX bad, even though it might not be needed:
+  // https://github.com/denoland/deno/issues/20075
   Module._extensions[".node"](module, filename);
   return module;
 }

--- a/test_napi/common.js
+++ b/test_napi/common.js
@@ -21,6 +21,8 @@ export function loadTestLibrary() {
 
   // Internal, used in ext/node
   const module = {};
-  process.dlopen(module, specifier);
+  // Pass some flag, it should be ignored, but make sure it doesn't print
+  // warnings.
+  process.dlopen(module, specifier, 0);
   return module.exports;
 }


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/20075