### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,41 @@
+name: 🐛 Bug Report
+description: Report an issue that should be fixed
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting a bug report. It helps make Deno better.
+
+        If you need help or support using Deno, and are not reporting a bug, please
+        join our [Discord](https://discord.gg/deno) server, where you can ask questions in the Help forum.
+
+        Please try to include as much information as possible.
+  - type: input
+    attributes:
+      label: What version of Deno is running?
+      description: Copy the output of `deno -V`
+  - type: input
+    attributes:
+      label: What platform is your computer?
+      description: |
+        For MacOS and Linux: copy the output of `uname -mprs`
+        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $(if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" })"` in the PowerShell console
+  - type: textarea
+    attributes:
+      label: What steps can reproduce the bug?
+      description: Explain the bug and provide a code snippet that can reproduce it.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the expected behavior?
+      description: If possible, please provide text instead of a screenshot.
+  - type: textarea
+    attributes:
+      label: What do you see instead?
+      description: If possible, please provide text instead of a screenshot.
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else you think we should know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💡 Community Feature Requets
+    url: https://discord.com/deno
+    about: Suggest an idea, feature or enhancement in the Ideas Discord forum.
+  - name: 💬 Ask a Question, Discuss and learn how others are using Deno
+    url: https://discord.com/deno
+    about: Join our Discord server for questions, support requests, or just to chat.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,23 @@
+name: 🚀 Deno land Feature request
+description: Suggest an idea, feature or enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting an idea. It helps make Deno better.
+
+        This is only for CLI / Deno land items. For community projects, please use the Ideas forum in [Discord](https://discord.com/deno).
+  - type: textarea
+    attributes:
+      label: What is the problem this feature would solve?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the feature you are proposing to solve the problem?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What alternatives have you considered?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,4 @@
-name: 🚀 Deno land Feature request
+name: 💡 Deno land Feature request
 description: Suggest an idea, feature or enhancement
 labels: [enhancement]
 body:


### PR DESCRIPTION
The lack of issue templates led has the unfortunate result that most bug reports are lacking key information about the reporters setup.

This adds templates for:

- Bug report (Github ticket)
- Deno land Feature request (Github ticket)
- Community Feature Requets (Discord -> Ideas)
- Ask a Question, Discuss and learn how others are using Deno (Discord)