### PR TITLE
perf(ext/event): optimize addEventListener options converter

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -897,8 +897,12 @@ function getDefaultTargetData() {
 }
 
 function addEventListenerOptionsConverter(V, prefix) {
+  if (webidl.type(V) !== "Object") {
+    return { capture: true, passive: false, once: false, signal: undefined };
+  }
+
   const options = {
-    capture: webidl.type(V) !== "Object" ? !!V : !!V.capture,
+    capture: !!V.capture,
     once: !!V?.once,
     passive: !!V?.passive,
   };

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -903,11 +903,11 @@ function addEventListenerOptionsConverter(V, prefix) {
 
   const options = {
     capture: !!V.capture,
-    once: !!V?.once,
-    passive: !!V?.passive,
+    once: !!V.once,
+    passive: !!V.passive,
   };
 
-  const signal = V?.signal;
+  const signal = V.signal;
   if (signal !== undefined) {
     options.signal = webidl.converters.AbortSignal(
       signal,

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -898,7 +898,7 @@ function getDefaultTargetData() {
 
 function addEventListenerOptionsConverter(V, prefix) {
   if (webidl.type(V) !== "Object") {
-    return { capture: true, passive: false, once: false, signal: undefined };
+    return { capture: !!V, once: false, passive: false };
   }
 
   const options = {

--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -903,9 +903,10 @@ function addEventListenerOptionsConverter(V, prefix) {
     passive: !!V?.passive,
   };
 
-  if (V?.signal !== undefined) {
+  const signal = V?.signal;
+  if (signal !== undefined) {
     options.signal = webidl.converters.AbortSignal(
-      V.signal,
+      signal,
       prefix,
       "'signal' of 'AddEventListenerOptions' (Argument 3)",
     );


### PR DESCRIPTION
This PR optimizes `addEventListener` by replacing `webidl.createDictionaryConverter("AddEventListenerOptions", ...)` with a custom options parsing function to avoid the overhead of `webidl` methods

**this PR**

```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark                                           time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------------------------------------------- -----------------------------
addEventListener options converter (undefined)       4.87 ns/iter 205,248,660.8     (4.7 ns … 13.18 ns)   4.91 ns    5.4 ns    5.6 ns
addEventListener options converter (signal)         13.02 ns/iter  76,782,031.2   (11.74 ns … 18.84 ns)  13.08 ns  16.22 ns  16.57 ns
```

**main**
```
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
runtime: deno 1.36.1 (x86_64-unknown-linux-gnu)

benchmark                                           time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------------------------------------------- -----------------------------
addEventListener options converter (undefined)     108.36 ns/iter   9,228,688.6  (103.5 ns … 129.88 ns) 109.69 ns 115.61 ns 125.28 ns
addEventListener options converter (signal)        134.03 ns/iter   7,460,878.1 (129.14 ns … 144.54 ns) 135.68 ns 141.13 ns  144.1 ns
```

```js
const tg = new EventTarget();
const signal = new AbortController().signal;

Deno.bench("addEventListener options converter (undefined)", () => {
  tg.addEventListener("foo", null); // null callback to only bench options converter
});

Deno.bench("addEventListener options converter (signal)", () => {
  tg.addEventListener("foo", null, { signal });
});
```

Towards https://github.com/denoland/deno/issues/20167