### PR TITLE
fix: add more warnings when using sloppy imports

### DIFF
--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -431,7 +431,7 @@ fn sloppy_imports_resolve(
   // show a warning when this happens in order to drive
   // the user towards correcting these specifiers
   log::warn!(
-    "{} Sloppy import resolution {}\n    at {}",
+    "{} Sloppy module resolution {}\n    at {}",
     crate::colors::yellow("Warning"),
     crate::colors::gray(format!("(hint: {})", hint_message)),
     if referrer_range.end == deno_graph::Position::zeroed() {

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -4787,7 +4787,8 @@ console.log(g.G);
     .args("run main.ts")
     .run()
     .assert_matches_text(
-      "Warning Sloppy import resolution (hint: update .js extension to .ts)
+      "Warning Sloppy import resolution is not recommended and may have a negative impact on performance.
+Warning Sloppy import resolution (hint: update .js extension to .ts)
     at file:///[WILDCARD]/main.ts:1:20
 Warning Sloppy import resolution (hint: add .js extension)
     at file:///[WILDCARD]/main.ts:2:20

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -4787,22 +4787,22 @@ console.log(g.G);
     .args("run main.ts")
     .run()
     .assert_matches_text(
-      "Warning Sloppy import resolution is not recommended and may have a negative impact on performance.
-Warning Sloppy import resolution (hint: update .js extension to .ts)
+      "Warning Sloppy imports are not recommended and may have a negative impact on performance.
+Warning Sloppy module resolution (hint: update .js extension to .ts)
     at file:///[WILDCARD]/main.ts:1:20
-Warning Sloppy import resolution (hint: add .js extension)
+Warning Sloppy module resolution (hint: add .js extension)
     at file:///[WILDCARD]/main.ts:2:20
-Warning Sloppy import resolution (hint: add .mts extension)
+Warning Sloppy module resolution (hint: add .mts extension)
     at file:///[WILDCARD]/main.ts:3:20
-Warning Sloppy import resolution (hint: add .mjs extension)
+Warning Sloppy module resolution (hint: add .mjs extension)
     at file:///[WILDCARD]/main.ts:4:20
-Warning Sloppy import resolution (hint: add .tsx extension)
+Warning Sloppy module resolution (hint: add .tsx extension)
     at file:///[WILDCARD]/main.ts:5:20
-Warning Sloppy import resolution (hint: update .js extension to .tsx)
+Warning Sloppy module resolution (hint: update .js extension to .tsx)
     at file:///[WILDCARD]/main.ts:6:21
-Warning Sloppy import resolution (hint: add .jsx extension)
+Warning Sloppy module resolution (hint: add .jsx extension)
     at file:///[WILDCARD]/main.ts:7:20
-Warning Sloppy import resolution (hint: specify path to index.tsx file in directory instead)
+Warning Sloppy module resolution (hint: specify path to index.tsx file in directory instead)
     at file:///[WILDCARD]/main.ts:8:20
 [class A]
 [class B]

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -42,7 +42,7 @@ pub async fn compile(
   if cli_options.unstable_sloppy_imports() {
     log::warn!(
       concat!(
-        "{} Sloppy import resolution is not supported in deno compile. ",
+        "{} Sloppy imports are not supported in deno compile. ",
         "The compiled executable may encouter runtime errors.",
       ),
       crate::colors::yellow("Warning"),

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -37,6 +37,18 @@ pub async fn compile(
     vec
   };
 
+  // this is not supported, so show a warning about it, but don't error in order
+  // to allow someone to still run `deno compile` when this is in a deno.json
+  if cli_options.unstable_sloppy_imports() {
+    log::warn!(
+      concat!(
+        "{} Sloppy import resolution is not supported in deno compile. ",
+        "The compiled executable may encouter runtime errors.",
+      ),
+      crate::colors::yellow("Warning"),
+    );
+  }
+
   let output_path = resolve_compile_executable_output_path(
     &compile_flags,
     cli_options.initial_cwd(),

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -47,7 +47,7 @@ To grant permissions, set them before the script argument. For example:
 
   if cli_options.unstable_sloppy_imports() {
     log::warn!(
-      "{} Sloppy import resolution is not recommended and may have a negative impact on performance.",
+      "{} Sloppy imports are not recommended and may have a negative impact on performance.",
       crate::colors::yellow("Warning"),
     );
   }

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -45,6 +45,13 @@ To grant permissions, set them before the script argument. For example:
   let http_client = factory.http_client();
   let cli_options = factory.cli_options();
 
+  if cli_options.unstable_sloppy_imports() {
+    log::warn!(
+      "{} Sloppy import resolution is not recommended and may have a negative impact on performance.",
+      crate::colors::yellow("Warning"),
+    );
+  }
+
   // Run a background task that checks for available upgrades or output
   // if an earlier run of this background task found a new version of Deno.
   #[cfg(feature = "upgrade")]


### PR DESCRIPTION
One warning for when using it with `deno compile` and another when using it with `deno run`.