### PR TITLE
fix(coverage): rename --pretty to --detailed

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -87,7 +87,7 @@ pub struct CompletionsFlags {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CoverageType {
   Summary,
-  Pretty,
+  Detailed,
   Lcov,
   Html,
 }
@@ -1415,9 +1415,9 @@ Generate html reports from lcov:
             .action(ArgAction::SetTrue),
         )
         .arg(
-          Arg::new("pretty")
-            .long("pretty")
-            .help("Output coverage report in pretty format in the terminal.")
+          Arg::new("detailed")
+            .long("detailed")
+            .help("Output coverage report in detailed format in the terminal.")
             .action(ArgAction::SetTrue),
         )
         .arg(
@@ -3327,8 +3327,8 @@ fn coverage_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     CoverageType::Lcov
   } else if matches.get_flag("html") {
     CoverageType::Html
-  } else if matches.get_flag("pretty") {
-    CoverageType::Pretty
+  } else if matches.get_flag("detailed") {
+    CoverageType::Detailed
   } else {
     CoverageType::Summary
   };

--- a/cli/tests/integration/coverage_tests.rs
+++ b/cli/tests/integration/coverage_tests.rs
@@ -117,7 +117,7 @@ fn run_coverage_text(test_name: &str, extension: &str) {
     .new_command()
     .args_vec(vec![
       "coverage".to_string(),
-      "--pretty".to_string(),
+      "--detailed".to_string(),
       format!("{}/", tempdir),
     ])
     .split_output()
@@ -190,7 +190,7 @@ fn multifile_coverage() {
     .new_command()
     .args_vec(vec![
       "coverage".to_string(),
-      "--pretty".to_string(),
+      "--detailed".to_string(),
       format!("{}/", tempdir),
     ])
     .split_output()
@@ -263,7 +263,7 @@ fn no_snaps_included(test_name: &str, extension: &str) {
     .args_vec(vec![
       "coverage".to_string(),
       "--include=no_snaps_included.ts".to_string(),
-      "--pretty".to_string(),
+      "--detailed".to_string(),
       format!("{}/", tempdir),
     ])
     .split_output()
@@ -312,7 +312,7 @@ fn no_tests_included(test_name: &str, extension: &str) {
     .args_vec(vec![
       "coverage".to_string(),
       format!("--exclude={}", util::std_path().canonicalize()),
-      "--pretty".to_string(),
+      "--detailed".to_string(),
       format!("{}/", tempdir),
     ])
     .split_output()
@@ -362,7 +362,7 @@ fn no_npm_cache_coverage() {
     .new_command()
     .args_vec(vec![
       "coverage".to_string(),
-      "--pretty".to_string(),
+      "--detailed".to_string(),
       format!("{}/", tempdir),
     ])
     .split_output()
@@ -411,7 +411,7 @@ fn no_transpiled_lines() {
     .args_vec(vec![
       "coverage".to_string(),
       "--include=no_transpiled_lines/index.ts".to_string(),
-      "--pretty".to_string(),
+      "--detailed".to_string(),
       format!("{}/", tempdir),
     ])
     .run();

--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -32,7 +32,7 @@ pub fn create(kind: CoverageType) -> Box<dyn CoverageReporter + Send> {
   match kind {
     CoverageType::Summary => Box::new(SummaryCoverageReporter::new()),
     CoverageType::Lcov => Box::new(LcovCoverageReporter::new()),
-    CoverageType::Pretty => Box::new(PrettyCoverageReporter::new()),
+    CoverageType::Detailed => Box::new(DetailedCoverageReporter::new()),
     CoverageType::Html => Box::new(HtmlCoverageReporter::new()),
   }
 }
@@ -304,15 +304,15 @@ impl CoverageReporter for LcovCoverageReporter {
   }
 }
 
-struct PrettyCoverageReporter {}
+struct DetailedCoverageReporter {}
 
-impl PrettyCoverageReporter {
-  pub fn new() -> PrettyCoverageReporter {
-    PrettyCoverageReporter {}
+impl DetailedCoverageReporter {
+  pub fn new() -> DetailedCoverageReporter {
+    DetailedCoverageReporter {}
   }
 }
 
-impl CoverageReporter for PrettyCoverageReporter {
+impl CoverageReporter for DetailedCoverageReporter {
   fn report(
     &mut self,
     coverage_report: &CoverageReport,


### PR DESCRIPTION
This PR changes `--pretty` flag of `deno coverage` command to `--detailed` as 'pretty' sounds confusing because the default (summary) output is already in a pretty format.

Note: `--pretty` flag has been landed in https://github.com/denoland/deno/pull/21535 and it's not yet been shipped.