### PR TITLE
fix(lsp): implement missing ts server host apis

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -545,6 +545,11 @@ delete Object.prototype.__proto__;
       return undefined;
     },
     // @ts-ignore Undocumented method.
+    toPath(fileName) {
+      // @ts-ignore Undocumented function.
+      ts.toPath(fileName, this.getCurrentDirectory(), this.getCanonicalFileName(fileName));
+    },
+    // @ts-ignore Undocumented method.
     watchNodeModulesForPackageJsonChanges() {
       return { close() {} };
     },

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -544,6 +544,10 @@ delete Object.prototype.__proto__;
     getGlobalTypingsCacheLocation() {
       return undefined;
     },
+    // @ts-ignore Undocumented method.
+    watchNodeModulesForPackageJsonChanges() {
+      return { close() {} };
+    },
     getSourceFile(
       specifier,
       languageVersion,

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -547,7 +547,11 @@ delete Object.prototype.__proto__;
     // @ts-ignore Undocumented method.
     toPath(fileName) {
       // @ts-ignore Undocumented function.
-      ts.toPath(fileName, this.getCurrentDirectory(), this.getCanonicalFileName(fileName));
+      ts.toPath(
+        fileName,
+        this.getCurrentDirectory(),
+        this.getCanonicalFileName(fileName),
+      );
     },
     // @ts-ignore Undocumented method.
     watchNodeModulesForPackageJsonChanges() {


### PR DESCRIPTION
Implements `host.toPath()` and `host.watchNodeModulesForPackageJsonChanges()`.

They're used here: https://github.com/microsoft/TypeScript/blob/v5.4.3/src/server/moduleSpecifierCache.ts#L30-L53.

There's an error for the latter API missing in the logs from #22391 (`toPath()` would apply to more recent versions). The call sites affected by this error (e.g. populating module specifier cache) seem related so it might fix it.