### PR TITLE
fix: allow npm: specifiers in import.meta.resolve

### DIFF
--- a/cli/tests/testdata/run/import_meta/importmap.json
+++ b/cli/tests/testdata/run/import_meta/importmap.json
@@ -6,6 +6,7 @@
     "1": "https://example.com/PASS-1",
     "null": "https://example.com/PASS-null",
     "undefined": "https://example.com/PASS-undefined",
-    "[object Object]": "https://example.com/PASS-object"
+    "[object Object]": "https://example.com/PASS-object",
+    "npm:preact": "https://example.com/preact"
   }
 }

--- a/cli/tests/testdata/run/import_meta/main.out
+++ b/cli/tests/testdata/run/import_meta/main.out
@@ -9,3 +9,4 @@ Resolving null from import map https://example.com/PASS-null
 Resolving object from import map https://example.com/PASS-object
 Resolving npm:cowsay npm:cowsay
 Resolving npm:cowsay@1 npm:cowsay@1
+Resolving npm:preact from import map https://example.com/preact

--- a/cli/tests/testdata/run/import_meta/main.out
+++ b/cli/tests/testdata/run/import_meta/main.out
@@ -7,5 +7,5 @@ Resolving without a value from import map https://example.com/PASS-undefined
 Resolving 1 from import map https://example.com/PASS-1
 Resolving null from import map https://example.com/PASS-null
 Resolving object from import map https://example.com/PASS-object
-TypeError: "npm:" specifiers are currently not supported in import.meta.resolve()
-    at file:///[WILDCARD]testdata/run/import_meta/main.ts:36:15
+Resolving npm:cowsay npm:cowsay
+Resolving npm:cowsay@1 npm:cowsay@1

--- a/cli/tests/testdata/run/import_meta/main.ts
+++ b/cli/tests/testdata/run/import_meta/main.ts
@@ -32,8 +32,11 @@ assertThrows(() => {
 assertThrows(() => {
   import.meta.resolve("://malformed/url?asdf");
 }, TypeError);
-try {
-  import.meta.resolve("npm:cowsay");
-} catch (e) {
-  console.log(e);
-}
+console.log(
+  "Resolving npm:cowsay",
+  import.meta.resolve("npm:cowsay"),
+);
+console.log(
+  "Resolving npm:cowsay@1",
+  import.meta.resolve("npm:cowsay@1"),
+);

--- a/cli/tests/testdata/run/import_meta/main.ts
+++ b/cli/tests/testdata/run/import_meta/main.ts
@@ -40,3 +40,7 @@ console.log(
   "Resolving npm:cowsay@1",
   import.meta.resolve("npm:cowsay@1"),
 );
+console.log(
+  "Resolving npm:preact from import map",
+  import.meta.resolve("npm:preact"),
+);

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -5,6 +5,7 @@ use crate::ops;
 use crate::permissions::PermissionsContainer;
 use crate::shared::runtime;
 use crate::tokio_util::create_and_run_current_thread;
+use crate::worker::import_meta_resolve_callback;
 use crate::worker::FormatJsErrorFn;
 use crate::BootstrapOptions;
 use deno_broadcast_channel::InMemoryBroadcastChannel;
@@ -536,6 +537,9 @@ impl WebWorker {
       inspector: options.maybe_inspector_server.is_some(),
       feature_checker: Some(options.feature_checker.clone()),
       op_metrics_factory_fn,
+      import_meta_resolve_callback: Some(Box::new(
+        import_meta_resolve_callback,
+      )),
       ..Default::default()
     });
 

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -50,6 +50,22 @@ use crate::BootstrapOptions;
 
 pub type FormatJsErrorFn = dyn Fn(&JsError) -> String + Sync + Send;
 
+pub fn import_meta_resolve_callback(
+  loader: &dyn deno_core::ModuleLoader,
+  specifier: String,
+  referrer: String,
+) -> Result<ModuleSpecifier, AnyError> {
+  if specifier.starts_with("npm:") {
+    return Ok(ModuleSpecifier::parse(&specifier)?);
+  }
+
+  loader.resolve(
+    &specifier,
+    &referrer,
+    deno_core::ResolutionKind::DynamicImport,
+  )
+}
+
 #[derive(Clone, Default)]
 pub struct ExitCode(Arc<AtomicI32>);
 
@@ -447,6 +463,9 @@ impl MainWorker {
       wait_for_inspector_disconnect_callback: Some(
         wait_for_inspector_disconnect_callback,
       ),
+      import_meta_resolve_callback: Some(Box::new(
+        import_meta_resolve_callback,
+      )),
       ..Default::default()
     });
 

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -55,10 +55,6 @@ pub fn import_meta_resolve_callback(
   specifier: String,
   referrer: String,
 ) -> Result<ModuleSpecifier, AnyError> {
-  if specifier.starts_with("npm:") {
-    return Ok(ModuleSpecifier::parse(&specifier)?);
-  }
-
   loader.resolve(
     &specifier,
     &referrer,


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/21298.

"npm:" specifiers are matched against import map entries
and if no match is found they are passed through.