### PR TITLE
BREAKING(ffi/unstable): Use BigInt representation in turbocall

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -220,7 +220,7 @@ declare namespace Deno {
       : T extends NativeU32Enum<infer U> ? U
       : T extends NativeI32Enum<infer U> ? U
       : number
-    : T extends NativeBigIntType ? number | bigint
+    : T extends NativeBigIntType ? bigint
     : T extends NativeBooleanType ? boolean
     : T extends NativePointerType
       ? T extends NativeTypedPointer<infer U> ? U | null : PointerValue
@@ -501,7 +501,7 @@ declare namespace Deno {
    */
   export class UnsafePointer {
     /** Create a pointer from a numeric value. This one is <i>really</i> dangerous! */
-    static create<T = unknown>(value: number | bigint): PointerValue<T>;
+    static create<T = unknown>(value: bigint): PointerValue<T>;
     /** Returns `true` if the two pointers point to the same address. */
     static equals<T = unknown>(a: PointerValue<T>, b: PointerValue<T>): boolean;
     /** Return the direct memory pointer to the typed array in memory. */
@@ -514,7 +514,7 @@ declare namespace Deno {
       offset: number,
     ): PointerValue<T>;
     /** Get the numeric value of a pointer */
-    static value(value: PointerValue): number | bigint;
+    static value(value: PointerValue): bigint;
   }
 
   /** **UNSTABLE**: New API, yet to be vetted.
@@ -554,10 +554,10 @@ declare namespace Deno {
     getInt32(offset?: number): number;
     /** Gets an unsigned 64-bit integer at the specified byte offset from the
      * pointer. */
-    getBigUint64(offset?: number): number | bigint;
+    getBigUint64(offset?: number): bigint;
     /** Gets a signed 64-bit integer at the specified byte offset from the
      * pointer. */
-    getBigInt64(offset?: number): number | bigint;
+    getBigInt64(offset?: number): bigint;
     /** Gets a signed 32-bit float at the specified byte offset from the
      * pointer. */
     getFloat32(offset?: number): number;

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -816,7 +816,7 @@ declare namespace Deno {
    * );
    *
    * // Call the symbol `add`
-   * const result = dylib.symbols.add(35, 34); // 69
+   * const result = dylib.symbols.add(35n, 34n); // 69n
    *
    * console.log(`Result from external addition of 35 and 34: ${result}`);
    * ```

--- a/ext/ffi/repr.rs
+++ b/ext/ffi/repr.rs
@@ -112,11 +112,11 @@ unsafe extern "C" fn noop_deleter_callback(
 }
 
 #[op2(fast)]
+#[bigint]
 pub fn op_ffi_ptr_value<FP>(
   state: &mut OpState,
   ptr: *mut c_void,
-  #[buffer] out: &mut [u32],
-) -> Result<(), AnyError>
+) -> Result<usize, AnyError>
 where
   FP: FfiPermissions + 'static,
 {
@@ -124,18 +124,7 @@ where
   let permissions = state.borrow_mut::<FP>();
   permissions.check_partial(None)?;
 
-  let outptr = out.as_ptr() as *mut usize;
-  let length = out.len();
-  assert!(
-    length >= (std::mem::size_of::<usize>() / std::mem::size_of::<u32>())
-  );
-  assert_eq!(outptr as usize % std::mem::size_of::<usize>(), 0);
-
-  // SAFETY: Out buffer was asserted to be at least large enough to hold a usize, and properly aligned.
-  let out = unsafe { &mut *outptr };
-  *out = ptr as usize;
-
-  Ok(())
+  Ok(ptr as usize)
 }
 
 #[op2]
@@ -398,12 +387,12 @@ where
 }
 
 #[op2(fast)]
+#[bigint]
 pub fn op_ffi_read_u64<FP>(
   state: &mut OpState,
   ptr: *mut c_void,
-  #[number] offset: isize,
-  #[buffer] out: &mut [u32],
-) -> Result<(), AnyError>
+  #[bigint] offset: isize,
+) -> Result<u64, AnyError>
 where
   FP: FfiPermissions + 'static,
 {
@@ -411,13 +400,6 @@ where
 
   let permissions = state.borrow_mut::<FP>();
   permissions.check_partial(None)?;
-
-  let outptr = out.as_mut_ptr() as *mut u64;
-
-  assert!(
-    out.len() >= (std::mem::size_of::<u64>() / std::mem::size_of::<u32>())
-  );
-  assert_eq!((outptr as usize % std::mem::size_of::<u64>()), 0);
 
   if ptr.is_null() {
     return Err(type_error("Invalid u64 pointer, pointer is null"));
@@ -427,32 +409,23 @@ where
   // SAFETY: ptr and offset are user provided.
     unsafe { ptr::read_unaligned::<u64>(ptr.offset(offset) as *const u64) };
 
-  // SAFETY: Length and alignment of out slice were asserted to be correct.
-  unsafe { *outptr = value };
-  Ok(())
+  Ok(value)
 }
 
 #[op2(fast)]
+#[bigint]
 pub fn op_ffi_read_i64<FP>(
   state: &mut OpState,
   ptr: *mut c_void,
-  #[number] offset: isize,
-  #[buffer] out: &mut [u32],
-) -> Result<(), AnyError>
+  #[bigint] offset: isize,
+) -> Result<i64, AnyError>
 where
   FP: FfiPermissions + 'static,
 {
-  check_unstable(state, "Deno.UnsafePointerView#getBigUint64");
+  check_unstable(state, "Deno.UnsafePointerView#getBigInt64");
 
   let permissions = state.borrow_mut::<FP>();
   permissions.check_partial(None)?;
-
-  let outptr = out.as_mut_ptr() as *mut i64;
-
-  assert!(
-    out.len() >= (std::mem::size_of::<i64>() / std::mem::size_of::<u32>())
-  );
-  assert_eq!((outptr as usize % std::mem::size_of::<i64>()), 0);
 
   if ptr.is_null() {
     return Err(type_error("Invalid i64 pointer, pointer is null"));
@@ -462,8 +435,7 @@ where
   // SAFETY: ptr and offset are user provided.
     unsafe { ptr::read_unaligned::<i64>(ptr.offset(offset) as *const i64) };
   // SAFETY: Length and alignment of out slice were asserted to be correct.
-  unsafe { *outptr = value };
-  Ok(())
+  Ok(value)
 }
 
 #[op2(fast)]

--- a/ext/ffi/repr.rs
+++ b/ext/ffi/repr.rs
@@ -391,6 +391,8 @@ where
 pub fn op_ffi_read_u64<FP>(
   state: &mut OpState,
   ptr: *mut c_void,
+  // Note: The representation of 64-bit integers is function-wide. We cannot
+  // choose to take this parameter as a number while returning a bigint.
   #[bigint] offset: isize,
 ) -> Result<u64, AnyError>
 where
@@ -417,6 +419,8 @@ where
 pub fn op_ffi_read_i64<FP>(
   state: &mut OpState,
   ptr: *mut c_void,
+  // Note: The representation of 64-bit integers is function-wide. We cannot
+  // choose to take this parameter as a number while returning a bigint.
   #[bigint] offset: isize,
 ) -> Result<i64, AnyError>
 where

--- a/tests/ffi/tests/bench.js
+++ b/tests/ffi/tests/bench.js
@@ -44,130 +44,179 @@ const dylib = Deno.dlopen(libPath, {
   "return_f64": { parameters: [], result: "f64" },
   "return_buffer": { parameters: [], result: "buffer" },
   // Nonblocking calls
-  "nop_nonblocking": { name: "nop", parameters: [], result: "void" },
+  "nop_nonblocking": {
+    name: "nop",
+    parameters: [],
+    result: "void",
+    nonblocking: true,
+  },
   "nop_bool_nonblocking": {
     name: "nop_bool",
     parameters: ["bool"],
     result: "void",
+    nonblocking: true,
   },
-  "nop_u8_nonblocking": { name: "nop_u8", parameters: ["u8"], result: "void" },
-  "nop_i8_nonblocking": { name: "nop_i8", parameters: ["i8"], result: "void" },
+  "nop_u8_nonblocking": {
+    name: "nop_u8",
+    parameters: ["u8"],
+    result: "void",
+    nonblocking: true,
+  },
+  "nop_i8_nonblocking": {
+    name: "nop_i8",
+    parameters: ["i8"],
+    result: "void",
+    nonblocking: true,
+  },
   "nop_u16_nonblocking": {
     name: "nop_u16",
     parameters: ["u16"],
     result: "void",
+    nonblocking: true,
   },
   "nop_i16_nonblocking": {
     name: "nop_i16",
     parameters: ["i16"],
     result: "void",
+    nonblocking: true,
   },
   "nop_u32_nonblocking": {
     name: "nop_u32",
     parameters: ["u32"],
     result: "void",
+    nonblocking: true,
   },
   "nop_i32_nonblocking": {
     name: "nop_i32",
     parameters: ["i32"],
     result: "void",
+    nonblocking: true,
   },
   "nop_u64_nonblocking": {
     name: "nop_u64",
     parameters: ["u64"],
     result: "void",
+    nonblocking: true,
   },
   "nop_i64_nonblocking": {
     name: "nop_i64",
     parameters: ["i64"],
     result: "void",
+    nonblocking: true,
   },
   "nop_usize_nonblocking": {
     name: "nop_usize",
     parameters: ["usize"],
     result: "void",
+    nonblocking: true,
   },
   "nop_isize_nonblocking": {
     name: "nop_isize",
     parameters: ["isize"],
     result: "void",
+    nonblocking: true,
   },
   "nop_f32_nonblocking": {
     name: "nop_f32",
     parameters: ["f32"],
     result: "void",
+    nonblocking: true,
   },
   "nop_f64_nonblocking": {
     name: "nop_f64",
     parameters: ["f64"],
     result: "void",
+    nonblocking: true,
   },
   "nop_buffer_nonblocking": {
     name: "nop_buffer",
     parameters: ["buffer"],
     result: "void",
+    nonblocking: true,
   },
   "return_bool_nonblocking": {
     name: "return_bool",
     parameters: [],
     result: "bool",
+    nonblocking: true,
   },
-  "return_u8_nonblocking": { name: "return_u8", parameters: [], result: "u8" },
-  "return_i8_nonblocking": { name: "return_i8", parameters: [], result: "i8" },
+  "return_u8_nonblocking": {
+    name: "return_u8",
+    parameters: [],
+    result: "u8",
+    nonblocking: true,
+  },
+  "return_i8_nonblocking": {
+    name: "return_i8",
+    parameters: [],
+    result: "i8",
+    nonblocking: true,
+  },
   "return_u16_nonblocking": {
     name: "return_u16",
     parameters: [],
     result: "u16",
+    nonblocking: true,
   },
   "return_i16_nonblocking": {
     name: "return_i16",
     parameters: [],
     result: "i16",
+    nonblocking: true,
   },
   "return_u32_nonblocking": {
     name: "return_u32",
     parameters: [],
     result: "u32",
+    nonblocking: true,
   },
   "return_i32_nonblocking": {
     name: "return_i32",
     parameters: [],
     result: "i32",
+    nonblocking: true,
   },
   "return_u64_nonblocking": {
     name: "return_u64",
     parameters: [],
     result: "u64",
+    nonblocking: true,
   },
   "return_i64_nonblocking": {
     name: "return_i64",
     parameters: [],
     result: "i64",
+    nonblocking: true,
   },
   "return_usize_nonblocking": {
     name: "return_usize",
     parameters: [],
     result: "usize",
+    nonblocking: true,
   },
   "return_isize_nonblocking": {
     name: "return_isize",
     parameters: [],
     result: "isize",
+    nonblocking: true,
   },
   "return_f32_nonblocking": {
     name: "return_f32",
     parameters: [],
     result: "f32",
+    nonblocking: true,
   },
   "return_f64_nonblocking": {
     name: "return_f64",
     parameters: [],
     result: "f64",
+    nonblocking: true,
   },
   "return_buffer_nonblocking": {
     name: "return_buffer",
     parameters: [],
     result: "buffer",
+    nonblocking: true,
   },
   // Parameter checking
   "nop_many_parameters": {
@@ -216,7 +265,7 @@ const dylib = Deno.dlopen(libPath, {
       "isize",
       "f32",
       "f64",
-      "pointer",
+      "buffer",
       "u8",
       "i8",
       "u16",
@@ -229,7 +278,7 @@ const dylib = Deno.dlopen(libPath, {
       "isize",
       "f32",
       "f64",
-      "pointer",
+      "buffer",
     ],
     result: "void",
     nonblocking: true,
@@ -265,8 +314,12 @@ Deno.bench("return_buffer()", () => {
 });
 
 const { add_u64 } = dylib.symbols;
-Deno.bench("add_u64()", () => {
+Deno.bench("add_u64() number", () => {
   add_u64(1, 2);
+});
+
+Deno.bench("add_u64() bigint", () => {
+  add_u64(1n, 2n);
 });
 
 const { return_u64 } = dylib.symbols;
@@ -315,13 +368,21 @@ Deno.bench("nop_i32()", () => {
 });
 
 const { nop_u64 } = dylib.symbols;
-Deno.bench("nop_u64()", () => {
+Deno.bench("nop_u64() number", () => {
   nop_u64(100);
 });
 
+Deno.bench("nop_u64() bigint", () => {
+  nop_u64(100n);
+});
+
 const { nop_i64 } = dylib.symbols;
-Deno.bench("nop_i64()", () => {
+Deno.bench("nop_i64() number", () => {
   nop_i64(100);
+});
+
+Deno.bench("nop_i64() bigint", () => {
+  nop_i64(100n);
 });
 
 const { nop_usize } = dylib.symbols;
@@ -457,22 +518,38 @@ Deno.bench("nop_i32_nonblocking()", async () => {
 });
 
 const { nop_u64_nonblocking } = dylib.symbols;
-Deno.bench("nop_u64_nonblocking()", async () => {
+Deno.bench("nop_u64_nonblocking() number", async () => {
+  await nop_u64_nonblocking(100);
+});
+
+Deno.bench("nop_u64_nonblocking() bigint", async () => {
   await nop_u64_nonblocking(100);
 });
 
 const { nop_i64_nonblocking } = dylib.symbols;
-Deno.bench("nop_i64_nonblocking()", async () => {
+Deno.bench("nop_i64_nonblocking() number", async () => {
+  await nop_i64_nonblocking(100);
+});
+
+Deno.bench("nop_i64_nonblocking() bigint", async () => {
   await nop_i64_nonblocking(100);
 });
 
 const { nop_usize_nonblocking } = dylib.symbols;
-Deno.bench("nop_usize_nonblocking()", async () => {
+Deno.bench("nop_usize_nonblocking() number", async () => {
+  await nop_usize_nonblocking(100);
+});
+
+Deno.bench("nop_usize_nonblocking() bigint", async () => {
   await nop_usize_nonblocking(100);
 });
 
 const { nop_isize_nonblocking } = dylib.symbols;
-Deno.bench("nop_isize_nonblocking()", async () => {
+Deno.bench("nop_isize_nonblocking() number", async () => {
+  await nop_isize_nonblocking(100);
+});
+
+Deno.bench("nop_isize_nonblocking() bigint", async () => {
   await nop_isize_nonblocking(100);
 });
 
@@ -628,6 +705,11 @@ Deno.bench("nop_many_parameters_nonblocking()", () => {
 
 Deno.bench("Deno.UnsafePointer.of", () => {
   Deno.UnsafePointer.of(buffer);
+});
+
+const bufferPointer = Deno.UnsafePointer.of(buffer);
+Deno.bench("Deno.UnsafePointer.value", () => {
+  Deno.UnsafePointer.value(bufferPointer);
 });
 
 const cstringBuffer = new TextEncoder().encode("Best believe it!\0");

--- a/tests/ffi/tests/ffi_types.ts
+++ b/tests/ffi/tests/ffi_types.ts
@@ -154,8 +154,8 @@ remote.symbols.method15({} as Deno.PointerValue);
 
 const result = remote.symbols.method16();
 // @ts-expect-error: Invalid argument
-let r_0: string = result;
-let r_1: number | bigint = result;
+let r_0: number = result;
+let r_1: bigint = result;
 
 const result2 = remote.symbols.method17();
 // @ts-expect-error: Invalid argument
@@ -290,17 +290,17 @@ let r42_1: number = remote.symbols.method24(true);
 remote.symbols.method25();
 
 // @ts-expect-error: Invalid member type
-const static1_wrong: null = remote.symbols.static1;
-const static1_right: number | bigint = remote.symbols.static1;
+const static1_wrong: number = remote.symbols.static1;
+const static1_right: bigint = remote.symbols.static1;
 // @ts-expect-error: Invalid member type
 const static2_wrong: null = remote.symbols.static2;
 const static2_right: null | Deno.UnsafePointer = remote.symbols.static2;
 // @ts-expect-error: Invalid member type
-const static3_wrong: null = remote.symbols.static3;
-const static3_right: number | bigint = remote.symbols.static3;
+const static3_wrong: number = remote.symbols.static3;
+const static3_right: bigint = remote.symbols.static3;
 // @ts-expect-error: Invalid member type
-const static4_wrong: null = remote.symbols.static4;
-const static4_right: number | bigint = remote.symbols.static4;
+const static4_wrong: number = remote.symbols.static4;
+const static4_right: bigint = remote.symbols.static4;
 // @ts-expect-error: Invalid member type
 const static5_wrong: null = remote.symbols.static5;
 const static5_right: number = remote.symbols.static5;
@@ -311,8 +311,8 @@ const static6_right: number = remote.symbols.static6;
 const static7_wrong: null = remote.symbols.static7;
 const static7_right: number = remote.symbols.static7;
 // @ts-expect-error: Invalid member type
-const static8_wrong: null = remote.symbols.static8;
-const static8_right: number | bigint = remote.symbols.static8;
+const static8_wrong: number = remote.symbols.static8;
+const static8_right: bigint = remote.symbols.static8;
 // @ts-expect-error: Invalid member type
 const static9_wrong: null = remote.symbols.static9;
 const static9_right: number = remote.symbols.static9;
@@ -323,8 +323,8 @@ const static10_right: number = remote.symbols.static10;
 const static11_wrong: null = remote.symbols.static11;
 const static11_right: number = remote.symbols.static11;
 // @ts-expect-error: Invalid member type
-const static12_wrong: null = remote.symbols.static12;
-const static12_right: number | bigint = remote.symbols.static12;
+const static12_wrong: number = remote.symbols.static12;
+const static12_right: bigint = remote.symbols.static12;
 // @ts-expect-error: Invalid member type
 const static13_wrong: null = remote.symbols.static13;
 const static13_right: number = remote.symbols.static13;

--- a/tests/ffi/tests/test.js
+++ b/tests/ffi/tests/test.js
@@ -703,17 +703,17 @@ assertEquals(view.getUint32(), 55);
   const createdPointer = Deno.UnsafePointer.create(1);
   assertNotEquals(createdPointer, null);
   assertEquals(typeof createdPointer, "object");
-  assertEquals(Deno.UnsafePointer.value(null), 0);
-  assertEquals(Deno.UnsafePointer.value(createdPointer), 1);
+  assertEquals(Deno.UnsafePointer.value(null), 0n);
+  assertEquals(Deno.UnsafePointer.value(createdPointer), 1n);
   assert(Deno.UnsafePointer.equals(null, null));
   assertFalse(Deno.UnsafePointer.equals(null, createdPointer));
   assertFalse(Deno.UnsafePointer.equals(Deno.UnsafePointer.create(2), createdPointer));
   // Do not allow offsetting from null, `create` function should be used instead.
   assertThrows(() => Deno.UnsafePointer.offset(null, 5));
   const offsetPointer = Deno.UnsafePointer.offset(createdPointer, 5);
-  assertEquals(Deno.UnsafePointer.value(offsetPointer), 6);
+  assertEquals(Deno.UnsafePointer.value(offsetPointer), 6n);
   const zeroPointer = Deno.UnsafePointer.offset(offsetPointer, -6);
-  assertEquals(Deno.UnsafePointer.value(zeroPointer), 0);
+  assertEquals(Deno.UnsafePointer.value(zeroPointer), 0n);
   assertEquals(zeroPointer, null);
 }
 

--- a/tests/ffi/tests/test.js
+++ b/tests/ffi/tests/test.js
@@ -420,7 +420,7 @@ function addU32Fast(a, b) {
 testOptimized(addU32Fast, () => addU32Fast(123, 456));
 
 function addU64Fast(a, b) { return add_usize_fast(a, b); };
-testOptimized(addU64Fast, () => addU64Fast(2, 3));
+testOptimized(addU64Fast, () => addU64Fast(2n, 3n));
 
 console.log(dylib.symbols.add_i32(123, 456));
 console.log(dylib.symbols.add_u64(0xffffffffn, 0xffffffffn));
@@ -578,7 +578,7 @@ function logManyParametersFast(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q
 testOptimized(
   logManyParametersFast,
   () => logManyParametersFast(
-    255, 65535, 4294967295, 4294967296, 123.456, 789.876, -1, -2, -3, -4, -1000, 1000,
+    255, 65535, 4294967295, 4294967296n, 123.456, 789.876, -1n, -2, -3, -4, -1000n, 1000n,
     12345.678910, 12345.678910, 12345.678910, 12345.678910, 12345.678910, 12345.678910, 12345.678910
   )
 );

--- a/tests/unit/ffi_test.ts
+++ b/tests/unit/ffi_test.ts
@@ -92,11 +92,11 @@ Deno.test({ permissions: { ffi: true } }, function pointerOf() {
   const uint8AddressOffset = Deno.UnsafePointer.value(
     Deno.UnsafePointer.of(new Uint8Array(buffer, 100)),
   );
-  assertEquals(Number(baseAddress) + 100, uint8AddressOffset);
+  assertEquals(baseAddress + 100n, uint8AddressOffset);
   const float64AddressOffset = Deno.UnsafePointer.value(
     Deno.UnsafePointer.of(new Float64Array(buffer, 80)),
   );
-  assertEquals(Number(baseAddress) + 80, float64AddressOffset);
+  assertEquals(baseAddress + 80n, float64AddressOffset);
 });
 
 Deno.test({ permissions: { ffi: true } }, function callWithError() {


### PR DESCRIPTION
Built ontop of #23981 and should only be merged after it; this sets FFI turbocalls (Fast Call API) to use the BigInt representation.