### PR TITLE
feat(jupyter): don't require --unstable flag

### DIFF
--- a/cli/tests/integration/jupyter_tests.rs
+++ b/cli/tests/integration/jupyter_tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 itest!(jupyter_install_command_not_exists {
-  args: "jupyter --unstable --install",
+  args: "jupyter --install",
   output: "jupyter/install_command_not_exists.out",
   envs: vec![("PATH".to_string(), "".to_string())],
   exit_code: 1,

--- a/cli/tests/testdata/jupyter/install_command_not_exists.out
+++ b/cli/tests/testdata/jupyter/install_command_not_exists.out
@@ -1,3 +1,4 @@
+Warning "deno jupyter" is unstable and might change in the future.
 error: Failed to spawn 'jupyter' command. Is JupyterLab installed (https://jupyter.org/install) and available on the PATH?
 
 Caused by:

--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -33,7 +33,7 @@ pub fn status() -> Result<(), AnyError> {
     }
   }
 
-  println!("ℹ️ Deno kernel is not yet installed, run `deno jupyter --unstable --install` to set it up");
+  println!("ℹ️ Deno kernel is not yet installed, run `deno jupyter --install` to set it up");
   Ok(())
 }
 
@@ -56,7 +56,7 @@ pub fn install() -> Result<(), AnyError> {
   // https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs
   // FIXME(bartlomieju): replace `current_exe` before landing?
   let json_data = json!({
-      "argv": [current_exe().unwrap().to_string_lossy(), "--unstable", "jupyter", "--kernel", "--conn", "{connection_file}"],
+      "argv": [current_exe().unwrap().to_string_lossy(), "jupyter", "--kernel", "--conn", "{connection_file}"],
       "display_name": "Deno",
       "language": "typescript",
   });

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -13,6 +13,7 @@ use deno_core::located_script_name;
 use deno_core::resolve_url_or_path;
 use deno_core::serde::Deserialize;
 use deno_core::serde_json;
+use deno_runtime::colors;
 use deno_runtime::deno_io::Stdio;
 use deno_runtime::deno_io::StdioPipe;
 use deno_runtime::permissions::Permissions;
@@ -33,12 +34,10 @@ pub async fn kernel(
   flags: Flags,
   jupyter_flags: JupyterFlags,
 ) -> Result<(), AnyError> {
-  if !flags.unstable {
-    eprintln!(
-      "Unstable subcommand 'deno jupyter'. The --unstable flag must be provided."
-    );
-    std::process::exit(70);
-  }
+  log::info!(
+    "{} \"deno jupyter\" is unstable and might change in the future.",
+    colors::yellow("Warning"),
+  );
 
   if !jupyter_flags.install && !jupyter_flags.kernel {
     install::status()?;


### PR DESCRIPTION
This commit removes the requirement for `--unstable` flag in `deno jupyter`
subcommand. The process will no longer exit if this flag is not provided,
however the subcommand itself is still considered unstable and might
change in the future.

Required for https://github.com/denoland/deno/pull/21452