### PR TITLE
chore: improve not implemented npm system info message

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -860,7 +860,13 @@ impl CliOptions {
             cpu: "x64".to_string(),
           },
           value => {
-            log::warn!("Not implemented NPM system info for target '{value}'. Using current system default. This may impact NPM ");
+            log::warn!(
+              concat!(
+                "Not implemented npm system info for target '{}'. Using current ",
+                "system default. This may impact architecture specific dependencies."
+              ),
+              value,
+            );
             NpmSystemInfo::default()
           }
         }


### PR DESCRIPTION
I just noticed the message on this was cut off.