### PR TITLE
chore(lsp): Add tracing to the deno LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.9",
@@ -1110,7 +1155,7 @@ dependencies = [
  "glob",
  "ignore",
  "import_map",
- "indexmap",
+ "indexmap 2.2.6",
  "jsonc-parser",
  "junction",
  "lazy-regex",
@@ -1124,6 +1169,10 @@ dependencies = [
  "notify",
  "once_cell",
  "open",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "os_pipe",
  "p256",
  "percent-encoding",
@@ -1152,6 +1201,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower-lsp",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "twox-hash",
  "typed-arena",
  "unicode-width",
@@ -1247,7 +1299,7 @@ checksum = "6cf517bddfd22d79d0f284500318e3f9aea193536c2b61cbf6ce7b50a85f1b6a"
 dependencies = [
  "anyhow",
  "deno_media_type",
- "indexmap",
+ "indexmap 2.2.6",
  "log",
  "once_cell",
  "parking_lot 0.12.1",
@@ -1278,7 +1330,7 @@ dependencies = [
  "anyhow",
  "glob",
  "import_map",
- "indexmap",
+ "indexmap 2.2.6",
  "jsonc-parser",
  "log",
  "percent-encoding",
@@ -1394,7 +1446,7 @@ dependencies = [
  "handlebars",
  "html-escape",
  "import_map",
- "indexmap",
+ "indexmap 2.2.6",
  "lazy_static",
  "regex",
  "serde",
@@ -1489,7 +1541,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "import_map",
- "indexmap",
+ "indexmap 2.2.6",
  "log",
  "monch",
  "once_cell",
@@ -1576,7 +1628,7 @@ dependencies = [
  "faster-hex",
  "log",
  "num-bigint",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "rand",
  "reqwest",
@@ -1694,7 +1746,7 @@ dependencies = [
  "hkdf",
  "http 0.2.12",
  "idna 0.3.0",
- "indexmap",
+ "indexmap 2.2.6",
  "k256",
  "lazy-regex",
  "libc",
@@ -2029,7 +2081,7 @@ dependencies = [
  "chrono",
  "futures",
  "num-bigint",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "serde",
  "uuid",
@@ -2049,7 +2101,7 @@ dependencies = [
  "denokv_proto",
  "futures",
  "log",
- "prost",
+ "prost 0.11.9",
  "rand",
  "reqwest",
  "serde",
@@ -2239,8 +2291,8 @@ checksum = "317f9cd1da390ab12e1858b3a71c7d6c8e8ad633454cb0b73ce5589964d9c177"
 dependencies = [
  "anyhow",
  "bumpalo",
- "hashbrown",
- "indexmap",
+ "hashbrown 0.14.3",
+ "indexmap 2.2.6",
  "rustc-hash",
  "serde",
  "unicode-width",
@@ -2981,8 +3033,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -3047,7 +3099,7 @@ checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.5.0",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3091,7 +3143,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3110,7 +3162,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.1.0",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3123,7 +3175,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -3144,6 +3196,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -3158,7 +3216,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3235,7 +3293,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9de2bdef6354361892492bab5e316b2d78a0ee9971db4d36da9b1eb0e11999"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
  "new_debug_unreachable",
  "once_cell",
  "phf 0.11.2",
@@ -3399,6 +3457,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.28",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,7 +3565,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696717335b077e26921a60be7b7bdc15d1246074f1ac79d9e8560792535f7d07"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "log",
  "percent-encoding",
  "serde",
@@ -3505,12 +3575,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -3982,10 +4062,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -4116,7 +4211,7 @@ dependencies = [
  "bitflags 2.5.0",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.2.6",
  "log",
  "num-traits",
  "rustc-hash",
@@ -4247,6 +4342,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
  "winapi",
 ]
 
@@ -4394,10 +4499,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost 0.12.3",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.12.3",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float 4.2.0",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -4423,6 +4611,12 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p224"
@@ -4637,7 +4831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -4943,7 +5137,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -4960,7 +5164,7 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.11.9",
  "prost-types",
  "regex",
  "syn 1.0.109",
@@ -4982,12 +5186,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -5023,7 +5240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1a341ae463320e9f8f34adda49c8a85d81d4e8f34cce4397fb0350481552224"
 dependencies = [
  "chrono",
- "indexmap",
+ "indexmap 2.2.6",
  "quick-xml",
  "strip-ansi-escapes",
  "thiserror",
@@ -5178,8 +5395,17 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5190,8 +5416,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5640,7 +5872,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -5670,7 +5902,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -5744,6 +5976,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -6072,7 +6313,7 @@ checksum = "21736fd17b258d4324f576e1d151d997fd5370a04b68dcb59f3e5050828de33f"
 dependencies = [
  "anyhow",
  "crc",
- "indexmap",
+ "indexmap 2.2.6",
  "is-macro",
  "once_cell",
  "parking_lot 0.12.1",
@@ -6141,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce837c5eae1cb200a310940de989fd9b3d12ed62d7752bc69b39ef8aa775ec04"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_json",
  "swc_cached",
@@ -6253,7 +6494,7 @@ checksum = "66539401f619730b26d380a120b91b499f80cbdd9bb15d00aa73bc3a4d4cc394"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
- "indexmap",
+ "indexmap 2.2.6",
  "once_cell",
  "phf 0.11.2",
  "rustc-hash",
@@ -6301,7 +6542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17889816334ce9d05ab0c292f93514fdd863b8537a35852dda609ebe3f48071d"
 dependencies = [
  "dashmap",
- "indexmap",
+ "indexmap 2.2.6",
  "once_cell",
  "petgraph",
  "rustc-hash",
@@ -6346,7 +6587,7 @@ checksum = "f0ec75c1194365abe4d44d94e58f918ec853469ecd39733b381a089cfdcdee1a"
 dependencies = [
  "base64",
  "dashmap",
- "indexmap",
+ "indexmap 2.2.6",
  "once_cell",
  "serde",
  "sha-1",
@@ -6385,7 +6626,7 @@ version = "0.127.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14482e455df85486d68a51533a31645d511e56df93a35cadf0eabbe7abe96b98"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "num_cpus",
  "once_cell",
  "rustc-hash",
@@ -6428,7 +6669,7 @@ version = "0.21.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bea847755eb7b131edb83c1a437d353e9d25cabd92ac27655420dd13c7267b"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "petgraph",
  "rustc-hash",
  "swc_common",
@@ -6503,6 +6744,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -6612,7 +6859,7 @@ dependencies = [
  "os_pipe",
  "parking_lot 0.12.1",
  "pretty_assertions",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "regex",
  "reqwest",
@@ -6742,6 +6989,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6822,6 +7079,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.3",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6829,10 +7113,16 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6910,6 +7200,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7182,6 +7520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7236,6 +7580,12 @@ dependencies = [
  "once_cell",
  "which 5.0.0",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-trait"
@@ -7404,6 +7754,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -119,6 +119,10 @@ monch.workspace = true
 notify.workspace = true
 once_cell.workspace = true
 open = "5.0.1"
+opentelemetry = "0.22.0"
+opentelemetry-otlp = "0.15.0"
+opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 os_pipe.workspace = true
 p256.workspace = true
 percent-encoding.workspace = true
@@ -144,6 +148,9 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-lsp.workspace = true
+tracing = "0.1.40"
+tracing-opentelemetry = "0.23.0"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 twox-hash = "=1.6.3"
 typed-arena = "=2.0.1"
 unicode-width = "0.1"
@@ -151,13 +158,6 @@ uuid = { workspace = true, features = ["serde"] }
 walkdir = "=2.3.2"
 zeromq.workspace = true
 zstd.workspace = true
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry = "0.22.0"
-opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
-tracing-opentelemetry = "0.23.0"
-opentelemetry-otlp = "0.15.0"
-opentelemetry-semantic-conventions = "0.14.0"
 
 [target.'cfg(windows)'.dependencies]
 fwdansi.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -151,6 +151,13 @@ uuid = { workspace = true, features = ["serde"] }
 walkdir = "=2.3.2"
 zeromq.workspace = true
 zstd.workspace = true
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+opentelemetry = "0.22.0"
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.23.0"
+opentelemetry-otlp = "0.15.0"
+opentelemetry-semantic-conventions = "0.14.0"
 
 [target.'cfg(windows)'.dependencies]
 fwdansi.workspace = true

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -531,6 +531,9 @@ pub struct WorkspaceSettings {
 
   #[serde(default)]
   pub typescript: LanguageWorkspaceSettings,
+
+  #[serde(default)]
+  pub tracing: Option<super::trace::TracingConfig>,
 }
 
 impl Default for WorkspaceSettings {
@@ -557,6 +560,7 @@ impl Default for WorkspaceSettings {
       unstable: false,
       javascript: Default::default(),
       typescript: Default::default(),
+      tracing: None,
     }
   }
 }
@@ -1920,6 +1924,7 @@ mod tests {
             enabled: UpdateImportsOnFileMoveEnabled::Prompt
           }
         },
+        tracing: None,
       }
     );
   }

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -533,7 +533,7 @@ pub struct WorkspaceSettings {
   pub typescript: LanguageWorkspaceSettings,
 
   #[serde(default)]
-  pub tracing: Option<super::trace::TracingConfig>,
+  pub tracing: Option<super::trace::TracingConfigOrEnabled>,
 }
 
 impl Default for WorkspaceSettings {

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -448,6 +448,12 @@ impl DiagnosticsServer {
             // channel has closed
             None => break,
             Some(message) => {
+              let sp = tracing::span!(
+                tracing::Level::INFO,
+                "diagnostics_server_loop_turn",
+                ?message
+              );
+              let _e = sp.enter();
               let message = match message {
                 ChannelMessage::Update(message) => message,
                 ChannelMessage::Clear => {
@@ -657,6 +663,7 @@ impl DiagnosticsServer {
     self.batch_counter.get()
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn update(
     &self,
     message: DiagnosticServerUpdateMessage,
@@ -1030,6 +1037,7 @@ impl DenoDiagnostic {
 
   /// A "static" method which for a diagnostic that originated from the
   /// structure returns a code action which can resolve the diagnostic.
+  #[tracing::instrument]
   pub fn get_code_action(
     specifier: &ModuleSpecifier,
     diagnostic: &lsp::Diagnostic,
@@ -1296,6 +1304,7 @@ fn relative_specifier(specifier: &lsp::Url, referrer: &lsp::Url) -> String {
   }
 }
 
+#[tracing::instrument(skip_all)]
 fn diagnose_resolution(
   snapshot: &language_server::StateSnapshot,
   dependency_key: &str,
@@ -1441,6 +1450,7 @@ fn diagnose_resolution(
 /// Generate diagnostics related to a dependency. The dependency is analyzed to
 /// determine if it can be remapped to the active import map as well as surface
 /// any diagnostics related to the resolved code or type dependency.
+#[tracing::instrument(skip(snapshot))]
 fn diagnose_dependency(
   diagnostics: &mut Vec<lsp::Diagnostic>,
   snapshot: &language_server::StateSnapshot,
@@ -1538,6 +1548,7 @@ fn diagnose_dependency(
 /// Generate diagnostics that come from Deno module resolution logic (like
 /// dependencies) or other Deno specific diagnostics, like the ability to use
 /// an import map to shorten an URL.
+#[tracing::instrument(skip_all)]
 fn generate_deno_diagnostics(
   snapshot: &language_server::StateSnapshot,
   config: &ConfigSnapshot,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -257,6 +257,12 @@ pub struct Document {
 }
 
 impl Document {
+  #[tracing::instrument(skip(
+    resolver,
+    npm_resolver,
+    text_info,
+    maybe_headers
+  ))]
   fn new(
     specifier: ModuleSpecifier,
     fs_version: String,
@@ -303,6 +309,7 @@ impl Document {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   fn maybe_with_new_resolver(
     &self,
     resolver: &dyn deno_graph::source::Resolver,
@@ -355,6 +362,7 @@ impl Document {
   }
 
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all)]
   fn open(
     specifier: ModuleSpecifier,
     version: i32,
@@ -513,6 +521,7 @@ impl Document {
     self.fs_version.as_str()
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn script_version(&self) -> String {
     self
       .maybe_lsp_version()
@@ -674,6 +683,7 @@ impl RedirectResolver {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn resolve(
     &self,
     specifier: &ModuleSpecifier,
@@ -725,6 +735,7 @@ struct FileSystemDocuments {
 }
 
 impl FileSystemDocuments {
+  #[tracing::instrument(skip_all)]
   pub fn get(
     &self,
     cache: &Arc<dyn HttpCache>,
@@ -912,6 +923,7 @@ impl Documents {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn module_graph_imports(&self) -> impl Iterator<Item = &ModuleSpecifier> {
     self
       .imports
@@ -924,6 +936,7 @@ impl Documents {
   /// requests for information from the document will come from the in-memory
   /// representation received from the language server client, versus reading
   /// information from the disk.
+  #[tracing::instrument(skip_all)]
   pub fn open(
     &mut self,
     specifier: ModuleSpecifier,
@@ -957,6 +970,7 @@ impl Documents {
   }
 
   /// Apply language server content changes to an open document.
+  #[tracing::instrument(skip_all)]
   pub fn change(
     &mut self,
     specifier: &ModuleSpecifier,
@@ -986,6 +1000,7 @@ impl Documents {
     Ok(doc)
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn save(&mut self, specifier: &ModuleSpecifier) {
     let doc = self
       .open_docs
@@ -1003,6 +1018,7 @@ impl Documents {
   /// Close an open document, this essentially clears any editor state that is
   /// being held, and the document store will revert to the file system if
   /// information about the document is required.
+  #[tracing::instrument(skip_all)]
   pub fn close(&mut self, specifier: &ModuleSpecifier) -> Result<(), AnyError> {
     if let Some(document) = self.open_docs.remove(specifier) {
       self
@@ -1017,6 +1033,7 @@ impl Documents {
 
   /// Return `true` if the provided specifier can be resolved to a document,
   /// otherwise `false`.
+  #[tracing::instrument(skip_all)]
   pub fn contains_import(
     &self,
     specifier: &str,
@@ -1041,6 +1058,7 @@ impl Documents {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn resolve_specifier(
     &self,
     specifier: &ModuleSpecifier,
@@ -1064,6 +1082,7 @@ impl Documents {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   fn resolve_unstable_sloppy_import<'a>(
     &self,
     specifier: &'a ModuleSpecifier,
@@ -1093,6 +1112,7 @@ impl Documents {
   }
 
   /// Return `true` if the specifier can be resolved to a document.
+  #[tracing::instrument(skip_all)]
   pub fn exists(&self, specifier: &ModuleSpecifier) -> bool {
     let specifier = self.resolve_specifier(specifier);
     if let Some(specifier) = specifier {
@@ -1115,6 +1135,7 @@ impl Documents {
   }
 
   /// Returns a collection of npm package requirements.
+  #[tracing::instrument(skip_all)]
   pub fn npm_package_reqs(&mut self) -> Arc<Vec<PackageReq>> {
     self.calculate_npm_reqs_if_dirty();
     self.npm_specifier_reqs.clone()
@@ -1196,6 +1217,7 @@ impl Documents {
   /// For a given set of string specifiers, resolve each one from the graph,
   /// for a given referrer. This is used to provide resolution information to
   /// tsc when type checking.
+  #[tracing::instrument(skip_all)]
   pub fn resolve(
     &self,
     specifiers: &[String],
@@ -1280,6 +1302,7 @@ impl Documents {
 
   /// Tries to cache a navigation tree that is associated with the provided specifier
   /// if the document stored has the same script version.
+  #[tracing::instrument(skip_all)]
   pub fn try_cache_navigation_tree(
     &self,
     specifier: &ModuleSpecifier,
@@ -1310,6 +1333,7 @@ impl Documents {
     self.lockfile = lockfile;
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn update_config(
     &mut self,
     config: &Config,
@@ -1514,6 +1538,7 @@ impl Documents {
     self.resolver.as_graph_npm_resolver()
   }
 
+  #[tracing::instrument(skip_all)]
   fn resolve_dependency(
     &self,
     specifier: &ModuleSpecifier,
@@ -1551,6 +1576,7 @@ impl Documents {
   /// Iterate through any "imported" modules, checking to see if a dependency
   /// is available. This is used to provide "global" imports like the JSX import
   /// source.
+  #[tracing::instrument(skip_all)]
   fn resolve_imports_dependency(&self, specifier: &str) -> Option<&Resolution> {
     for graph_imports in self.imports.values() {
       let maybe_dep = graph_imports.dependencies.get(specifier);
@@ -1590,6 +1616,7 @@ pub struct OpenDocumentsGraphLoader<'a> {
 }
 
 impl<'a> OpenDocumentsGraphLoader<'a> {
+  #[tracing::instrument(skip_all)]
   fn load_from_docs(
     &self,
     specifier: &ModuleSpecifier,
@@ -1609,6 +1636,7 @@ impl<'a> OpenDocumentsGraphLoader<'a> {
     None
   }
 
+  #[tracing::instrument(skip_all)]
   fn resolve_unstable_sloppy_import<'b>(
     &self,
     specifier: &'b ModuleSpecifier,
@@ -1637,6 +1665,7 @@ impl<'a> OpenDocumentsGraphLoader<'a> {
 }
 
 impl<'a> deno_graph::source::Loader for OpenDocumentsGraphLoader<'a> {
+  #[tracing::instrument(skip_all)]
   fn load(
     &mut self,
     specifier: &ModuleSpecifier,
@@ -1656,6 +1685,7 @@ impl<'a> deno_graph::source::Loader for OpenDocumentsGraphLoader<'a> {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   fn cache_module_info(
     &mut self,
     specifier: &deno_ast::ModuleSpecifier,
@@ -1668,6 +1698,7 @@ impl<'a> deno_graph::source::Loader for OpenDocumentsGraphLoader<'a> {
   }
 }
 
+#[tracing::instrument(skip_all)]
 fn parse_and_analyze_module(
   specifier: &ModuleSpecifier,
   text_info: SourceTextInfo,
@@ -1687,6 +1718,7 @@ fn parse_and_analyze_module(
   (Some(parsed_source_result), Some(module_result))
 }
 
+#[tracing::instrument(skip_all)]
 fn parse_source(
   specifier: &ModuleSpecifier,
   text_info: SourceTextInfo,
@@ -1702,6 +1734,7 @@ fn parse_source(
   })
 }
 
+#[tracing::instrument(skip_all)]
 fn analyze_module(
   specifier: &ModuleSpecifier,
   parsed_source_result: &ParsedSourceResult,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -257,12 +257,10 @@ pub struct Document {
 }
 
 impl Document {
-  #[tracing::instrument(skip(
-    resolver,
-    npm_resolver,
-    text_info,
-    maybe_headers
-  ))]
+  #[tracing::instrument(
+    level = "debug",
+    skip(resolver, npm_resolver, text_info, maybe_headers)
+  )]
   fn new(
     specifier: ModuleSpecifier,
     fs_version: String,
@@ -735,7 +733,7 @@ struct FileSystemDocuments {
 }
 
 impl FileSystemDocuments {
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(level = "debug", skip_all)]
   pub fn get(
     &self,
     cache: &Arc<dyn HttpCache>,
@@ -768,6 +766,7 @@ impl FileSystemDocuments {
 
   /// Adds or updates a document by reading the document from the file system
   /// returning the document.
+  #[tracing::instrument(level = "debug", skip_all)]
   fn refresh_document(
     &self,
     cache: &Arc<dyn HttpCache>,
@@ -1718,7 +1717,7 @@ fn parse_and_analyze_module(
   (Some(parsed_source_result), Some(module_result))
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn parse_source(
   specifier: &ModuleSpecifier,
   text_info: SourceTextInfo,
@@ -1734,7 +1733,7 @@ fn parse_source(
   })
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn analyze_module(
   specifier: &ModuleSpecifier,
   parsed_source_result: &ParsedSourceResult,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -851,7 +851,7 @@ impl Inner {
       .as_ref()
       .map(|c| std::borrow::Cow::Borrowed(c))
       .or_else(|| {
-        std::env::var("DENO_LSP_TRACING").ok().map(|_| {
+        std::env::var("DENO_LSP_TRACE").ok().map(|_| {
           std::borrow::Cow::Owned(super::trace::TracingConfig {
             enable: true,
             ..Default::default()

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1256,7 +1256,7 @@ impl Inner {
     Ok(())
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self, params))]
   async fn did_open(
     &mut self,
     specifier: &ModuleSpecifier,
@@ -1342,7 +1342,7 @@ impl Inner {
     }
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self))]
   async fn did_close(&mut self, params: DidCloseTextDocumentParams) {
     let mark = self.performance.mark_with_args("lsp.did_close", &params);
     self.diagnostics_state.clear(&params.text_document.uri);
@@ -1410,7 +1410,7 @@ impl Inner {
     self.send_testing_update();
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self))]
   async fn did_change_watched_files(
     &mut self,
     params: DidChangeWatchedFilesParams,
@@ -3315,7 +3315,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.write().await.did_change(params).await
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip_all, fields(uri=%params.text_document.uri))]
   async fn did_save(&self, params: DidSaveTextDocumentParams) {
     let uri = &params.text_document.uri;
     let specifier = {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -285,6 +285,7 @@ impl LanguageServer {
 
   /// Similar to `deno cache` on the command line, where modules will be cached
   /// in the Deno cache, including any of their dependencies.
+  #[tracing::instrument(skip_all)]
   pub async fn cache(
     &self,
     specifiers: Vec<ModuleSpecifier>,
@@ -381,6 +382,7 @@ impl LanguageServer {
     Ok(Some(json!(true)))
   }
 
+  #[tracing::instrument(skip_all)]
   /// This request is only used by the lsp integration tests to
   /// coordinate the tests receiving the latest diagnostics.
   pub async fn latest_diagnostic_batch_index_request(
@@ -459,6 +461,7 @@ impl LanguageServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn refresh_configuration(&self) {
     let (client, folders, capable) = {
       let ls = self.0.read().await;
@@ -565,6 +568,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   /// Searches assets and documents for the provided
   /// specifier erroring if it doesn't exist.
   pub fn get_asset_or_document(
@@ -593,6 +597,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_navigation_tree(
     &self,
     specifier: &ModuleSpecifier,
@@ -687,6 +692,7 @@ impl Inner {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn update_cache(&mut self) -> Result<(), AnyError> {
     let mark = self.performance.mark("lsp.update_cache");
     self.performance.measure(mark);
@@ -1052,6 +1058,7 @@ impl Inner {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   fn walk_workspace(config: &Config) -> (BTreeSet<ModuleSpecifier>, bool) {
     let mut workspace_files = Default::default();
     let entry_limit = 1000;
@@ -1154,6 +1161,7 @@ impl Inner {
     (workspace_files, false)
   }
 
+  #[tracing::instrument(skip_all)]
   fn refresh_workspace_files(&mut self) {
     let enable_settings_hash = self.config.settings.enable_settings_hash();
     if self.workspace_files_hash == enable_settings_hash {
@@ -1181,6 +1189,7 @@ impl Inner {
     self.workspace_files_hash = enable_settings_hash;
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_config_tree(&mut self) {
     let file_fetcher = self.create_file_fetcher(CacheSetting::RespectHeaders);
     self
@@ -1217,6 +1226,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_documents_config(&mut self) {
     self.documents.update_config(
       &self.config,
@@ -1236,6 +1246,7 @@ impl Inner {
     Ok(())
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_open(
     &mut self,
     specifier: &ModuleSpecifier,
@@ -1272,6 +1283,7 @@ impl Inner {
     document
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change(&mut self, params: DidChangeTextDocumentParams) {
     let mark = self.performance.mark_with_args("lsp.did_change", &params);
     let specifier = self
@@ -1301,6 +1313,7 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_npm_specifiers(&mut self) {
     let package_reqs = self.documents.npm_package_reqs();
     let npm_resolver = self.npm.resolver.clone();
@@ -1319,6 +1332,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_close(&mut self, params: DidCloseTextDocumentParams) {
     let mark = self.performance.mark_with_args("lsp.did_close", &params);
     self.diagnostics_state.clear(&params.text_document.uri);
@@ -1346,6 +1360,7 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change_configuration(
     &mut self,
     params: DidChangeConfigurationParams,
@@ -1385,6 +1400,7 @@ impl Inner {
     self.send_testing_update();
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change_watched_files(
     &mut self,
     params: DidChangeWatchedFilesParams,
@@ -1491,6 +1507,7 @@ impl Inner {
     self.config.set_workspace_folders(workspace_folders);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn document_symbol(
     &self,
     params: DocumentSymbolParams,
@@ -1533,6 +1550,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn formatting(
     &self,
     params: DocumentFormattingParams,
@@ -1625,6 +1643,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
     let specifier = self.url_map.normalize_url(
       &params.text_document_position_params.text_document.uri,
@@ -1743,6 +1762,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_action(
     &self,
     params: CodeActionParams,
@@ -1936,6 +1956,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_action_resolve(
     &self,
     params: CodeAction,
@@ -2051,6 +2072,7 @@ impl Inner {
     )
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_lens(
     &self,
     params: CodeLensParams,
@@ -2116,6 +2138,7 @@ impl Inner {
     Ok(Some(code_lenses))
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_lens_resolve(
     &self,
     code_lens: CodeLens,
@@ -2139,6 +2162,7 @@ impl Inner {
     result
   }
 
+  #[tracing::instrument(skip_all)]
   async fn document_highlight(
     &self,
     params: DocumentHighlightParams,
@@ -2182,6 +2206,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn references(
     &self,
     params: ReferenceParams,
@@ -2238,6 +2263,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn goto_definition(
     &self,
     params: GotoDefinitionParams,
@@ -2276,6 +2302,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn goto_type_definition(
     &self,
     params: GotoTypeDefinitionParams,
@@ -2321,6 +2348,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn completion(
     &self,
     params: CompletionParams,
@@ -2419,6 +2447,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn completion_resolve(
     &self,
     params: CompletionItem,
@@ -2499,6 +2528,7 @@ impl Inner {
     Ok(completion_item)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn goto_implementation(
     &self,
     params: GotoImplementationParams,
@@ -2544,6 +2574,7 @@ impl Inner {
     Ok(result)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn folding_range(
     &self,
     params: FoldingRangeParams,
@@ -2587,6 +2618,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn incoming_calls(
     &self,
     params: CallHierarchyIncomingCallsParams,
@@ -2632,6 +2664,7 @@ impl Inner {
     Ok(Some(resolved_items))
   }
 
+  #[tracing::instrument(skip_all)]
   async fn outgoing_calls(
     &self,
     params: CallHierarchyOutgoingCallsParams,
@@ -2678,6 +2711,7 @@ impl Inner {
     Ok(Some(resolved_items))
   }
 
+  #[tracing::instrument(skip_all)]
   async fn prepare_call_hierarchy(
     &self,
     params: CallHierarchyPrepareParams,
@@ -2741,6 +2775,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn rename(
     &self,
     params: RenameParams,
@@ -2784,6 +2819,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn selection_range(
     &self,
     params: SelectionRangeParams,
@@ -2821,6 +2857,7 @@ impl Inner {
     Ok(Some(selection_ranges))
   }
 
+  #[tracing::instrument(skip_all)]
   async fn semantic_tokens_full(
     &self,
     params: SemanticTokensParams,
@@ -2858,6 +2895,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn semantic_tokens_range(
     &self,
     params: SemanticTokensRangeParams,
@@ -2896,6 +2934,7 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn signature_help(
     &self,
     params: SignatureHelpParams,
@@ -2947,6 +2986,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn will_rename_files(
     &self,
     params: RenameFilesParams,
@@ -2995,6 +3035,7 @@ impl Inner {
     file_text_changes_to_workspace_edit(&changes, self)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn symbol(
     &self,
     params: WorkspaceSymbolParams,
@@ -3066,6 +3107,7 @@ impl Inner {
 
 #[tower_lsp::async_trait]
 impl tower_lsp::LanguageServer for LanguageServer {
+  #[tracing::instrument(skip_all)]
   async fn execute_command(
     &self,
     params: ExecuteCommandParams,
@@ -3092,6 +3134,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn initialize(
     &self,
     params: InitializeParams,
@@ -3101,6 +3144,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     language_server.initialize(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn initialized(&self, _: InitializedParams) {
     let mut registrations = Vec::with_capacity(2);
     let (client, http_client) = {
@@ -3235,6 +3279,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.write().await.shutdown()
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_open(&self, params: DidOpenTextDocumentParams) {
     if params.text_document.uri.scheme() == "deno" {
       // we can ignore virtual text documents opening, as they don't need to
@@ -3255,11 +3300,12 @@ impl tower_lsp::LanguageServer for LanguageServer {
       inner.send_testing_update();
     }
   }
-
+  #[tracing::instrument(skip_all)]
   async fn did_change(&self, params: DidChangeTextDocumentParams) {
     self.0.write().await.did_change(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_save(&self, params: DidSaveTextDocumentParams) {
     let uri = &params.text_document.uri;
     let specifier = {
@@ -3286,10 +3332,12 @@ impl tower_lsp::LanguageServer for LanguageServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_close(&self, params: DidCloseTextDocumentParams) {
     self.0.write().await.did_close(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change_configuration(
     &self,
     params: DidChangeConfigurationParams,
@@ -3308,6 +3356,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     inner.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change_watched_files(
     &self,
     params: DidChangeWatchedFilesParams,
@@ -3315,6 +3364,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.write().await.did_change_watched_files(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change_workspace_folders(
     &self,
     params: DidChangeWorkspaceFoldersParams,
@@ -3340,6 +3390,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn document_symbol(
     &self,
     params: DocumentSymbolParams,
@@ -3347,6 +3398,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.document_symbol(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn formatting(
     &self,
     params: DocumentFormattingParams,
@@ -3354,10 +3406,12 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.formatting(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
     self.0.read().await.hover(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn inlay_hint(
     &self,
     params: InlayHintParams,
@@ -3365,6 +3419,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.inlay_hint(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_action(
     &self,
     params: CodeActionParams,
@@ -3372,6 +3427,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.code_action(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_action_resolve(
     &self,
     params: CodeAction,
@@ -3379,6 +3435,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.code_action_resolve(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_lens(
     &self,
     params: CodeLensParams,
@@ -3386,10 +3443,12 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.code_lens(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn code_lens_resolve(&self, params: CodeLens) -> LspResult<CodeLens> {
     self.0.read().await.code_lens_resolve(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn document_highlight(
     &self,
     params: DocumentHighlightParams,
@@ -3397,6 +3456,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.document_highlight(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn references(
     &self,
     params: ReferenceParams,
@@ -3404,6 +3464,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.references(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn goto_definition(
     &self,
     params: GotoDefinitionParams,
@@ -3411,6 +3472,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.goto_definition(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn goto_type_definition(
     &self,
     params: GotoTypeDefinitionParams,
@@ -3418,6 +3480,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.goto_type_definition(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn completion(
     &self,
     params: CompletionParams,
@@ -3425,6 +3488,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.completion(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn completion_resolve(
     &self,
     params: CompletionItem,
@@ -3432,6 +3496,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.completion_resolve(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn goto_implementation(
     &self,
     params: GotoImplementationParams,
@@ -3439,6 +3504,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.goto_implementation(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn folding_range(
     &self,
     params: FoldingRangeParams,
@@ -3446,6 +3512,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.folding_range(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn incoming_calls(
     &self,
     params: CallHierarchyIncomingCallsParams,
@@ -3453,6 +3520,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.incoming_calls(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn outgoing_calls(
     &self,
     params: CallHierarchyOutgoingCallsParams,
@@ -3460,6 +3528,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.outgoing_calls(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn prepare_call_hierarchy(
     &self,
     params: CallHierarchyPrepareParams,
@@ -3467,6 +3536,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.prepare_call_hierarchy(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn rename(
     &self,
     params: RenameParams,
@@ -3474,6 +3544,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.rename(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn selection_range(
     &self,
     params: SelectionRangeParams,
@@ -3481,6 +3552,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.selection_range(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn semantic_tokens_full(
     &self,
     params: SemanticTokensParams,
@@ -3488,6 +3560,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.semantic_tokens_full(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn semantic_tokens_range(
     &self,
     params: SemanticTokensRangeParams,
@@ -3495,6 +3568,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.semantic_tokens_range(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn signature_help(
     &self,
     params: SignatureHelpParams,
@@ -3502,6 +3576,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.signature_help(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn will_rename_files(
     &self,
     params: RenameFilesParams,
@@ -3509,6 +3584,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     self.0.read().await.will_rename_files(params).await
   }
 
+  #[tracing::instrument(skip_all)]
   async fn symbol(
     &self,
     params: WorkspaceSymbolParams,
@@ -3581,6 +3657,7 @@ impl Inner {
     }))
   }
 
+  #[tracing::instrument(skip_all)]
   async fn post_cache(&self, mark: PerformanceMark) {
     // Now that we have dependencies loaded, we need to re-analyze all the files.
     // For that we're invalidating all the existing diagnostics and restarting
@@ -3630,6 +3707,7 @@ impl Inner {
     Ok(result)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn inlay_hint(
     &self,
     params: InlayHintParams,
@@ -3676,6 +3754,7 @@ impl Inner {
     Ok(maybe_inlay_hints)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn reload_import_registries(&mut self) -> LspResult<Option<Value>> {
     remove_dir_all_if_exists(&self.module_registries_location)
       .await

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2857,7 +2857,7 @@ impl Inner {
     Ok(Some(selection_ranges))
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self))]
   async fn semantic_tokens_full(
     &self,
     params: SemanticTokensParams,
@@ -2895,7 +2895,7 @@ impl Inner {
     Ok(response)
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self))]
   async fn semantic_tokens_range(
     &self,
     params: SemanticTokensRangeParams,
@@ -2934,7 +2934,7 @@ impl Inner {
     Ok(response)
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self))]
   async fn signature_help(
     &self,
     params: SignatureHelpParams,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -849,7 +849,7 @@ impl Inner {
       .workspace_settings()
       .tracing
       .as_ref()
-      .map(|c| std::borrow::Cow::Borrowed(c))
+      .map(std::borrow::Cow::Borrowed)
       .or_else(|| {
         std::env::var("DENO_LSP_TRACE").ok().map(|_| {
           std::borrow::Cow::Owned(super::trace::TracingConfig {

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -36,6 +36,7 @@ mod search;
 mod semantic_tokens;
 mod testing;
 mod text;
+mod trace;
 mod tsc;
 mod urls;
 

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -346,5 +346,6 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
       },
       ..Default::default()
     },
+    tracing: Default::default(),
   }
 }

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -48,7 +48,9 @@ pub(crate) fn make_tracer(
   )
 }
 
-pub(crate) struct TracingGuard(tracing::dispatcher::DefaultGuard);
+pub(crate) struct TracingGuard(
+  #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
+);
 
 impl fmt::Debug for TracingGuard {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -95,6 +95,40 @@ pub(crate) struct TracingConfig {
   pub(crate) max_queue_size: Option<usize>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub(crate) enum TracingConfigOrEnabled {
+  Config(TracingConfig),
+  Enabled(bool),
+}
+
+impl From<TracingConfig> for TracingConfigOrEnabled {
+  fn from(value: TracingConfig) -> Self {
+    TracingConfigOrEnabled::Config(value)
+  }
+}
+
+impl From<TracingConfigOrEnabled> for TracingConfig {
+  fn from(value: TracingConfigOrEnabled) -> Self {
+    match value {
+      TracingConfigOrEnabled::Config(config) => config,
+      TracingConfigOrEnabled::Enabled(enabled) => TracingConfig {
+        enable: enabled,
+        ..Default::default()
+      },
+    }
+  }
+}
+
+impl TracingConfigOrEnabled {
+  pub(crate) fn enabled(&self) -> bool {
+    match self {
+      TracingConfigOrEnabled::Config(config) => config.enable,
+      TracingConfigOrEnabled::Enabled(enabled) => *enabled,
+    }
+  }
+}
+
 pub(crate) fn init_tracing_subscriber(
   config: &TracingConfig,
 ) -> Result<TracingGuard, anyhow::Error> {

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use tracing::level_filters::LevelFilter;
 use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -93,9 +94,11 @@ pub(crate) fn init_tracing_subscriber(
     _ => None,
   };
   let logging_layer = match config.collector {
-    TracingCollector::Logging => {
-      Some(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-    }
+    TracingCollector::Logging => Some(
+      tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
+    ),
     _ => None,
   };
 

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -1,0 +1,101 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use std::fmt;
+
+use crate::lsp::logging::lsp_debug;
+use deno_core::anyhow;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::level_filters::LevelFilter;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+pub(crate) fn make_tracer(
+) -> Result<opentelemetry_sdk::trace::Tracer, anyhow::Error> {
+  Ok(
+    opentelemetry_otlp::new_pipeline()
+      .tracing()
+      .with_exporter(
+        opentelemetry_otlp::new_exporter()
+          .tonic()
+          .with_endpoint("http://localhost:4317"),
+      )
+      .with_trace_config(
+        opentelemetry_sdk::trace::config()
+          .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+          .with_resource(Resource::new(vec![KeyValue::new(
+            SERVICE_NAME,
+            "deno-lsp",
+          )])),
+      )
+      .install_batch(opentelemetry_sdk::runtime::Tokio)?,
+  )
+}
+
+pub(crate) struct TracingGuard(tracing::dispatcher::DefaultGuard);
+
+impl fmt::Debug for TracingGuard {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_tuple("TracingGuard").finish()
+  }
+}
+
+impl Drop for TracingGuard {
+  fn drop(&mut self) {
+    lsp_debug!("Shutting down tracing");
+    opentelemetry::global::shutdown_tracer_provider();
+  }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Copy)]
+pub(crate) enum TracingCollector {
+  OpenTelemetry,
+  Logging,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct TracingConfig {
+  pub(crate) enabled: bool,
+
+  pub(crate) collector: TracingCollector,
+
+  pub(crate) filter: Option<String>,
+}
+
+pub(crate) fn init_tracing_subscriber(
+  config: &TracingConfig,
+) -> Result<TracingGuard, anyhow::Error> {
+  if !config.enabled {
+    return Err(anyhow::anyhow!("Tracing is not enabled"));
+  }
+  let filter = tracing_subscriber::EnvFilter::builder()
+    .with_default_directive(LevelFilter::INFO.into());
+  let filter = if let Some(directive) = config.filter.as_ref() {
+    filter.parse(directive)?
+  } else {
+    filter.with_env_var("DENO_LSP_TRACE").from_env()?
+  };
+  let open_telemetry_layer = match config.collector {
+    TracingCollector::OpenTelemetry => {
+      Some(OpenTelemetryLayer::new(make_tracer()?))
+    }
+    _ => None,
+  };
+  let logging_layer = match config.collector {
+    TracingCollector::Logging => Some(tracing_subscriber::fmt::layer()),
+    _ => None,
+  };
+
+  let guard = tracing_subscriber::registry()
+    .with(filter)
+    .with(logging_layer)
+    .with(open_telemetry_layer)
+    .with(OpenTelemetryLayer::new(make_tracer()?))
+    .set_default();
+  Ok(TracingGuard(guard))
+}

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -67,10 +67,14 @@ pub(crate) enum TracingCollector {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(default)]
 pub(crate) struct TracingConfig {
+  /// Enable tracing.
   pub(crate) enable: bool,
 
+  /// The collector to use. Defaults to `OpenTelemetry`.
+  /// If `Logging` is used, the collected traces will be written to stderr.
   pub(crate) collector: TracingCollector,
 
+  /// The filter to use. Defaults to `INFO`.
   pub(crate) filter: Option<String>,
 }
 
@@ -97,6 +101,8 @@ pub(crate) fn init_tracing_subscriber(
     TracingCollector::Logging => Some(
       tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
+        // Include span events in the log output.
+        // Without this, only events get logged (and at the moment we have none).
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
     ),
     _ => None,

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -60,7 +60,7 @@ pub(crate) enum TracingCollector {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub(crate) struct TracingConfig {
-  pub(crate) enabled: bool,
+  pub(crate) enable: bool,
 
   pub(crate) collector: TracingCollector,
 
@@ -70,7 +70,7 @@ pub(crate) struct TracingConfig {
 pub(crate) fn init_tracing_subscriber(
   config: &TracingConfig,
 ) -> Result<TracingGuard, anyhow::Error> {
-  if !config.enabled {
+  if !config.enable {
     return Err(anyhow::anyhow!("Tracing is not enabled"));
   }
   let filter = tracing_subscriber::EnvFilter::builder()
@@ -87,7 +87,9 @@ pub(crate) fn init_tracing_subscriber(
     _ => None,
   };
   let logging_layer = match config.collector {
-    TracingCollector::Logging => Some(tracing_subscriber::fmt::layer()),
+    TracingCollector::Logging => {
+      Some(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+    }
     _ => None,
   };
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1045,7 +1045,6 @@ impl TsServer {
     self.request::<bool>(snapshot, req).await.unwrap();
   }
 
-  #[tracing::instrument(skip_all)]
   async fn request<R>(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1062,7 +1061,7 @@ impl TsServer {
     r
   }
 
-  #[tracing::instrument(skip_all)]
+  #[tracing::instrument(skip(self, snapshot, token))]
   async fn request_with_cancellation<R>(
     &self,
     snapshot: Arc<StateSnapshot>,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -328,6 +328,7 @@ impl TsServer {
       .ok();
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_diagnostics(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -356,6 +357,7 @@ impl TsServer {
     Ok(diagnostics_map)
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn find_references(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -382,6 +384,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_navigation_tree(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -395,6 +398,7 @@ impl TsServer {
     self.request(snapshot, req).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_supported_code_fixes(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -409,6 +413,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_quick_info(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -426,6 +431,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_code_fixes(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -469,6 +475,7 @@ impl TsServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_applicable_refactors(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -494,6 +501,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_combined_code_fix(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -528,6 +536,7 @@ impl TsServer {
   }
 
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all)]
   pub async fn get_edits_for_refactor(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -563,6 +572,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_edits_for_file_rename(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -600,6 +610,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_document_highlights(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -625,6 +636,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_definition(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -651,6 +663,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_type_definition(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -677,6 +690,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_completions(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -704,6 +718,7 @@ impl TsServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_completion_details(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -733,6 +748,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_implementations(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -759,6 +775,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_outlining_spans(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -775,6 +792,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn provide_call_hierarchy_incoming_calls(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -801,6 +819,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn provide_call_hierarchy_outgoing_calls(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -827,6 +846,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn prepare_call_hierarchy(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -861,6 +881,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn find_rename_locations(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -893,6 +914,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_smart_selection_range(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -910,6 +932,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_encoded_semantic_classifications(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -934,6 +957,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_signature_help_items(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -956,6 +980,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_navigate_to_items(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -988,6 +1013,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn provide_inlay_hints(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1010,6 +1036,7 @@ impl TsServer {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn restart(&self, snapshot: Arc<StateSnapshot>) {
     let req = TscRequest {
       method: "$restart",
@@ -1018,6 +1045,7 @@ impl TsServer {
     self.request::<bool>(snapshot, req).await.unwrap();
   }
 
+  #[tracing::instrument(skip_all)]
   async fn request<R>(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1034,6 +1062,7 @@ impl TsServer {
     r
   }
 
+  #[tracing::instrument(skip_all)]
   async fn request_with_cancellation<R>(
     &self,
     snapshot: Arc<StateSnapshot>,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3996,12 +3996,14 @@ impl State {
   }
 }
 
+#[tracing::instrument(skip(state))]
 #[op2(fast)]
 fn op_is_cancelled(state: &mut OpState) -> bool {
   let state = state.borrow_mut::<State>();
   state.token.is_cancelled()
 }
 
+#[tracing::instrument(skip(state))]
 #[op2(fast)]
 fn op_is_node_file(state: &mut OpState, #[string] path: String) -> bool {
   let state = state.borrow::<State>();
@@ -4028,6 +4030,7 @@ struct LoadResponse {
   is_cjs: bool,
 }
 
+#[tracing::instrument(skip(scope, state))]
 #[op2]
 fn op_load<'s>(
   scope: &'s mut v8::HandleScope,
@@ -4061,6 +4064,7 @@ fn op_load<'s>(
   Ok(serialized)
 }
 
+#[tracing::instrument(skip(scope, state))]
 #[op2]
 #[serde]
 fn op_resolve(
@@ -4101,12 +4105,14 @@ fn op_resolve_inner(
   Ok(specifiers)
 }
 
+#[tracing::instrument(skip_all)]
 #[op2(fast)]
 fn op_respond(state: &mut OpState, #[string] response: String) {
   let state = state.borrow_mut::<State>();
   state.response = Some(response);
 }
 
+#[tracing::instrument(skip_all)]
 #[op2]
 #[serde]
 fn op_script_names(state: &mut OpState) -> Vec<String> {
@@ -4164,6 +4170,7 @@ fn op_script_names(state: &mut OpState) -> Vec<String> {
   r
 }
 
+#[tracing::instrument(skip(state))]
 #[op2]
 #[string]
 fn op_script_version(
@@ -4178,6 +4185,7 @@ fn op_script_version(
   Ok(r)
 }
 
+#[tracing::instrument(skip_all)]
 #[op2]
 #[serde]
 fn op_ts_config(state: &mut OpState) -> serde_json::Value {
@@ -4188,6 +4196,7 @@ fn op_ts_config(state: &mut OpState) -> serde_json::Value {
   r
 }
 
+#[tracing::instrument(skip_all)]
 #[op2(fast)]
 #[number]
 fn op_project_version(state: &mut OpState) -> usize {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4063,7 +4063,7 @@ fn op_load<'s>(
   Ok(serialized)
 }
 
-#[tracing::instrument(skip(scope, state))]
+#[tracing::instrument(skip(state))]
 #[op2]
 #[serde]
 fn op_resolve(


### PR DESCRIPTION
Add tracing support to the LSP. Enabled via `deno.tracing.enable` in the editor settings or the `DENO_LSP_TRACE` environment variable. For instance, in your vscode `settings.json`, the following
```json
{
  "deno.tracing": {
    "enable": true,
    "filter": "debug"
   }
}
```
would enable tracing and filter to include all spans/events at a debug level or higher. By default, we use opentelemetry to export the data to a local opentelemetry collector. The easiest method is to just use [jaeger's all-in-one binary](https://www.jaegertracing.io/docs/1.56/getting-started/) to collect the tracing data, then open the jaeger UI to explore the data, for instance:
![Screenshot 2024-04-04 at 2 28 31 PM](https://github.com/denoland/deno/assets/17734409/39930218-86b7-4888-8aaa-fa696dab49d6)

The biggest downside of this PR, as I see it, is the additional dependencies and presumably a corresponding increase in compile times. The additional code will probably also increase binary size, though I haven't measured how much. It may be worth feature gating this at some point so we don't always pay the cost.

--
To review this, you probably want to look at the first 3 commits, as that's where all of the actual changes are. The commit that adds `instrument` attributes to a bunch of functions is pretty noisy.