### PR TITLE
chore(ext/web): fix ext/web build

### DIFF
--- a/ext/web/Cargo.toml
+++ b/ext/web/Cargo.toml
@@ -19,7 +19,7 @@ base64-simd = "0.8"
 bytes.workspace = true
 deno_core.workspace = true
 encoding_rs.workspace = true
-flate2.workspace = true
+flate2 = { workspace = true, features = ["default"] }
 futures.workspace = true
 serde = "1.0.149"
 tokio.workspace = true


### PR DESCRIPTION
`cargo build` passes in `ext/web` with this change. cf. https://github.com/denoland/deno/actions/runs/6899828165/job/18772042978

related https://github.com/denoland/deno/pull/21158