### PR TITLE
fix(node/package_json): Avoid panic when "exports" field is null

### DIFF
--- a/ext/node/package_json.rs
+++ b/ext/node/package_json.rs
@@ -240,3 +240,19 @@ fn is_conditional_exports_main_sugar(exports: &Value) -> bool {
 
   is_conditional_sugar
 }
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn null_exports_should_not_crash() {
+    let package_json = PackageJson::load_from_string(
+      PathBuf::from("/package.json"),
+      r#"{ "exports": null }"#.to_string(),
+    )
+    .unwrap();
+
+    assert!(package_json.exports.is_none());
+  }
+}

--- a/ext/node/package_json.rs
+++ b/ext/node/package_json.rs
@@ -114,14 +114,14 @@ impl PackageJson {
     let version_val = package_json.get("version");
     let type_val = package_json.get("type");
     let bin = package_json.get("bin").map(ToOwned::to_owned);
-    let exports = package_json.get("exports").map(|exports| {
-      if is_conditional_exports_main_sugar(exports) {
+    let exports = package_json.get("exports").and_then(|exports| {
+      Some(if is_conditional_exports_main_sugar(exports) {
         let mut map = Map::new();
         map.insert(".".to_string(), exports.to_owned());
         map
       } else {
-        exports.as_object().unwrap().to_owned()
-      }
+        exports.as_object()?.to_owned()
+      })
     });
 
     let imports = imports_val


### PR DESCRIPTION
Fixes #20558

Implementation: when package.json `exports` field is `null`, treat it as if it was not set