### PR TITLE
feat: `Deno.FsFile.dataSync()` and `Deno.FsFile.dataSyncSync()`

### DIFF
--- a/cli/js/40_testing.js
+++ b/cli/js/40_testing.js
@@ -94,7 +94,7 @@ const OP_DETAILS = {
     "op_net_send_udp": ["send a datagram message via UDP", "awaiting the result of `Deno.DatagramConn#send` call"],
     "op_net_send_unixpacket": ["send a datagram message via Unixpacket", "awaiting the result of `Deno.DatagramConn#send` call"],
     "op_dns_resolve": ["resolve a DNS name", "awaiting the result of a `Deno.resolveDns` call"],
-    "op_fdatasync_async": ["flush pending data operations for a file to disk", "awaiting the result of a `Deno.fdatasync` call"],
+    "op_fdatasync_async": ["flush pending data operations for a file to disk", "awaiting the result of a `file.fdatasync` call"],
     "op_fetch_send": ["send a HTTP request", "awaiting the result of a `fetch` call"],
     "op_ffi_call_nonblocking": ["do a non blocking ffi call", "awaiting the returned promise"],
     "op_ffi_call_ptr_nonblocking": ["do a non blocking ffi call", "awaiting the returned promise"],

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -851,3 +851,39 @@ Deno.test(
     // calling [Symbol.dispose] after manual close is a no-op
   },
 );
+
+Deno.test(
+  { permissions: { read: true, write: true } },
+  function fsFileDatasyncSyncSuccess() {
+    const filename = Deno.makeTempDirSync() + "/test_fdatasyncSync.txt";
+    const file = Deno.openSync(filename, {
+      read: true,
+      write: true,
+      create: true,
+    });
+    const data = new Uint8Array(64);
+    file.writeSync(data);
+    file.datasyncSync();
+    assertEquals(Deno.readFileSync(filename), data);
+    file.close();
+    Deno.removeSync(filename);
+  },
+);
+
+Deno.test(
+  { permissions: { read: true, write: true } },
+  async function fsFileDatasyncSuccess() {
+    const filename = (await Deno.makeTempDir()) + "/test_fdatasync.txt";
+    const file = await Deno.open(filename, {
+      read: true,
+      write: true,
+      create: true,
+    });
+    const data = new Uint8Array(64);
+    await file.write(data);
+    await file.datasync();
+    assertEquals(await Deno.readFile(filename), data);
+    file.close();
+    await Deno.remove(filename);
+  },
+);

--- a/cli/tests/unit/files_test.ts
+++ b/cli/tests/unit/files_test.ts
@@ -863,7 +863,7 @@ Deno.test(
     });
     const data = new Uint8Array(64);
     file.writeSync(data);
-    file.datasyncSync();
+    file.dataSyncSync();
     assertEquals(Deno.readFileSync(filename), data);
     file.close();
     Deno.removeSync(filename);
@@ -881,7 +881,7 @@ Deno.test(
     });
     const data = new Uint8Array(64);
     await file.write(data);
-    await file.datasync();
+    await file.dataSync();
     assertEquals(await Deno.readFile(filename), data);
     file.close();
     await Deno.remove(filename);

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -19,7 +19,7 @@ Deno.test(
     const atime = 1000;
     const mtime = 50000;
     await Deno.futime(file.rid, atime, mtime);
-    await Deno.fdatasync(file.rid);
+    await file.datasync();
 
     const fileInfo = Deno.statSync(filename);
     assertEquals(fileInfo.atime, new Date(atime * 1000));
@@ -41,7 +41,7 @@ Deno.test(
     const atime = 1000;
     const mtime = 50000;
     Deno.futimeSync(file.rid, atime, mtime);
-    Deno.fdatasyncSync(file.rid);
+    file.datasyncSync();
 
     const fileInfo = Deno.statSync(filename);
     assertEquals(fileInfo.atime, new Date(atime * 1000));

--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -19,7 +19,7 @@ Deno.test(
     const atime = 1000;
     const mtime = 50000;
     await Deno.futime(file.rid, atime, mtime);
-    await file.datasync();
+    await file.dataSync();
 
     const fileInfo = Deno.statSync(filename);
     assertEquals(fileInfo.atime, new Date(atime * 1000));
@@ -41,7 +41,7 @@ Deno.test(
     const atime = 1000;
     const mtime = 50000;
     Deno.futimeSync(file.rid, atime, mtime);
-    file.datasyncSync();
+    file.dataSyncSync();
 
     const fileInfo = Deno.statSync(filename);
     assertEquals(fileInfo.atime, new Date(atime * 1000));

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2160,6 +2160,9 @@ declare namespace Deno {
    * console.log(new TextDecoder().decode(await Deno.readFile("my_file.txt"))); // Hello World
    * ```
    *
+   * @deprecated Use {@linkcode Deno.FsFile.datasync} instead.
+   * {@linkcode Deno.fdatasync} will be removed in v2.0.0.
+   *
    * @category I/O
    */
   export function fdatasync(rid: number): Promise<void>;
@@ -2177,6 +2180,9 @@ declare namespace Deno {
    * Deno.fdatasyncSync(file.rid);
    * console.log(new TextDecoder().decode(Deno.readFileSync("my_file.txt"))); // Hello World
    * ```
+   *
+   * @deprecated Use {@linkcode Deno.FsFile.datasyncSync} instead.
+   * {@linkcode Deno.fdatasyncSync} will be removed in v2.0.0.
    *
    * @category I/O
    */
@@ -2487,6 +2493,38 @@ declare namespace Deno {
      * ```
      */
     statSync(): FileInfo;
+    /**
+     * Flushes any pending data operations of the given file stream to disk.
+     *  ```ts
+     * using file = await Deno.open(
+     *   "my_file.txt",
+     *   { read: true, write: true, create: true },
+     * );
+     * await file.write(new TextEncoder().encode("Hello World"));
+     * await file.datasync();
+     * console.log(await Deno.readTextFile("my_file.txt")); // Hello World
+     * ```
+     *
+     * @category I/O
+     */
+    datasync(): Promise<void>;
+    /**
+     * Synchronously flushes any pending data operations of the given file stream
+     * to disk.
+     *
+     *  ```ts
+     * using file = Deno.openSync(
+     *   "my_file.txt",
+     *   { read: true, write: true, create: true },
+     * );
+     * file.writeSync(new TextEncoder().encode("Hello World"));
+     * file.datasyncSync();
+     * console.log(Deno.readTextFileSync("my_file.txt")); // Hello World
+     * ```
+     *
+     * @category I/O
+     */
+    datasyncSync(): void;
     /** Close the file. Closing a file when you are finished with it is
      * important to avoid leaking resources.
      *

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2160,7 +2160,7 @@ declare namespace Deno {
    * console.log(new TextDecoder().decode(await Deno.readFile("my_file.txt"))); // Hello World
    * ```
    *
-   * @deprecated Use {@linkcode Deno.FsFile.datasync} instead.
+   * @deprecated Use {@linkcode Deno.FsFile.dataSync} instead.
    * {@linkcode Deno.fdatasync} will be removed in v2.0.0.
    *
    * @category I/O
@@ -2181,7 +2181,7 @@ declare namespace Deno {
    * console.log(new TextDecoder().decode(Deno.readFileSync("my_file.txt"))); // Hello World
    * ```
    *
-   * @deprecated Use {@linkcode Deno.FsFile.datasyncSync} instead.
+   * @deprecated Use {@linkcode Deno.FsFile.dataSyncSync} instead.
    * {@linkcode Deno.fdatasyncSync} will be removed in v2.0.0.
    *
    * @category I/O
@@ -2501,13 +2501,13 @@ declare namespace Deno {
      *   { read: true, write: true, create: true },
      * );
      * await file.write(new TextEncoder().encode("Hello World"));
-     * await file.datasync();
+     * await file.dataSync();
      * console.log(await Deno.readTextFile("my_file.txt")); // Hello World
      * ```
      *
      * @category I/O
      */
-    datasync(): Promise<void>;
+    dataSync(): Promise<void>;
     /**
      * Synchronously flushes any pending data operations of the given file stream
      * to disk.
@@ -2518,13 +2518,13 @@ declare namespace Deno {
      *   { read: true, write: true, create: true },
      * );
      * file.writeSync(new TextEncoder().encode("Hello World"));
-     * file.datasyncSync();
+     * file.dataSyncSync();
      * console.log(Deno.readTextFileSync("my_file.txt")); // Hello World
      * ```
      *
      * @category I/O
      */
-    datasyncSync(): void;
+    dataSyncSync(): void;
     /** Close the file. Closing a file when you are finished with it is
      * important to avoid leaking resources.
      *

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -561,7 +561,7 @@ function fdatasyncSync(rid) {
   internals.warnOnDeprecatedApi(
     "Deno.fdatasyncSync()",
     new Error().stack,
-    "Use `file.datasyncSync()` instead.",
+    "Use `file.dataSyncSync()` instead.",
   );
   op_fs_fdatasync_sync(rid);
 }
@@ -570,7 +570,7 @@ async function fdatasync(rid) {
   internals.warnOnDeprecatedApi(
     "Deno.fdatasync()",
     new Error().stack,
-    "Use `await file.datasync()` instead.",
+    "Use `await file.dataSync()` instead.",
   );
   await op_fs_fdatasync_async(rid);
 }
@@ -713,11 +713,11 @@ class FsFile {
     return fstatSync(this.rid);
   }
 
-  async datasync() {
+  async dataSync() {
     await op_fs_fdatasync_async(this.rid);
   }
 
-  datasyncSync() {
+  dataSyncSync() {
     op_fs_fdatasync_sync(this.rid);
   }
 

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
+import { core, internals, primordials } from "ext:core/mod.js";
 const {
   isDate,
 } = core;
@@ -558,10 +558,20 @@ async function symlink(
 }
 
 function fdatasyncSync(rid) {
+  internals.warnOnDeprecatedApi(
+    "Deno.fdatasyncSync()",
+    new Error().stack,
+    "Use `file.datasyncSync()` instead.",
+  );
   op_fs_fdatasync_sync(rid);
 }
 
 async function fdatasync(rid) {
+  internals.warnOnDeprecatedApi(
+    "Deno.fdatasync()",
+    new Error().stack,
+    "Use `await file.datasync()` instead.",
+  );
   await op_fs_fdatasync_async(rid);
 }
 
@@ -701,6 +711,14 @@ class FsFile {
 
   statSync() {
     return fstatSync(this.rid);
+  }
+
+  async datasync() {
+    await op_fs_fdatasync_async(this.rid);
+  }
+
+  datasyncSync() {
+    op_fs_fdatasync_sync(this.rid);
   }
 
   close() {

--- a/ext/node/polyfills/_fs/_fs_fdatasync.ts
+++ b/ext/node/polyfills/_fs/_fs_fdatasync.ts
@@ -4,14 +4,15 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
+import { FsFile } from "ext:deno_fs/30_fs.js";
 
 export function fdatasync(
   fd: number,
   callback: CallbackWithError,
 ) {
-  Deno.fdatasync(fd).then(() => callback(null), callback);
+  new FsFile(fd).datasync().then(() => callback(null), callback);
 }
 
 export function fdatasyncSync(fd: number) {
-  Deno.fdatasyncSync(fd);
+  new FsFile(fd).datasyncSync();
 }

--- a/ext/node/polyfills/_fs/_fs_fdatasync.ts
+++ b/ext/node/polyfills/_fs/_fs_fdatasync.ts
@@ -10,9 +10,9 @@ export function fdatasync(
   fd: number,
   callback: CallbackWithError,
 ) {
-  new FsFile(fd).datasync().then(() => callback(null), callback);
+  new FsFile(fd).dataSync().then(() => callback(null), callback);
 }
 
 export function fdatasyncSync(fd: number) {
-  new FsFile(fd).datasyncSync();
+  new FsFile(fd).dataSyncSync();
 }


### PR DESCRIPTION
This change:
1. Implements `Deno.FsFile.dataSync()` and `Deno.FsFile.dataSyncSync()`.
2. Deprecates `Deno.fdatasync()` and `Deno.fdatasyncSync()` for removal in Deno v2, in favour of the above corresponding methods.
3. Replaces use of `Deno.fdatasync()` and `Deno.fdatasyncSync()` with the above instance methods.

Related #21995