### PR TITLE
chore: fix `Deno.UnsafeWindowSurface` typings

### DIFF
--- a/cli/tests/unit/webgpu_test.ts
+++ b/cli/tests/unit/webgpu_test.ts
@@ -238,7 +238,6 @@ Deno.test({
 
   assertThrows(
     () => {
-      // @ts-expect-error: runtime test for null handle
       new Deno.UnsafeWindowSurface("cocoa", null, null);
     },
   );

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -783,8 +783,8 @@ declare namespace Deno {
   export class UnsafeWindowSurface {
     constructor(
       system: "cocoa" | "win32" | "x11",
-      windowHandle: UnsafePointerView,
-      displayHandle: UnsafePointerView | null,
+      windowHandle: Deno.PointerValue<unknown>,
+      displayHandle: Deno.PointerValue<unknown>,
     );
     getContext(context: "webgpu"): GPUCanvasContext;
     present(): void;

--- a/cli/tsc/dts/lib.deno_webgpu.d.ts
+++ b/cli/tsc/dts/lib.deno_webgpu.d.ts
@@ -1325,6 +1325,8 @@ declare interface GPUCanvasConfiguration {
   viewFormats?: GPUTextureFormat[];
   colorSpace?: "srgb" | "display-p3";
   alphaMode?: GPUCanvasAlphaMode;
+  width: number;
+  height: number;
 }
 /** @category WebGPU */
 declare interface GPUCanvasContext {

--- a/ext/webgpu/webgpu.idl
+++ b/ext/webgpu/webgpu.idl
@@ -1135,8 +1135,6 @@ enum GPUCanvasAlphaMode {
 dictionary GPUCanvasConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
-    required long width;
-    required long height;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     sequence<GPUTextureFormat> viewFormats = [];
     GPUCanvasAlphaMode alphaMode = "opaque";

--- a/ext/webgpu/webgpu.idl
+++ b/ext/webgpu/webgpu.idl
@@ -1135,8 +1135,8 @@ enum GPUCanvasAlphaMode {
 dictionary GPUCanvasConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
-    required float width;
-    required float height;
+    required long width;
+    required long height;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     sequence<GPUTextureFormat> viewFormats = [];
     GPUCanvasAlphaMode alphaMode = "opaque";

--- a/ext/webgpu/webgpu.idl
+++ b/ext/webgpu/webgpu.idl
@@ -1135,6 +1135,8 @@ enum GPUCanvasAlphaMode {
 dictionary GPUCanvasConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
+    required float width;
+    required float height;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     sequence<GPUTextureFormat> viewFormats = [];
     GPUCanvasAlphaMode alphaMode = "opaque";


### PR DESCRIPTION
- changed `Deno.UnsafeWindowSurface` typings from accepting `Deno.UnsafePointerView` to `Deno.PointerValue`
- added width and height to `GPUCanvasConfiguration`
