### PR TITLE
FUTURE(ext/fs): make `Deno.FsFile` constructor illegal

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -90,6 +90,7 @@ const {
   SymbolAsyncIterator,
   SymbolIterator,
   SymbolFor,
+  TypeError,
   Uint32Array,
 } = primordials;
 

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -673,6 +673,11 @@ class FsFile {
         new Error().stack,
         "Use `Deno.open` or `Deno.openSync` instead.",
       );
+      if (internals.future) {
+        throw new TypeError(
+          "`Deno.FsFile` cannot be constructed, use `Deno.open()` or `Deno.openSync()` instead.",
+        );
+      }
     }
   }
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -678,6 +678,11 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       9: future,
     } = runtimeOptions;
 
+    // TODO(iuioiua): remove in Deno v2. This allows us to dynamically delete
+    // class properties within constructors for classes that are not defined
+    // within the Deno namespace.
+    internals.future = future;
+
     removeImportedOps();
 
     deprecatedApiWarningDisabled = shouldDisableDeprecatedApiWarning;
@@ -839,6 +844,11 @@ function bootstrapWorkerRuntime(
       8: shouldUseVerboseDeprecatedApiWarning,
       9: future,
     } = runtimeOptions;
+
+    // TODO(iuioiua): remove in Deno v2. This allows us to dynamically delete
+    // class properties within constructors for classes that are not defined
+    // within the Deno namespace.
+    internals.future = future;
 
     deprecatedApiWarningDisabled = shouldDisableDeprecatedApiWarning;
     verboseDeprecatedApiWarning = shouldUseVerboseDeprecatedApiWarning;

--- a/tests/specs/future/runtime_api/main.js
+++ b/tests/specs/future/runtime_api/main.js
@@ -31,4 +31,16 @@ console.log("Deno.writeAllSync is", Deno.writeAllSync);
 console.log("Deno.write is", Deno.write);
 console.log("Deno.writeSync is", Deno.writeSync);
 
+try {
+  new Deno.FsFile(0);
+} catch (error) {
+  if (
+    error instanceof TypeError &&
+    error.message ===
+      "`Deno.FsFile` cannot be constructed, use `Deno.open()` or `Deno.openSync()` instead."
+  ) {
+    console.log("Deno.FsFile constructor is illegal");
+  }
+}
+
 self.close();

--- a/tests/specs/future/runtime_api/main.out
+++ b/tests/specs/future/runtime_api/main.out
@@ -27,3 +27,4 @@ Deno.writeAll is undefined
 Deno.writeAllSync is undefined
 Deno.write is undefined
 Deno.writeSync is undefined
+Deno.FsFile constructor is illegal


### PR DESCRIPTION
I'm unsure whether we're planning to make the `Deno.FsFile` constructor illegal or remove `FsFile` from the `Deno.*` namspace in Deno 2. Either way, this PR works towards the former. I'll create a superceding PR if the latter is planned instead.

Towards #23089