### PR TITLE
fix(ext/node): enable reuseport for net Socket on macOS

### DIFF
--- a/cli/tests/unit/net_test.ts
+++ b/cli/tests/unit/net_test.ts
@@ -1224,7 +1224,7 @@ Deno.test({
 });
 
 Deno.test({
-  ignore: Deno.build.os === "linux",
+  ignore: Deno.build.os === "linux" || Deno.build.os === "darwin",
   permissions: { net: true },
 }, function netTcpListenReusePortDoesNothing() {
   const listener1 = Deno.listen({ port: 4003, reusePort: true });

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -419,7 +419,11 @@ class Datagram {
 
 const listenOptionApiName = Symbol("listenOptionApiName");
 
-function listen(args, checkUnstable = true) {
+function listen(args) {
+  return listenInternal(args, true);
+}
+
+function listenInternal(args, checkUnstable = true) {
   switch (args.transport ?? "tcp") {
     case "tcp": {
       const { 0: rid, 1: addr } = ops.op_net_listen_tcp(
@@ -515,6 +519,7 @@ export {
   Datagram,
   listen,
   Listener,
+  listenInternal,
   listenOptionApiName,
   resolveDns,
   shutdown,

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -419,13 +419,13 @@ class Datagram {
 
 const listenOptionApiName = Symbol("listenOptionApiName");
 
-function listen(args) {
+function listen(args, checkUnstable = true) {
   switch (args.transport ?? "tcp") {
     case "tcp": {
       const { 0: rid, 1: addr } = ops.op_net_listen_tcp({
         hostname: args.hostname ?? "0.0.0.0",
         port: Number(args.port),
-      }, args.reusePort);
+      }, args.reusePort, checkUnstable);
       addr.transport = "tcp";
       return new Listener(rid, addr);
     }

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -422,10 +422,14 @@ const listenOptionApiName = Symbol("listenOptionApiName");
 function listen(args, checkUnstable = true) {
   switch (args.transport ?? "tcp") {
     case "tcp": {
-      const { 0: rid, 1: addr } = ops.op_net_listen_tcp({
-        hostname: args.hostname ?? "0.0.0.0",
-        port: Number(args.port),
-      }, args.reusePort, checkUnstable);
+      const { 0: rid, 1: addr } = ops.op_net_listen_tcp(
+        {
+          hostname: args.hostname ?? "0.0.0.0",
+          port: Number(args.port),
+        },
+        args.reusePort,
+        checkUnstable,
+      );
       addr.transport = "tcp";
       return new Listener(rid, addr);
     }

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -378,7 +378,7 @@ where
   #[cfg(not(windows))]
   socket.set_reuse_address(true)?;
   if reuse_port {
-    #[cfg(target_os = "linux")]
+    #[cfg(not(windows))]
     socket.set_reuse_port(true)?;
   }
   let socket_addr = socket2::SockAddr::from(addr);

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -356,11 +356,13 @@ pub fn op_net_listen_tcp<NP>(
   state: &mut OpState,
   #[serde] addr: IpAddr,
   reuse_port: bool,
+  check_unstable: bool,
 ) -> Result<(ResourceId, IpAddr), AnyError>
 where
   NP: NetPermissions + 'static,
 {
-  if reuse_port {
+  // Do not check for unstable if used by internal Node code,
+  if check_unstable && reuse_port {
     super::check_unstable(state, "Deno.listen({ reusePort: true })");
   }
   state

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -45,6 +45,7 @@ import {
   INITIAL_ACCEPT_BACKOFF_DELAY,
   MAX_ACCEPT_BACKOFF_DELAY,
 } from "ext:deno_node/internal_binding/_listen.ts";
+import { listen } from "ext:deno_net/01_net.js";
 
 /** The type of TCP socket. */
 enum socketType {
@@ -210,7 +211,7 @@ export class TCP extends ConnectionWrap {
     let listener;
 
     try {
-      listener = Deno.listen(listenOptions);
+      listener = listen(listenOptions, false);
     } catch (e) {
       if (e instanceof Deno.errors.AddrInUse) {
         return codeMap.get("EADDRINUSE")!;

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -45,7 +45,7 @@ import {
   INITIAL_ACCEPT_BACKOFF_DELAY,
   MAX_ACCEPT_BACKOFF_DELAY,
 } from "ext:deno_node/internal_binding/_listen.ts";
-import { listen } from "ext:deno_net/01_net.js";
+import { listenInternal } from "ext:deno_net/01_net.js";
 
 /** The type of TCP socket. */
 enum socketType {
@@ -211,7 +211,7 @@ export class TCP extends ConnectionWrap {
     let listener;
 
     try {
-      listener = listen(listenOptions, false);
+      listener = listenInternal(listenOptions, false);
     } catch (e) {
       if (e instanceof Deno.errors.AddrInUse) {
         return codeMap.get("EADDRINUSE")!;

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -204,6 +204,7 @@ export class TCP extends ConnectionWrap {
       hostname: this.#address!,
       port: this.#port!,
       transport: "tcp" as const,
+      reusePort: true,
     };
 
     let listener;


### PR DESCRIPTION
- Enables SO_REUSEPORT on macOS
- All Node `net.Socket` TCP sockets are set to `SO_REUSEPORT`.

Fixes #20618 
Fixes #18301 

Modules working: `npm:http-server`, `npm:portfinder` and Vuepress dev server