### PR TITLE
perf(lsp): Don't retain `SourceFileObject`s in `sourceFileCache` longer than necessary

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -786,9 +786,12 @@ delete Object.prototype.__proto__;
       if (logDebug) {
         debug(`host.getScriptSnapshot("${specifier}")`);
       }
-      let sourceFile = sourceFileCache.get(specifier)?.deref();
+      const isAsset = specifier.startsWith(ASSETS_URL_PREFIX);
+      let sourceFile = isAsset
+        ? assetSourceFileCache.get(specifier)
+        : sourceFileCache.get(specifier)?.deref();
       if (
-        !specifier.startsWith(ASSETS_URL_PREFIX) &&
+        !isAsset &&
         sourceFile?.version != this.getScriptVersion(specifier)
       ) {
         sourceFileCache.delete(specifier);


### PR DESCRIPTION
The TS language service requests source files via [getSourceFile](https://github.com/nathanwhit/deno/blob/7a25fd5ef0a82c2aac76594ccd467e9210e92b80/cli/tsc/99_main_compiler.js#L560). In that function, we [unconditionally add](https://github.com/nathanwhit/deno/blob/7a25fd5ef0a82c2aac76594ccd467e9210e92b80/cli/tsc/99_main_compiler.js#L613-L614) the source file to our sourceFileCache. The issue is that we only remove things from that cache if the source file [becomes out of date](https://github.com/nathanwhit/deno/blob/7a25fd5ef0a82c2aac76594ccd467e9210e92b80/cli/tsc/99_main_compiler.js#L777-L783). For files that don't get changed, we keep them in the cache indefinitely. So sometimes we keep SourceFile objects from being GC'ed because they're retained in our cache, even though TS doesn't refer to them any more. I see this in pretty much all of the heap snapshots I've taken.

---

The fix here is pretty direct - just store weak references to the sourcefiles in the cache. It doesn't really change our caching behavior, it just prevents us from being the only retainer of a `SourceFile`. I also split the `sourceFileCache` into a separate cache just for assets, as we rely on those being alive.

The simpler fix is to only cache assets, but presumably that has a perf impact.

---
In local testing, this PR reduced the size of the JS heap by about 1 GB when using `deno lsp` in the Typescript repo.