### PR TITLE
feat(lsp): send "deno/didChangeDenoConfiguration" on init

### DIFF
--- a/cli/lsp/lsp_custom.rs
+++ b/cli/lsp/lsp_custom.rs
@@ -62,6 +62,25 @@ pub struct DiagnosticBatchNotificationParams {
 
 #[derive(Debug, Eq, Hash, PartialEq, Copy, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub enum DenoConfigurationChangeType {
+  Added,
+  Changed,
+  Removed,
+}
+
+impl DenoConfigurationChangeType {
+  pub fn from_file_change_type(file_event: lsp::FileChangeType) -> Self {
+    match file_event {
+      lsp::FileChangeType::CREATED => Self::Added,
+      lsp::FileChangeType::CHANGED => Self::Changed,
+      lsp::FileChangeType::DELETED => Self::Removed,
+      _ => Self::Changed, // non-exhaustable enum
+    }
+  }
+}
+
+#[derive(Debug, Eq, Hash, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum DenoConfigurationType {
   DenoJson,
   PackageJson,
@@ -70,8 +89,9 @@ pub enum DenoConfigurationType {
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DenoConfigurationChangeEvent {
-  #[serde(flatten)]
-  pub file_event: lsp::FileEvent,
+  pub uri: lsp::Url,
+  #[serde(rename = "type")]
+  pub typ: DenoConfigurationChangeType,
   pub configuration_type: DenoConfigurationType,
 }
 

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -10037,9 +10037,8 @@ Deno.test({
   assert_eq!(res.enqueued[0].text_document.uri, specifier);
   assert_eq!(res.enqueued[0].ids.len(), 1);
   let id = res.enqueued[0].ids[0].clone();
-
-  let (method, notification) = client.read_notification::<Value>();
-  assert_eq!(method, "deno/testRunProgress");
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testRunProgress");
   assert_eq!(
     notification,
     Some(json!({
@@ -10056,8 +10055,8 @@ Deno.test({
     }))
   );
 
-  let (method, notification) = client.read_notification::<Value>();
-  assert_eq!(method, "deno/testRunProgress");
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testRunProgress");
   let notification_value = notification
     .as_ref()
     .unwrap()
@@ -10092,8 +10091,8 @@ Deno.test({
     }))
   );
 
-  let (method, notification) = client.read_notification::<Value>();
-  assert_eq!(method, "deno/testRunProgress");
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testRunProgress");
   assert_eq!(
     notification,
     Some(json!({
@@ -10111,8 +10110,8 @@ Deno.test({
     }))
   );
 
-  let (method, notification) = client.read_notification::<Value>();
-  assert_eq!(method, "deno/testRunProgress");
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testRunProgress");
   let mut notification = notification.unwrap();
   let duration = notification
     .as_object_mut()
@@ -10140,8 +10139,8 @@ Deno.test({
     })
   );
 
-  let (method, notification) = client.read_notification::<Value>();
-  assert_eq!(method, "deno/testRunProgress");
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testRunProgress");
   let notification = notification.unwrap();
   let obj = notification.as_object().unwrap();
   assert_eq!(obj.get("id"), Some(&json!(1)));
@@ -10159,8 +10158,8 @@ Deno.test({
       );
       assert!(message.contains_key("duration"));
 
-      let (method, notification) = client.read_notification::<Value>();
-      assert_eq!(method, "deno/testRunProgress");
+      let notification =
+        client.read_notification_with_method::<Value>("deno/testRunProgress");
       assert_eq!(
         notification,
         Some(json!({
@@ -10193,8 +10192,8 @@ Deno.test({
 
   assert_eq!(client.read_diagnostics().all().len(), 0);
 
-  let (method, notification) = client.read_notification::<Value>();
-  assert_eq!(method, "deno/testModuleDelete");
+  let notification =
+    client.read_notification_with_method::<Value>("deno/testModuleDelete");
   assert_eq!(
     notification,
     Some(json!({

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -857,7 +857,7 @@ fn lsp_did_change_deno_configuration_notification() {
     Some(json!({
       "changes": [{
         "uri": temp_dir.uri().join("deno.json").unwrap(),
-        "type": 1,
+        "type": "added",
         "configurationType": "denoJson"
       }],
     }))
@@ -880,7 +880,7 @@ fn lsp_did_change_deno_configuration_notification() {
     Some(json!({
       "changes": [{
         "uri": temp_dir.uri().join("deno.json").unwrap(),
-        "type": 2,
+        "type": "changed",
         "configurationType": "denoJson"
       }],
     }))
@@ -900,7 +900,7 @@ fn lsp_did_change_deno_configuration_notification() {
     Some(json!({
       "changes": [{
         "uri": temp_dir.uri().join("deno.json").unwrap(),
-        "type": 3,
+        "type": "removed",
         "configurationType": "denoJson"
       }],
     }))
@@ -920,7 +920,7 @@ fn lsp_did_change_deno_configuration_notification() {
     Some(json!({
       "changes": [{
         "uri": temp_dir.uri().join("package.json").unwrap(),
-        "type": 1,
+        "type": "added",
         "configurationType": "packageJson"
       }],
     }))
@@ -940,7 +940,7 @@ fn lsp_did_change_deno_configuration_notification() {
     Some(json!({
       "changes": [{
         "uri": temp_dir.uri().join("package.json").unwrap(),
-        "type": 2,
+        "type": "changed",
         "configurationType": "packageJson"
       }],
     }))
@@ -960,7 +960,7 @@ fn lsp_did_change_deno_configuration_notification() {
     Some(json!({
       "changes": [{
         "uri": temp_dir.uri().join("package.json").unwrap(),
-        "type": 3,
+        "type": "removed",
         "configurationType": "packageJson"
       }],
     }))


### PR DESCRIPTION
So the client can be aware of all active `deno.json` files without walking the workspace. This changes the interface of the notification parameter, but it's not read in the extension.