### PR TITLE
chore: remove wget from amd64 linux sysroot

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -101,11 +101,10 @@ if [[ \`uname -m\` == "aarch64" ]]; then
   echo "Copying libdl.so"
   sudo cp /sysroot/lib/aarch64-linux-gnu/libdl.so.2 /sysroot/lib/aarch64-linux-gnu/libdl.so
 else
-  wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.a
-  wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.so.2
-
-  sudo ln -s libdl.so.2 /sysroot/lib/x86_64-linux-gnu/libdl.so
-  sudo ln -s libdl.a /sysroot/lib/x86_64-linux-gnu/libdl.a
+  echo "Copying libdl.a"
+  sudo cp /sysroot/usr/lib/x86_64-linux-gnu/libdl.a /sysroot/lib/x86_64-linux-gnu/libdl.a
+  echo "Copying libdl.so"
+  sudo cp /sysroot/lib/x86_64-linux-gnu/libdl.so.2 /sysroot/lib/x86_64-linux-gnu/libdl.so
 fi
 
 # Configure the build environment. Both Rust and Clang will produce

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -83,7 +83,7 @@ sudo apt-get update
 # this was unreliable sometimes, so try again if it fails
 ${installPkgsCommand} || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && ${installPkgsCommand}
 # Fix alternatives
-(yes '' | sudo update-alternatives --force --all) || true > /dev/null 2> /dev/null
+(yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
 echo "Decompressing sysroot..."
 wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-\`uname -m\`.tar.xz -O /tmp/sysroot.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,11 +283,10 @@ jobs:
             echo "Copying libdl.so"
             sudo cp /sysroot/lib/aarch64-linux-gnu/libdl.so.2 /sysroot/lib/aarch64-linux-gnu/libdl.so
           else
-            wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.a
-            wget https://github.com/denoland/deno_third_party/raw/master/prebuilt/linux64/libdl/libdl.so.2
-
-            sudo ln -s libdl.so.2 /sysroot/lib/x86_64-linux-gnu/libdl.so
-            sudo ln -s libdl.a /sysroot/lib/x86_64-linux-gnu/libdl.a
+            echo "Copying libdl.a"
+            sudo cp /sysroot/usr/lib/x86_64-linux-gnu/libdl.a /sysroot/lib/x86_64-linux-gnu/libdl.a
+            echo "Copying libdl.so"
+            sudo cp /sysroot/lib/x86_64-linux-gnu/libdl.so.2 /sysroot/lib/x86_64-linux-gnu/libdl.so
           fi
 
           # Configure the build environment. Both Rust and Clang will produce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           # this was unreliable sometimes, so try again if it fails
           sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 clang-tools-16 clang-format-16 clang-tidy-16 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install --no-install-recommends debootstrap clang-16 lld-16 clang-tools-16 clang-format-16 clang-tidy-16
           # Fix alternatives
-          (yes '' | sudo update-alternatives --force --all) || true > /dev/null 2> /dev/null
+          (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20240207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz


### PR DESCRIPTION
We don't need to wget `libdl` because we can just copy the one from within the sysroot, saving two network accesses.

This allows amd64 to use the same build strategy as arm64.