### PR TITLE
fix(config): remove pkg name example and add pattern to schema

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -547,7 +547,7 @@
     "name": {
       "type": "string",
       "description": "The name of this JSR package. Must be scoped",
-      "examples": ["@luca/flag"]
+      "examples": ["@scope/name"]
     },
     "version": {
       "type": "string",

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -547,12 +547,11 @@
     "name": {
       "type": "string",
       "description": "The name of this JSR package. Must be scoped",
-      "examples": ["@scope/name"]
+      "pattern": "^@[a-z0-9-]+/[a-z0-9-]+$"
     },
     "version": {
       "type": "string",
-      "description": "The version of this JSR package.",
-      "examples": ["0.1.0", "1.0.0"]
+      "description": "The version of this JSR package."
     },
     "exports": {
       "oneOf": [


### PR DESCRIPTION
I was typing in my package name in a deno.json and got confused when it did this suggestion.

![image](https://github.com/denoland/deno/assets/1609021/e104676d-7b7f-402f-b88a-fca0ef7814e2)

Probably best to remove the example and instead replace it with a pattern.