### PR TITLE
perf(node): put pkg json into an `Rc`

### DIFF
--- a/cli/npm/byonm.rs
+++ b/cli/npm/byonm.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use deno_ast::ModuleSpecifier;
@@ -52,7 +53,7 @@ impl ByonmCliNpmResolver {
     &self,
     dep_name: &str,
     referrer: &ModuleSpecifier,
-  ) -> Option<PackageJson> {
+  ) -> Option<Rc<PackageJson>> {
     let referrer_path = referrer.to_file_path().ok()?;
     let mut current_folder = referrer_path.parent()?;
     loop {

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -36,6 +36,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::args::package_json::PackageJsonDeps;
@@ -98,7 +99,7 @@ impl CliNodeResolver {
     &self,
     referrer: &ModuleSpecifier,
     permissions: &dyn NodePermissions,
-  ) -> Result<Option<PackageJson>, AnyError> {
+  ) -> Result<Option<Rc<PackageJson>>, AnyError> {
     self
       .node_resolver
       .get_closest_package_json(referrer, permissions)

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -542,10 +542,12 @@ where
   )?;
   let node_resolver = state.borrow::<Rc<NodeResolver>>();
   let permissions = state.borrow::<P>();
-  node_resolver.get_closest_package_json(
-    &Url::from_file_path(filename).unwrap(),
-    permissions,
-  )
+  node_resolver
+    .get_closest_package_json(
+      &Url::from_file_path(filename).unwrap(),
+      permissions,
+    )
+    .map(|maybe_pkg| maybe_pkg.map(|pkg| (*pkg).clone()))
 }
 
 #[op2]
@@ -562,6 +564,7 @@ where
   let package_json_path = PathBuf::from(package_json_path);
   node_resolver
     .load_package_json(permissions, package_json_path)
+    .map(|pkg| (*pkg).clone())
     .ok()
 }
 


### PR DESCRIPTION
Was doing a bit of debugging on why some stuff is not working in a personal project and ran a quick debug profile and saw it cloning the pkg json a lot. We should put this in an Rc.