### PR TITLE
fix(check): ignore certain diagnostics in remote modules and when publishing

### DIFF
--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -200,27 +200,22 @@ impl TypeChecker {
       check_mode: type_check_mode,
     })?;
 
-    let mut diagnostics = if type_check_mode == TypeCheckMode::Local {
-      response.diagnostics.filter(|d| {
-        if let Some(file_name) = &d.file_name {
-          if !file_name.starts_with("http") {
-            if ModuleSpecifier::parse(file_name)
-              .map(|specifier| !self.node_resolver.in_npm_package(&specifier))
-              .unwrap_or(true)
-            {
-              Some(d.clone())
-            } else {
-              None
-            }
-          } else {
-            None
-          }
-        } else {
-          Some(d.clone())
-        }
-      })
+    let diagnostics = response.diagnostics.filter(|d| {
+      if self.is_remote_diagnostic(d) {
+        type_check_mode == TypeCheckMode::All || d.include_when_remote()
+      } else {
+        true
+      }
+    });
+
+    // don't include ignored remote diagnostics for local modules when publishing
+    let mut diagnostics = if matches!(
+      self.cli_options.sub_command(),
+      crate::args::DenoSubcommand::Publish(_)
+    ) {
+      diagnostics.without_remote_ignored_diagnostics_for_local_modules()
     } else {
-      response.diagnostics
+      diagnostics
     };
 
     diagnostics.apply_fast_check_source_maps(&graph);
@@ -238,6 +233,19 @@ impl TypeChecker {
     log::debug!("{}", response.stats);
 
     Ok((graph, diagnostics))
+  }
+
+  fn is_remote_diagnostic(&self, d: &tsc::Diagnostic) -> bool {
+    let Some(file_name) = &d.file_name else {
+      return false;
+    };
+    if file_name.starts_with("https://") || file_name.starts_with("http://") {
+      return false;
+    }
+    // check if in an npm package
+    ModuleSpecifier::parse(file_name)
+      .map(|specifier| self.node_resolver.in_npm_package(&specifier))
+      .unwrap_or(false)
   }
 }
 

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -200,16 +200,7 @@ impl TypeChecker {
       check_mode: type_check_mode,
     })?;
 
-    let is_publishing = matches!(
-      self.cli_options.sub_command(),
-      crate::args::DenoSubcommand::Publish(_)
-    );
     let mut diagnostics = response.diagnostics.filter(|d| {
-      if is_publishing && !d.include_when_remote() {
-        // don't include ignored remote diagnostics for local modules when publishing
-        return false;
-      }
-
       if self.is_remote_diagnostic(d) {
         type_check_mode == TypeCheckMode::All && d.include_when_remote()
       } else {

--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -924,6 +924,10 @@ async fn build_and_check_graph_for_publish(
           },
         )
         .await?;
+      // ignore unused parameter diagnostics that may occur due to fast check
+      // not having function body implementations
+      let check_diagnostics =
+        check_diagnostics.filter(|d| d.include_when_remote());
       if !check_diagnostics.is_empty() {
         bail!(
           concat!(

--- a/cli/tsc/diagnostics.rs
+++ b/cli/tsc/diagnostics.rs
@@ -280,12 +280,6 @@ impl Diagnostics {
     Diagnostics(diagnostics)
   }
 
-  pub fn without_remote_ignored_diagnostics_for_local_modules(
-    self,
-  ) -> crate::tsc::Diagnostics {
-    self.filter(|diagnostic| diagnostic.include_when_remote())
-  }
-
   /// Return a set of diagnostics where only the values where the predicate
   /// returns `true` are included.
   pub fn filter<P>(self, predicate: P) -> Self

--- a/tests/specs/jsr/no_unused_params/__test__.jsonc
+++ b/tests/specs/jsr/no_unused_params/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "base": "jsr",
+  "steps": [{
+    "args": "check --all main.ts",
+    "output": "main.out"
+  }, {
+    "args": "publish --dry-run",
+    "output": "publish.out"
+  }]
+}

--- a/tests/specs/jsr/no_unused_params/deno.json
+++ b/tests/specs/jsr/no_unused_params/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@scope/package",
+  "version": "0.0.0",
+  "exports": "./main.ts",
+  "lock": false,
+  "compilerOptions": {
+    "noUnusedParameters": true
+  }
+}

--- a/tests/specs/jsr/no_unused_params/main.out
+++ b/tests/specs/jsr/no_unused_params/main.out
@@ -1,0 +1,4 @@
+Download http://127.0.0.1:4250/@denotest/add/meta.json
+Download http://127.0.0.1:4250/@denotest/add/1.0.0_meta.json
+Download http://127.0.0.1:4250/@denotest/add/1.0.0/mod.ts
+Check file:///[WILDLINE]/no_unused_params/main.ts

--- a/tests/specs/jsr/no_unused_params/main.ts
+++ b/tests/specs/jsr/no_unused_params/main.ts
@@ -1,0 +1,5 @@
+import * as inner from "jsr:@denotest/add";
+
+export function add(a: number, b: number): number {
+  return inner.add(a, b);
+}

--- a/tests/specs/jsr/no_unused_params/publish.out
+++ b/tests/specs/jsr/no_unused_params/publish.out
@@ -1,0 +1,10 @@
+Check file:///[WILDLINE]/main.ts
+Checking for slow types in the public API...
+Check file:///[WILDLINE]/main.ts
+Simulating publish of @scope/package@0.0.0 with files:
+   file:///[WILDLINE]/__test__.jsonc ([WILDLINE])
+   file:///[WILDLINE]/deno.json ([WILDLINE])
+   file:///[WILDLINE]/main.out ([WILDLINE])
+   file:///[WILDLINE]/main.ts ([WILDLINE])
+   file:///[WILDLINE]/publish.out ([WILDLINE])
+Warning Aborting due to --dry-run


### PR DESCRIPTION
Unused locals and parameters don't make sense to surface in remote modules. Additionally, fast check can cause these kind of diagnostics when publishing, so they should be ignored.

Closes #22959