### PR TITLE
fix(ext/fetch): re-align return type in op_fetch docstring

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -67,7 +67,7 @@ const requestBodyReaders = new SafeWeakMap();
 /**
  * @param {{ method: string, url: string, headers: [string, string][], clientRid: number | null, hasBody: boolean }} args
  * @param {Uint8Array | null} body
- * @returns {{ requestRid: number, requestBodyRid: number | null }}
+ * @returns {{ requestRid: number, requestBodyRid: number | null, cancelHandleRid: number | null }}
  */
 function opFetch(method, url, headers, clientRid, hasBody, bodyLength, body) {
   return ops.op_fetch(


### PR DESCRIPTION
This adds a missing `cancelHandleRid` field in `op_fetch` return type, see Rust side:
https://github.com/denoland/deno/blob/fdb4953ea460d5c09ac73f3f37dd570d44893155/ext/fetch/lib.rs#L183-L189