### PR TITLE
feat(ext/webgpu): implement GPUQueue.copyExternalImageToTexture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,6 +3495,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "jpeg-decoder",
  "num-traits",
  "png",
 ]
@@ -3652,6 +3653,12 @@ checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"

--- a/cli/tsc/dts/lib.deno_webgpu.d.ts
+++ b/cli/tsc/dts/lib.deno_webgpu.d.ts
@@ -1249,6 +1249,52 @@ declare interface GPUImageCopyTexture {
  * @category GPU
  * @tags unstable
  */
+declare interface GPUImageCopyTextureTagged extends GPUImageCopyTexture {
+  colorSpace?: "srgb" | "display-p3";
+  premultipliedAlpha?: boolean;
+}
+
+/**
+ * @category GPU
+ * @tags unstable
+ */
+declare type GPUImageCopyExternalImageSource = any
+  // | HTMLImageElement
+  // | HTMLVideoElement
+  // | VideoFrame
+  // | HTMLCanvasElement
+  // | OffscreenCanvas
+  ;
+
+/**
+ * @category GPU
+ * @tags unstable
+ */
+declare interface GPUOrigin2DDict {
+  x: number,
+  y: number,
+}
+
+/**
+ * @category GPU
+ * @tags unstable
+ */
+declare type GPUOrigin2 = number[] | GPUOrigin2DDict;
+
+/**
+ * @category GPU
+ * @tags unstable
+ */
+declare interface GPUImageCopyExternalImage {
+  source: GPUImageCopyExternalImageSource,
+  origin?: GPUOrigin2,
+  flipY?: boolean,
+}
+
+/**
+ * @category GPU
+ * @tags unstable
+ */
 declare interface GPUProgrammablePassEncoder {
   setBindGroup(
     index: number,
@@ -1618,6 +1664,12 @@ declare class GPUQueue implements GPUObjectBase {
     data: BufferSource,
     dataLayout: GPUImageDataLayout,
     size: GPUExtent3D,
+  ): undefined;
+
+  copyExternalImageToTexture(
+    source: GPUImageCopyExternalImage,
+    destination: GPUImageCopyTextureTagged,
+    copySize: GPUExtent3D,
   ): undefined;
 }
 

--- a/ext/canvas/01_image.js
+++ b/ext/canvas/01_image.js
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { internals, primordials } from "ext:core/mod.js";
-import { op_image_decode_png, op_image_process } from "ext:core/ops";
+import { op_image_decode_blob, op_image_process } from "ext:core/ops";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
@@ -232,13 +232,13 @@ function createImageBitmap(
     return (async () => {
       const data = await image.arrayBuffer();
       const mimetype = sniffImage(image.type);
-      if (mimetype !== "image/png") {
+      if (mimetype !== "image/png" && mimetype !== "image/jpeg") {
         throw new DOMException(
           `Unsupported type '${image.type}'`,
           "InvalidStateError",
         );
       }
-      const { data: imageData, width, height } = op_image_decode_png(
+      const { data: imageData, width, height } = op_image_decode_blob(
         new Uint8Array(data),
       );
       const processedImage = processImage(
@@ -306,9 +306,9 @@ function processImage(input, width, height, sx, sy, sw, sh, options) {
     outputHeight = heightOfSourceRect;
   }
 
-  if (options.colorSpaceConversion === "none") {
-    throw new TypeError("options.colorSpaceConversion 'none' is not supported");
-  }
+  // if (options.colorSpaceConversion === "none") {
+  //   throw new TypeError("options.colorSpaceConversion 'none' is not supported");
+  // }
 
   /*
    * The cropping works differently than the spec specifies:

--- a/ext/canvas/Cargo.toml
+++ b/ext/canvas/Cargo.toml
@@ -16,6 +16,6 @@ path = "lib.rs"
 [dependencies]
 deno_core.workspace = true
 deno_webgpu.workspace = true
-image = { version = "0.24.7", default-features = false, features = ["png"] }
+image = { version = "0.24.7", default-features = false, features = ["png", "jpeg"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }

--- a/ext/webgpu/01_webgpu.js
+++ b/ext/webgpu/01_webgpu.js
@@ -128,8 +128,9 @@ import {
 } from "ext:deno_web/02_event.js";
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
-import { _bitmapData, ImageBitmap } from "ext:deno_canvas/01_image.js";
-import { ImageData } from "ext:web/16_image_data.js";
+import { ImageData } from "ext:deno_web/16_image_data.js";
+
+const loadImageBitmap = core.createLazyLoader("ext:deno_canvas/01_image.js");
 
 const _rid = Symbol("[[rid]]");
 const _size = Symbol("[[size]]");
@@ -2057,6 +2058,7 @@ class GPUQueue {
   copyExternalImageToTexture(source, destination, copySize) {
     const dataSource = source.source;
     let rgbaData, width, height;
+    const { _bitmapData, ImageBitmap } = loadImageBitmap();
     if (ObjectPrototypeIsPrototypeOf(ImageBitmap.prototype, dataSource)) {
       width = dataSource.width;
       height = dataSource.height;


### PR DESCRIPTION
- [x] create `ImageBitmap` from JPEG files
- [ ] save various pixel formats of [`DynamicImage`](https://docs.rs/image/latest/image/enum.DynamicImage.html) in `ImageBitmap`
- [ ] implement `flipY`
- [ ] support sRGB and Display P3 color space
