### PR TITLE
fix(runtime): allow r/w access to /etc without --allow-all

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1691,17 +1691,8 @@ impl PermissionsContainer {
           self.check_was_allow_all_flag_passed().map_err(error_all)?;
         }
       }
-      if path.starts_with("/etc") {
-        self.check_was_allow_all_flag_passed().map_err(error_all)?;
-      }
     } else if cfg!(unix) {
       if path.starts_with("/dev") {
-        self.check_was_allow_all_flag_passed().map_err(error_all)?;
-      }
-      if path.starts_with("/etc") {
-        self.check_was_allow_all_flag_passed().map_err(error_all)?;
-      }
-      if path.starts_with("/private/etc") {
         self.check_was_allow_all_flag_passed().map_err(error_all)?;
       }
     } else if cfg!(target_os = "windows") {

--- a/tests/specs/permission/special/main.js
+++ b/tests/specs/permission/special/main.js
@@ -4,8 +4,8 @@
 const testCases = [
   // Allowed, safe
   [["darwin", "linux"], null, "/dev/null"],
+  [["darwin", "linux"], null, "/etc/passwd"],
   // Denied, requires `--allow-all`
-  [["darwin", "linux"], /PermissionDenied/, "/etc/hosts"],
   [["darwin", "linux"], /PermissionDenied/, "/dev/ptmx"],
   [["linux"], /PermissionDenied/, "/proc/self/environ"],
   [["linux"], /PermissionDenied/, "/proc/self/mem"],


### PR DESCRIPTION
This is not a special path that can be used to escalate or bypass Deno permissions, such as `--allow-env` or `--allow-sys`.

Related #23703