### PR TITLE
fix(cli): use CliNodeResolver::resolve() for managed node_modules

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -29,7 +29,6 @@ use deno_core::ModuleSpecifier;
 use deno_graph::source::ResolutionMode;
 use deno_graph::Resolution;
 use deno_runtime::deno_node;
-use deno_runtime::deno_node::NodeResolutionMode;
 use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_semver::package::PackageReq;
@@ -1295,11 +1294,7 @@ impl Documents {
     }
 
     if let Ok(npm_ref) = NpmPackageReqReference::from_specifier(specifier) {
-      return self.resolver.npm_to_file_url(
-        &npm_ref,
-        referrer,
-        NodeResolutionMode::Types,
-      );
+      return self.resolver.npm_to_file_url(&npm_ref, referrer);
     }
     let Some(doc) = self.get(specifier) else {
       return Some((specifier.clone(), MediaType::from_specifier(specifier)));

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -229,7 +229,6 @@ impl LspResolver {
     &self,
     req_ref: &NpmPackageReqReference,
     referrer: &ModuleSpecifier,
-    mode: NodeResolutionMode,
   ) -> Option<(ModuleSpecifier, MediaType)> {
     let node_resolver = self.node_resolver.as_ref()?;
     Some(NodeResolution::into_specifier_and_media_type(
@@ -238,7 +237,7 @@ impl LspResolver {
           req_ref,
           &PermissionsContainer::allow_all(),
           referrer,
-          mode,
+          NodeResolutionMode::Types,
         )
         .ok(),
     ))

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -691,7 +691,13 @@ impl Resolver for CliGraphResolver {
       }
     }
 
-    result
+    let specifier = result?;
+    match &self.node_resolver {
+      Some(node_resolver) => node_resolver
+        .handle_if_in_node_modules(specifier)
+        .map_err(|e| e.into()),
+      None => Ok(specifier),
+    }
   }
 }
 

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -677,15 +677,21 @@ impl Resolver for CliGraphResolver {
           }
         }
       }
+    } else if referrer.scheme() == "file" {
+      if let Some(node_resolver) = &self.node_resolver {
+        let node_result = node_resolver.resolve_if_in_npm_package(
+          specifier,
+          referrer,
+          to_node_mode(mode),
+          &PermissionsContainer::allow_all(),
+        );
+        if let Some(Ok(Some(res))) = node_result {
+          return Ok(res.into_url());
+        }
+      }
     }
 
-    let specifier = result?;
-    match &self.node_resolver {
-      Some(node_resolver) => node_resolver
-        .handle_if_in_node_modules(specifier)
-        .map_err(|e| e.into()),
-      None => Ok(specifier),
-    }
+    result
   }
 }
 

--- a/tests/registry/npm/@denotest/types-nested-js-dts/1.0.0/import.d.mts
+++ b/tests/registry/npm/@denotest/types-nested-js-dts/1.0.0/import.d.mts
@@ -1,0 +1,1 @@
+export const someString: string;

--- a/tests/registry/npm/@denotest/types-nested-js-dts/1.0.0/index.d.mts
+++ b/tests/registry/npm/@denotest/types-nested-js-dts/1.0.0/index.d.mts
@@ -1,0 +1,1 @@
+export { someString } from "./import.mjs";

--- a/tests/registry/npm/@denotest/types-nested-js-dts/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/types-nested-js-dts/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/types-nested-js-dts",
+  "version": "1.0.0",
+  "types": "./index.d.mts"
+}


### PR DESCRIPTION
Fixes #23895.
Fixes #23878.

This was a regression in #23764 caused by removing this code block: https://github.com/denoland/deno/pull/23764/files#diff-5edc220fbc0fc6aebb443d977875a955bcb1304beb56fefbebae42925824d49aL1111-L1121. I supposed this was handled by the `CliGraphResolver`. This patch ensures `CliNodeResolver::node_resolve()` is called in `CliGraphResolver::resolve()`. ~~Maybe this was broken in `deno check` as well but no errors are surfaced because it produces a bunch of `any` types.~~ Not sure how to test this.