### PR TITLE
perf(ext/urlpattern): optimize URLPattern.exec

### DIFF
--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -36,6 +36,16 @@ const _components = Symbol("components");
  * @property {Component} search
  * @property {Component} hash
  */
+const COMPONENTS_KEYS = [
+  "protocol",
+  "username",
+  "password",
+  "hostname",
+  "port",
+  "pathname",
+  "search",
+  "hash",
+];
 
 /**
  * @typedef Component
@@ -45,7 +55,6 @@ const _components = Symbol("components");
  */
 
 class URLPattern {
-  #keys;
   /** @type {Components} */
   [_components];
 
@@ -64,9 +73,8 @@ class URLPattern {
 
     const components = ops.op_urlpattern_parse(input, baseURL);
 
-    this.#keys = ObjectKeys(components);
-    for (let i = 0; i < this.#keys.length; ++i) {
-      const key = this.#keys[i];
+    for (let i = 0; i < COMPONENTS_KEYS.length; ++i) {
+      const key = COMPONENTS_KEYS[i];
       try {
         components[key].regexp = new SafeRegExp(
           components[key].regexpString,
@@ -146,8 +154,8 @@ class URLPattern {
 
     const values = res[0];
 
-    for (let i = 0; i < this.#keys.length; ++i) {
-      const key = this.#keys[i];
+    for (let i = 0; i < COMPONENTS_KEYS.length; ++i) {
+      const key = COMPONENTS_KEYS[i];
       if (!RegExpPrototypeTest(this[_components][key].regexp, values[key])) {
         return false;
       }
@@ -186,8 +194,8 @@ class URLPattern {
     /** @type {URLPatternResult} */
     const result = { inputs };
 
-    for (let i = 0; i < this.#keys.length; ++i) {
-      const key = this.#keys[i];
+    for (let i = 0; i < COMPONENTS_KEYS.length; ++i) {
+      const key = COMPONENTS_KEYS[i];
       /** @type {Component} */
       const component = this[_components][key];
       const input = values[key];

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -13,7 +13,6 @@ import * as webidl from "ext:deno_webidl/00_webidl.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
   ArrayPrototypePop,
-  ObjectKeys,
   RegExpPrototypeExec,
   RegExpPrototypeTest,
   SafeRegExp,


### PR DESCRIPTION
This PR optimizes `URLPattern.exec` 

- Use component keys from constructor instead of calling it on every `.exec`. AFAIK keys should always be `protocol`,`username`,`password`,`hostname`,`port`,`pathname`,`search`,`hash`. Haven't looked much into it but I think it's safe to define these outside the constructor as well.
- Add a fast path for `/^$/u` (default regexp) and empty input
- Replaced `ArrayPrototypeMap` & `ObjectFromEntries` with a `for` loop.


**this PR**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
exec 1          2.17 µs/iter     461,022.8     (2.14 µs … 2.27 µs)   2.18 µs   2.27 µs   2.27 µs
exec 2          4.13 µs/iter     242,173.4     (4.08 µs … 4.27 µs)   4.15 µs   4.27 µs   4.27 µs
exec 3          2.55 µs/iter     391,508.1     (2.53 µs … 2.68 µs)   2.56 µs   2.68 µs   2.68 µs
```

**main**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
exec 1          2.45 µs/iter     408,092.4     (2.41 µs … 2.55 µs)   2.46 µs   2.55 µs   2.55 µs
exec 2          4.41 µs/iter     226,706.0   (3.49 µs … 399.56 µs)   4.39 µs   5.49 µs   6.07 µs
exec 3          2.99 µs/iter     334,833.4     (2.94 µs … 3.21 µs)   2.99 µs   3.21 µs   3.21 µs
```