### PR TITLE
feat(ext/fetch): allow `Deno.HttpClient` to be declared with `using`

### DIFF
--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1630,6 +1630,22 @@ Deno.test(
   },
 );
 
+Deno.test(
+  { permissions: { net: true } },
+  async function createHttpClientExplicitResourceManagementDoubleClose() {
+    using client = Deno.createHttpClient({});
+    const response = await fetch("http://localhost:4545/assets/fixture.json", {
+      client,
+    });
+    const json = await response.json();
+    assertEquals(json.name, "deno");
+    // Close the client even though we declared it with `using` to confirm that
+    // the cleanup done as per `Symbol.dispose` will not throw any errors.
+    client.close();
+  },
+);
+
+
 Deno.test({ permissions: { read: false } }, async function fetchFilePerm() {
   await assertRejects(async () => {
     await fetch(import.meta.resolve("../testdata/subdir/json_1.json"));

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1645,7 +1645,6 @@ Deno.test(
   },
 );
 
-
 Deno.test({ permissions: { read: false } }, async function fetchFilePerm() {
   await assertRejects(async () => {
     await fetch(import.meta.resolve("../testdata/subdir/json_1.json"));

--- a/cli/tests/unit/fetch_test.ts
+++ b/cli/tests/unit/fetch_test.ts
@@ -1618,6 +1618,18 @@ Deno.test(
   },
 );
 
+Deno.test(
+  { permissions: { net: true } },
+  async function createHttpClientExplicitResourceManagement() {
+    using client = Deno.createHttpClient({});
+    const response = await fetch("http://localhost:4545/assets/fixture.json", {
+      client,
+    });
+    const json = await response.json();
+    assertEquals(json.name, "deno");
+  },
+);
+
 Deno.test({ permissions: { read: false } }, async function fetchFilePerm() {
   await assertRejects(async () => {
     await fetch(import.meta.resolve("../testdata/subdir/json_1.json"));

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -847,7 +847,7 @@ declare namespace Deno {
    *
    * @category Fetch API
    */
-  export interface HttpClient {
+  export interface HttpClient extends Disposable {
     /** The resource ID associated with the client. */
     rid: number;
     /** Close the HTTP client. */

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -12,6 +12,7 @@
 
 const core = globalThis.Deno.core;
 const ops = core.ops;
+import { SymbolDispose } from "ext:deno_web/00_infra.js";
 
 /**
  * @param {Deno.CreateHttpClientOptions} options
@@ -33,8 +34,13 @@ class HttpClient {
   constructor(rid) {
     this.rid = rid;
   }
+
   close() {
     core.close(this.rid);
+  }
+
+  [SymbolDispose]() {
+    this.close();
   }
 }
 const HttpClientPrototype = HttpClient.prototype;

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -40,7 +40,7 @@ class HttpClient {
   }
 
   [SymbolDispose]() {
-    this.close();
+    core.tryClose(this.rid);
   }
 }
 const HttpClientPrototype = HttpClient.prototype;


### PR DESCRIPTION
This commit adds a method of `Symbol.dispose` to the object returned from `Deno.createHttpClient`, so we can make use of [explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) by declaring it with `using`.