### PR TITLE
perf(permissions): Fast exit from checks when permission is in "fully-granted" state

### DIFF
--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -867,7 +867,8 @@ mod tests {
   fn create_test_worker() -> MainWorker {
     let main_module =
       resolve_path("./hello.js", &std::env::current_dir().unwrap()).unwrap();
-    let permissions = PermissionsContainer::new(Permissions::default());
+    let permissions =
+      PermissionsContainer::new(Permissions::none_without_prompt());
 
     let options = WorkerOptions {
       startup_snapshot: crate::js::deno_isolate_init(),


### PR DESCRIPTION
Skips the access check if the specific unary permission is in an all-granted state. Generally prevents an allocation or two.

Hooks up a quiet "all" permission that is automatically inherited. This permission will be used in the future to indicate that the user wishes to accept all side-effects of the permissions they explicitly granted.

The "all" permission is an "ambient flag"-style permission that states whether "allow-all" was passed on the command-line.