### PR TITLE
fix(ext/node): stub ServerResponse#flushHeaders

### DIFF
--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -482,6 +482,26 @@ Deno.test("[node/http] ServerResponse _implicitHeader", async () => {
   await promise;
 });
 
+// https://github.com/denoland/deno/issues/21509
+Deno.test("[node/http] ServerResponse flushHeaders", async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const server = http.createServer((_req, res) => {
+    res.flushHeaders(); // no-op
+    res.end("Hello World");
+  });
+
+  server.listen(async () => {
+    const { port } = server.address() as { port: number };
+    const res = await fetch(`http://localhost:${port}`);
+    assertEquals(await res.text(), "Hello World");
+    server.close(() => {
+      resolve();
+    });
+  });
+
+  await promise;
+});
+
 Deno.test("[node/http] server unref", async () => {
   const [statusCode, _output] = await execCode(`
   import http from "node:http";

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1459,6 +1459,10 @@ export class ServerResponse extends NodeWritable {
     return super.end(chunk, encoding, cb);
   }
 
+  flushHeaders() {
+    // no-op
+  }
+
   // Undocumented API used by `npm:compression`.
   _implicitHeader() {
     this.writeHead(this.statusCode);


### PR DESCRIPTION
This commit adds a no-op flushHeaders method to the ServerResponse object. It is a nop because the ServerResponse implementation is based on top of the Deno server API instead of the Node `OutgoingMessage` base.

Fixes #21509 