### PR TITLE
chore: upgrade dprint-plugin-toml to 0.6.0

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -56,10 +56,10 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.88.8.wasm",
+    "https://plugins.dprint.dev/typescript-0.88.10.wasm",
     "https://plugins.dprint.dev/json-0.19.1.wasm",
     "https://plugins.dprint.dev/markdown-0.16.3.wasm",
-    "https://plugins.dprint.dev/toml-0.5.4.wasm",
+    "https://plugins.dprint.dev/toml-0.6.0.wasm",
     "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7"
   ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ members = [
   "bench_util",
   "cli",
   "cli/napi/sym",
-  "runtime",
-  "test_ffi",
-  "test_napi",
-  "test_util",
   "ext/broadcast_channel",
   "ext/cache",
   "ext/canvas",
@@ -22,6 +18,7 @@ members = [
   "ext/http",
   "ext/io",
   "ext/kv",
+  "ext/napi",
   "ext/net",
   "ext/node",
   "ext/url",
@@ -30,7 +27,10 @@ members = [
   "ext/webidl",
   "ext/websocket",
   "ext/webstorage",
-  "ext/napi",
+  "runtime",
+  "test_ffi",
+  "test_napi",
+  "test_util",
 ]
 exclude = ["test_util/std/hash/_wasm"]
 
@@ -44,17 +44,17 @@ repository = "https://github.com/denoland/deno"
 deno_ast = { version = "0.32.0", features = ["transpiling"] }
 deno_core = { version = "0.249.0" }
 
-deno_runtime = { version = "0.142.0", path = "./runtime" }
-napi_sym = { version = "0.64.0", path = "./cli/napi/sym" }
 deno_bench_util = { version = "0.128.0", path = "./bench_util" }
-test_util = { path = "./test_util" }
 deno_lockfile = "0.18.0"
 deno_media_type = { version = "0.1.1", features = ["module_specifier"] }
+deno_runtime = { version = "0.142.0", path = "./runtime" }
+napi_sym = { version = "0.64.0", path = "./cli/napi/sym" }
+test_util = { path = "./test_util" }
 
 denokv_proto = "0.5.0"
+denokv_remote = "0.5.0"
 # denokv_sqlite brings in bundled sqlite if we don't disable the default features
 denokv_sqlite = { default-features = false, version = "0.5.0" }
-denokv_remote = "0.5.0"
 
 # exts
 deno_broadcast_channel = { version = "0.128.0", path = "./ext/broadcast_channel" }
@@ -68,9 +68,10 @@ deno_ffi = { version = "0.121.0", path = "./ext/ffi" }
 deno_fs = { version = "0.44.0", path = "./ext/fs" }
 deno_http = { version = "0.131.0", path = "./ext/http" }
 deno_io = { version = "0.44.0", path = "./ext/io" }
+deno_kv = { version = "0.42.0", path = "./ext/kv" }
+deno_napi = { version = "0.64.0", path = "./ext/napi" }
 deno_net = { version = "0.126.0", path = "./ext/net" }
 deno_node = { version = "0.71.0", path = "./ext/node" }
-deno_kv = { version = "0.42.0", path = "./ext/kv" }
 deno_tls = { version = "0.121.0", path = "./ext/tls" }
 deno_url = { version = "0.134.0", path = "./ext/url" }
 deno_web = { version = "0.165.0", path = "./ext/web" }
@@ -78,7 +79,6 @@ deno_webgpu = { version = "0.101.0", path = "./ext/webgpu" }
 deno_webidl = { version = "0.134.0", path = "./ext/webidl" }
 deno_websocket = { version = "0.139.0", path = "./ext/websocket" }
 deno_webstorage = { version = "0.129.0", path = "./ext/webstorage" }
-deno_napi = { version = "0.64.0", path = "./ext/napi" }
 
 aes = "=0.8.3"
 anyhow = "1.0.57"
@@ -93,27 +93,29 @@ cbc = { version = "=0.1.2", features = ["alloc"] }
 #       Instead use util::time::utc_now()
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 console_static_text = "=0.8.1"
-data-url = "=0.3.0"
 data-encoding = "2.3.3"
+data-url = "=0.3.0"
 dlopen2 = "0.6.1"
-encoding_rs = "=0.8.33"
 ecb = "=0.1.2"
+elliptic-curve = { version = "0.13.4", features = ["alloc", "arithmetic", "ecdh", "std", "pem"] }
+encoding_rs = "=0.8.33"
 fastwebsockets = { version = "0.6", features = ["upgrade", "unstable-split"] }
 filetime = "0.2.16"
 flate2 = { version = "1.0.26", default-features = false }
 fs3 = "0.5.0"
 futures = "0.3.21"
 glob = "0.3.1"
-hex = "0.4"
-http_v02 = { package = "http", version = "0.2.9" }
-http = "1.0"
 h2 = "0.4"
-httparse = "1.8.0"
-hyper-util = { version = "=0.1.2", features = ["tokio", "server", "server-auto"] }
+hex = "0.4"
+http = "1.0"
 http-body-util = "0.1"
-hyper_v014 = { package = "hyper", version = "0.14.26", features = ["runtime", "http1"] }
+http_v02 = { package = "http", version = "0.2.9" }
+httparse = "1.8.0"
 hyper = { version = "=1.1.0", features = ["full"] }
+hyper-util = { version = "=0.1.2", features = ["tokio", "server", "server-auto"] }
+hyper_v014 = { package = "hyper", version = "0.14.26", features = ["runtime", "http1"] }
 indexmap = { version = "2", features = ["serde"] }
+lazy-regex = "3"
 libc = "0.2.126"
 libz-sys = { version = "1.1", default-features = false }
 log = "=0.4.20"
@@ -124,6 +126,9 @@ notify = "=5.0.0"
 num-bigint = { version = "0.4", features = ["rand"] }
 once_cell = "1.17.1"
 os_pipe = "=1.1.4"
+p224 = { version = "0.13.0", features = ["ecdh"] }
+p256 = { version = "0.13.2", features = ["ecdh"] }
+p384 = { version = "0.13.0", features = ["ecdh"] }
 parking_lot = "0.12.0"
 percent-encoding = "=2.3.0"
 pin-project = "1.0.11" # don't pin because they yank crates from cargo
@@ -132,7 +137,6 @@ prost = "0.11"
 prost-build = "0.11"
 rand = "=0.8.5"
 regex = "^1.7.0"
-lazy-regex = "3"
 reqwest = { version = "=0.11.20", default-features = false, features = ["rustls-tls", "stream", "gzip", "brotli", "socks", "json"] } # pinned because of https://github.com/seanmonstar/reqwest/pull/1955
 ring = "^0.17.0"
 rusqlite = { version = "=0.29.0", features = ["unlock_notify", "bundled"] }
@@ -141,9 +145,8 @@ rustls-pemfile = "1.0.0"
 rustls-tokio-stream = "=0.2.17"
 rustls-webpki = "0.101.4"
 rustyline = "=13.0.0"
-webpki-roots = "0.25.2"
-scopeguard = "1.2.0"
 saffron = "=0.1.0"
+scopeguard = "1.2.0"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0.85"
@@ -163,21 +166,18 @@ tokio-util = "0.7.4"
 tower-lsp = { version = "=0.20.0", features = ["proposed"] }
 url = { version = "2.3.1", features = ["serde", "expose_internals"] }
 uuid = { version = "1.3.0", features = ["v4"] }
+webpki-roots = "0.25.2"
 zstd = "=0.12.4"
-elliptic-curve = { version = "0.13.4", features = ["alloc", "arithmetic", "ecdh", "std", "pem"] }
-p224 = { version = "0.13.0", features = ["ecdh"] }
-p256 = { version = "0.13.2", features = ["ecdh"] }
-p384 = { version = "0.13.0", features = ["ecdh"] }
 
 # crypto
-rsa = { version = "0.9.3", default-features = false, features = ["std", "pem", "hazmat"] } # hazmat needed for PrehashSigner in ext/node
 hkdf = "0.12.3"
+rsa = { version = "0.9.3", default-features = false, features = ["std", "pem", "hazmat"] } # hazmat needed for PrehashSigner in ext/node
 
 # webgpu
 raw-window-handle = "0.5.0"
 wgpu-core = { version = "=0.18", features = ["raw-window-handle"] }
-wgpu-types = "=0.18"
 wgpu-hal = "=0.18"
+wgpu-types = "=0.18"
 
 # macros
 proc-macro2 = "1"
@@ -189,9 +189,9 @@ nix = "=0.26.2"
 
 # windows deps
 fwdansi = "=1.1.0"
-winres = "=0.1.12"
 winapi = "=0.3.9"
 windows-sys = { version = "0.48.0", features = ["Win32_Media"] }
+winres = "=0.1.12"
 
 # NB: the `bench` and `release` profiles must remain EXACTLY the same.
 [profile.release]


### PR DESCRIPTION
It now also sorts workspace members and dependencies in Cargo.toml files.