### PR TITLE
feat(coverage): add default coverage include dir

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -86,7 +86,8 @@ pub struct CompletionsFlags {
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub enum CoverageType {
-  #[default] Summary,
+  #[default]
+  Summary,
   Detailed,
   Lcov,
   Html,
@@ -7953,10 +7954,7 @@ mod tests {
 
   #[test]
   fn coverage_with_default_files() {
-    let r = flags_from_vec(svec![
-      "deno",
-      "coverage",
-    ]);
+    let r = flags_from_vec(svec!["deno", "coverage",]);
     assert_eq!(
       r.unwrap(),
       Flags {

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -7915,10 +7915,9 @@ mod tests {
             include: vec![PathBuf::from("foo.json")],
             ignore: vec![],
           },
-          output: None,
           include: vec![r"^file:".to_string()],
           exclude: vec![r"test\.(js|mjs|ts|jsx|tsx)$".to_string()],
-          r#type: CoverageType::Summary
+          ..CoverageFlags::default()
         }),
         ..Flags::default()
       }
@@ -7963,6 +7962,8 @@ mod tests {
             include: vec![PathBuf::from("coverage")],
             ignore: vec![],
           },
+          include: vec![r"^file:".to_string()],
+          exclude: vec![r"test\.(js|mjs|ts|jsx|tsx)$".to_string()],
           ..CoverageFlags::default()
         }),
         ..Flags::default()


### PR DESCRIPTION
This PR sets `coverage/` as the default include path for `deno coverage` command.

This default value is aligned with the default value of `--coverage` option of `deno test` command, which was added in https://github.com/denoland/deno/pull/21510

The idea is from https://github.com/denoland/deno/pull/21615#issuecomment-1859164539

related https://github.com/denoland/deno/issues/21325