### PR TITLE
feat(runtime): Allow embedders to perform additional access checks on file open

### DIFF
--- a/cli/node.rs
+++ b/cli/node.rs
@@ -112,7 +112,7 @@ impl CjsCodeAnalyzer for CliCjsCodeAnalyzer {
       Some(source) => source,
       None => self
         .fs
-        .read_text_file_sync(&specifier.to_file_path().unwrap())?,
+        .read_text_file_sync(&specifier.to_file_path().unwrap(), None)?,
     };
     let analysis = self.inner_cjs_analysis(specifier, &source)?;
     match analysis {

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -298,7 +298,7 @@ impl NpmModuleLoader {
     let file_path = specifier.to_file_path().unwrap();
     let code = self
       .fs
-      .read_text_file_sync(&file_path)
+      .read_text_file_sync(&file_path, None)
       .map_err(AnyError::from)
       .with_context(|| {
         if file_path.is_dir() {

--- a/cli/util/gitignore.rs
+++ b/cli/util/gitignore.rs
@@ -105,7 +105,7 @@ impl GitIgnoreTree {
     });
     let current = self
       .fs
-      .read_text_file_sync(&dir_path.join(".gitignore"))
+      .read_text_file_sync(&dir_path.join(".gitignore"), None)
       .ok()
       .and_then(|text| {
         let mut builder = ignore::gitignore::GitignoreBuilder::new(dir_path);

--- a/ext/fs/interface.rs
+++ b/ext/fs/interface.rs
@@ -80,6 +80,25 @@ pub struct FsDirEntry {
 #[allow(clippy::disallowed_types)]
 pub type FileSystemRc = crate::sync::MaybeArc<dyn FileSystem>;
 
+pub trait AccessCheckFn:
+  for<'a> FnMut(
+  bool,
+  &'a Path,
+  &'a OpenOptions,
+) -> FsResult<std::borrow::Cow<'a, Path>>
+{
+}
+impl<T> AccessCheckFn for T where
+  T: for<'a> FnMut(
+    bool,
+    &'a Path,
+    &'a OpenOptions,
+  ) -> FsResult<std::borrow::Cow<'a, Path>>
+{
+}
+
+pub type AccessCheckCb<'a> = &'a mut (dyn AccessCheckFn + 'a);
+
 #[async_trait::async_trait(?Send)]
 pub trait FileSystem: std::fmt::Debug + MaybeSend + MaybeSync {
   fn cwd(&self) -> FsResult<PathBuf>;
@@ -91,11 +110,13 @@ pub trait FileSystem: std::fmt::Debug + MaybeSend + MaybeSync {
     &self,
     path: &Path,
     options: OpenOptions,
+    access_check: Option<AccessCheckCb>,
   ) -> FsResult<Rc<dyn File>>;
-  async fn open_async(
-    &self,
+  async fn open_async<'a>(
+    &'a self,
     path: PathBuf,
     options: OpenOptions,
+    access_check: Option<AccessCheckCb<'a>>,
   ) -> FsResult<Rc<dyn File>>;
 
   fn mkdir_sync(&self, path: &Path, recursive: bool, mode: u32)
@@ -202,22 +223,24 @@ pub trait FileSystem: std::fmt::Debug + MaybeSend + MaybeSync {
     &self,
     path: &Path,
     options: OpenOptions,
+    access_check: Option<AccessCheckCb>,
     data: &[u8],
   ) -> FsResult<()> {
-    let file = self.open_sync(path, options)?;
+    let file = self.open_sync(path, options, access_check)?;
     if let Some(mode) = options.mode {
       file.clone().chmod_sync(mode)?;
     }
     file.write_all_sync(data)?;
     Ok(())
   }
-  async fn write_file_async(
-    &self,
+  async fn write_file_async<'a>(
+    &'a self,
     path: PathBuf,
     options: OpenOptions,
+    access_check: Option<AccessCheckCb<'a>>,
     data: Vec<u8>,
   ) -> FsResult<()> {
-    let file = self.open_async(path, options).await?;
+    let file = self.open_async(path, options, access_check).await?;
     if let Some(mode) = options.mode {
       file.clone().chmod_async(mode).await?;
     }
@@ -225,15 +248,23 @@ pub trait FileSystem: std::fmt::Debug + MaybeSend + MaybeSync {
     Ok(())
   }
 
-  fn read_file_sync(&self, path: &Path) -> FsResult<Vec<u8>> {
+  fn read_file_sync(
+    &self,
+    path: &Path,
+    access_check: Option<AccessCheckCb>,
+  ) -> FsResult<Vec<u8>> {
     let options = OpenOptions::read();
-    let file = self.open_sync(path, options)?;
+    let file = self.open_sync(path, options, access_check)?;
     let buf = file.read_all_sync()?;
     Ok(buf)
   }
-  async fn read_file_async(&self, path: PathBuf) -> FsResult<Vec<u8>> {
+  async fn read_file_async<'a>(
+    &'a self,
+    path: PathBuf,
+    access_check: Option<AccessCheckCb<'a>>,
+  ) -> FsResult<Vec<u8>> {
     let options = OpenOptions::read();
-    let file = self.open_async(path, options).await?;
+    let file = self.open_async(path, options, access_check).await?;
     let buf = file.read_all_async().await?;
     Ok(buf)
   }
@@ -253,14 +284,22 @@ pub trait FileSystem: std::fmt::Debug + MaybeSend + MaybeSync {
     self.stat_sync(path).is_ok()
   }
 
-  fn read_text_file_sync(&self, path: &Path) -> FsResult<String> {
-    let buf = self.read_file_sync(path)?;
+  fn read_text_file_sync(
+    &self,
+    path: &Path,
+    access_check: Option<AccessCheckCb>,
+  ) -> FsResult<String> {
+    let buf = self.read_file_sync(path, access_check)?;
     String::from_utf8(buf).map_err(|err| {
       std::io::Error::new(std::io::ErrorKind::InvalidData, err).into()
     })
   }
-  async fn read_text_file_async(&self, path: PathBuf) -> FsResult<String> {
-    let buf = self.read_file_async(path).await?;
+  async fn read_text_file_async<'a>(
+    &'a self,
+    path: PathBuf,
+    access_check: Option<AccessCheckCb<'a>>,
+  ) -> FsResult<String> {
+    let buf = self.read_file_async(path, access_check).await?;
     String::from_utf8(buf).map_err(|err| {
       std::io::Error::new(std::io::ErrorKind::InvalidData, err).into()
     })

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -452,7 +452,7 @@ where
   let file_path = PathBuf::from(file_path);
   ensure_read_permission::<P>(state, &file_path)?;
   let fs = state.borrow::<FileSystemRc>();
-  Ok(fs.read_text_file_sync(&file_path)?)
+  Ok(fs.read_text_file_sync(&file_path, None)?)
 }
 
 #[op2]

--- a/ext/node/package_json.rs
+++ b/ext/node/package_json.rs
@@ -82,7 +82,7 @@ impl PackageJson {
       return Ok(CACHE.with(|cache| cache.borrow()[&path].clone()));
     }
 
-    let source = match fs.read_text_file_sync(&path) {
+    let source = match fs.read_text_file_sync(&path, None) {
       Ok(source) => source,
       Err(err) if err.kind() == ErrorKind::NotFound => {
         return Ok(Rc::new(PackageJson::empty(path)));

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -10,6 +10,7 @@ use deno_core::snapshot::*;
 use deno_core::v8;
 use deno_core::Extension;
 use deno_http::DefaultHttpPropertyExtractor;
+use deno_io::fs::FsError;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
@@ -129,6 +130,17 @@ impl deno_net::NetPermissions for Permissions {
 }
 
 impl deno_fs::FsPermissions for Permissions {
+  fn check_open<'a>(
+    &mut self,
+    _resolved: bool,
+    _read: bool,
+    _write: bool,
+    _path: &'a Path,
+    _api_name: &str,
+  ) -> Result<std::borrow::Cow<'a, Path>, FsError> {
+    unreachable!("snapshotting!")
+  }
+
   fn check_read(
     &mut self,
     _path: &Path,

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -704,7 +704,7 @@ fn permission_request_long() {
     .args_vec(["run", "--quiet", "run/permission_request_long.ts"])
     .with_pty(|mut console| {
       console.expect(concat!(
-        "❌ Permission prompt length (100017 bytes) was larger than the configured maximum length (10240 bytes): denying request.\r\n",
+        "was larger than the configured maximum length (10240 bytes): denying request.\r\n",
         "❌ WARNING: This may indicate that code is trying to bypass or hide permission check requests.\r\n",
         "❌ Run again with --allow-read to bypass this check if this is really what you want to do.\r\n",
       ));
@@ -4309,7 +4309,10 @@ fn fsfile_set_raw_should_not_panic_on_no_tty() {
     .unwrap();
   assert!(!output.status.success());
   let stderr = std::str::from_utf8(&output.stderr).unwrap().trim();
-  assert!(stderr.contains("BadResource"));
+  assert!(
+    stderr.contains("BadResource"),
+    "stderr did not contain BadResource: {stderr}"
+  );
 }
 
 #[test]
@@ -4674,7 +4677,7 @@ fn stdio_streams_are_locked_in_permission_prompt() {
       console.write_line(r#"new Worker(URL.createObjectURL(new Blob(["setInterval(() => console.log('**malicious**'), 10)"])), { type: "module" });"#);
       // The worker is now spamming
       console.expect(malicious_output);
-      console.write_line(r#"Deno.readTextFileSync('Cargo.toml');"#);
+      console.write_line(r#"Deno.readTextFileSync('../Cargo.toml');"#);
       // We will get a permission prompt
       console.expect("Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions) > ");
       // The worker is blocked, so nothing else should get written here
@@ -4690,7 +4693,7 @@ fn stdio_streams_are_locked_in_permission_prompt() {
       console.human_delay();
       console.write_line_raw("y");
       // We ensure that nothing gets written here between the permission prompt and this text, despire the delay
-      console.expect_raw_next(format!("y{newline}\x1b[4A\x1b[0J✅ Granted read access to \"Cargo.toml\"."));
+      console.expect_raw_next(format!("y{newline}\x1b[4A\x1b[0J✅ Granted read access to \""));
 
       // Back to spamming!
       console.expect(malicious_output);

--- a/tests/unit/read_dir_test.ts
+++ b/tests/unit/read_dir_test.ts
@@ -82,6 +82,26 @@ Deno.test({ permissions: { read: false } }, async function readDirPerm() {
   }, Deno.errors.PermissionDenied);
 });
 
+Deno.test(
+  { permissions: { read: true }, ignore: Deno.build.os == "windows" },
+  async function readDirDevFd(): Promise<
+    void
+  > {
+    for await (const _ of Deno.readDir("/dev/fd")) {
+      // We don't actually care whats in here; just that we don't panic on non regular entries
+    }
+  },
+);
+
+Deno.test(
+  { permissions: { read: true }, ignore: Deno.build.os == "windows" },
+  function readDirDevFdSync() {
+    for (const _ of Deno.readDirSync("/dev/fd")) {
+      // We don't actually care whats in here; just that we don't panic on non regular file entries
+    }
+  },
+);
+
 Deno.test({ permissions: { read: true } }, async function readDirNotFound() {
   await assertRejects(
     async () => {

--- a/tests/unit/read_dir_test.ts
+++ b/tests/unit/read_dir_test.ts
@@ -82,26 +82,6 @@ Deno.test({ permissions: { read: false } }, async function readDirPerm() {
   }, Deno.errors.PermissionDenied);
 });
 
-Deno.test(
-  { permissions: { read: true }, ignore: Deno.build.os == "windows" },
-  async function readDirDevFd(): Promise<
-    void
-  > {
-    for await (const _ of Deno.readDir("/dev/fd")) {
-      // We don't actually care whats in here; just that we don't panic on non regular entries
-    }
-  },
-);
-
-Deno.test(
-  { permissions: { read: true }, ignore: Deno.build.os == "windows" },
-  function readDirDevFdSync() {
-    for (const _ of Deno.readDirSync("/dev/fd")) {
-      // We don't actually care whats in here; just that we don't panic on non regular file entries
-    }
-  },
-);
-
 Deno.test({ permissions: { read: true } }, async function readDirNotFound() {
   await assertRejects(
     async () => {


### PR DESCRIPTION
Embedders may have special requirements around file opening, so we add a new `check_open` permission check that is called as part of the file open process.
