### PR TITLE
chore: fix child_process test

### DIFF
--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -786,7 +786,7 @@ Deno.test(async function execFileWithUndefinedTimeout() {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   CP.execFile(
     "git",
-    ["-v"],
+    ["--version"],
     { timeout: undefined, encoding: "utf8" },
     (err) => {
       if (err) {


### PR DESCRIPTION
This test always fails for me because `git -v` is not a flag.