### PR TITLE
fix: ignore more paths in dynamic arg module search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f56934a1e3c8c7c3a5834613734b1e34c480f14e6815d52eae22481bd406195"
+checksum = "cde6dca752e0bdcf908082ff6852be911e72edf013c126fa2ce78e0420bc5838"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,7 +62,7 @@ deno_config = "=0.6.5"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.75.1", features = ["html"] }
 deno_emit = "=0.32.0"
-deno_graph = "=0.62.1"
+deno_graph = "=0.62.2"
 deno_lint = { version = "=0.52.2", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm = "0.15.3"


### PR DESCRIPTION
Upgrades deno_doc for https://github.com/denoland/deno_graph/pull/344