### PR TITLE
refactor: make 'rid' properties non-enumerable

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -83,6 +83,7 @@ const {
   Function,
   MathTrunc,
   ObjectEntries,
+  ObjectDefineProperty,
   ObjectPrototypeIsPrototypeOf,
   ObjectValues,
   StringPrototypeSlice,
@@ -656,14 +657,16 @@ function create(path) {
 }
 
 class FsFile {
-  [internalRidSymbol] = 0;
   #rid = 0;
 
   #readable;
   #writable;
 
   constructor(rid, symbol) {
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
     if (!symbol || symbol !== SymbolFor("Deno.internal.FsFile")) {
       internals.warnOnDeprecatedApi(

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -34,6 +34,7 @@ const {
   Error,
   Number,
   ObjectPrototypeIsPrototypeOf,
+  ObjectDefineProperty,
   PromiseResolve,
   SafeSet,
   SetPrototypeAdd,
@@ -91,7 +92,6 @@ async function resolveDns(query, recordType, options) {
 }
 
 class Conn {
-  [internalRidSymbol] = 0;
   #rid = 0;
   #remoteAddr = null;
   #localAddr = null;
@@ -102,7 +102,10 @@ class Conn {
   #writable;
 
   constructor(rid, remoteAddr, localAddr) {
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
     this.#remoteAddr = remoteAddr;
     this.#localAddr = localAddr;
@@ -201,12 +204,14 @@ class Conn {
 }
 
 class TcpConn extends Conn {
-  [internalRidSymbol] = 0;
   #rid = 0;
 
   constructor(rid, remoteAddr, localAddr) {
     super(rid, remoteAddr, localAddr);
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
   }
 
@@ -229,12 +234,14 @@ class TcpConn extends Conn {
 }
 
 class UnixConn extends Conn {
-  [internalRidSymbol] = 0;
   #rid = 0;
 
   constructor(rid, remoteAddr, localAddr) {
     super(rid, remoteAddr, localAddr);
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
   }
 
@@ -249,14 +256,16 @@ class UnixConn extends Conn {
 }
 
 class Listener {
-  [internalRidSymbol] = 0;
   #rid = 0;
   #addr = null;
   #unref = false;
   #promise = null;
 
   constructor(rid, addr) {
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
     this.#addr = addr;
   }

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -11,6 +11,7 @@ const {
 } = core.ensureFastOps();
 const {
   Number,
+  ObjectDefineProperty,
   TypeError,
 } = primordials;
 
@@ -25,12 +26,14 @@ function opTlsHandshake(rid) {
 }
 
 class TlsConn extends Conn {
-  [internalRidSymbol] = 0;
   #rid = 0;
 
   constructor(rid, remoteAddr, localAddr) {
     super(rid, remoteAddr, localAddr);
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
   }
 
@@ -78,12 +81,14 @@ async function connectTls({
 }
 
 class TlsListener extends Listener {
-  [internalRidSymbol] = 0;
   #rid = 0;
 
   constructor(rid, addr) {
     super(rid, addr);
-    this[internalRidSymbol] = rid;
+    ObjectDefineProperty(this, internalRidSymbol, {
+      enumerable: false,
+      value: rid,
+    });
     this.#rid = rid;
   }
 


### PR DESCRIPTION
Now these props will not show up when inspecting objects in console.