### PR TITLE
test: fix node_compat_test

### DIFF
--- a/tests/node_compat/test_runner.rs
+++ b/tests/node_compat/test_runner.rs
@@ -5,15 +5,18 @@ use util::deno_config_path;
 
 #[test]
 fn node_compat_tests() {
+  let _server = util::http_server();
+
   let mut deno = util::deno_cmd()
     .current_dir(util::root_path())
+    .envs(util::env_vars_for_npm_tests())
     .arg("test")
     .arg("--config")
     .arg(deno_config_path())
     .arg("--no-lock")
     .arg("--unstable")
     .arg("-A")
-    .arg(util::tests_path().join("node_compat"))
+    .arg(util::tests_path().join("node_compat/test.ts"))
     .spawn()
     .expect("failed to spawn script");
 


### PR DESCRIPTION
It's not clear to me how these tests worked correctly on CI,
 but they were failing hard locally because of two problems:
- missing env var that tests URL for fake npm registry
- trying to run a directory that contains native Node.js tests that
require a special harness