### PR TITLE
fix(jupyter-kernel): don't log errors from objects without a `Symbol.for("Jupyter.display")`

### DIFF
--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -483,8 +483,8 @@ async fn get_jupyter_display(
   let response = session
     .call_function_on_args(
       r#"function (object) {
-        const display = object[Symbol.for("Jupyter.display")]
-        if (display) {
+        const display = object[Symbol.for("Jupyter.display")];
+        if (typeof display === "function") {
           return JSON.stringify(display());
         } else {
           return null;
@@ -516,6 +516,7 @@ async fn get_jupyter_display(
       }
     },
     Some(serde_json::Value::Null) => {
+      // Object did not have the Jupyter display spec
       return Ok(None);
     },
     _ => {

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -490,7 +490,7 @@ async fn get_jupyter_display(
           return null;
         }
       }"#
-      .to_string(),
+        .to_string(),
       &[evaluate_result.clone()],
     )
     .await?;
@@ -504,21 +504,21 @@ async fn get_jupyter_display(
 
   match response.result.value {
     Some(serde_json::Value::String(json_str)) => {
-      let Ok(data) = serde_json::from_str::<HashMap<String, serde_json::Value>>(&json_str) else {
-        eprintln!(
-          "Unexpected response from Jupyter.display: {json_str}"
-        );
+      let Ok(data) =
+        serde_json::from_str::<HashMap<String, serde_json::Value>>(&json_str)
+      else {
+        eprintln!("Unexpected response from Jupyter.display: {json_str}");
         return Ok(None);
       };
 
       if !data.is_empty() {
         return Ok(Some(data));
       }
-    },
+    }
     Some(serde_json::Value::Null) => {
       // Object did not have the Jupyter display spec
       return Ok(None);
-    },
+    }
     _ => {
       eprintln!(
         "Unexpected response from Jupyter.display: {:?}",

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -490,9 +490,9 @@ async fn get_jupyter_display(
     )
     .await?;
 
-  if let Some(exception_details) = &response.exception_details {
-    // TODO(rgbkrk): Return an error in userspace instead of Jupyter logs
-    eprintln!("Exception encountered: {}", exception_details.text);
+  if response.exception_details.is_some() {
+    // If the object doesn't have a Jupyter.display method or it throws an
+    // exception, we just ignore it and let the caller handle it.
     return Ok(None);
   }
 


### PR DESCRIPTION
Fast follow up to #20537.

Before:

![image](https://github.com/denoland/deno/assets/836375/8a12e83d-9008-419b-bd1f-24c0ac90afd3)

After:

<img width="235" alt="image" src="https://github.com/denoland/deno/assets/836375/467bf381-278e-4577-a980-7b0ddb08d2af">
