### PR TITLE
fix(console): inspect for `{Set,Map}Iterator` and `Weak{Set,Map}`

### DIFF
--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1030,6 +1030,17 @@ Deno.test(function consoleTestIteratorValueAreNotConsumed() {
   assertEquals([...setIterator], [1, 2, 3]);
 });
 
+Deno.test(function consoleTestWeakSetAndWeakMapWithShowHidden() {
+  assertEquals(
+    stripColor(Deno.inspect(new WeakSet([{}]), { showHidden: true })),
+    "WeakSet { {} }",
+  );
+  assertEquals(
+    stripColor(Deno.inspect(new WeakMap([[{}, "foo"]]), { showHidden: true })),
+    'WeakMap { {} => "foo" }',
+  );
+});
+
 Deno.test(async function consoleTestStringifyPromises() {
   const pendingPromise = new Promise((_res, _rej) => {});
   assertEquals(stringify(pendingPromise), "Promise { <pending> }");

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -269,6 +269,14 @@ Deno.test(function consoleTestStringifyCircular() {
   );
   assertEquals(stringify(new Set([1, 2, 3])), "Set(3) { 1, 2, 3 }");
   assertEquals(
+    stringify(new Set([1, 2, 3]).values()),
+    "[Set Iterator] { 1, 2, 3 }",
+  );
+  assertEquals(
+    stringify(new Set([1, 2, 3]).entries()),
+    "[Set Entries] { [ 1, 1 ], [ 2, 2 ], [ 3, 3 ] }",
+  );
+  assertEquals(
     stringify(
       new Map([
         [1, "one"],
@@ -276,6 +284,14 @@ Deno.test(function consoleTestStringifyCircular() {
       ]),
     ),
     `Map(2) { 1 => "one", 2 => "two" }`,
+  );
+  assertEquals(
+    stringify(new Map([[1, "one"], [2, "two"]]).values()),
+    `[Map Iterator] { "one", "two" }`,
+  );
+  assertEquals(
+    stringify(new Map([[1, "one"], [2, "two"]]).entries()),
+    `[Map Entries] { [ 1, "one" ], [ 2, "two" ] }`,
   );
   assertEquals(stringify(new WeakSet()), "WeakSet { <items unknown> }");
   assertEquals(stringify(new WeakMap()), "WeakMap { <items unknown> }");
@@ -378,13 +394,16 @@ Deno.test(function consoleTestStringifyFunctionWithPrototypeRemoved() {
   assertEquals(stringify(f), "[Function (null prototype): f]");
   const af = async function af() {};
   Reflect.setPrototypeOf(af, null);
-  assertEquals(stringify(af), "[Function (null prototype): af]");
+  assertEquals(stringify(af), "[AsyncFunction (null prototype): af]");
   const gf = function* gf() {};
   Reflect.setPrototypeOf(gf, null);
-  assertEquals(stringify(gf), "[Function (null prototype): gf]");
+  assertEquals(stringify(gf), "[GeneratorFunction (null prototype): gf]");
   const agf = async function* agf() {};
   Reflect.setPrototypeOf(agf, null);
-  assertEquals(stringify(agf), "[Function (null prototype): agf]");
+  assertEquals(
+    stringify(agf),
+    "[AsyncGeneratorFunction (null prototype): agf]",
+  );
 });
 
 Deno.test(function consoleTestStringifyFunctionWithProperties() {
@@ -2279,7 +2298,7 @@ Deno.test(function inspectWithPrototypePollution() {
 Deno.test(function inspectPromiseLike() {
   assertEquals(
     Deno.inspect(Object.create(Promise.prototype)),
-    "Promise { <unknown> }",
+    "Promise {}",
   );
 });
 

--- a/cli/tests/unit/console_test.ts
+++ b/cli/tests/unit/console_test.ts
@@ -1021,6 +1021,15 @@ Deno.test(function consoleTestStringifyIterableWhenGrouped() {
   );
 });
 
+Deno.test(function consoleTestIteratorValueAreNotConsumed() {
+  const setIterator = new Set([1, 2, 3]).values();
+  assertEquals(
+    stringify(setIterator),
+    "[Set Iterator] { 1, 2, 3 }",
+  );
+  assertEquals([...setIterator], [1, 2, 3]);
+});
+
 Deno.test(async function consoleTestStringifyPromises() {
   const pendingPromise = new Promise((_res, _rej) => {});
   assertEquals(stringify(pendingPromise), "Promise { <pending> }");

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -10,7 +10,6 @@ const {
   ArrayBufferPrototypeGetByteLength,
   ArrayIsArray,
   ArrayPrototypeFill,
-  ArrayPrototypeConcat,
   ArrayPrototypeFilter,
   ArrayPrototypeFind,
   ArrayPrototypeForEach,
@@ -136,22 +135,6 @@ const {
   WeakSetPrototypeHas,
 } = primordials;
 const ops = core.ops;
-
-// supposed to be in node/internal_binding/util.ts
-export function previewEntries(iter, isKeyValue) {
-  if (isKeyValue) {
-    // deno-lint-ignore prefer-primordials
-    const arr = [...iter];
-    if (ArrayIsArray(arr[0]) && arr[0].length === 2) {
-      // deno-lint-ignore prefer-primordials
-      return [ArrayPrototypeConcat([], ...arr), true];
-    }
-    return [arr, false];
-  } else {
-    // deno-lint-ignore prefer-primordials
-    return [...iter];
-  }
-}
 
 let noColor = () => false;
 
@@ -1455,7 +1438,7 @@ function getIteratorBraces(type, tag) {
 
 const iteratorRegExp = new SafeRegExp(" Iterator] {$");
 function formatIterator(braces, ctx, value, recurseTimes) {
-  const { 0: entries, 1: isKeyValue } = previewEntries(value, true);
+  const { 0: entries, 1: isKeyValue } = ops.op_preview_entries(value, true);
   if (isKeyValue) {
     // Mark entry iterators as such.
     braces[0] = StringPrototypeReplace(
@@ -1664,12 +1647,12 @@ function formatWeakCollection(ctx) {
 }
 
 function formatWeakSet(ctx, value, recurseTimes) {
-  const entries = previewEntries(value);
+  const entries = ops.op_preview_entries(value, false);
   return formatSetIterInner(ctx, recurseTimes, entries, kWeak);
 }
 
 function formatWeakMap(ctx, value, recurseTimes) {
-  const entries = previewEntries(value);
+  const entries = ops.op_preview_entries(value, false);
   return formatMapIterInner(ctx, recurseTimes, entries, kWeak);
 }
 

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -74,7 +74,6 @@ const {
   ObjectPrototype,
   ObjectPrototypeIsPrototypeOf,
   ObjectPrototypePropertyIsEnumerable,
-  ObjectPrototypeToString,
   ObjectSetPrototypeOf,
   ObjectValues,
   Proxy,
@@ -347,11 +346,7 @@ function isModuleNamespaceObject(value) {
 }
 
 function isNativeError(value) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === undefined &&
-    ObjectPrototypeToString(value) === "[object Error]"
-  );
+  return ops.op_is_native_error(value);
 }
 
 function isNumberObject(value) {

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -1619,14 +1619,7 @@ const PromiseState = {
 
 function formatPromise(ctx, value, recurseTimes) {
   let output;
-  let opResult;
-  // This op will fail for non-promises, but we get here for some promise-likes.
-  try {
-    opResult = core.getPromiseDetails(value);
-  } catch {
-    return [ctx.stylize("<unknown>", "special")];
-  }
-  const { 0: state, 1: result } = opResult;
+  const { 0: state, 1: result } = core.getPromiseDetails(value);
   if (state === PromiseState.Pending) {
     output = [ctx.stylize("<pending>", "special")];
   } else {

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -1395,7 +1395,7 @@ function formatTypedArray(
 ) {
   const maxLength = MathMin(MathMax(0, ctx.maxArrayLength), length);
   const remaining = value.length - maxLength;
-  const output = new Array(maxLength);
+  const output = [];
   const elementFormatter = value.length > 0 && typeof value[0] === "number"
     ? formatNumber
     : formatBigInt;
@@ -1555,7 +1555,7 @@ function inspectError(value, ctx) {
 
 const hexSliceLookupTable = function () {
   const alphabet = "0123456789abcdef";
-  const table = new Array(256);
+  const table = [];
   for (let i = 0; i < 16; ++i) {
     const i16 = i * 16;
     for (let j = 0; j < 16; ++j) {
@@ -1773,7 +1773,7 @@ function formatNamespaceObject(
   value,
   recurseTimes,
 ) {
-  const output = new Array(keys.length);
+  const output = [];
   for (let i = 0; i < keys.length; i++) {
     try {
       output[i] = formatProperty(
@@ -1992,7 +1992,7 @@ function groupArrayElements(ctx, output, value) {
     outputLength--;
   }
   const separatorSpace = 2; // Add 1 for the space and 1 for the separator.
-  const dataLen = new Array(outputLength);
+  const dataLen = [];
   // Calculate the total length of all output entries and the individual max
   // entries length of all output entries. We have to remove colors first,
   // otherwise the length would not be calculated properly.
@@ -2106,7 +2106,7 @@ function formatMapIterInner(
   const len = entries.length / 2;
   const remaining = len - maxArrayLength;
   const maxLength = MathMin(maxArrayLength, len);
-  const output = new Array(maxLength);
+  const output = [];
   let i = 0;
   ctx.indentationLvl += 2;
   if (state === kWeak) {
@@ -2157,7 +2157,7 @@ function formatSetIterInner(
 ) {
   const maxArrayLength = MathMax(ctx.maxArrayLength, 0);
   const maxLength = MathMin(maxArrayLength, entries.length);
-  const output = new Array(maxLength);
+  const output = [];
   ctx.indentationLvl += 2;
   for (let i = 0; i < maxLength; i++) {
     output[i] = formatValue(ctx, entries[i], recurseTimes);

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -135,6 +135,7 @@ const {
   WeakMapPrototypeHas,
   WeakSetPrototypeHas,
 } = primordials;
+const ops = core.ops;
 
 // supposed to be in node/internal_binding/util.ts
 export function previewEntries(iter, isKeyValue) {
@@ -284,19 +285,15 @@ function isObjectLike(value) {
   return value !== null && typeof value === "object";
 }
 
-export function isAnyArrayBuffer(value) {
-  return isArrayBuffer(value) || isSharedArrayBuffer(value);
+function isAnyArrayBuffer(value) {
+  return ops.op_is_any_arraybuffer(value);
 }
 
-export function isArgumentsObject(value) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === undefined &&
-    ObjectPrototypeToString(value) === "[object Arguments]"
-  );
+function isArgumentsObject(value) {
+  return ops.op_is_arguments_object(value);
 }
 
-export function isArrayBuffer(value) {
+function isArrayBuffer(value) {
   try {
     ArrayBufferPrototypeGetByteLength(value);
     return true;
@@ -305,21 +302,11 @@ export function isArrayBuffer(value) {
   }
 }
 
-export function isAsyncFunction(value) {
-  return (
-    typeof value === "function" &&
-    (value[SymbolToStringTag] === "AsyncFunction")
-  );
+function isAsyncFunction(value) {
+  return ops.op_is_async_function(value);
 }
 
-export function isAsyncGeneratorFunction(value) {
-  return (
-    typeof value === "function" &&
-    (value[SymbolToStringTag] === "AsyncGeneratorFunction")
-  );
-}
-
-export function isBooleanObject(value) {
+function isBooleanObject(value) {
   if (!isObjectLike(value)) {
     return false;
   }
@@ -332,7 +319,7 @@ export function isBooleanObject(value) {
   }
 }
 
-export function isBoxedPrimitive(
+function isBoxedPrimitive(
   value,
 ) {
   return (
@@ -344,27 +331,22 @@ export function isBoxedPrimitive(
   );
 }
 
-export function isDataView(value) {
+function isDataView(value) {
   return (
     ArrayBufferIsView(value) &&
     TypedArrayPrototypeGetSymbolToStringTag(value) === undefined
   );
 }
 
-export function isTypedArray(value) {
+function isTypedArray(value) {
   return TypedArrayPrototypeGetSymbolToStringTag(value) !== undefined;
 }
 
-export function isGeneratorFunction(
-  value,
-) {
-  return (
-    typeof value === "function" &&
-    value[SymbolToStringTag] === "GeneratorFunction"
-  );
+function isGeneratorFunction(value) {
+  return ops.op_is_generator_function(value);
 }
 
-export function isMap(value) {
+function isMap(value) {
   try {
     MapPrototypeGetSize(value);
     return true;
@@ -373,25 +355,15 @@ export function isMap(value) {
   }
 }
 
-export function isMapIterator(
-  value,
-) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === "Map Iterator"
-  );
+function isMapIterator(value) {
+  return ops.op_is_map_iterator(value);
 }
 
-export function isModuleNamespaceObject(
-  value,
-) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === "Module"
-  );
+function isModuleNamespaceObject(value) {
+  return ops.op_is_module_namespace_object(value);
 }
 
-export function isNativeError(value) {
+function isNativeError(value) {
   return (
     isObjectLike(value) &&
     value[SymbolToStringTag] === undefined &&
@@ -399,7 +371,7 @@ export function isNativeError(value) {
   );
 }
 
-export function isNumberObject(value) {
+function isNumberObject(value) {
   if (!isObjectLike(value)) {
     return false;
   }
@@ -412,7 +384,7 @@ export function isNumberObject(value) {
   }
 }
 
-export function isBigIntObject(value) {
+function isBigIntObject(value) {
   if (!isObjectLike(value)) {
     return false;
   }
@@ -425,21 +397,15 @@ export function isBigIntObject(value) {
   }
 }
 
-export function isPromise(value) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === "Promise"
-  );
-}
-export function isRegExp(value) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === undefined &&
-    ObjectPrototypeToString(value) === "[object RegExp]"
-  );
+function isPromise(value) {
+  return ops.op_is_promise(value);
 }
 
-export function isSet(value) {
+function isRegExp(value) {
+  return ops.op_is_reg_exp(value);
+}
+
+function isSet(value) {
   try {
     SetPrototypeGetSize(value);
     return true;
@@ -448,27 +414,11 @@ export function isSet(value) {
   }
 }
 
-export function isSetIterator(
-  value,
-) {
-  return (
-    isObjectLike(value) &&
-    value[SymbolToStringTag] === "Set Iterator"
-  );
+function isSetIterator(value) {
+  return ops.op_is_set_iterator(value);
 }
 
-export function isSharedArrayBuffer(
-  value,
-) {
-  try {
-    getSharedArrayBufferByteLength(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function isStringObject(value) {
+function isStringObject(value) {
   if (!isObjectLike(value)) {
     return false;
   }
@@ -481,7 +431,7 @@ export function isStringObject(value) {
   }
 }
 
-export function isSymbolObject(value) {
+function isSymbolObject(value) {
   if (!isObjectLike(value)) {
     return false;
   }
@@ -494,7 +444,7 @@ export function isSymbolObject(value) {
   }
 }
 
-export function isWeakMap(
+function isWeakMap(
   value,
 ) {
   try {
@@ -505,7 +455,7 @@ export function isWeakMap(
   }
 }
 
-export function isWeakSet(
+function isWeakSet(
   value,
 ) {
   try {
@@ -793,9 +743,6 @@ function getFunctionBase(value, constructor, tag) {
   if (isAsyncFunction(value)) {
     type = `Async${type}`;
   }
-  if (isAsyncGeneratorFunction(value)) {
-    type = `AsyncGenerator${type}`;
-  }
   let base = `[${type}`;
   if (constructor === null) {
     base += " (null prototype)";
@@ -866,7 +813,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray, proxyDetails) {
         const prefix = (constructor !== "Array" || tag !== "")
           ? getPrefix(constructor, tag, "Array", `(${value.length})`)
           : "";
-        keys = core.ops.op_get_non_index_property_names(value, filter);
+        keys = ops.op_get_non_index_property_names(value, filter);
         braces = [`${prefix}[`, "]"];
         if (
           value.length === 0 && keys.length === 0 && protoProps === undefined

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -10,6 +10,7 @@ deno_core::extension!(
     op_is_arguments_object,
     op_is_async_function,
     op_is_generator_function,
+    op_is_generator_object,
     op_is_map_iterator,
     op_is_module_namespace_object,
     op_is_promise,

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -13,6 +13,7 @@ deno_core::extension!(
     op_is_generator_object,
     op_is_map_iterator,
     op_is_module_namespace_object,
+    op_is_native_error,
     op_is_promise,
     op_is_reg_exp,
     op_is_set_iterator,
@@ -58,6 +59,11 @@ pub fn op_is_map_iterator(value: &v8::Value) -> bool {
 #[op2(fast)]
 pub fn op_is_module_namespace_object(value: &v8::Value) -> bool {
   value.is_module_namespace_object()
+}
+
+#[op2(fast)]
+pub fn op_is_native_error(value: &v8::Value) -> bool {
+  value.is_native_error()
 }
 
 #[op2(fast)]

--- a/ext/console/lib.rs
+++ b/ext/console/lib.rs
@@ -1,8 +1,74 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use deno_core::op2;
+use deno_core::v8;
 use std::path::PathBuf;
 
-deno_core::extension!(deno_console, esm = ["01_console.js"],);
+deno_core::extension!(
+  deno_console,
+  ops = [
+    op_is_any_arraybuffer,
+    op_is_arguments_object,
+    op_is_async_function,
+    op_is_generator_function,
+    op_is_map_iterator,
+    op_is_module_namespace_object,
+    op_is_promise,
+    op_is_reg_exp,
+    op_is_set_iterator,
+  ],
+  esm = ["01_console.js"],
+);
 
 pub fn get_declaration() -> PathBuf {
   PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lib.deno_console.d.ts")
+}
+
+#[op2(fast)]
+fn op_is_any_arraybuffer(value: &v8::Value) -> bool {
+  value.is_array_buffer() || value.is_shared_array_buffer()
+}
+
+#[op2(fast)]
+pub fn op_is_arguments_object(value: &v8::Value) -> bool {
+  value.is_arguments_object()
+}
+
+#[op2(fast)]
+pub fn op_is_async_function(value: &v8::Value) -> bool {
+  value.is_async_function()
+}
+
+#[op2(fast)]
+pub fn op_is_generator_function(value: &v8::Value) -> bool {
+  value.is_generator_function()
+}
+
+#[op2(fast)]
+pub fn op_is_generator_object(value: &v8::Value) -> bool {
+  value.is_generator_object()
+}
+
+#[op2(fast)]
+pub fn op_is_map_iterator(value: &v8::Value) -> bool {
+  value.is_map_iterator()
+}
+
+#[op2(fast)]
+pub fn op_is_module_namespace_object(value: &v8::Value) -> bool {
+  value.is_module_namespace_object()
+}
+
+#[op2(fast)]
+pub fn op_is_promise(value: &v8::Value) -> bool {
+  value.is_promise()
+}
+
+#[op2(fast)]
+pub fn op_is_reg_exp(value: &v8::Value) -> bool {
+  value.is_reg_exp()
+}
+
+#[op2(fast)]
+pub fn op_is_set_iterator(value: &v8::Value) -> bool {
+  value.is_set_iterator()
 }

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -150,11 +150,6 @@ fn op_node_build_os() -> String {
 }
 
 #[op2(fast)]
-fn op_is_any_arraybuffer(value: &v8::Value) -> bool {
-  value.is_array_buffer() || value.is_shared_array_buffer()
-}
-
-#[op2(fast)]
 fn op_node_is_promise_rejected(value: v8::Local<v8::Value>) -> bool {
   let Ok(promise) = v8::Local::<v8::Promise>::try_from(value) else {
     return false;
@@ -285,7 +280,6 @@ deno_core::extension!(deno_node,
     ops::os::op_node_os_username<P>,
     ops::os::op_geteuid<P>,
     op_node_build_os,
-    op_is_any_arraybuffer,
     op_node_is_promise_rejected,
     op_npm_process_state,
     ops::require::op_require_init_paths,

--- a/ext/node/polyfills/internal/console/constructor.mjs
+++ b/ext/node/polyfills/internal/console/constructor.mjs
@@ -17,7 +17,6 @@ import {
   validateInteger,
   validateObject,
 } from "ext:deno_node/internal/validators.mjs";
-import { previewEntries } from "ext:deno_node/internal_binding/util.ts";
 import { Buffer } from "node:buffer";
 const { isBuffer } = Buffer;
 import {
@@ -500,7 +499,7 @@ const consoleMethods = {
     let isKeyValue = false;
     let i = 0;
     if (mapIter) {
-      const res = previewEntries(tabularData, true);
+      const res = ops.op_preview_entries(tabularData, true);
       tabularData = res[0];
       isKeyValue = res[1];
     }
@@ -535,7 +534,7 @@ const consoleMethods = {
 
     const setIter = isSetIterator(tabularData);
     if (setIter) {
-      tabularData = previewEntries(tabularData);
+      tabularData = ops.op_preview_entries(tabularData, false);
     }
 
     const setlike = setIter || mapIter || isSet(tabularData);

--- a/ext/node/polyfills/internal/console/constructor.mjs
+++ b/ext/node/polyfills/internal/console/constructor.mjs
@@ -4,6 +4,9 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
+import { core } from "ext:core/mod.js";
+const ops = core.ops;
+
 // Mock trace for now
 const trace = () => {};
 import {

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -94,11 +94,7 @@ export function isAnyArrayBuffer(
 }
 
 export function isArgumentsObject(value: unknown): value is IArguments {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === undefined &&
-    _toString.call(value) === "[object Arguments]"
-  );
+  return ops.op_is_arguments_object(value);
 }
 
 export function isArrayBuffer(value: unknown): value is ArrayBuffer {
@@ -113,11 +109,7 @@ export function isArrayBuffer(value: unknown): value is ArrayBuffer {
 export function isAsyncFunction(
   value: unknown,
 ): value is (...args: unknown[]) => Promise<unknown> {
-  return (
-    typeof value === "function" &&
-    // @ts-ignore: function is a kind of object
-    value[Symbol.toStringTag] === "AsyncFunction"
-  );
+  return ops.op_is_async_function(value);
 }
 
 // deno-lint-ignore ban-types
@@ -166,18 +158,11 @@ export function isDate(value: unknown): value is Date {
 export function isGeneratorFunction(
   value: unknown,
 ): value is GeneratorFunction {
-  return (
-    typeof value === "function" &&
-    // @ts-ignore: function is a kind of object
-    value[Symbol.toStringTag] === "GeneratorFunction"
-  );
+  return ops.op_is_generator_function(value);
 }
 
 export function isGeneratorObject(value: unknown): value is Generator {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === "Generator"
-  );
+  return ops.op_is_generator_object(value);
 }
 
 export function isMap(value: unknown): value is Map<unknown, unknown> {
@@ -192,19 +177,13 @@ export function isMap(value: unknown): value is Map<unknown, unknown> {
 export function isMapIterator(
   value: unknown,
 ): value is IterableIterator<[unknown, unknown]> {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === "Map Iterator"
-  );
+  return ops.op_is_map_iterator(value);
 }
 
 export function isModuleNamespaceObject(
   value: unknown,
 ): value is Record<string | number | symbol, unknown> {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === "Module"
-  );
+  return ops.op_is_module_namespace_object(value);
 }
 
 export function isNativeError(value: unknown): value is Error {
@@ -243,10 +222,7 @@ export function isBigIntObject(value: unknown): value is bigint {
 }
 
 export function isPromise(value: unknown): value is Promise<unknown> {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === "Promise"
-  );
+  return ops.op_is_promise(value);
 }
 
 export function isProxy(
@@ -256,11 +232,7 @@ export function isProxy(
 }
 
 export function isRegExp(value: unknown): value is RegExp {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === undefined &&
-    _toString.call(value) === "[object RegExp]"
-  );
+  return ops.op_is_reg_exp(value);
 }
 
 export function isSet(value: unknown): value is Set<unknown> {
@@ -275,10 +247,7 @@ export function isSet(value: unknown): value is Set<unknown> {
 export function isSetIterator(
   value: unknown,
 ): value is IterableIterator<unknown> {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === "Set Iterator"
-  );
+  return ops.op_is_set_iterator(value);
 }
 
 export function isSharedArrayBuffer(

--- a/ext/node/polyfills/internal_binding/types.ts
+++ b/ext/node/polyfills/internal_binding/types.ts
@@ -27,9 +27,6 @@
 const { core } = globalThis.__bootstrap;
 const { ops } = core;
 
-// https://tc39.es/ecma262/#sec-object.prototype.tostring
-const _toString = Object.prototype.toString;
-
 // https://tc39.es/ecma262/#sec-bigint.prototype.valueof
 const _bigIntValueOf = BigInt.prototype.valueOf;
 
@@ -187,11 +184,7 @@ export function isModuleNamespaceObject(
 }
 
 export function isNativeError(value: unknown): value is Error {
-  return (
-    isObjectLike(value) &&
-    value[Symbol.toStringTag] === undefined &&
-    _toString.call(value) === "[object Error]"
-  );
+  return ops.op_is_native_error(value);
 }
 
 // deno-lint-ignore ban-types

--- a/ext/node/polyfills/internal_binding/util.ts
+++ b/ext/node/polyfills/internal_binding/util.ts
@@ -129,5 +129,3 @@ export function getOwnNonIndexProperties(
   }
   return result;
 }
-
-export { previewEntries } from "ext:deno_console/01_console.js";

--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -109,15 +109,11 @@ export function isFunction(value: unknown): boolean {
   return typeof value === "function";
 }
 
-/** @deprecated Use util.types.RegExp() instead. */
-export function isRegExp(value: unknown): boolean {
-  return types.isRegExp(value);
-}
+/** @deprecated Use util.types.isRegExp() instead. */
+export const isRegExp = types.isRegExp;
 
 /** @deprecated Use util.types.isDate() instead. */
-export function isDate(value: unknown): boolean {
-  return types.isDate(value);
-}
+export const isDate = types.isDate;
 
 /** @deprecated - use `value === null || (typeof value !== "object" && typeof value !== "function")` instead. */
 export function isPrimitive(value: unknown): boolean {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This PR includes the following fixes:

## strict runtime type checking

Fixed a bug that `{Set, Map}Iterator`'s `[[Prototype]]` were not displaying properly

current:

```
> Object.getPrototypeOf( new Set([1, 2, 3]).values() )
[Internal Formatting Error] TypeError: Method Set Iterator.prototype.next called on incompatible receiver #<Iterator>
    at Set Iterator.next (<anonymous>)
    at previewEntries (ext:deno_console/01_console.js:143:21)
    at formatIterator (ext:deno_console/01_console.js:1511:41)
    at formatRaw (ext:deno_console/01_console.js:1053:14)
    at formatValue (ext:deno_console/01_console.js:736:10)
    at Object.inspectArgs (ext:deno_console/01_console.js:3128:28)
    at <anonymous>:3:55
```

this PR:

```
> Object.getPrototypeOf( new Set([1, 2, 3]).values() )
Iterator [Set Iterator] {}
```

This change also improves inspect, such as `Promise` and `AsyncFunction` and so on.

## use `op_preview_entries`

Since JavaScript consumes Iterators in inspect, so `op_preview_entries` is used

current:

```
> const setIterator = new Set([1, 2, 3]).values()
undefined
> setIterator
[Set Iterator] { 1, 2, 3 }
> setIterator
[Set Iterator] {  }
```

this PR:

```
> const setIterator = new Set([1, 2, 3]).values()
undefined
> setIterator
[Set Iterator] { 1, 2, 3 }
> setIterator
[Set Iterator] { 1, 2, 3 }
```

It also allows previews against the `Weak{Set, Map}` with `showHidden: true`

current:

```
> Deno.inspect(new WeakSet([{}]), { showHidden: true })
"[Internal Formatting Error] TypeError: iter is not iterable\n" +
  "    at previewEntries (ext:deno_console/"... 287 more characters
```

this PR:

```
> Deno.inspect(new WeakSet([{}]), { showHidden: true })
"WeakSet { {} }"
```