### PR TITLE
fix(ext/node): support NODE_DEBUG env

### DIFF
--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -29,7 +29,12 @@ function initialize(
 
     // FIXME(bartlomieju): not nice to depend on `Deno` namespace here
     // but it's the only way to get `args` and `version` and this point.
-    internals.__bootstrapNodeProcess(argv0, Deno.args, Deno.version);
+    internals.__bootstrapNodeProcess(
+      argv0,
+      Deno.args,
+      Deno.version,
+      Deno.env.get("NODE_DEBUG") ?? "",
+    );
     internals.__initWorkerThreads(
       runningOnMainThread,
       workerId,
@@ -40,7 +45,13 @@ function initialize(
     delete internals.requireImpl;
   } else {
     // Warm up the process module
-    internals.__bootstrapNodeProcess(undefined, undefined, undefined, true);
+    internals.__bootstrapNodeProcess(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
   }
 }
 

--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -12,7 +12,7 @@ let debugImpls: Record<string, (...args: unknown[]) => void>;
 let testEnabled: (str: string) => boolean;
 
 // `debugEnv` is initial value of process.env.NODE_DEBUG
-function initializeDebugEnv(debugEnv: string) {
+export function initializeDebugEnv(debugEnv: string) {
   debugImpls = Object.create(null);
   if (debugEnv) {
     // This is run before any user code, it's OK not to use primordials.
@@ -105,21 +105,5 @@ export function debuglog(
 
   return logger;
 }
-
-let debugEnv;
-/* TODO(kt3k): enable initializing debugEnv.
-It's not possible to access env var when snapshotting.
-
-try {
-  debugEnv = Deno.env.get("NODE_DEBUG") ?? "";
-} catch (error) {
-  if (error instanceof Deno.errors.PermissionDenied) {
-    debugEnv = "";
-  } else {
-    throw error;
-  }
-}
-*/
-initializeDebugEnv(debugEnv);
 
 export default { debuglog };

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -5,6 +5,7 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { core, internals } from "ext:core/mod.js";
+import { initializeDebugEnv } from "ext:deno_node/internal/util/debuglog.ts";
 import {
   op_geteuid,
   op_node_process_kill,
@@ -845,6 +846,7 @@ internals.__bootstrapNodeProcess = function (
   argv0Val: string | undefined,
   args: string[],
   denoVersions: Record<string, string>,
+  nodeDebug: string,
   warmup = false,
 ) {
   if (!warmup) {
@@ -890,6 +892,8 @@ internals.__bootstrapNodeProcess = function (
     arch = arch_();
     platform = isWindows ? "win32" : Deno.build.os;
     pid = Deno.pid;
+
+    initializeDebugEnv(nodeDebug);
 
     // @ts-ignore Remove setStartTime and #startTime is not modifiable
     delete process.setStartTime;

--- a/tests/specs/node/node_debug/__test__.jsonc
+++ b/tests/specs/node/node_debug/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "args": "run --allow-read main.mjs",
+  "envs": { "NODE_DEBUG": "*" },
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/node/node_debug/hello.txt
+++ b/tests/specs/node/node_debug/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/specs/node/node_debug/main.mjs
+++ b/tests/specs/node/node_debug/main.mjs
@@ -1,0 +1,14 @@
+import { createReadStream } from "node:fs";
+import path from "node:path";
+
+const filePath = path.join(import.meta.dirname, "hello.txt");
+const readableStream = createReadStream(filePath);
+readableStream.on("data", (chunk) => {
+  console.log(chunk.toString());
+});
+readableStream.on("end", () => {
+  console.log("Finished reading the file");
+});
+readableStream.on("error", (error) => {
+  console.error("Error reading the file:", error);
+});

--- a/tests/specs/node/node_debug/main.out
+++ b/tests/specs/node/node_debug/main.out
@@ -1,0 +1,36 @@
+STREAM [WILDCARD] 'resume'
+STREAM [WILDCARD] 'resume' false
+STREAM [WILDCARD] 'read' 0
+STREAM [WILDCARD] 'need readable' false
+STREAM [WILDCARD] 'length less than watermark' true
+STREAM [WILDCARD] 'reading, ended or constructing' false
+STREAM [WILDCARD] 'flow' true
+STREAM [WILDCARD] 'read' undefined
+STREAM [WILDCARD] 'need readable' true
+STREAM [WILDCARD] 'length less than watermark' true
+STREAM [WILDCARD] 'reading, ended or constructing' false
+STREAM [WILDCARD] 'read' 0
+STREAM [WILDCARD] 'need readable' true
+STREAM [WILDCARD] 'length less than watermark' true
+STREAM [WILDCARD] 'reading, ended or constructing' false
+STREAM [WILDCARD] 'maybeReadMore read 0'
+STREAM [WILDCARD] 'read' 0
+STREAM [WILDCARD] 'need readable' true
+STREAM [WILDCARD] 'length less than watermark' true
+STREAM [WILDCARD] 'do read'
+STREAM [WILDCARD] 'readableAddChunk' <Buffer 68 65 6c 6c 6f 20 77 6f 72 6c 64 0a>
+hello world
+
+STREAM [WILDCARD] 'maybeReadMore read 0'
+STREAM [WILDCARD] 'read' 0
+STREAM [WILDCARD] 'need readable' true
+STREAM [WILDCARD] 'length less than watermark' true
+STREAM [WILDCARD] 'do read'
+STREAM [WILDCARD] 'readableAddChunk' null
+STREAM [WILDCARD] 'onEofChunk'
+STREAM [WILDCARD] 'emitReadable_' false 0 true
+STREAM [WILDCARD] 'flow' true
+STREAM [WILDCARD] 'read' undefined
+STREAM [WILDCARD] 'endReadable' false
+STREAM [WILDCARD] 'endReadableNT' false 0
+Finished reading the file


### PR DESCRIPTION
Previously we didn't support NODE_DEBUG environment variable due to issues in snapshot process. The issue is solved by initializing the logger during bootstrap which is not included in the snapshot allowing the build to work.