### PR TITLE
fix: add missing `URL.canParse()` types

### DIFF
--- a/cli/tsc/dts/lib.dom.d.ts
+++ b/cli/tsc/dts/lib.dom.d.ts
@@ -22483,6 +22483,8 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL) */
     createObjectURL(obj: Blob | MediaSource): string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) */

--- a/cli/tsc/dts/lib.webworker.d.ts
+++ b/cli/tsc/dts/lib.webworker.d.ts
@@ -5559,6 +5559,8 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL) */
     createObjectURL(obj: Blob): string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) */


### PR DESCRIPTION
Reference: https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static