### PR TITLE
fix(cli): update import map url

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2810,9 +2810,7 @@ fn inspect_args(app: Command) -> Command {
 
 static IMPORT_MAP_HELP: &str = concat!(
   "Load import map file from local file or remote URL.
-Docs: https://deno.land/manual@v",
-  env!("CARGO_PKG_VERSION"),
-  "/linking_to_external_code/import_maps
+Docs: https://docs.deno.com/runtime/manual/basics/import_maps
 Specification: https://wicg.github.io/import-maps/
 Examples: https://github.com/WICG/import-maps#the-import-map",
 );


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/21822

This updates the import-maps help URL to the one mentioned in the issue 