### PR TITLE
fix: set `evalue` to a one space string for truthiness on old jupyter

### DIFF
--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -358,7 +358,7 @@ impl JupyterServer {
           .new_message("error")
           .with_content(json!({
             "ename": err.to_string(),
-            "evalue": "",
+            "evalue": " ", // Fake value, otherwise old Jupyter frontends don't show the error
             "traceback": [],
           }))
           .send(&mut *self.iopub_socket.lock().await)
@@ -425,7 +425,7 @@ impl JupyterServer {
         .new_message("error")
         .with_content(json!({
           "ename": name,
-          "evalue": "",
+          "evalue": " ", // Fake value, otherwise old Jupyter frontends don't show the error
           "traceback": [],
         }))
         .send(&mut *self.iopub_socket.lock().await)


### PR DESCRIPTION
"Fixes" the exception display issue of #20524 on older versions of Jupyter that required `evalue` to be truthy. For now, until we can do proper processing of the `ExceptionDetails` this will make Jupyter Notebook 6.5.1 and below happy.

This is the alternative "just work now" PR to #20530 

cc @mmastrac 

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
