### PR TITLE
chore(lsp): Print out stack trace if exception occurs in TS request

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4260,12 +4260,12 @@ impl TscRuntime {
       if tc_scope.has_caught() && !tc_scope.has_terminated() {
         if let Some(stack_trace) = tc_scope.stack_trace() {
           lsp_warn!(
-            "Error during TSC request {method} tsc runtime stack:\n\t{}",
+            "Error during TS request \"{method}\":\n  {}",
             stack_trace.to_rust_string_lossy(tc_scope),
           );
         } else {
           lsp_warn!(
-            "Error during TSC request {method} tsc runtime:\n\t{}",
+            "Error during TS request \"{method}\":\n  {}",
             tc_scope
               .exception()
               .map(|exc| exc.to_rust_string_lossy(tc_scope))

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4290,8 +4290,6 @@ impl TscRuntime {
   }
 }
 
-// fn print_exception(tc_scope: &mut v8::TryCatch<>)
-
 fn run_tsc_thread(
   mut request_rx: UnboundedReceiver<Request>,
   performance: Arc<Performance>,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4258,6 +4258,20 @@ impl TscRuntime {
 
       server_request_fn.call(tc_scope, undefined, &args);
       if tc_scope.has_caught() && !tc_scope.has_terminated() {
+        if let Some(stack_trace) = tc_scope.stack_trace() {
+          lsp_warn!(
+            "Error during TSC request {method} tsc runtime stack:\n\t{}",
+            stack_trace.to_rust_string_lossy(tc_scope),
+          );
+        } else {
+          lsp_warn!(
+            "Error during TSC request {method} tsc runtime:\n\t{}",
+            tc_scope
+              .exception()
+              .map(|exc| exc.to_rust_string_lossy(tc_scope))
+              .unwrap_or_default(),
+          );
+        }
         tc_scope.rethrow();
       }
     }
@@ -4275,6 +4289,8 @@ impl TscRuntime {
     })
   }
 }
+
+// fn print_exception(tc_scope: &mut v8::TryCatch<>)
 
 fn run_tsc_thread(
   mut request_rx: UnboundedReceiver<Request>,


### PR DESCRIPTION
Before this PR, there would just be an uninformative "Error occurred" message, after this PR you'll get a stack trace in the LSP output window like this:

```text
Error during TS request "$getSupportedCodeFixes":
  Error: i threw an exception
    at serverRequest (ext:deno_tsc/99_main_compiler.js:1089:11)
```