### PR TITLE
fix(ext/node): crypto.getCipherInfo()

### DIFF
--- a/ext/node/polyfills/crypto.ts
+++ b/ext/node/polyfills/crypto.ts
@@ -86,7 +86,6 @@ import {
 import {
   Cipheriv,
   Decipheriv,
-  getCipherInfo,
   privateDecrypt,
   privateEncrypt,
   publicDecrypt,
@@ -149,6 +148,7 @@ import type {
   X509CheckOptions,
 } from "ext:deno_node/internal/crypto/x509.ts";
 import {
+  getCipherInfo,
   getCiphers,
   getCurves,
   secureHeapUsed,

--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -22,11 +22,6 @@ import {
   op_node_public_encrypt,
 } from "ext:core/ops";
 
-import { ERR_INVALID_ARG_TYPE } from "ext:deno_node/internal/errors.ts";
-import {
-  validateInt32,
-  validateObject,
-} from "ext:deno_node/internal/validators.mjs";
 import { Buffer } from "node:buffer";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import type { TransformOptions } from "ext:deno_node/_stream.d.ts";

--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -405,41 +405,6 @@ export class Decipheriv extends Transform implements Cipher {
   }
 }
 
-export function getCipherInfo(
-  nameOrNid: string | number,
-  options?: { keyLength?: number; ivLength?: number },
-) {
-  if (typeof nameOrNid !== "string" && typeof nameOrNid !== "number") {
-    throw new ERR_INVALID_ARG_TYPE(
-      "nameOrNid",
-      ["string", "number"],
-      nameOrNid,
-    );
-  }
-
-  if (typeof nameOrNid === "number") {
-    validateInt32(nameOrNid, "nameOrNid");
-  }
-
-  let keyLength, ivLength;
-
-  if (options !== undefined) {
-    validateObject(options, "options");
-
-    ({ keyLength, ivLength } = options);
-
-    if (keyLength !== undefined) {
-      validateInt32(keyLength, "options.keyLength");
-    }
-
-    if (ivLength !== undefined) {
-      validateInt32(ivLength, "options.ivLength");
-    }
-  }
-
-  notImplemented("crypto.getCipherInfo");
-}
-
 export function privateEncrypt(
   privateKey: ArrayBufferView | string | KeyObject,
   buffer: ArrayBufferView | string | KeyObject,
@@ -503,5 +468,4 @@ export default {
   Cipheriv,
   Decipheriv,
   prepareKey,
-  getCipherInfo,
 };

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -256,3 +256,25 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "getCiphers",
+  fn() {
+    assertEquals(crypto.getCiphers().includes("aes-128-cbc"), true);
+  },
+});
+
+Deno.test({
+  name: "getCipherInfo",
+  fn() {
+    const info = crypto.getCipherInfo("aes-128-cbc")!;
+    assertEquals(info.name, "aes-128-cbc");
+    assertEquals(info.keyLength, 16);
+    assertEquals(info.ivLength, 16);
+
+    const info2 = crypto.getCipherInfo("aes128")!;
+    assertEquals(info2.name, "aes-128-cbc");
+    assertEquals(info2.keyLength, 16);
+    assertEquals(info2.ivLength, 16);
+  },
+});


### PR DESCRIPTION
Stub implementation of getCipherInfo(). Good enough for most cases.

Note: We do not support all OpenSSL ciphers (likely never will)

Fixes https://github.com/denoland/deno/issues/21805