### PR TITLE
fix: util.parseArgs() missing node:process import

### DIFF
--- a/ext/node/polyfills/internal/util/parse_args/parse_args.js
+++ b/ext/node/polyfills/internal/util/parse_args/parse_args.js
@@ -46,6 +46,8 @@ const {
   ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL,
 } = codes;
 
+import process from "node:process";
+
 function getMainArgs() {
   // Work out where to slice process.argv for user supplied arguments.
 

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -315,3 +315,10 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "[util] parseArgs() with no args works",
+  fn() {
+    util.parseArgs({});
+  },
+});


### PR DESCRIPTION
fix parseArgs() not working due to missing import of node:process

this commit fixes issue #22363

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
