### PR TITLE
chore(cli): use NPM_CONFIG_REGISTRY for all tests

### DIFF
--- a/cli/tests/integration/check_tests.rs
+++ b/cli/tests/integration/check_tests.rs
@@ -86,13 +86,17 @@ itest!(check_static_response_json {
 itest!(check_node_builtin_modules_ts {
   args: "check --quiet check/node_builtin_modules/mod.ts",
   output: "check/node_builtin_modules/mod.ts.out",
+  envs: env_vars_for_npm_tests(),
   exit_code: 1,
+  http_server: true,
 });
 
 itest!(check_node_builtin_modules_js {
   args: "check --quiet check/node_builtin_modules/mod.js",
   output: "check/node_builtin_modules/mod.js.out",
+  envs: env_vars_for_npm_tests(),
   exit_code: 1,
+  http_server: true,
 });
 
 itest!(check_no_error_truncation {

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use test_util as util;
 use test_util::TempDir;
+use util::env_vars_for_npm_tests;
 use util::TestContext;
 use util::TestContextBuilder;
 
@@ -326,7 +327,7 @@ fn no_tests_included(test_name: &str, extension: &str) {
 
 #[test]
 fn no_npm_cache_coverage() {
-  let context = TestContext::default();
+  let context = TestContext::with_http_server();
   let tempdir = context.temp_dir();
   let tempdir = tempdir.path().join("cov");
 
@@ -339,6 +340,7 @@ fn no_npm_cache_coverage() {
       format!("--coverage={}", tempdir),
       format!("coverage/no_npm_coverage/no_npm_coverage_test.ts"),
     ])
+    .envs(env_vars_for_npm_tests())
     .run();
 
   output.assert_exit_code(0);

--- a/cli/tests/integration/node_compat_tests.rs
+++ b/cli/tests/integration/node_compat_tests.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use test_util as util;
+use util::env_vars_for_npm_tests;
 
 #[test]
 fn node_compat_tests() {
@@ -21,5 +22,7 @@ fn node_compat_tests() {
 itest!(node_test_module {
   args: "test node/test.js",
   output: "node/test.out",
+  envs: env_vars_for_npm_tests(),
   exit_code: 1,
+  http_server: true,
 });

--- a/cli/tests/integration/node_unit_tests.rs
+++ b/cli/tests/integration/node_unit_tests.rs
@@ -109,6 +109,7 @@ fn node_unit_test(test: String) {
         .join("unit_node")
         .join(format!("{test}.ts")),
     )
+    .envs(env_vars_for_npm_tests())
     .stderr(Stdio::piped())
     .stdout(Stdio::piped())
     .spawn()

--- a/test_napi/tests/napi_tests.rs
+++ b/test_napi/tests/napi_tests.rs
@@ -2,6 +2,8 @@
 
 use std::process::Command;
 use test_util::deno_cmd;
+use test_util::env_vars_for_npm_tests;
+use test_util::http_server;
 
 #[cfg(debug_assertions)]
 const BUILD_VARIANT: &str = "debug";
@@ -53,6 +55,7 @@ fn build() {
 fn napi_tests() {
   build();
 
+  let _http_guard = http_server();
   let output = deno_cmd()
     .current_dir(test_util::napi_tests_path())
     .env("RUST_BACKTRACE", "1")
@@ -61,6 +64,7 @@ fn napi_tests() {
     .arg("--allow-env")
     .arg("--allow-ffi")
     .arg("--allow-run")
+    .envs(env_vars_for_npm_tests())
     .spawn()
     .unwrap()
     .wait_with_output()

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -160,6 +160,10 @@ pub fn npm_registry_url() -> String {
   "http://localhost:4545/npm/registry/".to_string()
 }
 
+pub fn npm_registry_unset_url() -> String {
+  "http://NPM_CONFIG_REGISTRY.is.unset".to_string()
+}
+
 pub fn std_path() -> PathRef {
   root_path().join("test_util").join("std")
 }
@@ -2309,6 +2313,7 @@ pub fn deno_cmd_with_deno_dir(deno_dir: &TempDir) -> DenoCmd {
   assert!(exe_path.exists());
   let mut cmd = Command::new(exe_path);
   cmd.env("DENO_DIR", deno_dir.path());
+  cmd.env("NPM_CONFIG_REGISTRY", npm_registry_unset_url());
   DenoCmd {
     _deno_dir: deno_dir.clone(),
     cmd,


### PR DESCRIPTION
We never want tests to hit the real npm registry because this causes test flakes. In addition, we set a sentinal "unset" value for `NPM_CONFIG_REGISTRY` to ensure that all tests requiring npm go through the test server.

