### PR TITLE
fix(lsp): allow query strings for "deno:/status.md"

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -3735,7 +3735,9 @@ impl Inner {
     let specifier = self
       .url_map
       .normalize_url(&params.text_document.uri, LspUrlKind::File);
-    let contents = if specifier.as_str() == "deno:/status.md" {
+    let contents = if specifier.scheme() == "deno"
+      && specifier.path() == "/status.md"
+    {
       let mut contents = String::new();
       let mut documents_specifiers = self
         .documents

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -4321,6 +4321,35 @@ fn test_lsp_code_actions_ordering() {
 }
 
 #[test]
+fn lsp_status_file() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+
+  let res = client.write_request(
+    "deno/virtualTextDocument",
+    json!({
+      "textDocument": {
+        "uri": "deno:/status.md"
+      }
+    }),
+  );
+  let res = res.as_str().unwrap().to_string();
+  assert!(res.starts_with("# Deno Language Server Status"));
+
+  let res = client.write_request(
+    "deno/virtualTextDocument",
+    json!({
+      "textDocument": {
+        "uri": "deno:/status.md?1"
+      }
+    }),
+  );
+  let res = res.as_str().unwrap().to_string();
+  assert!(res.starts_with("# Deno Language Server Status"));
+}
+
+#[test]
 fn lsp_code_actions_deno_cache() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let mut client = context.new_lsp_command().build();


### PR DESCRIPTION
Half of https://github.com/denoland/vscode_deno/issues/944. Coupled with https://github.com/denoland/vscode_deno/pull/946. This allows us to add an incremented index in the query string for each status request.