### PR TITLE
fix(node): error when throwing `FS_EISDIR`

### DIFF
--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -891,7 +891,7 @@ export const validateRmOptionsSync = hideStackFrames(
           message: "is a directory",
           path,
           syscall: "rm",
-          errno: EISDIR,
+          errno: osConstants.errno.EISDIR,
         });
       }
     }


### PR DESCRIPTION
The `EISDIR` error code is not available as a global variable, but must be accessed through the `osConstants.errno` object.

Fixes https://github.com/denoland/deno/issues/23695 