### PR TITLE
chore(ext/http): fix E0446 on some compiler versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.121.0"
+version = "0.122.0"
 dependencies = [
  "async-compression",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ deno_crypto = { version = "0.139.0", path = "./ext/crypto" }
 deno_fetch = { version = "0.149.0", path = "./ext/fetch" }
 deno_ffi = { version = "0.112.0", path = "./ext/ffi" }
 deno_fs = { version = "0.35.0", path = "./ext/fs" }
-deno_http = { version = "0.121.0", path = "./ext/http" }
+deno_http = { version = "0.122.0", path = "./ext/http" }
 deno_io = { version = "0.35.0", path = "./ext/io" }
 deno_net = { version = "0.117.0", path = "./ext/net" }
 deno_node = { version = "0.62.0", path = "./ext/node" }

--- a/ext/http/Cargo.toml
+++ b/ext/http/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_http"
-version = "0.121.0"
+version = "0.122.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ext/http/service.rs
+++ b/ext/http/service.rs
@@ -176,7 +176,7 @@ impl Drop for HttpRequestBodyAutocloser {
   }
 }
 
-pub async fn handle_request(
+pub(crate) async fn handle_request(
   request: Request,
   request_info: HttpConnectionProperties,
   server_state: SignallingRc<HttpServerState>, // Keep server alive for duration of this future.


### PR DESCRIPTION
Rust 1.74 may have made this code temporarily valid in [#113126 Replace old private-in-public diagnostic with type privacy lints](https://github.com/rust-lang/rust/pull/113126), so we didn't catch it at build time.

It fails in 1.73 and +nightly, however.