### PR TITLE
fix(task): do not eagerly auto-install packages in package.json when `"nodeModulesDir": false`

### DIFF
--- a/cli/tests/integration/task_tests.rs
+++ b/cli/tests/integration/task_tests.rs
@@ -178,6 +178,18 @@ itest!(task_package_json_npm_bin {
   http_server: true,
 });
 
+// should not auto-install the packages in the package.json
+// when using nodeModulesDir: false
+itest!(task_package_json_node_modules_dir_false {
+  args: "task echo",
+  cwd: Some("task/package_json_node_modules_dir_false/"),
+  output: "task/package_json_node_modules_dir_false/bin.out",
+  copy_temp_dir: Some("task/package_json_node_modules_dir_false/"),
+  envs: env_vars_for_npm_tests(),
+  exit_code: 0,
+  http_server: true,
+});
+
 itest!(task_both_no_arg {
   args: "task",
   cwd: Some("task/both/"),

--- a/cli/tests/testdata/task/package_json_node_modules_dir_false/bin.out
+++ b/cli/tests/testdata/task/package_json_node_modules_dir_false/bin.out
@@ -1,0 +1,2 @@
+Task echo deno eval 'console.log(1)'
+1

--- a/cli/tests/testdata/task/package_json_node_modules_dir_false/deno.json
+++ b/cli/tests/testdata/task/package_json_node_modules_dir_false/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": false
+}

--- a/cli/tests/testdata/task/package_json_node_modules_dir_false/package.json
+++ b/cli/tests/testdata/task/package_json_node_modules_dir_false/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "echo": "deno eval 'console.log(1)'"
+  },
+  "dependencies": {
+    "@denotest/bin": "0.5",
+    "other": "npm:@denotest/bin@1.0"
+  }
+}

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -88,10 +88,13 @@ pub async fn execute_script(
       }
     }
 
-    // install the npm packages if we're using a managed resolver
-    if let Some(npm_resolver) = npm_resolver.as_managed() {
-      npm_resolver.ensure_top_level_package_json_install().await?;
-      npm_resolver.resolve_pending().await?;
+    // ensure the npm packages are installed if using a node_modules
+    // directory and managed resolver
+    if cli_options.has_node_modules_dir() {
+      if let Some(npm_resolver) = npm_resolver.as_managed() {
+        npm_resolver.ensure_top_level_package_json_install().await?;
+        npm_resolver.resolve_pending().await?;
+      }
     }
 
     let cwd = match task_flags.cwd {


### PR DESCRIPTION
There's no need to auto-install the package.json if the user is not using a node_modules directory.

Closes #21850