### PR TITLE
fix(console): add missing AssertionError to js

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -172,6 +172,13 @@ function getStderrNoColor() {
   return noColorStderr();
 }
 
+class AssertionError extends Error {
+  name = "AssertionError";
+  constructor(message) {
+    super(message);
+  }
+}
+
 function assert(cond, msg = "Assertion failed.") {
   if (!cond) {
     throw new AssertionError(msg);


### PR DESCRIPTION
Previously it did not exist, so `assert` would crash the wrong way if it failed.

No issue filed but I can create one if needed, a repro to cause this if you want to test is pasting this in REPL: (sorry)
```js
new Proxy({}, { ownKeys: () => ['foo'], getOwnPropertyDescriptor: () => ({ configurable: false }) })
```