### PR TITLE
chore: upgrade to `arduino/setup-protoc@v3`

### DIFF
--- a/.github/workflows/bench_cron.yml
+++ b/.github/workflows/bench_cron.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -35,7 +35,7 @@ jobs:
           deno-version: v1.31.3
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: '21.12'
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -181,7 +181,7 @@ const installNodeStep = {
 };
 const installProtocStep = {
   name: "Install protoc",
-  uses: "arduino/setup-protoc@v2",
+  uses: "arduino/setup-protoc@v3",
   with: { "version": "21.12", "repo-token": "${{ secrets.GITHUB_TOKEN }}" },
 };
 const installDenoStep = {


### PR DESCRIPTION
No longer uses Node 16, which is deprecated.