### PR TITLE
fix(lsp): include mtime in tsc script version

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -565,7 +565,7 @@ impl Document {
   pub fn script_version(&self) -> String {
     self
       .maybe_lsp_version()
-      .map(|v| v.to_string())
+      .map(|v| format!("{}+{v}", self.fs_version()))
       .unwrap_or_else(|| self.fs_version().to_string())
   }
 


### PR DESCRIPTION
Fixes #10897. The LSP client will reset the version index to 1 if the file is deleted, which prevented tsc from refreshing diagnostics. This includes the `Document::fs_version()` (mtime) in the version that we pass to tsc.

In theory this shouldn't solve the issue for the duration where the new file is still unsaved, because there's no mtime to apply. But it seems no diagnostics are published or shown for unsaved files anyway so I can't reproduce an issue.