### PR TITLE
perf(lsp): check tsc request cancellation before execution

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -502,7 +502,12 @@ impl DiagnosticsServer {
                   )
                   .await
                   .map_err(|err| {
-                    error!("Error generating TypeScript diagnostics: {}", err);
+                    if !token.is_cancelled() {
+                      error!(
+                        "Error generating TypeScript diagnostics: {}",
+                        err
+                      );
+                    }
                   })
                   .unwrap_or_default();
 
@@ -1613,35 +1618,6 @@ let c: number = "a";
       .unwrap()
       .versioned
       .diagnostics
-  }
-
-  #[tokio::test]
-  async fn test_cancelled_ts_diagnostics_request() {
-    let temp_dir = TempDir::new();
-    let (snapshot, cache_location) = setup(
-      &temp_dir,
-      &[(
-        "file:///a.ts",
-        r#"export let a: string = 5;"#,
-        1,
-        LanguageId::TypeScript,
-      )],
-      None,
-    );
-    let snapshot = Arc::new(snapshot);
-    let cache =
-      Arc::new(GlobalHttpCache::new(cache_location, RealDenoCacheEnv));
-    let ts_server = TsServer::new(Default::default(), cache);
-
-    let config = mock_config();
-    let token = CancellationToken::new();
-    token.cancel();
-    let diagnostics =
-      generate_ts_diagnostics(snapshot.clone(), &config, &ts_server, token)
-        .await
-        .unwrap();
-    // should be none because it's cancelled
-    assert_eq!(diagnostics.len(), 0);
   }
 
   #[tokio::test]

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4414,6 +4414,9 @@ fn request(
   request: TscRequest,
   token: CancellationToken,
 ) -> Result<Value, AnyError> {
+  if token.is_cancelled() {
+    return Err(anyhow!("Operation was cancelled."));
+  }
   let (performance, id) = {
     let op_state = runtime.op_state();
     let mut op_state = op_state.borrow_mut();


### PR DESCRIPTION
A lot of requests get cancelled before they get to the front of the queue. This should speed up those cases.