### PR TITLE
fix(cli): Update lib.dom.d.ts with AbortSignal.any static method

### DIFF
--- a/cli/tsc/dts/lib.dom.d.ts
+++ b/cli/tsc/dts/lib.dom.d.ts
@@ -2342,6 +2342,8 @@ declare var AbortSignal: {
     abort(reason?: any): AbortSignal;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static) */
     timeout(milliseconds: number): AbortSignal;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) */
+    any(signals: AbortSignal[]): AbortSignal;
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbstractRange) */


### PR DESCRIPTION
Add typescript definition for AbortSignal.any() static method.

As #21087, the AbortSignal.any have been implemented but the typescript still doesn't detect the method.

