### PR TITLE
fix: update node process version to latest node LTS

### DIFF
--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -96,7 +96,7 @@ export const env: InstanceType<ObjectConstructor> & Record<string, string> =
  * it pointed to Deno version, but that led to incompability
  * with some packages.
  */
-export const version = "v18.18.0";
+export const version = "v20.11.1";
 
 /**
  * https://nodejs.org/api/process.html#process_process_versions
@@ -107,7 +107,7 @@ export const version = "v18.18.0";
  * with some packages. Value of `v8` field is still taken from `Deno.version`.
  */
 export const versions = {
-  node: "18.17.1",
+  node: "20.11.1",
   uv: "1.43.0",
   zlib: "1.2.11",
   brotli: "1.0.9",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
The issue seems to be already fixed since we upped to a newer 18.x version string in [another PR](https://github.com/denoland/deno/pull/20366). Updating to latest node LTS version can't hurt though.

Fixes https://github.com/denoland/deno/issues/21515