### PR TITLE
chore: update inner #\![allow] to #[allow]

### DIFF
--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -27,12 +27,12 @@ use editor::ReplEditor;
 use session::EvaluationOutput;
 use session::ReplSession;
 
+#[allow(clippy::await_holding_refcell_ref)]
 async fn read_line_and_poll(
   repl_session: &mut ReplSession,
   message_handler: &mut RustylineSyncMessageHandler,
   editor: ReplEditor,
 ) -> Result<String, ReadlineError> {
-  #![allow(clippy::await_holding_refcell_ref)]
   let mut line_fut = spawn_blocking(move || editor.readline());
   let mut poll_worker = true;
   let notifications_rc = repl_session.notifications.clone();

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -51,11 +51,11 @@ impl MessagePort {
     Ok(())
   }
 
+  #[allow(clippy::await_holding_refcell_ref)] // TODO(ry) remove!
   pub async fn recv(
     &self,
     state: Rc<RefCell<OpState>>,
   ) -> Result<Option<JsMessageData>, AnyError> {
-    #![allow(clippy::await_holding_refcell_ref)] // TODO(ry) remove!
     let mut rx = self
       .rx
       .try_borrow_mut()

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -336,11 +336,11 @@ fn op_spawn_child(
 
 // TODO(bartlomieju): op2 doesn't support clippy allows
 #[op]
+#[allow(clippy::await_holding_refcell_ref)]
 async fn op_spawn_wait(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,
 ) -> Result<ChildStatus, AnyError> {
-  #![allow(clippy::await_holding_refcell_ref)]
   let resource = state
     .borrow_mut()
     .resource_table

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -236,10 +236,10 @@ pub struct WebWorkerHandle {
 impl WebWorkerHandle {
   /// Get the WorkerEvent with lock
   /// Return error if more than one listener tries to get event
+  #[allow(clippy::await_holding_refcell_ref)] // TODO(ry) remove!
   pub async fn get_control_event(
     &self,
   ) -> Result<Option<WorkerControlEvent>, AnyError> {
-    #![allow(clippy::await_holding_refcell_ref)] // TODO(ry) remove!
     let mut receiver = self.receiver.borrow_mut();
     Ok(receiver.next().await)
   }


### PR DESCRIPTION
Functions should generally be annotated with `#[allow]` blocks rather than using inner `#![allow]` annotations.