### PR TITLE
fix(lsp): Remove client-facing format failure warning

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1576,7 +1576,6 @@ impl Inner {
         Ok(Some(text_edits))
       }
     } else {
-      self.client.show_message(MessageType::WARNING, format!("Unable to format \"{specifier}\". Likely due to unrecoverable syntax errors in the file."));
       Ok(None)
     }
   }


### PR DESCRIPTION
Fixes #23163.

The client-facing warning doesn't provide any value and is super annoying. We still emit a warning message on the server side for format errors, which should fulfill the same (less intrusive) purpose.