### PR TITLE
fix(ext/http): Throwing Error if the return value of Deno.serve handler is not a Response class

### DIFF
--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -3805,3 +3805,58 @@ Deno.test(
     await server.finished;
   },
 );
+
+
+// serve Handler must return Response class or promise that resolves Response class
+Deno.test({permissions: {net: true, run: true}}, async function handleServeCallbackReturn() {
+  const d = deferred();
+  const listeningPromise = deferred();
+  const ac = new AbortController();
+
+  const server = Deno.serve(
+    {
+      port: servePort,
+      onListen: onListen(listeningPromise),
+      signal: ac.signal,
+      onError: (error) => {
+      assert(error instanceof TypeError)
+      assert(error.message === "Return value from serve handler must be a response or a promise resolving to a response");
+      d.resolve();
+      return new Response("Customized Internal Error from onError");
+      } 
+    },
+    (_req) => {
+    return;
+  })
+  await listeningPromise;
+  const respText = await curlRequest([`http://localhost:${servePort}`])
+  await d;
+  ac.abort();
+  await server.finished;
+  assert(respText === "Customized Internal Error from onError");
+})
+
+
+// onError Handler must return Response class or promise that resolves Response class
+Deno.test({permissions: {net: true, run: true}}, async function handleServeErrorCallbackReturn() {
+  const listeningPromise = deferred();
+  const ac = new AbortController();
+
+  const server = Deno.serve(
+    {
+      port: servePort,
+      onListen: onListen(listeningPromise),
+      signal: ac.signal,
+      onError: (error) => {
+        return;
+      } 
+    },
+    (_req) => {
+    return;
+  })
+  await listeningPromise;
+  const respText = await curlRequest([`http://localhost:${servePort}`])
+  ac.abort()
+  await server.finished;
+  assert(respText === "Internal Server Error");
+})

--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -3829,8 +3829,9 @@ Deno.test(
           return new Response("Customized Internal Error from onError");
         },
       },
-      (_req) => {
-        return;
+      () => {
+        // Trick the typechecker
+        return <Response> <unknown> undefined;
       },
     );
     await listeningPromise;
@@ -3854,12 +3855,14 @@ Deno.test(
         port: servePort,
         onListen: onListen(listeningPromise),
         signal: ac.signal,
-        onError: (_error) => {
-          return;
+        onError: () => {
+          // Trick the typechecker
+          return <Response> <unknown> undefined;
         },
       },
-      (_req) => {
-        return;
+      () => {
+        // Trick the typechecker
+        return <Response> <unknown> undefined;
       },
     );
     await listeningPromise;

--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -3806,57 +3806,66 @@ Deno.test(
   },
 );
 
-
 // serve Handler must return Response class or promise that resolves Response class
-Deno.test({permissions: {net: true, run: true}}, async function handleServeCallbackReturn() {
-  const d = deferred();
-  const listeningPromise = deferred();
-  const ac = new AbortController();
+Deno.test(
+  { permissions: { net: true, run: true } },
+  async function handleServeCallbackReturn() {
+    const d = deferred();
+    const listeningPromise = deferred();
+    const ac = new AbortController();
 
-  const server = Deno.serve(
-    {
-      port: servePort,
-      onListen: onListen(listeningPromise),
-      signal: ac.signal,
-      onError: (error) => {
-      assert(error instanceof TypeError)
-      assert(error.message === "Return value from serve handler must be a response or a promise resolving to a response");
-      d.resolve();
-      return new Response("Customized Internal Error from onError");
-      } 
-    },
-    (_req) => {
-    return;
-  })
-  await listeningPromise;
-  const respText = await curlRequest([`http://localhost:${servePort}`])
-  await d;
-  ac.abort();
-  await server.finished;
-  assert(respText === "Customized Internal Error from onError");
-})
-
+    const server = Deno.serve(
+      {
+        port: servePort,
+        onListen: onListen(listeningPromise),
+        signal: ac.signal,
+        onError: (error) => {
+          assert(error instanceof TypeError);
+          assert(
+            error.message ===
+              "Return value from serve handler must be a response or a promise resolving to a response",
+          );
+          d.resolve();
+          return new Response("Customized Internal Error from onError");
+        },
+      },
+      (_req) => {
+        return;
+      },
+    );
+    await listeningPromise;
+    const respText = await curlRequest([`http://localhost:${servePort}`]);
+    await d;
+    ac.abort();
+    await server.finished;
+    assert(respText === "Customized Internal Error from onError");
+  },
+);
 
 // onError Handler must return Response class or promise that resolves Response class
-Deno.test({permissions: {net: true, run: true}}, async function handleServeErrorCallbackReturn() {
-  const listeningPromise = deferred();
-  const ac = new AbortController();
+Deno.test(
+  { permissions: { net: true, run: true } },
+  async function handleServeErrorCallbackReturn() {
+    const listeningPromise = deferred();
+    const ac = new AbortController();
 
-  const server = Deno.serve(
-    {
-      port: servePort,
-      onListen: onListen(listeningPromise),
-      signal: ac.signal,
-      onError: (error) => {
+    const server = Deno.serve(
+      {
+        port: servePort,
+        onListen: onListen(listeningPromise),
+        signal: ac.signal,
+        onError: (_error) => {
+          return;
+        },
+      },
+      (_req) => {
         return;
-      } 
-    },
-    (_req) => {
-    return;
-  })
-  await listeningPromise;
-  const respText = await curlRequest([`http://localhost:${servePort}`])
-  ac.abort()
-  await server.finished;
-  assert(respText === "Internal Server Error");
-})
+      },
+    );
+    await listeningPromise;
+    const respText = await curlRequest([`http://localhost:${servePort}`]);
+    ac.abort();
+    await server.finished;
+    assert(respText === "Internal Server Error");
+  },
+);

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -11,6 +11,7 @@ import {
   fromInnerResponse,
   newInnerResponse,
   toInnerResponse,
+  ResponsePrototype
 } from "ext:deno_fetch/23_response.js";
 import { fromInnerRequest, toInnerRequest } from "ext:deno_fetch/23_request.js";
 import { AbortController } from "ext:deno_web/03_abort_signal.js";
@@ -449,6 +450,11 @@ function mapToCallback(context, callback, onError) {
         fromInnerRequest(innerRequest, signal, "immutable"),
         new ServeHandlerInfo(innerRequest),
       );
+      
+      // Throwing Error if the handler return value is not a Response class
+      if(!(response && ObjectPrototypeIsPrototypeOf(ResponsePrototype, response))) {
+        throw TypeError("Invalid Response")
+      }
     } catch (error) {
       try {
         response = await onError(error);


### PR DESCRIPTION
Fixing this https://github.com/denoland/deno/issues/20947 and #20013
We are not checking the return value of handler passed through Deno.serve and directly passing it to toInnerResponse but thats expecting a Response class . So throwing error if handler return other than Response class. (Btw, its my first PR correct me if im wrong on anything :) )
