### PR TITLE
chore: update deno_config to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,13 +1041,13 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ff2a01961c72ef883375399677ccf046dba607dc14169b313e4a95bd26da2"
+checksum = "7f8d9004dbba353a54cd80f3eb420eb8511a8e49b6e791685c9adad0f0a82678"
 dependencies = [
  "anyhow",
  "deno_semver",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "jsonc-parser",
  "log",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8d9004dbba353a54cd80f3eb420eb8511a8e49b6e791685c9adad0f0a82678"
+checksum = "e6d1e823e6ab5ed41c4dd60d7e8b9b5d76db9d31ffded66d35e0bf4af11f2076"
 dependencies = [
  "anyhow",
  "deno_semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d1e823e6ab5ed41c4dd60d7e8b9b5d76db9d31ffded66d35e0bf4af11f2076"
+checksum = "cc0c89c37b55d33bdd3374fddb9e6bf74dd7d071d1217d1ef3ab7d09bcefb6d3"
 dependencies = [
  "anyhow",
  "deno_semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ hex = "0.4"
 http = "0.2.9"
 httparse = "1.8.0"
 hyper = { version = "0.14.26", features = ["runtime", "http1"] }
-# TODO(mmastrac): indexmap 2.0 will require multiple synchronized changes
+# TODO(mmastrac): remove once deno_graph is updated
 indexmap1 = { package = "indexmap", version = "1", features = ["serde"] }
 indexmap = { version = "2", features = ["serde"] }
 libc = "0.2.126"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = "=0.5.2"
-deno_config = "=0.2.1"
+deno_config = "=0.2.2"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "=0.65.0"
 deno_emit = "=0.26.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = "=0.5.2"
-deno_config = "=0.2.3"
+deno_config = "=0.2.4"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "=0.65.0"
 deno_emit = "=0.26.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = "=0.5.2"
-deno_config = "=0.2.2"
+deno_config = "=0.2.3"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = "=0.65.0"
 deno_emit = "=0.26.0"

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -15,7 +15,7 @@ use deno_npm::resolution::ValidSerializedNpmResolutionSnapshot;
 use deno_npm::NpmSystemInfo;
 use deno_runtime::deno_tls::RootCertStoreProvider;
 use deno_semver::npm::NpmPackageReqReference;
-use indexmap1::IndexMap;
+use indexmap::IndexMap;
 
 pub use deno_config::BenchConfig;
 pub use deno_config::CompilerOptions;

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -17,9 +17,7 @@ use deno_semver::package::PackageNv;
 use deno_task_shell::ExecuteResult;
 use deno_task_shell::ShellCommand;
 use deno_task_shell::ShellCommandContext;
-// TODO(mmastrac): Once upstream indexmap is updated, this can go away
 use indexmap::IndexMap;
-use indexmap1::IndexMap as IndexMap1;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -180,7 +178,7 @@ fn collect_env_vars() -> HashMap<String, String> {
 
 fn print_available_tasks(
   // order can be important, so these use an index map
-  tasks_config: &IndexMap1<String, String>,
+  tasks_config: &IndexMap<String, String>,
   package_json_scripts: &IndexMap<String, String>,
 ) {
   eprintln!("{}", colors::green("Available tasks:"));


### PR DESCRIPTION
Update "deno_config" to 0.2.2 and remove dependency on "indexmap" 1.X where applicable.