### PR TITLE
fix: add missing `Object.groupBy()` and `Map.groupBy()` types

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -251,6 +251,7 @@ mod ts {
       "esnext.decorators",
       "esnext.disposable",
       "esnext.intl",
+      "esnext.object",
     ];
 
     let path_dts = cwd.join("tsc/dts");

--- a/cli/tests/unit/globals_test.ts
+++ b/cli/tests/unit/globals_test.ts
@@ -153,3 +153,50 @@ Deno.test(async function promiseWithResolvers() {
     await assertRejects(() => promise, Error, "boom!");
   }
 });
+
+// Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy#examples
+Deno.test(function objectGroupBy() {
+  const inventory = [
+    { name: "asparagus", type: "vegetables", quantity: 5 },
+    { name: "bananas", type: "fruit", quantity: 0 },
+    { name: "goat", type: "meat", quantity: 23 },
+    { name: "cherries", type: "fruit", quantity: 5 },
+    { name: "fish", type: "meat", quantity: 22 },
+  ];
+  const result = Object.groupBy(inventory, ({ type }) => type);
+  assertEquals(result, {
+    vegetables: [
+      { name: "asparagus", type: "vegetables", quantity: 5 },
+    ],
+    fruit: [
+      { name: "bananas", type: "fruit", quantity: 0 },
+      { name: "cherries", type: "fruit", quantity: 5 },
+    ],
+    meat: [
+      { name: "goat", type: "meat", quantity: 23 },
+      { name: "fish", type: "meat", quantity: 22 },
+    ],
+  });
+});
+
+// Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy#examples
+Deno.test(function mapGroupBy() {
+  const inventory = [
+    { name: "asparagus", type: "vegetables", quantity: 9 },
+    { name: "bananas", type: "fruit", quantity: 5 },
+    { name: "goat", type: "meat", quantity: 23 },
+    { name: "cherries", type: "fruit", quantity: 12 },
+    { name: "fish", type: "meat", quantity: 22 },
+  ];
+  const restock = { restock: true };
+  const sufficient = { restock: false };
+  const result = Map.groupBy(
+    inventory,
+    ({ quantity }) => quantity < 6 ? restock : sufficient,
+  );
+  assertEquals(result.get(restock), [{
+    name: "bananas",
+    type: "fruit",
+    quantity: 5,
+  }]);
+});

--- a/cli/tsc/dts/lib.esnext.object.d.ts
+++ b/cli/tsc/dts/lib.esnext.object.d.ts
@@ -13,12 +13,20 @@ See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
 
-
 /// <reference no-default-lib="true"/>
 
-/// <reference lib="es2023" />
-/// <reference lib="esnext.array" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.object" />
-/// <reference lib="esnext.decorators" />
-/// <reference lib="esnext.disposable" />
+// NOTE(iuioiua): taken from https://github.com/microsoft/TypeScript/issues/47171#issuecomment-1697373352
+// while we wait for these types to officially ship
+interface ObjectConstructor {
+  groupBy<Item, Key extends PropertyKey>(
+    items: Iterable<Item>,
+    keySelector: (item: Item, index: number) => Key,
+  ): Record<Key, Item[]>;
+}
+
+interface MapConstructor {
+  groupBy<Item, Key>(
+    items: Iterable<Item>,
+    keySelector: (item: Item, index: number) => Key,
+  ): Map<Key, Item[]>;
+}


### PR DESCRIPTION
These methods were added in Deno 1.37. However, TypeScript hasn't published the types.

Related https://github.com/denoland/deno_std/pull/3663