### PR TITLE
fix(test) reduce queue persistence test time from 60 secs to 6 secs

### DIFF
--- a/cli/tests/unit/kv_test.ts
+++ b/cli/tests/unit/kv_test.ts
@@ -1741,6 +1741,12 @@ Deno.test({
       db.close();
       await listener;
 
+      // Wait at least MESSAGE_DEADLINE_TIMEOUT before reopening the database.
+      // This ensures that inflight messages are requeued immediately after
+      // the database is reopened.
+      // https://github.com/denoland/denokv/blob/efb98a1357d37291a225ed5cf1fc4ecc7c737fab/sqlite/backend.rs#L120
+      await sleep(6000);
+
       // Now reopen the database.
       db = await Deno.openKv(filename);
 


### PR DESCRIPTION
This PR reduces the time to run `queue persistence with inflight messages` test from 60 seconds down to about 6 seconds. 

The test simulates a crash to ensure that inflight messages are cleaned up and re-queued when the new process starts. Since messages are considered dead after 5 seconds of being queued, reopening the db within 5 seconds does not re-queue the messages on startup (they do get re-queued after 60 seconds, which is the cleanup frequency). By waiting for 5 seconds before reopening the db, the test ensures that the cleanup happens quickly when the db is opened.