### PR TITLE
chore(ext/web): use a non-resource stream for textDecoderStreamCleansUpOnCancel

### DIFF
--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -321,7 +321,12 @@ Deno.test(function binaryEncode() {
 });
 
 Deno.test(
-  { permissions: { read: true } },
+  {
+    permissions: { read: true },
+    // TODO(mmastrac): readableStreamForRid doesn't guarantee cancellation of ops, so we may be left with a
+    // dangling read op that triggers the sanitizer.
+    sanitizeOps: false,
+  },
   async function textDecoderStreamCleansUpOnCancel() {
     const filename = "cli/tests/testdata/assets/hello.txt";
     const file = await Deno.open(filename);

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -330,16 +330,13 @@ Deno.test(
     permissions: { read: true },
   },
   async function textDecoderStreamCleansUpOnCancel() {
-    let timeout: number | undefined = undefined;
+    let cancelled = false;
     const readable = new ReadableStream({
       start: (controller) => {
         controller.enqueue(new Uint8Array(12));
-        // This will never be called
-        timeout = setTimeout(() => controller.close());
       },
       cancel: () => {
-        clearTimeout(timeout);
-        timeout = undefined;
+        cancelled = true;
       },
     }).pipeThrough(new TextDecoderStream());
     const chunks = [];
@@ -350,6 +347,6 @@ Deno.test(
     }
     assertEquals(chunks.length, 1);
     assertEquals(chunks[0].length, 12);
-    assertStrictEquals(timeout, undefined);
+    assertStrictEquals(cancelled, true);
   },
 );

--- a/cli/tests/unit/text_encoding_test.ts
+++ b/cli/tests/unit/text_encoding_test.ts
@@ -326,9 +326,7 @@ Deno.test(function binaryEncode() {
 });
 
 Deno.test(
-  {
-    permissions: { read: true },
-  },
+  { permissions: { read: true } },
   async function textDecoderStreamCleansUpOnCancel() {
     let cancelled = false;
     const readable = new ReadableStream({


### PR DESCRIPTION
Follow-up fix to #21074