### PR TITLE
refactor: remove `DENO_UNSTABLE_NPM_SYNC_DOWNLOAD` and custom sync functionality

### DIFF
--- a/cli/npm/cache.rs
+++ b/cli/npm/cache.rs
@@ -18,7 +18,6 @@ use deno_npm::NpmPackageCacheFolderId;
 use deno_runtime::deno_fs;
 use deno_semver::package::PackageNv;
 use deno_semver::Version;
-use once_cell::sync::Lazy;
 
 use crate::args::CacheSetting;
 use crate::http_util::HttpClient;
@@ -28,17 +27,6 @@ use crate::util::path::root_url_to_safe_local_dirname;
 use crate::util::progress_bar::ProgressBar;
 
 use super::tarball::verify_and_extract_tarball;
-
-static SHOULD_SYNC_DOWNLOAD: Lazy<bool> =
-  Lazy::new(|| std::env::var("DENO_UNSTABLE_NPM_SYNC_DOWNLOAD").is_ok());
-
-/// For some of the tests, we want downloading of packages
-/// to be deterministic so that the output is always the same
-pub fn should_sync_download() -> bool {
-  // this gets called a lot when doing npm resolution and was taking
-  // a significant amount of time, so cache it in a lazy
-  *SHOULD_SYNC_DOWNLOAD
-}
 
 const NPM_PACKAGE_SYNC_LOCK_FILENAME: &str = ".deno_sync_lock";
 

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -7,7 +7,6 @@ mod resolution;
 mod resolvers;
 mod tarball;
 
-pub use cache::should_sync_download;
 pub use cache::NpmCache;
 pub use cache::NpmCacheDir;
 pub use installer::PackageJsonDepsInstaller;

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -26,7 +26,6 @@ use crate::npm::CliNpmRegistryApi;
 use crate::npm::NpmResolution;
 use crate::npm::PackageJsonDepsInstaller;
 use crate::util::sync::AtomicFlag;
-use crate::util::sync::TaskQueue;
 
 /// Result of checking if a specifier is mapped via
 /// an import map or package.json.
@@ -110,7 +109,6 @@ pub struct CliGraphResolver {
   npm_resolution: Arc<NpmResolution>,
   package_json_deps_installer: Arc<PackageJsonDepsInstaller>,
   found_package_json_dep_flag: Arc<AtomicFlag>,
-  sync_download_queue: Option<Arc<TaskQueue>>,
 }
 
 impl Default for CliGraphResolver {
@@ -136,7 +134,6 @@ impl Default for CliGraphResolver {
       npm_resolution,
       package_json_deps_installer: Default::default(),
       found_package_json_dep_flag: Default::default(),
-      sync_download_queue: Self::create_sync_download_queue(),
     }
   }
 }
@@ -176,15 +173,6 @@ impl CliGraphResolver {
       npm_resolution,
       package_json_deps_installer,
       found_package_json_dep_flag: Default::default(),
-      sync_download_queue: Self::create_sync_download_queue(),
-    }
-  }
-
-  fn create_sync_download_queue() -> Option<Arc<TaskQueue>> {
-    if crate::npm::should_sync_download() {
-      Some(Default::default())
-    } else {
-      None
     }
   }
 
@@ -314,21 +302,12 @@ impl NpmResolver for CliGraphResolver {
     // this will internally cache the package information
     let package_name = package_name.to_string();
     let api = self.npm_registry_api.clone();
-    let maybe_sync_download_queue = self.sync_download_queue.clone();
     async move {
-      let permit = if let Some(task_queue) = &maybe_sync_download_queue {
-        Some(task_queue.acquire().await)
-      } else {
-        None
-      };
-
-      let result = api
+      api
         .package_info(&package_name)
         .await
         .map(|_| ())
-        .map_err(|err| err.into());
-      drop(permit);
-      result
+        .map_err(|err| err.into())
     }
     .boxed()
   }

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -1689,8 +1689,10 @@ itest!(non_existent_dep {
   http_server: true,
   exit_code: 1,
   output_str: Some(concat!(
+    "[UNORDERED_START]\n",
     "Download http://localhost:4545/npm/registry/@denotest/non-existent-dep\n",
     "Download http://localhost:4545/npm/registry/@denotest/non-existent\n",
+    "[UNORDERED_END]\n",
     "error: npm package '@denotest/non-existent' does not exist.\n"
   )),
 });
@@ -1701,12 +1703,16 @@ itest!(non_existent_dep_version {
   http_server: true,
   exit_code: 1,
   output_str: Some(concat!(
+    "[UNORDERED_START]\n",
     "Download http://localhost:4545/npm/registry/@denotest/non-existent-dep-version\n",
     "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
+    "[UNORDERED_END]\n",
     // does two downloads because when failing once it max tries to
     // get the latest version a second time
+    "[UNORDERED_START]\n",
     "Download http://localhost:4545/npm/registry/@denotest/non-existent-dep-version\n",
     "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
+    "[UNORDERED_END]\n",
     "error: Could not find npm package '@denotest/esm-basic' matching '=99.99.99'.\n"
   )),
 });
@@ -1760,12 +1766,14 @@ fn reload_info_not_found_cache_but_exists_remote() {
     .args("cache main.ts npm:@denotest/esm-basic@1.0.0")
     .run();
   output.assert_matches_text(concat!(
+    "[UNORDERED_START]\n",
     "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
     "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
     "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
     "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export/1.0.0.tgz\n",
     "Download http://localhost:4545/npm/registry/@denotest/esm-basic/1.0.0.tgz\n",
     "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default/1.0.0.tgz\n",
+    "[UNORDERED_END]\n",
   ));
 
   // test in dependency
@@ -1788,8 +1796,10 @@ fn reload_info_not_found_cache_but_exists_remote() {
     // now try running without it, it should download the package now
     let output = test_context.new_command().args("run main.ts").run();
     output.assert_matches_text(concat!(
+      "[UNORDERED_START]\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
       "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
+      "[UNORDERED_END]\n",
       "Node esm importing node cjs\n[WILDCARD]",
     ));
     output.assert_exit_code(0);
@@ -1818,8 +1828,10 @@ fn reload_info_not_found_cache_but_exists_remote() {
     // now try running, it should work
     let output = test_context.new_command().args("run main.ts").run();
     output.assert_matches_text(concat!(
+      "[UNORDERED_START]\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
       "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
+      "[UNORDERED_END]\n",
       "Node esm importing node cjs\n[WILDCARD]",
     ));
     output.assert_exit_code(0);
@@ -1854,10 +1866,14 @@ fn reload_info_not_found_cache_but_exists_remote() {
     // now try running, it should work
     let output = test_context.new_command().args("run main.ts").run();
     output.assert_matches_text(concat!(
+      "[UNORDERED_START]\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
       "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
+      "[UNORDERED_END]\n",
+      "[UNORDERED_START]\n",
       "Initialize @denotest/cjs-default-export@1.0.0\n",
       "Initialize @denotest/esm-import-cjs-default@1.0.0\n",
+      "[UNORDERED_END]\n",
       "Node esm importing node cjs\n[WILDCARD]",
     ));
     output.assert_exit_code(0);
@@ -1887,9 +1903,11 @@ fn reload_info_not_found_cache_but_exists_remote() {
     // now try running, it should work and only initialize the new package
     let output = test_context.new_command().args("run main.ts").run();
     output.assert_matches_text(concat!(
+      "[UNORDERED_START]\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
       "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
+      "[UNORDERED_END]\n",
       "Initialize @denotest/esm-basic@1.0.0\n",
       "Node esm importing node cjs\n[WILDCARD]",
     ));
@@ -1923,9 +1941,11 @@ fn reload_info_not_found_cache_but_exists_remote() {
     // now try running, it should work and only initialize the new package
     let output = test_context.new_command().args("run main.ts").run();
     output.assert_matches_text(concat!(
+      "[UNORDERED_START]\n",
       "Download http://localhost:4545/npm/registry/@denotest/cjs-default-export\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-basic\n",
       "Download http://localhost:4545/npm/registry/@denotest/esm-import-cjs-default\n",
+      "[UNORDERED_END]\n",
       "Node esm importing node cjs\n[WILDCARD]",
     ));
     output.assert_exit_code(0);

--- a/cli/tests/testdata/check/jsx_not_checked/main.out
+++ b/cli/tests/testdata/check/jsx_not_checked/main.out
@@ -1,9 +1,11 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/react
 Download http://localhost:4545/npm/registry/loose-envify
 Download http://localhost:4545/npm/registry/js-tokens
 Download http://localhost:4545/npm/registry/react/react-18.2.0.tgz
 Download http://localhost:4545/npm/registry/loose-envify/loose-envify-1.4.0.tgz
 Download http://localhost:4545/npm/registry/js-tokens/js-tokens-4.0.0.tgz
+[UNORDERED_END]
 Check file:///[WILDCARD]/jsx_not_checked/main.jsx
 error: TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'number'.
 console.log(add("1", "2"));

--- a/cli/tests/testdata/npm/cjs_sub_path/main.out
+++ b/cli/tests/testdata/npm/cjs_sub_path/main.out
@@ -1,3 +1,4 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/ajv
 Download http://localhost:4545/npm/registry/ajv-formats
 Download http://localhost:4545/npm/registry/chai
@@ -13,6 +14,8 @@ Download http://localhost:4545/npm/registry/loupe
 Download http://localhost:4545/npm/registry/pathval
 Download http://localhost:4545/npm/registry/type-detect
 Download http://localhost:4545/npm/registry/punycode
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/ajv/ajv-8.11.0.tgz
 Download http://localhost:4545/npm/registry/ajv-formats/ajv-formats-2.1.1.tgz
 Download http://localhost:4545/npm/registry/assertion-error/assertion-error-1.1.0.tgz
@@ -28,4 +31,5 @@ Download http://localhost:4545/npm/registry/punycode/punycode-2.1.1.tgz
 Download http://localhost:4545/npm/registry/require-from-string/require-from-string-2.0.2.tgz
 Download http://localhost:4545/npm/registry/type-detect/type-detect-4.0.8.tgz
 Download http://localhost:4545/npm/registry/uri-js/uri-js-4.4.1.tgz
+[UNORDERED_END]
 Fini

--- a/cli/tests/testdata/npm/cjs_with_deps/main.out
+++ b/cli/tests/testdata/npm/cjs_with_deps/main.out
@@ -1,3 +1,4 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/chai
 Download http://localhost:4545/npm/registry/ansi-styles
@@ -12,6 +13,8 @@ Download http://localhost:4545/npm/registry/type-detect
 Download http://localhost:4545/npm/registry/color-convert
 Download http://localhost:4545/npm/registry/has-flag
 Download http://localhost:4545/npm/registry/color-name
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/ansi-styles/ansi-styles-4.3.0.tgz
 Download http://localhost:4545/npm/registry/assertion-error/assertion-error-1.1.0.tgz
 Download http://localhost:4545/npm/registry/chai/chai-4.3.6.tgz
@@ -26,4 +29,5 @@ Download http://localhost:4545/npm/registry/loupe/loupe-2.3.4.tgz
 Download http://localhost:4545/npm/registry/pathval/pathval-1.1.1.tgz
 Download http://localhost:4545/npm/registry/supports-color/supports-color-7.2.0.tgz
 Download http://localhost:4545/npm/registry/type-detect/type-detect-4.0.8.tgz
+[UNORDERED_END]
 chalk cjs loads

--- a/cli/tests/testdata/npm/cjs_with_deps/main_node_modules.out
+++ b/cli/tests/testdata/npm/cjs_with_deps/main_node_modules.out
@@ -1,3 +1,4 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/chai
 Download http://localhost:4545/npm/registry/ansi-styles
@@ -12,6 +13,8 @@ Download http://localhost:4545/npm/registry/type-detect
 Download http://localhost:4545/npm/registry/color-convert
 Download http://localhost:4545/npm/registry/has-flag
 Download http://localhost:4545/npm/registry/color-name
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/ansi-styles/ansi-styles-4.3.0.tgz
 Initialize ansi-styles@4.3.0
 Download http://localhost:4545/npm/registry/assertion-error/assertion-error-1.1.0.tgz
@@ -40,4 +43,5 @@ Download http://localhost:4545/npm/registry/supports-color/supports-color-7.2.0.
 Initialize supports-color@7.2.0
 Download http://localhost:4545/npm/registry/type-detect/type-detect-4.0.8.tgz
 Initialize type-detect@4.0.8
+[UNORDERED_END]
 chalk cjs loads

--- a/cli/tests/testdata/npm/cjs_yargs/main.out
+++ b/cli/tests/testdata/npm/cjs_yargs/main.out
@@ -1,3 +1,4 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/yargs
 Download http://localhost:4545/npm/registry/cliui
 Download http://localhost:4545/npm/registry/decamelize
@@ -24,6 +25,8 @@ Download http://localhost:4545/npm/registry/color-convert
 Download http://localhost:4545/npm/registry/p-limit
 Download http://localhost:4545/npm/registry/color-name
 Download http://localhost:4545/npm/registry/p-try
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/ansi-regex/ansi-regex-5.0.1.tgz
 Initialize ansi-regex@5.0.1
 Download http://localhost:4545/npm/registry/ansi-styles/ansi-styles-4.3.0.tgz
@@ -76,5 +79,6 @@ Download http://localhost:4545/npm/registry/yargs/yargs-15.4.1.tgz
 Initialize yargs@15.4.1
 Download http://localhost:4545/npm/registry/yargs-parser/yargs-parser-18.1.3.tgz
 Initialize yargs-parser@18.1.3
+[UNORDERED_END]
 start server on :8000
 [WILDCARD]

--- a/cli/tests/testdata/npm/compare_globals/main.out
+++ b/cli/tests/testdata/npm/compare_globals/main.out
@@ -1,7 +1,11 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@types/node
 Download http://localhost:4545/npm/registry/@denotest/globals
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/globals/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@types/node/node-18.8.2.tgz
+[UNORDERED_END]
 Check file:///[WILDCARD]/npm/compare_globals/main.ts
 true
 true

--- a/cli/tests/testdata/npm/conditional_exports/main.out
+++ b/cli/tests/testdata/npm/conditional_exports/main.out
@@ -1,11 +1,15 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/conditional-exports
 Download http://localhost:4545/npm/registry/supports-esm
 Download http://localhost:4545/npm/registry/has-package-exports
 Download http://localhost:4545/npm/registry/@ljharb/has-package-exports-patterns
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/conditional-exports/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@ljharb/has-package-exports-patterns/has-package-exports-patterns-0.0.2.tgz
 Download http://localhost:4545/npm/registry/has-package-exports/has-package-exports-1.3.0.tgz
 Download http://localhost:4545/npm/registry/supports-esm/supports-esm-1.0.0.tgz
+[UNORDERED_END]
 { hello: "from esm" }
 { hello: "from foo" }
 { hello: "from esm client" }

--- a/cli/tests/testdata/npm/conditional_exports/main_node_modules.out
+++ b/cli/tests/testdata/npm/conditional_exports/main_node_modules.out
@@ -1,7 +1,10 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/conditional-exports
 Download http://localhost:4545/npm/registry/supports-esm
 Download http://localhost:4545/npm/registry/has-package-exports
 Download http://localhost:4545/npm/registry/@ljharb/has-package-exports-patterns
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/conditional-exports/1.0.0.tgz
 Initialize @denotest/conditional-exports@1.0.0
 Download http://localhost:4545/npm/registry/@ljharb/has-package-exports-patterns/has-package-exports-patterns-0.0.2.tgz
@@ -10,6 +13,7 @@ Download http://localhost:4545/npm/registry/has-package-exports/has-package-expo
 Initialize has-package-exports@1.3.0
 Download http://localhost:4545/npm/registry/supports-esm/supports-esm-1.0.0.tgz
 Initialize supports-esm@1.0.0
+[UNORDERED_END]
 { hello: "from esm" }
 { hello: "from foo" }
 { hello: "from esm client" }

--- a/cli/tests/testdata/npm/deno_cache.out
+++ b/cli/tests/testdata/npm/deno_cache.out
@@ -1,4 +1,8 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/mkdirp
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
 Download http://localhost:4545/npm/registry/mkdirp/mkdirp-1.0.4.tgz
+[UNORDERED_END]

--- a/cli/tests/testdata/npm/import_map/main.out
+++ b/cli/tests/testdata/npm/import_map/main.out
@@ -1,6 +1,10 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/chalk
 Download http://localhost:4545/npm/registry/@denotest/dual-cjs-esm
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/dual-cjs-esm/1.0.0.tgz
 Download http://localhost:4545/npm/registry/chalk/chalk-5.0.1.tgz
+[UNORDERED_END]
 chalk import map loads
 esm

--- a/cli/tests/testdata/npm/mixed_case_package_name/global.out
+++ b/cli/tests/testdata/npm/mixed_case_package_name/global.out
@@ -1,5 +1,9 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/MixedCase
 Download http://localhost:4545/npm/registry/@denotest/CAPITALS
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/CAPITALS/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@denotest/MixedCase/1.0.0.tgz
+[UNORDERED_END]
 5

--- a/cli/tests/testdata/npm/mixed_case_package_name/local.out
+++ b/cli/tests/testdata/npm/mixed_case_package_name/local.out
@@ -1,9 +1,13 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/MixedCase
 Download http://localhost:4545/npm/registry/@denotest/CAPITALS
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/CAPITALS/1.0.0.tgz
 Initialize @denotest/CAPITALS@1.0.0
 Download http://localhost:4545/npm/registry/@denotest/MixedCase/1.0.0.tgz
 Initialize @denotest/MixedCase@1.0.0
+[UNORDERED_END]
 5
 true
 true

--- a/cli/tests/testdata/npm/peer_deps_with_copied_folders/main.out
+++ b/cli/tests/testdata/npm/peer_deps_with_copied_folders/main.out
@@ -1,10 +1,14 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-child
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-grandchild
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-peer
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-child/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-child/2.0.0.tgz
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-grandchild/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-peer/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-peer/2.0.0.tgz
+[UNORDERED_END]
 1
 2

--- a/cli/tests/testdata/npm/peer_deps_with_copied_folders/main_node_modules.out
+++ b/cli/tests/testdata/npm/peer_deps_with_copied_folders/main_node_modules.out
@@ -1,7 +1,9 @@
+[UNORDERED_START]
 Initialize @denotest/peer-dep-test-child@1.0.0
 Initialize @denotest/peer-dep-test-child@2.0.0
 Initialize @denotest/peer-dep-test-grandchild@1.0.0
 Initialize @denotest/peer-dep-test-peer@1.0.0
 Initialize @denotest/peer-dep-test-peer@2.0.0
+[UNORDERED_END]
 1
 2

--- a/cli/tests/testdata/npm/peer_deps_with_copied_folders/main_node_modules_reload.out
+++ b/cli/tests/testdata/npm/peer_deps_with_copied_folders/main_node_modules_reload.out
@@ -1,6 +1,9 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-child
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-grandchild
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-peer
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-child/1.0.0.tgz
 Initialize @denotest/peer-dep-test-child@1.0.0
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-child/2.0.0.tgz
@@ -11,5 +14,6 @@ Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-peer/1.0.0.t
 Initialize @denotest/peer-dep-test-peer@1.0.0
 Download http://localhost:4545/npm/registry/@denotest/peer-dep-test-peer/2.0.0.tgz
 Initialize @denotest/peer-dep-test-peer@2.0.0
+[UNORDERED_END]
 1
 2

--- a/cli/tests/testdata/npm/types_no_types_entry/main.out
+++ b/cli/tests/testdata/npm/types_no_types_entry/main.out
@@ -1,7 +1,11 @@
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/types-no-types-entry
 Download http://localhost:4545/npm/registry/@denotest/types-entry-value-not-exists
+[UNORDERED_END]
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/types-entry-value-not-exists/1.0.0.tgz
 Download http://localhost:4545/npm/registry/@denotest/types-no-types-entry/1.0.0.tgz
+[UNORDERED_END]
 Check file://[WILDCARD]/types_no_types_entry/main.ts
 error: TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
 const result: string = getValue();

--- a/cli/tests/testdata/task/package_json/bin.out
+++ b/cli/tests/testdata/task/package_json/bin.out
@@ -1,8 +1,10 @@
 Download http://localhost:4545/npm/registry/@denotest/bin
+[UNORDERED_START]
 Download http://localhost:4545/npm/registry/@denotest/bin/0.5.0.tgz
 Initialize @denotest/bin@0.5.0
 Download http://localhost:4545/npm/registry/@denotest/bin/1.0.0.tgz
 Initialize @denotest/bin@1.0.0
+[UNORDERED_END]
 Warning Currently only basic package.json `scripts` are supported. Programs like `rimraf` or `cross-env` will not work correctly. This will be fixed in an upcoming release.
 Task bin @denotest/bin hi && cli-esm testing this out && npx cli-cjs test "extra"
 hi

--- a/cli/util/sync.rs
+++ b/cli/util/sync.rs
@@ -57,6 +57,7 @@ impl TaskQueue {
 
   /// Alternate API that acquires a permit internally
   /// for the duration of the future.
+  #[allow(unused)]
   pub fn run<'a, R>(
     &'a self,
     future: impl Future<Output = R> + 'a,

--- a/test_util/src/assertions.rs
+++ b/test_util/src/assertions.rs
@@ -54,7 +54,8 @@ macro_rules! assert_not_contains {
 
 #[track_caller]
 pub fn assert_wildcard_match(actual: &str, expected: &str) {
-  if !expected.contains("[WILDCARD]") && !expected.contains("[IGNORE_START]") {
+  if !expected.contains("[WILDCARD]") && !expected.contains("[UNORDERED_START]")
+  {
     pretty_assertions::assert_eq!(actual, expected);
   } else {
     match crate::wildcard_match_detailed(expected, actual) {


### PR DESCRIPTION
https://github.com/denoland/deno/pull/20488 enables us to remove this functionality. This is better because our test suite is now not testing a separate code path.