### PR TITLE
feat: import.meta.filename and import.meta.dirname

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -1493,6 +1493,7 @@ itest!(if_main {
 itest!(import_meta {
   args: "run --quiet --reload --import-map=run/import_meta/importmap.json run/import_meta/main.ts",
   output: "run/import_meta/main.out",
+  http_server: true,
 });
 
 itest!(main_module {

--- a/cli/tests/testdata/run/import_meta/main.out
+++ b/cli/tests/testdata/run/import_meta/main.out
@@ -1,5 +1,5 @@
-other [WILDCARD]other.ts false
-main [WILDCARD]main.ts true
+other [WILDCARD]other.ts false [WILDCARD]other.ts [WILDCARD]
+main [WILDCARD]main.ts true [WILDCARD]main.ts [WILDCARD]
 Resolving ./foo.js file:///[WILDCARD]/foo.js
 Resolving bare from import map https://example.com/
 Resolving https://example.com/rewrite from import map https://example.com/rewritten

--- a/cli/tests/testdata/run/import_meta/main.out
+++ b/cli/tests/testdata/run/import_meta/main.out
@@ -1,3 +1,4 @@
+other remote [WILDCARD]other.ts false undefined undefined
 other [WILDCARD]other.ts false [WILDCARD]other.ts [WILDCARD]
 main [WILDCARD]main.ts true [WILDCARD]main.ts [WILDCARD]
 Resolving ./foo.js file:///[WILDCARD]/foo.js

--- a/cli/tests/testdata/run/import_meta/main.ts
+++ b/cli/tests/testdata/run/import_meta/main.ts
@@ -1,4 +1,6 @@
 import { assertThrows } from "../../../../../test_util/std/assert/mod.ts";
+import "http://localhost:4545/run/import_meta/other.ts";
+import "./other.ts";
 
 console.log(
   "main",
@@ -7,7 +9,6 @@ console.log(
   import.meta.filename,
   import.meta.dirname,
 );
-import "./other.ts";
 
 console.log("Resolving ./foo.js", import.meta.resolve("./foo.js"));
 console.log("Resolving bare from import map", import.meta.resolve("bare"));

--- a/cli/tests/testdata/run/import_meta/main.ts
+++ b/cli/tests/testdata/run/import_meta/main.ts
@@ -1,7 +1,12 @@
 import { assertThrows } from "../../../../../test_util/std/assert/mod.ts";
 
-console.log("main", import.meta.url, import.meta.main);
-
+console.log(
+  "main",
+  import.meta.url,
+  import.meta.main,
+  import.meta.filename,
+  import.meta.dirname,
+);
 import "./other.ts";
 
 console.log("Resolving ./foo.js", import.meta.resolve("./foo.js"));

--- a/cli/tests/testdata/run/import_meta/other.ts
+++ b/cli/tests/testdata/run/import_meta/other.ts
@@ -1,5 +1,5 @@
 console.log(
-  "other",
+  import.meta.url.startsWith("http") ? "other remote" : "other",
   import.meta.url,
   import.meta.main,
   import.meta.filename,

--- a/cli/tests/testdata/run/import_meta/other.ts
+++ b/cli/tests/testdata/run/import_meta/other.ts
@@ -1,1 +1,7 @@
-console.log("other", import.meta.url, import.meta.main);
+console.log(
+  "other",
+  import.meta.url,
+  import.meta.main,
+  import.meta.filename,
+  import.meta.dirname,
+);

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -28,6 +28,36 @@ declare interface ImportMeta {
    */
   url: string;
 
+  /** The absolute path of the current module.
+   *
+   * This property is only provided for local modules (ie. using `file://` URLs).
+   *
+   * Example:
+   * ```
+   * // Unix
+   * console.log(import.meta.filename); // /home/alice/my_module.ts
+   *
+   * // Windows
+   * console.log(import.meta.filename); // C:\alice\my_module.ts
+   * ```
+   */
+  filename?: string;
+
+  /** The absolute path of the dirrectory containing the current module.
+   *
+   * This property is only provided for local modules (ie. using `file://` URLs).
+   *
+   * * Example:
+   * ```
+   * // Unix
+   * console.log(import.meta.dirname); // /home/alice/
+   *
+   * // Windows
+   * console.log(import.meta.dirname); // C:\alice\
+   * ```
+   */
+  dirname?: string;
+
   /** A flag that indicates if the current module is the main module that was
    * called when starting the program under Deno.
    *


### PR DESCRIPTION
This commit adds `import.meta.filename` and `import.meta.dirname` APIs.

These APIs return string representation of filename and containing dirname.
They are only defined for local modules (modules that have `file:///` scheme).

Example:

```ts
console.log(import.meta.filename, import.meta.dirname)
```

Unix:
```
$ deno run /dev/my_module.ts
/dev/my_module.ts /dev/
```

Windows:
```
$ deno run C:\dev\my_module.ts
C:\dev\my_module.ts C:\
```