### PR TITLE
fix: Deno.ServeTlsOptions is an interface

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -6276,7 +6276,21 @@ declare namespace Deno {
    *
    * @category HTTP Server
    */
-  export type ServeTlsOptions = ServeOptions & TlsCertifiedKeyOptions;
+  export interface ServeTlsOptions extends ServeOptions, TlsCertifiedKeyPem {}
+
+  /** Additional options which are used when opening a TLS (HTTPS) server.
+   *
+   * @category HTTP Server
+   */
+  export interface ServeTlsOptions
+    extends ServeOptions, TlsCertifiedKeyFromFile {}
+
+  /** Additional options which are used when opening a TLS (HTTPS) server.
+   *
+   * @category HTTP Server
+   */
+  export interface ServeTlsOptions
+    extends ServeOptions, TlsCertifiedKeyConnectTls {}
 
   /**
    * @category HTTP Server

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3909,4 +3909,5 @@ Deno.test(
 
 // DO NOT REMOVE.
 // Regression test to make sure that `ServeTlsOptions` is an interface.
+// deno-lint-ignore no-empty-interface
 interface MyServeTlsOptions extends Deno.ServeTlsOptions {}

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -3906,3 +3906,7 @@ Deno.test(
     assert(respText === "Internal Server Error");
   },
 );
+
+// DO NOT REMOVE.
+// Regression test to make sure that `ServeTlsOptions` is an interface.
+interface MyServeTlsOptions extends Deno.ServeTlsOptions {}


### PR DESCRIPTION
Fixes `Deno.ServeTlsOptions` to be an interface that was changed to be a type by mistake in https://github.com/denoland/deno/pull/23300.