### PR TITLE
BREAKING(unstable): remove `Deno.cron()` overload

### DIFF
--- a/cli/tests/unit/cron_test.ts
+++ b/cli/tests/unit/cron_test.ts
@@ -297,13 +297,13 @@ Deno.test(async function retriesWithBackoffScheduleOldApi() {
 
   let count = 0;
   const ac = new AbortController();
-  const c = Deno.cron("abc2", "*/20 * * * *", async () => {
+  const c = Deno.cron("abc2", "*/20 * * * *", {
+    signal: ac.signal,
+    backoffSchedule: [10, 20],
+  }, async () => {
     count += 1;
     await sleep(10);
     throw new TypeError("cron error");
-  }, {
-    signal: ac.signal,
-    backoffSchedule: [10, 20],
   });
 
   try {
@@ -379,4 +379,15 @@ Deno.test("Parse CronSchedule to string", () => {
 Deno.test("Parse schedule to string - string", () => {
   const result = parseScheduleToString("* * * * *");
   assertEquals(result, "* * * * *");
+});
+
+Deno.test("error on two handlers", () => {
+  assertThrows(
+    () => {
+      // @ts-ignore test
+      Deno.cron("abc", "* * * * *", () => {}, () => {});
+    },
+    TypeError,
+    "Deno.cron requires a single handler",
+  );
 });

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1322,37 +1322,6 @@ declare namespace Deno {
 
   /** **UNSTABLE**: New API, yet to be vetted.
    *
-   * Create a cron job that will periodically execute the provided handler
-   * callback based on the specified schedule.
-   *
-   * `schedule` can be a string in the Unix cron format or in JSON format
-   * as specified by interface {@linkcode CronSchedule}, where time is specified
-   * using UTC time zone.
-   *
-   * ```ts
-   * Deno.cron("sample cron", "20 * * * *", () => {
-   *   console.log("cron job executed");
-   * });
-   * ```
-   * `backoffSchedule` option can be used to specify the retry policy for failed
-   * executions. Each element in the array represents the number of milliseconds
-   * to wait before retrying the execution. For example, `[1000, 5000, 10000]`
-   * means that a failed execution will be retried at most 3 times, with 1
-   * second, 5 seconds, and 10 seconds delay between each retry.
-   *
-   * @category Cron
-   * @deprecated Use other {@linkcode cron} overloads instead. This overload
-   * will be removed in the future.
-   */
-  export function cron(
-    name: string,
-    schedule: string | CronSchedule,
-    handler: () => Promise<void> | void,
-    options: { backoffSchedule?: number[]; signal?: AbortSignal },
-  ): Promise<void>;
-
-  /** **UNSTABLE**: New API, yet to be vetted.
-   *
    * A key to be persisted in a {@linkcode Deno.Kv}. A key is a sequence
    * of {@linkcode Deno.KvKeyPart}s.
    *

--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -84,9 +84,7 @@ function cron(
   handlerOrOptions1:
     | (() => Promise<void> | void)
     | ({ backoffSchedule?: number[]; signal?: AbortSignal }),
-  handlerOrOptions2?:
-    | (() => Promise<void> | void)
-    | ({ backoffSchedule?: number[]; signal?: AbortSignal }),
+  handler2?: () => Promise<void> | void,
 ) {
   if (name === undefined) {
     throw new TypeError("Deno.cron requires a unique name");
@@ -98,16 +96,17 @@ function cron(
   schedule = parseScheduleToString(schedule);
 
   let handler: () => Promise<void> | void;
-  let options: { backoffSchedule?: number[]; signal?: AbortSignal } | undefined;
+  let options:
+    | { backoffSchedule?: number[]; signal?: AbortSignal }
+    | undefined = undefined;
 
   if (typeof handlerOrOptions1 === "function") {
     handler = handlerOrOptions1;
-    if (typeof handlerOrOptions2 === "function") {
-      throw new TypeError("options must be an object");
+    if (handler2 !== undefined) {
+      throw new TypeError("Deno.cron requires a single handler");
     }
-    options = handlerOrOptions2;
-  } else if (typeof handlerOrOptions2 === "function") {
-    handler = handlerOrOptions2;
+  } else if (typeof handler2 === "function") {
+    handler = handler2;
     options = handlerOrOptions1;
   } else {
     throw new TypeError("Deno.cron requires a handler");


### PR DESCRIPTION
This change removes the currently deprecated `Deno.cron()` overload with `options` as a potential last argument.

This might be fine to do now, in a major release, as `Deno.cron()` is an unstable API. I thought of doing this while working on #22021. If this is not ready to remove, I can instead set the removal version of this overload for Deno v2.

Note: this overload was deprecated in Deno v1.38.2 (#21225). So it's been deprecated for over 2 months.

CC @losfair