### PR TITLE
perf(lsp): don't keep remote module ast's in memory

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -327,7 +327,8 @@ impl Document {
       maybe_lsp_version: None,
       maybe_module,
       maybe_navigation_tree: Mutex::new(None),
-      maybe_parsed_source,
+      maybe_parsed_source: maybe_parsed_source
+        .filter(|_| specifier.scheme() == "file"),
       text_info,
       specifier,
     }))
@@ -403,7 +404,8 @@ impl Document {
       maybe_headers: maybe_headers.map(ToOwned::to_owned),
       maybe_module,
       maybe_navigation_tree: Mutex::new(None),
-      maybe_parsed_source,
+      maybe_parsed_source: maybe_parsed_source
+        .filter(|_| specifier.scheme() == "file"),
       text_info,
       specifier,
     }))
@@ -474,7 +476,8 @@ impl Document {
       line_index,
       maybe_headers: self.0.maybe_headers.clone(),
       maybe_module,
-      maybe_parsed_source,
+      maybe_parsed_source: maybe_parsed_source
+        .filter(|_| self.0.specifier.scheme() == "file"),
       maybe_lsp_version: Some(version),
       maybe_navigation_tree: Mutex::new(None),
     })))

--- a/cli/lsp/testing/server.rs
+++ b/cli/lsp/testing/server.rs
@@ -98,6 +98,9 @@ impl TestServer {
                 .documents(DocumentsFilter::AllDiagnosable)
               {
                 let specifier = document.specifier();
+                if specifier.scheme() != "file" {
+                  continue;
+                }
                 if !snapshot.config.specifier_enabled_for_test(specifier) {
                   continue;
                 }


### PR DESCRIPTION
Cached ASTs are used for formatting, linting, code lenses and test collection. None of these are useful for remote modules.

Also fixes a bug where every module in the graph was being walked to collect tests.