### PR TITLE
ci: make upgrade_lsp_repl_sleeps less flaky

### DIFF
--- a/cli/tests/integration/upgrade_tests.rs
+++ b/cli/tests/integration/upgrade_tests.rs
@@ -253,7 +253,7 @@ fn upgrade_lsp_repl_sleeps() {
       pty.expect("579");
     });
 
-  // the test server will sleep for 45 seconds, so ensure this is less
+  // the test server will sleep for 95 seconds, so ensure this is less
   let elapsed_secs = start_instant.elapsed().as_secs();
-  assert!(elapsed_secs < 30, "elapsed_secs: {}", elapsed_secs);
+  assert!(elapsed_secs < 94, "elapsed_secs: {}", elapsed_secs);
 }

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -1274,7 +1274,7 @@ async fn main_server(
       )
     }
     (&hyper::Method::GET, "/upgrade/sleep/release-latest.txt") => {
-      tokio::time::sleep(Duration::from_secs(45)).await;
+      tokio::time::sleep(Duration::from_secs(95)).await;
       return Ok(
         Response::builder()
           .status(StatusCode::OK)
@@ -1283,7 +1283,7 @@ async fn main_server(
       );
     }
     (&hyper::Method::GET, "/upgrade/sleep/canary-latest.txt") => {
-      tokio::time::sleep(Duration::from_secs(45)).await;
+      tokio::time::sleep(Duration::from_secs(95)).await;
       return Ok(
         Response::builder()
           .status(StatusCode::OK)


### PR DESCRIPTION
Makes this test less flaky by allowing way more time for the test to occur in.