### PR TITLE
fix(ext/napi): don't close handle scopes in NAPI as the pointers are invalid

### DIFF
--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -1367,7 +1367,7 @@ fn napi_close_handle_scope(
   if env.open_handle_scopes == 0 {
     return napi_handle_scope_mismatch;
   }
-  let _scope = &mut *(scope as *mut v8::HandleScope);
+  // let _scope = &mut *(scope as *mut v8::HandleScope);
   env.open_handle_scopes -= 1;
   napi_ok
 }

--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -1361,7 +1361,7 @@ fn napi_close_escapable_handle_scope(
 #[napi_sym::napi_sym]
 fn napi_close_handle_scope(
   env: *mut Env,
-  scope: napi_handle_scope,
+  _scope: napi_handle_scope,
 ) -> napi_status {
   let env = &mut *env;
   if env.open_handle_scopes == 0 {

--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -1367,6 +1367,8 @@ fn napi_close_handle_scope(
   if env.open_handle_scopes == 0 {
     return napi_handle_scope_mismatch;
   }
+  // TODO: We are not opening a handle scope, therefore we cannot close it
+  // TODO: this is also not implemented in napi_open_handle_scope
   // let _scope = &mut *(scope as *mut v8::HandleScope);
   env.open_handle_scopes -= 1;
   napi_ok
@@ -2381,6 +2383,7 @@ fn napi_open_handle_scope(
 ) -> napi_status {
   let env = &mut *env;
 
+  // TODO: this is also not implemented in napi_close_handle_scope
   // *result = &mut env.scope() as *mut _ as napi_handle_scope;
   env.open_handle_scopes += 1;
   napi_ok


### PR DESCRIPTION
`napi_open_handle_scope` was returning a bogus handle_scope and we were trying to close it in `napi_close_handle_scope`.

This is a bit of a challenge to test, but the following testcase comes from #21601 and appears to be fixed by this.

```
import { decode } from "https://deno.land/std@0.209.0/encoding/base64.ts";
import sharp from "npm:sharp";

const img = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEWq09/P7Lz1AAAAH0lEQVRoge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg==';
Deno.test("async", async () => {
  const id = setTimeout(() => Deno.exit(1), 1000);
  await sharp(decode(img)).toBuffer();
  await sharp(decode(img)).toBuffer();
  clearTimeout(id);
});
```