### PR TITLE
chore: rename internal `Datagram` class to `DatagramConn`

### DIFF
--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -360,7 +360,7 @@ class Listener {
   }
 }
 
-class Datagram {
+class DatagramConn {
   #rid = 0;
   #addr = null;
   #unref = false;
@@ -557,7 +557,7 @@ function createListenDatagram(udpOpFn, unixOpFn) {
           args.loopback ?? false,
         );
         addr.transport = "udp";
-        return new Datagram(rid, addr);
+        return new DatagramConn(rid, addr);
       }
       case "unixpacket": {
         const { 0: rid, 1: path } = unixOpFn(args.path);
@@ -565,7 +565,7 @@ function createListenDatagram(udpOpFn, unixOpFn) {
           transport: "unixpacket",
           path,
         };
-        return new Datagram(rid, addr);
+        return new DatagramConn(rid, addr);
       }
       default:
         throw new TypeError(`Unsupported transport: '${transport}'`);


### PR DESCRIPTION
As having mismatched public and private class names may be confusing, without good reason, to those unfamiliar with the codebase.