### PR TITLE
fix: don't call `.rid` in `Deno.FsWatcher.close()`

### DIFF
--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -75,25 +75,9 @@ async function connectTls({
 }
 
 class TlsListener extends Listener {
-  #rid = 0;
-
-  constructor(rid, addr) {
-    super(rid, addr);
-    this.#rid = rid;
-  }
-
-  get rid() {
-    internals.warnOnDeprecatedApi(
-      "Deno.TlsListener.rid",
-      new Error().stack,
-      "Use `Deno.TlsListener` instance methods instead.",
-    );
-    return this.#rid;
-  }
-
   async accept() {
     const { 0: rid, 1: localAddr, 2: remoteAddr } = await op_net_accept_tls(
-      this.#rid,
+      this.rid,
     );
     localAddr.transport = "tcp";
     remoteAddr.transport = "tcp";

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -75,9 +75,25 @@ async function connectTls({
 }
 
 class TlsListener extends Listener {
+  #rid = 0;
+
+  constructor(rid, addr) {
+    super(rid, addr);
+    this.#rid = rid;
+  }
+
+  get rid() {
+    internals.warnOnDeprecatedApi(
+      "Deno.TlsListener.rid",
+      new Error().stack,
+      "Use `Deno.TlsListener` instance methods instead.",
+    );
+    return this.#rid;
+  }
+
   async accept() {
     const { 0: rid, 1: localAddr, 2: remoteAddr } = await op_net_accept_tls(
-      this.rid,
+      this.#rid,
     );
     localAddr.transport = "tcp";
     remoteAddr.transport = "tcp";

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -60,7 +60,7 @@ class FsWatcher {
   }
 
   close() {
-    core.close(this.rid);
+    core.close(this.#rid);
   }
 
   [SymbolAsyncIterator]() {


### PR DESCRIPTION
Otherwise, a deprecation warning will be printed.