### PR TITLE
test(bench): mark explicit timer test as flaky

### DIFF
--- a/cli/tests/integration/bench_tests.rs
+++ b/cli/tests/integration/bench_tests.rs
@@ -187,7 +187,7 @@ itest!(bench_explicit_start_end {
   exit_code: 1,
 });
 
-itest!(bench_explicit_start_end_low_precision {
+itest_flaky!(bench_explicit_start_end_low_precision {
   args: "bench --quiet -A bench/explicit_start_and_end_low_precision.ts",
   output: "bench/explicit_start_and_end_low_precision.out",
 });

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1012,7 +1012,7 @@ declare namespace Deno {
      * after doing setup work which should not be measured.
      *
      * Warning: This method should not be used for benchmarks averaging less
-     * than 0.01s per iteration. In such cases it will be disabled but the call
+     * than 10μs per iteration. In such cases it will be disabled but the call
      * will still have noticeable overhead, resulting in a warning.
      *
      * ```ts
@@ -1029,7 +1029,7 @@ declare namespace Deno {
      * before doing teardown work which should not be measured.
      *
      * Warning: This method should not be used for benchmarks averaging less
-     * than 0.01s per iteration. In such cases it will be disabled but the call
+     * than 10μs per iteration. In such cases it will be disabled but the call
      * will still have noticeable overhead, resulting in a warning.
      *
      * ```ts


### PR DESCRIPTION
https://github.com/denoland/deno/actions/runs/5990043261/job/16246927846?pr=18642

The test is just `b.start(); b.end()` where the time measured between must be less 10 μs during warmup. Can't improve it.
Also fixes doc mistake.