### PR TITLE
fix(ci): copyright year for console_test.ts

### DIFF
--- a/cli/tests/unit_node/console_test.ts
+++ b/cli/tests/unit_node/console_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import vm from "node:vm";
 import { stripColor } from "../../../test_util/std/fmt/colors.ts";


### PR DESCRIPTION
Missed in https://github.com/denoland/deno/commit/b2cd254c35b6b1b128beea0eacdb8e814d91e003#diff-0c2dcdd1ce20382e6ddefe52956cf2f570f18063cf09067f8a7ca44abaf33122