### PR TITLE
fix(node): track `SIG*` listeners in `process.listeners`

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -465,6 +465,7 @@ Process.prototype.on = function (
     } else if (event === "SIGTERM" && Deno.build.os === "windows") {
       // Ignores SIGTERM on windows.
     } else {
+      EventEmitter.prototype.on.call(this, event, listener);
       Deno.addSignalListener(event as Deno.Signal, listener);
     }
   } else {
@@ -490,6 +491,7 @@ Process.prototype.off = function (
     } else if (event === "SIGTERM" && Deno.build.os === "windows") {
       // Ignores SIGTERM on windows.
     } else {
+      EventEmitter.prototype.off.call(this, event, listener);
       Deno.removeSignalListener(event as Deno.Signal, listener);
     }
   } else {
@@ -533,6 +535,7 @@ Process.prototype.prependListener = function (
     if (event === "SIGBREAK" && Deno.build.os !== "windows") {
       // Ignores SIGBREAK if the platform is not windows.
     } else {
+      EventEmitter.prototype.prependListener.call(this, event, listener);
       Deno.addSignalListener(event as Deno.Signal, listener);
     }
   } else {

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1103,3 +1103,19 @@ Deno.test({
     process.constructor.call({});
   },
 });
+
+// Test for https://github.com/denoland/deno/issues/22892
+Deno.test("process.listeners - include SIG* events", () => {
+  const listener = () => console.log("SIGINT");
+  process.on("SIGINT", listener);
+  assertEquals(process.listeners("SIGINT").length, 1);
+
+  const listener2 = () => console.log("SIGINT");
+  process.prependListener("SIGINT", listener2);
+  assertEquals(process.listeners("SIGINT").length, 2);
+
+  process.off("SIGINT", listener);
+  assertEquals(process.listeners("SIGINT").length, 1);
+  process.off("SIGINT", listener2);
+  assertEquals(process.listeners("SIGINT").length, 0);
+});


### PR DESCRIPTION
Some npm libraries like `signal-exit` rely on the length of the listener array returned by `process.listeners("SIGNT")` to be correct to function. We weren't tracking `SIG*` events there, which broke those npm libraries.

Fixes https://github.com/denoland/deno/issues/22892