### PR TITLE
fix(ext/node): fix duplexify compatibility

### DIFF
--- a/cli/tests/node_compat/test/parallel/test-stream-duplex-from.js
+++ b/cli/tests/node_compat/test/parallel/test-stream-duplex-from.js
@@ -287,8 +287,6 @@ const { Blob } = require('buffer');
   duplex.write('test');
 }
 
-/*
-TODO(kt3k): Enable this test case
 {
   const through = new PassThrough({ objectMode: true });
 
@@ -309,7 +307,6 @@ TODO(kt3k): Enable this test case
     assert.strictEqual(res, 'foobar');
   })).on('close', common.mustCall());
 }
-*/
 
 function makeATestReadableStream(value) {
   return new ReadableStream({

--- a/ext/node/polyfills/_stream.mjs
+++ b/ext/node/polyfills/_stream.mjs
@@ -4474,6 +4474,7 @@ var require_duplexify = __commonJS({
           readable: false,
         });
       }
+
       if (typeof body === "function") {
         const { value, write, final, destroy } = fromAsyncGen(body);
         if (isIterable(value)) {
@@ -4669,8 +4670,6 @@ var require_duplexify = __commonJS({
           cb(err);
         } else if (err) {
           d.destroy(err);
-        } else if (!readable && !writable) {
-          d.destroy();
         }
       }
       d = new Duplexify({


### PR DESCRIPTION
This PR re-enables one test case disabled in #21328 by applying the same fix to `duplexify` as https://github.com/nodejs/node/pull/45133

part of #21336 (there are still other cases remaining)