### PR TITLE
perf(compile): Do not checksum eszip content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "eszip"
-version = "0.68.5"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4261ccce6111115c5b536e7f76222a779d69a038bb4c13958575f12ffe5606"
+checksum = "8f606daca1ce18c69ccdabc59aa1c7e077356b8ffcd74e12c7646f545320a2fd"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,7 +77,7 @@ deno_runtime = { workspace = true, features = ["include_js_files_for_snapshottin
 deno_semver = "=0.5.4"
 deno_task_shell = "=0.16.1"
 deno_terminal.workspace = true
-eszip = "=0.68.5"
+eszip = "=0.69.0"
 napi_sym.workspace = true
 
 async-trait.workspace = true


### PR DESCRIPTION
Related: https://github.com/denoland/eszip/pull/181

eszip < v0.69.0 hashes all its contents to ensure data integrity. This feature is not necessary in Deno CLI as the binary integrity guarantee is deemed an external responsibility (ie it is to be assumed that, if necessary, the compiled binary will be checksumed externally prior to being executed). 

eszip >= v0.69.0 no longer performs this checksum by default. This reduces the cold-start time of the compiled binaries, proportionally to their size. 