### PR TITLE
fix(ext/node): count MessagePort message listeners in hasMessageEventListener

### DIFF
--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -22,6 +22,7 @@ const {
   Symbol,
   SymbolFor,
   SymbolIterator,
+  SafeArrayIterator,
   TypeError,
 } = primordials;
 const {
@@ -39,6 +40,8 @@ import {
 } from "./02_event.js";
 import { isDetachedBuffer } from "./06_streams.js";
 import { DOMException } from "./01_dom_exception.js";
+
+let messageEventListenerCount = 0;
 
 class MessageChannel {
   /** @type {MessagePort} */
@@ -220,6 +223,20 @@ class MessagePort extends EventTarget {
       this[_id] = null;
       nodeWorkerThreadMaybeInvokeCloseCb(this);
     }
+  }
+
+  removeEventListener(...args) {
+    if (args[0] == "message") {
+      messageEventListenerCount--;
+    }
+    super.removeEventListener(...new SafeArrayIterator(args));
+  }
+
+  addEventListener(...args) {
+    if (args[0] == "message") {
+      messageEventListenerCount++;
+    }
+    super.addEventListener(...new SafeArrayIterator(args));
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
@@ -406,6 +423,7 @@ function structuredClone(value, options) {
 export {
   deserializeJsMessageData,
   MessageChannel,
+  messageEventListenerCount,
   MessagePort,
   MessagePortIdSymbol,
   MessagePortPrototype,

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -282,7 +282,8 @@ let isClosing = false;
 let globalDispatchEvent;
 
 function hasMessageEventListener() {
-  return event.listenerCount(globalThis, "message") > 0;
+  return event.listenerCount(globalThis, "message") > 0 ||
+    messagePort.messageEventListenerCount > 0;
 }
 
 async function pollForMessages() {


### PR DESCRIPTION
The patch is expected to let the script from #23199 not exit but to write a integration test we need to introduce messagePort.off as the test should exit (is it possible to have a timeout assertion in itest?). I didn't want do that in the same PR. I'm happy to introduce the same if we need a test.


Closes https://github.com/denoland/deno/issues/23199