### PR TITLE
feat: deprecate `window` global

### DIFF
--- a/runtime/js/98_global_scope_window.js
+++ b/runtime/js/98_global_scope_window.js
@@ -108,7 +108,15 @@ const mainRuntimeGlobalProperties = {
   Location: location.locationConstructorDescriptor,
   location: location.locationDescriptor,
   Window: globalInterfaces.windowConstructorDescriptor,
-  window: util.getterOnly(() => globalThis),
+  window: util.getterOnly(() => {
+    internals.warnOnDeprecatedApi(
+      "window",
+      new Error().stack,
+      "Use `globalThis` or `self` instead.",
+      "You can provide `window` in the current scope, using `const window = globalThis`.",
+    );
+    globalThis;
+  }),
   self: util.getterOnly(() => globalThis),
   Navigator: util.nonEnumerable(Navigator),
   navigator: util.getterOnly(() => navigator),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -98,7 +98,7 @@ let globalThis_;
 let deprecatedApiWarningDisabled = false;
 const ALREADY_WARNED_DEPRECATED = new SafeSet();
 
-function warnOnDeprecatedApi(apiName, stack, suggestion) {
+function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
   if (deprecatedApiWarningDisabled) {
     return;
   }
@@ -152,11 +152,14 @@ function warnOnDeprecatedApi(apiName, stack, suggestion) {
     "%c\u251c This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.",
     "color: yellow;",
   );
-  console.error("%c\u2502", "color: yellow;");
-  console.error(
-    `%c\u251c Suggestion: ${suggestion}`,
-    "color: yellow;",
-  );
+  for (let i = 0; i < suggestions.length; i++) {
+    const suggestion = suggestions[i];
+    console.error("%c\u2502", "color: yellow;");
+    console.error(
+      `%c\u251c Suggestion: ${suggestion}`,
+      "color: yellow;",
+    );
+  }
   if (isFromRemoteDependency) {
     console.error("%c\u2502", "color: yellow;");
     console.error(


### PR DESCRIPTION
This commit deprecates `window` global and adds deprecation
notice on each use of `window`.