### PR TITLE
feat(node): use i32 for priority_t on MacOS and {Free,Open}BSD

### DIFF
--- a/ext/node/ops/os.rs
+++ b/ext/node/ops/os.rs
@@ -60,7 +60,11 @@ mod priority {
   use libc::id_t;
   use libc::PRIO_PROCESS;
 
-  #[cfg(target_os = "macos")]
+  #[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd"
+  ))]
   #[allow(non_camel_case_types)]
   type priority_t = i32;
   #[cfg(target_os = "linux")]


### PR DESCRIPTION

Reference from the FreeBSD port
https://github.com/freebsd/freebsd-ports/blob/3afa24c6e301832f76304bb55f4e9ee72858c254/www/deno/files/patch-ext_node_ops_os.rs
