### PR TITLE
chore: disable PTR_HOST dns test for Node compat

### DIFF
--- a/cli/tests/node_compat/test/internet/test-dns-any.js
+++ b/cli/tests/node_compat/test/internet/test-dns-any.js
@@ -172,21 +172,23 @@ TEST(async function test_google_for_cname_and_srv(done) {
   checkWrap(req);
 });
 
-TEST(async function test_ptr(done) {
-  function validateResult(res) {
-    const types = processResult(res);
-    assert.ok(types.PTR);
-  }
+// TODO(bartlomieju): this test started failing on CI on Dec 28th, 2023 returning
+// ENOTFOUND. It's unclear what's going on, since `dig -x 8.8.8.8.in-addr.arpa`
+// TEST(async function test_ptr(done) {
+//   function validateResult(res) {
+//     const types = processResult(res);
+//     assert.ok(types.PTR);
+//   }
 
-  validateResult(await dnsPromises.resolve('8.8.8.8.in-addr.arpa', 'ANY'));
+//   validateResult(await dnsPromises.resolve('8.8.8.8.in-addr.arpa', 'ANY'));
 
-  const req = dns.resolve(
-    '8.8.8.8.in-addr.arpa',
-    'ANY',
-    common.mustSucceed((ret) => {
-      validateResult(ret);
-      done();
-    }));
+//   const req = dns.resolve(
+//     '8.8.8.8.in-addr.arpa',
+//     'ANY',
+//     common.mustSucceed((ret) => {
+//       validateResult(ret);
+//       done();
+//     }));
 
-  checkWrap(req);
-});
+//   checkWrap(req);
+// });

--- a/cli/tests/node_compat/test/internet/test-dns.js
+++ b/cli/tests/node_compat/test/internet/test-dns.js
@@ -281,26 +281,29 @@ TEST(async function test_resolveSrv(done) {
 //   checkWrap(req);
 // });
 
-TEST(async function test_resolvePtr(done) {
-  function validateResult(result) {
-    assert.ok(result.length > 0);
+// TODO(bartlomieju): this test started failing on CI on Dec 28th, 2023 returning
+// ENOTFOUND. It's unclear what's going on, since `dig -x 8.8.8.8.in-addr.arpa`
+// returns correct PTR record.
+// TEST(async function test_resolvePtr(done) {
+//   function validateResult(result) {
+//     assert.ok(result.length > 0);
 
-    for (const item of result) {
-      assert.ok(item);
-      assert.strictEqual(typeof item, 'string');
-    }
-  }
+//     for (const item of result) {
+//       assert.ok(item);
+//       assert.strictEqual(typeof item, 'string');
+//     }
+//   }
 
-  validateResult(await dnsPromises.resolvePtr(addresses.PTR_HOST));
+//   validateResult(await dnsPromises.resolvePtr(addresses.PTR_HOST));
 
-  const req = dns.resolvePtr(addresses.PTR_HOST, function(err, result) {
-    assert.ifError(err);
-    validateResult(result);
-    done();
-  });
+//   const req = dns.resolvePtr(addresses.PTR_HOST, function(err, result) {
+//     assert.ifError(err);
+//     validateResult(result);
+//     done();
+//   });
 
-  checkWrap(req);
-});
+//   checkWrap(req);
+// });
 
 // TODO(bartlomieju): this test became very flaky on CI, returning `UNKNOWN`
 // instead of `ENOTFOUND`.


### PR DESCRIPTION
These tests started failing on CI on Dec 28th, 2023 returning
ENOTFOUND. It's unclear what's going on, since `dig -x 8.8.8.8.in-addr.arpa`.

It needs a deeper investigation, but I want to unblock main branch
in the meantime.