### PR TITLE
Revert "refactor(lsp): clean up "enablePaths" handling (#20388)"

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1388,7 +1388,6 @@ mod tests {
   }
 
   fn mock_config() -> ConfigSnapshot {
-    let root_uri = resolve_url("file:///").unwrap();
     ConfigSnapshot {
       settings: Settings {
         workspace: WorkspaceSettings {
@@ -1398,13 +1397,6 @@ mod tests {
         },
         ..Default::default()
       },
-      workspace_folders: vec![(
-        root_uri.clone(),
-        lsp::WorkspaceFolder {
-          uri: root_uri,
-          name: "".to_string(),
-        },
-      )],
       ..Default::default()
     }
   }
@@ -1476,7 +1468,7 @@ let c: number = "a";
         specifier.clone(),
         SpecifierSettings {
           enable: Some(false),
-          enable_paths: None,
+          enable_paths: Vec::new(),
           code_lens: Default::default(),
         },
       );

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -403,32 +403,47 @@ impl LanguageServer {
   }
 
   pub async fn refresh_specifiers_from_client(&self) -> bool {
-    let (client, specifiers) = {
-      let ls = self.0.read().await;
-      let specifiers = if ls.config.client_capabilities.workspace_configuration
+    let (client, specifiers) =
       {
-        let root_capacity = std::cmp::max(ls.config.workspace_folders.len(), 1);
-        let config_specifiers = ls.config.get_specifiers();
-        let mut specifiers =
-          HashMap::with_capacity(root_capacity + config_specifiers.len());
-        for (specifier, folder) in &ls.config.workspace_folders {
-          specifiers
-            .insert(specifier.clone(), LspClientUrl::new(folder.uri.clone()));
-        }
-        specifiers.extend(
-          ls.config
-            .get_specifiers()
-            .iter()
-            .map(|s| (s.clone(), ls.url_map.normalize_specifier(s).unwrap())),
-        );
+        let ls = self.0.read().await;
+        let specifiers =
+          if ls.config.client_capabilities.workspace_configuration {
+            let root_capacity = match &ls.config.workspace_folders {
+              Some(folder) => folder.len(),
+              None => 1,
+            };
+            let config_specifiers = ls.config.get_specifiers();
+            let mut specifiers =
+              HashMap::with_capacity(root_capacity + config_specifiers.len());
+            match &ls.config.workspace_folders {
+              Some(entry) => {
+                for (specifier, folder) in entry {
+                  specifiers.insert(
+                    specifier.clone(),
+                    LspClientUrl::new(folder.uri.clone()),
+                  );
+                }
+              }
+              None => {
+                if let Some(root_uri) = &ls.config.root_uri {
+                  specifiers.insert(
+                    root_uri.clone(),
+                    ls.url_map.normalize_specifier(root_uri).unwrap(),
+                  );
+                }
+              }
+            }
+            specifiers.extend(ls.config.get_specifiers().iter().map(|s| {
+              (s.clone(), ls.url_map.normalize_specifier(s).unwrap())
+            }));
 
-        Some(specifiers.into_iter().collect::<Vec<_>>())
-      } else {
-        None
+            Some(specifiers.into_iter().collect::<Vec<_>>())
+          } else {
+            None
+          };
+
+        (ls.client.clone(), specifiers)
       };
-
-      (ls.client.clone(), specifiers)
-    };
 
     let mut touched = false;
     if let Some(specifiers) = specifiers {
@@ -461,6 +476,10 @@ impl LanguageServer {
             }
           }
         }
+      }
+
+      if ls.config.update_enabled_paths() {
+        touched = true;
       }
     }
     touched
@@ -682,7 +701,7 @@ impl Inner {
         lsp_log!("Setting Deno configuration from: \"{}\"", config_str);
         let config_url = if let Ok(url) = Url::from_file_path(config_str) {
           Ok(url)
-        } else if let Some(root_uri) = self.config.root_uri() {
+        } else if let Some(root_uri) = &self.config.root_uri {
           root_uri.join(config_str).map_err(|_| {
             anyhow!("Bad file path for configuration file: \"{}\"", config_str)
           })
@@ -704,7 +723,7 @@ impl Inner {
     // It is possible that root_uri is not set, for example when having a single
     // file open and not a workspace.  In those situations we can't
     // automatically discover the configuration
-    if let Some(root_uri) = self.config.root_uri() {
+    if let Some(root_uri) = &self.config.root_uri {
       let root_path = specifier_to_file_path(root_uri)?;
       let mut checked = std::collections::HashSet::new();
       let maybe_config = ConfigFile::discover_from(&root_path, &mut checked)?;
@@ -728,7 +747,7 @@ impl Inner {
     // It is possible that root_uri is not set, for example when having a single
     // file open and not a workspace.  In those situations we can't
     // automatically discover the configuration
-    if let Some(root_uri) = self.config.root_uri() {
+    if let Some(root_uri) = &self.config.root_uri {
       let root_path = specifier_to_file_path(root_uri)?;
       let maybe_package_json = package_json::discover_from(
         &root_path,
@@ -827,7 +846,7 @@ impl Inner {
       lsp_log!("Setting global cache path from: \"{}\"", cache_str);
       let cache_url = if let Ok(url) = Url::from_file_path(cache_str) {
         Ok(url)
-      } else if let Some(root_uri) = self.config.root_uri() {
+      } else if let Some(root_uri) = &self.config.root_uri {
         let root_path = specifier_to_file_path(root_uri)?;
         let cache_path = root_path.join(cache_str);
         Url::from_file_path(cache_path).map_err(|_| {
@@ -873,7 +892,8 @@ impl Inner {
     let workspace_settings = self.config.workspace_settings();
     let maybe_root_path = self
       .config
-      .root_uri()
+      .root_uri
+      .as_ref()
       .and_then(|uri| specifier_to_file_path(uri).ok());
     let root_cert_store = get_root_cert_store(
       maybe_root_path,
@@ -1054,7 +1074,7 @@ impl Inner {
             anyhow!("Bad data url for import map: {}", import_map_str)
           })?;
           Some(import_map_url)
-        } else if let Some(root_uri) = self.config.root_uri() {
+        } else if let Some(root_uri) = &self.config.root_uri {
           let root_path = specifier_to_file_path(root_uri)?;
           let import_map_path = root_path.join(&import_map_str);
           let import_map_url =
@@ -1262,14 +1282,20 @@ impl Inner {
     }
 
     {
+      // sometimes this root uri may not have a trailing slash, so force it to
+      self.config.root_uri = params
+        .root_uri
+        .map(|s| self.url_map.normalize_url(&s, LspUrlKind::Folder));
+
       if let Some(value) = params.initialization_options {
         self.config.set_workspace_settings(value).map_err(|err| {
           error!("Cannot set workspace settings: {}", err);
           LspError::internal_error()
         })?;
+        self.config.update_enabled_paths();
       }
-      if let Some(folders) = params.workspace_folders {
-        self.config.workspace_folders = folders
+      self.config.workspace_folders = params.workspace_folders.map(|folders| {
+        folders
           .into_iter()
           .map(|folder| {
             (
@@ -1277,31 +1303,8 @@ impl Inner {
               folder,
             )
           })
-          .collect();
-      }
-      // rootUri is deprecated by the LSP spec. If it's specified, merge it into
-      // workspace_folders.
-      if let Some(root_uri) = params.root_uri {
-        if !self
-          .config
-          .workspace_folders
-          .iter()
-          .any(|(_, f)| f.uri == root_uri)
-        {
-          let name = root_uri.path_segments().and_then(|s| s.last());
-          let name = name.unwrap_or_default().to_string();
-          self.config.workspace_folders.insert(
-            0,
-            (
-              self.url_map.normalize_url(&root_uri, LspUrlKind::Folder),
-              WorkspaceFolder {
-                uri: root_uri,
-                name,
-              },
-            ),
-          );
-        }
-      }
+          .collect()
+      });
       self.config.update_capabilities(&params.capabilities);
     }
 
@@ -1486,6 +1489,7 @@ impl Inner {
       if let Err(err) = self.config.set_workspace_settings(value) {
         error!("failed to update settings: {}", err);
       }
+      self.config.update_enabled_paths();
     }
 
     self.update_debug_flag();
@@ -1652,16 +1656,18 @@ impl Inner {
         )
       })
       .collect::<Vec<(ModuleSpecifier, WorkspaceFolder)>>();
-    for (specifier, folder) in &self.config.workspace_folders {
-      if !params.event.removed.is_empty()
-        && params.event.removed.iter().any(|f| f.uri == folder.uri)
-      {
-        continue;
+    if let Some(current_folders) = &self.config.workspace_folders {
+      for (specifier, folder) in current_folders {
+        if !params.event.removed.is_empty()
+          && params.event.removed.iter().any(|f| f.uri == folder.uri)
+        {
+          continue;
+        }
+        workspace_folders.push((specifier.clone(), folder.clone()));
       }
-      workspace_folders.push((specifier.clone(), folder.clone()));
     }
 
-    self.config.workspace_folders = workspace_folders;
+    self.config.workspace_folders = Some(workspace_folders);
   }
 
   async fn document_symbol(
@@ -2621,7 +2627,8 @@ impl Inner {
 
     let maybe_root_path_owned = self
       .config
-      .root_uri()
+      .root_uri
+      .as_ref()
       .and_then(|uri| specifier_to_file_path(uri).ok());
     let mut resolved_items = Vec::<CallHierarchyIncomingCall>::new();
     for item in incoming_calls.iter() {
@@ -2664,7 +2671,8 @@ impl Inner {
 
     let maybe_root_path_owned = self
       .config
-      .root_uri()
+      .root_uri
+      .as_ref()
       .and_then(|uri| specifier_to_file_path(uri).ok());
     let mut resolved_items = Vec::<CallHierarchyOutgoingCall>::new();
     for item in outgoing_calls.iter() {
@@ -2712,7 +2720,8 @@ impl Inner {
     let response = if let Some(one_or_many) = maybe_one_or_many {
       let maybe_root_path_owned = self
         .config
-        .root_uri()
+        .root_uri
+        .as_ref()
         .and_then(|uri| specifier_to_file_path(uri).ok());
       let mut resolved_items = Vec::<CallHierarchyItem>::new();
       match one_or_many {
@@ -3122,7 +3131,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
         let test_server = testing::TestServer::new(
           ls.client.clone(),
           ls.performance.clone(),
-          ls.config.root_uri().cloned(),
+          ls.config.root_uri.clone(),
         );
         ls.maybe_testing_server = Some(test_server);
       }
@@ -3199,6 +3208,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
         Ok(specifier_settings) => {
           ls.config
             .set_specifier_settings(specifier.clone(), specifier_settings);
+          ls.config.update_enabled_paths();
         }
         Err(err) => {
           error!("{}", err);

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -285,7 +285,7 @@ fn get_cwd_uri() -> Result<ModuleSpecifier, AnyError> {
 pub fn get_repl_workspace_settings() -> WorkspaceSettings {
   WorkspaceSettings {
     enable: Some(true),
-    enable_paths: None,
+    enable_paths: Vec::new(),
     config: None,
     certificate_stores: None,
     cache: None,

--- a/test_util/src/lsp.rs
+++ b/test_util/src/lsp.rs
@@ -591,7 +591,6 @@ impl LspClientBuilder {
       writer,
       deno_dir,
       stderr_lines_rx,
-      config: json!("{}"),
       supports_workspace_configuration: false,
     })
   }
@@ -606,7 +605,6 @@ pub struct LspClient {
   deno_dir: TempDir,
   context: TestContext,
   stderr_lines_rx: Option<mpsc::Receiver<String>>,
-  config: serde_json::Value,
   supports_workspace_configuration: bool,
 }
 
@@ -701,14 +699,21 @@ impl LspClient {
     };
     self.write_request("initialize", params);
     self.write_notification("initialized", json!({}));
-    self.config = config;
     if self.supports_workspace_configuration {
-      self.handle_configuration_request(self.config.clone());
+      self.handle_configuration_request(config);
     }
   }
 
   pub fn did_open(&mut self, params: Value) -> CollectedDiagnostics {
-    self.did_open_with_config(params, self.config.clone())
+    self.did_open_with_config(
+      params,
+      json!([{
+        "enable": true,
+        "codeLens": {
+          "test": true
+        }
+      }]),
+    )
   }
 
   pub fn did_open_with_config(


### PR DESCRIPTION
This reverts commit 4a11603c76b13ecf92ce3141ec317a42ae9f8d1d (#20388). 

Test failing on main on windows: https://github.com/denoland/deno/actions/runs/6115897398/job/16600239775.

I know what's wrong with the test. Let's fix CI to run all tests on PR workflows and then I'll try to reland this.
