### PR TITLE
chore: modify editorconfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 
 [*.out] # make editor neutral to .out files
-insert_final_newline = false
-trim_trailing_whitespace = false
+insert_final_newline = unset
+trim_trailing_whitespace = unset
 
-[*.py]
-indent_size = 4
+[cli/tests/node_compat/test/**]
+insert_final_newline = unset
+trim_trailing_whitespace = unset


### PR DESCRIPTION
This PR updates `.editorconfig`. In node compat test cases, they sometimes contain trailing spaces, and it's not desirable for the editor to automatically remove them. This change prevents it