### PR TITLE
fix(ext/node): include non-enumerable keys in `Reflect.ownKeys(globalThis)`

### DIFF
--- a/cli/tests/testdata/npm/compare_globals/main.out
+++ b/cli/tests/testdata/npm/compare_globals/main.out
@@ -25,3 +25,4 @@ false
 false
 bar
 bar
+true

--- a/cli/tests/testdata/npm/compare_globals/main.ts
+++ b/cli/tests/testdata/npm/compare_globals/main.ts
@@ -48,3 +48,5 @@ globals.checkWindowGlobal();
 (globalThis as any).foo = "bar";
 console.log((globalThis as any).foo);
 console.log(globals.getFoo());
+
+console.log(Reflect.ownKeys(globalThis).includes("console")); // non-enumerable keys are included

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -432,9 +432,14 @@ pub fn enumerator<'s>(
   };
   let inner = v8::Local::new(scope, inner);
 
-  let Some(array) =
-    inner.get_property_names(scope, GetPropertyNamesArgs::default())
-  else {
+  let Some(array) = inner.get_property_names(
+    scope,
+    GetPropertyNamesArgs {
+      mode: v8::KeyCollectionMode::OwnOnly,
+      property_filter: v8::PropertyFilter::ALL_PROPERTIES,
+      ..Default::default()
+    },
+  ) else {
     return;
   };
 


### PR DESCRIPTION
Closes #21484.