### PR TITLE
feat: deno_task_shell 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8ddb4362a79ef3d264df363eef77c25c976964132bf672b682c5816ebdcfd1"
+checksum = "4721cc23c43e05a8dce807ed322320b3538ce9a60d131c50b2301b14c984a9d4"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ deno_lockfile.workspace = true
 deno_npm = "=0.17.0"
 deno_runtime = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_semver = "=0.5.4"
-deno_task_shell = "=0.14.3"
+deno_task_shell = "=0.15.0"
 deno_terminal.workspace = true
 eszip = "=0.64.2"
 napi_sym.workspace = true


### PR DESCRIPTION
* feat: implement exit status var (https://github.com/denoland/deno_task_shell/pull/110)
* feat: support input redirects (https://github.com/denoland/deno_task_shell/pull/106)
* feat: support output fd redirects for stdout and stderr (https://github.com/denoland/deno_task_shell/pull/111)
* feat: support parsing fd redirects (https://github.com/denoland/deno_task_shell/pull/107)
* fix: exit error code on arg parse failure (https://github.com/denoland/deno_task_shell/pull/112)

Closes #22989