### PR TITLE
feat(check): allow using side effect imports with unknown module kinds (ex. css modules)

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -666,6 +666,7 @@ impl CliFactory {
         // todo(dsherret): ideally the graph container would not be used
         // for deno cache because it doesn't dynamically load modules
         DenoSubcommand::Cache(_) => GraphKind::All,
+        DenoSubcommand::Check(_) => GraphKind::TypesOnly,
         _ => self.options.type_check_mode().as_graph_kind(),
       };
       Arc::new(ModuleGraphContainer::new(graph_kind))

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -110,13 +110,23 @@ pub fn graph_valid(
         }
       }
 
+      if graph.graph_kind() == GraphKind::TypesOnly
+        && matches!(
+          error,
+          ModuleGraphError::ModuleError(ModuleError::UnsupportedMediaType(..))
+        )
+      {
+        log::debug!("Ignoring: {}", message);
+        return None;
+      }
+
       if options.is_vendoring {
         // warn about failing dynamic imports when vendoring, but don't fail completely
         if matches!(
           error,
           ModuleGraphError::ModuleError(ModuleError::MissingDynamic(_, _))
         ) {
-          log::warn!("Ignoring: {:#}", message);
+          log::warn!("Ignoring: {}", message);
           return None;
         }
 

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -508,7 +508,20 @@ fn op_load_inner(
     } else {
       &specifier
     };
-    let maybe_source = if let Some(module) = graph.get(specifier) {
+    let maybe_module = match graph.try_get(specifier) {
+      Ok(maybe_module) => maybe_module,
+      Err(err) => match err {
+        deno_graph::ModuleError::UnsupportedMediaType(_, media_type, _) => {
+          return Ok(Some(LoadResponse {
+            data: "".to_string(),
+            version: Some("1".to_string()),
+            script_kind: as_ts_script_kind(*media_type),
+          }))
+        }
+        err => return Err(err.clone().into()),
+      },
+    };
+    let maybe_source = if let Some(module) = maybe_module {
       match module {
         Module::Js(module) => {
           media_type = module.media_type;
@@ -674,7 +687,20 @@ fn resolve_graph_specifier_types(
   state: &State,
 ) -> Result<Option<(ModuleSpecifier, MediaType)>, AnyError> {
   let graph = &state.graph;
-  let maybe_module = graph.get(specifier);
+  let maybe_module = match graph.try_get(specifier) {
+    Ok(Some(module)) => Some(module),
+    Ok(None) => None,
+    Err(err) => match err {
+      deno_graph::ModuleError::UnsupportedMediaType(
+        specifier,
+        media_type,
+        _,
+      ) => {
+        return Ok(Some((specifier.clone(), *media_type)));
+      }
+      err => return Err(err.clone().into()),
+    },
+  };
   // follow the types reference directive, which may be pointing at an npm package
   let maybe_module = match maybe_module {
     Some(Module::Js(module)) => {

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -518,7 +518,7 @@ fn op_load_inner(
             script_kind: as_ts_script_kind(*media_type),
           }))
         }
-        err => return Err(err.clone().into()),
+        _ => None,
       },
     };
     let maybe_source = if let Some(module) = maybe_module {
@@ -698,7 +698,7 @@ fn resolve_graph_specifier_types(
       ) => {
         return Ok(Some((specifier.clone(), *media_type)));
       }
-      err => return Err(err.clone().into()),
+      _ => None,
     },
   };
   // follow the types reference directive, which may be pointing at an npm package

--- a/tests/specs/check/css_import/__test__.jsonc
+++ b/tests/specs/check/css_import/__test__.jsonc
@@ -14,5 +14,11 @@
     "args": "check exists_and_try_uses.ts",
     "output": "exists_and_try_uses.out",
     "exitCode": 1
+  }, {
+    "args": "check exists_dynamic_import.ts",
+    "output": "Check file:///[WILDCARD]exists_dynamic_import.ts\n"
+  }, {
+    "args": "run --check --reload exists_dynamic_import.ts",
+    "output": "Check file:///[WILDCARD]exists_dynamic_import.ts\n"
   }]
 }

--- a/tests/specs/check/css_import/__test__.jsonc
+++ b/tests/specs/check/css_import/__test__.jsonc
@@ -1,0 +1,18 @@
+{
+  "steps": [{
+    "args": "check exists.ts",
+    "output": "exists.out"
+  }, {
+    "args": "run --check exists.ts",
+    "output": "exists_run_with_check.out",
+    "exitCode": 1
+  }, {
+    "args": "check not_exists.ts",
+    "output": "not_exists.out",
+    "exitCode": 1
+  }, {
+    "args": "check exists_and_try_uses.ts",
+    "output": "exists_and_try_uses.out",
+    "exitCode": 1
+  }]
+}

--- a/tests/specs/check/css_import/exists.out
+++ b/tests/specs/check/css_import/exists.out
@@ -1,0 +1,1 @@
+Check [WILDLINE]exists.ts

--- a/tests/specs/check/css_import/exists.ts
+++ b/tests/specs/check/css_import/exists.ts
@@ -1,0 +1,2 @@
+// should not error for deno check
+import "./app.css";

--- a/tests/specs/check/css_import/exists_and_try_uses.out
+++ b/tests/specs/check/css_import/exists_and_try_uses.out
@@ -1,0 +1,5 @@
+Check file:///[WILDLINE]/exists_and_try_uses.ts
+error: TS1192 [ERROR]: Module '"file:///[WILDLINE]/app.css"' has no default export.
+import test from "./app.css";
+       ~~~~
+    at file:///[WILDLINE]/exists_and_try_uses.ts:1:8

--- a/tests/specs/check/css_import/exists_and_try_uses.ts
+++ b/tests/specs/check/css_import/exists_and_try_uses.ts
@@ -1,0 +1,3 @@
+import test from "./app.css";
+
+test(123);

--- a/tests/specs/check/css_import/exists_dynamic_import.ts
+++ b/tests/specs/check/css_import/exists_dynamic_import.ts
@@ -1,0 +1,3 @@
+if (false) {
+  await import("./app.css");
+}

--- a/tests/specs/check/css_import/exists_run_with_check.out
+++ b/tests/specs/check/css_import/exists_run_with_check.out
@@ -1,0 +1,3 @@
+error: Expected a JavaScript or TypeScript module, but identified a Unknown module. Importing these types of modules is currently not supported.
+  Specifier: file:///[WILDLINE]/app.css
+    at file:///[WILDLINE]/exists.ts:2:8

--- a/tests/specs/check/css_import/not_exists.out
+++ b/tests/specs/check/css_import/not_exists.out
@@ -1,0 +1,2 @@
+error: Module not found "file:///[WILDLINE]/not_exists.css".
+    at file:///[WILDLINE]/not_exists.ts:1:8

--- a/tests/specs/check/css_import/not_exists.ts
+++ b/tests/specs/check/css_import/not_exists.ts
@@ -1,0 +1,1 @@
+import "./not_exists.css";


### PR DESCRIPTION
This allows people to use imports like:

```ts
import "./app.css";
```

...with `deno check` in systems where there's a bundle step (ex. Vite). This will still error when using it with `deno run` or if the referenced file does not exist.

See test cases for behaviour.