### PR TITLE
fix(runtime): return number from `op_ppid` instead of bigint

### DIFF
--- a/cli/tests/unit/os_test.ts
+++ b/cli/tests/unit/os_test.ts
@@ -158,10 +158,12 @@ Deno.test({ permissions: { env: true } }, function envInvalidChars() {
 });
 
 Deno.test(function osPid() {
+  assertEquals(typeof Deno.pid, "number");
   assert(Deno.pid > 0);
 });
 
 Deno.test(function osPpid() {
+  assertEquals(typeof Deno.ppid, "number");
   assert(Deno.ppid > 0);
 });
 

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -85,12 +85,12 @@ pub fn op_ppid() -> i32 {
       // wherein the parent process already exited and the OS
       // reassigned its ID.
       let parent_id = entry.th32ParentProcessID;
-      parent_id.into()
+      parent_id as i32
     }
   }
   #[cfg(not(windows))]
   {
     use std::os::unix::process::parent_id;
-    parent_id().into()
+    parent_id() as i32
   }
 }

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -32,8 +32,8 @@ fn op_main_module(state: &mut OpState) -> Result<String, AnyError> {
 /// This is an op instead of being done at initialization time because
 /// it's expensive to retrieve the ppid on Windows.
 #[op2(fast)]
-#[bigint]
-pub fn op_ppid() -> i64 {
+#[smi]
+pub fn op_ppid() -> u32 {
   #[cfg(windows)]
   {
     // Adopted from rustup:
@@ -84,13 +84,12 @@ pub fn op_ppid() -> i64 {
       // FIXME: Using the process ID exposes a race condition
       // wherein the parent process already exited and the OS
       // reassigned its ID.
-      let parent_id = entry.th32ParentProcessID;
-      parent_id.into()
+      entry.th32ParentProcessID
     }
   }
   #[cfg(not(windows))]
   {
     use std::os::unix::process::parent_id;
-    parent_id().into()
+    parent_id()
   }
 }

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -32,8 +32,8 @@ fn op_main_module(state: &mut OpState) -> Result<String, AnyError> {
 /// This is an op instead of being done at initialization time because
 /// it's expensive to retrieve the ppid on Windows.
 #[op2(fast)]
-#[smi]
-pub fn op_ppid() -> i32 {
+#[number]
+pub fn op_ppid() -> i64 {
   #[cfg(windows)]
   {
     // Adopted from rustup:
@@ -85,12 +85,12 @@ pub fn op_ppid() -> i32 {
       // wherein the parent process already exited and the OS
       // reassigned its ID.
       let parent_id = entry.th32ParentProcessID;
-      parent_id as i32
+      parent_id.into()
     }
   }
   #[cfg(not(windows))]
   {
     use std::os::unix::process::parent_id;
-    parent_id() as i32
+    parent_id().into()
   }
 }

--- a/runtime/ops/runtime.rs
+++ b/runtime/ops/runtime.rs
@@ -33,7 +33,7 @@ fn op_main_module(state: &mut OpState) -> Result<String, AnyError> {
 /// it's expensive to retrieve the ppid on Windows.
 #[op2(fast)]
 #[smi]
-pub fn op_ppid() -> u32 {
+pub fn op_ppid() -> i32 {
   #[cfg(windows)]
   {
     // Adopted from rustup:
@@ -84,12 +84,13 @@ pub fn op_ppid() -> u32 {
       // FIXME: Using the process ID exposes a race condition
       // wherein the parent process already exited and the OS
       // reassigned its ID.
-      entry.th32ParentProcessID
+      let parent_id = entry.th32ParentProcessID;
+      parent_id.into()
     }
   }
   #[cfg(not(windows))]
   {
     use std::os::unix::process::parent_id;
-    parent_id()
+    parent_id().into()
   }
 }


### PR DESCRIPTION
Fixes #22166 
