### PR TITLE
fix(ext/node): panic on 'worker_threads.receiveMessageOnPort'

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -17,6 +17,7 @@ import {
   MessagePort,
   MessagePortIdSymbol,
   MessagePortPrototype,
+  MessagePortReceiveMessageOnPortSymbol,
   nodeWorkerThreadCloseCb,
   refMessagePort,
   serializeJsMessageData,
@@ -441,6 +442,7 @@ export function receiveMessageOnPort(port: MessagePort): object | undefined {
     err["code"] = "ERR_INVALID_ARG_TYPE";
     throw err;
   }
+  port[MessagePortReceiveMessageOnPortSymbol] = true;
   const data = op_message_port_recv_message_sync(port[MessagePortIdSymbol]);
   if (data === null) return undefined;
   return { message: deserializeJsMessageData(data)[0] };

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -235,6 +235,7 @@ pub fn op_message_port_recv_message_sync(
   #[smi] rid: ResourceId,
 ) -> Result<Option<JsMessageData>, AnyError> {
   let resource = state.resource_table.get::<MessagePortResource>(rid)?;
+  resource.cancel.cancel();
   let mut rx = resource.port.rx.borrow_mut();
 
   match rx.try_recv() {

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -414,3 +414,25 @@ Deno.test({
     mainPort.close();
   },
 });
+
+// Regression test for https://github.com/denoland/deno/issues/23362
+Deno.test("[node/worker_threads] receiveMessageOnPort works if there's pending read", async function () {
+  const { port1, port2 } = new workerThreads.MessageChannel();
+
+  const message1 = { hello: "world" };
+  const message2 = { foo: "bar" };
+
+  assertEquals(workerThreads.receiveMessageOnPort(port2), undefined);
+  port2.start();
+
+  port1.postMessage(message1);
+  port1.postMessage(message2);
+  assertEquals(workerThreads.receiveMessageOnPort(port2), {
+    message: message1,
+  });
+  assertEquals(workerThreads.receiveMessageOnPort(port2), {
+    message: message2,
+  });
+  port1.close();
+  port2.close();
+});

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -416,7 +416,7 @@ Deno.test({
 });
 
 // Regression test for https://github.com/denoland/deno/issues/23362
-Deno.test("[node/worker_threads] receiveMessageOnPort works if there's pending read", async function () {
+Deno.test("[node/worker_threads] receiveMessageOnPort works if there's pending read", function () {
   const { port1, port2 } = new workerThreads.MessageChannel();
 
   const message1 = { hello: "world" };


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/23362

Previously we were panicking if there was a pending read on a
port and `receiveMessageOnPort` was called. This is now fixed
by cancelling the pending read, trying to read a message and
resuming reading in a loop.