### PR TITLE
chore: remove op_spawn_child test

### DIFF
--- a/cli/tests/integration/run_tests.rs
+++ b/cli/tests/integration/run_tests.rs
@@ -4875,25 +4875,6 @@ fn permission_prompt_strips_ansi_codes_and_control_chars() {
     console.expect("undefined");
     console.write_line_raw(r#"const moveANSIStart = "\u001b[1000D";"#);
     console.expect("undefined");
-
-    console.write_line_raw(
-      r#"Deno[Deno.internal].core.ops.op_spawn_child({
-    cmd: "cat",
-    args: ["file.txt"],
-    clearEnv: false,
-    cwd: undefined,
-    env: [],
-    uid: undefined,
-    gid: undefined,
-    stdin: "null",
-    stdout: "inherit",
-    stderr: "piped",
-    signal: undefined,
-    windowsRawArguments: false,
-}, moveANSIUp + clearANSI + moveANSIStart + prompt)"#,
-    );
-
-    console.expect(r#"┌ ⚠️  Deno requests run access to "cat""#);
   });
 }
 

--- a/cli/tests/unit/ops_test.ts
+++ b/cli/tests/unit/ops_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-const EXPECTED_OP_COUNT = 45;
+const EXPECTED_OP_COUNT = 44;
 
 Deno.test(function checkExposedOps() {
   // @ts-ignore TS doesn't allow to index with symbol

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -618,10 +618,6 @@ const NOT_IMPORTED_OPS = [
   "op_ffi_unsafe_callback_close",
   "op_ffi_unsafe_callback_create",
   "op_ffi_unsafe_callback_ref",
-
-  // TODO(bartlomieju): used in a regression test, but probably not needed
-  // anymore if ops are not user accessible.
-  "op_spawn_child",
 ];
 
 function removeImportedOps() {


### PR DESCRIPTION
This test is not needed because the op is not available to user code anymore.

This brings number of ops exposed to user code down to 15.