### PR TITLE
fix(lsp): improved cjs tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,10 +2641,11 @@ checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "file_test_runner"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13bacb20a988be248a13adc6011bce718648f78d4684d4dd0444d05256f4a7b"
+checksum = "b66e9ef00f9f6b82b030b7a9d659030f73498921d4c021b0772e75dfd7090d80"
 dependencies = [
+ "anyhow",
  "crossbeam-channel",
  "deno_terminal",
  "parking_lot 0.12.1",

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3996,6 +3996,7 @@ struct LoadResponse {
   data: Arc<str>,
   script_kind: i32,
   version: Option<String>,
+  is_cjs: bool,
 }
 
 #[op2]
@@ -4018,6 +4019,10 @@ fn op_load<'s>(
         data: doc.text(),
         script_kind: crate::tsc::as_ts_script_kind(doc.media_type()),
         version: state.script_version(&specifier),
+        is_cjs: matches!(
+          doc.media_type(),
+          MediaType::Cjs | MediaType::Cts | MediaType::Dcts
+        ),
       })
     };
 

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -223,6 +223,13 @@ impl CliNodeResolver {
     Ok(specifier)
   }
 
+  pub fn url_to_node_resolution(
+    &self,
+    specifier: ModuleSpecifier,
+  ) -> Result<NodeResolution, AnyError> {
+    self.node_resolver.url_to_node_resolution(specifier)
+  }
+
   fn handle_node_resolve_result(
     &self,
     result: Result<Option<NodeResolution>, AnyError>,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -43,7 +43,7 @@ deno_lockfile.workspace = true
 deno_terminal.workspace = true
 deno_tls.workspace = true
 fastwebsockets = { workspace = true, features = ["upgrade", "unstable-split"] }
-file_test_runner = "0.2.0"
+file_test_runner = "0.4.0"
 flaky_test = "=0.1.0"
 http.workspace = true
 http-body-util.workspace = true

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -12310,24 +12310,29 @@ fn lsp_cjs_internal_types_default_export() {
 
   let mut client = context.new_lsp_command().build();
   client.initialize_default();
+  // this was previously being resolved as ESM and not correctly as CJS
+  let node_modules_index_d_ts = temp_dir.path().join(
+    "node_modules/@denotest/cjs-internal-types-default-export/index.d.ts",
+  );
+  client.did_open(json!({
+    "textDocument": {
+      "uri": node_modules_index_d_ts.uri_file(),
+      "languageId": "typescript",
+      "version": 1,
+      "text": node_modules_index_d_ts.read_to_string(),
+    }
+  }));
   let main_url = temp_dir.path().join("main.ts").uri_file();
-  client.did_open(
+  let diagnostics = client.did_open(
     json!({
       "textDocument": {
         "uri": main_url,
         "languageId": "typescript",
         "version": 1,
-        "text": "import * as mod from '@denotest/cjs-internal-types-default-export';\nmod.",
+        "text": "import * as mod from '@denotest/cjs-internal-types-default-export';\nmod.add(1, 2);",
       }
     }),
   );
-  let list =
-    client.get_completion_list(main_url, (1, 4), json!({ "triggerKind": 1 }));
-  assert!(!list.is_incomplete);
-  let items = list
-    .items
-    .iter()
-    .map(|item| item.label.clone())
-    .collect::<Vec<_>>();
-  assert_eq!(items, vec!["add"]);
+  // previously, diagnostic about `add` not being callable
+  assert_eq!(json!(diagnostics.all()), json!([]));
 }

--- a/tests/specs/mod.rs
+++ b/tests/specs/mod.rs
@@ -9,6 +9,10 @@ use std::sync::Arc;
 
 use deno_core::anyhow::Context;
 use deno_core::serde_json;
+use file_test_runner::collection::collect_tests_or_exit;
+use file_test_runner::collection::strategies::TestPerDirectoryCollectionStrategy;
+use file_test_runner::collection::CollectOptions;
+use file_test_runner::collection::CollectedTest;
 use serde::Deserialize;
 use test_util::tests_path;
 use test_util::PathRef;
@@ -78,15 +82,13 @@ struct StepMetaData {
 }
 
 pub fn main() {
-  let root_category =
-    file_test_runner::collect_tests_or_exit(file_test_runner::CollectOptions {
-      base: tests_path().join("specs").to_path_buf(),
-      strategy: file_test_runner::FileCollectionStrategy::TestPerDirectory {
-        file_name: MANIFEST_FILE_NAME.to_string(),
-      },
-      root_category_name: "specs".to_string(),
-      filter_override: None,
-    });
+  let root_category = collect_tests_or_exit(CollectOptions {
+    base: tests_path().join("specs").to_path_buf(),
+    strategy: Box::new(TestPerDirectoryCollectionStrategy {
+      file_name: MANIFEST_FILE_NAME.to_string(),
+    }),
+    filter_override: None,
+  });
 
   if root_category.is_empty() {
     return; // all tests filtered out
@@ -112,15 +114,13 @@ pub fn main() {
           output.extend(panic_output);
           file_test_runner::TestResult::Failed { output }
         }
+        file_test_runner::TestResult::Steps(_) => unreachable!(),
       }
     }),
   );
 }
 
-fn run_test(
-  test: &file_test_runner::CollectedTest,
-  diagnostic_logger: Rc<RefCell<Vec<u8>>>,
-) {
+fn run_test(test: &CollectedTest, diagnostic_logger: Rc<RefCell<Vec<u8>>>) {
   let metadata_path = PathRef::new(&test.path);
   let metadata_value = metadata_path.read_jsonc_value();
   // checking for "steps" leads to a more targeted error message

--- a/tests/specs/mod.rs
+++ b/tests/specs/mod.rs
@@ -69,6 +69,7 @@ struct StepMetaData {
   pub clean_deno_dir: bool,
   pub args: VecOrString,
   pub cwd: Option<String>,
+  pub command_name: Option<String>,
   #[serde(default)]
   pub envs: HashMap<String, String>,
   pub output: String,
@@ -180,6 +181,10 @@ fn run_test(
     };
     let command = match &step.cwd {
       Some(cwd) => command.current_dir(cwd),
+      None => command,
+    };
+    let command = match &step.command_name {
+      Some(command_name) => command.name(command_name),
       None => command,
     };
     let output = command.run();

--- a/tests/specs/npm/cjs_internal_types_default_export/__test__.jsonc
+++ b/tests/specs/npm/cjs_internal_types_default_export/__test__.jsonc
@@ -1,0 +1,15 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_FUTURE": "1"
+  },
+  "steps": [{
+    "commandName": "npm",
+    "args": "install",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "check main.ts",
+    "exitCode": 1,
+    "output": "main.out"
+  }]
+}

--- a/tests/specs/npm/cjs_internal_types_default_export/main.out
+++ b/tests/specs/npm/cjs_internal_types_default_export/main.out
@@ -1,0 +1,5 @@
+Check file:///[WILDLINE]/main.ts
+error: TS2345 [ERROR]: Argument of type 'string' is not assignable to parameter of type 'number'.
+add(1, "test"); // should error
+       ~~~~~~
+    at file:///[WILDLINE]/main.ts:3:8

--- a/tests/specs/npm/cjs_internal_types_default_export/main.ts
+++ b/tests/specs/npm/cjs_internal_types_default_export/main.ts
@@ -1,0 +1,3 @@
+import { add } from "@denotest/cjs-internal-types-default-export";
+
+add(1, "test"); // should error

--- a/tests/specs/npm/cjs_internal_types_default_export/package.json
+++ b/tests/specs/npm/cjs_internal_types_default_export/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/cjs-internal-types-default-export": "*"
+  }
+}

--- a/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/add.d.ts
+++ b/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/add.d.ts
@@ -1,0 +1,3 @@
+const _default: (a: number, b: number) => number;
+
+export default _default;

--- a/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/index.d.ts
+++ b/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/index.d.ts
@@ -1,0 +1,1 @@
+export { default as add } from './add';

--- a/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/index.js
+++ b/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports.add = (a, b) => a + b;

--- a/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/package.json
+++ b/tests/testdata/npm/registry/@denotest/cjs-internal-types-default-export/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@denotest/cjs-internal-types-default-export",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Our cjs tracking was a bit broken. It was marking stuff as esm that was actually cjs leading to type checking errors.