### PR TITLE
fix(ext/console): maxStringLength 10_000

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -2316,7 +2316,7 @@ const denoInspectDefaultOptions = {
 
   // node only
   maxArrayLength: 100,
-  maxStringLength: 100, // deno: strAbbreviateSize: 100
+  maxStringLength: 10_000, // deno: strAbbreviateSize: 10_000
   customInspect: true,
 
   // deno only

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -174,7 +174,7 @@ Deno.test(function consoleTestStringifyQuotes() {
 });
 
 Deno.test(function consoleTestStringifyLongStrings() {
-  const veryLongString = "a".repeat(10_000);
+  const veryLongString = "a".repeat(10_100);
   // If we stringify an object containing the long string, it gets abbreviated.
   let actual = stringify({ veryLongString });
   assert(actual.includes("..."));

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -174,11 +174,11 @@ Deno.test(function consoleTestStringifyQuotes() {
 });
 
 Deno.test(function consoleTestStringifyLongStrings() {
-  const veryLongString = "a".repeat(200);
+  const veryLongString = "a".repeat(10_000);
   // If we stringify an object containing the long string, it gets abbreviated.
   let actual = stringify({ veryLongString });
   assert(actual.includes("..."));
-  assert(actual.length < 200);
+  assert(actual.length < 10_100);
   // However if we stringify the string itself, we get it exactly.
   actual = stringify(veryLongString);
   assertEquals(actual, veryLongString);


### PR DESCRIPTION
fix https://github.com/denoland/deno/issues/22160

Default to logging full strings up to 10,000 matching Node.js behavior