### PR TITLE
fix(ext/node): handle closing process.stdin more than once

### DIFF
--- a/cli/tests/unit_node/process_test.ts
+++ b/cli/tests/unit_node/process_test.ts
@@ -365,6 +365,8 @@ Deno.test({
   name: "process.stdin readable with a TTY",
   // TODO(PolarETech): Run this test even in non tty environment
   ignore: !Deno.isatty(Deno.stdin.rid),
+  // stdin resource is present before the test starts.
+  sanitizeResources: false,
   async fn() {
     const promise = deferred();
     const expected = ["foo", "bar", null, "end"];

--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -241,7 +241,7 @@ class Stdin {
   }
 
   close() {
-    core.close(this.rid);
+    core.tryClose(this.rid);
   }
 
   get readable() {


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/21112

Aligns more towards what Node.js does. Closing stdin more than once is a nop.