### PR TITLE
fix: stop type checking during runtime

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -3,7 +3,6 @@
 use crate::args::jsr_url;
 use crate::args::CliOptions;
 use crate::args::Lockfile;
-use crate::args::TsTypeLib;
 use crate::args::DENO_DISABLE_PEDANTIC_NODE_WARNINGS;
 use crate::cache;
 use crate::cache::GlobalHttpCache;
@@ -46,7 +45,6 @@ use deno_runtime::permissions::PermissionsContainer;
 use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
 use import_map::ImportMapError;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -757,7 +755,6 @@ fn get_resolution_error_bare_specifier(
 #[derive(Debug)]
 struct GraphData {
   graph: Arc<ModuleGraph>,
-  checked_libs: HashMap<TsTypeLib, HashSet<ModuleSpecifier>>,
 }
 
 /// Holds the `ModuleGraph` and what parts of it are type checked.
@@ -775,7 +772,6 @@ impl ModuleGraphContainer {
       update_queue: Default::default(),
       graph_data: Arc::new(RwLock::new(GraphData {
         graph: Arc::new(ModuleGraph::new(graph_kind)),
-        checked_libs: Default::default(),
       })),
     }
   }
@@ -794,46 +790,6 @@ impl ModuleGraphContainer {
 
   pub fn graph(&self) -> Arc<ModuleGraph> {
     self.graph_data.read().graph.clone()
-  }
-
-  /// Mark `roots` and all of their dependencies as type checked under `lib`.
-  /// Assumes that all of those modules are known.
-  pub fn set_type_checked(&self, roots: &[ModuleSpecifier], lib: TsTypeLib) {
-    // It's ok to analyze and update this while the module graph itself is
-    // being updated in a permit because the module graph update is always
-    // additive and this will be a subset of the original graph
-    let graph = self.graph();
-    let entries = graph.walk(
-      roots,
-      deno_graph::WalkOptions {
-        check_js: true,
-        follow_dynamic: true,
-        follow_type_only: true,
-      },
-    );
-
-    // now update
-    let mut data = self.graph_data.write();
-    let checked_lib_set = data.checked_libs.entry(lib).or_default();
-    for (specifier, _) in entries {
-      checked_lib_set.insert(specifier.clone());
-    }
-  }
-
-  /// Check if `roots` are all marked as type checked under `lib`.
-  pub fn is_type_checked(
-    &self,
-    roots: &[ModuleSpecifier],
-    lib: TsTypeLib,
-  ) -> bool {
-    let data = self.graph_data.read();
-    match data.checked_libs.get(&lib) {
-      Some(checked_lib_set) => roots.iter().all(|r| {
-        let found = data.graph.resolve(r);
-        checked_lib_set.contains(&found)
-      }),
-      None => false,
-    }
   }
 }
 

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -145,7 +145,7 @@ impl ModuleLoadPreparer {
       self
         .type_checker
         .check(
-          (&*graph).clone(),
+          (*graph).clone(),
           check::CheckOptions {
             build_fast_check_graph: true,
             lib,

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -145,6 +145,10 @@ impl ModuleLoadPreparer {
       self
         .type_checker
         .check(
+          // todo(perf): since this is only done the first time the graph is
+          // created, we could avoid the clone of the graph here by providing
+          // the actual graph on the first run and then getting the Arc<ModuleGraph>
+          // back from the return value.
           (*graph).clone(),
           check::CheckOptions {
             build_fast_check_graph: true,

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -55,7 +55,6 @@ use deno_runtime::permissions::PermissionsContainer;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_terminal::colors;
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::str;
@@ -110,11 +109,7 @@ impl ModuleLoadPreparer {
     let mut graph_update_permit =
       self.graph_container.acquire_update_permit().await;
     let graph = graph_update_permit.graph_mut();
-
-    // Determine any modules that have already been emitted this session and
-    // should be skipped.
-    let reload_exclusions: HashSet<ModuleSpecifier> =
-      graph.specifiers().map(|(s, _)| s.clone()).collect();
+    let has_type_checked = !graph.roots.is_empty();
 
     self
       .module_graph_builder
@@ -146,25 +141,20 @@ impl ModuleLoadPreparer {
     drop(_pb_clear_guard);
 
     // type check if necessary
-    if self.options.type_check_mode().is_true()
-      && !self.graph_container.is_type_checked(&roots, lib)
-    {
-      let graph = graph.segment(&roots);
+    if self.options.type_check_mode().is_true() && !has_type_checked {
       self
         .type_checker
         .check(
-          graph,
+          (&*graph).clone(),
           check::CheckOptions {
             build_fast_check_graph: true,
             lib,
             log_ignored_options: false,
-            reload: self.options.reload_flag()
-              && !roots.iter().all(|r| reload_exclusions.contains(r)),
+            reload: self.options.reload_flag(),
             type_check_mode: self.options.type_check_mode(),
           },
         )
         .await?;
-      self.graph_container.set_type_checked(&roots, lib);
     }
 
     log::debug!("Prepared module load.");


### PR DESCRIPTION
In addition to the reasons for this outlined by @nayeemrmn in #14877 (which I think are reasons alone to not do this), this simplifies things a lot because then we don't need to implement the following:

1. Need to handle a JSR module dynamically importing a module within it.
2. Need to handle importing an export of a JSR dep then another export dynamically loaded later.

Additionally, people should be running `deno check dynamic_import.ts` instead of relying on this behaviour.

Landing this as a fix because it's blocking people in some scenarios and the current behaviour is broken (I didn't even have to change any tests to remove this, which is bad).

Closes #22852
Closes #14877
Closes #22580