### PR TITLE
feat(ext/kv): support key expiration in remote backend

### DIFF
--- a/ext/kv/proto/datapath.proto
+++ b/ext/kv/proto/datapath.proto
@@ -48,6 +48,7 @@ message KvMutation {
   bytes key = 1;
   KvValue value = 2;
   KvMutationType mutation_type = 3;
+  int64 expire_at_ms = 4;
 }
 
 message KvValue {


### PR DESCRIPTION
This patch adds support for [key expiration](https://docs.deno.com/kv/manual/key_expiration) in the remote backend.