### PR TITLE
chore: fully remove atty dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,17 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto_impl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,7 +1407,6 @@ dependencies = [
 name = "deno_runtime"
 version = "0.125.0"
 dependencies = [
- "atty",
  "console_static_text",
  "deno_ast",
  "deno_broadcast_channel",
@@ -1943,12 +1931,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -2450,15 +2438,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ deno_napi = { version = "0.47.0", path = "./ext/napi" }
 aes = "=0.8.2"
 anyhow = "1.0.57"
 async-trait = "0.1.51"
-atty = "=0.2.14"
 base64 = "=0.13.1"
 bencher = "0.1"
 brotli = "3.3.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,7 +77,7 @@ dprint-plugin-json = "=0.17.4"
 dprint-plugin-markdown = "=0.15.3"
 dprint-plugin-typescript = "=0.86.2"
 encoding_rs.workspace = true
-env_logger = "=0.9.0"
+env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"
 fastwebsockets.workspace = true
 flate2.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -90,7 +90,6 @@ deno_websocket.workspace = true
 deno_webstorage.workspace = true
 fastwebsockets.workspace = true
 
-atty.workspace = true
 console_static_text.workspace = true
 dlopen.workspace = true
 encoding_rs.workspace = true


### PR DESCRIPTION
This fully removes the `atty` crate from deno by bumping `env_logger` and removing the now-unused `atty` dep for runtime.