### PR TITLE
refactor: set removal version for `--jobs` flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2174,7 +2174,7 @@ Directory arguments are expanded to all contained files matching the glob
       Arg::new("jobs")
         .short('j')
         .long("jobs")
-        .help("deprecated: Number of parallel workers, defaults to number of available CPUs when no value is provided. Defaults to 1 when the option is not present.")
+        .help("deprecated: The `--jobs` flag is deprecated and will be removed in Deno 2.0. Use the `--parallel` flag with possibly the `DENO_JOBS` environment variable instead.")
         .hide(true)
         .num_args(0..=1)
         .value_parser(value_parser!(NonZeroUsize)),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3690,8 +3690,8 @@ fn test_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     // deprecated though so it's not worth changing the code to use the log
     // crate here and this is only done for testing anyway.
     eprintln!(
-      "{}",
-      crate::colors::yellow("Warning: --jobs flag is deprecated. Use the --parallel flag with possibly the 'DENO_JOBS' environment variable."),
+      "⚠️ {}",
+      crate::colors::yellow("The `--jobs` flag is deprecated and will be removed in Deno 2.0.\nUse the `--parallel` flag with possibly the `DENO_JOBS` environment variable instead.\nLearn more at: https://docs.deno.com/runtime/manual/basics/env_variables"),
     );
     if let Some(value) = matches.remove_one::<NonZeroUsize>("jobs") {
       Some(value)

--- a/cli/tests/testdata/test/short-pass-jobs-flag-warning.out
+++ b/cli/tests/testdata/test/short-pass-jobs-flag-warning.out
@@ -1,4 +1,6 @@
-Warning: --jobs flag is deprecated. Use the --parallel flag with possibly the 'DENO_JOBS' environment variable.
+⚠️ The `--jobs` flag is deprecated and will be removed in Deno 2.0.
+Use the `--parallel` flag with possibly the `DENO_JOBS` environment variable instead.
+Learn more at: https://docs.deno.com/runtime/manual/basics/env_variables
 Check [WILDCARD]/test/short-pass.ts
 ./test/short-pass.ts => test ... ok ([WILDCARD])
 


### PR DESCRIPTION
For removal in Deno v2. I'm uncertain of the output format but used #21452 as a guide.

Towards #22021