### PR TITLE
feat(ext/kv): report conflict keys when a commit failed

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1559,6 +1559,7 @@ declare namespace Deno {
   /** @category KV */
   export interface KvCommitError {
     ok: false;
+    failedChecks: WeakSet<KvKey>;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/ext/kv/dynamic.rs
+++ b/ext/kv/dynamic.rs
@@ -127,7 +127,7 @@ pub trait DynamicDb {
     &self,
     state: Rc<RefCell<OpState>>,
     write: AtomicWrite,
-  ) -> Result<Option<CommitResult>, AnyError>;
+  ) -> Result<CommitResult, AnyError>;
 
   async fn dyn_dequeue_next_message(
     &self,
@@ -154,7 +154,7 @@ impl Database for Box<dyn DynamicDb> {
     &self,
     state: Rc<RefCell<OpState>>,
     write: AtomicWrite,
-  ) -> Result<Option<CommitResult>, AnyError> {
+  ) -> Result<CommitResult, AnyError> {
     (**self).dyn_atomic_write(state, write).await
   }
 
@@ -189,7 +189,7 @@ where
     &self,
     state: Rc<RefCell<OpState>>,
     write: AtomicWrite,
-  ) -> Result<Option<CommitResult>, AnyError> {
+  ) -> Result<CommitResult, AnyError> {
     Ok(self.atomic_write(state, write).await?)
   }
 

--- a/ext/kv/interface.rs
+++ b/ext/kv/interface.rs
@@ -38,7 +38,7 @@ pub trait Database {
     &self,
     state: Rc<RefCell<OpState>>,
     write: AtomicWrite,
-  ) -> Result<Option<CommitResult>, AnyError>;
+  ) -> Result<CommitResult, AnyError>;
 
   async fn dequeue_next_message(
     &self,
@@ -326,8 +326,13 @@ impl MutationKind {
   }
 }
 
-/// The result of a successful commit of an atomic write operation.
+/// The result of a commit of an atomic write operation.
 pub struct CommitResult {
-  /// The new versionstamp of the data that was committed.
-  pub versionstamp: Versionstamp,
+  /// The new versionstamp of the data that was committed. This field is a
+  /// `Some` if the commit succeeded.
+  pub versionstamp: Option<Versionstamp>,
+
+  /// Indexes of failed checks in the atomic operation. Non-empty if the
+  /// commit has failed.
+  pub failed_checks: Vec<u32>,
 }

--- a/ext/kv/lib.rs
+++ b/ext/kv/lib.rs
@@ -439,10 +439,7 @@ type V8CommitResult = (String, Vec<u32>);
 impl From<CommitResult> for V8CommitResult {
   fn from(value: CommitResult) -> Self {
     (
-      value
-        .versionstamp
-        .map(|x| hex::encode(x))
-        .unwrap_or_default(),
+      value.versionstamp.map(hex::encode).unwrap_or_default(),
       value.failed_checks,
     )
   }

--- a/ext/kv/proto/datapath.proto
+++ b/ext/kv/proto/datapath.proto
@@ -37,6 +37,7 @@ message AtomicWriteOutput {
   AtomicWriteStatus status = 1;
   bytes versionstamp = 2;
   string primary_if_write_disabled = 3;
+  repeated uint32 failed_checks = 4;
 }
 
 message KvCheck {


### PR DESCRIPTION
When `commit()` returns `KvCommitError`, a `failedChecks` field is included to help determine which keys have caused the failure.