### PR TITLE
perf: improve async op santizer speed and accuracy

### DIFF
--- a/cli/tests/testdata/test/ops_sanitizer_step_leak.out
+++ b/cli/tests/testdata/test/ops_sanitizer_step_leak.out
@@ -1,0 +1,10 @@
+Check [WILDCARD]/cli/tests/testdata/test/ops_sanitizer_step_leak.ts
+running 1 test from ./cli/tests/testdata/test/ops_sanitizer_step_leak.ts
+timeout ...
+  step ... ok [WILDCARD]
+------- output -------
+done
+----- output end -----
+timeout ... ok [WILDCARD]
+
+ok | 1 passed (1 step) | 0 failed [WILDCARD]

--- a/cli/tests/testdata/test/ops_sanitizer_step_leak.ts
+++ b/cli/tests/testdata/test/ops_sanitizer_step_leak.ts
@@ -1,0 +1,10 @@
+Deno.test("timeout", async (t) => {
+  const timer = setTimeout(() => {
+    console.log("timeout");
+  }, 10000);
+  clearTimeout(timer);
+  await t.step("step", async () => {
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
+  });
+  console.log("done");
+});

--- a/cli/tests/unit/http_test.ts
+++ b/cli/tests/unit/http_test.ts
@@ -198,12 +198,14 @@ Deno.test(
       await respondWith(new Response(stream.readable));
     })();
 
-    const resp = await fetch(`http://127.0.0.1:${listenPort}/`);
+    const client = Deno.createHttpClient({});
+    const resp = await fetch(`http://127.0.0.1:${listenPort}/`, { client });
     const respBody = await resp.text();
     assertEquals("hello world", respBody);
     await promise;
     httpConn!.close();
     listener.close();
+    client.close();
   },
 );
 
@@ -216,8 +218,8 @@ Deno.test(
     writer.write(new TextEncoder().encode("world"));
     writer.close();
 
+    const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
-      const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
       const httpConn = Deno.serveHttp(conn);
       const evt = await httpConn.nextRequest();
@@ -235,14 +237,17 @@ Deno.test(
       listener.close();
     })();
 
+    const client = Deno.createHttpClient({});
     const resp = await fetch(`http://127.0.0.1:${listenPort}/`, {
       body: stream.readable,
       method: "POST",
       headers: { "connection": "close" },
+      client,
     });
 
     await resp.arrayBuffer();
     await promise;
+    client.close();
   },
 );
 
@@ -375,9 +380,11 @@ Deno.test(
       await respondWith(new Response("response"));
     })();
 
+    const client = Deno.createHttpClient({});
     const resp = await fetch(`http://127.0.0.1:${listenPort}/`, {
       method: "POST",
       body: "request",
+      client,
     });
     const respBody = await resp.text();
     assertEquals("response", respBody);
@@ -385,6 +392,7 @@ Deno.test(
 
     httpConn!.close();
     listener.close();
+    client.close();
   },
 );
 
@@ -427,9 +435,11 @@ Deno.test(
       listener.close();
     })();
 
+    const client = Deno.createHttpClient({});
     const resp = await fetch(`http://127.0.0.1:${listenPort}/`);
     await resp.body!.cancel();
     await promise;
+    client.close();
   },
 );
 
@@ -788,7 +798,11 @@ Deno.test({ permissions: { net: true } }, async function httpServerWebSocket() {
       socket.send(m.data);
       socket.close(1001);
     };
+    const close = new Promise<void>((resolve) => {
+      socket.onclose = () => resolve();
+    });
     await respondWith(response);
+    await close;
   })();
 
   const def = deferred();
@@ -1228,11 +1242,15 @@ Deno.test(
     async function client() {
       const socket = new WebSocket(`ws://${hostname}:${port}/`);
       socket.onopen = () => socket.send("bla bla");
+      const closed = new Promise<void>((resolve) => {
+        socket.onclose = () => resolve();
+      });
       const { data } = await new Promise<MessageEvent<string>>((res) =>
         socket.onmessage = res
       );
       assertStrictEquals(data, "bla bla");
       socket.close();
+      await closed;
     }
 
     await Promise.all([server(), client()]);

--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -901,7 +901,7 @@ Deno.test(
 );
 
 Deno.test({ permissions: { net: true } }, async function whatwgStreams() {
-  (async () => {
+  const server = (async () => {
     const listener = Deno.listen({ hostname: "127.0.0.1", port: listenPort });
     const conn = await listener.accept();
     await conn.readable.pipeTo(conn.writable);
@@ -920,6 +920,7 @@ Deno.test({ permissions: { net: true } }, async function whatwgStreams() {
   assert(!done);
   assertEquals(decoder.decode(value), "Hello World");
   await reader.cancel();
+  await server;
 });
 
 Deno.test(
@@ -973,7 +974,7 @@ Deno.test(
 
 Deno.test(
   { permissions: { read: true, run: true } },
-  async function netListenUnref() {
+  async function netListenUnref2() {
     const [statusCode, _output] = await execCode(`
       async function main() {
         const listener = Deno.listen({ port: ${listenPort} });

--- a/cli/tests/unit/streams_test.ts
+++ b/cli/tests/unit/streams_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { fail } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
-import { assertEquals, Deferred, deferred } from "./test_util.ts";
+import { assertEquals, Deferred, deferred, fail } from "./test_util.ts";
 
 const {
   core,

--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -497,9 +497,15 @@ Deno.test({
     );
     const childProcess = spawn(Deno.execPath(), ["run", script]);
     const p = withTimeout();
+    const pStdout = withTimeout();
+    const pStderr = withTimeout();
     childProcess.on("exit", () => p.resolve());
+    childProcess.stdout.on("close", () => pStdout.resolve());
+    childProcess.stderr.on("close", () => pStderr.resolve());
     childProcess.kill("SIGKILL");
     await p;
+    await pStdout;
+    await pStderr;
     assert(childProcess.killed);
     assertEquals(childProcess.signalCode, "SIGKILL");
     assertExists(childProcess.exitCode);

--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -639,9 +639,15 @@ Deno.test({
     // Spawn an infinite cat
     const cp = spawn("cat", ["-"]);
     const p = withTimeout();
+    const pStdout = withTimeout();
+    const pStderr = withTimeout();
     cp.on("exit", () => p.resolve());
+    cp.stdout.on("close", () => pStdout.resolve());
+    cp.stderr.on("close", () => pStderr.resolve());
     cp.kill("SIGIOT");
     await p;
+    await pStdout;
+    await pStderr;
     assert(cp.killed);
     assertEquals(cp.signalCode, "SIGIOT");
   },

--- a/ext/broadcast_channel/01_broadcast_channel.js
+++ b/ext/broadcast_channel/01_broadcast_channel.js
@@ -17,7 +17,7 @@ const {
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
-  PromiseThen,
+  PromisePrototypeThen,
   Symbol,
   Uint8Array,
 } = primordials;
@@ -71,7 +71,7 @@ function dispatch(source, name, data) {
 // for that reason: it lets promises make forward progress but can
 // still starve other parts of the event loop.
 function defer(go) {
-  PromiseThen(core.ops.op_void_async_deferred(), () => go());
+  PromisePrototypeThen(core.ops.op_void_async_deferred(), () => go());
 }
 
 class BroadcastChannel extends EventTarget {

--- a/ext/broadcast_channel/01_broadcast_channel.js
+++ b/ext/broadcast_channel/01_broadcast_channel.js
@@ -15,8 +15,9 @@ import DOMException from "ext:deno_web/01_dom_exception.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
   ArrayPrototypeIndexOf,
-  ArrayPrototypeSplice,
   ArrayPrototypePush,
+  ArrayPrototypeSplice,
+  PromiseThen,
   Symbol,
   Uint8Array,
 } = primordials;
@@ -70,7 +71,7 @@ function dispatch(source, name, data) {
 // for that reason: it lets promises make forward progress but can
 // still starve other parts of the event loop.
 function defer(go) {
-  core.ops.op_void_async_deferred().then(() => go());
+  PromiseThen(core.ops.op_void_async_deferred(), () => go());
 }
 
 class BroadcastChannel extends EventTarget {

--- a/ext/broadcast_channel/01_broadcast_channel.js
+++ b/ext/broadcast_channel/01_broadcast_channel.js
@@ -70,7 +70,7 @@ function dispatch(source, name, data) {
 // for that reason: it lets promises make forward progress but can
 // still starve other parts of the event loop.
 function defer(go) {
-  setTimeout(go, 1);
+  core.ops.op_void_async_deferred().then(() => go());
 }
 
 class BroadcastChannel extends EventTarget {

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -284,6 +284,9 @@ async function mainFetch(req, recursive, terminator) {
         cause: requestSendError,
       });
     }
+    if (requestBodyRid !== null) {
+      core.tryClose(requestBodyRid);
+    }
     throw err;
   } finally {
     if (cancelHandleRid !== null) {


### PR DESCRIPTION
This commit improves async op sanitizer speed by only delaying metrics
collection if there are `op_sleep` ops in the resource table. This
results in a speedup of around 30% for small CPU bound unit tests.

It performs this check and possible delay on every collection now,
fixing an issue with parent test leaks into steps. Fixes #20498

Before:

```
/m/a/P/g/d/deno ❯❯❯ deno test -A --unstable ./cli/tests/unit/abort_controller_test.ts
running 6 tests from ./cli/tests/unit/abort_controller_test.ts
basicAbortController ... ok (5ms)
signalCallsOnabort ... ok (4ms)
signalEventListener ... ok (3ms)
onlyAbortsOnce ... ok (4ms)
controllerHasProperToString ... ok (3ms)
abortReason ... ok (3ms)

ok | 6 passed | 0 failed (44ms)
```

After:

```
/m/a/P/g/d/deno ❯❯❯ ./target/release/deno test -A --unstable ./cli/tests/unit/abort_controller_test.ts
running 6 tests from ./cli/tests/unit/abort_controller_test.ts
basicAbortController ... ok (3ms)
signalCallsOnabort ... ok (2ms)
signalEventListener ... ok (1ms)
onlyAbortsOnce ... ok (1ms)
controllerHasProperToString ... ok (1ms)
abortReason ... ok (1ms)

ok | 6 passed | 0 failed (29ms)
```

