### PR TITLE
perf(lsp): Avoid passing struct into op_resolve

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4058,9 +4058,10 @@ fn op_release(
 #[serde]
 fn op_resolve(
   state: &mut OpState,
-  #[serde] args: ResolveArgs,
+  #[string] base: String,
+  #[serde] specifiers: Vec<String>,
 ) -> Result<Vec<Option<(String, String)>>, AnyError> {
-  op_resolve_inner(state, args)
+  op_resolve_inner(state, ResolveArgs { base, specifiers })
 }
 
 #[inline]

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -681,7 +681,8 @@ delete Object.prototype.__proto__;
         debug(`host.writeFile("${fileName}")`);
       }
       return ops.op_emit(
-        { fileName, data },
+        data,
+        fileName,
       );
     },
     getCurrentDirectory() {
@@ -717,10 +718,10 @@ delete Object.prototype.__proto__;
           : arg;
         if (fileReference.fileName.startsWith("npm:")) {
           /** @type {[string, ts.Extension] | undefined} */
-          const resolved = ops.op_resolve({
-            specifiers: [fileReference.fileName],
-            base: containingFilePath,
-          })?.[0];
+          const resolved = ops.op_resolve(
+            containingFilePath,
+            [fileReference.fileName],
+          )?.[0];
           if (resolved) {
             isCjsCache.maybeAdd(resolved);
             return {
@@ -750,10 +751,10 @@ delete Object.prototype.__proto__;
         debug(`  specifiers: ${specifiers.join(", ")}`);
       }
       /** @type {Array<[string, ts.Extension] | undefined>} */
-      const resolved = ops.op_resolve({
-        specifiers,
+      const resolved = ops.op_resolve(
         base,
-      });
+        specifiers,
+      );
       if (resolved) {
         const result = resolved.map((item) => {
           if (item) {

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -412,9 +412,13 @@ struct EmitArgs {
   file_name: String,
 }
 
-#[op2]
-fn op_emit(state: &mut OpState, #[serde] args: EmitArgs) -> bool {
-  op_emit_inner(state, args)
+#[op2(fast)]
+fn op_emit(
+  state: &mut OpState,
+  #[string] data: String,
+  #[string] file_name: String,
+) -> bool {
+  op_emit_inner(state, EmitArgs { data, file_name })
 }
 
 #[inline]
@@ -590,9 +594,10 @@ pub struct ResolveArgs {
 #[serde]
 fn op_resolve(
   state: &mut OpState,
-  #[serde] args: ResolveArgs,
+  #[string] base: String,
+  #[serde] specifiers: Vec<String>,
 ) -> Result<Vec<(String, String)>, AnyError> {
-  op_resolve_inner(state, args)
+  op_resolve_inner(state, ResolveArgs { base, specifiers })
 }
 
 #[inline]


### PR DESCRIPTION
Going through serde_v8 is slow, so just pass the args separately. `op_resolve` is especially hot, so any speedups are good.