### PR TITLE
feat(jupyter): Await return from `Jupyter.display`

### DIFF
--- a/cli/tests/testdata/jupyter/integration_test.ipynb
+++ b/cli/tests/testdata/jupyter/integration_test.ipynb
@@ -775,6 +775,43 @@
     "let sc = new SuperColor()\n",
     "sc"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "c1296291-a3e8-457b-8329-6cc58a1e528a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width: 32px; height: 32px; background-color: #239814\" />"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class SuperColorAsync {\n",
+    "  constructor() {\n",
+    "      this.color = \"#239814\"\n",
+    "  }\n",
+    "  hex() {\n",
+    "      return this.color\n",
+    "  }\n",
+    "    \n",
+    "  async [Symbol.for(\"Jupyter.display\")]() {\n",
+    "      return {\n",
+    "          \"text/html\": `<div style=\"width: 32px; height: 32px; background-color: ${this.hex()}\" />`\n",
+    "      }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "let sc = new SuperColorAsync()\n",
+    "sc"
+   ]
   }
  ],
  "metadata": {

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -551,13 +551,13 @@ async fn get_jupyter_display(
     .post_message_with_event_loop(
       "Runtime.callFunctionOn",
       Some(json!({
-        "functionDeclaration": r#"function (object) {
+        "functionDeclaration": r#"async function (object) {
       if (typeof object[Symbol.for("Jupyter.display")] !== "function") {
         return null;
       }
-      
+
       try {
-        const representation = object[Symbol.for("Jupyter.display")]();
+        const representation = await object[Symbol.for("Jupyter.display")]();
         return JSON.stringify(representation);
       } catch {
         return null;


### PR DESCRIPTION
Allows `Jupyter.display` to return a promise.


Silly example:

```javascript
class WikiPage {
    constructor(public name) {}
    async [Symbol.for("Jupyter.display")]() {
        let response = await fetch("https://en.wikipedia.org/wiki/" + this.name);
        return { "text/html": await response.text() }
    }
}

new WikiPage("Deno_(software)")
```

<img width="788" alt="image" src="https://github.com/denoland/deno/assets/24403730/edb7c67f-e7f8-44b7-9236-28af62e51956">

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
