### PR TITLE
ci: run macos aarch64 builds on PRs and main

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -140,7 +140,7 @@ const reconfigureWindowsStorage = {
   if: [
     "matrix.os == 'windows' &&",
     "!endsWith(matrix.runner, '-xl')",
-  ],
+  ].join("\n"),
   shell: "pwsh",
   run: `
 New-Item -ItemType "directory" -Path "$env:TEMP/__target__"

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -992,7 +992,8 @@ const ci = {
           name: "Save cache build output (main)",
           uses: "actions/cache/save@v3",
           if:
-            "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
+            // TODO(@lucacasonato): revert before landing
+            "(matrix.job == 'test' || matrix.job == 'lint')", // && github.ref == 'refs/heads/main'",
           with: {
             path: [
               "./target",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -7,29 +7,50 @@ import * as yaml from "https://deno.land/std@0.173.0/encoding/yaml.ts";
 // automatically via regex, so ensure that this line maintains this format.
 const cacheVersion = 72;
 
-const ubuntuRunner = "ubuntu-22.04";
-const ubuntuXlRunner = "ubuntu-22.04-xl";
-const windowsRunner = "windows-2022";
-const windowsXlRunner = "windows-2022-xl";
+const ubuntuX86Runner = "ubuntu-22.04";
+const ubuntuX86XlRunner = "ubuntu-22.04-xl";
+const windowsX86Runner = "windows-2022";
+const windowsX86XlRunner = "windows-2022-xl";
 const macosX86Runner = "macos-12";
-// https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
-const macosArmRunner = "macos-13-xlarge";
+const macosArmRunner = "macos-14";
 
-const Runners = (() => {
-  return {
-    ubuntuXl:
-      `\${{ github.repository == 'denoland/deno' && '${ubuntuXlRunner}' || '${ubuntuRunner}' }}`,
-    ubuntu: ubuntuRunner,
-    linux: ubuntuRunner,
-    macos: macosX86Runner,
-    macosArm: macosArmRunner,
-    windows: windowsRunner,
-    windowsXl:
-      `\${{ github.repository == 'denoland/deno' && '${windowsXlRunner}' || '${windowsRunner}' }}`,
-  };
-})();
+const Runners = {
+  linuxX86: {
+    os: "linux",
+    arch: "x86_64",
+    runner: ubuntuX86Runner,
+  },
+  linuxX86Xl: {
+    os: "linux",
+    arch: "x86_64",
+    runner:
+      `\${{ github.repository == 'denoland/deno' && '${ubuntuX86XlRunner}' || '${ubuntuX86Runner}' }}`,
+  },
+  macosX86: {
+    os: "macos",
+    arch: "x86_64",
+    runner: macosX86Runner,
+  },
+  macosArm: {
+    os: "macos",
+    arch: "aarch64",
+    runner: macosArmRunner,
+  },
+  windowsX86: {
+    os: "windows",
+    arch: "x86_64",
+    runner: windowsX86Runner,
+  },
+  windowsX86Xl: {
+    os: "windows",
+    arch: "x86_64",
+    runner:
+      `\${{ github.repository == 'denoland/deno' && '${windowsX86XlRunner}' || '${windowsX86Runner}' }}`,
+  },
+} as const;
+
 const prCacheKeyPrefix =
-  `${cacheVersion}-cargo-target-\${{ matrix.os }}-\${{ matrix.profile }}-\${{ matrix.job }}-`;
+  `${cacheVersion}-cargo-target-\${{ matrix.os }}-\${{ matrix.arch }}-\${{ matrix.profile }}-\${{ matrix.job }}-`;
 
 // Note that you may need to add more version to the `apt-get remove` line below if you change this
 const llvmVersion = 16;
@@ -117,7 +138,8 @@ const installBenchTools = "./tools/install_prebuilt.js wrk hyperfine";
 const reconfigureWindowsStorage = {
   name: "Reconfigure Windows Storage",
   if: [
-    "startsWith(matrix.os, 'windows') && !endsWith(matrix.os, '-xl')",
+    "matrix.os == 'windows' &&",
+    "!endsWith(matrix.runner, '-xl')",
   ],
   shell: "pwsh",
   run: `
@@ -158,7 +180,7 @@ const installPythonSteps = [{
   with: { "python-version": 3.11 },
 }, {
   name: "Remove unused versions of Python",
-  if: "startsWith(matrix.os, 'windows')",
+  if: "matrix.os == 'windows'",
   shell: "pwsh",
   run: [
     '$env:PATH -split ";" |',
@@ -240,26 +262,14 @@ function removeSurroundingExpression(text: string) {
 function handleMatrixItems(items: {
   skip_pr?: string | true;
   skip?: string;
-  os: string;
+  os: "linux" | "macos" | "windows";
+  arch: "x86_64" | "aarch64";
+  runner: string;
   profile?: string;
   job?: string;
   use_sysroot?: boolean;
   wpt?: string;
 }[]) {
-  function getOsDisplayName(os: string) {
-    if (os.includes("ubuntu")) {
-      return "ubuntu-x86_64";
-    } else if (os.includes("windows")) {
-      return "windows-x86_64";
-    } else if (os == macosX86Runner) {
-      return "macos-x86_64";
-    } else if (os == macosArmRunner) {
-      return "macos-aarch64";
-    } else {
-      throw new Error(`Display name not found: ${os}`);
-    }
-  }
-
   return items.map((item) => {
     // use a free "ubuntu" runner on jobs that are skipped
 
@@ -275,24 +285,21 @@ function handleMatrixItems(items: {
     }
 
     if (typeof item.skip === "string") {
-      let text =
+      let runner =
         "${{ (!contains(github.event.pull_request.labels.*.name, 'ci-full') && (";
-      text += removeSurroundingExpression(item.skip.toString()) + ")) && ";
-      text += `'${Runners.ubuntu}' || ${
-        removeSurroundingExpression(item.os)
+      runner += removeSurroundingExpression(item.skip.toString()) + ")) && ";
+      runner += `'${ubuntuX86Runner}' || ${
+        removeSurroundingExpression(item.runner)
       } }}`;
 
       // deno-lint-ignore no-explicit-any
-      (item as any).runner = text;
+      (item as any).runner = runner;
       item.skip =
         "${{ !contains(github.event.pull_request.labels.*.name, 'ci-full') && (" +
         removeSurroundingExpression(item.skip.toString()) + ") }}";
     }
 
-    return {
-      ...item,
-      os_display_name: getOsDisplayName(item.os),
-    };
+    return { ...item };
   });
 }
 
@@ -342,10 +349,10 @@ const ci = {
     },
     build: {
       name:
-        "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os_display_name }}",
+        "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}",
       needs: ["pre_build"],
       if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
-      "runs-on": "${{ matrix.runner || matrix.os }}",
+      "runs-on": "${{ matrix.runner }}",
       "timeout-minutes": 120,
       defaults: {
         run: {
@@ -357,32 +364,34 @@ const ci = {
       strategy: {
         matrix: {
           include: handleMatrixItems([{
-            os: Runners.macos,
+            ...Runners.macosX86,
             job: "test",
             profile: "debug",
           }, {
-            os: Runners.macos,
+            ...Runners.macosX86,
             job: "test",
             profile: "release",
             skip_pr: true,
           }, {
-            os: Runners.macosArm,
-            job: "test",
-            profile: "release",
-            // TODO(mmastrac): We don't want to run this M1 runner on every main commit because of the expense.
-            skip:
-              "${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}",
-          }, {
-            os: Runners.windows,
+            ...Runners.macosArm,
             job: "test",
             profile: "debug",
           }, {
-            os: Runners.windowsXl,
+            ...Runners.macosArm,
             job: "test",
             profile: "release",
             skip_pr: true,
           }, {
-            os: Runners.ubuntuXl,
+            ...Runners.windowsX86,
+            job: "test",
+            profile: "debug",
+          }, {
+            ...Runners.windowsX86Xl,
+            job: "test",
+            profile: "release",
+            skip_pr: true,
+          }, {
+            ...Runners.linuxX86Xl,
             job: "test",
             profile: "release",
             use_sysroot: true,
@@ -390,27 +399,27 @@ const ci = {
             // currently run the Web Platform tests only on Linux.
             wpt: "${{ !startsWith(github.ref, 'refs/tags/') }}",
           }, {
-            os: Runners.ubuntuXl,
+            ...Runners.linuxX86Xl,
             job: "bench",
             profile: "release",
             use_sysroot: true,
             skip_pr:
               "${{ !contains(github.event.pull_request.labels.*.name, 'ci-bench') }}",
           }, {
-            os: Runners.ubuntu,
+            ...Runners.linuxX86,
             job: "test",
             profile: "debug",
             use_sysroot: true,
           }, {
-            os: Runners.ubuntu,
+            ...Runners.linuxX86,
             job: "lint",
             profile: "debug",
           }, {
-            os: Runners.macos,
+            ...Runners.macosX86,
             job: "lint",
             profile: "debug",
           }, {
-            os: Runners.windows,
+            ...Runners.windowsX86,
             job: "lint",
             profile: "debug",
           }]),
@@ -439,12 +448,12 @@ const ci = {
         },
         {
           ...submoduleStep("./tools/node_compat/node"),
-          if: "matrix.job == 'lint' && startsWith(matrix.os, 'ubuntu')",
+          if: "matrix.job == 'lint' && matrix.os == 'linux'",
         },
         {
           name: "Create source tarballs (release, linux)",
           if: [
-            "startsWith(matrix.os, 'ubuntu') &&",
+            "matrix.os == 'linux' &&",
             "matrix.profile == 'release' &&",
             "matrix.job == 'test' &&",
             "github.repository == 'denoland/deno' &&",
@@ -484,7 +493,7 @@ const ci = {
         {
           name: "Setup gcloud (unix)",
           if: [
-            "runner.os != 'Windows' &&",
+            "matrix.os == 'windows' &&",
             "matrix.profile == 'release' &&",
             "matrix.job == 'test' &&",
             "github.repository == 'denoland/deno' &&",
@@ -499,7 +508,7 @@ const ci = {
         {
           name: "Setup gcloud (windows)",
           if: [
-            "runner.os == 'Windows' &&",
+            "matrix.os == 'windows' &&",
             "matrix.profile == 'release' &&",
             "matrix.job == 'test' &&",
             "github.repository == 'denoland/deno' &&",
@@ -529,11 +538,11 @@ const ci = {
           ...sysRootStep,
         },
         {
-          name: "Install aarch64 lld",
+          name: "Install macOS aarch64 lld",
           run: [
             "./tools/install_prebuilt.js ld64.lld",
           ].join("\n"),
-          if: `matrix.os == '${macosArmRunner}'`,
+          if: `matrix.os == 'macos' && matrix.arch == 'aarch64'`,
         },
         {
           name: "Install rust-codesign",
@@ -541,8 +550,7 @@ const ci = {
             "./tools/install_prebuilt.js rcodesign",
             "echo $GITHUB_WORKSPACE/third_party/prebuilt/mac >> $GITHUB_PATH",
           ].join("\n"),
-          if:
-            `(matrix.os == '${macosArmRunner}' || matrix.os == '${macosX86Runner}')`,
+          if: `matrix.os == 'macos'`,
         },
         {
           name: "Log versions",
@@ -575,9 +583,10 @@ const ci = {
               "~/.cargo/registry/cache",
             ].join("\n"),
             key:
-              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ hashFiles('Cargo.lock') }}`,
+              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}-\${{ hashFiles('Cargo.lock') }}`,
             // We will try to restore from the closest cargo-home we can find
-            "restore-keys": `${cacheVersion}-cargo-home-\${{ matrix.os }}`,
+            "restore-keys":
+              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}`,
           },
         },
         {
@@ -607,14 +616,14 @@ const ci = {
         },
         {
           name: "test_format.js",
-          if: "matrix.job == 'lint' && startsWith(matrix.os, 'ubuntu')",
+          if: "matrix.job == 'lint' && matrix.os == 'linux'",
           run:
             "deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check",
         },
         {
           name: "Lint PR title",
           if:
-            "matrix.job == 'lint' && github.event_name == 'pull_request' && startsWith(matrix.os, 'ubuntu')",
+            "matrix.job == 'lint' && github.event_name == 'pull_request' && matrix.os == 'linux'",
           env: {
             PR_TITLE: "${{ github.event.pull_request.title }}",
           },
@@ -628,7 +637,7 @@ const ci = {
         },
         {
           name: "node_compat/setup.ts --check",
-          if: "matrix.job == 'lint' && startsWith(matrix.os, 'ubuntu')",
+          if: "matrix.job == 'lint' && matrix.os == 'linux'",
           run:
             "deno run --allow-write --allow-read --allow-run=git ./tools/node_compat/setup.ts --check",
         },
@@ -675,21 +684,21 @@ const ci = {
         {
           name: "Pre-release (linux)",
           if: [
-            "startsWith(matrix.os, 'ubuntu') &&",
+            "matrix.os == 'linux' &&",
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno'",
           ].join("\n"),
           run: [
             "cd target/release",
-            "zip -r deno-x86_64-unknown-linux-gnu.zip deno",
+            "zip -r deno-${{ matrix.arch }}-unknown-linux-gnu.zip deno",
             "./deno types > lib.deno.d.ts",
           ].join("\n"),
         },
         {
-          name: "Pre-release (mac intel)",
+          name: "Pre-release (mac)",
           if: [
-            `matrix.os == '${macosX86Runner}' &&`,
+            `matrix.os == 'macos' &&`,
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno'",
@@ -706,45 +715,21 @@ const ci = {
             "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " +
             "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",
-            "zip -r deno-x86_64-apple-darwin.zip deno",
-          ]
-            .join("\n"),
-        },
-        {
-          name: "Pre-release (mac aarch64)",
-          if: [
-            `matrix.os == '${macosArmRunner}' &&`,
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "github.repository == 'denoland/deno'",
-          ].join("\n"),
-          env: {
-            "APPLE_CODESIGN_KEY": "${{ secrets.APPLE_CODESIGN_KEY }}",
-            "APPLE_CODESIGN_PASSWORD": "${{ secrets.APPLE_CODESIGN_PASSWORD }}",
-          },
-          run: [
-            'echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"',
-            "rcodesign sign target/release/deno " +
-            "--code-signature-flags=runtime " +
-            '--p12-password="$APPLE_CODESIGN_PASSWORD" ' +
-            "--p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) " +
-            "--entitlements-xml-file=cli/entitlements.plist",
-            "cd target/release",
-            "zip -r deno-aarch64-apple-darwin.zip deno",
+            "zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno",
           ]
             .join("\n"),
         },
         {
           name: "Pre-release (windows)",
           if: [
-            "startsWith(matrix.os, 'windows') &&",
+            "matrix.os == 'windows' &&",
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno'",
           ].join("\n"),
           shell: "pwsh",
           run:
-            "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip",
+            "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip",
         },
         {
           name: "Upload canary to dl.deno.land",
@@ -757,32 +742,38 @@ const ci = {
           run: [
             'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
             "echo ${{ github.sha }} > canary-latest.txt",
-            'gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt',
+            'gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-${{ matrix.arch }}-latest.txt',
           ].join("\n"),
         },
         {
           name: "Autobahn testsuite",
           if: [
-            "matrix.job == 'test' && matrix.profile == 'release' &&",
-            "!startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')",
+            "matrix.os == 'linux' &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
+            "!startsWith(github.ref, 'refs/tags/')",
           ].join("\n"),
           run:
             "target/release/deno run -A --unstable ext/websocket/autobahn/fuzzingclient.js",
         },
         {
-          name: "Test debug",
+          name: "Test (full, debug)",
           if: [
-            "matrix.job == 'test' && matrix.profile == 'debug' &&",
-            "!startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu')",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'debug' &&",
+            "!startsWith(github.ref, 'refs/tags/') &&",
+            // Run full tests only on Linux.
+            "matrix.os == 'linux'",
           ].join("\n"),
           run: "cargo test --locked",
           env: { CARGO_PROFILE_DEV_DEBUG: 0 },
         },
         {
-          name: "Test debug (fast)",
+          name: "Test (fast, debug)",
           if: [
-            "matrix.job == 'test' && matrix.profile == 'debug' &&",
-            "(startsWith(github.ref, 'refs/tags/') || !startsWith(matrix.os, 'ubuntu'))",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'debug' &&",
+            "(startsWith(github.ref, 'refs/tags/') || matrix.os != 'linux')",
           ].join("\n"),
           run: [
             // Run unit then integration tests. Skip doc tests here
@@ -793,9 +784,10 @@ const ci = {
           env: { CARGO_PROFILE_DEV_DEBUG: 0 },
         },
         {
-          name: "Test release",
+          name: "Test (release)",
           if: [
-            "matrix.job == 'test' && matrix.profile == 'release' &&",
+            "matrix.job == 'test' &&",
+            "matrix.profile == 'release' &&",
             "(matrix.use_sysroot || (",
             "github.repository == 'denoland/deno' &&",
             "!startsWith(github.ref, 'refs/tags/')))",
@@ -867,7 +859,7 @@ const ci = {
           "continue-on-error": true,
           if: [
             "matrix.wpt &&",
-            "runner.os == 'Linux' &&",
+            "matrix.os == 'linux' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno' &&",
             "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
@@ -885,7 +877,7 @@ const ci = {
           "continue-on-error": true,
           if: [
             "matrix.wpt &&",
-            "runner.os == 'Linux' &&",
+            "matrix.os == 'linux' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno' &&",
             "github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
@@ -949,7 +941,7 @@ const ci = {
         {
           name: "Upload release to dl.deno.land (unix)",
           if: [
-            "runner.os != 'Windows' &&",
+            "matrix.os != 'windows' &&",
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno' &&",
@@ -961,7 +953,7 @@ const ci = {
         {
           name: "Upload release to dl.deno.land (windows)",
           if: [
-            "runner.os == 'Windows' &&",
+            "matrix.os == 'windows' &&",
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno' &&",
@@ -1031,7 +1023,7 @@ const ci = {
     },
     "publish-canary": {
       name: "publish canary",
-      "runs-on": "ubuntu-22.04",
+      "runs-on": ubuntuX86Runner,
       needs: ["build"],
       if:
         "github.repository == 'denoland/deno' && github.ref == 'refs/heads/main'",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -336,7 +336,7 @@ const ci = {
       name:
         "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}",
       needs: ["pre_build"],
-      if: "${{ needs.pre_build.outputs.skip_build != 'true' && !(matrix.skip) }}",
+      if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
       "runs-on": "${{ matrix.runner }}",
       "timeout-minutes": 120,
       defaults: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -133,21 +133,6 @@ __0`,
 
 const installBenchTools = "./tools/install_prebuilt.js wrk hyperfine";
 
-// The Windows builder is a little strange -- there's lots of room on C: and not so much on D:
-// We'll check out to D:, but then all of our builds should happen on a C:-mapped drive
-const reconfigureWindowsStorage = {
-  name: "Reconfigure Windows Storage",
-  if: [
-    "matrix.os == 'windows' &&",
-    "!endsWith(matrix.runner, '-xl')",
-  ].join("\n"),
-  shell: "pwsh",
-  run: `
-New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno"
-`.trim(),
-};
-
 const cloneRepoStep = [{
   name: "Configure git",
   run: [
@@ -351,7 +336,7 @@ const ci = {
       name:
         "${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}",
       needs: ["pre_build"],
-      if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
+      if: "${{ needs.pre_build.outputs.skip_build != 'true' && !(matrix.skip) }}",
       "runs-on": "${{ matrix.runner }}",
       "timeout-minutes": 120,
       defaults: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -439,7 +439,6 @@ const ci = {
         RUST_LIB_BACKTRACE: 0,
       },
       steps: skipJobsIfPrAndMarkedSkip([
-        reconfigureWindowsStorage,
         ...cloneRepoStep,
         submoduleStep("./test_util/std"),
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
           draft: true
       - name: Save cache build output (main)
         uses: actions/cache/save@v3
-        if: '!(matrix.skip) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'')'
+        if: '!(matrix.skip) && ((matrix.job == ''test'' || matrix.job == ''lint''))'
         with:
           path: |-
             ./target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}'
     needs:
       - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build != ''true'' && !(matrix.skip) }}'
+    if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
     runs-on: '${{ matrix.runner }}'
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}'
     needs:
       - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
+    if: '${{ needs.pre_build.outputs.skip_build != ''true'' && !(matrix.skip) }}'
     runs-on: '${{ matrix.runner }}'
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,14 +127,6 @@ jobs:
       RUST_BACKTRACE: full
       RUST_LIB_BACKTRACE: 0
     steps:
-      - name: Reconfigure Windows Storage
-        if: |-
-          !(matrix.skip) && (matrix.os == 'windows' &&
-          !endsWith(matrix.runner, '-xl'))
-        shell: pwsh
-        run: |-
-          New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
-          New-Item -ItemType Junction -Target "$env:TEMP/__target__" -Path "D:/a/deno/deno"
       - name: Configure git
         run: |-
           git config --global core.symlinks true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,9 @@ jobs:
       RUST_LIB_BACKTRACE: 0
     steps:
       - name: Reconfigure Windows Storage
-        if: '!(matrix.skip) && (matrix.os == ''windows'' &&,!endsWith(matrix.runner, ''-xl''))'
+        if: |-
+          !(matrix.skip) && (matrix.os == 'windows' &&
+          !endsWith(matrix.runner, '-xl'))
         shell: pwsh
         run: |-
           New-Item -ItemType "directory" -Path "$env:TEMP/__target__"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
           echo $GIT_MESSAGE | grep '\[ci\]' || (echo 'Exiting due to draft PR. Commit with [ci] to bypass.' ; echo 'skip_build=true' >> $GITHUB_OUTPUT)
         if: github.event.pull_request.draft == true
   build:
-    name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os_display_name }}'
+    name: '${{ matrix.job }} ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}'
     needs:
       - pre_build
     if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
-    runs-on: '${{ matrix.runner || matrix.os }}'
+    runs-on: '${{ matrix.runner }}'
     timeout-minutes: 120
     defaults:
       run:
@@ -53,62 +53,74 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-12
+          - os: macos
+            arch: x86_64
+            runner: macos-12
             job: test
             profile: debug
-            os_display_name: macos-x86_64
-          - os: macos-12
-            job: test
-            profile: release
-            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
+          - os: macos
+            arch: x86_64
             runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || ''macos-12'' }}'
-            os_display_name: macos-x86_64
-          - os: macos-13-xlarge
-            job: test
-            profile: release
-            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' || github.ref == ''refs/heads/main'') }}'
-            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' || github.ref == ''refs/heads/main'')) && ''ubuntu-22.04'' || ''macos-13-xlarge'' }}'
-            os_display_name: macos-aarch64
-          - os: windows-2022
-            job: test
-            profile: debug
-            os_display_name: windows-x86_64
-          - os: '${{ github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
             job: test
             profile: release
             skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
+          - os: macos
+            arch: aarch64
+            runner: macos-14
+            job: test
+            profile: debug
+          - os: macos
+            arch: aarch64
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || ''macos-14'' }}'
+            job: test
+            profile: release
+            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
+          - os: windows
+            arch: x86_64
+            runner: windows-2022
+            job: test
+            profile: debug
+          - os: windows
+            arch: x86_64
             runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''windows-2022-xl'' || ''windows-2022'' }}'
-            os_display_name: windows-x86_64
-          - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
+            job: test
+            profile: release
+            skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
+          - os: linux
+            arch: x86_64
+            runner: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: test
             profile: release
             use_sysroot: true
             wpt: '${{ !startsWith(github.ref, ''refs/tags/'') }}'
-            os_display_name: ubuntu-x86_64
-          - os: '${{ github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
+          - os: linux
+            arch: x86_64
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench''))) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
             job: bench
             profile: release
             use_sysroot: true
             skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench'')) }}'
-            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench''))) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''ubuntu-22.04-xl'' || ''ubuntu-22.04'' }}'
-            os_display_name: ubuntu-x86_64
-          - os: ubuntu-22.04
+          - os: linux
+            arch: x86_64
+            runner: ubuntu-22.04
             job: test
             profile: debug
             use_sysroot: true
-            os_display_name: ubuntu-x86_64
-          - os: ubuntu-22.04
+          - os: linux
+            arch: x86_64
+            runner: ubuntu-22.04
             job: lint
             profile: debug
-            os_display_name: ubuntu-x86_64
-          - os: macos-12
+          - os: macos
+            arch: x86_64
+            runner: macos-12
             job: lint
             profile: debug
-            os_display_name: macos-x86_64
-          - os: windows-2022
+          - os: windows
+            arch: x86_64
+            runner: windows-2022
             job: lint
             profile: debug
-            os_display_name: windows-x86_64
       fail-fast: '${{ github.event_name == ''pull_request'' || (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')) }}'
     env:
       CARGO_TERM_COLOR: always
@@ -116,7 +128,7 @@ jobs:
       RUST_LIB_BACKTRACE: 0
     steps:
       - name: Reconfigure Windows Storage
-        if: '!(matrix.skip) && (startsWith(matrix.os, ''windows'') && !endsWith(matrix.os, ''-xl''))'
+        if: '!(matrix.skip) && (matrix.os == ''windows'' &&,!endsWith(matrix.runner, ''-xl''))'
         shell: pwsh
         run: |-
           New-Item -ItemType "directory" -Path "$env:TEMP/__target__"
@@ -140,10 +152,10 @@ jobs:
         if: '!(matrix.skip) && (matrix.wpt)'
       - name: Clone submodule ./tools/node_compat/node
         run: git submodule update --init --recursive --depth=1 -- ./tools/node_compat/node
-        if: '!(matrix.skip) && (matrix.job == ''lint'' && startsWith(matrix.os, ''ubuntu''))'
+        if: '!(matrix.skip) && (matrix.job == ''lint'' && matrix.os == ''linux'')'
       - name: 'Create source tarballs (release, linux)'
         if: |-
-          !(matrix.skip) && (startsWith(matrix.os, 'ubuntu') &&
+          !(matrix.skip) && (matrix.os == 'linux' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
@@ -165,7 +177,7 @@ jobs:
           python-version: 3.11
         if: '!(matrix.skip) && (matrix.job != ''lint'')'
       - name: Remove unused versions of Python
-        if: '!(matrix.skip) && (matrix.job != ''lint'' && (startsWith(matrix.os, ''windows'')))'
+        if: '!(matrix.skip) && (matrix.job != ''lint'' && (matrix.os == ''windows''))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |
@@ -198,7 +210,7 @@ jobs:
           create_credentials_file: true
       - name: Setup gcloud (unix)
         if: |-
-          !(matrix.skip) && (runner.os != 'Windows' &&
+          !(matrix.skip) && (matrix.os == 'windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
@@ -209,7 +221,7 @@ jobs:
           project_id: denoland
       - name: Setup gcloud (windows)
         if: |-
-          !(matrix.skip) && (runner.os == 'Windows' &&
+          !(matrix.skip) && (matrix.os == 'windows' &&
           matrix.profile == 'release' &&
           matrix.job == 'test' &&
           github.repository == 'denoland/deno' &&
@@ -301,14 +313,14 @@ jobs:
           CC=clang-16
           CFLAGS=-flto=thin --sysroot=/sysroot
           __0
-      - name: Install aarch64 lld
+      - name: Install macOS aarch64 lld
         run: ./tools/install_prebuilt.js ld64.lld
-        if: '!(matrix.skip) && (matrix.os == ''macos-13-xlarge'')'
+        if: '!(matrix.skip) && (matrix.os == ''macos'' && matrix.arch == ''aarch64'')'
       - name: Install rust-codesign
         run: |-
           ./tools/install_prebuilt.js rcodesign
           echo $GITHUB_WORKSPACE/third_party/prebuilt/mac >> $GITHUB_PATH
-        if: '!(matrix.skip) && ((matrix.os == ''macos-13-xlarge'' || matrix.os == ''macos-12''))'
+        if: '!(matrix.skip) && (matrix.os == ''macos'')'
       - name: Log versions
         run: |-
           python --version
@@ -330,8 +342,8 @@ jobs:
           path: |-
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
-          key: '72-cargo-home-${{ matrix.os }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '72-cargo-home-${{ matrix.os }}'
+          key: '72-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '72-cargo-home-${{ matrix.os }}-${{ matrix.arch }}'
         if: '!(matrix.skip)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v3
@@ -343,17 +355,17 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '72-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '72-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(matrix.skip) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
         with:
           cache-path: ./target
       - name: test_format.js
-        if: '!(matrix.skip) && (matrix.job == ''lint'' && startsWith(matrix.os, ''ubuntu''))'
+        if: '!(matrix.skip) && (matrix.job == ''lint'' && matrix.os == ''linux'')'
         run: deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check
       - name: Lint PR title
-        if: '!(matrix.skip) && (matrix.job == ''lint'' && github.event_name == ''pull_request'' && startsWith(matrix.os, ''ubuntu''))'
+        if: '!(matrix.skip) && (matrix.job == ''lint'' && github.event_name == ''pull_request'' && matrix.os == ''linux'')'
         env:
           PR_TITLE: '${{ github.event.pull_request.title }}'
         run: deno run ./tools/verify_pr_title.js "$PR_TITLE"
@@ -361,7 +373,7 @@ jobs:
         if: '!(matrix.skip) && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/lint.js
       - name: node_compat/setup.ts --check
-        if: '!(matrix.skip) && (matrix.job == ''lint'' && startsWith(matrix.os, ''ubuntu''))'
+        if: '!(matrix.skip) && (matrix.job == ''lint'' && matrix.os == ''linux'')'
         run: deno run --allow-write --allow-read --allow-run=git ./tools/node_compat/setup.ts --check
       - name: Build debug
         if: '!(matrix.skip) && (matrix.job == ''test'' && matrix.profile == ''debug'')'
@@ -393,17 +405,17 @@ jobs:
           path: target/release/deno
       - name: Pre-release (linux)
         if: |-
-          !(matrix.skip) && (startsWith(matrix.os, 'ubuntu') &&
+          !(matrix.skip) && (matrix.os == 'linux' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-
           cd target/release
-          zip -r deno-x86_64-unknown-linux-gnu.zip deno
+          zip -r deno-${{ matrix.arch }}-unknown-linux-gnu.zip deno
           ./deno types > lib.deno.d.ts
-      - name: Pre-release (mac intel)
+      - name: Pre-release (mac)
         if: |-
-          !(matrix.skip) && (matrix.os == 'macos-12' &&
+          !(matrix.skip) && (matrix.os == 'macos' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
@@ -414,29 +426,15 @@ jobs:
           echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
           rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
-          zip -r deno-x86_64-apple-darwin.zip deno
-      - name: Pre-release (mac aarch64)
-        if: |-
-          !(matrix.skip) && (matrix.os == 'macos-13-xlarge' &&
-          matrix.job == 'test' &&
-          matrix.profile == 'release' &&
-          github.repository == 'denoland/deno')
-        env:
-          APPLE_CODESIGN_KEY: '${{ secrets.APPLE_CODESIGN_KEY }}'
-          APPLE_CODESIGN_PASSWORD: '${{ secrets.APPLE_CODESIGN_PASSWORD }}'
-        run: |-
-          echo "Key is $(echo $APPLE_CODESIGN_KEY | base64 -d | wc -c) bytes"
-          rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
-          cd target/release
-          zip -r deno-aarch64-apple-darwin.zip deno
+          zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno
       - name: Pre-release (windows)
         if: |-
-          !(matrix.skip) && (startsWith(matrix.os, 'windows') &&
+          !(matrix.skip) && (matrix.os == 'windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         shell: pwsh
-        run: Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-x86_64-pc-windows-msvc.zip
+        run: 'Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip'
       - name: Upload canary to dl.deno.land
         if: |-
           !(matrix.skip) && (matrix.job == 'test' &&
@@ -446,31 +444,37 @@ jobs:
         run: |-
           gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/
           echo ${{ github.sha }} > canary-latest.txt
-          gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
+          gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-${{ matrix.arch }}-latest.txt
       - name: Autobahn testsuite
         if: |-
-          !(matrix.skip) && (matrix.job == 'test' && matrix.profile == 'release' &&
-          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu'))
+          !(matrix.skip) && (matrix.os == 'linux' &&
+          matrix.job == 'test' &&
+          matrix.profile == 'release' &&
+          !startsWith(github.ref, 'refs/tags/'))
         run: target/release/deno run -A --unstable ext/websocket/autobahn/fuzzingclient.js
-      - name: Test debug
+      - name: 'Test (full, debug)'
         if: |-
-          !(matrix.skip) && (matrix.job == 'test' && matrix.profile == 'debug' &&
-          !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu'))
+          !(matrix.skip) && (matrix.job == 'test' &&
+          matrix.profile == 'debug' &&
+          !startsWith(github.ref, 'refs/tags/') &&
+          matrix.os == 'linux')
         run: cargo test --locked
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-      - name: Test debug (fast)
+      - name: 'Test (fast, debug)'
         if: |-
-          !(matrix.skip) && (matrix.job == 'test' && matrix.profile == 'debug' &&
-          (startsWith(github.ref, 'refs/tags/') || !startsWith(matrix.os, 'ubuntu')))
+          !(matrix.skip) && (matrix.job == 'test' &&
+          matrix.profile == 'debug' &&
+          (startsWith(github.ref, 'refs/tags/') || matrix.os != 'linux'))
         run: |-
           cargo test --locked --lib
           cargo test --locked --test '*'
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
-      - name: Test release
+      - name: Test (release)
         if: |-
-          !(matrix.skip) && (matrix.job == 'test' && matrix.profile == 'release' &&
+          !(matrix.skip) && (matrix.job == 'test' &&
+          matrix.profile == 'release' &&
           (matrix.use_sysroot || (
           github.repository == 'denoland/deno' &&
           !startsWith(github.ref, 'refs/tags/'))))
@@ -520,7 +524,7 @@ jobs:
         continue-on-error: true
         if: |-
           !(matrix.skip) && (matrix.wpt &&
-          runner.os == 'Linux' &&
+          matrix.os == 'linux' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
@@ -534,7 +538,7 @@ jobs:
         continue-on-error: true
         if: |-
           !(matrix.skip) && (matrix.wpt &&
-          runner.os == 'Linux' &&
+          matrix.os == 'linux' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/'))
@@ -579,7 +583,7 @@ jobs:
           cat /proc/meminfo
       - name: Upload release to dl.deno.land (unix)
         if: |-
-          !(matrix.skip) && (runner.os != 'Windows' &&
+          !(matrix.skip) && (matrix.os != 'windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -587,7 +591,7 @@ jobs:
         run: 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/'
       - name: Upload release to dl.deno.land (windows)
         if: |-
-          !(matrix.skip) && (runner.os == 'Windows' &&
+          !(matrix.skip) && (matrix.os == 'windows' &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
@@ -632,7 +636,7 @@ jobs:
             !./target/*/gn_out
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '72-cargo-target-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '72-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   publish-canary:
     name: publish canary
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We run these on the free machines now.

Also cleans up some of our os and arch conditional step handling by introducing a new `matrix.os` and `matrix.arch`.
