### PR TITLE
perf(node): use faster utf8 byte length in Buffer#from

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -35,6 +35,8 @@ import {
 import { atob, btoa } from "ext:deno_web/05_base64.js";
 import { Blob } from "ext:deno_web/09_file.js";
 
+const { core } = globalThis.__bootstrap;
+
 export { atob, Blob, btoa };
 
 const utf8Encoder = new TextEncoder();
@@ -2126,7 +2128,7 @@ export function readInt40BE(buf, offset = 0) {
 }
 
 export function byteLengthUtf8(str) {
-  return utf8Encoder.encode(str).length;
+  return core.byteLength(str);
 }
 
 function base64ByteLength(str, bytes) {


### PR DESCRIPTION
Use the `core.byteLength` op for string utf8 length calculation in `node:buffer`

```
# This patch
file:///Users/divy/gh/deno/buffer.mjs
benchmark        time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------- -----------------------------
Buffer#from     272.11 ns/iter   3,675,029.3 (268.41 ns … 301.15 ns) 271.62 ns  295.5 ns 301.15 ns

# Deno 1.37.1
file:///Users/divy/gh/deno/buffer.mjs
benchmark        time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------- -----------------------------
Buffer#from     411.28 ns/iter   2,431,428.8 (393.82 ns … 439.92 ns) 418.85 ns  434.4 ns 439.92 ns
```