### PR TITLE
fix(cli): fix deadlock in test writer when test pipe is full

### DIFF
--- a/cli/tools/test/channel.rs
+++ b/cli/tools/test/channel.rs
@@ -572,10 +572,8 @@ mod tests {
           if let Some(stdout) = &mut stdout {
             stdout.write_all(b"message").unwrap();
           }
-        } else {
-          if let Some(stderr) = &mut stderr {
-            stderr.write_all(b"message").unwrap();
-          }
+        } else if let Some(stderr) = &mut stderr {
+          stderr.write_all(b"message").unwrap();
         }
         sender.send(TestEvent::StepWait(1)).unwrap();
       }

--- a/cli/tools/test/channel.rs
+++ b/cli/tools/test/channel.rs
@@ -227,8 +227,8 @@ impl TestEventSenderFactory {
   /// Create a [`TestEventWorkerSender`], along with a stdout/stderr stream.
   pub fn worker(&self) -> TestEventWorkerSender {
     let id = self.worker_id.fetch_add(1, Ordering::AcqRel);
-    let (stdout_reader, mut stdout_writer) = pipe().unwrap();
-    let (stderr_reader, mut stderr_writer) = pipe().unwrap();
+    let (stdout_reader, stdout_writer) = pipe().unwrap();
+    let (stderr_reader, stderr_writer) = pipe().unwrap();
     let (sync_sender, mut sync_receiver) =
       tokio::sync::mpsc::unbounded_channel::<(SendMutex, SendMutex)>();
     let stdout = stdout_writer.try_clone().unwrap();


### PR DESCRIPTION
The tests would deadlock if we tried to write the sync marker into a pipe that was full because one test streamed just enough data to fill the pipe, so when we went to actually write the sync marker we blocked when nobody was reading.

We use a two-phase lock for sync markers now: one to indicate "ready to sync" and the second to indicate that the sync bytes have been received.