### PR TITLE
chore(cli): Fix rename test for XFS

### DIFF
--- a/cli/tests/unit/rename_test.ts
+++ b/cli/tests/unit/rename_test.ts
@@ -2,6 +2,8 @@
 import {
   assert,
   assertEquals,
+  AssertionError,
+  assertIsError,
   assertThrows,
   pathToAbsoluteFileUrl,
 } from "./test_util.ts";
@@ -149,13 +151,22 @@ Deno.test(
       Error,
       "Is a directory",
     );
-    assertThrows(
-      () => {
-        Deno.renameSync(olddir, fulldir);
-      },
-      Error,
-      "Directory not empty",
-    );
+    try {
+      assertThrows(
+        () => {
+          Deno.renameSync(olddir, fulldir);
+        },
+        Error,
+        "Directory not empty",
+      );
+    } catch (e) {
+      // rename syscall may also return EEXIST, e.g. with XFS
+      assertIsError(
+        e,
+        AssertionError,
+        `Expected error message to include "Directory not empty", but got "File exists`,
+      );
+    }
     assertThrows(
       () => {
         Deno.renameSync(olddir, file);

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -8,6 +8,7 @@ export {
   assertEquals,
   assertFalse,
   AssertionError,
+  assertIsError,
   assertMatch,
   assertNotEquals,
   assertNotStrictEquals,


### PR DESCRIPTION
Renaming a directory to a path where a non-empty directory already exists was asserted to always fail with `ENOTEMPTY`
According to glibc manual the function may also fail with `EEXIST` on "some other systems". One such case is using XFS [^1].

This commit handles the EEXIST case.

[^1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/xfs/xfs_inode.c?h=v4.18&id=94710cac0ef4ee177a63b5227664b38c95bbf703#n3082

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
