### PR TITLE
fix(coverage): add tooltip to line count in html report

### DIFF
--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -644,7 +644,7 @@ impl HtmlCoverageReporter {
           if *count == 0 {
             "<span class='cline-any cline-no'>&nbsp</span>".to_string()
           } else {
-            format!("<span class='cline-any cline-yes'>x{count}</span>")
+            format!("<span class='cline-any cline-yes' title='This line is covered {count} time{}'>x{count}</span>", if *count > 1 { "s" } else { "" })
           }
         } else {
           "<span class='cline-any cline-neutral'>&nbsp</span>".to_string()

--- a/tests/integration/coverage_tests.rs
+++ b/tests/integration/coverage_tests.rs
@@ -441,6 +441,12 @@ fn no_internal_node_code() {
 
 #[test]
 fn test_html_reporter() {
+  // This test case generates a html coverage report of test cases in /tests/testdata/coverage/multisource
+  // You can get the same reports in ./cov_html by running the following command:
+  // ```
+  // ./target/debug/deno test --coverage=cov_html tests/testdata/coverage/multisource
+  // ./target/debug/deno coverage --html cov_html
+  // ```
   let context = TestContext::default();
   let tempdir = context.temp_dir();
   let tempdir = tempdir.path().join("cov");
@@ -481,6 +487,9 @@ fn test_html_reporter() {
 
   let foo_ts_html = tempdir.join("html").join("foo.ts.html").read_to_string();
   assert_contains!(foo_ts_html, "<h1>Coverage report for foo.ts</h1>");
+  // Check that line count has correct title attribute
+  assert_contains!(foo_ts_html, "<span class='cline-any cline-yes' title='This line is covered 1 time'>x1</span>");
+  assert_contains!(foo_ts_html, "<span class='cline-any cline-yes' title='This line is covered 3 times'>x3</span>");
 
   let bar_ts_html = tempdir.join("html").join("bar.ts.html").read_to_string();
   assert_contains!(bar_ts_html, "<h1>Coverage report for bar.ts</h1>");


### PR DESCRIPTION
closes #21582

This PR adds tooltip to the execution count part of html coverage report.

<img width="359" alt="Screenshot 2024-05-24 at 20 09 17" src="https://github.com/denoland/deno/assets/613956/7af55bb9-3647-49ed-92e0-a7cb46beb946">

<img width="382" alt="Screenshot 2024-05-24 at 20 09 29" src="https://github.com/denoland/deno/assets/613956/911f5c61-459c-4a0b-acdb-bc65a8651fe6">
