### PR TITLE
chore(cli): rename `--trace-ops` to `--trace-leaks`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1312,6 +1312,7 @@ supported in canary.
           .help("Target OS architecture")
           .value_parser([
             "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
             "x86_64-pc-windows-msvc",
             "x86_64-apple-darwin",
             "aarch64-apple-darwin",

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2154,6 +2154,7 @@ Directory arguments are expanded to all contained files matching the glob
       Arg::new("trace-ops")
         .long("trace-ops")
         .help("Deprecated alias for --trace-leaks.")
+        .hide(true)
         .action(ArgAction::SetTrue),
     )
     .arg(

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3699,7 +3699,10 @@ fn test_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let trace_leaks =
     matches.get_flag("trace-ops") || matches.get_flag("trace-leaks");
   if trace_leaks && matches.get_flag("trace-ops") {
-    // See note below about the log crate
+    // We can't change this to use the log crate because its not configured
+    // yet at this point since the flags haven't been parsed. This flag is
+    // deprecated though so it's not worth changing the code to use the log
+    // crate here and this is only done for testing anyway.
     eprintln!(
       "⚠️ {}",
       crate::colors::yellow("The `--trace-ops` flag is deprecated and will be removed in Deno 2.0.\nUse the `--trace-leaks` flag instead."),

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -333,7 +333,7 @@ pub struct TestOptions {
   pub filter: Option<String>,
   pub shuffle: Option<u64>,
   pub concurrent_jobs: NonZeroUsize,
-  pub trace_ops: bool,
+  pub trace_leaks: bool,
   pub reporter: TestReporterConfig,
   pub junit_path: Option<String>,
 }
@@ -361,7 +361,7 @@ impl TestOptions {
       filter: test_flags.filter,
       no_run: test_flags.no_run,
       shuffle: test_flags.shuffle,
-      trace_ops: test_flags.trace_ops,
+      trace_leaks: test_flags.trace_leaks,
       reporter: test_flags.reporter,
       junit_path: test_flags.junit_path,
     })

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -296,7 +296,7 @@ impl TestRun {
             test::TestSpecifierOptions {
               filter,
               shuffle: None,
-              trace_ops: false,
+              trace_leaks: false,
             },
           ))
         }
@@ -438,7 +438,7 @@ impl TestRun {
         .iter()
         .map(|s| s.as_str()),
     );
-    args.push("--trace-ops");
+    args.push("--trace-leaks");
     if self.workspace_settings.unstable && !args.contains(&"--unstable") {
       args.push("--unstable");
     }

--- a/cli/tools/test/fmt.rs
+++ b/cli/tools/test/fmt.rs
@@ -106,7 +106,7 @@ fn format_sanitizer_accum(
   }
 
   let mut output = vec![];
-  let mut needs_trace_ops = false;
+  let mut needs_trace_leaks = false;
   for ((item_type, item_name, trace), count) in accum.into_iter() {
     if item_type == RuntimeActivityType::Resource {
       let (name, action1, action2) = pretty_resource_name(&item_name);
@@ -142,7 +142,7 @@ fn format_sanitizer_accum(
       value += &if let Some(trace) = trace {
         format!(" The operation {tense} started here:\n{trace}")
       } else {
-        needs_trace_ops = true;
+        needs_trace_leaks = true;
         String::new()
       };
       output.push(value);
@@ -156,8 +156,8 @@ fn format_sanitizer_accum(
       );
     }
   }
-  if needs_trace_ops {
-    (output, vec!["To get more details where ops were leaked, run again with --trace-ops flag.".to_owned()])
+  if needs_trace_leaks {
+    (output, vec!["To get more details where leaks occurred, run again with the --trace-leaks flag.".to_owned()])
   } else {
     (output, vec![])
   }
@@ -356,5 +356,5 @@ mod tests {
   // https://github.com/denoland/deno/issues/13938
   leak_format_test!(op_unknown, true, [RuntimeActivity::AsyncOp(0, "op_unknown", None)], 
     " - An async call to op_unknown was started in this test, but never completed.\n\
-    To get more details where ops were leaked, run again with --trace-ops flag.\n");
+    To get more details where leaks occurred, run again with the --trace-leaks flag.\n");
 }

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -396,7 +396,7 @@ struct TestSpecifiersOptions {
 pub struct TestSpecifierOptions {
   pub shuffle: Option<u64>,
   pub filter: TestFilter,
-  pub trace_ops: bool,
+  pub trace_leaks: bool,
 }
 
 impl TestSummary {
@@ -515,7 +515,7 @@ async fn test_specifier_inner(
 
   let mut coverage_collector = worker.maybe_setup_coverage_collector().await?;
 
-  if options.trace_ops {
+  if options.trace_leaks {
     worker.execute_script_static(
       located_script_name!(),
       "Deno[Deno.internal].core.setOpCallTracingEnabled(true);",
@@ -1458,7 +1458,7 @@ pub async fn run_tests(
       specifier: TestSpecifierOptions {
         filter: TestFilter::from_flag(&test_options.filter),
         shuffle: test_options.shuffle,
-        trace_ops: test_options.trace_ops,
+        trace_leaks: test_options.trace_leaks,
       },
     },
   )
@@ -1602,7 +1602,7 @@ pub async fn run_tests_with_watch(
             specifier: TestSpecifierOptions {
               filter: TestFilter::from_flag(&test_options.filter),
               shuffle: test_options.shuffle,
-              trace_ops: test_options.trace_ops,
+              trace_leaks: test_options.trace_leaks,
             },
           },
         )

--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -219,7 +219,7 @@ itest!(allow_none {
 });
 
 itest!(ops_sanitizer_unstable {
-  args: "test --trace-leaks test/sanitizer/ops_sanitizer_unstable.ts",
+  args: "test --trace-ops test/sanitizer/ops_sanitizer_unstable.ts",
   exit_code: 1,
   output: "test/sanitizer/ops_sanitizer_unstable.out",
 });

--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -219,7 +219,7 @@ itest!(allow_none {
 });
 
 itest!(ops_sanitizer_unstable {
-  args: "test --trace-ops test/sanitizer/ops_sanitizer_unstable.ts",
+  args: "test --trace-leaks test/sanitizer/ops_sanitizer_unstable.ts",
   exit_code: 1,
   output: "test/sanitizer/ops_sanitizer_unstable.out",
 });
@@ -231,7 +231,7 @@ itest!(ops_sanitizer_timeout_failure {
 
 itest!(ops_sanitizer_multiple_timeout_tests {
   args:
-    "test --trace-ops test/sanitizer/ops_sanitizer_multiple_timeout_tests.ts",
+    "test --trace-leaks test/sanitizer/ops_sanitizer_multiple_timeout_tests.ts",
   exit_code: 1,
   output: "test/sanitizer/ops_sanitizer_multiple_timeout_tests.out",
 });
@@ -243,13 +243,13 @@ itest!(ops_sanitizer_multiple_timeout_tests_no_trace {
 });
 
 itest!(sanitizer_trace_ops_catch_error {
-  args: "test -A --trace-ops test/sanitizer/trace_ops_caught_error/main.ts",
+  args: "test -A --trace-leaks test/sanitizer/trace_ops_caught_error/main.ts",
   exit_code: 0,
   output: "test/sanitizer/trace_ops_caught_error/main.out",
 });
 
 itest!(ops_sanitizer_closed_inside_started_before {
-  args: "test --trace-ops test/sanitizer/ops_sanitizer_closed_inside_started_before.ts",
+  args: "test --trace-leaks test/sanitizer/ops_sanitizer_closed_inside_started_before.ts",
   exit_code: 1,
   output: "test/sanitizer/ops_sanitizer_closed_inside_started_before.out",
 });

--- a/tests/testdata/test/sanitizer/ops_sanitizer_multiple_timeout_tests_no_trace.out
+++ b/tests/testdata/test/sanitizer/ops_sanitizer_multiple_timeout_tests_no_trace.out
@@ -8,12 +8,12 @@ test 2 ... FAILED ([WILDCARD])
 test 1 => [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD]
 error: Leaks detected:
   - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call.
-To get more details where ops were leaked, run again with --trace-ops flag.
+To get more details where leaks occurred, run again with the --trace-leaks flag.
 
 test 2 => [WILDCARD]/ops_sanitizer_multiple_timeout_tests.ts:[WILDCARD]
 error: Leaks detected:
   - 2 async operations to sleep for a duration were started in this test, but never completed. This is often caused by not cancelling a `setTimeout` or `setInterval` call.
-To get more details where ops were leaked, run again with --trace-ops flag.
+To get more details where leaks occurred, run again with the --trace-leaks flag.
 
  FAILURES 
 

--- a/tests/testdata/test/sanitizer/ops_sanitizer_unstable.out
+++ b/tests/testdata/test/sanitizer/ops_sanitizer_unstable.out
@@ -1,3 +1,5 @@
+⚠️ The `--trace-ops` flag is deprecated and will be removed in Deno 2.0.
+Use the `--trace-leaks` flag instead.
 Check [WILDCARD]/ops_sanitizer_unstable.ts
 running 2 tests from [WILDCARD]/ops_sanitizer_unstable.ts
 no-op ... ok ([WILDCARD])


### PR DESCRIPTION
As we add tracing to more types of runtime activity, `--trace-ops` is less useful of a name. `--trace-leaks` better reflects that this feature traces both ops and timers, and will eventually trace resource opening as well.

This keeps `--trace-ops` as an alias for `--trace-leaks`, but prints a warning to the console suggesting migration to `--trace-leaks`.

One test continues to use `--trace-ops` to test the deprecation warning.