### PR TITLE
feat(doc): support multiple file entry

### DIFF
--- a/cli/tests/integration/doc_tests.rs
+++ b/cli/tests/integration/doc_tests.rs
@@ -17,12 +17,13 @@ fn deno_doc() {
     let output = context
       .new_command()
       .env("NO_COLOR", "1")
-      .args("doc doc/deno_doc.ts")
+      .args("doc doc/deno_doc.ts doc/deno_doc2.ts")
       .split_output()
       .run();
 
     output.assert_exit_code(0);
     assert_contains!(output.stdout(), "function foo");
+    assert_contains!(output.stdout(), "function bar");
   }
 }
 
@@ -54,7 +55,7 @@ itest!(deno_doc_referenced_private_types {
 
 itest!(_060_deno_doc_displays_all_overloads_in_details_view {
   args:
-    "doc doc/060_deno_doc_displays_all_overloads_in_details_view.ts NS.test",
+    "doc --filter NS.test doc/060_deno_doc_displays_all_overloads_in_details_view.ts",
   output: "doc/060_deno_doc_displays_all_overloads_in_details_view.ts.out",
 });
 

--- a/cli/tests/testdata/doc/deno_doc2.ts
+++ b/cli/tests/testdata/doc/deno_doc2.ts
@@ -1,0 +1,3 @@
+/** Some JSDoc */
+export function bar() {
+}


### PR DESCRIPTION
This commit adds support for multiple entry points to `deno doc`.

Unfortunately to achieve that, I had to change the semantics of the
command to explicitly require `--filter` parameter for filtering symbols,
instead of treating second free argument as the filter argument.

`deno doc --builtin` is still supported, but cannot be mixed with
actual entrypoints.