### PR TITLE
chore: rename DENO_REGISTRY_URL to JSR_URL

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -102,9 +102,9 @@ pub fn npm_registry_default_url() -> &'static Url {
   &NPM_REGISTRY_DEFAULT_URL
 }
 
-pub fn deno_registry_url() -> &'static Url {
-  static DENO_REGISTRY_URL: Lazy<Url> = Lazy::new(|| {
-    let env_var_name = "DENO_REGISTRY_URL";
+pub fn jsr_url() -> &'static Url {
+  static JSR_URL: Lazy<Url> = Lazy::new(|| {
+    let env_var_name = "JSR_URL";
     if let Ok(registry_url) = std::env::var(env_var_name) {
       // ensure there is a trailing slash for the directory
       let registry_url = format!("{}/", registry_url.trim_end_matches('/'));
@@ -125,14 +125,14 @@ pub fn deno_registry_url() -> &'static Url {
     Url::parse("https://jsr.io/").unwrap()
   });
 
-  &DENO_REGISTRY_URL
+  &JSR_URL
 }
 
-pub fn deno_registry_api_url() -> &'static Url {
+pub fn jsr_api_url() -> &'static Url {
   static DENO_REGISTRY_API_URL: Lazy<Url> = Lazy::new(|| {
-    let mut deno_registry_api_url = deno_registry_url().clone();
-    deno_registry_api_url.set_path("api/");
-    deno_registry_api_url
+    let mut jsr_api_url = jsr_url().clone();
+    jsr_api_url.set_path("api/");
+    jsr_api_url
   });
 
   &DENO_REGISTRY_API_URL
@@ -2018,10 +2018,10 @@ mod test {
   }
 
   #[test]
-  fn deno_registry_urls() {
-    let reg_url = deno_registry_url();
+  fn jsr_urls() {
+    let reg_url = jsr_url();
     assert!(reg_url.as_str().ends_with('/'));
-    let reg_api_url = deno_registry_api_url();
+    let reg_api_url = jsr_api_url();
     assert!(reg_api_url.as_str().ends_with('/'));
   }
 }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -129,13 +129,13 @@ pub fn jsr_url() -> &'static Url {
 }
 
 pub fn jsr_api_url() -> &'static Url {
-  static DENO_REGISTRY_API_URL: Lazy<Url> = Lazy::new(|| {
+  static JSR_API_URL: Lazy<Url> = Lazy::new(|| {
     let mut jsr_api_url = jsr_url().clone();
     jsr_api_url.set_path("api/");
     jsr_api_url
   });
 
-  &DENO_REGISTRY_API_URL
+  &JSR_API_URL
 }
 
 pub fn ts_config_to_emit_options(

--- a/cli/cache/mod.rs
+++ b/cli/cache/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use crate::args::deno_registry_url;
+use crate::args::jsr_url;
 use crate::args::CacheSetting;
 use crate::errors::get_error_class_name;
 use crate::file_fetcher::FetchOptions;
@@ -168,7 +168,7 @@ impl FetchCacher {
 
 impl Loader for FetchCacher {
   fn registry_url(&self) -> &Url {
-    deno_registry_url()
+    jsr_url()
   }
 
   fn get_cache_info(&self, specifier: &ModuleSpecifier) -> Option<CacheInfo> {

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -385,7 +385,7 @@ impl CliFactory {
               let nv = PackageNv::from_str(nv).ok()?;
               Some(
                 deno_graph::source::recommended_registry_package_url(
-                  crate::args::deno_registry_url(),
+                  crate::args::jsr_url(),
                   &nv,
                 )
                 .to_string(),

--- a/cli/lsp/jsr_resolver.rs
+++ b/cli/lsp/jsr_resolver.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use crate::args::deno_registry_url;
+use crate::args::jsr_url;
 use deno_cache_dir::HttpCache;
 use deno_core::parking_lot::Mutex;
 use deno_core::serde_json;
@@ -51,8 +51,8 @@ impl JsrResolver {
       if info_by_nv.contains_key(nv) {
         continue;
       }
-      let Ok(meta_url) = deno_registry_url()
-        .join(&format!("{}/{}_meta.json", &nv.name, &nv.version))
+      let Ok(meta_url) =
+        jsr_url().join(&format!("{}/{}_meta.json", &nv.name, &nv.version))
       else {
         continue;
       };
@@ -89,7 +89,7 @@ impl JsrResolver {
     let nv = self.nv_by_req.get(req_ref.req())?;
     let info = self.info_by_nv.get(nv)?;
     let path = info.export(&normalize_export_name(req_ref.sub_path()))?;
-    deno_registry_url()
+    jsr_url()
       .join(&format!("{}/{}/{}", &nv.name, &nv.version, &path))
       .ok()
   }

--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -22,8 +22,8 @@ use lsp_types::Url;
 use serde::Serialize;
 use sha2::Digest;
 
-use crate::args::deno_registry_api_url;
-use crate::args::deno_registry_url;
+use crate::args::jsr_api_url;
+use crate::args::jsr_url;
 use crate::args::CliOptions;
 use crate::args::Flags;
 use crate::args::PublishFlags;
@@ -446,8 +446,8 @@ async fn perform_publish(
   auth_method: AuthMethod,
 ) -> Result<(), AnyError> {
   let client = http_client.client()?;
-  let registry_api_url = deno_registry_api_url().to_string();
-  let registry_url = deno_registry_url().to_string();
+  let registry_api_url = jsr_api_url().to_string();
+  let registry_url = jsr_url().to_string();
 
   let packages = prepared_package_by_name
     .values()

--- a/test_util/src/builders.rs
+++ b/test_util/src/builders.rs
@@ -709,8 +709,8 @@ impl TestCommandBuilder {
     if !envs.contains_key("DENO_NO_UPDATE_CHECK") {
       envs.insert("DENO_NO_UPDATE_CHECK".to_string(), "1".to_string());
     }
-    if !envs.contains_key("DENO_REGISTRY_URL") {
-      envs.insert("DENO_REGISTRY_URL".to_string(), jsr_registry_unset_url());
+    if !envs.contains_key("JSR_URL") {
+      envs.insert("JSR_URL".to_string(), jsr_registry_unset_url());
     }
     for key in &self.envs_remove {
       envs.remove(key);

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -59,7 +59,7 @@ pub fn env_vars_for_npm_tests() -> Vec<(String, String)> {
 
 pub fn env_vars_for_jsr_tests() -> Vec<(String, String)> {
   vec![
-    ("DENO_REGISTRY_URL".to_string(), jsr_registry_url()),
+    ("JSR_URL".to_string(), jsr_registry_url()),
     ("NO_COLOR".to_string(), "1".to_string()),
   ]
 }
@@ -114,7 +114,7 @@ pub fn jsr_registry_url() -> String {
 }
 
 pub fn jsr_registry_unset_url() -> String {
-  "http://DENO_REGISTRY_URL.is.unset".to_string()
+  "http://JSR_URL.is.unset".to_string()
 }
 
 pub fn std_path() -> PathRef {
@@ -463,7 +463,7 @@ pub fn deno_cmd_with_deno_dir(deno_dir: &TempDir) -> TestCommandBuilder {
   TestCommandBuilder::new(deno_dir.clone())
     .env("DENO_DIR", deno_dir.path())
     .env("NPM_CONFIG_REGISTRY", npm_registry_unset_url())
-    .env("DENO_REGISTRY_URL", jsr_registry_unset_url())
+    .env("JSR_URL", jsr_registry_unset_url())
 }
 
 pub fn run_powershell_script_file(

--- a/test_util/src/lsp.rs
+++ b/test_util/src/lsp.rs
@@ -524,7 +524,7 @@ impl LspClientBuilder {
     command
       .env("DENO_DIR", deno_dir.path())
       .env("NPM_CONFIG_REGISTRY", npm_registry_url())
-      .env("DENO_REGISTRY_URL", jsr_registry_url())
+      .env("JSR_URL", jsr_registry_url())
       // turn on diagnostic synchronization communication
       .env(
         "DENO_DONT_USE_INTERNAL_LSP_DIAGNOSTIC_SYNC_FLAG",


### PR DESCRIPTION
`DENO_REGISTRY_URL` is from when `jsr:` was `deno:`.