### PR TITLE
fix(lsp): show diagnostics for type imports from untyped deps

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3810,6 +3810,13 @@ fn op_load(
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("op_load", Some(&args));
   let specifier = state.specifier_map.normalize(args.specifier)?;
+  if specifier.as_str() == "internal:///missing_dependency.d.ts" {
+    return Ok(Some(LoadResponse {
+      data: Arc::from("declare const __: any;\nexport = __;\n"),
+      script_kind: crate::tsc::as_ts_script_kind(MediaType::Dts),
+      version: Some("1".to_string()),
+    }));
+  }
   let asset_or_document = state.get_asset_or_document(&specifier);
   state.performance.measure(mark);
   Ok(asset_or_document.map(|doc| LoadResponse {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -7735,6 +7735,57 @@ fn lsp_diagnostics_refresh_dependents() {
 }
 
 #[test]
+fn lsp_npm_missing_type_imports_diagnostics() {
+  let context = TestContextBuilder::new()
+    .use_http_server()
+    .use_temp_cwd()
+    .build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.did_open(json!({
+    "textDocument": {
+      "uri": "file:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": r#"
+        import colorName, { type RGB } from 'npm:color-name';
+        const color: RGB = colorName.black;
+        console.log(color);
+      "#,
+    },
+  }));
+  client.write_request(
+    "workspace/executeCommand",
+    json!({
+      "command": "deno.cache",
+      "arguments": [[], "file:///a/file.ts"],
+    }),
+  );
+  let diagnostics = client.read_diagnostics();
+  assert_eq!(
+    json!(
+      diagnostics.messages_with_file_and_source("file:///a/file.ts", "deno-ts")
+    ),
+    json!({
+      "uri": "file:///a/file.ts",
+      "diagnostics": [
+        {
+          "range": {
+            "start": { "line": 1, "character": 33 },
+            "end": { "line": 1, "character": 36 },
+          },
+          "severity": 1,
+          "code": 2305,
+          "source": "deno-ts",
+          "message": "Module '\"npm:color-name\"' has no exported member 'RGB'.",
+        },
+      ],
+      "version": 1,
+    })
+  );
+}
+
+#[test]
 fn lsp_jupyter_diagnostics() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let mut client = context.new_lsp_command().build();


### PR DESCRIPTION
Example:
```ts
import colorName, { type RGB } from 'npm:color-name';
const color: RGB = colorName.black;
console.log(color);
```
This now shows a diagnostic on the import for `RGB`, since that package has no included type declarations. It already does with `deno check`.