### PR TITLE
fix(node:fs/promises): add missing cp and cpSync

### DIFF
--- a/cli/tests/integration/node_unit_tests.rs
+++ b/cli/tests/integration/node_unit_tests.rs
@@ -17,6 +17,7 @@ util::unit_test_factory!(
     _fs_chown_test = _fs / _fs_chown_test,
     _fs_close_test = _fs / _fs_close_test,
     _fs_copy_test = _fs / _fs_copy_test,
+    _fs_cp_test = _fs / _fs_cp_test,
     _fs_dir_test = _fs / _fs_dir_test,
     _fs_dirent_test = _fs / _fs_dirent_test,
     _fs_open_test = _fs / _fs_open_test,

--- a/cli/tests/unit_node/_fs/_fs_cp_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_cp_test.ts
@@ -1,8 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import {
-  assert,
-  assertEquals,
-} from "../../../../test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "../../../../test_util/std/assert/mod.ts";
 import { cp, exists, readFile } from "node:fs/promise";
 import { cpSync } from "node:fs";
 import * as path from "../../../../test_util/std/path/mod.ts";
@@ -16,8 +13,8 @@ Deno.test("[std/node/fs] cp", async function () {
     await cp(testData, destFile);
     assert(await exists(destFile));
     assertEquals(
-      (await readFile(destFile, { encoding: "utf8" })),
-        (await readFile(testData, { encoding: "utf8" }))
+      await readFile(destFile, { encoding: "utf8" }),
+      await readFile(testData, { encoding: "utf8" }),
     );
   } finally {
     Deno.removeSync(destFile);
@@ -28,8 +25,8 @@ Deno.test("[std/node/fs] cpSync", async function () {
   cpSync(testData, destFile);
   assert(await exists(destFile));
   assertEquals(
-    (await readFile(destFile, { encoding: "utf8" })),
-      (await readFile(testData, { encoding: "utf8" }))
+    await readFile(destFile, { encoding: "utf8" }),
+    await readFile(testData, { encoding: "utf8" }),
   );
   Deno.removeSync(destFile);
 });

--- a/cli/tests/unit_node/_fs/_fs_cp_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_cp_test.ts
@@ -1,0 +1,35 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import {
+  assert,
+  assertEquals,
+} from "../../../../test_util/std/assert/mod.ts";
+import { cp, exists, readFile } from "node:fs/promise";
+import { cpSync } from "node:fs";
+import * as path from "../../../../test_util/std/path/mod.ts";
+
+const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
+const testData = path.resolve(moduleDir, "testdata", "hello.txt");
+const destFile = "./destination.txt";
+
+Deno.test("[std/node/fs] cp", async function () {
+  try {
+    await cp(testData, destFile);
+    assert(await exists(destFile));
+    assertEquals(
+      (await readFile(destFile, { encoding: "utf8" })),
+        (await readFile(testData, { encoding: "utf8" }))
+    );
+  } finally {
+    Deno.removeSync(destFile);
+  }
+});
+
+Deno.test("[std/node/fs] cpSync", async function () {
+  cpSync(testData, destFile);
+  assert(await exists(destFile));
+  assertEquals(
+    (await readFile(destFile, { encoding: "utf8" })),
+      (await readFile(testData, { encoding: "utf8" }))
+  );
+  Deno.removeSync(destFile);
+});

--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -5,7 +5,6 @@ export const access = fsPromises.access;
 export const constants = fsPromises.constants;
 export const copyFile = fsPromises.copyFile;
 export const cp = fsPromises.cp;
-export const cpSync = fsPromises.cpSync;
 export const open = fsPromises.open;
 export const opendir = fsPromises.opendir;
 export const rename = fsPromises.rename;

--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -4,6 +4,8 @@ import { promises as fsPromises } from "node:fs";
 export const access = fsPromises.access;
 export const constants = fsPromises.constants;
 export const copyFile = fsPromises.copyFile;
+export const cp = fsPromises.cp;
+export const cpSync = fsPromises.cpSync;
 export const open = fsPromises.open;
 export const opendir = fsPromises.opendir;
 export const rename = fsPromises.rename;


### PR DESCRIPTION
I dont think the pull request requires any tests
Fixes a bug mentioned in https://github.com/discordjs/discord.js/issues/9810

As author of df062d2c788fd76546d59c67452d8d0fe569c533 added support for that didnt add it directly to fs/promises