### PR TITLE
fix(lsp): support test code lens for Deno.test.{ignore,only}()

### DIFF
--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -152,10 +152,25 @@ impl Visit for DenoTestCollector {
         }
         ast::Expr::Member(member_expr) => {
           if let ast::MemberProp::Ident(ns_prop_ident) = &member_expr.prop {
+            let mut member_expr = member_expr;
+            let mut ns_prop_ident = ns_prop_ident;
+            let range = ns_prop_ident.range();
+            if matches!(ns_prop_ident.sym.as_str(), "ignore" | "only") {
+              let ast::Expr::Member(member_expr_) = member_expr.obj.as_ref()
+              else {
+                return;
+              };
+              member_expr = member_expr_;
+              let ast::MemberProp::Ident(ns_prop_ident_) = &member_expr.prop
+              else {
+                return;
+              };
+              ns_prop_ident = ns_prop_ident_;
+            }
             if ns_prop_ident.sym == "test" {
               if let ast::Expr::Ident(ident) = member_expr.obj.as_ref() {
                 if ident.sym == "Deno" {
-                  self.check_call_expr(node, &ns_prop_ident.range());
+                  self.check_call_expr(node, &range);
                 }
               }
             }
@@ -528,6 +543,10 @@ mod tests {
       Deno.test(function useFnName() {});
 
       Deno.test("test b", function anotherTest() {});
+
+      Deno.test.ignore("test ignore", () => {});
+
+      Deno.test.only("test only", () => {});
     "#;
     let parsed_module = deno_ast::parse_module(deno_ast::ParseParams {
       specifier: specifier.to_string(),
@@ -687,7 +706,103 @@ mod tests {
             ])
           }),
           data: None,
-        }
+        },
+        lsp::CodeLens {
+          range: lsp::Range {
+            start: lsp::Position {
+              line: 10,
+              character: 16,
+            },
+            end: lsp::Position {
+              line: 10,
+              character: 22,
+            },
+          },
+          command: Some(lsp::Command {
+            title: "▶\u{fe0e} Run Test".to_string(),
+            command: "deno.test".to_string(),
+            arguments: Some(vec![
+              json!("https://deno.land/x/mod.ts"),
+              json!("test ignore"),
+              json!({
+                "inspect": false,
+              }),
+            ]),
+          }),
+          data: None,
+        },
+        lsp::CodeLens {
+          range: lsp::Range {
+            start: lsp::Position {
+              line: 10,
+              character: 16,
+            },
+            end: lsp::Position {
+              line: 10,
+              character: 22,
+            },
+          },
+          command: Some(lsp::Command {
+            title: "Debug".to_string(),
+            command: "deno.test".to_string(),
+            arguments: Some(vec![
+              json!("https://deno.land/x/mod.ts"),
+              json!("test ignore"),
+              json!({
+                "inspect": true,
+              }),
+            ]),
+          }),
+          data: None,
+        },
+        lsp::CodeLens {
+          range: lsp::Range {
+            start: lsp::Position {
+              line: 12,
+              character: 16,
+            },
+            end: lsp::Position {
+              line: 12,
+              character: 20,
+            },
+          },
+          command: Some(lsp::Command {
+            title: "▶\u{fe0e} Run Test".to_string(),
+            command: "deno.test".to_string(),
+            arguments: Some(vec![
+              json!("https://deno.land/x/mod.ts"),
+              json!("test only"),
+              json!({
+                "inspect": false,
+              }),
+            ]),
+          }),
+          data: None,
+        },
+        lsp::CodeLens {
+          range: lsp::Range {
+            start: lsp::Position {
+              line: 12,
+              character: 16,
+            },
+            end: lsp::Position {
+              line: 12,
+              character: 20,
+            },
+          },
+          command: Some(lsp::Command {
+            title: "Debug".to_string(),
+            command: "deno.test".to_string(),
+            arguments: Some(vec![
+              json!("https://deno.land/x/mod.ts"),
+              json!("test only"),
+              json!({
+                "inspect": true,
+              }),
+            ]),
+          }),
+          data: None,
+        },
       ]
     );
   }


### PR DESCRIPTION
Fixes https://github.com/denoland/vscode_deno/issues/989.