### PR TITLE
chore: start codesigning mac release builds

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -284,7 +284,9 @@ function handleMatrixItems(items: {
 
       // deno-lint-ignore no-explicit-any
       (item as any).runner = text;
-      item.skip = "${{ !contains(github.event.pull_request.labels.*.name, 'ci-full') && (" + removeSurroundingExpression(item.skip.toString()) + ") }}";
+      item.skip =
+        "${{ !contains(github.event.pull_request.labels.*.name, 'ci-full') && (" +
+        removeSurroundingExpression(item.skip.toString()) + ") }}";
     }
 
     return {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -718,7 +718,12 @@ const ci = {
             "github.repository == 'denoland/deno'",
           ].join("\n"),
           run: [
-            "rcodesign sign target/release/deno",
+            'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
+            "rcodesign sign target/release/deno " +
+            "--code-signature-flags=runtime " +
+            '--p12-password="$APPLE_CODESIGN_PASSWORD" ' +
+            "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " +
+            "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",
             "zip -r deno-aarch64-apple-darwin.zip deno",
           ]

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -701,7 +701,7 @@ const ci = {
             'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
             "rcodesign sign target/release/deno " +
             "--code-signature-flags=runtime " +
-            "--p12-password='$APPLE_CODESIGN_PASSWORD' " +
+            '--p12-password="$APPLE_CODESIGN_PASSWORD" ' +
             "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " +
             "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -693,7 +693,11 @@ const ci = {
             "github.repository == 'denoland/deno'",
           ].join("\n"),
           run: [
-            "rcodesign sign target/release/deno",
+            "rcodesign sign target/release/deno " + 
+              "--code-signature-flags=runtime " +
+              "--p12-password='$APPLE_CODESIGN_PASSWORD' " + 
+              "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " + 
+              "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",
             "zip -r deno-x86_64-apple-darwin.zip deno",
           ]

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -696,7 +696,9 @@ const ci = {
             "APPLE_CODESIGN_KEY": "${{ secrets.APPLE_CODESIGN_KEY }}",
             "APPLE_CODESIGN_PASSWORD": "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
           },
+          shell: "bash",
           run: [
+            'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
             "rcodesign sign target/release/deno " +
             "--code-signature-flags=runtime " +
             "--p12-password='$APPLE_CODESIGN_PASSWORD' " +

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -696,7 +696,6 @@ const ci = {
             "APPLE_CODESIGN_KEY": "${{ secrets.APPLE_CODESIGN_KEY }}",
             "APPLE_CODESIGN_PASSWORD": "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
           },
-          shell: "bash",
           run: [
             'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
             "rcodesign sign target/release/deno " +
@@ -717,6 +716,10 @@ const ci = {
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno'",
           ].join("\n"),
+          env: {
+            "APPLE_CODESIGN_KEY": "${{ secrets.APPLE_CODESIGN_KEY }}",
+            "APPLE_CODESIGN_PASSWORD": "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
+          },
           run: [
             'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
             "rcodesign sign target/release/deno " +

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -692,12 +692,16 @@ const ci = {
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno'",
           ].join("\n"),
+          env: {
+            "APPLE_CODESIGN_KEY": "${{ secrets.APPLE_CODESIGN_KEY }}",
+            "APPLE_CODESIGN_PASSWORD": "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
+          },
           run: [
-            "rcodesign sign target/release/deno " + 
-              "--code-signature-flags=runtime " +
-              "--p12-password='$APPLE_CODESIGN_PASSWORD' " + 
-              "--p12-file=<(echo $APPLE_CODESIGN_KEY) " + 
-              "--entitlements-xml-file=cli/entitlements.plist",
+            "rcodesign sign target/release/deno " +
+            "--code-signature-flags=runtime " +
+            "--p12-password='$APPLE_CODESIGN_PASSWORD' " +
+            "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " +
+            "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",
             "zip -r deno-x86_64-apple-darwin.zip deno",
           ]

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -696,7 +696,7 @@ const ci = {
             "rcodesign sign target/release/deno " + 
               "--code-signature-flags=runtime " +
               "--p12-password='$APPLE_CODESIGN_PASSWORD' " + 
-              "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " + 
+              "--p12-file=<(echo $APPLE_CODESIGN_KEY) " + 
               "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",
             "zip -r deno-x86_64-apple-darwin.zip deno",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
         shell: bash
         run: |-
           echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
-          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
+          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (mac aarch64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,9 @@ jobs:
         env:
           APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
           APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
+        shell: bash
         run: |-
+          echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
           rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,8 +406,11 @@ jobs:
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
+        env:
+          APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
+          APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
         run: |-
-          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY) --entitlements-xml-file=cli/entitlements.plist
+          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (mac aarch64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,14 @@ jobs:
           - os: macos-12
             job: test
             profile: release
-            skip: '${{ github.event_name == ''pull_request'' }}'
-            runner: '${{ (github.event_name == ''pull_request'') && ''ubuntu-22.04'' || ''macos-12'' }}'
+            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || ''macos-12'' }}'
             os_display_name: macos-x86_64
           - os: macos-13-xlarge
             job: test
             profile: release
-            skip: '${{ github.event_name == ''pull_request'' || github.ref == ''refs/heads/main'' }}'
-            runner: '${{ (github.event_name == ''pull_request'' || github.ref == ''refs/heads/main'') && ''ubuntu-22.04'' || ''macos-13-xlarge'' }}'
+            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' || github.ref == ''refs/heads/main'') }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' || github.ref == ''refs/heads/main'')) && ''ubuntu-22.04'' || ''macos-13-xlarge'' }}'
             os_display_name: macos-aarch64
           - os: windows-2022
             job: test
@@ -76,8 +76,8 @@ jobs:
           - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
             profile: release
-            skip: '${{ github.event_name == ''pull_request'' }}'
-            runner: '${{ (github.event_name == ''pull_request'') && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
+            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             os_display_name: windows-x86_64
           - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: test
@@ -89,8 +89,8 @@ jobs:
             job: bench
             profile: release
             use_sysroot: true
-            skip: '${{ github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench'') }}'
-            runner: '${{ (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench'')) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
+            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench'')) }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench''))) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             os_display_name: ubuntu-x86_64
           - os: ubuntu-22.04
             job: test
@@ -301,10 +301,13 @@ jobs:
           CFLAGS=-flto=thin --sysroot=/sysroot
           __0
       - name: Install aarch64 lld
-        run: |-
-          ./tools/install_prebuilt.js ld64.lld
-          echo $GITHUB_WORKSPACE/third_party/prebuilt/mac >> $GITHUB_PATH
+        run: ./tools/install_prebuilt.js ld64.lld
         if: '!(matrix.skip) && (matrix.os == ''macos-13-xlarge'')'
+      - name: Install rust-codesign
+        run: |-
+          ./tools/install_prebuilt.js rcodesign
+          echo $GITHUB_WORKSPACE/third_party/prebuilt/mac >> $GITHUB_PATH
+        if: '!(matrix.skip) && ((matrix.os == ''macos-13-xlarge'' || matrix.os == ''macos-12''))'
       - name: Log versions
         run: |-
           python --version
@@ -404,6 +407,7 @@ jobs:
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-
+          rcodesign sign target/release/deno
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (mac aarch64)
@@ -413,6 +417,7 @@ jobs:
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-
+          rcodesign sign target/release/deno
           cd target/release
           zip -r deno-aarch64-apple-darwin.zip deno
       - name: Pre-release (windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,6 @@ jobs:
         env:
           APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
           APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
-        shell: bash
         run: |-
           echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
           rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
@@ -421,6 +420,9 @@ jobs:
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
+        env:
+          APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
+          APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
         run: |-
           echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
           rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-
-          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
+          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (mac aarch64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,8 @@ jobs:
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-
-          rcodesign sign target/release/deno
+          echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
+          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-aarch64-apple-darwin.zip deno
       - name: Pre-release (windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-
-          rcodesign sign target/release/deno
+          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password='$APPLE_CODESIGN_PASSWORD' --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-x86_64-apple-darwin.zip deno
       - name: Pre-release (mac aarch64)

--- a/cli/entitlements.plist
+++ b/cli/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/util.js
+++ b/tools/util.js
@@ -17,7 +17,7 @@ const versions = {
   "dlint": "dlint 0.51.0",
 };
 
-const compressed = new Set(["ld64.lld"]);
+const compressed = new Set(["ld64.lld", "rcodesign"]);
 
 export const ROOT_PATH = dirname(dirname(fromFileUrl(import.meta.url)));
 
@@ -175,8 +175,9 @@ export function getPrebuiltToolPath(toolName) {
   return join(PREBUILT_TOOL_DIR, toolName + executableSuffix);
 }
 
+const commitId = "c249f61eaed67db26c2934b195dc51e3ab91ae03";
 const downloadUrl =
-  `https://raw.githubusercontent.com/denoland/deno_third_party/1fd66ef78ab40841db833d4a1efd5c5597faf066/prebuilt/${platformDirName}`;
+  `https://raw.githubusercontent.com/denoland/deno_third_party/${commitId}/prebuilt/${platformDirName}`;
 
 export async function downloadPrebuilt(toolName) {
   // Ensure only one download per tool happens at a time


### PR DESCRIPTION
- Adds a codesigning step to all mac targets
- Adds a new ci-full label to the build to force aarch64 builds on any PR

