### PR TITLE
fix(lsp): recreate npm search cache when cache path changes

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -913,6 +913,8 @@ impl Inner {
       module_registries_location.clone(),
       self.http_client.clone(),
     );
+    self.npm.search_api =
+      CliNpmSearchApi::new(self.module_registries.file_fetcher.clone(), None);
     self.module_registries_location = module_registries_location;
     // update the cache path
     let global_cache = Arc::new(GlobalHttpCache::new(


### PR DESCRIPTION
I was just looking into if there was a way to extract out the file fetcher construction (going to punt on that), but then noticed this was missing. The code for how we need to recreate lsp structs is very error prone at the moment. We need to redesign it eventually.