### PR TITLE
refactor: fastwebsockets renames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ data-encoding = "2.3.3"
 dlopen2 = "0.6.1"
 encoding_rs = "=0.8.33"
 ecb = "=0.1.2"
+fastwebsockets = { version = "0.6", features = ["upgrade", "unstable-split"] }
 filetime = "0.2.16"
 flate2 = { version = "1.0.26", default-features = false }
 fs3 = "0.5.0"
@@ -266,6 +267,8 @@ opt-level = 3
 [profile.bench.package.bytes]
 opt-level = 3
 [profile.bench.package.futures-util]
+opt-level = 3
+[profile.bench.package.fastwebsockets]
 opt-level = 3
 [profile.bench.package.hyper]
 opt-level = 3

--- a/ext/websocket/Cargo.toml
+++ b/ext/websocket/Cargo.toml
@@ -18,7 +18,7 @@ bytes.workspace = true
 deno_core.workspace = true
 deno_net.workspace = true
 deno_tls.workspace = true
-fastwebsockets_06 = { package = "fastwebsockets", version = "0.6", features = ["upgrade", "unstable-split"] }
+fastwebsockets.workspace = true
 h2_04 = { package = "h2", version = "0.4" }
 http-body-util = "0.1"
 http_1 = { package = "http", version = "1.0" }

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -54,13 +54,13 @@ use tokio::io::ReadHalf;
 use tokio::io::WriteHalf;
 use tokio::net::TcpStream;
 
-use fastwebsockets_06::CloseCode;
-use fastwebsockets_06::FragmentCollectorRead;
-use fastwebsockets_06::Frame;
-use fastwebsockets_06::OpCode;
-use fastwebsockets_06::Role;
-use fastwebsockets_06::WebSocket;
-use fastwebsockets_06::WebSocketWrite;
+use fastwebsockets::CloseCode;
+use fastwebsockets::FragmentCollectorRead;
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use fastwebsockets::Role;
+use fastwebsockets::WebSocket;
+use fastwebsockets::WebSocketWrite;
 
 mod stream;
 
@@ -175,7 +175,7 @@ async fn handshake_websocket(
     .header(CONNECTION, "Upgrade")
     .header(
       "Sec-WebSocket-Key",
-      fastwebsockets_06::handshake::generate_key(),
+      fastwebsockets::handshake::generate_key(),
     );
 
   let user_agent = state.borrow().borrow::<WsUserAgent>().0.clone();
@@ -305,8 +305,7 @@ async fn handshake_connection<
   socket: S,
 ) -> Result<(WebSocket<WebSocketStream>, http_1::HeaderMap), AnyError> {
   let (upgraded, response) =
-    fastwebsockets_06::handshake::client(&LocalExecutor, request, socket)
-      .await?;
+    fastwebsockets::handshake::client(&LocalExecutor, request, socket).await?;
 
   let upgraded = upgraded.into_inner();
   let stream =

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -97,7 +97,7 @@ deno_webstorage.workspace = true
 console_static_text.workspace = true
 dlopen2.workspace = true
 encoding_rs.workspace = true
-fastwebsockets_06 = { package = "fastwebsockets", version = "0.6", features = ["upgrade"] }
+fastwebsockets.workspace = true
 filetime = "0.2.16"
 fs3.workspace = true
 http.workspace = true

--- a/runtime/inspector_server.rs
+++ b/runtime/inspector_server.rs
@@ -19,9 +19,9 @@ use deno_core::url::Url;
 use deno_core::InspectorMsg;
 use deno_core::InspectorSessionProxy;
 use deno_core::JsRuntime;
-use fastwebsockets_06::Frame;
-use fastwebsockets_06::OpCode;
-use fastwebsockets_06::WebSocket;
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use fastwebsockets::WebSocket;
 use hyper::body::Bytes;
 use hyper_util::rt::TokioIo;
 use std::cell::RefCell;
@@ -139,7 +139,7 @@ fn handle_ws_request(
   let (parts, _) = req.into_parts();
   let mut req = http_1::Request::from_parts(parts, body);
 
-  let (resp, fut) = match fastwebsockets_06::upgrade::upgrade(&mut req) {
+  let (resp, fut) = match fastwebsockets::upgrade::upgrade(&mut req) {
     Ok((resp, fut)) => {
       let (parts, _body) = resp.into_parts();
       let resp = http_1::Response::from_parts(

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -20,7 +20,7 @@ base64.workspace = true
 bytes.workspace = true
 console_static_text.workspace = true
 denokv_proto.workspace = true
-fastwebsockets_06 = { package = "fastwebsockets", version = "0.6", features = ["upgrade"] }
+fastwebsockets.workspace = true
 flate2 = { workspace = true, features = ["default"] }
 futures.workspace = true
 glob.workspace = true

--- a/test_util/src/servers/ws.rs
+++ b/test_util/src/servers/ws.rs
@@ -2,11 +2,11 @@
 
 use anyhow::anyhow;
 use bytes::Bytes;
-use fastwebsockets_06::FragmentCollector;
-use fastwebsockets_06::Frame;
-use fastwebsockets_06::OpCode;
-use fastwebsockets_06::Role;
-use fastwebsockets_06::WebSocket;
+use fastwebsockets::FragmentCollector;
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use fastwebsockets::Role;
+use fastwebsockets::WebSocket;
 use futures::future::join3;
 use futures::future::poll_fn;
 use futures::Future;
@@ -99,7 +99,7 @@ pub async fn run_wss2_server(port: u16) {
 }
 
 async fn echo_websocket_handler(
-  ws: fastwebsockets_06::WebSocket<TokioIo<Upgraded>>,
+  ws: fastwebsockets::WebSocket<TokioIo<Upgraded>>,
 ) -> Result<(), anyhow::Error> {
   let mut ws = FragmentCollector::new(ws);
 
@@ -119,7 +119,7 @@ async fn echo_websocket_handler(
 
 type WsHandler =
   fn(
-    fastwebsockets_06::WebSocket<TokioIo<Upgraded>>,
+    fastwebsockets::WebSocket<TokioIo<Upgraded>>,
   ) -> Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send>>;
 
 fn spawn_ws_server<S>(stream: S, handler: WsHandler)
@@ -128,10 +128,8 @@ where
 {
   let service = hyper1::service::service_fn(
     move |mut req: http_1::Request<hyper1::body::Incoming>| async move {
-      let (response, upgrade_fut) =
-        fastwebsockets_06::upgrade::upgrade(&mut req).map_err(|e| {
-          anyhow!("Error upgrading websocket connection: {}", e)
-        })?;
+      let (response, upgrade_fut) = fastwebsockets::upgrade::upgrade(&mut req)
+        .map_err(|e| anyhow!("Error upgrading websocket connection: {}", e))?;
 
       tokio::spawn(async move {
         let ws = upgrade_fut
@@ -228,7 +226,7 @@ async fn handle_wss_stream(
 }
 
 async fn close_websocket_handler(
-  ws: fastwebsockets_06::WebSocket<TokioIo<Upgraded>>,
+  ws: fastwebsockets::WebSocket<TokioIo<Upgraded>>,
 ) -> Result<(), anyhow::Error> {
   let mut ws = FragmentCollector::new(ws);
 
@@ -240,7 +238,7 @@ async fn close_websocket_handler(
 }
 
 async fn ping_websocket_handler(
-  ws: fastwebsockets_06::WebSocket<TokioIo<Upgraded>>,
+  ws: fastwebsockets::WebSocket<TokioIo<Upgraded>>,
 ) -> Result<(), anyhow::Error> {
   let mut ws = FragmentCollector::new(ws);
 


### PR DESCRIPTION
We now use only a single version of "fastwebsockets" crate, so we no
longer need to have an alias.