### PR TITLE
fix(lsp): ensure project version is incremented when config changes

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1628,6 +1628,7 @@ mod tests {
       config.tree.inject_config_file(config_file).await;
     }
     StateSnapshot {
+      project_version: 0,
       documents,
       assets: Default::default(),
       cache_metadata: cache::CacheMetadata::new(Arc::new(

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -851,7 +851,6 @@ pub struct Documents {
   redirect_resolver: Arc<RedirectResolver>,
   /// If --unstable-sloppy-imports is enabled.
   unstable_sloppy_imports: bool,
-  project_version: usize,
 }
 
 impl Documents {
@@ -878,7 +877,6 @@ impl Documents {
       has_injected_types_node_package: false,
       redirect_resolver: Arc::new(RedirectResolver::new(cache)),
       unstable_sloppy_imports: false,
-      project_version: 0,
     }
   }
 
@@ -888,14 +886,6 @@ impl Documents {
       .values()
       .flat_map(|i| i.dependencies.values())
       .flat_map(|value| value.get_type().or_else(|| value.get_code()))
-  }
-
-  pub fn project_version(&self) -> String {
-    self.project_version.to_string()
-  }
-
-  pub fn increment_project_version(&mut self) {
-    self.project_version += 1;
   }
 
   /// "Open" a document from the perspective of the editor, meaning that
@@ -925,7 +915,6 @@ impl Documents {
     self.file_system_docs.set_dirty(true);
 
     self.open_docs.insert(specifier, document.clone());
-    self.increment_project_version();
     self.dirty = true;
     document
   }
@@ -957,7 +946,6 @@ impl Documents {
       self.get_npm_resolver(),
     )?;
     self.open_docs.insert(doc.specifier().clone(), doc.clone());
-    self.increment_project_version();
     Ok(doc)
   }
 
@@ -985,7 +973,6 @@ impl Documents {
         .docs
         .insert(specifier.clone(), document);
 
-      self.increment_project_version();
       self.dirty = true;
     }
     Ok(())

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -165,7 +165,7 @@ delete Object.prototype.__proto__;
   /** @type {ts.CompilerOptions | null} */
   let tsConfigCache = null;
 
-  /** @type {string | null} */
+  /** @type {number | null} */
   let projectVersionCache = null;
 
   const ChangeKind = {
@@ -1039,7 +1039,7 @@ delete Object.prototype.__proto__;
       case "$projectChanged": {
         /** @type {[string, number][]} */
         const changedScripts = args[0];
-        /** @type {string} */
+        /** @type {number} */
         const newProjectVersion = args[1];
         /** @type {boolean} */
         const configChanged = args[2];


### PR DESCRIPTION
I'm running into a node resolution bug in the lsp only and while tracking it down I noticed this one.

Fixed by moving the project version out of `Documents`.