### PR TITLE
fix(node): set default http server response code 200

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1332,7 +1332,7 @@ function onError(self, error, cb) {
 }
 
 export class ServerResponse extends NodeWritable {
-  statusCode?: number = undefined;
+  statusCode = 200;
   statusMessage?: string = undefined;
   #headers = new Headers({});
   #readable: ReadableStream;
@@ -1444,8 +1444,7 @@ export class ServerResponse extends NodeWritable {
   }
 
   #ensureHeaders(singleChunk?: Chunk) {
-    if (this.statusCode === undefined) {
-      this.statusCode = 200;
+    if (this.statusCode === 200 && this.statusMessage === undefined) {
       this.statusMessage = "OK";
     }
     if (
@@ -1460,7 +1459,7 @@ export class ServerResponse extends NodeWritable {
     this.headersSent = true;
     this.#ensureHeaders(singleChunk);
     let body = singleChunk ?? (final ? null : this.#readable);
-    if (ServerResponse.#bodyShouldBeNull(this.statusCode!)) {
+    if (ServerResponse.#bodyShouldBeNull(this.statusCode)) {
       body = null;
     }
     this.#resolve(

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1004,6 +1004,12 @@ Deno.test("[node/http] ServerResponse getHeaders", () => {
   assertEquals(res.getHeaders(), { "bar": "baz", "foo": "bar" });
 });
 
+Deno.test("[node/http] ServerResponse default status code 200", () => {
+  const req = new http.IncomingMessage(new net.Socket());
+  const res = new http.ServerResponse(req);
+  assertEquals(res.statusCode, 200);
+});
+
 Deno.test("[node/http] maxHeaderSize is defined", () => {
   assertEquals(http.maxHeaderSize, 16_384);
 });


### PR DESCRIPTION
Node sets the default HTTP response status code to 200 on the `ServerResponse`. We initialised it as `undefined` before which caused a problem with 11ty's dev server.

Thanks to @vrugtehagel for reporting this issue and finding the correct fix as well 🎉 

Fixes https://github.com/denoland/deno/issues/23970