### PR TITLE
fix(lsp): do not warn about local file "redirects" from .js to .d.ts files

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1323,11 +1323,21 @@ fn diagnose_resolution(
         // If the module was redirected, we want to issue an informational
         // diagnostic that indicates this. This then allows us to issue a code
         // action to replace the specifier with the final redirected one.
-        if specifier.scheme() != "jsr" && doc_specifier != specifier {
-          diagnostics.push(DenoDiagnostic::Redirect {
-            from: specifier.clone(),
-            to: doc_specifier.clone(),
-          });
+        if specifier.scheme() != "jsr"
+          && doc_specifier != specifier
+          && !doc.media_type().is_declaration()
+        {
+          let is_in_node_modules_folder = snapshot
+            .npm
+            .as_ref()
+            .map(|npm| npm.node_resolver.in_npm_package(doc_specifier))
+            .unwrap_or(false);
+          if !is_in_node_modules_folder {
+            diagnostics.push(DenoDiagnostic::Redirect {
+              from: specifier.clone(),
+              to: doc_specifier.clone(),
+            });
+          }
         }
         if doc.media_type() == MediaType::Json {
           match maybe_assert_type {

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1345,9 +1345,7 @@ fn diagnose_resolution(
           diagnostics.push(DenoDiagnostic::DenoWarn(message));
         }
       }
-      eprintln!("Searching for: {}", specifier);
       if let Some(doc) = snapshot.documents.get(specifier) {
-        eprintln!("Found: {}", doc.specifier());
         if let Some(diagnostic) = check_redirect_diagnostic(specifier, &doc) {
           diagnostics.push(diagnostic);
         }

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8368,40 +8368,6 @@ fn lsp_diagnostics_warn_redirect() {
 }
 
 #[test]
-fn lsp_diagnostics_not_warn_redirect_in_npm_package() {
-  let context = TestContextBuilder::for_npm().use_temp_cwd().build();
-  context
-    .temp_dir()
-    .write("deno.json", r#"{ "unstable": ["byonm"] }"#);
-  context.temp_dir().write(
-    "package.json",
-    r#"{ "dependencies": { "@denotest/file-dts-dmts-dcts": "*" } }"#,
-  );
-  context.run_npm("install");
-
-  let mut client = context.new_lsp_command().build();
-  client.initialize_default();
-  let diagnostics = client.did_open(
-    json!({
-      "textDocument": {
-        "uri": context.temp_dir().path().join("file.ts").uri_file(),
-        "languageId": "typescript",
-        "version": 1,
-        "text": concat!(
-          "import * as a from \"./node_modules/@denotest/file-dts-dmts-dcts/main.mjs\";\n",
-          "import * as b from \"@denotest/file-dts-dmts-dcts/mjs\";\n",
-          "console.log(a)\n",
-          "console.log(b)\n",
-        )
-      },
-    }),
-  );
-  let diagnostics = diagnostics.all();
-  assert!(diagnostics.is_empty(), "{:?}", diagnostics);
-  client.shutdown();
-}
-
-#[test]
 fn lsp_redirect_quick_fix() {
   let context = TestContextBuilder::new()
     .use_http_server()


### PR DESCRIPTION
The diagnostic was incorrect when importing a `.js` file with a corresponding `.d.ts` file with sloppy imports because it would say to change the `.js` extension to `.d.ts`, which is incorrect. We might as well just hide this diagnostic.