### PR TITLE
fix(lsp): apply specifier rewrite to CompletionItem::text_edit

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3112,6 +3112,23 @@ impl CompletionEntryDetails {
     } else {
       None
     };
+    let mut text_edit = original_item.text_edit.clone();
+    if let Some(specifier_rewrite) = &data.specifier_rewrite {
+      if let Some(text_edit) = &mut text_edit {
+        match text_edit {
+          lsp::CompletionTextEdit::Edit(text_edit) => {
+            text_edit.new_text = text_edit
+              .new_text
+              .replace(&specifier_rewrite.0, &specifier_rewrite.1);
+          }
+          lsp::CompletionTextEdit::InsertAndReplace(insert_replace_edit) => {
+            insert_replace_edit.new_text = insert_replace_edit
+              .new_text
+              .replace(&specifier_rewrite.0, &specifier_rewrite.1);
+          }
+        }
+      }
+    }
     let (command, additional_text_edits) = parse_code_actions(
       self.code_actions.as_ref(),
       data,
@@ -3136,6 +3153,7 @@ impl CompletionEntryDetails {
       detail,
       documentation,
       command,
+      text_edit,
       additional_text_edits,
       insert_text,
       // NOTE(bartlomieju): it's not entirely clear to me why we need to do that,


### PR DESCRIPTION
Fixes #21557.
Fixes #21559.

In some cases tsc's auto-import completions will have the edit in `CompletionItem::text_edit` rather than `CompletionEntryDetails::code_actions`. I can make it happen in the fresh repo but I don't know how to simply reproduce it.