### PR TITLE
test(ext/node): enable some compat test cases

### DIFF
--- a/cli/tests/node_compat/config.jsonc
+++ b/cli/tests/node_compat/config.jsonc
@@ -21,7 +21,6 @@
       "test-assert.js",
       "test-buffer-alloc.js",
       "test-buffer-arraybuffer.js",
-      "test-buffer-bytelength.js",
       "test-buffer-from.js",
       "test-buffer-includes.js",
       "test-buffer-indexof.js",

--- a/cli/tests/node_compat/test/parallel/test-buffer-alloc.js
+++ b/cli/tests/node_compat/test/parallel/test-buffer-alloc.js
@@ -9,7 +9,7 @@
 const common = require('../common');
 
 const assert = require('assert');
-// const vm = require('vm');
+const vm = require('vm');
 
 const SlowBuffer = require('buffer').SlowBuffer;
 
@@ -1154,11 +1154,11 @@ assert.throws(() => {
 // Regression test to verify that an empty ArrayBuffer does not throw.
 Buffer.from(new ArrayBuffer());
 
-// TODO(kt3k): Enable this test when vm.runInNewContext is available
+
 // Test that ArrayBuffer from a different context is detected correctly.
-// const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
-// Buffer.from(arrayBuf);
-// Buffer.from({ buffer: arrayBuf });
+const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
+Buffer.from(arrayBuf);
+Buffer.from({ buffer: arrayBuf });
 
 assert.throws(() => Buffer.alloc({ valueOf: () => 1 }),
               /"size" argument must be of type number/);

--- a/cli/tests/node_compat/test/parallel/test-buffer-bytelength.js
+++ b/cli/tests/node_compat/test/parallel/test-buffer-bytelength.js
@@ -10,7 +10,7 @@
 const common = require('../common');
 const assert = require('assert');
 const SlowBuffer = require('buffer').SlowBuffer;
-// const vm = require('vm');
+const vm = require('vm');
 
 [
   [32, 'latin1'],
@@ -125,11 +125,9 @@ assert.strictEqual(Buffer.byteLength('Il était tué', 'utf8'), 14);
     assert.strictEqual(Buffer.byteLength('Il était tué', encoding), 24);
   });
 
-// TODO(Soremwar)
-// Enable once vm module is available
 // Test that ArrayBuffer from a different context is detected correctly
-// const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
-// assert.strictEqual(Buffer.byteLength(arrayBuf), 0);
+const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
+assert.strictEqual(Buffer.byteLength(arrayBuf), 0);
 
 // Verify that invalid encodings are treated as utf8
 for (let i = 1; i < 10; i++) {

--- a/cli/tests/node_compat/test/parallel/test-querystring.js
+++ b/cli/tests/node_compat/test/parallel/test-querystring.js
@@ -155,14 +155,13 @@ const qsWeirdObjects = [
   [{ a: 1, b: [] }, 'a=1', { 'a': '1' }],
 ];
 
-// TODO(wafuwafu13): Enable this when `vm` is implemented.
-// const vm = require('vm');
-// const foreignObject = vm.runInNewContext('({"foo": ["bar", "baz"]})');
+const vm = require('vm');
+const foreignObject = vm.runInNewContext('({"foo": ["bar", "baz"]})');
 
 const qsNoMungeTestCases = [
   ['', {}],
   ['foo=bar&foo=baz', { 'foo': ['bar', 'baz'] }],
-  // ['foo=bar&foo=baz', foreignObject],
+  ['foo=bar&foo=baz', foreignObject],
   ['blah=burp', { 'blah': 'burp' }],
   ['a=!-._~\'()*', { 'a': '!-._~\'()*' }],
   ['a=abcdefghijklmnopqrstuvwxyz', { 'a': 'abcdefghijklmnopqrstuvwxyz' }],

--- a/cli/tests/node_compat/test/parallel/test-util-inspect.js
+++ b/cli/tests/node_compat/test/parallel/test-util-inspect.js
@@ -33,8 +33,7 @@ const assert = require('assert');
 // const { internalBinding } = require('internal/test/binding');
 // const JSStream = internalBinding('js_stream').JSStream;
 const util = require('util');
-// TODO(wafuwafu13): Implement 'vm'
-// const vm = require('vm');
+const vm = require('vm');
 // TODO(wafuwafu13): Implement 'v8'
 // const v8 = require('v8');
 // TODO(wafuwafu13): Implement 'internal/test/binding'
@@ -566,16 +565,15 @@ assert.strictEqual(
                      '2010-02-14T11:48:40.000Z { aprop: 42 }');
 }
 
-// TODO(wafuwafu13): Implement 'vm'
-// // Test the internal isDate implementation.
-// {
-//   const Date2 = vm.runInNewContext('Date');
-//   const d = new Date2();
-//   const orig = util.inspect(d);
-//   Date2.prototype.foo = 'bar';
-//   const after = util.inspect(d);
-//   assert.strictEqual(orig, after);
-// }
+// Test the internal isDate implementation.
+{
+  const Date2 = vm.runInNewContext('Date');
+  const d = new Date2();
+  const orig = util.inspect(d);
+  Date2.prototype.foo = 'bar';
+  const after = util.inspect(d);
+  assert.strictEqual(orig, after);
+}
 
 // Test positive/negative zero.
 assert.strictEqual(util.inspect(0), '0');

--- a/cli/tests/node_compat/test/parallel/test-util-promisify.js
+++ b/cli/tests/node_compat/test/parallel/test-util-promisify.js
@@ -81,12 +81,11 @@ const stat = promisify(fs.stat);
 //   }));
 // }
 
-// TODO(wafuwafu13): Implement "vm.runInNewContext"
-// {
-//   const fn = vm.runInNewContext('(function() {})');
-//   assert.notStrictEqual(Object.getPrototypeOf(promisify(fn)),
-//                         Function.prototype);
-// }
+{
+  const fn = vm.runInNewContext('(function() {})');
+  assert.notStrictEqual(Object.getPrototypeOf(promisify(fn)),
+                        Function.prototype);
+}
 
 {
   function fn(callback) {

--- a/cli/tests/node_compat/test/parallel/test-util-types.js
+++ b/cli/tests/node_compat/test/parallel/test-util-types.js
@@ -10,8 +10,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { types, inspect } = require('util');
-// TODO(wafuwafu13): Implement "vm"
-// const vm = require('vm');
+const vm = require('vm');
 // TODO(wafuwafu13): Implement "internalBinding"
 // const { internalBinding } = require('internal/test/binding');
 // const { JSStream } = internalBinding('js_stream');
@@ -87,45 +86,44 @@ for (const [ value, _method ] of [
   Object(BigInt(0)),
 ].forEach((entry) => assert(types.isBoxedPrimitive(entry)));
 
-// TODO(wafuwafu13): Fix
-// {
-//   assert(!types.isUint8Array({ [Symbol.toStringTag]: 'Uint8Array' }));
-//   assert(types.isUint8Array(vm.runInNewContext('new Uint8Array')));
+{
+  assert(!types.isUint8Array({ [Symbol.toStringTag]: 'Uint8Array' }));
+  assert(types.isUint8Array(vm.runInNewContext('new Uint8Array')));
 
-//   assert(!types.isUint8ClampedArray({
-//     [Symbol.toStringTag]: 'Uint8ClampedArray'
-//   }));
-//   assert(types.isUint8ClampedArray(
-//     vm.runInNewContext('new Uint8ClampedArray')
-//   ));
+  assert(!types.isUint8ClampedArray({
+    [Symbol.toStringTag]: 'Uint8ClampedArray'
+  }));
+  assert(types.isUint8ClampedArray(
+    vm.runInNewContext('new Uint8ClampedArray')
+  ));
 
-//   assert(!types.isUint16Array({ [Symbol.toStringTag]: 'Uint16Array' }));
-//   assert(types.isUint16Array(vm.runInNewContext('new Uint16Array')));
+  assert(!types.isUint16Array({ [Symbol.toStringTag]: 'Uint16Array' }));
+  assert(types.isUint16Array(vm.runInNewContext('new Uint16Array')));
 
-//   assert(!types.isUint32Array({ [Symbol.toStringTag]: 'Uint32Array' }));
-//   assert(types.isUint32Array(vm.runInNewContext('new Uint32Array')));
+  assert(!types.isUint32Array({ [Symbol.toStringTag]: 'Uint32Array' }));
+  assert(types.isUint32Array(vm.runInNewContext('new Uint32Array')));
 
-//   assert(!types.isInt8Array({ [Symbol.toStringTag]: 'Int8Array' }));
-//   assert(types.isInt8Array(vm.runInNewContext('new Int8Array')));
+  assert(!types.isInt8Array({ [Symbol.toStringTag]: 'Int8Array' }));
+  assert(types.isInt8Array(vm.runInNewContext('new Int8Array')));
 
-//   assert(!types.isInt16Array({ [Symbol.toStringTag]: 'Int16Array' }));
-//   assert(types.isInt16Array(vm.runInNewContext('new Int16Array')));
+  assert(!types.isInt16Array({ [Symbol.toStringTag]: 'Int16Array' }));
+  assert(types.isInt16Array(vm.runInNewContext('new Int16Array')));
 
-//   assert(!types.isInt32Array({ [Symbol.toStringTag]: 'Int32Array' }));
-//   assert(types.isInt32Array(vm.runInNewContext('new Int32Array')));
+  assert(!types.isInt32Array({ [Symbol.toStringTag]: 'Int32Array' }));
+  assert(types.isInt32Array(vm.runInNewContext('new Int32Array')));
 
-//   assert(!types.isFloat32Array({ [Symbol.toStringTag]: 'Float32Array' }));
-//   assert(types.isFloat32Array(vm.runInNewContext('new Float32Array')));
+  assert(!types.isFloat32Array({ [Symbol.toStringTag]: 'Float32Array' }));
+  assert(types.isFloat32Array(vm.runInNewContext('new Float32Array')));
 
-//   assert(!types.isFloat64Array({ [Symbol.toStringTag]: 'Float64Array' }));
-//   assert(types.isFloat64Array(vm.runInNewContext('new Float64Array')));
+  assert(!types.isFloat64Array({ [Symbol.toStringTag]: 'Float64Array' }));
+  assert(types.isFloat64Array(vm.runInNewContext('new Float64Array')));
 
-//   assert(!types.isBigInt64Array({ [Symbol.toStringTag]: 'BigInt64Array' }));
-//   assert(types.isBigInt64Array(vm.runInNewContext('new BigInt64Array')));
+  assert(!types.isBigInt64Array({ [Symbol.toStringTag]: 'BigInt64Array' }));
+  assert(types.isBigInt64Array(vm.runInNewContext('new BigInt64Array')));
 
-//   assert(!types.isBigUint64Array({ [Symbol.toStringTag]: 'BigUint64Array' }));
-//   assert(types.isBigUint64Array(vm.runInNewContext('new BigUint64Array')));
-// }
+  assert(!types.isBigUint64Array({ [Symbol.toStringTag]: 'BigUint64Array' }));
+  assert(types.isBigUint64Array(vm.runInNewContext('new BigUint64Array')));
+}
 
 {
   const primitive = true;


### PR DESCRIPTION
This PR uncomments Node.js compat test cases which was enabled by the addition of `vm.runInNewContext` https://github.com/denoland/deno/pull/21527