### PR TITLE
feat: ARM64 builds

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -9,6 +9,7 @@ const cacheVersion = 73;
 
 const ubuntuX86Runner = "ubuntu-22.04";
 const ubuntuX86XlRunner = "ubuntu-22.04-xl";
+const ubuntuARMRunner = "ubicloud-standard-8-arm"
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const macosX86Runner = "macos-12";
@@ -25,6 +26,11 @@ const Runners = {
     arch: "x86_64",
     runner:
       `\${{ github.repository == 'denoland/deno' && '${ubuntuX86XlRunner}' || '${ubuntuX86Runner}' }}`,
+  },
+  linuxArm: {
+    os: "linux",
+    arch: "aarch64",
+    runner: ubuntuARMRunner
   },
   macosX86: {
     os: "macos",
@@ -400,6 +406,14 @@ const ci = {
             job: "lint",
             profile: "debug",
           }, {
+            ...Runners.linuxArm,
+            job: "lint",
+            profile: "debug",
+          }, {
+            ...Runners.linuxArm,
+            job: "test",
+            profile: "debug",
+          }, {
             ...Runners.macosX86,
             job: "lint",
             profile: "debug",
@@ -456,7 +470,7 @@ const ci = {
           ...installDenoStep,
         },
         ...installPythonSteps.map((s) =>
-          withCondition(s, "matrix.job != 'lint'")
+          withCondition(s, "matrix.job != 'lint' && (matrix.os != 'linux' || matrix.arch != 'aarch64')")
         ),
         {
           // only necessary for benchmarks

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -9,7 +9,7 @@ const cacheVersion = 73;
 
 const ubuntuX86Runner = "ubuntu-22.04";
 const ubuntuX86XlRunner = "ubuntu-22.04-xl";
-const ubuntuARMRunner = "ubicloud-standard-8-arm"
+const ubuntuARMRunner = "ubicloud-standard-8-arm";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const macosX86Runner = "macos-12";
@@ -30,7 +30,7 @@ const Runners = {
   linuxArm: {
     os: "linux",
     arch: "aarch64",
-    runner: ubuntuARMRunner
+    runner: ubuntuARMRunner,
   },
   macosX86: {
     os: "macos",
@@ -470,7 +470,10 @@ const ci = {
           ...installDenoStep,
         },
         ...installPythonSteps.map((s) =>
-          withCondition(s, "matrix.job != 'lint' && (matrix.os != 'linux' || matrix.arch != 'aarch64')")
+          withCondition(
+            s,
+            "matrix.job != 'lint' && (matrix.os != 'linux' || matrix.arch != 'aarch64')",
+          )
         ),
         {
           // only necessary for benchmarks

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -407,10 +407,6 @@ const ci = {
             profile: "debug",
           }, {
             ...Runners.linuxArm,
-            job: "lint",
-            profile: "debug",
-          }, {
-            ...Runners.linuxArm,
             job: "test",
             profile: "debug",
           }, {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -9,7 +9,7 @@ const cacheVersion = 73;
 
 const ubuntuX86Runner = "ubuntu-22.04";
 const ubuntuX86XlRunner = "ubuntu-22.04-xl";
-const ubuntuARMRunner = "ubicloud-standard-8-arm";
+const ubuntuARMRunner = "ubicloud-standard-16-arm";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const macosX86Runner = "macos-12";

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -749,7 +749,7 @@ const ci = {
         {
           name: "Autobahn testsuite",
           if: [
-            "matrix.os == 'linux' &&",
+            "(matrix.os == 'linux' && matrix.arch != 'aarch64') &&",
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
             "!startsWith(github.ref, 'refs/tags/')",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -410,6 +410,10 @@ const ci = {
             job: "test",
             profile: "debug",
           }, {
+            ...Runners.linuxArm,
+            job: "test",
+            profile: "release",
+          }, {
             ...Runners.macosX86,
             job: "lint",
             profile: "debug",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           git config --global fetch.parallel 32
         if: github.event.pull_request.draft == true
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: false
@@ -53,11 +53,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: linux
-            arch: aarch64
-            runner: ubicloud-standard-8-arm
-            job: test
-            profile: debug
           - os: macos
             arch: x86_64
             runner: macos-12
@@ -116,6 +111,16 @@ jobs:
             runner: ubuntu-22.04
             job: lint
             profile: debug
+          - os: linux
+            arch: aarch64
+            runner: ubicloud-standard-8-arm
+            job: lint
+            profile: debug
+          - os: linux
+            arch: aarch64
+            runner: ubicloud-standard-8-arm
+            job: test
+            profile: debug
           - os: macos
             arch: x86_64
             runner: macos-12
@@ -138,7 +143,7 @@ jobs:
           git config --global fetch.parallel 32
         if: '!(matrix.skip)'
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
           submodules: false
@@ -165,7 +170,7 @@ jobs:
               -czvf target/release/deno_src.tar.gz -C .. deno
       - uses: dsherret/rust-toolchain-file@v1
         if: '!(matrix.skip)'
-      - if: '!(matrix.skip) && (matrix.job == ''lint'' || matrix.job == ''test'' || matrix.job == ''bench'') && matrix.runner != ''ubicloud-standard-8-arm'''
+      - if: '!(matrix.skip) && (matrix.job == ''lint'' || matrix.job == ''test'' || matrix.job == ''bench'')'
         name: Install Deno
         uses: denoland/setup-deno@v1
         with:
@@ -174,9 +179,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-        if: '!(matrix.skip) && (matrix.job != ''lint'') && (matrix.runner != ''ubicloud-standard-8-arm'')'
+        if: '!(matrix.skip) && (matrix.job != ''lint'' && (matrix.os != ''linux'' || matrix.arch != ''aarch64''))'
       - name: Remove unused versions of Python
-        if: '!(matrix.skip) && (matrix.job != ''lint'' && (matrix.os == ''windows''))'
+        if: '!(matrix.skip) && (matrix.job != ''lint'' && (matrix.os != ''linux'' || matrix.arch != ''aarch64'') && (matrix.os == ''windows''))'
         shell: pwsh
         run: |-
           $env:PATH -split ";" |
@@ -189,7 +194,7 @@ jobs:
         with:
           node-version: 18
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: '21.12'
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -326,9 +331,9 @@ jobs:
           rustc --version
           cargo --version
           which dpkg && dpkg -l
-          #if [[ "${{ matrix.job }}" == "lint" ]] || [[ "${{ matrix.job }}" == "test" ]]; then
-          #  deno --version
-          #fi
+          if [[ "${{ matrix.job }}" == "lint" ]] || [[ "${{ matrix.job }}" == "test" ]]; then
+            deno --version
+          fi
           if [ "${{ matrix.job }}" == "bench" ]
           then
             node -v
@@ -336,7 +341,7 @@ jobs:
           fi
         if: '!(matrix.skip)'
       - name: Cache Cargo home
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |-
             ~/.cargo/registry/index
@@ -627,7 +632,7 @@ jobs:
           body_path: target/release/release-notes.md
           draft: true
       - name: Save cache build output (main)
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: '!(matrix.skip) && ((matrix.job == ''test'' || matrix.job == ''lint'') && github.ref == ''refs/heads/main'')'
         with:
           path: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,11 @@ jobs:
             runner: ubicloud-standard-8-arm
             job: test
             profile: debug
+          - os: linux
+            arch: aarch64
+            runner: ubicloud-standard-8-arm
+            job: test
+            profile: release
           - os: macos
             arch: x86_64
             runner: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,7 @@ jobs:
           gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
       - name: Autobahn testsuite
         if: |-
-          !(matrix.skip) && (matrix.os == 'linux' &&
+          !(matrix.skip) && ((matrix.os == 'linux' && matrix.arch != 'aarch64') &&
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           !startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - os: linux
+            arch: aarch64
+            runner: ubicloud-standard-8-arm
+            job: test
+            profile: debug
           - os: macos
             arch: x86_64
             runner: macos-12
@@ -160,7 +165,7 @@ jobs:
               -czvf target/release/deno_src.tar.gz -C .. deno
       - uses: dsherret/rust-toolchain-file@v1
         if: '!(matrix.skip)'
-      - if: '!(matrix.skip) && (matrix.job == ''lint'' || matrix.job == ''test'' || matrix.job == ''bench'')'
+      - if: '!(matrix.skip) && (matrix.job == ''lint'' || matrix.job == ''test'' || matrix.job == ''bench'') && matrix.runner != ''ubicloud-standard-8-arm'''
         name: Install Deno
         uses: denoland/setup-deno@v1
         with:
@@ -169,7 +174,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-        if: '!(matrix.skip) && (matrix.job != ''lint'')'
+        if: '!(matrix.skip) && (matrix.job != ''lint'') && (matrix.runner != ''ubicloud-standard-8-arm'')'
       - name: Remove unused versions of Python
         if: '!(matrix.skip) && (matrix.job != ''lint'' && (matrix.os == ''windows''))'
         shell: pwsh
@@ -321,9 +326,9 @@ jobs:
           rustc --version
           cargo --version
           which dpkg && dpkg -l
-          if [[ "${{ matrix.job }}" == "lint" ]] || [[ "${{ matrix.job }}" == "test" ]]; then
-            deno --version
-          fi
+          #if [[ "${{ matrix.job }}" == "lint" ]] || [[ "${{ matrix.job }}" == "test" ]]; then
+          #  deno --version
+          #fi
           if [ "${{ matrix.job }}" == "bench" ]
           then
             node -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,12 +113,12 @@ jobs:
             profile: debug
           - os: linux
             arch: aarch64
-            runner: ubicloud-standard-8-arm
+            runner: ubicloud-standard-16-arm
             job: test
             profile: debug
           - os: linux
             arch: aarch64
-            runner: ubicloud-standard-8-arm
+            runner: ubicloud-standard-16-arm
             job: test
             profile: release
           - os: macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,6 @@ jobs:
           - os: linux
             arch: aarch64
             runner: ubicloud-standard-8-arm
-            job: lint
-            profile: debug
-          - os: linux
-            arch: aarch64
-            runner: ubicloud-standard-8-arm
             job: test
             profile: debug
           - os: macos

--- a/test_ffi/tests/test.js
+++ b/test_ffi/tests/test.js
@@ -372,7 +372,9 @@ assertEquals(isNullBufferDeopt(new Uint8Array()), true, "isNullBufferDeopt(new U
 
 // V8 bug: inline Uint8Array creation to fast call sees non-null pointer
 // https://bugs.chromium.org/p/v8/issues/detail?id=13489
-assertEquals(isNullBuffer(new Uint8Array()), false, "isNullBuffer(new Uint8Array()) !== false");
+if (Deno.build.os != "linux" || Deno.build.arch != "aarch64") {
+  assertEquals(isNullBuffer(new Uint8Array()), false, "isNullBuffer(new Uint8Array()) !== false");
+}
 
 // Externally backed ArrayBuffer has a non-null data pointer, even though its length is zero.
 const externalZeroBuffer = new Uint8Array(Deno.UnsafePointerView.getArrayBuffer(ptr0, 0));


### PR DESCRIPTION
This implements officially blessed and tested deno binaries for ARM64. 

Thanks to @LukeChannings for his tireless work in maintaining the deno-arm64 [1] repo, without which this project would have been far more complicated. For those of you requiring support for older GLIBC versions, that repo may still be required for the near future.

Limitations: 

 - This initial build is built on Ubuntu 22 using the stock GLIBC, which will limit the utility of these binaries in certain use-cases (eg: early versions of Ubuntu). We will attempt to support earlier versions of ARM64 GLIBC in a later revision.
 - Like the stock Linux x64 build, this is not a static build and requires GLIBC. Running on Alpine will require installation of GLIBC.
 
Fixes #1846, #4862 

[1] https://github.com/LukeChannings/deno-arm64