### PR TITLE
fix(ext/node): use ext/io stdio in WriteStream

### DIFF
--- a/ext/node/polyfills/tty.js
+++ b/ext/node/polyfills/tty.js
@@ -80,7 +80,7 @@ export class WriteStream extends Socket {
     if (fd > 2) throw new Error("Only fd 0, 1 and 2 are supported.");
 
     const tty = new TTY(
-      fd === 0 ? Deno.stdin : fd === 1 ? Deno.stdout : Deno.stderr,
+      fd === 0 ? io.stdin : fd === 1 ? io.stdout : io.stderr,
     );
 
     super({


### PR DESCRIPTION
This is the same issue as https://github.com/denoland/deno/pull/23044 but in `WriteStream`.

Adding a docusarus test in npm_smoke_tests repo.
