### PR TITLE
fix: don't include source maps in release mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73fa2b215c93d44b55228a6c69aa92ffa200cfa683ebaf45202ecfbd749bf52"
+checksum = "58d986a1df3f1538ffa04162b5c5f00b856121391b860dc003bde2a6a741e878"
 dependencies = [
  "anyhow",
  "base64",
@@ -7276,7 +7276,7 @@ dependencies = [
  "codespan-reporting",
  "log",
  "naga",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "ron",
@@ -7317,7 +7317,7 @@ dependencies = [
  "naga",
  "objc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",

--- a/runtime/shared.rs
+++ b/runtime/shared.rs
@@ -97,13 +97,17 @@ pub fn maybe_transpile_source(
   let transpiled_source = parsed.transpile(&deno_ast::EmitOptions {
     imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Remove,
     inline_source_map: false,
-    source_map: cfg!(debug_assertions),
+    source_map: true,
     ..Default::default()
   })?;
 
-  let maybe_source_map: Option<SourceMapData> = transpiled_source
-    .source_map
-    .map(|sm| sm.into_bytes().into());
+  let maybe_source_map: Option<SourceMapData> = if cfg!(debug_assertions) {
+    transpiled_source
+      .source_map
+      .map(|sm| sm.into_bytes().into())
+  } else {
+    None
+  };
 
   Ok((transpiled_source.text.into(), maybe_source_map))
 }

--- a/runtime/shared.rs
+++ b/runtime/shared.rs
@@ -97,17 +97,13 @@ pub fn maybe_transpile_source(
   let transpiled_source = parsed.transpile(&deno_ast::EmitOptions {
     imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Remove,
     inline_source_map: false,
-    source_map: true,
+    source_map: cfg!(debug_assertions),
     ..Default::default()
   })?;
 
-  let maybe_source_map: Option<SourceMapData> = if cfg!(debug_assertions) {
-    transpiled_source
-      .source_map
-      .map(|sm| sm.into_bytes().into())
-  } else {
-    None
-  };
+  let maybe_source_map: Option<SourceMapData> = transpiled_source
+    .source_map
+    .map(|sm| sm.into_bytes().into());
 
   Ok((transpiled_source.text.into(), maybe_source_map))
 }


### PR DESCRIPTION
Due to bug in `deno_ast` the `source_map` setting is ignored and source map
is always emitted. This is fixed by updating `deno_ast`.