### PR TITLE
chore: deno_core bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.261.0"
+version = "0.262.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743b191a1004e4989caf50c4ace8e3208732456118e79d433e2aff246772066"
+checksum = "bb0c12fbe4f2c497ff53de92dd698a27d93f8e9c2519ea5684f608cb9f4ef44b"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.137.0"
+version = "0.138.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5973f100f3ff9dea83a5b6261276d233c51ebc7f4c4fcdebd4c0d476b4fe5"
+checksum = "04698b09128a026abe3d8a82fdb231baf1a35f07443844728fe1441b2c2340f1"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5450,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.170.0"
+version = "0.171.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cce12a1cbf76530919847280a975a7831dab85a73d513161a5e6153a8e75d6"
+checksum = "88a2746b1f9e4015ee5f325bb87ab0f1891b76c38dfb1675bc83857eaf6451d0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "0.33.2", features = ["transpiling"] }
-deno_core = { version = "0.261.0" }
+deno_core = { version = "0.262.0" }
 
 deno_bench_util = { version = "0.131.0", path = "./bench_util" }
 deno_lockfile = "0.18.2"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -266,33 +266,36 @@ mod ts {
     )
     .unwrap();
 
-    let output = create_snapshot(CreateSnapshotOptions {
-      cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
-      snapshot_path,
-      startup_snapshot: None,
-      extensions: vec![deno_tsc::init_ops_and_esm(
-        op_crate_libs,
-        build_libs,
-        path_dts,
-      )],
-      // NOTE(bartlomieju): Compressing the TSC snapshot in debug build took
-      // ~45s on M1 MacBook Pro; without compression it took ~1s.
-      // Thus we're not not using compressed snapshot, trading off
-      // a lot of build time for some startup time in debug build.
-      #[cfg(debug_assertions)]
-      compression_cb: None,
+    let output = create_snapshot(
+      CreateSnapshotOptions {
+        cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
+        snapshot_path,
+        startup_snapshot: None,
+        extensions: vec![deno_tsc::init_ops_and_esm(
+          op_crate_libs,
+          build_libs,
+          path_dts,
+        )],
+        // NOTE(bartlomieju): Compressing the TSC snapshot in debug build took
+        // ~45s on M1 MacBook Pro; without compression it took ~1s.
+        // Thus we're not not using compressed snapshot, trading off
+        // a lot of build time for some startup time in debug build.
+        #[cfg(debug_assertions)]
+        compression_cb: None,
 
-      #[cfg(not(debug_assertions))]
-      compression_cb: Some(Box::new(|vec, snapshot_slice| {
-        eprintln!("Compressing TSC snapshot...");
-        vec.extend_from_slice(
-          &zstd::bulk::compress(snapshot_slice, 22)
-            .expect("snapshot compression failed"),
-        );
-      })),
-      with_runtime_cb: None,
-      skip_op_registration: false,
-    });
+        #[cfg(not(debug_assertions))]
+        compression_cb: Some(Box::new(|vec, snapshot_slice| {
+          eprintln!("Compressing TSC snapshot...");
+          vec.extend_from_slice(
+            &zstd::bulk::compress(snapshot_slice, 22)
+              .expect("snapshot compression failed"),
+          );
+        })),
+        with_runtime_cb: None,
+        skip_op_registration: false,
+      },
+      None,
+    );
     for path in output.files_loaded_during_snapshot {
       println!("cargo:rerun-if-changed={}", path.display());
     }

--- a/cli/tools/test/fmt.rs
+++ b/cli/tools/test/fmt.rs
@@ -133,7 +133,7 @@ fn format_sanitizer_accum_item(
 ) -> (RuntimeActivityType, Cow<'static, str>) {
   let activity_type = activity.activity();
   match activity {
-    RuntimeActivity::AsyncOp(_, name) => (activity_type, name.into()),
+    RuntimeActivity::AsyncOp(_, name, _) => (activity_type, name.into()),
     RuntimeActivity::Interval(_) => (activity_type, "".into()),
     RuntimeActivity::Resource(_, name) => (activity_type, name.into()),
     RuntimeActivity::Timer(_) => (activity_type, "".into()),

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -265,21 +265,24 @@ pub fn create_runtime_snapshot(
     }
   }
 
-  let output = create_snapshot(CreateSnapshotOptions {
-    cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
-    snapshot_path,
-    startup_snapshot: None,
-    extensions,
-    compression_cb: None,
-    with_runtime_cb: Some(Box::new(|rt| {
-      let isolate = rt.v8_isolate();
-      let scope = &mut v8::HandleScope::new(isolate);
+  let output = create_snapshot(
+    CreateSnapshotOptions {
+      cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
+      snapshot_path,
+      startup_snapshot: None,
+      extensions,
+      compression_cb: None,
+      with_runtime_cb: Some(Box::new(|rt| {
+        let isolate = rt.v8_isolate();
+        let scope = &mut v8::HandleScope::new(isolate);
 
-      let ctx = v8::Context::new(scope);
-      assert_eq!(scope.add_context(ctx), deno_node::VM_CONTEXT_INDEX);
-    })),
-    skip_op_registration: false,
-  });
+        let ctx = v8::Context::new(scope);
+        assert_eq!(scope.add_context(ctx), deno_node::VM_CONTEXT_INDEX);
+      })),
+      skip_op_registration: false,
+    },
+    None,
+  );
   for path in output.files_loaded_during_snapshot {
     println!("cargo:rerun-if-changed={}", path.display());
   }

--- a/tests/testdata/test/ops_sanitizer_multiple_timeout_tests.out
+++ b/tests/testdata/test/ops_sanitizer_multiple_timeout_tests.out
@@ -10,13 +10,13 @@ error: Leaking async ops:
   - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operations were started here:
     at [WILDCARD]
     at setTimeout ([WILDCARD])
-    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:4:3)
+    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
     at [WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:8:27
     at [WILDCARD]
 
     at [WILDCARD]
     at setTimeout ([WILDCARD])
-    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:5:3)
+    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
     at [WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:8:27
     at [WILDCARD]
 
@@ -25,13 +25,13 @@ error: Leaking async ops:
   - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operations were started here:
     at [WILDCARD]
     at setTimeout ([WILDCARD])
-    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:4:3)
+    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
     at [WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:10:27
     at [WILDCARD]
 
     at [WILDCARD]
     at setTimeout ([WILDCARD])
-    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:5:3)
+    at test ([WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
     at [WILDCARD]/testdata/test/ops_sanitizer_multiple_timeout_tests.ts:10:27
     at [WILDCARD]
 


### PR DESCRIPTION
 - Adding `None` flag for warmup script.
 - Modify opcall trace interface to match new Rust implementation