### PR TITLE
fix(fmt/markdown): ignore trailing words in code block info string for language detection

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -55,9 +55,9 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.86.1.wasm",
+    "https://plugins.dprint.dev/typescript-0.86.2.wasm",
     "https://plugins.dprint.dev/json-0.17.4.wasm",
-    "https://plugins.dprint.dev/markdown-0.15.3.wasm",
+    "https://plugins.dprint.dev/markdown-0.16.0.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072"
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-markdown"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20e5763efd89925412ac0f525a25bbba9066b2ba924eae87ab8a7120df0744c"
+checksum = "e9c557186cbae35d90a72fd6081c5c321ff002e5883d134497c433961992fc8c"
 dependencies = [
  "anyhow",
  "dprint-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ console_static_text.workspace = true
 data-url.workspace = true
 dissimilar = "=1.0.4"
 dprint-plugin-json = "=0.17.4"
-dprint-plugin-markdown = "=0.15.3"
+dprint-plugin-markdown = "=0.16.0"
 dprint-plugin-typescript = "=0.86.2"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"


### PR DESCRIPTION
Let's wait for 1.37 before merging this one.

Closes #20309