### PR TITLE
fix: make deprecation warnings less verbose

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -685,6 +685,7 @@ pub struct CliOptions {
   overrides: CliOptionOverrides,
   maybe_workspace_config: Option<WorkspaceConfig>,
   pub disable_deprecated_api_warning: bool,
+  pub verbose_deprecated_api_warning: bool,
 }
 
 impl CliOptions {
@@ -739,6 +740,9 @@ impl CliOptions {
       == Some(log::Level::Error)
       || std::env::var("DENO_NO_DEPRECATION_WARNINGS").ok().is_some();
 
+    let verbose_deprecated_api_warning =
+      std::env::var("DENO_VERBOSE_WARNINGS").ok().is_some();
+
     Ok(Self {
       flags,
       initial_cwd,
@@ -750,6 +754,7 @@ impl CliOptions {
       overrides: Default::default(),
       maybe_workspace_config,
       disable_deprecated_api_warning,
+      verbose_deprecated_api_warning,
     })
   }
 
@@ -1096,6 +1101,7 @@ impl CliOptions {
       maybe_workspace_config: self.maybe_workspace_config.clone(),
       overrides: self.overrides.clone(),
       disable_deprecated_api_warning: self.disable_deprecated_api_warning,
+      verbose_deprecated_api_warning: self.verbose_deprecated_api_warning,
     }
   }
 

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -751,6 +751,7 @@ impl CliFactory {
       self.create_cli_main_worker_options()?,
       self.options.node_ipc_fd(),
       self.options.disable_deprecated_api_warning,
+      self.options.verbose_deprecated_api_warning,
     ))
   }
 

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -540,6 +540,7 @@ pub async fn run(
     },
     None,
     metadata.disable_deprecated_api_warning,
+    false,
   );
 
   v8_set_flags(construct_v8_flags(&[], &metadata.v8_flags, vec![]));

--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -5099,6 +5099,14 @@ itest!(warn_on_deprecated_api {
   exit_code: 0,
 });
 
+itest!(warn_on_deprecated_api_verbose {
+  args: "run -A run/warn_on_deprecated_api/main.js",
+  output: "run/warn_on_deprecated_api/main.verbose.out",
+  envs: vec![("DENO_VERBOSE_WARNINGS".to_string(), "1".to_string())],
+  http_server: true,
+  exit_code: 0,
+});
+
 itest!(warn_on_deprecated_api_with_flag {
   args: "run -A --quiet run/warn_on_deprecated_api/main.js",
   output: "run/warn_on_deprecated_api/main_disabled_flag.out",

--- a/cli/tests/testdata/run/warn_on_deprecated_api/main.out
+++ b/cli/tests/testdata/run/warn_on_deprecated_api/main.out
@@ -1,38 +1,5 @@
 Download http://localhost:4545/run/warn_on_deprecated_api/mod.ts
-warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
-
-Stack trace:
-  at [WILDCARD]warn_on_deprecated_api/main.js:3:16
-
-hint: Use "Deno.Command()" API instead.
-
-hello world
-warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
-
-Stack trace:
-  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
-  at [WILDCARD]warn_on_deprecated_api/main.js:25:7
-
-hint: Use "Deno.Command()" API instead.
-
-hello world
-warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
-
-Stack trace:
-  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
-  at [WILDCARD]warn_on_deprecated_api/main.js:26:7
-
-hint: Use "Deno.Command()" API instead.
-
-hello world
-warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
-
-Stack trace:
-  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
-  at [WILDCARD]warn_on_deprecated_api/main.js:29:9
-
-hint: Use "Deno.Command()" API instead.
-
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2. Run again with DENO_VERBOSE_WARNINGS=1 to get more details.
 hello world
 hello world
 hello world
@@ -43,13 +10,7 @@ hello world
 hello world
 hello world
 hello world
-warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
-
-Stack trace:
-  at runEcho (http://localhost:4545/run/warn_on_deprecated_api/mod.ts:2:18)
-  at [WILDCARD]warn_on_deprecated_api/main.js:32:7
-
-hint: Use "Deno.Command()" API instead.
-hint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.
-
+hello world
+hello world
+hello world
 hello world

--- a/cli/tests/testdata/run/warn_on_deprecated_api/main.verbose.out
+++ b/cli/tests/testdata/run/warn_on_deprecated_api/main.verbose.out
@@ -1,0 +1,55 @@
+Download http://localhost:4545/run/warn_on_deprecated_api/mod.ts
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at [WILDCARD]warn_on_deprecated_api/main.js:3:16
+
+hint: Use "Deno.Command()" API instead.
+
+hello world
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:25:7
+
+hint: Use "Deno.Command()" API instead.
+
+hello world
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:26:7
+
+hint: Use "Deno.Command()" API instead.
+
+hello world
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho ([WILDCARD]warn_on_deprecated_api/main.js:14:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:29:9
+
+hint: Use "Deno.Command()" API instead.
+
+hello world
+hello world
+hello world
+hello world
+hello world
+hello world
+hello world
+hello world
+hello world
+hello world
+warning: Use of deprecated "Deno.run()" API. This API will be removed in Deno 2.
+
+Stack trace:
+  at runEcho (http://localhost:4545/run/warn_on_deprecated_api/mod.ts:2:18)
+  at [WILDCARD]warn_on_deprecated_api/main.js:32:7
+
+hint: Use "Deno.Command()" API instead.
+hint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.
+
+hello world

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -126,6 +126,7 @@ struct SharedWorkerState {
   feature_checker: Arc<FeatureChecker>,
   node_ipc: Option<i64>,
   disable_deprecated_api_warning: bool,
+  verbose_deprecated_api_warning: bool,
 }
 
 impl SharedWorkerState {
@@ -407,6 +408,7 @@ impl CliMainWorkerFactory {
     options: CliMainWorkerOptions,
     node_ipc: Option<i64>,
     disable_deprecated_api_warning: bool,
+    verbose_deprecated_api_warning: bool,
   ) -> Self {
     Self {
       shared: Arc::new(SharedWorkerState {
@@ -429,6 +431,7 @@ impl CliMainWorkerFactory {
         feature_checker,
         node_ipc,
         disable_deprecated_api_warning,
+        verbose_deprecated_api_warning,
       }),
     }
   }
@@ -592,6 +595,7 @@ impl CliMainWorkerFactory {
           .clone(),
         node_ipc_fd: shared.node_ipc,
         disable_deprecated_api_warning: shared.disable_deprecated_api_warning,
+        verbose_deprecated_api_warning: shared.verbose_deprecated_api_warning,
       },
       extensions: custom_extensions,
       startup_snapshot: crate::js::deno_isolate_init(),
@@ -797,6 +801,7 @@ fn create_web_worker_callback(
           .clone(),
         node_ipc_fd: None,
         disable_deprecated_api_warning: shared.disable_deprecated_api_warning,
+        verbose_deprecated_api_warning: shared.verbose_deprecated_api_warning,
       },
       extensions: vec![],
       startup_snapshot: crate::js::deno_isolate_init(),

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -96,11 +96,25 @@ ObjectDefineProperties(Symbol, {
 let windowIsClosing = false;
 let globalThis_;
 
+let verboseDeprecatedApiWarning = false;
 let deprecatedApiWarningDisabled = false;
 const ALREADY_WARNED_DEPRECATED = new SafeSet();
 
 function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
   if (deprecatedApiWarningDisabled) {
+    return;
+  }
+
+  if (!verboseDeprecatedApiWarning) {
+    if (ALREADY_WARNED_DEPRECATED.has(apiName)) {
+      return;
+    }
+    ALREADY_WARNED_DEPRECATED.add(apiName);
+    console.error(
+      `%cwarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2. Run again with DENO_VERBOSE_WARNINGS=1 to get more details.`,
+      "color: yellow;",
+      "font-weight: bold;",
+    );
     return;
   }
 
@@ -563,9 +577,11 @@ function bootstrapMainRuntime(runtimeOptions) {
     5: hasNodeModulesDir,
     6: maybeBinaryNpmCommandName,
     7: shouldDisableDeprecatedApiWarning,
+    8: shouldUseVerboseDeprecatedApiWarning,
   } = runtimeOptions;
 
   deprecatedApiWarningDisabled = shouldDisableDeprecatedApiWarning;
+  verboseDeprecatedApiWarning = shouldUseVerboseDeprecatedApiWarning;
   performance.setTimeOrigin(DateNow());
   globalThis_ = globalThis;
 
@@ -703,9 +719,11 @@ function bootstrapWorkerRuntime(
     5: hasNodeModulesDir,
     6: maybeBinaryNpmCommandName,
     7: shouldDisableDeprecatedApiWarning,
+    8: shouldUseVerboseDeprecatedApiWarning,
   } = runtimeOptions;
 
   deprecatedApiWarningDisabled = shouldDisableDeprecatedApiWarning;
+  verboseDeprecatedApiWarning = shouldUseVerboseDeprecatedApiWarning;
   performance.setTimeOrigin(DateNow());
   globalThis_ = globalThis;
 

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -61,6 +61,7 @@ pub struct BootstrapOptions {
   pub maybe_binary_npm_command_name: Option<String>,
   pub node_ipc_fd: Option<i64>,
   pub disable_deprecated_api_warning: bool,
+  pub verbose_deprecated_api_warning: bool,
 }
 
 impl Default for BootstrapOptions {
@@ -90,6 +91,7 @@ impl Default for BootstrapOptions {
       maybe_binary_npm_command_name: None,
       node_ipc_fd: None,
       disable_deprecated_api_warning: false,
+      verbose_deprecated_api_warning: false,
     }
   }
 }
@@ -121,6 +123,8 @@ struct BootstrapV8<'a>(
   Option<&'a str>,
   // disable_deprecated_api_warning,
   bool,
+  // verbose_deprecated_api_warning
+  bool,
 );
 
 impl BootstrapOptions {
@@ -141,6 +145,7 @@ impl BootstrapOptions {
       self.has_node_modules_dir,
       self.maybe_binary_npm_command_name.as_deref(),
       self.disable_deprecated_api_warning,
+      self.verbose_deprecated_api_warning,
     );
 
     bootstrap.serialize(ser).unwrap()


### PR DESCRIPTION
This commit makes deprecation warnings less verbose by default.

Only a single warnings is issued per deprecated API use.

`DENO_VERBOSE_WARNINGS` env var can be provided to enable more detailed
logging for each use of API including a stack trace.

![Screenshot 2024-01-26 at 15 20 48](https://github.com/denoland/deno/assets/13602871/9c036c84-0044-4cb6-9c8e-deb641f43712)
