### PR TITLE
chore: force import assertion support

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -405,7 +405,10 @@ fn resolve_flags_and_init(
         // TODO(petamoriken): Need to check TypeScript `assert` keywords in deno_ast
         vec!["--no-harmony-import-assertions".to_string()]
       } else {
-        vec![]
+        // If we're still in v1.X version we want to support import assertions.
+        // V8 12.6 unshipped the support by default, so force it by passing a
+        // flag.
+        vec!["--harmony-import-assertions".to_string()]
       }
     }
   };


### PR DESCRIPTION
https://github.com/denoland/deno/pull/23838 might accidentally disable
import assertions support because of V8 12.6 unshipping it, but we want
import assertions to be supported until Deno 2.