### PR TITLE
feat: deprecate `Deno.read()` and `Deno.readSync()`

### DIFF
--- a/cli/tests/unit_node/tls_test.ts
+++ b/cli/tests/unit_node/tls_test.ts
@@ -111,20 +111,20 @@ Deno.test("tls.createServer creates a TLS server", async () => {
     });
 
     const buf = new Uint8Array(100);
-    await Deno.read(conn.rid, buf);
+    await conn.read(buf);
     let text: string;
     text = new TextDecoder().decode(buf);
     assertEquals(text.replaceAll("\0", ""), "welcome!\n");
     buf.fill(0);
 
     Deno.write(conn.rid, new TextEncoder().encode("hey\n"));
-    await Deno.read(conn.rid, buf);
+    await conn.read(buf);
     text = new TextDecoder().decode(buf);
     assertEquals(text.replaceAll("\0", ""), "hey\n");
     buf.fill(0);
 
     Deno.write(conn.rid, new TextEncoder().encode("goodbye\n"));
-    await Deno.read(conn.rid, buf);
+    await conn.read(buf);
     text = new TextDecoder().decode(buf);
     assertEquals(text.replaceAll("\0", ""), "goodbye\n");
 

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1984,6 +1984,9 @@ declare namespace Deno {
    * Deno.close(file.rid);
    * ```
    *
+   * @deprecated Use `reader.read()` instead. {@linkcode Deno.read} will be
+   * removed in Deno 2.0.
+   *
    * @category I/O
    */
   export function read(rid: number, buffer: Uint8Array): Promise<number | null>;
@@ -2013,6 +2016,9 @@ declare namespace Deno {
    * const text = new TextDecoder().decode(buf);  // "hello world"
    * Deno.close(file.rid);
    * ```
+   *
+   * @deprecated Use `reader.readSync()` instead. {@linkcode Deno.readSync}
+   * will be removed in Deno 2.0.
    *
    * @category I/O
    */

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -96,8 +96,22 @@ const denoNs = {
   iter: io.iter,
   iterSync: io.iterSync,
   SeekMode: io.SeekMode,
-  read: io.read,
-  readSync: io.readSync,
+  read(rid, buffer) {
+    internals.warnOnDeprecatedApi(
+      "Deno.read()",
+      new Error().stack,
+      "Use `reader.read()` instead.",
+    );
+    return io.read(rid, buffer);
+  },
+  readSync(rid, buffer) {
+    internals.warnOnDeprecatedApi(
+      "Deno.readSync()",
+      new Error().stack,
+      "Use `reader.readSync()` instead.",
+    );
+    return io.readSync(rid, buffer);
+  },
   write: io.write,
   writeSync: io.writeSync,
   File: fs.File,


### PR DESCRIPTION
For removal in Deno v2.