### PR TITLE
feat: deprecate `Deno.seek()` and `Deno.seekSync()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2100,7 +2100,7 @@ declare namespace Deno {
    * console.log(await Deno.seek(file.rid, -2, Deno.SeekMode.End)); // "9" (i.e. 11-2)
    * ```
    *
-   * @deprecated Use `seeker.seek()` instead. {@linkcode Deno.seek} will be
+   * @deprecated Use `file.seek()` instead. {@linkcode Deno.seek} will be
    * removed in Deno 2.0.
    *
    * @category I/O
@@ -2148,7 +2148,7 @@ declare namespace Deno {
    * console.log(Deno.seekSync(file.rid, -2, Deno.SeekMode.End)); // "9" (i.e. 11-2)
    * ```
    *
-   * @deprecated Use `seeker.seekSync()` instead. {@linkcode Deno.seekSync}
+   * @deprecated Use `file.seekSync()` instead. {@linkcode Deno.seekSync}
    * will be removed in Deno 2.0.
    *
    * @category I/O

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2101,7 +2101,7 @@ declare namespace Deno {
    * ```
    *
    * @deprecated Use `seeker.seek()` instead. {@linkcode Deno.seek} will be
-   * removed in Deno v2.
+   * removed in Deno 2.0.
    *
    * @category I/O
    */
@@ -2149,7 +2149,7 @@ declare namespace Deno {
    * ```
    *
    * @deprecated Use `seeker.seekSync()` instead. {@linkcode Deno.seekSync}
-   * will be removed in v2.0.0.
+   * will be removed in Deno 2.0.
    *
    * @category I/O
    */

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2100,6 +2100,9 @@ declare namespace Deno {
    * console.log(await Deno.seek(file.rid, -2, Deno.SeekMode.End)); // "9" (i.e. 11-2)
    * ```
    *
+   * @deprecated Use `seeker.seek()` instead. {@linkcode Deno.seek} will be
+   * removed in Deno v2.
+   *
    * @category I/O
    */
   export function seek(
@@ -2144,6 +2147,9 @@ declare namespace Deno {
    * // Seek backwards 2 bytes from the end of the file
    * console.log(Deno.seekSync(file.rid, -2, Deno.SeekMode.End)); // "9" (i.e. 11-2)
    * ```
+   *
+   * @deprecated Use `seeker.seekSync()` instead. {@linkcode Deno.seekSync}
+   * will be removed in v2.0.0.
    *
    * @category I/O
    */

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -113,7 +113,7 @@ const denoNs = {
     internals.warnOnDeprecatedApi(
       "Deno.seek()",
       new Error().stack,
-      "Use `seeker.seek()` instead.",
+      "Use `file.seek()` instead.",
     );
     return fs.seek(rid, offset, whence);
   },
@@ -121,7 +121,7 @@ const denoNs = {
     internals.warnOnDeprecatedApi(
       "Deno.seekSync()",
       new Error().stack,
-      "Use `seeker.seekSync()` instead.",
+      "Use `file.seekSync()` instead.",
     );
     return fs.seekSync(rid, offset, whence);
   },

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
+import { core, internals } from "ext:core/mod.js";
 const {
   op_net_listen_udp,
   op_net_listen_unixpacket,
@@ -109,8 +109,22 @@ const denoNs = {
   stdin: io.stdin,
   stdout: io.stdout,
   stderr: io.stderr,
-  seek: fs.seek,
-  seekSync: fs.seekSync,
+  seek(rid, offset, whence) {
+    internals.warnOnDeprecatedApi(
+      "Deno.seek()",
+      new Error().stack,
+      "Use `seeker.seek()` instead.",
+    );
+    return fs.seek(rid, offset, whence);
+  },
+  seekSync(rid, offset, whence) {
+    internals.warnOnDeprecatedApi(
+      "Deno.seekSync()",
+      new Error().stack,
+      "Use `seeker.seekSync()` instead.",
+    );
+    return fs.seekSync(rid, offset, whence);
+  },
   connect: net.connect,
   listen: net.listen,
   loadavg: os.loadavg,


### PR DESCRIPTION
For removal in Deno v2.