### PR TITLE
feat(jupyter): send binary data with `Deno.jupyter.broadcast`

### DIFF
--- a/cli/js/40_jupyter.js
+++ b/cli/js/40_jupyter.js
@@ -9,7 +9,10 @@ function enableJupyter() {
   } = core.ensureFastOps();
 
   globalThis.Deno.jupyter = {
-    async broadcast(msgType, content, { metadata = {} } = {}) {
+    async broadcast(msgType, content, { metadata = {}, buffers } = {}) {
+      if (buffers) {
+        throw new Error("Not implemented");
+      }
       await op_jupyter_broadcast(msgType, content, metadata);
     },
   };

--- a/cli/ops/jupyter.rs
+++ b/cli/ops/jupyter.rs
@@ -48,12 +48,15 @@ pub async fn op_jupyter_broadcast(
     )
   };
 
+  // TODO: Support multiple buffers - Option<Vec<Bytes>>
+  let buffers = None;
   let maybe_last_request = last_execution_request.borrow().clone();
   if let Some(last_request) = maybe_last_request {
     last_request
       .new_message(&message_type)
       .with_content(content)
       .with_metadata(metadata)
+      .with_buffers(buffers)
       .send(&mut *iopub_socket.lock().await)
       .await?;
   }

--- a/cli/tools/jupyter/jupyter_msg.rs
+++ b/cli/tools/jupyter/jupyter_msg.rs
@@ -122,6 +122,7 @@ pub(crate) struct JupyterMessage {
   parent_header: serde_json::Value,
   metadata: serde_json::Value,
   content: serde_json::Value,
+  buffers: Option<Vec<Bytes>>,
 }
 
 const DELIMITER: &[u8] = b"<IDS|MSG>";
@@ -146,6 +147,11 @@ impl JupyterMessage {
       parent_header: serde_json::from_slice(&raw_message.jparts[1])?,
       metadata: serde_json::from_slice(&raw_message.jparts[2])?,
       content: serde_json::from_slice(&raw_message.jparts[3])?,
+      buffers: if raw_message.jparts.len() > 4 {
+        Some(raw_message.jparts[4..].to_vec())
+      } else {
+        None
+      }
     })
   }
 
@@ -179,6 +185,7 @@ impl JupyterMessage {
       parent_header: self.header.clone(),
       metadata: json!({}),
       content: json!({}),
+      buffers: None,
     }
   }
 
@@ -214,36 +221,48 @@ impl JupyterMessage {
     self
   }
 
+  pub(crate) fn with_buffers(
+    mut self,
+    buffers: Option<Vec<Bytes>>
+  ) -> JupyterMessage {
+    self.buffers = buffers;
+    self
+  }
+
   pub(crate) async fn send<S: zeromq::SocketSend>(
     &self,
     connection: &mut Connection<S>,
   ) -> Result<(), AnyError> {
     // If performance is a concern, we can probably avoid the clone and to_vec calls with a bit
     // of refactoring.
+    let mut jparts: Vec<Bytes> = vec![
+      serde_json::to_string(&self.header)
+        .unwrap()
+        .as_bytes()
+        .to_vec()
+        .into(),
+      serde_json::to_string(&self.parent_header)
+        .unwrap()
+        .as_bytes()
+        .to_vec()
+        .into(),
+      serde_json::to_string(&self.metadata)
+        .unwrap()
+        .as_bytes()
+        .to_vec()
+        .into(),
+      serde_json::to_string(&self.content)
+        .unwrap()
+        .as_bytes()
+        .to_vec()
+        .into(),
+    ];
+    if let Some(buffers) = &self.buffers {
+      jparts.extend_from_slice(buffers);
+    }
     let raw_message = RawMessage {
       zmq_identities: self.zmq_identities.clone(),
-      jparts: vec![
-        serde_json::to_string(&self.header)
-          .unwrap()
-          .as_bytes()
-          .to_vec()
-          .into(),
-        serde_json::to_string(&self.parent_header)
-          .unwrap()
-          .as_bytes()
-          .to_vec()
-          .into(),
-        serde_json::to_string(&self.metadata)
-          .unwrap()
-          .as_bytes()
-          .to_vec()
-          .into(),
-        serde_json::to_string(&self.content)
-          .unwrap()
-          .as_bytes()
-          .to_vec()
-          .into(),
-      ],
+      jparts,
     };
     raw_message.send(connection).await
   }

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1980,6 +1980,7 @@ declare namespace Deno {
       content: Record<string, unknown>,
       extra?: {
         metadata?: Record<string, unknown>;
+        buffers?: Uint8Array[];
       },
     ): Promise<void>;
   }


### PR DESCRIPTION
Adds `buffers` to the `Deno.jupyter.broadcast` API to send binary data via comms. This affords the ability to send binary data via websockets to the jupyter widget frontend.

Currently, this just implements the correct messaging on the Rust side. I couldn't figure out how to correctly serialize `Array<Uint8Array>`
from JS to Rust via the op call. Any help there would be greatly appreciated!

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
