### PR TITLE
fix(ext/webgpu): Allow `depthClearValue` to be undefined when `depthLoadOp` is not "clear"

### DIFF
--- a/ext/webgpu/command_encoder.rs
+++ b/ext/webgpu/command_encoder.rs
@@ -79,7 +79,7 @@ pub struct GpuRenderPassColorAttachment {
 #[serde(rename_all = "camelCase")]
 pub struct GpuRenderPassDepthStencilAttachment {
   view: ResourceId,
-  depth_clear_value: f32,
+  depth_clear_value: Option<f32>,
   depth_load_op: Option<wgpu_core::command::LoadOp>,
   depth_store_op: Option<wgpu_core::command::StoreOp>,
   depth_read_only: bool,
@@ -168,7 +168,9 @@ pub fn op_webgpu_command_encoder_begin_render_pass(
           store_op: attachment
             .depth_store_op
             .unwrap_or(wgpu_core::command::StoreOp::Store),
-          clear_value: attachment.depth_clear_value,
+          // In "01_webgpu.js", `depthLoadOp` is cheked to ensure its value is not "clear"
+          // when `depthClearValue` is undefined, so the default 0.0 doesn't matter.
+          clear_value: attachment.depth_clear_value.unwrap_or(0.0),
           read_only: attachment.depth_read_only,
         },
         stencil: wgpu_core::command::PassChannel {

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -496,6 +496,36 @@ Deno.test({
   device.destroy();
 });
 
+Deno.test({
+  ignore: isWsl || isLinuxOrMacCI,
+}, async function beginRenderPassWithoutDepthClearValue() {
+  const adapter = await navigator.gpu.requestAdapter();
+  assert(adapter);
+  const device = await adapter.requestDevice();
+  assert(device);
+
+  const encoder = device.createCommandEncoder();
+
+  const depthTexture = device.createTexture({
+    size: [256, 256],
+    format: "depth32float",
+    usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  const depthView = depthTexture.createView();
+
+  const renderPass = encoder.beginRenderPass({
+    colorAttachments: [],
+    depthStencilAttachment: {
+      view: depthView,
+      depthLoadOp: "load",
+    },
+  });
+
+  assert(renderPass);
+
+  device.destroy();
+});
+
 async function checkIsWsl() {
   return Deno.build.os === "linux" && await hasMicrosoftProcVersion();
 


### PR DESCRIPTION
The current implemention would panic at `op_webgpu_command_encoder_begin_render_pass` with legal JavaScript code, because `GpuRenderPassDepthStencilAttachment` require `depth_clear_value` to always appear.

The current WebGPU specification says[^1]

> (depthClearValue is) Ignored if `depthLoadOp` is not "clear"

[^1]: https://gpuweb.github.io/gpuweb/#dom-gpurenderpassdepthstencilattachment-depthclearvalue

The modification is tiny and easy to understand. Should I open a issue and/or add a unit test? 
