### PR TITLE
chore(tests): Remove vestiges of cli/tests folder

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -26,7 +26,7 @@
     "cli/tsc/dts/lib.dom*.d.ts",
     "cli/tsc/dts/lib.es*.d.ts",
     "cli/tsc/dts/typescript.d.ts",
-    "cli/tests/node_compat/test",
+    "tests/node_compat/test",
     "tests/testdata/file_extensions/ts_with_js_extension.js",
     "tests/testdata/fmt/badly_formatted.json",
     "tests/testdata/fmt/badly_formatted.md",

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = true
 insert_final_newline = unset
 trim_trailing_whitespace = unset
 
-[cli/tests/node_compat/test/**]
+[tests/node_compat/test/**]
 insert_final_newline = unset
 trim_trailing_whitespace = unset

--- a/tests/node_compat/test.ts
+++ b/tests/node_compat/test.ts
@@ -24,7 +24,7 @@ import {
 } from "./common.ts";
 
 // If the test case is invoked like
-// deno test -A cli/tests/node_compat/test.ts -- <test-names>
+// deno test -A tests/node_compat/test.ts -- <test-names>
 // Use the <test-names> as filters
 const filters = Deno.args;
 const hasFilters = filters.length > 0;
@@ -108,7 +108,7 @@ async function runTest(t: Deno.TestContext, path: string): Promise<void> {
         }
         const stderrOutput = decoder.decode(stderr);
         const repeatCmd = magenta(
-          `./target/debug/deno test -A cli/tests/node_compat/test.ts -- ${path}`,
+          `./target/debug/deno test -A tests/node_compat/test.ts -- ${path}`,
         );
         const msg = `"${magenta(path)}" failed:
 

--- a/tools/node_compat/README.md
+++ b/tools/node_compat/README.md
@@ -11,18 +11,17 @@ Node.js compat testing in Deno repository.
   - This script sets up the Node.js compat tests.
 - `//tools/node_compat/versions/`
   - Node.js source tarballs and extracted test cases are stored here.
-- `//cli/tests/node_compat/config.jsonc`
+- `//tests/node_compat/config.jsonc`
   - This json file stores the settings about which Node.js compat test to run
     with Deno.
-- `//cli/tests/node_compat/test`
+- `//tests/node_compat/test`
   - The actual test cases are stored here.
 
 ## Steps to add new test cases from Node.js test cases
 
-1. Update `tests` property of `//cli/tests/node_compat/config.jsonc`. For
-   example, if you want to add `test/parallel/test-foo.js` from Node.js test
-   cases, then add `test-foo.js` entry in `tests.parallel` array property in
-   `config.jsonc`
+1. Update `tests` property of `//tests/node_compat/config.jsonc`. For example,
+   if you want to add `test/parallel/test-foo.js` from Node.js test cases, then
+   add `test-foo.js` entry in `tests.parallel` array property in `config.jsonc`
 1. Run `deno task setup` in `tools/node_compat` dir.
 
 The above command copies the updated items from Node.js tarball to the Deno

--- a/tools/node_compat/deno.json
+++ b/tools/node_compat/deno.json
@@ -5,6 +5,6 @@
   },
   "tasks": {
     "setup": "deno run --allow-read --allow-write ./setup.ts",
-    "test": "deno test -A ../../cli/tests/node_compat/test.ts --"
+    "test": "deno test -A ../../tests/node_compat/test.ts --"
   }
 }


### PR DESCRIPTION
The old location of test was still haunting around in a few places. These are mainly comments but the `tools/node_compat/deno.json` is pretty crucial. Presumably editorconfig and dprint.json are likewise important.