### PR TITLE
perf(lsp): Only evict caches on JS side when things actually change

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -514,6 +514,7 @@ impl DiagnosticsServer {
                         "Error generating TypeScript diagnostics: {}",
                         err
                       );
+                      token.cancel();
                     }
                   })
                   .unwrap_or_default();

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1147,7 +1147,7 @@ impl Inner {
       .ts_server
       .project_changed(
         self.snapshot(),
-        vec![],
+        &[],
         self.documents.project_version(),
         true,
       )
@@ -1229,7 +1229,7 @@ impl Inner {
     let version = self.documents.project_version();
     self
       .ts_server
-      .project_changed(self.snapshot(), vec![], version, false)
+      .project_changed(self.snapshot(), &[document.specifier()], version, false)
       .await;
 
     self.performance.measure(mark);
@@ -1253,7 +1253,7 @@ impl Inner {
             .ts_server
             .project_changed(
               self.snapshot(),
-              vec![document.specifier().to_string()],
+              &[document.specifier()],
               version,
               false,
             )
@@ -1315,7 +1315,7 @@ impl Inner {
     let version = self.documents.project_version();
     self
       .ts_server
-      .project_changed(self.snapshot(), vec![], version, false)
+      .project_changed(self.snapshot(), &[&specifier], version, false)
       .await;
     self.performance.measure(mark);
   }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -279,6 +279,27 @@ impl TsServer {
     });
   }
 
+  pub async fn project_changed(
+    &self,
+    snapshot: Arc<StateSnapshot>,
+    modified_scripts: Vec<String>,
+    new_project_version: String,
+    tsconfig_changed: bool,
+  ) {
+    let req = TscRequest {
+      method: "$projectChanged",
+      args: json!([modified_scripts, new_project_version, tsconfig_changed]),
+    };
+    self
+      .request::<()>(snapshot, req)
+      .await
+      .map_err(|err| {
+        log::error!("Failed to request to tsserver {}", err);
+        LspError::invalid_request()
+      })
+      .ok();
+  }
+
   pub async fn get_diagnostics(
     &self,
     snapshot: Arc<StateSnapshot>,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -282,7 +282,7 @@ impl TsServer {
   pub async fn project_changed(
     &self,
     snapshot: Arc<StateSnapshot>,
-    modified_scripts: Vec<String>,
+    modified_scripts: &[&ModuleSpecifier],
     new_project_version: String,
     tsconfig_changed: bool,
   ) {
@@ -5156,6 +5156,14 @@ mod tests {
         ..snapshot.as_ref().clone()
       })
     };
+    ts_server
+      .project_changed(
+        snapshot.clone(),
+        &[&specifier_dep],
+        snapshot.documents.project_version(),
+        false,
+      )
+      .await;
     let specifier = resolve_url("file:///a.ts").unwrap();
     let diagnostics = ts_server
       .get_diagnostics(snapshot.clone(), vec![specifier], Default::default())

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -308,10 +308,13 @@ impl TsServer {
   ) -> Result<HashMap<String, Vec<crate::tsc::Diagnostic>>, AnyError> {
     let req = TscRequest {
       method: "$getDiagnostics",
-      args: json!([specifiers
-        .into_iter()
-        .map(|s| self.specifier_map.denormalize(&s))
-        .collect::<Vec<String>>(),]),
+      args: json!([
+        specifiers
+          .into_iter()
+          .map(|s| self.specifier_map.denormalize(&s))
+          .collect::<Vec<String>>(),
+        snapshot.documents.project_version()
+      ]),
     };
     let raw_diagnostics = self.request_with_cancellation::<HashMap<String, Vec<crate::tsc::Diagnostic>>>(snapshot, req, token).await?;
     let mut diagnostics_map = HashMap::with_capacity(raw_diagnostics.len());

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1046,7 +1046,7 @@ delete Object.prototype.__proto__;
         }
 
         if (projectVersionCache !== newProjectVersion) {
-          // TODO: this could be more granular
+          // TODO(nathanwhit): this could be more granular
           scriptFileNamesCache = undefined;
         }
 

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1072,6 +1072,14 @@ delete Object.prototype.__proto__;
         return respond(id, getAssets());
       }
       case "$getDiagnostics": {
+        const projectVersion = args[1];
+        // there's a possibility that we receive a change notification
+        // but the diagnostic server queues a `$getDiagnostics` request
+        // with a stale project version. in that case, treat it as cancelled
+        // (it's about to be invalidated anyway).
+        if (projectVersionCache && projectVersion !== projectVersionCache) {
+          return respond(id, {});
+        }
         try {
           /** @type {Record<string, any[]>} */
           const diagnosticMap = {};

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -9047,15 +9047,15 @@ fn lsp_performance() {
       "tsc.host.$getAssets",
       "tsc.host.$getDiagnostics",
       "tsc.host.$getSupportedCodeFixes",
+      "tsc.host.$projectChanged",
       "tsc.host.getQuickInfoAtPosition",
       "tsc.op.op_is_node_file",
       "tsc.op.op_load",
-      "tsc.op.op_project_version",
       "tsc.op.op_script_names",
-      "tsc.op.op_script_version",
       "tsc.op.op_ts_config",
       "tsc.request.$getAssets",
       "tsc.request.$getSupportedCodeFixes",
+      "tsc.request.$projectChanged",
       "tsc.request.getQuickInfoAtPosition",
     ]
   );


### PR DESCRIPTION
Currently we evict a lot of the caches on the JS side of things on every request, namely script versions, script file names, and compiler settings (as of #23283, it's not quite every request but it's still unnecessarily often).

This PR reports changes to the JS side, so that it can evict exactly the caches that it needs too. We might want to do some batching in the future so as not to do 1 request per change.