### PR TITLE
perf(http/serve): add ServeHandlerResponse

### DIFF
--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -3641,12 +3641,20 @@ Deno.test(
         headers?: [string, string][];
       };
       response: {
-        body: string | Uint8Array | ReadableStream;
+        body?: string | Uint8Array | ReadableStream;
         status?: number;
         headers?: Headers | HeadersInit;
       };
     };
     const responses: ResponseItem[] = [
+      {
+        expect: {
+          status: 204,
+          body: "",
+        },
+        response: { status: 204 },
+      },
+
       {
         expect: {
           status: 200,

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5840,6 +5840,17 @@ declare namespace Deno {
     remoteAddr: Deno.NetAddr;
   }
 
+  /**
+   * Response data for {@linkcode ServeHandler}.
+   *
+   * @category HTTP Server
+   */
+  export interface ServeHandlerResponse {
+    body?: string | Uint8Array | ReadableStream<Uint8Array>;
+    headers?: Headers | HeadersInit;
+    status?: number;
+  }
+
   /** A handler for HTTP requests. Consumes a request and returns a response.
    *
    * If a handler throws, the server calling the handler will assume the impact
@@ -5851,7 +5862,11 @@ declare namespace Deno {
   export type ServeHandler = (
     request: Request,
     info: ServeHandlerInfo,
-  ) => Response | Promise<Response>;
+  ) =>
+    | Response
+    | Promise<Response>
+    | ServeHandlerResponse
+    | Promise<ServeHandlerResponse>;
 
   /** Options which can be set when calling {@linkcode Deno.serve}.
    *

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5864,9 +5864,8 @@ declare namespace Deno {
     info: ServeHandlerInfo,
   ) =>
     | Response
-    | Promise<Response>
     | ServeHandlerResponse
-    | Promise<ServeHandlerResponse>;
+    | Promise<Response | ServeHandlerResponse>;
 
   /** Options which can be set when calling {@linkcode Deno.serve}.
    *

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -482,7 +482,7 @@ function mapToCallback(context, callback, onError) {
     let headers;
     let body;
 
-    let inner = toInnerResponse(response);
+    const inner = toInnerResponse(response);
     if (inner) {
       status = inner.status;
       headers = inner.headerList;

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -13,6 +13,7 @@ import {
   toInnerResponse,
 } from "ext:deno_fetch/23_response.js";
 import { fromInnerRequest, toInnerRequest } from "ext:deno_fetch/23_request.js";
+import { headerListFromHeaders } from "ext:deno_fetch/20_headers.js";
 import { AbortController } from "ext:deno_web/03_abort_signal.js";
 import {
   _eventLoop,
@@ -375,9 +376,7 @@ function fastSyncResponseOrStream(req, respBody, status) {
     return;
   }
 
-  const stream = respBody.streamOrStatic;
-  const body = stream.body;
-
+  const body = respBody.streamOrStatic?.body ?? respBody;
   if (ObjectPrototypeIsPrototypeOf(Uint8ArrayPrototype, body)) {
     op_http_set_response_body_bytes(req, body, status);
     return;
@@ -388,6 +387,7 @@ function fastSyncResponseOrStream(req, respBody, status) {
     return;
   }
 
+  const stream = respBody?.streamOrStatic ?? respBody;
   // At this point in the response it needs to be a stream
   if (!ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, stream)) {
     throw TypeError("invalid response");
@@ -452,7 +452,6 @@ function mapToCallback(context, callback, onError) {
       }
     }
 
-    const inner = toInnerResponse(response);
     if (innerRequest?.[_upgraded]) {
       // We're done here as the connection has been upgraded during the callback and no longer requires servicing.
       if (response !== UPGRADE_RESPONSE_SENTINEL) {
@@ -471,8 +470,27 @@ function mapToCallback(context, callback, onError) {
       return;
     }
 
-    const status = inner.status;
-    const headers = inner.headerList;
+    let status;
+    let headers;
+    let body;
+
+    let inner = toInnerResponse(response);
+    if (inner) {
+      status = inner.status;
+      headers = inner.headerList;
+      body = inner.body;
+    } else {
+      // response is a ServeHandlerResponse
+      status = response.status ?? 200;
+      body = response.body;
+      if (response.headers) {
+        headers = Array.isArray(response.headers)
+          ? response.headers
+          : (headerListFromHeaders(response.headers) ??
+            Object.entries(response.headers));
+      }
+    }
+
     if (headers && headers.length > 0) {
       if (headers.length == 1) {
         op_http_set_response_header(req, headers[0][0], headers[0][1]);
@@ -481,7 +499,7 @@ function mapToCallback(context, callback, onError) {
       }
     }
 
-    fastSyncResponseOrStream(req, inner.body, status);
+    fastSyncResponseOrStream(req, body, status);
     innerRequest?.close();
   };
 }

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -38,9 +38,11 @@ import {
 import { listen, TcpConn } from "ext:deno_net/01_net.js";
 import { listenTls } from "ext:deno_net/02_tls.js";
 const {
+  ArrayIsArray,
   ArrayPrototypePush,
   Error,
   ObjectPrototypeIsPrototypeOf,
+  ObjectEntries,
   PromisePrototypeCatch,
   Symbol,
   SymbolFor,
@@ -490,10 +492,10 @@ function mapToCallback(context, callback, onError) {
       status = response.status ?? 200;
       body = response.body;
       if (response.headers) {
-        headers = Array.isArray(response.headers)
+        headers = ArrayIsArray(response.headers)
           ? response.headers
           : (headerListFromHeaders(response.headers) ??
-            Object.entries(response.headers));
+            ObjectEntries(response.headers));
       }
     }
 


### PR DESCRIPTION
This PR introduces `ServeHandlerResponse` as a return value option for `ServeHandler`. The goal is to optimize response times and minimize overhead associated with using the `Response` constructor.

## Performance Improvements:
- Approximately **12-16%** faster for string/Uint8Array responses.
- Roughly **20% improvement** when providing headers.
- For larger (>1mb) `Uint8Array` responses, the performance gains are even better since it avoids a copy https://github.com/denoland/deno/blob/08d2a32060a66e47dcccd99428d2ad13d7af29a9/ext/fetch/22_body.js#L415

This enhancement is based on [fast-response](https://github.com/marcosc90/fast-response).

### Examples

```javascript
Deno.serve(() => ({ body: 'hello' }));
```
```javascript
Deno.serve(() => ({ body: 'hello', status: 200, headers: [["content-type", "text/plain"]] }));
```



---

### Benchmarks

```wrk -d 10s --latency http://127.0.0.1:3000```

| Type                        | `Response` (req/s)     | `ServeHandlerResponse`  (req/s)   | Improvement     |
|-----------------------------|------------------|------------------|-----------------|
| "hello world" u8      | 241,594       | 282,483      | +40,889     |
| "hello world"         | 253,721       | 269,206      | +15,485    |
| 1mb Uint8Array      | 222,288       | 275,132      | +52,844     |
| 2 headers       | 216,248      | 247,430      | +31,182     |



