### PR TITLE
chore: upgrade deno_core 0.257.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.256.0"
+version = "0.257.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5997286bcc46199bbae727f43ee65cf4bd073ac2d240a36a6ceae3bfab14ac"
+checksum = "2a9283383b7fe9712396c09407cbfb41c90778168f67d2ad1112a00a9df2e8f4"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.132.0"
+version = "0.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02163d08afdd6fcf21e37c399c7425987c7170203a853052a800e80c91c2e87b"
+checksum = "ecf506732df72384bed194ce601bc6b77a5508d2de5da197c97c0a112013d504"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5407,9 +5407,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.165.0"
+version = "0.166.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88862d513bcbc04a7f93b0f454dffd0b01a5c0d8e1964c7532ec55f52b9a6351"
+checksum = "3cdf59dc8e11fc49804a1b677b41859fc4b24efbcd1cb162ebc4f0f39e15d2e1"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "0.32.0", features = ["transpiling"] }
-deno_core = { version = "0.256.0" }
+deno_core = { version = "0.257.0" }
 
 deno_bench_util = { version = "0.130.0", path = "./bench_util" }
 deno_lockfile = "0.18.0"


### PR DESCRIPTION
This upgrade includes all the necessary APIs for WASM imports