### PR TITLE
feat(jupyter-kernel): accept nested objects from display calls

### DIFF
--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -490,6 +490,12 @@ async fn get_jupyter_display(
     )
     .await?;
 
+  if let Some(exception_details) = &response.exception_details {
+    // TODO(rgbkrk): Return an error in userspace instead of Jupyter logs
+    eprintln!("Exception encountered: {}", exception_details.text);
+    return Ok(None);
+  }
+
   if let Some(serde_json::Value::String(json_str)) = response.result.value {
     let data: HashMap<String, serde_json::Value> =
       serde_json::from_str(&json_str)?;

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -490,8 +490,6 @@ async fn get_jupyter_display(
     )
     .await?;
 
-  let json_str = response.result.clone().value.unwrap_or_default();
-
   if let Some(serde_json::Value::String(json_str)) = response.result.value {
     let data: HashMap<String, serde_json::Value> =
       serde_json::from_str(&json_str)?;
@@ -500,7 +498,10 @@ async fn get_jupyter_display(
       return Ok(Some(data));
     }
   } else {
-    eprintln!("Unexpected response from Jupyter.display: {:?}", json_str);
+    eprintln!(
+      "Unexpected response from Jupyter.display: {:?}",
+      response.result.clone().value.unwrap_or_default()
+    );
   }
 
   Ok(None)

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -506,7 +506,7 @@ async fn get_jupyter_display(
   } else {
     eprintln!(
       "Unexpected response from Jupyter.display: {:?}",
-      response.result.clone().value.unwrap_or_default()
+      response.result.clone().value
     );
   }
 


### PR DESCRIPTION
Closes #20535.

# Screenshots

## JSON
<img width="779" alt="image" src="https://github.com/denoland/deno/assets/836375/668bb1a6-3f76-4b36-974e-cdc6c93f94c3">

## Vegalite

<img width="558" alt="image" src="https://github.com/denoland/deno/assets/836375/a5e70908-6b87-42d8-85c3-1323ad52a00f">

# Implementation

Instead of going the route of recursively getting all the objects under `application/.*json` keys, I went with `JSON.stringify`ing in denospace then parsing it from rust. One of the key benefits of serializing and deserializing is that non-JSON-able entries will get stripped automatically. This also keeps the code pretty simple.

In the future we should _only_ do this for `application/.*json` keys.

cc @mmastrac 