### PR TITLE
fix(coverage): Error if no files are included in the report

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -485,6 +485,9 @@ pub async fn cover_files(
     coverage_flags.exclude,
     npm_resolver.as_ref(),
   );
+  if script_coverages.is_empty() {
+    return Err(generic_error("No covered files included in the report"));
+  }
 
   let proc_coverages: Vec<_> = script_coverages
     .into_iter()

--- a/tests/specs/coverage/no_files_after_filter/__test__.jsonc
+++ b/tests/specs/coverage/no_files_after_filter/__test__.jsonc
@@ -1,0 +1,15 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "test --coverage test.ts",
+      "output": "test_coverage.out",
+      "exitCode": 0
+    },
+    {
+      "args": "coverage ./coverage",
+      "output": "no_files_in_report.out",
+      "exitCode": 1
+    }
+  ]
+}

--- a/tests/specs/coverage/no_files_after_filter/no_files_in_report.out
+++ b/tests/specs/coverage/no_files_after_filter/no_files_in_report.out
@@ -1,0 +1,1 @@
+error: No covered files included in the report

--- a/tests/specs/coverage/no_files_after_filter/test.ts
+++ b/tests/specs/coverage/no_files_after_filter/test.ts
@@ -1,0 +1,1 @@
+Deno.test("test", () => {});

--- a/tests/specs/coverage/no_files_after_filter/test_coverage.out
+++ b/tests/specs/coverage/no_files_after_filter/test_coverage.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]/test.ts
+running 1 test from ./test.ts
+test ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed ([WILDCARD])
+


### PR DESCRIPTION
Fixes #22941.

In that case, the only file with coverage was the `test.ts` file. The coverage reporter filters out test files before compiling its report, so after filtering we were left with an empty set of files. Later on it's assumed that there is at least 1 file to be reported on, and we panic. Instead of panicking, just issue an error after filtering.