### PR TITLE
feat(jupyter): allow for ipc transport in Deno

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -139,7 +139,7 @@ twox-hash = "=1.6.3"
 typed-arena = "=2.0.1"
 uuid = { workspace = true, features = ["serde"] }
 walkdir = "=2.3.2"
-zeromq = { version = "=0.3.4", default-features = false, features = ["tcp-transport", "tokio-runtime"] }
+zeromq = { version = "=0.3.4", default-features = false, features = ["ipc-transport", "tcp-transport", "tokio-runtime"] }
 zstd.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -139,7 +139,7 @@ twox-hash = "=1.6.3"
 typed-arena = "=2.0.1"
 uuid = { workspace = true, features = ["serde"] }
 walkdir = "=2.3.2"
-zeromq = { version = "=0.3.4", default-features = false, features = ["ipc-transport", "tcp-transport", "tokio-runtime"] }
+zeromq = { version = "=0.3.4", default-features = false, features = ["tcp-transport", "tokio-runtime"] }
 zstd.workspace = true
 
 [target.'cfg(windows)'.dependencies]
@@ -149,6 +149,12 @@ winapi = { workspace = true, features = ["knownfolders", "mswsock", "objbase", "
 
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true
+
+# On *nix systems we allow ipc transport
+[target.'cfg(unix)'.dependencies.zeromq]
+version = "=0.3.4"
+default-features = false
+features = ["ipc-transport", "tcp-transport", "tokio-runtime"]
 
 [dev-dependencies]
 deno_bench_util.workspace = true


### PR DESCRIPTION
Allowing for IPC transport in Deno will allow Deno to be run on Colab.

(potentially) Closes #21589

We already accept arbitrary transport in our `bind_socket` setup from the `kernel.json`, so it was merely a missing feature flag on the `zeromq.rs` crate.

My debug build has a kernel spec named `deno-super-debug` and I run it like this:

```
jupyter console --ConnectionFileMixin.transport=ipc --kernel deno-super-debug
```

However, I'm running into an issue at least on my Mac.