### PR TITLE
fix(node): add crypto.pseudoRandomBytes

### DIFF
--- a/cli/tests/unit_node/internal/_randomBytes_test.ts
+++ b/cli/tests/unit_node/internal/_randomBytes_test.ts
@@ -6,7 +6,7 @@ import {
   assertThrows,
 } from "../../../../test_util/std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
-import { randomBytes } from "node:crypto";
+import { pseudoRandomBytes, randomBytes } from "node:crypto";
 
 const MAX_RANDOM_VALUES = 65536;
 const MAX_SIZE = 4294967295;
@@ -89,4 +89,24 @@ Deno.test("[std/node/crypto] randomBytes callback isn't called twice if error is
     prelude: `import { randomBytes } from ${JSON.stringify(importUrl)}`,
     invocation: "randomBytes(0, ",
   });
+});
+
+// https://github.com/denoland/deno/issues/21632
+Deno.test("pseudoRandomBytes works", function () {
+  assertEquals(pseudoRandomBytes(0).length, 0, "len: " + 0);
+  assertEquals(pseudoRandomBytes(3).length, 3, "len: " + 3);
+  assertEquals(pseudoRandomBytes(30).length, 30, "len: " + 30);
+  assertEquals(pseudoRandomBytes(300).length, 300, "len: " + 300);
+  assertEquals(
+    pseudoRandomBytes(17 + MAX_RANDOM_VALUES).length,
+    17 + MAX_RANDOM_VALUES,
+    "len: " + 17 + MAX_RANDOM_VALUES,
+  );
+  assertEquals(
+    pseudoRandomBytes(MAX_RANDOM_VALUES * 100).length,
+    MAX_RANDOM_VALUES * 100,
+    "len: " + MAX_RANDOM_VALUES * 100,
+  );
+  assertThrows(() => pseudoRandomBytes(MAX_SIZE + 1));
+  assertThrows(() => pseudoRandomBytes(-1));
 });

--- a/ext/node/polyfills/crypto.ts
+++ b/ext/node/polyfills/crypto.ts
@@ -306,6 +306,9 @@ const setFips = fipsForced ? setFipsForced : setFipsCrypto;
 const sign = signOneShot;
 const verify = verifyOneShot;
 
+/* Deprecated in Node.js, alias of randomBytes */
+const pseudoRandomBytes = randomBytes;
+
 export default {
   Certificate,
   checkPrime,
@@ -353,6 +356,7 @@ export default {
   publicDecrypt,
   publicEncrypt,
   randomBytes,
+  pseudoRandomBytes,
   randomFill,
   randomFillSync,
   randomInt,
@@ -485,6 +489,8 @@ export {
   pbkdf2Sync,
   privateDecrypt,
   privateEncrypt,
+  /* Deprecated in Node.js, alias of randomBytes */
+  pseudoRandomBytes,
   publicDecrypt,
   publicEncrypt,
   randomBytes,


### PR DESCRIPTION
Deprecated in Node.js, alias of randomBytes.

Fixes https://github.com/denoland/deno/issues/21632