### PR TITLE
fix(publish): ability to un-exclude when .gitignore ignores everything

### DIFF
--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -373,8 +373,11 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
         let path = e.path().to_path_buf();
         let maybe_gitignore =
           maybe_git_ignores.as_mut().and_then(|git_ignores| {
-            let dir_path = if is_dir { &path } else { path.parent()? };
-            git_ignores.get_resolved_git_ignore(dir_path)
+            if is_dir {
+              git_ignores.get_resolved_git_ignore_for_dir(&path)
+            } else {
+              git_ignores.get_resolved_git_ignore_for_file(&path)
+            }
           });
         if !is_pattern_matched(
           maybe_gitignore.as_deref(),


### PR DESCRIPTION
This is an unrealistic scenario, but it's still a good thing to fix and have a test for because it probably fixes some other underlying issues with how the gitignore was being resolved for the root directory.

From https://github.com/denoland/deno/pull/22720#issuecomment-1986134425