### PR TITLE
perf(lsp): Batch "$projectChanged" notification in with the next JS request

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1198,7 +1198,7 @@ impl Inner {
     Ok(())
   }
 
-  async fn did_open(
+  fn did_open(
     &mut self,
     specifier: &ModuleSpecifier,
     params: DidOpenTextDocumentParams,
@@ -3205,7 +3205,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     let specifier = inner
       .url_map
       .normalize_url(&params.text_document.uri, LspUrlKind::File);
-    let document = inner.did_open(&specifier, params).await;
+    let document = inner.did_open(&specifier, params);
     if document.is_diagnosable() {
       inner.refresh_npm_specifiers().await;
       inner.diagnostics_server.invalidate(&[specifier]);

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1191,7 +1191,7 @@ impl Inner {
     // a @types/node package and now's a good time to do that anyway
     self.refresh_npm_specifiers().await;
 
-    self.project_changed(&[], true).await;
+    self.project_changed([], true);
   }
 
   fn shutdown(&self) -> LspResult<()> {
@@ -1226,9 +1226,7 @@ impl Inner {
       params.text_document.language_id.parse().unwrap(),
       params.text_document.text.into(),
     );
-    self
-      .project_changed(&[(document.specifier(), ChangeKind::Opened)], false)
-      .await;
+    self.project_changed([(document.specifier(), ChangeKind::Opened)], false);
 
     self.performance.measure(mark);
     document
@@ -1246,12 +1244,10 @@ impl Inner {
     ) {
       Ok(document) => {
         if document.is_diagnosable() {
-          self
-            .project_changed(
-              &[(document.specifier(), ChangeKind::Modified)],
-              false,
-            )
-            .await;
+          self.project_changed(
+            [(document.specifier(), ChangeKind::Modified)],
+            false,
+          );
           self.refresh_npm_specifiers().await;
           self.diagnostics_server.invalidate(&[specifier]);
           self.send_diagnostics_update();
@@ -1302,9 +1298,7 @@ impl Inner {
     if let Err(err) = self.documents.close(&specifier) {
       error!("{:#}", err);
     }
-    self
-      .project_changed(&[(&specifier, ChangeKind::Closed)], false)
-      .await;
+    self.project_changed([(&specifier, ChangeKind::Closed)], false);
     self.performance.measure(mark);
   }
 
@@ -1418,15 +1412,10 @@ impl Inner {
       self.recreate_npm_services_if_necessary().await;
       self.refresh_documents_config().await;
       self.diagnostics_server.invalidate_all();
-      self
-        .project_changed(
-          &changes
-            .iter()
-            .map(|(s, _)| (s, ChangeKind::Modified))
-            .collect::<Vec<_>>(),
-          false,
-        )
-        .await;
+      self.project_changed(
+        changes.iter().map(|(s, _)| (s, ChangeKind::Modified)),
+        false,
+      );
       self.ts_server.cleanup_semantic_cache(self.snapshot()).await;
       self.send_diagnostics_update();
       self.send_testing_update();
@@ -2998,16 +2987,17 @@ impl Inner {
     Ok(maybe_symbol_information)
   }
 
-  async fn project_changed(
+  fn project_changed<'a>(
     &mut self,
-    modified_scripts: &[(&ModuleSpecifier, ChangeKind)],
+    modified_scripts: impl IntoIterator<Item = (&'a ModuleSpecifier, ChangeKind)>,
     config_changed: bool,
   ) {
     self.project_version += 1; // increment before getting the snapshot
-    self
-      .ts_server
-      .project_changed(self.snapshot(), modified_scripts, config_changed)
-      .await;
+    self.ts_server.project_changed(
+      self.snapshot(),
+      modified_scripts,
+      config_changed,
+    );
   }
 
   fn send_diagnostics_update(&self) {
@@ -3555,7 +3545,7 @@ impl Inner {
     // the language server for TypeScript (as it might hold to some stale
     // documents).
     self.diagnostics_server.invalidate_all();
-    self.project_changed(&[], false).await;
+    self.project_changed([], false);
     self.ts_server.cleanup_semantic_cache(self.snapshot()).await;
     self.send_diagnostics_update();
     self.send_testing_update();

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -5271,7 +5271,7 @@ mod tests {
     };
     ts_server.project_changed(
       snapshot.clone(),
-      &[(&specifier_dep, ChangeKind::Opened)],
+      [(&specifier_dep, ChangeKind::Opened)],
       false,
     );
     let specifier = resolve_url("file:///a.ts").unwrap();

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -542,7 +542,7 @@ delete Object.prototype.__proto__;
     }
   }
 
-  /** @type {ts.LanguageService} */
+  /** @type {ts.LanguageService & { [k:string]: any }} */
   let languageService;
 
   /** An object literal of the incremental compiler host, which provides the

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -1072,42 +1072,43 @@ delete Object.prototype.__proto__;
     ops.op_respond(JSON.stringify(data));
   }
 
-  function serverRequest(id, method, args) {
+  /**
+   * @param {number} id
+   * @param {string} method
+   * @param {any[]} args
+   * @param {[[string, number][], number, boolean] | null} maybeChange
+   */
+  function serverRequest(id, method, args, maybeChange) {
     if (logDebug) {
-      debug(`serverRequest()`, id, method, args);
+      debug(`serverRequest()`, id, method, args, maybeChange);
     }
     lastRequestMethod = method;
-    switch (method) {
-      case "$projectChanged": {
-        /** @type {[string, number][]} */
-        const changedScripts = args[0];
-        /** @type {number} */
-        const newProjectVersion = args[1];
-        /** @type {boolean} */
-        const configChanged = args[2];
+    if (maybeChange !== null) {
+      const changedScripts = maybeChange[0];
+      const newProjectVersion = maybeChange[1];
+      const configChanged = maybeChange[2];
 
-        if (configChanged) {
-          tsConfigCache = null;
-          isNodeSourceFileCache.clear();
-        }
-
-        projectVersionCache = newProjectVersion;
-
-        let opened = false;
-        for (const { 0: script, 1: changeKind } of changedScripts) {
-          if (changeKind == ChangeKind.Opened) {
-            opened = true;
-          }
-          scriptVersionCache.delete(script);
-          sourceTextCache.delete(script);
-        }
-
-        if (configChanged || opened) {
-          scriptFileNamesCache = undefined;
-        }
-
-        return respond(id);
+      if (configChanged) {
+        tsConfigCache = null;
+        isNodeSourceFileCache.clear();
       }
+
+      projectVersionCache = newProjectVersion;
+
+      let opened = false;
+      for (const { 0: script, 1: changeKind } of changedScripts) {
+        if (changeKind == ChangeKind.Opened) {
+          opened = true;
+        }
+        scriptVersionCache.delete(script);
+        sourceTextCache.delete(script);
+      }
+
+      if (configChanged || opened) {
+        scriptFileNamesCache = undefined;
+      }
+    }
+    switch (method) {
       case "$getSupportedCodeFixes": {
         return respond(
           id,

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -9044,7 +9044,6 @@ fn lsp_performance() {
       "tsc.host.$getAssets",
       "tsc.host.$getDiagnostics",
       "tsc.host.$getSupportedCodeFixes",
-      "tsc.host.$projectChanged",
       "tsc.host.getQuickInfoAtPosition",
       "tsc.op.op_is_node_file",
       "tsc.op.op_load",
@@ -9052,7 +9051,6 @@ fn lsp_performance() {
       "tsc.op.op_ts_config",
       "tsc.request.$getAssets",
       "tsc.request.$getSupportedCodeFixes",
-      "tsc.request.$projectChanged",
       "tsc.request.getQuickInfoAtPosition",
     ]
   );


### PR DESCRIPTION
The actual handling of `$projectChanged` is quick, but JS requests are not. The cleared caches only get repopulated on the next actual request, so just batch the change notification in with the next actual request.

No significant difference in benchmarks on my machine, but this speeds up `did_change` handling and reduces our total number of JS requests (in addition to coalescing multiple JS change notifs into one).