### PR TITLE
Revert "feat: deprecate `window` global (#22057)"

### DIFF
--- a/cli/tests/testdata/npm/compare_globals/main.out
+++ b/cli/tests/testdata/npm/compare_globals/main.out
@@ -20,7 +20,6 @@ false
 true
 true
 true
-[WILDCARD]
 true
 false
 false

--- a/cli/tests/testdata/run/webstorage/logger.ts
+++ b/cli/tests/testdata/run/webstorage/logger.ts
@@ -1,1 +1,1 @@
-console.log(globalThis.localStorage);
+console.log(window.localStorage);

--- a/cli/tests/testdata/run/webstorage/serialization.ts
+++ b/cli/tests/testdata/run/webstorage/serialization.ts
@@ -1,4 +1,4 @@
-globalThis.sessionStorage.setItem("hello", "deno");
+window.sessionStorage.setItem("hello", "deno");
 
-console.log(globalThis.localStorage);
-console.log(globalThis.sessionStorage);
+console.log(window.localStorage);
+console.log(window.sessionStorage);

--- a/cli/tests/testdata/run/webstorage/setter.ts
+++ b/cli/tests/testdata/run/webstorage/setter.ts
@@ -1,1 +1,1 @@
-globalThis.localStorage.setItem("hello", "deno");
+window.localStorage.setItem("hello", "deno");

--- a/runtime/js/98_global_scope_window.js
+++ b/runtime/js/98_global_scope_window.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, internals, primordials } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
 const {
   op_bootstrap_language,
   op_bootstrap_numcpus,
@@ -108,15 +108,7 @@ const mainRuntimeGlobalProperties = {
   Location: location.locationConstructorDescriptor,
   location: location.locationDescriptor,
   Window: globalInterfaces.windowConstructorDescriptor,
-  window: util.getterOnly(() => {
-    internals.warnOnDeprecatedApi(
-      "window",
-      new Error().stack,
-      "Use `globalThis` or `self` instead.",
-      "You can provide `window` in the current scope with: `const window = globalThis`.",
-    );
-    return globalThis;
-  }),
+  window: util.getterOnly(() => globalThis),
   self: util.getterOnly(() => globalThis),
   Navigator: util.nonEnumerable(Navigator),
   navigator: util.getterOnly(() => navigator),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -99,7 +99,7 @@ let globalThis_;
 let deprecatedApiWarningDisabled = false;
 const ALREADY_WARNED_DEPRECATED = new SafeSet();
 
-function warnOnDeprecatedApi(apiName, stack, suggestions) {
+function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
   if (deprecatedApiWarningDisabled) {
     return;
   }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -99,7 +99,7 @@ let globalThis_;
 let deprecatedApiWarningDisabled = false;
 const ALREADY_WARNED_DEPRECATED = new SafeSet();
 
-function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
+function warnOnDeprecatedApi(apiName, stack, suggestions) {
   if (deprecatedApiWarningDisabled) {
     return;
   }
@@ -164,6 +164,7 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
       "font-weight: bold;",
     );
   }
+
   if (isFromRemoteDependency) {
     console.error(
       `%chint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.`,


### PR DESCRIPTION
This reverts commit 930ce2087051b4e45b2026ce7a77c14360a6993f.

This is producing false-positives that are not actionable to users. We're gonna
address this in another release.