### PR TITLE
test: npm registry handles two test scopes

### DIFF
--- a/tests/specs/npm/denotest2_scope/__test__.jsonc
+++ b/tests/specs/npm/denotest2_scope/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "run -A main.js",
+  "output": "main.out"
+}

--- a/tests/specs/npm/denotest2_scope/main.js
+++ b/tests/specs/npm/denotest2_scope/main.js
@@ -1,0 +1,3 @@
+import * as test from "npm:@denotest2/basic";
+
+console.log(test.getValue());

--- a/tests/specs/npm/denotest2_scope/main.out
+++ b/tests/specs/npm/denotest2_scope/main.out
@@ -1,0 +1,3 @@
+Download http://localhost:4545/npm/registry/@denotest2/basic
+Download http://localhost:4545/npm/registry/@denotest2/basic/1.0.0.tgz
+0

--- a/tests/testdata/npm/registry/@denotest2/basic/1.0.0/main.d.mts
+++ b/tests/testdata/npm/registry/@denotest2/basic/1.0.0/main.d.mts
@@ -1,0 +1,3 @@
+export declare function setValue(val: number): void;
+export declare function getValue(): number;
+export declare const url: string;

--- a/tests/testdata/npm/registry/@denotest2/basic/1.0.0/main.mjs
+++ b/tests/testdata/npm/registry/@denotest2/basic/1.0.0/main.mjs
@@ -1,0 +1,11 @@
+let value = 0;
+
+export function setValue(newValue) {
+  value = newValue;
+}
+
+export function getValue() {
+  return value;
+}
+
+export const url = import.meta.url;

--- a/tests/testdata/npm/registry/@denotest2/basic/1.0.0/other.mjs
+++ b/tests/testdata/npm/registry/@denotest2/basic/1.0.0/other.mjs
@@ -1,0 +1,3 @@
+export function hello() {
+    return "hello, world!";
+}

--- a/tests/testdata/npm/registry/@denotest2/basic/1.0.0/package.json
+++ b/tests/testdata/npm/registry/@denotest2/basic/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest2/basic",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "main.mjs",
+  "types": "main.d.mts"
+}

--- a/tests/util/server/src/npm.rs
+++ b/tests/util/server/src/npm.rs
@@ -16,6 +16,7 @@ use tar::Builder;
 use crate::testdata_path;
 
 pub const DENOTEST_SCOPE_NAME: &str = "@denotest";
+pub const DENOTEST2_SCOPE_NAME: &str = "@denotest2";
 
 pub static PUBLIC_TEST_NPM_REGISTRY: Lazy<TestNpmRegistry> = Lazy::new(|| {
   TestNpmRegistry::new(
@@ -121,16 +122,33 @@ impl TestNpmRegistry {
     uri_path.strip_prefix(&self.path)
   }
 
-  pub fn strip_denotest_prefix_from_uri_path<'s>(
+  pub fn get_test_scope_and_package_name_with_path_from_uri_path<'s>(
     &self,
     uri_path: &'s str,
-  ) -> Option<&'s str> {
+  ) -> Option<(&'s str, &'s str)> {
     let prefix1 = format!("{}{}/", self.path, DENOTEST_SCOPE_NAME);
     let prefix2 = format!("{}{}%2f", self.path, DENOTEST_SCOPE_NAME);
 
-    uri_path
+    let maybe_package_name_with_path = uri_path
       .strip_prefix(&prefix1)
-      .or_else(|| uri_path.strip_prefix(&prefix2))
+      .or_else(|| uri_path.strip_prefix(&prefix2));
+
+    if let Some(package_name_with_path) = maybe_package_name_with_path {
+      return Some((DENOTEST_SCOPE_NAME, package_name_with_path));
+    }
+
+    let prefix1 = format!("{}{}/", self.path, DENOTEST2_SCOPE_NAME);
+    let prefix2 = format!("{}{}%2f", self.path, DENOTEST2_SCOPE_NAME);
+
+    let maybe_package_name_with_path = uri_path
+      .strip_prefix(&prefix1)
+      .or_else(|| uri_path.strip_prefix(&prefix2));
+
+    if let Some(package_name_with_path) = maybe_package_name_with_path {
+      return Some((DENOTEST2_SCOPE_NAME, package_name_with_path));
+    }
+
+    None
   }
 
   pub fn uri_path_starts_with_registry_path(&self, uri_path: &str) -> bool {

--- a/tests/util/server/src/servers/mod.rs
+++ b/tests/util/server/src/servers/mod.rs
@@ -1217,23 +1217,26 @@ async fn private_npm_registry1(
 }
 
 fn handle_custom_npm_registry_path(
+  scope_name: &str,
   path: &str,
   test_npm_registry: &npm::TestNpmRegistry,
 ) -> Result<Option<Response<UnsyncBoxBody<Bytes, Infallible>>>, anyhow::Error> {
-  let parts = path
+  let mut parts = path
     .split('/')
     .filter(|p| !p.is_empty())
     .collect::<Vec<_>>();
+  let remainder = parts.split_off(1);
+  let name = parts[0];
+  let package_name = format!("{}/{}", scope_name, name);
 
-  let package_name = format!("@denotest/{}", parts[0]);
-  if parts.len() == 2 {
+  if remainder.len() == 1 {
     if let Some(file_bytes) = test_npm_registry
-      .tarball_bytes(&package_name, parts[1].trim_end_matches(".tgz"))?
+      .tarball_bytes(&package_name, remainder[0].trim_end_matches(".tgz"))?
     {
       let file_resp = custom_headers("file.tgz", file_bytes);
       return Ok(Some(file_resp));
     }
-  } else if parts.len() == 1 {
+  } else if remainder.is_empty() {
     if let Some(registry_file) =
       test_npm_registry.registry_file(&package_name)?
     {
@@ -1256,12 +1259,16 @@ async fn try_serve_npm_registry(
   mut testdata_file_path: PathBuf,
   test_npm_registry: &npm::TestNpmRegistry,
 ) -> Option<Result<Response<UnsyncBoxBody<Bytes, Infallible>>, anyhow::Error>> {
-  if let Some(suffix) =
-    test_npm_registry.strip_denotest_prefix_from_uri_path(uri_path)
+  if let Some((scope_name, package_name_with_path)) = test_npm_registry
+    .get_test_scope_and_package_name_with_path_from_uri_path(uri_path)
   {
-    // serve all requests to the `DENOTEST_SCOPE_NAME` using the file system
-    // at that path
-    match handle_custom_npm_registry_path(suffix, test_npm_registry) {
+    // serve all requests to the `DENOTEST_SCOPE_NAME` or `DENOTEST2_SCOPE_NAME`
+    // using the file system at that path
+    match handle_custom_npm_registry_path(
+      scope_name,
+      package_name_with_path,
+      test_npm_registry,
+    ) {
       Ok(Some(response)) => return Some(Ok(response)),
       Ok(None) => {} // ignore, not found
       Err(err) => {


### PR DESCRIPTION
This commit updates our testing npm registry to handle
additional `@denotest2` scope in addition to `@denotest`
scope. I might have to update it further in the future to handle
additional scopes, but it's good enough for now.