### PR TITLE
perf(lsp): fix redundant serialization of sources

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -555,9 +555,13 @@ delete Object.prototype.__proto__;
       }
 
       /** @type {{ data: string; scriptKind: ts.ScriptKind; version: string; }} */
-      const { data, scriptKind, version } = ops.op_load(
+      const fileInfo = ops.op_load(
         { specifier },
       );
+      if (!fileInfo) {
+        return undefined;
+      }
+      const { data, scriptKind, version } = fileInfo;
       assert(
         data != null,
         `"data" is unexpectedly null for "${specifier}".`,
@@ -713,10 +717,6 @@ delete Object.prototype.__proto__;
       if (logDebug) {
         debug(`host.getScriptVersion("${specifier}")`);
       }
-      const sourceFile = sourceFileCache.get(specifier);
-      if (sourceFile) {
-        return sourceFile.version ?? "1";
-      }
       // tsc requests the script version multiple times even though it can't
       // possibly have changed, so we will memoize it on a per request basis.
       if (scriptVersionCache.has(specifier)) {
@@ -730,30 +730,26 @@ delete Object.prototype.__proto__;
       if (logDebug) {
         debug(`host.getScriptSnapshot("${specifier}")`);
       }
-      const sourceFile = sourceFileCache.get(specifier);
+      let sourceFile = sourceFileCache.get(specifier);
+      if (
+        !specifier.startsWith(ASSETS_URL_PREFIX) &&
+        sourceFile?.version != this.getScriptVersion(specifier)
+      ) {
+        sourceFileCache.delete(specifier);
+        sourceFile = undefined;
+      }
+      if (!sourceFile) {
+        sourceFile = this.getSourceFile(
+          specifier,
+          specifier.endsWith(".json")
+            ? ts.ScriptTarget.JSON
+            : ts.ScriptTarget.ESNext,
+        );
+      }
       if (sourceFile) {
-        return {
-          getText(start, end) {
-            return sourceFile.text.substring(start, end);
-          },
-          getLength() {
-            return sourceFile.text.length;
-          },
-          getChangeRange() {
-            return undefined;
-          },
-        };
+        return ts.ScriptSnapshot.fromString(sourceFile.text);
       }
-
-      const fileInfo = ops.op_load(
-        { specifier },
-      );
-      if (fileInfo) {
-        scriptVersionCache.set(specifier, fileInfo.version);
-        return ts.ScriptSnapshot.fromString(fileInfo.data);
-      } else {
-        return undefined;
-      }
+      return undefined;
     },
   };
 


### PR DESCRIPTION
Our `host.getScriptSnapshot()` had not been populating the `sourceFileCache`.