### PR TITLE
chore(ext/node): use libz-sys w/`zlib-ng` feature in node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "junction",
  "lazy-regex",
  "libc",
+ "libz-sys",
  "log",
  "lsp-types",
  "monch",
@@ -1552,6 +1553,7 @@ dependencies = [
  "encoding_rs",
  "fastwebsockets",
  "filetime",
+ "flate2",
  "fs3",
  "fwdansi",
  "http",
@@ -2338,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -3133,22 +3135,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
+ "cmake",
  "libc",
  "pkg-config",
  "vcpkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ encoding_rs = "=0.8.33"
 ecb = "=0.1.2"
 fastwebsockets = "=0.5.0"
 filetime = "0.2.16"
-flate2 = { version = "1.0.26", features = ["zlib-ng"], default-features = false }
+flate2 = { version = "1.0.26", default-features = false }
 fs3 = "0.5.0"
 futures = "0.3.21"
 glob = "0.3.1"
@@ -107,6 +107,7 @@ httparse = "1.8.0"
 hyper = { version = "0.14.26", features = ["runtime", "http1"] }
 indexmap = { version = "2", features = ["serde"] }
 libc = "0.2.126"
+libz-sys = { version = "1.1", default-features = false }
 log = "=0.4.20"
 lsp-types = "=0.94.1" # used by tower-lsp and "proposed" feature is unstable in patch releases
 memmem = "0.1.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,9 +27,12 @@ harness = false
 path = "./bench/lsp_bench_standalone.rs"
 
 [features]
+default = ["__vendored_zlib_ng"]
 # A dev feature to disable creations and loading of snapshots in favor of
 # loading JS sources at runtime.
 __runtime_js_sources = ["deno_runtime/__runtime_js_sources"]
+# Vendor zlib as zlib-ng
+__vendored_zlib_ng = ["flate2/zlib-ng-compat", "libz-sys/zlib-ng"]
 
 [build-dependencies]
 deno_runtime = { workspace = true, features = ["exclude_runtime_main_js", "include_js_files_for_snapshotting"] }
@@ -39,6 +42,7 @@ serde.workspace = true
 serde_json.workspace = true
 zstd.workspace = true
 glibc_version = "0.1.2"
+flate2 = { workspace = true, features = ["default"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winapi.workspace = true
@@ -84,6 +88,7 @@ encoding_rs.workspace = true
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"
 fastwebsockets.workspace = true
+# If you disable the default __vendored_zlib_ng feature above, you _must_ be able to link against `-lz`.
 flate2.workspace = true
 fs3.workspace = true
 glob = "0.3.1"
@@ -95,6 +100,7 @@ indexmap.workspace = true
 jsonc-parser = { version = "=0.21.1", features = ["serde"] }
 lazy-regex.workspace = true
 libc.workspace = true
+libz-sys.workspace = true
 log = { workspace = true, features = ["serde"] }
 lsp-types.workspace = true
 monch.workspace = true

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -41,7 +41,7 @@ indexmap.workspace = true
 k256 = "0.13.1"
 lazy-regex.workspace = true
 libc.workspace = true
-libz-sys = { version = "1.1.8", features = ["static"] }
+libz-sys.workspace = true
 md-5 = "0.10.5"
 md4 = "0.10.2"
 num-bigint.workspace = true

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -18,6 +18,8 @@ use deno_fs::sync::MaybeSend;
 use deno_fs::sync::MaybeSync;
 use once_cell::sync::Lazy;
 
+extern crate libz_sys as zlib;
+
 pub mod analyze;
 pub mod errors;
 mod global;

--- a/ext/node/ops/zlib/mod.rs
+++ b/ext/node/ops/zlib/mod.rs
@@ -1,15 +1,14 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-
 use deno_core::error::bad_resource_id;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
-use libz_sys::*;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::future::Future;
 use std::rc::Rc;
+use zlib::*;
 
 mod alloc;
 pub mod brotli;

--- a/ext/node/ops/zlib/mode.rs
+++ b/ext/node/ops/zlib/mode.rs
@@ -1,7 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use libz_sys as sys;
-
 #[derive(Debug)]
 pub enum Error {
   BadArgument,
@@ -60,12 +58,12 @@ repr_i32! {
   #[derive(Clone, Copy, Debug, PartialEq, Default)]
   pub enum Flush {
     #[default]
-    None = sys::Z_NO_FLUSH,
-    Partial = sys::Z_PARTIAL_FLUSH,
-    Sync = sys::Z_SYNC_FLUSH,
-    Full = sys::Z_FULL_FLUSH,
-    Finish = sys::Z_FINISH,
-    Block = sys::Z_BLOCK,
-    Trees = sys::Z_TREES,
+    None = zlib::Z_NO_FLUSH,
+    Partial = zlib::Z_PARTIAL_FLUSH,
+    Sync = zlib::Z_SYNC_FLUSH,
+    Full = zlib::Z_FULL_FLUSH,
+    Finish = zlib::Z_FINISH,
+    Block = zlib::Z_BLOCK,
+    Trees = zlib::Z_TREES,
   }
 }

--- a/ext/node/ops/zlib/stream.rs
+++ b/ext/node/ops/zlib/stream.rs
@@ -2,19 +2,18 @@
 
 use super::mode::Flush;
 use super::mode::Mode;
-use libz_sys as sys;
 use std::ffi::c_int;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
 pub struct StreamWrapper {
-  pub strm: sys::z_stream,
+  pub strm: zlib::z_stream,
 }
 
 impl Default for StreamWrapper {
   fn default() -> Self {
     Self {
-      strm: sys::z_stream {
+      strm: zlib::z_stream {
         next_in: std::ptr::null_mut(),
         avail_in: 0,
         total_in: 0,
@@ -25,7 +24,7 @@ impl Default for StreamWrapper {
         state: std::ptr::null_mut(),
         zalloc: super::alloc::zalloc,
         zfree: super::alloc::zfree,
-        opaque: 0 as sys::voidpf,
+        opaque: 0 as zlib::voidpf,
         data_type: 0,
         adler: 0,
         reserved: 0,
@@ -35,7 +34,7 @@ impl Default for StreamWrapper {
 }
 
 impl Deref for StreamWrapper {
-  type Target = sys::z_stream;
+  type Target = zlib::z_stream;
 
   fn deref(&self) -> &Self::Target {
     &self.strm
@@ -50,14 +49,14 @@ impl DerefMut for StreamWrapper {
 
 impl StreamWrapper {
   pub fn reset(&mut self, mode: Mode) -> c_int {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
     unsafe {
       match mode {
         Mode::Deflate | Mode::Gzip | Mode::DeflateRaw => {
-          sys::deflateReset(&mut self.strm)
+          zlib::deflateReset(&mut self.strm)
         }
         Mode::Inflate | Mode::Gunzip | Mode::InflateRaw | Mode::Unzip => {
-          sys::inflateReset(&mut self.strm)
+          zlib::inflateReset(&mut self.strm)
         }
         Mode::None => unreachable!(),
       }
@@ -65,14 +64,14 @@ impl StreamWrapper {
   }
 
   pub fn end(&mut self, mode: Mode) {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
     unsafe {
       match mode {
         Mode::Deflate | Mode::Gzip | Mode::DeflateRaw => {
-          sys::deflateEnd(&mut self.strm);
+          zlib::deflateEnd(&mut self.strm);
         }
         Mode::Inflate | Mode::Gunzip | Mode::InflateRaw | Mode::Unzip => {
-          sys::inflateEnd(&mut self.strm);
+          zlib::inflateEnd(&mut self.strm);
         }
         Mode::None => {}
       }
@@ -86,47 +85,47 @@ impl StreamWrapper {
     mem_level: c_int,
     strategy: c_int,
   ) -> c_int {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
     unsafe {
-      sys::deflateInit2_(
+      zlib::deflateInit2_(
         &mut self.strm,
         level,
-        sys::Z_DEFLATED,
+        zlib::Z_DEFLATED,
         window_bits,
         mem_level,
         strategy,
-        sys::zlibVersion(),
-        std::mem::size_of::<sys::z_stream>() as i32,
+        zlib::zlibVersion(),
+        std::mem::size_of::<zlib::z_stream>() as i32,
       )
     }
   }
 
   pub fn inflate_init(&mut self, window_bits: c_int) -> c_int {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
     unsafe {
-      sys::inflateInit2_(
+      zlib::inflateInit2_(
         &mut self.strm,
         window_bits,
-        sys::zlibVersion(),
-        std::mem::size_of::<sys::z_stream>() as i32,
+        zlib::zlibVersion(),
+        std::mem::size_of::<zlib::z_stream>() as i32,
       )
     }
   }
 
   pub fn deflate(&mut self, flush: Flush) -> c_int {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
-    unsafe { sys::deflate(&mut self.strm, flush as _) }
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
+    unsafe { zlib::deflate(&mut self.strm, flush as _) }
   }
 
   pub fn inflate(&mut self, flush: Flush) -> c_int {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
-    unsafe { sys::inflate(&mut self.strm, flush as _) }
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
+    unsafe { zlib::inflate(&mut self.strm, flush as _) }
   }
 
   pub fn inflate_set_dictionary(&mut self, dictionary: &[u8]) -> c_int {
-    // SAFETY: `self.strm` is an initialized `z_stream`.
+    // SAFETY: `self.strm` is an initialized `zlib::z_stream`.
     unsafe {
-      sys::inflateSetDictionary(
+      zlib::inflateSetDictionary(
         &mut self.strm,
         dictionary.as_ptr() as *const _,
         dictionary.len() as _,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -61,6 +61,7 @@ deno_webidl.workspace = true
 deno_websocket.workspace = true
 deno_webstorage.workspace = true
 deno_napi.workspace = true
+flate2 = { workspace = true, features = ["default"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres.workspace = true

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -21,7 +21,7 @@ bytes.workspace = true
 console_static_text.workspace = true
 denokv_proto.workspace = true
 fastwebsockets = { workspace = true, features = ["upgrade"] }
-flate2.workspace = true
+flate2 = { workspace = true, features = ["default"] }
 futures.workspace = true
 glob.workspace = true
 h2.workspace = true


### PR DESCRIPTION
We only want one zlib dependency.

Zlib dependencies are reorganized so they use a hidden `__vendored_zlib_ng` flag in cli that enables zlib-ng for both libz-sys (used by ext/node) and flate2 (used by deno_web).

