### PR TITLE
chore: use `std@main`

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -647,7 +647,7 @@ const ci = {
           name: "test_format.js",
           if: "matrix.job == 'lint' && matrix.os == 'linux'",
           run:
-            "deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check",
+            "deno run --unstable --allow-write --allow-read --allow-run --allow-net --config=tests/util/std/deno.json ./tools/format.js --check",
         },
         {
           name: "Lint PR title",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
           cache-path: ./target
       - name: test_format.js
         if: '!(matrix.skip) && (matrix.job == ''lint'' && matrix.os == ''linux'')'
-        run: deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check
+        run: deno run --unstable --allow-write --allow-read --allow-run --allow-net --config=tests/util/std/deno.json ./tools/format.js --check
       - name: Lint PR title
         if: '!(matrix.skip) && (matrix.job == ''lint'' && github.event_name == ''pull_request'' && matrix.os == ''linux'')'
         env:


### PR DESCRIPTION
Yoshiya and I would like to experiment with using `std`'s main branch for this repo, seeing as new codebase-wide versions are no longer published since migrating to JSR.