### PR TITLE
Revert "refactor: rewrite ops that use 'deferred' to use 'op2(async(lazy))' (#20303)

### DIFF
--- a/cli/tests/unit/timers_test.ts
+++ b/cli/tests/unit/timers_test.ts
@@ -756,3 +756,20 @@ Deno.test({
     assertEquals(timeoutsFired.length, 300);
   },
 });
+
+// Regression test for https://github.com/denoland/deno/issues/20367
+Deno.test({
+  name: "regression for #20367",
+  fn: async () => {
+    const promise = deferred<number>();
+    const start = performance.now();
+    setTimeout(() => {
+      const end = performance.now();
+      promise.resolve(end - start);
+    }, 1000);
+    clearTimeout(setTimeout(() => {}, 1000));
+
+    const result = await promise;
+    assert(result >= 1000);
+  },
+});

--- a/ext/web/timers.rs
+++ b/ext/web/timers.rs
@@ -5,7 +5,6 @@
 use crate::hr_timer_lock::hr_timer_lock;
 use deno_core::error::AnyError;
 use deno_core::op;
-use deno_core::op2;
 use deno_core::CancelFuture;
 use deno_core::CancelHandle;
 use deno_core::OpState;
@@ -80,15 +79,13 @@ pub fn op_timer_handle(state: &mut OpState) -> ResourceId {
 /// [`TimerHandle`] resource given by `rid` has been canceled.
 ///
 /// If the timer is canceled, this returns `false`. Otherwise, it returns `true`.
-#[op2(async(lazy))]
+#[op(deferred)]
 pub async fn op_sleep(
   state: Rc<RefCell<OpState>>,
-  #[bigint] millis: u64,
-  #[smi] rid: ResourceId,
+  millis: u64,
+  rid: ResourceId,
 ) -> Result<bool, AnyError> {
-  let Ok(handle) = state.borrow().resource_table.get::<TimerHandle>(rid) else {
-    return Ok(true);
-  };
+  let handle = state.borrow().resource_table.get::<TimerHandle>(rid)?;
 
   // If a timer is requested with <=100ms resolution, request the high-res timer. Since the default
   // Windows timer period is 15ms, this means a 100ms timer could fire at 115ms (15% late). We assume that

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -5,7 +5,6 @@ use deno_core::error::invalid_hostname;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::op;
-use deno_core::op2;
 use deno_core::url;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
@@ -529,12 +528,12 @@ pub async fn op_ws_send_ping(
     .await
 }
 
-#[op2(async(lazy))]
+#[op(deferred)]
 pub async fn op_ws_close(
   state: Rc<RefCell<OpState>>,
-  #[smi] rid: ResourceId,
+  rid: ResourceId,
   code: Option<u16>,
-  #[string] reason: Option<String>,
+  reason: Option<String>,
 ) -> Result<(), AnyError> {
   let resource = state
     .borrow_mut()

--- a/runtime/ops/web_worker.rs
+++ b/runtime/ops/web_worker.rs
@@ -6,7 +6,6 @@ use crate::web_worker::WebWorkerInternalHandle;
 use crate::web_worker::WebWorkerType;
 use deno_core::error::AnyError;
 use deno_core::op;
-use deno_core::op2;
 
 use deno_core::CancelFuture;
 use deno_core::OpState;
@@ -38,8 +37,7 @@ fn op_worker_post_message(
   Ok(())
 }
 
-#[op2(async(lazy))]
-#[serde]
+#[op(deferred)]
 async fn op_worker_recv_message(
   state: Rc<RefCell<OpState>>,
 ) -> Result<Option<JsMessageData>, AnyError> {


### PR DESCRIPTION
This reverts commit https://github.com/denoland/deno/commit/83426be6eead06c680ae527468aeaf8723543ff2.

Includes a regression test.

Closes https://github.com/denoland/deno/issues/20367