### PR TITLE
test: add test for DENO_FUTURE=1 runtime API

### DIFF
--- a/tests/specs/future/runtime_api/__test__.jsonc
+++ b/tests/specs/future/runtime_api/__test__.jsonc
@@ -1,0 +1,7 @@
+{
+  "args": "run main.js",
+  "output": "main.out",
+  "envs": {
+    "DENO_FUTURE": "1"
+  }
+}

--- a/tests/specs/future/runtime_api/main.js
+++ b/tests/specs/future/runtime_api/main.js
@@ -1,0 +1,1 @@
+console.log("window is", globalThis.window);

--- a/tests/specs/future/runtime_api/main.out
+++ b/tests/specs/future/runtime_api/main.out
@@ -1,0 +1,1 @@
+window is undefined


### PR DESCRIPTION
Add a test that asserts that certain symbols are no longer available
if running with `DENO_FUTURE=1` env var.

Currently only checks `window` global.