### PR TITLE
feat(lsp): complete parameters as tab stops and placeholders

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3057,7 +3057,11 @@ fn get_parameters_from_parts(parts: &[SymbolDisplayPart]) -> Vec<String> {
           matches!(parts.get(idx + 1), Some(next) if next.text == "?");
         // Skip `this` and optional parameters.
         if !is_optional && part.text != "this" {
-          parameters.push(part.text.clone());
+          parameters.push(format!(
+            "${{{}:{}}}",
+            parameters.len() + 1,
+            &part.text
+          ));
         }
       }
     } else if part.kind == "punctuation" {
@@ -3165,7 +3169,9 @@ impl CompletionEntryDetails {
       specifier,
       language_server,
     )?;
+    let mut insert_text_format = original_item.insert_text_format;
     let insert_text = if data.use_code_snippet {
+      insert_text_format = Some(lsp::InsertTextFormat::SNIPPET);
       Some(format!(
         "{}({})",
         original_item
@@ -3186,6 +3192,7 @@ impl CompletionEntryDetails {
       text_edit,
       additional_text_edits,
       insert_text,
+      insert_text_format,
       // NOTE(bartlomieju): it's not entirely clear to me why we need to do that,
       // but when `completionItem/resolve` is called, we get a list of commit chars
       // even though we might have returned an empty list in `completion` request.

--- a/cli/tests/integration/lsp_tests.rs
+++ b/cli/tests/integration/lsp_tests.rs
@@ -9037,8 +9037,8 @@ fn lsp_completions_complete_function_calls() {
         "value": "Calls a defined callback function on each element of an array, and returns an array that contains the results.\n\n*@param* - callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.*@param* - thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value."
       },
       "sortText": "1",
-      "insertText": "map(callbackfn)",
-      "insertTextFormat": 1
+      "insertText": "map(${1:callbackfn})",
+      "insertTextFormat": 2,
     })
   );
   client.shutdown();
@@ -11130,7 +11130,7 @@ function a() {
     };
   };
 }
-        
+
 class C {
   @a()
   static test() {


### PR DESCRIPTION
Fixes https://github.com/denoland/vscode_deno/issues/1036.

When you have `"typescript.suggest.completeFunctionCalls": true` and get completions with function parameters, now they are pre-highlighted and you can cycle through them with tab. See https://github.com/denoland/vscode_deno/issues/1036#issuecomment-1911107706 for a demo.