### PR TITLE
refactor(ext/node): worker_threads.isMainThread setup

### DIFF
--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -13,6 +13,7 @@ let initialized = false;
 function initialize(
   usesLocalNodeModulesDir,
   argv0,
+  runningOnMainThread,
 ) {
   if (initialized) {
     throw Error("Node runtime already initialized");
@@ -37,7 +38,7 @@ function initialize(
   // FIXME(bartlomieju): not nice to depend on `Deno` namespace here
   // but it's the only way to get `args` and `version` and this point.
   internals.__bootstrapNodeProcess(argv0, Deno.args, Deno.version);
-  internals.__initWorkerThreads();
+  internals.__initWorkerThreads(runningOnMainThread);
   internals.__setupChildProcessIpcChannel();
   // `Deno[Deno.internal].requireImpl` will be unreachable after this line.
   delete internals.requireImpl;

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -143,7 +143,7 @@ class _Worker extends EventEmitter {
     const handle = this[kHandle] = new Worker(
       specifier,
       {
-        name: (options?.name ?? "").trim(),
+        name,
         type: "module",
       } as globalThis.WorkerOptions, // bypass unstable type error
     );

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -223,8 +223,6 @@ internals.__initWorkerThreads = (runningOnMainThread: boolean) => {
 
   if (!isMainThread) {
     // deno-lint-ignore no-explicit-any
-    delete (globalThis as any).name;
-    // deno-lint-ignore no-explicit-any
     const listeners = new WeakMap<(...args: any[]) => void, (ev: any) => any>();
 
     parentPort = self as ParentPort;

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -33,6 +33,7 @@ const {
   StringPrototypeMatch,
   StringPrototypeReplaceAll,
   StringPrototypeToString,
+  StringPrototypeTrim,
   SafeWeakMap,
   SafeRegExp,
   SafeMap,
@@ -55,6 +56,7 @@ export interface WorkerOptions {
     codeRangeSizeMb?: number;
     stackSizeMb?: number;
   };
+  // deno-lint-ignore prefer-primordials
   eval?: boolean;
   transferList?: Transferable[];
   workerData?: unknown;
@@ -186,7 +188,7 @@ class NodeWorker extends EventEmitter {
 
     // TODO(bartlomieu): this doesn't match the Node.js behavior, it should be
     // `[worker {threadId}] {name}` or empty string.
-    let name = (options?.name ?? "").trim();
+    let name = StringPrototypeTrim(options?.name ?? "");
     if (options?.eval) {
       name = "[worker eval]";
     }

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -139,7 +139,10 @@ class _Worker extends EventEmitter {
 
     // TODO(bartlomieu): this doesn't match the Node.js behavior, it should be
     // `[worker {threadId}] {name}` or empty string.
-    const name = (options?.name ?? "").trim();
+    let name = (options?.name ?? "").trim();
+    if (options?.eval) {
+      name = "[worker eval]";
+    }
     const handle = this[kHandle] = new Worker(
       specifier,
       {

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -234,12 +234,16 @@ internals.__initWorkerThreads = (runningOnMainThread: boolean) => {
       parentPort,
       "message",
     ).then((result) => {
+      // TODO(bartlomieju): just so we don't error out here. It's still racy,
+      // but should be addressed by https://github.com/denoland/deno/issues/22783
+      // shortly.
+      const data = result[0].data ?? {};
       // TODO(kt3k): The below values are set asynchronously
       // using the first message from the parent.
       // This should be done synchronously.
-      threadId = result[0].data.threadId;
-      workerData = result[0].data.workerData;
-      environmentData = result[0].data.environmentData;
+      threadId = data.threadId;
+      workerData = data.workerData;
+      environmentData = data.environmentData;
 
       defaultExport.threadId = threadId;
       defaultExport.workerData = workerData;

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -133,7 +133,6 @@ function toFileUrl(path: string): URL {
 
 let threads = 0;
 const privateWorkerRef = Symbol("privateWorkerRef");
-const PRIVATE_WORKER_THREAD_NAME = "$DENO_STD_NODE_WORKER_THREAD";
 class NodeWorker extends EventEmitter {
   #id = 0;
   #name = "";

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -774,7 +774,7 @@ function bootstrapMainRuntime(runtimeOptions) {
   ObjectDefineProperty(globalThis, "Deno", core.propReadOnly(finalDenoNs));
 
   if (nodeBootstrap) {
-    nodeBootstrap(hasNodeModulesDir, argv0);
+    nodeBootstrap(hasNodeModulesDir, argv0, /* runningOnMainThread */ true);
   }
 
   if (future) {
@@ -909,7 +909,7 @@ function bootstrapWorkerRuntime(
   ObjectDefineProperty(globalThis, "Deno", core.propReadOnly(finalDenoNs));
 
   if (nodeBootstrap) {
-    nodeBootstrap(hasNodeModulesDir, argv0);
+    nodeBootstrap(hasNodeModulesDir, argv0, /* runningOnMainThread */ false);
   }
 }
 


### PR DESCRIPTION
This commit changes how we figure out if we're running on main
thread in `node:worker_threads` module. Instead of relying on quirky
"magic variable" for a name to check if we're on main thread, we are
now explicitly passing this information during bootstrapping of the
runtime. As a side effect, `WorkerOptions.name` is more useful
and matches what Node.js does more closely (though not fully).

Towards https://github.com/denoland/deno/issues/22783