### PR TITLE
fix(lsp): ignore code errors when type passes for non-`@deno-types` reolution

### DIFF
--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8611,6 +8611,39 @@ fn lsp_ts_diagnostics_refresh_on_lsp_version_reset() {
 }
 
 #[test]
+fn lsp_diagnostics_none_for_resolving_types() {
+  let context = TestContextBuilder::for_npm().use_temp_cwd().build();
+  context
+    .temp_dir()
+    .write("deno.json", r#"{ "unstable": ["byonm"] }"#);
+  context.temp_dir().write(
+    "package.json",
+    r#"{ "dependencies": { "@denotest/monaco-editor": "*" } }"#,
+  );
+  context.run_npm("install");
+
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  // The types for this package will succeed, but the code will fail
+  // because the package is only made for bundling and not meant to
+  // run in Deno or Node.
+  let diagnostics = client.did_open(json!({
+    "textDocument": {
+      "uri": context.temp_dir().path().join("file.ts").uri_file(),
+      "languageId": "typescript",
+      "version": 1,
+      "text": concat!(
+        "import * as a from \"@denotest/monaco-editor\";\n",
+        "console.log(new a.Editor())\n",
+      )
+    },
+  }));
+  let diagnostics = diagnostics.all();
+  assert!(diagnostics.is_empty(), "{:?}", diagnostics);
+  client.shutdown();
+}
+
+#[test]
 fn lsp_jupyter_diagnostics() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let mut client = context.new_lsp_command().build();

--- a/tests/testdata/npm/registry/@denotest/monaco-editor/1.0.0/main.js
+++ b/tests/testdata/npm/registry/@denotest/monaco-editor/1.0.0/main.js
@@ -1,0 +1,4 @@
+// The monaco-editor package uses an entry in the package.json
+// where it has no "type": "module" and then only specifies a
+// "module": "./main.js"-like entry that points at an ESM file.
+export class Editor {}

--- a/tests/testdata/npm/registry/@denotest/monaco-editor/1.0.0/main.types.d.ts
+++ b/tests/testdata/npm/registry/@denotest/monaco-editor/1.0.0/main.types.d.ts
@@ -1,0 +1,1 @@
+export class Editor {}

--- a/tests/testdata/npm/registry/@denotest/monaco-editor/1.0.0/package.json
+++ b/tests/testdata/npm/registry/@denotest/monaco-editor/1.0.0/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@denotest/monaco-editor",
+  "version": "1.0.0",
+  "module": "./main.js",
+  "types": "./main.types.d.ts"
+}


### PR DESCRIPTION
I'm working with monaco-editor in ts-ast-viewer.com and monaco-editor only provides a `"module": "./esm/vs/editor/editor.main.js",` entry in the package.json which also uses esm even though there's no `"type": "module"`, so it errors in Deno (https://www.npmjs.com/package/monaco-editor?activeTab=code). I believe `"module"` is not part of node resolution and in my case this is fine because the code is going to be bundled by a bundler and not run by Deno. Anyway, I was thinking that we could either just resolve the module entry or probably we shouldn't bother surfacing these issues as errors in the lsp and just leave it up to runtime? Not sure what the right solution is here, but erroring less in the lsp seems ok?

Before:

![image](https://github.com/denoland/deno/assets/1609021/cb92690a-36ea-4a48-ae00-d76666765071)

After:

![image](https://github.com/denoland/deno/assets/1609021/11dc1cf7-588c-4931-8cd1-c0729f9e7406)

Will write tests for this on Monday.