### PR TITLE
perf(ext/http): cache abort signal error

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -126,6 +126,8 @@ function addTrailers(resp, headerList) {
   op_http_set_response_trailers(inner.external, headerList);
 }
 
+let signalAbortError;
+
 class InnerRequest {
   #external;
   #context;
@@ -156,9 +158,15 @@ class InnerRequest {
         );
       }
     }
+    if (!signalAbortError) {
+      signalAbortError = new DOMException(
+        "The signal has already been aborted.",
+        "AbortError",
+      );
+    }
     // Unconditionally abort the request signal. Note that we don't use
     // an error here.
-    this.#abortController.abort();
+    this.#abortController.abort(signalAbortError);
     this.#external = null;
   }
 

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -160,7 +160,7 @@ class InnerRequest {
     }
     if (!signalAbortError) {
       signalAbortError = new DOMException(
-        "The signal has already been aborted.",
+        "The request has been cancelled.",
         "AbortError",
       );
     }


### PR DESCRIPTION
Fixes a perf regression introduced in https://github.com/denoland/deno/commit/eed2598e6cf1db643b4edd07b5eff94c59eb9408 ([flamegraph](https://profiler.firefox.com/public/83whz7mrfkshk5q6hd6hjmrmw8tgmw67s96m4p0/flame-graph/?globalTrackOrder=0&hiddenLocalTracksByPid=12691-0we&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F316cvciry38ippl9i74fmcxrd5q9asfrr28xp02&thread=0&v=10))

this patch:
```
Summary:
  Success rate: 100.00%
  Total:        10.0007 secs
  Slowest:      0.0145 secs
  Fastest:      0.0001 secs
  Average:      0.0006 secs
  Requests/sec: 80341.4816

  Total data:   9.19 MiB
  Size/request: 12
  Size/sec:     941.44 KiB
```

main:
```
Summary:
  Success rate: 100.00%
  Total:        10.0007 secs
  Slowest:      0.0068 secs
  Fastest:      0.0002 secs
  Average:      0.0009 secs
  Requests/sec: 56560.0551

  Total data:   6.47 MiB
  Size/request: 12
  Size/sec:     662.75 KiB
```