### PR TITLE
chore: increase unit test timeout to 3m

### DIFF
--- a/cli/tests/integration/js_unit_tests.rs
+++ b/cli/tests/integration/js_unit_tests.rs
@@ -163,7 +163,7 @@ fn js_unit_test(test: String) {
     }
   });
 
-  const PER_TEST_TIMEOUT: Duration = Duration::from_secs(2 * 60);
+  const PER_TEST_TIMEOUT: Duration = Duration::from_secs(3 * 60);
 
   let now = Instant::now();
   let status = loop {


### PR DESCRIPTION
Alternative to #21758 to fix timing out tests on Windows.