### PR TITLE
feat: Expand 'imports' section of deno.json

### DIFF
--- a/cli/tests/testdata/compile/npm_fs/main.ts
+++ b/cli/tests/testdata/compile/npm_fs/main.ts
@@ -154,7 +154,7 @@ await assert.rejects(
 }
 
 // read dir
-const readDirNames = ["main.d.mts", "main.mjs", "package.json"];
+const readDirNames = ["main.d.mts", "main.mjs", "other.mjs", "package.json"];
 {
   const names = Array.from(Deno.readDirSync(dirPath))
     .map((e) => e.name);

--- a/cli/tests/testdata/npm/registry/@denotest/esm-basic/1.0.0/other.mjs
+++ b/cli/tests/testdata/npm/registry/@denotest/esm-basic/1.0.0/other.mjs
@@ -1,0 +1,3 @@
+export function hello() {
+    return "hello, world!";
+}

--- a/cli/tests/testdata/package_json/basic/main.info.out
+++ b/cli/tests/testdata/package_json/basic/main.info.out
@@ -5,4 +5,4 @@ size: [WILDCARD]
 
 file:///[WILDCARD]/main.ts (63B)
 └─┬ file:///[WILDCARD]/lib.ts (166B)
-  └── npm:/@denotest/esm-basic@1.0.0 (416B)
+  └── npm:/@denotest/esm-basic@1.0.0 (471B)


### PR DESCRIPTION
This commit adds automatic expansion of "imports" field in "deno.json" file.

If "npm:" or "jsr:" imports are encountered we automatically try to add a "directory"
remapping.

Previously users had to specify entries for both `foo` and `foo/` to be able to import like
`import { symbol1 } from "foo";` and `import { symbol2 } from "foo/some_file.js"`:
```
{
  "imports": {
    "foo": "npm:@foo/bar",
    "foo/": "npm:/@foo/bar/",
}
```

With this change users can only add entry for `foo`:
```
{
  "imports": {
    "foo": "npm:@foo/bar",
}
```
The entry for `foo/` will be provided automatically.

Similarly if user provides "directory" remapping explicitly, we will not overwrite it.