### PR TITLE
fix(test): strip ansi colors in junit output

### DIFF
--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -3,13 +3,10 @@
 use std::collections::VecDeque;
 use std::path::PathBuf;
 
-use lazy_regex::Lazy;
+use console_static_text::ansi::strip_ansi_codes;
 
 use super::fmt::to_relative_path_or_remote_url;
 use super::*;
-
-static ANSI_ESCAPE_REMOVE: Lazy<Regex> =
-  lazy_regex::lazy_regex!(r#"\x1b\[([\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e])"#);
 
 pub struct JunitTestReporter {
   cwd: Url,
@@ -39,10 +36,8 @@ impl JunitTestReporter {
       TestResult::Failed(failure) => {
         let message = failure.overview();
         let detail = failure.detail();
-        let message_stripped =
-          ANSI_ESCAPE_REMOVE.replace_all(message.as_str(), "");
-        let detail_stripped =
-          ANSI_ESCAPE_REMOVE.replace_all(detail.as_str(), "");
+        let message_stripped = strip_ansi_codes(message.as_str());
+        let detail_stripped = strip_ansi_codes(detail.as_str());
         quick_junit::TestCaseStatus::NonSuccess {
           kind: quick_junit::NonSuccessKind::Failure,
           message: Some(message_stripped.into()),
@@ -70,10 +65,8 @@ impl JunitTestReporter {
       TestStepResult::Failed(failure) => {
         let message = failure.overview();
         let detail = failure.detail();
-        let message_stripped =
-          ANSI_ESCAPE_REMOVE.replace_all(message.as_str(), "");
-        let detail_stripped =
-          ANSI_ESCAPE_REMOVE.replace_all(detail.as_str(), "");
+        let message_stripped = strip_ansi_codes(message.as_str());
+        let detail_stripped = strip_ansi_codes(detail.as_str());
         quick_junit::TestCaseStatus::NonSuccess {
           kind: quick_junit::NonSuccessKind::Failure,
           message: Some(message_stripped.into()),

--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -338,6 +338,12 @@ itest!(junit_multiple_test_files {
   exit_code: 1,
 });
 
+itest!(junit_strip_ansi {
+  args: "test --reporter junit test/fail_color.ts",
+  output: "test/junit_strip_ansi.junit.out",
+  exit_code: 1,
+});
+
 #[test]
 fn junit_path() {
   let context = TestContextBuilder::new().use_temp_cwd().build();

--- a/tests/testdata/test/fail_color.ts
+++ b/tests/testdata/test/fail_color.ts
@@ -1,0 +1,10 @@
+Deno.test("fail color", () => {
+  throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
+});
+
+// deno-lint-ignore no-explicit-any
+Deno.test("step fail color", async (t: any) => {
+  await t.step("step", () => {
+    throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
+  });
+});

--- a/tests/testdata/test/fail_color.ts
+++ b/tests/testdata/test/fail_color.ts
@@ -2,8 +2,7 @@ Deno.test("fail color", () => {
   throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
 });
 
-// deno-lint-ignore no-explicit-any
-Deno.test("step fail color", async (t: any) => {
+Deno.test("step fail color", async (t) => {
   await t.step("step", () => {
     throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
   });

--- a/tests/testdata/test/junit_strip_ansi.junit.out
+++ b/tests/testdata/test/junit_strip_ansi.junit.out
@@ -1,0 +1,27 @@
+Check file:///[WILDCARD]/test/fail_color.ts
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="deno test" tests="3" failures="3" errors="0" time="[WILDCARD]">
+    <testsuite name="./test/fail_color.ts" tests="3" disabled="0" errors="0" failures="3">
+        <testcase name="fail color" classname="./test/fail_color.ts" time="[WILDCARD]" line="1" col="6">
+            <failure message="Uncaught Error: RedMessage: This should be red text">Error: RedMessage: This should be red text
+  throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
+        ^
+    at file:///[WILDCARD]/test/fail_color.ts:2:9</failure>
+        </testcase>
+        <testcase name="step fail color" classname="./test/fail_color.ts" time="[WILDCARD]" line="6" col="6">
+            <failure message="1 test step failed">1 test step failed.</failure>
+        </testcase>
+        <testcase name="step fail color &gt; step" classname="./test/fail_color.ts" time="[WILDCARD]" line="7" col="11">
+            <failure message="Uncaught Error: RedMessage: This should be red text">Error: RedMessage: This should be red text
+    throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
+          ^
+    at file:///[WILDCARD]/test/fail_color.ts:8:11
+    at innerWrapped (ext:cli/40_test.js:174:11)
+    at exitSanitizer (ext:cli/40_test.js:103:33)
+    at Object.outerWrapped [as fn] (ext:cli/40_test.js:117:20)
+    at TestContext.step (ext:cli/40_test.js:475:37)
+    at file:///[WILDCARD]/test/fail_color.ts:7:11</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+error: Test failed

--- a/tests/testdata/test/junit_strip_ansi.junit.out
+++ b/tests/testdata/test/junit_strip_ansi.junit.out
@@ -16,10 +16,7 @@ Check file:///[WILDCARD]/test/fail_color.ts
     throw new Error(`RedMessage: \x1b[31mThis should be red text\x1b[39m`);
           ^
     at file:///[WILDCARD]/test/fail_color.ts:8:11
-    at innerWrapped (ext:cli/40_test.js:174:11)
-    at exitSanitizer (ext:cli/40_test.js:103:33)
-    at Object.outerWrapped [as fn] (ext:cli/40_test.js:117:20)
-    at TestContext.step (ext:cli/40_test.js:475:37)
+    at [WILDCARD]
     at file:///[WILDCARD]/test/fail_color.ts:7:11</failure>
         </testcase>
     </testsuite>


### PR DESCRIPTION
This PR strips ansi escape codes in the JUnit reporter.

Fixes https://github.com/denoland/deno/issues/23316