### PR TITLE
ci: try to fix flaky stdio_streams_are_locked_in_permission_prompt

### DIFF
--- a/cli/tests/testdata/run/stdio_streams_are_locked_in_permission_prompt/worker.js
+++ b/cli/tests/testdata/run/stdio_streams_are_locked_in_permission_prompt/worker.js
@@ -1,1 +1,3 @@
-console.log("Are you sure you want to continue?");
+setTimeout(() => {
+  console.log("Are you sure you want to continue?");
+}, 10); // ensure we don't output too quickly before the permission prompt


### PR DESCRIPTION
The "Are you sure you want to continue" was outputting before the `await Deno.writeTextFile` could run.

```
new Worker(url, *** type: \"module\" ***); await Deno.writeTextFile(\"./text.txt\", \"some code\");\r\u***1b***[11C\u***1b***[?2004l\r\nAre you sure you want to continue?\r\n┌ ⚠\u***fe0f***  Deno requests write access to \"./text.txt\".\r\n├ Requested by `Deno.writeFile()` API.\r\n├ Run again with --allow-write to bypass this prompt.\r\n└ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all write permissions) > invalid\r\n\u***1b***[1A\u***1b***[0J└ Unrecognized option. Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all write permissions) > y\r\n\u***1b***[4A\u***1b***[0J✅ Granted write access to \"./text.txt\".\r\nundefined\r\n\u***1b***[?2004h\r\u***1b***[K> \r\u***1b***[2C
```

The attempt to make it less flaky is to add a slight delay on outputting the "Are you sure you want to continue?" prompt.