### PR TITLE
docs(dts): Update edge case in `prompt()` docs

### DIFF
--- a/cli/tsc/dts/lib.deno.window.d.ts
+++ b/cli/tsc/dts/lib.deno.window.d.ts
@@ -152,7 +152,8 @@ declare function confirm(message?: string): boolean;
  * If the default value is given and the user inputs the empty string, then it returns the given
  * default value.
  *
- * If the default value is not given and the user inputs the empty string, it returns null.
+ * If the default value is not given and the user inputs the empty string, it returns the empty
+ * string.
  *
  * If the stdin is not interactive, it returns null.
  *


### PR DESCRIPTION
This has been incorrect since the function adopted its (more intuitive) current behavior in 9268df5f3. The same behavior change was backported to v1.39.3 in 87e954f54.
