### PR TITLE
fix(cli): panic with __runtime_js_sources

### DIFF
--- a/cli/ops/mod.rs
+++ b/cli/ops/mod.rs
@@ -29,6 +29,7 @@ deno_core::extension!(cli,
   esm = [
     dir "js",
     "40_testing.js",
+    "40_jupyter.js",
     "99_main.js"
   ],
   options = {

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -173,13 +173,6 @@ pub struct TestDescription {
   pub location: TestLocation,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum TestOutput {
-  String(String),
-  Bytes(Vec<u8>),
-}
-
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Also a drive-by cleanup elsewhere (removing unused enum).

Fixes #20702
