### PR TITLE
feat: make `deno test --filter` 166x faster

### DIFF
--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1219,7 +1219,6 @@ async fn fetch_specifiers_with_test_mode(
     }
 
     if let Some(filter) = filter_opt {
-      println!("source {:?} {:?}", filter, file.source.to_string());
       let mut collector = TestFilterCollector::new(filter);
       let parsed_module = parse_module(ParseParams {
         specifier: specifier.to_string(),

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1218,6 +1218,15 @@ async fn fetch_specifiers_with_test_mode(
       *mode = TestMode::Documentation
     }
 
+    // If the `--filter` argument is set, we do a quick AST pass
+    // to check if any of the tests in this file match the filter.
+    // If one matches or when we cannot statically determine if a
+    // test case matches, we'll mark this file as needing to be run.
+    // If we analyze all tests cases and none of them match, we'll
+    // filter this test out. Even though this may seem a bit wasteful
+    // because we don't re-use the parsed AST result, this is roughly
+    // about 166x faster than running the JS test file only to realize
+    // after that, that none of the tests in it matched.
     if let Some(filter) = filter_opt {
       let mut collector = TestFilterCollector::new(filter);
       let parsed_module = parse_module(ParseParams {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This PR speeds up test collection when the `--filter "some-filter"` argument is set. Before this PR we'd run load all JS/TS test files and run them, only to then realize that none of the tests in a file matched. If the user is supplying the `--filter` argument, then there is a very high likelihood that the number of ignored test files is higher than the ones the user cares about.

So this PR changes that behavior, so that during test collection we check if we can statically determine that the test file contains no tests that match the filter. If none match in a file, we skip running this file in the first place. If we cannot statically determine the name of a test for cases like `Deno.test(`foo ${something}`, ...)`, then we are forced to load this test file regardless.

With the reproduction case in #20384 I get the following numbers on my M1 Air:

| What | Time |
|---|--:|
| main | 15.00s |
| this PR | 0.09s |

That's roughly a **166x** speed up.

Before:


https://github.com/denoland/deno/assets/1062408/99575140-eceb-4416-a793-205d586e48b5

After:


https://github.com/denoland/deno/assets/1062408/925207bd-1b47-4b97-88b4-53ed80a7dd37

This PR needs a couple of tests and I probably need help to make the code more "rust-like". Marking as draft for that reason.

Fixes #20384