### PR TITLE
refactor(npm): break up `NpmModuleLoader` and move more methods into the managed `CliNpmResolver`

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1236,10 +1236,14 @@ fn diagnose_resolution(
       } else if let Ok(pkg_ref) =
         NpmPackageReqReference::from_specifier(specifier)
       {
-        if let Some(npm) = &snapshot.npm {
+        if let Some(npm_resolver) = snapshot
+          .npm
+          .as_ref()
+          .and_then(|n| n.npm_resolver.as_managed())
+        {
           // show diagnostics for npm package references that aren't cached
           let req = pkg_ref.into_inner().req;
-          if !npm.npm_resolver.is_pkg_req_folder_cached(&req) {
+          if !npm_resolver.is_pkg_req_folder_cached(&req) {
             diagnostics
               .push(DenoDiagnostic::NoCacheNpm(req, specifier.clone()));
           }
@@ -1249,10 +1253,14 @@ fn diagnose_resolution(
         if !deno_node::is_builtin_node_module(module_name) {
           diagnostics
             .push(DenoDiagnostic::InvalidNodeSpecifier(specifier.clone()));
-        } else if let Some(npm) = &snapshot.npm {
+        } else if let Some(npm_resolver) = snapshot
+          .npm
+          .as_ref()
+          .and_then(|n| n.npm_resolver.as_managed())
+        {
           // check that a @types/node package exists in the resolver
           let types_node_req = PackageReq::from_str("@types/node").unwrap();
-          if !npm.npm_resolver.is_pkg_req_folder_cached(&types_node_req) {
+          if !npm_resolver.is_pkg_req_folder_cached(&types_node_req) {
             diagnostics.push(DenoDiagnostic::NoCacheNpm(
               types_node_req,
               ModuleSpecifier::parse("npm:@types/node").unwrap(),

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -50,10 +50,10 @@ use deno_runtime::deno_node::NodeResolution;
 use deno_runtime::deno_node::NodeResolutionMode;
 use deno_runtime::deno_node::NodeResolver;
 use deno_runtime::permissions::PermissionsContainer;
-use deno_semver::npm::NpmPackageNvReference;
 use deno_semver::npm::NpmPackageReqReference;
 use std::borrow::Cow;
 use std::collections::HashSet;
+use std::path::Path;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::str;
@@ -309,6 +309,7 @@ struct SharedCliModuleLoaderState {
   module_load_preparer: Arc<ModuleLoadPreparer>,
   prepared_module_loader: PreparedModuleLoader,
   resolver: Arc<CliGraphResolver>,
+  node_resolver: Arc<CliNodeResolver>,
   npm_module_loader: NpmModuleLoader,
 }
 
@@ -317,6 +318,7 @@ pub struct CliModuleLoaderFactory {
 }
 
 impl CliModuleLoaderFactory {
+  #[allow(clippy::too_many_arguments)]
   pub fn new(
     options: &CliOptions,
     emitter: Arc<Emitter>,
@@ -324,6 +326,7 @@ impl CliModuleLoaderFactory {
     module_load_preparer: Arc<ModuleLoadPreparer>,
     parsed_source_cache: Arc<ParsedSourceCache>,
     resolver: Arc<CliGraphResolver>,
+    node_resolver: Arc<CliNodeResolver>,
     npm_module_loader: NpmModuleLoader,
   ) -> Self {
     Self {
@@ -343,6 +346,7 @@ impl CliModuleLoaderFactory {
         graph_container,
         module_load_preparer,
         resolver,
+        node_resolver,
         npm_module_loader,
       }),
     }
@@ -471,11 +475,11 @@ impl ModuleLoader for CliModuleLoader {
     let referrer_result = deno_core::resolve_url_or_path(referrer, &cwd);
 
     if let Ok(referrer) = referrer_result.as_ref() {
-      if let Some(result) = self
-        .shared
-        .npm_module_loader
-        .resolve_if_in_npm_package(specifier, referrer, permissions)
-      {
+      if let Some(result) = self.shared.node_resolver.resolve_if_in_npm_package(
+        specifier,
+        referrer,
+        permissions,
+      ) {
         return result;
       }
 
@@ -492,10 +496,28 @@ impl ModuleLoader for CliModuleLoader {
           let specifier = &resolved.specifier;
 
           return match graph.get(specifier) {
-            Some(Module::Npm(module)) => self
-              .shared
-              .npm_module_loader
-              .resolve_nv_ref(&module.nv_reference, permissions),
+            Some(Module::Npm(module)) => {
+              let package_folder = self
+                .shared
+                .node_resolver
+                .npm_resolver
+                .as_managed()
+                .unwrap() // byonm won't create a Module::Npm
+                .resolve_pkg_folder_from_deno_module(
+                  module.nv_reference.nv(),
+                )?;
+              self
+                .shared
+                .node_resolver
+                .resolve_package_sub_path(
+                  &package_folder,
+                  module.nv_reference.sub_path(),
+                  permissions,
+                )
+                .with_context(|| {
+                  format!("Could not resolve '{}'.", module.nv_reference)
+                })
+            }
             Some(Module::Node(module)) => Ok(module.specifier.clone()),
             Some(Module::Esm(module)) => Ok(module.specifier.clone()),
             Some(Module::Json(module)) => Ok(module.specifier.clone()),
@@ -538,10 +560,11 @@ impl ModuleLoader for CliModuleLoader {
         if let Ok(reference) =
           NpmPackageReqReference::from_specifier(&specifier)
         {
-          return self
-            .shared
-            .npm_module_loader
-            .resolve_req_reference(&reference, permissions);
+          return self.shared.node_resolver.resolve_req_reference(
+            &reference,
+            permissions,
+            &referrer,
+          );
         }
       }
     }
@@ -642,29 +665,27 @@ impl SourceMapGetter for CliSourceMapGetter {
   }
 }
 
-pub struct NpmModuleLoader {
+pub struct CliNodeResolver {
   cjs_resolutions: Arc<CjsResolutionStore>,
-  node_code_translator: Arc<CliNodeCodeTranslator>,
-  fs: Arc<dyn deno_fs::FileSystem>,
   node_resolver: Arc<NodeResolver>,
   npm_resolver: Arc<dyn CliNpmResolver>,
 }
 
-impl NpmModuleLoader {
+impl CliNodeResolver {
   pub fn new(
     cjs_resolutions: Arc<CjsResolutionStore>,
-    node_code_translator: Arc<CliNodeCodeTranslator>,
-    fs: Arc<dyn deno_fs::FileSystem>,
     node_resolver: Arc<NodeResolver>,
     npm_resolver: Arc<dyn CliNpmResolver>,
   ) -> Self {
     Self {
       cjs_resolutions,
-      node_code_translator,
-      fs,
       node_resolver,
       npm_resolver,
     }
+  }
+
+  pub fn in_npm_package(&self, referrer: &ModuleSpecifier) -> bool {
+    self.npm_resolver.in_npm_package(referrer)
   }
 
   pub fn resolve_if_in_npm_package(
@@ -673,7 +694,7 @@ impl NpmModuleLoader {
     referrer: &ModuleSpecifier,
     permissions: &PermissionsContainer,
   ) -> Option<Result<ModuleSpecifier, AnyError>> {
-    if self.node_resolver.in_npm_package(referrer) {
+    if self.in_npm_package(referrer) {
       // we're in an npm package, so use node resolution
       Some(
         self
@@ -692,40 +713,74 @@ impl NpmModuleLoader {
     }
   }
 
-  pub fn resolve_nv_ref(
-    &self,
-    nv_ref: &NpmPackageNvReference,
-    permissions: &PermissionsContainer,
-  ) -> Result<ModuleSpecifier, AnyError> {
-    let package_folder = self
-      .npm_resolver
-      .resolve_pkg_folder_from_deno_module(nv_ref.nv())?;
-    self
-      .handle_node_resolve_result(self.node_resolver.resolve_npm_reference(
-        &package_folder,
-        nv_ref.sub_path(),
-        NodeResolutionMode::Execution,
-        permissions,
-      ))
-      .with_context(|| format!("Could not resolve '{}'.", nv_ref))
-  }
-
   pub fn resolve_req_reference(
     &self,
     req_ref: &NpmPackageReqReference,
     permissions: &PermissionsContainer,
+    referrer: &ModuleSpecifier,
   ) -> Result<ModuleSpecifier, AnyError> {
     let package_folder = self
       .npm_resolver
-      .resolve_pkg_folder_from_deno_module_req(req_ref.req())?;
+      .resolve_pkg_folder_from_deno_module_req(req_ref.req(), referrer)?;
     self
-      .handle_node_resolve_result(self.node_resolver.resolve_npm_reference(
+      .resolve_package_sub_path(
         &package_folder,
         req_ref.sub_path(),
-        NodeResolutionMode::Execution,
         permissions,
-      ))
+      )
       .with_context(|| format!("Could not resolve '{}'.", req_ref))
+  }
+
+  fn resolve_package_sub_path(
+    &self,
+    package_folder: &Path,
+    sub_path: Option<&str>,
+    permissions: &PermissionsContainer,
+  ) -> Result<ModuleSpecifier, AnyError> {
+    self.handle_node_resolve_result(self.node_resolver.resolve_npm_reference(
+      package_folder,
+      sub_path,
+      NodeResolutionMode::Execution,
+      permissions,
+    ))
+  }
+
+  fn handle_node_resolve_result(
+    &self,
+    result: Result<Option<NodeResolution>, AnyError>,
+  ) -> Result<ModuleSpecifier, AnyError> {
+    let response = match result? {
+      Some(response) => response,
+      None => return Err(generic_error("not found")),
+    };
+    if let NodeResolution::CommonJs(specifier) = &response {
+      // remember that this was a common js resolution
+      self.cjs_resolutions.insert(specifier.clone());
+    }
+    Ok(response.into_url())
+  }
+}
+
+pub struct NpmModuleLoader {
+  cjs_resolutions: Arc<CjsResolutionStore>,
+  node_code_translator: Arc<CliNodeCodeTranslator>,
+  fs: Arc<dyn deno_fs::FileSystem>,
+  node_resolver: Arc<CliNodeResolver>,
+}
+
+impl NpmModuleLoader {
+  pub fn new(
+    cjs_resolutions: Arc<CjsResolutionStore>,
+    node_code_translator: Arc<CliNodeCodeTranslator>,
+    fs: Arc<dyn deno_fs::FileSystem>,
+    node_resolver: Arc<CliNodeResolver>,
+  ) -> Self {
+    Self {
+      cjs_resolutions,
+      node_code_translator,
+      fs,
+      node_resolver,
+    }
   }
 
   pub fn maybe_prepare_load(
@@ -811,21 +866,6 @@ impl NpmModuleLoader {
       found_url: specifier.clone(),
       media_type: MediaType::from_specifier(specifier),
     })
-  }
-
-  fn handle_node_resolve_result(
-    &self,
-    result: Result<Option<NodeResolution>, AnyError>,
-  ) -> Result<ModuleSpecifier, AnyError> {
-    let response = match result? {
-      Some(response) => response,
-      None => return Err(generic_error("not found")),
-    };
-    if let NodeResolution::CommonJs(specifier) = &response {
-      // remember that this was a common js resolution
-      self.cjs_resolutions.insert(specifier.clone());
-    }
-    Ok(response.into_url())
   }
 }
 

--- a/cli/npm/common.rs
+++ b/cli/npm/common.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+/// Gets the corresponding @types package for the provided package name.
+pub fn types_package_name(package_name: &str) -> String {
+  debug_assert!(!package_name.starts_with("@types/"));
+  // Scoped packages will get two underscores for each slash
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/tree/15f1ece08f7b498f4b9a2147c2a46e94416ca777#what-about-scoped-packages
+  format!("@types/{}", package_name.replace('/', "__"))
+}
+
+#[cfg(test)]
+mod test {
+  use super::types_package_name;
+
+  #[test]
+  fn test_types_package_name() {
+    assert_eq!(types_package_name("name"), "@types/name");
+    assert_eq!(
+      types_package_name("@scoped/package"),
+      "@types/@scoped__package"
+    );
+  }
+}

--- a/cli/npm/managed/resolvers/common.rs
+++ b/cli/npm/managed/resolvers/common.rs
@@ -149,25 +149,3 @@ pub async fn cache_packages(
   }
   Ok(())
 }
-
-/// Gets the corresponding @types package for the provided package name.
-pub fn types_package_name(package_name: &str) -> String {
-  debug_assert!(!package_name.starts_with("@types/"));
-  // Scoped packages will get two underscores for each slash
-  // https://github.com/DefinitelyTyped/DefinitelyTyped/tree/15f1ece08f7b498f4b9a2147c2a46e94416ca777#what-about-scoped-packages
-  format!("@types/{}", package_name.replace('/', "__"))
-}
-
-#[cfg(test)]
-mod test {
-  use super::types_package_name;
-
-  #[test]
-  fn test_types_package_name() {
-    assert_eq!(types_package_name("name"), "@types/name");
-    assert_eq!(
-      types_package_name("@scoped/package"),
-      "@types/@scoped__package"
-    );
-  }
-}

--- a/cli/npm/managed/resolvers/global.rs
+++ b/cli/npm/managed/resolvers/global.rs
@@ -20,10 +20,10 @@ use deno_runtime::deno_fs::FileSystem;
 use deno_runtime::deno_node::NodePermissions;
 use deno_runtime::deno_node::NodeResolutionMode;
 
+use super::super::super::common::types_package_name;
 use super::super::cache::NpmCache;
 use super::super::resolution::NpmResolution;
 use super::common::cache_packages;
-use super::common::types_package_name;
 use super::common::NpmPackageFsResolver;
 use super::common::RegistryReadPermissionChecker;
 

--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -45,9 +45,9 @@ use crate::npm::cache_dir::mixed_case_package_name_encode;
 use crate::util::fs::copy_dir_recursive;
 use crate::util::fs::hard_link_dir_recursive;
 
+use super::super::super::common::types_package_name;
 use super::super::cache::NpmCache;
 use super::super::resolution::NpmResolution;
-use super::common::types_package_name;
 use super::common::NpmPackageFsResolver;
 use super::common::RegistryReadPermissionChecker;
 

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -1,21 +1,15 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 mod cache_dir;
+mod common;
 mod managed;
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
-use deno_core::url::Url;
-use deno_graph::NpmPackageReqResolution;
-use deno_npm::resolution::PackageReqNotFoundError;
 use deno_runtime::deno_node::NpmResolver;
-use deno_semver::npm::NpmPackageNvReference;
-use deno_semver::npm::NpmPackageReqReference;
-use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
 
 pub use self::cache_dir::NpmCacheDir;
@@ -64,8 +58,6 @@ pub trait CliNpmResolver: NpmResolver {
 
   fn clone_snapshotted(&self) -> Arc<dyn CliNpmResolver>;
 
-  fn root_dir_url(&self) -> &Url;
-
   fn as_inner(&self) -> InnerCliNpmResolverRef;
 
   fn as_managed(&self) -> Option<&ManagedCliNpmResolver> {
@@ -75,27 +67,16 @@ pub trait CliNpmResolver: NpmResolver {
     }
   }
 
-  fn node_modules_path(&self) -> Option<PathBuf>;
+  fn as_byonm(&self) -> Option<&ByonmCliNpmResolver> {
+    match self.as_inner() {
+      InnerCliNpmResolverRef::Managed(_) => None,
+      InnerCliNpmResolverRef::Byonm(inner) => Some(inner),
+    }
+  }
 
-  /// Checks if the provided package req's folder is cached.
-  fn is_pkg_req_folder_cached(&self, req: &PackageReq) -> bool;
-
-  /// Resolves a package requirement for deno graph. This should only be
-  /// called by deno_graph's NpmResolver or for resolving packages in
-  /// a package.json
-  fn resolve_npm_for_deno_graph(
-    &self,
-    pkg_req: &PackageReq,
-  ) -> NpmPackageReqResolution;
-
-  fn resolve_pkg_nv_ref_from_pkg_req_ref(
-    &self,
-    req_ref: &NpmPackageReqReference,
-  ) -> Result<NpmPackageNvReference, PackageReqNotFoundError>;
+  fn root_node_modules_path(&self) -> Option<PathBuf>;
 
   /// Resolve the root folder of the package the provided specifier is in.
-  ///
-  /// This will error when the provided specifier is not in an npm package.
   fn resolve_pkg_folder_from_specifier(
     &self,
     specifier: &ModuleSpecifier,
@@ -104,19 +85,15 @@ pub trait CliNpmResolver: NpmResolver {
   fn resolve_pkg_folder_from_deno_module_req(
     &self,
     req: &PackageReq,
-  ) -> Result<PathBuf, AnyError>;
-
-  fn resolve_pkg_folder_from_deno_module(
-    &self,
-    nv: &PackageNv,
+    referrer: &ModuleSpecifier,
   ) -> Result<PathBuf, AnyError>;
 
   /// Gets the state of npm for the process.
   fn get_npm_process_state(&self) -> String;
 
-  // todo(#18967): should instead return a hash state of the resolver
-  // or perhaps this could be non-BYONM only and byonm always runs deno check
-  fn package_reqs(&self) -> HashMap<PackageReq, PackageNv>;
+  /// Returns a hash returning the state of the npm resolver
+  /// or `None` if the state currently can't be determined.
+  fn check_state_hash(&self) -> Option<u64>;
 }
 
 // todo(#18967): implement this

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -22,6 +22,7 @@ use crate::args::package_json::PackageJsonDeps;
 use crate::args::JsxImportSourceConfig;
 use crate::args::PackageJsonDepsProvider;
 use crate::npm::CliNpmResolver;
+use crate::npm::InnerCliNpmResolverRef;
 use crate::util::sync::AtomicFlag;
 
 /// Result of checking if a specifier is mapped via
@@ -118,10 +119,10 @@ impl CliGraphResolver {
     options: CliGraphResolverOptions,
   ) -> Self {
     Self {
-      mapped_specifier_resolver: MappedSpecifierResolver {
-        maybe_import_map: options.maybe_import_map,
+      mapped_specifier_resolver: MappedSpecifierResolver::new(
+        options.maybe_import_map,
         package_json_deps_provider,
-      },
+      ),
       maybe_default_jsx_import_source: options
         .maybe_jsx_import_source_config
         .as_ref()
@@ -167,19 +168,18 @@ impl Resolver for CliGraphResolver {
     specifier: &str,
     referrer: &ModuleSpecifier,
   ) -> Result<ModuleSpecifier, AnyError> {
-    use MappedResolution::*;
     let result = match self
       .mapped_specifier_resolver
       .resolve(specifier, referrer)?
     {
-      ImportMap(specifier) => Ok(specifier),
-      PackageJson(specifier) => {
+      MappedResolution::ImportMap(specifier) => Ok(specifier),
+      MappedResolution::PackageJson(specifier) => {
         // found a specifier in the package.json, so mark that
         // we need to do an "npm install" later
         self.found_package_json_dep_flag.raise();
         Ok(specifier)
       }
-      None => deno_graph::resolve_import(specifier, referrer)
+      MappedResolution::None => deno_graph::resolve_import(specifier, referrer)
         .map_err(|err| err.into()),
     };
 
@@ -263,9 +263,14 @@ impl NpmResolver for CliGraphResolver {
 
   fn resolve_npm(&self, package_req: &PackageReq) -> NpmPackageReqResolution {
     match &self.npm_resolver {
-      Some(npm_resolver) => {
-        npm_resolver.resolve_npm_for_deno_graph(package_req)
-      }
+      Some(npm_resolver) => match npm_resolver.as_inner() {
+        InnerCliNpmResolverRef::Managed(npm_resolver) => {
+          npm_resolver.resolve_npm_for_deno_graph(package_req)
+        }
+        // if we are using byonm, then this should never be called because
+        // we don't use deno_graph's npm resolution in this case
+        InnerCliNpmResolverRef::Byonm(_) => unreachable!(),
+      },
       None => NpmPackageReqResolution::Err(anyhow!(
         "npm specifiers were requested; but --no-npm is specified"
       )),

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -523,7 +523,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       ca_data,
       entrypoint: entrypoint.clone(),
       maybe_import_map,
-      node_modules_dir: self.npm_resolver.node_modules_path().is_some(),
+      node_modules_dir: self.npm_resolver.root_node_modules_path().is_some(),
       package_json_deps: self
         .package_json_deps_provider
         .deps()
@@ -543,7 +543,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
   fn build_vfs(&self) -> Result<VfsBuilder, AnyError> {
     match self.npm_resolver.as_inner() {
       InnerCliNpmResolverRef::Managed(npm_resolver) => {
-        if let Some(node_modules_path) = npm_resolver.node_modules_path() {
+        if let Some(node_modules_path) = npm_resolver.root_node_modules_path() {
           let mut builder = VfsBuilder::new(node_modules_path.clone())?;
           builder.add_dir_recursive(&node_modules_path)?;
           Ok(builder)

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -11,8 +10,6 @@ use deno_graph::Module;
 use deno_graph::ModuleGraph;
 use deno_runtime::colors;
 use deno_runtime::deno_node::NodeResolver;
-use deno_semver::package::PackageNv;
-use deno_semver::package::PackageReq;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
@@ -95,19 +92,28 @@ impl TypeChecker {
     let debug = self.cli_options.log_level() == Some(log::Level::Debug);
     let cache = TypeCheckCache::new(self.caches.type_checking_cache_db());
     let check_js = ts_config.get_check_js();
-    let check_hash = match get_check_hash(
-      &graph,
-      self.npm_resolver.package_reqs(),
-      type_check_mode,
-      &ts_config,
-    ) {
-      CheckHashResult::NoFiles => return Ok(()),
-      CheckHashResult::Hash(hash) => hash,
+    let maybe_check_hash = match self.npm_resolver.check_state_hash() {
+      Some(npm_check_hash) => {
+        match get_check_hash(
+          &graph,
+          npm_check_hash,
+          type_check_mode,
+          &ts_config,
+        ) {
+          CheckHashResult::NoFiles => return Ok(()),
+          CheckHashResult::Hash(hash) => Some(hash),
+        }
+      }
+      None => None, // we can't determine a check hash
     };
 
     // do not type check if we know this is type checked
-    if !options.reload && cache.has_check_hash(check_hash) {
-      return Ok(());
+    if !options.reload {
+      if let Some(check_hash) = maybe_check_hash {
+        if cache.has_check_hash(check_hash) {
+          return Ok(());
+        }
+      }
     }
 
     for root in &graph.roots {
@@ -174,7 +180,9 @@ impl TypeChecker {
     }
 
     if diagnostics.is_empty() {
-      cache.add_check_hash(check_hash);
+      if let Some(check_hash) = maybe_check_hash {
+        cache.add_check_hash(check_hash);
+      }
     }
 
     log::debug!("{}", response.stats);
@@ -196,7 +204,7 @@ enum CheckHashResult {
 /// be used to tell
 fn get_check_hash(
   graph: &ModuleGraph,
-  package_reqs: HashMap<PackageReq, PackageNv>,
+  package_reqs_hash: u64,
   type_check_mode: TypeCheckMode,
   ts_config: &TsConfig,
 ) -> CheckHashResult {
@@ -270,15 +278,7 @@ fn get_check_hash(
     }
   }
 
-  // Check if any of the top level npm packages have changed. We could go
-  // further and check all the individual npm packages, but that's
-  // probably overkill.
-  let mut package_reqs = package_reqs.into_iter().collect::<Vec<_>>();
-  package_reqs.sort_by(|a, b| a.0.cmp(&b.0)); // determinism
-  for (pkg_req, pkg_nv) in package_reqs {
-    hasher.write_hashable(&pkg_req);
-    hasher.write_hashable(&pkg_nv);
-  }
+  hasher.write_hashable(package_reqs_hash);
 
   if !has_file || !check_js && !has_file_to_type_check {
     // no files to type check

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -5,6 +5,7 @@ use crate::args::FileFlags;
 use crate::args::Flags;
 use crate::colors;
 use crate::factory::CliFactory;
+use crate::npm::CliNpmResolver;
 use crate::tools::fmt::format_json;
 use crate::tools::test::is_supported_test_path;
 use crate::util::fs::FileCollector;
@@ -601,7 +602,7 @@ fn filter_coverages(
   coverages: Vec<ScriptCoverage>,
   include: Vec<String>,
   exclude: Vec<String>,
-  npm_root_dir: &str,
+  npm_resolver: &dyn CliNpmResolver,
 ) -> Vec<ScriptCoverage> {
   let include: Vec<Regex> =
     include.iter().map(|e| Regex::new(e).unwrap()).collect();
@@ -613,11 +614,14 @@ fn filter_coverages(
     .into_iter()
     .filter(|e| {
       let is_internal = e.url.starts_with("ext:")
-        || e.url.starts_with(npm_root_dir)
         || e.url.ends_with("__anonymous__")
         || e.url.ends_with("$deno$test.js")
         || e.url.ends_with(".snap")
-        || is_supported_test_path(Path::new(e.url.as_str()));
+        || is_supported_test_path(Path::new(e.url.as_str()))
+        || Url::parse(&e.url)
+          .ok()
+          .map(|url| npm_resolver.in_npm_package(&url))
+          .unwrap_or(false);
 
       let is_included = include.iter().any(|p| p.is_match(&e.url));
       let is_excluded = exclude.iter().any(|p| p.is_match(&e.url));
@@ -636,7 +640,7 @@ pub async fn cover_files(
   }
 
   let factory = CliFactory::from_flags(flags).await?;
-  let root_dir_url = factory.npm_resolver().await?.root_dir_url();
+  let npm_resolver = factory.npm_resolver().await?;
   let file_fetcher = factory.file_fetcher()?;
   let cli_options = factory.cli_options();
   let emitter = factory.emitter()?;
@@ -646,7 +650,7 @@ pub async fn cover_files(
     script_coverages,
     coverage_flags.include,
     coverage_flags.exclude,
-    root_dir_url.as_str(),
+    npm_resolver.as_ref(),
   );
 
   let proc_coverages: Vec<_> = script_coverages

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -126,7 +126,7 @@ pub async fn execute_script(
           }
           None => Default::default(),
         };
-        let env_vars = match npm_resolver.node_modules_path() {
+        let env_vars = match npm_resolver.root_node_modules_path() {
           Some(dir_path) => collect_env_vars_with_node_modules_dir(&dir_path),
           None => collect_env_vars(),
         };

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -657,9 +657,11 @@ fn resolve_graph_specifier_types(
       Ok(Some((module.specifier.clone(), module.media_type)))
     }
     Some(Module::Npm(module)) => {
-      if let Some(npm) = &state.maybe_npm {
+      if let Some(npm) = &state.maybe_npm.as_ref() {
         let package_folder = npm
           .npm_resolver
+          .as_managed()
+          .unwrap() // should never be byonm because it won't create Module::Npm
           .resolve_pkg_folder_from_deno_module(module.nv_reference.nv())?;
         let maybe_resolution = npm.node_resolver.resolve_npm_reference(
           &package_folder,
@@ -718,7 +720,7 @@ fn resolve_non_graph_specifier_types(
     // injected and not part of the graph
     let package_folder = npm
       .npm_resolver
-      .resolve_pkg_folder_from_deno_module_req(npm_req_ref.req())?;
+      .resolve_pkg_folder_from_deno_module_req(npm_req_ref.req(), referrer)?;
     let maybe_resolution = node_resolver.resolve_npm_reference(
       &package_folder,
       npm_req_ref.sub_path(),

--- a/ext/node/package_json.rs
+++ b/ext/node/package_json.rs
@@ -97,7 +97,13 @@ impl PackageJson {
       return Ok(PackageJson::empty(path));
     }
 
-    Self::load_from_string(path, source)
+    let package_json = Self::load_from_string(path, source)?;
+    CACHE.with(|cache| {
+      cache
+        .borrow_mut()
+        .insert(package_json.path.clone(), package_json.clone());
+    });
+    Ok(package_json)
   }
 
   pub fn load_from_string(
@@ -199,11 +205,6 @@ impl PackageJson {
       scripts,
     };
 
-    CACHE.with(|cache| {
-      cache
-        .borrow_mut()
-        .insert(package_json.path.clone(), package_json.clone());
-    });
     Ok(package_json)
   }
 


### PR DESCRIPTION
Part of https://github.com/denoland/deno/issues/18967