### PR TITLE
Add `Deno.exitCode` API

### DIFF
--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -139,6 +139,7 @@ export {
   env,
   execPath,
   exit,
+  exitCode,
   gid,
   hostname,
   loadavg,

--- a/runtime/js/30_os.js
+++ b/runtime/js/30_os.js
@@ -94,6 +94,19 @@ function exit(code) {
   throw new Error("Code not reachable");
 }
 
+let _exitCode;
+const exitCode = {
+  get() {
+    return _exitCode;
+  },
+  set(value) {
+    _exitCode = parseInt(value) || undefined;
+    if (typeof _exitCode === "number") {
+      op_set_exit_code(_exitCode);
+    }
+  }
+};
+
 function setEnv(key, value) {
   op_set_env(key, value);
 }


### PR DESCRIPTION
Related to #23605

Implements the `Deno.exitCode` API to allow setting a would-be exit code without immediately terminating the process.
- Introduces a getter and setter for `Deno.exitCode` within `runtime/js/30_os.js`. The setter allows setting a would-be exit code that is stored in a private variable `_exitCode`. If a number is provided, it is parsed with `parseInt` and then passed to the `op_set_exit_code` Rust operation to update the process's exit code without exiting.
- Ensures that setting `Deno.exitCode` does not trigger an immediate process exit, allowing for asynchronous cleanup or other operations before the process terminates.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/denoland/deno/issues/23605?shareId=37b09675-cee7-4172-bc05-aaa53d587626).