### PR TITLE
Create node.js.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test


### PR DESCRIPTION
            - nombre: caché
  usos: acciones/cache@v3.3.2
  con:
    # Una lista de archivos, directorios y patrones comodín para almacenar en caché y restaurar
    camino:
    # Una clave explícita para restaurar y guardar el caché
    llave:
    # Una lista ordenada de claves que se utilizarán para restaurar el caché obsoleto si no se produjo ningún acierto en el caché para la clave. Tenga en cuenta que `cache-hit` devuelve falso en este caso.
    restaurar claves: # opcional
    # El tamaño del fragmento utilizado para dividir archivos grandes durante la carga, en bytes
    tamaño del fragmento de carga: # opcional
    # Un valor booleano opcional, cuando está habilitado, permite a los corredores de Windows guardar o restaurar cachés que se pueden restaurar o guardar respectivamente en otras plataformas.
    enableCrossOsArchive: # opcional, el valor predeterminado es falso
    # Falla el flujo de trabajo si no se encuentra la entrada de caché
    fail-on-cache-miss: # opcional, el valor predeterminado es falso
    # Comprobar si existe una entrada de caché para las entradas dadas (clave, claves de restauración) sin descargar el caché
    solo búsqueda: # opcional, el valor predeterminado es falso

<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
