### PR TITLE
fix: Provide source map for internal extension code

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -451,6 +451,10 @@ class Process extends EventEmitter {
 
   dlopen = dlopen;
 
+  foobar() {
+    throw new Error("boom!");
+  }
+
   /** https://nodejs.org/api/process.html#process_process_events */
   override on(event: "exit", listener: (code: number) => void): this;
   override on(

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -451,10 +451,6 @@ class Process extends EventEmitter {
 
   dlopen = dlopen;
 
-  foobar() {
-    throw new Error("boom!");
-  }
-
   /** https://nodejs.org/api/process.html#process_process_events */
   override on(event: "exit", listener: (code: number) => void): this;
   override on(

--- a/runtime/shared.rs
+++ b/runtime/shared.rs
@@ -97,7 +97,7 @@ pub fn maybe_transpile_source(
   let transpiled_source = parsed.transpile(&deno_ast::EmitOptions {
     imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Remove,
     inline_source_map: false,
-    source_map: true,
+    source_map: cfg!(debug_assertions),
     ..Default::default()
   })?;
 

--- a/runtime/shared.rs
+++ b/runtime/shared.rs
@@ -97,8 +97,13 @@ pub fn maybe_transpile_source(
   let transpiled_source = parsed.transpile(&deno_ast::EmitOptions {
     imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Remove,
     inline_source_map: false,
+    source_map: true,
     ..Default::default()
   })?;
 
-  Ok((transpiled_source.text.into(), None))
+  let maybe_source_map: Option<SourceMapData> = transpiled_source
+    .source_map
+    .map(|sm| sm.into_bytes().into());
+
+  Ok((transpiled_source.text.into(), maybe_source_map))
 }


### PR DESCRIPTION
This commit adds support for source maps for `ext/` crates that are authored
in TypeScript. As a result any exceptions thrown from eg. `ext/node` will now
have correct stack traces.

This is only enabled in debug mode as it adds about 2Mb to the binary.