### PR TITLE
fix(lsp): properly handle disabled configuration requests

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -718,13 +718,12 @@ impl Config {
     if let Some(workspace_folders) = self.workspace_folders.clone() {
       let mut touched = false;
       for (workspace, _) in workspace_folders {
-        if let Some(settings) = self.settings.specifiers.get(&workspace) {
-          if self.update_enabled_paths_entry(
-            workspace,
-            settings.enable_paths.clone(),
-          ) {
-            touched = true;
-          }
+        let enabled_paths = match self.settings.specifiers.get(&workspace) {
+          Some(settings) => settings.enable_paths.clone(),
+          None => self.settings.workspace.enable_paths.clone(),
+        };
+        if self.update_enabled_paths_entry(workspace, enabled_paths) {
+          touched = true;
         }
       }
       touched

--- a/test_util/src/lsp.rs
+++ b/test_util/src/lsp.rs
@@ -591,6 +591,7 @@ impl LspClientBuilder {
       writer,
       deno_dir,
       stderr_lines_rx,
+      supports_workspace_configuration: false,
     })
   }
 }
@@ -604,6 +605,7 @@ pub struct LspClient {
   deno_dir: TempDir,
   context: TestContext,
   stderr_lines_rx: Option<mpsc::Receiver<String>>,
+  supports_workspace_configuration: bool,
 }
 
 impl Drop for LspClient {
@@ -689,9 +691,17 @@ impl LspClient {
     let mut builder = InitializeParamsBuilder::new();
     builder.set_root_uri(self.context.temp_dir().uri());
     do_build(&mut builder);
-    self.write_request("initialize", builder.build());
+    let params: InitializeParams = builder.build();
+    self.supports_workspace_configuration = match &params.capabilities.workspace
+    {
+      Some(workspace) => workspace.configuration == Some(true),
+      _ => false,
+    };
+    self.write_request("initialize", params);
     self.write_notification("initialized", json!({}));
-    self.handle_configuration_request(config);
+    if self.supports_workspace_configuration {
+      self.handle_configuration_request(config);
+    }
   }
 
   pub fn did_open(&mut self, params: Value) -> CollectedDiagnostics {
@@ -712,7 +722,9 @@ impl LspClient {
     config: Value,
   ) -> CollectedDiagnostics {
     self.did_open_raw(params);
-    self.handle_configuration_request(config);
+    if self.supports_workspace_configuration {
+      self.handle_configuration_request(config);
+    }
     self.read_diagnostics()
   }
 


### PR DESCRIPTION
Fixes #19802.

Properly respect when clients do not have the `workspace/configuration` capability, a.k.a. when an editor cannot provide scoped settings on request from the LSP.

- Fix one spot where we weren't checking for the capability before sending this request.
- For `enablePaths`, fall back to the settings passed in the initialization options in more cases.
- Respect the `workspace/configuration` capability in the test harness client.

See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration.