### PR TITLE
chore: finish indexmap1 removal from deno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,6 @@ dependencies = [
  "http",
  "hyper 0.14.27",
  "import_map",
- "indexmap 1.9.3",
  "indexmap 2.0.2",
  "jsonc-parser",
  "junction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,6 @@ http = "0.2.9"
 h2 = { version = "0.3.17", features = ["unstable"] }
 httparse = "1.8.0"
 hyper = { version = "0.14.26", features = ["runtime", "http1"] }
-# TODO(mmastrac): indexmap 2.0 will require multiple synchronized changes
-indexmap1 = { package = "indexmap", version = "1", features = ["serde"] }
 indexmap = { version = "2", features = ["serde"] }
 libc = "0.2.126"
 log = "=0.4.20"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -92,7 +92,6 @@ http.workspace = true
 hyper.workspace = true
 import_map = "=0.15.0"
 indexmap.workspace = true
-indexmap1.workspace = true
 jsonc-parser = { version = "=0.21.1", features = ["serde"] }
 lazy-regex.workspace = true
 libc.workspace = true


### PR DESCRIPTION
We still pull the dep in from a few other places, but we can let those get fixed over time.