### PR TITLE
chore: bump rustls-tokio-stream to 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,9 +4569,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-tokio-stream"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8101c6e909600a3648a7774cb06837a5f976eb3265736d7135b4c177fa3020b9"
+checksum = "cb55523a1a023f0e9eb66038515964b59dd0ef63f188ca759360a0e4cf0ee632"
 dependencies = [
  "futures",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ ring = "^0.17.0"
 rusqlite = { version = "=0.29.0", features = ["unlock_notify", "bundled"] }
 rustls = "0.21.8"
 rustls-pemfile = "1.0.0"
-rustls-tokio-stream = "0.2.4"
+rustls-tokio-stream = "=0.2.6"
 rustls-webpki = "0.101.4"
 rustls-native-certs = "0.6.2"
 webpki-roots = "0.25.2"


### PR DESCRIPTION
Small perf bump for WSS websockets due to a log message that was accidentally left in.