### PR TITLE
fix(ext/websocket): pass on uncaught errors in idleTimeout

### DIFF
--- a/cli/tests/unit/websocket_test.ts
+++ b/cli/tests/unit/websocket_test.ts
@@ -407,6 +407,7 @@ Deno.test(
 );
 
 Deno.test(
+  { sanitizeOps: false },
   async function websocketServerGetsGhosted() {
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();

--- a/cli/tests/unit/websocket_test.ts
+++ b/cli/tests/unit/websocket_test.ts
@@ -416,7 +416,7 @@ Deno.test(
         const { socket, response } = Deno.upgradeWebSocket(req, {
           idleTimeout: 2,
         });
-        socket.onerror = () => ac.abort();
+        socket.onerror = () => socket.close();
         socket.onclose = () => ac.abort();
         return response;
       },

--- a/cli/tests/unit/websocket_test.ts
+++ b/cli/tests/unit/websocket_test.ts
@@ -416,11 +416,7 @@ Deno.test(
         const { socket, response } = Deno.upgradeWebSocket(req, {
           idleTimeout: 2,
         });
-        socket.onerror = (e) => {
-          // @ts-ignore: message is part of ErrorEvent
-          assert(e.message.includes("Connection reset by peer"));
-          ac.abort();
-        };
+        socket.onerror = () => ac.abort();
         socket.onclose = () => ac.abort();
         return response;
       },

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -502,12 +502,14 @@ class WebSocket extends EventTarget {
       clearTimeout(this[_idleTimeoutTimeout]);
       this[_idleTimeoutTimeout] = setTimeout(async () => {
         if (this[_readyState] === OPEN) {
-          await op_ws_send_ping(this[_rid]);
+          await op_ws_send_ping(this[_rid])
+            .catch(() => {});
           this[_idleTimeoutTimeout] = setTimeout(async () => {
             if (this[_readyState] === OPEN) {
               this[_readyState] = CLOSING;
               const reason = "No response from ping frame.";
-              await op_ws_close(this[_rid], 1001, reason);
+              await op_ws_close(this[_rid], 1001, reason)
+                .catch(() => {});
               this[_readyState] = CLOSED;
 
               const errEvent = new ErrorEvent("error", {

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -502,14 +502,15 @@ class WebSocket extends EventTarget {
       clearTimeout(this[_idleTimeoutTimeout]);
       this[_idleTimeoutTimeout] = setTimeout(async () => {
         if (this[_readyState] === OPEN) {
-          await op_ws_send_ping(this[_rid])
-            .catch(() => {});
+          await PromisePrototypeCatch(op_ws_send_ping(this[_rid]), () => {});
           this[_idleTimeoutTimeout] = setTimeout(async () => {
             if (this[_readyState] === OPEN) {
               this[_readyState] = CLOSING;
               const reason = "No response from ping frame.";
-              await op_ws_close(this[_rid], 1001, reason)
-                .catch(() => {});
+              await PromisePrototypeCatch(
+                op_ws_close(this[_rid], 1001, reason),
+                () => {},
+              );
               this[_readyState] = CLOSED;
 
               const errEvent = new ErrorEvent("error", {

--- a/test_util/src/servers/mod.rs
+++ b/test_util/src/servers/mod.rs
@@ -455,6 +455,54 @@ async fn main_server(
       );
       Ok(response)
     }
+    (&Method::GET, "/ghost_ws_client") => {
+      use tokio::io::AsyncReadExt;
+
+      let mut tcp_stream = TcpStream::connect("localhost:4248").await.unwrap();
+      #[cfg(unix)]
+      // SAFETY: set socket keep alive.
+      unsafe {
+        use std::os::fd::AsRawFd;
+
+        let fd = tcp_stream.as_raw_fd();
+        let mut val: libc::c_int = 1;
+        let r = libc::setsockopt(
+          fd,
+          libc::SOL_SOCKET,
+          libc::SO_KEEPALIVE,
+          &mut val as *mut _ as *mut libc::c_void,
+          std::mem::size_of_val(&val) as libc::socklen_t,
+        );
+        assert_eq!(r, 0);
+      }
+
+      // Typical websocket handshake request.
+      let headers = [
+        "GET / HTTP/1.1",
+        "Host: localhost",
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        "Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==",
+        "Sec-WebSocket-Version: 13",
+        "\r\n",
+      ]
+      .join("\r\n");
+      tcp_stream.write_all(headers.as_bytes()).await.unwrap();
+
+      let mut buf = [0u8; 200];
+      let n = tcp_stream.read(&mut buf).await.unwrap();
+      assert!(n > 0);
+
+      // Ghost the server:
+      // - Close the read half of the connection.
+      // - forget the TcpStream.
+      let tcp_stream = tcp_stream.into_std().unwrap();
+      let _ = tcp_stream.shutdown(std::net::Shutdown::Read);
+      std::mem::forget(tcp_stream);
+
+      let res = Response::new(empty_body());
+      Ok(res)
+    }
     (_, "/multipart_form_data.txt") => {
       let b = "Preamble\r\n\
              --boundary\t \r\n\


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/21840

The problem was hard to reproduce as its a race condition. I've added a test that reproduces the problem 1/10 tries. We should move the idleTimeout handling to Rust (maybe even built into fastwebsocket).