### PR TITLE
chore(ext/ffi): sym is unused on aarch64 linux

### DIFF
--- a/ext/ffi/turbocall.rs
+++ b/ext/ffi/turbocall.rs
@@ -27,6 +27,7 @@ pub(crate) fn is_compatible(sym: &Symbol) -> bool {
       .any(|t| matches!(t, NativeType::Struct(_)))
 }
 
+// Unused on linux aarch64
 #[allow(unused)]
 pub(crate) fn compile_trampoline(sym: &Symbol) -> Trampoline {
   #[cfg(all(target_arch = "x86_64", target_family = "unix"))]

--- a/ext/ffi/turbocall.rs
+++ b/ext/ffi/turbocall.rs
@@ -27,6 +27,7 @@ pub(crate) fn is_compatible(sym: &Symbol) -> bool {
       .any(|t| matches!(t, NativeType::Struct(_)))
 }
 
+#[allow(unused)]
 pub(crate) fn compile_trampoline(sym: &Symbol) -> Trampoline {
   #[cfg(all(target_arch = "x86_64", target_family = "unix"))]
   return SysVAmd64::compile(sym);


### PR DESCRIPTION
Fix a warning on linux aarch64