### PR TITLE
chore: fix nightly bench

### DIFF
--- a/.github/workflows/bench_cron.yml
+++ b/.github/workflows/bench_cron.yml
@@ -37,6 +37,11 @@ jobs:
           version: "21.12"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
       - name: Build release
         run: cargo build --release --locked --all-targets
 


### PR DESCRIPTION
This has been broken for a while, but I think `setup-deno` is all that it needs.