### PR TITLE
perf(lsp): optimize formatting minified files

### DIFF
--- a/cli/lsp/text.rs
+++ b/cli/lsp/text.rs
@@ -210,6 +210,18 @@ pub fn get_edits(a: &str, b: &str, line_index: &LineIndex) -> Vec<TextEdit> {
   if a == b {
     return vec![];
   }
+  // Heuristic to detect things like minified files. `diff()` is expensive.
+  if b.chars().filter(|c| *c == '\n').count()
+    > line_index.utf8_offsets.len() * 3
+  {
+    return vec![TextEdit {
+      range: lsp::Range {
+        start: lsp::Position::new(0, 0),
+        end: line_index.position_utf16(TextSize::from(a.len() as u32)),
+      },
+      new_text: b.to_string(),
+    }];
+  }
   let chunks = diff(a, b);
   let mut text_edits = Vec::<TextEdit>::new();
   let mut iter = chunks.iter().peekable();


### PR DESCRIPTION
Fixes #20754. Uses one big text edit if the formatter produces a substantial change in line count. Also moves diff generation to the blocking thread.