### PR TITLE
perf(ext/http): experimental speedups for serve

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -392,6 +392,10 @@ function extractBody(object) {
     if (object.type.length !== 0) {
       contentType = object.type;
     }
+  } else if (ObjectPrototypeIsPrototypeOf(ArrayBufferPrototype, object)) {
+    source = object;
+  } else if (ObjectPrototypeIsPrototypeOf(Uint8Array, object)) {
+    source = object;
   } else if (ArrayBufferIsView(object)) {
     const tag = TypedArrayPrototypeGetSymbolToStringTag(object);
     if (tag !== undefined) {
@@ -413,8 +417,6 @@ function extractBody(object) {
       );
     }
     source = TypedArrayPrototypeSlice(object);
-  } else if (ObjectPrototypeIsPrototypeOf(ArrayBufferPrototype, object)) {
-    source = TypedArrayPrototypeSlice(new Uint8Array(object));
   } else if (ObjectPrototypeIsPrototypeOf(FormDataPrototype, object)) {
     const res = formDataToBlob(object);
     stream = res.stream();


### PR DESCRIPTION
In the case of a single-argument string, Uint8Array, or ResponseStream, bypass init machinery. For Uint8Array or ArrayBuffer responses, don't perform a copy.

Test w/short string:

main: 

```
  1322955 requests in 10.10s, 189.25MB read
Requests/sec: 131024.63
Transfer/sec:     18.74MB
```

this patch:

```
  1357711 requests in 10.10s, 194.22MB read
Requests/sec: 134423.96
Transfer/sec:     19.23MB
```

Test w/large buffer:

main:

```
  53292 requests in 10.10s, 52.05GB read
Requests/sec:   5274.71
Transfer/sec:      5.15GB
```

this patch:

```
  72226 requests in 10.10s, 70.54GB read
Requests/sec:   7150.93
Transfer/sec:      6.98GB
```