### PR TITLE
fix: don't panic in test and bench if ops not available

### DIFF
--- a/cli/js/40_bench.js
+++ b/cli/js/40_bench.js
@@ -47,6 +47,11 @@ function bench(
   optionsOrFn,
   maybeFn,
 ) {
+  // No-op if we're not running in `deno bench` subcommand.
+  if (typeof op_register_bench !== "function") {
+    return;
+  }
+
   if (!registeredWarmupBench) {
     registeredWarmupBench = true;
     const warmupBenchDesc = {

--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -198,6 +198,11 @@ function testInner(
   maybeFn,
   overrides = {},
 ) {
+  // No-op if we're not running in `deno test` subcommand.
+  if (typeof op_register_test !== "function") {
+    return;
+  }
+
   let testDesc;
   const defaults = {
     ignore: false,

--- a/tests/specs/bench/test_and_bench/__test__.jsonc
+++ b/tests/specs/bench/test_and_bench/__test__.jsonc
@@ -1,0 +1,5 @@
+// Regression test for https://github.com/denoland/deno/issues/23041
+{
+  "args": "bench main.js",
+  "output": "main.out"
+}

--- a/tests/specs/bench/test_and_bench/main.js
+++ b/tests/specs/bench/test_and_bench/main.js
@@ -1,0 +1,3 @@
+Deno.test("test", () => {});
+
+Deno.bench("bench", () => {});

--- a/tests/specs/bench/test_and_bench/main.out
+++ b/tests/specs/bench/test_and_bench/main.out
@@ -1,0 +1,3 @@
+[WILDCARD]
+[WILDCARD]main.js
+benchmark[WILDCARD]

--- a/tests/specs/test/test_and_bench/__test__.jsonc
+++ b/tests/specs/test/test_and_bench/__test__.jsonc
@@ -1,0 +1,5 @@
+// Regression test for https://github.com/denoland/deno/issues/23041
+{
+  "args": "test main.js",
+  "output": "main.out"
+}

--- a/tests/specs/test/test_and_bench/main.js
+++ b/tests/specs/test/test_and_bench/main.js
@@ -1,0 +1,3 @@
+Deno.test("test", () => {});
+
+Deno.bench("bench", () => {});

--- a/tests/specs/test/test_and_bench/main.out
+++ b/tests/specs/test/test_and_bench/main.out
@@ -1,0 +1,5 @@
+running 1 test from ./main.js
+test ... ok (0ms)
+
+ok | 1 passed | 0 failed (1ms)
+

--- a/tests/specs/test/test_and_bench/main.out
+++ b/tests/specs/test/test_and_bench/main.out
@@ -1,5 +1,5 @@
 running 1 test from ./main.js
-test ... ok (0ms)
+test ... ok ([WILDCARD])
 
-ok | 1 passed | 0 failed (1ms)
+ok | 1 passed | 0 failed ([WILDCARD])
 


### PR DESCRIPTION
Fixes regression introduced in https://github.com/denoland/deno/pull/22112 that
removed checks if `Deno.test` or `Deno.bench` are not used in respective subcommands.

Closes https://github.com/denoland/deno/issues/23041