### PR TITLE
perf(test): use fast ops for deno test register

### DIFF
--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -1,5 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+// TODO: allow everywhere because `#[allow(clippy::too_many_arguments)]` on
+// `#[op(fast)]` does not work. https://github.com/denoland/rusty_v8/issues/1332
+#![allow(clippy::too_many_arguments)]
+
 use crate::tools::test::TestDescription;
 use crate::tools::test::TestEvent;
 use crate::tools::test::TestEventSender;
@@ -114,7 +118,7 @@ static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[op2]
 #[string]
-fn op_register_test<'a>(
+fn op_register_test(
   state: &mut OpState,
   #[global] function: v8::Global<v8::Function>,
   #[string] name: String,
@@ -157,6 +161,7 @@ fn op_register_test<'a>(
 
 #[op2(fast)]
 #[smi]
+#[allow(clippy::too_many_arguments)]
 fn op_register_test_step(
   state: &mut OpState,
   #[string] name: String,


### PR DESCRIPTION
Use fast ops for test registration. This speeds up `Deno.test` and `t.step()`
significantly (2x over Deno 1.37.0).

Depends on #20669

# `Deno.test`

```ts
for (let i = 0; i < 10000; i++) {
  Deno.test(`test ${i}`, () => {});
}
```

```
~/p/g/d/deno ❯❯❯ hyperfine --warmup=3 -- "deno test --no-check -A test.ts"  "./target/release/deno test --no-check -A test.ts"
Benchmark 1: deno test --no-check -A test.ts
  Time (mean ± σ):     587.4 ms ±   2.8 ms    [User: 594.9 ms, System: 131.3 ms]
  Range (min … max):   584.2 ms … 593.1 ms    10 runs

Benchmark 2: ./target/release/deno test --no-check -A test.ts
  Time (mean ± σ):     288.1 ms ±   2.5 ms    [User: 280.7 ms, System: 105.0 ms]
  Range (min … max):   286.6 ms … 295.1 ms    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  './target/release/deno test --no-check -A test.ts' ran
    2.04 ± 0.02 times faster than 'deno test --no-check -A test.ts'
```


# `Deno.test` with `await t.step()`

```ts
for (let i = 0; i < 100; i++) {
  Deno.test(`test ${i}`, async (t) => {
    for (let j = 0; j < 100; j++) {
      await t.step(`step ${j}`, async () => {});
    }
  });
}
```

```
~/p/g/d/deno ❯❯❯ hyperfine --warmup=3 -- "deno test --no-check -A test.ts"  "./target/release/deno test --no-check -A test.ts"
Benchmark 1: deno test --no-check -A test.ts
  Time (mean ± σ):      1.085 s ±  0.018 s    [User: 0.987 s, System: 0.310 s]
  Range (min … max):    1.071 s …  1.128 s    10 runs

Benchmark 2: ./target/release/deno test --no-check -A test.ts
  Time (mean ± σ):     524.4 ms ±   3.1 ms    [User: 399.1 ms, System: 238.2 ms]
  Range (min … max):   518.9 ms … 527.8 ms    10 runs

Summary
  './target/release/deno test --no-check -A test.ts' ran
    2.07 ± 0.04 times faster than 'deno test --no-check -A test.ts'
```