### PR TITLE
chore(ext/web): migrate to deno_core typed externals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,8 +1114,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.227.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6218d09d15ef76df4f81178b9d97d176d7e780565c323a42c4860b67c214101"
+source = "git+https://github.com/mmastrac/deno_core?branch=typed_externals#769711be09f1c7fe5853b0da3d9cfd68e0595f3e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1540,8 +1539,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14decb93ef6058b9c237ca86d8807563cc4ca19a3c0424e9ea8f1df3045723ad"
+source = "git+https://github.com/mmastrac/deno_core?branch=typed_externals#769711be09f1c7fe5853b0da3d9cfd68e0595f3e"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -4784,8 +4782,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.136.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813256f4379caece177ca747ffa35a7f4c0422cec9258f9cecaa9b15ded0cc5c"
+source = "git+https://github.com/mmastrac/deno_core?branch=typed_externals#769711be09f1c7fe5853b0da3d9cfd68e0595f3e"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,29 +974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno-proc-macro-rules"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
-dependencies = [
- "deno-proc-macro-rules-macros",
- "proc-macro2",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "deno-proc-macro-rules-macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3047b312b7451e3190865713a4dd6e1f821aed614ada219766ebc3024a690435"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "deno_ast"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,8 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.227.0"
-source = "git+https://github.com/mmastrac/deno_core?branch=typed_externals#769711be09f1c7fe5853b0da3d9cfd68e0595f3e"
+version = "0.228.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78996b42de9975a052cfc9234be39eabf3d6f7721e7cfe79f14a5bd0a252b552"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1538,14 +1516,15 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.103.0"
-source = "git+https://github.com/mmastrac/deno_core?branch=typed_externals#769711be09f1c7fe5853b0da3d9cfd68e0595f3e"
+version = "0.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06291034a0ad5293efcfa01826e4af6adabdfd513b766e2f2cc60dd6c75a94f"
 dependencies = [
- "deno-proc-macro-rules",
  "lazy-regex",
  "once_cell",
  "pmutil",
  "proc-macro-crate",
+ "proc-macro-rules",
  "proc-macro2",
  "quote",
  "regex",
@@ -3981,11 +3960,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "once_cell",
  "toml_edit",
 ]
 
@@ -4018,6 +3996,29 @@ name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
+name = "proc-macro-rules"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c277e4e643ef00c1233393c673f655e3672cf7eb3ba08a00bdd0ea59139b5f"
+dependencies = [
+ "proc-macro-rules-macros",
+ "proc-macro2",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "proc-macro-rules-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207fffb0fe655d1d47f6af98cc2793405e85929bdbc420d685554ff07be27ac7"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -4781,8 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.136.0"
-source = "git+https://github.com/mmastrac/deno_core?branch=typed_externals#769711be09f1c7fe5853b0da3d9cfd68e0595f3e"
+version = "0.137.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c22cbbd634a5b13e9c6a0c6718ae9a8da3696aec5e5eff48fb90e4c9be0809e"
 dependencies = [
  "bytes",
  "derive_more",
@@ -5876,15 +5878,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.0.2",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "0.31.2", features = ["transpiling"] }
-deno_core = { git = "https://github.com/mmastrac/deno_core", branch = "typed_externals" }
+deno_core = { version = "0.228.0" }
 
 deno_runtime = { version = "0.130.0", path = "./runtime" }
 napi_sym = { version = "0.52.0", path = "./cli/napi/sym" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "0.31.2", features = ["transpiling"] }
-deno_core = { version = "0.227.0" }
+deno_core = { git = "https://github.com/mmastrac/deno_core", branch = "typed_externals" }
 
 deno_runtime = { version = "0.130.0", path = "./runtime" }
 napi_sym = { version = "0.52.0", path = "./cli/napi/sym" }


### PR DESCRIPTION
Use our safer typed externals for the external required for resource streams.