### PR TITLE
chore: speed up test_multi_task test on Windows

### DIFF
--- a/ext/web/stream_resource.rs
+++ b/ext/web/stream_resource.rs
@@ -649,8 +649,14 @@ mod tests {
 
     // Slightly slower reader
     let b = deno_core::unsync::spawn(async move {
-      for _ in 0..BUFFER_CHANNEL_SIZE * 2 {
-        tokio::time::sleep(Duration::from_millis(1)).await;
+      for i in 0..BUFFER_CHANNEL_SIZE * 2 {
+        if cfg!(windows) {
+          // windows has ~15ms resolution on sleep, so just yield so
+          // this test doesn't take a long time to run
+          tokio::task::yield_now().await;
+        } else {
+          tokio::time::sleep(Duration::from_millis(1)).await;
+        }
         poll_fn(|cx| channel.poll_read_ready(cx)).await;
         channel.read(BUFFER_AGGREGATION_LIMIT).unwrap();
       }

--- a/ext/web/stream_resource.rs
+++ b/ext/web/stream_resource.rs
@@ -649,10 +649,10 @@ mod tests {
 
     // Slightly slower reader
     let b = deno_core::unsync::spawn(async move {
-      for i in 0..BUFFER_CHANNEL_SIZE * 2 {
+      for _ in 0..BUFFER_CHANNEL_SIZE * 2 {
         if cfg!(windows) {
           // windows has ~15ms resolution on sleep, so just yield so
-          // this test doesn't take a long time to run
+          // this test doesn't take 30 seconds to run
           tokio::task::yield_now().await;
         } else {
           tokio::time::sleep(Duration::from_millis(1)).await;


### PR DESCRIPTION
Previously it was around 30s to run: `1024*2*15 = 30720ms`