### PR TITLE
chore: upgrade CI workflows to use Node 20

### DIFF
--- a/.github/mtime_cache/action.js
+++ b/.github/mtime_cache/action.js
@@ -1,9 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This file contains the implementation of a Github Action. Github uses
-// Node.js v12.x to run actions, so this is Node code and not Deno code.
+// Node.js v20.x to run actions, so this is Node code and not Deno code.
 
 const { spawn } = require("child_process");
-const fs = require("fs");
+const { existsSync } = require("fs");
 const { utimes, mkdir, readFile, writeFile } = require("fs/promises");
 const { dirname, resolve } = require("path");
 const { StringDecoder } = require("string_decoder");
@@ -147,7 +147,7 @@ async function* ls(dir = "") {
         break;
       case "160000": // Git submodule.
         // sometimes we don't checkout all submodules
-        if (fs.existsSync(path)) {
+        if (existsSync(path)) {
           yield* ls(path);
         }
         break;

--- a/.github/mtime_cache/action.yml
+++ b/.github/mtime_cache/action.yml
@@ -7,4 +7,4 @@ inputs:
     required: true
 runs:
   main: action.js
-  using: node16
+  using: node20

--- a/.github/workflows/bench_cron.yml
+++ b/.github/workflows/bench_cron.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench_cron.yml
+++ b/.github/workflows/bench_cron.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global fetch.parallel 32
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.DENOBOT_PAT }}
           submodules: recursive

--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -35,7 +35,7 @@ jobs:
           deno-version: v1.31.3
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: '21.12'
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -181,7 +181,7 @@ const installNodeStep = {
 };
 const installProtocStep = {
   name: "Install protoc",
-  uses: "arduino/setup-protoc@v2",
+  uses: "arduino/setup-protoc@v3",
   with: { "version": "21.12", "repo-token": "${{ secrets.GITHUB_TOKEN }}" },
 };
 const installDenoStep = {
@@ -558,7 +558,7 @@ const ci = {
         },
         {
           name: "Cache Cargo home",
-          uses: "actions/cache@v3",
+          uses: "actions/cache@v4",
           with: {
             // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
             // Note that with the new sparse registry format, we no longer have to cache a `.git` dir
@@ -990,7 +990,7 @@ const ci = {
         {
           // In main branch, always create a fresh cache
           name: "Save cache build output (main)",
-          uses: "actions/cache/save@v3",
+          uses: "actions/cache/save@v4",
           if:
             "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
           with: {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -141,7 +141,7 @@ const cloneRepoStep = [{
   ].join("\n"),
 }, {
   name: "Clone repository",
-  uses: "actions/checkout@v3",
+  uses: "actions/checkout@v4",
   with: {
     // Use depth > 1, because sometimes we need to rebuild main and if
     // other commits have landed it will become impossible to rebuild if

--- a/.github/workflows/start_release.yml
+++ b/.github/workflows/start_release.yml
@@ -31,7 +31,7 @@ jobs:
           git config --global fetch.parallel 32
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -31,7 +31,7 @@ jobs:
           git config --global fetch.parallel 32
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.DENOBOT_PAT }}
           submodules: recursive

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           persist-credentials: false


### PR DESCRIPTION
Upgrades to the following GitHub Actions: `actions/checkout@v4`, `arduino/setup-protoc@v2`, `actions/cache@v4`, `actions/cache/save@v4` and `.github/mtime_cache`.