### PR TITLE
docs(cli): add unit info for idleTimeout

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5717,7 +5717,8 @@ declare namespace Deno {
      * `pong` within the timeout specified, the connection is deemed
      * unhealthy and is closed. The `close` and `error` event will be emitted.
      *
-     * The default is 120 seconds. Set to `0` to disable timeouts. */
+     * The unit is seconds, with a default of 120.
+     * Set to `0` to disable timeouts. */
     idleTimeout?: number;
   }
 


### PR DESCRIPTION
I think this is a properly formatted PR. Not sure it is worth opening an issue for.

Note: I got "Page not found" for https://deno.com/manual/contributing
