### PR TITLE
BREAKING: add `Deno.CreateHttpClientOptions.{cert,key}`

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -896,10 +896,10 @@ declare namespace Deno {
     caCerts?: string[];
     /** A HTTP proxy to use for new connections. */
     proxy?: Proxy;
-    /** PEM formatted client certificate chain. */
-    certChain?: string;
-    /** PEM formatted (RSA or PKCS8) private key of client certificate. */
-    privateKey?: string;
+    /** Server private key in PEM format. */
+    cert?: string;
+    /** Cert chain in PEM format. */
+    key?: string;
     /** Sets the maximum numer of idle connections per host allowed in the pool. */
     poolMaxIdlePerHost?: number;
     /** Set an optional timeout for idle sockets being kept-alive.

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -794,8 +794,8 @@ impl HttpClientResource {
 pub struct CreateHttpClientArgs {
   ca_certs: Vec<String>,
   proxy: Option<Proxy>,
-  cert_chain: Option<String>,
-  private_key: Option<String>,
+  cert: Option<String>,
+  key: Option<String>,
   pool_max_idle_per_host: Option<usize>,
   pool_idle_timeout: Option<serde_json::Value>,
   #[serde(default = "default_true")]
@@ -826,12 +826,12 @@ where
   }
 
   let client_cert_chain_and_key = {
-    if args.cert_chain.is_some() || args.private_key.is_some() {
+    if args.cert.is_some() || args.key.is_some() {
       let cert_chain = args
-        .cert_chain
+        .cert
         .ok_or_else(|| type_error("No certificate chain provided"))?;
       let private_key = args
-        .private_key
+        .key
         .ok_or_else(|| type_error("No private key provided"))?;
 
       Some((cert_chain, private_key))

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1333,8 +1333,8 @@ Deno.test(
   async function fetchClientCertWrongPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       const client = Deno.createHttpClient({
-        certChain: "bad data",
-        privateKey: await Deno.readTextFile(
+        cert: "bad data",
+        key: await Deno.readTextFile(
           "tests/testdata/tls/localhost.key",
         ),
       });
@@ -1350,10 +1350,10 @@ Deno.test(
   async function fetchClientCertBadPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       const client = Deno.createHttpClient({
-        certChain: await Deno.readTextFile(
+        cert: await Deno.readTextFile(
           "tests/testdata/tls/localhost.crt",
         ),
-        privateKey: "bad data",
+        key: "bad data",
       });
       await fetch("https://localhost:5552/assets/fixture.json", {
         client,
@@ -1367,10 +1367,10 @@ Deno.test(
   async function fetchClientCertNotPrivateKey(): Promise<void> {
     await assertRejects(async () => {
       const client = Deno.createHttpClient({
-        certChain: await Deno.readTextFile(
+        cert: await Deno.readTextFile(
           "tests/testdata/tls/localhost.crt",
         ),
-        privateKey: "",
+        key: "",
       });
       await fetch("https://localhost:5552/assets/fixture.json", {
         client,
@@ -1387,10 +1387,10 @@ Deno.test(
     const data = "Hello World";
     const caCert = await Deno.readTextFile("tests/testdata/tls/RootCA.crt");
     const client = Deno.createHttpClient({
-      certChain: await Deno.readTextFile(
+      cert: await Deno.readTextFile(
         "tests/testdata/tls/localhost.crt",
       ),
-      privateKey: await Deno.readTextFile(
+      key: await Deno.readTextFile(
         "tests/testdata/tls/localhost.key",
       ),
       caCerts: [caCert],


### PR DESCRIPTION
This change deprecates `Deno.CreateHttpClientOptions.{certChain,privateKey}` in favour of `Deno.CreateHttpClientOptions.{cert,key}`.

Closes #22278