### PR TITLE
refactor: remove TimersPermissions::check_unstable

### DIFF
--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -7,7 +7,6 @@ use deno_bench_util::bencher::Bencher;
 use deno_core::Extension;
 use deno_core::ExtensionFileSource;
 use deno_core::ExtensionFileSourceCode;
-use deno_core::OpState;
 
 #[derive(Clone)]
 struct Permissions;
@@ -15,9 +14,6 @@ struct Permissions;
 impl deno_web::TimersPermission for Permissions {
   fn allow_hrtime(&mut self) -> bool {
     false
-  }
-  fn check_unstable(&self, _state: &OpState, _api_name: &'static str) {
-    unreachable!()
   }
 }
 

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -7,7 +7,6 @@ use deno_bench_util::bencher::Bencher;
 use deno_core::Extension;
 use deno_core::ExtensionFileSource;
 use deno_core::ExtensionFileSourceCode;
-use deno_core::OpState;
 
 #[derive(Clone)]
 struct Permissions;
@@ -16,7 +15,6 @@ impl deno_web::TimersPermission for Permissions {
   fn allow_hrtime(&mut self) -> bool {
     true
   }
-  fn check_unstable(&self, _state: &OpState, _api_name: &'static str) {}
 }
 
 fn setup() -> Vec<Extension> {

--- a/ext/web/timers.rs
+++ b/ext/web/timers.rs
@@ -19,7 +19,6 @@ use std::time::Instant;
 
 pub trait TimersPermission {
   fn allow_hrtime(&mut self) -> bool;
-  fn check_unstable(&self, state: &OpState, api_name: &'static str);
 }
 
 pub type StartTime = Instant;

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -55,14 +55,6 @@ mod startup_snapshot {
     fn allow_hrtime(&mut self) -> bool {
       unreachable!("snapshotting!")
     }
-
-    fn check_unstable(
-      &self,
-      _state: &deno_core::OpState,
-      _api_name: &'static str,
-    ) {
-      unreachable!("snapshotting!")
-    }
   }
 
   impl deno_ffi::FfiPermissions for Permissions {

--- a/runtime/permissions/mod.rs
+++ b/runtime/permissions/mod.rs
@@ -15,7 +15,6 @@ use deno_core::serde_json;
 use deno_core::url;
 use deno_core::url::Url;
 use deno_core::ModuleSpecifier;
-use deno_core::OpState;
 use log;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
@@ -1433,11 +1432,6 @@ impl deno_web::TimersPermission for PermissionsContainer {
   #[inline(always)]
   fn allow_hrtime(&mut self) -> bool {
     self.0.lock().hrtime.check().is_ok()
-  }
-
-  #[inline(always)]
-  fn check_unstable(&self, state: &OpState, api_name: &'static str) {
-    crate::ops::check_unstable(state, api_name);
   }
 }
 


### PR DESCRIPTION
This is dead code that was not used in any way.

Ref https://github.com/denoland/deno/pull/20797