### PR TITLE
chore: remove benchmarks for ops

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -5,33 +5,13 @@ Deno.bench("date_now", { n: 5e5 }, () => {
   Date.now();
 });
 
-const { op_void_sync, op_void_async, op_add } = Deno[Deno.internal].core
-  .ensureFastOps();
-
-// Fast API calls
-{
-  // deno-lint-ignore no-inner-declarations
-  function addJS(a, b) {
-    return a + b;
-  }
-  Deno.bench("op_add", () => op_add(1, 2));
-  Deno.bench("add_js", () => addJS(1, 2));
+function addJS(a, b) {
+  return a + b;
 }
+Deno.bench("add_js", () => addJS(1, 2));
 
 // Void ops measure op-overhead
 Deno.bench("op_void_sync", () => op_void_sync());
-
-Deno.bench(
-  "op_void_async",
-  { n: 1e6 },
-  () => op_void_async(),
-);
-
-Deno.bench(
-  "op_void_await_async",
-  { n: 1e6 },
-  async () => await op_void_async(),
-);
 
 // A very lightweight op, that should be highly optimizable
 Deno.bench("perf_now", { n: 5e5 }, () => {


### PR DESCRIPTION
These are not useful, as we bench them in `deno_core` already.