### PR TITLE
deps: add v8 workspace dependency back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
+v8 = { version = "0.75.0", default-features = false }
 deno_ast = { version = "0.28.0", features = ["transpiling"] }
 
 deno_core = "0.202.0"


### PR DESCRIPTION
this v8 workspace dependency got removed in #20135, which breaks [the homebrew build](https://github.com/Homebrew/homebrew-core/pull/140079), adding this explicit dependency back to unblock the downstream package manager builds.