### PR TITLE
fix(polyfill): correctly handle flag when its equal 0

### DIFF
--- a/cli/tests/unit_node/_fs/_fs_open_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_open_test.ts
@@ -397,4 +397,14 @@ Deno.test("[std/node/fs] open callback isn't called twice if error is thrown", a
       await Deno.remove(tempFile);
     },
   });
+
+  Deno.test({
+    name: "SYNC: open file with flag set to 0 (readonly)",
+    fn() {
+      const file = Deno.makeTempFileSync();
+      const fd = openSync(file, 0);
+      assert(Deno.resources()[fd]);
+      closeSync(fd);
+    },
+  });
 });

--- a/cli/tests/unit_node/_fs/_fs_read_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_read_test.ts
@@ -316,7 +316,7 @@ Deno.test({
     const fd = openSync(testData, "r");
     const _bytesRead = readSync(
       fd,
-      buffer
+      buffer,
     );
     closeSync(fd);
   },

--- a/cli/tests/unit_node/_fs/_fs_read_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_read_test.ts
@@ -306,3 +306,18 @@ Deno.test({
     await Deno.remove(file);
   },
 });
+
+Deno.test({
+  name: "SYNC: read with no offsetOropts argument",
+  fn() {
+    const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+    const testData = path.resolve(moduleDir, "testdata", "hello.txt");
+    const buffer = Buffer.alloc(1024);
+    const fd = openSync(testData, "r");
+    const _bytesRead = readSync(
+      fd,
+      buffer
+    );
+    closeSync(fd);
+  },
+});

--- a/ext/node/polyfills/_fs/_fs_common.ts
+++ b/ext/node/polyfills/_fs/_fs_common.ts
@@ -108,7 +108,7 @@ export function checkEncoding(encoding: Encodings | null): Encodings | null {
 export function getOpenOptions(
   flag: string | number | undefined,
 ): Deno.OpenOptions {
-  if (!flag) {
+  if (flag === undefined) {
     return { create: true, append: true };
   }
 

--- a/ext/node/polyfills/_fs/_fs_open.ts
+++ b/ext/node/polyfills/_fs/_fs_open.ts
@@ -57,8 +57,8 @@ function convertFlagAndModeToOptions(
   flag?: openFlags,
   mode?: number,
 ): Deno.OpenOptions | undefined {
-  if (!flag && !mode) return undefined;
-  if (!flag && mode) return { mode };
+  if (flag === undefined && mode === undefined) return undefined;
+  if (flag === undefined && mode) return { mode };
   return { ...getOpenOptions(flag), mode };
 }
 
@@ -133,6 +133,7 @@ export function open(
       }
       return;
     }
+
     Deno.open(
       path as string,
       convertFlagAndModeToOptions(flags as openFlags, mode),

--- a/ext/node/polyfills/_fs/_fs_open.ts
+++ b/ext/node/polyfills/_fs/_fs_open.ts
@@ -133,7 +133,6 @@ export function open(
       }
       return;
     }
-
     Deno.open(
       path as string,
       convertFlagAndModeToOptions(flags as openFlags, mode),

--- a/ext/node/polyfills/_fs/_fs_read.ts
+++ b/ext/node/polyfills/_fs/_fs_read.ts
@@ -167,7 +167,7 @@ export function readSync(
   if (typeof offsetOrOpt === "number") {
     offset = offsetOrOpt;
     validateInteger(offset, "offset", 0);
-  } else {
+  } else if (offsetOrOpt !== undefined) {
     const opt = offsetOrOpt as readSyncOptions;
     offset = opt.offset ?? 0;
     length = opt.length ?? buffer.byteLength;


### PR DESCRIPTION
fix https://github.com/denoland/deno/issues/20910

I guess the code must have many hidden issues like this, can we have a lint that obligate using comparison to undefined so `if (var !== undefined)` instead of `if (!var)`  ?

- [x] todo tests 