### PR TITLE
refactor(cli): move op sanitizer to Rust

### DIFF
--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -11,30 +11,21 @@ const {
   op_test_event_step_result_ignored,
   op_test_event_step_result_ok,
   op_test_event_step_wait,
-  op_test_op_sanitizer_collect,
-  op_test_op_sanitizer_finish,
-  op_test_op_sanitizer_get_async_message,
-  op_test_op_sanitizer_report,
 } = core.ops;
 const {
   ArrayPrototypeFilter,
-  ArrayPrototypeJoin,
   ArrayPrototypePush,
-  ArrayPrototypeShift,
   DateNow,
   Error,
   Map,
   MapPrototypeGet,
-  MapPrototypeHas,
   MapPrototypeSet,
-  Promise,
   SafeArrayIterator,
   SymbolToStringTag,
   TypeError,
 } = primordials;
 
 import { setExitHandler } from "ext:runtime/30_os.js";
-import { setTimeout } from "ext:deno_web/02_timers.js";
 
 /**
  * @typedef {{
@@ -94,183 +85,6 @@ import { setTimeout } from "ext:deno_web/02_timers.js";
 
 /** @type {Map<number, TestState | TestStepState>} */
 const testStates = new Map();
-
-const opSanitizerDelayResolveQueue = [];
-let hasSetOpSanitizerDelayMacrotask = false;
-
-// Even if every resource is closed by the end of a test, there can be a delay
-// until the pending ops have all finished. This function returns a promise
-// that resolves when it's (probably) fine to run the op sanitizer.
-//
-// This is implemented by adding a macrotask callback that runs after the
-// all ready async ops resolve, and the timer macrotask. Using just a macrotask
-// callback without delaying is sufficient, because when the macrotask callback
-// runs after async op dispatch, we know that all async ops that can currently
-// return `Poll::Ready` have done so, and have been dispatched to JS.
-//
-// Worker ops are an exception to this, because there is no way for the user to
-// await shutdown of the worker from the thread calling `worker.terminate()`.
-// Because of this, we give extra leeway for worker ops to complete, by waiting
-// for a whole millisecond if there are pending worker ops.
-function opSanitizerDelay(hasPendingWorkerOps) {
-  if (!hasSetOpSanitizerDelayMacrotask) {
-    core.setMacrotaskCallback(handleOpSanitizerDelayMacrotask);
-    hasSetOpSanitizerDelayMacrotask = true;
-  }
-  const p = new Promise((resolve) => {
-    // Schedule an async op to complete immediately to ensure the macrotask is
-    // run. We rely on the fact that enqueueing the resolver callback during the
-    // timeout callback will mean that the resolver gets called in the same
-    // event loop tick as the timeout callback.
-    setTimeout(() => {
-      ArrayPrototypePush(opSanitizerDelayResolveQueue, resolve);
-    }, hasPendingWorkerOps ? 1 : 0);
-  });
-  return p;
-}
-
-function handleOpSanitizerDelayMacrotask() {
-  const resolve = ArrayPrototypeShift(opSanitizerDelayResolveQueue);
-  if (resolve) {
-    resolve();
-    return opSanitizerDelayResolveQueue.length === 0;
-  }
-  return undefined; // we performed no work, so can skip microtasks checkpoint
-}
-
-let opIdHostRecvMessage = -1;
-let opIdHostRecvCtrl = -1;
-let opNames = null;
-
-function populateOpNames() {
-  opNames = core.opNames();
-  opIdHostRecvMessage = opNames.indexOf("op_host_recv_message");
-  opIdHostRecvCtrl = opNames.indexOf("op_host_recv_ctrl");
-}
-
-// Wrap test function in additional assertion that makes sure
-// the test case does not leak async "ops" - ie. number of async
-// completed ops after the test is the same as number of dispatched
-// ops. Note that "unref" ops are ignored since in nature that are
-// optional.
-function assertOps(fn) {
-  /** @param desc {TestDescription | TestStepDescription} */
-  return async function asyncOpSanitizer(desc) {
-    let hasTraces = false;
-    if (opNames === null) populateOpNames();
-    const res = op_test_op_sanitizer_collect(
-      desc.id,
-      false,
-      opIdHostRecvMessage,
-      opIdHostRecvCtrl,
-    );
-    if (res !== 0) {
-      await opSanitizerDelay(res === 2);
-      op_test_op_sanitizer_collect(
-        desc.id,
-        true,
-        opIdHostRecvMessage,
-        opIdHostRecvCtrl,
-      );
-    }
-    const preTraces = core.getAllOpCallTraces();
-    let postTraces;
-    let report = null;
-
-    try {
-      const innerResult = await fn(desc);
-      if (innerResult) return innerResult;
-    } finally {
-      let res = op_test_op_sanitizer_finish(
-        desc.id,
-        false,
-        opIdHostRecvMessage,
-        opIdHostRecvCtrl,
-      );
-      if (res === 1 || res === 2) {
-        await opSanitizerDelay(res === 2);
-        res = op_test_op_sanitizer_finish(
-          desc.id,
-          true,
-          opIdHostRecvMessage,
-          opIdHostRecvCtrl,
-        );
-      }
-      postTraces = core.getAllOpCallTraces();
-      if (res === 3) {
-        report = op_test_op_sanitizer_report(desc.id);
-      }
-    }
-
-    if (report === null) return null;
-
-    const details = [];
-    for (const opReport of report) {
-      const opName = opNames[opReport.id];
-      const diff = opReport.diff;
-
-      if (diff > 0) {
-        const [name, hint] = op_test_op_sanitizer_get_async_message(opName);
-        const count = diff;
-        let message = `${count} async operation${
-          count === 1 ? "" : "s"
-        } to ${name} ${
-          count === 1 ? "was" : "were"
-        } started in this test, but never completed.`;
-        if (hint) {
-          message += ` This is often caused by not ${hint}.`;
-        }
-        const traces = [];
-        for (const [id, stack] of postTraces) {
-          if (MapPrototypeHas(preTraces, id)) continue;
-          ArrayPrototypePush(traces, stack);
-        }
-        if (traces.length === 1) {
-          message += " The operation was started here:\n";
-          message += traces[0];
-        } else if (traces.length > 1) {
-          message += " The operations were started here:\n";
-          message += ArrayPrototypeJoin(traces, "\n\n");
-        }
-        hasTraces |= traces.length > 0;
-        ArrayPrototypePush(details, message);
-      } else if (diff < 0) {
-        const [name, hint] = op_test_op_sanitizer_get_async_message(opName);
-        const count = -diff;
-        let message = `${count} async operation${
-          count === 1 ? "" : "s"
-        } to ${name} ${
-          count === 1 ? "was" : "were"
-        } started before this test, but ${
-          count === 1 ? "was" : "were"
-        } completed during the test. Async operations should not complete in a test if they were not started in that test.`;
-        if (hint) {
-          message += ` This is often caused by not ${hint}.`;
-        }
-        const traces = [];
-        for (const [id, stack] of preTraces) {
-          if (MapPrototypeHas(postTraces, id)) continue;
-          ArrayPrototypePush(traces, stack);
-        }
-        if (traces.length === 1) {
-          message += " The operation was started here:\n";
-          message += traces[0];
-        } else if (traces.length > 1) {
-          message += " The operations were started here:\n";
-          message += ArrayPrototypeJoin(traces, "\n\n");
-        }
-        hasTraces |= traces.length > 0;
-        ArrayPrototypePush(details, message);
-      } else {
-        throw new Error("unreachable");
-      }
-    }
-
-    return {
-      failed: { leakedOps: [details, hasTraces] },
-    };
-  };
-}
 
 // Wrap test function in additional assertion that makes sure
 // that the test case does not accidentally exit prematurely.
@@ -474,7 +288,7 @@ function testInner(
     testDesc.name,
     testDesc.ignore,
     testDesc.only,
-    false, /*testDesc.sanitizeOps*/
+    testDesc.sanitizeOps,
     testDesc.sanitizeResources,
     testDesc.location.fileName,
     testDesc.location.lineNumber,
@@ -663,9 +477,6 @@ function createTestContext(desc) {
  */
 function wrapTest(desc) {
   let testFn = wrapInner(desc.fn);
-  if (desc.sanitizeOps) {
-    testFn = assertOps(testFn);
-  }
   if (desc.sanitizeExit) {
     testFn = assertExit(testFn, true);
   }

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use crate::tools::test::fmt::OP_DETAILS;
 use crate::tools::test::TestDescription;
 use crate::tools::test::TestEvent;
 use crate::tools::test::TestEventSender;
@@ -15,17 +14,11 @@ use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
 use deno_core::ModuleSpecifier;
-use deno_core::OpMetricsSummary;
-use deno_core::OpMetricsSummaryTracker;
 use deno_core::OpState;
-use deno_runtime::deno_fetch::reqwest;
 use deno_runtime::permissions::create_child_permissions;
 use deno_runtime::permissions::ChildPermissionsArg;
 use deno_runtime::permissions::PermissionsContainer;
 use serde::Serialize;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use uuid::Uuid;
@@ -45,10 +38,6 @@ deno_core::extension!(deno_test,
     op_test_event_step_result_ok,
     op_test_event_step_result_ignored,
     op_test_event_step_result_failed,
-    op_test_op_sanitizer_collect,
-    op_test_op_sanitizer_finish,
-    op_test_op_sanitizer_report,
-    op_test_op_sanitizer_get_async_message,
   ],
   options = {
     sender: TestEventSender,
@@ -56,7 +45,6 @@ deno_core::extension!(deno_test,
   state = |state, options| {
     state.put(options.sender);
     state.put(TestContainer::default());
-    state.put(TestOpSanitizers::default());
   },
 );
 
@@ -244,193 +232,4 @@ fn op_test_event_step_result_failed(
       duration,
     ))
     .ok();
-}
-
-#[derive(Default)]
-struct TestOpSanitizers(HashMap<u32, TestOpSanitizerState>);
-
-enum TestOpSanitizerState {
-  Collecting { metrics: Vec<OpMetricsSummary> },
-  Finished { report: Vec<TestOpSanitizerReport> },
-}
-
-fn try_collect_metrics(
-  metrics: &OpMetricsSummaryTracker,
-  force: bool,
-  op_id_host_recv_msg: usize,
-  op_id_host_recv_ctrl: usize,
-) -> Result<std::cell::Ref<Vec<OpMetricsSummary>>, bool> {
-  let metrics = metrics.per_op();
-  let host_recv_msg = metrics
-    .get(op_id_host_recv_msg)
-    .map(OpMetricsSummary::has_outstanding_ops)
-    .unwrap_or(false);
-  let host_recv_ctrl = metrics
-    .get(op_id_host_recv_ctrl)
-    .map(OpMetricsSummary::has_outstanding_ops)
-    .unwrap_or(false);
-
-  for op_metric in metrics.iter() {
-    if op_metric.has_outstanding_ops() && !force {
-      return Err(host_recv_msg || host_recv_ctrl);
-    }
-  }
-  Ok(metrics)
-}
-
-#[op2(fast)]
-#[smi]
-// Returns:
-// 0 - success
-// 1 - for more accurate results, spin event loop and call again with force=true
-// 2 - for more accurate results, delay(1ms) and call again with force=true
-fn op_test_op_sanitizer_collect(
-  state: &mut OpState,
-  #[smi] id: u32,
-  force: bool,
-  #[smi] op_id_host_recv_msg: usize,
-  #[smi] op_id_host_recv_ctrl: usize,
-) -> Result<u8, AnyError> {
-  let metrics = state.borrow::<Rc<OpMetricsSummaryTracker>>();
-  let metrics = match try_collect_metrics(
-    metrics,
-    force,
-    op_id_host_recv_msg,
-    op_id_host_recv_ctrl,
-  ) {
-    Ok(metrics) => metrics,
-    Err(false) => {
-      return Ok(1);
-    }
-    Err(true) => {
-      return Ok(2);
-    }
-  }
-  .clone();
-
-  let op_sanitizers = state.borrow_mut::<TestOpSanitizers>();
-  match op_sanitizers.0.entry(id) {
-    Entry::Vacant(entry) => {
-      entry.insert(TestOpSanitizerState::Collecting { metrics });
-    }
-    Entry::Occupied(_) => {
-      return Err(generic_error(format!(
-        "Test metrics already being collected for test id {id}",
-      )));
-    }
-  }
-  Ok(0)
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TestOpSanitizerReport {
-  id: usize,
-  diff: i64,
-}
-
-#[op2(fast)]
-#[smi]
-// Returns:
-// 0 - sanitizer finished with no pending ops
-// 1 - for more accurate results, spin event loop and call again with force=true
-// 2 - for more accurate results, delay(1ms) and call again with force=true
-// 3 - sanitizer finished with pending ops, collect the report with op_test_op_sanitizer_report
-fn op_test_op_sanitizer_finish(
-  state: &mut OpState,
-  #[smi] id: u32,
-  force: bool,
-  #[smi] op_id_host_recv_msg: usize,
-  #[smi] op_id_host_recv_ctrl: usize,
-) -> Result<u8, AnyError> {
-  // Drop `fetch` connection pool at the end of a test
-  state.try_take::<reqwest::Client>();
-  let metrics = state.borrow::<Rc<OpMetricsSummaryTracker>>();
-
-  // Generate a report of pending ops
-  let report = {
-    let after_metrics = match try_collect_metrics(
-      metrics,
-      force,
-      op_id_host_recv_msg,
-      op_id_host_recv_ctrl,
-    ) {
-      Ok(metrics) => metrics,
-      Err(false) => {
-        return Ok(1);
-      }
-      Err(true) => {
-        return Ok(2);
-      }
-    };
-
-    let op_sanitizers = state.borrow::<TestOpSanitizers>();
-    let before_metrics = match op_sanitizers.0.get(&id) {
-      Some(TestOpSanitizerState::Collecting { metrics }) => metrics,
-      _ => {
-        return Err(generic_error(format!(
-          "Metrics not collected before for test id {id}",
-        )));
-      }
-    };
-    let mut report = vec![];
-
-    for (id, (before, after)) in
-      before_metrics.iter().zip(after_metrics.iter()).enumerate()
-    {
-      let async_pending_before =
-        before.ops_dispatched_async - before.ops_completed_async;
-      let async_pending_after =
-        after.ops_dispatched_async - after.ops_completed_async;
-      let diff = async_pending_after as i64 - async_pending_before as i64;
-      if diff != 0 {
-        report.push(TestOpSanitizerReport { id, diff });
-      }
-    }
-
-    report
-  };
-
-  let op_sanitizers = state.borrow_mut::<TestOpSanitizers>();
-
-  if report.is_empty() {
-    op_sanitizers
-      .0
-      .remove(&id)
-      .expect("TestOpSanitizerState::Collecting");
-    Ok(0)
-  } else {
-    op_sanitizers
-      .0
-      .insert(id, TestOpSanitizerState::Finished { report })
-      .expect("TestOpSanitizerState::Collecting");
-    Ok(3)
-  }
-}
-
-#[op2]
-#[serde]
-fn op_test_op_sanitizer_report(
-  state: &mut OpState,
-  #[smi] id: u32,
-) -> Result<Vec<TestOpSanitizerReport>, AnyError> {
-  let op_sanitizers = state.borrow_mut::<TestOpSanitizers>();
-  match op_sanitizers.0.remove(&id) {
-    Some(TestOpSanitizerState::Finished { report }) => Ok(report),
-    _ => Err(generic_error(format!(
-      "Metrics not finished collecting for test id {id}",
-    ))),
-  }
-}
-
-#[op2]
-#[serde]
-fn op_test_op_sanitizer_get_async_message(
-  #[string] op_name: &str,
-) -> (String, Option<String>) {
-  if let Some(output) = OP_DETAILS.get(op_name) {
-    (output[0].to_string(), Some(output[1].to_string()))
-  } else {
-    (op_name.to_string(), None)
-  }
 }

--- a/tests/testdata/test/sanitizer/ops_sanitizer_closed_inside_started_before.out
+++ b/tests/testdata/test/sanitizer/ops_sanitizer_closed_inside_started_before.out
@@ -5,8 +5,8 @@ test 1 ... FAILED [WILDCARD]
  ERRORS 
 
 test 1 => [WILDCARD]/ops_sanitizer_closed_inside_started_before.ts:[WILDCARD]
-error: Leaking async ops:
-  - 1 async operation to sleep for a duration was started before this test, but was completed during the test. Async operations should not complete in a test if they were not started in that test. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
+error: Leaks detected:
+  - An async operation to sleep for a duration was started before the test, but completed during the test. Async operations should not complete in a test if they were not started in that test. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at [WILDCARD]/ops_sanitizer_closed_inside_started_before.ts:[WILDCARD]
 

--- a/tests/testdata/test/sanitizer/ops_sanitizer_multiple_timeout_tests.out
+++ b/tests/testdata/test/sanitizer/ops_sanitizer_multiple_timeout_tests.out
@@ -6,14 +6,14 @@ test 2 ... FAILED ([WILDCARD])
  ERRORS 
 
 test 1 => [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD]
-error: Leaking async ops:
-  - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operations were started here:
+error: Leaks detected:
+  - An async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at setTimeout ([WILDCARD])
     at test ([WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
     at [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:8:27
     at [WILDCARD]
-
+  - An async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at setTimeout ([WILDCARD])
     at test ([WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
@@ -21,14 +21,14 @@ error: Leaking async ops:
     at [WILDCARD]
 
 test 2 => [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD]
-error: Leaking async ops:
-  - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operations were started here:
+error: Leaks detected:
+  - An async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at setTimeout ([WILDCARD])
     at test ([WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])
     at [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:10:27
     at [WILDCARD]
-
+  - An async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at setTimeout ([WILDCARD])
     at test ([WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD])

--- a/tests/testdata/test/sanitizer/ops_sanitizer_multiple_timeout_tests_no_trace.out
+++ b/tests/testdata/test/sanitizer/ops_sanitizer_multiple_timeout_tests_no_trace.out
@@ -6,12 +6,12 @@ test 2 ... FAILED ([WILDCARD])
  ERRORS 
 
 test 1 => [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD]
-error: Leaking async ops:
+error: Leaks detected:
   - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call.
 To get more details where ops were leaked, run again with --trace-ops flag.
 
 test 2 => [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD]
-error: Leaking async ops:
+error: Leaks detected:
   - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call.
 To get more details where ops were leaked, run again with --trace-ops flag.
 

--- a/tests/testdata/test/sanitizer/ops_sanitizer_unstable.out
+++ b/tests/testdata/test/sanitizer/ops_sanitizer_unstable.out
@@ -6,8 +6,8 @@ leak interval ... FAILED ([WILDCARD])
  ERRORS 
 
 leak interval => [WILDCARD]/ops_sanitizer_unstable.ts:[WILDCARD]
-error: Leaking async ops:
-  - 1 async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
+error: Leaks detected:
+  - An async operation to sleep for a duration was started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call. The operation was started here:
     at [WILDCARD]
     at setInterval ([WILDCARD])
     at fn ([WILDCARD]/ops_sanitizer_unstable.ts:[WILDCARD])

--- a/tests/testdata/test/sanitizer/resource_sanitizer.out
+++ b/tests/testdata/test/sanitizer/resource_sanitizer.out
@@ -5,7 +5,7 @@ leak ... FAILED ([WILDCARD])
  ERRORS 
 
 leak => [WILDCARD]/resource_sanitizer.ts:[WILDCARD]
-error: Leaking resources:
+error: Leaks detected:
 [UNORDERED_START]
   - The stdin pipe was opened before the test started, but was closed during the test. Do not close resources in a test that were not created during that test.
   - A file was opened during the test, but not closed during the test. Close the file handle by calling `file.close()`.

--- a/tests/unit/ops_test.ts
+++ b/tests/unit/ops_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-const EXPECTED_OP_COUNT = 15;
+const EXPECTED_OP_COUNT = 11;
 
 Deno.test(function checkExposedOps() {
   // @ts-ignore TS doesn't allow to index with symbol


### PR DESCRIPTION
The format of the sanitizers will change a little bit:

 - If multiple async ops leak and traces are on, we repeat the async op header once per stack trace.
 - All leaks are aggregated under a "Leaks detected:" banner as the new timers are eventually going to be added, and these are neither ops nor resources.
 - `1 async op` is now `An async op`
 - If ops and resources leak, we show both (rather than op leaks masking resources)

Follow-on to https://github.com/denoland/deno/pull/22226