### PR TITLE
fix(coverage): escape source code in html coverage report

### DIFF
--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -553,6 +553,8 @@ fn test_html_reporter() {
   let bar_ts_html =
     fs::read_to_string(tempdir.join("html").join("bar.ts.html")).unwrap();
   assert!(bar_ts_html.contains("<h1>Coverage report for bar.ts</h1>"));
+  // Check <T> in source code is escaped to &lt;T&gt;
+  assert!(bar_ts_html.contains("&lt;T&gt;"));
 
   let baz_index_html =
     fs::read_to_string(tempdir.join("html").join("baz").join("index.html"))

--- a/cli/tests/testdata/coverage/multisource/bar.ts
+++ b/cli/tests/testdata/coverage/multisource/bar.ts
@@ -1,4 +1,4 @@
-export function bar(cond: boolean) {
+export function bar<T>(cond: T) {
   if (cond) {
     return 1;
   } else {

--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -548,6 +548,8 @@ impl HtmlCoverageReporter {
       .collect::<Vec<_>>()
       .join("\n");
 
+    let file_text = file_text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+
     // TODO(kt3k): Add syntax highlight to source code
     format!(
       "<table class='coverage'>


### PR DESCRIPTION
This PR fixes the escaping behavior of the html coverage reporter. Closes #21529 

BEFORE
<img width="385" alt="Screenshot 2023-12-11 at 13 42 14" src="https://github.com/denoland/deno/assets/613956/0f3dd4ae-bf3a-4cd3-9904-6eed643f48ba">

AFTER
<img width="410" alt="Screenshot 2023-12-11 at 13 41 34" src="https://github.com/denoland/deno/assets/613956/7b396fa7-4854-4310-9fbf-186008827bb9">
