### PR TITLE
fix(node/zlib): consistently return buffer

### DIFF
--- a/cli/tests/unit_node/zlib_test.ts
+++ b/cli/tests/unit_node/zlib_test.ts
@@ -3,6 +3,7 @@
 import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
 import { fromFileUrl, relative } from "../../../test_util/std/path/mod.ts";
 import {
+  brotliCompress,
   brotliCompressSync,
   brotliDecompressSync,
   createBrotliCompress,
@@ -15,6 +16,18 @@ import { createReadStream, createWriteStream } from "node:fs";
 Deno.test("brotli compression sync", () => {
   const buf = Buffer.from("hello world");
   const compressed = brotliCompressSync(buf);
+  const decompressed = brotliDecompressSync(compressed);
+  assertEquals(decompressed.toString(), "hello world");
+});
+
+Deno.test("brotli compression async", async () => {
+  const buf = Buffer.from("hello world");
+  const compressed: Buffer = await new Promise((resolve) =>
+    brotliCompress(buf, (_, res) => {
+      return resolve(res);
+    })
+  );
+  assertEquals(compressed instanceof Buffer, true);
   const decompressed = brotliDecompressSync(compressed);
   assertEquals(decompressed.toString(), "hello world");
 });

--- a/ext/node/polyfills/_brotli.js
+++ b/ext/node/polyfills/_brotli.js
@@ -122,7 +122,7 @@ export function brotliCompress(
 
   const { quality, lgwin, mode } = oneOffCompressOptions(options);
   op_brotli_compress_async(buf, quality, lgwin, mode)
-    .then((result) => callback(null, result))
+    .then((result) => callback(null, Buffer.from(result)))
     .catch((err) => callback(err));
 }
 


### PR DESCRIPTION
This fixes point 3 of https://github.com/denoland/deno/issues/20516

This PR creates consistency between the sync and async versions of the brotli compress where we will always return a buffer like Node.