### PR TITLE
perf(lsp): use lockfile to reduce npm pkg resolution time

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1298,10 +1298,7 @@ impl Documents {
     &self.jsr_resolver
   }
 
-  pub fn refresh_lockfile(
-    &mut self,
-    lockfile: Option<Arc<Mutex<Lockfile>>>,
-  ) {
+  pub fn refresh_lockfile(&mut self, lockfile: Option<Arc<Mutex<Lockfile>>>) {
     self.jsr_resolver =
       Arc::new(JsrCacheResolver::new(self.cache.clone(), lockfile.clone()));
     self.lockfile = lockfile;

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1502,7 +1502,7 @@ impl Documents {
     // fill the reqs from the lockfile
     if let Some(lockfile) = self.lockfile.as_ref() {
       let lockfile = lockfile.lock();
-      for (key, _) in &lockfile.content.packages.specifiers {
+      for key in lockfile.content.packages.specifiers.keys() {
         if let Some(key) = key.strip_prefix("npm:") {
           if let Ok(req) = PackageReq::from_str(key) {
             npm_reqs.insert(req);

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -855,6 +855,7 @@ pub struct Documents {
   /// settings.
   resolver: Arc<CliGraphResolver>,
   jsr_resolver: Arc<JsrCacheResolver>,
+  lockfile: Option<Arc<Mutex<Lockfile>>>,
   /// The npm package requirements found in npm specifiers.
   npm_specifier_reqs: Arc<Vec<PackageReq>>,
   /// Gets if any document had a node: specifier such that a @types/node package
@@ -887,6 +888,7 @@ impl Documents {
         sloppy_imports_resolver: None,
       })),
       jsr_resolver: Arc::new(JsrCacheResolver::new(cache.clone(), None)),
+      lockfile: None,
       npm_specifier_reqs: Default::default(),
       has_injected_types_node_package: false,
       redirect_resolver: Arc::new(RedirectResolver::new(cache)),
@@ -1296,12 +1298,13 @@ impl Documents {
     &self.jsr_resolver
   }
 
-  pub fn refresh_jsr_resolver(
+  pub fn refresh_lockfile(
     &mut self,
     lockfile: Option<Arc<Mutex<Lockfile>>>,
   ) {
     self.jsr_resolver =
-      Arc::new(JsrCacheResolver::new(self.cache.clone(), lockfile));
+      Arc::new(JsrCacheResolver::new(self.cache.clone(), lockfile.clone()));
+    self.lockfile = lockfile;
   }
 
   pub fn update_config(
@@ -1339,6 +1342,7 @@ impl Documents {
       self.cache.clone(),
       config.tree.root_lockfile().cloned(),
     ));
+    self.lockfile = config.tree.root_lockfile().cloned();
     self.redirect_resolver =
       Arc::new(RedirectResolver::new(self.cache.clone()));
     let resolver = self.resolver.as_graph_resolver();
@@ -1494,6 +1498,19 @@ impl Documents {
     }
 
     let mut npm_reqs = doc_analyzer.npm_reqs;
+
+    // fill the reqs from the lockfile
+    if let Some(lockfile) = self.lockfile.as_ref() {
+      let lockfile = lockfile.lock();
+      for (key, _) in &lockfile.content.packages.specifiers {
+        if let Some(key) = key.strip_prefix("npm:") {
+          if let Ok(req) = PackageReq::from_str(key) {
+            npm_reqs.insert(req);
+          }
+        }
+      }
+    }
+
     // Ensure a @types/node package exists when any module uses a node: specifier.
     // Unlike on the command line, here we just add @types/node to the npm package
     // requirements since this won't end up in the lockfile.

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -364,7 +364,7 @@ impl LanguageServer {
       {
         let mut inner = self.0.write().await;
         let lockfile = inner.config.tree.root_lockfile().cloned();
-        inner.documents.refresh_jsr_resolver(lockfile);
+        inner.documents.refresh_lockfile(lockfile);
         inner.refresh_npm_specifiers().await;
       }
       // now refresh the data in a read
@@ -998,6 +998,7 @@ impl Inner {
 
     self.recreate_npm_services_if_necessary().await;
     self.assets.initialize(self.snapshot()).await;
+    self.refresh_documents_config().await;
 
     self.performance.measure(mark);
     Ok(InitializeResult {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -998,7 +998,6 @@ impl Inner {
 
     self.recreate_npm_services_if_necessary().await;
     self.assets.initialize(self.snapshot()).await;
-    self.refresh_documents_config().await;
 
     self.performance.measure(mark);
     Ok(InitializeResult {

--- a/cli/npm/managed/resolution.rs
+++ b/cli/npm/managed/resolution.rs
@@ -310,9 +310,10 @@ async fn add_package_reqs_to_snapshot(
       .iter()
       .all(|req| snapshot.package_reqs().contains_key(req))
   {
-    log::debug!("Snapshot already up to date. Skipping pending resolution.");
+    log::debug!("Snapshot already up to date. Skipping pending npm resolution.");
     snapshot
   } else {
+    log::debug!(/* this string is used in tests!! */ "Running pending npm resolution.");
     let pending_resolver = get_npm_pending_resolver(api);
     let result = pending_resolver
       .resolve_pending(snapshot, package_reqs)

--- a/cli/npm/managed/resolution.rs
+++ b/cli/npm/managed/resolution.rs
@@ -310,10 +310,15 @@ async fn add_package_reqs_to_snapshot(
       .iter()
       .all(|req| snapshot.package_reqs().contains_key(req))
   {
-    log::debug!("Snapshot already up to date. Skipping pending npm resolution.");
+    log::debug!(
+      "Snapshot already up to date. Skipping pending npm resolution."
+    );
     snapshot
   } else {
-    log::debug!(/* this string is used in tests!! */ "Running pending npm resolution.");
+    log::debug!(
+      /* this string is used in tests!! */
+      "Running pending npm resolution."
+    );
     let pending_resolver = get_npm_pending_resolver(api);
     let result = pending_resolver
       .resolve_pending(snapshot, package_reqs)

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -12261,18 +12261,30 @@ fn lsp_uses_lockfile_for_npm_initialization() {
   temp_dir.write("deno.json", "{}");
   // use two npm packages here
   temp_dir.write("main.ts", "import 'npm:@denotest/esm-basic'; import 'npm:@denotest/cjs-default-export';");
-  context.new_command().args("run main.ts").run().skip_output_check();
+  context
+    .new_command()
+    .args("run main.ts")
+    .run()
+    .skip_output_check();
   // remove one of the npm packages and let the other one be found via the lockfile
   temp_dir.write("main.ts", "import 'npm:@denotest/esm-basic';");
   assert!(temp_dir.path().join("deno.lock").exists());
-  let mut client = context.new_lsp_command().capture_stderr().log_debug().build();
+  let mut client = context
+    .new_lsp_command()
+    .capture_stderr()
+    .log_debug()
+    .build();
   client.initialize_default();
   let mut skipping_count = 0;
   client.wait_until_stderr_line(|line| {
     if line.contains("Skipping pending npm resolution.") {
       skipping_count += 1;
     }
-    assert!(!line.contains("Running pending npm resolution."), "Line: {}", line);
+    assert!(
+      !line.contains("Running pending npm resolution."),
+      "Line: {}",
+      line
+    );
     line.contains("Server ready.")
   });
   assert_eq!(skipping_count, 1);

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -12253,3 +12253,28 @@ C.test();
 
   client.shutdown();
 }
+
+#[test]
+fn lsp_uses_lockfile_for_npm_initialization() {
+  let context = TestContextBuilder::for_npm().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("deno.json", "{}");
+  // use two npm packages here
+  temp_dir.write("main.ts", "import 'npm:@denotest/esm-basic'; import 'npm:@denotest/cjs-default-export';");
+  context.new_command().args("run main.ts").run().skip_output_check();
+  // remove one of the npm packages and let the other one be found via the lockfile
+  temp_dir.write("main.ts", "import 'npm:@denotest/esm-basic';");
+  assert!(temp_dir.path().join("deno.lock").exists());
+  let mut client = context.new_lsp_command().capture_stderr().log_debug().build();
+  client.initialize_default();
+  let mut skipping_count = 0;
+  client.wait_until_stderr_line(|line| {
+    if line.contains("Skipping pending npm resolution.") {
+      skipping_count += 1;
+    }
+    assert!(!line.contains("Running pending npm resolution."), "Line: {}", line);
+    line.contains("Server ready.")
+  });
+  assert_eq!(skipping_count, 1);
+  client.shutdown();
+}

--- a/tests/util/server/src/lsp.rs
+++ b/tests/util/server/src/lsp.rs
@@ -662,7 +662,10 @@ impl LspClient {
   }
 
   #[track_caller]
-  pub fn wait_until_stderr_line(&self, mut condition: impl FnMut(&str) -> bool) {
+  pub fn wait_until_stderr_line(
+    &self,
+    mut condition: impl FnMut(&str) -> bool,
+  ) {
     let timeout_time =
       Instant::now().checked_add(Duration::from_secs(5)).unwrap();
     let lines_rx = self

--- a/tests/util/server/src/lsp.rs
+++ b/tests/util/server/src/lsp.rs
@@ -464,6 +464,7 @@ impl InitializeParamsBuilder {
 pub struct LspClientBuilder {
   print_stderr: bool,
   capture_stderr: bool,
+  log_debug: bool,
   deno_exe: PathRef,
   root_dir: PathRef,
   use_diagnostic_sync: bool,
@@ -481,6 +482,7 @@ impl LspClientBuilder {
     Self {
       print_stderr: false,
       capture_stderr: false,
+      log_debug: false,
       deno_exe: deno_exe_path(),
       root_dir: deno_dir.path().clone(),
       use_diagnostic_sync: true,
@@ -504,6 +506,11 @@ impl LspClientBuilder {
 
   pub fn capture_stderr(mut self) -> Self {
     self.capture_stderr = true;
+    self
+  }
+
+  pub fn log_debug(mut self) -> Self {
+    self.log_debug = true;
     self
   }
 
@@ -537,6 +544,10 @@ impl LspClientBuilder {
   pub fn build_result(&self) -> Result<LspClient> {
     let deno_dir = self.deno_dir.clone();
     let mut command = Command::new(&self.deno_exe);
+    let mut args = vec!["lsp".to_string()];
+    if self.log_debug {
+      args.push("--log-level=debug".to_string());
+    }
     command
       .env("DENO_DIR", deno_dir.path())
       .env("NPM_CONFIG_REGISTRY", npm_registry_url())
@@ -547,7 +558,7 @@ impl LspClientBuilder {
         if self.use_diagnostic_sync { "1" } else { "" },
       )
       .env("DENO_NO_UPDATE_CHECK", "1")
-      .arg("lsp")
+      .args(args)
       .stdin(Stdio::piped())
       .stdout(Stdio::piped());
     for (key, value) in &self.envs {
@@ -651,7 +662,7 @@ impl LspClient {
   }
 
   #[track_caller]
-  pub fn wait_until_stderr_line(&self, condition: impl Fn(&str) -> bool) {
+  pub fn wait_until_stderr_line(&self, mut condition: impl FnMut(&str) -> bool) {
     let timeout_time =
       Instant::now().checked_add(Duration::from_secs(5)).unwrap();
     let lines_rx = self


### PR DESCRIPTION
This functionality was broken. The series of events was:

1. Load the npm resolution from the lockfile.
2. Discover only a subset of the specifiers in the documents.
3. Clear the npm snapshot.
4. Redo npm resolution with the new specifiers (~500ms).

What this now does:

1. Load the npm resolution from the lockfile.
2. Discover only a subset of the specifiers in the documents and take into account the specifiers from the lockfile.
3. Do not redo resolution (~1ms).