### PR TITLE
BREAKING(ext/buffer): remove `Deno.writeAll[Sync]()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3077,29 +3077,6 @@ declare namespace Deno {
   export function readAllSync(r: ReaderSync): Uint8Array;
 
   /**
-   * Write all the content of the array buffer (`arr`) to the writer (`w`).
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
-
-  /**
-   * Synchronously write all the content of the array buffer (`arr`) to the
-   * writer (`w`).
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function writeAllSync(w: WriterSync, arr: Uint8Array): void;
-
-  /**
    * Options which can be set when using {@linkcode Deno.mkdir} and
    * {@linkcode Deno.mkdirSync}.
    *

--- a/runtime/js/13_buffer.js
+++ b/runtime/js/13_buffer.js
@@ -256,28 +256,4 @@ function readAllSync(r) {
   return buf.bytes();
 }
 
-async function writeAll(w, arr) {
-  internals.warnOnDeprecatedApi(
-    "Deno.writeAll()",
-    new Error().stack,
-    "Use `writeAll()` from `https://deno.land/std/io/write_all.ts` instead.",
-  );
-  let nwritten = 0;
-  while (nwritten < arr.length) {
-    nwritten += await w.write(TypedArrayPrototypeSubarray(arr, nwritten));
-  }
-}
-
-function writeAllSync(w, arr) {
-  internals.warnOnDeprecatedApi(
-    "Deno.writeAllSync()",
-    new Error().stack,
-    "Use `writeAllSync()` from `https://deno.land/std/io/write_all.ts` instead.",
-  );
-  let nwritten = 0;
-  while (nwritten < arr.length) {
-    nwritten += w.writeSync(TypedArrayPrototypeSubarray(arr, nwritten));
-  }
-}
-
-export { Buffer, readAll, readAllSync, writeAll, writeAllSync };
+export { Buffer, readAll, readAllSync };

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -121,8 +121,6 @@ const denoNs = {
   Buffer: buffer.Buffer,
   readAll: buffer.readAll,
   readAllSync: buffer.readAllSync,
-  writeAll: buffer.writeAll,
-  writeAllSync: buffer.writeAllSync,
   copy: io.copy,
   iter: io.iter,
   iterSync: io.iterSync,

--- a/tests/unit/buffer_test.ts
+++ b/tests/unit/buffer_test.ts
@@ -11,6 +11,7 @@ import {
   assertRejects,
   assertThrows,
 } from "./test_util.ts";
+import { writeAllSync } from "../util/std/streams/write_all.ts";
 
 const MAX_SIZE = 2 ** 32 - 2;
 // N controls how many iterations of certain checks are performed.
@@ -405,7 +406,7 @@ Deno.test(function testBufferBytesArrayBufferLength() {
     const bufSize = 64 * 1024;
     const bytes = new TextEncoder().encode("a".repeat(bufSize));
     const reader = new Deno.Buffer();
-    Deno.writeAllSync(reader, bytes);
+    writeAllSync(reader, bytes);
 
     const writer = new Deno.Buffer();
     writer.readFromSync(reader);
@@ -421,7 +422,7 @@ Deno.test(function testBufferBytesCopyFalse() {
   const bufSize = 64 * 1024;
   const bytes = new TextEncoder().encode("a".repeat(bufSize));
   const reader = new Deno.Buffer();
-  Deno.writeAllSync(reader, bytes);
+  writeAllSync(reader, bytes);
 
   const writer = new Deno.Buffer();
   writer.readFromSync(reader);
@@ -436,7 +437,7 @@ Deno.test(function testBufferBytesCopyFalseGrowExactBytes() {
   const bufSize = 64 * 1024;
   const bytes = new TextEncoder().encode("a".repeat(bufSize));
   const reader = new Deno.Buffer();
-  Deno.writeAllSync(reader, bytes);
+  writeAllSync(reader, bytes);
 
   const writer = new Deno.Buffer();
   writer.grow(bufSize);

--- a/tests/unit/buffer_test.ts
+++ b/tests/unit/buffer_test.ts
@@ -375,30 +375,6 @@ Deno.test(function testReadAllSync() {
   }
 });
 
-Deno.test(async function testWriteAll() {
-  init();
-  assert(testBytes);
-  const writer = new Deno.Buffer();
-  await Deno.writeAll(writer, testBytes);
-  const actualBytes = writer.bytes();
-  assertEquals(testBytes.byteLength, actualBytes.byteLength);
-  for (let i = 0; i < testBytes.length; ++i) {
-    assertEquals(testBytes[i], actualBytes[i]);
-  }
-});
-
-Deno.test(function testWriteAllSync() {
-  init();
-  assert(testBytes);
-  const writer = new Deno.Buffer();
-  Deno.writeAllSync(writer, testBytes);
-  const actualBytes = writer.bytes();
-  assertEquals(testBytes.byteLength, actualBytes.byteLength);
-  for (let i = 0; i < testBytes.length; ++i) {
-    assertEquals(testBytes[i], actualBytes[i]);
-  }
-});
-
 Deno.test(function testBufferBytesArrayBufferLength() {
   // defaults to copy
   const args = [{}, { copy: undefined }, undefined, { copy: true }];


### PR DESCRIPTION
Early work towards Deno v2. Please do not merge yet.