### PR TITLE
fix(ext/node): fix timeout param validation in cp.execFile

### DIFF
--- a/cli/tests/unit_node/child_process_test.ts
+++ b/cli/tests/unit_node/child_process_test.ts
@@ -754,3 +754,20 @@ Deno.test(async function forkIpcKillDoesNotHang() {
 
   await p.promise;
 });
+
+Deno.test(async function execFileWithUndefinedTimeout() {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  CP.execFile(
+    "git",
+    ["-v"],
+    { timeout: undefined, encoding: "utf8" },
+    (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    },
+  );
+  await promise;
+});

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -436,15 +436,7 @@ export function execFile(
     shell: false,
     ...options,
   };
-  if (!Number.isInteger(execOptions.timeout) || execOptions.timeout < 0) {
-    // In Node source, the first argument to error constructor is "timeout" instead of "options.timeout".
-    // timeout is indeed a member of options object.
-    throw new ERR_OUT_OF_RANGE(
-      "timeout",
-      "an unsigned integer",
-      execOptions.timeout,
-    );
-  }
+  validateTimeout(execOptions.timeout);
   if (execOptions.maxBuffer < 0) {
     throw new ERR_OUT_OF_RANGE(
       "options.maxBuffer",


### PR DESCRIPTION
fixes https://github.com/denoland/deno/issues/22261