### PR TITLE
fix(runtime): Allow opening /dev/fd/XXX for unix

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1716,6 +1716,7 @@ impl PermissionsContainer {
     if cfg!(target_os = "linux") {
       // On Linux, we also allow opening /proc/self/fd/XXX for valid FDs that
       // are pipes.
+      #[cfg(unix)]
       if path.starts_with("/proc/self/fd") && is_fd_file_is_pipe(path) {
         return Ok(());
       }

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1693,10 +1693,10 @@ impl PermissionsContainer {
               // SAFETY: This is proper use of the stat syscall
               unsafe {
                 let mut stat = std::mem::zeroed::<libc::stat>();
-                if libc::fstat(n, &mut stat as _) == 0 {
-                  if ((stat.st_mode & libc::S_IFMT) & libc::S_IFIFO) != 0 {
-                    return true;
-                  }
+                if libc::fstat(n, &mut stat as _) == 0
+                  && ((stat.st_mode & libc::S_IFMT) & libc::S_IFIFO) != 0
+                {
+                  return true;
                 }
               };
             }

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1714,7 +1714,7 @@ impl PermissionsContainer {
     }
 
     if cfg!(target_os = "linux") {
-      // On unixy systems, we also allow opening /proc/self/fd/XXX for valid FDs that
+      // On Linux, we also allow opening /proc/self/fd/XXX for valid FDs that
       // are pipes.
       if path.starts_with("/proc/self/fd") && is_fd_file_is_pipe(path) {
         return Ok(());

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1680,6 +1680,10 @@ impl PermissionsContainer {
       return Ok(());
     }
 
+    /// We'll allow opening /proc/self/fd/{n} without additional permissions under the following conditions:
+    ///
+    /// 1. n > 2. This allows for opening bash-style redirections, but not stdio
+    /// 2. the fd referred to by n is a pipe
     #[cfg(unix)]
     fn is_fd_file_is_pipe(path: &Path) -> bool {
       if let Some(fd) = path.file_name() {
@@ -1710,10 +1714,8 @@ impl PermissionsContainer {
     }
 
     if cfg!(target_os = "linux") {
-      // We'll allow opening /proc/self/fd/{n} without additional permissions under the following conditions:
-      //
-      // 1. n > 2. This allows for opening bash-style redirections, but not stdio
-      // 2. the fd referred to by n is a pipe
+      // On unixy systems, we also allow opening /proc/self/fd/XXX for valid FDs that
+      // are pipes.
       if path.starts_with("/proc/self/fd") && is_fd_file_is_pipe(path) {
         return Ok(());
       }

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1680,7 +1680,42 @@ impl PermissionsContainer {
       return Ok(());
     }
 
+    #[cfg(unix)]
+    fn is_fd_file(path: &Path) -> bool {
+      if let Some(fd) = path.file_name() {
+        if let Ok(s) = std::str::from_utf8(fd.as_encoded_bytes()) {
+          if let Ok(n) = s.parse::<i32>() {
+            if n > 2 {
+              // SAFETY: This is proper use of the stat syscall
+              unsafe {
+                let mut stat = std::mem::zeroed::<libc::stat>();
+                if libc::fstat(n, &mut stat as _) == 0 {
+                  if ((stat.st_mode & libc::S_IFMT) & libc::S_IFIFO) != 0 {
+                    return true;
+                  }
+                }
+              };
+            }
+          }
+        }
+      }
+      false
+    }
+
+    if cfg!(unix) {
+      if path.starts_with("/dev/fd") && is_fd_file(path) {
+        return Ok(());
+      }
+    }
+
     if cfg!(target_os = "linux") {
+      // We'll allow opening /proc/self/fd/{n} without additional permissions under the following conditions:
+      //
+      // 1. n > 2. This allows for opening bash-style redirections, but not stdio
+      // 2. the fd referred to by n is a pipe
+      if path.starts_with("/proc/self/fd") && is_fd_file(path) {
+        return Ok(());
+      }
       if path.starts_with("/dev")
         || path.starts_with("/proc")
         || path.starts_with("/sys")

--- a/tests/specs/permission/proc_self_fd/__test__.jsonc
+++ b/tests/specs/permission/proc_self_fd/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run -A main.js",
+  "output": "[WILDCARD]",
+  "exitCode": 123
+}

--- a/tests/specs/permission/proc_self_fd/__test__.jsonc
+++ b/tests/specs/permission/proc_self_fd/__test__.jsonc
@@ -1,5 +1,5 @@
 {
   "args": "run -A main.js",
-  "output": "hi\n\n",
+  "output": "hi\n\n0\n",
   "exitCode": 123
 }

--- a/tests/specs/permission/proc_self_fd/__test__.jsonc
+++ b/tests/specs/permission/proc_self_fd/__test__.jsonc
@@ -1,5 +1,5 @@
 {
   "args": "run -A main.js",
-  "output": "[WILDCARD]",
+  "output": "hi\n\n",
   "exitCode": 123
 }

--- a/tests/specs/permission/proc_self_fd/main.js
+++ b/tests/specs/permission/proc_self_fd/main.js
@@ -1,5 +1,6 @@
 // This test is Linux/Darwin only
 if (Deno.build.os !== "linux" && Deno.build.os !== "darwin") {
+  console.log("hi\n\n0");
   Deno.exit(123);
 }
 

--- a/tests/specs/permission/proc_self_fd/main.js
+++ b/tests/specs/permission/proc_self_fd/main.js
@@ -1,0 +1,17 @@
+// This test is Linux/Darwin only
+if (Deno.build.os !== "linux" && Deno.build.os !== "darwin") {
+  Deno.exit(123);
+}
+
+const cmd = new Deno.Command("/usr/bin/env", {
+  args: [
+    "bash",
+    "-c",
+    [Deno.execPath(), "run", "--allow-read", "reader.ts", '<(echo "hi")'].join(
+      " ",
+    ),
+  ],
+}).spawn();
+
+await cmd.status;
+Deno.exit(123);

--- a/tests/specs/permission/proc_self_fd/main.js
+++ b/tests/specs/permission/proc_self_fd/main.js
@@ -13,5 +13,5 @@ const cmd = new Deno.Command("/usr/bin/env", {
   ],
 }).spawn();
 
-await cmd.status;
+console.log((await cmd.status).code);
 Deno.exit(123);

--- a/tests/specs/permission/proc_self_fd/reader.ts
+++ b/tests/specs/permission/proc_self_fd/reader.ts
@@ -1,0 +1,1 @@
+console.log(Deno.readTextFileSync(Deno.args[0]));


### PR DESCRIPTION
`deno run script.ts <(some command)` is a valid use case -- let's allow this to work without `--allow-all`.

Fixes #23703 