### PR TITLE
fix(ext/node): fix no arg call of fs.promises.readFile

### DIFF
--- a/cli/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
-import { readFile, readFileSync } from "node:fs";
+import { promises, readFile, readFileSync } from "node:fs";
 import * as path from "../../../../test_util/std/path/mod.ts";
 import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
 
@@ -115,4 +115,9 @@ Deno.test("[std/node/fs] readFile callback isn't called twice if error is thrown
       await Deno.remove(tempFile);
     },
   });
+});
+
+Deno.test("fs.promises.readFile with no arg call rejects with error correctly", async () => {
+  // @ts-ignore no arg call needs to be supported
+  await promises.readFile().catch((_e) => {});
 });

--- a/ext/node/polyfills/_fs/_fs_readFile.ts
+++ b/ext/node/polyfills/_fs/_fs_readFile.ts
@@ -18,7 +18,6 @@ import {
   Encodings,
   TextEncodings,
 } from "ext:deno_node/_utils.ts";
-import { promisify } from "ext:deno_node/internal/util.mjs";
 
 function maybeDecode(data: Uint8Array, encoding: TextEncodings): string;
 function maybeDecode(
@@ -91,11 +90,18 @@ export function readFile(
   }
 }
 
-export const readFilePromise = promisify(readFile) as (
-  & ((path: Path, opt: TextOptionsArgument) => Promise<string>)
-  & ((path: Path, opt?: BinaryOptionsArgument) => Promise<Buffer>)
-  & ((path: Path, opt?: FileOptionsArgument) => Promise<Buffer>)
-);
+export function readFilePromise(
+  path: Path,
+  options?: FileOptionsArgument | null | undefined,
+  // deno-lint-ignore no-explicit-any
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    readFile(path, options, (err, data) => {
+      if (err) reject(err);
+      else resolve(data);
+    });
+  });
+}
 
 export function readFileSync(
   path: string | URL,


### PR DESCRIPTION
We use `util.promisify` for creating `fs.promises.readFile`, but that doesn't support the case when it's called with no args (With no arg call, promisify passes the callback as the first arg of `fs.readFile`, and that is not supported). As reported in #21795, [isomorphic-git](https://www.npmjs.com/package/isomorphic-git) uses `fs.promises.readFile()` for checking the availability of `fs.promises`, and that causes an uncaught error.

This PR fixes the above by avoiding to use `promisify`, but using more primitive wrapper structure for creating promise version of `readFile`.

See also the comment https://github.com/denoland/deno/issues/21795#issuecomment-1903901348

closes #21795