### PR TITLE
fix(ext/node): fix Buffer.copy when sourceStart > source.length

### DIFF
--- a/cli/tests/node_compat/config.jsonc
+++ b/cli/tests/node_compat/config.jsonc
@@ -22,7 +22,6 @@
       "test-buffer-alloc.js",
       "test-buffer-arraybuffer.js",
       "test-buffer-bytelength.js",
-      "test-buffer-copy.js",
       "test-buffer-from.js",
       "test-buffer-includes.js",
       "test-buffer-indexof.js",

--- a/cli/tests/node_compat/test/parallel/test-buffer-alloc.js
+++ b/cli/tests/node_compat/test/parallel/test-buffer-alloc.js
@@ -131,7 +131,7 @@ b.copy(Buffer.alloc(0), 1, 1, 1);
 b.copy(Buffer.alloc(1), 1, 1, 1);
 
 // Try to copy 0 bytes from past the end of the source buffer
-b.copy(Buffer.alloc(1), 0, 2048, 2048);
+b.copy(Buffer.alloc(1), 0, 1024, 1024);
 
 // Testing for smart defaults and ability to pass string values as offset
 {

--- a/cli/tests/node_compat/test/parallel/test-buffer-copy.js
+++ b/cli/tests/node_compat/test/parallel/test-buffer-copy.js
@@ -165,7 +165,6 @@ assert.throws(
   }
 );
 
-/*
 // Copy throws if sourceStart is greater than length of source
 assert.throws(
   () => Buffer.allocUnsafe(5).copy(Buffer.allocUnsafe(5), 0, 100),
@@ -174,7 +173,6 @@ assert.throws(
     name: 'RangeError',
   }
 );
-*/
 
 {
   // Check sourceEnd resets to targetEnd if former is greater than the latter

--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -1536,8 +1536,12 @@ Buffer.prototype.copy = function copy(
     sourceStart = 0;
   } else {
     sourceStart = toInteger(sourceStart, 0);
-    if (sourceStart < 0) {
-      throw new codes.ERR_OUT_OF_RANGE("sourceStart", ">= 0", sourceStart);
+    if (sourceStart < 0 || sourceStart > this.length) {
+      throw new codes.ERR_OUT_OF_RANGE(
+        "sourceStart",
+        `>= 0 && <= ${this.length}`,
+        sourceStart,
+      );
     }
     if (sourceStart >= MAX_UINT32) {
       throw new codes.ERR_OUT_OF_RANGE(


### PR DESCRIPTION
This PR re-enables a test case ignored in #21328. The test case revealed the bug of Buffer#copy implementation, which has been fixed in https://github.com/nodejs/node/pull/47758 in Node.js repo.

closes #21335