### PR TITLE
BREAKING(ext/io): remove `Deno.read[Sync]()`

### DIFF
--- a/cli/bench/deno_common.js
+++ b/cli/bench/deno_common.js
@@ -46,7 +46,7 @@ Deno.bench("b64_rt_short", { n: 1e6 }, () => {
   const buf = new Uint8Array(100);
   const file = Deno.openSync("/dev/zero");
   Deno.bench("read_zero", { n: 5e5 }, () => {
-    Deno.readSync(file.rid, buf);
+    file.readSync(buf);
   });
 }
 

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1968,70 +1968,6 @@ declare namespace Deno {
    */
   export function createSync(path: string | URL): FsFile;
 
-  /** Read from a resource ID (`rid`) into an array buffer (`buffer`).
-   *
-   * Resolves to either the number of bytes read during the operation or EOF
-   * (`null`) if there was nothing more to read.
-   *
-   * It is possible for a read to successfully return with `0` bytes. This does
-   * not indicate EOF.
-   *
-   * This function is one of the lowest level APIs and most users should not
-   * work with this directly, but rather use {@linkcode ReadableStream} and
-   * {@linkcode https://deno.land/std/streams/mod.ts?s=toArrayBuffer|toArrayBuffer}
-   * instead.
-   *
-   * **It is not guaranteed that the full buffer will be read in a single call.**
-   *
-   * ```ts
-   * // if "/foo/bar.txt" contains the text "hello world":
-   * using file = await Deno.open("/foo/bar.txt");
-   * const buf = new Uint8Array(100);
-   * const numberOfBytesRead = await Deno.read(file.rid, buf); // 11 bytes
-   * const text = new TextDecoder().decode(buf);  // "hello world"
-   * ```
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function read(rid: number, buffer: Uint8Array): Promise<number | null>;
-
-  /** Synchronously read from a resource ID (`rid`) into an array buffer
-   * (`buffer`).
-   *
-   * Returns either the number of bytes read during the operation or EOF
-   * (`null`) if there was nothing more to read.
-   *
-   * It is possible for a read to successfully return with `0` bytes. This does
-   * not indicate EOF.
-   *
-   * This function is one of the lowest level APIs and most users should not
-   * work with this directly, but rather use {@linkcode ReadableStream} and
-   * {@linkcode https://deno.land/std/streams/mod.ts?s=toArrayBuffer|toArrayBuffer}
-   * instead.
-   *
-   * **It is not guaranteed that the full buffer will be read in a single
-   * call.**
-   *
-   * ```ts
-   * // if "/foo/bar.txt" contains the text "hello world":
-   * using file = Deno.openSync("/foo/bar.txt");
-   * const buf = new Uint8Array(100);
-   * const numberOfBytesRead = Deno.readSync(file.rid, buf); // 11 bytes
-   * const text = new TextDecoder().decode(buf);  // "hello world"
-   * ```
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function readSync(rid: number, buffer: Uint8Array): number | null;
-
   /** Write to the resource ID (`rid`) the contents of the array buffer (`data`).
    *
    * Resolves to the number of bytes written. This function is one of the lowest
@@ -5429,7 +5365,7 @@ declare namespace Deno {
    * await file.write(new TextEncoder().encode("Hello World"));
    * await Deno.ftruncate(file.rid, 7);
    * const data = new Uint8Array(32);
-   * await Deno.read(file.rid, data);
+   * await file.read(data);
    * console.log(new TextDecoder().decode(data)); // Hello W
    * ```
    *
@@ -5475,7 +5411,7 @@ declare namespace Deno {
    * Deno.ftruncateSync(file.rid, 7);
    * Deno.seekSync(file.rid, 0, Deno.SeekMode.Start);
    * const data = new Uint8Array(32);
-   * Deno.readSync(file.rid, data);
+   * file.readSync(data);
    * console.log(new TextDecoder().decode(data)); // Hello W
    * ```
    *

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -127,22 +127,6 @@ const denoNs = {
   iter: io.iter,
   iterSync: io.iterSync,
   SeekMode: io.SeekMode,
-  read(rid, buffer) {
-    internals.warnOnDeprecatedApi(
-      "Deno.read()",
-      new Error().stack,
-      "Use `reader.read()` instead.",
-    );
-    return io.read(rid, buffer);
-  },
-  readSync(rid, buffer) {
-    internals.warnOnDeprecatedApi(
-      "Deno.readSync()",
-      new Error().stack,
-      "Use `reader.readSync()` instead.",
-    );
-    return io.readSync(rid, buffer);
-  },
   write(rid, data) {
     internals.warnOnDeprecatedApi(
       "Deno.write()",


### PR DESCRIPTION
Early work towards Deno v2. Please do not merge yet.