### PR TITLE
fix(lsp): show diagnostics for untitled files

### DIFF
--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -2,7 +2,7 @@
 
 use super::client::Client;
 use super::config::ConfigSnapshot;
-use super::documents::cell_to_file_specifier;
+use super::documents::file_like_to_file_specifier;
 use super::documents::Documents;
 use super::documents::DocumentsFilter;
 use super::lsp_custom;
@@ -365,7 +365,7 @@ fn get_local_completions(
   current: &str,
   range: &lsp::Range,
 ) -> Option<Vec<lsp::CompletionItem>> {
-  let base = match cell_to_file_specifier(base) {
+  let base = match file_like_to_file_specifier(base) {
     Some(s) => s,
     None => base.clone(),
   };

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -89,12 +89,13 @@ static TSX_HEADERS: Lazy<HashMap<String, String>> = Lazy::new(|| {
     .collect()
 });
 
-pub const DOCUMENT_SCHEMES: [&str; 6] = [
+pub const DOCUMENT_SCHEMES: [&str; 7] = [
   "data",
   "blob",
   "file",
   "http",
   "https",
+  "untitled",
   "deno-notebook-cell",
 ];
 
@@ -259,22 +260,24 @@ impl AssetOrDocument {
   }
 }
 
-/// Convert a `deno-notebook-cell:` specifier to a `file:` specifier.
+/// Convert a e.g. `deno-notebook-cell:` specifier to a `file:` specifier.
 /// ```rust
 /// assert_eq!(
-///   cell_to_file_specifier(
+///   file_like_to_file_specifier(
 ///     &Url::parse("deno-notebook-cell:/path/to/file.ipynb#abc").unwrap(),
 ///   ),
 ///   Some(Url::parse("file:///path/to/file.ipynb#abc").unwrap()),
 /// );
-pub fn cell_to_file_specifier(specifier: &Url) -> Option<Url> {
-  if specifier.scheme() == "deno-notebook-cell" {
-    if let Ok(specifier) = ModuleSpecifier::parse(&format!(
+pub fn file_like_to_file_specifier(specifier: &Url) -> Option<Url> {
+  if matches!(specifier.scheme(), "untitled" | "deno-notebook-cell") {
+    if let Ok(mut s) = ModuleSpecifier::parse(&format!(
       "file://{}",
       &specifier.as_str()
         [url::quirks::internal_components(specifier).host_end as usize..],
     )) {
-      return Some(specifier);
+      s.query_pairs_mut()
+        .append_pair("scheme", specifier.scheme());
+      return Some(s);
     }
   }
   None
@@ -300,22 +303,28 @@ impl DocumentDependencies {
       deps: module.dependencies.clone(),
       maybe_types_dependency: module.maybe_types_dependency.clone(),
     };
-    if module.specifier.scheme() == "deno-notebook-cell" {
+    if file_like_to_file_specifier(&module.specifier).is_some() {
       for (_, dep) in &mut deps.deps {
         if let Resolution::Ok(resolved) = &mut dep.maybe_code {
-          if let Some(specifier) = cell_to_file_specifier(&resolved.specifier) {
+          if let Some(specifier) =
+            file_like_to_file_specifier(&resolved.specifier)
+          {
             resolved.specifier = specifier;
           }
         }
         if let Resolution::Ok(resolved) = &mut dep.maybe_type {
-          if let Some(specifier) = cell_to_file_specifier(&resolved.specifier) {
+          if let Some(specifier) =
+            file_like_to_file_specifier(&resolved.specifier)
+          {
             resolved.specifier = specifier;
           }
         }
       }
       if let Some(dep) = &mut deps.maybe_types_dependency {
         if let Resolution::Ok(resolved) = &mut dep.dependency {
-          if let Some(specifier) = cell_to_file_specifier(&resolved.specifier) {
+          if let Some(specifier) =
+            file_like_to_file_specifier(&resolved.specifier)
+          {
             resolved.specifier = specifier;
           }
         }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -191,7 +191,6 @@ impl TsServer {
         .map(|s| self.specifier_map.denormalize(&s))
         .collect::<Vec<String>>(),]),
     };
-    dbg!(&req);
     let diagnostics_map_ = self.request_with_cancellation::<HashMap<String, Vec<crate::tsc::Diagnostic>>>(snapshot, req, token).await?;
     let mut diagnostics_map = HashMap::new();
     for (mut specifier, mut diagnostics) in diagnostics_map_ {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -8041,6 +8041,49 @@ fn lsp_jupyter_diagnostics() {
   client.shutdown();
 }
 
+#[test]
+fn lsp_untitled_file_diagnostics() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": "untitled:///a/file.ts",
+      "languageId": "typescript",
+      "version": 1,
+      "text": "Deno.readTextFileSync(1234);",
+    },
+  }));
+  assert_eq!(
+    json!(diagnostics.all_messages()),
+    json!([
+      {
+        "uri": "untitled:///a/file.ts",
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 22,
+              },
+              "end": {
+                "line": 0,
+                "character": 26,
+              },
+            },
+            "severity": 1,
+            "code": 2345,
+            "source": "deno-ts",
+            "message": "Argument of type 'number' is not assignable to parameter of type 'string | URL'.",
+          },
+        ],
+        "version": 1,
+      },
+    ])
+  );
+  client.shutdown();
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PerformanceAverage {


### PR DESCRIPTION
Coupled with https://github.com/denoland/vscode_deno/pull/978. If you open a yet-to-be-saved file, maybe through `code file.ts` for VSCode, that file wouldn't show diagnostics until it was saved to the FS. That's because we weren't handling `untitled:///` specifiers passed from VSCode.