### PR TITLE
chore: move `test_util/std` to `tests/util/std`

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -46,7 +46,7 @@
     "gh-pages",
     "target",
     "tests/ffi/tests/test.js",
-    "test_util/std",
+    "tests/util/std",
     "test_util/wpt",
     "third_party",
     "tools/node_compat/TODO.md",

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -445,7 +445,7 @@ const ci = {
       },
       steps: skipJobsIfPrAndMarkedSkip([
         ...cloneRepoStep,
-        submoduleStep("./test_util/std"),
+        submoduleStep("./tests/util/std"),
         {
           ...submoduleStep("./test_util/wpt"),
           if: "matrix.wpt",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
           fetch-depth: 5
           submodules: false
         if: '!(matrix.skip)'
-      - name: Clone submodule ./test_util/std
-        run: git submodule update --init --recursive --depth=1 -- ./test_util/std
+      - name: Clone submodule ./tests/util/std
+        run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
         if: '!(matrix.skip)'
       - name: Clone submodule ./test_util/wpt
         run: git submodule update --init --recursive --depth=1 -- ./test_util/wpt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
-[submodule "test_util/std"]
-	path = test_util/std
+[submodule "tests/util/std"]
+	path = tests/util/std
 	url = https://github.com/denoland/deno_std
 	shallow = true
 [submodule "test_util/wpt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
   "tests/ffi",
   "tests/napi",
 ]
-exclude = ["test_util/std/hash/_wasm"]
+exclude = ["tests/util/std/hash/_wasm"]
 
 [workspace.package]
 authors = ["the Deno authors"]

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -123,7 +123,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
       "check",
       "--reload",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "tests/util/std/http/file_server_test.ts",
     ],
     None,
   ),
@@ -134,7 +134,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
       "--reload",
       "--no-check",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "tests/util/std/http/file_server_test.ts",
     ],
     None,
   ),
@@ -143,7 +143,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &[
       "bundle",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "tests/util/std/http/file_server_test.ts",
     ],
     None,
   ),
@@ -153,7 +153,7 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
       "bundle",
       "--no-check",
       "--unstable",
-      "test_util/std/http/file_server_test.ts",
+      "tests/util/std/http/file_server_test.ts",
     ],
     None,
   ),
@@ -306,7 +306,7 @@ fn get_binary_sizes(target_dir: &Path) -> Result<HashMap<String, i64>> {
 }
 
 const BUNDLES: &[(&str, &str)] = &[
-  ("file_server", "./test_util/std/http/file_server.ts"),
+  ("file_server", "./tests/util/std/http/file_server.ts"),
   ("welcome", "./tests/testdata/welcome.ts"),
 ];
 fn bundle_benchmark(deno_exe: &Path) -> Result<HashMap<String, i64>> {

--- a/ext/websocket/autobahn/autobahn_server.js
+++ b/ext/websocket/autobahn/autobahn_server.js
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { parse } from "../../../test_util/std/flags/mod.ts";
+import { parse } from "../../../tests/util/std/flags/mod.ts";
 
 const { port } = parse(Deno.args, {
   number: ["port"],

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -118,7 +118,7 @@ pub fn jsr_registry_unset_url() -> String {
 }
 
 pub fn std_path() -> PathRef {
-  root_path().join("test_util").join("std")
+  root_path().join("tests").join("util").join("std")
 }
 
 pub fn std_file_url() -> String {

--- a/tests/config/deno.json
+++ b/tests/config/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "@test_util/": "../../test_util/",
-    "@std/": "../../test_util/std/"
+    "@std/": "../util/std/"
   }
 }

--- a/tests/node_compat/deno.json
+++ b/tests/node_compat/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
     "@test_util/": "../../test_util/",
-    "@std/": "../../test_util/std/"
+    "@std/": "../util/std/"
   }
 }

--- a/tests/testdata/bench/allow_all.ts
+++ b/tests/testdata/bench/allow_all.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../tests/util/std/assert/mod.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/tests/testdata/bench/allow_none.ts
+++ b/tests/testdata/bench/allow_none.ts
@@ -1,4 +1,4 @@
-import { unreachable } from "../../../test_util/std/assert/mod.ts";
+import { unreachable } from "../../../tests/util/std/assert/mod.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/tests/testdata/cat.ts
+++ b/tests/testdata/cat.ts
@@ -1,4 +1,4 @@
-import { copy } from "../../test_util/std/streams/copy.ts";
+import { copy } from "../../tests/util/std/streams/copy.ts";
 async function main() {
   for (let i = 1; i < Deno.args.length; i++) {
     const filename = Deno.args[i];

--- a/tests/testdata/cert/listen_tls_alpn_fail.ts
+++ b/tests/testdata/cert/listen_tls_alpn_fail.ts
@@ -1,4 +1,4 @@
-import { assertRejects } from "../../../test_util/std/assert/mod.ts";
+import { assertRejects } from "../../../tests/util/std/assert/mod.ts";
 
 const listener = Deno.listenTls({
   port: Number(Deno.args[0]),

--- a/tests/testdata/compile/dynamic_imports/main_unanalyzable.ts
+++ b/tests/testdata/compile/dynamic_imports/main_unanalyzable.ts
@@ -1,4 +1,4 @@
-import { join } from "../../../../test_util/std/path/mod.ts";
+import { join } from "../../../../tests/util/std/path/mod.ts";
 
 console.log("Starting the main module");
 

--- a/tests/testdata/compile/standalone_follow_redirects_2.js
+++ b/tests/testdata/compile/standalone_follow_redirects_2.js
@@ -2,4 +2,4 @@
 import {
   assertNotEquals as _a,
   assertStrictEquals as _b,
-} from "../../../test_util/std/assert/mod.ts";
+} from "../../../tests/util/std/assert/mod.ts";

--- a/tests/testdata/coverage/no_snaps_included/no_snaps_included_test.ts
+++ b/tests/testdata/coverage/no_snaps_included/no_snaps_included_test.ts
@@ -1,4 +1,4 @@
-import { assertSnapshot } from "../../../../test_util/std/testing/snapshot.ts";
+import { assertSnapshot } from "../../../../tests/util/std/testing/snapshot.ts";
 import { truth } from "./no_snaps_included.ts";
 
 Deno.test("the truth", () => {

--- a/tests/testdata/coverage/no_tests_included/foo.test.js
+++ b/tests/testdata/coverage/no_tests_included/foo.test.js
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../tests/util/std/assert/mod.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/tests/testdata/coverage/no_tests_included/foo.test.mts
+++ b/tests/testdata/coverage/no_tests_included/foo.test.mts
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../tests/util/std/assert/mod.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/tests/testdata/coverage/no_tests_included/foo.test.ts
+++ b/tests/testdata/coverage/no_tests_included/foo.test.ts
@@ -1,5 +1,5 @@
 import { addNumbers } from "./foo.ts";
-import { assertEquals } from "../../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../../tests/util/std/assert/mod.ts";
 
 Deno.test("addNumbers works", () => {
   assertEquals(addNumbers(1, 2), 3);

--- a/tests/testdata/coverage/no_transpiled_lines/index.ts
+++ b/tests/testdata/coverage/no_transpiled_lines/index.ts
@@ -1,3 +1,3 @@
-export { assertStrictEquals } from "../../../../test_util/std/assert/mod.ts";
+export { assertStrictEquals } from "../../../../tests/util/std/assert/mod.ts";
 
 export * from "./interface.ts";

--- a/tests/testdata/echo_server.ts
+++ b/tests/testdata/echo_server.ts
@@ -1,4 +1,4 @@
-import { copy } from "../../test_util/std/streams/copy.ts";
+import { copy } from "../../tests/util/std/streams/copy.ts";
 const addr = Deno.args[0] || "0.0.0.0:4544";
 const [hostname, port] = addr.split(":");
 const listener = Deno.listen({ hostname, port: Number(port) });

--- a/tests/testdata/run/045_proxy_test.ts
+++ b/tests/testdata/run/045_proxy_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { Server } from "../../../test_util/std/http/server.ts";
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { Server } from "../../../tests/util/std/http/server.ts";
+import { assertEquals } from "../../../tests/util/std/assert/mod.ts";
 
 const addr = Deno.args[1] || "localhost:4555";
 

--- a/tests/testdata/run/import_meta/main.ts
+++ b/tests/testdata/run/import_meta/main.ts
@@ -1,4 +1,4 @@
-import { assertThrows } from "../../../../test_util/std/assert/mod.ts";
+import { assertThrows } from "../../../../tests/util/std/assert/mod.ts";
 import "http://localhost:4545/run/import_meta/other.ts";
 import "./other.ts";
 

--- a/tests/testdata/run/onload/imported.ts
+++ b/tests/testdata/run/onload/imported.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-window-prefix
-import { assert } from "../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../tests/util/std/assert/mod.ts";
 import "./nest_imported.ts";
 
 const handler = (e: Event) => {

--- a/tests/testdata/run/onload/main.ts
+++ b/tests/testdata/run/onload/main.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-window-prefix no-prototype-builtins
-import { assert } from "../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../tests/util/std/assert/mod.ts";
 import "./imported.ts";
 
 assert(window.hasOwnProperty("onload"));

--- a/tests/testdata/run/onload/nest_imported.ts
+++ b/tests/testdata/run/onload/nest_imported.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-window-prefix
-import { assert } from "../../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../../tests/util/std/assert/mod.ts";
 
 const handler = (e: Event) => {
   assert(e.type === "beforeunload" ? e.cancelable : !e.cancelable);

--- a/tests/testdata/run/textproto.ts
+++ b/tests/testdata/run/textproto.ts
@@ -17,8 +17,8 @@
 import type {
   BufReader,
   ReadLineResult,
-} from "../../../test_util/std/io/buf_reader.ts";
-import { concat } from "../../../test_util/std/bytes/concat.ts";
+} from "../../../tests/util/std/io/buf_reader.ts";
+import { concat } from "../../../tests/util/std/bytes/concat.ts";
 
 // Constants created for DRY
 const CHAR_SPACE: number = " ".charCodeAt(0);

--- a/tests/testdata/run/tls_connecttls.js
+++ b/tests/testdata/run/tls_connecttls.js
@@ -1,5 +1,5 @@
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
-import { BufReader, BufWriter } from "../../../test_util/std/io/mod.ts";
+import { assert, assertEquals } from "../../../tests/util/std/assert/mod.ts";
+import { BufReader, BufWriter } from "../../../tests/util/std/io/mod.ts";
 import { TextProtoReader } from "./textproto.ts";
 
 const encoder = new TextEncoder();

--- a/tests/testdata/run/tls_starttls.js
+++ b/tests/testdata/run/tls_starttls.js
@@ -1,6 +1,6 @@
-import { assert, assertEquals } from "../../../test_util/std/assert/mod.ts";
-import { BufReader } from "../../../test_util/std/io/buf_reader.ts";
-import { BufWriter } from "../../../test_util/std/io/buf_writer.ts";
+import { assert, assertEquals } from "../../../tests/util/std/assert/mod.ts";
+import { BufReader } from "../../../tests/util/std/io/buf_reader.ts";
+import { BufWriter } from "../../../tests/util/std/io/buf_writer.ts";
 import { TextProtoReader } from "./textproto.ts";
 
 const encoder = new TextEncoder();

--- a/tests/testdata/run/websocket_server_idletimeout.ts
+++ b/tests/testdata/run/websocket_server_idletimeout.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../tests/util/std/assert/mod.ts";
 
 const errorDeferred = Promise.withResolvers<void>();
 const closeDeferred = Promise.withResolvers<void>();

--- a/tests/testdata/test/allow_all.ts
+++ b/tests/testdata/test/allow_all.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../../../test_util/std/assert/mod.ts";
+import { assertEquals } from "../../../tests/util/std/assert/mod.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/tests/testdata/test/allow_none.ts
+++ b/tests/testdata/test/allow_none.ts
@@ -1,4 +1,4 @@
-import { unreachable } from "../../../test_util/std/assert/mod.ts";
+import { unreachable } from "../../../tests/util/std/assert/mod.ts";
 
 const permissions: Deno.PermissionName[] = [
   "read",

--- a/tests/testdata/test/ops_sanitizer_missing_details.ts
+++ b/tests/testdata/test/ops_sanitizer_missing_details.ts
@@ -1,6 +1,6 @@
 // https://github.com/denoland/deno/issues/13729
 // https://github.com/denoland/deno/issues/13938
-import { writeAll } from "../../../test_util/std/streams/write_all.ts";
+import { writeAll } from "../../../tests/util/std/streams/write_all.ts";
 
 Deno.test("test 1", { permissions: { write: true, read: true } }, async () => {
   const tmpFile = await Deno.makeTempFile();

--- a/tests/testdata/workers/deno_worker.ts
+++ b/tests/testdata/workers/deno_worker.ts
@@ -1,4 +1,4 @@
-import { assert } from "../../../test_util/std/assert/mod.ts";
+import { assert } from "../../../tests/util/std/assert/mod.ts";
 
 onmessage = function (e) {
   if (typeof self.Deno === "undefined") {

--- a/tools/node_compat/deno.json
+++ b/tools/node_compat/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "@test_util/": "../../test_util/",
-    "@std/": "../../test_util/std/"
+    "@std/": "../../tests/util/std/"
   },
   "tasks": {
     "setup": "deno run --allow-read --allow-write ./setup.ts",

--- a/tools/util.js
+++ b/tools/util.js
@@ -5,12 +5,12 @@ import {
   join,
   resolve,
   toFileUrl,
-} from "../test_util/std/path/mod.ts";
+} from "../tests/util/std/path/mod.ts";
 import { wait } from "https://deno.land/x/wait@0.1.13/mod.ts";
 export { dirname, fromFileUrl, join, resolve, toFileUrl };
-export { existsSync, walk } from "../test_util/std/fs/mod.ts";
-export { TextLineStream } from "../test_util/std/streams/text_line_stream.ts";
-export { delay } from "../test_util/std/async/delay.ts";
+export { existsSync, walk } from "../tests/util/std/fs/mod.ts";
+export { TextLineStream } from "../tests/util/std/streams/text_line_stream.ts";
+export { delay } from "../tests/util/std/async/delay.ts";
 
 // [toolName] --version output
 const versions = {

--- a/tools/wpt.ts
+++ b/tools/wpt.ts
@@ -32,9 +32,15 @@ import {
   updateManifest,
   wptreport,
 } from "./wpt/utils.ts";
-import { pooledMap } from "../test_util/std/async/pool.ts";
-import { blue, bold, green, red, yellow } from "../test_util/std/fmt/colors.ts";
-import { writeAll, writeAllSync } from "../test_util/std/streams/write_all.ts";
+import { pooledMap } from "../tests/util/std/async/pool.ts";
+import {
+  blue,
+  bold,
+  green,
+  red,
+  yellow,
+} from "../tests/util/std/fmt/colors.ts";
+import { writeAll, writeAllSync } from "../tests/util/std/streams/write_all.ts";
 import { saveExpectation } from "./wpt/utils.ts";
 
 class TestFilter {

--- a/tools/wpt/utils.ts
+++ b/tools/wpt/utils.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 /// FLAGS
 
-import { parse } from "../../test_util/std/flags/mod.ts";
+import { parse } from "../../tests/util/std/flags/mod.ts";
 import { join, resolve, ROOT_PATH } from "../util.js";
 
 export const {


### PR DESCRIPTION
Note: tests are not the only part of the codebase that uses `std`. Other parts, like `tools/`, do too. So, it could be argued that this is a little misleading. Either way, I'm doing this as discussed with @mmastrac.