### PR TITLE
fix(runtime): negate partial condition for deny flags

### DIFF
--- a/runtime/permissions/mod.rs
+++ b/runtime/permissions/mod.rs
@@ -2985,15 +2985,21 @@ mod tests {
 
   #[test]
   fn test_check_partial_denied() {
-    let mut perms = Permissions::allow_all();
-    perms
-      .read
-      .flag_denied_list
-      .insert(ReadDescriptor(PathBuf::from("/foo/bar")));
-    perms
-      .write
-      .flag_denied_list
-      .insert(WriteDescriptor(PathBuf::from("/foo/bar")));
+    let mut perms = Permissions {
+      read: Permissions::new_read(
+        &Some(vec![]),
+        &Some(vec![PathBuf::from("/foo/bar")]),
+        false,
+      )
+      .unwrap(),
+      write: Permissions::new_write(
+        &Some(vec![]),
+        &Some(vec![PathBuf::from("/foo/bar")]),
+        false,
+      )
+      .unwrap(),
+      ..Default::default()
+    };
 
     perms.read.check_partial(Path::new("/foo"), None).unwrap();
     assert!(perms.read.check(Path::new("/foo"), None).is_err());


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
