### PR TITLE
fix(cli): ensure that pre- and post-test output is flushed at the appropriate times

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -397,6 +397,9 @@ impl TestRun {
                 );
               }
             }
+            test::TestEvent::Completed => {
+              reporter.report_completed();
+            }
             test::TestEvent::ForceEndReport => {}
             test::TestEvent::Sigint => {}
           }
@@ -740,6 +743,10 @@ impl LspTestReporter {
         })
       }
     }
+  }
+
+  fn report_completed(&mut self) {
+    // there is nothing to do on report_completed
   }
 
   fn report_summary(

--- a/cli/tools/test/reporters/compound.rs
+++ b/cli/tools/test/reporters/compound.rs
@@ -101,6 +101,12 @@ impl TestReporter for CompoundTestReporter {
     }
   }
 
+  fn report_completed(&mut self) {
+    for reporter in &mut self.test_reporters {
+      reporter.report_completed();
+    }
+  }
+
   fn flush_report(
     &mut self,
     elapsed: &Duration,

--- a/cli/tools/test/reporters/dot.rs
+++ b/cli/tools/test/reporters/dot.rs
@@ -206,6 +206,8 @@ impl TestReporter for DotTestReporter {
     );
   }
 
+  fn report_completed(&mut self) {}
+
   fn flush_report(
     &mut self,
     _elapsed: &Duration,

--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -158,6 +158,11 @@ impl TestReporter for JunitTestReporter {
     }
   }
 
+  fn report_completed(&mut self) {
+    // TODO(mmastrac): This reporter does not handle stdout/stderr yet, and when we do, we may need to redirect
+    // pre-and-post-test output somewhere.
+  }
+
   fn flush_report(
     &mut self,
     elapsed: &Duration,

--- a/cli/tools/test/reporters/mod.rs
+++ b/cli/tools/test/reporters/mod.rs
@@ -49,6 +49,7 @@ pub trait TestReporter {
     tests: &IndexMap<usize, TestDescription>,
     test_steps: &IndexMap<usize, TestStepDescription>,
   );
+  fn report_completed(&mut self);
   fn flush_report(
     &mut self,
     elapsed: &Duration,

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -8,6 +8,7 @@ pub struct PrettyTestReporter {
   parallel: bool,
   echo_output: bool,
   in_new_line: bool,
+  phase: &'static str,
   filter: bool,
   repl: bool,
   scope_test_id: Option<usize>,
@@ -32,6 +33,7 @@ impl PrettyTestReporter {
       parallel,
       echo_output,
       in_new_line: true,
+      phase: "",
       filter,
       repl,
       scope_test_id: None,
@@ -151,7 +153,7 @@ impl PrettyTestReporter {
       writeln!(
         &mut self.writer,
         "{}",
-        colors::gray("----- output end -----")
+        colors::gray(format!("----- {}output end -----", self.phase))
       )
       .unwrap();
       self.in_new_line = true;
@@ -204,17 +206,17 @@ impl TestReporter for PrettyTestReporter {
       if !self.in_new_line {
         writeln!(&mut self.writer).unwrap();
       }
-      let phase = if !self.started_tests {
-        "pre-test output"
+      self.phase = if !self.started_tests {
+        "pre-test "
       } else if self.ended_tests {
-        "post-test output"
+        "post-test "
       } else {
-        "output"
+        ""
       };
       writeln!(
         &mut self.writer,
         "{}",
-        colors::gray(format!("------- {phase} -------"))
+        colors::gray(format!("------- {}output -------", self.phase))
       )
       .unwrap();
       self.in_new_line = true;

--- a/cli/tools/test/reporters/tap.rs
+++ b/cli/tools/test/reporters/tap.rs
@@ -236,6 +236,8 @@ impl TestReporter for TapTestReporter {
     );
   }
 
+  fn report_completed(&mut self) {}
+
   fn flush_report(
     &mut self,
     _elapsed: &Duration,

--- a/tests/testdata/run/websocket_server_idletimeout.ts
+++ b/tests/testdata/run/websocket_server_idletimeout.ts
@@ -11,10 +11,12 @@ const { response, socket } = Deno.upgradeWebSocket(request, {
   idleTimeout: 1,
 });
 socket.onerror = (e) => {
+  console.log(e);
   assertEquals((e as ErrorEvent).message, "No response from ping frame.");
   errorDeferred.resolve();
 };
 socket.onclose = (e) => {
+  console.log(e);
   assertEquals(e.reason, "No response from ping frame.");
   closeDeferred.resolve();
 };
@@ -22,4 +24,6 @@ await respondWith(response);
 
 await errorDeferred.promise;
 await closeDeferred.promise;
-listener.close();
+
+// TODO(mmastrac): this doesn't exit on its own. Why?
+Deno.exit(123);

--- a/tests/testdata/test/load_unload.out
+++ b/tests/testdata/test/load_unload.out
@@ -1,6 +1,16 @@
-Check [WILDCARD]/test/load_unload.ts
-running 1 test from ./test/load_unload.ts
+Check [WILDCARD]/load_unload.ts
+------- pre-test output -------
+load
+----- output end -----
+running 1 test from [WILDCARD]/load_unload.ts
+test ...
+------- output -------
+test
+----- output end -----
 test ... ok ([WILDCARD])
+------- post-test output -------
+unload
+----- output end -----
 
 ok | 1 passed | 0 failed ([WILDCARD])
 

--- a/tests/testdata/test/load_unload.out
+++ b/tests/testdata/test/load_unload.out
@@ -1,7 +1,7 @@
 Check [WILDCARD]/load_unload.ts
 ------- pre-test output -------
 load
------ output end -----
+----- pre-test output end -----
 running 1 test from [WILDCARD]/load_unload.ts
 test ...
 ------- output -------
@@ -10,7 +10,7 @@ test
 test ... ok ([WILDCARD])
 ------- post-test output -------
 unload
------ output end -----
+----- post-test output end -----
 
 ok | 1 passed | 0 failed ([WILDCARD])
 

--- a/tests/testdata/test/load_unload.ts
+++ b/tests/testdata/test/load_unload.ts
@@ -4,6 +4,7 @@ addEventListener("load", () => {
     throw new Error("Interval is already set");
   }
 
+  console.log("load");
   interval = setInterval(() => {}, 0);
 });
 
@@ -12,10 +13,12 @@ addEventListener("unload", () => {
     throw new Error("Interval was not set");
   }
 
+  console.log("unload");
   clearInterval(interval);
 });
 
 Deno.test("test", () => {
+  console.log("test");
   if (!interval) {
     throw new Error("Interval was not set");
   }

--- a/tests/util/server/src/macros.rs
+++ b/tests/util/server/src/macros.rs
@@ -30,7 +30,9 @@ macro_rules! timeout {
       let timeout = *timeout.get(0).unwrap_or(&300);
       ::std::thread::spawn(move || {
         if rx.recv_timeout(::std::time::Duration::from_secs(timeout)) == Err(::std::sync::mpsc::RecvTimeoutError::Timeout) {
+          use std::io::Write;
           eprintln!("Test {function} timed out after {timeout} seconds, aborting");
+          _ = std::io::stderr().flush();
           ::std::process::exit(1);
         }
       });


### PR DESCRIPTION
Some `deno_std` tests were failing to print output that was resolved after the last test finished. In addition, output printed before tests began would sometimes appear above the "running X tests ..." line, and sometimes below it depending on timing.

We now guarantee that all output is flushed before and after tests run, making the output consistent.

Pre-test and post-test output are captured in `------ pre-test output ------` and `------ post-test output ------` blocks to differentiate them from the regular output blocks.

Here's an example of a test (that is much noisier than normal, but an example of what the output will look like):

```
Check ./load_unload.ts
------- pre-test output -------
load
----- output end -----
running 1 test from ./load_unload.ts
test ...
------- output -------
test
----- output end -----
test ... ok ([WILDCARD])
------- post-test output -------
unload
----- output end -----
```
