### PR TITLE
perf(ext/request): optimize Request constructor

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -366,20 +366,16 @@ class Request {
     this[_headers] = headersFromHeaderList(request.headerList, "request");
 
     // 32.
-    if (ObjectKeys(init).length > 0) {
-      let headers = ArrayPrototypeSlice(
-        headerListFromHeaders(this[_headers]),
+    if (init.headers || ObjectKeys(init).length > 0) {
+      const headerList = headerListFromHeaders(this[_headers]);
+      const headers = init.headers ?? ArrayPrototypeSlice(
+        headerList,
         0,
-        headerListFromHeaders(this[_headers]).length,
+        headerList.length,
       );
-      if (init.headers !== undefined) {
-        headers = init.headers;
+      if (headerList.length !== 0) {
+        ArrayPrototypeSplice(headerList, 0, headerList.length);
       }
-      ArrayPrototypeSplice(
-        headerListFromHeaders(this[_headers]),
-        0,
-        headerListFromHeaders(this[_headers]).length,
-      );
       fillHeaders(this[_headers], headers);
     }
 


### PR DESCRIPTION
This PR optimizes `Request` constructor when `init` is not empty. This path is also used by `fetch` when `options` argument is used
```js
fetch("https://deno.land", {
  method: "POST",
  body: 'land'
});
```

- Removed 3 extra calls to `headerListFromHeaders`
- Avoid `Object.keys` & `headerList` clone if `init.headers` is set
- Only empty `headersList` (`.splice`) if it's not already empty. 

## Benchmarks

**this patch**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark                    time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------------- -----------------------------
Request without headers       1.86 µs/iter     536,440.7     (1.67 µs … 2.76 µs)   1.89 µs   2.76 µs   2.76 µs
Request with headers          1.96 µs/iter     509,440.5     (1.83 µs … 2.17 µs)   1.99 µs   2.17 µs   2.17 µs
```

**main**

```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark                    time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------------- -----------------------------
Request without headers       1.96 µs/iter     510,201.5     (1.81 µs … 2.64 µs)      2 µs   2.64 µs   2.64 µs
Request with headers          2.03 µs/iter     493,526.6     (1.84 µs … 2.31 µs)   2.08 µs   2.31 µs   2.31 µs
```

```js
Deno.bench("Request without headers", () => {
  const r = new Request("https://deno.land", {
    method: "POST",
    body: '{"foo": "bar"}',
  });
});

Deno.bench("Request with headers", () => {
  const r = new Request("https://deno.land", {
    method: "POST",
    body: '{"foo": "bar"}',
    headers: {
      "Content-Type": "application/json",
    },
  });
});
```