### PR TITLE
chore: provide error message when a deno.json will be auto-discovered by the test suite

### DIFF
--- a/test_util/src/builders.rs
+++ b/test_util/src/builders.rs
@@ -32,6 +32,37 @@ use crate::testdata_path;
 use crate::HttpServerGuard;
 use crate::TempDir;
 
+// Gives the developer a nice error message if they have a deno configuration
+// file that will be auto-discovered by the tests and cause a lot of failures.
+static HAS_DENO_JSON_IN_WORKING_DIR_ERR: once_cell::sync::Lazy<Option<String>> =
+  once_cell::sync::Lazy::new(|| {
+    let testdata_path = testdata_path();
+    let mut current_dir = testdata_path.as_path();
+    let deno_json_names = ["deno.json", "deno.jsonc"];
+    loop {
+      for name in deno_json_names {
+        let deno_json_path = current_dir.join(name);
+        if deno_json_path.exists() {
+          return Some(format!(
+            concat!(
+              "Found deno configuration file at {}. The test suite relies on ",
+              "a deno.json not existing in any ancestor directory. Please ",
+              "delete this file so the tests won't auto-discover it.",
+            ),
+            deno_json_path.display(),
+          ));
+        }
+      }
+      if let Some(parent) = current_dir.parent() {
+        current_dir = parent;
+      } else {
+        break;
+      }
+    }
+
+    None
+  });
+
 #[derive(Default)]
 pub struct TestContextBuilder {
   use_http_server: bool,
@@ -121,6 +152,10 @@ impl TestContextBuilder {
   }
 
   pub fn build(&self) -> TestContext {
+    if let Some(err) = &*HAS_DENO_JSON_IN_WORKING_DIR_ERR {
+      panic!("{}", err);
+    }
+
     let temp_dir_path = self
       .temp_dir_path
       .clone()

--- a/test_util/src/pty.rs
+++ b/test_util/src/pty.rs
@@ -45,7 +45,7 @@ impl Pty {
             .contains("exit using ctrl+d, ctrl+c, or close()")
         },
         // it sometimes takes a while to startup on the CI, so use a longer timeout
-        Duration::from_secs(30),
+        Duration::from_secs(60),
       );
     }
 


### PR DESCRIPTION
Example:

```
---- integration::upgrade::upgrade_lsp_repl_sleeps stdout ----
thread 'integration::upgrade::upgrade_lsp_repl_sleeps' panicked at test_util\src\builders.rs:156:7:
Found deno configuration file at V:\deno.jsonc. The test suite relies on a deno.json not existing in any ancestor directory. Please delete this file so the tests won't auto-discover it.

---- integration::upgrade::upgrade_prompt stdout ----
thread 'integration::upgrade::upgrade_prompt' panicked at test_util\src\builders.rs:156:7:
Found deno configuration file at V:\deno.jsonc. The test suite relies on a deno.json not existing in any ancestor directory. Please delete this file so the tests won't auto-discover it.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Closes #21312
Closes #21311