### PR TITLE
fix(publish): include explicitly specified .gitignored files and directories

### DIFF
--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -318,27 +318,6 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
             .as_ref()
             .map(|git_ignore| git_ignore.is_ignored(path, is_dir))
             .unwrap_or(false);
-          if is_gitignored && !is_dir {
-            // For .gitignore with `deno publish`, check for and still
-            // include any exact file matches, but not for non-gitignored
-            // because the include paths might be CLI args that a user would
-            // want excluded.
-            // todo(dsherret): ideally we could implement a way to also do
-            // this for directories, but make sure to still make gitignored
-            // descendants still be ignored unless the user opts-out of it.
-            // For directories, it's not as simple as doing a check here because
-            // a sub directory might be explicitly ignored. Most likely it could
-            // be achieved by appending the included paths to the gitignore
-            if let Some(include) = &file_patterns.include {
-              for path_or_pattern in include.inner().iter().rev() {
-                if let PathOrPattern::Path(p) = path_or_pattern {
-                  if path == p {
-                    return true;
-                  }
-                }
-              }
-            }
-          }
           !is_gitignored
         }
         FilePatternsMatch::PassedOptedOutExclude => true,
@@ -347,7 +326,27 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
     }
 
     let mut maybe_git_ignores = if self.use_gitignore {
-      Some(GitIgnoreTree::new(Arc::new(deno_runtime::deno_fs::RealFs)))
+      let include_paths = file_patterns
+        .include
+        .as_ref()
+        .map(|include| {
+          include
+            .inner()
+            .iter()
+            .filter_map(|path_or_pattern| {
+              if let PathOrPattern::Path(p) = path_or_pattern {
+                Some(p.clone())
+              } else {
+                None
+              }
+            })
+            .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+      Some(GitIgnoreTree::new(
+        Arc::new(deno_runtime::deno_fs::RealFs),
+        include_paths,
+      ))
     } else {
       None
     };

--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -326,6 +326,9 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
     }
 
     let mut maybe_git_ignores = if self.use_gitignore {
+      // Override explicitly specified include paths in the
+      // .gitignore file. This does not apply to globs because
+      // that is way too complicated to reason about.
       let include_paths = file_patterns
         .include
         .as_ref()

--- a/tests/integration/publish_tests.rs
+++ b/tests/integration/publish_tests.rs
@@ -417,20 +417,26 @@ fn not_include_gitignored_file_even_if_matched_in_include() {
     "version": "1.0.0",
     "exports": "./main.ts",
     "publish": {
-      // won't match ignored because it needs to be
+      // won't match ignored.ts because it needs to be
       // unexcluded via a negated glob in exclude
-      "include": [ "deno.json", "*.ts" ]
+      "include": [
+        "deno.json", "*.ts", "exact_include.ts" ]
     }
   }));
 
-  temp_dir.join(".gitignore").write("ignored.ts");
+  temp_dir
+    .join(".gitignore")
+    .write("ignored.ts\nexact_include.ts");
   temp_dir.join("main.ts").write("");
   temp_dir.join("ignored.ts").write("");
+  temp_dir.join("exact_include.ts").write("");
 
   let output = context.new_command().arg("publish").arg("--dry-run").run();
   output.assert_exit_code(0);
   let output = output.combined_output();
   assert_contains!(output, "main.ts");
+  // will match this exact match
+  assert_contains!(output, "exact_include.ts");
   // it's gitignored
   assert_not_contains!(output, "ignored.ts");
 }

--- a/tests/integration/publish_tests.rs
+++ b/tests/integration/publish_tests.rs
@@ -409,7 +409,7 @@ fn ignores_directories() {
 }
 
 #[test]
-fn not_include_gitignored_file_even_if_matched_in_include() {
+fn not_include_gitignored_file_unless_exact_match_in_include() {
   let context = publish_context_builder().build();
   let temp_dir = context.temp_dir().path();
   temp_dir.join("deno.json").write_json(&json!({
@@ -420,16 +420,27 @@ fn not_include_gitignored_file_even_if_matched_in_include() {
       // won't match ignored.ts because it needs to be
       // unexcluded via a negated glob in exclude
       "include": [
-        "deno.json", "*.ts", "exact_include.ts" ]
+        "deno.json",
+        "*.ts",
+        "exact_include.ts",
+        "sub"
+      ]
     }
   }));
 
   temp_dir
     .join(".gitignore")
-    .write("ignored.ts\nexact_include.ts");
+    .write("ignored.ts\nexact_include.ts\nsub/\n/sub_ignored\n");
   temp_dir.join("main.ts").write("");
   temp_dir.join("ignored.ts").write("");
   temp_dir.join("exact_include.ts").write("");
+  let sub_dir = temp_dir.join("sub");
+  sub_dir.create_dir_all();
+  sub_dir.join("sub_included.ts").write("");
+  sub_dir.join("ignored.ts").write(""); // this one is gitignored
+  let sub_ignored_dir = temp_dir.join("sub_ignored");
+  sub_ignored_dir.create_dir_all();
+  sub_ignored_dir.join("sub_ignored.ts").write("");
 
   let output = context.new_command().arg("publish").arg("--dry-run").run();
   output.assert_exit_code(0);
@@ -437,8 +448,11 @@ fn not_include_gitignored_file_even_if_matched_in_include() {
   assert_contains!(output, "main.ts");
   // will match this exact match
   assert_contains!(output, "exact_include.ts");
+  // will include this because the sub directory is included
+  assert_contains!(output, "sub_included.ts");
   // it's gitignored
   assert_not_contains!(output, "ignored.ts");
+  assert_not_contains!(output, "sub_ignored.ts");
 }
 
 #[test]

--- a/tests/integration/publish_tests.rs
+++ b/tests/integration/publish_tests.rs
@@ -430,7 +430,7 @@ fn not_include_gitignored_file_unless_exact_match_in_include() {
 
   temp_dir
     .join(".gitignore")
-    .write("ignored.ts\nexact_include.ts\nsub/\n/sub_ignored\n");
+    .write("ignored.ts\nexact_include.ts\nsub/\nsub/ignored\n/sub_ignored\n");
   temp_dir.join("main.ts").write("");
   temp_dir.join("ignored.ts").write("");
   temp_dir.join("exact_include.ts").write("");
@@ -438,6 +438,8 @@ fn not_include_gitignored_file_unless_exact_match_in_include() {
   sub_dir.create_dir_all();
   sub_dir.join("sub_included.ts").write("");
   sub_dir.join("ignored.ts").write(""); // this one is gitignored
+  sub_dir.join("ignored").create_dir_all();
+  sub_dir.join("ignored").join("ignored_also.ts").write("");
   let sub_ignored_dir = temp_dir.join("sub_ignored");
   sub_ignored_dir.create_dir_all();
   sub_ignored_dir.join("sub_ignored.ts").write("");
@@ -452,6 +454,7 @@ fn not_include_gitignored_file_unless_exact_match_in_include() {
   assert_contains!(output, "sub_included.ts");
   // it's gitignored
   assert_not_contains!(output, "ignored.ts");
+  assert_not_contains!(output, "ignored_also.ts");
   assert_not_contains!(output, "sub_ignored.ts");
 }
 


### PR DESCRIPTION
This allows explicitly overriding a .gitignore by specifying files and directories in "include". This does not apply to globs in an include as files matching those will still be gitignored. Additionally, individually gitignored files within an included directory will still be ignored (those can be opted out of being excluded by using a negated glob).