### PR TITLE
fix(cli/coverage): invalid line id in html reporter

### DIFF
--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -633,7 +633,7 @@ impl HtmlCoverageReporter {
   ) -> String {
     let line_num = file_text.lines().count();
     let line_count = (1..line_num + 1)
-      .map(|i| format!("<a name='L{i}'></a><a href='#{i}'>{i}</a>"))
+      .map(|i| format!("<a name='L{i}'></a><a href='#L{i}'>{i}</a>"))
       .collect::<Vec<_>>()
       .join("\n");
     let line_coverage = (0..line_num)

--- a/tests/integration/coverage_tests.rs
+++ b/tests/integration/coverage_tests.rs
@@ -486,6 +486,9 @@ fn test_html_reporter() {
   assert_contains!(bar_ts_html, "<h1>Coverage report for bar.ts</h1>");
   // Check <T> in source code is escaped to &lt;T&gt;
   assert_contains!(bar_ts_html, "&lt;T&gt;");
+  // Check that line anchors are correctly referenced by line number links
+  assert_contains!(bar_ts_html, "<a name='L1'></a>");
+  assert_contains!(bar_ts_html, "<a href='#L1'>1</a>");
 
   let baz_index_html = tempdir
     .join("html")


### PR DESCRIPTION
The `name` for the anchors are prefixed with a `L`, but the links are currently missing it so they don't work currently:
![image](https://github.com/denoland/deno/assets/22963968/4ffa5cde-ae6b-4074-9fc6-76a747846baa)