### PR TITLE
fix(task): use exit code 127 for command not found and parse escaped parens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94a6fd5d889087748f4794887f28756a01b718dae92a316db0951222231325a"
+checksum = "cc333d47d4ec12897c2efd25031c02191ec115b4099470daeee10f8300035e0d"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,7 +61,7 @@ deno_lockfile.workspace = true
 deno_npm = "0.15.2"
 deno_runtime = { workspace = true, features = ["dont_create_runtime_snapshot", "exclude_runtime_main_js", "include_js_files_for_snapshotting"] }
 deno_semver = "0.5.1"
-deno_task_shell = "=0.14.0"
+deno_task_shell = "=0.14.2"
 eszip = "=0.55.4"
 napi_sym.workspace = true
 


### PR DESCRIPTION
Has these two fixes for `deno task`:

* https://github.com/denoland/deno_task_shell/pull/98
* https://github.com/denoland/deno_task_shell/pull/99