### PR TITLE
fix(lsp): don't normalize urls in cache command params

### DIFF
--- a/cli/lsp/lsp_custom.rs
+++ b/cli/lsp/lsp_custom.rs
@@ -4,25 +4,11 @@ use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
 use tower_lsp::lsp_types as lsp;
 
-pub const CACHE_REQUEST: &str = "deno/cache";
 pub const PERFORMANCE_REQUEST: &str = "deno/performance";
 pub const TASK_REQUEST: &str = "deno/taskDefinitions";
-pub const RELOAD_IMPORT_REGISTRIES_REQUEST: &str =
-  "deno/reloadImportRegistries";
 pub const VIRTUAL_TEXT_DOCUMENT: &str = "deno/virtualTextDocument";
 pub const LATEST_DIAGNOSTIC_BATCH_INDEX: &str =
   "deno/internalLatestDiagnosticBatchIndex";
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CacheParams {
-  /// The document currently open in the editor.  If there are no `uris`
-  /// supplied, the referrer will be cached.
-  pub referrer: lsp::TextDocumentIdentifier,
-  /// Any documents that have been specifically asked to be cached via the
-  /// command.
-  pub uris: Vec<lsp::TextDocumentIdentifier>,
-}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -48,19 +48,9 @@ pub async fn start() -> Result<(), AnyError> {
       token.clone(),
     )
   })
-  // TODO(nayeemrmn): The extension has replaced this with the `deno.cache`
-  // command as of vscode_deno 3.21.0 / 2023.09.05. Remove this eventually.
-  .custom_method(lsp_custom::CACHE_REQUEST, LanguageServer::cache_request)
   .custom_method(
     lsp_custom::PERFORMANCE_REQUEST,
     LanguageServer::performance_request,
-  )
-  // TODO(nayeemrmn): The extension has replaced this with the
-  // `deno.reloadImportRegistries` command as of vscode_deno
-  // 3.26.0 / 2023.10.10. Remove this eventually.
-  .custom_method(
-    lsp_custom::RELOAD_IMPORT_REGISTRIES_REQUEST,
-    LanguageServer::reload_import_registries_request,
   )
   .custom_method(lsp_custom::TASK_REQUEST, LanguageServer::task_definitions)
   // TODO(nayeemrmn): Rename this to `deno/taskDefinitions` in vscode_deno and


### PR DESCRIPTION
Fixes #22122. We shouldn't do this normalization because the params to the cache command come from the server's quick-fixes and are never denormalized to client URLs in the first place. It was causing a faulty memoization in the URL mapper.

BTW the fix is a one line change removing the `normalize_url()` call from https://github.com/denoland/deno/blob/v1.40.2/cli/lsp/language_server.rs#L3723. But I cleaned up the param types across the cache command helpers to make it clear that these are actual module specifiers, not client URLs. Also removed some old custom requests that were moved to commands.