### PR TITLE
fix(lsp): use a dedicated thread for the parent process checker

### DIFF
--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -1,20 +1,17 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::unsync::spawn;
-use tokio::time::sleep;
-use tokio::time::Duration;
+use std::time::Duration;
 
-/// Starts a task that will check for the existence of the
+/// Starts a thread that will check for the existence of the
 /// provided process id. Once that process no longer exists
 /// it will terminate the current process.
 pub fn start(parent_process_id: u32) {
-  spawn(async move {
-    loop {
-      sleep(Duration::from_secs(30)).await;
+  // use a separate thread in case the runtime gets hung up
+  std::thread::spawn(move || loop {
+    std::thread::sleep(Duration::from_secs(30));
 
-      if !is_process_active(parent_process_id) {
-        std::process::exit(1);
-      }
+    if !is_process_active(parent_process_id) {
+      std::process::exit(1);
     }
   });
 }

--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 pub fn start(parent_process_id: u32) {
   // use a separate thread in case the runtime gets hung up
   std::thread::spawn(move || loop {
-    std::thread::sleep(Duration::from_secs(15));
+    std::thread::sleep(Duration::from_secs(10));
 
     if !is_process_active(parent_process_id) {
       std::process::exit(1);

--- a/cli/lsp/parent_process_checker.rs
+++ b/cli/lsp/parent_process_checker.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 pub fn start(parent_process_id: u32) {
   // use a separate thread in case the runtime gets hung up
   std::thread::spawn(move || loop {
-    std::thread::sleep(Duration::from_secs(30));
+    std::thread::sleep(Duration::from_secs(15));
 
     if !is_process_active(parent_process_id) {
       std::process::exit(1);


### PR DESCRIPTION
Ensures the Deno process is brought down even when the runtime gets hung up on something.

Marvin found that the lsp was running without a parent vscode around so this is maybe/probably related.