### PR TITLE
chore(ext/web): refactor timer ops before landing op sanitizer

### DIFF
--- a/cli/tools/test/fmt.rs
+++ b/cli/tools/test/fmt.rs
@@ -271,6 +271,7 @@ pub const OP_DETAILS: phf::Map<&'static str, [&'static str; 2]> = phf_map! {
   "op_run_status" => ["get the status of a subprocess", "awaiting the result of a `Deno.Process#status` call"],
   "op_seek_async" => ["seek in a file", "awaiting the result of a `Deno.File#seek` call"],
   "op_signal_poll" => ["get the next signal", "un-registering a OS signal handler"],
+  "op_sleep_interval" => ["sleep for a duration", "cancelling a `setTimeout` or `setInterval` call"],
   "op_sleep" => ["sleep for a duration", "cancelling a `setTimeout` or `setInterval` call"],
   "op_stat_async" => ["get file metadata", "awaiting the result of a `Deno.stat` call"],
   "op_symlink_async" => ["create a symlink", "awaiting the result of a `Deno.symlink` call"],

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -52,6 +52,7 @@ pub use crate::message_port::MessagePort;
 
 use crate::timers::op_now;
 use crate::timers::op_sleep;
+use crate::timers::op_sleep_interval;
 use crate::timers::op_timer_handle;
 use crate::timers::StartTime;
 pub use crate::timers::TimersPermission;
@@ -86,6 +87,7 @@ deno_core::extension!(deno_web,
     op_now<P>,
     op_timer_handle,
     op_sleep,
+    op_sleep_interval,
     op_transfer_arraybuffer,
     stream_resource::op_readable_stream_resource_allocate,
     stream_resource::op_readable_stream_resource_allocate_sized,


### PR DESCRIPTION
Splitting the sleep and interval ops allows us to detect an interval timer. We also remove the use of the `op_async_void_deferred` call.

A future PR will be able to split the op sanitizer messages for timers and intervals.