### PR TITLE
chore(ext/http): bump version for re-release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.119.0"
+version = "0.120.0"
 dependencies = [
  "async-compression",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ deno_crypto = { version = "0.138.0", path = "./ext/crypto" }
 deno_fetch = { version = "0.148.0", path = "./ext/fetch" }
 deno_ffi = { version = "0.111.0", path = "./ext/ffi" }
 deno_fs = { version = "0.34.0", path = "./ext/fs" }
-deno_http = { version = "0.119.0", path = "./ext/http" }
+deno_http = { version = "0.120.0", path = "./ext/http" }
 deno_io = { version = "0.34.0", path = "./ext/io" }
 deno_net = { version = "0.116.0", path = "./ext/net" }
 deno_node = { version = "0.61.0", path = "./ext/node" }

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_http"
-version = "0.119.0"
+version = "0.120.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Syncs the changes to main for a deno_http version bump we needed to do. `deno_http` v1.20 was released from the v1.38 branch.