### PR TITLE
fix(lsp): Denormalize specifiers before calling `$projectChanged`

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -303,6 +303,10 @@ impl TsServer {
     new_project_version: String,
     config_changed: bool,
   ) {
+    let modified_scripts = modified_scripts
+      .into_iter()
+      .map(|(spec, change)| (self.specifier_map.denormalize(spec), change))
+      .collect::<Vec<_>>();
     let req = TscRequest {
       method: "$projectChanged",
       args: json!([modified_scripts, new_project_version, config_changed,]),

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -304,7 +304,7 @@ impl TsServer {
     config_changed: bool,
   ) {
     let modified_scripts = modified_scripts
-      .into_iter()
+      .iter()
       .map(|(spec, change)| (self.specifier_map.denormalize(spec), change))
       .collect::<Vec<_>>();
     let req = TscRequest {


### PR DESCRIPTION
Fixes the regression described in https://github.com/denoland/deno/pull/23293#issuecomment-2049819724. This affected jupyter notebooks, as the LSP was passing in already denormalized specifiers, while the jupyter kernel was not. We need to denormalize the specifiers to evict the proper keys from our caches.