### PR TITLE
[WIP] feat(ext/web): Add ImageData Web API

### DIFF
--- a/cli/tests/integration/js_unit_tests.rs
+++ b/cli/tests/integration/js_unit_tests.rs
@@ -43,6 +43,7 @@ util::unit_test_factory!(
     globals_test,
     headers_test,
     http_test,
+    image_data_test,
     internals_test,
     intl_test,
     io_test,

--- a/cli/tests/unit/image_data_test.ts
+++ b/cli/tests/unit/image_data_test.ts
@@ -1,0 +1,34 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "./test_util.ts";
+
+Deno.test(function imageDataInitializedWithSourceWidthAndHeight() {
+  const imageData = new ImageData(16, 9);
+
+  assertEquals(imageData.width, 16);
+  assertEquals(imageData.height, 9);
+  assertEquals(imageData.data.length, 16 * 9 * 4); // width * height * 4 (RGBA pixels)
+  assertEquals(imageData.colorSpace, "srgb");
+});
+
+Deno.test(function imageDataInitializedWithImageDataAndWidth() {
+  const imageData = new ImageData(new Uint8ClampedArray(16 * 9 * 4), 16);
+
+  assertEquals(imageData.width, 16);
+  assertEquals(imageData.height, 9);
+  assertEquals(imageData.data.length, 16 * 9 * 4); // width * height * 4 (RGBA pixels)
+  assertEquals(imageData.colorSpace, "srgb");
+});
+
+Deno.test(
+  function imageDataInitializedWithImageDataAndWidthAndHeightAndColorSpace() {
+    const imageData = new ImageData(new Uint8ClampedArray(16 * 9 * 4), 16, 9, {
+      colorSpace: "display-p3",
+    });
+
+    assertEquals(imageData.width, 16);
+    assertEquals(imageData.height, 9);
+    assertEquals(imageData.data.length, 16 * 9 * 4); // width * height * 4 (RGBA pixels)
+    assertEquals(imageData.colorSpace, "display-p3");
+  },
+);

--- a/cli/tsc/dts/lib.deno.window.d.ts
+++ b/cli/tsc/dts/lib.deno.window.d.ts
@@ -296,3 +296,6 @@ declare var location: Location;
 
 /** @category Web APIs */
 declare var name: string;
+
+/** @category Web APIs */
+declare var ImageData: any;

--- a/ext/web/16_image_data.js
+++ b/ext/web/16_image_data.js
@@ -1,0 +1,174 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import * as webidl from "ext:deno_webidl/00_webidl.js";
+import DOMException from "ext:deno_web/01_dom_exception.js";
+const primordials = globalThis.__bootstrap.primordials;
+const {
+  TypeError,
+} = primordials;
+
+const PredefinedColorSpace = [
+  "srgb",
+  "display-p3",
+];
+
+class ImageData {
+  /** @type {number} */
+  #width;
+  /** @type {height} */
+  #height;
+  /** @type {Uint8Array} */
+  #data;
+  /** @type {'srgb' | 'display-p3'} */
+  #colorSpace;
+
+  constructor() {
+    webidl.requiredArguments(
+      arguments.length,
+      2,
+      'Failed to construct "ImageData"',
+    );
+
+    const [arg0, arg1, arg2, arg3] = arguments;
+    let sourceWidth;
+    let sourceHeight;
+    let data;
+    let settings;
+
+    // Overload: new ImageData(data, sw [, sh [, settings ] ])
+    if (typeof arg0 === "object") {
+      data = arg0;
+      sourceWidth = typeof arg1 !== "undefined"
+        ? parseInt(arg1, 10)
+        : undefined;
+      sourceHeight = typeof arg2 !== "undefined"
+        ? parseInt(arg2, 10)
+        : undefined;
+      settings = arg3;
+
+      if (!(data instanceof Uint8ClampedArray)) {
+        throw new TypeError(
+          "Failed to construct 'ImageData': The provided value is not an instance of Uint8ClampedArray.",
+          "TypeError",
+        );
+      }
+
+      if (Number.isNaN(sourceWidth) || sourceWidth < 1) {
+        throw new DOMException(
+          "Failed to construct 'ImageData': The source width is zero or not a number.",
+          "IndexSizeError",
+        );
+      }
+
+      if (
+        typeof sourceHeight !== "undefined" && Number.isNaN(sourceWidth) ||
+        sourceHeight < 1
+      ) {
+        throw new DOMException(
+          "Failed to construct 'ImageData': The source height is zero or not a number.",
+          "IndexSizeError",
+        );
+      }
+
+      if (data.length % 4 !== 0) {
+        throw new DOMException(
+          "Failed to construct 'ImageData': The input data length is not a multiple of 4.",
+          "InvalidStateError",
+        );
+      }
+
+      if (data.length / 4 % sourceWidth !== 0) {
+        throw new DOMException(
+          "Failed to construct 'ImageData': The input data length is not a multiple of (4 * width).",
+          "IndexSizeError",
+        );
+      }
+
+      if (
+        typeof sourceHeight !== "undefined" &&
+        (sourceWidth * sourceHeight * 4 !== data.length)
+      ) {
+        throw new DOMException(
+          "Failed to construct 'ImageData': The input data length is not equal to (4 * width * height).",
+          "IndexSizeError",
+        );
+      }
+
+      if (
+        typeof settings !== "undefined" &&
+        typeof settings.colorSpace !== "undefined" &&
+        !PredefinedColorSpace.includes(settings.colorSpace)
+      ) {
+        throw new TypeError(
+          `Failed to read the 'colorSpace' property from 'ImageDataSettings': The provided value '${settings.colorSpace}' is not a valid enum value of type PredefinedColorSpace.`,
+        );
+      }
+
+      this.#width = sourceWidth;
+      this.#height = typeof sourceHeight === "undefined"
+        ? data.length / 4 / sourceWidth
+        : sourceHeight;
+      this.#data = data;
+      this.#colorSpace = typeof settings !== "undefined" &&
+          typeof settings.colorSpace !== "undefined"
+        ? settings.colorSpace
+        : "srgb";
+      return;
+    }
+
+    // Overload: new ImageData(sw, sh [, settings])
+    sourceWidth = typeof arg0 !== "undefined" ? parseInt(arg0, 10) : undefined;
+    sourceHeight = typeof arg1 !== "undefined" ? parseInt(arg1, 10) : undefined;
+    settings = arg2;
+
+    if (Number.isNaN(sourceWidth) || sourceWidth < 1) {
+      throw new DOMException(
+        "Failed to construct 'ImageData': The source width is zero or not a number.",
+        "IndexSizeError",
+      );
+    }
+
+    if (Number.isNaN(sourceWidth) || sourceHeight < 1) {
+      throw new DOMException(
+        "Failed to construct 'ImageData': The source height is zero or not a number.",
+        "IndexSizeError",
+      );
+    }
+
+    if (
+      typeof settings !== "undefined" &&
+      typeof settings.colorSpace !== "undefined" &&
+      !PredefinedColorSpace.includes(settings.colorSpace)
+    ) {
+      throw new TypeError(
+        `Failed to read the 'colorSpace' property from 'ImageDataSettings': The provided value '${settings.colorSpace}' is not a valid enum value of type PredefinedColorSpace.`,
+      );
+    }
+
+    this.#width = sourceWidth;
+    this.#height = sourceHeight;
+    this.#colorSpace = typeof settings !== "undefined" &&
+        typeof settings.colorSpace !== "undefined"
+      ? settings.colorSpace
+      : "srgb";
+    this.#data = new Uint8ClampedArray(sourceWidth * sourceHeight * 4);
+  }
+
+  get width() {
+    return this.#width;
+  }
+
+  get height() {
+    return this.#height;
+  }
+
+  get data() {
+    return this.#data;
+  }
+
+  get colorSpace() {
+    return this.#colorSpace;
+  }
+}
+
+export { ImageData };

--- a/ext/web/internal.d.ts
+++ b/ext/web/internal.d.ts
@@ -111,3 +111,7 @@ declare module "ext:deno_web/13_message_port.js" {
     transferables: Transferable[];
   }
 }
+
+declare module "ext:deno_web/16_image_data.js" {
+  const ImageData: typeof ImageData;
+}

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -116,6 +116,7 @@ deno_core::extension!(deno_web,
     "13_message_port.js",
     "14_compression.js",
     "15_performance.js",
+    "16_image_data.js",
   ],
   options = {
     blob_store: Arc<BlobStore>,

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -40,6 +40,7 @@ import * as abortSignal from "ext:deno_web/03_abort_signal.js";
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
 import * as webStorage from "ext:deno_webstorage/01_webstorage.js";
 import * as prompt from "ext:runtime/41_prompt.js";
+import * as imageData from "ext:deno_web/16_image_data.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
 const windowOrWorkerGlobalScope = {
@@ -65,6 +66,7 @@ const windowOrWorkerGlobalScope = {
   FileReader: util.nonEnumerable(fileReader.FileReader),
   FormData: util.nonEnumerable(formData.FormData),
   Headers: util.nonEnumerable(headers.Headers),
+  ImageData: util.nonEnumerable(imageData.ImageData),
   MessageEvent: util.nonEnumerable(event.MessageEvent),
   Performance: util.nonEnumerable(performance.Performance),
   PerformanceEntry: util.nonEnumerable(performance.PerformanceEntry),

--- a/tools/core_import_map.json
+++ b/tools/core_import_map.json
@@ -221,6 +221,7 @@
     "ext:deno_web/13_message_port.js": "../ext/web/13_message_port.js",
     "ext:deno_web/14_compression.js": "../ext/web/14_compression.js",
     "ext:deno_web/15_performance.js": "../ext/web/15_performance.js",
+    "ext:deno_web/16_image_data.js": "../ext/web/16_image_data.js",
     "ext:deno_webidl/00_webidl.js": "../ext/webidl/00_webidl.js",
     "ext:deno_websocket/01_websocket.js": "../ext/websocket/01_websocket.js",
     "ext:deno_websocket/02_websocketstream.js": "../ext/websocket/02_websocketstream.js",

--- a/tools/wpt/expectation.json
+++ b/tools/wpt/expectation.json
@@ -6908,6 +6908,9 @@
         }
       },
       "embedded-content": {
+        "the-canvas-element": {
+          "imagedata.html": true
+        },
         "the-iframe-element": {
           "cross-origin-to-whom-part-2.window.html": false,
           "cross-origin-to-whom.window.html": false,


### PR DESCRIPTION
Fixes #19288

Adds the `ImageData` Web API. 

This would be beneficial to projects using `ImageData` as a convenient spec compliant transport layer for pixel data. This is common in Web Assembly projects that manipulate images. Having this global available in Deno would improve compatibility of existing JS libraries.

**References**
- [MDN ImageData Web API](https://developer.mozilla.org/en-US/docs/Web/API/ImageData)
- [whatwg HTML Standard Canvas Spec](https://html.spec.whatwg.org/multipage/canvas.html#pixel-manipulation)

