### PR TITLE
fix(ext/node): add alternative RSA OID

### DIFF
--- a/ext/node/ops/crypto/mod.rs
+++ b/ext/node/ops/crypto/mod.rs
@@ -1270,6 +1270,8 @@ static MGF1_SHA1_MASK_ALGORITHM: Lazy<
 
 pub const RSA_ENCRYPTION_OID: const_oid::ObjectIdentifier =
   const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+pub const RSA_ENCRYPTION_OID_ALT: const_oid::ObjectIdentifier =
+  const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.3.1");
 pub const RSASSA_PSS_OID: const_oid::ObjectIdentifier =
   const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
 pub const EC_OID: const_oid::ObjectIdentifier =
@@ -1390,7 +1392,7 @@ pub fn op_node_create_private_key(
   let alg = pk_info.algorithm.oid;
 
   match alg {
-    RSA_ENCRYPTION_OID => {
+    RSA_ENCRYPTION_OID | RSA_ENCRYPTION_OID_ALT => {
       let private_key =
         rsa::pkcs1::RsaPrivateKey::from_der(pk_info.private_key)?;
       let modulus_length = private_key.modulus.as_bytes().len() * 8;


### PR DESCRIPTION
While working on #22489, I noticed that [this private key](https://github.com/nodejs/node/blob/0951e7b79d8509f6d80789109bb8d2e06bc130c3/test/parallel/test-crypto-dh-stateless.js#L75-L88) was unable to be created using `crypto.createPrivateKey()`. This is because it uses an RSA OID, `1.2.840.113549.1.3.1`, which is less commonly used than the currently used one, `1.2.840.113549.1.1.1`. This change adds the lesser-used RSA OID.

CC @littledivy 