### PR TITLE
refactor: set removal version for `deno bundle`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1133,7 +1133,10 @@ fn bundle_subcommand() -> Command {
   Command::new("bundle")
     .about("Bundle module and dependencies into single file")
     .long_about(
-      "Output a single JavaScript file with all dependencies.
+      "⚠️ Warning: `deno bundle` is deprecated and will be removed in Deno 2.0.
+Use an alternative bundler like \"deno_emit\", \"esbuild\" or \"rollup\" instead.
+
+Output a single JavaScript file with all dependencies.
 
   deno bundle https://deno.land/std/http/file_server.ts file_server.bundle.js
 

--- a/cli/tests/testdata/bundle/shebang_file.bundle.out
+++ b/cli/tests/testdata/bundle/shebang_file.bundle.out
@@ -1,5 +1,5 @@
-Warning "deno bundle" is deprecated and will be removed in the future.
-Use alternative bundlers like "deno_emit", "esbuild" or "rollup" instead.
+⚠️ Warning: `deno bundle` is deprecated and will be removed in Deno 2.0.
+Use an alternative bundler like "deno_emit", "esbuild" or "rollup" instead.
 Bundle file:///[WILDCARD]/subdir/shebang_file.js
 #!/usr/bin/env -S deno run --allow-read
 // deno-fmt-ignore-file

--- a/cli/tools/bundle.rs
+++ b/cli/tools/bundle.rs
@@ -20,7 +20,7 @@ pub async fn bundle(
   flags: Flags,
   bundle_flags: BundleFlags,
 ) -> Result<(), AnyError> {
-  eprintln!(
+  log::info!(
     "{}",
     colors::yellow("⚠️ Warning: `deno bundle` is deprecated and will be removed in Deno 2.0.\nUse an alternative bundler like \"deno_emit\", \"esbuild\" or \"rollup\" instead."),
   );

--- a/cli/tools/bundle.rs
+++ b/cli/tools/bundle.rs
@@ -20,12 +20,9 @@ pub async fn bundle(
   flags: Flags,
   bundle_flags: BundleFlags,
 ) -> Result<(), AnyError> {
-  log::info!(
-    "{} \"deno bundle\" is deprecated and will be removed in the future.",
-    colors::yellow("Warning"),
-  );
-  log::info!(
-    "Use alternative bundlers like \"deno_emit\", \"esbuild\" or \"rollup\" instead."
+  eprintln!(
+    "{}",
+    colors::yellow("⚠️ Warning: `deno bundle` is deprecated and will be removed in Deno 2.0.\nUse an alternative bundler like \"deno_emit\", \"esbuild\" or \"rollup\" instead."),
   );
 
   if let Some(watch_flags) = &bundle_flags.watch {


### PR DESCRIPTION
This change sets the removal version for the `deno bundle` sub-command for Deno v2. The warnings appear when `deno bundle` is run and in the `--help` menu.