### PR TITLE
perf: analyze cjs exports and emit typescript in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ version = "0.88.0"
 dependencies = [
  "aead-gcm-stream",
  "aes",
+ "async-trait",
  "brotli 3.5.0",
  "bytes",
  "cbc",

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -89,6 +89,7 @@ impl Emitter {
     media_type: MediaType,
     source: &Arc<str>,
   ) -> Result<ModuleCodeString, AnyError> {
+    // Note: keep this in sync with the sync version below
     let helper = EmitParsedSourceHelper(self);
     match helper.pre_emit_parsed_source(specifier, source) {
       PreEmitResult::Cached(emitted_text) => Ok(emitted_text),
@@ -127,6 +128,7 @@ impl Emitter {
     media_type: MediaType,
     source: &Arc<str>,
   ) -> Result<ModuleCodeString, AnyError> {
+    // Note: keep this in sync with the async version above
     let helper = EmitParsedSourceHelper(self);
     match helper.pre_emit_parsed_source(specifier, source) {
       PreEmitResult::Cached(emitted_text) => Ok(emitted_text),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -120,7 +120,7 @@ async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
       main_graph_container
         .load_and_type_check_files(&cache_flags.files)
         .await?;
-      emitter.cache_module_emits(&main_graph_container.graph())
+      emitter.cache_module_emits(&main_graph_container.graph()).await
     }),
     DenoSubcommand::Check(check_flags) => spawn_subcommand(async move {
       let factory = CliFactory::from_flags(flags)?;

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -275,7 +275,7 @@ impl CliModuleLoaderFactory {
     root_permissions: PermissionsContainer,
     dynamic_permissions: PermissionsContainer,
   ) -> ModuleLoaderAndSourceMapGetter {
-    let loader = Rc::new(CliModuleLoader {
+    let loader = Rc::new(CliModuleLoader(Rc::new(CliModuleLoaderInner {
       lib,
       root_permissions,
       dynamic_permissions,
@@ -283,7 +283,7 @@ impl CliModuleLoaderFactory {
       emitter: self.shared.emitter.clone(),
       parsed_source_cache: self.shared.parsed_source_cache.clone(),
       shared: self.shared.clone(),
-    });
+    })));
     ModuleLoaderAndSourceMapGetter {
       module_loader: loader.clone(),
       source_map_getter: Some(loader),
@@ -322,7 +322,7 @@ impl ModuleLoaderFactory for CliModuleLoaderFactory {
   }
 }
 
-struct CliModuleLoader<TGraphContainer: ModuleGraphContainer> {
+struct CliModuleLoaderInner<TGraphContainer: ModuleGraphContainer> {
   lib: TsTypeLib,
   /// The initial set of permissions used to resolve the static imports in the
   /// worker. These are "allow all" for main worker, and parent thread
@@ -337,8 +337,10 @@ struct CliModuleLoader<TGraphContainer: ModuleGraphContainer> {
   graph_container: TGraphContainer,
 }
 
-impl<TGraphContainer: ModuleGraphContainer> CliModuleLoader<TGraphContainer> {
-  fn load_sync(
+impl<TGraphContainer: ModuleGraphContainer>
+  CliModuleLoaderInner<TGraphContainer>
+{
+  async fn load_inner(
     &self,
     specifier: &ModuleSpecifier,
     maybe_referrer: Option<&ModuleSpecifier>,
@@ -353,11 +355,12 @@ impl<TGraphContainer: ModuleGraphContainer> CliModuleLoader<TGraphContainer> {
     let code_source = if let Some(result) = self
       .shared
       .npm_module_loader
-      .load_sync_if_in_npm_package(specifier, maybe_referrer, permissions)
+      .load_if_in_npm_package(specifier, maybe_referrer, permissions)
+      .await
     {
       result?
     } else {
-      self.load_prepared_module(specifier, maybe_referrer)?
+      self.load_prepared_module(specifier, maybe_referrer).await?
     };
     let code = if self.shared.is_inspecting {
       // we need the code with the source map in order for
@@ -574,7 +577,7 @@ impl<TGraphContainer: ModuleGraphContainer> CliModuleLoader<TGraphContainer> {
     Ok(Some(timestamp))
   }
 
-  fn load_prepared_module(
+  async fn load_prepared_module(
     &self,
     specifier: &ModuleSpecifier,
     maybe_referrer: Option<&ModuleSpecifier>,
@@ -618,7 +621,86 @@ impl<TGraphContainer: ModuleGraphContainer> CliModuleLoader<TGraphContainer> {
             // get emit text
             self
               .emitter
-              .emit_parsed_source(specifier, *media_type, source)?
+              .emit_parsed_source(specifier, *media_type, source)
+              .await?
+          }
+          MediaType::TsBuildInfo | MediaType::Wasm | MediaType::SourceMap => {
+            panic!("Unexpected media type {media_type} for {specifier}")
+          }
+        };
+
+        // at this point, we no longer need the parsed source in memory, so free it
+        self.parsed_source_cache.free(specifier);
+
+        Ok(ModuleCodeStringSource {
+          code,
+          found_url: specifier.clone(),
+          media_type: *media_type,
+        })
+      }
+      Some(
+        deno_graph::Module::External(_)
+        | deno_graph::Module::Node(_)
+        | deno_graph::Module::Npm(_),
+      )
+      | None => {
+        let mut msg = format!("Loading unprepared module: {specifier}");
+        if let Some(referrer) = maybe_referrer {
+          msg = format!("{}, imported from: {}", msg, referrer.as_str());
+        }
+        Err(anyhow!(msg))
+      }
+    }
+  }
+
+  // todo(THIS PR): add a private method that consolidates the duplicate code with the above
+  fn load_prepared_module_sync(
+    &self,
+    specifier: &ModuleSpecifier,
+    maybe_referrer: Option<&ModuleSpecifier>,
+  ) -> Result<ModuleCodeStringSource, AnyError> {
+    if specifier.scheme() == "node" {
+      unreachable!(); // Node built-in modules should be handled internally.
+    }
+
+    let graph = self.graph_container.graph();
+    match graph.get(specifier) {
+      Some(deno_graph::Module::Json(JsonModule {
+        source,
+        media_type,
+        specifier,
+        ..
+      })) => Ok(ModuleCodeStringSource {
+        code: source.clone().into(),
+        found_url: specifier.clone(),
+        media_type: *media_type,
+      }),
+      Some(deno_graph::Module::Js(JsModule {
+        source,
+        media_type,
+        specifier,
+        ..
+      })) => {
+        let code: ModuleCodeString = match media_type {
+          MediaType::JavaScript
+          | MediaType::Unknown
+          | MediaType::Cjs
+          | MediaType::Mjs
+          | MediaType::Json => source.clone().into(),
+          MediaType::Dts | MediaType::Dcts | MediaType::Dmts => {
+            Default::default()
+          }
+          MediaType::TypeScript
+          | MediaType::Mts
+          | MediaType::Cts
+          | MediaType::Jsx
+          | MediaType::Tsx => {
+            // get emit text
+            self.emitter.emit_parsed_source_sync(
+              specifier,
+              *media_type,
+              source,
+            )?
           }
           MediaType::TsBuildInfo | MediaType::Wasm | MediaType::SourceMap => {
             panic!("Unexpected media type {media_type} for {specifier}")
@@ -650,6 +732,11 @@ impl<TGraphContainer: ModuleGraphContainer> CliModuleLoader<TGraphContainer> {
   }
 }
 
+// todo(dsherret): this double Rc boxing is not ideal
+struct CliModuleLoader<TGraphContainer: ModuleGraphContainer>(
+  Rc<CliModuleLoaderInner<TGraphContainer>>,
+);
+
 impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
   for CliModuleLoader<TGraphContainer>
 {
@@ -672,8 +759,8 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
       Ok(())
     }
 
-    let referrer = self.resolve_referrer(referrer)?;
-    let specifier = self.inner_resolve(specifier, &referrer, kind)?;
+    let referrer = self.0.resolve_referrer(referrer)?;
+    let specifier = self.0.inner_resolve(specifier, &referrer, kind)?;
     ensure_not_jsr_non_jsr_remote_import(&specifier, &referrer)?;
     Ok(specifier)
   }
@@ -685,15 +772,22 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     is_dynamic: bool,
     requested_module_type: RequestedModuleType,
   ) -> deno_core::ModuleLoadResponse {
-    // NOTE: this block is async only because of `deno_core` interface
-    // requirements; module was already loaded when constructing module graph
-    // during call to `prepare_load` so we can load it synchronously.
-    deno_core::ModuleLoadResponse::Sync(self.load_sync(
-      specifier,
-      maybe_referrer,
-      is_dynamic,
-      requested_module_type,
-    ))
+    let inner = self.0.clone();
+    let specifier = specifier.clone();
+    let maybe_referrer = maybe_referrer.cloned();
+    deno_core::ModuleLoadResponse::Async(
+      async move {
+        inner
+          .load_inner(
+            &specifier,
+            maybe_referrer.as_ref(),
+            is_dynamic,
+            requested_module_type,
+          )
+          .await
+      }
+      .boxed_local(),
+    )
   }
 
   fn prepare_load(
@@ -702,22 +796,23 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     _maybe_referrer: Option<String>,
     is_dynamic: bool,
   ) -> Pin<Box<dyn Future<Output = Result<(), AnyError>>>> {
-    if self.shared.node_resolver.in_npm_package(specifier) {
+    if self.0.shared.node_resolver.in_npm_package(specifier) {
       return Box::pin(deno_core::futures::future::ready(Ok(())));
     }
 
     let specifier = specifier.clone();
-    let graph_container = self.graph_container.clone();
-    let module_load_preparer = self.shared.module_load_preparer.clone();
-
-    let root_permissions = if is_dynamic {
-      self.dynamic_permissions.clone()
-    } else {
-      self.root_permissions.clone()
-    };
-    let lib = self.lib;
+    let inner = self.0.clone();
 
     async move {
+      let graph_container = inner.graph_container.clone();
+      let module_load_preparer = inner.shared.module_load_preparer.clone();
+
+      let root_permissions = if is_dynamic {
+        inner.dynamic_permissions.clone()
+      } else {
+        inner.root_permissions.clone()
+      };
+      let lib = inner.lib;
       let mut update_permit = graph_container.acquire_update_permit().await;
       let graph = update_permit.graph_mut();
       module_load_preparer
@@ -740,9 +835,10 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     specifier: &ModuleSpecifier,
     code_cache: &[u8],
   ) -> Pin<Box<dyn Future<Output = ()>>> {
-    if let Some(cache) = self.shared.code_cache.as_ref() {
+    if let Some(cache) = self.0.shared.code_cache.as_ref() {
       let media_type = MediaType::from_specifier(specifier);
       let code_hash = self
+        .0
         .get_code_hash_or_timestamp(specifier, media_type)
         .ok()
         .flatten();
@@ -774,7 +870,7 @@ impl<TGraphContainer: ModuleGraphContainer> SourceMapGetter
       "wasm" | "file" | "http" | "https" | "data" | "blob" => (),
       _ => return None,
     }
-    let source = self.load_prepared_module(&specifier, None).ok()?;
+    let source = self.0.load_prepared_module_sync(&specifier, None).ok()?;
     source_map_from_code(&source.code)
   }
 
@@ -783,7 +879,7 @@ impl<TGraphContainer: ModuleGraphContainer> SourceMapGetter
     file_name: &str,
     line_number: usize,
   ) -> Option<String> {
-    let graph = self.graph_container.graph();
+    let graph = self.0.graph_container.graph();
     let code = match graph.get(&resolve_url(file_name).ok()?) {
       Some(deno_graph::Module::Js(module)) => &module.source,
       Some(deno_graph::Module::Json(module)) => &module.source,

--- a/cli/node.rs
+++ b/cli/node.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use std::sync::Arc;
+
 use deno_ast::MediaType;
 use deno_ast::ModuleSpecifier;
 use deno_core::error::AnyError;
@@ -56,7 +58,7 @@ impl CliCjsCodeAnalyzer {
     Self { cache, fs }
   }
 
-  fn inner_cjs_analysis(
+  async fn inner_cjs_analysis(
     &self,
     specifier: &ModuleSpecifier,
     source: &str,
@@ -77,23 +79,32 @@ impl CliCjsCodeAnalyzer {
       });
     }
 
-    let parsed_source = deno_ast::parse_program(deno_ast::ParseParams {
-      specifier: specifier.clone(),
-      text_info: deno_ast::SourceTextInfo::new(source.into()),
-      media_type,
-      capture_tokens: true,
-      scope_analysis: false,
-      maybe_syntax: None,
-    })?;
-    let analysis = if parsed_source.is_script() {
-      let analysis = parsed_source.analyze_cjs();
-      CliCjsAnalysis::Cjs {
-        exports: analysis.exports,
-        reexports: analysis.reexports,
+    let analysis = deno_core::unsync::spawn_blocking({
+      let specifier = specifier.clone();
+      let source: Arc<str> = source.into();
+      move || -> Result<_, deno_ast::ParseDiagnostic> {
+        let parsed_source = deno_ast::parse_program(deno_ast::ParseParams {
+          specifier,
+          text_info: deno_ast::SourceTextInfo::new(source),
+          media_type,
+          capture_tokens: true,
+          scope_analysis: false,
+          maybe_syntax: None,
+        })?;
+        if parsed_source.is_script() {
+          let analysis = parsed_source.analyze_cjs();
+          Ok(CliCjsAnalysis::Cjs {
+            exports: analysis.exports,
+            reexports: analysis.reexports,
+          })
+        } else {
+          Ok(CliCjsAnalysis::Esm)
+        }
       }
-    } else {
-      CliCjsAnalysis::Esm
-    };
+    })
+    .await
+    .unwrap()?;
+
     self
       .cache
       .set_cjs_analysis(specifier.as_str(), &source_hash, &analysis);
@@ -102,19 +113,23 @@ impl CliCjsCodeAnalyzer {
   }
 }
 
+#[async_trait::async_trait(?Send)]
 impl CjsCodeAnalyzer for CliCjsCodeAnalyzer {
-  fn analyze_cjs(
+  async fn analyze_cjs(
     &self,
     specifier: &ModuleSpecifier,
     source: Option<String>,
   ) -> Result<ExtNodeCjsAnalysis, AnyError> {
     let source = match source {
       Some(source) => source,
-      None => self
-        .fs
-        .read_text_file_sync(&specifier.to_file_path().unwrap(), None)?,
+      None => {
+        self
+          .fs
+          .read_text_file_async(specifier.to_file_path().unwrap(), None)
+          .await?
+      }
     };
-    let analysis = self.inner_cjs_analysis(specifier, &source)?;
+    let analysis = self.inner_cjs_analysis(specifier, &source).await?;
     match analysis {
       CliCjsAnalysis::Esm => Ok(ExtNodeCjsAnalysis::Esm(source)),
       CliCjsAnalysis::Cjs { exports, reexports } => {

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [dependencies]
 aead-gcm-stream = "0.1"
 aes.workspace = true
+async-trait.workspace = true
 brotli.workspace = true
 bytes.workspace = true
 cbc.workspace = true

--- a/tests/integration/inspector_tests.rs
+++ b/tests/integration/inspector_tests.rs
@@ -929,19 +929,32 @@ async fn inspector_with_ts_files() {
     .await;
 
   // receive messages with sources from this test
-  let script1 = tester.recv().await;
-  assert_contains!(script1, "testdata/inspector/test.ts");
+  let mut scripts = vec![
+    tester.recv().await,
+    tester.recv().await,
+    tester.recv().await,
+  ];
+  let script1 = scripts.remove(
+    scripts
+      .iter()
+      .position(|s| s.contains("testdata/inspector/test.ts"))
+      .unwrap(),
+  );
   let script1_id = {
     let v: serde_json::Value = serde_json::from_str(&script1).unwrap();
     v["params"]["scriptId"].as_str().unwrap().to_string()
   };
-  let script2 = tester.recv().await;
-  assert_contains!(script2, "testdata/inspector/foo.ts");
+  let script2 = scripts.remove(
+    scripts
+      .iter()
+      .position(|s| s.contains("testdata/inspector/foo.ts"))
+      .unwrap(),
+  );
   let script2_id = {
     let v: serde_json::Value = serde_json::from_str(&script2).unwrap();
     v["params"]["scriptId"].as_str().unwrap().to_string()
   };
-  let script3 = tester.recv().await;
+  let script3 = scripts.remove(0);
   assert_contains!(script3, "testdata/inspector/bar.js");
   let script3_id = {
     let v: serde_json::Value = serde_json::from_str(&script3).unwrap();

--- a/tests/specs/npm/local_dir_no_duplicate_resolution/__test__.jsonc
+++ b/tests/specs/npm/local_dir_no_duplicate_resolution/__test__.jsonc
@@ -1,5 +1,5 @@
 {
   "tempDir": true,
-  "args": "run -A --log-level=debug main.tsx",
+  "args": "run -A run_main_sorted_lines.ts",
   "output": "main.out"
 }

--- a/tests/specs/npm/local_dir_no_duplicate_resolution/main.out
+++ b/tests/specs/npm/local_dir_no_duplicate_resolution/main.out
@@ -1,5 +1,5 @@
-[WILDCARD]Resolved preact from file:///[WILDLINE]/preact@10.19.6/node_modules/preact/jsx-runtime/dist/jsxRuntime.mjs to [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]preact@10.19.6[WILDCHAR]node_modules[WILDCHAR]preact
-DEBUG RS - [WILDLINE] - Resolved preact from file:///[WILDLINE]/preact@10.19.6/node_modules/preact/hooks/dist/hooks.mjs to [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]preact@10.19.6[WILDCHAR]node_modules[WILDCHAR]preact
 [# ensure that preact is resolving to .deno/preact@10.19.6/node_modules/preact and not .deno/preact-render-to-string@6.4.0/node_modules/preact]
-DEBUG RS - [WILDLINE] - Resolved preact from file:///[WILDLINE]/preact-render-to-string@6.4.0/node_modules/preact-render-to-string/dist/index.mjs to [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]preact@10.19.6[WILDCHAR]node_modules[WILDCHAR]preact
+[WILDCARD]/preact-render-to-string@6.4.0/node_modules/preact-render-to-string/dist/index.mjs to [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]preact@10.19.6[WILDCHAR]node_modules[WILDCHAR]preact
+[WILDCARD]/preact@10.19.6/node_modules/preact/hooks/dist/hooks.mjs to [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]preact@10.19.6[WILDCHAR]node_modules[WILDCHAR]preact
+[WILDCARD]/preact@10.19.6/node_modules/preact/jsx-runtime/dist/jsxRuntime.mjs to [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]preact@10.19.6[WILDCHAR]node_modules[WILDCHAR]preact
 [WILDCARD]

--- a/tests/specs/npm/local_dir_no_duplicate_resolution/run_main_sorted_lines.ts
+++ b/tests/specs/npm/local_dir_no_duplicate_resolution/run_main_sorted_lines.ts
@@ -1,0 +1,19 @@
+const { success, stderr } = new Deno.Command(
+  Deno.execPath(),
+  {
+    args: ["run", "-A", "--log-level=debug", "main.tsx"],
+  },
+).outputSync();
+const stderrText = new TextDecoder().decode(stderr);
+if (!success) {
+  console.error(stderrText);
+  throw new Error("Failed to run script.");
+}
+
+// create some stability with the output
+const lines = stderrText.split("\n")
+  .filter((line) => line.includes("Resolved preact from"));
+lines.sort();
+for (const line of lines) {
+  console.error(line);
+}


### PR DESCRIPTION
Two main things we can do in parallel:

1. CJS export analysis
1. TypeScript emit

This makes the loader async to make doing this easier.

Deleting the node analysis cache between runs and importing some npm packages (this only makes the first run much faster due to the caches... the second run is the same speed as befroe):

```
Benchmark 1: ../deno/deno_old run -A ts_morph.ts
  Time (mean ± σ):     406.1 ms ±   6.5 ms    [User: 358.1 ms, System: 62.2 ms]
  Range (min … max):   395.9 ms … 412.9 ms    10 runs
 
Benchmark 2: ../deno/target/release/deno run -A ts_morph.ts
  Time (mean ± σ):     278.2 ms ±   9.3 ms    [User: 411.1 ms, System: 81.4 ms]
  Range (min … max):   266.1 ms … 292.9 ms    10 runs
 
Summary
  ../deno/target/release/deno run -A ts_morph.ts ran
    1.46 ± 0.05 times faster than ../deno/deno_old run -A ts_morph.ts
% cat ts_morph.ts
import "npm:ts-morph@22.0.0";
import "npm:ts-morph@21.0.0";
import "npm:ts-morph@20.0.0";
import "npm:ts-morph@19.0.0";
```

Deleting the TypeScript emit and module analysis cache between runs and importing multiple copies of Dax:

```
Benchmark 1: ../deno/deno_old run -A dax_deno_land_x.ts
  Time (mean ± σ):     587.3 ms ±  24.0 ms    [User: 347.5 ms, System: 221.0 ms]
  Range (min … max):   569.2 ms … 650.7 ms    10 runs
 
Benchmark 2: ../deno/target/release/deno run -A dax_deno_land_x.ts
  Time (mean ± σ):     489.3 ms ±  14.3 ms    [User: 554.8 ms, System: 411.2 ms]
  Range (min … max):   473.9 ms … 510.2 ms    10 runs
 
Summary
  ../deno/target/release/deno run -A dax_deno_land_x.ts ran
    1.20 ± 0.06 times faster than ../deno/deno_old run -A dax_deno_land_x.ts
scratch % cat dax_deno_land_x.ts
import "https://deno.land/x/dax@0.39.2/mod.ts";
import "https://deno.land/x/dax@0.38.0/mod.ts";
import "https://deno.land/x/dax@0.37.0/mod.ts";
import "https://deno.land/x/dax@0.36.0/mod.ts";
import "https://deno.land/x/dax@0.35.0/mod.ts";
```

Note that this is still parsing typescript files sequentially because it doesn't include (https://github.com/denoland/deno_graph/pull/477). It is just emitting typescript files in parallel.