### PR TITLE
perf(lsp): use host-owned cache for auto-import completions

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -537,6 +537,14 @@ delete Object.prototype.__proto__;
     getProjectVersion() {
       return ops.op_project_version();
     },
+    // @ts-ignore Undocumented method.
+    getModuleSpecifierCache() {
+      return moduleSpecifierCache;
+    },
+    // @ts-ignore Undocumented method.
+    getCachedExportInfoMap() {
+      return exportMapCache;
+    },
     getSourceFile(
       specifier,
       languageVersion,
@@ -765,6 +773,12 @@ delete Object.prototype.__proto__;
       return undefined;
     },
   };
+
+  // @ts-ignore Undocumented function.
+  const moduleSpecifierCache = ts.server.createModuleSpecifierCache(host);
+
+  // @ts-ignore Undocumented function.
+  const exportMapCache = ts.createCacheableExportInfoMap(host);
 
   // override the npm install @types package diagnostics to be deno specific
   ts.setLocalizedDiagnosticMessages((() => {


### PR DESCRIPTION
Fixes #21558. It's a sporadic error so not sure how to test for it, but it's definitely fixed.