### PR TITLE
feat: use sysroot for ARM64

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -682,9 +682,9 @@ const ci = {
             "(github.ref == 'refs/heads/main' ||",
             "startsWith(github.ref, 'refs/tags/'))))",
           ].join("\n"),
-          uses: "actions/upload-artifact@v3",
+          uses: "actions/upload-artifact@v4",
           with: {
-            name: "deno-${{ github.event.number }}",
+            name: "deno-${{ matrix.os }}-${{ matrix.arch }}-${{ github.event.number }}",
             path: "target/release/deno",
           },
         },

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -68,9 +68,10 @@ const sysRootStep = {
 export DEBIAN_FRONTEND=noninteractive
 # Avoid running man-db triggers, which sometimes takes several minutes
 # to complete.
-sudo apt-get -qq remove --purge -y man-db
+sudo apt-get -qq remove --purge -y man-db  > /dev/null 2> /dev/null
 # Remove older clang before we install
-sudo apt-get -qq remove 'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*'
+sudo apt-get -qq remove \
+  'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*' > /dev/null 2> /dev/null
 
 # Install clang-XXX, lld-XXX, and debootstrap.
 echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${llvmVersion} main" |
@@ -82,7 +83,7 @@ sudo apt-get update
 # this was unreliable sometimes, so try again if it fails
 ${installPkgsCommand} || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && ${installPkgsCommand}
 # Fix alternatives
-(yes '' | sudo update-alternatives --force --all) || true > /dev/null
+(yes '' | sudo update-alternatives --force --all) || true > /dev/null 2> /dev/null
 
 echo "Decompressing sysroot..."
 wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-\`uname -m\`.tar.xz -O /tmp/sysroot.tar.xz

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -88,7 +88,11 @@ echo "Decompressing sysroot..."
 wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-\`uname -m\`.tar.xz -O /tmp/sysroot.tar.xz
 cd /
 xzcat /tmp/sysroot.tar.xz | sudo tar -x
-cd /tmp/
+sudo mount --rbind /dev /sysroot/dev
+sudo mount --rbind /sys /sysroot/sys
+sudo mount --rbind /home /sysroot/home
+sudo mount -t proc /proc /sysroot/proc
+cd
 
 if [[ \`uname -m\` == "aarch64" ]]; then
   echo "Copying libdl.a"

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -816,7 +816,8 @@ const ci = {
           // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
           // TODO(mmastrac): make this work for aarch64 as well
           name: "Check deno binary (in sysroot)",
-          if: "matrix.profile == 'release' && matrix.use_sysroot && matrix.arch != 'aarch64'",
+          if:
+            "matrix.profile == 'release' && matrix.use_sysroot && matrix.arch != 'aarch64'",
           run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',
         },
         {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -814,6 +814,7 @@ const ci = {
         },
         {
           // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
+          // TODO(mmastrac): make this work for aarch64 as well
           name: "Check deno binary (in sysroot)",
           if: "matrix.profile == 'release' && matrix.use_sysroot && matrix.arch != 'aarch64'",
           run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -685,7 +685,8 @@ const ci = {
           ].join("\n"),
           uses: "actions/upload-artifact@v4",
           with: {
-            name: "deno-${{ matrix.os }}-${{ matrix.arch }}-${{ github.event.number }}",
+            name:
+              "deno-${{ matrix.os }}-${{ matrix.arch }}-${{ github.event.number }}",
             path: "target/release/deno",
           },
         },

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -815,7 +815,7 @@ const ci = {
         {
           // Verify that the binary actually works in the Ubuntu-16.04 sysroot.
           name: "Check deno binary (in sysroot)",
-          if: "matrix.profile == 'release' && matrix.use_sysroot",
+          if: "matrix.profile == 'release' && matrix.use_sysroot && matrix.arch != 'aarch64'",
           run: 'sudo chroot /sysroot "$(pwd)/target/release/deno" --version',
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,11 @@ jobs:
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
           cd /
           xzcat /tmp/sysroot.tar.xz | sudo tar -x
-          cd /tmp/
+          sudo mount --rbind /dev /sysroot/dev
+          sudo mount --rbind /sys /sysroot/sys
+          sudo mount --rbind /home /sysroot/home
+          sudo mount -t proc /proc /sysroot/proc
+          cd
 
           if [[ `uname -m` == "aarch64" ]]; then
             echo "Copying libdl.a"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
         env:
           NO_COLOR: 1
       - name: Check deno binary (in sysroot)
-        if: '!(matrix.skip) && (matrix.profile == ''release'' && matrix.use_sysroot)'
+        if: '!(matrix.skip) && (matrix.profile == ''release'' && matrix.use_sysroot && matrix.arch != ''aarch64'')'
         run: sudo chroot /sysroot "$(pwd)/target/release/deno" --version
       - name: Configure hosts file for WPT
         if: '!(matrix.skip) && (matrix.wpt)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,9 +251,9 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           # Avoid running man-db triggers, which sometimes takes several minutes
           # to complete.
-          sudo apt-get -qq remove --purge -y man-db
+          sudo apt-get -qq remove --purge -y man-db  > /dev/null 2> /dev/null
           # Remove older clang before we install
-          sudo apt-get -qq remove 'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*'
+          sudo apt-get -qq remove   'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*' > /dev/null 2> /dev/null
 
           # Install clang-XXX, lld-XXX, and debootstrap.
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" |
@@ -265,7 +265,7 @@ jobs:
           # this was unreliable sometimes, so try again if it fails
           sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 clang-tools-16 clang-format-16 clang-tidy-16 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 clang-tools-16 clang-format-16 clang-tidy-16
           # Fix alternatives
-          (yes '' | sudo update-alternatives --force --all) || true > /dev/null
+          (yes '' | sudo update-alternatives --force --all) || true > /dev/null 2> /dev/null
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,9 +409,9 @@ jobs:
           (github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' ||
           startsWith(github.ref, 'refs/tags/')))))
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: 'deno-${{ github.event.number }}'
+          name: 'deno-${{ matrix.os }}-${{ matrix.arch }}-${{ github.event.number }}'
           path: target/release/deno
       - name: Pre-release (linux)
         if: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
             runner: ubicloud-standard-16-arm
             job: test
             profile: release
+            use_sysroot: true
           - os: macos
             arch: x86_64
             runner: macos-12
@@ -246,11 +247,13 @@ jobs:
       - if: '!(matrix.skip) && (matrix.use_sysroot)'
         name: Set up incremental LTO and sysroot build
         run: |-
+          # Setting up sysroot
+          export DEBIAN_FRONTEND=noninteractive
           # Avoid running man-db triggers, which sometimes takes several minutes
           # to complete.
-          sudo apt-get remove --purge -y man-db
+          sudo apt-get -qq remove --purge -y man-db
           # Remove older clang before we install
-          sudo apt-get remove 'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*'
+          sudo apt-get -qq remove 'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*'
 
           # Install clang-XXX, lld-XXX, and debootstrap.
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" |
@@ -262,27 +265,26 @@ jobs:
           # this was unreliable sometimes, so try again if it fails
           sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 clang-tools-16 clang-format-16 clang-tidy-16 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 clang-tools-16 clang-format-16 clang-tidy-16
           # Fix alternatives
-          (yes '' | sudo update-alternatives --force --all) || true
+          (yes '' | sudo update-alternatives --force --all) || true > /dev/null
 
-          # Create ubuntu-16.04 sysroot environment, which is used to avoid
-          # depending on a very recent version of glibc.
-          # `libc6-dev` is required for building any C source files.
-          # `file` and `make` are needed to build libffi-sys.
-          # `curl` is needed to build rusty_v8.
-          sudo debootstrap                                     \
-            --include=ca-certificates,curl,file,libc6-dev,make \
-            --no-merged-usr --variant=minbase xenial /sysroot  \
-            http://azure.archive.ubuntu.com/ubuntu
-          sudo mount --rbind /dev /sysroot/dev
-          sudo mount --rbind /sys /sysroot/sys
-          sudo mount --rbind /home /sysroot/home
-          sudo mount -t proc /proc /sysroot/proc
+          echo "Decompressing sysroot..."
+          wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
+          cd /
+          xzcat /tmp/sysroot.tar.xz | sudo tar -x
+          cd /tmp/
 
-          wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.a
-          wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.so.2
+          if [[ `uname -m` == "aarch64" ]]; then
+            echo "Copying libdl.a"
+            sudo cp /sysroot/usr/lib/aarch64-linux-gnu/libdl.a /sysroot/lib/aarch64-linux-gnu/libdl.a
+            echo "Copying libdl.so"
+            sudo cp /sysroot/lib/aarch64-linux-gnu/libdl.so.2 /sysroot/lib/aarch64-linux-gnu/libdl.so
+          else
+            wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.a
+            wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.so.2
 
-          sudo ln -s libdl.so.2 /sysroot/lib/x86_64-linux-gnu/libdl.so
-          sudo ln -s libdl.a /sysroot/lib/x86_64-linux-gnu/libdl.a
+            sudo ln -s libdl.so.2 /sysroot/lib/x86_64-linux-gnu/libdl.so
+            sudo ln -s libdl.a /sysroot/lib/x86_64-linux-gnu/libdl.a
+          fi
 
           # Configure the build environment. Both Rust and Clang will produce
           # llvm bitcode only, so we can use lld's incremental LTO support.


### PR DESCRIPTION
Follow-up from #22298: Use a sysroot to build ARM64 so we work all the way back to Xenial.

We generate a sysroot ahead-of-time in the https://github.com/denoland/deno_sysroot_build project and use that to bootstrap a sysroot here.