### PR TITLE
fix: empty `process.platform` with `__runtime_js_sources`

### DIFF
--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -42,9 +42,9 @@ pub struct SnapshotOptions {
 
 impl Default for SnapshotOptions {
   fn default() -> Self {
-    let arch = std::env::consts::ARCH.to_owned();
-    let platform = std::env::consts::OS.to_owned();
-    let target = match platform.as_str() {
+    let arch = std::env::consts::ARCH;
+    let platform = std::env::consts::OS;
+    let target = match platform {
       "macos" => format!("{}-apple-darwin", arch),
       "linux" => format!("{}-unknown-linux-gnu", arch),
       "windows" => format!("{}-pc-windows-msvc", arch),

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -42,11 +42,20 @@ pub struct SnapshotOptions {
 
 impl Default for SnapshotOptions {
   fn default() -> Self {
+    let arch = std::env::consts::ARCH.to_owned();
+    let platform = std::env::consts::OS.to_owned();
+    let target = match platform.as_str() {
+      "macos" => format!("{}-apple-darwin", arch),
+      "linux" => format!("{}-unknown-linux-gnu", arch),
+      "windows" => format!("{}-pc-windows-msvc", arch),
+      rest => format!("{}-{}", arch, rest),
+    };
+
     Self {
       deno_version: "dev".to_owned(),
       ts_version: "n/a".to_owned(),
       v8_version: deno_core::v8_version(),
-      target: std::env::consts::ARCH.to_owned(),
+      target,
     }
   }
 }


### PR DESCRIPTION
We use the `target` property of the snapshot options to derive `process.platform` and `process.arch` from. This value had an incorrect format when compiled with `__runtime_js_sources` enabled. This PR fixes that so that `process.platform` holds the proper value.

Fixes https://github.com/denoland/deno/issues/23164