### PR TITLE
perf(lsp): use a stub module in tsc for failed resolutions

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4039,13 +4039,15 @@ fn op_resolve<'s>(
       );
       resolved
         .into_iter()
-        .map(|o| {
-          o.map(|(s, mt)| {
-            (
-              state.specifier_map.denormalize(&s),
-              mt.as_ts_extension().to_string(),
-            )
-          })
+        .map(|o| match o {
+          Some((s, mt)) => Some((
+            state.specifier_map.denormalize(&s),
+            mt.as_ts_extension().to_string(),
+          )),
+          None => Some((
+            "internal://missing_dependency.d.ts".to_string(),
+            ".d.ts".to_string(),
+          )),
         })
         .collect()
     }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4028,7 +4028,7 @@ fn op_load<'s>(
 
 #[op2]
 #[serde]
-fn op_resolve<'s>(
+fn op_resolve(
   state: &mut OpState,
   #[serde] args: ResolveArgs,
 ) -> Result<Vec<Option<(String, String)>>, AnyError> {

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -725,14 +725,6 @@ delete Object.prototype.__proto__;
           if (item) {
             isCjsCache.add(item);
             const [resolvedFileName, extension] = item;
-            if (resolvedFileName.startsWith("node:")) {
-              // probably means the user doesn't have @types/node, so resolve to stub
-              return {
-                resolvedFileName: "internal://missing_dependency.d.ts",
-                extension: ".d.ts",
-                isExternalLibraryImport: false,
-              };
-            }
             return {
               resolvedFileName,
               extension,

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -726,8 +726,12 @@ delete Object.prototype.__proto__;
             isCjsCache.add(item);
             const [resolvedFileName, extension] = item;
             if (resolvedFileName.startsWith("node:")) {
-              // probably means the user doesn't have @types/node, so resolve to undefined
-              return undefined;
+              // probably means the user doesn't have @types/node, so resolve to stub
+              return {
+                resolvedFileName: "internal://missing_dependency.d.ts",
+                extension: ".d.ts",
+                isExternalLibraryImport: false,
+              };
             }
             return {
               resolvedFileName,


### PR DESCRIPTION
Previously when you edited any import statement, the ts server would re-resolve `jsxImportSource` from all modules in the graph. The resolution would return null because it's not a deno_graph-discovered dependency of those modules. Resolutions that return null are frequently retried. Instead make it resolve to a stub module `internal://missing_dependency.d.ts`.

Also resolve `jsxImportSource` up front using the `deno.json` as the referrer.