### PR TITLE
chore(tests): increase repl timeout on ci

### DIFF
--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -4610,8 +4610,8 @@ fn file_fetcher_preserves_permissions() {
     .args("repl --quiet")
     .with_pty(|mut console| {
       console.write_line(
-      "const a = await import('http://localhost:4545/run/019_media_types.ts');",
-    );
+        "const a = await import('http://localhost:4545/run/019_media_types.ts');",
+      );
       console.expect("Allow?");
       console.human_delay();
       console.write_line_raw("y");

--- a/tests/util/server/src/pty.rs
+++ b/tests/util/server/src/pty.rs
@@ -209,7 +209,12 @@ impl Pty {
 
   #[track_caller]
   fn read_until_condition(&mut self, condition: impl FnMut(&mut Self) -> bool) {
-    self.read_until_condition_with_timeout(condition, Duration::from_secs(15));
+    let duration = if std::env::var_os("CI").is_some() {
+      Duration::from_secs(30)
+    } else {
+      Duration::from_secs(15)
+    };
+    self.read_until_condition_with_timeout(condition, duration);
   }
 
   #[track_caller]


### PR DESCRIPTION
https://github.com/denoland/deno/actions/runs/9084225162/job/24964698935

```
---- run::file_fetcher_preserves_permissions stdout ----
command /Users/runner/work/deno/deno/target/debug/deno repl --quiet
command cwd /Users/runner/work/deno/deno/tests/testdata
------ Start Full Text ------
"const a = await import('http://localhost:4545/run/019_media_types.ts');\r\n"
------- End Full Text -------
Next text: "\r\n"
thread 'run::file_fetcher_preserves_permissions' panicked at tests/integration/run_tests.rs:4615:15:
Timed out.
```

Closes https://github.com/denoland/deno/issues/23690
Closes https://github.com/denoland/deno/issues/23682
Closes https://github.com/denoland/deno/issues/23625