### PR TITLE
fix: display unstable flags at bottom of help text

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -946,6 +946,8 @@ fn clap_root() -> Command {
     .max_term_width(80)
     .version(crate::version::deno())
     .long_version(long_version)
+    // cause --unstable flags to display at the bottom of the help text
+    .next_display_order(1000)
     .arg(
       Arg::new("unstable")
         .long("unstable")
@@ -992,6 +994,8 @@ fn clap_root() -> Command {
   }
 
   cmd
+    // reset the display order after the unstable flags
+    .next_display_order(0)
     .arg(
       Arg::new("log-level")
         .short('L')


### PR DESCRIPTION
Moves the unstable flags to be at the bottom of the help text. They were previously all over the place for some reason.

New output:

```
> cargo run -- help fmt
    Blocking waiting for file lock on build directory
   Compiling deno v1.38.4 (V:\deno\cli)
    Finished dev [unoptimized + debuginfo] target(s) in 28.14s
     Running `target\debug\deno.exe help fmt`
Auto-format JavaScript, TypeScript, Markdown, and JSON files.

  deno fmt
  deno fmt myfile1.ts myfile2.ts
  deno fmt --check

Format stdin and write to stdout:

  cat file.ts | deno fmt -

Ignore formatting code by preceding it with an ignore comment:

  // deno-fmt-ignore

Ignore formatting a file by adding an ignore comment at the top of the file:

  // deno-fmt-ignore-file

Usage: deno fmt [OPTIONS] [files]...

Arguments:
  [files]...


Options:
  -c, --config <FILE>
          The configuration file can be used to configure different aspects of
          deno including TypeScript, linting, and code formatting. Typically the
          configuration file will be called `deno.json` or `deno.jsonc` and
          automatically detected; in that case this flag is not necessary.
          See https://deno.land/manual@v1.38.4/getting_started/configuration_file

      --no-config
          Disable automatic loading of the configuration file.

  -q, --quiet
          Suppress diagnostic output

      --check
          Check if the source files are formatted

      --ext <ext>
          Set content type of the supplied file

          [default: ts]
          [possible values: ts, tsx, js, jsx, md, json, jsonc, ipynb]

      --ignore=<ignore>...
          Ignore formatting particular source files

      --watch
          Watch for file changes and restart process automatically.
                Only local files from entry point module graph are watched.

      --no-clear-screen
          Do not clear terminal screen when under watch mode

      --use-tabs[=<use-tabs>]
          Use tabs instead of spaces for indentation. Defaults to false.

          [possible values: true, false]

      --line-width <line-width>
          Define maximum line width. Defaults to 80.

      --indent-width <indent-width>
          Define indentation width. Defaults to 2.

      --single-quote[=<single-quote>]
          Use single quotes. Defaults to false.

          [possible values: true, false]

      --prose-wrap <prose-wrap>
          Define how prose should be wrapped. Defaults to always.

          [possible values: always, never, preserve]

      --no-semicolons[=<no-semicolons>]
          Don't use semicolons except where necessary. Defaults to false.

          [possible values: true, false]

  -h, --help
          Print help (see a summary with '-h')

      --unstable
          Enable unstable features and APIs

      --unstable-bare-node-builtins
          Enable unstable bare node builtins feature

          [env: DENO_UNSTABLE_BARE_NODE_BUILTINS=]

      --unstable-byonm
          Enable unstable 'bring your own node_modules' feature

          [env: DENO_UNSTABLE_BYONM=]

      --unstable-workspaces
          Enable unstable 'workspaces' feature

          [env: DENO_UNSTABLE_WORKSPACES=]

      --unstable-broadcast-channel
          Enable unstable `BroadcastChannel` API

      --unstable-ffi
          Enable unstable FFI APIs

      --unstable-fs
          Enable unstable file system APIs

      --unstable-kv
          Enable unstable Key-Value store APIs

      --unstable-net
          Enable unstable net APIs

      --unstable-http
          Enable unstable HTTP APIs

      --unstable-worker-options
          Enable unstable Web Worker APIs

      --unstable-cron
          Enable unstable Deno.cron API

      --unstable-unsafe-proto
          Enable unsafe __proto__ support. This is a security risk.
```