### PR TITLE
fix(coverage): handle ignore patterns

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -397,11 +397,7 @@ fn collect_coverages(
         )?
       }
     }),
-    exclude: PathOrPatternSet::from_exclude_relative_path_or_patterns(
-      initial_cwd,
-      &files.ignore,
-    )
-    .context("Invalid ignore pattern.")?,
+    exclude: PathOrPatternSet::new(vec![]),
   };
   let file_paths = FileCollector::new(|e| {
     e.path.extension().map(|ext| ext == "json").unwrap_or(false)
@@ -411,12 +407,28 @@ fn collect_coverages(
   .set_vendor_folder(cli_options.vendor_dir_path().map(ToOwned::to_owned))
   .collect_file_patterns(file_patterns)?;
 
+  let exclude_patterns = FilePatterns {
+    base: initial_cwd.to_path_buf(),
+    include: None,
+    exclude: PathOrPatternSet::from_exclude_relative_path_or_patterns(
+      initial_cwd,
+      &files.ignore,
+    )
+    .context("Invalid ignore pattern.")?,
+  };
+
   for file_path in file_paths {
     let new_coverage = fs::read_to_string(file_path.as_path())
       .map_err(AnyError::from)
-      .and_then(|json| serde_json::from_str(&json).map_err(AnyError::from))
+      .and_then(|json| {
+        serde_json::from_str::<cdp::ScriptCoverage>(&json)
+          .map_err(AnyError::from)
+      })
       .with_context(|| format!("Failed reading '{}'", file_path.display()))?;
-    coverages.push(new_coverage);
+    let url = Url::parse(&new_coverage.url)?;
+    if exclude_patterns.matches_specifier(&url) {
+      coverages.push(new_coverage);
+    }
   }
 
   coverages.sort_by_key(|k| k.url.clone());

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -407,7 +407,7 @@ fn collect_coverages(
   .set_vendor_folder(cli_options.vendor_dir_path().map(ToOwned::to_owned))
   .collect_file_patterns(file_patterns)?;
 
-  let exclude_patterns = FilePatterns {
+  let coverage_patterns = FilePatterns {
     base: initial_cwd.to_path_buf(),
     include: None,
     exclude: PathOrPatternSet::from_exclude_relative_path_or_patterns(
@@ -426,7 +426,7 @@ fn collect_coverages(
       })
       .with_context(|| format!("Failed reading '{}'", file_path.display()))?;
     let url = Url::parse(&new_coverage.url)?;
-    if exclude_patterns.matches_specifier(&url) {
+    if coverage_patterns.matches_specifier(&url) {
       coverages.push(new_coverage);
     }
   }

--- a/tests/integration/coverage_tests.rs
+++ b/tests/integration/coverage_tests.rs
@@ -538,14 +538,15 @@ fn test_summary_reporter() {
   output.assert_exit_code(0);
   output.skip_output_check();
 
-  let output = context
-    .new_command()
-    .args_vec(vec!["coverage".to_string(), format!("{}/", tempdir)])
-    .run();
+  {
+    let output = context
+      .new_command()
+      .args_vec(vec!["coverage".to_string(), format!("{}/", tempdir)])
+      .run();
 
-  output.assert_exit_code(0);
-  output.assert_matches_text(
-    "----------------------------------
+    output.assert_exit_code(0);
+    output.assert_matches_text(
+      "----------------------------------
 File         | Branch % | Line % |
 ----------------------------------
  bar.ts      |      0.0 |   57.1 |
@@ -556,7 +557,33 @@ File         | Branch % | Line % |
  All files   |     40.0 |   61.0 |
 ----------------------------------
 ",
-  );
+    );
+  }
+
+  // test --ignore flag works
+  {
+    let output = context
+      .new_command()
+      .args_vec(vec![
+        "coverage".to_string(),
+        format!("{}/", tempdir),
+        "--ignore=**/bar.ts,**/quux.ts".to_string(),
+      ])
+      .run();
+
+    output.assert_exit_code(0);
+    output.assert_matches_text(
+      "---------------------------------
+File        | Branch % | Line % |
+---------------------------------
+ baz/qux.ts |    100.0 |  100.0 |
+ foo.ts     |     50.0 |   76.9 |
+---------------------------------
+ All files  |     66.7 |   85.0 |
+---------------------------------
+",
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
`--ignore` pattern is currently matched against the coverage raw data path (`<UUID>.json`) and doesn't work as ignore pattern.

This PR adds the path pattern checks against `url` property of each json object, and excludes the ignored patterns correctly.

closes #23972 