### PR TITLE
fix(config): regression - handle relative patterns with leading dot slash

### DIFF
--- a/cli/tests/integration/test_tests.rs
+++ b/cli/tests/integration/test_tests.rs
@@ -663,3 +663,9 @@ fn conditionally_loads_type_graph() {
     .run();
   assert_not_contains!(output.combined_output(), "type_reference.d.ts");
 }
+
+itest!(test_include_relative_pattern_dot_slash {
+  args: "test",
+  output: "test/relative_pattern_dot_slash/output.out",
+  cwd: Some("test/relative_pattern_dot_slash"),
+});

--- a/cli/tests/testdata/test/relative_pattern_dot_slash/deno.json
+++ b/cli/tests/testdata/test/relative_pattern_dot_slash/deno.json
@@ -1,0 +1,7 @@
+{
+  "test": {
+    "include": [
+      "./test/**/*.test.mjs"
+    ]
+  }
+}

--- a/cli/tests/testdata/test/relative_pattern_dot_slash/output.out
+++ b/cli/tests/testdata/test/relative_pattern_dot_slash/output.out
@@ -1,0 +1,5 @@
+running 1 test from ./test/add.test.mjs
+should add ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed ([WILDCARD])
+

--- a/cli/tests/testdata/test/relative_pattern_dot_slash/test/add.mjs
+++ b/cli/tests/testdata/test/relative_pattern_dot_slash/test/add.mjs
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b;
+}

--- a/cli/tests/testdata/test/relative_pattern_dot_slash/test/add.test.mjs
+++ b/cli/tests/testdata/test/relative_pattern_dot_slash/test/add.test.mjs
@@ -1,0 +1,7 @@
+import { add } from "./add.mjs";
+
+Deno.test("should add", () => {
+  if (add(1, 2) !== 3) {
+    throw new Error("FAIL");
+  }
+});

--- a/cli/util/glob.rs
+++ b/cli/util/glob.rs
@@ -248,9 +248,11 @@ impl GlobPattern {
   }
 
   pub fn new(pattern: &str) -> Result<Self, AnyError> {
-    let pattern =
-      glob::Pattern::new(&escape_brackets(pattern).replace('\\', "/"))
-        .with_context(|| format!("Failed to expand glob: \"{}\"", pattern))?;
+    let pattern = escape_brackets(pattern)
+      .replace('\\', "/")
+      .replace("/./", "/");
+    let pattern = glob::Pattern::new(&pattern)
+      .with_context(|| format!("Failed to expand glob: \"{}\"", pattern))?;
     Ok(Self(pattern))
   }
 


### PR DESCRIPTION
This is a hacky quick fix. We need to spend more time cleaning up this code and push more stuff down into deno_config.

Closes #21916