### PR TITLE
fix(cron): move deprecated Deno.cron overload

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1348,39 +1348,14 @@ declare namespace Deno {
    * Create a cron job that will periodically execute the provided handler
    * callback based on the specified schedule.
    *
-   * `schedule` can be a string in the Unix cron format or in JSON format
-   * as specified by interface {@linkcode CronSchedule}, where time is specified
-   * using UTC time zone.
-   *
    * ```ts
    * Deno.cron("sample cron", "20 * * * *", () => {
    *   console.log("cron job executed");
    * });
    * ```
-   * `backoffSchedule` option can be used to specify the retry policy for failed
-   * executions. Each element in the array represents the number of milliseconds
-   * to wait before retrying the execution. For example, `[1000, 5000, 10000]`
-   * means that a failed execution will be retried at most 3 times, with 1
-   * second, 5 seconds, and 10 seconds delay between each retry.
-   *
-   * @category Cron
-   * @deprecated Use other {@linkcode cron} overloads instead. This overload
-   * will be removed in the future.
-   */
-  export function cron(
-    name: string,
-    schedule: string | CronSchedule,
-    handler: () => Promise<void> | void,
-    options: { backoffSchedule?: number[]; signal?: AbortSignal },
-  ): Promise<void>;
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
-   * Create a cron job that will periodically execute the provided handler
-   * callback based on the specified schedule.
    *
    * ```ts
-   * Deno.cron("sample cron", "20 * * * *", () => {
+   * Deno.cron("sample cron", { hour: { every: 6 } }, () => {
    *   console.log("cron job executed");
    * });
    * ```
@@ -1427,6 +1402,37 @@ declare namespace Deno {
     schedule: string | CronSchedule,
     options: { backoffSchedule?: number[]; signal?: AbortSignal },
     handler: () => Promise<void> | void,
+  ): Promise<void>;
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * Create a cron job that will periodically execute the provided handler
+   * callback based on the specified schedule.
+   *
+   * `schedule` can be a string in the Unix cron format or in JSON format
+   * as specified by interface {@linkcode CronSchedule}, where time is specified
+   * using UTC time zone.
+   *
+   * ```ts
+   * Deno.cron("sample cron", "20 * * * *", () => {
+   *   console.log("cron job executed");
+   * });
+   * ```
+   * `backoffSchedule` option can be used to specify the retry policy for failed
+   * executions. Each element in the array represents the number of milliseconds
+   * to wait before retrying the execution. For example, `[1000, 5000, 10000]`
+   * means that a failed execution will be retried at most 3 times, with 1
+   * second, 5 seconds, and 10 seconds delay between each retry.
+   *
+   * @category Cron
+   * @deprecated Use other {@linkcode cron} overloads instead. This overload
+   * will be removed in the future.
+   */
+  export function cron(
+    name: string,
+    schedule: string | CronSchedule,
+    handler: () => Promise<void> | void,
+    options: { backoffSchedule?: number[]; signal?: AbortSignal },
   ): Promise<void>;
 
   /** **UNSTABLE**: New API, yet to be vetted.


### PR DESCRIPTION
Moving the deprecated `Deno.cron` overload to be the last one.