### PR TITLE
feat(lint): automatically opt-in packages to `jsr` lint tag

### DIFF
--- a/tests/specs/lint/jsr_tag/__test__.jsonc
+++ b/tests/specs/lint/jsr_tag/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  // packages will be automatically entered into the "jsr" tag
+  "steps": [{
+    "args": "lint",
+    "cwd": "./package",
+    "output": "package.out",
+    "exitCode": 1
+  }, {
+    "args": "lint",
+    "cwd": "./non_package",
+    "output": "non_package.out",
+    "exitCode": 0
+  }]
+}

--- a/tests/specs/lint/jsr_tag/non_package.out
+++ b/tests/specs/lint/jsr_tag/non_package.out
@@ -1,0 +1,1 @@
+Checked 2 files

--- a/tests/specs/lint/jsr_tag/non_package/mod.ts
+++ b/tests/specs/lint/jsr_tag/non_package/mod.ts
@@ -1,0 +1,3 @@
+import { MyType } from "./type.ts";
+
+export const myVar: MyType = "hello";

--- a/tests/specs/lint/jsr_tag/non_package/type.ts
+++ b/tests/specs/lint/jsr_tag/non_package/type.ts
@@ -1,0 +1,1 @@
+export type MyType = string;

--- a/tests/specs/lint/jsr_tag/package.out
+++ b/tests/specs/lint/jsr_tag/package.out
@@ -1,0 +1,12 @@
+error[verbatim-module-syntax]: All import identifiers are used in types
+ --> [WILDCARD]mod.ts:1:1
+  | 
+1 | import { MyType } from "./type.ts";
+  | ^^^^^^
+  = hint: Change `import` to `import type` and optionally add an explicit side effect import
+
+  docs: https://lint.deno.land/rules/verbatim-module-syntax
+
+
+Found 1 problem (1 fixable via --fix)
+Checked 2 files

--- a/tests/specs/lint/jsr_tag/package/deno.json
+++ b/tests/specs/lint/jsr_tag/package/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/package",
+  "version": "1.0.0",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/lint/jsr_tag/package/mod.ts
+++ b/tests/specs/lint/jsr_tag/package/mod.ts
@@ -1,0 +1,3 @@
+import { MyType } from "./type.ts";
+
+export const myVar: MyType = "hello";

--- a/tests/specs/lint/jsr_tag/package/type.ts
+++ b/tests/specs/lint/jsr_tag/package/type.ts
@@ -1,0 +1,1 @@
+export type MyType = string;


### PR DESCRIPTION
This automatically opts packages (deno.json's with a name, version, and exports field) into the "jsr" lint tag.