### PR TITLE
fix(ext/web): add webkitRelativePath to File

### DIFF
--- a/cli/tests/unit/file_test.ts
+++ b/cli/tests/unit/file_test.ts
@@ -8,6 +8,7 @@ function testFirstArgument(arg1: any[], expectedSize: number) {
   assertEquals(file.name, "name");
   assertEquals(file.size, expectedSize);
   assertEquals(file.type, "");
+  assertEquals(file.webkitRelativePath, "");
 }
 
 Deno.test(function fileEmptyFileBits() {

--- a/ext/web/09_file.js
+++ b/ext/web/09_file.js
@@ -535,6 +535,12 @@ class File extends Blob {
     webidl.assertBranded(this, FilePrototype);
     return this[_LastModified];
   }
+
+  /** @returns {string} */
+  get webkitRelativePath() {
+    webidl.assertBranded(this, FilePrototype);
+    return "";
+  }
 }
 
 webidl.configurePrototype(File);

--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -562,6 +562,7 @@ declare interface FilePropertyBag extends BlobPropertyBag {
 declare interface File extends Blob {
   readonly lastModified: number;
   readonly name: string;
+  readonly webkitRelativePath: string;
 }
 
 /** Provides information about files and allows JavaScript in a web page to


### PR DESCRIPTION
This PR adds `webkitRelativePath` property to `File` interface.

- MDN https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath
- spec https://wicg.github.io/entries-api/#file-interface
  - See also https://github.com/WICG/entries-api/issues/42
- lib.dom already has this https://github.com/denoland/deno/blob/c2547ba039096d2f8e07a2fd89360956ac94014a/cli/tsc/dts/lib.dom.d.ts#L8226C8-L8226C8
- There's WPT case https://github.com/web-platform-tests/wpt/blob/99995985f35d81a4c929464ae43151996b001d0a/entries-api/file-webkitRelativePath-manual.html#L27