### PR TITLE
chore: use `@std` import instead of `@test_util/std`

### DIFF
--- a/tests/node_compat/common.ts
+++ b/tests/node_compat/common.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { partition } from "@test_util/std/collections/partition.ts";
-import { join } from "@test_util/std/path/mod.ts";
-import * as JSONC from "@test_util/std/jsonc/mod.ts";
+import { partition } from "@std/collections/partition.ts";
+import { join } from "@std/path/mod.ts";
+import * as JSONC from "@std/jsonc/mod.ts";
 /**
  * The test suite matches the folders inside the `test` folder inside the
  * node repo

--- a/tests/node_compat/runner.ts
+++ b/tests/node_compat/runner.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import "./polyfill_globals.js";
 import { createRequire } from "node:module";
-import { toFileUrl } from "@test_util/std/path/mod.ts";
+import { toFileUrl } from "@std/path/mod.ts";
 const file = Deno.args[0];
 if (!file) {
   throw new Error("No file provided");

--- a/tests/node_compat/test.ts
+++ b/tests/node_compat/test.ts
@@ -13,10 +13,10 @@
  * all share the same working directory.
  */
 
-import { magenta } from "@test_util/std/fmt/colors.ts";
-import { pooledMap } from "@test_util/std/async/pool.ts";
-import { dirname, fromFileUrl, join } from "@test_util/std/path/mod.ts";
-import { fail } from "@test_util/std/assert/mod.ts";
+import { magenta } from "@std/fmt/colors.ts";
+import { pooledMap } from "@std/async/pool.ts";
+import { dirname, fromFileUrl, join } from "@std/path/mod.ts";
+import { fail } from "@std/assert/mod.ts";
 import {
   config,
   getPathsFromTestSuites,

--- a/tests/unit/blob_test.ts
+++ b/tests/unit/blob_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertStringIncludes } from "./test_util.ts";
-import { concat } from "@test_util/std/bytes/concat.ts";
+import { concat } from "@std/bytes/concat.ts";
 
 Deno.test(function blobString() {
   const b1 = new Blob(["Hello World"]);

--- a/tests/unit/broadcast_channel_test.ts
+++ b/tests/unit/broadcast_channel_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 
 Deno.test("BroadcastChannel worker", async () => {
   const intercom = new BroadcastChannel("intercom");

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -14,7 +14,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "./test_util.ts";
-import { stripColor } from "@test_util/std/fmt/colors.ts";
+import { stripColor } from "@std/fmt/colors.ts";
 
 const customInspect = Symbol.for("Deno.customInspect");
 const {

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -8,7 +8,7 @@ import {
   fail,
   unimplemented,
 } from "./test_util.ts";
-import { Buffer } from "@test_util/std/io/buffer.ts";
+import { Buffer } from "@std/io/buffer.ts";
 
 const listenPort = 4506;
 

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -8,7 +8,7 @@ import {
   assertRejects,
   assertThrows,
 } from "./test_util.ts";
-import { copy } from "@test_util/std/streams/copy.ts";
+import { copy } from "@std/streams/copy.ts";
 
 Deno.test(function filesStdioFileDescriptors() {
   assertEquals(Deno.stdin.rid, 0);

--- a/tests/unit/http_test.ts
+++ b/tests/unit/http_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { Buffer, BufReader, BufWriter } from "@test_util/std/io/mod.ts";
+import { Buffer, BufReader, BufWriter } from "@std/io/mod.ts";
 import { TextProtoReader } from "../testdata/run/textproto.ts";
 import {
   assert,
@@ -10,7 +10,7 @@ import {
   delay,
   fail,
 } from "./test_util.ts";
-import { join } from "@test_util/std/path/mod.ts";
+import { join } from "@std/path/mod.ts";
 
 const listenPort = 4507;
 const listenPort2 = 4508;

--- a/tests/unit/io_test.ts
+++ b/tests/unit/io_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "./test_util.ts";
-import { Buffer } from "@test_util/std/io/buffer.ts";
+import { Buffer } from "@std/io/buffer.ts";
 
 const DEFAULT_BUF_SIZE = 32 * 1024;
 

--- a/tests/unit/kv_test.ts
+++ b/tests/unit/kv_test.ts
@@ -7,7 +7,7 @@ import {
   assertRejects,
   assertThrows,
 } from "./test_util.ts";
-import { assertType, IsExact } from "@test_util/std/testing/types.ts";
+import { assertType, IsExact } from "@std/testing/types.ts";
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 

--- a/tests/unit/message_channel_test.ts
+++ b/tests/unit/message_channel_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // NOTE: these are just sometests to test the TypeScript types. Real coverage is
 // provided by WPT.
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 
 Deno.test("messagechannel", async () => {
   const mc = new MessageChannel();

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertMatch, assertRejects } from "@test_util/std/assert/mod.ts";
-import { Buffer, BufReader, BufWriter } from "@test_util/std/io/mod.ts";
+import { assertMatch, assertRejects } from "@std/assert/mod.ts";
+import { Buffer, BufReader, BufWriter } from "@std/io/mod.ts";
 import { TextProtoReader } from "../testdata/run/textproto.ts";
 import {
   assert,

--- a/tests/unit/test_util.ts
+++ b/tests/unit/test_util.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import * as colors from "@test_util/std/fmt/colors.ts";
+import * as colors from "@std/fmt/colors.ts";
 export { colors };
-import { join, resolve } from "@test_util/std/path/mod.ts";
+import { join, resolve } from "@std/path/mod.ts";
 export {
   assert,
   assertEquals,
@@ -19,10 +19,10 @@ export {
   fail,
   unimplemented,
   unreachable,
-} from "@test_util/std/assert/mod.ts";
-export { delay } from "@test_util/std/async/delay.ts";
-export { readLines } from "@test_util/std/io/read_lines.ts";
-export { parse as parseArgs } from "@test_util/std/flags/mod.ts";
+} from "@std/assert/mod.ts";
+export { delay } from "@std/async/delay.ts";
+export { readLines } from "@std/io/read_lines.ts";
+export { parse as parseArgs } from "@std/flags/mod.ts";
 
 export function pathToAbsoluteFileUrl(path: string): URL {
   path = resolve(path);

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -7,9 +7,9 @@ import {
   assertStrictEquals,
   assertThrows,
 } from "./test_util.ts";
-import { BufReader, BufWriter } from "@test_util/std/io/mod.ts";
-import { readAll } from "@test_util/std/streams/read_all.ts";
-import { writeAll } from "@test_util/std/streams/write_all.ts";
+import { BufReader, BufWriter } from "@std/io/mod.ts";
+import { readAll } from "@std/streams/read_all.ts";
+import { writeAll } from "@std/streams/write_all.ts";
 import { TextProtoReader } from "../testdata/run/textproto.ts";
 
 const encoder = new TextEncoder();

--- a/tests/unit/urlpattern_test.ts
+++ b/tests/unit/urlpattern_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "./test_util.ts";
-import { assertType, IsExact } from "@test_util/std/testing/types.ts";
+import { assertType, IsExact } from "@std/testing/types.ts";
 
 Deno.test(function urlPatternFromString() {
   const pattern = new URLPattern("https://deno.land/foo/:bar");

--- a/tests/unit/websocketstream_test.ts.disabled
+++ b/tests/unit/websocketstream_test.ts.disabled
@@ -6,7 +6,7 @@ import {
   assertRejects,
   assertThrows,
   unreachable,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 
 Deno.test("fragment", () => {
   assertThrows(() => new WebSocketStream("ws://localhost:4242/#"));

--- a/tests/unit/worker_test.ts
+++ b/tests/unit/worker_test.ts
@@ -7,7 +7,7 @@ import {
   assertEquals,
   assertMatch,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 
 function resolveWorker(worker: string): string {
   return import.meta.resolve(`../testdata/workers/${worker}`);

--- a/tests/unit_node/_fs/_fs_access_test.ts
+++ b/tests/unit_node/_fs/_fs_access_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import * as fs from "node:fs";
-import { assertRejects, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assertRejects, assertThrows } from "@std/assert/mod.ts";
 
 Deno.test(
   "[node/fs.access] Uses the owner permission when the user is the owner",

--- a/tests/unit_node/_fs/_fs_appendFile_test.ts
+++ b/tests/unit_node/_fs/_fs_appendFile_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows, fail } from "@std/assert/mod.ts";
 import { appendFile, appendFileSync } from "node:fs";
-import { fromFileUrl } from "@test_util/std/path/mod.ts";
+import { fromFileUrl } from "@std/path/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 
 const decoder = new TextDecoder("utf-8");

--- a/tests/unit_node/_fs/_fs_chmod_test.ts
+++ b/tests/unit_node/_fs/_fs_chmod_test.ts
@@ -4,7 +4,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { chmod, chmodSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_chown_test.ts
+++ b/tests/unit_node/_fs/_fs_chown_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { chown, chownSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_close_test.ts
+++ b/tests/unit_node/_fs/_fs_close_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assert, assertThrows, fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { close, closeSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_copy_test.ts
+++ b/tests/unit_node/_fs/_fs_copy_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import * as path from "@test_util/std/path/mod.ts";
-import { assert } from "@test_util/std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
+import { assert } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { copyFile, copyFileSync, existsSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_dir_test.ts
+++ b/tests/unit_node/_fs/_fs_dir_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals, fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { Dir as DirOrig, type Dirent } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_dirent_test.ts
+++ b/tests/unit_node/_fs/_fs_dirent_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { Dirent as Dirent_ } from "node:fs";
 
 // deno-lint-ignore no-explicit-any

--- a/tests/unit_node/_fs/_fs_exists_test.ts
+++ b/tests/unit_node/_fs/_fs_exists_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertEquals,
   assertStringIncludes,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { exists, existsSync } from "node:fs";
 import { promisify } from "node:util";
 

--- a/tests/unit_node/_fs/_fs_fdatasync_test.ts
+++ b/tests/unit_node/_fs/_fs_fdatasync_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 import { fdatasync, fdatasyncSync } from "node:fs";
 
 Deno.test({

--- a/tests/unit_node/_fs/_fs_fstat_test.ts
+++ b/tests/unit_node/_fs/_fs_fstat_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { fstat, fstatSync } from "node:fs";
-import { fail } from "@test_util/std/assert/mod.ts";
+import { fail } from "@std/assert/mod.ts";
 import { assertStats, assertStatsBigInt } from "./_fs_stat_test.ts";
 import type { BigIntStats, Stats } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_fsync_test.ts
+++ b/tests/unit_node/_fs/_fs_fsync_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 import { fsync, fsyncSync } from "node:fs";
 
 Deno.test({

--- a/tests/unit_node/_fs/_fs_ftruncate_test.ts
+++ b/tests/unit_node/_fs/_fs_ftruncate_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows, fail } from "@std/assert/mod.ts";
 import { ftruncate, ftruncateSync } from "node:fs";
 
 Deno.test({

--- a/tests/unit_node/_fs/_fs_futimes_test.ts
+++ b/tests/unit_node/_fs/_fs_futimes_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows, fail } from "@std/assert/mod.ts";
 import { futimes, futimesSync } from "node:fs";
 
 const randomDate = new Date(Date.now() + 1000);

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import * as path from "@test_util/std/path/mod.ts";
+import * as path from "@std/path/mod.ts";
 import { Buffer } from "node:buffer";
 import * as fs from "node:fs/promises";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");

--- a/tests/unit_node/_fs/_fs_link_test.ts
+++ b/tests/unit_node/_fs/_fs_link_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import * as path from "@test_util/std/path/mod.ts";
-import { assert, assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
+import { assert, assertEquals, fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { link, linkSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_lstat_test.ts
+++ b/tests/unit_node/_fs/_fs_lstat_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { lstat, lstatSync } from "node:fs";
-import { fail } from "@test_util/std/assert/mod.ts";
+import { fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { assertStats, assertStatsBigInt } from "./_fs_stat_test.ts";
 import type { BigIntStats, Stats } from "node:fs";

--- a/tests/unit_node/_fs/_fs_mkdir_test.ts
+++ b/tests/unit_node/_fs/_fs_mkdir_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import * as path from "@test_util/std/path/mod.ts";
-import { assert } from "@test_util/std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
+import { assert } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { existsSync, mkdir, mkdirSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_mkdtemp_test.ts
+++ b/tests/unit_node/_fs/_fs_mkdtemp_test.ts
@@ -3,7 +3,7 @@ import {
   assert,
   assertRejects,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { EncodingOption, existsSync, mkdtemp, mkdtempSync } from "node:fs";
 import { env } from "node:process";
 import { promisify } from "node:util";

--- a/tests/unit_node/_fs/_fs_open_test.ts
+++ b/tests/unit_node/_fs/_fs_open_test.ts
@@ -9,7 +9,7 @@ import {
   O_TRUNC,
   O_WRONLY,
 } from "node:constants";
-import { assertEquals, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows, fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { open, openSync } from "node:fs";
 import { join, parse } from "node:path";

--- a/tests/unit_node/_fs/_fs_opendir_test.ts
+++ b/tests/unit_node/_fs/_fs_opendir_test.ts
@@ -6,7 +6,7 @@ import {
   assertFalse,
   assertInstanceOf,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { opendir, opendirSync } from "node:fs";
 import { Buffer } from "node:buffer";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";

--- a/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { promises, readFile, readFileSync } from "node:fs";
-import * as path from "@test_util/std/path/mod.ts";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");

--- a/tests/unit_node/_fs/_fs_read_test.ts
+++ b/tests/unit_node/_fs/_fs_read_test.ts
@@ -4,11 +4,11 @@ import {
   assertFalse,
   assertMatch,
   assertStrictEquals,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { read, readSync } from "node:fs";
 import { open, openSync } from "node:fs";
 import { Buffer } from "node:buffer";
-import * as path from "@test_util/std/path/mod.ts";
+import * as path from "@std/path/mod.ts";
 import { closeSync } from "node:fs";
 
 async function readTest(

--- a/tests/unit_node/_fs/_fs_readdir_test.ts
+++ b/tests/unit_node/_fs/_fs_readdir_test.ts
@@ -3,10 +3,10 @@ import {
   assertEquals,
   assertNotEquals,
   fail,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readdir, readdirSync } from "node:fs";
-import { join } from "@test_util/std/path/mod.ts";
+import { join } from "@std/path/mod.ts";
 
 Deno.test({
   name: "ASYNC: reading empty directory",

--- a/tests/unit_node/_fs/_fs_readlink_test.ts
+++ b/tests/unit_node/_fs/_fs_readlink_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readlink, readlinkSync } from "node:fs";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
-import * as path from "@test_util/std/path/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
 
 const testDir = Deno.makeTempDirSync();
 const oldname = path.join(testDir, "oldname");

--- a/tests/unit_node/_fs/_fs_realpath_test.ts
+++ b/tests/unit_node/_fs/_fs_realpath_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import * as path from "@test_util/std/path/mod.ts";
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { realpath, realpathSync } from "node:fs";
 

--- a/tests/unit_node/_fs/_fs_rename_test.ts
+++ b/tests/unit_node/_fs/_fs_rename_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { rename, renameSync } from "node:fs";
 import { existsSync } from "node:fs";
-import { join, parse } from "@test_util/std/path/mod.ts";
+import { join, parse } from "@std/path/mod.ts";
 
 Deno.test({
   name: "ASYNC: renaming a file",

--- a/tests/unit_node/_fs/_fs_rm_test.ts
+++ b/tests/unit_node/_fs/_fs_rm_test.ts
@@ -4,10 +4,10 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { rm, rmSync } from "node:fs";
 import { existsSync } from "node:fs";
-import { join } from "@test_util/std/path/mod.ts";
+import { join } from "@std/path/mod.ts";
 
 Deno.test({
   name: "ASYNC: removing empty folder",

--- a/tests/unit_node/_fs/_fs_rmdir_test.ts
+++ b/tests/unit_node/_fs/_fs_rmdir_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 import { rmdir, rmdirSync } from "node:fs";
 import { existsSync } from "node:fs";
-import { join } from "@test_util/std/path/mod.ts";
+import { join } from "@std/path/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 
 Deno.test({

--- a/tests/unit_node/_fs/_fs_stat_test.ts
+++ b/tests/unit_node/_fs/_fs_stat_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { BigIntStats, stat, Stats, statSync } from "node:fs";
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 
 export function assertStats(actual: Stats, expected: Deno.FileInfo) {
   assertEquals(actual.dev, expected.dev);

--- a/tests/unit_node/_fs/_fs_symlink_test.ts
+++ b/tests/unit_node/_fs/_fs_symlink_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assert, assertThrows, fail } from "@std/assert/mod.ts";
 import { symlink, symlinkSync } from "node:fs";
 
 Deno.test({

--- a/tests/unit_node/_fs/_fs_truncate_test.ts
+++ b/tests/unit_node/_fs/_fs_truncate_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows, fail } from "@std/assert/mod.ts";
 import { truncate, truncateSync } from "node:fs";
 
 Deno.test({

--- a/tests/unit_node/_fs/_fs_unlink_test.ts
+++ b/tests/unit_node/_fs/_fs_unlink_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, fail } from "@std/assert/mod.ts";
 import { existsSync } from "node:fs";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { unlink, unlinkSync } from "node:fs";

--- a/tests/unit_node/_fs/_fs_utimes_test.ts
+++ b/tests/unit_node/_fs/_fs_utimes_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertThrows, fail } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows, fail } from "@std/assert/mod.ts";
 import { utimes, utimesSync } from "node:fs";
 
 const randomDate = new Date(Date.now() + 1000);

--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { watch } from "node:fs";
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 
 function wait(time: number) {
   return new Promise((resolve) => {

--- a/tests/unit_node/_fs/_fs_writeFile_test.ts
+++ b/tests/unit_node/_fs/_fs_writeFile_test.ts
@@ -5,9 +5,9 @@ import {
   assertNotEquals,
   assertRejects,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { writeFile, writeFileSync } from "node:fs";
-import * as path from "@test_util/std/path/mod.ts";
+import * as path from "@std/path/mod.ts";
 
 type TextEncodings =
   | "ascii"

--- a/tests/unit_node/_fs/_fs_write_test.ts
+++ b/tests/unit_node/_fs/_fs_write_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { write, writeSync } from "node:fs";
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 import { Buffer } from "node:buffer";
 
 const decoder = new TextDecoder("utf-8");

--- a/tests/unit_node/_test_utils.ts
+++ b/tests/unit_node/_test_utils.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertStringIncludes } from "@test_util/std/assert/mod.ts";
+import { assert, assertStringIncludes } from "@std/assert/mod.ts";
 
 /** Asserts that an error thrown in a callback will not be wrongly caught. */
 export async function assertCallbackErrorUncaught(

--- a/tests/unit_node/assertion_error_test.ts
+++ b/tests/unit_node/assertion_error_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { stripColor } from "@test_util/std/fmt/colors.ts";
-import { assert, assertStrictEquals } from "@test_util/std/assert/mod.ts";
+import { stripColor } from "@std/fmt/colors.ts";
+import { assert, assertStrictEquals } from "@std/assert/mod.ts";
 import { AssertionError } from "node:assert";
 
 Deno.test({

--- a/tests/unit_node/async_hooks_test.ts
+++ b/tests/unit_node/async_hooks_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 
 Deno.test(async function foo() {
   const asyncLocalStorage = new AsyncLocalStorage();

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { Buffer } from "node:buffer";
-import { assertEquals, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows } from "@std/assert/mod.ts";
 
 Deno.test({
   name: "[node/buffer] alloc fails if size is not a number",

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -9,8 +9,8 @@ import {
   assertNotStrictEquals,
   assertStrictEquals,
   assertStringIncludes,
-} from "@test_util/std/assert/mod.ts";
-import * as path from "@test_util/std/path/mod.ts";
+} from "@std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
 
 const { spawn, spawnSync, execFile, execFileSync, ChildProcess } = CP;
 

--- a/tests/unit_node/console_test.ts
+++ b/tests/unit_node/console_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import vm from "node:vm";
-import { stripColor } from "@test_util/std/fmt/colors.ts";
-import { assertStringIncludes } from "@test_util/std/assert/mod.ts";
+import { stripColor } from "@std/fmt/colors.ts";
+import { assertStringIncludes } from "@std/assert/mod.ts";
 
 Deno.test(function inspectCrossRealmObjects() {
   assertStringIncludes(

--- a/tests/unit_node/crypto/crypto_cipher_gcm_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_gcm_test.ts
@@ -4,7 +4,7 @@ import crypto from "node:crypto";
 import { Buffer } from "node:buffer";
 import testVectors128 from "./gcmEncryptExtIV128.json" assert { type: "json" };
 import testVectors256 from "./gcmEncryptExtIV256.json" assert { type: "json" };
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 
 const aesGcm = (bits: string, key: Uint8Array) => {
   const ALGO = bits == "128" ? `aes-128-gcm` : `aes-256-gcm`;

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
 import { buffer, text } from "node:stream/consumers";
-import { assertEquals, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows } from "@std/assert/mod.ts";
 
 const rsaPrivateKey = Deno.readTextFileSync(
   new URL("../testdata/rsa_private.pem", import.meta.url),

--- a/tests/unit_node/crypto/crypto_hash_test.ts
+++ b/tests/unit_node/crypto/crypto_hash_test.ts
@@ -8,7 +8,7 @@ import {
 } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 
 // https://github.com/denoland/deno/issues/18140
 Deno.test({

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -11,7 +11,7 @@ import {
 } from "node:crypto";
 import { promisify } from "node:util";
 import { Buffer } from "node:buffer";
-import { assertEquals, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows } from "@std/assert/mod.ts";
 import { createHmac } from "node:crypto";
 
 const RUN_SLOW_TESTS = Deno.env.get("SLOW_TESTS") === "1";

--- a/tests/unit_node/crypto/crypto_sign_test.ts
+++ b/tests/unit_node/crypto/crypto_sign_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals } from "@test_util/std/testing/asserts.ts";
+import { assert, assertEquals } from "@std/testing/asserts.ts";
 import { createSign, createVerify, sign, verify } from "node:crypto";
 import { Buffer } from "node:buffer";
 

--- a/tests/unit_node/dgram_test.ts
+++ b/tests/unit_node/dgram_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 import { execCode } from "../unit/test_util.ts";
 import { createSocket } from "node:dgram";
 

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -4,7 +4,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -2,7 +2,7 @@
 
 import * as http2 from "node:http2";
 import * as net from "node:net";
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 
 for (const url of ["http://127.0.0.1:4246", "https://127.0.0.1:4247"]) {
   Deno.test(`[node/http2 client] ${url}`, {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -3,12 +3,12 @@
 import EventEmitter from "node:events";
 import http, { type RequestOptions } from "node:http";
 import https from "node:https";
-import { assert, assertEquals, fail } from "@test_util/std/assert/mod.ts";
-import { assertSpyCalls, spy } from "@test_util/std/testing/mock.ts";
+import { assert, assertEquals, fail } from "@std/assert/mod.ts";
+import { assertSpyCalls, spy } from "@std/testing/mock.ts";
 
 import { gzip } from "node:zlib";
 import { Buffer } from "node:buffer";
-import { serve } from "@test_util/std/http/server.ts";
+import { serve } from "@std/http/server.ts";
 import { execCode } from "../unit/test_util.ts";
 
 Deno.test("[node/http listen]", async () => {

--- a/tests/unit_node/internal/_randomBytes_test.ts
+++ b/tests/unit_node/internal/_randomBytes_test.ts
@@ -4,7 +4,7 @@ import {
   assertEquals,
   assertRejects,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { pseudoRandomBytes, randomBytes } from "node:crypto";
 

--- a/tests/unit_node/internal/_randomFill_test.ts
+++ b/tests/unit_node/internal/_randomFill_test.ts
@@ -5,7 +5,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 
 const validateNonZero = (buf: Buffer) => {
   if (!buf.some((ch) => ch > 0)) throw new Error("Error");

--- a/tests/unit_node/internal/_randomInt_test.ts
+++ b/tests/unit_node/internal/_randomInt_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { randomInt } from "node:crypto";
-import { assert, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assert, assertThrows } from "@std/assert/mod.ts";
 
 const between = (x: number, min: number, max: number) => x >= min && x < max;
 

--- a/tests/unit_node/internal/pbkdf2_test.ts
+++ b/tests/unit_node/internal/pbkdf2_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { pbkdf2, pbkdf2Sync } from "node:crypto";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 
 type Algorithms =
   | "md5"

--- a/tests/unit_node/internal/scrypt_test.ts
+++ b/tests/unit_node/internal/scrypt_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { scrypt, scryptSync } from "node:crypto";
 import { Buffer } from "node:buffer";
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 
 Deno.test("scrypt works correctly", async () => {
   const { promise, resolve } = Promise.withResolvers<boolean>();

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { createRequire, Module } from "node:module";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
 import process from "node:process";
 import * as path from "node:path";
 

--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import * as net from "node:net";
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
-import * as path from "@test_util/std/path/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
+import * as path from "@std/path/mod.ts";
 import * as http from "node:http";
 
 Deno.test("[node/net] close event emits after error event", async () => {

--- a/tests/unit_node/os_test.ts
+++ b/tests/unit_node/os_test.ts
@@ -7,7 +7,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
+} from "@std/assert/mod.ts";
 
 Deno.test({
   name: "build architecture is a string",

--- a/tests/unit_node/path_test.ts
+++ b/tests/unit_node/path_test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import posix from "node:path/posix";
 import win32 from "node:path/win32";
 
-import { assertStrictEquals } from "@test_util/std/assert/mod.ts";
+import { assertStrictEquals } from "@std/assert/mod.ts";
 
 Deno.test("[node/path] posix and win32 objects", () => {
   assertStrictEquals(path.posix, posix);

--- a/tests/unit_node/perf_hooks_test.ts
+++ b/tests/unit_node/perf_hooks_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import * as perfHooks from "node:perf_hooks";
 import { performance } from "node:perf_hooks";
-import { assertEquals, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows } from "@std/assert/mod.ts";
 
 Deno.test({
   name: "[perf_hooks] performance",

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -11,10 +11,10 @@ import {
   assertObjectMatch,
   assertStrictEquals,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
-import { stripColor } from "@test_util/std/fmt/colors.ts";
-import * as path from "@test_util/std/path/mod.ts";
-import { delay } from "@test_util/std/async/delay.ts";
+} from "@std/assert/mod.ts";
+import { stripColor } from "@std/fmt/colors.ts";
+import * as path from "@std/path/mod.ts";
+import { delay } from "@std/async/delay.ts";
 
 const testDir = new URL(".", import.meta.url);
 

--- a/tests/unit_node/querystring_test.ts
+++ b/tests/unit_node/querystring_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 import { parse, stringify } from "node:querystring";
 
 Deno.test({

--- a/tests/unit_node/readline_test.ts
+++ b/tests/unit_node/readline_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { createInterface, Interface } from "node:readline";
-import { assertInstanceOf } from "@test_util/std/assert/mod.ts";
+import { assertInstanceOf } from "@std/assert/mod.ts";
 import { Readable, Writable } from "node:stream";
 
 Deno.test("[node/readline] createInstance", () => {

--- a/tests/unit_node/repl_test.ts
+++ b/tests/unit_node/repl_test.ts
@@ -2,7 +2,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import repl from "node:repl";
-import { assert } from "@test_util/std/assert/mod.ts";
+import { assert } from "@std/assert/mod.ts";
 
 Deno.test({
   name: "repl module exports",

--- a/tests/unit_node/stream_test.ts
+++ b/tests/unit_node/stream_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert } from "@test_util/std/assert/mod.ts";
-import { fromFileUrl, relative } from "@test_util/std/path/mod.ts";
+import { assert } from "@std/assert/mod.ts";
+import { fromFileUrl, relative } from "@std/path/mod.ts";
 import { pipeline } from "node:stream/promises";
 import { createReadStream, createWriteStream } from "node:fs";
 

--- a/tests/unit_node/string_decoder_test.ts
+++ b/tests/unit_node/string_decoder_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 import { Buffer } from "node:buffer";
 import { StringDecoder } from "node:string_decoder";
 

--- a/tests/unit_node/timers_test.ts
+++ b/tests/unit_node/timers_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert, fail } from "@test_util/std/assert/mod.ts";
+import { assert, fail } from "@std/assert/mod.ts";
 import * as timers from "node:timers";
 import * as timersPromises from "node:timers/promises";
 

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertInstanceOf } from "@test_util/std/assert/mod.ts";
-import { delay } from "@test_util/std/async/delay.ts";
-import { fromFileUrl, join } from "@test_util/std/path/mod.ts";
-import { serveTls } from "@test_util/std/http/server.ts";
+import { assertEquals, assertInstanceOf } from "@std/assert/mod.ts";
+import { delay } from "@std/async/delay.ts";
+import { fromFileUrl, join } from "@std/path/mod.ts";
+import { serveTls } from "@std/http/server.ts";
 import * as tls from "node:tls";
 import * as net from "node:net";
 import * as stream from "node:stream";

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 
-import { assert } from "@test_util/std/assert/mod.ts";
+import { assert } from "@std/assert/mod.ts";
 import { isatty } from "node:tty";
 import process from "node:process";
 

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -5,8 +5,8 @@ import {
   assertEquals,
   assertStrictEquals,
   assertThrows,
-} from "@test_util/std/assert/mod.ts";
-import { stripColor } from "@test_util/std/fmt/colors.ts";
+} from "@std/assert/mod.ts";
+import { stripColor } from "@std/fmt/colors.ts";
 import * as util from "node:util";
 import { Buffer } from "node:buffer";
 

--- a/tests/unit_node/v8_test.ts
+++ b/tests/unit_node/v8_test.ts
@@ -4,7 +4,7 @@ import {
   getHeapStatistics,
   setFlagsFromString,
 } from "node:v8";
-import { assertEquals } from "@test_util/std/assert/mod.ts";
+import { assertEquals } from "@std/assert/mod.ts";
 
 // https://github.com/nodejs/node/blob/a2bbe5ff216bc28f8dac1c36a8750025a93c3827/test/parallel/test-v8-version-tag.js#L6
 Deno.test({

--- a/tests/unit_node/vm_test.ts
+++ b/tests/unit_node/vm_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { isContext, runInNewContext } from "node:vm";
-import { assertEquals, assertThrows } from "@test_util/std/assert/mod.ts";
+import { assertEquals, assertThrows } from "@std/assert/mod.ts";
 
 Deno.test({
   name: "vm runInNewContext",

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -4,8 +4,8 @@ import {
   assert,
   assertEquals,
   assertObjectMatch,
-} from "@test_util/std/assert/mod.ts";
-import { fromFileUrl, relative } from "@test_util/std/path/mod.ts";
+} from "@std/assert/mod.ts";
+import { fromFileUrl, relative } from "@std/path/mod.ts";
 import * as workerThreads from "node:worker_threads";
 import { EventEmitter, once } from "node:events";
 

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals } from "@test_util/std/assert/mod.ts";
-import { fromFileUrl, relative } from "@test_util/std/path/mod.ts";
+import { assert, assertEquals } from "@std/assert/mod.ts";
+import { fromFileUrl, relative } from "@std/path/mod.ts";
 import {
   brotliCompress,
   brotliCompressSync,

--- a/tools/node_compat/setup.ts
+++ b/tools/node_compat/setup.ts
@@ -3,12 +3,12 @@
 
 /** This copies the test files according to the config file `tests/node_compat/config.jsonc` */
 
-import { walk } from "@test_util/std/fs/walk.ts";
-import { sep } from "@test_util/std/path/mod.ts";
-import { ensureFile } from "@test_util/std/fs/ensure_file.ts";
-import { writeAll } from "@test_util/std/streams/write_all.ts";
-import { withoutAll } from "@test_util/std/collections/without_all.ts";
-import { relative } from "@test_util/std/path/posix.ts";
+import { walk } from "@std/fs/walk.ts";
+import { sep } from "@std/path/mod.ts";
+import { ensureFile } from "@std/fs/ensure_file.ts";
+import { writeAll } from "@std/streams/write_all.ts";
+import { withoutAll } from "@std/collections/without_all.ts";
+import { relative } from "@std/path/posix.ts";
 
 import { config, ignoreList } from "../../tests/node_compat/common.ts";
 


### PR DESCRIPTION
This PR does one thing: replaces `@test_util/std`-prefixed imports with `@std`.