### PR TITLE
fix: exclude internal JS files from coverage

### DIFF
--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -472,3 +472,35 @@ fn no_internal_code() {
     assert_starts_with!(url, "file:");
   }
 }
+
+#[test]
+fn no_internal_node_code() {
+  let context = TestContext::default();
+  let tempdir = context.temp_dir();
+  let tempdir = tempdir.path().join("cov");
+
+  let output = context
+    .new_command()
+    .args_vec(vec![
+      "test".to_string(),
+      "--quiet".to_string(),
+      "--no-check".to_string(),
+      format!("--coverage={}", tempdir),
+      "coverage/no_internal_node_code_test.ts".to_string(),
+    ])
+    .run();
+
+  output.assert_exit_code(0);
+  output.skip_output_check();
+
+  // Check that coverage files contain no internal urls
+  let paths = fs::read_dir(tempdir).unwrap();
+  for path in paths {
+    let unwrapped = path.unwrap().path();
+    let data = fs::read_to_string(&unwrapped.clone()).unwrap();
+
+    let value: serde_json::Value = serde_json::from_str(&data).unwrap();
+    let url = value["url"].as_str().unwrap();
+    assert_starts_with!(url, "file:");
+  }
+}

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -1,8 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use deno_core::serde_json;
 use std::fs;
 use test_util as util;
 use test_util::TempDir;
+use util::assert_starts_with;
 use util::env_vars_for_npm_tests;
 use util::TestContext;
 use util::TestContextBuilder;
@@ -438,4 +440,35 @@ fn no_transpiled_lines() {
   }
 
   output.assert_exit_code(0);
+}
+
+#[test]
+fn no_internal_code() {
+  let context = TestContext::default();
+  let tempdir = context.temp_dir();
+  let tempdir = tempdir.path().join("cov");
+
+  let output = context
+    .new_command()
+    .args_vec(vec![
+      "test".to_string(),
+      "--quiet".to_string(),
+      format!("--coverage={}", tempdir),
+      "coverage/no_internal_code_test.ts".to_string(),
+    ])
+    .run();
+
+  output.assert_exit_code(0);
+  output.skip_output_check();
+
+  // Check that coverage files contain no internal urls
+  let paths = fs::read_dir(tempdir).unwrap();
+  for path in paths {
+    let unwrapped = path.unwrap().path();
+    let data = fs::read_to_string(&unwrapped.clone()).unwrap();
+
+    let value: serde_json::Value = serde_json::from_str(&data).unwrap();
+    let url = value["url"].as_str().unwrap();
+    assert_starts_with!(url, "file:");
+  }
 }

--- a/cli/tests/testdata/coverage/no_internal_code_test.ts
+++ b/cli/tests/testdata/coverage/no_internal_code_test.ts
@@ -1,0 +1,7 @@
+const add = (a: number, b: number) => a + b;
+
+Deno.test(function addTest() {
+  if (add(2, 3) !== 5) {
+    throw new Error("fail");
+  }
+});

--- a/cli/tests/testdata/coverage/no_internal_node_code_test.ts
+++ b/cli/tests/testdata/coverage/no_internal_node_code_test.ts
@@ -1,0 +1,8 @@
+import * as path from "node:path";
+
+Deno.test(function test() {
+  const res = path.join("foo", "bar");
+  if (!res.includes("foo")) {
+    throw new Error("fail");
+  }
+});

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -128,7 +128,9 @@ impl CoverageCollector {
     let script_coverages = self.take_precise_coverage().await?.result;
     for script_coverage in script_coverages {
       // Filter out internal JS files from being included in coverage reports
-      if script_coverage.url.starts_with("ext:") || script_coverage.url.starts_with("[ext:") {
+      if script_coverage.url.starts_with("ext:")
+        || script_coverage.url.starts_with("[ext:")
+      {
         continue;
       }
 

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -127,6 +127,11 @@ impl CoverageCollector {
 
     let script_coverages = self.take_precise_coverage().await?.result;
     for script_coverage in script_coverages {
+      // Filter out internal JS files from being included in coverage reports
+      if script_coverage.url.starts_with("ext:") || script_coverage.url.starts_with("[ext:") {
+        continue;
+      }
+
       let filename = format!("{}.json", Uuid::new_v4());
       let filepath = self.dir.join(filename);
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
This PR changes the `deno test --coverage=...` behavior so that internal deno JS files are excluded.

Fixes #20447