### PR TITLE
fix(lsp): use registry cache for completion search

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -503,23 +503,14 @@ impl Inner {
       module_registries_location.clone(),
       http_client.clone(),
     );
-    let location = dir.deps_folder_path();
-    let deps_http_cache = Arc::new(GlobalHttpCache::new(
-      location,
-      crate::cache::RealDenoCacheEnv,
-    ));
-    let mut deps_file_fetcher = FileFetcher::new(
-      deps_http_cache.clone(),
-      CacheSetting::RespectHeaders,
-      true,
-      http_client.clone(),
-      Default::default(),
-      None,
-    );
-    deps_file_fetcher.set_download_log_level(super::logging::lsp_log_level());
-    let jsr_search_api = CliJsrSearchApi::new(deps_file_fetcher);
+    let jsr_search_api =
+      CliJsrSearchApi::new(module_registries.file_fetcher.clone());
     let npm_search_api =
       CliNpmSearchApi::new(module_registries.file_fetcher.clone());
+    let deps_http_cache = Arc::new(GlobalHttpCache::new(
+      dir.deps_folder_path(),
+      crate::cache::RealDenoCacheEnv,
+    ));
     let documents = Documents::new(deps_http_cache.clone());
     let cache_metadata = cache::CacheMetadata::new(deps_http_cache.clone());
     let performance = Arc::new(Performance::default());
@@ -751,34 +742,26 @@ impl Inner {
     )?;
     let root_cert_store_provider =
       Arc::new(LspRootCertStoreProvider(root_cert_store));
-    let module_registries_location = dir.registries_folder_path();
     self.http_client = Arc::new(HttpClient::new(
       Some(root_cert_store_provider),
       workspace_settings
         .unsafely_ignore_certificate_errors
         .clone(),
     ));
+    self.module_registries_location = dir.registries_folder_path();
     self.module_registries = ModuleRegistry::new(
-      module_registries_location.clone(),
+      self.module_registries_location.clone(),
       self.http_client.clone(),
     );
-    self.module_registries_location = module_registries_location;
+    self.jsr_search_api =
+      CliJsrSearchApi::new(self.module_registries.file_fetcher.clone());
+    self.npm.search_api =
+      CliNpmSearchApi::new(self.module_registries.file_fetcher.clone());
     // update the cache path
     let global_cache = Arc::new(GlobalHttpCache::new(
       dir.deps_folder_path(),
       crate::cache::RealDenoCacheEnv,
     ));
-    let mut deps_file_fetcher = FileFetcher::new(
-      global_cache.clone(),
-      CacheSetting::RespectHeaders,
-      true,
-      self.http_client.clone(),
-      Default::default(),
-      None,
-    );
-    deps_file_fetcher.set_download_log_level(super::logging::lsp_log_level());
-    self.jsr_search_api = CliJsrSearchApi::new(deps_file_fetcher.clone());
-    self.npm.search_api = CliNpmSearchApi::new(deps_file_fetcher);
     let maybe_local_cache =
       self.config.tree.root_vendor_dir().map(|local_path| {
         Arc::new(LocalLspHttpCache::new(local_path, global_cache.clone()))


### PR DESCRIPTION
Otherwise this won't be refreshed when the user runs `Deno: Reload Import Registries Cache` in the command palette and they can't see newer package versions in completions. Testing this would require complex changes to the harness.