### PR TITLE
fix: upgrade dprint-plugin-markdown 0.16.2 and typescript 0.88.1

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -55,9 +55,9 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.87.1.wasm",
+    "https://plugins.dprint.dev/typescript-0.88.1.wasm",
     "https://plugins.dprint.dev/json-0.17.4.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.16.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072"
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6be002070326615a3faf423ad398dac631fc5e3289ff7a6ea5bfe2919c21ad6"
+checksum = "726638912cda718e8c5dc9e2f65eb7c14c7a99b5ce1a7a1bbf3950e72ec39562"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-markdown"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf3e228c56be47b43af72309c2b8025491012b41d5397cd7b91172ce1368cf3"
+checksum = "0f1eee7353bc4d7031dde53468356eeba7cdfe8e237085647cec3be41c3cdbc7"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -6109,8 +6109,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.7.3",
+ "cfg-if 1.0.0",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -78,7 +78,7 @@ data-url.workspace = true
 dissimilar = "=1.0.4"
 dprint-plugin-json = "=0.17.4"
 dprint-plugin-markdown = "=0.16.2"
-dprint-plugin-typescript = "=0.87.1"
+dprint-plugin-typescript = "=0.88.1"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,7 +77,7 @@ data-encoding.workspace = true
 data-url.workspace = true
 dissimilar = "=1.0.4"
 dprint-plugin-json = "=0.17.4"
-dprint-plugin-markdown = "=0.16.1"
+dprint-plugin-markdown = "=0.16.2"
 dprint-plugin-typescript = "=0.87.1"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"


### PR DESCRIPTION
Markdown:

* fix: hard break in list was incorrectly being converted to soft with hard break https://github.com/dprint/dprint-plugin-markdown/commit/6678390b27f05fd23a972eab7918e8badca60505

TypeScript:

* fix: multi-line string indent was broken in some cases (https://github.com/dprint/dprint-plugin-typescript/pull/566)
* feat: add parens around unary expressions in in/instanceof (https://github.com/dprint/dprint-plugin-typescript/pull/564)