### PR TITLE
chore(lsp): remove diagnostics for redirected http imports

### DIFF
--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -5,7 +5,6 @@ use deno_core::serde::Deserialize;
 use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
-use deno_core::url::Url;
 use pretty_assertions::assert_eq;
 use std::fs;
 use test_util::assert_starts_with;
@@ -8563,169 +8562,6 @@ fn lsp_tls_cert() {
 }
 
 #[test]
-fn lsp_diagnostics_warn_redirect() {
-  let context = TestContextBuilder::new()
-    .use_http_server()
-    .use_temp_cwd()
-    .build();
-  let mut client = context.new_lsp_command().build();
-  client.initialize_default();
-  client.did_open(
-    json!({
-      "textDocument": {
-        "uri": "file:///a/file.ts",
-        "languageId": "typescript",
-        "version": 1,
-        "text": "import * as a from \"http://127.0.0.1:4545/x_deno_warning.js\";\n\nconsole.log(a)\n",
-      },
-    }),
-  );
-  client.write_request(
-    "workspace/executeCommand",
-    json!({
-      "command": "deno.cache",
-      "arguments": [
-        ["http://127.0.0.1:4545/x_deno_warning.js"],
-        "file:///a/file.ts",
-      ],
-    }),
-  );
-  let diagnostics = client.read_diagnostics();
-  assert_eq!(
-    diagnostics.messages_with_source("deno"),
-    lsp::PublishDiagnosticsParams {
-      uri: Url::parse("file:///a/file.ts").unwrap(),
-      diagnostics: vec![
-        lsp::Diagnostic {
-          range: lsp::Range {
-            start: lsp::Position {
-              line: 0,
-              character: 19
-            },
-            end: lsp::Position {
-              line: 0,
-              character: 60
-            }
-          },
-          severity: Some(lsp::DiagnosticSeverity::WARNING),
-          code: Some(lsp::NumberOrString::String("deno-warn".to_string())),
-          source: Some("deno".to_string()),
-          message: "foobar".to_string(),
-          ..Default::default()
-        },
-        lsp::Diagnostic {
-          range: lsp::Range {
-            start: lsp::Position {
-              line: 0,
-              character: 19
-            },
-            end: lsp::Position {
-              line: 0,
-              character: 60
-            }
-          },
-          severity: Some(lsp::DiagnosticSeverity::INFORMATION),
-          code: Some(lsp::NumberOrString::String("redirect".to_string())),
-          source: Some("deno".to_string()),
-          message: "The import of \"http://127.0.0.1:4545/x_deno_warning.js\" was redirected to \"http://127.0.0.1:4545/lsp/x_deno_warning_redirect.js\".".to_string(),
-          data: Some(json!({"specifier": "http://127.0.0.1:4545/x_deno_warning.js", "redirect": "http://127.0.0.1:4545/lsp/x_deno_warning_redirect.js"})),
-          ..Default::default()
-        }
-      ],
-      version: Some(1),
-    }
-  );
-  client.shutdown();
-}
-
-#[test]
-fn lsp_redirect_quick_fix() {
-  let context = TestContextBuilder::new()
-    .use_http_server()
-    .use_temp_cwd()
-    .build();
-  let mut client = context.new_lsp_command().build();
-  client.initialize_default();
-  client.did_open(
-    json!({
-      "textDocument": {
-        "uri": "file:///a/file.ts",
-        "languageId": "typescript",
-        "version": 1,
-        "text": "import * as a from \"http://127.0.0.1:4545/x_deno_warning.js\";\n\nconsole.log(a)\n",
-      },
-    }),
-  );
-  client.write_request(
-    "workspace/executeCommand",
-    json!({
-      "command": "deno.cache",
-      "arguments": [
-        ["http://127.0.0.1:4545/x_deno_warning.js"],
-        "file:///a/file.ts",
-      ],
-    }),
-  );
-  let diagnostics = client
-    .read_diagnostics()
-    .messages_with_source("deno")
-    .diagnostics;
-  let res = client.write_request(
-    "textDocument/codeAction",
-    json!(json!({
-      "textDocument": {
-        "uri": "file:///a/file.ts"
-      },
-      "range": {
-        "start": { "line": 0, "character": 19 },
-        "end": { "line": 0, "character": 60 }
-      },
-      "context": {
-        "diagnostics": diagnostics,
-        "only": ["quickfix"]
-      }
-    })),
-  );
-  assert_eq!(
-    res,
-    json!([{
-      "title": "Update specifier to its redirected specifier.",
-      "kind": "quickfix",
-      "diagnostics": [
-        {
-          "range": {
-            "start": { "line": 0, "character": 19 },
-            "end": { "line": 0, "character": 60 }
-          },
-          "severity": 3,
-          "code": "redirect",
-          "source": "deno",
-          "message": "The import of \"http://127.0.0.1:4545/x_deno_warning.js\" was redirected to \"http://127.0.0.1:4545/lsp/x_deno_warning_redirect.js\".",
-          "data": {
-            "specifier": "http://127.0.0.1:4545/x_deno_warning.js",
-            "redirect": "http://127.0.0.1:4545/lsp/x_deno_warning_redirect.js"
-          }
-        }
-      ],
-      "edit": {
-        "changes": {
-          "file:///a/file.ts": [
-            {
-              "range": {
-                "start": { "line": 0, "character": 19 },
-                "end": { "line": 0, "character": 60 }
-              },
-              "newText": "\"http://127.0.0.1:4545/lsp/x_deno_warning_redirect.js\""
-            }
-          ]
-        }
-      }
-    }])
-  );
-  client.shutdown();
-}
-
-#[test]
 fn lsp_diagnostics_deprecated() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let mut client = context.new_lsp_command().build();
@@ -12117,17 +11953,16 @@ fn lsp_sloppy_imports_warn() {
               character: 24
             }
           },
-          severity: Some(lsp::DiagnosticSeverity::INFORMATION),
-          code: Some(lsp::NumberOrString::String("redirect".to_string())),
+          severity: Some(lsp::DiagnosticSeverity::WARNING),
+          code: Some(lsp::NumberOrString::String("non-canonical".to_string())),
           source: Some("deno".to_string()),
           message: format!(
-            "The import of \"{}\" was redirected to \"{}\".",
+            "The import of \"{}\" was canonicalized to \"{}\".",
             temp_dir.join("a").uri_file(),
             temp_dir.join("a.ts").uri_file()
           ),
           data: Some(json!({
-            "specifier": temp_dir.join("a").uri_file(),
-            "redirect": temp_dir.join("a.ts").uri_file()
+            "specifier": temp_dir.join("a.ts").uri_file()
           })),
           ..Default::default()
         },
@@ -12142,17 +11977,16 @@ fn lsp_sloppy_imports_warn() {
               character: 27
             }
           },
-          severity: Some(lsp::DiagnosticSeverity::INFORMATION),
-          code: Some(lsp::NumberOrString::String("redirect".to_string())),
+          severity: Some(lsp::DiagnosticSeverity::WARNING),
+          code: Some(lsp::NumberOrString::String("non-canonical".to_string())),
           source: Some("deno".to_string()),
           message: format!(
-            "The import of \"{}\" was redirected to \"{}\".",
+            "The import of \"{}\" was canonicalized to \"{}\".",
             temp_dir.join("b.js").uri_file(),
             temp_dir.join("b.ts").uri_file()
           ),
           data: Some(json!({
-            "specifier": temp_dir.join("b.js").uri_file(),
-            "redirect": temp_dir.join("b.ts").uri_file()
+            "specifier": temp_dir.join("b.ts").uri_file()
           })),
           ..Default::default()
         }
@@ -12178,16 +12012,15 @@ fn lsp_sloppy_imports_warn() {
             "end": { "line": 0, "character": 24 }
           },
           "severity": 3,
-          "code": "redirect",
+          "code": "non-canonical",
           "source": "deno",
           "message": format!(
-            "The import of \"{}\" was redirected to \"{}\".",
+            "The import of \"{}\" was canonicalized to \"{}\".",
             temp_dir.join("a").uri_file(),
             temp_dir.join("a.ts").uri_file()
           ),
           "data": {
-            "specifier": temp_dir.join("a").uri_file(),
-            "redirect": temp_dir.join("a.ts").uri_file(),
+            "specifier": temp_dir.join("a.ts").uri_file(),
           },
         }],
         "only": ["quickfix"]
@@ -12197,7 +12030,7 @@ fn lsp_sloppy_imports_warn() {
   assert_eq!(
     res,
     json!([{
-      "title": "Update specifier to its redirected specifier.",
+      "title": "Update specifier to its canonicalized specifier.",
       "kind": "quickfix",
       "diagnostics": [{
         "range": {
@@ -12205,16 +12038,15 @@ fn lsp_sloppy_imports_warn() {
           "end": { "line": 0, "character": 24 }
         },
         "severity": 3,
-        "code": "redirect",
+        "code": "non-canonical",
         "source": "deno",
         "message": format!(
-          "The import of \"{}\" was redirected to \"{}\".",
+          "The import of \"{}\" was canonicalized to \"{}\".",
           temp_dir.join("a").uri_file(),
           temp_dir.join("a.ts").uri_file()
         ),
         "data": {
-          "specifier": temp_dir.join("a").uri_file(),
-          "redirect": temp_dir.join("a.ts").uri_file()
+          "specifier": temp_dir.join("a.ts").uri_file()
         },
       }],
       "edit": {


### PR DESCRIPTION
These 'info' diagnostics are bothersome to users. If it's not a warning or error we shouldn't show it. We added these to discourage unversioned `deno.land/x` imports but we can possibly pivot to more targeted diagnostics for `jsr:` and `npm:` specifiers in the future.

Diagnostics for extensionless imports under `--unstable-sloppy-imports` are preserved and upgraded to warnings ('redirect' -> 'canonicalization').