### PR TITLE
refactor(ext/ffi): use v8::Value instead of serde_v8::Value

### DIFF
--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -38,6 +38,7 @@ import {
   op_ffi_unsafe_callback_ref,
 } from "ext:core/ops";
 const {
+  Array,
   ArrayBufferIsView,
   ArrayBufferPrototypeGetByteLength,
   ArrayPrototypeMap,
@@ -478,7 +479,9 @@ class DynamicLibrary {
   symbols = {};
 
   constructor(path, symbols) {
-    ({ 0: this.#rid, 1: this.symbols } = op_ffi_load({ path, symbols }));
+    const outArray = new Array(2);
+    op_ffi_load({ path, symbols }, outArray);
+    ({ 0: this.#rid, 1: this.symbols } = outArray);
     for (const symbol in symbols) {
       if (!ObjectHasOwn(symbols, symbol)) {
         continue;

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -38,7 +38,6 @@ import {
   op_ffi_unsafe_callback_ref,
 } from "ext:core/ops";
 const {
-  Array,
   ArrayBufferIsView,
   ArrayBufferPrototypeGetByteLength,
   ArrayPrototypeMap,
@@ -479,9 +478,7 @@ class DynamicLibrary {
   symbols = {};
 
   constructor(path, symbols) {
-    const outArray = new Array(2);
-    op_ffi_load({ path, symbols }, outArray);
-    ({ 0: this.#rid, 1: this.symbols } = outArray);
+    ({ 0: this.#rid, 1: this.symbols } = op_ffi_load({ path, symbols }));
     for (const symbol in symbols) {
       if (!ObjectHasOwn(symbols, symbol)) {
         continue;

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -134,8 +134,7 @@ pub fn op_ffi_load<'scope, FP>(
   scope: &mut v8::HandleScope<'scope>,
   state: &mut OpState,
   #[serde] args: FfiLoadArgs,
-  out_array: v8::Local<'scope, v8::Array>,
-) -> Result<(), AnyError>
+) -> Result<v8::Local<'scope, v8::Value>, AnyError>
 where
   FP: FfiPermissions + 'static,
 {
@@ -220,11 +219,12 @@ where
     }
   }
 
+  let out = v8::Array::new(scope, 2);
   let rid = state.resource_table.add(resource);
   let rid_v8 = v8::Integer::new_from_unsigned(scope, rid);
-  out_array.set_index(scope, 0, rid_v8.into());
-  out_array.set_index(scope, 1, obj.into());
-  Ok(())
+  out.set_index(scope, 0, rid_v8.into());
+  out.set_index(scope, 1, obj.into());
+  Ok(out.into())
 }
 
 // Create a JavaScript function for synchronous FFI call to


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/23034 that removes
another usage of `serde_v8::Value`.