### PR TITLE
fix(ext/websocket): change default idleTimeout to 30s

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -5730,7 +5730,7 @@ declare namespace Deno {
      * `pong` within the timeout specified, the connection is deemed
      * unhealthy and is closed. The `close` and `error` event will be emitted.
      *
-     * The unit is seconds, with a default of 120.
+     * The unit is seconds, with a default of 30.
      * Set to `0` to disable timeouts. */
     idleTimeout?: number;
   }

--- a/ext/http/02_websocket.ts
+++ b/ext/http/02_websocket.ts
@@ -91,7 +91,7 @@ function upgradeWebSocket(request, options = { __proto__: null }) {
   const socket = createWebSocketBranded(WebSocket);
   setEventTargetData(socket);
   socket[_server] = true;
-  socket[_idleTimeoutDuration] = options.idleTimeout ?? 120;
+  socket[_idleTimeoutDuration] = options.idleTimeout ?? 30;
   socket[_idleTimeoutTimeout] = null;
 
   if (inner._wantsUpgrade) {

--- a/ext/http/02_websocket.ts
+++ b/ext/http/02_websocket.ts
@@ -91,6 +91,7 @@ function upgradeWebSocket(request, options = { __proto__: null }) {
   const socket = createWebSocketBranded(WebSocket);
   setEventTargetData(socket);
   socket[_server] = true;
+  // Nginx timeout is 60s, so default to a lower number: https://github.com/denoland/deno/pull/23985
   socket[_idleTimeoutDuration] = options.idleTimeout ?? 30;
   socket[_idleTimeoutTimeout] = null;
 


### PR DESCRIPTION
Nginx has a default timeout of 60 seconds. I fell down this rabbit hole trying to figure out why WebSockets kept getting closed every 60 seconds in my application. First I found #15430 and assumed ping/pong doesn't work in Deno at all. Then I found #13172 and the discussion in https://github.com/denoland/deno/discussions/13168.

It turns out, there is already an automatic ping/pong in Deno. But it only happens every 120 seconds by default.

So I [set the idleTimeout](https://gitlab.com/soapbox-pub/ditto/-/merge_requests/320) to 30s in my application, and suddenly my problems went away.

It seems to me that the default should be 30s. Otherwise people will continue to have this problem. With 30s it "just works" with common setups.