### PR TITLE
chore(lsp): remove recursion in recurse_dependents

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -649,9 +649,9 @@ fn recurse_dependents(
   specifier: &ModuleSpecifier,
   map: &HashMap<ModuleSpecifier, HashSet<ModuleSpecifier>>,
 ) -> Vec<ModuleSpecifier> {
+  let mut dependents = HashSet::new();
   let mut pending = VecDeque::new();
   pending.push_front(specifier);
-  let mut dependents = HashSet::new();
   while let Some(specifier) = pending.pop_front() {
     if let Some(deps) = map.get(specifier) {
       for dep in deps {

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -661,7 +661,7 @@ fn recurse_dependents(
       }
     }
   }
-  dependents.into_iter().map(|s| s.clone()).collect()
+  dependents.into_iter().cloned().collect()
 }
 
 #[derive(Debug)]

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -648,16 +648,20 @@ pub fn to_lsp_range(range: &deno_graph::Range) -> lsp::Range {
 fn recurse_dependents(
   specifier: &ModuleSpecifier,
   map: &HashMap<ModuleSpecifier, HashSet<ModuleSpecifier>>,
-  dependents: &mut HashSet<ModuleSpecifier>,
-) {
-  if let Some(deps) = map.get(specifier) {
-    for dep in deps {
-      if !dependents.contains(dep) {
-        dependents.insert(dep.clone());
-        recurse_dependents(dep, map, dependents);
+) -> Vec<ModuleSpecifier> {
+  let mut pending = VecDeque::new();
+  pending.push_front(specifier);
+  let mut dependents = HashSet::new();
+  while let Some(specifier) = pending.pop_front() {
+    if let Some(deps) = map.get(specifier) {
+      for dep in deps {
+        if dependents.insert(dep) {
+          pending.push_front(dep);
+        }
       }
     }
   }
+  dependents.into_iter().map(|s| s.clone()).collect()
 }
 
 #[derive(Debug)]
@@ -1106,10 +1110,8 @@ impl Documents {
     specifier: &ModuleSpecifier,
   ) -> Vec<ModuleSpecifier> {
     self.calculate_dependents_if_dirty();
-    let mut dependents = HashSet::new();
     if let Some(specifier) = self.resolve_specifier(specifier) {
-      recurse_dependents(&specifier, &self.dependents_map, &mut dependents);
-      dependents.into_iter().collect()
+      recurse_dependents(&specifier, &self.dependents_map)
     } else {
       vec![]
     }


### PR DESCRIPTION
Was investigating a separate stack overflow (that I've now found in the node resolution code) and came across this. We should avoid recursion (this is very old code).