### PR TITLE
chore: fix 1.39.4 release

### DIFF
--- a/cli/deno_std.rs
+++ b/cli/deno_std.rs
@@ -2,4 +2,4 @@
 
 // WARNING: Ensure this is the only deno_std version reference as this
 // is automatically updated by the version bump workflow.
-pub const CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.213.0/";
+pub const CURRENT_STD_URL_STR: &str = "https://deno.land/std@0.212.0/";


### PR DESCRIPTION
I accidentally merged the past PR (wanted to do auto-merge). This fixes it.