### PR TITLE
fix(cli): handle missing `now` field in cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd2de39c0d15e801f5968334998336c159ac7e335f8acddd781982777195152"
+checksum = "85e4ee308992ed5bd4977d251c0ce4bdfa4cc59efa4ee93d17ebe46eae1e4563"
 dependencies = [
  "anyhow",
  "deno_media_type",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,7 +46,7 @@ winres.workspace = true
 
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
-deno_cache_dir = "=0.5.0"
+deno_cache_dir = "=0.5.2"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "=0.64.0"
 deno_emit = "=0.25.0"


### PR DESCRIPTION
Fixes this error message:

```
error: missing field `now` at line 32 column 1
```

This would occur if someone used an old version of the deno_cache library to cache information in the cache then tried to load it with the latest CLI. Regression in the last patch when migrating to the deno_cache_dir crate.

Tests are in the deno_cache repo.