### PR TITLE
perf(lsp): use null types instead of stub modules

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3877,11 +3877,7 @@ fn op_load<'s>(
   let specifier = state.specifier_map.normalize(specifier)?;
   let maybe_load_response =
     if specifier.as_str() == "internal:///missing_dependency.d.ts" {
-      Some(LoadResponse {
-        data: Arc::from("declare const __: any;\nexport = __;\n"),
-        script_kind: crate::tsc::as_ts_script_kind(MediaType::Dts),
-        version: Some("1".to_string()),
-      })
+      None
     } else {
       let asset_or_document = state.get_asset_or_document(&specifier);
       asset_or_document.map(|doc| LoadResponse {

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -8117,57 +8117,6 @@ fn lsp_ts_diagnostics_refresh_on_lsp_version_reset() {
 }
 
 #[test]
-fn lsp_npm_missing_type_imports_diagnostics() {
-  let context = TestContextBuilder::new()
-    .use_http_server()
-    .use_temp_cwd()
-    .build();
-  let mut client = context.new_lsp_command().build();
-  client.initialize_default();
-  client.did_open(json!({
-    "textDocument": {
-      "uri": "file:///a/file.ts",
-      "languageId": "typescript",
-      "version": 1,
-      "text": r#"
-        import colorName, { type RGB } from 'npm:color-name';
-        const color: RGB = colorName.black;
-        console.log(color);
-      "#,
-    },
-  }));
-  client.write_request(
-    "workspace/executeCommand",
-    json!({
-      "command": "deno.cache",
-      "arguments": [[], "file:///a/file.ts"],
-    }),
-  );
-  let diagnostics = client.read_diagnostics();
-  assert_eq!(
-    json!(
-      diagnostics.messages_with_file_and_source("file:///a/file.ts", "deno-ts")
-    ),
-    json!({
-      "uri": "file:///a/file.ts",
-      "diagnostics": [
-        {
-          "range": {
-            "start": { "line": 1, "character": 33 },
-            "end": { "line": 1, "character": 36 },
-          },
-          "severity": 1,
-          "code": 2305,
-          "source": "deno-ts",
-          "message": "Module '\"npm:color-name\"' has no exported member 'RGB'.",
-        },
-      ],
-      "version": 1,
-    })
-  );
-}
-
-#[test]
 fn lsp_jupyter_diagnostics() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let mut client = context.new_lsp_command().build();

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -528,7 +528,7 @@ delete Object.prototype.__proto__;
       if (logDebug) {
         debug(`host.readFile("${specifier}")`);
       }
-      return ops.op_load(specifier).data;
+      return ops.op_load(specifier)?.data;
     },
     getCancellationToken() {
       // createLanguageService will call this immediately and cache it

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1111,16 +1111,8 @@ mod tests {
   async fn test_load_missing_specifier() {
     let mut state = setup(None, None, None).await;
     let actual = op_load::call(&mut state, "https://deno.land/x/mod.ts")
-      .expect("should have invoked op")
-      .expect("load should have succeeded");
-    assert_eq!(
-      serde_json::to_value(actual).unwrap(),
-      json!({
-        "data": null,
-        "version": null,
-        "scriptKind": 0,
-      })
-    )
+      .expect("should have invoked op");
+    assert_eq!(serde_json::to_value(actual).unwrap(), json!(null));
   }
 
   #[tokio::test]

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -441,7 +441,7 @@ pub fn as_ts_script_kind(media_type: MediaType) -> i32 {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LoadResponse {
-  data: Option<String>,
+  data: String,
   version: Option<String>,
   script_kind: i32,
 }
@@ -451,7 +451,7 @@ struct LoadResponse {
 fn op_load(
   state: &mut OpState,
   #[string] load_specifier: &str,
-) -> Result<LoadResponse, AnyError> {
+) -> Result<Option<LoadResponse>, AnyError> {
   let state = state.borrow_mut::<State>();
 
   let specifier = normalize_specifier(load_specifier, &state.current_dir)
@@ -466,9 +466,7 @@ fn op_load(
   // in certain situations we return a "blank" module to tsc and we need to
   // handle the request for that module here.
   } else if load_specifier == "internal:///missing_dependency.d.ts" {
-    hash = Some("1".to_string());
-    media_type = MediaType::Dts;
-    Some(Cow::Borrowed("declare const __: any;\nexport = __;\n"))
+    None
   } else if let Some(name) = load_specifier.strip_prefix("asset:///") {
     let maybe_source = get_lazily_loaded_asset(name);
     hash = get_maybe_hash(maybe_source, state.hash_data);
@@ -521,18 +519,19 @@ fn op_load(
         .with_context(|| format!("Unable to load {}", file_path.display()))?;
       Some(Cow::Owned(code))
     } else {
-      media_type = MediaType::Unknown;
       None
     };
     hash = get_maybe_hash(maybe_source.as_deref(), state.hash_data);
     maybe_source
   };
-
-  Ok(LoadResponse {
-    data: data.map(String::from),
+  let Some(data) = data else {
+    return Ok(None);
+  };
+  Ok(Some(LoadResponse {
+    data: data.into_owned(),
     version: hash,
     script_kind: as_ts_script_kind(media_type),
-  })
+  }))
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1079,9 +1078,10 @@ mod tests {
     )
     .await;
     let actual = op_load::call(&mut state, "asset:///lib.dom.d.ts")
-      .expect("should have invoked op");
+      .expect("should have invoked op")
+      .expect("load should have succeeded");
     let expected = get_lazily_loaded_asset("lib.dom.d.ts").unwrap();
-    assert_eq!(actual.data.unwrap(), expected);
+    assert_eq!(actual.data, expected);
     assert!(actual.version.is_some());
     assert_eq!(actual.script_kind, 3);
   }
@@ -1095,7 +1095,8 @@ mod tests {
     )
     .await;
     let actual = op_load::call(&mut state, "internal:///.tsbuildinfo")
-      .expect("should have invoked op");
+      .expect("should have invoked op")
+      .expect("load should have succeeded");
     assert_eq!(
       serde_json::to_value(actual).unwrap(),
       json!({
@@ -1110,7 +1111,8 @@ mod tests {
   async fn test_load_missing_specifier() {
     let mut state = setup(None, None, None).await;
     let actual = op_load::call(&mut state, "https://deno.land/x/mod.ts")
-      .expect("should have invoked op");
+      .expect("should have invoked op")
+      .expect("load should have succeeded");
     assert_eq!(
       serde_json::to_value(actual).unwrap(),
       json!({


### PR DESCRIPTION
When tsc tries to load types for a module which had failed to resolve (labelled `internal:///missing_dependency.d.ts`), return null instead of a stub module like:
```ts
declare const __: any;
export = __;
```

#20780 fixed a discrepancy between `deno check` and LSP type-checking where that latter was returning null from `op_load()` instead of using the above stub module. After seeing https://github.com/denoland/vscode_deno/issues/895#issuecomment-1850960544 we suspect that this caused a slowdown in projects using node compat. So this PR flips them both the other way.

As far as we know this change only affects the behaviour of doing erroneous `type` imports from untyped modules. These will no longer error and there's no real reason they should.