### PR TITLE
fix(ext/node): tty streams extends net socket

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -13,7 +13,6 @@ import {
 } from "ext:deno_node/internal/readline/callbacks.mjs";
 import { Duplex, Readable, Writable } from "node:stream";
 import * as io from "ext:deno_io/12_io.js";
-import * as tty from "node:tty";
 import { guessHandleType } from "ext:deno_node/internal_binding/util.ts";
 
 // https://github.com/nodejs/node/blob/00738314828074243c9a52a228ab4c68b04259ef/lib/internal/bootstrap/switches/is_main_thread.js#L41
@@ -112,6 +111,11 @@ const _read = function (size) {
   );
 };
 
+let readStream;
+export function setReadStream(s) {
+  readStream = s;
+}
+
 /** https://nodejs.org/api/process.html#process_process_stdin */
 // https://github.com/nodejs/node/blob/v18.12.1/lib/internal/bootstrap/switches/is_main_thread.js#L189
 /** Create process.stdin */
@@ -134,7 +138,8 @@ export const initStdin = () => {
       break;
     }
     case "TTY": {
-      stdin = new tty.ReadStream(fd);
+      //      stdin = new tty.ReadStream(fd);
+      stdin = new readStream(fd);
       break;
     }
     case "PIPE":

--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -138,7 +138,6 @@ export const initStdin = () => {
       break;
     }
     case "TTY": {
-      //      stdin = new tty.ReadStream(fd);
       stdin = new readStream(fd);
       break;
     }

--- a/ext/node/polyfills/tty.js
+++ b/ext/node/polyfills/tty.js
@@ -3,7 +3,8 @@
 import { ERR_INVALID_FD } from "ext:deno_node/internal/errors.ts";
 import { LibuvStreamWrap } from "ext:deno_node/internal_binding/stream_wrap.ts";
 import { providerType } from "ext:deno_node/internal_binding/async_wrap.ts";
-import { Duplex } from "node:stream";
+import { Socket } from "node:net";
+import { setReadStream } from "ext:deno_node/_process/streams.mjs";
 const { Error } = globalThis.__bootstrap.primordials;
 
 // Returns true when the given numeric fd is associated with a TTY and false otherwise.
@@ -24,7 +25,7 @@ class TTY extends LibuvStreamWrap {
   }
 }
 
-export class ReadStream extends Duplex {
+export class ReadStream extends Socket {
   constructor(fd, options) {
     if (fd >> 0 !== fd || fd < 0) {
       throw new ERR_INVALID_FD(fd);
@@ -54,7 +55,9 @@ export class ReadStream extends Duplex {
   }
 }
 
-export class WriteStream extends Duplex {
+setReadStream(ReadStream);
+
+export class WriteStream extends Socket {
   constructor(fd) {
     if (fd >> 0 !== fd || fd < 0) {
       throw new ERR_INVALID_FD(fd);


### PR DESCRIPTION
Workaround the circular references issue by using a initializer function to give tty stream class to `initStdin`.

Fixes https://github.com/denoland/deno/issues/21024
Fixes https://github.com/denoland/deno/issues/20611
Fixes https://github.com/denoland/deno/issues/20890
Fixes https://github.com/denoland/deno/issues/20336

`create-svelte` works now:
```
divy@mini /t/a> ~/gh/deno/target/debug/deno run -A --unstable --reload npm:create-svelte@latest sveltekit-deno

create-svelte version 5.1.1

┌  Welcome to SvelteKit!
│
◇  Which Svelte app template?
│  Skeleton project
│
◇  Add type checking with TypeScript?
│  Yes, using JavaScript with JSDoc comments
│
◇  Select additional options (use arrow keys/space bar)
│  none
│
└  Your project is ready!

✔ Type-checked JavaScript
  https://www.typescriptlang.org/tsconfig#checkJs

Install community-maintained integrations:
  https://github.com/svelte-add/svelte-add

Next steps:
  1: cd sveltekit-deno
  2: npm install
  3: git init && git add -A && git commit -m "Initial commit" (optional)
  4: npm run dev -- --open

To close the dev server, hit Ctrl-C

Stuck? Visit us at https://svelte.dev/chat
```