### PR TITLE
fix(ext/node): set fs.Stats prototype

### DIFF
--- a/cli/tests/unit_node/_fs/_fs_stat_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_stat_test.ts
@@ -4,6 +4,7 @@ import { BigIntStats, stat, Stats, statSync } from "node:fs";
 import { assertEquals, fail } from "../../../../test_util/std/assert/mod.ts";
 
 export function assertStats(actual: Stats, expected: Deno.FileInfo) {
+  assertEquals(actual instanceof Stats, true);
   assertEquals(actual.dev, expected.dev);
   assertEquals(actual.gid, expected.gid);
   assertEquals(actual.size, expected.size);

--- a/ext/node/polyfills/_fs/_fs_stat.ts
+++ b/ext/node/polyfills/_fs/_fs_stat.ts
@@ -5,6 +5,7 @@
 
 import { denoErrorToNodeError } from "ext:deno_node/internal/errors.ts";
 import { promisify } from "ext:deno_node/internal/util.mjs";
+import { Stats } from "ext:deno_node/internal/fs/utils.mjs";
 
 export type statOptions = {
   bigint: boolean;
@@ -162,7 +163,7 @@ export type BigIntStats = {
 };
 
 export function convertFileInfoToStats(origin: Deno.FileInfo): Stats {
-  return {
+  return Object.assign(Object.create(Stats.prototype), {
     dev: origin.dev,
     ino: origin.ino,
     mode: origin.mode,
@@ -189,7 +190,7 @@ export function convertFileInfoToStats(origin: Deno.FileInfo): Stats {
     isSocket: () => false,
     ctime: origin.mtime,
     ctimeMs: origin.mtime?.getTime() || null,
-  };
+  });
 }
 
 function toBigInt(number?: number | null) {


### PR DESCRIPTION
Fixes #21921

Sorry, this is a weird hack. Maybe there's something cleaner?

`BigIntStats` isn't exported from Node, so that doesn't need changing.