### PR TITLE
fix(ext/http): don't create abort signal during request abort

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -592,8 +592,8 @@ const signalAbortError = new DOMException(
 );
 ObjectFreeze(signalAbortError);
 
-function abortRequest(request) {
-  if (request[_signalCache]) {
+function abortRequest(request, createNew = false) {
+  if (request[_signalCache] || createNew) {
     request[_signal][signalAbort](signalAbortError);
   }
 }

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -593,7 +593,7 @@ const signalAbortError = new DOMException(
 ObjectFreeze(signalAbortError);
 
 function abortRequest(request) {
-  if (request[_signal]) {
+  if (request[_signalCache]) {
     request[_signal][signalAbort](signalAbortError);
   }
 }

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -382,7 +382,7 @@ function createRespondWith(
         ws[_serverHandleIdleTimeout]();
       }
     } catch (error) {
-      abortRequest(request);
+      abortRequest(request, true);
       throw error;
     } finally {
       if (deleteManagedResource(httpConn, readStreamRid)) {


### PR DESCRIPTION
`request[_signal]` will always create a new signal if there isn't one. It seems this check should use `_signalCache` instead? cc @mmastrac 