### PR TITLE
chore: update `Deno.{fsync,fsyncSync}()` deprecation notices

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2168,8 +2168,8 @@ declare namespace Deno {
    * console.log(await Deno.readTextFile("my_file.txt")); // H
    * ```
    *
-   * @deprecated Use `file.sync()` instead. {@linkcode Deno.fsync} will be
-   * removed in v2.0.0.
+   * @deprecated Use {@linkcode Deno.FsFile.sync} instead.
+   * {@linkcode Deno.fsync} will be removed in Deno 2.0.
    *
    * @category I/O
    */
@@ -2190,8 +2190,8 @@ declare namespace Deno {
    * console.log(Deno.readTextFileSync("my_file.txt")); // H
    * ```
    *
-   * @deprecated Use `file.syncSync()` instead. {@linkcode Deno.fsyncSync} will
-   * be removed in v2.0.0.
+   * @deprecated Use {@linkcode Deno.FsFile.syncSync} instead.
+   * {@linkcode Deno.fsyncSync} will be removed in Deno 2.0.
    *
    * @category I/O
    */

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -576,20 +576,10 @@ async function fdatasync(rid) {
 }
 
 function fsyncSync(rid) {
-  internals.warnOnDeprecatedApi(
-    "Deno.fsyncSync()",
-    new Error().stack,
-    "Use `file.syncSync()` instead.",
-  );
   op_fs_fsync_sync(rid);
 }
 
 async function fsync(rid) {
-  internals.warnOnDeprecatedApi(
-    "Deno.fsync()",
-    new Error().stack,
-    "Use `file.sync()` instead.",
-  );
   await op_fs_fsync_async(rid);
 }
 

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -120,8 +120,22 @@ const denoNs = {
   shutdown: net.shutdown,
   fstatSync: fs.fstatSync,
   fstat: fs.fstat,
-  fsyncSync: fs.fsyncSync,
-  fsync: fs.fsync,
+  fsyncSync(rid) {
+    internals.warnOnDeprecatedApi(
+      "Deno.fsyncSync()",
+      new Error().stack,
+      "Use `Deno.FsFile.syncSync()` instead.",
+    );
+    fs.fsyncSync(rid);
+  },
+  async fsync(rid) {
+    internals.warnOnDeprecatedApi(
+      "Deno.fsync()",
+      new Error().stack,
+      "Use `Deno.FsFile.sync()` instead.",
+    );
+    await fs.fsync(rid);
+  },
   fdatasyncSync: fs.fdatasyncSync,
   fdatasync: fs.fdatasync,
   symlink: fs.symlink,


### PR DESCRIPTION
To align with other deprecations.