### PR TITLE
chore(ext/kv): limit total key size in an atomic op to 80 KiB

### DIFF
--- a/cli/tests/unit/kv_test.ts
+++ b/cli/tests/unit/kv_test.ts
@@ -1283,6 +1283,21 @@ dbTest("total mutation size limit", async (db) => {
   );
 });
 
+dbTest("total key size limit", async (db) => {
+  const longString = new Array(1100).fill("a").join("");
+  const keys: Deno.KvKey[] = new Array(80).fill(0).map(() => [longString]);
+
+  const atomic = db.atomic();
+  for (const key of keys) {
+    atomic.set(key, "foo");
+  }
+  await assertRejects(
+    () => atomic.commit(),
+    TypeError,
+    "total key size too large (max 81920 bytes)",
+  );
+});
+
 dbTest("keys must be arrays", async (db) => {
   await assertRejects(
     // @ts-expect-error invalid type


### PR DESCRIPTION
Keys are expensive metadata. We track it for various purposes, e.g. transaction conflict check, and key expiration.

This patch limits the total key size in an atomic operation to 80 KiB (81920 bytes). This helps ensure efficiency in implementations.