### PR TITLE
feat: `Deno.FsFile.{utime,utimeSync}()` and deprecate `Deno.{futime,futimeSync}`

### DIFF
--- a/cli/tests/unit/utime_test.ts
+++ b/cli/tests/unit/utime_test.ts
@@ -29,6 +29,27 @@ Deno.test(
 
 Deno.test(
   { permissions: { read: true, write: true } },
+  async function fsFileUtimeSyncSuccess() {
+    const testDir = await Deno.makeTempDir();
+    const filename = testDir + "/file.txt";
+    using file = await Deno.open(filename, {
+      create: true,
+      write: true,
+    });
+
+    const atime = 1000;
+    const mtime = 50000;
+    await file.utime(atime, mtime);
+    await file.dataSync();
+
+    const fileInfo = Deno.statSync(filename);
+    assertEquals(fileInfo.atime, new Date(atime * 1000));
+    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
+  },
+);
+
+Deno.test(
+  { permissions: { read: true, write: true } },
   function futimeSyncSuccess() {
     const testDir = Deno.makeTempDirSync();
     const filename = testDir + "/file.txt";
@@ -40,6 +61,27 @@ Deno.test(
     const atime = 1000;
     const mtime = 50000;
     Deno.futimeSync(file.rid, atime, mtime);
+    file.dataSyncSync();
+
+    const fileInfo = Deno.statSync(filename);
+    assertEquals(fileInfo.atime, new Date(atime * 1000));
+    assertEquals(fileInfo.mtime, new Date(mtime * 1000));
+  },
+);
+
+Deno.test(
+  { permissions: { read: true, write: true } },
+  function futimeSyncSuccess() {
+    const testDir = Deno.makeTempDirSync();
+    const filename = testDir + "/file.txt";
+    using file = Deno.openSync(filename, {
+      create: true,
+      write: true,
+    });
+
+    const atime = 1000;
+    const mtime = 50000;
+    file.utimeSync(atime, mtime);
     file.dataSyncSync();
 
     const fileInfo = Deno.statSync(filename);

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2604,6 +2604,40 @@ declare namespace Deno {
      * @category I/O
      */
     dataSyncSync(): void;
+    /**
+     * Changes the access (`atime`) and modification (`mtime`) times of a file
+     * stream resource referenced by `rid`. Given times are either in seconds
+     * (UNIX epoch time) or as `Date` objects.
+     *
+     * ```ts
+     * using file = await Deno.open("file.txt", { create: true, write: true });
+     * await file.utime(1556495550, new Date());
+     * ```
+     *
+     * @category File System
+     */
+    utime(
+      rid: number,
+      atime: number | Date,
+      mtime: number | Date,
+    ): Promise<void>;
+    /**
+     * Synchronously changes the access (`atime`) and modification (`mtime`) times
+     * of a file stream resource referenced by `rid`. Given times are either in
+     * seconds (UNIX epoch time) or as `Date` objects.
+     *
+     * ```ts
+     * using file = Deno.openSync("file.txt", { create: true, write: true });
+     * file.utime(1556495550, new Date());
+     * ```
+     *
+     * @category File System
+     */
+    utimeSync(
+      rid: number,
+      atime: number | Date,
+      mtime: number | Date,
+    ): void;
     /** Close the file. Closing a file when you are finished with it is
      * important to avoid leaking resources.
      *
@@ -5347,6 +5381,9 @@ declare namespace Deno {
    * Deno.futimeSync(file.rid, 1556495550, new Date());
    * ```
    *
+   * @deprecated Use {@linkcode Deno.FsFile.utimeSync} instead.
+   * {@linkcode Deno.futimeSync} will be removed in Deno 2.0.
+   *
    * @category File System
    */
   export function futimeSync(
@@ -5364,6 +5401,9 @@ declare namespace Deno {
    * const file = await Deno.open("file.txt", { create: true, write: true });
    * await Deno.futime(file.rid, 1556495550, new Date());
    * ```
+   *
+   * @deprecated Use {@linkcode Deno.FsFile.utime} instead.
+   * {@linkcode Deno.futime} will be removed in Deno 2.0.
    *
    * @category File System
    */

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -757,6 +757,14 @@ class FsFile {
     op_fs_fsync_sync(this.rid);
   }
 
+  async utime(atime, mtime) {
+    await futime(this.#rid, atime, mtime);
+  }
+
+  utimeSync(atime, mtime) {
+    futimeSync(this.#rid, atime, mtime);
+  }
+
   [SymbolDispose]() {
     core.tryClose(this.rid);
   }

--- a/ext/node/polyfills/_fs/_fs_futimes.ts
+++ b/ext/node/polyfills/_fs/_fs_futimes.ts
@@ -4,6 +4,7 @@
 // deno-lint-ignore-file prefer-primordials
 
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
+import { FsFile } from "ext:deno_fs/30_fs.js";
 
 function getValidTime(
   time: number | string | Date,
@@ -38,7 +39,7 @@ export function futimes(
   atime = getValidTime(atime, "atime");
   mtime = getValidTime(mtime, "mtime");
 
-  Deno.futime(fd, atime, mtime).then(() => callback(null), callback);
+  new FsFile(fd).utime(atime, mtime).then(() => callback(null), callback);
 }
 
 export function futimesSync(
@@ -49,5 +50,5 @@ export function futimesSync(
   atime = getValidTime(atime, "atime");
   mtime = getValidTime(mtime, "mtime");
 
-  Deno.futimeSync(fd, atime, mtime);
+  new FsFile(fd).utimeSync(atime, mtime);
 }

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
+import { core, internals } from "ext:core/mod.js";
 const {
   op_net_listen_udp,
   op_net_listen_unixpacket,
@@ -80,8 +80,22 @@ const denoNs = {
   truncate: fs.truncate,
   ftruncateSync: fs.ftruncateSync,
   ftruncate: fs.ftruncate,
-  futime: fs.futime,
-  futimeSync: fs.futimeSync,
+  async futime(rid, atime, mtime) {
+    internals.warnOnDeprecatedApi(
+      "Deno.futime()",
+      new Error().stack,
+      "Use `Deno.FsFile.utime()` instead.",
+    );
+    await fs.futime(rid, atime, mtime);
+  },
+  futimeSync(rid, atime, mtime) {
+    internals.warnOnDeprecatedApi(
+      "Deno.futimeSync()",
+      new Error().stack,
+      "Use `Deno.FsFile.utimeSync()` instead.",
+    );
+    fs.futimeSync(rid, atime, mtime);
+  },
   errors: errors.errors,
   inspect: console.inspect,
   env: os.env,


### PR DESCRIPTION
For removal in Deno v2.