### PR TITLE
perf(lsp): Only deserialize response from `op_respond` once

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1060,8 +1060,7 @@ impl TsServer {
     }
     let value = rx.await??;
     drop(droppable_token);
-    let Response { data } = serde_json::from_str::<Response<R>>(&value)?;
-    Ok(data)
+    Ok(serde_json::from_str(&value)?)
   }
 }
 
@@ -3847,12 +3846,6 @@ impl SelectionRange {
       }),
     }
   }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct Response<T> {
-  // id: usize,
-  data: T,
 }
 
 #[derive(Debug, Default)]

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1028,7 +1028,7 @@ delete Object.prototype.__proto__;
   // and language server use it with inefficient serialization. Id is not used
   // anyway...
   function respond(id, data = null) {
-    ops.op_respond({ id, data });
+    ops.op_respond(JSON.stringify({ id, data }));
   }
 
   function serverRequest(id, method, args) {

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1021,14 +1021,14 @@ delete Object.prototype.__proto__;
   }
 
   /**
-   * @param {number} id
+   * @param {number} _id
    * @param {any} data
    */
   // TODO(bartlomieju): this feels needlessly generic, both type chcking
   // and language server use it with inefficient serialization. Id is not used
   // anyway...
-  function respond(id, data = null) {
-    ops.op_respond(JSON.stringify({ id, data }));
+  function respond(_id, data = null) {
+    ops.op_respond(JSON.stringify(data));
   }
 
   function serverRequest(id, method, args) {


### PR DESCRIPTION
Previously we were deserializing it twice - once to `serde_json::Value`, and then again from the `serde_json::Value` to a concrete type