### PR TITLE
chore: bump deno_core + cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2824cd5e1ae7b64dc22796aac6f1dce6502a0d7315948f4dd9ff223f6587ad"
+checksum = "28278061bf4a75c3ec368e6a23c719da1f6484ca91e81059f64ea6445bc07a45"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51e472f06968470a92508160d344e14e5e033e7d2c76b26e335e7688bd5eef3"
+checksum = "0d58eed3067316c73b2edf802dca6466ddd8ada6c71b5343a9a32764cf63bba4"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4832,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.124.0"
+version = "0.125.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7e9e142530a7be1e08a9fb3bdc10bdef76e2555868b157b727ab8cf249b4fe"
+checksum = "38b1c706e561399a8bcc88fbc87dc4ec8ccb11bfd6773a41419ec3cb09601b20"
 dependencies = [
  "bytes",
  "derive_more",
@@ -6312,9 +6312,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.77.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c1cc5961099892fa7a60b2486cf07065c6006118bc34ae12ef18f36d0d2489"
+checksum = "f6c96f70e8fc6c009af99d4e8ac4f5e84655a0fc3ec6e58147933b9c99f8b43c"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1061,7 +1061,7 @@ dependencies = [
  "text_lines",
  "thiserror",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tower-lsp",
  "trust-dns-client",
  "trust-dns-server",
@@ -1216,14 +1216,14 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.214.0"
+version = "0.215.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0af76effe9a766f7c9a253171ab10b9adfaf4b10c6eb0b9f005f9dd0ba2948"
+checksum = "db2824cd5e1ae7b64dc22796aac6f1dce6502a0d7315948f4dd9ff223f6587ad"
 dependencies = [
  "anyhow",
  "bytes",
  "deno_ops",
- "deno_unsync 0.2.1",
+ "deno_unsync 0.3.0",
  "futures",
  "indexmap 2.0.0",
  "libc",
@@ -1323,7 +1323,7 @@ dependencies = [
  "reqwest",
  "serde",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
 ]
 
 [[package]]
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.90.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568aba570695e05f08c2181bcd6cd3579684af42f489b9ae42712348044b4af7"
+checksum = "f51e472f06968470a92508160d344e14e5e033e7d2c76b26e335e7688bd5eef3"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -1717,7 +1717,7 @@ dependencies = [
  "os_pipe",
  "path-dedot",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
 ]
 
 [[package]]
@@ -1745,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "deno_unsync"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0720e562455d6374a5292baec3fc895ed8bfed0937428e3245e50979924e5b15"
+checksum = "f8a8f3722afd50e566ecfc783cc8a3a046bc4dd5eb45007431dfb2776aeb8993"
 dependencies = [
  "tokio",
 ]
@@ -2671,7 +2671,7 @@ dependencies = [
  "indexmap 1.9.3",
  "slab",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tracing",
 ]
 
@@ -3293,10 +3293,11 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md-5"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
+ "cfg-if 1.0.0",
  "digest 0.10.7",
 ]
 
@@ -4362,7 +4363,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-socks",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4504,9 +4505,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno 0.3.3",
@@ -4550,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -4831,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.123.0"
+version = "0.124.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3e1c4d2b20f6983e86077c66b25b8d768f2e102e09659af2af034ac47ae709"
+checksum = "5d7e9e142530a7be1e08a9fb3bdc10bdef76e2555868b157b727ab8cf249b4fe"
 dependencies = [
  "bytes",
  "derive_more",
@@ -4858,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4936,9 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smartstring"
@@ -5878,9 +5879,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5954,7 +5955,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tower",
  "tower-lsp-macros",
 ]
@@ -6311,9 +6312,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4e8ae7ef8b4e852e728e343cb6bb471a0424dfefa22585ea0c14a61252d73f"
+checksum = "d2c1cc5961099892fa7a60b2486cf07065c6006118bc34ae12ef18f36d0d2489"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",
@@ -6533,9 +6534,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -6655,7 +6656,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 4.1.0",
+ "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/denoland/deno"
 [workspace.dependencies]
 deno_ast = { version = "0.29.3", features = ["transpiling"] }
 
-deno_core = { version = "0.214.0" }
+deno_core = { version = "0.215.0" }
 
 deno_runtime = { version = "0.127.0", path = "./runtime" }
 napi_sym = { version = "0.49.0", path = "./cli/napi/sym" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/denoland/deno"
 [workspace.dependencies]
 deno_ast = { version = "0.29.3", features = ["transpiling"] }
 
-deno_core = { version = "0.215.0" }
+deno_core = { version = "0.216.0" }
 
 deno_runtime = { version = "0.127.0", path = "./runtime" }
 napi_sym = { version = "0.49.0", path = "./cli/napi/sym" }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -328,8 +328,6 @@ function runtimeStart(
   core.setBuildInfo(target);
   util.setLogLevel(logLevel, source);
   setNoColor(noColor || !isTty);
-  // deno-lint-ignore prefer-primordials
-  Error.prepareStackTrace = core.prepareStackTrace;
 }
 
 const pendingRejections = [];


### PR DESCRIPTION
```
    Updating aes-gcm v0.10.2 -> v0.10.3
    Updating aho-corasick v1.1.0 -> v1.1.1
    Updating curve25519-dalek v4.1.0 -> v4.1.1
    Updating deno_core v0.214.0 -> v0.215.0
    Updating deno_ops v0.90.0 -> v0.91.0
    Updating deno_unsync v0.2.1 -> v0.3.0
    Updating md-5 v0.10.5 -> v0.10.6
    Updating rustix v0.38.13 -> v0.38.14
    Updating rustls-webpki v0.101.5 -> v0.101.6
    Updating serde_v8 v0.123.0 -> v0.124.0
    Updating sha1 v0.10.5 -> v0.10.6
    Updating smallvec v1.11.0 -> v1.11.1
    Updating tokio-util v0.7.8 -> v0.7.9
    Updating v8 v0.76.0 -> v0.77.0
    Updating winapi-util v0.1.5 -> v0.1.6
```