### PR TITLE
feat: Start warning on each use of a deprecated API

### DIFF
--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -4,7 +4,7 @@
 // Documentation liberally lifted from them too.
 // Thank you! We love Go! <3
 
-import { core, primordials } from "ext:core/mod.js";
+import { core, internals, primordials } from "ext:core/mod.js";
 const {
   op_stdin_set_raw,
 } = core.ensureFastOps(true);
@@ -39,6 +39,7 @@ async function copy(
   dst,
   options,
 ) {
+  internals.warnOnDeprecatedApi("Deno.copy()", (new Error()).stack);
   let n = 0;
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
   const b = new Uint8Array(bufSize);
@@ -64,6 +65,7 @@ async function* iter(
   r,
   options,
 ) {
+  internals.warnOnDeprecatedApi("Deno.iter()", (new Error()).stack);
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
   const b = new Uint8Array(bufSize);
   while (true) {
@@ -80,6 +82,7 @@ function* iterSync(
   r,
   options,
 ) {
+  internals.warnOnDeprecatedApi("Deno.iterSync()", (new Error()).stack);
   const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
   const b = new Uint8Array(bufSize);
   while (true) {
@@ -115,6 +118,7 @@ function write(rid, data) {
 const READ_PER_ITER = 64 * 1024; // 64kb
 
 async function readAll(r) {
+  internals.warnOnDeprecatedApi("Deno.readAll()", (new Error()).stack);
   const buffers = [];
 
   while (true) {
@@ -131,6 +135,7 @@ async function readAll(r) {
 }
 
 function readAllSync(r) {
+  internals.warnOnDeprecatedApi("Deno.readAllSync()", (new Error()).stack);
   const buffers = [];
 
   while (true) {

--- a/runtime/js/13_buffer.js
+++ b/runtime/js/13_buffer.js
@@ -4,7 +4,7 @@
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
 // https://github.com/golang/go/blob/master/LICENSE
 
-import { primordials } from "ext:core/mod.js";
+import { internals, primordials } from "ext:core/mod.js";
 const {
   ArrayBufferPrototypeGetByteLength,
   TypedArrayPrototypeSubarray,
@@ -242,6 +242,7 @@ function readAllSync(r) {
 }
 
 async function writeAll(w, arr) {
+  internals.warnOnDeprecatedApi("Deno.writeAll()", (new Error()).stack);
   let nwritten = 0;
   while (nwritten < arr.length) {
     nwritten += await w.write(TypedArrayPrototypeSubarray(arr, nwritten));
@@ -249,6 +250,7 @@ async function writeAll(w, arr) {
 }
 
 function writeAllSync(w, arr) {
+  internals.warnOnDeprecatedApi("Deno.writeAllSync()", (new Error()).stack);
   let nwritten = 0;
   while (nwritten < arr.length) {
     nwritten += w.writeSync(TypedArrayPrototypeSubarray(arr, nwritten));

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
+import { core, internals, primordials } from "ext:core/mod.js";
 const {
   BadResourcePrototype,
   InterruptedPrototype,
@@ -49,6 +49,10 @@ class FsWatcher {
   // TODO(kt3k): This is deprecated. Will be removed in v2.0.
   // See https://github.com/denoland/deno/issues/10577 for details
   return(value) {
+    internals.warnOnDeprecatedApi(
+      "Deno.FsWatcher.return()",
+      (new Error()).stack,
+    );
     core.close(this.rid);
     return PromiseResolve({ value, done: true });
   }

--- a/runtime/js/40_http.js
+++ b/runtime/js/40_http.js
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { core } from "ext:core/mod.js";
+import { core, internals } from "ext:core/mod.js";
 const {
   op_http_start,
 } = core.ensureFastOps();
@@ -7,6 +7,7 @@ const {
 import { HttpConn } from "ext:deno_http/01_http.js";
 
 function serveHttp(conn) {
+  internals.warnOnDeprecatedApi("Deno.serveHttp()", (new Error()).stack);
   const rid = op_http_start(conn.rid);
   return new HttpConn(rid, conn.remoteAddr, conn.localAddr);
 }

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -140,6 +140,7 @@ function run({
       ...new SafeArrayIterator(ArrayPrototypeSlice(cmd, 1)),
     ];
   }
+  internals.warnOnDeprecatedApi("Deno.run()", (new Error()).stack);
   const res = opRun({
     cmd: ArrayPrototypeMap(cmd, String),
     cwd,

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
+import { core, internals } from "ext:core/mod.js";
 const {
   op_net_listen_udp,
   op_net_listen_unixpacket,
@@ -31,7 +31,10 @@ import * as kv from "ext:deno_kv/01_db.ts";
 import * as cron from "ext:deno_cron/01_cron.ts";
 
 const denoNs = {
-  metrics: core.metrics,
+  metrics: () => {
+    internals.warnOnDeprecatedApi("Deno.metrics()", (new Error()).stack);
+    return core.metrics();
+  },
   Process: process.Process,
   run: process.run,
   isatty: tty.isatty,


### PR DESCRIPTION
Eg:

```js
const p = Deno.run({
  cmd: ["echo", "hello world"],
  stderr: "piped",
  stdout: "piped",
});
const [status, stdout, stderr] = await Promise.all([
  p.status(),
  p.output(),
  p.stderrOutput(),
]);
p.close();

async function runEcho() {
  const p = Deno.run({
    cmd: ["echo", "hello world"],
    stderr: "piped",
    stdout: "piped",
  });
  const [status, stdout, stderr] = await Promise.all([
    p.status(),
    p.output(),
    p.stderrOutput(),
  ]);
  p.close();
}

await runEcho();
await runEcho();

```

```
$ deno run --allow-read foo.js
Warning Use of deprecated API `Deno.run()`. This API will be removed in Deno 2.
    at Object.run (ext:runtime/40_process.js:143:48)
    at file:///Users/ib/dev/deno/foo.js:1:16
Warning Use of deprecated API `Deno.run()`. This API will be removed in Deno 2.
    at Object.run (ext:runtime/40_process.js:143:48)
    at runEcho (file:///Users/ib/dev/deno/foo.js:14:18)
    at file:///Users/ib/dev/deno/foo.js:27:7
    at eventLoopTick (ext:core/01_core.js:182:7)
Warning Use of deprecated API `Deno.run()`. This API will be removed in Deno 2.
    at Object.run (ext:runtime/40_process.js:143:48)
    at runEcho (file:///Users/ib/dev/deno/foo.js:14:18)
    at file:///Users/ib/dev/deno/foo.js:28:7
    at eventLoopTick (ext:core/01_core.js:182:7)
```