### PR TITLE
perf(ext/event): replace ReflectHas with object lookup

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -31,7 +31,6 @@ const {
   ObjectGetOwnPropertyDescriptor,
   ObjectPrototypeIsPrototypeOf,
   ReflectDefineProperty,
-  ReflectHas,
   SafeArrayIterator,
   SafeMap,
   StringPrototypeStartsWith,
@@ -113,7 +112,7 @@ function setStopImmediatePropagation(
 function hasRelatedTarget(
   event,
 ) {
-  return ReflectHas(event, "relatedTarget");
+  return !!event.relatedTarget;
 }
 
 const isTrusted = ObjectGetOwnPropertyDescriptor({
@@ -501,9 +500,12 @@ function isShadowRoot(nodeImpl) {
 }
 
 function isSlottable(
-  nodeImpl,
+  /* nodeImpl, */
 ) {
-  return Boolean(isNode(nodeImpl) && ReflectHas(nodeImpl, "assignedSlot"));
+  // TODO(marcosc90) currently there aren't any slottables nodes
+  // https://dom.spec.whatwg.org/#concept-slotable
+  // return isNode(nodeImpl) && ReflectHas(nodeImpl, "assignedSlot");
+  return false;
 }
 
 // DOM Logic functions
@@ -972,7 +974,7 @@ class EventTarget {
 
     const { listeners } = self[eventTargetData];
 
-    if (!(ReflectHas(listeners, type))) {
+    if (!listeners[type]) {
       listeners[type] = [];
     }
 
@@ -1020,7 +1022,7 @@ class EventTarget {
     );
 
     const { listeners } = self[eventTargetData];
-    if (callback !== null && ReflectHas(listeners, type)) {
+    if (callback !== null && listeners[type]) {
       listeners[type] = ArrayPrototypeFilter(
         listeners[type],
         (listener) => listener.callback !== callback,
@@ -1069,7 +1071,7 @@ class EventTarget {
     }
 
     const { listeners } = self[eventTargetData];
-    if (!ReflectHas(listeners, event.type)) {
+    if (!listeners[event.type]) {
       setTarget(event, this);
       return true;
     }

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -107,14 +107,6 @@ function setStopImmediatePropagation(
   event[_stopImmediatePropagationFlag] = value;
 }
 
-// Type guards that widen the event type
-
-function hasRelatedTarget(
-  event,
-) {
-  return !!event.relatedTarget;
-}
-
 const isTrusted = ObjectGetOwnPropertyDescriptor({
   get isTrusted() {
     return this[_isTrusted];
@@ -548,9 +540,7 @@ function dispatch(
   setDispatched(eventImpl, true);
 
   targetOverride = targetOverride ?? targetImpl;
-  const eventRelatedTarget = hasRelatedTarget(eventImpl)
-    ? eventImpl.relatedTarget
-    : null;
+  const eventRelatedTarget = eventImpl.relatedTarget;
   let relatedTarget = retarget(eventRelatedTarget, targetImpl);
 
   if (targetImpl !== relatedTarget || targetImpl === eventRelatedTarget) {


### PR DESCRIPTION
This PR optimizes event dispatch by replacing `ReflectHas` with object lookup. I also made `isSlottable` return `false` since AFAIK there aren't any slottables nodes in Deno

**This PR**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark            time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------------- -----------------------------
event dispatch       80.46 ns/iter  12,428,739.4  (73.84 ns … 120.07 ns)  81.82 ns  86.34 ns  91.18 ns
```

**main**

```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark            time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------------- -----------------------------
event dispatch      102.66 ns/iter   9,741,319.6  (96.66 ns … 132.88 ns) 104.18 ns 114.58 ns 118.45 ns
```

```js
const tg = new EventTarget();
const ev = new Event("foo");

const listener = () => {};
tg.addEventListener("foo", listener);

Deno.bench("event dispatch ", () => {
  tg.dispatchEvent(ev);
});
```

towards https://github.com/denoland/deno/issues/20167
