### PR TITLE
fix(ext/http): ensure signal is created iff requested

### DIFF
--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -23,6 +23,7 @@ const {
   addTrailers,
   serveHttpOnListener,
   serveHttpOnConnection,
+  getCachedAbortSignal,
   // @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
 } = Deno[Deno.internal];
 
@@ -2837,6 +2838,31 @@ for (const delay of ["delay", "nodelay"]) {
     });
   }
 }
+
+// Test for the internal implementation detail of cached request signals. Ensure that the request's
+// signal is aborted if we try to access it after the request has been completed.
+Deno.test(
+  { permissions: { net: true } },
+  async function httpServerSignalCancelled() {
+    let stashedRequest;
+    const { finished, abort } = await makeServer(async (req) => {
+      assertEquals(getCachedAbortSignal(req), undefined);
+      stashedRequest = req;
+      return new Response("ok");
+    });
+    await (await fetch(`http://localhost:${servePort}`)).text();
+    abort();
+    await finished;
+
+    // False is a semaphore for a signal that should be aborted on creation
+    assertEquals(getCachedAbortSignal(stashedRequest!), false);
+    assert(stashedRequest!.signal.aborted);
+    assertEquals(
+      getCachedAbortSignal(stashedRequest!).constructor,
+      AbortSignal,
+    );
+  },
+);
 
 Deno.test(
   { permissions: { net: true } },


### PR DESCRIPTION
This correctly creates the `AbortSignal` regardless of when we request it. If the signal is requested after the request has completed, the signal is created in the aborted state.

Using GC counts, we can see a reduction in object creation:

This PR: 440
deno 1.42.4: 1650
deno 1.43.0+b02ffec: 874
