### PR TITLE
chore: deflake unit_node/crypto/crypto_key_test.ts

### DIFF
--- a/cli/tests/unit_node/crypto/crypto_key_test.ts
+++ b/cli/tests/unit_node/crypto/crypto_key_test.ts
@@ -17,6 +17,8 @@ import {
 } from "../../../../test_util/std/testing/asserts.ts";
 import { createHmac } from "node:crypto";
 
+const RUN_SLOW_TESTS = Deno.env.get("SLOW_TESTS") === "1";
+
 const generateKeyPairAsync = promisify(
   (
     type: any,
@@ -77,10 +79,12 @@ Deno.test({
   },
 });
 
+const modulusLengths = RUN_SLOW_TESTS ? [2048, 3072] : [2048];
+
 for (const type of ["rsa", "rsa-pss", "dsa"]) {
-  for (const modulusLength of [2048, 3072]) {
+  for (const modulusLength of modulusLengths) {
     Deno.test({
-      name: `generate ${type} key`,
+      name: `generate ${type} key ${modulusLength}`,
       fn() {
         const { publicKey, privateKey } = generateKeyPairSync(type as any, {
           modulusLength,
@@ -92,7 +96,7 @@ for (const type of ["rsa", "rsa-pss", "dsa"]) {
     });
 
     Deno.test({
-      name: `generate ${type} key async`,
+      name: `generate ${type} key async ${modulusLength}`,
       async fn() {
         const x = await generateKeyPairAsync(type as any, {
           modulusLength,
@@ -174,7 +178,9 @@ for (
   });
 }
 
-for (const primeLength of [1024, 2048, 4096]) {
+const primeLengths = RUN_SLOW_TESTS ? [1024, 2048, 4096] : [1024];
+
+for (const primeLength of primeLengths) {
   Deno.test({
     name: `generate dh key ${primeLength}`,
     fn() {


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/21187

On CI we are going to run only fast tests, with an option to
pass `SLOW_TESTS=1` env var to enable more comprehensive tests.