### PR TITLE
feat(lint): --rules print all rules

### DIFF
--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -207,11 +207,7 @@ pub fn print_rules_list(json: bool, maybe_rules_tags: Option<Vec<String>>) {
   let lint_rules = if maybe_rules_tags.is_none() {
     rules::get_all_rules()
   } else {
-    rules::get_filtered_rules(
-      maybe_rules_tags.or_else(|| Some(vec!["recommended".to_string()])),
-      None,
-      None,
-    )
+    rules::get_filtered_rules(maybe_rules_tags, None, None)
   };
 
   if json {

--- a/cli/tools/lint.rs
+++ b/cli/tools/lint.rs
@@ -228,13 +228,19 @@ pub fn print_rules_list(json: bool, maybe_rules_tags: Option<Vec<String>>) {
     // so use `println!` here instead of `info!`.
     println!("Available rules:");
     for rule in lint_rules.iter() {
-      print!(" - {}", rule.code());
+      print!(" - {}", colors::cyan(rule.code()));
       if rule.tags().is_empty() {
         println!();
       } else {
-        println!(" [{}]", rule.tags().join(", "))
+        println!(" [{}]", colors::gray(rule.tags().join(", ")))
       }
-      println!("   help: https://lint.deno.land/#{}", rule.code());
+      println!(
+        "{}",
+        colors::gray(format!(
+          "   help: https://lint.deno.land/#{}",
+          rule.code()
+        ))
+      );
       println!();
     }
   }


### PR DESCRIPTION
The motivation is If I'm using deno lint --rules, I want to see all the rules especially the one that have no tags, since the recommend ones are already active

This pr also prints the tags associated with the rule inline 

![image](https://github.com/denoland/deno/assets/22427111/99158390-ab11-46ae-97b9-5bbd771badae)

Side question: we can filter with --rules-tags, but what If I want to see only the rules with no tags (not possible currently)