### PR TITLE
fix(cli): TestEventSender should be !Clone

### DIFF
--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -92,7 +92,7 @@ pub async fn kernel(
       permissions,
       vec![
         ops::jupyter::deno_jupyter::init_ops(stdio_tx.clone()),
-        ops::testing::deno_test::init_ops(test_event_sender.clone()),
+        ops::testing::deno_test::init_ops(test_event_sender),
       ],
       // FIXME(nayeemrmn): Test output capturing currently doesn't work.
       Stdio {
@@ -114,7 +114,6 @@ pub async fn kernel(
     resolver,
     worker,
     main_module,
-    test_event_sender,
     test_event_receiver,
   )
   .await?;

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -172,9 +172,7 @@ pub async fn run(flags: Flags, repl_flags: ReplFlags) -> Result<i32, AnyError> {
     .create_custom_worker(
       main_module.clone(),
       permissions,
-      vec![crate::ops::testing::deno_test::init_ops(
-        test_event_sender.clone(),
-      )],
+      vec![crate::ops::testing::deno_test::init_ops(test_event_sender)],
       Default::default(),
     )
     .await?;
@@ -186,7 +184,6 @@ pub async fn run(flags: Flags, repl_flags: ReplFlags) -> Result<i32, AnyError> {
     resolver,
     worker,
     main_module,
-    test_event_sender,
     test_event_receiver,
   )
   .await?;

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -12,10 +12,10 @@ use crate::tools::test::report_tests;
 use crate::tools::test::reporters::PrettyTestReporter;
 use crate::tools::test::reporters::TestReporter;
 use crate::tools::test::run_tests_for_worker;
+use crate::tools::test::send_test_event;
 use crate::tools::test::worker_has_tests;
 use crate::tools::test::TestEvent;
 use crate::tools::test::TestEventReceiver;
-use crate::tools::test::TestEventSender;
 
 use deno_ast::diagnostics::Diagnostic;
 use deno_ast::swc::ast as swc_ast;
@@ -463,14 +463,11 @@ impl ReplSession {
       )
       .await
       .unwrap();
-      self
-        .worker
-        .js_runtime
-        .op_state()
-        .borrow_mut()
-        .borrow_mut::<TestEventSender>()
-        .send(TestEvent::ForceEndReport)
-        .unwrap();
+      send_test_event(
+        &self.worker.js_runtime.op_state(),
+        TestEvent::ForceEndReport,
+      )
+      .unwrap();
       self.test_event_receiver = Some(report_tests_handle.await.unwrap().1);
     }
 

--- a/cli/tools/test/channel.rs
+++ b/cli/tools/test/channel.rs
@@ -16,7 +16,6 @@ use std::io::Write;
 use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::task::ready;
 use std::task::Poll;
 use std::time::Duration;
@@ -310,7 +309,6 @@ impl TestEventSenderFactory {
 
     let sender = TestEventSender {
       id,
-      ref_count: Default::default(),
       sender: self.sender.clone(),
       sync_sender,
       stdout_writer,
@@ -373,24 +371,10 @@ pub struct TestEventWorkerSender {
 /// are not guaranteed to be sent on drop unless flush is explicitly called.
 pub struct TestEventSender {
   pub id: usize,
-  ref_count: Arc<()>,
   sender: UnboundedSender<(usize, TestEvent)>,
   sync_sender: UnboundedSender<(SendMutex, SendMutex)>,
   stdout_writer: PipeWrite,
   stderr_writer: PipeWrite,
-}
-
-impl Clone for TestEventSender {
-  fn clone(&self) -> Self {
-    Self {
-      id: self.id,
-      ref_count: self.ref_count.clone(),
-      sender: self.sender.clone(),
-      sync_sender: self.sync_sender.clone(),
-      stdout_writer: self.stdout_writer.try_clone().unwrap(),
-      stderr_writer: self.stderr_writer.try_clone().unwrap(),
-    }
-  }
 }
 
 impl TestEventSender {

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -764,8 +764,9 @@ pub async fn run_tests_for_worker(
   fail_fast_tracker: &FailFastTracker,
 ) -> Result<(), AnyError> {
   let state_rc = worker.js_runtime.op_state();
+  // Take whatever tests have been registered
   let TestContainer(tests, test_functions) =
-    state_rc.borrow_mut().take::<TestContainer>();
+    std::mem::take(&mut *state_rc.borrow_mut().borrow_mut::<TestContainer>());
 
   let tests: Arc<TestDescriptions> = tests.into();
   send_test_event(&state_rc, TestEvent::Register(tests.clone()))?;


### PR DESCRIPTION
`TestEventSender` should not be Clone so we don't end up with multiple copies of the same writer FD. This is probably not the cause of the test channel lockups, but it's a lot easier to reason about.