### PR TITLE
fix: handle cache body file not existing when using etag

### DIFF
--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -5137,3 +5137,36 @@ console.log(add(3, 4));
   let output = test_context.new_command().args("run main.ts").run();
   output.assert_matches_text("[WILDCARD]5\n7\n");
 }
+
+#[test]
+fn run_etag_delete_source_cache() {
+  let test_context = TestContextBuilder::new()
+    .use_temp_cwd()
+    .use_http_server()
+    .build();
+  test_context
+    .temp_dir()
+    .write("main.ts", "import 'http://localhost:4545/etag_script.ts'");
+  test_context
+    .new_command()
+    .args("cache main.ts")
+    .run()
+    .skip_output_check();
+
+  // The cache is currently stored unideally in two files where one file has the headers
+  // and the other contains the body. An issue can happen with the etag header where the
+  // headers file exists, but the body was deleted. We need to get the cache to gracefully
+  // handle this scenario.
+  let deno_dir = test_context.deno_dir().path();
+  let etag_script_path = deno_dir.join("deps/http/localhost_PORT4545/26110db7d42c9bad32386735cbc05c301f83e4393963deb8da14fec3b4202a13");
+  assert!(etag_script_path.exists());
+  etag_script_path.remove_file();
+
+  test_context
+    .new_command()
+    .args("cache --reload --log-level=debug main.ts")
+    .run()
+    .assert_matches_text(
+      "[WILDCARD]Cache body not found. Trying again without etag.[WILDCARD]",
+    );
+}


### PR DESCRIPTION
Removes this unwrap:

```
> ../deno/target/debug/deno install -Afr jsr:@deno/deployctl
Loading: https://jsr.io/@deno/deployctl/meta.json ReloadAll
NOT MODIFIED: https://jsr.io/@deno/deployctl/meta.json

============================================================
Deno has panicked. This is a bug in Deno. Please report this
at https://github.com/denoland/deno/issues/new.
If you can reliably reproduce this panic, include the
reproduction steps and re-run with the RUST_BACKTRACE=1 env
var set and include the backtrace in your report.

Platform: windows x86_64
Version: 1.41.2
Args: ["V:\\deno\\target\\debug\\deno.exe", "install", "-Afr", "jsr:@deno/deployctl"]

thread 'main' panicked at cli\file_fetcher.rs:394:16:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```