### PR TITLE
feat(lsp): support more vscode built-in settings

### DIFF
--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -309,22 +309,18 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
     },
     testing: TestingSettings { args: vec![] },
     javascript: LanguageWorkspaceSettings {
-      inlay_hints: Default::default(),
       suggest: CompletionSettings {
-        complete_function_calls: false,
-        names: false,
-        paths: false,
-        auto_imports: false,
+        enabled: false,
+        ..Default::default()
       },
+      ..Default::default()
     },
     typescript: LanguageWorkspaceSettings {
-      inlay_hints: Default::default(),
       suggest: CompletionSettings {
-        complete_function_calls: false,
-        names: false,
-        paths: false,
-        auto_imports: false,
+        enabled: false,
+        ..Default::default()
       },
+      ..Default::default()
     },
   }
 }

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -32,10 +32,12 @@ use tower_lsp::lsp_types::WorkDoneProgressParams;
 use tower_lsp::LanguageServer;
 
 use super::client::Client;
+use super::config::ClassMemberSnippets;
 use super::config::CompletionSettings;
 use super::config::DenoCompletionSettings;
 use super::config::ImportCompletionSettings;
 use super::config::LanguageWorkspaceSettings;
+use super::config::ObjectLiteralMethodSnippets;
 use super::config::TestingSettings;
 use super::config::WorkspaceSettings;
 
@@ -310,15 +312,33 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
     testing: TestingSettings { args: vec![] },
     javascript: LanguageWorkspaceSettings {
       suggest: CompletionSettings {
-        enabled: false,
-        ..Default::default()
+        auto_imports: false,
+        class_member_snippets: ClassMemberSnippets { enabled: false },
+        complete_function_calls: false,
+        enabled: true,
+        include_automatic_optional_chain_completions: false,
+        include_completions_for_import_statements: true,
+        names: false,
+        object_literal_method_snippets: ObjectLiteralMethodSnippets {
+          enabled: false,
+        },
+        paths: false,
       },
       ..Default::default()
     },
     typescript: LanguageWorkspaceSettings {
       suggest: CompletionSettings {
-        enabled: false,
-        ..Default::default()
+        auto_imports: false,
+        class_member_snippets: ClassMemberSnippets { enabled: false },
+        complete_function_calls: false,
+        enabled: true,
+        include_automatic_optional_chain_completions: false,
+        include_completions_for_import_statements: true,
+        names: false,
+        object_literal_method_snippets: ObjectLiteralMethodSnippets {
+          enabled: false,
+        },
+        paths: false,
       },
       ..Default::default()
     },


### PR DESCRIPTION
This supports more settings from VSCode's `typescript` and `javascript` sections. Note that most of these are enabled by default for us, so really it's a way to disable features.

This will work with vscode_deno 3.24.0 onwards.

### 1.37.0

<details>
<summary>
No <code>typescript</code> or <code>javascript</code> settings are supported. Some are supported under mirroring settings in the `deno` section:
</summary>

```js
{
  "deno.inlayHints.enumMemberValues.enabled": false,
  "deno.inlayHints.functionLikeReturnTypes.enabled": false,
  "deno.inlayHints.parameterNames.enabled": "none",
  "deno.inlayHints.parameterNames.suppressWhenArgumentMatchesName": true,
  "deno.inlayHints.parameterTypes.enabled": false,
  "deno.inlayHints.propertyDeclarationTypes.enabled": false,
  "deno.inlayHints.variableTypes.enabled": false,
  "deno.inlayHints.variableTypes.suppressWhenTypeMatchesName": true,
  "deno.suggest.autoImports": true,
  "deno.suggest.completeFunctionCalls": false,
  "deno.suggest.names": true, // JS only
  "deno.suggest.paths": true,
}
```
</details>

### `main` (as of #20593)

<details>
<summary>
The above settings are supported under their original keys, along with their <code>javascript</code> equivalents:
</summary>

```js
{
  "typescript.inlayHints.enumMemberValues.enabled": false,
  "typescript.inlayHints.functionLikeReturnTypes.enabled": false,
  "typescript.inlayHints.parameterNames.enabled": "none",
  "typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName": true,
  "typescript.inlayHints.parameterTypes.enabled": false,
  "typescript.inlayHints.propertyDeclarationTypes.enabled": false,
  "typescript.inlayHints.variableTypes.enabled": false,
  "typescript.inlayHints.variableTypes.suppressWhenTypeMatchesName": true,
  "typescript.suggest.autoImports": true,
  "typescript.suggest.completeFunctionCalls": false,
  "javascript.suggest.names": true, // JS only
  "typescript.suggest.paths": true,
}
```
</details>

### This PR

Added piping for more settings, along with their `javascript` equivalents:

```js
{
  "typescript.preferences.autoImportFileExcludePatterns": [],
  "typescript.preferences.importModuleSpecifier": "shortest",
  "typescript.preferences.jsxAttributeCompletionStyle": "auto",
  "typescript.preferences.useAliasesForRenames": true,
  "typescript.suggest.classMemberSnippets.enabled": true,
  "typescript.suggest.enabled": true,
  "typescript.suggest.includeAutomaticOptionalChainCompletions": true,
  "typescript.suggest.includeCompletionsForImportStatements": true,
  "typescript.suggest.objectLiteralMethodSnippets.enabled": true,
  "typescript.updateImportsOnFileMove.enabled": "prompt",
}
```

