### PR TITLE
fix(ext/node): ServerResponse getHeader() return undefined

### DIFF
--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -855,7 +855,6 @@ Deno.test("[node/http] node:http request.setHeader(header, null) doesn't throw",
   }
 });
 
-
 Deno.test("[node/http] ServerResponse getHeader", async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
   const server = http.createServer((_req, res) => {

--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -854,3 +854,25 @@ Deno.test("[node/http] node:http request.setHeader(header, null) doesn't throw",
     req.destroy();
   }
 });
+
+
+Deno.test("[node/http] ServerResponse getHeader", async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const server = http.createServer((_req, res) => {
+    res.setHeader("foo", "bar");
+    assertEquals(res.getHeader("foo"), "bar");
+    assertEquals(res.getHeader("ligma"), undefined);
+    res.end("Hello World");
+  });
+
+  server.listen(async () => {
+    const { port } = server.address() as { port: number };
+    const res = await fetch(`http://localhost:${port}`);
+    assertEquals(await res.text(), "Hello World");
+    server.close(() => {
+      resolve();
+    });
+  });
+
+  await promise;
+});

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1394,7 +1394,7 @@ export class ServerResponse extends NodeWritable {
   }
 
   getHeader(name: string) {
-    return this.#headers.get(name);
+    return this.#headers.get(name) ?? undefined;
   }
   removeHeader(name: string) {
     return this.#headers.delete(name);


### PR DESCRIPTION
Matches Node's return type.

Next.js check for `if (header === undefined)`:
https://github.com/vercel/next.js/blob/e02fe314dcd0ae614c65b505c6daafbdeebb920e/packages/next/src/server/base-http/node.ts#L93