### PR TITLE
chore: bump jsonc-parser and dprint-core dependencies

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -55,9 +55,9 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.88.4.wasm",
-    "https://plugins.dprint.dev/json-0.19.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.2.wasm",
+    "https://plugins.dprint.dev/typescript-0.88.5.wasm",
+    "https://plugins.dprint.dev/json-0.19.1.wasm",
+    "https://plugins.dprint.dev/markdown-0.16.3.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",
     "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7"
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c6b9137fcc5c6f81d12214fc31cdddf2c64d0667a5458803e081ddd856d5b6"
+checksum = "97979f94af93f388822233278ede930414efa273d6eb495de7680f2a6862a4d3"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -1915,13 +1915,13 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dprint-core"
-version = "0.62.1"
+version = "0.63.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6563addfa2b6c6fa96acdda0341090beba2c5c4ff6ef91f3a232a6d4dd34156"
+checksum = "7227b28d24aafee21ff72512336c797fa00bb3ea803186b1b105a68abc97660b"
 dependencies = [
  "anyhow",
  "bumpalo",
- "indexmap 1.9.3",
+ "indexmap 2.0.2",
  "rustc-hash",
  "serde",
  "unicode-width",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-json"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8631287de4a33f7246c846e7a6cbbfd42ab8eef89520ae414e371e7bfbb85401"
+checksum = "0b6bf034eebeab36b78f45c07df87c6a578215e4f3238b5c0b6e5e66300ac348"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-markdown"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1eee7353bc4d7031dde53468356eeba7cdfe8e237085647cec3be41c3cdbc7"
+checksum = "afa43a107cebe8989fa739fa4bafcce3b98725e13dddfe061744bce86071eb60"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.88.4"
+version = "0.88.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5be6e2f026971bd4b75ed2b77203c4195587229818ddef23721f66a044907b"
+checksum = "6a4830d36624ef81389cebbefecffd437058d003698756760e4b6288b586e685"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -2986,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b56a20e76235284255a09fcd1f45cf55d3c524ea657ebd3854735925c57743d"
+checksum = "7725c320caac8c21d8228c1d055af27a995d371f78cc763073d3e068323641b5"
 dependencies = [
  "serde_json",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = "=0.6.1"
-deno_config = "=0.6.4"
+deno_config = "=0.6.5"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.73.3", features = ["html"] }
 deno_emit = "=0.31.4"
@@ -81,9 +81,9 @@ data-encoding.workspace = true
 data-url.workspace = true
 dissimilar = "=1.0.4"
 dotenvy = "0.15.7"
-dprint-plugin-json = "=0.19.0"
-dprint-plugin-markdown = "=0.16.2"
-dprint-plugin-typescript = "=0.88.4"
+dprint-plugin-json = "=0.19.1"
+dprint-plugin-markdown = "=0.16.3"
+dprint-plugin-typescript = "=0.88.5"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"
@@ -97,7 +97,7 @@ http.workspace = true
 hyper.workspace = true
 import_map = { version = "=0.17.0", features = ["ext"] }
 indexmap.workspace = true
-jsonc-parser = { version = "=0.21.1", features = ["serde"] }
+jsonc-parser = { version = "=0.23.0", features = ["serde"] }
 lazy-regex.workspace = true
 libc.workspace = true
 libz-sys.workspace = true


### PR DESCRIPTION
This is to reduce duplicate dependencies for https://github.com/denoland/deno/pull/21310