### PR TITLE
refactor(ext/http): use scopeguard defer to handle async drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "ring",
+ "scopeguard",
  "serde",
  "slab",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ rustls-pemfile = "1.0.0"
 rustls-webpki = "0.101.4"
 rustls-native-certs = "0.6.2"
 webpki-roots = "0.25.2"
+scopeguard = "1.2.0"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0.85"

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -44,6 +44,7 @@ percent-encoding.workspace = true
 phf = { version = "0.10", features = ["macros"] }
 pin-project.workspace = true
 ring.workspace = true
+scopeguard.workspace = true
 serde.workspace = true
 slab.workspace = true
 smallvec.workspace = true

--- a/ext/http/slab.rs
+++ b/ext/http/slab.rs
@@ -10,6 +10,7 @@ use http::HeaderMap;
 use hyper1::body::Incoming;
 use hyper1::upgrade::OnUpgrade;
 
+use scopeguard::defer;
 use slab::Slab;
 use std::cell::RefCell;
 use std::cell::RefMut;
@@ -50,6 +51,27 @@ impl Drop for HttpRequestBodyAutocloser {
       res.close();
     }
   }
+}
+
+pub async fn new_slab_future(
+  request: Request,
+  request_info: HttpConnectionProperties,
+  refcount: RefCount,
+  tx: tokio::sync::mpsc::Sender<SlabId>,
+) -> Result<Response, hyper::Error> {
+  let index = slab_insert(request, request_info, refcount);
+  defer! {
+    slab_drop(index);
+  }
+  let rx = slab_get(index).promise();
+  if tx.send(index).await.is_ok() {
+    http_trace!(index, "SlabFuture await");
+    // We only need to wait for completion if we aren't closed
+    rx.await;
+    http_trace!(index, "SlabFuture complete");
+  }
+  let response = slab_get(index).take_response();
+  Ok(response)
 }
 
 pub struct HttpSlabRecord {


### PR DESCRIPTION
Use the [scopeguard](https://docs.rs/scopeguard/) defer macro to run cleanup code for `new_slab_future`.
This means it can be a single async function, avoiding the need to create a struct and implement `PinnedDrop`

Async cleanup in Rust is awkward because async functions may be cancelled at any await point when their Future is dropped.
The scopeguard approach comes from the following articles:
* [How to think about `async`/`await` in Rust](http://cliffle.com/blog/async-inversion/)
* [Async Cancellation I](https://blog.yoshuawuyts.com/async-cancellation-1/) (Reddit [discussion](https://www.reddit.com/r/rust/comments/qrhg39/blog_post_async_cancellation/))