### PR TITLE
feat(ext/node): add riscv64 in process.arch

### DIFF
--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -19,6 +19,8 @@ export function arch(): string {
     return "x64";
   } else if (core.build.arch == "aarch64") {
     return "arm64";
+  } else if (core.build.arch == "riscv64gc") {
+    return "riscv64";
   } else {
     throw Error("unreachable");
   }


### PR DESCRIPTION
Rust triple for riscv64 is riscv64gc. Although there are no official builds for architectures other than x86_64 and aarch64, Arch Linux RISC-V has managed to package Deno on riscv64: https://github.com/felixonmars/archriscv-packages/blob/master/deno/riscv64.patch

Ref: https://github.com/denoland/deno/issues/18702

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
