### PR TITLE
fix(jupyter): Deno.test() panic

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1245,7 +1245,9 @@ impl CliOptions {
     self.flags.enable_op_summary_metrics
       || matches!(
         self.flags.subcommand,
-        DenoSubcommand::Test(_) | DenoSubcommand::Repl(_)
+        DenoSubcommand::Test(_)
+          | DenoSubcommand::Repl(_)
+          | DenoSubcommand::Jupyter(_)
       )
   }
 


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/21594

I verified locally that this fixes the problem. I'm working on testing 
harness for Jupyter kernel to catch regressions like this and will
add it in a follow up PR.