### PR TITLE
chore: make test server less noisy

### DIFF
--- a/test_util/src/servers/hyper_utils.rs
+++ b/test_util/src/servers/hyper_utils.rs
@@ -56,7 +56,10 @@ where
     .boxed_local();
 
   if let Err(e) = fut.await {
-    eprintln!("{}: {:?}", options.error_msg, e);
+    let err_str = e.to_string();
+    if !err_str.contains("early eof") {
+      eprintln!("{}: {:?}", options.error_msg, e);
+    }
   }
 }
 
@@ -84,7 +87,10 @@ pub async fn run_server_with_acceptor<'a, A, F, S>(
     .boxed_local();
 
   if let Err(e) = fut.await {
-    eprintln!("{}: {:?}", error_msg, e);
+    let err_str = e.to_string();
+    if !err_str.contains("early eof") {
+      eprintln!("{}: {:?}", error_msg, e);
+    }
   }
 }
 
@@ -127,7 +133,10 @@ async fn hyper_serve_connection<I, F, S>(
   };
 
   if let Err(e) = result {
-    eprintln!("{}: {:?}", error_msg, e);
+    let err_str = e.to_string();
+    if !err_str.contains("early eof") {
+      eprintln!("{}: {:?}", error_msg, e);
+    }
   }
 }
 


### PR DESCRIPTION
Test server was printing a lot of "early eof" messages eg when running
`cargo test integration::npm`. This commit filters out these messages.