### PR TITLE
chore: speed up test name escapeing

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -526,12 +526,27 @@ const ESCAPE_ASCII_CHARS = [
   ["\v", "\\v"],
 ];
 
+/**
+ * @param {string} name
+ * @returns {string}
+ */
 function escapeName(name) {
-  for (const [escape, replaceWith] of ESCAPE_ASCII_CHARS) {
-    name = StringPrototypeReplaceAll(name, escape, replaceWith);
+  // Check if we need to escape a character
+  for (let i = 0; i < name.length; i++) {
+    const ch = name.charCodeAt(i);
+    if (ch <= 13 && ch >= 8) {
+      // Slow path: We do need to escape it
+      for (const [escape, replaceWith] of ESCAPE_ASCII_CHARS) {
+        name = StringPrototypeReplaceAll(name, escape, replaceWith);
+      }
+      return name;
+    }
   }
+
+  // We didn't need to escape anything, return original string
   return name;
 }
+
 /**
  * @typedef {{
  *   id: number,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This PR speeds up our test name escape function. Found this in #20438 . The most common scenario is that the name doesn't need to be escaped, so this PR optimizes for that. However, it turns out that the current implementation for escaping strings is pretty good, even better than I thought. Could only beat it for very short strings, but my approaches were slower for longer ones. So I decided to keep the current way for escaping. Since that's the uncommon case, it shouldn't matter much for performance anyway if we optimize that.

When name doesn't need to be escaped:

```sh
benchmark       time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------- -----------------------------
before       439.08 ns/iter   2,277,490.1 (434.48 ns … 459.64 ns) 439.11 ns 448.88 ns 459.64 ns
after         12.32 ns/iter  81,192,975.9   (12.27 ns … 15.54 ns)  12.29 ns   12.8 ns  13.39 ns
```

There is a super tiny overhead for names that need escaping, but to me that seems worth it.

With name that needs escaping (250 chars):

```sh
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
before          1.59 µs/iter     630,643.5     (1.57 µs … 1.64 µs)   1.59 µs   1.64 µs   1.64 µs
after           1.65 µs/iter     606,076.1     (1.62 µs … 1.69 µs)   1.66 µs   1.69 µs   1.69 µs
```

With name that needs escaping (1000 chars):

```sh
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
before          4.65 µs/iter     214,979.5     (4.61 µs … 4.68 µs)   4.66 µs   4.68 µs   4.68 µs
after            4.7 µs/iter     212,613.8      (4.66 µs … 4.8 µs)   4.72 µs    4.8 µs    4.8 µs
```
