### PR TITLE
fix(ext/node): check resource exists before close

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -1015,7 +1015,7 @@ export class ClientHttp2Stream extends Duplex {
           this.emit("trailers", trailers);
         }
 
-        debugHttp2("tryClose");
+        debugHttp2(">>> tryClose", this[kDenoResponse]?.bodyRid);
         core.tryClose(this[kDenoResponse].bodyRid);
         this.push(null);
         debugHttp2(">>> read null chunk");
@@ -1246,10 +1246,12 @@ function finishCloseStream(stream, code) {
         debugHttp2(
           ">>> finishCloseStream close",
           stream[kDenoRid],
-          stream[kDenoResponse].bodyRid,
+          stream[kDenoResponse]?.bodyRid,
         );
         core.tryClose(stream[kDenoRid]);
-        core.tryClose(stream[kDenoResponse].bodyRid);
+        if (stream[kDenoResponse]) {
+          core.tryClose(stream[kDenoResponse].bodyRid);
+        }
         stream.emit("close");
       });
     });
@@ -1265,7 +1267,9 @@ function finishCloseStream(stream, code) {
         stream[kDenoResponse].bodyRid,
       );
       core.tryClose(stream[kDenoRid]);
-      core.tryClose(stream[kDenoResponse].bodyRid);
+      if (stream[kDenoResponse]) {
+        core.tryClose(stream[kDenoResponse].bodyRid);
+      }
       nextTick(() => {
         stream.emit("close");
       });
@@ -1273,10 +1277,12 @@ function finishCloseStream(stream, code) {
       debugHttp2(
         ">>> finishCloseStream close2 catch",
         stream[kDenoRid],
-        stream[kDenoResponse].bodyRid,
+        stream[kDenoResponse]?.bodyRid,
       );
       core.tryClose(stream[kDenoRid]);
-      core.tryClose(stream[kDenoResponse].bodyRid);
+      if (stream[kDenoResponse]) {
+        core.tryClose(stream[kDenoResponse].bodyRid);
+      }
       nextTick(() => {
         stream.emit("close");
       });


### PR DESCRIPTION
The patch fixes grpc deadline example:

```sh
➜deno run -A deadline/client.js
Warning: Not implemented: Http2Session.socket
[1] wanted = OK got = OK
Warning: Not implemented: Http2Session.socket
[2] wanted = DEADLINE_EXCEEDED got = DEADLINE_EXCEEDED
Warning: Not implemented: Http2Session.socket
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'bodyRid')
    at node:http2:888:96
    at eventLoopTick (ext:core/01_core.js:207:9)
```

Fixed:

```
➜  examples git:(es_examples) denod run -A deadline/client.js
Warning: Not implemented: Http2Session.socket
[1] wanted = OK got = OK
Warning: Not implemented: Http2Session.socket
[2] wanted = DEADLINE_EXCEEDED got = DEADLINE_EXCEEDED
Warning: Not implemented: Http2Session.socket
[3] wanted = OK got = OK
Warning: Not implemented: Http2Session.socket
[4] wanted = DEADLINE_EXCEEDED got = DEADLINE_EXCEEDED
Warning: Not implemented: Http2Session.socket
[5] wanted = OK got = OK
Warning: Not implemented: Http2Session.socket
[6] wanted = DEADLINE_EXCEEDED got = DEADLINE_EXCEEDED
```

I added a smoke test in the internal repo.
