### PR TITLE
fix(ext/node): patch MessagePort if provided as workerData

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -463,6 +463,7 @@ function webMessagePortToNodeMessagePort(port: MessagePort) {
   return port;
 }
 
+// deno-lint-ignore no-explicit-any
 function patchMessagePortIfFound(data: any) {
   if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, data)) {
     data = webMessagePortToNodeMessagePort(data);

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -343,14 +343,7 @@ internals.__initWorkerThreads = (
     defaultExport.parentPort = parentPort;
     defaultExport.threadId = threadId;
 
-    for (const obj in workerData as Record<string, unknown>) {
-      if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, workerData[obj])) {
-        workerData[obj] = webMessagePortToNodeMessagePort(
-          workerData[obj] as MessagePort,
-        );
-        break;
-      }
-    }
+    workerData = patchMessagePortIfFound(workerData);
 
     parentPort.off = parentPort.removeListener = function (
       this: ParentPort,
@@ -369,18 +362,7 @@ internals.__initWorkerThreads = (
       // deno-lint-ignore no-explicit-any
       const _listener = (ev: any) => {
         let message = ev.data;
-        if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, message)) {
-          message = webMessagePortToNodeMessagePort(message);
-        } else {
-          for (const obj in message) {
-            if (
-              ObjectPrototypeIsPrototypeOf(MessagePortPrototype, message[obj])
-            ) {
-              message[obj] = webMessagePortToNodeMessagePort(message[obj]);
-              break;
-            }
-          }
-        }
+        message = patchMessagePortIfFound(message);
         return listener(message);
       };
       listeners.set(listener, _listener);
@@ -479,6 +461,20 @@ function webMessagePortToNodeMessagePort(port: MessagePort) {
     port.dispatchEvent(new Event("close"));
   };
   return port;
+}
+
+function patchMessagePortIfFound(data: any) {
+  if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, data)) {
+    data = webMessagePortToNodeMessagePort(data);
+  } else {
+    for (const obj in data as Record<string, unknown>) {
+      if (ObjectPrototypeIsPrototypeOf(MessagePortPrototype, data[obj])) {
+        data[obj] = webMessagePortToNodeMessagePort(data[obj] as MessagePort);
+        break;
+      }
+    }
+  }
+  return data;
 }
 
 export {

--- a/tests/testdata/workers/node_worker_message_port.mjs
+++ b/tests/testdata/workers/node_worker_message_port.mjs
@@ -9,7 +9,7 @@ const deferred = createDeferred();
 const worker = new workerThreads.Worker(
   import.meta.resolve("./node_worker_message_port_1.cjs"),
   {
-    workerData: { workerPort },
+    workerData: workerPort,
     transferList: [workerPort],
   },
 );

--- a/tests/testdata/workers/node_worker_message_port_1.cjs
+++ b/tests/testdata/workers/node_worker_message_port_1.cjs
@@ -1,7 +1,7 @@
 const { parentPort, workerData } = require("worker_threads");
 
 parentPort.on("message", (msg) => {
-  const workerPort = workerData.workerPort;
+  const workerPort = workerData;
   parentPort.postMessage("Hello from worker on parentPort!");
   workerPort.postMessage("Hello from worker on workerPort!");
   workerPort.on("close", () => console.log("worker port closed"));


### PR DESCRIPTION
MessagePort if directly assigned to workerData property instead of embedding it in an object then it is not patched to a NodeMessagePort. This PR fixes that issue.