### PR TITLE
feat(standalone/webstorage): Add --origin-data flag to compile command

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -68,6 +68,7 @@ pub struct CompileFlags {
   pub target: Option<String>,
   pub no_terminal: bool,
   pub include: Vec<String>,
+  pub origin_data_folder_path: Option<PathBuf>,
 }
 
 impl CompileFlags {
@@ -1284,6 +1285,13 @@ supported in canary.
           .long("no-terminal")
           .help("Hide terminal on Windows")
           .action(ArgAction::SetTrue),
+      )
+      .arg(
+        Arg::new("origin-data-folder-path")
+        .long("origin-data")
+        .value_parser(value_parser!(PathBuf))
+        .help("Specify origin data folder path (required to use Web Storage)")
+        .value_hint(ValueHint::FilePath),
       )
       .arg(executable_ext_arg())
       .arg(env_file_arg())
@@ -3240,6 +3248,8 @@ fn compile_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     Some(f) => f.collect(),
     None => vec![],
   };
+  let origin_data_folder_path =
+    matches.remove_one::<PathBuf>("origin-data-folder-path");
   ext_arg_parse(flags, matches);
 
   flags.subcommand = DenoSubcommand::Compile(CompileFlags {
@@ -3249,6 +3259,7 @@ fn compile_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     target,
     no_terminal,
     include,
+    origin_data_folder_path,
   });
 }
 
@@ -7808,7 +7819,8 @@ mod tests {
           args: vec![],
           target: None,
           no_terminal: false,
-          include: vec![]
+          include: vec![],
+          origin_data_folder_path: None
         }),
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()
@@ -7830,7 +7842,8 @@ mod tests {
           args: svec!["foo", "bar", "-p", "8080"],
           target: None,
           no_terminal: true,
-          include: vec![]
+          include: vec![],
+          origin_data_folder_path: None
         }),
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -149,6 +149,7 @@ pub struct Metadata {
   pub maybe_import_map: Option<(Url, String)>,
   pub entrypoint: ModuleSpecifier,
   pub node_modules: Option<NodeModules>,
+  pub origin_data_folder_path: Option<PathBuf>,
 }
 
 pub fn load_npm_vfs(root_dir_path: PathBuf) -> Result<FileBackedVfs, AnyError> {
@@ -555,6 +556,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       entrypoint: entrypoint.clone(),
       maybe_import_map,
       node_modules,
+      origin_data_folder_path: compile_flags.origin_data_folder_path.clone(),
     };
 
     write_binary_bytes(

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -523,7 +523,7 @@ pub async fn run(
       )
       .ok()
       .map(|req_ref| npm_pkg_req_ref_to_binary_command(&req_ref)),
-      origin_data_folder_path: None,
+      origin_data_folder_path: metadata.origin_data_folder_path,
       seed: metadata.seed,
       unsafely_ignore_certificate_errors: metadata
         .unsafely_ignore_certificate_errors,

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -220,6 +220,7 @@ mod test {
         target: Some("x86_64-unknown-linux-gnu".to_string()),
         no_terminal: false,
         include: vec![],
+        origin_data_folder_path: None,
       },
       &std::env::current_dir().unwrap(),
     )
@@ -242,6 +243,7 @@ mod test {
         target: Some("x86_64-pc-windows-msvc".to_string()),
         include: vec![],
         no_terminal: false,
+        origin_data_folder_path: None,
       },
       &std::env::current_dir().unwrap(),
     )

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -547,14 +547,18 @@ impl CliMainWorkerFactory {
     let maybe_storage_key = shared
       .storage_key_resolver
       .resolve_storage_key(&main_module);
-    let origin_storage_dir = maybe_storage_key.as_ref().map(|key| {
-      shared
-        .options
-        .origin_data_folder_path
-        .as_ref()
-        .unwrap() // must be set if storage key resolver returns a value
-        .join(checksum::gen(&[key.as_bytes()]))
-    });
+    let origin_storage_dir = maybe_storage_key
+      .as_ref()
+      .map(|key| {
+        shared
+          .options
+          .origin_data_folder_path
+          .as_ref()
+          .unwrap() // must be set if storage key resolver returns a value
+          .join(checksum::gen(&[key.as_bytes()]))
+      })
+      .or(shared.options.origin_data_folder_path.clone());
+
     let cache_storage_dir = maybe_storage_key.map(|key| {
       // TODO(@satyarohith): storage quota management
       // Note: we currently use temp_dir() to avoid managing storage size.


### PR DESCRIPTION
Add an optional `--origin-data` argument to the compile command in order to specify where WebStorage data should be stored. This would (at least partially) fix #10693.

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
