### PR TITLE
fix(ext/web): webstorage has trap for symbol

### DIFF
--- a/cli/tests/unit/webstorage_test.ts
+++ b/cli/tests/unit/webstorage_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 
-import { assert, assertThrows } from "./test_util.ts";
+import { assert, assertEquals, assertThrows } from "./test_util.ts";
 
 Deno.test({ permissions: "none" }, function webStoragesReassignable() {
   // Can reassign to web storages
@@ -21,7 +21,7 @@ Deno.test(function webstorageSizeLimit() {
     Error,
     "Exceeded maximum storage size",
   );
-  assert(localStorage.getItem("k") === null);
+  assertEquals(localStorage.getItem("k"), null);
   assertThrows(
     () => {
       localStorage.setItem("k".repeat(15 * 1024 * 1024), "v");
@@ -39,4 +39,14 @@ Deno.test(function webstorageSizeLimit() {
     Error,
     "Exceeded maximum storage size",
   );
+});
+
+Deno.test(function webstorageProxy() {
+  localStorage.clear();
+  localStorage.foo = "foo";
+  assertEquals(localStorage.foo, "foo");
+  const symbol = Symbol("bar");
+  localStorage[symbol as any] = "bar";
+  assertEquals(localStorage[symbol as any], "bar");
+  assertEquals(symbol in localStorage, true);
 });

--- a/ext/webstorage/01_webstorage.js
+++ b/ext/webstorage/01_webstorage.js
@@ -117,9 +117,11 @@ function createStorage(persistent) {
       }
       return true;
     },
-    has(target, p) {
-      return p === SymbolFor("Deno.customInspect") ||
-        (typeof target.getItem(p)) === "string";
+    has(target, key) {
+      if (ReflectHas(target, key)) {
+        return true;
+      }
+      return typeof key === "string" && typeof target.getItem(key) === "string";
     },
     ownKeys() {
       return ops.op_webstorage_iterate_keys(persistent);

--- a/ext/webstorage/01_webstorage.js
+++ b/ext/webstorage/01_webstorage.js
@@ -7,12 +7,12 @@ const ops = core.ops;
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
-  SafeArrayIterator,
   Symbol,
   SymbolFor,
-  ObjectDefineProperty,
   ObjectFromEntries,
   ObjectEntries,
+  ReflectDefineProperty,
+  ReflectDeleteProperty,
   ReflectGet,
   ReflectHas,
   Proxy,
@@ -83,53 +83,54 @@ function createStorage(persistent) {
 
   const proxy = new Proxy(storage, {
     deleteProperty(target, key) {
-      if (typeof key == "symbol") {
-        delete target[key];
-      } else {
-        target.removeItem(key);
+      if (typeof key === "symbol") {
+        return ReflectDeleteProperty(target, key);
       }
+      target.removeItem(key);
       return true;
     },
+
     defineProperty(target, key, descriptor) {
-      if (typeof key == "symbol") {
-        ObjectDefineProperty(target, key, descriptor);
-      } else {
-        target.setItem(key, descriptor.value);
+      if (typeof key === "symbol") {
+        return ReflectDefineProperty(target, key, descriptor);
       }
+      target.setItem(key, descriptor.value);
       return true;
     },
-    get(target, key) {
-      if (typeof key == "symbol") return target[key];
-      if (ReflectHas(target, key)) {
-        return ReflectGet(...new SafeArrayIterator(arguments));
-      } else {
-        return target.getItem(key) ?? undefined;
+
+    get(target, key, receiver) {
+      if (typeof key === "symbol") {
+        return target[key];
       }
+      if (ReflectHas(target, key)) {
+        return ReflectGet(target, key, receiver);
+      }
+      return target.getItem(key) ?? undefined;
     },
+
     set(target, key, value) {
-      if (typeof key == "symbol") {
-        ObjectDefineProperty(target, key, {
+      if (typeof key === "symbol") {
+        return ReflectDefineProperty(target, key, {
           value,
           configurable: true,
         });
-      } else {
-        target.setItem(key, value);
       }
+      target.setItem(key, value);
       return true;
     },
+
     has(target, key) {
       if (ReflectHas(target, key)) {
         return true;
       }
       return typeof key === "string" && typeof target.getItem(key) === "string";
     },
+
     ownKeys() {
       return ops.op_webstorage_iterate_keys(persistent);
     },
+
     getOwnPropertyDescriptor(target, key) {
-      if (arguments.length === 1) {
-        return undefined;
-      }
       if (ReflectHas(target, key)) {
         return undefined;
       }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Fixed a bug that webstorage `has` trap that passed `symbol` to `storage.getItem`.

```
> Symbol() in localStorage
Uncaught TypeError: Failed to execute 'getItem' on 'Storage': Argument 1 is a symbol, which cannot be converted to a string
    at makeException (ext:deno_webidl/00_webidl.js:88:10)
    at Array.converters.DOMString (ext:deno_webidl/00_webidl.js:392:11)
    at Storage.getItem (ext:deno_webstorage/01_webstorage.js:58:29)
    at Object.has (ext:deno_webstorage/01_webstorage.js:122:24)
    at <anonymous>:2:10
```
