### PR TITLE
feat(lsp): jupyter notebook analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_fig",
  "console_static_text",
+ "dashmap 5.5.3",
  "data-encoding",
  "data-url",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ clap = { version = "=4.3.3", features = ["string"] }
 clap_complete = "=4.3.1"
 clap_complete_fig = "=4.3.1"
 console_static_text.workspace = true
+dashmap = "5.5.3"
 data-encoding.workspace = true
 data-url.workspace = true
 dissimilar = "=1.0.4"

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -2,7 +2,7 @@
 
 use super::client::Client;
 use super::config::ConfigSnapshot;
-use super::documents::notebook_specifier;
+use super::documents::cell_to_file_specifier;
 use super::documents::Documents;
 use super::documents::DocumentsFilter;
 use super::lsp_custom;
@@ -365,7 +365,7 @@ fn get_local_completions(
   current: &str,
   range: &lsp::Range,
 ) -> Option<Vec<lsp::CompletionItem>> {
-  let base = match notebook_specifier(base) {
+  let base = match cell_to_file_specifier(base) {
     Some(s) => s,
     None => base.clone(),
   };

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -2,6 +2,7 @@
 
 use super::client::Client;
 use super::config::ConfigSnapshot;
+use super::documents::file_from_fragment_specifier;
 use super::documents::Documents;
 use super::documents::DocumentsFilter;
 use super::lsp_custom;
@@ -364,11 +365,16 @@ fn get_local_completions(
   current: &str,
   range: &lsp::Range,
 ) -> Option<Vec<lsp::CompletionItem>> {
+  let base = match file_from_fragment_specifier(base) {
+    Some(s) => s,
+    None => base.clone(),
+  };
+
   if base.scheme() != "file" {
     return None;
   }
 
-  let mut base_path = specifier_to_file_path(base).ok()?;
+  let mut base_path = specifier_to_file_path(&base).ok()?;
   base_path.pop();
   let mut current_path = normalize_path(base_path.join(current));
   // if the current text does not end in a `/` then we are still selecting on
@@ -388,10 +394,10 @@ fn get_local_completions(
           let de = de.ok()?;
           let label = de.path().file_name()?.to_string_lossy().to_string();
           let entry_specifier = resolve_path(de.path().to_str()?, &cwd).ok()?;
-          if &entry_specifier == base {
+          if entry_specifier == base {
             return None;
           }
-          let full_text = relative_specifier(base, &entry_specifier)?;
+          let full_text = relative_specifier(&base, &entry_specifier)?;
           // this weeds out situations where we are browsing in the parent, but
           // we want to filter out non-matches when the completion is manually
           // invoked by the user, but still allows for things like `../src/../`

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -2,7 +2,7 @@
 
 use super::client::Client;
 use super::config::ConfigSnapshot;
-use super::documents::file_from_fragment_specifier;
+use super::documents::notebook_specifier;
 use super::documents::Documents;
 use super::documents::DocumentsFilter;
 use super::lsp_custom;
@@ -365,7 +365,7 @@ fn get_local_completions(
   current: &str,
   range: &lsp::Range,
 ) -> Option<Vec<lsp::CompletionItem>> {
-  let base = match file_from_fragment_specifier(base) {
+  let base = match notebook_specifier(base) {
     Some(s) => s,
     None => base.clone(),
   };

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -692,10 +692,14 @@ impl WorkspaceSettings {
     self.code_lens.implementations || self.code_lens.references
   }
 
+  // TODO(nayeemrmn): Factor in out-of-band media type here.
   pub fn language_settings_for_specifier(
     &self,
     specifier: &ModuleSpecifier,
   ) -> Option<&LanguageWorkspaceSettings> {
+    if specifier.scheme() == "deno-notebook-cell" {
+      return Some(&self.typescript);
+    }
     match MediaType::from_specifier(specifier) {
       MediaType::JavaScript
       | MediaType::Jsx

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -262,7 +262,15 @@ impl AssetOrDocument {
   }
 }
 
-pub fn notebook_specifier(specifier: &Url) -> Option<Url> {
+/// Convert a `deno-notebook-cell:` specifier to a `file:` specifier.
+/// ```rust
+/// assert_eq!(
+///   cell_to_file_specifier(
+///     &Url::parse("deno-notebook-cell:/path/to/file.ipynb#abc").unwrap(),
+///   ),
+///   Some(Url::parse("file:///path/to/file.ipynb#abc").unwrap()),
+/// );
+pub fn cell_to_file_specifier(specifier: &Url) -> Option<Url> {
   if specifier.scheme() == "deno-notebook-cell" {
     if let Ok(specifier) = ModuleSpecifier::parse(&format!(
       "file://{}",
@@ -298,19 +306,19 @@ impl DocumentDependencies {
     if module.specifier.scheme() == "deno-notebook-cell" {
       for (_, dep) in &mut deps.deps {
         if let Resolution::Ok(resolved) = &mut dep.maybe_code {
-          if let Some(specifier) = notebook_specifier(&resolved.specifier) {
+          if let Some(specifier) = cell_to_file_specifier(&resolved.specifier) {
             resolved.specifier = specifier;
           }
         }
         if let Resolution::Ok(resolved) = &mut dep.maybe_type {
-          if let Some(specifier) = notebook_specifier(&resolved.specifier) {
+          if let Some(specifier) = cell_to_file_specifier(&resolved.specifier) {
             resolved.specifier = specifier;
           }
         }
       }
       if let Some(dep) = &mut deps.maybe_types_dependency {
         if let Resolution::Ok(resolved) = &mut dep.dependency {
-          if let Some(specifier) = notebook_specifier(&resolved.specifier) {
+          if let Some(specifier) = cell_to_file_specifier(&resolved.specifier) {
             resolved.specifier = specifier;
           }
         }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3,6 +3,7 @@
 use super::analysis::CodeActionData;
 use super::code_lens;
 use super::config;
+use super::documents::notebook_specifier;
 use super::documents::AssetOrDocument;
 use super::documents::DocumentsFilter;
 use super::language_server;
@@ -127,14 +128,32 @@ pub enum SemicolonPreference {
   Remove,
 }
 
+fn normalize_diagnostic(
+  diagnostic: &mut crate::tsc::Diagnostic,
+  specifier_map: &TscSpecifierMap,
+) -> Result<(), AnyError> {
+  if let Some(file_name) = &mut diagnostic.file_name {
+    *file_name = specifier_map.normalize(&file_name)?.to_string();
+  }
+  for ri in diagnostic.related_information.iter_mut().flatten() {
+    normalize_diagnostic(ri, specifier_map)?;
+  }
+  Ok(())
+}
+
 #[derive(Clone, Debug)]
-pub struct TsServer(mpsc::UnboundedSender<Request>);
+pub struct TsServer {
+  sender: mpsc::UnboundedSender<Request>,
+  specifier_map: Arc<TscSpecifierMap>,
+}
 
 impl TsServer {
   pub fn new(performance: Arc<Performance>, cache: Arc<dyn HttpCache>) -> Self {
+    let specifier_map = Arc::new(TscSpecifierMap::default());
+    let specifier_map_ = specifier_map.clone();
     let (tx, mut rx) = mpsc::unbounded_channel::<Request>();
     let _join_handle = thread::spawn(move || {
-      let mut ts_runtime = js_runtime(performance, cache);
+      let mut ts_runtime = js_runtime(performance, cache, specifier_map_);
 
       let runtime = create_basic_runtime();
       runtime.block_on(async {
@@ -153,7 +172,10 @@ impl TsServer {
       })
     });
 
-    Self(tx)
+    Self {
+      sender: tx,
+      specifier_map,
+    }
   }
 
   pub async fn get_diagnostics(
@@ -163,7 +185,16 @@ impl TsServer {
     token: CancellationToken,
   ) -> Result<HashMap<String, Vec<crate::tsc::Diagnostic>>, AnyError> {
     let req = RequestMethod::GetDiagnostics(specifiers);
-    self.request_with_cancellation(snapshot, req, token).await
+    let diagnostics_map_ = self.request_with_cancellation::<HashMap<String, Vec<crate::tsc::Diagnostic>>>(snapshot, req, token).await?;
+    let mut diagnostics_map = HashMap::new();
+    for (mut specifier, mut diagnostics) in diagnostics_map_ {
+      specifier = self.specifier_map.normalize(&specifier)?.to_string();
+      for diagnostic in &mut diagnostics {
+        normalize_diagnostic(diagnostic, &self.specifier_map)?;
+      }
+      diagnostics_map.insert(specifier, diagnostics);
+    }
+    Ok(diagnostics_map)
   }
 
   pub async fn find_references(
@@ -176,10 +207,19 @@ impl TsServer {
       specifier,
       position,
     };
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Unable to get references from TypeScript: {}", err);
-      LspError::internal_error()
-    })
+    self
+      .request::<Option<Vec<ReferencedSymbol>>>(snapshot, req)
+      .await
+      .and_then(|mut symbols| {
+        for symbol in symbols.iter_mut().flatten() {
+          symbol.normalize(&self.specifier_map)?;
+        }
+        Ok(symbols)
+      })
+      .map_err(|err| {
+        log::error!("Unable to get references from TypeScript: {}", err);
+        LspError::internal_error()
+      })
   }
 
   pub async fn get_navigation_tree(
@@ -245,7 +285,16 @@ impl TsServer {
       format_code_settings,
       preferences,
     ));
-    match self.request(snapshot, req).await {
+    let result = self
+      .request::<Vec<CodeFixAction>>(snapshot, req)
+      .await
+      .and_then(|mut actions| {
+        for action in &mut actions {
+          action.normalize(&self.specifier_map)?;
+        }
+        Ok(actions)
+      });
+    match result {
       Ok(items) => items,
       Err(err) => {
         // sometimes tsc reports errors when retrieving code actions
@@ -294,10 +343,17 @@ impl TsServer {
       format_code_settings,
       preferences,
     ));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Unable to get combined fix from TypeScript: {}", err);
-      LspError::internal_error()
-    })
+    self
+      .request::<CombinedCodeActions>(snapshot, req)
+      .await
+      .and_then(|mut actions| {
+        actions.normalize(&self.specifier_map)?;
+        Ok(actions)
+      })
+      .map_err(|err| {
+        log::error!("Unable to get combined fix from TypeScript: {}", err);
+        LspError::internal_error()
+      })
   }
 
   #[allow(clippy::too_many_arguments)]
@@ -322,10 +378,17 @@ impl TsServer {
       action_name,
       preferences,
     ));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<RefactorEditInfo>(snapshot, req)
+      .await
+      .and_then(|mut info| {
+        info.normalize(&self.specifier_map)?;
+        Ok(info)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn get_edits_for_file_rename(
@@ -342,10 +405,19 @@ impl TsServer {
       format_code_settings,
       user_preferences,
     ));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Vec<FileTextChanges>>(snapshot, req)
+      .await
+      .and_then(|mut changes| {
+        for changes in &mut changes {
+          changes.normalize(&self.specifier_map)?;
+        }
+        Ok(changes)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn get_document_highlights(
@@ -373,10 +445,19 @@ impl TsServer {
     position: u32,
   ) -> Result<Option<DefinitionInfoAndBoundSpan>, LspError> {
     let req = RequestMethod::GetDefinition((specifier, position));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Unable to get definition from TypeScript: {}", err);
-      LspError::internal_error()
-    })
+    self
+      .request::<Option<DefinitionInfoAndBoundSpan>>(snapshot, req)
+      .await
+      .and_then(|mut info| {
+        if let Some(info) = &mut info {
+          info.normalize(&self.specifier_map)?;
+        }
+        Ok(info)
+      })
+      .map_err(|err| {
+        log::error!("Unable to get definition from TypeScript: {}", err);
+        LspError::internal_error()
+      })
   }
 
   pub async fn get_type_definition(
@@ -389,10 +470,19 @@ impl TsServer {
       specifier,
       position,
     };
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Unable to get type definition from TypeScript: {}", err);
-      LspError::internal_error()
-    })
+    self
+      .request::<Option<Vec<DefinitionInfo>>>(snapshot, req)
+      .await
+      .and_then(|mut infos| {
+        for info in infos.iter_mut().flatten() {
+          info.normalize(&self.specifier_map)?;
+        }
+        Ok(infos)
+      })
+      .map_err(|err| {
+        log::error!("Unable to get type definition from TypeScript: {}", err);
+        LspError::internal_error()
+      })
   }
 
   pub async fn get_completions(
@@ -424,7 +514,15 @@ impl TsServer {
     args: GetCompletionDetailsArgs,
   ) -> Result<Option<CompletionEntryDetails>, AnyError> {
     let req = RequestMethod::GetCompletionDetails(args);
-    self.request(snapshot, req).await
+    self
+      .request::<Option<CompletionEntryDetails>>(snapshot, req)
+      .await
+      .and_then(|mut details| {
+        if let Some(details) = &mut details {
+          details.normalize(&self.specifier_map)?;
+        }
+        Ok(details)
+      })
   }
 
   pub async fn get_implementations(
@@ -434,10 +532,19 @@ impl TsServer {
     position: u32,
   ) -> Result<Option<Vec<ImplementationLocation>>, LspError> {
     let req = RequestMethod::GetImplementation((specifier, position));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Option<Vec<ImplementationLocation>>>(snapshot, req)
+      .await
+      .and_then(|mut locations| {
+        for location in locations.iter_mut().flatten() {
+          location.normalize(&self.specifier_map)?;
+        }
+        Ok(locations)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn get_outlining_spans(
@@ -460,10 +567,19 @@ impl TsServer {
   ) -> Result<Vec<CallHierarchyIncomingCall>, LspError> {
     let req =
       RequestMethod::ProvideCallHierarchyIncomingCalls((specifier, position));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Vec<CallHierarchyIncomingCall>>(snapshot, req)
+      .await
+      .and_then(|mut calls| {
+        for call in &mut calls {
+          call.normalize(&self.specifier_map)?;
+        }
+        Ok(calls)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn provide_call_hierarchy_outgoing_calls(
@@ -474,10 +590,19 @@ impl TsServer {
   ) -> Result<Vec<CallHierarchyOutgoingCall>, LspError> {
     let req =
       RequestMethod::ProvideCallHierarchyOutgoingCalls((specifier, position));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Vec<CallHierarchyOutgoingCall>>(snapshot, req)
+      .await
+      .and_then(|mut calls| {
+        for call in &mut calls {
+          call.normalize(&self.specifier_map)?;
+        }
+        Ok(calls)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn prepare_call_hierarchy(
@@ -487,10 +612,27 @@ impl TsServer {
     position: u32,
   ) -> Result<Option<OneOrMany<CallHierarchyItem>>, LspError> {
     let req = RequestMethod::PrepareCallHierarchy((specifier, position));
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Option<OneOrMany<CallHierarchyItem>>>(snapshot, req)
+      .await
+      .and_then(|mut items| {
+        match &mut items {
+          Some(OneOrMany::One(item)) => {
+            item.normalize(&self.specifier_map)?;
+          }
+          Some(OneOrMany::Many(items)) => {
+            for item in items {
+              item.normalize(&self.specifier_map)?;
+            }
+          }
+          None => {}
+        }
+        Ok(items)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn find_rename_locations(
@@ -506,10 +648,19 @@ impl TsServer {
       find_in_comments: false,
       provide_prefix_and_suffix_text_for_rename: false,
     };
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed to request to tsserver {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Option<Vec<RenameLocation>>>(snapshot, req)
+      .await
+      .and_then(|mut locations| {
+        for location in locations.iter_mut().flatten() {
+          location.normalize(&self.specifier_map)?;
+        }
+        Ok(locations)
+      })
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn get_smart_selection_range(
@@ -566,10 +717,19 @@ impl TsServer {
     args: GetNavigateToItemsArgs,
   ) -> Result<Vec<NavigateToItem>, LspError> {
     let req = RequestMethod::GetNavigateToItems(args);
-    self.request(snapshot, req).await.map_err(|err| {
-      log::error!("Failed request to tsserver: {}", err);
-      LspError::invalid_request()
-    })
+    self
+      .request::<Vec<NavigateToItem>>(snapshot, req)
+      .await
+      .and_then(|mut items| {
+        for items in &mut items {
+          items.normalize(&self.specifier_map)?;
+        }
+        Ok(items)
+      })
+      .map_err(|err| {
+        log::error!("Failed request to tsserver: {}", err);
+        LspError::invalid_request()
+      })
   }
 
   pub async fn provide_inlay_hints(
@@ -620,7 +780,7 @@ impl TsServer {
     R: de::DeserializeOwned,
   {
     let (tx, rx) = oneshot::channel::<Result<Value, AnyError>>();
-    if self.0.send((req, snapshot, tx, token)).is_err() {
+    if self.sender.send((req, snapshot, tx, token)).is_err() {
       return Err(anyhow!("failed to send request to tsc thread"));
     }
     let value = rx.await??;
@@ -1282,6 +1442,16 @@ pub struct DocumentSpan {
 }
 
 impl DocumentSpan {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.file_name = specifier_map.normalize(&self.file_name)?.to_string();
+    Ok(())
+  }
+}
+
+impl DocumentSpan {
   pub fn to_link(
     &self,
     line_index: Arc<LineIndex>,
@@ -1376,6 +1546,16 @@ pub struct NavigateToItem {
   text_span: TextSpan,
   container_name: Option<String>,
   // container_kind: ScriptElementKind,
+}
+
+impl NavigateToItem {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.file_name = specifier_map.normalize(&self.file_name)?.to_string();
+    Ok(())
+  }
 }
 
 impl NavigateToItem {
@@ -1630,6 +1810,14 @@ pub struct ImplementationLocation {
 }
 
 impl ImplementationLocation {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.document_span.normalize(specifier_map)?;
+    Ok(())
+  }
+
   pub fn to_location(
     &self,
     line_index: Arc<LineIndex>,
@@ -1666,6 +1854,16 @@ pub struct RenameLocation {
   // RenameLocation props
   // prefix_text: Option<String>,
   // suffix_text: Option<String>,
+}
+
+impl RenameLocation {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.document_span.normalize(specifier_map)?;
+    Ok(())
+  }
 }
 
 pub struct RenameLocations {
@@ -1745,7 +1943,7 @@ pub struct HighlightSpan {
   kind: HighlightSpanKind,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DefinitionInfo {
   // kind: ScriptElementKind,
@@ -1756,6 +1954,16 @@ pub struct DefinitionInfo {
   pub document_span: DocumentSpan,
 }
 
+impl DefinitionInfo {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.document_span.normalize(specifier_map)?;
+    Ok(())
+  }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DefinitionInfoAndBoundSpan {
@@ -1764,6 +1972,16 @@ pub struct DefinitionInfoAndBoundSpan {
 }
 
 impl DefinitionInfoAndBoundSpan {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    for definition in self.definitions.iter_mut().flatten() {
+      definition.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
+
   pub async fn to_definition(
     &self,
     line_index: Arc<LineIndex>,
@@ -1850,6 +2068,20 @@ pub struct FileTextChanges {
 }
 
 impl FileTextChanges {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    let mut specifier = specifier_map.normalize(&self.file_name)?;
+    if self.is_new_file == Some(true) {
+      if let Some(s) = notebook_specifier(&specifier) {
+        specifier = s;
+      }
+    }
+    self.file_name = specifier.to_string();
+    Ok(())
+  }
+
   pub fn to_text_document_edit(
     &self,
     language_server: &language_server::Inner,
@@ -2120,7 +2352,7 @@ pub fn file_text_changes_to_workspace_edit(
   }))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RefactorEditInfo {
   edits: Vec<FileTextChanges>,
@@ -2129,6 +2361,16 @@ pub struct RefactorEditInfo {
 }
 
 impl RefactorEditInfo {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    for changes in &mut self.edits {
+      changes.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
+
   pub async fn to_workspace_edit(
     &self,
     language_server: &language_server::Inner,
@@ -2144,6 +2386,18 @@ pub struct CodeAction {
   changes: Vec<FileTextChanges>,
   #[serde(skip_serializing_if = "Option::is_none")]
   commands: Option<Vec<Value>>,
+}
+
+impl CodeAction {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    for changes in &mut self.changes {
+      changes.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -2167,6 +2421,18 @@ pub struct CodeFixAction {
   pub fix_all_description: Option<String>,
 }
 
+impl CodeFixAction {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    for changes in &mut self.changes {
+      changes.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CombinedCodeActions {
@@ -2174,21 +2440,56 @@ pub struct CombinedCodeActions {
   pub commands: Option<Vec<Value>>,
 }
 
-#[derive(Debug, Deserialize)]
+impl CombinedCodeActions {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    for changes in &mut self.changes {
+      changes.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReferencedSymbol {
   pub definition: ReferencedSymbolDefinitionInfo,
   pub references: Vec<ReferencedSymbolEntry>,
 }
 
-#[derive(Debug, Deserialize)]
+impl ReferencedSymbol {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.definition.normalize(specifier_map)?;
+    for reference in &mut self.references {
+      reference.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReferencedSymbolDefinitionInfo {
   #[serde(flatten)]
   pub definition_info: DefinitionInfo,
 }
 
-#[derive(Debug, Deserialize)]
+impl ReferencedSymbolDefinitionInfo {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.definition_info.normalize(specifier_map)?;
+    Ok(())
+  }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReferencedSymbolEntry {
   #[serde(default)]
@@ -2197,13 +2498,33 @@ pub struct ReferencedSymbolEntry {
   pub entry: ReferenceEntry,
 }
 
-#[derive(Debug, Deserialize)]
+impl ReferencedSymbolEntry {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.entry.normalize(specifier_map)?;
+    Ok(())
+  }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReferenceEntry {
   // is_write_access: bool,
   // is_in_string: Option<bool>,
   #[serde(flatten)]
   pub document_span: DocumentSpan,
+}
+
+impl ReferenceEntry {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.document_span.normalize(specifier_map)?;
+    Ok(())
+  }
 }
 
 impl ReferenceEntry {
@@ -2239,6 +2560,14 @@ pub struct CallHierarchyItem {
 }
 
 impl CallHierarchyItem {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.file = specifier_map.normalize(&self.file)?.to_string();
+    Ok(())
+  }
+
   pub fn try_resolve_call_hierarchy_item(
     &self,
     language_server: &language_server::Inner,
@@ -2338,6 +2667,14 @@ pub struct CallHierarchyIncomingCall {
 }
 
 impl CallHierarchyIncomingCall {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.from.normalize(specifier_map)?;
+    Ok(())
+  }
+
   pub fn try_resolve_call_hierarchy_incoming_call(
     &self,
     language_server: &language_server::Inner,
@@ -2370,6 +2707,14 @@ pub struct CallHierarchyOutgoingCall {
 }
 
 impl CallHierarchyOutgoingCall {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    self.to.normalize(specifier_map)?;
+    Ok(())
+  }
+
   pub fn try_resolve_call_hierarchy_outgoing_call(
     &self,
     line_index: Arc<LineIndex>,
@@ -2525,6 +2870,16 @@ pub struct CompletionEntryDetails {
 }
 
 impl CompletionEntryDetails {
+  pub fn normalize(
+    &mut self,
+    specifier_map: &TscSpecifierMap,
+  ) -> Result<(), AnyError> {
+    for action in self.code_actions.iter_mut().flatten() {
+      action.normalize(specifier_map)?;
+    }
+    Ok(())
+  }
+
   pub fn as_completion_item(
     &self,
     original_item: &lsp::CompletionItem,
@@ -3165,41 +3520,26 @@ struct Response {
   data: Value,
 }
 
-struct State {
-  last_id: usize,
-  performance: Arc<Performance>,
-  response: Option<Response>,
-  state_snapshot: Arc<StateSnapshot>,
-  normalized_specifiers: HashMap<String, ModuleSpecifier>,
-  denormalized_specifiers: HashMap<ModuleSpecifier, String>,
-  token: CancellationToken,
+#[derive(Debug, Default)]
+pub struct TscSpecifierMap {
+  normalized_specifiers: Mutex<HashMap<String, ModuleSpecifier>>,
+  denormalized_specifiers: Mutex<HashMap<ModuleSpecifier, String>>,
 }
 
-impl State {
-  fn new(
-    state_snapshot: Arc<StateSnapshot>,
-    performance: Arc<Performance>,
-  ) -> Self {
-    Self {
-      last_id: 1,
-      performance,
-      response: None,
-      state_snapshot,
-      normalized_specifiers: HashMap::default(),
-      denormalized_specifiers: HashMap::default(),
-      token: Default::default(),
-    }
-  }
-
+impl TscSpecifierMap {
   /// Convert the specifier to one compatible with tsc. Cache the resulting
   /// mapping in case it needs to be reversed.
-  fn denormalize_specifier(&mut self, specifier: &ModuleSpecifier) -> String {
+  pub fn denormalize(&self, specifier: &ModuleSpecifier) -> String {
     let original = specifier;
-    if let Some(specifier) = self.denormalized_specifiers.get(original) {
+    if let Some(specifier) = self.denormalized_specifiers.lock().get(original) {
       return specifier.to_string();
     }
     let mut specifier = original.to_string();
-    let media_type = MediaType::from_specifier(original);
+    let media_type = if original.scheme() == "deno-notebook-cell" {
+      MediaType::TypeScript
+    } else {
+      MediaType::from_specifier(original)
+    };
     // If the URL-inferred media type doesn't correspond to tsc's path-inferred
     // media type, force it to be the same by appending an extension.
     if MediaType::from_path(Path::new(specifier.as_str())) != media_type {
@@ -3208,6 +3548,7 @@ impl State {
     if specifier != original.as_str() {
       self
         .normalized_specifiers
+        .lock()
         .insert(specifier.clone(), original.clone());
     }
     specifier
@@ -3215,12 +3556,12 @@ impl State {
 
   /// Convert the specifier from one compatible with tsc. Cache the resulting
   /// mapping in case it needs to be reversed.
-  fn normalize_specifier<S: AsRef<str>>(
-    &mut self,
+  pub fn normalize<S: AsRef<str>>(
+    &self,
     specifier: S,
   ) -> Result<ModuleSpecifier, AnyError> {
     let original = specifier.as_ref();
-    if let Some(specifier) = self.normalized_specifiers.get(original) {
+    if let Some(specifier) = self.normalized_specifiers.lock().get(original) {
       return Ok(specifier.clone());
     }
     let specifier_str = original.replace(".d.ts.d.ts", ".d.ts");
@@ -3231,9 +3572,36 @@ impl State {
     if specifier.as_str() != original {
       self
         .denormalized_specifiers
+        .lock()
         .insert(specifier.clone(), original.to_string());
     }
     Ok(specifier)
+  }
+}
+
+struct State {
+  last_id: usize,
+  performance: Arc<Performance>,
+  response: Option<Response>,
+  state_snapshot: Arc<StateSnapshot>,
+  specifier_map: Arc<TscSpecifierMap>,
+  token: CancellationToken,
+}
+
+impl State {
+  fn new(
+    state_snapshot: Arc<StateSnapshot>,
+    specifier_map: Arc<TscSpecifierMap>,
+    performance: Arc<Performance>,
+  ) -> Self {
+    Self {
+      last_id: 1,
+      performance,
+      response: None,
+      state_snapshot,
+      specifier_map,
+      token: Default::default(),
+    }
   }
 
   fn get_asset_or_document(
@@ -3317,7 +3685,7 @@ fn op_load(
 ) -> Result<Option<LoadResponse>, AnyError> {
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("op_load", Some(&args));
-  let specifier = state.normalize_specifier(args.specifier)?;
+  let specifier = state.specifier_map.normalize(args.specifier)?;
   let asset_or_document = state.get_asset_or_document(&specifier);
   state.performance.measure(mark);
   Ok(asset_or_document.map(|doc| LoadResponse {
@@ -3335,7 +3703,7 @@ fn op_resolve(
 ) -> Result<Vec<Option<(String, String)>>, AnyError> {
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("op_resolve", Some(&args));
-  let referrer = state.normalize_specifier(&args.base)?;
+  let referrer = state.specifier_map.normalize(&args.base)?;
   let result = match state.get_asset_or_document(&referrer) {
     Some(referrer_doc) => {
       let resolved = state.state_snapshot.documents.resolve(
@@ -3349,7 +3717,7 @@ fn op_resolve(
           .map(|o| {
             o.map(|(s, mt)| {
               (
-                state.denormalize_specifier(&s),
+                state.specifier_map.denormalize(&s),
                 mt.as_ts_extension().to_string(),
               )
             })
@@ -3420,6 +3788,12 @@ fn op_script_names(state: &mut OpState) -> Vec<String> {
   }
 
   result
+    .into_iter()
+    .map(|s| match ModuleSpecifier::parse(&s) {
+      Ok(s) => state.specifier_map.denormalize(&s),
+      Err(_) => s,
+    })
+    .collect()
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -3437,7 +3811,7 @@ fn op_script_version(
   let state = state.borrow_mut::<State>();
   // this op is very "noisy" and measuring its performance is not useful, so we
   // don't measure it uniquely anymore.
-  let specifier = state.normalize_specifier(args.specifier)?;
+  let specifier = state.specifier_map.normalize(args.specifier)?;
   Ok(state.script_version(&specifier))
 }
 
@@ -3447,9 +3821,10 @@ fn op_script_version(
 fn js_runtime(
   performance: Arc<Performance>,
   cache: Arc<dyn HttpCache>,
+  specifier_map: Arc<TscSpecifierMap>,
 ) -> JsRuntime {
   JsRuntime::new(RuntimeOptions {
-    extensions: vec![deno_tsc::init_ops(performance, cache)],
+    extensions: vec![deno_tsc::init_ops(performance, cache, specifier_map)],
     startup_snapshot: Some(tsc::compiler_snapshot()),
     ..Default::default()
   })
@@ -3468,6 +3843,7 @@ deno_core::extension!(deno_tsc,
   options = {
     performance: Arc<Performance>,
     cache: Arc<dyn HttpCache>,
+    specifier_map: Arc<TscSpecifierMap>,
   },
   state = |state, options| {
     state.put(State::new(
@@ -3479,6 +3855,7 @@ deno_core::extension!(deno_tsc,
         maybe_import_map: None,
         npm: None,
       }),
+      options.specifier_map,
       options.performance,
     ));
   },
@@ -3970,7 +4347,7 @@ impl RequestMethod {
         json!({
           "id": id,
           "method": "findRenameLocations",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position,
           "findInStrings": find_in_strings,
           "findInComments": find_in_comments,
@@ -3989,7 +4366,7 @@ impl RequestMethod {
       )) => json!({
         "id": id,
         "method": "getApplicableRefactors",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "range": { "pos": span.start, "end": span.start + span.length },
         "preferences": preferences,
         "kind": kind,
@@ -4004,7 +4381,7 @@ impl RequestMethod {
       )) => json!({
         "id": id,
         "method": "getEditsForRefactor",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "formatCodeSettings": format_code_settings,
         "range": { "pos": span.start, "end": span.start + span.length},
         "refactorName": refactor_name,
@@ -4019,8 +4396,8 @@ impl RequestMethod {
       )) => json!({
         "id": id,
         "method": "getEditsForFileRename",
-        "oldSpecifier": state.denormalize_specifier(old_specifier),
-        "newSpecifier": state.denormalize_specifier(new_specifier),
+        "oldSpecifier": state.specifier_map.denormalize(old_specifier),
+        "newSpecifier": state.specifier_map.denormalize(new_specifier),
         "formatCodeSettings": format_code_settings,
         "preferences": preferences,
       }),
@@ -4034,7 +4411,7 @@ impl RequestMethod {
       )) => json!({
         "id": id,
         "method": "getCodeFixes",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "startPosition": start_pos,
         "endPosition": end_pos,
         "errorCodes": error_codes,
@@ -4049,16 +4426,24 @@ impl RequestMethod {
       )) => json!({
         "id": id,
         "method": "getCombinedCodeFix",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "fixId": fix_id,
         "formatCodeSettings": format_code_settings,
         "preferences": preferences,
       }),
-      RequestMethod::GetCompletionDetails(args) => json!({
-        "id": id,
-        "method": "getCompletionDetails",
-        "args": args
-      }),
+      RequestMethod::GetCompletionDetails(args) => {
+        let mut args = json!(args);
+        let specifier =
+          args.as_object_mut().unwrap().get_mut("specifier").unwrap();
+        if let Ok(s) = ModuleSpecifier::parse(specifier.as_str().unwrap()) {
+          *specifier = json!(state.specifier_map.denormalize(&s));
+        }
+        json!({
+          "id": id,
+          "method": "getCompletionDetails",
+          "args": args
+        })
+      }
       RequestMethod::GetCompletions((
         specifier,
         position,
@@ -4068,7 +4453,7 @@ impl RequestMethod {
         json!({
           "id": id,
           "method": "getCompletions",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position,
           "preferences": preferences,
           "formatCodeSettings": format_code_settings,
@@ -4077,13 +4462,13 @@ impl RequestMethod {
       RequestMethod::GetDefinition((specifier, position)) => json!({
         "id": id,
         "method": "getDefinition",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "position": position,
       }),
       RequestMethod::GetDiagnostics(specifiers) => json!({
         "id": id,
         "method": "getDiagnostics",
-        "specifiers": specifiers.iter().map(|s| state.denormalize_specifier(s)).collect::<Vec<String>>(),
+        "specifiers": specifiers.iter().map(|s| state.specifier_map.denormalize(s)).collect::<Vec<String>>(),
       }),
       RequestMethod::GetDocumentHighlights((
         specifier,
@@ -4092,22 +4477,22 @@ impl RequestMethod {
       )) => json!({
         "id": id,
         "method": "getDocumentHighlights",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "position": position,
-        "filesToSearch": files_to_search,
+        "filesToSearch": files_to_search.iter().map(|s| state.specifier_map.denormalize(s)).collect::<Vec<_>>(),
       }),
       RequestMethod::GetEncodedSemanticClassifications((specifier, span)) => {
         json!({
           "id": id,
           "method": "getEncodedSemanticClassifications",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "span": span,
         })
       }
       RequestMethod::GetImplementation((specifier, position)) => json!({
         "id": id,
         "method": "getImplementation",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "position": position,
       }),
       RequestMethod::GetNavigateToItems(GetNavigateToItemsArgs {
@@ -4124,17 +4509,17 @@ impl RequestMethod {
       RequestMethod::GetNavigationTree(specifier) => json!({
         "id": id,
         "method": "getNavigationTree",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
       }),
       RequestMethod::GetOutliningSpans(specifier) => json!({
         "id": id,
         "method": "getOutliningSpans",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
       }),
       RequestMethod::GetQuickInfo((specifier, position)) => json!({
         "id": id,
         "method": "getQuickInfo",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "position": position,
       }),
       RequestMethod::FindReferences {
@@ -4143,14 +4528,14 @@ impl RequestMethod {
       } => json!({
         "id": id,
         "method": "findReferences",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "position": position,
       }),
       RequestMethod::GetSignatureHelpItems((specifier, position, options)) => {
         json!({
           "id": id,
           "method": "getSignatureHelpItems",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position,
           "options": options,
         })
@@ -4159,7 +4544,7 @@ impl RequestMethod {
         json!({
           "id": id,
           "method": "getSmartSelectionRange",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position
         })
       }
@@ -4173,14 +4558,14 @@ impl RequestMethod {
       } => json!({
         "id": id,
         "method": "getTypeDefinition",
-        "specifier": state.denormalize_specifier(specifier),
+        "specifier": state.specifier_map.denormalize(specifier),
         "position": position
       }),
       RequestMethod::PrepareCallHierarchy((specifier, position)) => {
         json!({
           "id": id,
           "method": "prepareCallHierarchy",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position
         })
       }
@@ -4191,7 +4576,7 @@ impl RequestMethod {
         json!({
           "id": id,
           "method": "provideCallHierarchyIncomingCalls",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position
         })
       }
@@ -4202,7 +4587,7 @@ impl RequestMethod {
         json!({
           "id": id,
           "method": "provideCallHierarchyOutgoingCalls",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "position": position
         })
       }
@@ -4210,7 +4595,7 @@ impl RequestMethod {
         json!({
           "id": id,
           "method": "provideInlayHints",
-          "specifier": state.denormalize_specifier(specifier),
+          "specifier": state.specifier_map.denormalize(specifier),
           "span": span,
           "preferences": preferences,
         })
@@ -4317,7 +4702,7 @@ mod tests {
     let cache =
       Arc::new(GlobalHttpCache::new(location.clone(), RealDenoCacheEnv));
     let state_snapshot = Arc::new(mock_state_snapshot(sources, &location));
-    let mut runtime = js_runtime(Default::default(), cache);
+    let mut runtime = js_runtime(Default::default(), cache, Default::default());
     start(&mut runtime, debug).unwrap();
     let ts_config = TsConfig::new(config);
     assert_eq!(

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7741,7 +7741,7 @@ fn lsp_jupyter_diagnostics() {
   client.initialize_default();
   let diagnostics = client.did_open(json!({
     "textDocument": {
-      "uri": "deno-notebook-cell:/a/file.ts#abc.ts",
+      "uri": "deno-notebook-cell:/a/file.ts#abc",
       "languageId": "typescript",
       "version": 1,
       "text": "Deno.readTextFileSync(1234);",
@@ -7751,7 +7751,7 @@ fn lsp_jupyter_diagnostics() {
     json!(diagnostics.all_messages()),
     json!([
       {
-        "uri": "deno-notebook-cell:/a/file.ts#abc.ts",
+        "uri": "deno-notebook-cell:/a/file.ts#abc",
         "diagnostics": [
           {
             "range": {
@@ -9547,7 +9547,7 @@ fn lsp_data_urls_with_jsx_compiler_option() {
         "end": { "line": 1, "character": 1 }
       }
     }, {
-      "uri": "deno:/5c42b5916c4a3fb55be33fdb0c3b1f438639420592d150fca1b6dc043c1df3d9/data_url.ts",
+      "uri": "deno:/ed0224c51f7e2a845dfc0941ed6959675e5e3e3d2a39b127f0ff569c1ffda8d8/data_url.ts",
       "range": {
         "start": { "line": 0, "character": 7 },
         "end": {"line": 0, "character": 14 },

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7734,6 +7734,49 @@ fn lsp_diagnostics_refresh_dependents() {
   assert_eq!(client.queue_len(), 0);
 }
 
+#[test]
+fn lsp_jupyter_diagnostics() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": "deno-file-fragment:/a/file.ts#abc.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "Deno.readTextFileSync(1234);",
+    },
+  }));
+  assert_eq!(
+    json!(diagnostics.all_messages()),
+    json!([
+      {
+        "uri": "deno-file-fragment:/a/file.ts#abc.ts",
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 22,
+              },
+              "end": {
+                "line": 0,
+                "character": 26,
+              },
+            },
+            "severity": 1,
+            "code": 2345,
+            "source": "deno-ts",
+            "message": "Argument of type 'number' is not assignable to parameter of type 'string | URL'.",
+          },
+        ],
+        "version": 1,
+      },
+    ])
+  );
+  client.shutdown();
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PerformanceAverage {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7741,7 +7741,7 @@ fn lsp_jupyter_diagnostics() {
   client.initialize_default();
   let diagnostics = client.did_open(json!({
     "textDocument": {
-      "uri": "deno-file-fragment:/a/file.ts#abc.ts",
+      "uri": "deno-notebook-cell:/a/file.ts#abc.ts",
       "languageId": "typescript",
       "version": 1,
       "text": "Deno.readTextFileSync(1234);",
@@ -7751,7 +7751,7 @@ fn lsp_jupyter_diagnostics() {
     json!(diagnostics.all_messages()),
     json!([
       {
-        "uri": "deno-file-fragment:/a/file.ts#abc.ts",
+        "uri": "deno-notebook-cell:/a/file.ts#abc.ts",
         "diagnostics": [
           {
             "range": {


### PR DESCRIPTION
All of our analysis and editor features will work in vscode notebook cells with this.

About 5/6 of this PR is making sure we re-normalize module specifiers that come out of tsc, since notebook cell URIs have to be transformed on the way in.

Coupled with https://github.com/denoland/vscode_deno/pull/949.
Fixes #20657.
~~Fixes .. #20662.~~

Todo (not in this PR):
- Local variables aren't remembered between cells. They're essentially different modules.
  Ref: https://github.com/denoland/vscode_deno/issues/932.