### PR TITLE
feat(cli/tools/jupyter) Add --directory flag to control where jupyter kernelspec installs

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3832,8 +3832,8 @@ fn jupyter_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let conn_file = matches.remove_one::<String>("conn");
   let kernel = matches.get_flag("kernel");
   let install = matches.get_flag("install");
-  let directory = if matches.contains_id("directory") {
-    matches.remove_one::<PathBuf>("directory")
+  let directory = if matches.contains_id("dir") {
+    matches.remove_one::<PathBuf>("dir")
   } else {
     None
   };

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -9305,7 +9305,7 @@ mod tests {
           install: true,
           kernel: false,
           conn_file: None,
-          directory: Some(PathBuf::from_str("/tmp/deno").unwrap()),
+          directory: Some(PathBuf::from_str("/tmp/deno"))
         }),
         ..Flags::default()
       }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2058,8 +2058,8 @@ fn jupyter_subcommand() -> Command {
         .value_hint(ValueHint::FilePath)
         .conflicts_with("install"))
     .arg(
-      Arg::new("directory")
-        .long("directory")
+      Arg::new("dir")
+        .long("dir")
         .help("Sets the directory to install kernelspec.")
         .value_parser(value_parser!(PathBuf))
         .value_hint(ValueHint::DirPath)
@@ -9295,7 +9295,7 @@ mod tests {
       "deno",
       "jupyter",
       "--install",
-      "--directory",
+      "--dir",
       "/tmp/deno"
     ]);
     assert_eq!(
@@ -9305,7 +9305,7 @@ mod tests {
           install: true,
           kernel: false,
           conn_file: None,
-          directory: Some(PathBuf::from_str("/tmp/deno"))
+          directory: Some(PathBuf::from_str("/tmp/deno").unwrap_or_default())
         }),
         ..Flags::default()
       }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -9305,7 +9305,7 @@ mod tests {
           install: true,
           kernel: false,
           conn_file: None,
-          directory: Some(PathBuf::from_str("/tmp/deno"))
+          directory: Some(PathBuf::from_str("/tmp/deno").unwrap()),
         }),
         ..Flags::default()
       }

--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -55,12 +55,8 @@ pub fn install(directory: Option<PathBuf>) -> Result<(), AnyError> {
     None => install_via_jupyter(),
   };
 
-  match outcome {
-    Ok(()) => Ok(()),
-    Err(err) => {
-        println!("{}", err);
-        bail!();
-    }
+  if outcome.is_err() {
+    bail!("🆘 Failed to install Deno kernel");
   }
 
   println!("✅ Deno kernelspec installed successfully.");
@@ -100,11 +96,11 @@ fn create_kernelspec_in_directory(directory: &PathBuf) -> Result<(), AnyError> {
   Ok(())
 }
 
-
 fn install_via_jupyter() -> Result<(), AnyError> {
   let temp_dir = TempDir::new().unwrap();
 
-  let create_kernelspec_result = create_kernelspec_in_directory(&temp_dir.path().to_path_buf());
+  let create_kernelspec_result =
+    create_kernelspec_in_directory(&temp_dir.path().to_path_buf());
   if create_kernelspec_result.is_err() {
     return create_kernelspec_result;
   }

--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -55,8 +55,12 @@ pub fn install(directory: Option<PathBuf>) -> Result<(), AnyError> {
     None => install_via_jupyter(),
   };
 
-  if outcome.is_err() {
-    bail!("🆘 Failed to install Deno kernel");
+  match outcome {
+    Ok(()) => Ok(()),
+    Err(err) => {
+        println!("{}", err);
+        bail!();
+    }
   }
 
   println!("✅ Deno kernelspec installed successfully.");
@@ -96,11 +100,11 @@ fn create_kernelspec_in_directory(directory: &PathBuf) -> Result<(), AnyError> {
   Ok(())
 }
 
+
 fn install_via_jupyter() -> Result<(), AnyError> {
   let temp_dir = TempDir::new().unwrap();
 
-  let create_kernelspec_result =
-    create_kernelspec_in_directory(&temp_dir.path().to_path_buf());
+  let create_kernelspec_result = create_kernelspec_in_directory(&temp_dir.path().to_path_buf());
   if create_kernelspec_result.is_err() {
     return create_kernelspec_result;
   }

--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -56,7 +56,7 @@ pub fn install(directory: Option<PathBuf>) -> Result<(), AnyError> {
   };
 
   if outcome.is_err() {
-    bail!("🆘 Failed to install Deno kernel");
+    bail!("🆘 Failed to install Deno kernel: {:?}", outcome.unwrap_err());
   }
 
   println!("✅ Deno kernelspec installed successfully.");

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -46,7 +46,7 @@ pub async fn kernel(
   }
 
   if jupyter_flags.install {
-    install::install()?;
+    install::install(jupyter_flags.directory)?;
     return Ok(());
   }
 


### PR DESCRIPTION
Closes: https://github.com/denoland/deno/issues/20744

Adds ability to specify the kernelspec location for deno's jupyter kernel during install with --directory flag without the requirement of having Jupyter binary on the PATH.

Advanced installs can specify their own path:
`deno jupyter --install --dir ~/.kernelspec_custom_location/deno`
(Edited from directory -> dir)

Standard installs continue with default behavior by installing in user's kernelspec folder via jupyter shelling out:
`deno jupyter --install`

In the advanced case deno builds and installs the files directly rather than relying on calling out to jupyter to determine path.

This is useful in the circumstance where jupyter is not on PATH at time of installing deno jupyter, but it is available and used via a wrapping library.

# Action Items

- [x] Give the PR a descriptive title.
- [x] Ensure there is a related issue and it is referenced in the PR text.
- [ ] Ensure there are tests that cover the changes.
- [ ] Ensure `cargo test` passes.
- [ ] Ensure `./tools/format.js` passes without changing files.
- [ ] Ensure `./tools/lint.js` passes.
- [x] Open as a draft PR if your work is still in progress. The CI won't run
      all steps, but you can add '[ci]' to a commit message to force it to.
      If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
