### PR TITLE
chore(ext/web): use `Error.captureStackTrace` in `DOMException` constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.283.0"
+version = "0.284.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5043f9f636a3fe021e63e41c946499e1706d7565126065c60912fe5c77e54e"
+checksum = "f4a5c809e81be26fcfbbce4275573251f6a156137b67059889e9e38f73e75b63"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1753,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.159.0"
+version = "0.160.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26cc5277982de16514282447f8674f9048d4f1b2c0d55c088d0a7d3bf6db385"
+checksum = "517e54d41a2da6a69b8f534294334d79d9115ddd43aea88a5ceefdb717e6d85e"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5754,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.192.0"
+version = "0.193.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b616df6c4ff5643dd503cbfe119175ebebfd4132512e33de4971f1e91d5739"
+checksum = "21ec612dfc7ab70330b5405e8015b25e637bbfe1d79c4bd173557933aea66e76"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.38.2", features = ["transpiling"] }
-deno_core = { version = "0.283.0" }
+deno_core = { version = "0.284.0" }
 
 deno_bench_util = { version = "0.148.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -9,12 +9,12 @@
 
 import { primordials } from "ext:core/mod.js";
 const {
-  ArrayPrototypeSlice,
-  Error,
   ErrorPrototype,
+  ErrorCaptureStackTrace,
   ObjectDefineProperty,
   ObjectCreate,
   ObjectEntries,
+  ObjectHasOwn,
   ObjectPrototypeIsPrototypeOf,
   ObjectSetPrototypeOf,
   Symbol,
@@ -27,7 +27,6 @@ import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 const _name = Symbol("name");
 const _message = Symbol("message");
 const _code = Symbol("code");
-const _error = Symbol("error");
 
 // Defined in WebIDL 4.3.
 // https://webidl.spec.whatwg.org/#idl-DOMException
@@ -113,8 +112,7 @@ class DOMException {
     this[_code] = code;
     this[webidl.brand] = webidl.brand;
 
-    this[_error] = new Error(message);
-    this[_error].name = "DOMException";
+    ErrorCaptureStackTrace(this, DOMException);
   }
 
   get message() {
@@ -133,49 +131,26 @@ class DOMException {
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {
-    if (ObjectPrototypeIsPrototypeOf(DOMExceptionPrototype, this)) {
-      return this[_error].stack;
-    } else {
-      return inspect(
-        createFilteredInspectProxy({
-          object: this,
-          evaluate: false,
-          keys: [
-            "message",
-            "name",
-            "code",
-          ],
-        }),
-        inspectOptions,
-      );
+    if (ObjectHasOwn(this, "stack")) {
+      const stack = this.stack;
+      if (typeof stack === "string") {
+        return stack;
+      }
     }
+    return inspect(
+      createFilteredInspectProxy({
+        object: this,
+        evaluate: ObjectPrototypeIsPrototypeOf(DOMExceptionPrototype, this),
+        keys: [
+          "message",
+          "name",
+          "code",
+        ],
+      }),
+      inspectOptions,
+    );
   }
 }
-
-ObjectDefineProperty(DOMException.prototype, "stack", {
-  get() {
-    return this[_error].stack;
-  },
-  set(value) {
-    this[_error].stack = value;
-  },
-  configurable: true,
-});
-
-// `DOMException` isn't a native error, so `Error.prepareStackTrace()` is
-// not called when accessing `.stack`, meaning our structured stack trace
-// hack doesn't apply. This patches it in.
-ObjectDefineProperty(DOMException.prototype, "__callSiteEvals", {
-  get() {
-    // Call the stack getter so `__callSiteEvals` get populated.
-    this[_error].stack;
-    // To be extra sure, use an empty array if `__callSiteEvals` is still not there,
-    // eg. if the user overrides `Error.prepareStackTrace`.
-    const callSiteEvals = this[_error].__callSiteEvals ?? [];
-    return ArrayPrototypeSlice(callSiteEvals, 1);
-  },
-  configurable: true,
-});
 
 ObjectSetPrototypeOf(DOMException.prototype, ErrorPrototype);
 

--- a/tests/testdata/run/eval_context_throw_dom_exception.js.out
+++ b/tests/testdata/run/eval_context_throw_dom_exception.js.out
@@ -1,6 +1,5 @@
 {
-  thrown: DOMException: foo
-    at new DOMException (ext:deno_web/01_dom_exception.js:[WILDCARD])
+  thrown: Error: foo
     at [WILDCARD]
     at Object.evalContext (ext:core/01_core.js:[WILDCARD])
     at file:///[WILDCARD]/eval_context_throw_dom_exception.js:1:48,

--- a/tests/unit/dom_exception_test.ts
+++ b/tests/unit/dom_exception_test.ts
@@ -23,8 +23,10 @@ Deno.test(function nameToCodeMappingPrototypeAccess() {
   Reflect.deleteProperty(objectPrototype, "pollution");
 });
 
-Deno.test(function callSitesEvalsDoesntThrow() {
+Deno.test(function hasStackAccessor() {
   const e2 = new DOMException("asdf");
-  // @ts-ignore no types for `__callSiteEvals` but it's observable.
-  assert(Array.isArray(e2.__callSiteEvals));
+  const desc = Object.getOwnPropertyDescriptor(e2, "stack");
+  assert(desc);
+  assert(typeof desc.get === "function");
+  assert(typeof desc.set === "function");
 });


### PR DESCRIPTION
This makes `DOMException`'s `stack` property behave the same as native errors' – `stack` is now an own accessor property on every instance, and the getter calls `Error.prepareStackTrace`.

denoland/deno_core#754 depends on this.
