### PR TITLE
feat: Change deprecation warning formatting

### DIFF
--- a/cli/tests/testdata/run/warn_on_deprecated_api/main.out
+++ b/cli/tests/testdata/run/warn_on_deprecated_api/main.out
@@ -1,49 +1,37 @@
 Download http://localhost:4545/run/warn_on_deprecated_api/mod.ts
-Warning
-├ Use of deprecated "Deno.run()" API.
-│
-├ This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.
-│
-├ Suggestion: Use "Deno.Command()" API instead.
-│
-└ Stack trace:
-  └─ at [WILDCARD]warn_on_deprecated_api/main.js:3:16
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at [WILDCARD]warn_on_deprecated_api/main.js:3:16
+
+hint: Use "Deno.Command()" API instead.
 
 hello world
-Warning
-├ Use of deprecated "Deno.run()" API.
-│
-├ This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.
-│
-├ Suggestion: Use "Deno.Command()" API instead.
-│
-└ Stack trace:
-  ├─ at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
-  └─ at [WILDCARD]warn_on_deprecated_api/main.js:25:7
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:25:7
+
+hint: Use "Deno.Command()" API instead.
 
 hello world
-Warning
-├ Use of deprecated "Deno.run()" API.
-│
-├ This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.
-│
-├ Suggestion: Use "Deno.Command()" API instead.
-│
-└ Stack trace:
-  ├─ at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
-  └─ at [WILDCARD]warn_on_deprecated_api/main.js:26:7
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:26:7
+
+hint: Use "Deno.Command()" API instead.
 
 hello world
-Warning
-├ Use of deprecated "Deno.run()" API.
-│
-├ This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.
-│
-├ Suggestion: Use "Deno.Command()" API instead.
-│
-└ Stack trace:
-  ├─ at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
-  └─ at [WILDCARD]warn_on_deprecated_api/main.js:29:9
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:29:9
+
+hint: Use "Deno.Command()" API instead.
 
 hello world
 hello world
@@ -55,18 +43,13 @@ hello world
 hello world
 hello world
 hello world
-Warning
-├ Use of deprecated "Deno.run()" API.
-│
-├ This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.
-│
-├ Suggestion: Use "Deno.Command()" API instead.
-│
-├ Suggestion: It appears this API is used by a remote dependency.
-│             Try upgrading to the latest version of that dependency.
-│
-└ Stack trace:
-  ├─ at runEcho (http://localhost:4545/run/warn_on_deprecated_api/mod.ts:2:18)
-  └─ at [WILDCARD]warn_on_deprecated_api/main.js:32:7
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho (http://localhost:4545/run/warn_on_deprecated_api/mod.ts:2:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:32:7
+
+hint: Use "Deno.Command()" API instead.
+hint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.
 
 hello world

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -143,48 +143,38 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
 
   ALREADY_WARNED_DEPRECATED.add(apiName + stack);
   console.error(
-    "%cWarning",
+    `%cWarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.0.`,
     "color: yellow; font-weight: bold;",
-  );
-  console.error(
-    `%c\u251c Use of deprecated "${apiName}" API.`,
     "color: yellow;",
   );
-  console.error("%c\u2502", "color: yellow;");
+  console.error();
+  if (stackLines.length > 0) {
+    console.error("%cStack trace:", "color: yellow;");
+    for (let i = 0; i < stackLines.length; i++) {
+      console.error(
+        `%c  ${StringPrototypeTrim(stackLines[i])}`,
+        "color: yellow;",
+      );
+    }
+    console.error();
+  }
   console.error(
-    "%c\u251c This API will be removed in Deno 2.0. Make sure to upgrade to a stable API before then.",
+    "%cMake sure to upgrade to a stable API before then.",
     "color: yellow;",
   );
+  console.error();
   for (let i = 0; i < suggestions.length; i++) {
     const suggestion = suggestions[i];
-    console.error("%c\u2502", "color: yellow;");
     console.error(
-      `%c\u251c Suggestion: ${suggestion}`,
+      `%hint: ${suggestion}`,
       "color: yellow;",
     );
   }
   if (isFromRemoteDependency) {
-    console.error("%c\u2502", "color: yellow;");
     console.error(
-      `%c\u251c Suggestion: It appears this API is used by a remote dependency.`,
+      `%hint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.`,
       "color: yellow;",
     );
-    console.error(
-      "%c\u2502             Try upgrading to the latest version of that dependency.",
-      "color: yellow;",
-    );
-  }
-  if (stackLines.length > 0) {
-    console.error("%c\u2502", "color: yellow;");
-    console.error("%c\u2514 Stack trace:", "color: yellow;");
-    for (let i = 0; i < stackLines.length; i++) {
-      console.error(
-        `%c  ${i == stackLines.length - 1 ? "\u2514" : "\u251c"}\u2500 ${
-          StringPrototypeTrim(stackLines[i])
-        }`,
-        "color: yellow;",
-      );
-    }
   }
   console.error();
 }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -143,7 +143,7 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
 
   ALREADY_WARNED_DEPRECATED.add(apiName + stack);
   console.error(
-    `%cWarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.0.`,
+    `%cWarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.`,
     "color: yellow;",
     "font-weight: bold;",
   );

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -158,21 +158,17 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
     }
     console.error();
   }
-  console.error(
-    "%cMake sure to upgrade to a stable API before then.",
-    "color: yellow;",
-  );
   console.error();
   for (let i = 0; i < suggestions.length; i++) {
     const suggestion = suggestions[i];
     console.error(
-      `%hint: ${suggestion}`,
+      `%chint: ${suggestion}`,
       "color: yellow;",
     );
   }
   if (isFromRemoteDependency) {
     console.error(
-      `%hint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.`,
+      `%chint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.`,
       "color: yellow;",
     );
   }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -144,34 +144,30 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
   ALREADY_WARNED_DEPRECATED.add(apiName + stack);
   console.error(
     `%cWarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.0.`,
-    "color: yellow; font-weight: bold;",
     "color: yellow;",
+    "font-weight: bold;",
   );
 
   console.error();
   if (stackLines.length > 0) {
-    console.error("%cStack trace:", "color: yellow;");
+    console.error("Stack trace:");
     for (let i = 0; i < stackLines.length; i++) {
-      console.error(
-        `%c  ${StringPrototypeTrim(stackLines[i])}`,
-        "color: yellow;",
-      );
+      console.error(`  ${StringPrototypeTrim(stackLines[i])}`);
     }
     console.error();
   }
-  console.error();
 
   for (let i = 0; i < suggestions.length; i++) {
     const suggestion = suggestions[i];
     console.error(
       `%chint: ${suggestion}`,
-      "color: yellow;",
+      "font-weight: bold;",
     );
   }
   if (isFromRemoteDependency) {
     console.error(
       `%chint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.`,
-      "color: yellow;",
+      "font-weight: bold;",
     );
   }
   console.error();

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -143,7 +143,7 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
 
   ALREADY_WARNED_DEPRECATED.add(apiName + stack);
   console.error(
-    `%cWarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.`,
+    `%cwarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.`,
     "color: yellow;",
     "font-weight: bold;",
   );


### PR DESCRIPTION
Removes weird "frame like" characters and simplifies the output:

```
warning: Use of deprecated "Deno.isatty()" API. This API will be removed in Deno 2.

Stack trace:
  at file:///Users/ib/dev/deno/foo.js:2:8

hint: Use `stdStream.isTerminal()` instead.

warning: Use of deprecated "Deno.isatty()" API. This API will be removed in Deno 2.

Stack trace:
  at file:///Users/ib/dev/deno/foo.js:7:8

hint: Use `stdStream.isTerminal()` instead.

```

![Screenshot 2024-01-24 at 15 45 06](https://github.com/denoland/deno/assets/13602871/7a6e24bf-44ec-4dbf-ac96-2af1db9f2ab9)

