### PR TITLE
1.38.1

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -5,7 +5,7 @@ import * as yaml from "https://deno.land/std@0.173.0/encoding/yaml.ts";
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 57;
+const cacheVersion = 58;
 
 const Runners = (() => {
   const ubuntuRunner = "ubuntu-22.04";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,8 +315,8 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-          key: '57-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '57-cargo-home-${{ matrix.os }}'
+          key: '58-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '58-cargo-home-${{ matrix.os }}'
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
@@ -328,7 +328,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '57-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '58-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(github.event_name == ''pull_request'' && matrix.skip_pr) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
@@ -609,7 +609,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '57-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '58-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "1.38.0"
+version = "1.38.1"
 dependencies = [
  "async-trait",
  "base32",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "deno_bench_util"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "bencher",
  "deno_core",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "deno_broadcast_channel"
-version = "0.116.0"
+version = "0.117.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "deno_core",
 ]
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "deno_cron"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.136.0"
+version = "0.137.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.146.0"
+version = "0.147.0"
 dependencies = [
  "bytes",
  "data-url",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ffi"
-version = "0.109.0"
+version = "0.110.0"
 dependencies = [
  "deno_core",
  "dlopen",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "deno_fs"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "deno_io"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "deno_kv"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "deno_core",
  "libloading",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "aead-gcm-stream",
  "aes",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "console_static_text",
  "deno_ast",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.109.0"
+version = "0.110.0"
 dependencies = [
  "deno_core",
  "deno_native_certs",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "deno_bench_util",
  "deno_core",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.153.0"
+version = "0.154.0"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "deno_bench_util",
  "deno_core",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "deno_websocket"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "bytes",
  "deno_core",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "napi_sym"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ repository = "https://github.com/denoland/deno"
 deno_ast = { version = "0.31.2", features = ["transpiling"] }
 deno_core = { version = "0.224.0" }
 
-deno_runtime = { version = "0.130.0", path = "./runtime" }
-napi_sym = { version = "0.52.0", path = "./cli/napi/sym" }
-deno_bench_util = { version = "0.116.0", path = "./bench_util" }
+deno_runtime = { version = "0.131.0", path = "./runtime" }
+napi_sym = { version = "0.53.0", path = "./cli/napi/sym" }
+deno_bench_util = { version = "0.117.0", path = "./bench_util" }
 test_util = { path = "./test_util" }
 deno_lockfile = "0.17.2"
 deno_media_type = { version = "0.1.1", features = ["module_specifier"] }
@@ -54,26 +54,26 @@ denokv_sqlite = "0.2.1"
 denokv_remote = "0.2.3"
 
 # exts
-deno_broadcast_channel = { version = "0.116.0", path = "./ext/broadcast_channel" }
-deno_cache = { version = "0.54.0", path = "./ext/cache" }
-deno_console = { version = "0.122.0", path = "./ext/console" }
-deno_cron = { version = "0.2.0", path = "./ext/cron" }
-deno_crypto = { version = "0.136.0", path = "./ext/crypto" }
-deno_fetch = { version = "0.146.0", path = "./ext/fetch" }
-deno_ffi = { version = "0.109.0", path = "./ext/ffi" }
-deno_fs = { version = "0.32.0", path = "./ext/fs" }
-deno_http = { version = "0.117.0", path = "./ext/http" }
-deno_io = { version = "0.32.0", path = "./ext/io" }
-deno_net = { version = "0.114.0", path = "./ext/net" }
-deno_node = { version = "0.59.0", path = "./ext/node" }
-deno_kv = { version = "0.30.0", path = "./ext/kv" }
-deno_tls = { version = "0.109.0", path = "./ext/tls" }
-deno_url = { version = "0.122.0", path = "./ext/url" }
-deno_web = { version = "0.153.0", path = "./ext/web" }
-deno_webidl = { version = "0.122.0", path = "./ext/webidl" }
-deno_websocket = { version = "0.127.0", path = "./ext/websocket" }
-deno_webstorage = { version = "0.117.0", path = "./ext/webstorage" }
-deno_napi = { version = "0.52.0", path = "./ext/napi" }
+deno_broadcast_channel = { version = "0.117.0", path = "./ext/broadcast_channel" }
+deno_cache = { version = "0.55.0", path = "./ext/cache" }
+deno_console = { version = "0.123.0", path = "./ext/console" }
+deno_cron = { version = "0.3.0", path = "./ext/cron" }
+deno_crypto = { version = "0.137.0", path = "./ext/crypto" }
+deno_fetch = { version = "0.147.0", path = "./ext/fetch" }
+deno_ffi = { version = "0.110.0", path = "./ext/ffi" }
+deno_fs = { version = "0.33.0", path = "./ext/fs" }
+deno_http = { version = "0.118.0", path = "./ext/http" }
+deno_io = { version = "0.33.0", path = "./ext/io" }
+deno_net = { version = "0.115.0", path = "./ext/net" }
+deno_node = { version = "0.60.0", path = "./ext/node" }
+deno_kv = { version = "0.31.0", path = "./ext/kv" }
+deno_tls = { version = "0.110.0", path = "./ext/tls" }
+deno_url = { version = "0.123.0", path = "./ext/url" }
+deno_web = { version = "0.154.0", path = "./ext/web" }
+deno_webidl = { version = "0.123.0", path = "./ext/webidl" }
+deno_websocket = { version = "0.128.0", path = "./ext/websocket" }
+deno_webstorage = { version = "0.118.0", path = "./ext/webstorage" }
+deno_napi = { version = "0.53.0", path = "./ext/napi" }
 
 aes = "=0.8.3"
 anyhow = "1.0.57"

--- a/Releases.md
+++ b/Releases.md
@@ -8,6 +8,30 @@ https://github.com/denoland/deno_install
 
 ### 1.38.1 / 2023.11.10
 
+- feat(ext/kv): increase checks limit (#21055)
+- fix small Deno.createHttpClient typo in lib.deno.unstable.d.ts (#21115)
+- fix(byonm): correct resolution for scoped packages (#21083)
+- fix(core/types): `Promise.withResolvers`: Unmark callback param as optional
+  (#21085)
+- fix(cron): update Deno.cron doc example (#21078)
+- fix(doc): `deno doc --lint mod.ts` should output how many files checked
+  (#21084)
+- fix(doc): require source files if --html or --lint used (#21072)
+- fix(ext): use `String#toWellFormed` in ext/webidl and ext/node (#21054)
+- fix(ext/fetch): re-align return type in op_fetch docstring (#21098)
+- fix(ext/http): Throwing Error if the return value of Deno.serve handler is not
+  a Response class (#21099)
+- fix(node): cjs export analysis should probe for json files (#21113)
+- fix(node): implement createPrivateKey (#20981)
+- fix(node): inspect ancestor directories when resolving cjs re-exports during
+  analysis (#21104)
+- fix(node): use closest package.json to resolve package.json imports (#21075)
+- fix(node/child_process): properly normalize stdio for 'spawnSync' (#21103)
+- fix(node/http): socket.setTimeout (#20930)
+- fix(test) reduce queue persistence test time from 60 secs to 6 secs (#21142)
+- perf: lazy `atexit` setup (#21053)
+- perf: remove knowledge of promise IDs from deno (#21132)
+
 ### 1.38.0 / 2023.11.01
 
 - feat(cron) implement Deno.cron() (#21019)

--- a/Releases.md
+++ b/Releases.md
@@ -6,6 +6,8 @@ https://github.com/denoland/deno/releases
 We also have one-line install commands at:
 https://github.com/denoland/deno_install
 
+### 1.38.1 / 2023.11.10
+
 ### 1.38.0 / 2023.11.01
 
 - feat(cron) implement Deno.cron() (#21019)

--- a/bench_util/Cargo.toml
+++ b/bench_util/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_bench_util"
-version = "0.116.0"
+version = "0.117.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "1.38.0"
+version = "1.38.1"
 authors.workspace = true
 default-run = "deno"
 edition.workspace = true

--- a/cli/deno_std.rs
+++ b/cli/deno_std.rs
@@ -2,4 +2,4 @@
 
 // WARNING: Ensure this is the only deno_std version reference as this
 // is automatically updated by the version bump workflow.
-pub const CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.205.0/";
+pub const CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.206.0/";

--- a/cli/napi/sym/Cargo.toml
+++ b/cli/napi/sym/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "napi_sym"
-version = "0.52.0"
+version = "0.53.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/broadcast_channel/Cargo.toml
+++ b/ext/broadcast_channel/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_broadcast_channel"
-version = "0.116.0"
+version = "0.117.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/cache/Cargo.toml
+++ b/ext/cache/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_cache"
-version = "0.54.0"
+version = "0.55.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/console/Cargo.toml
+++ b/ext/console/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_console"
-version = "0.122.0"
+version = "0.123.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/cron/Cargo.toml
+++ b/ext/cron/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_cron"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/crypto/Cargo.toml
+++ b/ext/crypto/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_crypto"
-version = "0.136.0"
+version = "0.137.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_fetch"
-version = "0.146.0"
+version = "0.147.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_ffi"
-version = "0.109.0"
+version = "0.110.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_fs"
-version = "0.32.0"
+version = "0.33.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_http"
-version = "0.117.0"
+version = "0.118.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/io/Cargo.toml
+++ b/ext/io/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_io"
-version = "0.32.0"
+version = "0.33.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/kv/Cargo.toml
+++ b/ext/kv/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_kv"
-version = "0.30.0"
+version = "0.31.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_napi"
-version = "0.52.0"
+version = "0.53.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_net"
-version = "0.114.0"
+version = "0.115.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_node"
-version = "0.59.0"
+version = "0.60.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/tls/Cargo.toml
+++ b/ext/tls/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_tls"
-version = "0.109.0"
+version = "0.110.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/url/Cargo.toml
+++ b/ext/url/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_url"
-version = "0.122.0"
+version = "0.123.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_web"
-version = "0.153.0"
+version = "0.154.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webidl/Cargo.toml
+++ b/ext/webidl/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webidl"
-version = "0.122.0"
+version = "0.123.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_websocket"
-version = "0.127.0"
+version = "0.128.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/webstorage/Cargo.toml
+++ b/ext/webstorage/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_webstorage"
-version = "0.117.0"
+version = "0.118.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_runtime"
-version = "0.130.0"
+version = "0.131.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumped versions for 1.38.1

Github API failed to open this PR in CI https://github.com/denoland/deno/actions/runs/6824153629/job/18559473627

- [x] Target branch is correct (vX.XX if a patch release, main if minor)
- [x] Crate versions are bumped correctly
- [x] deno_std version is incremented in the code (see cli/deno_std.rs)
- [x] Releases.md is updated correctly (think relevancy and remove reverts)