### PR TITLE
chore(cli): remove extract_standalone path from CLI

### DIFF
--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -1,5 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// Allow unused code warnings because we share
+// code between the two bin targets.
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
 use crate::args::create_default_npmrc;
 use crate::args::get_root_cert_store;
 use crate::args::npm_pkg_req_ref_to_binary_command;


### PR DESCRIPTION
No longer needed as standalone binaries use `denort`