### PR TITLE
fix(console): invalid unchanged color check with %c

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -2939,15 +2939,20 @@ function parseCss(cssString) {
   return css;
 }
 
-function colorEquals(color1, color2) {
-  return color1?.[0] == color2?.[0] && color1?.[1] == color2?.[1] &&
-    color1?.[2] == color2?.[2];
+// The same color can be represented in multiple formats. This function
+// returns `false` in that case.
+function colorsObviouslyEqual(color1, color2) {
+  if (ArrayIsArray(color1) && ArrayIsArray(color2)) {
+    return color1[0] === color2[0] && color1[1] === color2[1] &&
+      color1[2] === color2[2];
+  }
+  return color1 === color2;
 }
 
 function cssToAnsi(css, prevCss = null) {
   prevCss = prevCss ?? getDefaultCss();
   let ansi = "";
-  if (!colorEquals(css.backgroundColor, prevCss.backgroundColor)) {
+  if (!colorsObviouslyEqual(css.backgroundColor, prevCss.backgroundColor)) {
     if (css.backgroundColor == null) {
       ansi += "\x1b[49m";
     } else if (css.backgroundColor == "black") {
@@ -2981,7 +2986,7 @@ function cssToAnsi(css, prevCss = null) {
       }
     }
   }
-  if (!colorEquals(css.color, prevCss.color)) {
+  if (!colorsObviouslyEqual(css.color, prevCss.color)) {
     if (css.color == null) {
       ansi += "\x1b[39m";
     } else if (css.color == "black") {
@@ -3029,7 +3034,9 @@ function cssToAnsi(css, prevCss = null) {
       ansi += "\x1b[23m";
     }
   }
-  if (!colorEquals(css.textDecorationColor, prevCss.textDecorationColor)) {
+  if (
+    !colorsObviouslyEqual(css.textDecorationColor, prevCss.textDecorationColor)
+  ) {
     if (css.textDecorationColor != null) {
       const { 0: r, 1: g, 2: b } = css.textDecorationColor;
       ansi += `\x1b[58;2;${r};${g};${b}m`;


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/21605

`cssToAnsi` is sometimes called with parsed colors (i.e. an array with three components) and sometimes with unparsed colors (i.e. a string). I assume this is because some features, such as `background-color`, defer to built-in colors for well-known values (such as white).

This breaks the optimization to avoid duplicate ANSI escapes, which only emits the color if it's changed. The fix will cause duplicate colors sometimes (e.g. when there is first a `#FFFFFF` background and then a `rgb(255, 255, 255)` background), but at least it makes sure that there are no false positives.

I cannot figure out how to add a test. The right level to test would be `inspectArgs` (or higher), since it's the function that builds the arguments for `cssToAnsi`, but all the `inspectArgs` tests in `cli/tests/unit/console_test.ts` call `stripColor`.