### PR TITLE
Revert "perf: hard link npm cache"

### DIFF
--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -332,12 +332,8 @@ async fn sync_resolution_with_fs(
           .with_context(|| format!("Creating '{}'", folder_path.display()))?;
         let cache_folder = cache
           .package_folder_for_name_and_version(&package.id.nv, &registry_url);
-        if hard_link_dir_recursive(&cache_folder, &package_path).is_err() {
-          // Fallback to copying the directory.
-          //
-          // Also handles EXDEV when when trying to hard link across volumes.
-          copy_dir_recursive(&cache_folder, &package_path)?;
-        }
+        // for now copy, but in the future consider hard linking
+        copy_dir_recursive(&cache_folder, &package_path)?;
         // write out a file that indicates this folder has been initialized
         fs::write(initialized_file, "")?;
         // finally stop showing the progress bar


### PR DESCRIPTION
Reverts denoland/deno#22773 due to unanswered questions in https://github.com/denoland/deno/pull/22773#pullrequestreview-1923188700 (approval w/ caveats caused auto-merge) and we're doing a patch release today (unless questions can be answered before the patch).

cc @littledivy 