### PR TITLE
fix(ext/http): don't panic on stream responses in cancelled requests

### DIFF
--- a/ext/http/slab.rs
+++ b/ext/http/slab.rs
@@ -234,7 +234,7 @@ impl SlabEntry {
     self.self_mut().request_body = Some(RequestBodyState::Resource(res));
   }
 
-  /// Complete this entry, potentially expunging it if it is complete.
+  /// Complete this entry, potentially expunging it if it is fully complete (ie: dropped as well).
   pub fn complete(self) {
     let promise = &self.self_ref().promise;
     assert!(
@@ -249,6 +249,12 @@ impl SlabEntry {
       drop(self);
       slab_expunge(index);
     }
+  }
+
+  /// Has the future for this entry been dropped? ie, has the underlying TCP connection
+  /// been closed?
+  pub fn cancelled(&self) -> bool {
+    self.self_ref().been_dropped
   }
 
   /// Get a mutable reference to the response.


### PR DESCRIPTION
When a TCP connection is force-closed (ie: browser refresh), the underlying future we pass to Hyper is dropped which may cause us to try to drop the body resource while the OpState lock is still held.

Preconditions for this bug to trigger:

 - The body resource must have been taken
 - The response must return a resource (which requires us to take the OpState lock)
 - The TCP connection must have been dropped before this

Fixes #20315 and #20298