### PR TITLE
chore: disable test-fs-watchfile.js on Mac ARM

### DIFF
--- a/cli/tests/node_compat/test/parallel/test-fs-watchfile.js
+++ b/cli/tests/node_compat/test/parallel/test-fs-watchfile.js
@@ -91,7 +91,7 @@ watcher.on('stop', common.mustCall());
 
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
-if (common.isLinux || common.isOSX || common.isWindows) {
+if (common.isLinux || (common.isOSX && process.arch !== "arm64") || common.isWindows) {
   const dir = path.join(tmpdir.path, 'watch');
 
   fs.mkdir(dir, common.mustCall(function(err) {


### PR DESCRIPTION
This is super flaky on new Mac ARM runner. Disabling for now to unblock main branch.