### PR TITLE
Revert "chore: bump rustls-tokio-stream and rustls (#21955)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,9 +5074,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-tokio-stream"
-version = "0.2.20"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f0b619386efa23ba0955910896567698dc802cab625ea97a69e7340f986e6f"
+checksum = "ded7a36e8ac05b8ada77a84c5ceec95361942ee9dedb60a82f93f788a791aae8"
 dependencies = [
  "futures",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ lazy-regex = "3"
 reqwest = { version = "=0.11.20", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks", "json"] } # pinned because of https://github.com/seanmonstar/reqwest/pull/1955
 ring = "^0.17.0"
 rusqlite = { version = "=0.29.0", features = ["unlock_notify", "bundled"] }
-rustls = "0.21.10"
+rustls = "0.21.8"
 rustls-pemfile = "1.0.0"
-rustls-tokio-stream = "=0.2.20"
+rustls-tokio-stream = "=0.2.17"
 rustls-webpki = "0.101.4"
 rustyline = "=13.0.0"
 webpki-roots = "0.25.2"

--- a/cli/tests/integration/cert_tests.rs
+++ b/cli/tests/integration/cert_tests.rs
@@ -2,7 +2,6 @@
 
 use deno_runtime::deno_net::ops_tls::TlsStream;
 use deno_runtime::deno_tls::rustls;
-use deno_runtime::deno_tls::rustls::ClientConnection;
 use deno_runtime::deno_tls::rustls_pemfile;
 use lsp_types::Url;
 use std::io::BufReader;
@@ -241,11 +240,8 @@ async fn listen_tls_alpn() {
   let tcp_stream = tokio::net::TcpStream::connect("localhost:4504")
     .await
     .unwrap();
-  let mut tls_stream = TlsStream::new_client_side(
-    tcp_stream,
-    ClientConnection::new(cfg, hostname).unwrap(),
-    None,
-  );
+  let mut tls_stream =
+    TlsStream::new_client_side(tcp_stream, cfg, hostname, None);
 
   let handshake = tls_stream.handshake().await.unwrap();
 
@@ -293,11 +289,8 @@ async fn listen_tls_alpn_fail() {
   let tcp_stream = tokio::net::TcpStream::connect("localhost:4505")
     .await
     .unwrap();
-  let mut tls_stream = TlsStream::new_client_side(
-    tcp_stream,
-    ClientConnection::new(cfg, hostname).unwrap(),
-    None,
-  );
+  let mut tls_stream =
+    TlsStream::new_client_side(tcp_stream, cfg, hostname, None);
 
   tls_stream.handshake().await.unwrap_err();
 

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -27,7 +27,6 @@ use deno_tls::create_client_config;
 use deno_tls::load_certs;
 use deno_tls::load_private_keys;
 use deno_tls::rustls::Certificate;
-use deno_tls::rustls::ClientConnection;
 use deno_tls::rustls::PrivateKey;
 use deno_tls::rustls::ServerConfig;
 use deno_tls::rustls::ServerName;
@@ -231,7 +230,8 @@ where
   let tls_config = Arc::new(tls_config);
   let tls_stream = TlsStream::new_client_side(
     tcp_stream,
-    ClientConnection::new(tls_config, hostname_dns).unwrap(),
+    tls_config,
+    hostname_dns,
     TLS_BUFFER_SIZE,
   );
 
@@ -327,7 +327,8 @@ where
 
   let tls_stream = TlsStream::new_client_side(
     tcp_stream,
-    ClientConnection::new(tls_config, hostname_dns).unwrap(),
+    tls_config,
+    hostname_dns,
     TLS_BUFFER_SIZE,
   );
 

--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -23,7 +23,6 @@ use deno_core::ToJsBuffer;
 use deno_net::raw::NetworkStream;
 use deno_tls::create_client_config;
 use deno_tls::rustls::ClientConfig;
-use deno_tls::rustls::ClientConnection;
 use deno_tls::RootCertStoreProvider;
 use deno_tls::SocketUse;
 use http::header::CONNECTION;
@@ -237,7 +236,8 @@ async fn handshake_http1_wss(
     ServerName::try_from(domain).map_err(|_| invalid_hostname(domain))?;
   let mut tls_connector = TlsStream::new_client_side(
     tcp_socket,
-    ClientConnection::new(tls_config.into(), dnsname).unwrap(),
+    tls_config.into(),
+    dnsname,
     NonZeroUsize::new(65536),
   );
   // If we can bail on an http/1.1 ALPN mismatch here, we can avoid doing extra work
@@ -261,11 +261,8 @@ async fn handshake_http2_wss(
   let dnsname =
     ServerName::try_from(domain).map_err(|_| invalid_hostname(domain))?;
   // We need to better expose the underlying errors here
-  let mut tls_connector = TlsStream::new_client_side(
-    tcp_socket,
-    ClientConnection::new(tls_config.into(), dnsname).unwrap(),
-    None,
-  );
+  let mut tls_connector =
+    TlsStream::new_client_side(tcp_socket, tls_config.into(), dnsname, None);
   let handshake = tls_connector.handshake().await?;
   if handshake.alpn.is_none() {
     bail!("Didn't receive h2 alpn, aborting connection");


### PR DESCRIPTION
This reverts commit 971eb0e5e836cdeaaefc25b2bab4c6a6a9f8e213.

To unblock v1.40 release.