### PR TITLE
fix(lsp): respect types dependencies for tsc roots

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1280,7 +1280,7 @@ impl Documents {
     self.dirty = false;
   }
 
-  fn resolve_dependency(
+  pub fn resolve_dependency(
     &self,
     specifier: &ModuleSpecifier,
     referrer: &ModuleSpecifier,


### PR DESCRIPTION
Addresses an odd case where you have an unimported JS file in the project (the LSP should still treat unimported files as roots) which has `/// <reference types="..." />` to a file which creates global types, that types file should also be included as a root.