### PR TITLE
ci: fix failing upgrade_prompt test on main

### DIFF
--- a/test_util/src/servers/mod.rs
+++ b/test_util/src/servers/mod.rs
@@ -1056,7 +1056,15 @@ async fn main_server(
           .unwrap(),
       );
     }
-    (&Method::GET, "/canary-latest.txt") => {
+    (
+      &Method::GET,
+      "/canary-latest.txt"
+      | "/canary-x86_64-apple-darwin-latest.txt"
+      | "/canary-aarch64-apple-darwin-latest.txt"
+      | "/canary-x86_64-unknown-linux-latest.txt"
+      | "/canary-aarch64-unknown-linux-latest.txt"
+      | "/canary-x86_64-pc-windows-msvc-latest.txt",
+    ) => {
       return Ok(
         Response::builder()
           .status(StatusCode::OK)


### PR DESCRIPTION
Understandably accidentally caused by https://github.com/denoland/deno/pull/22187