### PR TITLE
fix(cli): update `deno doc` help to fit current usage

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1614,7 +1614,7 @@ Target a specific symbol:
 Show documentation for runtime built-ins:
 
     deno doc
-    deno doc --builtin Deno.Listener",
+    deno doc --filter Deno.Listener",
     )
     .defer(|cmd| {
       cmd


### PR DESCRIPTION
# Summary

Update the `deno doc` help to fit the current usage.

# Motivation

The current help give the following example:
```
Show documentation for runtime built-ins:

    deno doc
    deno doc --builtin Deno.Listener
```

But the current corresponding flag is:
```
--filter <filter>
          Dot separated path to symbol
```

# Changes

- Update documentation in [cli/args/flags.rs](https://github.com/JOTSR/deno/commit/7a5599ac817a1366918c316c3dfdd6003876b9e8#diff-4d551b564156523c7284c9498573bb585fa98279dc39009ee95819c697697e43)