### PR TITLE
chore(lsp): revert import map pre-resolution for jsxImportSource

### DIFF
--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -10628,7 +10628,7 @@ export function B() {
   );
 
   let diagnostics = client.read_diagnostics();
-  assert_eq!(diagnostics.all().len(), 0);
+  assert_eq!(json!(diagnostics.all()), json!([]));
 
   let res = client.write_request(
     "textDocument/hover",


### PR DESCRIPTION
This was initially a red herring solution added in #23313, the proper fix was #23329. I kept it because it seemed nice but actually it's superfluous -- if tsc wants to resolve the `jsxImportSource` specifier with each module as a referrer then we should align. Plus it was inconsistent with `deno check`.