### PR TITLE
fix(devcontainer): Add build deps and update extension in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,11 @@
 FROM mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye
 
+# Install cmake and protobuf-compiler
+RUN apt-get update \
+  && apt-get install -y cmake \
+  && apt-get install -y protobuf-compiler \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install Deno
 ENV DENO_INSTALL=/usr/local
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 
   "extensions": [
     "rust-lang.rust-analyzer",
-    "bungcip.better-toml",
+    "tamasfe.even-better-toml",
     "vadimcn.vscode-lldb",
     "mutantdino.resourcemonitor"
   ],


### PR DESCRIPTION
* Installs `cmake` and `protoc` build dependencies in the docker container.
* Replaced deprecated TOML extension with its suggested alternative.

Note: At least 16GB is required to build Deno, so ensure you use 'New with options' and select at least the 4-core/16GB machine type when starting in GitHub Codespaces.