### PR TITLE
chore(tests): update flaky timer test

### DIFF
--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -228,26 +228,6 @@ Deno.test(function intervalCancelInvalidSilentFail() {
   clearInterval(2147483647);
 });
 
-Deno.test(async function callbackTakesLongerThanInterval() {
-  const { promise, resolve } = Promise.withResolvers<void>();
-
-  let timeEndOfFirstCallback: number | undefined;
-  const interval = setInterval(() => {
-    if (timeEndOfFirstCallback === undefined) {
-      // First callback
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300);
-      timeEndOfFirstCallback = Date.now();
-    } else {
-      // Second callback should be nearly instantaneous
-      assert(Date.now() - timeEndOfFirstCallback < 10);
-      clearInterval(interval);
-      resolve();
-    }
-  }, 100);
-
-  await promise;
-});
-
 // https://github.com/denoland/deno/issues/11398
 Deno.test(async function clearTimeoutAfterNextTimerIsDue1() {
   const { promise, resolve } = Promise.withResolvers<void>();

--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -228,6 +228,8 @@ Deno.test(function intervalCancelInvalidSilentFail() {
   clearInterval(2147483647);
 });
 
+// If a repeating timer is dispatched, the next interval that should first is based on
+// when the timer is dispatched, not when the timer handler completes.
 Deno.test(async function callbackTakesLongerThanInterval() {
   const { promise, resolve } = Promise.withResolvers<void>();
   const output: number[] = [];

--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -244,7 +244,9 @@ Deno.test(async function callbackTakesLongerThanInterval() {
       }
     }
     last = now;
-    while (performance.now() - now < 300) {}
+    while (performance.now() - now < 300) {
+      /* hot loop */
+    }
   }, 100);
   await promise;
   const total = output.reduce((t, n) => t + n, 0) / output.length;


### PR DESCRIPTION
This test was flaky after landing the new timer rewrite.