### PR TITLE
docs(contributing): Fix README link to contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Deno.serve((_req) => new Response("Hello, World!"));
 We appreciate your help!
 
 To contribute, please read our
-[contributing instructions](https://deno.land/manual/contributing).
+[contributing instructions](https://deno.land/manual/references/contributing/).
 
 [Build status - Cirrus]: https://github.com/denoland/deno/workflows/ci/badge.svg?branch=main&event=push
 [Build status]: https://github.com/denoland/deno/actions


### PR DESCRIPTION
Fixing a broken link to the contributing docs

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
