### PR TITLE
perf(lsp): fix redundant walk when collecting tsc code lenses

### DIFF
--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -427,6 +427,11 @@ async fn collect_tsc(
   line_index: Arc<LineIndex>,
   navigation_tree: &NavigationTree,
 ) -> Result<Vec<lsp::CodeLens>, AnyError> {
+  if !workspace_settings.code_lens.implementations
+    && !workspace_settings.code_lens.references
+  {
+    return Ok(vec![]);
+  }
   let code_lenses = Rc::new(RefCell::new(Vec::new()));
   navigation_tree.walk(&|i, mp| {
     let mut code_lenses = code_lenses.borrow_mut();


### PR DESCRIPTION
This is a common case since it affects the default settings. Unfortunately not related to the CPU spikes under investigation.