### PR TITLE
fix(runtime): fix Deno.noColor when stdout is not tty

### DIFF
--- a/cli/tests/unit/tty_color_test.ts
+++ b/cli/tests/unit/tty_color_test.ts
@@ -13,3 +13,14 @@ Deno.test(
     assertEquals(output, "1\n");
   },
 );
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function denoNoColorIsNotAffectedByNonTty() {
+    const { stdout } = await new Deno.Command(Deno.execPath(), {
+      args: ["eval", "console.log(Deno.noColor)"],
+    }).output();
+    const output = new TextDecoder().decode(stdout);
+    assertEquals(output, "false\n");
+  },
+);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -241,7 +241,7 @@ function opMainModule() {
 const opArgs = memoizeLazy(() => ops.op_bootstrap_args());
 const opPid = memoizeLazy(() => ops.op_bootstrap_pid());
 const opPpid = memoizeLazy(() => ops.op_ppid());
-setNoColorFn(() => ops.op_bootstrap_no_color());
+setNoColorFn(() => ops.op_bootstrap_no_color() || !ops.op_bootstrap_is_tty());
 
 function formatException(error) {
   if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, error)) {
@@ -530,7 +530,7 @@ function bootstrapMainRuntime(runtimeOptions) {
   ObjectDefineProperties(finalDenoNs, {
     pid: util.getterOnly(opPid),
     ppid: util.getterOnly(opPpid),
-    noColor: util.getterOnly(getNoColor),
+    noColor: util.getterOnly(() => ops.op_bootstrap_no_color()),
     args: util.getterOnly(opArgs),
     mainModule: util.getterOnly(opMainModule),
   });
@@ -666,7 +666,7 @@ function bootstrapWorkerRuntime(
   }
   ObjectDefineProperties(finalDenoNs, {
     pid: util.getterOnly(opPid),
-    noColor: util.getterOnly(getNoColor),
+    noColor: util.getterOnly(() => ops.op_bootstrap_no_color()),
     args: util.getterOnly(opArgs),
   });
   // Setup `Deno` global - we're actually overriding already

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -15,6 +15,7 @@ deno_core::extension!(
     op_bootstrap_language,
     op_bootstrap_log_level,
     op_bootstrap_no_color,
+    op_bootstrap_is_tty,
   ],
 );
 
@@ -57,5 +58,11 @@ pub fn op_bootstrap_log_level(state: &mut OpState) -> i32 {
 #[op2(fast)]
 pub fn op_bootstrap_no_color(state: &mut OpState) -> bool {
   let options = state.borrow::<BootstrapOptions>();
-  options.no_color || !options.is_tty
+  options.no_color
+}
+
+#[op2(fast)]
+pub fn op_bootstrap_is_tty(state: &mut OpState) -> bool {
+  let options = state.borrow::<BootstrapOptions>();
+  options.is_tty
 }


### PR DESCRIPTION
`Deno.noColor` is only based on `NO_COLOR` env var, and `noColor` flag for `console` is based on `NO_COLOR` and `isTty` of stdout. But it seems these were aligned to the latter in #21164.

This PR restores the original handling of `Deno.noColor`

closes #21207