### PR TITLE
fix(node/fs): promises not exporting fs constants

### DIFF
--- a/cli/tests/unit_node/fs_test.ts
+++ b/cli/tests/unit_node/fs_test.ts
@@ -1,9 +1,21 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertThrows } from "../../../test_util/std/assert/mod.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+} from "../../../test_util/std/assert/mod.ts";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  constants,
+  existsSync,
+  mkdtempSync,
+  promises,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { constants as fsPromiseConstants } from "node:fs/promises";
 import { pathToAbsoluteFileUrl } from "../unit/test_util.ts";
 
 Deno.test(
@@ -78,5 +90,13 @@ Deno.test(
   { permissions: { read: true } },
   () => {
     assert(!existsSync("bad_filename"));
+  },
+);
+
+Deno.test(
+  "[node/fs/promises constants] is the same as from node:fs",
+  () => {
+    assertEquals(constants, fsPromiseConstants);
+    assertEquals(constants, promises.constants);
   },
 );

--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -137,6 +137,7 @@ const {
 
 const promises = {
   access: accessPromise,
+  constants,
   copyFile: copyFilePromise,
   cp: cpPromise,
   open: openPromise,

--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -2,6 +2,7 @@
 import { promises as fsPromises } from "node:fs";
 
 export const access = fsPromises.access;
+export const constants = fsPromises.constants;
 export const copyFile = fsPromises.copyFile;
 export const open = fsPromises.open;
 export const opendir = fsPromises.opendir;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.com/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

We were missing the `constants` export in the promise `fs` API which is available in node.

```ts
import { constants, promises } from "node:fs";
import { constants as fsPromiseConstants } from "node:fs/promises";
console.log(constants === promises.constants); // logs: true
console.log(constants === fsPromiseConstants); // logs: true
```

Fixes https://github.com/denoland/deno/issues/21994