### PR TITLE
chore(lsp): Add benchmark for performance on a large real-world repo

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -19,6 +19,7 @@
     ".git",
     "cli/bench/testdata/express-router.js",
     "cli/bench/testdata/npm/",
+    "cli/bench/testdata/lsp_benchdata/",
     "cli/tsc/dts/lib.d.ts",
     "cli/tsc/dts/lib.scripthost.d.ts",
     "cli/tsc/dts/lib.decorators*.d.ts",

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "tests/node_compat/runner/suite"]
 	path = tests/node_compat/runner/suite
 	url = https://github.com/denoland/node_test.git
+[submodule "cli/bench/testdata/lsp_benchdata"]
+	path = cli/bench/testdata/lsp_benchdata
+	url = https://github.com/nathanwhit/deno_lsp_benchdata

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,4 +11,4 @@
 	url = https://github.com/denoland/node_test.git
 [submodule "cli/bench/testdata/lsp_benchdata"]
 	path = cli/bench/testdata/lsp_benchdata
-	url = https://github.com/nathanwhit/deno_lsp_benchdata
+	url = https://github.com/denoland/deno_lsp_benchdata.git

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -108,7 +108,7 @@ fn bench_deco_apps_edits(deno_exe: &Path) -> Duration {
       client.write_notification(req.method(), req.params());
     } else {
       reqs += 1;
-      client.write_request_no_wait(req.method(), req.params());
+      client.write_jsonrpc(req.method(), req.params());
     }
   }
   for _ in 0..reqs {

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -9,11 +9,14 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 use test_util::lsp::LspClientBuilder;
+use test_util::PathRef;
 use tower_lsp::lsp_types as lsp;
 
 static FIXTURE_CODE_LENS_TS: &str = include_str!("testdata/code_lens.ts");
 static FIXTURE_DB_TS: &str = include_str!("testdata/db.ts");
 static FIXTURE_DB_MESSAGES: &[u8] = include_bytes!("testdata/db_messages.json");
+static FIXTURE_DECO_APPS: &[u8] =
+  include_bytes!("testdata/deco_apps_requests.json");
 
 #[derive(Debug, Deserialize)]
 enum FixtureType {
@@ -34,6 +37,107 @@ struct FixtureMessage {
   #[serde(rename = "type")]
   fixture_type: FixtureType,
   params: Value,
+}
+
+/// replaces the root directory in the URIs of the requests
+/// with the given root path
+fn patch_uris<'a>(
+  reqs: impl IntoIterator<Item = &'a mut tower_lsp::jsonrpc::Request>,
+  root: &PathRef,
+) {
+  for req in reqs {
+    let mut params = req.params().unwrap().clone();
+    let new_req = if let Some(doc) = params.get_mut("textDocument") {
+      if let Some(uri_val) = doc.get_mut("uri") {
+        let uri = uri_val.as_str().unwrap();
+        *uri_val =
+          Value::from(uri.replace(
+            "file:///",
+            &format!("file://{}/", root.to_string_lossy()),
+          ));
+      }
+      let builder = tower_lsp::jsonrpc::Request::build(req.method().to_owned());
+      let builder = if let Some(id) = req.id() {
+        builder.id(id.clone())
+      } else {
+        builder
+      };
+
+      Some(builder.params(params).finish())
+    } else {
+      None
+    };
+
+    if let Some(new_req) = new_req {
+      *req = new_req;
+    }
+  }
+}
+
+fn bench_deco_apps_edits(deno_exe: &Path) -> Duration {
+  let mut requests: Vec<tower_lsp::jsonrpc::Request> =
+    serde_json::from_slice(FIXTURE_DECO_APPS).unwrap();
+  let apps =
+    test_util::root_path().join("cli/bench/testdata/lsp_benchdata/apps");
+
+  // it's a bit wasteful to do this for every run, but it's the easiest with the way things
+  // are currently structured
+  patch_uris(&mut requests, &apps);
+
+  let mut client = LspClientBuilder::new()
+    .use_diagnostic_sync(false)
+    .set_root_dir(apps.clone())
+    .deno_exe(deno_exe)
+    .build();
+  client.initialize(|c| {
+    c.set_workspace_folders(vec![lsp_types::WorkspaceFolder {
+      uri: Url::from_file_path(&apps).unwrap(),
+      name: "apps".to_string(),
+    }]);
+    c.set_deno_enable(true);
+    c.set_unstable(true);
+    c.set_preload_limit(1000);
+    c.set_config(apps.join("deno.json").as_path().to_string_lossy());
+  });
+
+  let start = std::time::Instant::now();
+
+  let mut reqs = 0;
+  for req in requests {
+    if req.id().is_none() {
+      client.write_notification(req.method(), req.params());
+    } else {
+      reqs += 1;
+      client.write_request_no_wait(req.method(), req.params());
+    }
+  }
+  for _ in 0..reqs {
+    let _ = client.read_latest_response();
+  }
+
+  let end = start.elapsed();
+
+  // part of the motivation of including this benchmark is to see how we perform
+  // with a fairly large number of documents in memory.
+  // make sure that's the case
+  let res = client.write_request(
+    "deno/virtualTextDocument",
+    json!({
+      "textDocument": {
+        "uri": "deno:/status.md"
+      }
+    }),
+  );
+  let re = lazy_regex::regex!(r"Documents in memory: (\d+)");
+  let res = res.as_str().unwrap().to_string();
+  assert!(res.starts_with("# Deno Language Server Status"));
+  let captures = re.captures(&res).unwrap();
+  let count = captures.get(1).unwrap().as_str().parse::<usize>().unwrap();
+  assert!(count > 1000, "count: {}", count);
+
+  client.shutdown();
+
+  end
 }
 
 /// A benchmark that opens a 8000+ line TypeScript document, adds a function to
@@ -308,6 +412,15 @@ pub fn benchmarks(deno_exe: &Path) -> HashMap<String, i64> {
     (times.iter().sum::<Duration>() / times.len() as u32).as_millis() as i64;
   println!("      ({} runs, mean: {}ms)", times.len(), mean);
   exec_times.insert("code_lens".to_string(), mean);
+
+  println!("   - deco-cx/apps Multiple Edits + Navigation");
+  let mut times = Vec::new();
+  for _ in 0..5 {
+    times.push(bench_deco_apps_edits(deno_exe));
+  }
+  let mean =
+    (times.iter().sum::<Duration>() / times.len() as u32).as_millis() as i64;
+  println!("      ({} runs, mean: {}ms)", times.len(), mean);
 
   println!("<- End benchmarking lsp");
 

--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -431,7 +431,11 @@ async fn main() -> Result<()> {
   println!("Starting Deno benchmark");
 
   let target_dir = test_util::target_dir();
-  let deno_exe = test_util::deno_exe_path().to_path_buf();
+  let deno_exe = if let Ok(p) = std::env::var("DENO_BENCH_EXE") {
+    PathBuf::from(p)
+  } else {
+    test_util::deno_exe_path().to_path_buf()
+  };
   env::set_current_dir(test_util::root_path())?;
 
   let mut new_data = BenchResult {

--- a/cli/bench/testdata/deco_apps_requests.json
+++ b/cli/bench/testdata/deco_apps_requests.json
@@ -1,0 +1,2905 @@
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didOpen",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "languageId": "typescript",
+        "version": 1,
+        "text": "import { ImportMap } from \"deco/blocks/app.ts\";\nimport { buildImportMap } from \"deco/blocks/utils.tsx\";\nimport { notUndefined } from \"deco/engine/core/utils.ts\";\nimport { type App, AppModule, context, type FnContext } from \"deco/mod.ts\";\nimport { Markdown } from \"./components/Markdown.tsx\";\nimport manifest, { Manifest } from \"./manifest.gen.ts\";\n\n/**\n * @title App\n */\nexport interface DynamicApp {\n  importUrl: string;\n  name: string;\n  importMap?: ImportMap;\n}\n\nexport interface State {\n  enableAdmin?: boolean;\n  apps: DynamicApp[];\n}\n\nconst DENY_DYNAMIC_IMPORT = Deno.env.get(\"DENY_DYNAMIC_IMPORT\") === \"true\";\n\n/**\n * @title Deco Hub\n * @description Unlock apps and integrations on deco.cx\n * @category Tool\n * @logo https://raw.githubusercontent.com/deco-cx/apps/main/decohub/logo.png\n */\nconst ADMIN_APP = \"decohub/apps/admin.ts\";\nconst FILES_APP = \"decohub/apps/files.ts\";\nexport default async function App(\n  state: State,\n): Promise<App<Manifest, State>> {\n  const resolvedAdminImport = import.meta.resolve(\"../admin/mod.ts\");\n  const resolvedFilesImport = import.meta.resolve(\"../files/mod.ts\");\n  const baseImportMap = buildImportMap(manifest);\n  const appModules = DENY_DYNAMIC_IMPORT ? [] : await Promise.all(\n    (state?.apps ?? []).filter(Boolean).map(async (app) => {\n      const appMod = await import(app.importUrl).catch((err) => {\n        console.error(\"error when importing app\", app.name, app.importUrl, err);\n        return null;\n      });\n      if (!appMod) {\n        return null;\n      }\n      return {\n        module: appMod,\n        importUrl: app.importUrl,\n        importMap: app.importMap,\n        name: app.name,\n      };\n    }),\n  );\n  const [dynamicApps, enhancedImportMap] = appModules.filter(notUndefined)\n    .reduce(\n      ([apps, importmap], app) => {\n        const appTs = `${app.name}.ts`;\n        const appName = `${manifest.name}/apps/${appTs}`;\n        return [{\n          ...apps,\n          [appName]: app.module,\n        }, {\n          ...importmap,\n          ...app.importMap ?? {},\n          imports: {\n            ...importmap?.imports ?? {},\n            ...app.importMap?.imports ?? {},\n            [appName]: app.importUrl,\n          },\n        }];\n      },\n      [{} as Record<string, AppModule>, baseImportMap],\n    );\n  return {\n    manifest: {\n      ...manifest,\n      apps: {\n        // build apps based on name\n        ...dynamicApps,\n        ...manifest.apps,\n        ...context.play || state.enableAdmin // this is an optimization to not include the admin code for everyone in case of play is not being used.\n          ? {\n            [ADMIN_APP]: await import(\n              resolvedAdminImport\n            ),\n            [FILES_APP]: await import(\n              resolvedFilesImport\n            ),\n          }\n          : {},\n      },\n    } as Manifest,\n    state,\n    ...context.play || state.enableAdmin\n      ? {\n        importMap: {\n          ...enhancedImportMap,\n          imports: {\n            ...enhancedImportMap?.imports ?? {},\n            [ADMIN_APP]: ADMIN_APP,\n            [FILES_APP]: FILES_APP,\n          },\n        },\n      }\n      : {},\n  };\n}\n\nexport type AppContext = FnContext<State, Manifest>;\n\nexport const Preview = await Markdown(\n  new URL(\"./README.md\", import.meta.url).href,\n);\n"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 0
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 201
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 202
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 203
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 204
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/range",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 205
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 22,
+          "character": 0
+        },
+        "end": {
+          "line": 22,
+          "character": 0
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 206
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 207
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 208
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 209
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 210
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 111,
+          "character": 38
+        }
+      }
+    },
+    "id": 211
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/hover",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 33,
+        "character": 31
+      }
+    },
+    "id": 212
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 43,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 213
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 214
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 215
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 216
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 217
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 108,
+          "character": 0
+        }
+      }
+    },
+    "id": 218
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 219
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 108,
+          "character": 0
+        }
+      }
+    },
+    "id": 220
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/hover",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 31,
+        "character": 33
+      }
+    },
+    "id": 221
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 114,
+          "character": 0
+        }
+      }
+    },
+    "id": 222
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 223
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 108,
+          "character": 0
+        }
+      }
+    },
+    "id": 224
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/hover",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "id": 225
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentHighlight",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "id": 226
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/definition",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "id": 227
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/references",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      },
+      "context": {
+        "includeDeclaration": true
+      }
+    },
+    "id": 228
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentHighlight",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "id": 229
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/definition",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "id": 230
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 62,
+          "character": 12
+        }
+      }
+    },
+    "id": 231
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 9
+        },
+        "end": {
+          "line": 0,
+          "character": 9
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 232
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 91,
+          "character": 8
+        }
+      }
+    },
+    "id": 233
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 14
+        },
+        "end": {
+          "line": 0,
+          "character": 14
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 234
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/hover",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "id": 235
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 236
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 237
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 238
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/hover",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 13
+      }
+    },
+    "id": 239
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 108,
+          "character": 0
+        }
+      }
+    },
+    "id": 240
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/hover",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 41
+      }
+    },
+    "id": 241
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/definition",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 41
+      }
+    },
+    "id": 242
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentHighlight",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 41
+      }
+    },
+    "id": 245
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/definition",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 41
+      }
+    },
+    "id": 246
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentHighlight",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 0,
+        "character": 41
+      }
+    },
+    "id": 247
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 0
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 267
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 108,
+          "character": 0
+        }
+      }
+    },
+    "id": 268
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 41
+        },
+        "end": {
+          "line": 0,
+          "character": 41
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 269
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 270
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 271
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 272
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 273
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 55
+        },
+        "end": {
+          "line": 5,
+          "character": 55
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 274
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 2
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 55
+            },
+            "end": {
+              "line": 5,
+              "character": 55
+            }
+          },
+          "rangeLength": 0,
+          "text": "\n"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 0
+        },
+        "end": {
+          "line": 6,
+          "character": 0
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 275
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 276
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 277
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 278
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 279
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 3
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 0
+            },
+            "end": {
+              "line": 6,
+              "character": 0
+            }
+          },
+          "rangeLength": 0,
+          "text": "i"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/completion",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 6,
+        "character": 1
+      },
+      "context": {
+        "triggerKind": 1
+      }
+    },
+    "id": 280
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 281
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 4
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 1
+            },
+            "end": {
+              "line": 6,
+              "character": 1
+            }
+          },
+          "rangeLength": 0,
+          "text": "m"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 5
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 2
+            },
+            "end": {
+              "line": 6,
+              "character": 2
+            }
+          },
+          "rangeLength": 0,
+          "text": "p"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 6
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 3
+            },
+            "end": {
+              "line": 6,
+              "character": 3
+            }
+          },
+          "rangeLength": 0,
+          "text": "o"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 283
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 284
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 285
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 286
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 4
+        },
+        "end": {
+          "line": 6,
+          "character": 4
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 287
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 288
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 4
+        },
+        "end": {
+          "line": 6,
+          "character": 4
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 4
+              }
+            },
+            "message": "Cannot find name 'impo'.",
+            "code": 2304,
+            "severity": 1,
+            "source": "deno-ts"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 289
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 7
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 4
+            },
+            "end": {
+              "line": 6,
+              "character": 4
+            }
+          },
+          "rangeLength": 0,
+          "text": "r"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 8
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 5
+            },
+            "end": {
+              "line": 6,
+              "character": 5
+            }
+          },
+          "rangeLength": 0,
+          "text": "t"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 9
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 6
+            },
+            "end": {
+              "line": 6,
+              "character": 6
+            }
+          },
+          "rangeLength": 0,
+          "text": " "
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 10
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 7
+            },
+            "end": {
+              "line": 6,
+              "character": 7
+            }
+          },
+          "rangeLength": 0,
+          "text": "{}"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 290
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 11
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 8
+            },
+            "end": {
+              "line": 6,
+              "character": 8
+            }
+          },
+          "rangeLength": 0,
+          "text": " "
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 12
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 9
+            },
+            "end": {
+              "line": 6,
+              "character": 9
+            }
+          },
+          "rangeLength": 0,
+          "text": "AppFunc"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 291
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 16
+        },
+        "end": {
+          "line": 6,
+          "character": 16
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 292
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 293
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 13
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 16
+            },
+            "end": {
+              "line": 6,
+              "character": 16
+            }
+          },
+          "rangeLength": 0,
+          "text": " "
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 294
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 295
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 296
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 297
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 298
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 14
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 18
+            },
+            "end": {
+              "line": 6,
+              "character": 18
+            }
+          },
+          "rangeLength": 0,
+          "text": " "
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 299
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 15
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 19
+            },
+            "end": {
+              "line": 6,
+              "character": 19
+            }
+          },
+          "rangeLength": 0,
+          "text": "f"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/completion",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 6,
+        "character": 20
+      },
+      "context": {
+        "triggerKind": 1
+      }
+    },
+    "id": 300
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 16
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 20
+            },
+            "end": {
+              "line": 6,
+              "character": 20
+            }
+          },
+          "rangeLength": 0,
+          "text": "r"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 17
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 21
+            },
+            "end": {
+              "line": 6,
+              "character": 21
+            }
+          },
+          "rangeLength": 0,
+          "text": "o"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 18
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 22
+            },
+            "end": {
+              "line": 6,
+              "character": 22
+            }
+          },
+          "rangeLength": 0,
+          "text": "m"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 19
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 23
+            },
+            "end": {
+              "line": 6,
+              "character": 23
+            }
+          },
+          "rangeLength": 0,
+          "text": " "
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 302
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 20
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 24
+            },
+            "end": {
+              "line": 6,
+              "character": 24
+            }
+          },
+          "rangeLength": 0,
+          "text": "\"\""
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/completion",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 6,
+        "character": 25
+      },
+      "context": {
+        "triggerKind": 2,
+        "triggerCharacter": "\""
+      }
+    },
+    "id": 303
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 305
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 25
+        },
+        "end": {
+          "line": 6,
+          "character": 25
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 24
+              },
+              "end": {
+                "line": 6,
+                "character": 26
+              }
+            },
+            "message": "Relative import path \"\" not prefixed with / or ./ or ../ and not in import map from \"file:///decohub/mod.ts\"",
+            "code": "resolver-error",
+            "severity": 1,
+            "source": "deno"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 306
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 307
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 308
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 309
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 310
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 25
+        },
+        "end": {
+          "line": 6,
+          "character": 25
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 24
+              },
+              "end": {
+                "line": 6,
+                "character": 26
+              }
+            },
+            "message": "Relative import path \"\" not prefixed with / or ./ or ../ and not in import map from \"file:///decohub/mod.ts\"",
+            "code": "resolver-error",
+            "severity": 1,
+            "source": "deno"
+          },
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 26
+              }
+            },
+            "message": "'AppFunc' is declared but its value is never read.",
+            "code": 6133,
+            "severity": 4,
+            "tags": [
+              1
+            ],
+            "source": "deno-ts"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 311
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 21
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 25
+            },
+            "end": {
+              "line": 6,
+              "character": 25
+            }
+          },
+          "rangeLength": 0,
+          "text": "d"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 22
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 26
+            },
+            "end": {
+              "line": 6,
+              "character": 26
+            }
+          },
+          "rangeLength": 0,
+          "text": "e"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 23
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 27
+            },
+            "end": {
+              "line": 6,
+              "character": 27
+            }
+          },
+          "rangeLength": 0,
+          "text": "c"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 313
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 24
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 28
+            },
+            "end": {
+              "line": 6,
+              "character": 28
+            }
+          },
+          "rangeLength": 0,
+          "text": "o"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 25
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 29
+            },
+            "end": {
+              "line": 6,
+              "character": 29
+            }
+          },
+          "rangeLength": 0,
+          "text": "/"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/completion",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 6,
+        "character": 30
+      },
+      "context": {
+        "triggerKind": 2,
+        "triggerCharacter": "/"
+      }
+    },
+    "id": 315
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 26
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 30
+            },
+            "end": {
+              "line": 6,
+              "character": 30
+            }
+          },
+          "rangeLength": 0,
+          "text": "b"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 316
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 27
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 31
+            },
+            "end": {
+              "line": 6,
+              "character": 31
+            }
+          },
+          "rangeLength": 0,
+          "text": "l"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 28
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 32
+            },
+            "end": {
+              "line": 6,
+              "character": 32
+            }
+          },
+          "rangeLength": 0,
+          "text": "o"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 29
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 33
+            },
+            "end": {
+              "line": 6,
+              "character": 33
+            }
+          },
+          "rangeLength": 0,
+          "text": "c"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 30
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 34
+            },
+            "end": {
+              "line": 6,
+              "character": 34
+            }
+          },
+          "rangeLength": 0,
+          "text": "k"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 318
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 31
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 35
+            },
+            "end": {
+              "line": 6,
+              "character": 35
+            }
+          },
+          "rangeLength": 0,
+          "text": "s"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 32
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 36
+            },
+            "end": {
+              "line": 6,
+              "character": 36
+            }
+          },
+          "rangeLength": 0,
+          "text": "/"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/completion",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "position": {
+        "line": 6,
+        "character": 37
+      },
+      "context": {
+        "triggerKind": 2,
+        "triggerCharacter": "/"
+      }
+    },
+    "id": 319
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 321
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 37
+        },
+        "end": {
+          "line": 6,
+          "character": 37
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 24
+              },
+              "end": {
+                "line": 6,
+                "character": 38
+              }
+            },
+            "message": "Uncached or missing remote URL: https://denopkg.com/deco-cx/deco@1.57.17/blocks/",
+            "data": {
+              "specifier": "https://denopkg.com/deco-cx/deco@1.57.17/blocks/"
+            },
+            "code": "no-cache",
+            "severity": 1,
+            "source": "deno"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 322
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 323
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 324
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 325
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 326
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 37
+        },
+        "end": {
+          "line": 6,
+          "character": 37
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 24
+              },
+              "end": {
+                "line": 6,
+                "character": 38
+              }
+            },
+            "message": "Uncached or missing remote URL: https://denopkg.com/deco-cx/deco@1.57.17/blocks/",
+            "data": {
+              "specifier": "https://denopkg.com/deco-cx/deco@1.57.17/blocks/"
+            },
+            "code": "no-cache",
+            "severity": 1,
+            "source": "deno"
+          },
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 38
+              }
+            },
+            "message": "'AppFunc' is declared but its value is never read.",
+            "code": 6133,
+            "severity": 4,
+            "tags": [
+              1
+            ],
+            "source": "deno-ts"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 327
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 33
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 37
+            },
+            "end": {
+              "line": 6,
+              "character": 37
+            }
+          },
+          "rangeLength": 0,
+          "text": "a"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 34
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 38
+            },
+            "end": {
+              "line": 6,
+              "character": 38
+            }
+          },
+          "rangeLength": 0,
+          "text": "p"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 35
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 39
+            },
+            "end": {
+              "line": 6,
+              "character": 39
+            }
+          },
+          "rangeLength": 0,
+          "text": "p"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 329
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 40
+        },
+        "end": {
+          "line": 6,
+          "character": 40
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 24
+              },
+              "end": {
+                "line": 6,
+                "character": 41
+              }
+            },
+            "message": "Uncached or missing remote URL: https://denopkg.com/deco-cx/deco@1.57.17/blocks/app",
+            "data": {
+              "specifier": "https://denopkg.com/deco-cx/deco@1.57.17/blocks/app"
+            },
+            "code": "no-cache",
+            "severity": 1,
+            "source": "deno"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 330
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 331
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 332
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 333
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 334
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 36
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 25
+            },
+            "end": {
+              "line": 6,
+              "character": 40
+            }
+          },
+          "rangeLength": 15,
+          "text": "deco/blocks/app.ts"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 335
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 336
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 337
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 338
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 339
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 44
+        },
+        "end": {
+          "line": 6,
+          "character": 44
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 44
+              }
+            },
+            "message": "'AppFunc' is declared but its value is never read.",
+            "code": 6133,
+            "severity": 4,
+            "tags": [
+              1
+            ],
+            "source": "deno-ts"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 340
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didChange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts",
+        "version": 37
+      },
+      "contentChanges": [
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 44
+            },
+            "end": {
+              "line": 6,
+              "character": 44
+            }
+          },
+          "rangeLength": 0,
+          "text": ";"
+        }
+      ]
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 45
+        },
+        "end": {
+          "line": 6,
+          "character": 45
+        }
+      },
+      "context": {
+        "diagnostics": [],
+        "triggerKind": 2
+      }
+    },
+    "id": 341
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/foldingRange",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 342
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 343
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 344
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/documentSymbol",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 345
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/didSave",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/semanticTokens/full",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 346
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeAction",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 45
+        },
+        "end": {
+          "line": 6,
+          "character": 45
+        }
+      },
+      "context": {
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 45
+              }
+            },
+            "message": "'AppFunc' is declared but its value is never read.",
+            "code": 6133,
+            "severity": 4,
+            "tags": [
+              1
+            ],
+            "source": "deno-ts"
+          }
+        ],
+        "triggerKind": 2
+      }
+    },
+    "id": 347
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/codeLens",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      }
+    },
+    "id": 348
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "textDocument/inlayHint",
+    "params": {
+      "textDocument": {
+        "uri": "file:///decohub/mod.ts"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 108,
+          "character": 1
+        }
+      }
+    },
+    "id": 349
+  }
+]

--- a/tests/util/server/src/lsp.rs
+++ b/tests/util/server/src/lsp.rs
@@ -941,6 +941,21 @@ impl LspClient {
     })
   }
 
+  pub fn write_request_no_wait(
+    &mut self,
+    method: impl AsRef<str>,
+    params: impl Serialize,
+  ) {
+    let value = json!({
+      "jsonrpc": "2.0",
+      "id": self.request_id,
+      "method": method.as_ref(),
+      "params": params,
+    });
+    self.write(value);
+    self.request_id += 1;
+  }
+
   fn write(&mut self, value: Value) {
     let value_str = value.to_string();
     let msg = format!(
@@ -1025,6 +1040,17 @@ impl LspClient {
           panic!("LSP ERROR: {error:?}");
         }
         Some(maybe_result.clone().unwrap())
+      }
+      _ => None,
+    })
+  }
+
+  pub fn read_latest_response(
+    &mut self,
+  ) -> (u64, Option<Value>, Option<LspResponseError>) {
+    self.reader.read_message(|msg| match msg {
+      LspMessage::Response(id, val, err) => {
+        Some((*id, val.clone(), err.clone()))
       }
       _ => None,
     })

--- a/tests/util/server/src/lsp.rs
+++ b/tests/util/server/src/lsp.rs
@@ -941,7 +941,7 @@ impl LspClient {
     })
   }
 
-  pub fn write_request_no_wait(
+  pub fn write_jsonrpc(
     &mut self,
     method: impl AsRef<str>,
     params: impl Serialize,


### PR DESCRIPTION
This PR adds a benchmark intended to measure how the LSP handles larger repos, as well as its performance on a more realistic workload.

The repo being benchmarked is [deco-cx/apps](https://github.com/deco-cx/apps) which has been vendored along with its dependencies. It's included as a git submodule as its fairly large. The LSP requests used in the benchmark are the actual requests sent by VSCode as I opened, modified, and navigated around a file (to simulate an actual user interaction).

The main motivation is to have a more realistic benchmark that measures how we do with a large number of files and dependencies. The improvements made from 1.42 to 1.42.3 mostly improved performance with larger repos, so none of our existing benchmarks showed an improvement. 

Here are the results for the changes made from 1.42 to 1.42.3 (the new benchmark is the last one listed):

**1.42.0**

```test
Starting Deno benchmark
-> Start benchmarking lsp
   - Simple Startup/Shutdown 
      (10 runs, mean: 379ms)
   - Big Document/Several Edits 
      (5 runs, mean: 1142ms)
   - Find/Replace
      (10 runs, mean: 51ms)
   - Code Lens
      (10 runs, mean: 443ms)
   - deco-cx/apps Multiple Edits + Navigation
      (5 runs, mean: 25121ms)
<- End benchmarking lsp
```

**1.42.3**

```text
Starting Deno benchmark
-> Start benchmarking lsp
   - Simple Startup/Shutdown 
      (10 runs, mean: 383ms)
   - Big Document/Several Edits 
      (5 runs, mean: 1135ms)
   - Find/Replace
      (10 runs, mean: 55ms)
   - Code Lens
      (10 runs, mean: 440ms)
   - deco-cx/apps Multiple Edits + Navigation
      (5 runs, mean: 11675ms)
<- End benchmarking lsp
```


