### PR TITLE
fix(ext/node): Fix invalid length variable reference in blitBuffer

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -1760,22 +1760,23 @@ function utf8ToBytes(string, units) {
 }
 
 function blitBuffer(src, dst, offset, byteLength = Infinity) {
+  const srcLength = src.length;
   // Establish the number of bytes to be written
   const bytesToWrite = Math.min(
     // If byte length is defined in the call, then it sets an upper bound,
     // otherwise it is Infinity and is never chosen.
     byteLength,
     // The length of the source sets an upper bound being the source of data.
-    src.length,
+    srcLength,
     // The length of the destination minus any offset into it sets an upper bound.
     dst.length - offset,
   );
-  if (bytesToWrite < src.length) {
+  if (bytesToWrite < srcLength) {
     // Resize the source buffer to the number of bytes we're about to write.
     // This both makes sure that we're actually only writing what we're told to
     // write but also prevents `Uint8Array#set` from throwing an error if the
     // source is longer than the target.
-    src = src.subarray(0, length);
+    src = src.subarray(0, bytesToWrite);
   }
   dst.set(src, offset);
   return bytesToWrite;


### PR DESCRIPTION
My previous work with buffer optimisations / reworks included a mistaken reference to a `length` variable that probably existed at one point or another but was since (likely) renamed to be the ´bytesToWrite`.

At the same time I joined two `src.length` accesses into a single one.