### PR TITLE
chore: fix upgrade_prompt test on main

### DIFF
--- a/cli/tests/integration/upgrade_tests.rs
+++ b/cli/tests/integration/upgrade_tests.rs
@@ -223,7 +223,11 @@ fn upgrade_prompt() {
     // - We need to use a pty here because the upgrade prompt
     //   doesn't occur except when there's a pty.
     // - Version comes from the test server.
-    pty.expect(" 99999.99.99 Run `deno upgrade` to install it.");
+    pty.expect_any(&[
+      " 99999.99.99 Run `deno upgrade` to install it.",
+      // it builds canary releases on main, so check for this in that case
+      "Run `deno upgrade --canary` to install it.",
+    ]);
   });
 }
 

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1282,12 +1282,29 @@ async fn main_server(
           .unwrap(),
       );
     }
+    (&hyper::Method::GET, "/upgrade/sleep/canary-latest.txt") => {
+      tokio::time::sleep(Duration::from_secs(45)).await;
+      return Ok(
+        Response::builder()
+          .status(StatusCode::OK)
+          .body(Body::from("bda3850f84f24b71e02512c1ba2d6bf2e3daa2fd"))
+          .unwrap(),
+      );
+    }
     (&hyper::Method::GET, "/release-latest.txt") => {
       return Ok(
         Response::builder()
           .status(StatusCode::OK)
           // use a deno version that will never happen
           .body(Body::from("99999.99.99"))
+          .unwrap(),
+      );
+    }
+    (&hyper::Method::GET, "/canary-latest.txt") => {
+      return Ok(
+        Response::builder()
+          .status(StatusCode::OK)
+          .body(Body::from("bda3850f84f24b71e02512c1ba2d6bf2e3daa2fd"))
           .unwrap(),
       );
     }


### PR DESCRIPTION
Issue was main does canary builds, which broke this test because it didn't handle searching for a canary release. Tested by building as canary locally.