### PR TITLE
perf: remove knowledge of promise IDs from deno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,19 +1084,17 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.228.0"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78996b42de9975a052cfc9234be39eabf3d6f7721e7cfe79f14a5bd0a252b552"
+checksum = "6bba7ed998f57ecd03640a82e6ddef281328b6d4c48c55e9e17cd906bab08020"
 dependencies = [
  "anyhow",
  "bytes",
  "deno_ops",
  "deno_unsync 0.3.0",
  "futures",
- "indexmap 2.0.2",
  "libc",
  "log",
- "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
  "serde",
@@ -1509,18 +1507,13 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.104.0"
+version = "0.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06291034a0ad5293efcfa01826e4af6adabdfd513b766e2f2cc60dd6c75a94f"
+checksum = "32976e42a50a1ac64d065a9219f5daf82a3ad6938da9d4aa3071890c08e1cd97"
 dependencies = [
- "lazy-regex",
- "once_cell",
- "pmutil",
- "proc-macro-crate",
  "proc-macro-rules",
  "proc-macro2",
  "quote",
- "regex",
  "strum",
  "strum_macros",
  "syn 2.0.37",
@@ -3943,15 +3936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,15 +4739,14 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.137.0"
+version = "0.138.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c22cbbd634a5b13e9c6a0c6718ae9a8da3696aec5e5eff48fb90e4c9be0809e"
+checksum = "add36cea4acc8cbfa4a1614a9e985e1057fd6748b672c8b4c4496f889d25e539"
 dependencies = [
  "bytes",
  "derive_more",
  "num-bigint",
  "serde",
- "serde_bytes",
  "smallvec",
  "thiserror",
  "v8",
@@ -5844,23 +5827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.0.2",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,15 +6512,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "winnow"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "0.31.2", features = ["transpiling"] }
-deno_core = { version = "0.228.0" }
+deno_core = { version = "0.229.0" }
 
 deno_runtime = { version = "0.130.0", path = "./runtime" }
 napi_sym = { version = "0.52.0", path = "./cli/napi/sym" }

--- a/cli/tests/unit/ref_unref_test.ts
+++ b/cli/tests/unit/ref_unref_test.ts
@@ -2,11 +2,11 @@
 
 import { assertNotEquals, execCode } from "./test_util.ts";
 
-Deno.test("[unrefOp] unref'ing invalid ops does not have effects", async () => {
+Deno.test("[unrefOpPromise] unref'ing invalid ops does not have effects", async () => {
   const [statusCode, _] = await execCode(`
-    Deno[Deno.internal].core.unrefOp(-1);
+    Deno[Deno.internal].core.unrefOpPromise(new Promise(r => null));
     setTimeout(() => { throw new Error() }, 10)
   `);
-  // Invalid unrefOp call doesn't affect exit condition of event loop
+  // Invalid unrefOpPromise call doesn't affect exit condition of event loop
   assertNotEquals(statusCode, 0);
 });

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -32,7 +32,6 @@ const {
   SafeMap,
   SafeArrayIterator,
   SafeWeakMap,
-  SymbolFor,
 } = primordials;
 import { pathFromURL } from "ext:deno_web/00_infra.js";
 
@@ -52,8 +51,6 @@ function getBufferSourceByteLength(source) {
   }
   return ArrayBufferPrototypeGetByteLength(source);
 }
-const promiseIdSymbol = SymbolFor("Deno.core.internalPromiseId");
-
 const U32_BUFFER = new Uint32Array(2);
 const U64_BUFFER = new BigUint64Array(TypedArrayPrototypeGetBuffer(U32_BUFFER));
 const I64_BUFFER = new BigInt64Array(TypedArrayPrototypeGetBuffer(U32_BUFFER));
@@ -422,7 +419,7 @@ class UnsafeCallback {
     if (this.#refcount++ === 0) {
       if (this.#refpromise) {
         // Re-refing
-        core.refOp(this.#refpromise[promiseIdSymbol]);
+        core.refOpPromise(this.#refpromise);
       } else {
         this.#refpromise = core.opAsync(
           "op_ffi_unsafe_callback_ref",
@@ -437,7 +434,7 @@ class UnsafeCallback {
     // Only decrement refcount if it is positive, and only
     // unref the callback if refcount reaches zero.
     if (this.#refcount > 0 && --this.#refcount === 0) {
-      core.unrefOp(this.#refpromise[promiseIdSymbol]);
+      core.unrefOpPromise(this.#refpromise);
     }
     return this.#refcount;
   }

--- a/ext/http/00_serve.js
+++ b/ext/http/00_serve.js
@@ -44,7 +44,6 @@ const {
   ObjectPrototypeIsPrototypeOf,
   PromisePrototypeCatch,
   Symbol,
-  SymbolFor,
   TypeError,
   Uint8Array,
   Uint8ArrayPrototype,
@@ -642,7 +641,6 @@ function serveHttpOnConnection(connection, signal, handler, onError, onListen) {
 function serveHttpOn(context, callback) {
   let ref = true;
   let currentPromise = null;
-  const promiseIdSymbol = SymbolFor("Deno.core.internalPromiseId");
 
   const promiseErrorHandler = (error) => {
     // Abnormal exit
@@ -666,7 +664,7 @@ function serveHttpOn(context, callback) {
         }
         currentPromise = op_http_wait(rid);
         if (!ref) {
-          core.unrefOp(currentPromise[promiseIdSymbol]);
+          core.unrefOpPromise(currentPromise);
         }
         req = await currentPromise;
         currentPromise = null;
@@ -708,13 +706,13 @@ function serveHttpOn(context, callback) {
     ref() {
       ref = true;
       if (currentPromise) {
-        core.refOp(currentPromise[promiseIdSymbol]);
+        core.refOpPromise(currentPromise);
       }
     },
     unref() {
       ref = false;
       if (currentPromise) {
-        core.unrefOp(currentPromise[promiseIdSymbol]);
+        core.unrefOpPromise(currentPromise);
       }
     },
     [SymbolAsyncDispose]() {

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -13,22 +13,20 @@ import { SymbolDispose } from "ext:deno_web/00_infra.js";
 
 const primordials = globalThis.__bootstrap.primordials;
 const {
-  ArrayPrototypeFilter,
-  ArrayPrototypeForEach,
-  ArrayPrototypePush,
   Error,
   Number,
   ObjectPrototypeIsPrototypeOf,
   PromiseResolve,
+  SafeSet,
+  SetPrototypeAdd,
+  SetPrototypeDelete,
+  SetPrototypeForEach,
   SymbolAsyncIterator,
   Symbol,
-  SymbolFor,
   TypeError,
   TypedArrayPrototypeSubarray,
   Uint8Array,
 } = primordials;
-
-const promiseIdSymbol = SymbolFor("Deno.core.internalPromiseId");
 
 async function write(rid, data) {
   return await core.write(rid, data);
@@ -70,7 +68,7 @@ class Conn {
   #remoteAddr = null;
   #localAddr = null;
   #unref = false;
-  #pendingReadPromiseIds = [];
+  #pendingReadPromises = new SafeSet();
 
   #readable;
   #writable;
@@ -102,19 +100,15 @@ class Conn {
       return 0;
     }
     const promise = core.read(this.rid, buffer);
-    const promiseId = promise[promiseIdSymbol];
-    if (this.#unref) core.unrefOp(promiseId);
-    ArrayPrototypePush(this.#pendingReadPromiseIds, promiseId);
+    if (this.#unref) core.unrefOpPromise(promise);
+    SetPrototypeAdd(this.#pendingReadPromises, promise);
     let nread;
     try {
       nread = await promise;
     } catch (e) {
       throw e;
     } finally {
-      this.#pendingReadPromiseIds = ArrayPrototypeFilter(
-        this.#pendingReadPromiseIds,
-        (id) => id !== promiseId,
-      );
+      SetPrototypeDelete(this.#pendingReadPromises, promise);
     }
     return nread === 0 ? null : nread;
   }
@@ -149,7 +143,11 @@ class Conn {
     if (this.#readable) {
       readableStreamForRidUnrefableRef(this.#readable);
     }
-    ArrayPrototypeForEach(this.#pendingReadPromiseIds, (id) => core.refOp(id));
+
+    SetPrototypeForEach(
+      this.#pendingReadPromises,
+      (promise) => core.refOpPromise(promise),
+    );
   }
 
   unref() {
@@ -157,9 +155,9 @@ class Conn {
     if (this.#readable) {
       readableStreamForRidUnrefableUnref(this.#readable);
     }
-    ArrayPrototypeForEach(
-      this.#pendingReadPromiseIds,
-      (id) => core.unrefOp(id),
+    SetPrototypeForEach(
+      this.#pendingReadPromises,
+      (promise) => core.unrefOpPromise(promise),
     );
   }
 
@@ -184,7 +182,7 @@ class Listener {
   #rid = 0;
   #addr = null;
   #unref = false;
-  #promiseId = null;
+  #promise = null;
 
   constructor(rid, addr) {
     this.#rid = rid;
@@ -211,10 +209,10 @@ class Listener {
       default:
         throw new Error(`Unsupported transport: ${this.addr.transport}`);
     }
-    this.#promiseId = promise[promiseIdSymbol];
-    if (this.#unref) core.unrefOp(this.#promiseId);
+    this.#promise = promise;
+    if (this.#unref) core.unrefOpPromise(promise);
     const { 0: rid, 1: localAddr, 2: remoteAddr } = await promise;
-    this.#promiseId = null;
+    this.#promise = null;
     if (this.addr.transport == "tcp") {
       localAddr.transport = "tcp";
       remoteAddr.transport = "tcp";
@@ -265,15 +263,15 @@ class Listener {
 
   ref() {
     this.#unref = false;
-    if (typeof this.#promiseId === "number") {
-      core.refOp(this.#promiseId);
+    if (this.#promise !== null) {
+      core.refOpPromise(this.#promise);
     }
   }
 
   unref() {
     this.#unref = true;
-    if (typeof this.#promiseId === "number") {
-      core.unrefOp(this.#promiseId);
+    if (this.#promise !== null) {
+      core.unrefOpPromise(this.#promise);
     }
   }
 }

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -68,7 +68,7 @@ const kDenoResponse = Symbol("kDenoResponse");
 const kDenoRid = Symbol("kDenoRid");
 const kDenoClientRid = Symbol("kDenoClientRid");
 const kDenoConnRid = Symbol("kDenoConnRid");
-const kPollConnPromiseId = Symbol("kPollConnPromiseId");
+const kPollConnPromise = Symbol("kPollConnPromise");
 
 const STREAM_FLAGS_PENDING = 0x0;
 const STREAM_FLAGS_READY = 0x1;
@@ -364,7 +364,7 @@ export class ClientHttp2Session extends Http2Session {
     this[kPendingRequestCalls] = null;
     this[kDenoClientRid] = undefined;
     this[kDenoConnRid] = undefined;
-    this[kPollConnPromiseId] = undefined;
+    this[kPollConnPromise] = undefined;
 
     socket.on("error", socketOnError);
     socket.on("close", socketOnClose);
@@ -394,8 +394,7 @@ export class ClientHttp2Session extends Http2Session {
             "op_http2_poll_client_connection",
             this[kDenoConnRid],
           );
-          this[kPollConnPromiseId] =
-            promise[Symbol.for("Deno.core.internalPromiseId")];
+          this[kPollConnPromise] = promise;
           if (!this.#refed) {
             this.unref();
           }
@@ -410,15 +409,15 @@ export class ClientHttp2Session extends Http2Session {
 
   ref() {
     this.#refed = true;
-    if (this[kPollConnPromiseId]) {
-      core.refOp(this[kPollConnPromiseId]);
+    if (this[kPollConnPromise]) {
+      core.refOpPromise(this[kPollConnPromise]);
     }
   }
 
   unref() {
     this.#refed = false;
-    if (this[kPollConnPromiseId]) {
-      core.unrefOp(this[kPollConnPromiseId]);
+    if (this[kPollConnPromise]) {
+      core.unrefOpPromise(this[kPollConnPromise]);
     }
   }
 

--- a/runtime/js/40_signals.js
+++ b/runtime/js/40_signals.js
@@ -8,7 +8,6 @@ const {
   SafeSetIterator,
   SetPrototypeAdd,
   SetPrototypeDelete,
-  SymbolFor,
   TypeError,
 } = primordials;
 
@@ -18,7 +17,7 @@ function bindSignal(signo) {
 
 function pollSignal(rid) {
   const promise = core.opAsync("op_signal_poll", rid);
-  core.unrefOp(promise[SymbolFor("Deno.core.internalPromiseId")]);
+  core.unrefOpPromise(promise);
   return promise;
 }
 


### PR DESCRIPTION
We can move all promise ID knowledge to deno_core, allowing us to better experiment with promise implementation in deno_core.

`{un,}refOpPromise(promise)` is equivalent to `{un,}refOp(promise[promiseIdSymbol])`