### PR TITLE
perf: measure document acquisition time

### DIFF
--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -683,7 +683,7 @@ mod tests {
       location.to_path_buf(),
       crate::cache::RealDenoCacheEnv,
     ));
-    let mut documents = Documents::new(cache);
+    let mut documents = Documents::new(cache, Default::default());
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1555,7 +1555,7 @@ mod tests {
       location.to_path_buf(),
       RealDenoCacheEnv,
     ));
-    let mut documents = Documents::new(cache);
+    let mut documents = Documents::new(cache, Default::default());
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -470,9 +470,10 @@ impl Inner {
       location,
       crate::cache::RealDenoCacheEnv,
     ));
-    let documents = Documents::new(deps_http_cache.clone());
-    let cache_metadata = cache::CacheMetadata::new(deps_http_cache.clone());
     let performance = Arc::new(Performance::default());
+    let documents =
+      Documents::new(deps_http_cache.clone(), performance.clone());
+    let cache_metadata = cache::CacheMetadata::new(deps_http_cache.clone());
     let ts_server =
       Arc::new(TsServer::new(performance.clone(), deps_http_cache.clone()));
     let config = Config::new();

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4045,7 +4045,7 @@ deno_core::extension!(deno_tsc,
         assets: Default::default(),
         cache_metadata: CacheMetadata::new(options.cache.clone()),
         config: Default::default(),
-        documents: Documents::new(options.cache.clone()),
+        documents: Documents::new(options.cache.clone(), options.performance.clone()),
         maybe_import_map: None,
         npm: None,
       }),
@@ -4480,7 +4480,7 @@ mod tests {
       location.to_path_buf(),
       RealDenoCacheEnv,
     ));
-    let mut documents = Documents::new(cache.clone());
+    let mut documents = Documents::new(cache.clone(), Default::default());
     for (specifier, source, version, language_id) in fixtures {
       let specifier =
         resolve_url(specifier).expect("failed to create specifier");

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -8303,6 +8303,7 @@ fn lsp_performance() {
     averages,
     vec![
       "lsp.did_open",
+      "lsp.get_document",
       "lsp.hover",
       "lsp.initialize",
       "lsp.testing_update",


### PR DESCRIPTION
Adds performance measurements when loading documents from
memory cache or file system.