### PR TITLE
chore: add back dotcom step to release

### DIFF
--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -162,6 +162,9 @@ verify on GitHub that everything looks correct.
 
 - [ ] Publish the release on Github
 
+- [ ] Update https://github.com/denoland/dotcom/blob/main/versions.json, open a
+      PR and merge.
+
 - [ ] Run
       https://github.com/denoland/deno-docs/actions/workflows/update_versions.yml
       and merge the PR.


### PR DESCRIPTION
Accidentally removed in https://github.com/denoland/deno/commit/69b7166c20b47d320fc85e33dca9414c92ec9c6f