### PR TITLE
fix(coverage): skip generating coverage json for http(s) scripts

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -71,6 +71,8 @@ impl crate::worker::CoverageCollector for CoverageCollector {
       // Filter out internal JS files from being included in coverage reports
       if script_coverage.url.starts_with("ext:")
         || script_coverage.url.starts_with("[ext:")
+        || script_coverage.url.starts_with("http:")
+        || script_coverage.url.starts_with("https:")
         || script_coverage.url.starts_with("node:")
       {
         continue;

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -68,7 +68,7 @@ impl crate::worker::CoverageCollector for CoverageCollector {
 
     let script_coverages = self.take_precise_coverage().await?.result;
     for script_coverage in script_coverages {
-      // Filter out internal JS files from being included in coverage reports
+      // Filter out internal and http/https JS files from being included in coverage reports
       if script_coverage.url.starts_with("ext:")
         || script_coverage.url.starts_with("[ext:")
         || script_coverage.url.starts_with("http:")

--- a/tests/testdata/coverage/no_http_coverage_data_test.ts
+++ b/tests/testdata/coverage/no_http_coverage_data_test.ts
@@ -1,0 +1,5 @@
+import "http://localhost:4546/run/001_hello.js";
+
+Deno.test("hello", async () => {
+  console.log("hello");
+});


### PR DESCRIPTION
This PR skips saving the coverage raw data from http(s) modules.

closes #21784
