### PR TITLE
feat: deprecate `Deno.ftruncate()` and `Deno.ftruncateSync()`

### DIFF
--- a/cli/tests/unit/sync_test.ts
+++ b/cli/tests/unit/sync_test.ts
@@ -47,7 +47,7 @@ Deno.test(
       create: true,
     });
     const size = 64;
-    Deno.ftruncateSync(file.rid, size);
+    file.truncateSync(size);
     Deno.fsyncSync(file.rid);
     assertEquals(Deno.statSync(filename).size, size);
     Deno.close(file.rid);
@@ -65,7 +65,7 @@ Deno.test(
       create: true,
     });
     const size = 64;
-    await Deno.ftruncate(file.rid, size);
+    await file.truncate(size);
     await Deno.fsync(file.rid);
     assertEquals((await Deno.stat(filename)).size, size);
     Deno.close(file.rid);

--- a/cli/tests/unit/truncate_test.ts
+++ b/cli/tests/unit/truncate_test.ts
@@ -11,11 +11,11 @@ Deno.test(
       write: true,
     });
 
-    Deno.ftruncateSync(file.rid, 20);
+    file.truncateSync(20);
     assertEquals(Deno.readFileSync(filename).byteLength, 20);
-    Deno.ftruncateSync(file.rid, 5);
+    file.truncateSync(5);
     assertEquals(Deno.readFileSync(filename).byteLength, 5);
-    Deno.ftruncateSync(file.rid, -5);
+    file.truncateSync(-5);
     assertEquals(Deno.readFileSync(filename).byteLength, 0);
 
     Deno.close(file.rid);
@@ -33,11 +33,11 @@ Deno.test(
       write: true,
     });
 
-    await Deno.ftruncate(file.rid, 20);
+    await file.truncate(20);
     assertEquals((await Deno.readFile(filename)).byteLength, 20);
-    await Deno.ftruncate(file.rid, 5);
+    await file.truncate(5);
     assertEquals((await Deno.readFile(filename)).byteLength, 5);
-    await Deno.ftruncate(file.rid, -5);
+    await file.truncate(-5);
     assertEquals((await Deno.readFile(filename)).byteLength, 0);
 
     Deno.close(file.rid);

--- a/cli/tests/unit_node/_fs/_fs_fsync_test.ts
+++ b/cli/tests/unit_node/_fs/_fs_fsync_test.ts
@@ -5,32 +5,31 @@ import { fsync, fsyncSync } from "node:fs";
 Deno.test({
   name: "ASYNC: flush any pending data of the given file stream to disk",
   async fn() {
-    const file: string = await Deno.makeTempFile();
-    const { rid } = await Deno.open(file, {
+    const filePath = await Deno.makeTempFile();
+    using file = await Deno.open(filePath, {
       read: true,
       write: true,
       create: true,
     });
     const size = 64;
-    await Deno.ftruncate(rid, size);
+    await file.truncate(size);
 
     await new Promise<void>((resolve, reject) => {
-      fsync(rid, (err: Error | null) => {
+      fsync(file.rid, (err: Error | null) => {
         if (err !== null) reject();
         else resolve();
       });
     })
       .then(
         async () => {
-          assertEquals((await Deno.stat(file)).size, size);
+          assertEquals((await Deno.stat(filePath)).size, size);
         },
         () => {
           fail("No error expected");
         },
       )
       .finally(async () => {
-        await Deno.remove(file);
-        Deno.close(rid);
+        await Deno.remove(filePath);
       });
   },
 });
@@ -38,21 +37,20 @@ Deno.test({
 Deno.test({
   name: "SYNC: flush any pending data the given file stream to disk",
   fn() {
-    const file: string = Deno.makeTempFileSync();
-    const { rid } = Deno.openSync(file, {
+    const filePath = Deno.makeTempFileSync();
+    using file = Deno.openSync(filePath, {
       read: true,
       write: true,
       create: true,
     });
     const size = 64;
-    Deno.ftruncateSync(rid, size);
+    file.truncateSync(size);
 
     try {
-      fsyncSync(rid);
-      assertEquals(Deno.statSync(file).size, size);
+      fsyncSync(file.rid);
+      assertEquals(Deno.statSync(filePath).size, size);
     } finally {
-      Deno.removeSync(file);
-      Deno.close(rid);
+      Deno.removeSync(filePath);
     }
   },
 });

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2163,7 +2163,7 @@ declare namespace Deno {
    *   { read: true, write: true, create: true },
    * );
    * await Deno.write(file.rid, new TextEncoder().encode("Hello World"));
-   * await Deno.ftruncate(file.rid, 1);
+   * await file.truncate(1);
    * await Deno.fsync(file.rid);
    * console.log(await Deno.readTextFile("my_file.txt")); // H
    * ```
@@ -2185,7 +2185,7 @@ declare namespace Deno {
    *   { read: true, write: true, create: true },
    * );
    * Deno.writeSync(file.rid, new TextEncoder().encode("Hello World"));
-   * Deno.ftruncateSync(file.rid, 1);
+   * file.truncateSync(1);
    * Deno.fsyncSync(file.rid);
    * console.log(Deno.readTextFileSync("my_file.txt")); // H
    * ```
@@ -5291,6 +5291,9 @@ declare namespace Deno {
    * console.log(new TextDecoder().decode(data)); // Hello W
    * ```
    *
+   * @deprecated Use {@linkcode Deno.FsFile.truncate} instead.
+   * {@linkcode Deno.ftruncate} will be removed in Deno 2.0.
+   *
    * @category File System
    */
   export function ftruncate(rid: number, len?: number): Promise<void>;
@@ -5332,6 +5335,9 @@ declare namespace Deno {
    * Deno.readSync(file.rid, data);
    * console.log(new TextDecoder().decode(data)); // Hello W
    * ```
+   *
+   * @deprecated Use {@linkcode Deno.FsFile.truncateSync} instead.
+   * {@linkcode Deno.ftruncateSync} will be removed in Deno 2.0.
    *
    * @category File System
    */

--- a/ext/node/polyfills/_fs/_fs_ftruncate.ts
+++ b/ext/node/polyfills/_fs/_fs_ftruncate.ts
@@ -4,6 +4,7 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
+import { FsFile } from "ext:deno_fs/30_fs.js";
 
 export function ftruncate(
   fd: number,
@@ -19,9 +20,9 @@ export function ftruncate(
 
   if (!callback) throw new Error("No callback function supplied");
 
-  Deno.ftruncate(fd, len).then(() => callback(null), callback);
+  new FsFile(fd).truncate(len).then(() => callback(null), callback);
 }
 
 export function ftruncateSync(fd: number, len?: number) {
-  Deno.ftruncateSync(fd, len);
+  new FsFile(fd).truncateSync(len);
 }

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
+import { core, internals } from "ext:core/mod.js";
 const {
   op_net_listen_udp,
   op_net_listen_unixpacket,
@@ -78,8 +78,22 @@ const denoNs = {
   lstat: fs.lstat,
   truncateSync: fs.truncateSync,
   truncate: fs.truncate,
-  ftruncateSync: fs.ftruncateSync,
-  ftruncate: fs.ftruncate,
+  ftruncateSync(rid, len) {
+    internals.warnOnDeprecatedApi(
+      "Deno.ftruncateSync()",
+      new Error().stack,
+      "Use `Deno.FsFile.truncateSync()` instead.",
+    );
+    return fs.ftruncateSync(rid, len);
+  },
+  ftruncate(rid, len) {
+    internals.warnOnDeprecatedApi(
+      "Deno.ftruncate()",
+      new Error().stack,
+      "Use `Deno.FsFile.truncate()` instead.",
+    );
+    return fs.ftruncate(rid, len);
+  },
   futime: fs.futime,
   futimeSync: fs.futimeSync,
   errors: errors.errors,


### PR DESCRIPTION
For removal in Deno 2.0.