### PR TITLE
perf(ext/node): cache `IncomingMessageForServer.headers`

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1438,6 +1438,7 @@ export class ServerResponse extends NodeWritable {
 // TODO(@AaronO): optimize
 export class IncomingMessageForServer extends NodeReadable {
   #req: Request;
+  #headers: Record<string, string>;
   url: string;
   method: string;
   // Polyfills part of net.Socket object.
@@ -1484,7 +1485,10 @@ export class IncomingMessageForServer extends NodeReadable {
   }
 
   get headers() {
-    return Object.fromEntries(this.#req.headers.entries());
+    if (!this.#headers) {
+      this.#headers = Object.fromEntries(this.#req.headers.entries());
+    }
+    return this.#headers;
   }
 
   get upgrade(): boolean {


### PR DESCRIPTION
This PR adds caching to node's `req.headers`

```js
import express from "npm:express";
const app = express();

app.get("/", function (req, res) {
  const ua = req.header("User-Agent");
  const auth = req.header("Authorization");
  const type = req.header("Content-Type");
  const ip = req.header("X-Forwarded-For");
  res.end();
});

app.listen(3000);
```

**this PR**
```
wrk -d 10s --latency http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   155.64us  152.14us   5.74ms   97.39%
    Req/Sec    35.00k     1.97k   39.10k    80.69%
  Latency Distribution
     50%  123.00us
     75%  172.00us
     90%  214.00us
     99%  563.00us
  703420 requests in 10.10s, 50.31MB read
Requests/sec:  69648.45
Transfer/sec:      4.98MB
```

**main**
```
wrk -d 10s --latency http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   217.95us  786.89us  26.26ms   98.23%
    Req/Sec    32.32k     2.54k   37.19k    87.13%
  Latency Distribution
     50%  130.00us
     75%  191.00us
     90%  232.00us
     99%    1.88ms
  649411 requests in 10.10s, 46.45MB read
Requests/sec:  64300.44
Transfer/sec:      4.60MB
```