### PR TITLE
fix(web): raise intr in prompt()

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+while (true) {
+  console.log(prompt());
+}

--- a/test.js
+++ b/test.js
@@ -1,3 +1,0 @@
-while (true) {
-  console.log(prompt());
-}


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/21602 https://github.com/denoland/deno/issues/21631 https://github.com/denoland/deno/issues/21641

This patch only fixes `prompt()`.

 I think we should revert https://github.com/denoland/deno/commit/346d8127095f46bd5c58667f860521690ddd9cd7. `alert()` and `confirm()` swallows ^C , the previous 
 implementation handled it properly. Browser consistency is not worth it when the usage is so 
 different. 