### PR TITLE
feat(unstable): kv atomic sum on bigints and numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "denokv_proto"
 version = "0.6.1"
-source = "git+https://github.com/denoland/denokv?rev=c5b2ff5641ae73079cfa0483bf990efc14a8b4a1#c5b2ff5641ae73079cfa0483bf990efc14a8b4a1"
+source = "git+https://github.com/denoland/denokv?rev=16686f6b92d8ad07fc0fe38965ea82f24f6d76d6#16686f6b92d8ad07fc0fe38965ea82f24f6d76d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1810,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "denokv_remote"
 version = "0.6.1"
-source = "git+https://github.com/denoland/denokv?rev=c5b2ff5641ae73079cfa0483bf990efc14a8b4a1#c5b2ff5641ae73079cfa0483bf990efc14a8b4a1"
+source = "git+https://github.com/denoland/denokv?rev=16686f6b92d8ad07fc0fe38965ea82f24f6d76d6#16686f6b92d8ad07fc0fe38965ea82f24f6d76d6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1834,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "denokv_sqlite"
 version = "0.6.1"
-source = "git+https://github.com/denoland/denokv?rev=c5b2ff5641ae73079cfa0483bf990efc14a8b4a1#c5b2ff5641ae73079cfa0483bf990efc14a8b4a1"
+source = "git+https://github.com/denoland/denokv?rev=16686f6b92d8ad07fc0fe38965ea82f24f6d76d6#16686f6b92d8ad07fc0fe38965ea82f24f6d76d6"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,9 +1793,8 @@ dependencies = [
 
 [[package]]
 name = "denokv_proto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a79f7e98bfd3c148ce782c27c1494e77c3c94ab87c9e7e86e901cbc1643449"
+version = "0.6.1"
+source = "git+https://github.com/denoland/denokv?rev=c5b2ff5641ae73079cfa0483bf990efc14a8b4a1#c5b2ff5641ae73079cfa0483bf990efc14a8b4a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1810,9 +1809,8 @@ dependencies = [
 
 [[package]]
 name = "denokv_remote"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518e181eb14f1a3b8fc423e48de431048249780fb0815d81e8139faf347c3269"
+version = "0.6.1"
+source = "git+https://github.com/denoland/denokv?rev=c5b2ff5641ae73079cfa0483bf990efc14a8b4a1#c5b2ff5641ae73079cfa0483bf990efc14a8b4a1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1835,9 +1833,8 @@ dependencies = [
 
 [[package]]
 name = "denokv_sqlite"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90af93f2ab8eec43fea9f8931fa99d38e73fa0af60aba0fae79de3fb87a0ed06"
+version = "0.6.1"
+source = "git+https://github.com/denoland/denokv?rev=c5b2ff5641ae73079cfa0483bf990efc14a8b4a1#c5b2ff5641ae73079cfa0483bf990efc14a8b4a1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1854,6 +1851,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "uuid",
+ "v8_valueserializer",
 ]
 
 [[package]]
@@ -6520,6 +6518,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "v8_valueserializer"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97599c400fc79925922b58303e98fcb8fa88f573379a08ddb652e72cbd2e70f6"
+dependencies = [
+ "bitflags 2.4.1",
+ "encoding_rs",
+ "indexmap 2.1.0",
+ "num-bigint",
+ "serde",
+ "thiserror",
+ "wtf8",
+]
+
+[[package]]
 name = "value-trait"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6997,6 +7010,12 @@ checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml",
 ]
+
+[[package]]
+name = "wtf8"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01ae8492c38f52376efd3a17d0994b6bcf3df1e39c0226d458b7d81670b2a06"
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ test_util = { path = "./test_util" }
 deno_lockfile = "0.17.2"
 deno_media_type = { version = "0.1.1", features = ["module_specifier"] }
 
-denokv_proto = "0.5.0"
+denokv_proto = { git = "https://github.com/denoland/denokv", rev = "c5b2ff5641ae73079cfa0483bf990efc14a8b4a1" }
 # denokv_sqlite brings in bundled sqlite if we don't disable the default features
-denokv_sqlite = { default-features = false, version = "0.5.0" }
-denokv_remote = "0.5.0"
+denokv_sqlite = { git = "https://github.com/denoland/denokv", rev = "c5b2ff5641ae73079cfa0483bf990efc14a8b4a1" } 
+denokv_remote = { git = "https://github.com/denoland/denokv", rev = "c5b2ff5641ae73079cfa0483bf990efc14a8b4a1" }
 
 # exts
 deno_broadcast_channel = { version = "0.122.0", path = "./ext/broadcast_channel" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ test_util = { path = "./test_util" }
 deno_lockfile = "0.17.2"
 deno_media_type = { version = "0.1.1", features = ["module_specifier"] }
 
-denokv_proto = { git = "https://github.com/denoland/denokv", rev = "c5b2ff5641ae73079cfa0483bf990efc14a8b4a1" }
+denokv_proto = { git = "https://github.com/denoland/denokv", rev = "16686f6b92d8ad07fc0fe38965ea82f24f6d76d6" }
 # denokv_sqlite brings in bundled sqlite if we don't disable the default features
-denokv_sqlite = { git = "https://github.com/denoland/denokv", rev = "c5b2ff5641ae73079cfa0483bf990efc14a8b4a1" } 
-denokv_remote = { git = "https://github.com/denoland/denokv", rev = "c5b2ff5641ae73079cfa0483bf990efc14a8b4a1" }
+denokv_sqlite = { git = "https://github.com/denoland/denokv", rev = "16686f6b92d8ad07fc0fe38965ea82f24f6d76d6" } 
+denokv_remote = { git = "https://github.com/denoland/denokv", rev = "16686f6b92d8ad07fc0fe38965ea82f24f6d76d6" }
 
 # exts
 deno_broadcast_channel = { version = "0.122.0", path = "./ext/broadcast_channel" }

--- a/cli/tests/unit/kv_test.ts
+++ b/cli/tests/unit/kv_test.ts
@@ -2261,6 +2261,22 @@ dbTest("generic atomic sum (number)", async (db) => {
     TypeError,
     "Cannot sum Number with BigInt",
   );
+
+  await assertRejects(
+    async () => await db.atomic().sum(["t"], 3, { max: 5 }).commit(),
+    TypeError,
+    "The result of a Sum operation would exceed its range limit",
+  );
+  await db.atomic().sum(["t"], 3, { max: 5, clamp: true }).commit();
+  assertEquals((await db.get(["t"])).value, 5);
+
+  await assertRejects(
+    async () => await db.atomic().sum(["t"], -2, { min: 4 }).commit(),
+    TypeError,
+    "The result of a Sum operation would exceed its range limit",
+  );
+  await db.atomic().sum(["t"], -2, { min: 4, clamp: true }).commit();
+  assertEquals((await db.get(["t"])).value, 4);
 });
 
 dbTest("generic atomic sum (bigint)", async (db) => {
@@ -2275,4 +2291,20 @@ dbTest("generic atomic sum (bigint)", async (db) => {
     TypeError,
     "Cannot sum BigInt with Number",
   );
+
+  await assertRejects(
+    async () => await db.atomic().sum(["t"], 3n, { max: 5n }).commit(),
+    TypeError,
+    "The result of a Sum operation would exceed its range limit",
+  );
+  await db.atomic().sum(["t"], 3n, { max: 5n, clamp: true }).commit();
+  assertEquals((await db.get(["t"])).value, 5n);
+
+  await assertRejects(
+    async () => await db.atomic().sum(["t"], -2n, { min: 4n }).commit(),
+    TypeError,
+    "The result of a Sum operation would exceed its range limit",
+  );
+  await db.atomic().sum(["t"], -2n, { min: 4n, clamp: true }).commit();
+  assertEquals((await db.get(["t"])).value, 4n);
 });

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1563,6 +1563,20 @@ declare namespace Deno {
       | { type: "set"; value: unknown; expireIn?: number }
       | { type: "delete" }
       | { type: "sum"; value: KvU64 }
+      | {
+        type: "sum";
+        value: bigint;
+        min?: bigint;
+        max?: bigint;
+        clamp?: boolean;
+      }
+      | {
+        type: "sum";
+        value: number;
+        min?: number;
+        max?: number;
+        clamp?: boolean;
+      }
       | { type: "max"; value: KvU64 }
       | { type: "min"; value: KvU64 }
     );
@@ -1756,7 +1770,7 @@ declare namespace Deno {
      * {@linkcode Deno.KvU64}, so the value of `n` must be in the range
      * `[0, 2^64-1]`.
      */
-    sum(key: KvKey, n: bigint): this;
+    sum(key: KvKey, n: bigint | number): this;
     /**
      * Shortcut for creating a `min` mutation. This method wraps `n` in a
      * {@linkcode Deno.KvU64}, so the value of `n` must be in the range

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1770,7 +1770,16 @@ declare namespace Deno {
      * {@linkcode Deno.KvU64}, so the value of `n` must be in the range
      * `[0, 2^64-1]`.
      */
-    sum(key: KvKey, n: bigint | number): this;
+    sum(key: Deno.KvKey, n: bigint, options?: {
+      min?: bigint;
+      max?: bigint;
+      clamp?: boolean;
+    }): this;
+    sum(key: Deno.KvKey, n: number, options?: {
+      min?: number;
+      max?: number;
+      clamp?: boolean;
+    }): this;
     /**
      * Shortcut for creating a `min` mutation. This method wraps `n` in a
      * {@linkcode Deno.KvU64}, so the value of `n` must be in the range


### PR DESCRIPTION
This patch allows to call `kv.atomic().sum()` directly on values of type `bigint` and `number`. `Deno.KvU64` is no longer needed.

Also adds an option bag to `sum()` that allows to specify min/max value of result and behavior when this limit is exceeded (clamp or error).