### PR TITLE
fix(fmt): remove debug output when formatting dynamic imports

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -56,7 +56,7 @@
     "ext/websocket/autobahn/reports"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.89.0.wasm",
+    "https://plugins.dprint.dev/typescript-0.89.1.wasm",
     "https://plugins.dprint.dev/json-0.19.1.wasm",
     "https://plugins.dprint.dev/markdown-0.16.3.wasm",
     "https://plugins.dprint.dev/toml-0.6.0.wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.89.0"
+version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dedd02b402282e71c309aa3e1e27bc8557517c968effe52783cdeeafdd17cc2"
+checksum = "6199631b4ff3462c4a0bd90dbecf73265e92eea9eb64c4671e7ddbf0ac0d1ec0"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -98,7 +98,7 @@ dotenvy = "0.15.7"
 dprint-plugin-json = "=0.19.1"
 dprint-plugin-jupyter = "=0.1.2"
 dprint-plugin-markdown = "=0.16.3"
-dprint-plugin-typescript = "=0.89.0"
+dprint-plugin-typescript = "=0.89.1"
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"
 # If you disable the default __vendored_zlib_ng feature above, you _must_ be able to link against `-lz`.


### PR DESCRIPTION
deno fmt sometimes had stuff like:

```
NODE: Evaluation
```

...in the output, as pointed out by @kt3k