### PR TITLE
fix(runtime): Restore default signal handler after user handlers are unregistered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -1780,6 +1780,7 @@ dependencies = [
  "ring",
  "rustyline",
  "serde",
+ "signal-hook",
  "signal-hook-registry",
  "test_server",
  "tokio",
@@ -5651,6 +5652,16 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -119,6 +119,7 @@ regex.workspace = true
 ring.workspace = true
 rustyline = { workspace = true, features = ["custom-bindings"] }
 serde.workspace = true
+signal-hook = "0.3.17"
 signal-hook-registry = "1.4.0"
 tokio.workspace = true
 tokio-metrics.workspace = true

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -13,7 +13,9 @@ use deno_core::ResourceId;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
+#[cfg(unix)]
 use std::sync::atomic::AtomicBool;
+#[cfg(unix)]
 use std::sync::Arc;
 
 #[cfg(unix)]

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -618,9 +618,14 @@ pub fn op_signal_unbind(
   #[smi] rid: ResourceId,
 ) -> Result<(), AnyError> {
   let resource = state.resource_table.take::<SignalStreamResource>(rid)?;
-  resource
-    .use_default_handler
-    .store(true, std::sync::atomic::Ordering::Release);
+
+  #[cfg(unix)]
+  {
+    resource
+      .use_default_handler
+      .store(true, std::sync::atomic::Ordering::Release);
+  }
+
   resource.close();
   Ok(())
 }

--- a/tests/unit/signal_test.ts
+++ b/tests/unit/signal_test.ts
@@ -172,10 +172,20 @@ Deno.test(
     }
 
     // Sends SIGUSR1 (irrelevant signal) 3 times.
+    // By default SIGUSR1 terminates, so set it to a no-op for this test.
+    let count = 0;
+    const irrelevant = () => {
+      count++;
+    };
+    Deno.addSignalListener("SIGUSR1", irrelevant);
     for (const _ of Array(3)) {
       await delay(20);
       Deno.kill(Deno.pid, "SIGUSR1");
     }
+    while (count < 3) {
+      await delay(20);
+    }
+    Deno.removeSignalListener("SIGUSR1", irrelevant);
 
     // No change
     assertEquals(c, "010101000");

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -237,7 +237,6 @@ Deno.test({
 
 Deno.test({
   name: "process.off signal",
-  ignore: true, // This test fails to terminate
   async fn() {
     const testTimeout = setTimeout(() => fail("Test timed out"), 10_000);
     try {
@@ -246,13 +245,13 @@ Deno.test({
           "eval",
           `
           import process from "node:process";
-          console.log("ready");
           setInterval(() => {}, 1000);
           const listener = () => {
+            process.off("SIGINT", listener);
             console.log("foo");
-            process.off("SIGINT", listener)
           };
           process.on("SIGINT", listener);
+          console.log("ready");
           `,
         ],
         stdout: "piped",
@@ -275,6 +274,7 @@ Deno.test({
       while (!output.includes("foo\n")) {
         await delay(10);
       }
+      process.kill("SIGINT");
       await process.status;
     } finally {
       clearTimeout(testTimeout);

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -237,6 +237,7 @@ Deno.test({
 
 Deno.test({
   name: "process.off signal",
+  ignore: Deno.build.os == "windows",
   async fn() {
     const testTimeout = setTimeout(() => fail("Test timed out"), 10_000);
     try {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Fixes #22724. Fixes #7164.

This does add a dependency on `signal-hook`, but it's just a higher level API on top of `signal-hook-registry` (which we and `tokio` already depend on) and doesn't add any transitive deps.