### PR TITLE
perf(lsp): replace document registry source cache on update

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -304,6 +304,7 @@ delete Object.prototype.__proto__;
             /** @type {ts.IScriptSnapshot} */ (sourceFile.scriptSnapShot),
           ),
         );
+        documentRegistrySourceFileCache.set(mapKey, sourceFile);
       }
       return sourceFile;
     },


### PR DESCRIPTION
Fixes redundant calls to `op_resolve()` for unchanged modules.