### PR TITLE
fix(cli): ensure that an exception in getOwnPropertyDescriptor('constructor') doesn't break Deno.inspect

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1051,6 +1051,17 @@ Deno.test(function consoleTestWithCustomInspectorUsingInspectFunc() {
   assertEquals(stringify(new A()), "b { c: 1 }");
 });
 
+Deno.test(function consoleTestWithConstructorError() {
+  let obj = new Proxy({}, {
+    getOwnPropertyDescriptor(_target, name) {
+      if (name == "constructor") {
+        throw "yikes";
+      }
+    },
+  });
+  assertEquals(Deno.inspect(obj), "{}");
+});
+
 Deno.test(function consoleTestWithCustomInspectorError() {
   class A {
     [customInspect](): never {

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1052,7 +1052,7 @@ Deno.test(function consoleTestWithCustomInspectorUsingInspectFunc() {
 });
 
 Deno.test(function consoleTestWithConstructorError() {
-  let obj = new Proxy({}, {
+  const obj = new Proxy({}, {
     getOwnPropertyDescriptor(_target, name) {
       if (name == "constructor") {
         throw "yikes";

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1057,6 +1057,7 @@ Deno.test(function consoleTestWithConstructorError() {
       if (name == "constructor") {
         throw "yikes";
       }
+      return undefined;
     },
   });
   assertEquals(Deno.inspect(obj), "{}");

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -1202,7 +1202,12 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
   let firstProto;
   const tmp = obj;
   while (obj || isUndetectableObject(obj)) {
-    const descriptor = ObjectGetOwnPropertyDescriptor(obj, "constructor");
+    let descriptor;
+    try {
+      descriptor = ObjectGetOwnPropertyDescriptor(obj, "constructor");
+    } catch {
+      /* this could fail */
+    }
     if (
       descriptor !== undefined &&
       typeof descriptor.value === "function" &&


### PR DESCRIPTION
Fixes #20561 