### PR TITLE
chore: deprecate Deno.metrics() API

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3721,7 +3721,10 @@ declare namespace Deno {
    */
   export function truncateSync(name: string, len?: number): void;
 
-  /** @category Observability */
+  /** @category Observability
+   *
+   * @deprecated This API has been deprecated in Deno v1.37.1.
+   */
   export interface OpMetrics {
     opsDispatched: number;
     opsDispatchedSync: number;
@@ -3736,7 +3739,10 @@ declare namespace Deno {
     bytesReceived: number;
   }
 
-  /** @category Observability */
+  /** @category Observability
+   *
+   * @deprecated This API has been deprecated in Deno v1.37.1.
+   */
   export interface Metrics extends OpMetrics {
     ops: Record<string, OpMetrics>;
   }
@@ -3765,6 +3771,8 @@ declare namespace Deno {
    * ```
    *
    * @category Observability
+   *
+   * @deprecated This API has been deprecated in Deno v1.37.1.
    */
   export function metrics(): Metrics;
 


### PR DESCRIPTION
This API is providing hoops to jump through with undergoing migration to 
`#[op2]` macro. 

The overhead of supporting this API is non-trivial and besides internal use 
of it in test sanitizers is very rarely used in the wild.