### PR TITLE
ci: allow "FUTURE" PR title

### DIFF
--- a/tools/verify_pr_title.js
+++ b/tools/verify_pr_title.js
@@ -33,6 +33,9 @@ const validPrefixes = [
   "Reland ",
   // Allow landing breaking changes that are properly marked
   "BREAKING",
+  // Allow landing breaking changes that will be applied in Deno 2, or available
+  // immediately with DENO_FUTURE=1 env var
+  "FUTURE",
 ];
 
 if (validPrefixes.some((prefix) => prTitle.startsWith(prefix))) {


### PR DESCRIPTION
Allows to use `BREAKING` prefix in the PR title.

This change will allow us to land PRs that change behavior with `DENO_FUTURE=1` env var,
and prepare for Deno 2.0 release.