### PR TITLE
chore: fix flaky lsp_vendor_dir

### DIFF
--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -10666,6 +10666,10 @@ fn lsp_vendor_dir() {
 
   assert!(!temp_dir.path().join("vendor").exists());
 
+  // read the diagnostic update after caching
+  let diagnostics = client.read_diagnostics();
+  assert_eq!(diagnostics.all().len(), 0);
+
   temp_dir.write(
     temp_dir.path().join("deno.json"),
     "{ \"vendor\": true, \"lock\": false }\n",

--- a/tests/util/server/src/lsp.rs
+++ b/tests/util/server/src/lsp.rs
@@ -799,7 +799,7 @@ impl LspClient {
     result.as_u64().unwrap() as usize
   }
 
-  /// Reads the latest diagnostics. It's assumed that
+  /// Reads the latest diagnostics.
   pub fn read_diagnostics(&mut self) -> CollectedDiagnostics {
     // wait for three (deno, lint, and typescript diagnostics) batch
     // notification messages for that index


### PR DESCRIPTION
I think it was occassionally reading the diagnostics from the previous cache command rather than the config update.

Closes #22481