### PR TITLE
chore: deno_core -> 0.202.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.201.0"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ff7b3b7d4816823b1f7c634bd0fe8e1a2a8f267ad2abd6f3f2f154ce94c543"
+checksum = "e9d4f3ad9c2861e0bb8745e1f228aaee04782a9ab6a3c3bbb887e60d7faf087a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edb529affdca4df63d1944da504222fb258f945acb82f9f0a5d482e463e3f1d"
+checksum = "abb6a1ceabfbab1c29b32872e68ec994d393b58ccdf12a835d150199555496f3"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4474,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ae4c921323143d916329b179df58f47b7ed614dee2b5baa6d60360179bc666"
+checksum = "3fa7b3ecd650d790ff8781402d0704d35a2f51c3bec87fe92d43eea6d371f05d"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.200.0"
+version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ba264b90ceb6e95b39d82e674d8ecae86ca012f900338ea50d1a077d9d75fd"
+checksum = "d9ff7b3b7d4816823b1f7c634bd0fe8e1a2a8f267ad2abd6f3f2f154ce94c543"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd1c83b1fd465ee0156f2917c9af9ca09fe2bf54052a2cae1a8dcbc7b89aefc"
+checksum = "3edb529affdca4df63d1944da504222fb258f945acb82f9f0a5d482e463e3f1d"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4474,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309b3060a9627882514f3a3ce3cc08ceb347a76aeeadc58f138c3f189cf88b71"
+checksum = "66ae4c921323143d916329b179df58f47b7ed614dee2b5baa6d60360179bc666"
 dependencies = [
  "bytes",
  "derive_more",
@@ -5903,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.74.3"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eedac634b8dd39b889c5b62349cbc55913780226239166435c5cf66771792ea"
+checksum = "f9be435abe79a8427b0969f1ac0a3c0e91644235f68a3de5da4a27ec69666985"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ repository = "https://github.com/denoland/deno"
 v8 = { version = "0.74.1", default-features = false }
 deno_ast = { version = "0.27.0", features = ["transpiling"] }
 
-deno_core = "0.200.0"
+deno_core = "0.201.0"
 
 deno_runtime = { version = "0.123.0", path = "./runtime" }
 napi_sym = { version = "0.45.0", path = "./cli/napi/sym" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/denoland/deno"
 [workspace.dependencies]
 deno_ast = { version = "0.27.0", features = ["transpiling"] }
 
-deno_core = "0.201.0"
+deno_core = "0.202.0"
 
 deno_runtime = { version = "0.123.0", path = "./runtime" }
 napi_sym = { version = "0.45.0", path = "./cli/napi/sym" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
-v8 = { version = "0.74.1", default-features = false }
 deno_ast = { version = "0.27.0", features = ["transpiling"] }
 
 deno_core = "0.201.0"

--- a/cli/tests/testdata/node/test.out
+++ b/cli/tests/testdata/node/test.out
@@ -147,7 +147,7 @@ error: Error: rejected from reject fail
     at [WILDCARD]
 
 ./node/test.js (uncaught error)
-error: Error: rejected from unhandled rejection fail
+error: (in promise) Error: rejected from unhandled rejection fail
   Promise.reject(new Error("rejected from unhandled rejection fail"));
                  ^
     at [WILDCARD]

--- a/cli/tests/testdata/run/heapstats.js.out
+++ b/cli/tests/testdata/run/heapstats.js.out
@@ -1,2 +1,2 @@
-Allocated: 8MB
-Freed: -8MB
+Allocated: 4MB
+Freed: -4MB

--- a/ext/io/fs.rs
+++ b/ext/io/fs.rs
@@ -170,14 +170,10 @@ impl FsStat {
 pub trait File {
   fn read_sync(self: Rc<Self>, buf: &mut [u8]) -> FsResult<usize>;
   async fn read(self: Rc<Self>, limit: usize) -> FsResult<BufView> {
-    let vec = vec![0; limit];
-    let buf = BufMutView::from(vec);
-    let (nread, buf) = self.read_byob(buf).await?;
-    let mut vec = buf.unwrap_vec();
-    if vec.len() != nread {
-      vec.truncate(nread);
-    }
-    Ok(BufView::from(vec))
+    let buf = BufMutView::new(limit);
+    let (nread, mut buf) = self.read_byob(buf).await?;
+    buf.truncate(nread);
+    Ok(buf.into_view())
   }
   async fn read_byob(
     self: Rc<Self>,

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -2807,8 +2807,12 @@
       },
       "class-string-interface.any.html": true,
       "class-string-interface.any.worker.html": true,
-      "class-string-iterator-prototype-object.any.html": true,
-      "class-string-iterator-prototype-object.any.worker.html": true,
+      "class-string-iterator-prototype-object.any.html": [
+        "Object.prototype.toString applied after deleting @@toStringTag"
+      ],
+      "class-string-iterator-prototype-object.any.worker.html": [
+        "Object.prototype.toString applied after deleting @@toStringTag"
+      ],
       "class-string-named-properties-object.window.html": false,
       "global-immutable-prototype.any.html": [
         "Setting to a different prototype"


### PR DESCRIPTION
 - Patches from `deno_core` work upstream
 - Removed explicit v8 dep from `Cargo.toml`
 - Pointer compression enabled - fixes #18935