### PR TITLE
perf: lazy `atexit` setup

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -272,7 +272,6 @@ pub(crate) fn unstable_warn_cb(feature: &str) {
 pub fn main() {
   setup_panic_hook();
 
-  util::unix::prepare_stdio();
   util::unix::raise_fd_limit();
   util::windows::ensure_stdio_open();
   #[cfg(windows)]

--- a/cli/util/unix.rs
+++ b/cli/util/unix.rs
@@ -43,27 +43,3 @@ pub fn raise_fd_limit() {
     }
   }
 }
-
-pub fn prepare_stdio() {
-  #[cfg(unix)]
-  // SAFETY: Save current state of stdio and restore it when we exit.
-  unsafe {
-    use libc::atexit;
-    use libc::tcgetattr;
-    use libc::tcsetattr;
-    use libc::termios;
-
-    let mut termios = std::mem::zeroed::<termios>();
-    if tcgetattr(libc::STDIN_FILENO, &mut termios) == 0 {
-      static mut ORIG_TERMIOS: Option<termios> = None;
-      ORIG_TERMIOS = Some(termios);
-
-      extern "C" fn reset_stdio() {
-        // SAFETY: Reset the stdio state.
-        unsafe { tcsetattr(libc::STDIN_FILENO, 0, &ORIG_TERMIOS.unwrap()) };
-      }
-
-      atexit(reset_stdio);
-    }
-  }
-}

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -126,9 +126,14 @@ fn op_stdin_set_raw(
         use libc::tcsetattr;
         use libc::termios;
 
+        static mut ORIG_TERMIOS: Option<termios> = None;
+        // Only save original state once.
+        if ORIG_TERMIOS.is_some() {
+          return;
+        }
+
         let mut termios = std::mem::zeroed::<termios>();
         if tcgetattr(libc::STDIN_FILENO, &mut termios) == 0 {
-          static mut ORIG_TERMIOS: Option<termios> = None;
           ORIG_TERMIOS = Some(termios);
 
           extern "C" fn reset_stdio() {


### PR DESCRIPTION
`libc::atexit` incurrs 2% dyld cost at startup on macOS. This PR moves the setup to when the tty mode is changed using op_stdin_set_raw.