### PR TITLE
perf(test): use core.currentUserCallSite

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -769,22 +769,8 @@ function testInner(
 
   // Delete this prop in case the user passed it. It's used to detect steps.
   delete testDesc.parent;
-  const jsError = core.destructureError(new Error());
-  let location;
 
-  for (let i = 0; i < jsError.frames.length; i++) {
-    const filename = jsError.frames[i].fileName;
-    if (filename.startsWith("ext:") || filename.startsWith("node:")) {
-      continue;
-    }
-    location = {
-      fileName: jsError.frames[i].fileName,
-      lineNumber: jsError.frames[i].lineNumber,
-      columnNumber: jsError.frames[i].columnNumber,
-    };
-    break;
-  }
-  testDesc.location = location;
+  testDesc.location = core.currentUserCallSite();
   testDesc.fn = wrapTest(testDesc);
   testDesc.name = escapeName(testDesc.name);
 
@@ -1307,12 +1293,7 @@ function createTestContext(desc) {
       stepDesc.sanitizeOps ??= desc.sanitizeOps;
       stepDesc.sanitizeResources ??= desc.sanitizeResources;
       stepDesc.sanitizeExit ??= desc.sanitizeExit;
-      const jsError = core.destructureError(new Error());
-      stepDesc.location = {
-        fileName: jsError.frames[1].fileName,
-        lineNumber: jsError.frames[1].lineNumber,
-        columnNumber: jsError.frames[1].columnNumber,
-      };
+      stepDesc.location = core.currentUserCallSite();
       stepDesc.level = level + 1;
       stepDesc.parent = desc;
       stepDesc.rootId = rootId;

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -154,10 +154,8 @@ fn op_create_worker(
   };
   let parent_permissions = parent_permissions.clone();
   let worker_id = state.take::<WorkerId>();
-  let create_web_worker_cb = state.take::<CreateWebWorkerCbHolder>();
-  state.put::<CreateWebWorkerCbHolder>(create_web_worker_cb.clone());
-  let format_js_error_fn = state.take::<FormatJsErrorFnHolder>();
-  state.put::<FormatJsErrorFnHolder>(format_js_error_fn.clone());
+  let create_web_worker_cb = state.borrow::<CreateWebWorkerCbHolder>().clone();
+  let format_js_error_fn = state.borrow::<FormatJsErrorFnHolder>().clone();
   state.put::<WorkerId>(worker_id.next().unwrap());
 
   let module_specifier = deno_core::resolve_url(&specifier)?;


### PR DESCRIPTION
Speeds up `Deno.test` calls by a bit.