### PR TITLE
fix(tools/publish): correctly handle importing from self in unfurling

### DIFF
--- a/cli/tools/registry/unfurl.rs
+++ b/cli/tools/registry/unfurl.rs
@@ -280,7 +280,15 @@ fn relative_url(
   referrer: &ModuleSpecifier,
 ) -> String {
   if resolved.scheme() == "file" {
-    format!("./{}", referrer.make_relative(resolved).unwrap())
+    let relative = referrer.make_relative(resolved).unwrap();
+    if relative == "" {
+      let last = resolved.path_segments().unwrap().last().unwrap();
+      format!("./{last}")
+    } else if relative.starts_with("../") {
+      relative
+    } else {
+      format!("./{relative}")
+    }
   } else {
     resolved.to_string()
   }
@@ -380,6 +388,7 @@ import chalk from "chalk";
 import baz from "./baz";
 import b from "./b.js";
 import b2 from "./b";
+import "./mod.ts";
 import url from "url";
 // TODO: unfurl these to jsr
 // import "npm:@jsr/std__fs@1/file";
@@ -428,6 +437,7 @@ import chalk from "npm:chalk@5";
 import baz from "./baz/index.js";
 import b from "./b.ts";
 import b2 from "./b.ts";
+import "./mod.ts";
 import url from "node:url";
 // TODO: unfurl these to jsr
 // import "npm:@jsr/std__fs@1/file";

--- a/cli/tools/registry/unfurl.rs
+++ b/cli/tools/registry/unfurl.rs
@@ -281,7 +281,7 @@ fn relative_url(
 ) -> String {
   if resolved.scheme() == "file" {
     let relative = referrer.make_relative(resolved).unwrap();
-    if relative == "" {
+    if relative.is_empty() {
       let last = resolved.path_segments().unwrap().last().unwrap();
       format!("./{last}")
     } else if relative.starts_with("../") {


### PR DESCRIPTION
We emitted `import "./` rather than `import "./$NAME"`. This is now fixed.

Also makes a cosmetic change so that `../` imports are now just imported as `../`, not `./../`.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
