### PR TITLE
refactor(ext/ffi): don't go through serde_v8::Value

### DIFF
--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -291,7 +291,7 @@ fn make_sync_fn<'s>(
               let result =
                 // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
                 unsafe { result.to_v8(scope, symbol.result_type.clone()) };
-              rv.set(result.v8_value);
+              rv.set(result);
             }
           }
         }

--- a/ext/ffi/ir.rs
+++ b/ext/ffi/ir.rs
@@ -5,7 +5,6 @@ use crate::MAX_SAFE_INTEGER;
 use crate::MIN_SAFE_INTEGER;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
-use deno_core::serde_v8;
 use deno_core::v8;
 use libffi::middle::Arg;
 use std::ffi::c_void;
@@ -85,47 +84,22 @@ impl NativeValue {
     &self,
     scope: &mut v8::HandleScope<'scope>,
     native_type: NativeType,
-  ) -> serde_v8::Value<'scope> {
+  ) -> v8::Local<'scope, v8::Value> {
     match native_type {
-      NativeType::Void => {
-        let local_value: v8::Local<v8::Value> = v8::undefined(scope).into();
-        local_value.into()
-      }
-      NativeType::Bool => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Boolean::new(scope, self.bool_value).into();
-        local_value.into()
-      }
+      NativeType::Void => v8::undefined(scope).into(),
+      NativeType::Bool => v8::Boolean::new(scope, self.bool_value).into(),
       NativeType::U8 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Integer::new_from_unsigned(scope, self.u8_value as u32).into();
-        local_value.into()
+        v8::Integer::new_from_unsigned(scope, self.u8_value as u32).into()
       }
-      NativeType::I8 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Integer::new(scope, self.i8_value as i32).into();
-        local_value.into()
-      }
+      NativeType::I8 => v8::Integer::new(scope, self.i8_value as i32).into(),
       NativeType::U16 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Integer::new_from_unsigned(scope, self.u16_value as u32).into();
-        local_value.into()
+        v8::Integer::new_from_unsigned(scope, self.u16_value as u32).into()
       }
-      NativeType::I16 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Integer::new(scope, self.i16_value as i32).into();
-        local_value.into()
-      }
+      NativeType::I16 => v8::Integer::new(scope, self.i16_value as i32).into(),
       NativeType::U32 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Integer::new_from_unsigned(scope, self.u32_value).into();
-        local_value.into()
+        v8::Integer::new_from_unsigned(scope, self.u32_value).into()
       }
-      NativeType::I32 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Integer::new(scope, self.i32_value).into();
-        local_value.into()
-      }
+      NativeType::I32 => v8::Integer::new(scope, self.i32_value).into(),
       NativeType::U64 => {
         let value = self.u64_value;
         let local_value: v8::Local<v8::Value> =
@@ -134,7 +108,7 @@ impl NativeValue {
           } else {
             v8::Number::new(scope, value as f64).into()
           };
-        local_value.into()
+        local_value
       }
       NativeType::I64 => {
         let value = self.i64_value;
@@ -145,7 +119,7 @@ impl NativeValue {
           } else {
             v8::Number::new(scope, value as f64).into()
           };
-        local_value.into()
+        local_value
       }
       NativeType::USize => {
         let value = self.usize_value;
@@ -155,7 +129,7 @@ impl NativeValue {
           } else {
             v8::Number::new(scope, value as f64).into()
           };
-        local_value.into()
+        local_value
       }
       NativeType::ISize => {
         let value = self.isize_value;
@@ -165,30 +139,19 @@ impl NativeValue {
           } else {
             v8::Number::new(scope, value as f64).into()
           };
-        local_value.into()
+        local_value
       }
-      NativeType::F32 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Number::new(scope, self.f32_value as f64).into();
-        local_value.into()
-      }
-      NativeType::F64 => {
-        let local_value: v8::Local<v8::Value> =
-          v8::Number::new(scope, self.f64_value).into();
-        local_value.into()
-      }
+      NativeType::F32 => v8::Number::new(scope, self.f32_value as f64).into(),
+      NativeType::F64 => v8::Number::new(scope, self.f64_value).into(),
       NativeType::Pointer | NativeType::Buffer | NativeType::Function => {
         let local_value: v8::Local<v8::Value> = if self.pointer.is_null() {
           v8::null(scope).into()
         } else {
           v8::External::new(scope, self.pointer).into()
         };
-        local_value.into()
+        local_value
       }
-      NativeType::Struct(_) => {
-        let local_value: v8::Local<v8::Value> = v8::null(scope).into();
-        local_value.into()
-      }
+      NativeType::Struct(_) => v8::null(scope).into(),
     }
   }
 }


### PR DESCRIPTION
Removes unnecessary indirection - after creating `serde_v8::Value` it was immediately
unwrapped to `v8::Value` by the caller.