### PR TITLE
fix: allow WPT to successfully exit using `--exit-zero`

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -72,7 +72,7 @@ jobs:
           deno run --unstable --allow-write --allow-read --allow-net           \
             --allow-env --allow-run --lock=tools/deno.lock.json                \
             ./tests/wpt/wpt.ts run                                                 \                                                \
-            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json
+            --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json --exit-zero
 
       - name: Upload wpt results to wpt.fyi
         env:

--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -550,6 +550,12 @@ function reportFinal(
     }. ${finalPassedCount} passed; ${finalFailedCount} failed; ${finalExpectedFailedAndFailedCount} expected failure; total ${finalTotalCount} (${duration}ms)\n`,
   );
 
+  // We ignore the exit code of the test run because the CI job reports the
+  // results to WPT.fyi, and we still want to report failure.
+  if (Deno.args.includes("--exit-zero")) {
+    return 0;
+  }
+
   return failed ? 1 : 0;
 }
 


### PR DESCRIPTION
I went with `--exit-zero`. Happy to change to `--no-exit` if feelings are strong.

Supercedes #23417