### PR TITLE
fix(test/regression): handle CLI arg directory using `../` in path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca0a5b9d2693efb14c8c80d66a052464f24cbf6b3473648037e282c0c616917"
+checksum = "e587768367b7b1e353407feccaf1fee9358f83ccd2d75ce405d59ec480172831"
 dependencies = [
  "anyhow",
  "glob",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,7 +55,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "dep_graph", "module_specifier", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = "=0.6.1"
-deno_config = "=0.9.1"
+deno_config = "=0.9.2"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.100.0", features = ["html"] }
 deno_emit = "=0.35.0"


### PR DESCRIPTION
Tests are in https://github.com/denoland/deno_config/pull/37 (only ran a manual integration test as I think the tests in deno_config are sufficient).

Closes #22239