### PR TITLE
fix(node/zlib): cast Dataview and Buffer to uint8

### DIFF
--- a/cli/tests/unit_node/zlib_test.ts
+++ b/cli/tests/unit_node/zlib_test.ts
@@ -96,3 +96,19 @@ Deno.test(
     handle.destroy();
   },
 );
+
+Deno.test("should work with dataview", () => {
+  const buf = Buffer.from("hello world");
+  const compressed = brotliCompressSync(new DataView(buf.buffer));
+  const decompressed = brotliDecompressSync(compressed);
+  assertEquals(decompressed.toString(), "hello world");
+});
+
+Deno.test("should work with a buffer from an encoded string", () => {
+  const encoder = new TextEncoder();
+  const buffer = encoder.encode("hello world");
+  const buf = Buffer.from(buffer);
+  const compressed = brotliCompressSync(buf);
+  const decompressed = brotliDecompressSync(compressed);
+  assertEquals(decompressed.toString(), "hello world");
+});

--- a/ext/node/polyfills/_brotli.js
+++ b/ext/node/polyfills/_brotli.js
@@ -19,6 +19,10 @@ const toU8 = (input) => {
     return enc.encode(input);
   }
 
+  if (input.buffer) {
+    return new Uint8Array(input.buffer);
+  }
+
   return input;
 };
 


### PR DESCRIPTION
This fixes point 2 of #20516 

This adds a conversion from Dataview/Buffer by returning `obj.buffer` which can be converted to a `UInt8Array`.

Question: Regarding point 4 of the mentioned issue would it be appropriate to copy the toU8 helper to the `zlib.mjs` methods?