### PR TITLE
refactor(npm): add referrer when resolving npm package sub path from deno module

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1587,9 +1587,10 @@ fn node_resolve_npm_req_ref(
         .and_then(|package_folder| {
           npm
             .node_resolver
-            .resolve_npm_reference(
+            .resolve_package_subpath_from_deno_module(
               &package_folder,
               npm_req_ref.sub_path(),
+              referrer,
               NodeResolutionMode::Types,
               &PermissionsContainer::allow_all(),
             )

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -512,6 +512,7 @@ impl ModuleLoader for CliModuleLoader {
                 .resolve_package_sub_path(
                   &package_folder,
                   module.nv_reference.sub_path(),
+                  referrer,
                   permissions,
                 )
                 .with_context(|| {
@@ -726,6 +727,7 @@ impl CliNodeResolver {
       .resolve_package_sub_path(
         &package_folder,
         req_ref.sub_path(),
+        referrer,
         permissions,
       )
       .with_context(|| format!("Could not resolve '{}'.", req_ref))
@@ -735,14 +737,18 @@ impl CliNodeResolver {
     &self,
     package_folder: &Path,
     sub_path: Option<&str>,
+    referrer: &ModuleSpecifier,
     permissions: &PermissionsContainer,
   ) -> Result<ModuleSpecifier, AnyError> {
-    self.handle_node_resolve_result(self.node_resolver.resolve_npm_reference(
-      package_folder,
-      sub_path,
-      NodeResolutionMode::Execution,
-      permissions,
-    ))
+    self.handle_node_resolve_result(
+      self.node_resolver.resolve_package_subpath_from_deno_module(
+        package_folder,
+        sub_path,
+        referrer,
+        NodeResolutionMode::Execution,
+        permissions,
+      ),
+    )
   }
 
   fn handle_node_resolve_result(

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -571,12 +571,18 @@ impl CliMainWorkerFactory {
       return Ok(None);
     }
 
-    let Some(resolution) = self.shared.node_resolver.resolve_npm_reference(
-      package_folder,
-      sub_path,
-      NodeResolutionMode::Execution,
-      permissions,
-    )?
+    let referrer =
+      ModuleSpecifier::from_directory_path(package_folder).unwrap();
+    let Some(resolution) = self
+      .shared
+      .node_resolver
+      .resolve_package_subpath_from_deno_module(
+        package_folder,
+        sub_path,
+        &referrer,
+        NodeResolutionMode::Execution,
+        permissions,
+      )?
     else {
       return Ok(None);
     };

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -571,6 +571,7 @@ impl CliMainWorkerFactory {
       return Ok(None);
     }
 
+    // use a fake referrer since a real one doesn't exist
     let referrer =
       ModuleSpecifier::from_directory_path(package_folder).unwrap();
     let Some(resolution) = self

--- a/ext/node/resolution.rs
+++ b/ext/node/resolution.rs
@@ -325,15 +325,15 @@ impl NodeResolver {
     Ok(resolved)
   }
 
-  pub fn resolve_npm_reference(
+  pub fn resolve_package_subpath_from_deno_module(
     &self,
     package_dir: &Path,
     package_subpath: Option<&str>,
+    referrer: &ModuleSpecifier,
     mode: NodeResolutionMode,
     permissions: &dyn NodePermissions,
   ) -> Result<Option<NodeResolution>, AnyError> {
     let package_json_path = package_dir.join("package.json");
-    let referrer = ModuleSpecifier::from_directory_path(package_dir).unwrap();
     let package_json =
       self.load_package_json(permissions, package_json_path.clone())?;
     let node_module_kind = NodeModuleKind::Esm;

--- a/ext/node/resolution.rs
+++ b/ext/node/resolution.rs
@@ -344,7 +344,7 @@ impl NodeResolver {
       .resolve_package_subpath(
         &package_json,
         &package_subpath,
-        &referrer,
+        referrer,
         node_module_kind,
         DEFAULT_CONDITIONS,
         mode,


### PR DESCRIPTION
Adds a `referrer` parameter to this function instead of using a fake one.