### PR TITLE
chore(tools): pull dprint from npm instead of third_party

### DIFF
--- a/tools/format.js
+++ b/tools/format.js
@@ -8,6 +8,7 @@ const cmd = new Deno.Command("deno", {
   args: [
     "run",
     "-A",
+    "--no-config",
     "npm:dprint@0.43.0",
     subcommand,
     "--config=" + configFile,

--- a/tools/format.js
+++ b/tools/format.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env -S deno run --unstable --allow-write --allow-read --allow-run --allow-net
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { getPrebuilt, join, ROOT_PATH } from "./util.js";
+import { join, ROOT_PATH } from "./util.js";
 
 const subcommand = Deno.args.includes("--check") ? "check" : "fmt";
 const configFile = join(ROOT_PATH, ".dprint.json");
-const execPath = await getPrebuilt("dprint");
-const cmd = new Deno.Command(execPath, {
-  args: [subcommand, "--config=" + configFile],
+const cmd = new Deno.Command("deno", {
+  args: [
+    "run",
+    "-A",
+    "npm:dprint@0.43.0",
+    subcommand,
+    "--config=" + configFile,
+  ],
   cwd: ROOT_PATH,
   stdout: "inherit",
   stderr: "inherit",

--- a/tools/util.js
+++ b/tools/util.js
@@ -15,7 +15,6 @@ export { delay } from "../test_util/std/async/delay.ts";
 
 // [toolName] --version output
 const versions = {
-  "dprint": "dprint 0.40.0",
   "dlint": "dlint 0.51.0",
 };
 


### PR DESCRIPTION
This will allow this format script to work on more architectures. Also, this upgrade fixes the issue with the unstable incremental cache that's currently on main.