### PR TITLE
fix(lsp): Pass diagnostic codes to TSC as numbers

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1586,8 +1586,14 @@ impl Inner {
         match diagnostic.source.as_deref() {
           Some("deno-ts") => {
             let code = match diagnostic.code.as_ref().unwrap() {
-              NumberOrString::String(code) => code.to_string(),
-              NumberOrString::Number(code) => code.to_string(),
+              NumberOrString::String(code) => match code.parse() {
+                Ok(c) => c,
+                Err(e) => {
+                  lsp_warn!("Invalid diagnostic code {code}: {e}");
+                  continue;
+                }
+              },
+              NumberOrString::Number(code) => *code,
             };
             let codes = vec![code];
             let actions = self

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -511,7 +511,7 @@ impl TsServer {
     snapshot: Arc<StateSnapshot>,
     specifier: ModuleSpecifier,
     range: Range<u32>,
-    codes: Vec<String>,
+    codes: Vec<i32>,
     format_code_settings: FormatCodeSettings,
     preferences: UserPreferences,
   ) -> Vec<CodeFixAction> {
@@ -4802,7 +4802,7 @@ pub enum TscRequest {
       String,
       u32,
       u32,
-      Vec<String>,
+      Vec<i32>,
       FormatCodeSettings,
       UserPreferences,
     )>,

--- a/tests/integration/jupyter_tests.rs
+++ b/tests/integration/jupyter_tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use test_util::assertions::assert_json_subset;
 use test_util::DenoChild;
 use test_util::TestContext;
 use test_util::TestContextBuilder;
@@ -434,31 +435,6 @@ async fn setup() -> (TestContext, JupyterClient, JupyterServerProcess) {
   (context, client, process)
 }
 
-/// Asserts that the actual value is equal to the expected value, but
-/// only for the keys present in the expected value.
-/// In other words, `assert_eq_subset(json!({"a": 1, "b": 2}), json!({"a": 1}))` would pass.
-#[track_caller]
-fn assert_eq_subset(actual: Value, expected: Value) {
-  match (actual, expected) {
-    (Value::Object(actual), Value::Object(expected)) => {
-      for (k, v) in expected.iter() {
-        let Some(actual_v) = actual.get(k) else {
-          panic!("Key {k:?} not found in actual value ({actual:#?})");
-        };
-        assert_eq_subset(actual_v.clone(), v.clone());
-      }
-    }
-    (Value::Array(actual), Value::Array(expected)) => {
-      for (i, v) in expected.iter().enumerate() {
-        assert_eq_subset(actual[i].clone(), v.clone());
-      }
-    }
-    (actual, expected) => {
-      assert_eq!(actual, expected);
-    }
-  }
-}
-
 #[tokio::test]
 async fn jupyter_heartbeat_echoes() -> Result<()> {
   let (_ctx, client, _process) = setup().await;
@@ -477,7 +453,7 @@ async fn jupyter_kernel_info() -> Result<()> {
     .await?;
   let msg = client.recv(Control).await?;
   assert_eq!(msg.header.msg_type, "kernel_info_reply");
-  assert_eq_subset(
+  assert_json_subset(
     msg.content,
     json!({
       "status": "ok",
@@ -514,7 +490,7 @@ async fn jupyter_execute_request() -> Result<()> {
     .await?;
   let reply = client.recv(Shell).await?;
   assert_eq!(reply.header.msg_type, "execute_reply");
-  assert_eq_subset(
+  assert_json_subset(
     reply.content,
     json!({
       "status": "ok",
@@ -548,7 +524,7 @@ async fn jupyter_execute_request() -> Result<()> {
     })
     .expect("execution_state idle not found");
   assert_eq!(execution_idle.parent_header, request.header.to_json());
-  assert_eq_subset(
+  assert_json_subset(
     execution_idle.content.clone(),
     json!({
       "execution_state": "idle",
@@ -561,7 +537,7 @@ async fn jupyter_execute_request() -> Result<()> {
     .expect("stream not found");
   assert_eq!(execution_result.header.msg_type, "stream");
   assert_eq!(execution_result.parent_header, request.header.to_json());
-  assert_eq_subset(
+  assert_json_subset(
     execution_result.content.clone(),
     json!({
       "name": "stdout",
@@ -589,7 +565,7 @@ async fn jupyter_store_history_false() -> Result<()> {
 
   let reply = client.recv(Shell).await?;
   assert_eq!(reply.header.msg_type, "execute_reply");
-  assert_eq_subset(
+  assert_json_subset(
     reply.content,
     json!({
       "status": "ok",

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -32,7 +32,7 @@ fn range_of_nth(
     .match_indices(text)
     .nth(n)
     .map(|(i, _)| i)
-    .expect(&*format!("couldn't find text {text} in source {src}"));
+    .unwrap_or_else(|| panic!("couldn't find text {text} in source {src}"));
   let end = start + text.len();
   let mut line = 0;
   let mut col = 0;
@@ -12610,5 +12610,5 @@ fn lsp_ts_code_fix_any_param() {
     }
   }
 
-  panic!("failed to find 'Infer parameter types from usage' fix in {fixes:?}");
+  panic!("failed to find 'Infer parameter types from usage' fix in fixes: {fixes:#?}");
 }

--- a/tests/util/server/src/assertions.rs
+++ b/tests/util/server/src/assertions.rs
@@ -111,9 +111,17 @@ pub fn assert_wildcard_match_with_logger(
 
 /// Asserts that the actual `serde_json::Value` is equal to the expected `serde_json::Value`, but
 /// only for the keys present in the expected value.
-/// In other words, `assert_eq_subset(json!({"a": 1, "b": 2}), json!({"a": 1}))` would pass.
-/// Arrays are compared element by element, i.e. `assert_eq_subset(json!([{ "a": 1, "b": 2 }, {}]), json!([{"a": 1}, {}]))`
-/// would pass.
+///
+/// # Example
+///
+/// ```
+/// # use serde_json::json;
+///
+/// assert_json_subset(json!({"a": 1, "b": 2}), json!({"a": 1}));
+///
+/// // Arrays are compared element by element
+/// assert_json_subset(json!([{ "a": 1, "b": 2 }, {}]), json!([{"a": 1}, {}]));
+/// ```
 #[track_caller]
 pub fn assert_json_subset(
   actual: serde_json::Value,

--- a/tests/util/server/src/assertions.rs
+++ b/tests/util/server/src/assertions.rs
@@ -116,7 +116,7 @@ pub fn assert_wildcard_match_with_logger(
 ///
 /// ```
 /// # use serde_json::json;
-///
+/// # use test_server::assertions::assert_json_subset;
 /// assert_json_subset(json!({"a": 1, "b": 2}), json!({"a": 1}));
 ///
 /// // Arrays are compared element by element


### PR DESCRIPTION
Fixes the `Debug Failure` errors described in https://github.com/denoland/deno/issues/23643#issuecomment-2094552765 .

The issue here was that we were passing diagnostic codes as strings but TSC expects the codes to be numbers. This resulted in some quick fixes not working (as illustrated by the test added here which fails before this PR).

The first commit is the actual fix. The rest are just test related.