### PR TITLE
perf(ext/node): optimize http headers

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -508,6 +508,14 @@ function guardFromHeaders(headers) {
   return headers[_guard];
 }
 
+/**
+ * @param {Headers} headers
+ * @returns {[string, string][]}
+ */
+function headersEntries(headers) {
+  return headers[_iterableHeaders];
+}
+
 export {
   fillHeaders,
   getDecodeSplitHeader,
@@ -515,5 +523,6 @@ export {
   guardFromHeaders,
   headerListFromHeaders,
   Headers,
+  headersEntries,
   headersFromHeaderList,
 };

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -55,6 +55,7 @@ import {
 import { getTimerDuration } from "ext:deno_node/internal/timers.mjs";
 import { serve, upgradeHttpRaw } from "ext:deno_http/00_serve.js";
 import { createHttpClient } from "ext:deno_fetch/22_http_client.js";
+import { headersEntries } from "ext:deno_fetch/20_headers.js";
 import { timerId } from "ext:deno_web/03_abort_signal.js";
 import { clearTimeout as webClearTimeout } from "ext:deno_web/02_timers.js";
 import { TcpConn } from "ext:deno_net/01_net.js";
@@ -1486,7 +1487,12 @@ export class IncomingMessageForServer extends NodeReadable {
 
   get headers() {
     if (!this.#headers) {
-      this.#headers = Object.fromEntries(this.#req.headers.entries());
+      this.#headers = {};
+      const entries = headersEntries(this.#req.headers);
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        this.#headers[entry[0]] = entry[1];
+      }
     }
     return this.#headers;
   }


### PR DESCRIPTION
This PR optimizes Node's `IncomingMessageForServer.headers` by replacing `Object.fromEntries()` with a loop and `headers.entries` with `headersEntries` which returns the internal array directly instead of an iterator

## Benchmarks

Using `wrk` with 5 headers

```
wrk -d 10s --latency -H "X-Deno: true" -H "Accept: application/json" -H "X-Foo: bar" -H "User-Agent: wrk" -H "Accept-Encoding: gzip, br" http://127.0.0.1:3000
```

**this PR**

```
Running 10s test @ http://127.0.0.1:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   167.53us  136.89us   2.75ms   97.33%
    Req/Sec    31.98k     1.38k   36.39k    70.30%
  Latency Distribution
     50%  134.00us
     75%  191.00us
     90%  234.00us
     99%  544.00us
  642548 requests in 10.10s, 45.96MB read
Requests/sec:  63620.36
Transfer/sec:      4.55MB
```

**main**

```
Running 10s test @ http://127.0.0.1:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   181.31us  132.54us   3.79ms   97.13%
    Req/Sec    29.21k     1.45k   32.93k    79.21%
  Latency Distribution
     50%  148.00us
     75%  198.00us
     90%  261.00us
     99%  545.00us
  586939 requests in 10.10s, 41.98MB read
Requests/sec:  58114.01
Transfer/sec:      4.16MB
```

```js
import express from "npm:express";

const app = express();
app.get("/", function (req, res) {
  req.headers;
  res.end();
});
app.listen(3000);
```