### PR TITLE
feat(cli): allow --log-level=trace for additional deep debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower-lsp",
+ "tracing",
  "trust-dns-client",
  "trust-dns-server",
  "twox-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ tar = "=0.4.40"
 tempfile = "3.4.0"
 termcolor = "1.1.3"
 thiserror = "1.0.40"
+tracing = "0"
 tokio = { version = "1.28.1", features = ["full"] }
 tokio-metrics = { version = "0.3.0", features = ["rt"] }
 tokio-rustls = "0.24.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -116,6 +116,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-lsp.workspace = true
+tracing.workspace = true
 twox-hash = "=1.6.3"
 typed-arena = "=2.0.1"
 uuid = { workspace = true, features = ["serde"] }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -796,6 +796,7 @@ pub fn flags_from_vec(args: Vec<String>) -> clap::error::Result<Flags> {
     flags.log_level = Some(Level::Error);
   } else if let Some(log_level) = matches.get_one::<String>("log-level") {
     flags.log_level = match log_level.as_str() {
+      "trace" => Some(Level::Trace),
       "debug" => Some(Level::Debug),
       "info" => Some(Level::Info),
       _ => unreachable!(),
@@ -891,7 +892,7 @@ fn clap_root() -> Command {
         .long("log-level")
         .help("Set log level")
         .hide(true)
-        .value_parser(["debug", "info"])
+        .value_parser(["trace", "debug", "info"])
         .global(true),
     )
     .arg(


### PR DESCRIPTION
This allows us to opt in to extremely detailed tracing from dependency libraries, like so:

```
cargo run --features tracing/log,tracing/max_level_trace -- test --log-level=trace -A --unstable ./cli/tests/unit/serve_test.ts 
```

It will not impact normal operation as it requires the `tracing/max_level_trace` and `tracing/log` to be active. 

Note that tracing is already a dependency -- this just makes it a direct dep of cli so we can access its features more easily.