### PR TITLE
feat(cli): Add slow test warning

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -613,7 +613,7 @@ impl LspTestReporter {
     self.progress(lsp_custom::TestRunProgressMessage::Started { test });
   }
 
-  fn report_slow(&mut self, desc: &test::TestDescription, elapsed: u64) {}
+  fn report_slow(&mut self, _desc: &test::TestDescription, _elapsed: u64) {}
 
   fn report_output(&mut self, output: &[u8]) {
     let test = self

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -353,6 +353,9 @@ impl TestRun {
             test::TestEvent::Output(_, output) => {
               reporter.report_output(&output);
             }
+            test::TestEvent::Slow(id, elapsed) => {
+              reporter.report_slow(tests.read().get(&id).unwrap(), elapsed);
+            }
             test::TestEvent::Result(id, result, elapsed) => {
               if tests_with_result.insert(id) {
                 let description = tests.read().get(&id).unwrap().clone();
@@ -609,6 +612,8 @@ impl LspTestReporter {
     let test = desc.as_test_identifier(&self.tests);
     self.progress(lsp_custom::TestRunProgressMessage::Started { test });
   }
+
+  fn report_slow(&mut self, desc: &test::TestDescription, elapsed: u64) {}
 
   fn report_output(&mut self, output: &[u8]) {
     let test = self

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -454,6 +454,7 @@ pub enum TestEvent {
   Plan(TestPlan),
   Wait(usize),
   Output(TestStdioStream, Vec<u8>),
+  Slow(usize, u64),
   Result(usize, TestResult, u64),
   UncaughtError(String, Box<JsError>),
   StepRegister(TestStepDescription),
@@ -1457,6 +1458,9 @@ pub async fn report_tests(
       }
       TestEvent::Output(_, output) => {
         reporter.report_output(&output);
+      }
+      TestEvent::Slow(id, elapsed) => {
+        reporter.report_slow(tests.get(&id).unwrap(), elapsed);
       }
       TestEvent::Result(id, result, elapsed) => {
         if tests_with_result.insert(id) {

--- a/cli/tools/test/reporters/compound.rs
+++ b/cli/tools/test/reporters/compound.rs
@@ -31,6 +31,12 @@ impl TestReporter for CompoundTestReporter {
     }
   }
 
+  fn report_slow(&mut self, description: &TestDescription, elapsed: u64) {
+    for reporter in &mut self.test_reporters {
+      reporter.report_slow(description, elapsed);
+    }
+  }
+
   fn report_output(&mut self, output: &[u8]) {
     for reporter in &mut self.test_reporters {
       reporter.report_output(output);

--- a/cli/tools/test/reporters/dot.rs
+++ b/cli/tools/test/reporters/dot.rs
@@ -95,6 +95,7 @@ impl TestReporter for DotTestReporter {
     std::io::stdout().flush().unwrap();
   }
 
+  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
   fn report_output(&mut self, _output: &[u8]) {}
 
   fn report_result(

--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -92,6 +92,7 @@ impl TestReporter for JunitTestReporter {
 
   fn report_plan(&mut self, _plan: &TestPlan) {}
 
+  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
   fn report_wait(&mut self, _description: &TestDescription) {}
 
   fn report_output(&mut self, _output: &[u8]) {

--- a/cli/tools/test/reporters/mod.rs
+++ b/cli/tools/test/reporters/mod.rs
@@ -19,6 +19,7 @@ pub trait TestReporter {
   fn report_register(&mut self, description: &TestDescription);
   fn report_plan(&mut self, plan: &TestPlan);
   fn report_wait(&mut self, description: &TestDescription);
+  fn report_slow(&mut self, description: &TestDescription, elapsed: u64);
   fn report_output(&mut self, output: &[u8]);
   fn report_result(
     &mut self,

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -202,7 +202,7 @@ impl TestReporter for PrettyTestReporter {
       &mut self.writer,
       "{}",
       colors::yellow_bold(format!(
-        "'{}' is running very slowly {}",
+        "'{}' has been running for over {}",
         description.name,
         colors::gray(format!("({})", display::human_elapsed(elapsed.into()))),
       ))

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -197,6 +197,18 @@ impl TestReporter for PrettyTestReporter {
     self.started_tests = true;
   }
 
+  fn report_slow(&mut self, description: &TestDescription, elapsed: u64) {
+    writeln!(
+      &mut self.writer,
+      "{}",
+      colors::yellow_bold(format!(
+        "{} is running very slowly {}",
+        description.name,
+        colors::gray(format!("({})", display::human_elapsed(elapsed.into()))),
+      ))
+    )
+    .unwrap();
+  }
   fn report_output(&mut self, output: &[u8]) {
     if !self.echo_output {
       return;

--- a/cli/tools/test/reporters/pretty.rs
+++ b/cli/tools/test/reporters/pretty.rs
@@ -202,7 +202,7 @@ impl TestReporter for PrettyTestReporter {
       &mut self.writer,
       "{}",
       colors::yellow_bold(format!(
-        "{} is running very slowly {}",
+        "'{}' is running very slowly {}",
         description.name,
         colors::gray(format!("({})", display::human_elapsed(elapsed.into()))),
       ))

--- a/cli/tools/test/reporters/tap.rs
+++ b/cli/tools/test/reporters/tap.rs
@@ -140,7 +140,7 @@ impl TestReporter for TapTestReporter {
     std::io::stdout().flush().unwrap();
   }
 
-  fn report_slow(&mut self, _description: &TestDescription, elapsed: u64) {}
+  fn report_slow(&mut self, _description: &TestDescription, _elapsed: u64) {}
   fn report_output(&mut self, _output: &[u8]) {}
 
   fn report_result(

--- a/cli/tools/test/reporters/tap.rs
+++ b/cli/tools/test/reporters/tap.rs
@@ -140,6 +140,7 @@ impl TestReporter for TapTestReporter {
     std::io::stdout().flush().unwrap();
   }
 
+  fn report_slow(&mut self, _description: &TestDescription, elapsed: u64) {}
   fn report_output(&mut self, _output: &[u8]) {}
 
   fn report_result(

--- a/tests/specs/test/slow_test/__test__.jsonc
+++ b/tests/specs/test/slow_test/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "args": "test main.js",
+  "envs": {
+    "DENO_SLOW_TEST_TIMEOUT": "1"
+  },
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/test/slow_test/main.js
+++ b/tests/specs/test/slow_test/main.js
@@ -1,0 +1,4 @@
+Deno.test(async function test() {
+  // We want to get at least one slow test warning
+  await new Promise((r) => setTimeout(r, 3_000));
+});

--- a/tests/specs/test/slow_test/main.out
+++ b/tests/specs/test/slow_test/main.out
@@ -1,3 +1,3 @@
 running 1 test from [WILDCARD]
-test ...'test' is running very slowly (1s)
+test ...'test' has been running for over (1s)
 [WILDCARD]

--- a/tests/specs/test/slow_test/main.out
+++ b/tests/specs/test/slow_test/main.out
@@ -1,0 +1,3 @@
+running 1 test from [WILDCARD]
+test ...'test' is running very slowly (1s)
+[WILDCARD]


### PR DESCRIPTION
By default, uses a 60 second timeout, backing off 2x each time (can be overridden using the hidden `DENO_SLOW_TEST_TIMEOUT` which we implement only really for spec testing.

```
Deno.test(async function test() {
  await new Promise(r => setTimeout(r, 130_000));
});
```

```
$ target/debug/deno test /tmp/test_slow.ts 
Check file:///tmp/test_slow.ts
running 1 test from ../../../../../../tmp/test_slow.ts
test ...'test' is running very slowly (1m0s)
'test' is running very slowly (2m0s)
 ok (2m10s)

ok | 1 passed | 0 failed (2m10s)
```