### PR TITLE
feat(ext/ffi): Improve FFI types

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -126,21 +126,6 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * A utility type conversion for foreign symbol parameters and unsafe callback
-   * return types.
-   *
-   * @category FFI
-   */
-  type ToNativeTypeMap =
-    & Record<NativeNumberType, number>
-    & Record<NativeBigIntType, number | bigint>
-    & Record<NativeBooleanType, boolean>
-    & Record<NativePointerType, PointerValue>
-    & Record<NativeFunctionType, PointerValue>
-    & Record<NativeBufferType, BufferSource | null>;
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
    * Type conversion for foreign symbol parameters and unsafe callback return
    * types.
    *
@@ -148,15 +133,13 @@ declare namespace Deno {
    */
   type ToNativeType<T extends NativeType = NativeType> = T extends
     NativeStructType ? BufferSource
-    : ToNativeTypeMap[Exclude<T, NativeStructType>];
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
-   * A utility type for conversion for unsafe callback return types.
-   *
-   * @category FFI
-   */
-  type ToNativeResultTypeMap = ToNativeTypeMap & Record<NativeVoidType, void>;
+    : T extends NativeNumberType ? number
+    : T extends NativeBigIntType ? number | bigint
+    : T extends NativeBooleanType ? boolean
+    : T extends NativePointerType ? PointerValue
+    : T extends NativeFunctionType ? PointerValue
+    : T extends NativeBufferType ? BufferSource | null
+    : never;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
@@ -166,7 +149,14 @@ declare namespace Deno {
    */
   type ToNativeResultType<T extends NativeResultType = NativeResultType> =
     T extends NativeStructType ? BufferSource
-      : ToNativeResultTypeMap[Exclude<T, NativeStructType>];
+      : T extends NativeNumberType ? number
+      : T extends NativeBigIntType ? number | bigint
+      : T extends NativeBooleanType ? boolean
+      : T extends NativePointerType ? PointerValue
+      : T extends NativeFunctionType ? PointerValue
+      : T extends NativeBufferType ? BufferSource | null
+      : T extends NativeVoidType ? void
+      : never;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
@@ -186,21 +176,6 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * A utility type for conversion of foreign symbol return types and unsafe
-   * callback parameters.
-   *
-   * @category FFI
-   */
-  type FromNativeTypeMap =
-    & Record<NativeNumberType, number>
-    & Record<NativeBigIntType, number | bigint>
-    & Record<NativeBooleanType, boolean>
-    & Record<NativePointerType, PointerValue>
-    & Record<NativeBufferType, PointerValue>
-    & Record<NativeFunctionType, PointerValue>;
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
    * Type conversion for foreign symbol return types and unsafe callback
    * parameters.
    *
@@ -208,17 +183,13 @@ declare namespace Deno {
    */
   type FromNativeType<T extends NativeType = NativeType> = T extends
     NativeStructType ? Uint8Array
-    : FromNativeTypeMap[Exclude<T, NativeStructType>];
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
-   * A utility type for conversion for foreign symbol return types.
-   *
-   * @category FFI
-   */
-  type FromNativeResultTypeMap =
-    & FromNativeTypeMap
-    & Record<NativeVoidType, void>;
+    : T extends NativeNumberType ? number
+    : T extends NativeBigIntType ? number | bigint
+    : T extends NativeBooleanType ? boolean
+    : T extends NativePointerType ? PointerValue
+    : T extends NativeBufferType ? PointerValue
+    : T extends NativeFunctionType ? PointerValue
+    : never;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
@@ -228,7 +199,14 @@ declare namespace Deno {
    */
   type FromNativeResultType<T extends NativeResultType = NativeResultType> =
     T extends NativeStructType ? Uint8Array
-      : FromNativeResultTypeMap[Exclude<T, NativeStructType>];
+      : T extends NativeNumberType ? number
+      : T extends NativeBigIntType ? number | bigint
+      : T extends NativeBooleanType ? boolean
+      : T extends NativePointerType ? PointerValue
+      : T extends NativeBufferType ? PointerValue
+      : T extends NativeFunctionType ? PointerValue
+      : T extends NativeVoidType ? void
+      : never;
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
@@ -356,16 +334,27 @@ declare namespace Deno {
 
   /** @category FFI */
   const brand: unique symbol;
-  /** @category FFI */
-  type PointerObject = { [brand]: unknown };
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * A non-null pointer, represented as an object
+   * at runtime. The object's prototype is `null`
+   * and cannot be changed. The object cannot be
+   * assigned to either and is thus entirely read-only.
+   *
+   * To interact with memory through a pointer use the
+   * {@linkcode UnsafePointerView} class. To create a
+   * pointer from an address or the get the address of
+   * a pointer use the static methods of the
+   * {@linkcode UnsafePointer} class.
+   *
+   * @category FFI
+   */
+  export type PointerObject = { [brand]: unknown };
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * Pointer type depends on the architecture and actual pointer value.
-   *
-   * On a 32 bit host system all pointer values are plain numbers. On a 64 bit
-   * host system pointer values are represented as numbers if the value is below
-   * `Number.MAX_SAFE_INTEGER`, otherwise they are provided as bigints.
+   * Pointers are represented either with a {@linkcode PointerObject}
+   * object or a `null` if the pointer is null.
    *
    * @category FFI
    */
@@ -373,8 +362,7 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * An unsafe pointer to a memory location for passing and returning pointers
-   * to and from the FFI.
+   * A collection of static functions for interacting with pointer objects.
    *
    * @category FFI
    */

--- a/test_ffi/tests/ffi_types.ts
+++ b/test_ffi/tests/ffi_types.ts
@@ -358,6 +358,13 @@ type AssertNotEqual<
   $ = [Equal<Expected, Got>] extends [true] ? never : Expected,
 > = never;
 
+declare const brand: unique symbol;
+const enum Enum {
+  Foo,
+  Bar,
+}
+type U8Enum = "u8" & { [brand]: Enum };
+
 type __Tests__ = [
   empty: AssertEqual<
     { symbols: Record<never, never>; close(): void },
@@ -440,6 +447,17 @@ type __Tests__ = [
     },
     Deno.DynamicLibrary<
       { foo: { parameters: []; result: "i32" } }
+    >
+  >,
+  extended_params: AssertEqual<
+    {
+      symbols: {
+        foo: (arg: number) => void;
+      };
+      close(): void;
+    },
+    Deno.DynamicLibrary<
+      { foo: { parameters: [U8Enum]; result: "void" } }
     >
   >,
 ];

--- a/test_ffi/tests/ffi_types.ts
+++ b/test_ffi/tests/ffi_types.ts
@@ -173,7 +173,7 @@ result4.then((_0: Deno.BufferSource) => {});
 result4.then((_1: null | Deno.UnsafePointer) => {});
 
 const fnptr = new Deno.UnsafeFnPointer(
-  {} as NonNullable<Deno.PointerValue>,
+  {} as Deno.PointerObject,
   {
     parameters: ["u32", "pointer"],
     result: "void",
@@ -358,12 +358,23 @@ type AssertNotEqual<
   $ = [Equal<Expected, Got>] extends [true] ? never : Expected,
 > = never;
 
-declare const brand: unique symbol;
-const enum Enum {
+const enum FooEnum {
   Foo,
   Bar,
 }
-type U8Enum = "u8" & { [brand]: Enum };
+const foo = "u8" as Deno.NativeU8Enum<FooEnum>;
+
+declare const brand: unique symbol;
+class MyPointerClass {}
+type MyPointer = Deno.PointerObject & { [brand]: MyPointerClass };
+const myPointer = "pointer" as Deno.NativeTypedPointer<MyPointer>;
+type MyFunctionDefinition = Deno.UnsafeCallbackDefinition<
+  [typeof foo, "u32"],
+  typeof myPointer
+>;
+const myFunction = "function" as Deno.NativeTypedFunction<
+  MyFunctionDefinition
+>;
 
 type __Tests__ = [
   empty: AssertEqual<
@@ -449,15 +460,70 @@ type __Tests__ = [
       { foo: { parameters: []; result: "i32" } }
     >
   >,
-  extended_params: AssertEqual<
+  enum_param: AssertEqual<
     {
       symbols: {
-        foo: (arg: number) => void;
+        foo: (arg: FooEnum) => void;
       };
       close(): void;
     },
     Deno.DynamicLibrary<
-      { foo: { parameters: [U8Enum]; result: "void" } }
+      { foo: { parameters: [typeof foo]; result: "void" } }
+    >
+  >,
+  enum_return: AssertEqual<
+    {
+      symbols: {
+        foo: () => FooEnum;
+      };
+      close(): void;
+    },
+    Deno.DynamicLibrary<
+      { foo: { parameters: []; result: typeof foo } }
+    >
+  >,
+  typed_pointer_param: AssertEqual<
+    {
+      symbols: {
+        foo: (arg: MyPointer | null) => void;
+      };
+      close(): void;
+    },
+    Deno.DynamicLibrary<
+      { foo: { parameters: [typeof myPointer]; result: "void" } }
+    >
+  >,
+  typed_pointer_return: AssertEqual<
+    {
+      symbols: {
+        foo: () => MyPointer | null;
+      };
+      close(): void;
+    },
+    Deno.DynamicLibrary<
+      { foo: { parameters: []; result: typeof myPointer } }
+    >
+  >,
+  typed_function_param: AssertEqual<
+    {
+      symbols: {
+        foo: (arg: Deno.PointerObject<MyFunctionDefinition> | null) => void;
+      };
+      close(): void;
+    },
+    Deno.DynamicLibrary<
+      { foo: { parameters: [typeof myFunction]; result: "void" } }
+    >
+  >,
+  typed_function_return: AssertEqual<
+    {
+      symbols: {
+        foo: () => Deno.PointerObject<MyFunctionDefinition> | null;
+      };
+      close(): void;
+    },
+    Deno.DynamicLibrary<
+      { foo: { parameters: []; result: typeof myFunction } }
     >
   >,
 ];


### PR DESCRIPTION
Few improvements to FFI types:
1. Export `PointerObject` for convenience. It's fairly commonly used in library code and thus should be exported.
2. Fix various comments around `PointerValue` and `UnsafePointer` and expand upon them to better reflect reality.
3. Instead of using a `Record<"value", type>[T]` for determining the type of an FFI symbol parameter use direct `T extends "value" ? type : never` comparison.

The last part enables smuggling extra information into the parameter and return value string declarations at the type level. eg. Instead of just `"u8"` the parameter can be `"u8" & { [brand]: T }` for some `T extends number`. That `T` can then be extracted from the parameter to form the TypeScript function's parameter or return value type. Essentially, this enables type-safe FFI!

The foremost use-cases for this are enums and pointer safety. These are implemented in the second commit which should enable, in a backwards compatible way, for pointer parameters to declare what sort of pointer they mean, functions to declare what the API definition of the native function is, and for numbers to declare what Enum they stand for (if any).