### PR TITLE
test: use unordered assertion for node worker test

### DIFF
--- a/tests/testdata/workers/node_worker_message_port.mjs.out
+++ b/tests/testdata/workers/node_worker_message_port.mjs.out
@@ -1,4 +1,6 @@
+[UNORDERED_START]
 worker port closed
 worker: Hello from worker on parentPort!
 mainPort: Hello from worker on workerPort!
 mainPort closed
+[UNORDERED_END]


### PR DESCRIPTION
This ordering of events is important here, but it's very hard to get right.

In the meantime to avoid flakes I'm adding an unordered assertion.