### PR TITLE
perf: strip `denort`

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -704,6 +704,7 @@ const ci = {
           run: [
             "cd target/release",
             "zip -r deno-${{ matrix.arch }}-unknown-linux-gnu.zip deno",
+            "strip denort",
             "zip -r denort-${{ matrix.arch }}-unknown-linux-gnu.zip denort",
             "./deno types > lib.deno.d.ts",
           ].join("\n"),
@@ -729,6 +730,7 @@ const ci = {
             "--entitlements-xml-file=cli/entitlements.plist",
             "cd target/release",
             "zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno",
+            "strip denort",
             "zip -r denort-${{ matrix.arch }}-apple-darwin.zip denort",
           ]
             .join("\n"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,7 @@ jobs:
         run: |-
           cd target/release
           zip -r deno-${{ matrix.arch }}-unknown-linux-gnu.zip deno
+          strip denort
           zip -r denort-${{ matrix.arch }}-unknown-linux-gnu.zip denort
           ./deno types > lib.deno.d.ts
       - name: Pre-release (mac)
@@ -440,6 +441,7 @@ jobs:
           rcodesign sign target/release/deno --code-signature-flags=runtime --p12-password="$APPLE_CODESIGN_PASSWORD" --p12-file=<(echo $APPLE_CODESIGN_KEY | base64 -d) --entitlements-xml-file=cli/entitlements.plist
           cd target/release
           zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno
+          strip denort
           zip -r denort-${{ matrix.arch }}-apple-darwin.zip denort
       - name: Pre-release (windows)
         if: |-


### PR DESCRIPTION
denort are release binaries for `deno compile`. Stripping debuginfo and symbols lets us ship a smaller binary. The same source can be run under `deno` CLI to get the proper Rust backtrace.

stripped denort is 55MB on macOS.