### PR TITLE
perf(cli): fast path common argument patterns

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -17,6 +17,7 @@ use deno_runtime::permissions::parse_sys_kind;
 use log::debug;
 use log::Level;
 use std::env;
+use std::ffi::OsString;
 use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::num::NonZeroU8;
@@ -909,7 +910,7 @@ To evaluate code in the shell:
 );
 
 /// Main entry point for parsing deno's command line flags.
-pub fn flags_from_vec(args: Vec<String>) -> clap::error::Result<Flags> {
+pub fn flags_from_vec(args: Vec<OsString>) -> clap::error::Result<Flags> {
   let mut app = clap_root();
   let mut matches = app.try_get_matches_from_mut(&args)?;
 
@@ -4294,7 +4295,7 @@ mod tests {
 
   /// Creates vector of strings, Vec<String>
   macro_rules! svec {
-    ($($x:expr),* $(,)?) => (vec![$($x.to_string()),*]);
+    ($($x:expr),* $(,)?) => (vec![$($x.to_string().into()),*]);
   }
 
   #[test]

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -212,7 +212,7 @@ impl TestRun {
   ) -> Result<(), AnyError> {
     let args = self.get_args();
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
-    let flags = flags_from_vec(args.into_iter().map(String::from).collect())?;
+    let flags = flags_from_vec(args.into_iter().map(From::from).collect())?;
     let factory = CliFactory::from_flags(flags)?;
     // Various test files should not share the same permissions in terms of
     // `PermissionsContainer` - otherwise granting/revoking permissions in one

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -320,7 +320,7 @@ pub fn main() {
     Box::new(util::draw_thread::DrawThread::show),
   );
 
-  let args: Vec<String> = env::args().collect();
+  let args: Vec<_> = env::args_os().collect();
 
   // NOTE(lucacasonato): due to new PKU feature introduced in V8 11.6 we need to
   // initialize the V8 platform on a parent thread of all threads that will spawn

--- a/cli/mainrt.rs
+++ b/cli/mainrt.rs
@@ -68,10 +68,9 @@ fn unwrap_or_exit<T>(result: Result<T, AnyError>) -> T {
 }
 
 fn main() {
-  let args: Vec<String> = env::args().collect();
+  let args: Vec<_> = env::args_os().collect();
   let current_exe_path = current_exe().unwrap();
-  let standalone =
-    standalone::extract_standalone(&current_exe_path, args.clone());
+  let standalone = standalone::extract_standalone(&current_exe_path, args);
   let future = async move {
     match standalone {
       Ok(Some(future)) => {


### PR DESCRIPTION


```

15:20 $ hyperfine -S none --warmup 25 '/tmp/deno run /tmp/empty.js' 'target/release/deno run /tmp/empty.js'
Benchmark 1: /tmp/deno run /tmp/empty.js
  Time (mean ± σ):      17.6 ms ±   5.3 ms    [User: 11.4 ms, System: 4.2 ms]
  Range (min … max):    15.1 ms …  85.0 ms    169 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: target/release/deno run /tmp/empty.js
  Time (mean ± σ):      16.4 ms ±   0.7 ms    [User: 10.8 ms, System: 4.0 ms]
  Range (min … max):    14.6 ms …  20.1 ms    193 runs
 
Summary
  'target/release/deno run /tmp/empty.js' ran
    1.07 ± 0.33 times faster than '/tmp/deno run /tmp/empty.js'
```