### PR TITLE
feat: add jsx precompile skip element option

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -185,7 +185,7 @@ pub fn ts_config_to_transpile_and_emit_options(
       jsx_fragment_factory: options.jsx_fragment_factory,
       jsx_import_source: options.jsx_import_source,
       precompile_jsx,
-      precompile_jsx_skip_elements: None,
+      precompile_jsx_skip_elements: options.jsx_precompile_skip_elements,
       transform_jsx,
       var_decl_imports: false,
     },

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -76,6 +76,14 @@
           "default": "react",
           "markdownDescription": "Specify module specifier used to import the JSX factory functions when using jsx: `react-jsx*`.\n\nSee more: https://www.typescriptlang.org/tsconfig/#jsxImportSource"
         },
+        "jsxPrecompileSkipElements": {
+          "description": "Specify list of elements that should be exempt from being precompiled when the jsx 'precompile' transform is used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Specify list of elements that should be exempt from being precompiled when the jsx `precompile` transform is used."
+        },
         "keyofStringsOnly": {
           "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
           "type": "boolean",

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -958,6 +958,9 @@ delete Object.prototype.__proto__;
     if (config.jsx === "precompile") {
       config.jsx = "react-jsx";
     }
+    if (config.jsxPrecompileSkipElements) {
+      delete config.jsxPrecompileSkipElements;
+    }
     return config;
   }
 

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -2098,6 +2098,12 @@ itest!(jsx_import_source_precompile_import_map {
   http_server: true,
 });
 
+itest!(jsx_import_source_precompile_import_map_skip_element {
+  args: "run --reload --check --import-map jsx/import-map.json --no-lock --config jsx/deno-jsx-precompile-skip.jsonc run/jsx_precompile/skip.tsx",
+  output: "run/jsx_precompile/skip.out",
+  http_server: true,
+});
+
 itest!(jsx_import_source_import_map {
   args: "run --reload --import-map jsx/import-map.json --no-lock --config jsx/deno-jsx-import-map.jsonc run/jsx_import_source_no_pragma.tsx",
   output: "run/jsx_import_source_import_map.out",

--- a/tests/testdata/jsx/deno-jsx-precompile-skip.jsonc
+++ b/tests/testdata/jsx/deno-jsx-precompile-skip.jsonc
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "jsx": "precompile",
+    "jsxImportSource": "jsx-precompile",
+    "jsxPrecompileSkipElements": ["a", "img"]
+  }
+}

--- a/tests/testdata/run/jsx_precompile/skip.out
+++ b/tests/testdata/run/jsx_precompile/skip.out
@@ -1,0 +1,3 @@
+Download http://localhost:4545/jsx/jsx-precompile/index.ts
+Check file:///[WILDCARD]/run/jsx_precompile/skip.tsx
+imported http://localhost:4545/jsx/jsx-precompile/index.ts

--- a/tests/testdata/run/jsx_precompile/skip.tsx
+++ b/tests/testdata/run/jsx_precompile/skip.tsx
@@ -1,0 +1,9 @@
+export function A() {
+  return (
+    <div>
+      <a href="#">foo</a>
+      <p>hello</p>
+      <img src="#" alt="" />
+    </div>
+  );
+}

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -213,7 +213,7 @@ async function ensureNoNewITests() {
     "pm_tests.rs": 0,
     "publish_tests.rs": 28,
     "repl_tests.rs": 0,
-    "run_tests.rs": 381,
+    "run_tests.rs": 382,
     "shared_library_tests.rs": 0,
     "task_tests.rs": 30,
     "test_tests.rs": 80,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
This PR wires up a new `jsxPrecompileSkipElements` option in `compilerOptions` that can be used to exempt a list of elements from being precompiled with the `precompile` JSX transform. 