### PR TITLE
BREAKING(ext/net): remove `Deno.ConnectTlsOptions.{certChain,certFile,keyFile}`

### DIFF
--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -47,53 +47,17 @@ async function connectTls({
   port,
   hostname = "127.0.0.1",
   transport = "tcp",
-  certFile = undefined,
   caCerts = [],
-  certChain = undefined,
-  privateKey = undefined,
   cert = undefined,
   key = undefined,
   alpnProtocols = undefined,
 }) {
-  if (certFile !== undefined) {
-    internals.warnOnDeprecatedApi(
-      "Deno.ConnectTlsOptions.certFile",
-      new Error().stack,
-      "Pass the cert file contents to the `Deno.ConnectTlsOptions.cert` option instead.",
-    );
-  }
-  if (certChain !== undefined) {
-    internals.warnOnDeprecatedApi(
-      "Deno.ConnectTlsOptions.certChain",
-      new Error().stack,
-      "Use the `Deno.ConnectTlsOptions.cert` option instead.",
-    );
-  }
-  if (privateKey !== undefined) {
-    internals.warnOnDeprecatedApi(
-      "Deno.ConnectTlsOptions.privateKey",
-      new Error().stack,
-      "Use the `Deno.ConnectTlsOptions.key` option instead.",
-    );
-  }
   if (transport !== "tcp") {
     throw new TypeError(`Unsupported transport: '${transport}'`);
   }
-  if (certChain !== undefined && cert !== undefined) {
-    throw new TypeError(
-      "Cannot specify both `certChain` and `cert`",
-    );
-  }
-  if (privateKey !== undefined && key !== undefined) {
-    throw new TypeError(
-      "Cannot specify both `privateKey` and `key`",
-    );
-  }
-  cert ??= certChain;
-  key ??= privateKey;
   const { 0: rid, 1: localAddr, 2: remoteAddr } = await op_net_connect_tls(
     { hostname, port },
-    { certFile, caCerts, cert, key, alpnProtocols },
+    { caCerts, cert, key, alpnProtocols },
   );
   localAddr.transport = "tcp";
   remoteAddr.transport = "tcp";

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -330,14 +330,6 @@ declare namespace Deno {
      *
      * @default {"127.0.0.1"} */
     hostname?: string;
-    /**
-     * Server certificate file.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    certFile?: string;
     /** A list of root certificates that will be used in addition to the
      * default root certificates to verify the peer's certificate.
      *
@@ -348,22 +340,6 @@ declare namespace Deno {
      * TLS handshake.
      */
     alpnProtocols?: string[];
-    /**
-     * PEM formatted client certificate chain.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    certChain?: string;
-    /**
-     * PEM formatted (RSA or PKCS8) private key of client certificate.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    privateKey?: string;
     /** Server private key in PEM format. */
     key?: string;
     /** Cert chain in PEM format. */

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -257,6 +257,13 @@ where
     .try_borrow::<UnsafelyIgnoreCertificateErrors>()
     .and_then(|it| it.0.clone());
 
+  {
+    let mut s = state.borrow_mut();
+    let permissions = s.borrow_mut::<NP>();
+    permissions
+      .check_net(&(&addr.hostname, Some(addr.port)), "Deno.connectTls()")?;
+  }
+
   let ca_certs = args
     .ca_certs
     .into_iter()

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -1265,7 +1265,7 @@ Deno.test(
     const connectPromise = Deno.connectTls({
       hostname,
       port,
-      cert: await Deno.readTextFile("tests/testdata/tls/RootCA.crt"),
+      caCerts: [await Deno.readTextFile("tests/testdata/tls/RootCA.crt")],
     });
     const [conn1, conn2] = await Promise.all([acceptPromise, connectPromise]);
     listener.close();

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -42,19 +42,6 @@ Deno.test(
 );
 
 Deno.test(
-  { permissions: { net: true, read: false } },
-  async function connectTLSCertFileNoReadPerm() {
-    await assertRejects(async () => {
-      await Deno.connectTls({
-        hostname: "deno.land",
-        port: 443,
-        certFile: "tests/testdata/tls/RootCA.crt",
-      });
-    }, Deno.errors.PermissionDenied);
-  },
-);
-
-Deno.test(
   { permissions: { read: true, net: true } },
   function listenTLSNonExistentCertKeyFiles() {
     const options = {
@@ -1160,22 +1147,6 @@ Deno.test(
 
 Deno.test(
   { permissions: { read: true, net: true } },
-  async function connectTLSBadClientCertPrivateKey(): Promise<void> {
-    await assertRejects(async () => {
-      await Deno.connectTls({
-        hostname: "deno.land",
-        port: 443,
-        certChain: "bad data",
-        privateKey: await Deno.readTextFile(
-          "tests/testdata/tls/localhost.key",
-        ),
-      });
-    }, Deno.errors.InvalidData);
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
   async function connectTLSBadCertKey(): Promise<void> {
     await assertRejects(async () => {
       await Deno.connectTls({
@@ -1185,22 +1156,6 @@ Deno.test(
         key: await Deno.readTextFile(
           "tests/testdata/tls/localhost.key",
         ),
-      });
-    }, Deno.errors.InvalidData);
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
-  async function connectTLSBadPrivateKey(): Promise<void> {
-    await assertRejects(async () => {
-      await Deno.connectTls({
-        hostname: "deno.land",
-        port: 443,
-        certChain: await Deno.readTextFile(
-          "tests/testdata/tls/localhost.crt",
-        ),
-        privateKey: "bad data",
       });
     }, Deno.errors.InvalidData);
   },
@@ -1224,22 +1179,6 @@ Deno.test(
 
 Deno.test(
   { permissions: { read: true, net: true } },
-  async function connectTLSNotPrivateKey(): Promise<void> {
-    await assertRejects(async () => {
-      await Deno.connectTls({
-        hostname: "deno.land",
-        port: 443,
-        certChain: await Deno.readTextFile(
-          "tests/testdata/tls/localhost.crt",
-        ),
-        privateKey: "",
-      });
-    }, Deno.errors.InvalidData);
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
   async function connectTLSNotKey(): Promise<void> {
     await assertRejects(async () => {
       await Deno.connectTls({
@@ -1251,31 +1190,6 @@ Deno.test(
         key: "",
       });
     }, Deno.errors.InvalidData);
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
-  async function connectWithClientCert() {
-    // The test_server running on port 4552 responds with 'PASS' if client
-    // authentication was successful. Try it by running test_server and
-    //   curl --key tests/testdata/tls/localhost.key \
-    //        --cert tests/testdata/tls/localhost.crt \
-    //        --cacert tests/testdata/tls/RootCA.crt https://localhost:4552/
-    const conn = await Deno.connectTls({
-      hostname: "localhost",
-      port: 4552,
-      certChain: await Deno.readTextFile(
-        "tests/testdata/tls/localhost.crt",
-      ),
-      privateKey: await Deno.readTextFile(
-        "tests/testdata/tls/localhost.key",
-      ),
-      caCerts: [Deno.readTextFileSync("tests/testdata/tls/RootCA.pem")],
-    });
-    const result = decoder.decode(await readAll(conn));
-    assertEquals(result, "PASS");
-    conn.close();
   },
 );
 
@@ -1306,75 +1220,11 @@ Deno.test(
 
 Deno.test(
   { permissions: { read: true, net: true } },
-  async function connectTlsConflictingCertOptions(): Promise<void> {
-    await assertRejects(
-      async () => {
-        await Deno.connectTls({
-          hostname: "deno.land",
-          port: 443,
-          cert: await Deno.readTextFile(
-            "tests/testdata/tls/localhost.crt",
-          ),
-          certChain: await Deno.readTextFile(
-            "tests/testdata/tls/localhost.crt",
-          ),
-          key: await Deno.readTextFile(
-            "tests/testdata/tls/localhost.key",
-          ),
-        });
-      },
-      TypeError,
-      "Cannot specify both `certChain` and `cert`",
-    );
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
-  async function connectTlsConflictingKeyOptions(): Promise<void> {
-    await assertRejects(
-      async () => {
-        await Deno.connectTls({
-          hostname: "deno.land",
-          port: 443,
-          cert: await Deno.readTextFile(
-            "tests/testdata/tls/localhost.crt",
-          ),
-          privateKey: await Deno.readTextFile(
-            "tests/testdata/tls/localhost.crt",
-          ),
-          key: await Deno.readTextFile(
-            "tests/testdata/tls/localhost.key",
-          ),
-        });
-      },
-      TypeError,
-      "Cannot specify both `privateKey` and `key`",
-    );
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
   async function connectTLSCaCerts() {
     const conn = await Deno.connectTls({
       hostname: "localhost",
       port: 4557,
       caCerts: [Deno.readTextFileSync("tests/testdata/tls/RootCA.pem")],
-    });
-    const result = decoder.decode(await readAll(conn));
-    assertEquals(result, "PASS");
-    conn.close();
-  },
-);
-
-Deno.test(
-  { permissions: { read: true, net: true } },
-  async function connectTLSCertFile() {
-    const conn = await Deno.connectTls({
-      hostname: "localhost",
-      port: 4557,
-      certFile: "tests/testdata/tls/RootCA.pem",
     });
     const result = decoder.decode(await readAll(conn));
     assertEquals(result, "PASS");
@@ -1415,7 +1265,7 @@ Deno.test(
     const connectPromise = Deno.connectTls({
       hostname,
       port,
-      certFile: "tests/testdata/tls/RootCA.crt",
+      cert: Deno.readTextFile("tests/testdata/tls/RootCA.crt"),
     });
     const [conn1, conn2] = await Promise.all([acceptPromise, connectPromise]);
     listener.close();

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -1265,7 +1265,7 @@ Deno.test(
     const connectPromise = Deno.connectTls({
       hostname,
       port,
-      cert: Deno.readTextFile("tests/testdata/tls/RootCA.crt"),
+      cert: await Deno.readTextFile("tests/testdata/tls/RootCA.crt"),
     });
     const [conn1, conn2] = await Promise.all([acceptPromise, connectPromise]);
     listener.close();


### PR DESCRIPTION
Early work towards Deno v2. Please do not merge yet.