### PR TITLE
fix(node): errno property when command missing

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -275,6 +275,9 @@ export class ChildProcess extends EventEmitter {
         });
       })();
     } catch (err) {
+      if (err instanceof Deno.errors.NotFound) {
+        err = _createSpawnSyncError("ENOENT", command, args);
+      }
       this.#_handleError(err);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/22604

`remix dev` with Node adapter works:
```
$ ~/gh/littledivy/deno/target/debug/deno task dev
Task dev remix dev --manual

 💿  remix dev

 info  building...
 info  built (619ms)
[remix-serve] http://localhost:3000 (http://192.168.1.24:3000)

GET / 200 - - 3.090 ms
```