### PR TITLE
fix(publish): regression - publishing with vendor folder

### DIFF
--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -97,9 +97,9 @@ async fn prepare_publish(
   deno_json: &ConfigFile,
   source_cache: Arc<ParsedSourceCache>,
   graph: Arc<deno_graph::ModuleGraph>,
+  cli_options: Arc<CliOptions>,
   mapped_resolver: Arc<MappedSpecifierResolver>,
   sloppy_imports_resolver: Option<SloppyImportsResolver>,
-  bare_node_builtins: bool,
   diagnostics_collector: &PublishDiagnosticsCollector,
 ) -> Result<Rc<PreparedPublishPackage>, AnyError> {
   let config_path = deno_json.specifier.to_file_path().unwrap();
@@ -145,6 +145,7 @@ async fn prepare_publish(
 
   let diagnostics_collector = diagnostics_collector.clone();
   let tarball = deno_core::unsync::spawn_blocking(move || {
+    let bare_node_builtins = cli_options.unstable_bare_node_builtins();
     let unfurler = SpecifierUnfurler::new(
       &mapped_resolver,
       sloppy_imports_resolver.as_ref(),
@@ -152,6 +153,7 @@ async fn prepare_publish(
     );
     tar::create_gzipped_tarball(
       &dir_path,
+      &cli_options,
       LazyGraphSourceParser::new(&source_cache, &graph),
       &diagnostics_collector,
       &unfurler,
@@ -745,7 +747,6 @@ async fn prepare_packages_for_publishing(
   let type_checker = cli_factory.type_checker().await?;
   let fs = cli_factory.fs();
   let cli_options = cli_factory.cli_options();
-  let bare_node_builtins = cli_options.unstable_bare_node_builtins();
 
   if members.len() > 1 {
     println!("Publishing a workspace...");
@@ -776,15 +777,16 @@ async fn prepare_packages_for_publishing(
         None
       };
       let graph = graph.clone();
+      let cli_options = cli_options.clone();
       async move {
         let package = prepare_publish(
           &member.package_name,
           &member.config_file,
           source_cache.clone(),
           graph,
+          cli_options,
           mapped_resolver,
           sloppy_imports_resolver,
-          bare_node_builtins,
           diagnostics_collector,
         )
         .await

--- a/cli/tools/registry/tar.rs
+++ b/cli/tools/registry/tar.rs
@@ -14,6 +14,7 @@ use std::io::Write;
 use std::path::Path;
 use tar::Header;
 
+use crate::args::CliOptions;
 use crate::cache::LazyGraphSourceParser;
 use crate::tools::registry::paths::PackagePath;
 use crate::util::fs::FileCollector;
@@ -39,6 +40,7 @@ pub struct PublishableTarball {
 
 pub fn create_gzipped_tarball(
   dir: &Path,
+  cli_options: &CliOptions,
   source_parser: LazyGraphSourceParser,
   diagnostics_collector: &PublishDiagnosticsCollector,
   unfurler: &SpecifierUnfurler,
@@ -70,7 +72,7 @@ pub fn create_gzipped_tarball(
   })
   .ignore_git_folder()
   .ignore_node_modules()
-  .ignore_vendor_folder()
+  .set_vendor_folder(cli_options.vendor_dir_path().map(ToOwned::to_owned))
   .use_gitignore()
   .collect_file_patterns(file_patterns)?;
 

--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -261,6 +261,7 @@ pub struct FileCollector<TFilter: Fn(WalkEntry) -> bool> {
   ignore_git_folder: bool,
   ignore_node_modules: bool,
   ignore_vendor_folder: bool,
+  vendor_folder: Option<PathBuf>,
   use_gitignore: bool,
 }
 
@@ -271,6 +272,7 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
       ignore_git_folder: false,
       ignore_node_modules: false,
       ignore_vendor_folder: false,
+      vendor_folder: None,
       use_gitignore: false,
     }
   }
@@ -282,6 +284,11 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
 
   pub fn ignore_vendor_folder(mut self) -> Self {
     self.ignore_vendor_folder = true;
+    self
+  }
+
+  pub fn set_vendor_folder(mut self, vendor_folder: Option<PathBuf>) -> Self {
+    self.vendor_folder = vendor_folder;
     self
   }
 
@@ -403,7 +410,12 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
               file != path && is_ignored_file
             })
             .unwrap_or(false)
-            || !visited_paths.insert(path.clone());
+            || !visited_paths.insert(path.clone())
+            || self
+              .vendor_folder
+              .as_ref()
+              .map(|vendor_folder| path.starts_with(vendor_folder))
+              .unwrap_or(false);
           if should_ignore_dir {
             iterator.skip_current_dir();
           }


### PR DESCRIPTION
In https://github.com/denoland/deno/pull/22720/files#diff-d62d85de2a7ffb816cd2fdbaa47e588352f521c7c43d058b75649bbb255e0ae1R70 , I copy and pasted from another area of the code and didn't think about removing how it ignores the vendor folder by default.