### PR TITLE
chore: add upgrade prompt integration test

### DIFF
--- a/cli/tests/integration/upgrade_tests.rs
+++ b/cli/tests/integration/upgrade_tests.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use std::process::Stdio;
 use test_util as util;
 use test_util::TempDir;
+use util::TestContextBuilder;
 
 // Warning: this test requires internet access.
 // TODO(#7412): reenable. test is flaky
@@ -191,4 +192,36 @@ fn upgrade_invalid_canary_version() {
     "error: Invalid commit hash passed\n",
     util::strip_ansi_codes(&String::from_utf8(output.stderr).unwrap())
   );
+}
+
+#[test]
+fn upgrade_prompt() {
+  let context = TestContextBuilder::new()
+    .use_http_server()
+    .use_temp_cwd()
+    .env(
+      "DENO_DONT_USE_INTERNAL_BASE_UPGRADE_URL",
+      "http://localhost:4545",
+    )
+    .build();
+  let temp_dir = context.temp_dir();
+  // start a task that goes indefinitely in order to allow
+  // the upgrade check to occur
+  temp_dir.write("main.js", "setInterval(() => {}, 1_000)");
+  let cmd = context
+    .new_command()
+    .args("run --log-level=debug main.js")
+    .env_remove("DENO_NO_UPDATE_CHECK");
+  // run once and wait for the version to be stored
+  cmd.with_pty(|mut pty| {
+    pty.expect("Finished upgrade checker.");
+  });
+  // now check that the upgrade prompt is shown the next time this is run
+  temp_dir.write("main.js", "");
+  cmd.with_pty(|mut pty| {
+    // - We need to use a pty here because the upgrade prompt
+    //   doesn't occur except when there's a pty.
+    // - Version comes from the test server.
+    pty.expect(" 99999.99.99 Run `deno upgrade` to install it.");
+  });
 }

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -263,6 +263,9 @@ pub fn check_for_upgrades(
       tokio::time::sleep(UPGRADE_CHECK_FETCH_DELAY).await;
 
       fetch_and_store_latest_version(&env, &version_provider).await;
+
+      // text is used by the test suite
+      log::debug!("Finished upgrade checker.")
     });
   }
 
@@ -593,7 +596,16 @@ fn get_url(
     UpgradeCheckKind::Execution => "",
     UpgradeCheckKind::Lsp => "?lsp",
   };
-  format!("https://dl.deno.land/{}{}", file_name, query_param)
+  format!("{}/{}{}", base_upgrade_url(), file_name, query_param)
+}
+
+fn base_upgrade_url() -> Cow<'static, str> {
+  // this is used by the test suite
+  if let Ok(url) = env::var("DENO_DONT_USE_INTERNAL_BASE_UPGRADE_URL") {
+    Cow::Owned(url)
+  } else {
+    Cow::Borrowed("https://dl.deno.land")
+  }
 }
 
 async fn download_package(

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -593,16 +593,7 @@ fn get_url(
     UpgradeCheckKind::Execution => "",
     UpgradeCheckKind::Lsp => "?lsp",
   };
-  format!("{}/{}{}", base_upgrade_url(), file_name, query_param)
-}
-
-fn base_upgrade_url() -> Cow<'static, str> {
-  // this is used to get the current version
-  if let Ok(url) = env::var("DENO_DONT_USE_INTERNAL_BASE_UPGRADE_URL") {
-    Cow::Owned(url)
-  } else {
-    Cow::Borrowed("https://dl.deno.land")
-  }
+  format!("https://dl.deno.land/{}{}", file_name, query_param)
 }
 
 async fn download_package(

--- a/test_util/src/builders.rs
+++ b/test_util/src/builders.rs
@@ -635,6 +635,9 @@ impl TestCommandBuilder {
     if !envs.contains_key("NPM_CONFIG_REGISTRY") {
       envs.insert("NPM_CONFIG_REGISTRY".to_string(), npm_registry_unset_url());
     }
+    if !envs.contains_key("DENO_NO_UPDATE_CHECK") {
+      envs.insert("DENO_NO_UPDATE_CHECK".to_string(), "1".to_string());
+    }
     for key in &self.envs_remove {
       envs.remove(key);
     }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1273,6 +1273,15 @@ async fn main_server(
           .unwrap(),
       )
     }
+    (&hyper::Method::GET, "/upgrade/sleep/release-latest.txt") => {
+      tokio::time::sleep(Duration::from_secs(45)).await;
+      return Ok(
+        Response::builder()
+          .status(StatusCode::OK)
+          .body(Body::from("99999.99.99"))
+          .unwrap(),
+      );
+    }
     (&hyper::Method::GET, "/release-latest.txt") => {
       return Ok(
         Response::builder()

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1273,6 +1273,15 @@ async fn main_server(
           .unwrap(),
       )
     }
+    (&hyper::Method::GET, "/release-latest.txt") => {
+      return Ok(
+        Response::builder()
+          .status(StatusCode::OK)
+          // use a deno version that will never happen
+          .body(Body::from("99999.99.99"))
+          .unwrap(),
+      );
+    }
     _ => {
       let mut file_path = testdata_path().to_path_buf();
       file_path.push(&req.uri().path()[1..].replace("%2f", "/"));


### PR DESCRIPTION
1. Adds an upgrade prompt integration test.
1. Adds a test for when the upgrade check takes a long time in the repl.
1. ~~Maybe makes the REPL tests more reliable by disabling the upgrade check in the repl tests.~~ Edit: Nope