### PR TITLE
fix(lsp): implement host.getGlobalTypingsCacheLocation()

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -545,6 +545,9 @@ delete Object.prototype.__proto__;
     getCachedExportInfoMap() {
       return exportMapCache;
     },
+    getGlobalTypingsCacheLocation() {
+      return undefined;
+    },
     getSourceFile(
       specifier,
       languageVersion,

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1023,6 +1023,7 @@ delete Object.prototype.__proto__;
           debug(ts.formatDiagnostics(errors, host));
         }
         compilationSettings = options;
+        moduleSpecifierCache.clear();
         return respond(id, true);
       }
       case "$getSupportedCodeFixes": {


### PR DESCRIPTION
Since #21852 I started seeing this error randomly sometimes for top-level completions:
```
Unable to get completion info from TypeScript: TypeError: host.getGlobalTypingsCacheLocation is not a function
    at isNotShadowedByDeeperNodeModulesPackage (ext:deno_tsc/00_typescript.js:132847:41)
    at ext:deno_tsc/00_typescript.js:132745:58
    at Array.filter (<anonymous>)
    at ext:deno_tsc/00_typescript.js:132745:41
    at forEachEntry (ext:deno_tsc/00_typescript.js:12975:22)
    at Object.search (ext:deno_tsc/00_typescript.js:132740:16)
    at ext:deno_tsc/00_typescript.js:159128:22
    at resolvingModuleSpecifiers (ext:deno_tsc/00_typescript.js:156655:20)
    at collectAutoImports (ext:deno_tsc/00_typescript.js:159118:7)
    at getGlobalCompletions (ext:deno_tsc/00_typescript.js:159048:7)
```
Some obscure location where this method isn't feature-checked before calling.