### PR TITLE
refactor: Use virtul ops module

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -28,11 +28,11 @@ const {
   isWeakMap,
   isWeakSet,
 } = core;
-const {
+import {
   op_get_constructor_name,
   op_get_non_index_property_names,
   op_preview_entries,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 const {
   Array,
   ArrayBufferPrototypeGetByteLength,

--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -13,13 +13,10 @@
 import { core, primordials } from "ext:core/mod.js";
 import {
   op_fetch,
+  op_fetch_send,
   op_wasm_streaming_feed,
   op_wasm_streaming_set_url,
 } from "ext:core/ops";
-// TODO(bartlomieju): this ops is also used in `ext/node/polyfills/http.ts`.
-const {
-  op_fetch_send,
-} = core.ensureFastOps(true);
 const {
   ArrayPrototypePush,
   ArrayPrototypeSplice,

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -6,7 +6,7 @@ const {
   isDataView,
   isTypedArray,
 } = core;
-const {
+import {
   op_ffi_buf_copy_into,
   op_ffi_call_nonblocking,
   op_ffi_call_ptr,
@@ -36,7 +36,7 @@ const {
   op_ffi_unsafe_callback_close,
   op_ffi_unsafe_callback_create,
   op_ffi_unsafe_callback_ref,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 const {
   ArrayBufferIsView,
   ArrayBufferPrototypeGetByteLength,

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -6,6 +6,7 @@ const {
   internalRidSymbol,
 } = core;
 import {
+  op_cancel_handle,
   op_fs_chdir,
   op_fs_chmod_async,
   op_fs_chmod_sync,
@@ -72,9 +73,6 @@ import {
   op_fs_write_file_async,
   op_fs_write_file_sync,
 } from "ext:core/ops";
-const {
-  op_cancel_handle,
-} = core.ensureFastOps(true);
 const {
   ArrayPrototypeFilter,
   Date,

--- a/ext/io/12_io.js
+++ b/ext/io/12_io.js
@@ -5,10 +5,7 @@
 // Thank you! We love Go! <3
 
 import { core, internals, primordials } from "ext:core/mod.js";
-const {
-  op_stdin_set_raw,
-  op_is_terminal,
-} = core.ensureFastOps(true);
+import { op_is_terminal, op_stdin_set_raw } from "ext:core/ops";
 const {
   Uint8Array,
   ArrayPrototypePush,

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -7,6 +7,7 @@ const {
   internalRidSymbol,
 } = core;
 import {
+  op_cancel_handle,
   op_dns_resolve,
   op_net_accept_tcp,
   op_net_accept_unix,
@@ -27,9 +28,6 @@ import {
   op_set_keepalive,
   op_set_nodelay,
 } from "ext:core/ops";
-const {
-  op_cancel_handle,
-} = core.ensureFastOps(true);
 const {
   Error,
   Number,

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -4,6 +4,7 @@
 
 import { core, internals, primordials } from "ext:core/mod.js";
 import {
+  op_napi_open,
   op_require_as_file_path,
   op_require_break_on_next_statement,
   op_require_init_paths,
@@ -16,6 +17,7 @@ import {
   op_require_path_is_absolute,
   op_require_path_resolve,
   op_require_proxy_path,
+  op_require_read_closest_package_json,
   op_require_read_file,
   op_require_read_package_scope,
   op_require_real_path,
@@ -26,10 +28,6 @@ import {
   op_require_try_self,
   op_require_try_self_parent_path,
 } from "ext:core/ops";
-const {
-  op_napi_open,
-  op_require_read_closest_package_json,
-} = core.ensureFastOps(true);
 const {
   ArrayIsArray,
   ArrayPrototypeIncludes,

--- a/ext/node/polyfills/_util/os.ts
+++ b/ext/node/polyfills/_util/os.ts
@@ -1,9 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
-const {
-  op_node_build_os,
-} = core.ensureFastOps(true);
+import { op_node_build_os } from "ext:core/ops";
 
 export type OSType =
   | "windows"

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -6,14 +6,12 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { core, internals } from "ext:core/mod.js";
+import { internals } from "ext:core/mod.js";
 import {
   op_bootstrap_unstable_args,
   op_node_child_ipc_pipe,
-} from "ext:core/ops";
-const {
   op_npm_process_state,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 
 import {
   ChildProcess,

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -4,11 +4,11 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { core } from "ext:core/mod.js";
-import { op_fetch_response_upgrade, op_node_http_request } from "ext:core/ops";
-// TODO(bartlomieju): this ops is also used in `ext/fetch/26_fetch.js`.
-const {
+import {
+  op_fetch_response_upgrade,
   op_fetch_send,
-} = core.ensureFastOps(true);
+  op_node_http_request,
+} from "ext:core/ops";
 
 import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { setTimeout } from "ext:deno_web/02_timers.js";

--- a/ext/node/polyfills/internal/console/constructor.mjs
+++ b/ext/node/polyfills/internal/console/constructor.mjs
@@ -4,10 +4,7 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { core } from "ext:core/mod.js";
-const {
-  op_preview_entries,
-} = core.ensureFastOps(true);
+import { op_preview_entries } from "ext:core/ops";
 
 // Mock trace for now
 const trace = () => {};

--- a/ext/node/polyfills/internal/crypto/_randomFill.mjs
+++ b/ext/node/polyfills/internal/crypto/_randomFill.mjs
@@ -3,11 +3,10 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { core } from "ext:core/mod.js";
-const {
+import {
   op_node_generate_secret,
   op_node_generate_secret_async,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 
 import {
   MAX_SIZE as kMaxUint32,

--- a/ext/node/polyfills/internal/crypto/diffiehellman.ts
+++ b/ext/node/polyfills/internal/crypto/diffiehellman.ts
@@ -4,17 +4,14 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { core } from "ext:core/mod.js";
 import {
   op_node_dh_compute_secret,
   op_node_dh_generate2,
   op_node_ecdh_compute_public_key,
   op_node_ecdh_compute_secret,
   op_node_ecdh_generate_keys,
-} from "ext:core/ops";
-const {
   op_node_gen_prime,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import {

--- a/ext/node/polyfills/internal/crypto/keygen.ts
+++ b/ext/node/polyfills/internal/crypto/keygen.ts
@@ -29,7 +29,6 @@ import {
 import { Buffer } from "node:buffer";
 import { KeyFormat, KeyType } from "ext:deno_node/internal/crypto/types.ts";
 
-import { core } from "ext:core/mod.js";
 import {
   op_node_dh_generate,
   op_node_dh_generate_async,
@@ -43,13 +42,11 @@ import {
   op_node_ed25519_generate_async,
   op_node_generate_rsa,
   op_node_generate_rsa_async,
+  op_node_generate_secret,
+  op_node_generate_secret_async,
   op_node_x25519_generate,
   op_node_x25519_generate_async,
 } from "ext:core/ops";
-const {
-  op_node_generate_secret,
-  op_node_generate_secret_async,
-} = core.ensureFastOps(true);
 
 function validateGenerateKey(
   type: "hmac" | "aes",

--- a/ext/node/polyfills/internal/crypto/random.ts
+++ b/ext/node/polyfills/internal/crypto/random.ts
@@ -4,17 +4,15 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { core, primordials } from "ext:core/mod.js";
+import { primordials } from "ext:core/mod.js";
 import {
   op_node_check_prime,
   op_node_check_prime_async,
   op_node_check_prime_bytes,
   op_node_check_prime_bytes_async,
+  op_node_gen_prime,
   op_node_gen_prime_async,
 } from "ext:core/ops";
-const {
-  op_node_gen_prime,
-} = core.ensureFastOps(true);
 const {
   StringPrototypePadStart,
   StringPrototypeToString,

--- a/ext/node/polyfills/internal_binding/constants.ts
+++ b/ext/node/polyfills/internal_binding/constants.ts
@@ -1,9 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
-const {
-  op_node_build_os,
-} = core.ensureFastOps(true);
+import { op_node_build_os } from "ext:core/ops";
 
 let os: {
   dlopen: {

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -5,10 +5,7 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { core, internals } from "ext:core/mod.js";
-import { op_geteuid, op_process_abort } from "ext:core/ops";
-const {
-  op_set_exit_code,
-} = core.ensureFastOps(true);
+import { op_geteuid, op_process_abort, op_set_exit_code } from "ext:core/ops";
 
 import { notImplemented, warnNotImplemented } from "ext:deno_node/_utils.ts";
 import { EventEmitter } from "node:events";

--- a/ext/node/polyfills/tty.js
+++ b/ext/node/polyfills/tty.js
@@ -1,12 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
+import { primordials } from "ext:core/mod.js";
 const {
   Error,
 } = primordials;
-const {
-  op_is_terminal,
-} = core.ensureFastOps(true);
+import { op_is_terminal } from "ext:core/ops";
 
 import { ERR_INVALID_FD } from "ext:deno_node/internal/errors.ts";
 import { LibuvStreamWrap } from "ext:deno_node/internal_binding/stream_wrap.ts";

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -5,9 +5,7 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { core, internals } from "ext:core/mod.js";
-const {
-  op_require_read_closest_package_json,
-} = core.ensureFastOps(true);
+import { op_require_read_closest_package_json } from "ext:core/ops";
 
 import { isAbsolute, resolve } from "node:path";
 import { notImplemented } from "ext:deno_node/_utils.ts";

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -15,6 +15,8 @@ const {
 } = core;
 import {
   op_arraybuffer_was_detached,
+  // TODO(mmastrac): use readAll
+  op_read_all,
   op_readable_stream_resource_allocate,
   op_readable_stream_resource_allocate_sized,
   op_readable_stream_resource_await_close,
@@ -25,10 +27,6 @@ import {
   op_readable_stream_resource_write_sync,
   op_transfer_arraybuffer,
 } from "ext:core/ops";
-const {
-  // TODO(mmastrac): use readAll
-  op_read_all,
-} = core.ensureFastOps(true);
 const {
   ArrayBuffer,
   ArrayBufferIsView,

--- a/ext/webgpu/00_init.js
+++ b/ext/webgpu/00_init.js
@@ -1,9 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core } from "ext:core/mod.js";
-const {
-  op_lazy_load_esm,
-} = core.ensureFastOps(true);
+import { op_lazy_load_esm } from "ext:core/ops";
 
 let webgpu;
 

--- a/runtime/js/40_tty.js
+++ b/runtime/js/40_tty.js
@@ -1,9 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { core, internals, primordials } from "ext:core/mod.js";
-const {
-  op_console_size,
-  op_is_terminal,
-} = core.ensureFastOps(true);
+import { internals, primordials } from "ext:core/mod.js";
+import { op_console_size, op_is_terminal } from "ext:core/ops";
 const {
   Uint32Array,
 } = primordials;

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { core } from "ext:core/mod.js";
+import { op_lazy_load_esm } from "ext:core/ops";
 
 import * as util from "ext:runtime/06_util.js";
 import * as event from "ext:deno_web/02_event.js";
@@ -35,7 +36,6 @@ import { webgpu, webGPUNonEnumerable } from "ext:deno_webgpu/00_init.js";
 import * as webgpuSurface from "ext:deno_webgpu/02_surface.js";
 import { unstableIds } from "ext:runtime/90_deno_ns.js";
 
-const { op_lazy_load_esm } = core.ensureFastOps(true);
 let image;
 
 function ImageNonEnumerable(getter) {

--- a/runtime/js/98_global_scope_window.js
+++ b/runtime/js/98_global_scope_window.js
@@ -1,11 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
-const {
+import { primordials } from "ext:core/mod.js";
+import {
   op_bootstrap_language,
   op_bootstrap_numcpus,
   op_bootstrap_user_agent,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 const {
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,

--- a/runtime/js/98_global_scope_worker.js
+++ b/runtime/js/98_global_scope_worker.js
@@ -1,11 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
-const {
+import { primordials } from "ext:core/mod.js";
+import {
   op_bootstrap_language,
   op_bootstrap_numcpus,
   op_bootstrap_user_agent,
-} = core.ensureFastOps(true);
+} from "ext:core/ops";
 const {
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,


### PR DESCRIPTION
Follow up to #22157.

This leaves us with 4 usages of `ensureFastOps()` in `deno` itself. There's also about 150 usages of `Deno.core.ops.<op_name>` left as well.