### PR TITLE
docs: Fix typo "discreet" to "discrete"

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2283,7 +2283,7 @@ declare namespace Deno {
   /** The Deno abstraction for reading and writing files.
    *
    * This is the most straight forward way of handling files within Deno and is
-   * recommended over using the discreet functions within the `Deno` namespace.
+   * recommended over using the discrete functions within the `Deno` namespace.
    *
    * ```ts
    * using file = await Deno.open("/foo/bar.txt", { read: true });
@@ -2786,7 +2786,7 @@ declare namespace Deno {
    */
   export const stdin: Reader & ReaderSync & Closer & {
     /**
-     * The resource ID assigned to `stdin`. This can be used with the discreet
+     * The resource ID assigned to `stdin`. This can be used with the discrete
      * I/O functions in the `Deno` namespace.
      *
      * @deprecated This will be soft-removed in Deno 2.0. See the
@@ -2834,7 +2834,7 @@ declare namespace Deno {
    */
   export const stdout: Writer & WriterSync & Closer & {
     /**
-     * The resource ID assigned to `stdout`. This can be used with the discreet
+     * The resource ID assigned to `stdout`. This can be used with the discrete
      * I/O functions in the `Deno` namespace.
      *
      * @deprecated This will be soft-removed in Deno 2.0. See the
@@ -2868,7 +2868,7 @@ declare namespace Deno {
    */
   export const stderr: Writer & WriterSync & Closer & {
     /**
-     * The resource ID assigned to `stderr`. This can be used with the discreet
+     * The resource ID assigned to `stderr`. This can be used with the discrete
      * I/O functions in the `Deno` namespace.
      *
      * @deprecated This will be soft-removed in Deno 2.0. See the


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Changes `discreet` in the documentation for `discrete`

"Discreet" means careful to avoid being noticed, "discrete" means separate parts, and is what the documentation refers to.