### PR TITLE
chore: Fix failing `task_npx_non_existent` test

### DIFF
--- a/tests/testdata/task/npx/non_existent.out
+++ b/tests/testdata/task/npx/non_existent.out
@@ -1,4 +1,4 @@
 Task non-existent npx this-command-should-not-exist-for-you
-npm ERR! code E404
-npm ERR! 404 Not Found - GET http://localhost:4260/this-command-should-not-exist-for-you
+npm [WILDCARD] code E404
+npm [WILDCARD] 404 Not Found - GET http://localhost:4260/this-command-should-not-exist-for-you
 [WILDCARD]


### PR DESCRIPTION
Currently `task::task_npx_non_existent` is consistently failing in CI ([example](https://github.com/denoland/deno/actions/runs/9192958846/job/25282900321#step:43:2772)) due to the output changing slightly

```
-- OUTPUT START --
Task non-existent npx this-command-should-not-exist-for-you
npm ERR! code E404
npm ERR! 404 Not Found - GET http://localhost:4260/this-command-should-not-exist-for-you
npm ERR! 404 
npm ERR! 404  'this-command-should-not-exist-for-you@*' is not in this registry.
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in: /Users/runner/.npm/_logs/2024-05-22T17_58_42_473Z-debug-0.log

-- OUTPUT END --
-- EXPECTED START --
Task non-existent npx this-command-should-not-exist-for-you
npm error code E404
npm error 404 Not Found - GET http://localhost:4260/this-command-should-not-exist-for-you
[WILDCARD]

-- EXPECTED END --
```

I'm not sure what changed in CI to cause this (and I can't repro it locally, even matching the version of npm and node on the github runners), but fix it with more lenient expected output for that test.
