### PR TITLE
perf(lsp): use LanguageServiceHost::getProjectVersion()

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1346,6 +1346,7 @@ impl Inner {
           self
             .diagnostics_server
             .invalidate(&self.documents.dependents(&specifier));
+          self.ts_server.increment_project_version();
           self.send_diagnostics_update();
           self.send_testing_update();
         }
@@ -1390,6 +1391,7 @@ impl Inner {
       let mut specifiers = self.documents.dependents(&specifier);
       specifiers.push(specifier.clone());
       self.diagnostics_server.invalidate(&specifiers);
+      self.ts_server.increment_project_version();
       self.send_diagnostics_update();
       self.send_testing_update();
     }
@@ -1442,6 +1444,7 @@ impl Inner {
     self.refresh_documents_config().await;
 
     self.diagnostics_server.invalidate_all();
+    self.ts_server.increment_project_version();
     self.send_diagnostics_update();
     self.send_testing_update();
   }
@@ -3303,6 +3306,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
       inner.refresh_npm_specifiers().await;
       let specifiers = inner.documents.dependents(&specifier);
       inner.diagnostics_server.invalidate(&specifiers);
+      inner.ts_server.increment_project_version();
       inner.send_diagnostics_update();
       inner.send_testing_update();
     }
@@ -3393,6 +3397,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
       let mut ls = self.0.write().await;
       ls.refresh_documents_config().await;
       ls.diagnostics_server.invalidate_all();
+      ls.ts_server.increment_project_version();
       ls.send_diagnostics_update();
     }
     performance.measure(mark);

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3937,7 +3937,6 @@ fn op_load<'s>(
     .performance
     .mark_with_args("tsc.op.op_load", specifier);
   let specifier = state.specifier_map.normalize(specifier)?;
-  eprintln!("  op_load(\"{}\")", specifier.as_str());
   let maybe_load_response =
     if specifier.as_str() == "internal:///missing_dependency.d.ts" {
       None
@@ -4007,7 +4006,6 @@ fn op_respond(state: &mut OpState, #[serde] args: Response) {
 #[op2]
 #[serde]
 fn op_script_names(state: &mut OpState) -> Vec<String> {
-  eprintln!("  op_script_names()");
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("tsc.op.op_script_names");
   let documents = &state.state_snapshot.documents;
@@ -4069,7 +4067,6 @@ fn op_script_version(
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("tsc.op.op_script_version");
   let specifier = state.specifier_map.normalize(specifier)?;
-  eprintln!("  op_script_version(\"{}\")", specifier.as_str());
   let r = state.script_version(&specifier);
   state.performance.measure(mark);
   Ok(r)
@@ -4080,7 +4077,6 @@ fn op_script_version(
 fn op_project_version(state: &mut OpState) -> String {
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("tsc.op.op_project_version");
-  eprintln!("  op_project_version()");
   let r = state.project_version.load(Ordering::Relaxed).to_string();
   state.performance.measure(mark);
   r
@@ -4580,7 +4576,6 @@ fn request(
     "globalThis.serverRequest({id}, \"{}\", {});",
     request.method, &request.args
   );
-  eprintln!("request(\"{}\")", request.method);
   runtime.execute_script(located_script_name!(), request_src.into())?;
 
   let op_state = runtime.op_state();

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -8269,6 +8269,7 @@ fn lsp_performance() {
       "tsc.host.getQuickInfoAtPosition",
       "tsc.op.op_is_node_file",
       "tsc.op.op_load",
+      "tsc.op.op_project_version",
       "tsc.op.op_script_names",
       "tsc.op.op_script_version",
       "tsc.request.$configure",

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -534,6 +534,9 @@ delete Object.prototype.__proto__;
       // createLanguageService will call this immediately and cache it
       return new CancellationToken();
     },
+    getProjectVersion() {
+      return ops.op_project_version();
+    },
     getSourceFile(
       specifier,
       languageVersion,

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -587,6 +587,9 @@ delete Object.prototype.__proto__;
       );
       sourceFile.moduleName = specifier;
       sourceFile.version = version;
+      if (specifier.startsWith(ASSETS_URL_PREFIX)) {
+        sourceFile.version = "1";
+      }
       sourceFileCache.set(specifier, sourceFile);
       scriptVersionCache.set(specifier, version);
       return sourceFile;
@@ -723,6 +726,9 @@ delete Object.prototype.__proto__;
     getScriptVersion(specifier) {
       if (logDebug) {
         debug(`host.getScriptVersion("${specifier}")`);
+      }
+      if (specifier.startsWith(ASSETS_URL_PREFIX)) {
+        return "1";
       }
       // tsc requests the script version multiple times even though it can't
       // possibly have changed, so we will memoize it on a per request basis.


### PR DESCRIPTION
For a project containing `deno.json | file1.ts | file2.ts | file3.ts`, when typing a single character in `file1.ts`, with logs set up for tsc requests; `op_project_version()`; `op_script_names()`; `op_load()` and `op_script_version()`, you get the following output:

<details>
<summary>Before (501 lines):</summary>

```
request("getCompletionsAtPosition")
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_load("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
request("getCompletionEntryDetails")
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
request("$getDiagnostics")
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
request("getOutliningSpans")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
request("getEncodedSemanticClassifications")
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
request("getCodeFixesAtPosition")
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
request("getApplicableRefactors")
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
```
</details>

<details>
<summary>After (103 lines):</summary>

```
request("getCompletionsAtPosition")
  op_project_version()
  op_script_names()
  op_script_version("asset:///lib.es5.d.ts")
  op_script_version("asset:///lib.es2015.d.ts")
  op_script_version("asset:///lib.es2016.d.ts")
  op_script_version("asset:///lib.es2017.d.ts")
  op_script_version("asset:///lib.es2018.d.ts")
  op_script_version("asset:///lib.es2019.d.ts")
  op_script_version("asset:///lib.es2020.d.ts")
  op_script_version("asset:///lib.es2021.d.ts")
  op_script_version("asset:///lib.es2022.d.ts")
  op_script_version("asset:///lib.es2023.d.ts")
  op_script_version("asset:///lib.esnext.d.ts")
  op_script_version("asset:///lib.es2015.core.d.ts")
  op_script_version("asset:///lib.es2015.collection.d.ts")
  op_script_version("asset:///lib.es2015.generator.d.ts")
  op_script_version("asset:///lib.es2015.iterable.d.ts")
  op_script_version("asset:///lib.es2015.promise.d.ts")
  op_script_version("asset:///lib.es2015.proxy.d.ts")
  op_script_version("asset:///lib.es2015.reflect.d.ts")
  op_script_version("asset:///lib.es2015.symbol.d.ts")
  op_script_version("asset:///lib.es2015.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2016.array.include.d.ts")
  op_script_version("asset:///lib.es2017.date.d.ts")
  op_script_version("asset:///lib.es2017.object.d.ts")
  op_script_version("asset:///lib.es2017.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2017.string.d.ts")
  op_script_version("asset:///lib.es2017.intl.d.ts")
  op_script_version("asset:///lib.es2017.typedarrays.d.ts")
  op_script_version("asset:///lib.es2018.asyncgenerator.d.ts")
  op_script_version("asset:///lib.es2018.asynciterable.d.ts")
  op_script_version("asset:///lib.es2018.intl.d.ts")
  op_script_version("asset:///lib.es2018.promise.d.ts")
  op_script_version("asset:///lib.es2018.regexp.d.ts")
  op_script_version("asset:///lib.es2019.array.d.ts")
  op_script_version("asset:///lib.es2019.object.d.ts")
  op_script_version("asset:///lib.es2019.string.d.ts")
  op_script_version("asset:///lib.es2019.symbol.d.ts")
  op_script_version("asset:///lib.es2019.intl.d.ts")
  op_script_version("asset:///lib.es2020.bigint.d.ts")
  op_script_version("asset:///lib.es2020.date.d.ts")
  op_script_version("asset:///lib.es2020.promise.d.ts")
  op_script_version("asset:///lib.es2020.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2020.string.d.ts")
  op_script_version("asset:///lib.es2020.symbol.wellknown.d.ts")
  op_script_version("asset:///lib.es2020.intl.d.ts")
  op_script_version("asset:///lib.es2020.number.d.ts")
  op_script_version("asset:///lib.es2021.promise.d.ts")
  op_script_version("asset:///lib.es2021.string.d.ts")
  op_script_version("asset:///lib.es2021.weakref.d.ts")
  op_script_version("asset:///lib.es2021.intl.d.ts")
  op_script_version("asset:///lib.es2022.array.d.ts")
  op_script_version("asset:///lib.es2022.error.d.ts")
  op_script_version("asset:///lib.es2022.intl.d.ts")
  op_script_version("asset:///lib.es2022.object.d.ts")
  op_script_version("asset:///lib.es2022.sharedmemory.d.ts")
  op_script_version("asset:///lib.es2022.string.d.ts")
  op_script_version("asset:///lib.es2022.regexp.d.ts")
  op_script_version("asset:///lib.es2023.array.d.ts")
  op_script_version("asset:///lib.es2023.collection.d.ts")
  op_script_version("asset:///lib.esnext.array.d.ts")
  op_script_version("asset:///lib.esnext.intl.d.ts")
  op_script_version("asset:///lib.esnext.disposable.d.ts")
  op_script_version("asset:///lib.esnext.decorators.d.ts")
  op_script_version("asset:///lib.decorators.d.ts")
  op_script_version("asset:///lib.decorators.legacy.d.ts")
  op_script_version("asset:///lib.deno.window.d.ts")
  op_script_version("asset:///lib.deno.shared_globals.d.ts")
  op_script_version("asset:///lib.deno.ns.d.ts")
  op_script_version("asset:///lib.esnext.object.d.ts")
  op_script_version("asset:///lib.deno.cache.d.ts")
  op_script_version("asset:///lib.deno.url.d.ts")
  op_script_version("asset:///lib.deno.webstorage.d.ts")
  op_script_version("asset:///lib.deno.web.d.ts")
  op_script_version("asset:///lib.deno.websocket.d.ts")
  op_script_version("asset:///lib.deno.crypto.d.ts")
  op_script_version("asset:///lib.deno.net.d.ts")
  op_script_version("asset:///lib.deno.fetch.d.ts")
  op_script_version("asset:///lib.deno.console.d.ts")
  op_script_version("asset:///lib.deno.webgpu.d.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_load("file:///home/nayeem/projects/deno-hello/file1.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file2.ts")
  op_script_version("file:///home/nayeem/projects/deno-hello/file3.ts")
request("getCompletionEntryDetails")
  op_project_version()
request("$getDiagnostics")
  op_project_version()
  op_project_version()
  op_project_version()
  op_project_version()
  op_project_version()
  op_project_version()
request("getOutliningSpans")
  op_script_version("file:///home/nayeem/projects/deno-hello/file1.ts")
request("getEncodedSemanticClassifications")
  op_project_version()
request("getCodeFixesAtPosition")
  op_project_version()
request("getApplicableRefactors")
  op_project_version()
  op_project_version()
```
</details>

This fixes a lot of redundant dirty checking that was being done for a single keypress.