### PR TITLE
feat: deprecate `Deno.shutdown()`

### DIFF
--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -397,7 +397,7 @@ declare namespace Deno {
    * Deno.shutdown(conn.rid);
    * ```
    *
-   * @deprecated Use `conn.closeWrite()` instead.
+   * @deprecated Use {@linkcode Deno.Conn.closeWrite} instead.
    * {@linkcode Deno.shutdown} will be removed in Deno 2.0.
    *
    * @category Network

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -397,6 +397,9 @@ declare namespace Deno {
    * Deno.shutdown(conn.rid);
    * ```
    *
+   * @deprecated Use `conn.closeWrite()` instead.
+   * {@linkcode Deno.shutdown} will be removed in Deno 2.0.
+   *
    * @category Network
    */
   export function shutdown(rid: number): Promise<void>;

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
+import { core, internals } from "ext:core/mod.js";
 const {
   op_net_listen_udp,
   op_net_listen_unixpacket,
@@ -117,7 +117,14 @@ const denoNs = {
   connectTls: tls.connectTls,
   listenTls: tls.listenTls,
   startTls: tls.startTls,
-  shutdown: net.shutdown,
+  shutdown(rid) {
+    internals.warnOnDeprecatedApi(
+      "Deno.shutdown()",
+      new Error().stack,
+      "Use `conn.closeWrite()` instead.",
+    );
+    net.shutdown(rid);
+  },
   fstatSync: fs.fstatSync,
   fstat: fs.fstat,
   fsyncSync: fs.fsyncSync,

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -121,7 +121,7 @@ const denoNs = {
     internals.warnOnDeprecatedApi(
       "Deno.shutdown()",
       new Error().stack,
-      "Use `conn.closeWrite()` instead.",
+      "Use `Deno.Conn.closeWrite()` instead.",
     );
     net.shutdown(rid);
   },


### PR DESCRIPTION
For removal in Deno v2.