### PR TITLE
FUTURE: enable BYONM by default

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1102,7 +1102,11 @@ impl CliOptions {
   }
 
   pub fn has_node_modules_dir(&self) -> bool {
-    self.maybe_node_modules_folder.is_some() || self.unstable_byonm()
+    if self.enable_future_features() {
+      self.maybe_node_modules_folder.is_some() && self.unstable_byonm()
+    } else {
+      self.maybe_node_modules_folder.is_some() || self.unstable_byonm()
+    }
   }
 
   pub fn node_modules_dir_path(&self) -> Option<PathBuf> {
@@ -1591,7 +1595,8 @@ impl CliOptions {
   }
 
   pub fn unstable_byonm(&self) -> bool {
-    self.flags.unstable_config.byonm
+    self.enable_future_features()
+      || self.flags.unstable_config.byonm
       || NPM_PROCESS_STATE
         .as_ref()
         .map(|s| matches!(s.kind, NpmProcessStateKind::Byonm))

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1103,7 +1103,7 @@ impl CliOptions {
 
   pub fn has_node_modules_dir(&self) -> bool {
     if self.enable_future_features() {
-      self.maybe_node_modules_folder.is_some() && self.unstable_byonm()
+      self.maybe_node_modules_folder.is_some()
     } else {
       self.maybe_node_modules_folder.is_some() || self.unstable_byonm()
     }
@@ -1594,9 +1594,12 @@ impl CliOptions {
         .unwrap_or(false)
   }
 
-  pub fn unstable_byonm(&self) -> bool {
+  pub fn use_byonm(&self) -> bool {
     self.enable_future_features()
-      || self.flags.unstable_config.byonm
+  }
+
+  pub fn unstable_byonm(&self) -> bool {
+    self.flags.unstable_config.byonm
       || NPM_PROCESS_STATE
         .as_ref()
         .map(|s| matches!(s.kind, NpmProcessStateKind::Byonm))

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -402,7 +402,7 @@ impl CliFactory {
       .npm_resolver
       .get_or_try_init_async(async {
         let fs = self.fs();
-        create_cli_npm_resolver(if self.options.unstable_byonm() {
+        create_cli_npm_resolver(if self.options.use_byonm() || self.options.unstable_byonm() {
           CliNpmResolverCreateOptions::Byonm(CliNpmResolverByonmCreateOptions {
             fs: fs.clone(),
             root_node_modules_dir: match self.options.node_modules_dir_path().clone() {

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -635,7 +635,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       unstable_config: UnstableConfig {
         legacy_flag_enabled: cli_options.legacy_unstable_flag(),
         bare_node_builtins: cli_options.unstable_bare_node_builtins(),
-        byonm: cli_options.unstable_byonm(),
+        byonm: cli_options.use_byonm() || cli_options.unstable_byonm(),
         sloppy_imports: cli_options.unstable_sloppy_imports(),
         features: cli_options.unstable_features(),
       },


### PR DESCRIPTION
When `DENO_FUTURE=1` env var is present, then BYONM
("bring your own node_modules") is enabled by default.
That means that is there's a `package.json` present, users
are expected to explicitly install dependencies from that file.

Towards https://github.com/denoland/deno/issues/23151