### PR TITLE
fix(node): update `req.socket` on WS upgrade

### DIFF
--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -743,7 +743,7 @@ Deno.test(
       const req = http.request(options);
       req.end();
 
-      req.on("upgrade", (res, socket, _upgradeHead) => {
+      req.on("upgrade", (_res, socket, _upgradeHead) => {
         socket.end();
         // @ts-ignore it's a socket for real
         serverSocket!.end();

--- a/cli/tests/unit_node/http_test.ts
+++ b/cli/tests/unit_node/http_test.ts
@@ -716,7 +716,9 @@ Deno.test(
     });
     // @ts-ignore it's a socket for real
     let serverSocket;
-    server.on("upgrade", (_req, socket, _head) => {
+    server.on("upgrade", (req, socket, _head) => {
+      // https://github.com/denoland/deno/issues/21979
+      assert(req.socket?.write);
       socket.write(
         "HTTP/1.1 101 Web Socket Protocol Handshake\r\n" +
           "Upgrade: WebSocket\r\n" +
@@ -741,7 +743,7 @@ Deno.test(
       const req = http.request(options);
       req.end();
 
-      req.on("upgrade", (_res, socket, _upgradeHead) => {
+      req.on("upgrade", (res, socket, _upgradeHead) => {
         socket.end();
         // @ts-ignore it's a socket for real
         serverSocket!.end();

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1637,6 +1637,8 @@ export class ServerImpl extends EventEmitter {
         const socket = new Socket({
           handle: new TCP(constants.SERVER, conn),
         });
+        // Update socket held by `req`.
+        req.socket = socket;
         this.emit("upgrade", req, socket, Buffer.from([]));
         return response;
       } else {


### PR DESCRIPTION
Update the `req.socket` to be a `net.Socket` from `FakeSocket`

Fixes #21979 