### PR TITLE
feat(ext/cron) modify Deno.cron API to make handler arg last

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1377,11 +1377,11 @@ declare namespace Deno {
    * }, () => {
    *   console.log("cron job executed");
    * });
+   * ```
    *
    * `schedule` is a Unix cron format expression, where time is specified
    * using UTC time zone.
    *
-   * ```
    * `backoffSchedule` option can be used to specify the retry policy for failed
    * executions. Each element in the array represents the number of milliseconds
    * to wait before retrying the execution. For example, `[1000, 5000, 10000]`

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1334,12 +1334,67 @@ declare namespace Deno {
    * second, 5 seconds, and 10 seconds delay between each retry.
    *
    * @category Cron
+   * @deprecated Use other {@linkcode cron} overloads instead. This overload
+   * will be removed in the future.
    */
   export function cron(
     name: string,
     schedule: string,
     handler: () => Promise<void> | void,
-    options?: { backoffSchedule?: number[]; signal?: AbortSignal },
+    options: { backoffSchedule?: number[]; signal?: AbortSignal },
+  ): Promise<void>;
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * Create a cron job that will periodically execute the provided handler
+   * callback based on the specified schedule.
+   *
+   * ```ts
+   * Deno.cron("sample cron", "20 * * * *", () => {
+   *   console.log("cron job executed");
+   * });
+   * ```
+   *
+   * `schedule` is a Unix cron format expression, where time is specified
+   * using UTC time zone.
+   *
+   * @category Cron
+   */
+  export function cron(
+    name: string,
+    schedule: string,
+    handler: () => Promise<void> | void,
+  ): Promise<void>;
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * Create a cron job that will periodically execute the provided handler
+   * callback based on the specified schedule.
+   *
+   * ```ts
+   * Deno.cron("sample cron", "20 * * * *", {
+   *   backoffSchedule: [10, 20]
+   * }, () => {
+   *   console.log("cron job executed");
+   * });
+   *
+   * `schedule` is a Unix cron format expression, where time is specified
+   * using UTC time zone.
+   *
+   * ```
+   * `backoffSchedule` option can be used to specify the retry policy for failed
+   * executions. Each element in the array represents the number of milliseconds
+   * to wait before retrying the execution. For example, `[1000, 5000, 10000]`
+   * means that a failed execution will be retried at most 3 times, with 1
+   * second, 5 seconds, and 10 seconds delay between each retry.
+   *
+   * @category Cron
+   */
+  export function cron(
+    name: string,
+    schedule: string,
+    options: { backoffSchedule?: number[]; signal?: AbortSignal },
+    handler: () => Promise<void> | void,
   ): Promise<void>;
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -6,8 +6,12 @@ const core = Deno.core;
 function cron(
   name: string,
   schedule: string,
-  handler: () => Promise<void> | void,
-  options?: { backoffSchedule?: number[]; signal?: AbortSignal },
+  handlerOrOptions1:
+    | (() => Promise<void> | void)
+    | ({ backoffSchedule?: number[]; signal?: AbortSignal }),
+  handlerOrOptions2?:
+    | (() => Promise<void> | void)
+    | ({ backoffSchedule?: number[]; signal?: AbortSignal }),
 ) {
   if (name === undefined) {
     throw new TypeError("Deno.cron requires a unique name");
@@ -15,7 +19,20 @@ function cron(
   if (schedule === undefined) {
     throw new TypeError("Deno.cron requires a valid schedule");
   }
-  if (handler === undefined) {
+
+  let handler: () => Promise<void> | void;
+  let options: { backoffSchedule?: number[]; signal?: AbortSignal } | undefined;
+
+  if (typeof handlerOrOptions1 === "function") {
+    handler = handlerOrOptions1;
+    if (typeof handlerOrOptions2 === "function") {
+      throw new TypeError("options must be an object");
+    }
+    options = handlerOrOptions2;
+  } else if (typeof handlerOrOptions2 === "function") {
+    handler = handlerOrOptions2;
+    options = handlerOrOptions1;
+  } else {
     throw new TypeError("Deno.cron requires a handler");
   }
 

--- a/ext/cron/local.rs
+++ b/ext/cron/local.rs
@@ -174,8 +174,11 @@ impl RuntimeState {
             .map(move |name| (*ts, name.clone()))
             .collect::<Vec<_>>()
         })
-        .map(|(_, name)| {
-          (name.clone(), self.crons.get(&name).unwrap().next_tx.clone())
+        .filter_map(|(_, name)| {
+          self
+            .crons
+            .get(&name)
+            .map(|c| (name.clone(), c.next_tx.clone()))
         })
         .collect::<Vec<_>>()
     };


### PR DESCRIPTION
This PR changes the `Deno.cron` API:
* Marks the existing function as deprecated
* Introduces 2 new overloads, where the handler arg is always last:
```ts
Deno.cron(
  name: string,
  schedule: string,
  handler: () => Promise<void> | void,
)

Deno.cron(
  name: string,
  schedule: string,
  options?: { backoffSchedule?: number[]; signal?: AbortSignal },
  handler: () => Promise<void> | void,
)
```

This PR also fixes a bug, when other crons continue execution after one of the crons was closed using `signal`.