### PR TITLE
fix(node): use `cppgc` for managing X509Certificate

### DIFF
--- a/.cargo/local-build.toml
+++ b/.cargo/local-build.toml
@@ -12,4 +12,4 @@
 deno_core = { path = "../deno_core/core" }
 deno_ops = { path = "../deno_core/ops" }
 serde_v8 = { path = "../deno_core/serde_v8" }
-v8 = { path = "../rusty_v8" }
+# v8 = { path = "../rusty_v8" }

--- a/.cargo/local-build.toml
+++ b/.cargo/local-build.toml
@@ -12,4 +12,4 @@
 deno_core = { path = "../deno_core/core" }
 deno_ops = { path = "../deno_core/ops" }
 serde_v8 = { path = "../deno_core/serde_v8" }
-# v8 = { path = "../rusty_v8" }
+v8 = { path = "../rusty_v8" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,8 +1151,6 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.247.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e8ee2e08528c1da4f5a48659c67d12012e831c737f6266534d4f550ccc8c3"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -1601,8 +1599,6 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.123.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f29c5fe78479c3fa437409dca009363feb77036c067d6f3682adff8d06f547"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5256,8 +5252,6 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.156.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ad52e56e21faee5d310a898ab77f83abdab737fde1e97fa6a8cd6615d139ef"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.247.0"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974d075b6647aa6cca14ea75c3833f8996b1c3e487adcde490977f21ac14e27e"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -1598,7 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.123.0"
+version = "0.124.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1bc46bc85a26530e196a5f675dab6e06fb86b9104dc6fdc31cfc9ae1832d911"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5251,7 +5255,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.156.0"
+version = "0.157.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8853e607c700ade0acb853aafda7e4cc1f752f4ebb35b0e2ecbf42e784e6d0e0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "1.0.1", features = ["transpiling"] }
-deno_core = { version = "0.247.0" }
+deno_core = { version = "0.248.0" }
 
 deno_runtime = { version = "0.140.0", path = "./runtime" }
 napi_sym = { version = "0.62.0", path = "./cli/napi/sym" }


### PR DESCRIPTION
Introduces the first cppgc backed Resource into Deno.

This fixes the memory leak when using `X509Certificate`

**Comparison**:

```js
import { X509Certificate } from 'node:crypto';

const r = Deno.readFileSync('cli/tests/node_compat/test/fixtures/keys/agent1-cert.pem');

setInterval(() => {
  for (let i = 0; i < 10000; i++) {
    const cert = new X509Certificate(r);
  }
}, 1000);
```

Memory usage after 5 secs

`main`: 1692MB
`cppgc`: peaks at 400MB