### PR TITLE
fix(fmt): remove trailing comma for single type param in default export in jsx

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -56,7 +56,7 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.88.6.wasm",
+    "https://plugins.dprint.dev/typescript-0.88.7.wasm",
     "https://plugins.dprint.dev/json-0.19.1.wasm",
     "https://plugins.dprint.dev/markdown-0.16.3.wasm",
     "https://plugins.dprint.dev/toml-0.5.4.wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.88.6"
+version = "0.88.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7fe06e34987533797220544a8baea26bacbbbc1e81f41c7e654d2e68f41f72"
+checksum = "f75fc11fffe73e21ebea5bc1dabb647ef88189bbac91749fbe22ea8c8e660bf3"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -88,7 +88,7 @@ dotenvy = "0.15.7"
 dprint-plugin-json = "=0.19.1"
 dprint-plugin-jupyter = "=0.1.2"
 dprint-plugin-markdown = "=0.16.3"
-dprint-plugin-typescript = "=0.88.6"
+dprint-plugin-typescript = "=0.88.7"
 encoding_rs.workspace = true
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"


### PR DESCRIPTION
Reported by Luca. Fix is at https://github.com/dprint/dprint-plugin-typescript/pull/589