### PR TITLE
feat(init): skip existing files

### DIFF
--- a/cli/tests/testdata/init/main.ts
+++ b/cli/tests/testdata/init/main.ts
@@ -1,0 +1,8 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+// Learn more at https://deno.land/manual/examples/module_metadata#concepts
+if (import.meta.main) {
+  console.log("Add 1 + 2 =", add(1, 2));
+}

--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -14,13 +14,19 @@ fn create_file(
   filename: &str,
   content: &str,
 ) -> Result<(), AnyError> {
-  let mut file = std::fs::OpenOptions::new()
-    .write(true)
-    .create_new(true)
-    .open(dir.join(filename))
-    .with_context(|| format!("Failed to create {filename} file"))?;
-  file.write_all(content.as_bytes())?;
-  Ok(())
+  let path = dir.join(filename);
+  if path.exists() {
+    info!("ℹ️ Skipped creating {filename} as already exists");
+    Ok(())
+  } else {
+    let mut file = std::fs::OpenOptions::new()
+      .write(true)
+      .create_new(true)
+      .open(path)
+      .with_context(|| format!("Failed to create {filename} file"))?;
+    file.write_all(content.as_bytes())?;
+    Ok(())
+  }
 }
 
 pub async fn init_project(init_flags: InitFlags) -> Result<(), AnyError> {


### PR DESCRIPTION
### What
Skip writing files from the template if the files already exist in the project directory.

### Why
When I run deno init in a directory that already has a main.ts, or one of the other template files, I usually want to initialize a workspace around a file I've started working in. A hard error in this case seems counter productive. An informational message about what's being skipped seems sufficient.

Close #20433