### PR TITLE
fix(node): stub findSourceMap for `ava`

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1261,6 +1261,15 @@ internals.requireImpl = {
   nativeModuleExports,
 };
 
+/**
+ * @param {string} path
+ * @returns {SourceMap | undefined}
+ */
+export function findSourceMap(_path) {
+  // TODO(@marvinhagemeister): Stub implementation for now to unblock ava
+  return undefined;
+}
+
 export { builtinModules, createRequire, isBuiltin, Module };
 export const _cache = Module._cache;
 export const _extensions = Module._extensions;

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -1,6 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { builtinModules, createRequire, isBuiltin, Module, findSourceMap } from "node:module";
+import {
+  builtinModules,
+  createRequire,
+  findSourceMap,
+  isBuiltin,
+  Module,
+} from "node:module";
 import { assert, assertEquals } from "@std/assert/mod.ts";
 import process from "node:process";
 import * as path from "node:path";

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -95,7 +95,7 @@ Deno.test("[node/module builtinModules] has 'module' in builtins", () => {
   assert(builtinModules.includes("module"));
 });
 
-// https://github.com/denoland/deno/issues/22731
+// https://github.com/denoland/deno/issues/18666
 Deno.test("[node/module findSourceMap] is a function", () => {
-  assertEquals(typeof findSourceMap, "function");
+  assertEquals(findSourceMap("foo"), undefined);
 });

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { builtinModules, createRequire, isBuiltin, Module } from "node:module";
+import { builtinModules, createRequire, isBuiltin, Module, findSourceMap } from "node:module";
 import { assert, assertEquals } from "@std/assert/mod.ts";
 import process from "node:process";
 import * as path from "node:path";
@@ -87,4 +87,9 @@ Deno.test("[node/module isBuiltin] recognizes node builtins", () => {
 // https://github.com/denoland/deno/issues/22731
 Deno.test("[node/module builtinModules] has 'module' in builtins", () => {
   assert(builtinModules.includes("module"));
+});
+
+// https://github.com/denoland/deno/issues/22731
+Deno.test("[node/module findSourceMap] is a function", () => {
+  assertEquals(typeof findSourceMap, "function");
 });


### PR DESCRIPTION
This stubs `findSourceMap` in `node:module` by always returning `undefined` as if it never found a source map. This unblocks the `ava` test runner.

Fixes https://github.com/denoland/deno/issues/18666