### PR TITLE
Revert "chore: update to `std@0.207.0` (#21284)"

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -130,7 +130,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
       "check",
       "--reload",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "test_util/std/examples/chat/server_test.ts",
     ],
     None,
   ),
@@ -141,7 +141,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
       "--reload",
       "--no-check",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "test_util/std/examples/chat/server_test.ts",
     ],
     None,
   ),
@@ -150,7 +150,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &[
       "bundle",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "test_util/std/examples/chat/server_test.ts",
     ],
     None,
   ),
@@ -160,7 +160,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
       "bundle",
       "--no-check",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "test_util/std/examples/chat/server_test.ts",
     ],
     None,
   ),
@@ -314,7 +314,7 @@ fn get_binary_sizes(target_dir: &Path) -> Result<HashMap<String, i64>> {
 
 const BUNDLES: &[(&str, &str)] = &[
   ("file_server", "./test_util/std/http/file_server.ts"),
-  ("gist", "./cli/tests/testdata/welcome.ts"),
+  ("gist", "./test_util/std/examples/gist.ts"),
 ];
 fn bundle_benchmark(deno_exe: &Path) -> Result<HashMap<String, i64>> {
   let mut sizes = HashMap::<String, i64>::new();

--- a/cli/tests/integration/compile_tests.rs
+++ b/cli/tests/integration/compile_tests.rs
@@ -24,7 +24,7 @@ fn compile_basic() {
         "compile",
         "--output",
         &exe.to_string_lossy(),
-        "./welcome.ts",
+        "../../../test_util/std/examples/welcome.ts",
       ])
       .run();
     output.assert_exit_code(0);

--- a/cli/tests/node_compat/common.ts
+++ b/cli/tests/node_compat/common.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { partition } from "../../../test_util/std/collections/partition.ts";
 import { join } from "../../../test_util/std/path/mod.ts";
-import * as JSONC from "../../../test_util/std/jsonc/mod.ts";
+import * as JSONC from "../../../test_util/std/encoding/jsonc.ts";
 /**
  * The test suite matches the folders inside the `test` folder inside the
  * node repo

--- a/cli/tests/node_compat/test.ts
+++ b/cli/tests/node_compat/test.ts
@@ -16,7 +16,7 @@
 import { magenta } from "../../../test_util/std/fmt/colors.ts";
 import { pooledMap } from "../../../test_util/std/async/pool.ts";
 import { dirname, fromFileUrl, join } from "../../../test_util/std/path/mod.ts";
-import { fail } from "../../../test_util/std/assert/mod.ts";
+import { fail } from "../../../test_util/std/testing/asserts.ts";
 import {
   config,
   getPathsFromTestSuites,

--- a/cli/tests/testdata/bench/allow_all.ts
+++ b/cli/tests/testdata/bench/allow_all.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/cli/tests/testdata/bench/allow_none.ts
+++ b/cli/tests/testdata/bench/allow_none.ts
@@ -1,4 +1,4 @@
-import { unreachable } from "../../../../test_util/std/assert/mod.ts";
+import { unreachable } from "../../../../test_util/std/testing/asserts.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/cli/tests/testdata/cert/listen_tls_alpn_fail.ts
+++ b/cli/tests/testdata/cert/listen_tls_alpn_fail.ts
@@ -1,4 +1,4 @@
-import { assertRejects } from "../../../../test_util/std/assert/mod.ts";
+import { assertRejects } from "../../../../test_util/std/testing/asserts.ts";
 
 const listener = Deno.listenTls({
   port: Number(Deno.args[0]),

--- a/cli/tests/testdata/compile/standalone_follow_redirects_2.js
+++ b/cli/tests/testdata/compile/standalone_follow_redirects_2.js
@@ -2,4 +2,4 @@
 import {
   assertNotEquals as _a,
   assertStrictEquals as _b,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";

--- a/cli/tests/testdata/coverage/no_tests_included/foo.test.js
+++ b/cli/tests/testdata/coverage/no_tests_included/foo.test.js
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "../../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/cli/tests/testdata/coverage/no_tests_included/foo.test.mts
+++ b/cli/tests/testdata/coverage/no_tests_included/foo.test.mts
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "../../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/cli/tests/testdata/coverage/no_tests_included/foo.test.ts
+++ b/cli/tests/testdata/coverage/no_tests_included/foo.test.ts
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "../../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/cli/tests/testdata/coverage/no_transpiled_lines/expected.lcov
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/expected.lcov
@@ -4,7 +4,9 @@ FNH:0
 BRF:0
 BRH:0
 DA:1,1
+DA:2,1
 DA:3,1
-LH:2
-LF:2
+DA:5,1
+LH:4
+LF:4
 end_of_record

--- a/cli/tests/testdata/coverage/no_transpiled_lines/expected.out
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/expected.out
@@ -1,1 +1,1 @@
-cover [WILDCARD]index.ts ... 100.000% (2/2)
+cover [WILDCARD]index.ts ... 100.000% (4/4)

--- a/cli/tests/testdata/coverage/no_transpiled_lines/index.ts
+++ b/cli/tests/testdata/coverage/no_transpiled_lines/index.ts
@@ -1,3 +1,5 @@
-export { assertStrictEquals } from "../../../../../test_util/std/assert/mod.ts";
+export {
+  assertStrictEquals,
+} from "../../../../../test_util/std/testing/asserts.ts";
 
 export * from "./interface.ts";

--- a/cli/tests/testdata/run/045_proxy_test.ts
+++ b/cli/tests/testdata/run/045_proxy_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { Server } from "../../../../test_util/std/http/server.ts";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 
 const addr = Deno.args[1] || "localhost:4555";
 

--- a/cli/tests/testdata/run/import_meta/main.ts
+++ b/cli/tests/testdata/run/import_meta/main.ts
@@ -1,4 +1,4 @@
-import { assertThrows } from "../../../../../test_util/std/assert/mod.ts";
+import { assertThrows } from "../../../../../test_util/std/testing/asserts.ts";
 
 console.log("main", import.meta.url, import.meta.main);
 

--- a/cli/tests/testdata/run/onload/imported.ts
+++ b/cli/tests/testdata/run/onload/imported.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-window-prefix
-import { assert } from "../../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 import "./nest_imported.ts";
 
 const handler = (e: Event) => {

--- a/cli/tests/testdata/run/onload/main.ts
+++ b/cli/tests/testdata/run/onload/main.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-window-prefix no-prototype-builtins
-import { assert } from "../../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 import "./imported.ts";
 
 assert(window.hasOwnProperty("onload"));

--- a/cli/tests/testdata/run/onload/nest_imported.ts
+++ b/cli/tests/testdata/run/onload/nest_imported.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-window-prefix
-import { assert } from "../../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../../test_util/std/testing/asserts.ts";
 
 const handler = (e: Event) => {
   assert(e.type === "beforeunload" ? e.cancelable : !e.cancelable);

--- a/cli/tests/testdata/run/tls_connecttls.js
+++ b/cli/tests/testdata/run/tls_connecttls.js
@@ -1,5 +1,8 @@
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { BufReader, BufWriter } from "../../../../test_util/std/io/mod.ts";
 import { TextProtoReader } from "./textproto.ts";
 

--- a/cli/tests/testdata/run/tls_starttls.js
+++ b/cli/tests/testdata/run/tls_starttls.js
@@ -1,5 +1,8 @@
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { BufReader } from "../../../../test_util/std/io/buf_reader.ts";
 import { BufWriter } from "../../../../test_util/std/io/buf_writer.ts";
 import { TextProtoReader } from "./textproto.ts";

--- a/cli/tests/testdata/run/websocket_server_idletimeout.ts
+++ b/cli/tests/testdata/run/websocket_server_idletimeout.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
 
 const errorDeferred = deferred();

--- a/cli/tests/testdata/run/websocket_test.ts
+++ b/cli/tests/testdata/run/websocket_test.ts
@@ -4,7 +4,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
 
 Deno.test("invalid scheme", () => {

--- a/cli/tests/testdata/run/websocketstream_test.ts
+++ b/cli/tests/testdata/run/websocketstream_test.ts
@@ -7,7 +7,7 @@ import {
   assertRejects,
   assertThrows,
   unreachable,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 
 Deno.test("fragment", () => {
   assertThrows(() => new WebSocketStream("ws://localhost:4242/#"));

--- a/cli/tests/testdata/test/allow_all.ts
+++ b/cli/tests/testdata/test/allow_all.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/cli/tests/testdata/test/allow_none.ts
+++ b/cli/tests/testdata/test/allow_none.ts
@@ -1,4 +1,4 @@
-import { unreachable } from "../../../../test_util/std/assert/mod.ts";
+import { unreachable } from "../../../../test_util/std/testing/asserts.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/cli/tests/testdata/welcome.ts
+++ b/cli/tests/testdata/welcome.ts
@@ -1,1 +1,0 @@
-console.log("Welcome to Deno!");

--- a/cli/tests/testdata/workers/deno_worker.ts
+++ b/cli/tests/testdata/workers/deno_worker.ts
@@ -1,4 +1,4 @@
-import { assert } from "../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../test_util/std/testing/asserts.ts";
 
 onmessage = function (e) {
   if (typeof self.Deno === "undefined") {

--- a/cli/tests/testdata/workers/test.ts
+++ b/cli/tests/testdata/workers/test.ts
@@ -7,7 +7,7 @@ import {
   assertEquals,
   assertMatch,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
 
 Deno.test({

--- a/cli/tests/unit/broadcast_channel_test.ts
+++ b/cli/tests/unit/broadcast_channel_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test("BroadcastChannel worker", async () => {
   const intercom = new BroadcastChannel("intercom");

--- a/cli/tests/unit/message_channel_test.ts
+++ b/cli/tests/unit/message_channel_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // NOTE: these are just sometests to test the TypeScript types. Real coverage is
 // provided by WPT.
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test("messagechannel", async () => {
   const mc = new MessageChannel();

--- a/cli/tests/unit/opcall_test.ts
+++ b/cli/tests/unit/opcall_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 import { assert, assertStringIncludes, unreachable } from "./test_util.ts";
 
 Deno.test(async function sendAsyncStackTrace() {

--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -3,7 +3,7 @@
 import {
   assertMatch,
   assertRejects,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { Buffer, BufReader, BufWriter } from "../../../test_util/std/io/mod.ts";
 import { TextProtoReader } from "../testdata/run/textproto.ts";
 import {

--- a/cli/tests/unit/test_util.ts
+++ b/cli/tests/unit/test_util.ts
@@ -19,7 +19,7 @@ export {
   fail,
   unimplemented,
   unreachable,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 export { deferred } from "../../../test_util/std/async/deferred.ts";
 export type { Deferred } from "../../../test_util/std/async/deferred.ts";
 export { delay } from "../../../test_util/std/async/delay.ts";

--- a/cli/tests/unit_node/_fs/_fs_access_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_access_test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import {
   assertRejects,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 
 Deno.test(
   "[node/fs.access] Uses the owner permission when the user is the owner",

--- a/cli/tests/unit_node/_fs/_fs_appendFile_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_appendFile_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { appendFile, appendFileSync } from "node:fs";
 import { fromFileUrl } from "../../../../test_util/std/path/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";

--- a/cli/tests/unit_node/_fs/_fs_chmod_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_chmod_test.ts
@@ -4,7 +4,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { chmod, chmodSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_chown_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_chown_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { chown, chownSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_close_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_close_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { close, closeSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_copy_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_copy_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../../../test_util/std/path/mod.ts";
-import { assert } from "../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { copyFile, copyFileSync, existsSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_dir_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_dir_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { Dir as DirOrig, type Dirent } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_dirent_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_dirent_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { Dirent as Dirent_ } from "node:fs";
 
 // deno-lint-ignore no-explicit-any

--- a/cli/tests/unit_node/_fs/_fs_exists_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_exists_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { exists, existsSync } from "node:fs";
 import { promisify } from "node:util";
 

--- a/cli/tests/unit_node/_fs/_fs_fdatasync_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_fdatasync_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { fdatasync, fdatasyncSync } from "node:fs";
 
 Deno.test({

--- a/cli/tests/unit_node/_fs/_fs_fstat_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_fstat_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { fstat, fstatSync } from "node:fs";
-import { fail } from "../../../../test_util/std/assert/mod.ts";
+import { fail } from "../../../../test_util/std/testing/asserts.ts";
 import { assertStats, assertStatsBigInt } from "./_fs_stat_test.ts";
 import type { BigIntStats, Stats } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_fsync_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_fsync_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { fsync, fsyncSync } from "node:fs";
 
 Deno.test({

--- a/cli/tests/unit_node/_fs/_fs_ftruncate_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_ftruncate_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { ftruncate, ftruncateSync } from "node:fs";
 
 Deno.test({

--- a/cli/tests/unit_node/_fs/_fs_futimes_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_futimes_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { futimes, futimesSync } from "node:fs";
 
 const randomDate = new Date(Date.now() + 1000);

--- a/cli/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_handle_test.ts
@@ -2,7 +2,10 @@
 import * as path from "../../../../test_util/std/path/mod.ts";
 import { Buffer } from "node:buffer";
 import * as fs from "node:fs/promises";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");

--- a/cli/tests/unit_node/_fs/_fs_link_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_link_test.ts
@@ -4,7 +4,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { link, linkSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_lstat_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_lstat_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { lstat, lstatSync } from "node:fs";
-import { fail } from "../../../../test_util/std/assert/mod.ts";
+import { fail } from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { assertStats, assertStatsBigInt } from "./_fs_stat_test.ts";
 import type { BigIntStats, Stats } from "node:fs";

--- a/cli/tests/unit_node/_fs/_fs_mkdir_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_mkdir_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../../../test_util/std/path/mod.ts";
-import { assert } from "../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { existsSync, mkdir, mkdirSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_mkdtemp_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_mkdtemp_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertRejects,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { EncodingOption, existsSync, mkdtemp, mkdtempSync } from "node:fs";
 import { env } from "node:process";
 import { promisify } from "node:util";

--- a/cli/tests/unit_node/_fs/_fs_open_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_open_test.ts
@@ -14,7 +14,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { open, openSync } from "node:fs";
 import { join, parse } from "node:path";

--- a/cli/tests/unit_node/_fs/_fs_opendir_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_opendir_test.ts
@@ -6,7 +6,7 @@ import {
   assertFalse,
   assertInstanceOf,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { opendir, opendirSync } from "node:fs";
 import { Buffer } from "node:buffer";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";

--- a/cli/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -2,7 +2,10 @@
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readFile, readFileSync } from "node:fs";
 import * as path from "../../../../test_util/std/path/mod.ts";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");

--- a/cli/tests/unit_node/_fs/_fs_read_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_read_test.ts
@@ -4,7 +4,7 @@ import {
   assertFalse,
   assertMatch,
   assertStrictEquals,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { read, readSync } from "node:fs";
 import { open, openSync } from "node:fs";
 import { Buffer } from "node:buffer";

--- a/cli/tests/unit_node/_fs/_fs_readdir_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_readdir_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertNotEquals,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readdir, readdirSync } from "node:fs";
 import { join } from "../../../../test_util/std/path/mod.ts";

--- a/cli/tests/unit_node/_fs/_fs_readlink_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_readlink_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readlink, readlinkSync } from "node:fs";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 import * as path from "../../../../test_util/std/path/mod.ts";
 
 const testDir = Deno.makeTempDirSync();

--- a/cli/tests/unit_node/_fs/_fs_realpath_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_realpath_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import * as path from "../../../../test_util/std/path/mod.ts";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { realpath, realpathSync } from "node:fs";
 

--- a/cli/tests/unit_node/_fs/_fs_rename_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_rename_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { rename, renameSync } from "node:fs";
 import { existsSync } from "node:fs";

--- a/cli/tests/unit_node/_fs/_fs_rm_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_rm_test.ts
@@ -4,7 +4,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { rm, rmSync } from "node:fs";
 import { closeSync, existsSync } from "node:fs";
 import { join } from "../../../../test_util/std/path/mod.ts";

--- a/cli/tests/unit_node/_fs/_fs_rmdir_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_rmdir_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { rmdir, rmdirSync } from "node:fs";
 import { closeSync } from "node:fs";
 import { existsSync } from "node:fs";

--- a/cli/tests/unit_node/_fs/_fs_stat_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_stat_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { BigIntStats, stat, Stats, statSync } from "node:fs";
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 
 export function assertStats(actual: Stats, expected: Deno.FileInfo) {
   assertEquals(actual.dev, expected.dev);

--- a/cli/tests/unit_node/_fs/_fs_symlink_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_symlink_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { symlink, symlinkSync } from "node:fs";
 
 Deno.test({

--- a/cli/tests/unit_node/_fs/_fs_truncate_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_truncate_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { truncate, truncateSync } from "node:fs";
 
 Deno.test({

--- a/cli/tests/unit_node/_fs/_fs_unlink_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_unlink_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assertEquals,
+  fail,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { existsSync } from "node:fs";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { unlink, unlinkSync } from "node:fs";

--- a/cli/tests/unit_node/_fs/_fs_utimes_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_utimes_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { utimes, utimesSync } from "node:fs";
 
 const randomDate = new Date(Date.now() + 1000);

--- a/cli/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_watch_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { watch } from "node:fs";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 
 function wait(time: number) {
   return new Promise((resolve) => {

--- a/cli/tests/unit_node/_fs/_fs_writeFile_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_writeFile_test.ts
@@ -5,7 +5,7 @@ import {
   assertNotEquals,
   assertRejects,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { writeFile, writeFileSync } from "node:fs";
 import * as path from "../../../../test_util/std/path/mod.ts";
 

--- a/cli/tests/unit_node/_fs/_fs_write_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_write_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { write, writeSync } from "node:fs";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 import { Buffer } from "node:buffer";
 
 const decoder = new TextDecoder("utf-8");

--- a/cli/tests/unit_node/_test_utils.ts
+++ b/cli/tests/unit_node/_test_utils.ts
@@ -3,7 +3,7 @@
 import {
   assert,
   assertStringIncludes,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 
 /** Asserts that an error thrown in a callback will not be wrongly caught. */
 export async function assertCallbackErrorUncaught(

--- a/cli/tests/unit_node/assertion_error_test.ts
+++ b/cli/tests/unit_node/assertion_error_test.ts
@@ -3,7 +3,7 @@ import { stripColor } from "../../../test_util/std/fmt/colors.ts";
 import {
   assert,
   assertStrictEquals,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { AssertionError } from "node:assert";
 
 Deno.test({

--- a/cli/tests/unit_node/async_hooks_test.ts
+++ b/cli/tests/unit_node/async_hooks_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
 
 Deno.test(async function foo() {

--- a/cli/tests/unit_node/buffer_test.ts
+++ b/cli/tests/unit_node/buffer_test.ts
@@ -3,7 +3,7 @@ import { Buffer } from "node:buffer";
 import {
   assertEquals,
   assertThrows,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test({
   name: "[node/buffer] alloc fails if size is not a number",

--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -9,7 +9,7 @@ import {
   assertNotStrictEquals,
   assertStrictEquals,
   assertStringIncludes,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { Deferred, deferred } from "../../../test_util/std/async/deferred.ts";
 import * as path from "../../../test_util/std/path/mod.ts";
 

--- a/cli/tests/unit_node/crypto/crypto_cipher_gcm_test.ts
+++ b/cli/tests/unit_node/crypto/crypto_cipher_gcm_test.ts
@@ -4,7 +4,7 @@ import crypto from "node:crypto";
 import { Buffer } from "node:buffer";
 import testVectors128 from "./gcmEncryptExtIV128.json" assert { type: "json" };
 import testVectors256 from "./gcmEncryptExtIV256.json" assert { type: "json" };
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 
 const aesGcm = (bits: string, key: Uint8Array) => {
   const ALGO = bits == "128" ? `aes-128-gcm` : `aes-256-gcm`;

--- a/cli/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/cli/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -6,7 +6,7 @@ import { buffer, text } from "node:stream/consumers";
 import {
   assertEquals,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 
 const rsaPrivateKey = Deno.readTextFileSync(
   new URL("../testdata/rsa_private.pem", import.meta.url),

--- a/cli/tests/unit_node/crypto/crypto_hash_test.ts
+++ b/cli/tests/unit_node/crypto/crypto_hash_test.ts
@@ -8,7 +8,10 @@ import {
 } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 
 // https://github.com/denoland/deno/issues/18140
 Deno.test({

--- a/cli/tests/unit_node/crypto/crypto_key_test.ts
+++ b/cli/tests/unit_node/crypto/crypto_key_test.ts
@@ -14,7 +14,7 @@ import { Buffer } from "node:buffer";
 import {
   assertEquals,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { createHmac } from "node:crypto";
 
 const generateKeyPairAsync = promisify(

--- a/cli/tests/unit_node/crypto/crypto_sign_test.ts
+++ b/cli/tests/unit_node/crypto/crypto_sign_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 import { createSign, createVerify, sign, verify } from "node:crypto";
 import { Buffer } from "node:buffer";
 

--- a/cli/tests/unit_node/fs_test.ts
+++ b/cli/tests/unit_node/fs_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertThrows } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertThrows,
+} from "../../../test_util/std/testing/asserts.ts";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";

--- a/cli/tests/unit_node/http2_test.ts
+++ b/cli/tests/unit_node/http2_test.ts
@@ -3,7 +3,7 @@
 import * as http2 from "node:http2";
 import * as net from "node:net";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 
 for (const url of ["http://127.0.0.1:4246", "https://127.0.0.1:4247"]) {
   Deno.test(`[node/http2 client] ${url}`, {

--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -7,7 +7,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { assertSpyCalls, spy } from "../../../test_util/std/testing/mock.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
 

--- a/cli/tests/unit_node/internal/_randomBytes_test.ts
+++ b/cli/tests/unit_node/internal/_randomBytes_test.ts
@@ -4,7 +4,7 @@ import {
   assertEquals,
   assertRejects,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { randomBytes } from "node:crypto";
 

--- a/cli/tests/unit_node/internal/_randomFill_test.ts
+++ b/cli/tests/unit_node/internal/_randomFill_test.ts
@@ -5,7 +5,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertThrows,
-} from "../../../../test_util/std/assert/mod.ts";
+} from "../../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
 
 const validateNonZero = (buf: Buffer) => {

--- a/cli/tests/unit_node/internal/_randomInt_test.ts
+++ b/cli/tests/unit_node/internal/_randomInt_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { randomInt } from "node:crypto";
-import { assert, assertThrows } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertThrows,
+} from "../../../../test_util/std/testing/asserts.ts";
 
 const between = (x: number, min: number, max: number) => x >= min && x < max;
 

--- a/cli/tests/unit_node/internal/pbkdf2_test.ts
+++ b/cli/tests/unit_node/internal/pbkdf2_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { pbkdf2, pbkdf2Sync } from "node:crypto";
-import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/testing/asserts.ts";
 
 type Algorithms =
   | "md5"

--- a/cli/tests/unit_node/internal/scrypt_test.ts
+++ b/cli/tests/unit_node/internal/scrypt_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { scrypt, scryptSync } from "node:crypto";
 import { Buffer } from "node:buffer";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../../test_util/std/async/deferred.ts";
 
 Deno.test("scrypt works correctly", async () => {

--- a/cli/tests/unit_node/module_test.ts
+++ b/cli/tests/unit_node/module_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import { createRequire, Module } from "node:module";
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../test_util/std/testing/asserts.ts";
 import process from "node:process";
 import * as path from "node:path";
 

--- a/cli/tests/unit_node/net_test.ts
+++ b/cli/tests/unit_node/net_test.ts
@@ -1,7 +1,10 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import * as net from "node:net";
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../test_util/std/testing/asserts.ts";
 import { Deferred, deferred } from "../../../test_util/std/async/deferred.ts";
 import * as path from "../../../test_util/std/path/mod.ts";
 import * as http from "node:http";

--- a/cli/tests/unit_node/os_test.ts
+++ b/cli/tests/unit_node/os_test.ts
@@ -7,7 +7,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertThrows,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test({
   name: "build architecture is a string",

--- a/cli/tests/unit_node/path_test.ts
+++ b/cli/tests/unit_node/path_test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import posix from "node:path/posix";
 import win32 from "node:path/win32";
 
-import { assertStrictEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertStrictEquals } from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test("[node/path] posix and win32 objects", () => {
   assertStrictEquals(path.posix, posix);

--- a/cli/tests/unit_node/perf_hooks_test.ts
+++ b/cli/tests/unit_node/perf_hooks_test.ts
@@ -4,7 +4,7 @@ import { performance } from "node:perf_hooks";
 import {
   assertEquals,
   assertThrows,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test({
   name: "[perf_hooks] performance",

--- a/cli/tests/unit_node/process_test.ts
+++ b/cli/tests/unit_node/process_test.ts
@@ -11,7 +11,7 @@ import {
   assertObjectMatch,
   assertStrictEquals,
   assertThrows,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { stripColor } from "../../../test_util/std/fmt/colors.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
 import * as path from "../../../test_util/std/path/mod.ts";

--- a/cli/tests/unit_node/querystring_test.ts
+++ b/cli/tests/unit_node/querystring_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 import { parse, stringify } from "node:querystring";
 
 Deno.test({

--- a/cli/tests/unit_node/readline_test.ts
+++ b/cli/tests/unit_node/readline_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { createInterface, Interface } from "node:readline";
-import { assertInstanceOf } from "../../../test_util/std/assert/mod.ts";
+import { assertInstanceOf } from "../../../test_util/std/testing/asserts.ts";
 import { Readable, Writable } from "node:stream";
 
 Deno.test("[node/readline] createInstance", () => {

--- a/cli/tests/unit_node/repl_test.ts
+++ b/cli/tests/unit_node/repl_test.ts
@@ -2,7 +2,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 import repl from "node:repl";
-import { assert } from "../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../test_util/std/testing/asserts.ts";
 
 Deno.test({
   name: "repl module exports",

--- a/cli/tests/unit_node/stream_test.ts
+++ b/cli/tests/unit_node/stream_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assert } from "../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../test_util/std/testing/asserts.ts";
 import { fromFileUrl, relative } from "../../../test_util/std/path/mod.ts";
 import { pipeline } from "node:stream/promises";
 import { createReadStream, createWriteStream } from "node:fs";

--- a/cli/tests/unit_node/string_decoder_test.ts
+++ b/cli/tests/unit_node/string_decoder_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 import { Buffer } from "node:buffer";
 import { StringDecoder } from "node:string_decoder";
 

--- a/cli/tests/unit_node/timers_test.ts
+++ b/cli/tests/unit_node/timers_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assert, fail } from "../../../test_util/std/assert/mod.ts";
+import { assert, fail } from "../../../test_util/std/testing/asserts.ts";
 import * as timers from "node:timers";
 import * as timersPromises from "node:timers/promises";
 

--- a/cli/tests/unit_node/tls_test.ts
+++ b/cli/tests/unit_node/tls_test.ts
@@ -3,7 +3,7 @@
 import {
   assertEquals,
   assertInstanceOf,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { delay } from "../../../test_util/std/async/delay.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
 import { fromFileUrl, join } from "../../../test_util/std/path/mod.ts";

--- a/cli/tests/unit_node/tty_test.ts
+++ b/cli/tests/unit_node/tty_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 
-import { assert } from "../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../test_util/std/testing/asserts.ts";
 import { isatty } from "node:tty";
 
 Deno.test("[node/tty isatty] returns true when fd is a tty, false otherwise", () => {

--- a/cli/tests/unit_node/util_test.ts
+++ b/cli/tests/unit_node/util_test.ts
@@ -5,7 +5,7 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { stripColor } from "../../../test_util/std/fmt/colors.ts";
 import * as util from "node:util";
 

--- a/cli/tests/unit_node/v8_test.ts
+++ b/cli/tests/unit_node/v8_test.ts
@@ -4,7 +4,7 @@ import {
   getHeapStatistics,
   setFlagsFromString,
 } from "node:v8";
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../test_util/std/testing/asserts.ts";
 
 // https://github.com/nodejs/node/blob/a2bbe5ff216bc28f8dac1c36a8750025a93c3827/test/parallel/test-v8-version-tag.js#L6
 Deno.test({

--- a/cli/tests/unit_node/worker_threads_test.ts
+++ b/cli/tests/unit_node/worker_threads_test.ts
@@ -4,7 +4,7 @@ import {
   assert,
   assertEquals,
   assertObjectMatch,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../test_util/std/testing/asserts.ts";
 import { fromFileUrl, relative } from "../../../test_util/std/path/mod.ts";
 import * as workerThreads from "node:worker_threads";
 import { EventEmitter, once } from "node:events";

--- a/cli/tests/unit_node/zlib_test.ts
+++ b/cli/tests/unit_node/zlib_test.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "../../../test_util/std/testing/asserts.ts";
 import { deferred } from "../../../test_util/std/async/deferred.ts";
 import { fromFileUrl, relative } from "../../../test_util/std/path/mod.ts";
 import {

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -10,7 +10,7 @@ import {
   assertInstanceOf,
   assertEquals,
   assertFalse,
-} from "../../test_util/std/assert/mod.ts";
+} from "../../test_util/std/testing/asserts.ts";
 
 const targetDir = Deno.execPath().replace(/[^\/\\]+$/, "");
 const [libPrefix, libSuffix] = {

--- a/test_napi/common.js
+++ b/test_napi/common.js
@@ -5,7 +5,7 @@ export {
   assertEquals,
   assertRejects,
   assertThrows,
-} from "../test_util/std/assert/mod.ts";
+} from "../test_util/std/testing/asserts.ts";
 export { fromFileUrl } from "../test_util/std/path/mod.ts";
 import process from "node:process";
 


### PR DESCRIPTION
This reverts commit 20aa0796e6ff7651cdfce4d0292bdb11da5dfe2e.

`main` has been failing consistenly on `kv_undelivered_test` and `serve_test` after this upgrade.