### PR TITLE
fix: cache bust jsr deps on constraint failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "bytes",
  "deno_ast",
  "deno_bench_util",
+ "deno_cache_dir",
  "deno_core",
  "deno_fetch",
  "deno_lockfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "serde"
 console_static_text = "=0.8.1"
 data-encoding = "2.3.3"
 data-url = "=0.3.0"
+deno_cache_dir = "=0.6.1"
 dlopen2 = "0.6.1"
 ecb = "=0.1.2"
 elliptic-curve = { version = "0.13.4", features = ["alloc", "arithmetic", "ecdh", "std", "pem"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -60,7 +60,7 @@ winres.workspace = true
 
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
-deno_cache_dir = "=0.6.1"
+deno_cache_dir = { workspace = true }
 deno_config = "=0.9.2"
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.103.0", features = ["html"] }

--- a/cli/tests/Cargo.toml
+++ b/cli/tests/Cargo.toml
@@ -24,6 +24,7 @@ required-features = ["run"]
 bytes.workspace = true
 deno_ast.workspace = true
 deno_bench_util.workspace = true
+deno_cache_dir = { workspace = true }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting", "unsafe_use_unprotected_platform"] }
 deno_fetch.workspace = true
 deno_lockfile.workspace = true

--- a/cli/tests/testdata/jsr/version_not_found/main.out
+++ b/cli/tests/testdata/jsr/version_not_found/main.out
@@ -1,4 +1,5 @@
 Download http://127.0.0.1:4250/@denotest/deps/meta.json
+Download http://127.0.0.1:4250/@denotest/deps/meta.json
 error: Could not find constraint in the list of versions: @denotest/deps@0.1.4
   Specifier: jsr:@denotest/deps@0.1.4/mod.ts
     at file:///[WILDCARD]/version_not_found/main.ts:1:19

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -91,7 +91,7 @@ pub async fn run_from_stdin(flags: Flags) -> Result<i32, AnyError> {
   std::io::stdin().read_to_end(&mut source)?;
   // Save a fake file into file fetcher cache
   // to allow module access by TS compiler
-  file_fetcher.insert_cached(File {
+  file_fetcher.insert_memory_files(File {
     specifier: main_module.clone(),
     maybe_headers: None,
     source: source.into(),
@@ -174,7 +174,7 @@ pub async fn eval_command(
 
   // Save a fake file into file fetcher cache
   // to allow module access by TS compiler.
-  file_fetcher.insert_cached(File {
+  file_fetcher.insert_memory_files(File {
     specifier: main_module.clone(),
     maybe_headers: None,
     source: source_code.into_bytes().into(),

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -873,7 +873,7 @@ pub async fn check_specifiers(
       .collect();
 
     for file in inline_files {
-      file_fetcher.insert_cached(file);
+      file_fetcher.insert_memory_files(file);
     }
 
     module_load_preparer


### PR DESCRIPTION
Removes the `FileFetcher`'s internal cache because I don't believe it's necessary (we already cache this kind of stuff in places like deno_graph or config files in different places). Removing it fixes this bug because this functionality was already implemented in deno_graph and lowers memory usage of the CLI a little bit.