### PR TITLE
feat(unstable): only allow http2 for kv remote backend

### DIFF
--- a/ext/kv/remote.rs
+++ b/ext/kv/remote.rs
@@ -137,7 +137,7 @@ impl<P: RemoteDbHandlerPermissions + 'static> DatabaseHandler
         client_cert_chain_and_key: options.client_cert_chain_and_key.clone(),
         pool_max_idle_per_host: None,
         pool_idle_timeout: None,
-        http1: true,
+        http1: false,
         http2: true,
       },
     )?;


### PR DESCRIPTION
The [KV Connect specification](https://github.com/denoland/denokv/blob/main/proto/kv-connect.md) says:

> KV Connect compatible backends MUST support HTTP/1.1 and HTTP/2.

So we can default to HTTP/2 in the CLI to maximize performance.