### PR TITLE
chore: upgrade to `actions/cache/save@v4`

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -990,7 +990,7 @@ const ci = {
         {
           // In main branch, always create a fresh cache
           name: "Save cache build output (main)",
-          uses: "actions/cache/save@v3",
+          uses: "actions/cache/save@v4",
           if:
             "(matrix.job == 'test' || matrix.job == 'lint') && github.ref == 'refs/heads/main'",
           with: {


### PR DESCRIPTION
No longer uses Node, which is deprecated.