### PR TITLE
fix(lsp): always enable semantic tokens responses

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2832,9 +2832,7 @@ impl Inner {
     let specifier = self
       .url_map
       .normalize_url(&params.text_document.uri, LspUrlKind::File);
-    if !self.is_diagnosable(&specifier)
-      || !self.config.specifier_enabled(&specifier)
-    {
+    if !self.is_diagnosable(&specifier) {
       return Ok(None);
     }
 
@@ -2869,9 +2867,7 @@ impl Inner {
     let specifier = self
       .url_map
       .normalize_url(&params.text_document.uri, LspUrlKind::File);
-    if !self.is_diagnosable(&specifier)
-      || !self.config.specifier_enabled(&specifier)
-    {
+    if !self.is_diagnosable(&specifier) {
       return Ok(None);
     }
 

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -5500,6 +5500,45 @@ fn lsp_npm_completions_auto_import_and_quick_fix_no_import_map() {
 }
 
 #[test]
+fn lsp_semantic_tokens_for_disabled_module() {
+  let context = TestContextBuilder::new()
+    .use_http_server()
+    .use_temp_cwd()
+    .build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_with_config(
+    |builder| {
+      builder.set_deno_enable(false);
+    },
+    json!({
+      "enable": false
+    }),
+  );
+  client.did_open(json!({
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "const someConst = 1; someConst"
+    }
+  }));
+  let res = client.write_request(
+    "textDocument/semanticTokens/full",
+    json!({
+      "textDocument": {
+        "uri": "file:///a/file.ts"
+      }
+    }),
+  );
+  assert_eq!(
+    res,
+    json!({
+      "data": [0, 6, 9, 7, 9, 0, 15, 9, 7, 8],
+    })
+  );
+}
+
+#[test]
 fn lsp_completions_auto_import_and_quick_fix_with_import_map() {
   let context = TestContextBuilder::new()
     .use_http_server()


### PR DESCRIPTION
Fixes https://github.com/denoland/vscode_deno/issues/486.

This isn't a perfect solution. We want these requests to go to the Deno LSP for enabled modules and the regular TS server for disabled ones. But the language client's document selector isn't granular enough so they all must go to one. As a result, in a project with `"deno.enable": false`, you might not get semantic highlighting for e.g. Node built-in classes or require-imports.

But this is an objective improvement. Since these requests were being sent to our LSP anyway, we may as well give a best-effort response irrespective of `deno.enable`. Most things will work like `const` references in https://github.com/denoland/vscode_deno/issues/486#issue-963079667.