### PR TITLE
fix(lsp): remove Document::open_data on close

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -610,11 +610,7 @@ impl Inner {
             .assets
             .cache_navigation_tree(specifier, navigation_tree.clone())?,
           AssetOrDocument::Document(doc) => {
-            self.documents.try_cache_navigation_tree(
-              specifier,
-              &doc.script_version(),
-              navigation_tree.clone(),
-            )?
+            doc.cache_navigation_tree(navigation_tree.clone());
           }
         }
         navigation_tree
@@ -1304,9 +1300,7 @@ impl Inner {
       self.send_diagnostics_update();
       self.send_testing_update();
     }
-    if let Err(err) = self.documents.close(&specifier) {
-      error!("{:#}", err);
-    }
+    self.documents.close(&specifier);
     self
       .project_changed(&[(&specifier, ChangeKind::Closed)], false)
       .await;

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8811,7 +8811,7 @@ fn lsp_diagnostics_refresh_dependents() {
     }),
   );
   let diagnostics = client.read_diagnostics();
-  assert_eq!(diagnostics.all().len(), 0); // no diagnostics now
+  assert_eq!(json!(diagnostics.all()), json!([])); // no diagnostics now
 
   client.shutdown();
   assert_eq!(client.queue_len(), 0);


### PR DESCRIPTION
Adds `Document::closed()` which discards `Document::open_data`. `DocumentOpenData` now includes the LSP version. Unify `Document::open()` into `Document::new()`. Cleanup navigation tree caching a bit.

This fixes a bug where imported and unopened JSON modules were being parsed in rust even though the result won't be used. In other words, this expectation never held: https://github.com/denoland/deno/blob/v1.42.4/cli/lsp/documents.rs#L269-L271. Though these would hit syntax errors from parsing them as a block.