### PR TITLE
fix(ext/node): use node:process in _streams.mjs

### DIFF
--- a/ext/node/polyfills/_stream.mjs
+++ b/ext/node/polyfills/_stream.mjs
@@ -48,7 +48,7 @@ import {
 // generated with
 // $ esbuild --bundle --legal-comments=none --target=es2022 --tree-shaking=true --format=esm .
 // ... then making sure the file uses the existing ext:deno_node stuff instead of bundling it
-const __process$ = { nextTick };
+import __process$ from "node:process";
 import __buffer$ from "node:buffer";
 import __string_decoder$ from "node:string_decoder";
 import __events$ from "node:events";


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/21644

`next build` works:
```
~/gh/deno/target/debug/deno run -A --unstable-byonm ./node_modules/.bin/next build
Warning: Not implemented: process.on("rejectionHandled")
   ▲ Next.js 14.0.4

 ✓ Creating an optimized production build
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
   Collecting page data  ..Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
 ✓ Collecting page data
   Generating static pages (0/5)  [    ]Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
Warning: Not implemented: process.on("rejectionHandled")
 ✓ Generating static pages (5/5)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    5.32 kB        87.4 kB
└ ○ /_not-found                          875 B            83 kB
+ First Load JS shared by all            82.1 kB
  ├ chunks/938-5e061ba0d46125b1.js       26.8 kB
  ├ chunks/fd9d1056-735d320b4b8745cb.js  53.5 kB
  ├ chunks/main-app-2945f337109ea73c.js  220 B
  └ chunks/webpack-e3c6517d4ab8d680.js   1.68 kB


○  (Static)  prerendered as static content
```