### PR TITLE
perf(cli): forget worker on run

### DIFF
--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -72,6 +72,10 @@ To grant permissions, set them before the script argument. For example:
     .await?;
 
   let exit_code = worker.run().await?;
+
+  // We don't need to drop the worker here since we're exiting the process
+  std::mem::forget(worker);
+
   Ok(exit_code)
 }
 


### PR DESCRIPTION
**DO NOT MERGE**

~4% boost on empty script:

```
Benchmark 1: /tmp/deno run /tmp/empty.js
  Time (mean ± σ):      16.6 ms ±   1.0 ms    [User: 11.0 ms, System: 4.1 ms]
  Range (min … max):    14.8 ms …  19.5 ms    178 runs
 
Benchmark 2: target/release/deno run /tmp/empty.js
  Time (mean ± σ):      15.9 ms ±   0.8 ms    [User: 10.7 ms, System: 3.8 ms]
  Range (min … max):    14.5 ms …  18.0 ms    189 runs
 
Summary
  'target/release/deno run /tmp/empty.js' ran
    1.04 ± 0.08 times faster than '/tmp/deno run /tmp/empty.js'
```