### PR TITLE
fix: Support Symbol.metadata

### DIFF
--- a/cli/tests/integration/js_unit_tests.rs
+++ b/cli/tests/integration/js_unit_tests.rs
@@ -84,6 +84,7 @@ util::unit_test_factory!(
     stdio_test,
     streams_test,
     structured_clone_test,
+    symbol_test,
     symlink_test,
     sync_test,
     test_util,

--- a/cli/tests/unit/symbol_test.ts
+++ b/cli/tests/unit/symbol_test.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert } from "./test_util.ts";
 
-// Note tests for Deno.stdin.setRaw is in integration tests.
+// Test that `Symbol.metadata` is defined. This file can be removed when V8
+// supports `Symbol.metadata` natively.
 
 Deno.test(
   function symbolMetadataIsDefined() {

--- a/cli/tests/unit/symbol_test.ts
+++ b/cli/tests/unit/symbol_test.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assert } from "./test_util.ts";
+
+// Note tests for Deno.stdin.setRaw is in integration tests.
+
+Deno.test(
+  function symbolMetadataIsDefined() {
+    assert(typeof Symbol.metadata === "symbol");
+  },
+);

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -463,6 +463,9 @@ export const SymbolDispose = Symbol.dispose ?? Symbol("Symbol.dispose");
 // deno-lint-ignore prefer-primordials
 export const SymbolAsyncDispose = Symbol.asyncDispose ??
   Symbol("Symbol.asyncDispose");
+// deno-lint-ignore prefer-primordials
+export const SymbolMetadata = Symbol.metadata ??
+  Symbol("Symbol.metadata");
 
 export {
   ASCII_ALPHA,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -89,9 +89,21 @@ import {
 import {
   workerRuntimeGlobalProperties,
 } from "ext:runtime/98_global_scope_worker.js";
-import { SymbolAsyncDispose, SymbolDispose } from "ext:deno_web/00_infra.js";
+import {
+  SymbolAsyncDispose,
+  SymbolDispose,
+  SymbolMetadata,
+} from "ext:deno_web/00_infra.js";
 // deno-lint-ignore prefer-primordials
 if (Symbol.dispose) throw "V8 supports Symbol.dispose now, no need to shim it!";
+// deno-lint-ignore prefer-primordials
+if (Symbol.asyncDispose) {
+  throw "V8 supports Symbol.asyncDispose now, no need to shim it!";
+}
+// deno-lint-ignore prefer-primordials
+if (Symbol.metadata) {
+  throw "V8 supports Symbol.metadata now, no need to shim it!";
+}
 ObjectDefineProperties(Symbol, {
   dispose: {
     value: SymbolDispose,
@@ -101,6 +113,12 @@ ObjectDefineProperties(Symbol, {
   },
   asyncDispose: {
     value: SymbolAsyncDispose,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  },
+  metadata: {
+    value: SymbolMetadata,
     enumerable: false,
     writable: false,
     configurable: false,


### PR DESCRIPTION
This commit adds support for "Symbol.metadata" which was 
omitted when adding support for the Decorators Proposal.

Closes https://github.com/denoland/deno/issues/22111