### PR TITLE
fix(npm): upgrade to deno_npm 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aba69155a585297af4b9ba8d204567bcd51b25af77b5f4c8856b867019093ba"
+checksum = "210f62105862f1ff371e278c623c7ed73d62b0efece4d417c15663d37b730098"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,7 +54,7 @@ deno_emit = "=0.28.0"
 deno_graph = "=0.55.0"
 deno_lint = { version = "=0.51.0", features = ["docs"] }
 deno_lockfile.workspace = true
-deno_npm = "0.15.1"
+deno_npm = "0.15.2"
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "exclude_runtime_main_js", "include_js_files_for_snapshotting"] }
 deno_semver = "0.5.1"
 deno_task_shell = "=0.13.2"

--- a/cli/tests/integration/npm_tests.rs
+++ b/cli/tests/integration/npm_tests.rs
@@ -1760,6 +1760,15 @@ fn reload_info_not_found_cache_but_exists_remote() {
       serde_json::from_str(&deno_dir.read_to_string(&registry_json_path))
         .unwrap();
     remove_version(&mut registry_json, version);
+    // for the purpose of this test, just remove the dist-tag as it might contain this version
+    registry_json
+      .as_object_mut()
+      .unwrap()
+      .get_mut("dist-tags")
+      .unwrap()
+      .as_object_mut()
+      .unwrap()
+      .remove("latest");
     deno_dir.write(
       &registry_json_path,
       serde_json::to_string(&registry_json).unwrap(),


### PR DESCRIPTION
* fix: handle optional deps not found in dependencies map (https://github.com/denoland/deno_npm/pull/38)
* fix: resolve a version requirement to the latest dist tag if it matches (https://github.com/denoland/deno_npm/pull/37)

Closes #20771