### PR TITLE
fix: unexpected lsp function arg comma completion

### DIFF
--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -53,9 +53,10 @@ pub fn server_capabilities(
     )),
     hover_provider: Some(HoverProviderCapability::Simple(true)),
     completion_provider: Some(CompletionOptions {
+      // Don't include "," here as it leads to confusing completion
+      // behavior with function arguments. See https://github.com/denoland/deno/issues/20160
       all_commit_characters: Some(vec![
         ".".to_string(),
-        ",".to_string(),
         ";".to_string(),
         "(".to_string(),
       ]),


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
I got annoyed by having to manually delete the automatically inserted completions and tracked the behaviour down to a single line in the lsp code. Played around with the fix enabled for a while this morning in vscode and didn't run into any downsides to this change. Quite the opposite actually, it makes the integration much nicer to use.

Fixes https://github.com/denoland/deno/issues/20160