### PR TITLE
perf(ext/url): improve URLPattern perf

### DIFF
--- a/ext/url/01_urlpattern.js
+++ b/ext/url/01_urlpattern.js
@@ -13,17 +13,20 @@ import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 const primordials = globalThis.__bootstrap.primordials;
 const {
-  ArrayPrototypePop,
+  ArrayPrototypePush,
+  MathRandom,
+  ObjectAssign,
+  ObjectCreate,
+  ObjectPrototypeIsPrototypeOf,
   RegExpPrototypeExec,
   RegExpPrototypeTest,
-  ObjectPrototypeIsPrototypeOf,
+  SafeMap,
   SafeRegExp,
   Symbol,
   SymbolFor,
   TypeError,
 } = primordials;
 
-const EMPTY_MATCH = [""];
 const _components = Symbol("components");
 
 /**
@@ -55,9 +58,67 @@ const COMPONENTS_KEYS = [
  * @property {string[]} groupNameList
  */
 
+/**
+ * @template K
+ * @template V
+ */
+class LRUCache {
+  /** @type {Map<K, V>} */
+  #map = new SafeMap();
+  #capacity = 0;
+
+  /** @type {K} */
+  #lastUsedKey = undefined;
+  /** @type {V} */
+  #lastUsedValue = undefined;
+
+  /** @param {number} capacity */
+  constructor(capacity) {
+    this.#capacity = capacity;
+  }
+
+  /**
+   * @param {K} key
+   * @param {(key: K) => V} factory
+   * @return {V}
+   */
+  getOrInsert(key, factory) {
+    if (this.#lastUsedKey === key) return this.#lastUsedValue;
+    const value = this.#map.get(key);
+    if (value !== undefined) {
+      if (MathRandom() < 0.1) {
+        // put the item into the map
+        this.#map.delete(key);
+        this.#map.set(key, value);
+      }
+      this.#lastUsedKey = key;
+      this.#lastUsedValue = value;
+      return value;
+    } else {
+      // value doesn't exist yet, create
+      const value = factory(key);
+      if (MathRandom() < 0.1) {
+        // if the map is at capacity, delete the oldest (first) element
+        if (this.#map.size > this.#capacity) {
+          this.#map.delete(this.#map.keys().next().value);
+        }
+        // insert the new value
+        this.#map.set(key, value);
+      }
+      this.#lastUsedKey = key;
+      this.#lastUsedValue = value;
+      return value;
+    }
+  }
+}
+
+const matchInputCache = new LRUCache(4096);
+
 class URLPattern {
   /** @type {Components} */
   [_components];
+
+  #reusedResult;
 
   /**
    * @param {URLPatternInput} input
@@ -81,9 +142,6 @@ class URLPattern {
           components[key].regexpString,
           "u",
         );
-        // used for fast path
-        components[key].matchOnEmptyInput =
-          components[key].regexpString === "^$";
       } catch (e) {
         throw new TypeError(`${prefix}: ${key} is invalid; ${e.message}`);
       }
@@ -145,20 +203,28 @@ class URLPattern {
       baseURL = webidl.converters.USVString(baseURL, prefix, "Argument 2");
     }
 
-    const res = ops.op_urlpattern_process_match_input(
-      input,
-      baseURL,
-    );
-    if (res === null) {
-      return false;
-    }
+    const res = baseURL === undefined
+      ? matchInputCache.getOrInsert(
+        input,
+        ops.op_urlpattern_process_match_input,
+      )
+      : ops.op_urlpattern_process_match_input(input, baseURL);
+    if (res === null) return false;
 
     const values = res[0];
 
     for (let i = 0; i < COMPONENTS_KEYS.length; ++i) {
       const key = COMPONENTS_KEYS[i];
-      if (!RegExpPrototypeTest(this[_components][key].regexp, values[key])) {
-        return false;
+      const component = this[_components][key];
+      switch (component.regexpString) {
+        case "^$":
+          if (values[key] !== "") return false;
+          break;
+        case "^(.*)$":
+          break;
+        default: {
+          if (!RegExpPrototypeTest(component.regexp, values[key])) return false;
+        }
       }
     }
 
@@ -179,48 +245,65 @@ class URLPattern {
       baseURL = webidl.converters.USVString(baseURL, prefix, "Argument 2");
     }
 
-    const res = ops.op_urlpattern_process_match_input(
-      input,
-      baseURL,
-    );
+    const res = baseURL === undefined
+      ? matchInputCache.getOrInsert(
+        input,
+        ops.op_urlpattern_process_match_input,
+      )
+      : ops.op_urlpattern_process_match_input(input, baseURL);
     if (res === null) {
       return null;
     }
 
-    const { 0: values, 1: inputs } = res;
-    if (inputs[1] === null) {
-      ArrayPrototypePop(inputs);
-    }
+    const { 0: values, 1: inputs } = res; /** @type {URLPatternResult} */
 
-    /** @type {URLPatternResult} */
-    const result = { inputs };
+    // globalThis.allocAttempt++;
+    this.#reusedResult ??= { inputs: [undefined] };
+    const result = this.#reusedResult;
+    // We don't construct the `inputs` until after the matching is done under
+    // the assumption that most patterns do not match.
+
+    const components = this[_components];
 
     for (let i = 0; i < COMPONENTS_KEYS.length; ++i) {
       const key = COMPONENTS_KEYS[i];
       /** @type {Component} */
-      const component = this[_components][key];
-      const input = values[key];
+      const component = components[key];
 
-      const match = component.matchOnEmptyInput && input === ""
-        ? EMPTY_MATCH // fast path
-        : RegExpPrototypeExec(component.regexp, input);
-
-      if (match === null) {
-        return null;
-      }
-
-      const groups = {};
-      const groupList = component.groupNameList;
-      for (let i = 0; i < groupList.length; ++i) {
-        groups[groupList[i]] = match[i + 1] ?? "";
-      }
-
-      result[key] = {
-        input,
-        groups,
+      const res = result[key] ??= {
+        input: values[key],
+        groups: component.regexpString === "^(.*)$" ? { "0": values[key] } : {},
       };
+
+      switch (component.regexpString) {
+        case "^$":
+          if (values[key] !== "") return null;
+          break;
+        case "^(.*)$":
+          res.groups["0"] = values[key];
+          break;
+        default: {
+          const match = RegExpPrototypeExec(component.regexp, values[key]);
+          if (match === null) return null;
+          const groupList = component.groupNameList;
+          const groups = res.groups;
+          for (let i = 0; i < groupList.length; ++i) {
+            // TODO: this should use ObjectDefineProperty
+            groups[groupList[i]] = match[i + 1] ?? "";
+          }
+          break;
+        }
+      }
+      res.input = values[key];
     }
 
+    // Now populate result.inputs
+    result.inputs[0] = typeof inputs[0] === "string"
+      ? inputs[0]
+      : ObjectAssign(ObjectCreate(null), inputs[0]);
+    if (inputs[1] !== null) ArrayPrototypePush(result.inputs, inputs[1]);
+
+    this.#reusedResult = undefined;
     return result;
   }
 


### PR DESCRIPTION
This significantly optimizes URLPattern in the case where the same
URL is matched against many patterns (like in a router).

Also minor speedups to other use-cases.

---

Bench code:

```ts
const pattern = new URLPattern({ pathname: "/:bar" });
const pattern2 = new URLPattern({ pathname: "/bar" });

const urls = Array.from({ length: 100 }, () => {
  return `https://example.com/${crypto.randomUUID()}`;
});

const patterns = urls.filter((_, i) => i % Math.ceil(urls.length / 100) === 0)
  .map((url) => new URLPattern({ pathname: new URL(url).pathname }));
console.log(patterns.length);

Deno.bench("one pattern, random url, match", () => {
  const res = pattern.exec(`https://example.com/${crypto.randomUUID()}`);
});

Deno.bench("one pattern, random url, no match", () => {
  const res = pattern2.exec(`https://example.com/${crypto.randomUUID()}`);
});

Deno.bench("one pattern, same url, match", () => {
  const res = pattern.exec("https://example.com/foo");
});

Deno.bench("one pattern, same url, no match", () => {
  const res = pattern2.exec("https://example.com/foo");
});

Deno.bench("many patterns, different url, until match", () => {
  const randomUrlIndex = Math.floor(Math.random() * urls.length);
  for (const pattern of patterns) {
    const res = pattern.exec(urls[randomUrlIndex]);
    if (res !== null) return;
  }
});
```

---

```
v1.38.5
cpu: Apple M1
runtime: deno 1.38.5 (aarch64-apple-darwin)

file:///Users/lucacasonato/projects/github.com/denoland/deno/bench.ts
benchmark                                      time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------------------------------- -----------------------------
one pattern, random url, match                  6.59 µs/iter     151,791.1   (6.08 µs … 302.54 µs)   6.42 µs  11.54 µs  14.12 µs
one pattern, random url, no match                5.7 µs/iter     175,587.0     (5.59 µs … 5.87 µs)   5.73 µs   5.87 µs   5.87 µs
one pattern, same url, match                    4.29 µs/iter     233,029.7     (4.24 µs … 4.47 µs)    4.3 µs   4.47 µs   4.47 µs
one pattern, same url, no match                 3.71 µs/iter     269,867.4     (3.64 µs … 3.94 µs)    3.7 µs   3.94 µs   3.94 µs
many patterns, different url, until match     248.63 µs/iter       4,022.1   (5.42 µs … 710.71 µs)  370.5 µs 540.71 µs 595.17 µs
```

```
main
cpu: Apple M1
runtime: deno 1.38.5 (aarch64-apple-darwin)

file:///Users/lucacasonato/projects/github.com/denoland/deno/bench.ts
benchmark                                      time (avg)        iter/s             (min … max)       p75       p99      p995
----------------------------------------------------------------------------------------------- -----------------------------
one pattern, random url, match                  6.56 µs/iter     152,369.3     (5.62 µs … 2.22 ms)   6.21 µs  10.88 µs     15 µs
one pattern, random url, no match               5.65 µs/iter     176,876.6     (5.44 µs … 5.98 µs)   5.73 µs   5.98 µs   5.98 µs
one pattern, same url, match                    1.24 µs/iter     808,545.2     (1.22 µs … 1.33 µs)   1.24 µs   1.33 µs   1.33 µs
one pattern, same url, no match               554.29 ns/iter   1,804,102.6 (540.52 ns … 577.54 ns) 558.08 ns 573.21 ns 577.54 ns
many patterns, different url, until match      32.51 µs/iter      30,759.8      (1 µs … 415.96 µs)  47.62 µs  71.71 µs  79.29 µs
```