### PR TITLE
error(cli/args): more descriptive error message

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1355,7 +1355,7 @@ impl CliOptions {
     } else if self.maybe_package_json.is_some() {
       Ok(Default::default())
     } else {
-      bail!("No config file found")
+      bail!("deno task error: No config file found. See https://deno.land/manual@v{}/getting_started/configuration_file", env!("CARGO_PKG_VERSION"))
     }
   }
 


### PR DESCRIPTION
#23990 Added a more descriptive error message for a missing deno.json config file.