### PR TITLE
fix(ext/node): fix argv[1] in Worker

### DIFF
--- a/cli/tests/unit_node/process_test.ts
+++ b/cli/tests/unit_node/process_test.ts
@@ -784,5 +784,5 @@ Deno.test({
     );
     await delay(10);
     worker.terminate();
-  }
-})
+  },
+});

--- a/cli/tests/unit_node/process_test.ts
+++ b/cli/tests/unit_node/process_test.ts
@@ -774,3 +774,15 @@ Deno.test({
     assertEquals(process.title, "deno");
   },
 });
+
+Deno.test({
+  name: "process.argv[1] in Worker",
+  async fn() {
+    const worker = new Worker(
+      `data:text/javascript,import process from "node:process";console.log(process.argv[1]);`,
+      { type: "module" },
+    );
+    await delay(10);
+    worker.terminate();
+  }
+})

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -873,7 +873,7 @@ internals.__bootstrapNodeProcess = function (
   // Overwrites the 2st item with getter.
   Object.defineProperty(argv, "1", {
     get: () => {
-      if (Deno.mainModule.startsWith("file:")) {
+      if (Deno.mainModule?.startsWith("file:")) {
         return pathFromURL(new URL(Deno.mainModule));
       } else {
         return join(Deno.cwd(), "$deno$node.js");


### PR DESCRIPTION
closes #18305

This PR fixes `process.argv[1]` in Worker context.