### PR TITLE
chore: fail properly in web platform test

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -72,7 +72,7 @@ jobs:
           deno run --unstable --allow-write --allow-read --allow-net           \
             --allow-env --allow-run --lock=tools/deno.lock.json                \
             ./tools/wpt.ts run                                                 \
-            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json || true
+            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json
 
       - name: Upload wpt results to wpt.fyi
         env:


### PR DESCRIPTION
Having `|| true` means that the job always executes with a success code, even when it really fails. Credit to Bartek for spotting this possible mistake.

Towards #22257