### PR TITLE
Revert "chore: update to Rust 1.74"

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -812,7 +812,7 @@ impl Config {
   pub fn new() -> Self {
     Self {
       client_capabilities: ClientCapabilities::default(),
-      // Root provided by the initialization parameters.
+      /// Root provided by the initialization parameters.
       settings: Default::default(),
       workspace_folders: vec![],
       maybe_config_file_info: None,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -812,7 +812,7 @@ impl Config {
   pub fn new() -> Self {
     Self {
       client_capabilities: ClientCapabilities::default(),
-      /// Root provided by the initialization parameters.
+      // Root provided by the initialization parameters.
       settings: Default::default(),
       workspace_folders: vec![],
       maybe_config_file_info: None,

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -298,7 +298,6 @@ fn main() {
     let snapshot_slice = &[];
     #[allow(clippy::needless_borrow)]
     #[allow(clippy::disallowed_methods)]
-    #[allow(clippy::needless_borrows_for_generic_args)]
     std::fs::write(&runtime_snapshot_path, snapshot_slice).unwrap();
   }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.73.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Reverts denoland/deno#21210

This is likely causing multiple flakes in http tests, but we're not sure why. 

```
[serve_test 026.32] httpServeCurlH2C => ./cli/tests/unit/serve_test.ts:3638:6
[serve_test 026.32] error: AssertionError
[serve_test 026.32]     throw new AssertionError(msg);
[serve_test 026.32]           ^
[serve_test 026.32]     at assert (file:///D:/a/deno/deno/test_util/std/testing/asserts.ts:141:11)
[serve_test 026.32]     at curlRequest (file:///D:/a/deno/deno/cli/tests/unit/serve_test.ts:3750:3)
[serve_test 026.32]     at eventLoopTick (ext:core/01_core.js:178:11)
[serve_test 026.32]     at async httpServeCurlH2C (file:///D:/a/deno/deno/cli/tests/unit/serve_test.ts:3653:7)
```