### PR TITLE
fix(BREAKING): remove dead `--prompt` flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2722,15 +2722,6 @@ fn permission_args(app: Command) -> Command {
         .help(ALLOW_ALL_HELP),
     )
     .arg(
-      Arg::new("prompt")
-        .long("prompt")
-        .action(ArgAction::SetTrue)
-        .hide(true)
-        .help(
-          "deprecated: Fallback to prompt if required permission wasn't passed",
-        ),
-    )
-    .arg(
       Arg::new("no-prompt")
         .long("no-prompt")
         .action(ArgAction::SetTrue)

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -2913,7 +2913,7 @@ itest!(byte_order_mark {
 fn issue9750() {
   TestContext::default()
     .new_command()
-    .args_vec(["run", "--prompt", "run/issue9750.js"])
+    .args_vec(["run", "run/issue9750.js"])
     .with_pty(|mut console| {
       console.expect("Enter 'yy':");
       console.write_line_raw("yy");


### PR DESCRIPTION
It appears the `--prompt` flag has done nothing for some time. Perhaps, since #13650. Classifying this as a dead functionality removal for this reason.

Did this while working on #22021.