### PR TITLE
experiment: save module info and code cache in background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,8 +1304,6 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.280.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d26f2d3e243bbbdd0851ab542b20ec48ac1fcf6c64ab06e81133da3113ebdd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1754,8 +1752,6 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.156.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8237b272db1a6cb941b8a5a63ba63539004a8263e8b0230a11136d76eea273f9"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5752,8 +5748,6 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.189.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893c995255d6fbf55c33166b651fd037c4e3cc7864bf82213ea18d0ec94ed165"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7498,7 +7492,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "ron",
@@ -7540,7 +7534,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,3 +368,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.base64-simd]
 opt-level = 3
+
+[patch.crates-io]
+deno_core = { path = "../deno_core/core" }

--- a/cli/cache/background_processor.rs
+++ b/cli/cache/background_processor.rs
@@ -1,0 +1,37 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::unsync::JoinHandle;
+
+pub struct BackgroundProcessor<TData> {
+  sender: tokio::sync::mpsc::UnboundedSender<TData>,
+  task: JoinHandle<()>,
+}
+
+impl<TData: Send + Sync + 'static> BackgroundProcessor<TData> {
+  pub fn new(
+    process_func: impl Fn(TData) -> () + Send + Sync + Clone + 'static,
+  ) -> Self {
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let task = deno_core::unsync::spawn(async move {
+      while let Some(data) = receiver.recv().await {
+        let process_func = process_func.clone();
+        deno_core::unsync::spawn_blocking(move || {
+          process_func(data);
+        })
+        .await
+        .unwrap()
+      }
+    });
+
+    Self { sender, task }
+  }
+
+  pub async fn shutdown(self) {
+    drop(self.sender);
+    self.task.await.unwrap();
+  }
+
+  pub fn send(&self, data: TData) {
+    self.sender.send(data).unwrap();
+  }
+}

--- a/cli/cache/mod.rs
+++ b/cli/cache/mod.rs
@@ -24,6 +24,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+mod background_processor;
 mod cache_db;
 mod caches;
 mod check;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -120,7 +120,9 @@ async fn run_subcommand(flags: Flags) -> Result<i32, AnyError> {
       main_graph_container
         .load_and_type_check_files(&cache_flags.files)
         .await?;
-      emitter.cache_module_emits(&main_graph_container.graph()).await
+      let result = emitter.cache_module_emits(&main_graph_container.graph()).await;
+      factory.ensure_caches_filled().await;
+      result
     }),
     DenoSubcommand::Check(check_flags) => spawn_subcommand(async move {
       let factory = CliFactory::from_flags(flags)?;

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -14,7 +14,6 @@ use crate::args::DenoSubcommand;
 use crate::args::TsTypeLib;
 use crate::cache::CodeCache;
 use crate::cache::FastInsecureHasher;
-use crate::cache::ModuleInfoCache;
 use crate::cache::ParsedSourceCache;
 use crate::emit::Emitter;
 use crate::factory::CliFactory;
@@ -69,7 +68,6 @@ use deno_graph::Resolution;
 use deno_lockfile::Lockfile;
 use deno_runtime::code_cache;
 use deno_runtime::deno_node::NodeResolutionMode;
-use deno_runtime::fs_util::code_timestamp;
 use deno_runtime::permissions::PermissionsContainer;
 use deno_semver::npm::NpmPackageReqReference;
 
@@ -223,7 +221,6 @@ struct SharedCliModuleLoaderState {
   code_cache: Option<Arc<CodeCache>>,
   emitter: Arc<Emitter>,
   main_module_graph_container: Arc<MainModuleGraphContainer>,
-  module_info_cache: Arc<ModuleInfoCache>,
   module_load_preparer: Arc<ModuleLoadPreparer>,
   node_resolver: Arc<CliNodeResolver>,
   npm_module_loader: NpmModuleLoader,
@@ -242,7 +239,6 @@ impl CliModuleLoaderFactory {
     code_cache: Option<Arc<CodeCache>>,
     emitter: Arc<Emitter>,
     main_module_graph_container: Arc<MainModuleGraphContainer>,
-    module_info_cache: Arc<ModuleInfoCache>,
     module_load_preparer: Arc<ModuleLoadPreparer>,
     node_resolver: Arc<CliNodeResolver>,
     npm_module_loader: NpmModuleLoader,
@@ -263,7 +259,6 @@ impl CliModuleLoaderFactory {
         code_cache,
         emitter,
         main_module_graph_container,
-        module_info_cache,
         module_load_preparer,
         node_resolver,
         npm_module_loader,
@@ -845,7 +840,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
 
   fn code_cache_ready(
     &self,
-    specifier: &ModuleSpecifier,
+    specifier: ModuleSpecifier,
     hash: u64,
     code_cache: &[u8],
   ) -> Pin<Box<dyn Future<Output = ()>>> {

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -73,6 +73,7 @@ To grant permissions, set them before the script argument. For example:
     .await?;
 
   let exit_code = worker.run().await?;
+  factory.ensure_caches_filled().await;
   Ok(exit_code)
 }
 
@@ -102,6 +103,7 @@ pub async fn run_from_stdin(flags: Flags) -> Result<i32, AnyError> {
     .create_main_worker(WorkerExecutionMode::Run, main_module, permissions)
     .await?;
   let exit_code = worker.run().await?;
+  factory.ensure_caches_filled().await;
   Ok(exit_code)
 }
 
@@ -189,6 +191,7 @@ pub async fn eval_command(
     .create_main_worker(WorkerExecutionMode::Eval, main_module, permissions)
     .await?;
   let exit_code = worker.run().await?;
+  factory.ensure_caches_filled().await;
   Ok(exit_code)
 }
 

--- a/runtime/code_cache.rs
+++ b/runtime/code_cache.rs
@@ -6,7 +6,7 @@ pub enum CodeCacheType {
 }
 
 impl CodeCacheType {
-  pub fn as_str(&self) -> &str {
+  pub fn as_str(&self) -> &'static str {
     match self {
       Self::EsModule => "esmodule",
       Self::Script => "script",


### PR DESCRIPTION
Requires: https://github.com/denoland/deno_core/pull/752

```
Benchmark 3: DENO_DIR=/Users/david/dev/scratch/writable_deno_dir ../deno/deno_old run --cached-only -A demo.ts
  Time (mean ± σ):     203.1 ms ±  35.3 ms    [User: 110.9 ms, System: 101.1 ms]
  Range (min … max):   177.4 ms … 297.3 ms    12 runs
 
Benchmark 4: DENO_DIR=/Users/david/dev/scratch/writable_deno_dir ../deno/target/release/deno run --cached-only -A demo.ts
  Time (mean ± σ):     176.6 ms ±  30.3 ms    [User: 110.3 ms, System: 104.5 ms]
  Range (min … max):   161.1 ms … 285.4 ms    16 runs
```

With WAL:

```
Benchmark 4: DENO_DIR=/Users/david/dev/scratch/writable_deno_dir ../deno/target/release/deno run --cached-only -A demo.ts
  Time (mean ± σ):     142.7 ms ±   5.9 ms    [User: 110.0 ms, System: 69.3 ms]
  Range (min … max):   135.6 ms … 153.2 ms    19 runs
```