### PR TITLE
refactor(ext/net): extract TLS key and certificate from interfaces

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -6281,13 +6281,7 @@ declare namespace Deno {
    *
    * @category HTTP Server
    */
-  export interface ServeTlsOptions extends ServeOptions {
-    /** Server private key in PEM format */
-    cert: string;
-
-    /** Cert chain in PEM format */
-    key: string;
-  }
+  export type ServeTlsOptions = ServeOptions & TlsCertifiedKeyOptions;
 
   /**
    * @category HTTP Server

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -967,7 +967,8 @@ declare namespace Deno {
    * @example ```ts
    * const caCert = await Deno.readTextFile("./ca.pem");
    * // Load a client key and certificate that we'll use to connect
-   * const { key, cert } = await loadKey("./cert.crt", "./key.key");
+   * const key = await Deno.readTextFile("./cert.crt");
+   * const value = await Deno.readTextFile("./key.key");
    * const client = Deno.createHttpClient({ caCerts: [ caCert ], key, cert });
    * const response = await fetch("https://myserver.com", { client });
    * ```

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -966,14 +966,9 @@ declare namespace Deno {
    *
    * @example ```ts
    * const caCert = await Deno.readTextFile("./ca.pem");
-   * const client = Deno.createHttpClient({ caCerts: [ caCert ] });
-   * const response = await fetch("https://myserver.com", { client });
-   * ```
-   *
-   * @example ```ts
-   * const client = Deno.createHttpClient({
-   *   proxy: { url: "http://myproxy.com:8080" }
-   * });
+   * // Load a client key and certificate that we'll use to connect
+   * const { key, cert } = await loadKey("./cert.crt", "./key.key");
+   * const client = Deno.createHttpClient({ caCerts: [ caCert ], key, cert });
    * const response = await fetch("https://myserver.com", { client });
    * ```
    *

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -882,10 +882,6 @@ declare namespace Deno {
     caCerts?: string[];
     /** A HTTP proxy to use for new connections. */
     proxy?: Proxy;
-    /** Cert chain in PEM format. */
-    cert?: string;
-    /** Server private key in PEM format. */
-    key?: string;
     /** Sets the maximum numer of idle connections per host allowed in the pool. */
     poolMaxIdlePerHost?: number;
     /** Set an optional timeout for idle sockets being kept-alive.
@@ -960,6 +956,31 @@ declare namespace Deno {
    */
   export function createHttpClient(
     options: CreateHttpClientOptions,
+  ): HttpClient;
+
+  /** **UNSTABLE**: New API, yet to be vetted.
+   *
+   * Create a custom HttpClient to use with {@linkcode fetch}. This is an
+   * extension of the web platform Fetch API which allows Deno to use custom
+   * TLS certificates and connect via a proxy while using `fetch()`.
+   *
+   * @example ```ts
+   * const caCert = await Deno.readTextFile("./ca.pem");
+   * const client = Deno.createHttpClient({ caCerts: [ caCert ] });
+   * const response = await fetch("https://myserver.com", { client });
+   * ```
+   *
+   * @example ```ts
+   * const client = Deno.createHttpClient({
+   *   proxy: { url: "http://myproxy.com:8080" }
+   * });
+   * const response = await fetch("https://myserver.com", { client });
+   * ```
+   *
+   * @category Fetch API
+   */
+  export function createHttpClient(
+    options: CreateHttpClientOptions & TlsCertifiedKeyOptions,
   ): HttpClient;
 
   /** **UNSTABLE**: New API, yet to be vetted.

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -967,8 +967,8 @@ declare namespace Deno {
    * @example ```ts
    * const caCert = await Deno.readTextFile("./ca.pem");
    * // Load a client key and certificate that we'll use to connect
-   * const key = await Deno.readTextFile("./cert.crt");
-   * const value = await Deno.readTextFile("./key.key");
+   * const key = await Deno.readTextFile("./key.key");
+   * const cert = await Deno.readTextFile("./cert.crt");
    * const client = Deno.createHttpClient({ caCerts: [ caCert ], key, cert });
    * const response = await fetch("https://myserver.com", { client });
    * ```

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -25,12 +25,7 @@ const { ObjectDefineProperty } = primordials;
  */
 function createHttpClient(options) {
   options.caCerts ??= [];
-  const keyPair = loadTlsKeyPair(
-    options.cert,
-    undefined,
-    options.key,
-    undefined,
-  );
+  const keyPair = loadTlsKeyPair(options);
   return new HttpClient(
     op_fetch_custom_client(
       options,

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -25,7 +25,7 @@ const { ObjectDefineProperty } = primordials;
  */
 function createHttpClient(options) {
   options.caCerts ??= [];
-  const keyPair = loadTlsKeyPair(options);
+  const keyPair = loadTlsKeyPair("Deno.createHttpClient", options);
   return new HttpClient(
     op_fetch_custom_client(
       options,

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -115,6 +115,7 @@ function hasTlsKeyPairOptions(options) {
  * returns a special Null keypair.
  */
 function loadTlsKeyPair({
+  keyFormat,
   cert,
   certFile,
   certChain,
@@ -122,6 +123,9 @@ function loadTlsKeyPair({
   keyFile,
   privateKey,
 }) {
+  if (keyFormat !== undefined && keyFormat !== "pem") {
+    throw new TypeError("If keyFormat is specified, it must be pem");
+  }
   // Pick one pair of cert/key, certFile/keyFile or certChain/privateKey
   if ((cert !== undefined) ^ (key !== undefined)) {
     throw new TypeError("If cert is specified, key must also be specified");

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -123,21 +123,22 @@ function loadTlsKeyPair({
   keyFile,
   privateKey,
 }) {
+  // Check for "pem" format
   if (keyFormat !== undefined && keyFormat !== "pem") {
-    throw new TypeError("If keyFormat is specified, it must be pem");
+    throw new TypeError('If `keyFormat` is specified, it must be "pem"');
   }
   // Pick one pair of cert/key, certFile/keyFile or certChain/privateKey
   if ((cert !== undefined) ^ (key !== undefined)) {
-    throw new TypeError("If cert is specified, key must also be specified");
+    throw new TypeError("If `cert` is specified, `key` must also be specified");
   }
   if ((certFile !== undefined) ^ (keyFile !== undefined)) {
     throw new TypeError(
-      "If certFile is specified, keyFile must also be specified",
+      "If `certFile` is specified, `keyFile` must also be specified",
     );
   }
   if ((certChain !== undefined) ^ (privateKey !== undefined)) {
     throw new TypeError(
-      "If certChain is specified, privateKey must also be specified",
+      "If `certChain` is specified, `privateKey` must also be specified",
     );
   }
 
@@ -157,24 +158,24 @@ function loadTlsKeyPair({
     internals.warnOnDeprecatedApi(
       "Deno.TlsCertifiedKeyOptions.keyFile",
       new Error().stack,
-      "Pass the key file contents to the `Deno.TlsCertifiedKeyOptions.key` option instead.",
+      "Pass the key file's contents to the `Deno.TlsCertifiedKeyPem.key` option instead.",
     );
     internals.warnOnDeprecatedApi(
       "Deno.TlsCertifiedKeyOptions.certFile",
       new Error().stack,
-      "Pass the cert file contents to the `Deno.TlsCertifiedKeyOptions.cert` option instead.",
+      "Pass the cert file's contents to the `Deno.TlsCertifiedKeyPem.cert` option instead.",
     );
     return op_tls_key_static_from_file("Deno.listenTls", certFile, keyFile);
   } else if (certChain !== undefined) {
     internals.warnOnDeprecatedApi(
       "Deno.TlsCertifiedKeyOptions.privateKey",
       new Error().stack,
-      "Use the `Deno.TlsCertifiedKeyOptions.key` option instead.",
+      "Use the `Deno.TlsCertifiedKeyPem.key` option instead.",
     );
     internals.warnOnDeprecatedApi(
       "Deno.TlsCertifiedKeyOptions.certChain",
       new Error().stack,
-      "Use the `Deno.TlsCertifiedKeyOptions.cert` option instead.",
+      "Use the `Deno.TlsCertifiedKeyPem.cert` option instead.",
     );
     return op_tls_key_static_from_file("Deno.listenTls", certChain, privateKey);
   } else if (cert !== undefined) {

--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -151,24 +151,24 @@ function loadTlsKeyPair({
 
   if (certFile !== undefined) {
     internals.warnOnDeprecatedApi(
-      "Deno.ListenTlsOptions.keyFile",
+      "Deno.TlsCertifiedKeyOptions.keyFile",
       new Error().stack,
       "Pass the key file contents to the `Deno.TlsCertifiedKeyOptions.key` option instead.",
     );
     internals.warnOnDeprecatedApi(
-      "Deno.ListenTlsOptions.certFile",
+      "Deno.TlsCertifiedKeyOptions.certFile",
       new Error().stack,
       "Pass the cert file contents to the `Deno.TlsCertifiedKeyOptions.cert` option instead.",
     );
     return op_tls_key_static_from_file("Deno.listenTls", certFile, keyFile);
   } else if (certChain !== undefined) {
     internals.warnOnDeprecatedApi(
-      "Deno.ConnectTlsOptions.privateKey",
+      "Deno.TlsCertifiedKeyOptions.privateKey",
       new Error().stack,
       "Use the `Deno.TlsCertifiedKeyOptions.key` option instead.",
     );
     internals.warnOnDeprecatedApi(
-      "Deno.ConnectTlsOptions.certChain",
+      "Deno.TlsCertifiedKeyOptions.certChain",
       new Error().stack,
       "Use the `Deno.TlsCertifiedKeyOptions.cert` option instead.",
     );

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -412,6 +412,16 @@ declare namespace Deno {
      *
      * @default {"127.0.0.1"} */
     hostname?: string;
+    /** Path to a file containing a PEM formatted list of root certificates that will
+     * be used in addition to the default root certificates to verify the peer's certificate. Requires
+     * `--allow-read`.
+     *
+     * @tags allow-read
+     * @deprecated This will be removed in Deno 2.0. See the
+     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
+     * for migration instructions.
+     */
+    certFile?: string;
     /** A list of root certificates that will be used in addition to the
      * default root certificates to verify the peer's certificate.
      *

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -212,7 +212,7 @@ declare namespace Deno {
    * `PEM`-format (Privacy Enhanced Mail, https://www.rfc-editor.org/rfc/rfc1422) which can be identified by having
    * `-----BEGIN-----` and `-----END-----` markers at the beginning and end of the strings. This type of key is not compatible
    * with `DER`-format keys which are binary.
-   * 
+   *
    * Deno supports RSA, EC, and PKCS8-format keys.
    *
    * ```ts
@@ -441,6 +441,27 @@ declare namespace Deno {
    * @category Network
    */
   export function connectTls(options: ConnectTlsOptions): Promise<TlsConn>;
+
+  /** Establishes a secure connection over TLS (transport layer security) using
+   * an optional cert file, client certificate, hostname (default is "127.0.0.1") and
+   * port.  The cert file is optional and if not included Mozilla's root certificates will
+   * be used (see also https://github.com/ctz/webpki-roots for specifics)
+   *
+   * ```ts
+   * const caCert = await Deno.readTextFile("./certs/my_custom_root_CA.pem");
+   * const key = "----BEGIN PRIVATE KEY----...";
+   * const cert = "----BEGIN CERTIFICATE----...";
+   * const conn1 = await Deno.connectTls({ port: 80, key, cert });
+   * const conn2 = await Deno.connectTls({ caCerts: [caCert], hostname: "192.0.2.1", port: 80, key, cert });
+   * const conn3 = await Deno.connectTls({ hostname: "[2001:db8::1]", port: 80, key, cert });
+   * const conn4 = await Deno.connectTls({ caCerts: [caCert], hostname: "golang.org", port: 80, key, cert });
+   * ```
+   *
+   * Requires `allow-net` permission.
+   *
+   * @tags allow-net
+   * @category Network
+   */
   export function connectTls(
     options: ConnectTlsOptions & TlsCertifiedKeyOptions,
   ): Promise<TlsConn>;

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -203,7 +203,7 @@ declare namespace Deno {
    * @category Network
    */
   export type TlsCertifiedKeyOptions =
-    | TlsCertifiedKeyFromString
+    | TlsCertifiedKeyPem
     | TlsCertifiedKeyFromFile
     | TlsCertifiedKeyConnectTls;
 
@@ -224,7 +224,9 @@ declare namespace Deno {
    *
    * @category Network
    */
-  export interface TlsCertifiedKeyFromString {
+  export interface TlsCertifiedKeyPem {
+    /** The format of this key material, which must be PEM. */
+    keyFormat?: "pem";
     /** Private key in `PEM` format. RSA, EC, and PKCS8-format keys are supported. */
     key: string;
     /** Certificate chain in `PEM` format. */

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -212,6 +212,8 @@ declare namespace Deno {
    * `PEM`-format (Privacy Enhanced Mail, https://www.rfc-editor.org/rfc/rfc1422) which can be identified by having
    * `-----BEGIN-----` and `-----END-----` markers at the beginning and end of the strings. This type of key is not compatible
    * with `DER`-format keys which are binary.
+   * 
+   * Deno supports RSA, EC, and PKCS8-format keys.
    *
    * ```ts
    * const key = {
@@ -223,9 +225,9 @@ declare namespace Deno {
    * @category Network
    */
   export interface TlsCertifiedKeyFromString {
-    /** Private key in `PEM` format */
+    /** Private key in `PEM` format. RSA, EC, and PKCS8-format keys are supported. */
     key: string;
-    /** Certificate chain in `PEM` format */
+    /** Certificate chain in `PEM` format. */
     cert: string;
   }
 
@@ -265,7 +267,7 @@ declare namespace Deno {
    */
   export interface TlsCertifiedKeyConnectTls {
     /**
-     * PEM formatted client certificate chain.
+     * Certificate chain in `PEM` format.
      *
      * @deprecated This will be removed in Deno 2.0. See the
      * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
@@ -273,7 +275,7 @@ declare namespace Deno {
      */
     certChain: string;
     /**
-     * PEM formatted (RSA or PKCS8) private key of client certificate.
+     * Private key in `PEM` format. RSA, EC, and PKCS8-format keys are supported.
      *
      * @deprecated This will be removed in Deno 2.0. See the
      * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -1336,7 +1336,7 @@ Deno.test(
         });
       },
       TypeError,
-      "Cannot specify both `privateKey` and `key` for `Deno.connectTls`.",
+      "Cannot specify both `key` and `privateKey` for `Deno.connectTls`.",
     );
   },
 );

--- a/tests/unit/tls_test.ts
+++ b/tests/unit/tls_test.ts
@@ -1336,7 +1336,7 @@ Deno.test(
         });
       },
       TypeError,
-      "Cannot specify both `privateKey` and `key`",
+      "Cannot specify both `privateKey` and `key` for `Deno.connectTls`.",
     );
   },
 );


### PR DESCRIPTION
Removes the certificate options from all the interfaces and replaces them with a new `TlsCertifiedKeyOptions`. This allows us to centralize the documentation for TLS key management for both client and server, and will allow us to add key object support in the future.

Also adds an option `keyFormat` field to the cert/key that must be omitted or set to `pem`. This will allow us to load other format keys in the future `der`, `pfx`, etc.

In a future PR, we will add a way to load a certified key object, and we will add another option to `TlsCertifiedKeyOptions` like so:

```ts
export interface TlsCertifiedKeyOptions =
    | TlsCertifiedKeyPem
    | TlsCertifiedKeyFromFile
    | TlsCertifiedKeyConnectTls
    | { key: Deno.CertifiedKey }
```
