### PR TITLE
Revert "chore: use kqueue backend of notify on macOS"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,11 +760,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-channel",
+ "crossbeam-channel 0.4.4",
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -773,8 +773,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.16",
 ]
 
 [[package]]
@@ -784,7 +794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -796,7 +806,7 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset 0.5.6",
@@ -810,7 +820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -823,6 +833,15 @@ dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2604,6 +2623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fslock"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,7 +3690,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
  "bitflags 1.3.2",
+ "crossbeam-channel 0.5.8",
  "filetime",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,7 @@ log = "=0.4.20"
 lsp-types = "=0.94.1" # used by tower-lsp and "proposed" feature is unstable in patch releases
 memmem = "0.1.1"
 monch = "=0.4.3"
-# Note: Do not use the "macos_fsevent" feature of notify, as it links us to CoreFoundation on macOS.
-notify = { version = "=5.0.0", default-features = false, features = ["macos_kqueue"] }
+notify = "=5.0.0"
 num-bigint = { version = "0.4", features = ["rand"] }
 once_cell = "1.17.1"
 os_pipe = "=1.1.4"

--- a/cli/tests/integration/shared_library_tests.rs
+++ b/cli/tests/integration/shared_library_tests.rs
@@ -43,9 +43,11 @@ fn macos_shared_libraries() {
   use test_util as util;
 
   // target/release/deno:
+  //  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1953.1.0)
   // 	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
   // 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
-  const EXPECTED: [&str; 3] = [
+  const EXPECTED: [&str; 4] = [
+    "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
     "/usr/lib/libiconv.2.dylib",
     "/usr/lib/libSystem.B.dylib",
     "/usr/lib/libobjc.A.dylib",

--- a/cli/tests/integration/shared_library_tests.rs
+++ b/cli/tests/integration/shared_library_tests.rs
@@ -44,10 +44,12 @@ fn macos_shared_libraries() {
 
   // target/release/deno:
   //  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1953.1.0)
+  //  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1228.0.0)
   // 	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
   // 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
-  const EXPECTED: [&str; 4] = [
+  const EXPECTED: [&str; 5] = [
     "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation",
+    "/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices",
     "/usr/lib/libiconv.2.dylib",
     "/usr/lib/libSystem.B.dylib",
     "/usr/lib/libobjc.A.dylib",

--- a/cli/tests/node_compat/config.jsonc
+++ b/cli/tests/node_compat/config.jsonc
@@ -70,7 +70,6 @@
       "test-fs-open.js",
       "test-fs-opendir.js",
       "test-fs-rmdir-recursive.js",
-      "test-fs-watchfile.js",
       "test-fs-write-file.js",
       "test-fs-write.js",
       "test-http-url.parse-https.request.js",

--- a/cli/tests/node_compat/test/parallel/test-fs-watchfile.js
+++ b/cli/tests/node_compat/test/parallel/test-fs-watchfile.js
@@ -107,6 +107,6 @@ if (common.isLinux || common.isOSX || common.isWindows) {
       fs.writeFile(path.join(dir, 'foo.txt'), 'foo', common.mustCall((err) => {
         if (err) assert.fail(err);
       }));
-    }, 20);
+    }, 1);
   }));
 }

--- a/cli/tests/unit/fs_events_test.ts
+++ b/cli/tests/unit/fs_events_test.ts
@@ -22,7 +22,7 @@ Deno.test({ permissions: { read: true } }, function watchFsInvalidPath() {
   } else {
     assertThrows(() => {
       Deno.watchFs("non-existent.file");
-    }, Error);
+    }, Deno.errors.NotFound);
   }
 });
 
@@ -32,7 +32,7 @@ async function getTwoEvents(
   const events = [];
   for await (const event of iter) {
     events.push(event);
-    if (events.length == 2) break;
+    if (events.length > 2) break;
   }
   return events;
 }


### PR DESCRIPTION
Reverts denoland/deno#21028

Reason: https://github.com/notify-rs/notify/blob/main/notify/src/kqueue.rs#L79-L81 Need to wait for the watcher thread to spawn otherwise we hit flakes