### PR TITLE
chore(doc): add license section in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,17 @@ To contribute, please read our
 [YouTube link]: https://www.youtube.com/@deno_land
 [Discord badge]: https://img.shields.io/discord/684898665143206084?logo=discord&style=social
 [Discord link]: https://discord.gg/deno
+
+### License
+
+<table>
+  <tr>
+     <td>
+       <p align="center"> <img src="https://github.com/malivinayak/malivinayak/blob/main/LICENSE-Logo/MIT.png?raw=true" width="80%"></img>
+    </td>
+    <td> 
+      <img src="https://img.shields.io/badge/License-MIT-yellow.svg"/> <br> 
+This project is licensed under <a href="./LICENSE">MIT</a>. <img width=2300/>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
## Description

I have added the LICENSE section in the README file with enhanced presentation. Also I have added a MIT logo, license badge and updated text with a cleaner format, including a hyperlink to the LICENSE file.

## Screenshot

![MIT](https://user-images.githubusercontent.com/66154908/275214103-f26ee346-74b9-4aa9-8912-d2de23f02e4e.png)

### Issue fix
- resolves #20912