### PR TITLE
feat: `Deno.Build`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5223,7 +5223,7 @@ declare namespace Deno {
    *
    * @category Runtime Environment
    */
-  export const build: {
+  export interface Build {
     /** The [LLVM](https://llvm.org/) target triple, which is the combination
      * of `${arch}-${vendor}-${os}` and represent the specific build target that
      * the current runtime was built for. */
@@ -5246,7 +5246,20 @@ declare namespace Deno {
     vendor: string;
     /** Optional environment flags that were set for this build of Deno CLI. */
     env?: string;
-  };
+  }
+
+  /** Returns information related to the build of the current Deno runtime.
+   *
+   * Users are discouraged from code branching based on this information, as
+   * assumptions about what is available in what build environment might change
+   * over time. Developers should specifically sniff out the features they
+   * intend to use.
+   *
+   * The intended use for the information is for logging and debugging purposes.
+   *
+   * @category Runtime Environment
+   */
+  export const build: Build;
 
   /** Version information related to the current Deno CLI runtime environment.
    *

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -6114,10 +6114,10 @@ fn lsp_completions() {
     json!({
       "label": "build",
       "kind": 6,
-      "detail": "const Deno.build: {\n    target: string;\n    arch: \"x86_64\" | \"aarch64\";\n    os: \"darwin\" | \"linux\" | \"android\" | \"windows\" | \"freebsd\" | \"netbsd\" | \"aix\" | \"solaris\" | \"illumos\";\n    vendor: string;\n    env?: string | undefined;\n}",
+      "detail": "const Deno.build: Deno.Build",
       "documentation": {
         "kind": "markdown",
-        "value": "Information related to the build of the current Deno runtime.\n\nUsers are discouraged from code branching based on this information, as\nassumptions about what is available in what build environment might change\nover time. Developers should specifically sniff out the features they\nintend to use.\n\nThe intended use for the information is for logging and debugging purposes.\n\n*@category* - Runtime Environment"
+        "value": "Returns information related to the build of the current Deno runtime.\n\nUsers are discouraged from code branching based on this information, as\nassumptions about what is available in what build environment might change\nover time. Developers should specifically sniff out the features they\nintend to use.\n\nThe intended use for the information is for logging and debugging purposes.\n\n*@category* - Runtime Environment"
       },
       "sortText": "1",
       "insertTextFormat": 1


### PR DESCRIPTION
The runtime API documentation doesn't correctly display the return type of [`Deno.build`](https://deno.land/api@v1.40.4?s=Deno.build). This is because it's an object type rather than an interface. This change introduces the new interface so its documentation is fully available.

Related to #22168