### PR TITLE
chore: bump deno_core 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,11 +1239,12 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.262.0"
+version = "0.263.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0c12fbe4f2c497ff53de92dd698a27d93f8e9c2519ea5684f608cb9f4ef44b"
+checksum = "51813f22cdde234648c7aa7b070f92ba176ec5f5b48c232218102917e8c8672c"
 dependencies = [
  "anyhow",
+ "bincode",
  "bit-set",
  "bit-vec",
  "bytes",
@@ -1690,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.138.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04698b09128a026abe3d8a82fdb231baf1a35f07443844728fe1441b2c2340f1"
+checksum = "cd7ceebc85c86baad21fff65fd8c603ee14430dd560e0c63591ed0c75b538f51"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5530,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.171.0"
+version = "0.172.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a2746b1f9e4015ee5f325bb87ab0f1891b76c38dfb1675bc83857eaf6451d0"
+checksum = "b1700eea7391e2979f456a77f735cadacfb63b557d638950f64f81accecba980"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "0.33.2", features = ["transpiling"] }
-deno_core = { version = "0.262.0" }
+deno_core = { version = "0.263.0", features = ["snapshot_data_bincode"] }
 
 deno_bench_util = { version = "0.132.0", path = "./bench_util" }
 deno_lockfile = "0.19.0"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -292,6 +292,7 @@ mod ts {
           |snapshot| {
             eprintln!("Compressing TSC snapshot...");
             let mut vec = Vec::with_capacity(snapshot.len());
+            vec.extend((snapshot.len() as u32).to_le_bytes());
             vec.extend_from_slice(
               &zstd::bulk::compress(&snapshot, 22)
                 .expect("snapshot compression failed"),

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::path::PathBuf;
 
-use deno_core::snapshot_util::*;
+use deno_core::snapshot::*;
 use deno_runtime::*;
 
 mod ts {
@@ -266,10 +266,13 @@ mod ts {
     )
     .unwrap();
 
+    let snapshot_to_file = SnapshotFileSerializer::new(
+      std::fs::File::create(snapshot_path).unwrap(),
+    );
+
     let output = create_snapshot(
       CreateSnapshotOptions {
         cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
-        snapshot_path,
         startup_snapshot: None,
         extensions: vec![deno_tsc::init_ops_and_esm(
           op_crate_libs,
@@ -281,21 +284,27 @@ mod ts {
         // Thus we're not not using compressed snapshot, trading off
         // a lot of build time for some startup time in debug build.
         #[cfg(debug_assertions)]
-        compression_cb: None,
+        serializer: Box::new(snapshot_to_file),
 
         #[cfg(not(debug_assertions))]
-        compression_cb: Some(Box::new(|vec, snapshot_slice| {
-          eprintln!("Compressing TSC snapshot...");
-          vec.extend_from_slice(
-            &zstd::bulk::compress(snapshot_slice, 22)
-              .expect("snapshot compression failed"),
-          );
-        })),
+        serializer: Box::new(SnapshotBulkCompressingSerializer::new(
+          snapshot_to_file,
+          |snapshot| {
+            eprintln!("Compressing TSC snapshot...");
+            let mut vec = Vec::with_capacity(snapshot.len());
+            vec.extend_from_slice(
+              &zstd::bulk::compress(&snapshot, 22)
+                .expect("snapshot compression failed"),
+            );
+            vec
+          },
+        )),
         with_runtime_cb: None,
         skip_op_registration: false,
       },
       None,
-    );
+    )
+    .unwrap();
     for path in output.files_loaded_during_snapshot {
       println!("cargo:rerun-if-changed={}", path.display());
     }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -296,7 +296,7 @@ mod ts {
               &zstd::bulk::compress(&snapshot, 22)
                 .expect("snapshot compression failed"),
             );
-            vec
+            Ok(vec)
           },
         )),
         with_runtime_cb: None,


### PR DESCRIPTION
Migrations:

 - Use the new SnapshotSerializer for TSC/compiler snapshots