### PR TITLE
perf(url): optimize URLPattern

### DIFF
--- a/bench.mjs
+++ b/bench.mjs
@@ -1,0 +1,10 @@
+const pattern = new URLPattern({ pathname: "/" });
+
+console.log(pattern.exec({ pathname: "/" }));
+
+Deno.bench({
+  name: "URLPattern",
+  fn() {
+    pattern.exec({ pathname: "/" });
+  },
+});

--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -10,6 +10,8 @@
 const core = globalThis.Deno.core;
 const ops = core.ops;
 import * as webidl from "ext:deno_webidl/00_webidl.js";
+import { parseMatchInput, processMatchInput } from "ext:deno_url/02_quirks.js";
+
 const primordials = globalThis.__bootstrap.primordials;
 const {
   ArrayPrototypePop,
@@ -177,21 +179,16 @@ class URLPattern {
       baseURL = webidl.converters.USVString(baseURL, prefix, "Argument 2");
     }
 
-    const res = ops.op_urlpattern_process_match_input(
+    const values = processMatchInput(
       input,
       baseURL,
     );
-    if (res === null) {
+    if (values === null) {
       return null;
     }
 
-    const { 0: values, 1: inputs } = res;
-    if (inputs[1] === null) {
-      ArrayPrototypePop(inputs);
-    }
-
     /** @type {URLPatternResult} */
-    const result = { inputs };
+    const result = { inputs: [""] };
 
     for (let i = 0; i < COMPONENTS_KEYS.length; ++i) {
       const key = COMPONENTS_KEYS[i];

--- a/ext/url/02_quirks.js
+++ b/ext/url/02_quirks.js
@@ -1,0 +1,85 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// @ts-check
+/// <reference path="../../core/internal.d.ts" />
+/// <reference path="../../core/lib.deno_core.d.ts" />
+/// <reference path="../webidl/internal.d.ts" />
+/// <reference path="./internal.d.ts" />
+/// <reference path="./lib.deno_url.d.ts" />
+
+const core = globalThis.Deno.core;
+const ops = core.ops;
+
+export function processMatchInput(input, baseURL) {
+  if (typeof input == "string") {
+    try {
+      return parseMatchInput(new URL(input));
+    } catch {
+      return null;
+    }
+  }
+
+  return processInit(parseMatchInput(input), baseURL, input);
+
+  // TODO: input init
+}
+
+export function parseMatchInput(input) {
+  return {
+    protocol: input.protocol,
+    username: input.username,
+    password: input.password,
+    hostname: input.hostname,
+    port: input.port,
+    pathname: input.pathname,
+    search: input.search,
+    hash: input.hash,
+  };
+}
+
+// https://wicg.github.io/urlpattern/#process-a-urlpatterninit
+function processInit(init, baseURL, i) {
+  let result = {
+    protocol: i.protocol || "",
+    username: i.username || "",
+    password: i.password || "",
+    hostname: i.hostname || "",
+    port: i.port || "",
+    pathname: i.pathname || "",
+    search: i.search || "",
+    hash: i.hash || "",
+  };
+
+  // TODO: other components.
+
+  if (init.pathname !== undefined) {
+    // TODO: base URL
+    result.pathname = processPathnameForInit(init.pathname, i.protocol);
+  }
+
+  return result;
+}
+
+// https://wicg.github.io/urlpattern/#process-pathname-for-init
+function processPathnameForInit(pathname, protocol) {
+  if (!protocol) {
+    return canonicalizeOpaquePathname(pathname);
+  }
+
+  // TODO
+}
+
+// https://wicg.github.io/urlpattern/#canonicalize-an-opaque-pathname
+function canonicalizeOpaquePathname(pathname) {
+  if (pathname === "") {
+    return pathname;
+  }
+
+  if (pathname === "/") {
+    return pathname;
+  }
+
+  let url = new URL("http://example");
+  url.pathname = pathname;
+  return url.pathname;
+}

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -28,7 +28,7 @@ deno_core::extension!(
     op_urlpattern_parse,
     op_urlpattern_process_match_input
   ],
-  esm = ["00_url.js", "01_urlpattern.js"],
+  esm = ["00_url.js", "01_urlpattern.js", "02_quirks.js"],
 );
 
 /// Parse `href` with a `base_href`. Fills the out `buf` with URL components.


### PR DESCRIPTION
Currently a POC. Rewrite `urlpattern::quirks` in JS to avoid Rust<->JS trips.

2.5x faster in simple pathname matching.

```
benchmark       time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------- -----------------------------
URLPattern      3.11 µs/iter      321,443.2      (3.05 µs … 3.49 µs)    3.11 µs   3.49 µs   3.49 µs
URLPattern      1.24 µs/iter     803,437.8      (1.23 µs … 1.3 µs)       1.25 µs    1.3 µs    1.3 µs
```