### PR TITLE
feat(ext/web): add typings for `ReadableStream.from`

### DIFF
--- a/ext/web/lib.deno_web.d.ts
+++ b/ext/web/lib.deno_web.d.ts
@@ -784,6 +784,7 @@ declare var ByteLengthQueuingStrategy: {
  */
 declare interface ReadableStream<R = any> {
   readonly locked: boolean;
+  from<T>(iterable: Iterable<T> | AsyncIterable<T>): ReadableStream<R>;
   cancel(reason?: any): Promise<void>;
   getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
   getReader(options?: { mode?: undefined }): ReadableStreamDefaultReader<R>;


### PR DESCRIPTION
fixes https://github.com/denoland/deno/issues/21981

This typing implementation goes well below.

```typescript
/// <reference no-default-lib="true" />
/// <reference lib="deno.web" />

function* iterable() {
  yield 1;
  yield 2;
  yield 3;
}

const asyncIterable = (async function* () {
  yield "a";
  yield "b";
  yield "c";
})();

const stream = ReadableStream.from(iterable());

for await (const value of stream) {
  console.log(value);
}

const asyncStream = ReadableStream.from(asyncIterable);

for await (const value of asyncStream) {
  console.log(value);
}
```

- https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/from_static