### PR TITLE
fix(ext/node): support `throwIfNoEntry` option in `fs.lstatSync`

### DIFF
--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -7,6 +7,7 @@ import {
   constants,
   createWriteStream,
   existsSync,
+  lstatSync,
   mkdtempSync,
   promises,
   readFileSync,
@@ -156,3 +157,11 @@ Deno.test("[node/fs createWriteStream", async () => {
     await Deno.remove(tempDir, { recursive: true });
   }
 });
+
+Deno.test(
+  "[node/fs lstatSync] supports throwIfNoEntry option",
+  () => {
+    const result = lstatSync("non-existing-path", { throwIfNoEntry: false });
+    assertEquals(result, undefined);
+  },
+);


### PR DESCRIPTION
We didn't support the `throwIfNoEntry` option for Node's `fs.lstatSync` method. Note that the async variant doesn't have this option.

Fixes https://github.com/denoland/deno/issues/23996