### PR TITLE
refactor: remove conditional color code in bench reporter

### DIFF
--- a/cli/tools/bench/reporters.rs
+++ b/cli/tools/bench/reporters.rs
@@ -138,7 +138,6 @@ impl BenchReporter for ConsoleReporter {
     let options = self.options.as_mut().unwrap();
 
     options.percentiles = true;
-    options.colors = colors::use_color();
 
     if FIRST_PLAN
       .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
@@ -246,10 +245,9 @@ impl BenchReporter for ConsoleReporter {
   }
 
   fn report_group_summary(&mut self) {
-    let options = match self.options.as_ref() {
-      None => return,
-      Some(options) => options,
-    };
+    if self.options.is_none() {
+      return;
+    }
 
     if 2 <= self.group_measurements.len()
       && (self.group.is_some() || (self.group.is_none() && self.baseline))
@@ -275,7 +273,6 @@ impl BenchReporter for ConsoleReporter {
               },
             })
             .collect::<Vec<mitata::reporter::GroupBenchmark>>(),
-          options
         )
       );
     }


### PR DESCRIPTION
There is no need for this conditional code because it's handled by the `colors` module.