### PR TITLE
feat(http): upgradeWebSocketStream

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1936,6 +1936,65 @@ declare namespace Deno {
     /** The value of this unsigned 64-bit integer, represented as a bigint. */
     readonly value: bigint;
   }
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * The object that is returned from a {@linkcode Deno.upgradeWebSocketStream}
+   * request.
+   *
+   * @category Web Sockets */
+  export interface WebSocketStreamUpgrade {
+    /** The response object that represents the HTTP response to the client,
+     * which should be used to the {@linkcode RequestEvent} `.respondWith()` for
+     * the upgrade to be successful. */
+    response: Response;
+    /** The {@linkcode WebSocketStream} interface to communicate to the client
+     * via a web socket stream. */
+    stream: WebSocketStream;
+  }
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * Upgrade an incoming HTTP request to a WebSocketStream.
+   *
+   * Given a {@linkcode Request}, returns a pair of {@linkcode WebSocketStream}
+   * and {@linkcode Response} instances. The original request must be responded
+   * to with the returned response for the websocket upgrade to be successful.
+   *
+   * ```ts
+   * const conn = Deno.listen({ port: 80 });
+   * const httpConn = Deno.serveHttp(await conn.accept());
+   * const e = await httpConn.nextRequest();
+   * if (e) {
+   *   const { stream, response } = Deno.upgradeWebSocketStream(e.request);
+   *   handle(stream);
+   *   e.respondWith(response);
+   * }
+   *
+   * async function handle(stream: WebSocketStream) {
+   *   const { writable, readable } = await stream.connection;
+   *
+   *   const writer = writable.getWriter();
+   *   await writer.write("Hello World!");
+   *
+   *   for await (const message of readable) {
+   *     console.log(message);
+   *   }
+   * }
+   * ```
+   *
+   * If the request body is disturbed (read from) before the upgrade is
+   * completed, upgrading fails.
+   *
+   * This operation does not yet consume the request or open the websocket. This
+   * only happens once the returned response has been passed to `respondWith()`.
+   *
+   * @category Web Sockets
+   */
+  export function upgradeWebSocketStream(
+    request: Request,
+    options?: UpgradeWebSocketOptions,
+  ): WebSocketStreamUpgrade;
 }
 
 /** **UNSTABLE**: New API, yet to be vetted.

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -163,6 +163,7 @@ const denoNsUnstable = {
   createHttpClient: httpClient.createHttpClient,
   // TODO(bartlomieju): why is it needed?
   http,
+  upgradeWebSocketStream: http.upgradeWebSocketStream,
   dlopen: ffi.dlopen,
   UnsafeCallback: ffi.UnsafeCallback,
   UnsafePointer: ffi.UnsafePointer,


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/14064
Added unstable `upgradeWebSocketStream` to enable server-side `WebSocketStream` usage. I took some inspiration from https://github.com/denoland/deno/pull/16732, which seemed to have gone stale and had some issues. Idle timeout (ping interval) didn't work as `[_serverHandleIdleTimeout]` was never called, and op calls were outdated.