### PR TITLE
chore(lsp): bump tower-lsp to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,18 +325,6 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
@@ -3263,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.2"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
@@ -5521,7 +5509,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b996222612382d0d297d0315f5eedc5a830c37e62476c69774884633d31177"
 dependencies = [
- "auto_impl 1.1.0",
+ "auto_impl",
  "petgraph",
  "swc_common",
  "swc_fast_graph",
@@ -5940,17 +5928,16 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-lsp"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
 dependencies = [
  "async-trait",
- "auto_impl 0.5.0",
+ "auto_impl",
  "bytes",
  "dashmap 5.5.3",
  "futures",
  "httparse",
- "log",
  "lsp-types",
  "memchr",
  "serde",
@@ -5959,17 +5946,18 @@ dependencies = [
  "tokio-util 0.7.9",
  "tower",
  "tower-lsp-macros",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ indexmap1 = { package = "indexmap", version = "1", features = ["serde"] }
 indexmap = { version = "2", features = ["serde"] }
 libc = "0.2.126"
 log = "=0.4.20"
-lsp-types = "=0.93.2" # used by tower-lsp and "proposed" feature is unstable in patch releases
+lsp-types = "=0.94.1" # used by tower-lsp and "proposed" feature is unstable in patch releases
 memmem = "0.1.1"
 monch = "=0.4.3"
 notify = "=5.0.0"
@@ -147,7 +147,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-metrics = { version = "0.3.0", features = ["rt"] }
 tokio-rustls = "0.24.0"
 tokio-util = "0.7.4"
-tower-lsp = { version = "=0.17.0", features = ["proposed"] }
+tower-lsp = { version = "=0.20.0", features = ["proposed"] }
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
 uuid = { version = "1.3.0", features = ["v4"] }
 zstd = "=0.12.4"

--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -153,5 +153,8 @@ pub fn server_capabilities(
     })),
     inlay_hint_provider: Some(OneOf::Left(true)),
     position_encoding: None,
+    // TODO(nayeemrmn): Support pull-based diagnostics.
+    diagnostic_provider: None,
+    inline_value_provider: None,
   }
 }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -381,13 +381,6 @@ impl LanguageServer {
     }
   }
 
-  pub async fn inlay_hint(
-    &self,
-    params: InlayHintParams,
-  ) -> LspResult<Option<Vec<InlayHint>>> {
-    self.0.read().await.inlay_hint(params).await
-  }
-
   pub async fn virtual_text_document(
     &self,
     params: Option<Value>,
@@ -3156,7 +3149,9 @@ impl tower_lsp::LanguageServer for LanguageServer {
         // are interested in.
         let options = DidChangeWatchedFilesRegistrationOptions {
           watchers: vec![FileSystemWatcher {
-            glob_pattern: "**/*.{json,jsonc,lock}".to_string(),
+            glob_pattern: GlobPattern::String(
+              "**/*.{json,jsonc,lock}".to_string(),
+            ),
             kind: None,
           }],
         };
@@ -3415,6 +3410,13 @@ impl tower_lsp::LanguageServer for LanguageServer {
 
   async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
     self.0.read().await.hover(params).await
+  }
+
+  async fn inlay_hint(
+    &self,
+    params: InlayHintParams,
+  ) -> LspResult<Option<Vec<InlayHint>>> {
+    self.0.read().await.inlay_hint(params).await
   }
 
   async fn code_action(

--- a/cli/lsp/lsp_custom.rs
+++ b/cli/lsp/lsp_custom.rs
@@ -13,9 +13,6 @@ pub const VIRTUAL_TEXT_DOCUMENT: &str = "deno/virtualTextDocument";
 pub const LATEST_DIAGNOSTIC_BATCH_INDEX: &str =
   "deno/internalLatestDiagnosticBatchIndex";
 
-// While lsp_types supports inlay hints currently, tower_lsp does not.
-pub const INLAY_HINT: &str = "textDocument/inlayHint";
-
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CacheParams {

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -42,6 +42,8 @@ pub async fn start() -> Result<(), AnyError> {
   let builder = LspService::build(|client| {
     language_server::LanguageServer::new(client::Client::from_tower(client))
   })
+  // TODO(nayeemrmn): The extension has replaced this with the `deno.cache`
+  // command as of vscode_deno 3.21.0 / 2023.09.05. Remove this eventually.
   .custom_method(lsp_custom::CACHE_REQUEST, LanguageServer::cache_request)
   .custom_method(
     lsp_custom::PERFORMANCE_REQUEST,
@@ -60,8 +62,7 @@ pub async fn start() -> Result<(), AnyError> {
   .custom_method(
     lsp_custom::VIRTUAL_TEXT_DOCUMENT,
     LanguageServer::virtual_text_document,
-  )
-  .custom_method(lsp_custom::INLAY_HINT, LanguageServer::inlay_hint);
+  );
 
   let builder = if should_send_diagnostic_batch_index_notifications() {
     builder.custom_method(

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2992,6 +2992,7 @@ impl OutliningSpan {
         Some(range.end.character)
       },
       kind: self.get_folding_range_kind(&self.kind),
+      collapsed_text: None,
     }
   }
 

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -235,10 +235,7 @@ fn lsp_import_map_remote() {
     "workspace/executeCommand",
     json!({
       "command": "deno.cache",
-      "arguments": [
-        [],
-        temp_dir.uri().join("file.ts").unwrap(),
-      ],
+      "arguments": [[], temp_dir.uri().join("file.ts").unwrap()],
     }),
   );
 
@@ -1966,12 +1963,10 @@ fn lsp_hover_dependency() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [],
+      "command": "deno.cache",
+      "arguments": [[], "file:///a/file.ts"],
     }),
   );
   let res = client.write_request(
@@ -2199,15 +2194,12 @@ fn lsp_hover_typescript_types() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "http://127.0.0.1:4545/xTypeScriptTypes.js",
-        }
+      "command": "deno.cache",
+      "arguments": [
+        ["http://127.0.0.1:4545/xTypeScriptTypes.js"],
+        "file:///a/file.ts",
       ],
     }),
   );
@@ -5809,18 +5801,13 @@ fn lsp_npm_completions_auto_import_and_quick_fix_no_import_map() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "npm:@denotest/types-exports-subpaths@1/client",
-        }, {
-          "uri": "npm:chalk@5.0",
-        }
-      ]
+      "command": "deno.cache",
+      "arguments": [
+        ["npm:@denotest/types-exports-subpaths@1/client", "npm:chalk@5.0"],
+        "file:///a/file.ts",
+      ],
     }),
   );
 
@@ -6123,22 +6110,18 @@ fn lsp_completions_auto_import_and_quick_fix_with_import_map() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "npm:@denotest/types-exports-subpaths@1/client",
-        }, {
-          "uri": "npm:chalk@^5.0",
-        }, {
-          "uri": "npm:chalk@~5",
-        }, {
-          "uri": "http://localhost:4545/subdir/print_hello.ts",
-        }
-      ]
+      "command": "deno.cache",
+      "arguments": [
+        [
+          "npm:@denotest/types-exports-subpaths@1/client",
+          "npm:chalk@^5.0",
+          "npm:chalk@~5",
+          "http://localhost:4545/subdir/print_hello.ts",
+        ],
+        "file:///a/file.ts",
+      ],
     }),
   );
 
@@ -6643,18 +6626,13 @@ fn lsp_completions_npm() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "npm:@denotest/cjs-default-export",
-        }, {
-          "uri": "npm:chalk",
-        }
-      ]
+      "command": "deno.cache",
+      "arguments": [
+        ["npm:@denotest/cjs-default-export", "npm:chalk"],
+        "file:///a/file.ts",
+      ],
     }),
   );
 
@@ -7021,16 +6999,10 @@ fn lsp_completions_node_specifier() {
   );
 
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "npm:@types/node",
-        }
-      ]
+      "command": "deno.cache",
+      "arguments": [["npm:@types/node"], "file:///a/file.ts"],
     }),
   );
 
@@ -7265,12 +7237,10 @@ fn lsp_cache_location() {
     }));
   assert_eq!(diagnostics.all().len(), 6);
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [],
+      "command": "deno.cache",
+      "arguments": [[], "file:///a/file.ts"],
     }),
   );
   let res = client.write_request(
@@ -7361,12 +7331,10 @@ fn lsp_tls_cert() {
   let diagnostics = diagnostics.all();
   assert_eq!(diagnostics.len(), 6);
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [],
+      "command": "deno.cache",
+      "arguments": [[], "file:///a/file.ts"],
     }),
   );
   let res = client.write_request(
@@ -7435,15 +7403,12 @@ fn lsp_diagnostics_warn_redirect() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "http://127.0.0.1:4545/x_deno_warning.js",
-        }
+      "command": "deno.cache",
+      "arguments": [
+        ["http://127.0.0.1:4545/x_deno_warning.js"],
+        "file:///a/file.ts",
       ],
     }),
   );
@@ -7514,15 +7479,12 @@ fn lsp_redirect_quick_fix() {
     }),
   );
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.ts",
-      },
-      "uris": [
-        {
-          "uri": "http://127.0.0.1:4545/x_deno_warning.js",
-        }
+      "command": "deno.cache",
+      "arguments": [
+        ["http://127.0.0.1:4545/x_deno_warning.js"],
+        "file:///a/file.ts",
       ],
     }),
   );
@@ -8984,14 +8946,13 @@ export function B() {
     }
   }));
   client.write_request(
-    "deno/cache",
+    "workspace/executeCommand",
     json!({
-      "referrer": {
-        "uri": "file:///a/file.tsx",
-      },
-      "uris": [{
-        "uri": "http://127.0.0.1:4545/jsx/jsx-runtime",
-      }],
+      "command": "deno.cache",
+      "arguments": [
+        ["http://127.0.0.1:4545/jsx/jsx-runtime"],
+        "file:///a/file.tsx",
+      ],
     }),
   );
   let res = client.write_request(
@@ -9550,19 +9511,10 @@ fn lsp_node_modules_dir() {
   }));
   let cache = |client: &mut LspClient| {
     client.write_request(
-      "deno/cache",
+      "workspace/executeCommand",
       json!({
-        "referrer": {
-          "uri": file_uri,
-        },
-        "uris": [
-          {
-            "uri": "npm:chalk",
-          },
-          {
-            "uri": "npm:@types/node",
-          }
-        ]
+        "command": "deno.cache",
+        "arguments": [["npm:chalk", "npm:@types/node"], file_uri],
       }),
     );
   };
@@ -9688,16 +9640,10 @@ fn lsp_vendor_dir() {
   }));
   let cache = |client: &mut LspClient| {
     client.write_request(
-      "deno/cache",
+      "workspace/executeCommand",
       json!({
-        "referrer": {
-          "uri": local_file_uri,
-        },
-        "uris": [
-          {
-            "uri": "http://localhost:4545/subdir/mod1.ts",
-          }
-        ]
+        "command": "deno.cache",
+        "arguments": [["http://localhost:4545/subdir/mod1.ts"], local_file_uri],
       }),
     );
   };

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -2155,8 +2155,11 @@ fn top_level_install_package_json_explicit_opt_in() {
     }
   }));
   client.write_request(
-    "deno/cache",
-    json!({ "referrer": { "uri": file_uri }, "uris": [] }),
+    "workspace/executeCommand",
+    json!({
+      "command": "deno.cache",
+      "arguments": [[], file_uri],
+    }),
   );
 
   assert!(node_modules_dir.join("@denotest").exists());


### PR DESCRIPTION
Also replace deprecated `deno/cache` request usages in tests with `deno.cache` command.