### PR TITLE
refactor: set removal version for `Deno.Server`

### DIFF
--- a/cli/tests/unit/serve_test.ts
+++ b/cli/tests/unit/serve_test.ts
@@ -3816,7 +3816,7 @@ async function curlRequestWithStdErr(args: string[]) {
   return [new TextDecoder().decode(stdout), new TextDecoder().decode(stderr)];
 }
 
-Deno.test("Deno.Server is not thenable", async () => {
+Deno.test("Deno.HttpServer is not thenable", async () => {
   // deno-lint-ignore require-await
   async function serveTest() {
     const server = Deno.serve({ port: servePort }, (_) => new Response(""));

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -6037,7 +6037,9 @@ declare namespace Deno {
 
   /**
    * @category HTTP Server
-   * @deprecated Use {@linkcode HttpServer} instead.
+   *
+   * @deprecated Use {@linkcode Deno.HttpServer} instead.
+   * {@linkcode Deno.Server} will be removed in Deno 2.0.
    */
   export type Server = HttpServer;
 

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1575,7 +1575,7 @@ export class ServerImpl extends EventEmitter {
 
   #addr: Deno.NetAddr;
   #hasClosed = false;
-  #server: Deno.Server;
+  #server: Deno.HttpServer;
   #unref = false;
   #ac?: AbortController;
   #serveDeferred: ReturnType<typeof Promise.withResolvers<void>>;


### PR DESCRIPTION
This change sets the removal version for the deprecated `Deno.Server` interface for Deno 2.0.

Towards #22021