### PR TITLE
feat(cli): Add file URI scheme support in FileSystem API

### DIFF
--- a/cli/tests/unit/path_from_url_test.ts
+++ b/cli/tests/unit/path_from_url_test.ts
@@ -8,6 +8,7 @@ const { pathFromURL } = Deno[Deno.internal];
 Deno.test(
   { ignore: Deno.build.os === "windows" },
   function pathFromURLPosix() {
+    assertEquals(pathFromURL("file:///test/directory"), "/test/directory");
     assertEquals(
       pathFromURL(new URL("file:///test/directory")),
       "/test/directory",
@@ -20,6 +21,7 @@ Deno.test(
 Deno.test(
   { ignore: Deno.build.os !== "windows" },
   function pathFromURLWin32() {
+    assertEquals(pathFromURL("file:///c:/windows/test"), "c:\\windows\\test");
     assertEquals(
       pathFromURL(new URL("file:///c:/windows/test")),
       "c:\\windows\\test",

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -456,7 +456,7 @@ function pathFromURL(pathOrUrl) {
       : pathFromURLPosix(pathOrUrl);
   }
 
-  if (StringPrototypeStartsWith(pathOrUrl, "file:")) {
+  if (StringPrototypeStartsWith(pathOrUrl, "file:///")) {
     return core.build.os == "windows"
       ? pathFromURLWin32(new URL(pathOrUrl))
       : pathFromURLPosix(new URL(pathOrUrl));

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -30,6 +30,7 @@ const {
   StringPrototypeReplace,
   StringPrototypeReplaceAll,
   StringPrototypeSlice,
+  StringPrototypeStartsWith,
   StringPrototypeSubstring,
   StringPrototypeToLowerCase,
   StringPrototypeToUpperCase,
@@ -37,7 +38,7 @@ const {
   TypeError,
 } = primordials;
 
-import { URLPrototype } from "ext:deno_url/00_url.js";
+import { URL, URLPrototype } from "ext:deno_url/00_url.js";
 
 const ASCII_DIGIT = ["\u0030-\u0039"];
 const ASCII_UPPER_ALPHA = ["\u0041-\u005A"];
@@ -454,6 +455,13 @@ function pathFromURL(pathOrUrl) {
       ? pathFromURLWin32(pathOrUrl)
       : pathFromURLPosix(pathOrUrl);
   }
+
+  if (StringPrototypeStartsWith(pathOrUrl, "file:")) {
+    return core.build.os == "windows"
+      ? pathFromURLWin32(new URL(pathOrUrl))
+      : pathFromURLPosix(new URL(pathOrUrl));
+  }
+
   return pathOrUrl;
 }
 


### PR DESCRIPTION
Hi! 

After having used Deno for a while, I noticed a small but frustrating inconsistency in the FileSystem API related to file URI schemes.

Currently, the FileSystem API behaves like this:

**FileSystem API**
```js
// 🚫 Invalid
Deno.readTextFile(import.meta.resolve("./example.txt"));

// ✅ Valid
Deno.readTextFile(new URL(import.meta.resolve("./example.txt")));

// ✅ Valid (resolves from the current working directory)
Deno.readTextFile("./example.txt");
```

The FileSystem API doesn't support file URI schemes as a `string`, but it does support it as an `URL` object.

This is the only API I could find in Deno that has this behavior. All other APIs support both `string` and `URL` objects:

**Workers**
```ts
// ✅ Valid
new Worker(import.meta.resolve("./worker.ts"), { type: "module" });

// ✅ Valid
new Worker(new URL(import.meta.resolve("./worker.ts")), { type: "module" });

// ⚠️ Valid if the --location flag is used, as it resolves from the current URL.
new Worker("./worker.ts", { type: "module" });
```

**Dynamic Imports**
```ts
// ✅ Valid
import(import.meta.resolve("./foo.ts"));

// ⚠️ Valid, despite warning from the type system. Seems like the URL is coersed into a file URI string.
import(new URL(import.meta.resolve("./bar.ts")));

// ✅ Valid
import("./baz.ts");
```

**Fetch API**
```ts
// ✅ Valid
await fetch(import.meta.resolve("./example.txt"));

// ✅ Valid
await fetch(new URL(import.meta.resolve("./example.txt")));

// ⚠️ Valid if the --location flag is used, as it resolves from the current URL.
await fetch("./example.txt"); 
```

I believe the FileSystem API should support file URI schemes as a `string`.

# Changes

I modified the `pathFromURL` internal function which is used by the FileSystem API.

It now checks if the path starts with `file:` if it does, it assumes its a URI scheme and will parse it as one.

## Known limitations

This change is _technically_ breaking.

While `file:something` is not a valid filename in Windows, it is a valid filename in Unix systems.

If a user has a file start with `file:`, they'll need to indicate that it is indeed a local file by adding `./`:

```ts
// This used to read the `./file:example.txt` file on Unix systems, but this will now break.
Deno.readTextFile("file:example.txt"));

// This will remain valid, as it is clearly reading a local file relatively.
Deno.readTextFile("./file:example.txt"));
```

# Prior discussions

Prior discussions about this issue: 
- https://github.com/denoland/deno/issues/8579

Concern raised about `file:` potentially being an actual file name:
- https://github.com/denoland/deno/pull/5990#issuecomment-642356996

It raised some bugs at the time:
- https://github.com/denoland/deno/issues/6401
- https://github.com/denoland/deno/issues/6401#issuecomment-648388203

Let me know what you think! Thank you for your time 🙇