### PR TITLE
feat(fmt): Support `.ipynb` extension

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -30,6 +30,7 @@
     "cli/tests/testdata/file_extensions/ts_with_js_extension.js",
     "cli/tests/testdata/fmt/badly_formatted.json",
     "cli/tests/testdata/fmt/badly_formatted.md",
+    "cli/tests/testdata/fmt/badly_formatted.ipynb",
     "cli/tests/testdata/byte_order_mark.ts",
     "cli/tests/testdata/encoding",
     "cli/tests/testdata/fmt/",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "dissimilar",
  "dotenvy",
  "dprint-plugin-json",
+ "dprint-plugin-jupyter",
  "dprint-plugin-markdown",
  "dprint-plugin-typescript",
  "encoding_rs",
@@ -1938,6 +1939,19 @@ dependencies = [
  "jsonc-parser",
  "serde",
  "text_lines",
+]
+
+[[package]]
+name = "dprint-plugin-jupyter"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65cf5dd43b15bf9dbb69a2d0e331106d6e3d33d8678d32385245993e8855c02"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "jsonc-parser",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,6 +84,7 @@ dotenvy = "0.15.7"
 dprint-plugin-json = "=0.19.1"
 dprint-plugin-markdown = "=0.16.3"
 dprint-plugin-typescript = "=0.88.5"
+dprint-plugin-jupyter = "=0.1.1"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1613,7 +1613,9 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
             .help("Set content type of the supplied file")
             // prefer using ts for formatting instead of js because ts works in more scenarios
             .default_value("ts")
-            .value_parser(["ts", "tsx", "js", "jsx", "md", "json", "jsonc"]),
+            .value_parser([
+              "ts", "tsx", "js", "jsx", "md", "json", "jsonc", "ipynb",
+            ]),
         )
         .arg(
           Arg::new("ignore")

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -359,11 +359,7 @@ fn create_cli_snapshot(snapshot_path: PathBuf) -> CreateSnapshotOutput {
   // Ideally we could deduplicate that code.
   fn deno_version() -> String {
     if env::var("DENO_CANARY").is_ok() {
-      format!(
-        "{}+{}",
-        env!("CARGO_PKG_VERSION"),
-        git_commit_hash()[..7].to_string()
-      )
+      format!("{}+{}", env!("CARGO_PKG_VERSION"), &git_commit_hash()[..7])
     } else {
       env!("CARGO_PKG_VERSION").to_string()
     }

--- a/cli/tests/integration/fmt_tests.rs
+++ b/cli/tests/integration/fmt_tests.rs
@@ -27,18 +27,24 @@ fn fmt_test() {
     testdata_fmt_dir.join("badly_formatted.json");
   let badly_formatted_json = t.path().join("badly_formatted.json");
   badly_formatted_original_json.copy(&badly_formatted_json);
-  // First, check formatting by ignoring the badly formatted file.
 
+  let fixed_ipynb = testdata_fmt_dir.join("badly_formatted_fixed.ipynb");
+  let badly_formatted_original_ipynb =
+    testdata_fmt_dir.join("badly_formatted.ipynb");
+  let badly_formatted_ipynb = t.path().join("badly_formatted.ipynb");
+  badly_formatted_original_ipynb.copy(&badly_formatted_ipynb);
+
+  // First, check formatting by ignoring the badly formatted file.
   let output = context
     .new_command()
     .current_dir(&testdata_fmt_dir)
     .args_vec(vec![
       "fmt".to_string(),
       format!(
-        "--ignore={badly_formatted_js},{badly_formatted_md},{badly_formatted_json}",
+        "--ignore={badly_formatted_js},{badly_formatted_md},{badly_formatted_json},{badly_formatted_ipynb}",
       ),
       format!(
-        "--check {badly_formatted_js} {badly_formatted_md} {badly_formatted_json}",
+        "--check {badly_formatted_js} {badly_formatted_md} {badly_formatted_json} {badly_formatted_ipynb}",
       ),
     ])
     .run();
@@ -57,6 +63,7 @@ fn fmt_test() {
       badly_formatted_js.to_string(),
       badly_formatted_md.to_string(),
       badly_formatted_json.to_string(),
+      badly_formatted_ipynb.to_string(),
     ])
     .run();
 
@@ -72,6 +79,7 @@ fn fmt_test() {
       badly_formatted_js.to_string(),
       badly_formatted_md.to_string(),
       badly_formatted_json.to_string(),
+      badly_formatted_ipynb.to_string(),
     ])
     .run();
 
@@ -81,12 +89,15 @@ fn fmt_test() {
   let expected_js = fixed_js.read_to_string();
   let expected_md = fixed_md.read_to_string();
   let expected_json = fixed_json.read_to_string();
+  let expected_ipynb = fixed_ipynb.read_to_string();
   let actual_js = badly_formatted_js.read_to_string();
   let actual_md = badly_formatted_md.read_to_string();
   let actual_json = badly_formatted_json.read_to_string();
+  let actual_ipynb = badly_formatted_ipynb.read_to_string();
   assert_eq!(expected_js, actual_js);
   assert_eq!(expected_md, actual_md);
   assert_eq!(expected_json, actual_json);
+  assert_eq!(expected_ipynb, actual_ipynb);
 }
 
 #[test]
@@ -196,6 +207,12 @@ itest!(fmt_stdin_json {
   args: "fmt --ext=json -",
   input: Some("{    \"key\":   \"value\"}"),
   output_str: Some("{ \"key\": \"value\" }\n"),
+});
+
+itest!(fmt_stdin_ipynb {
+  args: "fmt --ext=ipynb -",
+  input: Some(include_str!("../testdata/fmt/badly_formatted.ipynb")),
+  output_str: Some(include_str!("../testdata/fmt/badly_formatted_fixed.ipynb")),
 });
 
 itest!(fmt_stdin_check_formatted {

--- a/cli/tests/testdata/fmt/badly_formatted.ipynb
+++ b/cli/tests/testdata/fmt/badly_formatted.ipynb
@@ -1,80 +1,105 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Hello      Markdown\n",
-        "this isn't formatted properly\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Hello World\n"
-          ]
-        }
-      ],
-      "source": [
-        "console.log(\"Hello World\"\n",
-        "\n",
-        ");\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "alice\n"
-          ]
-        }
-      ],
-      "source": [
-        "function hello(name: string    ) {\n",
-        "                  console.log(name);\n",
-        "};\n",
-        "\n",
-        "hello(        \"alice\");\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "function foo(): number {\n",
-        "  return       2;\n",
-        "}\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Deno",
-      "language": "typescript",
-      "name": "deno"
-    },
-    "language_info": {
-      "file_extension": ".ts",
-      "mimetype": "text/x.typescript",
-      "name": "typescript",
-      "nb_converter": "script",
-      "pygments_lexer": "typescript",
-      "version": "5.2.2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hello      Markdown\n",
+    "this isn't formatted properly"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello World\n"
+     ]
+    }
+   ],
+   "source": [
+    "console.log(\"Hello World\"\n",
+    "\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "raw text\n",
+    "  here too\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alice\n"
+     ]
+    }
+   ],
+   "source": [
+    "function hello(name: string    ) {\n",
+    "                  console.log(name);\n",
+    "};\n",
+    "\n",
+    "hello(        \"alice\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function foo(): number {\n",
+    "  return       2;\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\n"
+     ]
+    }
+   ],
+   "source": [
+    "console.log(\"loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Deno",
+   "language": "typescript",
+   "name": "deno"
+  },
+  "language_info": {
+   "file_extension": ".ts",
+   "mimetype": "text/x.typescript",
+   "name": "typescript",
+   "nb_converter": "script",
+   "pygments_lexer": "typescript",
+   "version": "5.2.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/cli/tests/testdata/fmt/badly_formatted.ipynb
+++ b/cli/tests/testdata/fmt/badly_formatted.ipynb
@@ -1,0 +1,80 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Hello      Markdown\n",
+        "this isn't formatted properly\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Hello World\n"
+          ]
+        }
+      ],
+      "source": [
+        "console.log(\"Hello World\"\n",
+        "\n",
+        ");\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "alice\n"
+          ]
+        }
+      ],
+      "source": [
+        "function hello(name: string    ) {\n",
+        "                  console.log(name);\n",
+        "};\n",
+        "\n",
+        "hello(        \"alice\");\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "function foo(): number {\n",
+        "  return       2;\n",
+        "}\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Deno",
+      "language": "typescript",
+      "name": "deno"
+    },
+    "language_info": {
+      "file_extension": ".ts",
+      "mimetype": "text/x.typescript",
+      "name": "typescript",
+      "nb_converter": "script",
+      "pygments_lexer": "typescript",
+      "version": "5.2.2"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/cli/tests/testdata/fmt/badly_formatted_fixed.ipynb
+++ b/cli/tests/testdata/fmt/badly_formatted_fixed.ipynb
@@ -1,79 +1,106 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Hello Markdown\n",
-        "\n",
-        "this isn't formatted properly\n"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "console.log(\"Hello World\");\n"
-      ],
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Hello World\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "function hello(name: string) {\n",
-        "  console.log(name);\n",
-        "}\n",
-        "\n",
-        "hello(\"alice\");\n"
-      ],
-      "execution_count": 2,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "alice\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "function foo(): number {\n",
-        "  return 2;\n",
-        "}\n"
-      ],
-      "execution_count": 3,
-      "metadata": {},
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "language_info": {
-      "name": "typescript",
-      "file_extension": ".ts",
-      "mimetype": "text/x.typescript",
-      "nb_converter": "script",
-      "pygments_lexer": "typescript",
-      "version": "5.2.2"
-    },
-    "kernelspec": {
-      "display_name": "Deno",
-      "language": "typescript",
-      "name": "deno"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hello Markdown\n",
+    "\n",
+    "this isn't formatted properly"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello World\n"
+     ]
+    }
+   ],
+   "source": [
+    "console.log(\"Hello World\");"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "raw text\n",
+    "  here too\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alice\n"
+     ]
+    }
+   ],
+   "source": [
+    "function hello(name: string) {\n",
+    "  console.log(name);\n",
+    "}\n",
+    "\n",
+    "hello(\"alice\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function foo(): number {\n",
+    "  return 2;\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\n"
+     ]
+    }
+   ],
+   "source": [
+    "console.log(\n",
+    "  \"loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\",\n",
+    ");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Deno",
+   "language": "typescript",
+   "name": "deno"
+  },
+  "language_info": {
+   "file_extension": ".ts",
+   "mimetype": "text/x.typescript",
+   "name": "typescript",
+   "nb_converter": "script",
+   "pygments_lexer": "typescript",
+   "version": "5.2.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/cli/tests/testdata/fmt/badly_formatted_fixed.ipynb
+++ b/cli/tests/testdata/fmt/badly_formatted_fixed.ipynb
@@ -1,0 +1,79 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Hello Markdown\n",
+        "\n",
+        "this isn't formatted properly\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "console.log(\"Hello World\");\n"
+      ],
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Hello World\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "function hello(name: string) {\n",
+        "  console.log(name);\n",
+        "}\n",
+        "\n",
+        "hello(\"alice\");\n"
+      ],
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "alice\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "function foo(): number {\n",
+        "  return 2;\n",
+        "}\n"
+      ],
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "typescript",
+      "file_extension": ".ts",
+      "mimetype": "text/x.typescript",
+      "nb_converter": "script",
+      "pygments_lexer": "typescript",
+      "version": "5.2.2"
+    },
+    "kernelspec": {
+      "display_name": "Deno",
+      "language": "typescript",
+      "name": "deno"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/cli/tests/testdata/fmt/expected_fmt_check_verbose_tests_dir.out
+++ b/cli/tests/testdata/fmt/expected_fmt_check_verbose_tests_dir.out
@@ -1,2 +1,2 @@
 [WILDCARD]
-error: Found 1 not formatted file in [WILDCARD] files
+error: Found 2 not formatted file in [WILDCARD] files

--- a/cli/tests/testdata/fmt/expected_fmt_check_verbose_tests_dir.out
+++ b/cli/tests/testdata/fmt/expected_fmt_check_verbose_tests_dir.out
@@ -1,2 +1,0 @@
-[WILDCARD]
-error: Found 2 not formatted file in [WILDCARD] files

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -29,10 +29,14 @@ use deno_core::error::generic_error;
 use deno_core::error::AnyError;
 use deno_core::futures;
 use deno_core::parking_lot::Mutex;
+use deno_core::serde_json;
 use deno_core::unsync::spawn_blocking;
 use log::debug;
 use log::info;
 use log::warn;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::stdin;
 use std::io::stdout;
@@ -45,6 +49,57 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::cache::IncrementalCache;
+
+/// Representation of a Jupyter Notebook file.
+/// To preserve the structure of file, extra fields are stored in `extra` field.
+///
+/// See <https://nbformat.readthedocs.io/en/latest/format_description.html>
+#[derive(Serialize, Deserialize)]
+struct Ipynb {
+  cells: Vec<Cell>,
+  metadata: Metadata,
+
+  #[serde(flatten)]
+  extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl Ipynb {
+  fn is_typescript(&self) -> bool {
+    self.metadata.language_info.name == "typescript"
+  }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Cell {
+  cell_type: String,
+  source: Source,
+
+  #[serde(flatten)]
+  extra: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum Source {
+  String(String),
+  Array(Vec<String>),
+}
+
+#[derive(Serialize, Deserialize)]
+struct Metadata {
+  language_info: LanguageInfo,
+
+  #[serde(flatten)]
+  extra: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct LanguageInfo {
+  name: String,
+
+  #[serde(flatten)]
+  extra: BTreeMap<String, serde_json::Value>,
+}
 
 /// Format JavaScript/TypeScript files.
 pub async fn format(flags: Flags, fmt_flags: FmtFlags) -> Result<(), AnyError> {
@@ -223,6 +278,63 @@ pub fn format_json(
   dprint_plugin_json::format_text(file_path, file_text, &config)
 }
 
+/// Formats IPYNB files.
+///
+/// attempt to format `code` cells if metadata indicates it's TypeScript.
+fn format_ipynb(
+  ipynb: Ipynb,
+  fmt_options: &FmtOptionsConfig,
+) -> Result<Option<String>, AnyError> {
+  fn source_from(text: String) -> Source {
+    Source::Array(text.split_inclusive('\n').map(|x| x.into()).collect())
+  }
+
+  let is_typescript = ipynb.is_typescript();
+  let cells: Vec<Result<Cell, Cell>> = ipynb
+    .cells
+    .into_iter()
+    .map(|cell| {
+      let source = match cell.source {
+        Source::String(text) => text,
+        Source::Array(texts) => texts.join(""),
+      };
+
+      let formatted = match cell.cell_type.as_str() {
+        "code" if is_typescript => Some("temp.ts"),
+        "markdown" => Some("temp.md"),
+        _ => None,
+      }
+      .map(|path| format_file(&PathBuf::from(path), &source, fmt_options))
+      .unwrap_or(Ok(None));
+
+      match formatted {
+        Ok(Some(text)) => Ok(Cell {
+          source: source_from(text),
+          ..cell
+        }),
+        _ => Err(Cell {
+          source: source_from(source),
+          ..cell
+        }),
+      }
+    })
+    .collect();
+
+  let already_formatted = cells.iter().all(|cell| cell.is_err());
+
+  if already_formatted {
+    return Ok(None);
+  }
+  let cells = cells
+    .into_iter()
+    .map(|cell| cell.unwrap_or_else(|cell| cell))
+    .collect::<Vec<_>>();
+
+  let result = serde_json::to_string_pretty(&Ipynb { cells, ..ipynb });
+
+  Ok(result.map(Some)?)
+}
+
 /// Formats a single TS, TSX, JS, JSX, JSONC, JSON,  MD, or IPYNB file.
 pub fn format_file(
   file_path: &Path,
@@ -236,6 +348,10 @@ pub fn format_file(
       format_markdown(file_text, fmt_options)
     }
     "json" | "jsonc" => format_json(file_path, file_text, fmt_options),
+    "ipynb" => {
+      let ipynb = serde_json::from_str::<Ipynb>(file_text)?;
+      format_ipynb(ipynb, fmt_options)
+    }
     _ => {
       let config = get_resolved_typescript_config(fmt_options);
       dprint_plugin_typescript::format_text(file_path, file_text, &config)
@@ -686,6 +802,7 @@ fn is_supported_ext_fmt(path: &Path) -> bool {
         | "mdwn"
         | "mdown"
         | "markdown"
+        | "ipynb"
     )
   })
 }

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -223,7 +223,7 @@ pub fn format_json(
   dprint_plugin_json::format_text(file_path, file_text, &config)
 }
 
-/// Formats a single TS, TSX, JS, JSX, JSONC, JSON,  MD, or IPYNB file.
+/// Formats a single TS, TSX, JS, JSX, JSONC, JSON, MD, or IPYNB file.
 pub fn format_file(
   file_path: &Path,
   file_text: &str,

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -223,23 +223,23 @@ pub fn format_json(
   dprint_plugin_json::format_text(file_path, file_text, &config)
 }
 
-/// Formats a single TS, TSX, JS, JSX, JSONC, JSON, or MD file.
+/// Formats a single TS, TSX, JS, JSX, JSONC, JSON,  MD, or IPYNB file.
 pub fn format_file(
   file_path: &Path,
   file_text: &str,
   fmt_options: &FmtOptionsConfig,
 ) -> Result<Option<String>, AnyError> {
   let ext = get_extension(file_path).unwrap_or_default();
-  if matches!(
-    ext.as_str(),
-    "md" | "mkd" | "mkdn" | "mdwn" | "mdown" | "markdown"
-  ) {
-    format_markdown(file_text, fmt_options)
-  } else if matches!(ext.as_str(), "json" | "jsonc") {
-    format_json(file_path, file_text, fmt_options)
-  } else {
-    let config = get_resolved_typescript_config(fmt_options);
-    dprint_plugin_typescript::format_text(file_path, file_text, &config)
+
+  match ext.as_str() {
+    "md" | "mkd" | "mkdn" | "mdwn" | "mdown" | "markdown" => {
+      format_markdown(file_text, fmt_options)
+    }
+    "json" | "jsonc" => format_json(file_path, file_text, fmt_options),
+    _ => {
+      let config = get_resolved_typescript_config(fmt_options);
+      dprint_plugin_typescript::format_text(file_path, file_text, &config)
+    }
   }
 }
 
@@ -667,7 +667,7 @@ where
 /// This function is similar to is_supported_ext but adds additional extensions
 /// supported by `deno fmt`.
 fn is_supported_ext_fmt(path: &Path) -> bool {
-  if let Some(ext) = get_extension(path) {
+  get_extension(path).is_some_and(|ext| {
     matches!(
       ext.as_str(),
       "ts"
@@ -687,9 +687,7 @@ fn is_supported_ext_fmt(path: &Path) -> bool {
         | "mdown"
         | "markdown"
     )
-  } else {
-    false
-  }
+  })
 }
 
 #[cfg(test)]
@@ -721,6 +719,7 @@ mod test {
     assert!(is_supported_ext_fmt(Path::new("foo.JSONC")));
     assert!(is_supported_ext_fmt(Path::new("foo.json")));
     assert!(is_supported_ext_fmt(Path::new("foo.JsON")));
+    assert!(is_supported_ext_fmt(Path::new("foo.ipynb")));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- resolves #20810

<details><summary>outdated</summary>

changed to using dprint's jupyter plugin

## Questions

### Extracting structs

I'm not sure if  `cli/tools/fmt.rs` is the correct place for 4 struct for jupyter notebook definition. Which module should i move the structs to?

### Checking whether it's TypeScript notebook

not sure which field is the best. currently using
`self.metadata.language_info.name == "typescript"`

### Frequent rebuilds

I'm suspecting `include_str!` macro is busting incremental build caches.

### mutation vs cloning

iterating twice (first: format cells, second: check if changes are identical) sounds inefficient, but i'm slightly against using mutation here.

### ~~`serde(flatten)` is unstable~~

```
$ cargo run --features __runtime_js_sources -- fmt cli/tests/testdata/fmt/badly_formatted_fixed.ipynb
$ cargo test --features __runtime_js_sources integration::fmt
```

EDIT: fixed by changing from `HashMap` to `BTreeMap`.

related: https://old.reddit.com/r/rust/comments/krgvcu/is_the_iteration_order_of_hashset_deterministic/

</details>