### PR TITLE
Revert: chore: fail properly in web platform test

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -65,14 +65,17 @@ jobs:
 
       - name: Run web platform tests
         shell: bash
+        # Setup WPT and run tests. We ignore the exit code of the test run
+        # because the CI job reports the results to WPT.fyi, and we still want
+        # to report failure.
         run: |
           deno run --unstable --allow-write --allow-read --allow-net           \
             --allow-env --allow-run --lock=tools/deno.lock.json                \
             ./tests/wpt/wpt.ts setup
           deno run --unstable --allow-write --allow-read --allow-net           \
             --allow-env --allow-run --lock=tools/deno.lock.json                \
-            ./tests/wpt/wpt.ts run                                                 \                                                \
-            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json
+            ./tests/wpt/wpt.ts run                                             \
+            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json || true
 
       - name: Upload wpt results to wpt.fyi
         env:


### PR DESCRIPTION
The previous behaviour was correct. The process exit code does not matter, because failures are expected (we are running all tests here intentionally, even failing ones). This is done so we can report both success and failure accurately to wpt.fyi.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
