### PR TITLE
fix(kv): throw error if already closed

### DIFF
--- a/cli/tests/integration/js_unit_tests.rs
+++ b/cli/tests/integration/js_unit_tests.rs
@@ -48,6 +48,7 @@ util::unit_test_factory!(
     jupyter_test,
     kv_test,
     kv_queue_test_no_db_close,
+    kv_queue_test,
     kv_queue_undelivered_test,
     link_test,
     make_temp_test,

--- a/cli/tests/unit/kv_queue_test.ts
+++ b/cli/tests/unit/kv_queue_test.ts
@@ -5,8 +5,8 @@ Deno.test({}, async function queueTestDbClose() {
   const db: Deno.Kv = await Deno.openKv(":memory:");
   db.close();
   await assertRejects(
-    async () => {
-      await db.listenQueue(() => {});
+    () => {
+      return db.listenQueue(() => {});
     },
     Error,
     "already closed",

--- a/cli/tests/unit/kv_queue_test.ts
+++ b/cli/tests/unit/kv_queue_test.ts
@@ -1,0 +1,13 @@
+import { assertRejects } from "./test_util.ts";
+
+Deno.test({}, async function queueTestDbClose() {
+  const db: Deno.Kv = await Deno.openKv(":memory:");
+  db.close();
+  await assertRejects(
+    async () => {
+      await db.listenQueue(() => {});
+    },
+    Error,
+    "already closed",
+  );
+});

--- a/cli/tests/unit/kv_queue_test.ts
+++ b/cli/tests/unit/kv_queue_test.ts
@@ -1,11 +1,12 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "./test_util.ts";
+import { assertEquals, assertFalse } from "./test_util.ts";
 
 Deno.test({}, async function queueTestDbClose() {
   const db: Deno.Kv = await Deno.openKv(":memory:");
   db.close();
   try {
     await db.listenQueue(() => {});
+    assertFalse(false);
   } catch (e) {
     assertEquals(e.message, "already closed");
   }

--- a/cli/tests/unit/kv_queue_test.ts
+++ b/cli/tests/unit/kv_queue_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { assertRejects } from "./test_util.ts";
 
 Deno.test({}, async function queueTestDbClose() {

--- a/cli/tests/unit/kv_queue_test.ts
+++ b/cli/tests/unit/kv_queue_test.ts
@@ -1,14 +1,12 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertRejects } from "./test_util.ts";
+import { assertEquals } from "./test_util.ts";
 
 Deno.test({}, async function queueTestDbClose() {
   const db: Deno.Kv = await Deno.openKv(":memory:");
   db.close();
-  await assertRejects(
-    () => {
-      return db.listenQueue(() => {});
-    },
-    Error,
-    "already closed",
-  );
+  try {
+    await db.listenQueue(() => {});
+  } catch (e) {
+    assertEquals(e.message, "already closed");
+  }
 });

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, assertRejects } from "./test_util.ts";
+import { assertEquals, assertRejects } from "./test_util.ts";
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "./test_util.ts";
+import { assert, assertEquals, assertRejects } from "./test_util.ts";
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 
@@ -53,4 +53,15 @@ queueTest("queue with undelivered", async (db) => {
     db.close();
     await listener;
   }
+});
+
+queueTest("throw error if already closed", async (db) => {
+  db.close();
+  await assertRejects(
+    async () => {
+      await db.listenQueue(() => {});
+    },
+    Error,
+    "already closed",
+  );
 });

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -55,12 +55,12 @@ queueTest("queue with undelivered", async (db) => {
   }
 });
 
-queueTest("throw error if already closed", async (db) => {
+Deno.test({}, async function queueTestDbClose() {
+  const db: Deno.Kv = await Deno.openKv(":memory:");
   db.close();
   await assertRejects(
     async () => {
-      await db.listenQueue(() => {
-      });
+      await db.listenQueue(() => {});
     },
     Error,
     "already closed",

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows } from "./test_util.ts";
+import { assertEquals, assertRejects } from "./test_util.ts";
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 
@@ -56,10 +56,13 @@ queueTest("queue with undelivered", async (db) => {
 });
 
 queueTest("throw error if already closed", async (db) => {
+  const { resolve } = Promise.withResolvers<void>();
   db.close();
-  await assertThrows(
+  await assertRejects(
     async () => {
-      await db.listenQueue(() => {});
+      await db.listenQueue(() => {
+        resolve();
+      });
     },
     Error,
     "already closed",

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertRejects } from "./test_util.ts";
+import { assertEquals } from "./test_util.ts";
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 
@@ -53,16 +53,4 @@ queueTest("queue with undelivered", async (db) => {
     db.close();
     await listener;
   }
-});
-
-Deno.test({}, async function queueTestDbClose() {
-  const db: Deno.Kv = await Deno.openKv(":memory:");
-  db.close();
-  await assertRejects(
-    async () => {
-      await db.listenQueue(() => {});
-    },
-    Error,
-    "already closed",
-  );
 });

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertRejects } from "./test_util.ts";
+import { assertEquals, assertThrows } from "./test_util.ts";
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 
@@ -57,7 +57,7 @@ queueTest("queue with undelivered", async (db) => {
 
 queueTest("throw error if already closed", async (db) => {
   db.close();
-  await assertRejects(
+  await assertThrows(
     async () => {
       await db.listenQueue(() => {});
     },

--- a/cli/tests/unit/kv_queue_undelivered_test.ts
+++ b/cli/tests/unit/kv_queue_undelivered_test.ts
@@ -56,12 +56,10 @@ queueTest("queue with undelivered", async (db) => {
 });
 
 queueTest("throw error if already closed", async (db) => {
-  const { resolve } = Promise.withResolvers<void>();
   db.close();
   await assertRejects(
     async () => {
       await db.listenQueue(() => {
-        resolve();
       });
     },
     Error,

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -62,6 +62,7 @@ const kvSymbol = Symbol("KvRid");
 
 class Kv {
   #rid: number;
+  #isClosed: boolean;
 
   constructor(rid: number = undefined, symbol: symbol = undefined) {
     if (kvSymbol !== symbol) {
@@ -70,6 +71,7 @@ class Kv {
       );
     }
     this.#rid = rid;
+    this.#isClosed = false;
   }
 
   atomic() {
@@ -249,6 +251,9 @@ class Kv {
   async listenQueue(
     handler: (message: unknown) => Promise<void> | void,
   ): Promise<void> {
+    if (this.#isClosed) {
+      throw new Error("already closed");
+    }
     const finishMessageOps = new Map<number, Promise<void>>();
     while (true) {
       // Wait for the next message.
@@ -299,6 +304,7 @@ class Kv {
 
   close() {
     core.close(this.#rid);
+    this.#isClosed = true;
   }
 
   [SymbolDispose]() {


### PR DESCRIPTION
## Description
If KV is closed and tries to listen queue should throw an error.

## Issue
-  https://github.com/denoland/deno/issues/20991
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
