### PR TITLE
fix(evt/kv): Add serde feature to uuid

### DIFF
--- a/ext/kv/Cargo.toml
+++ b/ext/kv/Cargo.toml
@@ -30,7 +30,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 url.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["serde"] }
 
 [build-dependencies]
 prost-build.workspace = true


### PR DESCRIPTION
`cargo publish` for v1.36.4 failed due to missing `serde` feature on `uuid` dependency.