### PR TITLE
BREAKING(net): remove `Deno.DatagramConn.rid`

### DIFF
--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -372,17 +372,13 @@ class Datagram {
     this.bufSize = bufSize;
   }
 
-  get rid() {
-    return this.#rid;
-  }
-
   get addr() {
     return this.#addr;
   }
 
   async joinMulticastV4(addr, multiInterface) {
     await op_net_join_multi_v4_udp(
-      this.rid,
+      this.#rid,
       addr,
       multiInterface,
     );
@@ -390,19 +386,19 @@ class Datagram {
     return {
       leave: () =>
         op_net_leave_multi_v4_udp(
-          this.rid,
+          this.#rid,
           addr,
           multiInterface,
         ),
       setLoopback: (loopback) =>
         op_net_set_multi_loopback_udp(
-          this.rid,
+          this.#rid,
           true,
           loopback,
         ),
       setTTL: (ttl) =>
         op_net_set_multi_ttl_udp(
-          this.rid,
+          this.#rid,
           ttl,
         ),
     };
@@ -410,7 +406,7 @@ class Datagram {
 
   async joinMulticastV6(addr, multiInterface) {
     await op_net_join_multi_v6_udp(
-      this.rid,
+      this.#rid,
       addr,
       multiInterface,
     );
@@ -418,13 +414,13 @@ class Datagram {
     return {
       leave: () =>
         op_net_leave_multi_v6_udp(
-          this.rid,
+          this.#rid,
           addr,
           multiInterface,
         ),
       setLoopback: (loopback) =>
         op_net_set_multi_loopback_udp(
-          this.rid,
+          this.#rid,
           false,
           loopback,
         ),
@@ -438,7 +434,7 @@ class Datagram {
     switch (this.addr.transport) {
       case "udp": {
         this.#promise = op_net_recv_udp(
-          this.rid,
+          this.#rid,
           buf,
         );
         if (this.#unref) core.unrefOpPromise(this.#promise);
@@ -449,7 +445,7 @@ class Datagram {
       case "unixpacket": {
         let path;
         ({ 0: nread, 1: path } = await op_net_recv_unixpacket(
-          this.rid,
+          this.#rid,
           buf,
         ));
         remoteAddr = { transport: "unixpacket", path };
@@ -466,13 +462,13 @@ class Datagram {
     switch (this.addr.transport) {
       case "udp":
         return await op_net_send_udp(
-          this.rid,
+          this.#rid,
           { hostname: opts.hostname ?? "127.0.0.1", port: opts.port },
           p,
         );
       case "unixpacket":
         return await op_net_send_unixpacket(
-          this.rid,
+          this.#rid,
           opts.path,
           p,
         );
@@ -482,7 +478,7 @@ class Datagram {
   }
 
   close() {
-    core.close(this.rid);
+    core.close(this.#rid);
   }
 
   ref() {


### PR DESCRIPTION
As part of ongoing efforts to remove `rid` properties from the public API. Note: this property is undocumented.