### PR TITLE
perf(web/Event): move constructor field to class field again

### DIFF
--- a/ext/web/02_event.js
+++ b/ext/web/02_event.js
@@ -125,8 +125,6 @@ const _path = Symbol("[[path]]");
 
 class Event {
   constructor(type, eventInitDict = {}) {
-    // TODO(lucacasonato): remove when this interface is spec aligned
-    this[SymbolToStringTag] = "Event";
     this[_canceledFlag] = false;
     this[_stopPropagationFlag] = false;
     this[_stopImmediatePropagationFlag] = false;
@@ -383,6 +381,9 @@ class Event {
   get timeStamp() {
     return this[_attributes].timeStamp;
   }
+
+  // TODO(lucacasonato): remove when this interface is spec aligned
+  [SymbolToStringTag] = "Event";
 }
 
 // Not spec compliant. The spec defines it as [LegacyUnforgeable]


### PR DESCRIPTION
reverts https://github.com/denoland/deno/pull/12265/files, see @robpalme's reply. https://v8.dev/blog/faster-class-features references Deno for why they made the class fields faster in V8 v10. Deno uses V8 v11+ by now, so we can safely revert.

Please add the label ci-bench so we see if it's really faster for Deno.

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
