### PR TITLE
fix(fmt): maintain parens for jsx in member expr

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -55,10 +55,10 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.88.3.wasm",
+    "https://plugins.dprint.dev/typescript-0.88.4.wasm",
     "https://plugins.dprint.dev/json-0.19.0.wasm",
     "https://plugins.dprint.dev/markdown-0.16.2.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
-    "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072"
+    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.88.3"
+version = "0.88.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c51dda57191fcc97f1da77927a29ecb6f5ec7133f705dcc7134533f3090681c"
+checksum = "3a5be6e2f026971bd4b75ed2b77203c4195587229818ddef23721f66a044907b"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -83,7 +83,7 @@ dissimilar = "=1.0.4"
 dotenvy = "0.15.7"
 dprint-plugin-json = "=0.19.0"
 dprint-plugin-markdown = "=0.16.2"
-dprint-plugin-typescript = "=0.88.3"
+dprint-plugin-typescript = "=0.88.4"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"


### PR DESCRIPTION
Fix in https://github.com/dprint/dprint-plugin-typescript/commit/0b44991bb9cbc35999796c9864e68d8e4a0f9245

Closes https://github.com/denoland/deno/issues/21279