### PR TITLE
perf(cli): Improve concurrency when setting up `node_modules` and loading cached npm package info

### DIFF
--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -332,9 +332,18 @@ async fn sync_resolution_with_fs(
           join_package_name(&sub_node_modules, &package.id.nv.name);
         let cache_folder =
           cache.package_folder_for_name_and_version(&package.id.nv);
-        clone_dir_recursive(&cache_folder, &package_path)?;
-        // write out a file that indicates this folder has been initialized
-        fs::write(initialized_file, "")?;
+
+        deno_core::unsync::spawn_blocking({
+          let package_path = package_path.clone();
+          move || {
+            clone_dir_recursive(&cache_folder, &package_path)?;
+            // write out a file that indicates this folder has been initialized
+            fs::write(initialized_file, "")?;
+
+            Ok::<_, AnyError>(())
+          }
+        })
+        .await??;
 
         if package.bin.is_some() {
           bin_entries_to_setup
@@ -374,9 +383,16 @@ async fn sync_resolution_with_fs(
           .join("node_modules"),
         &package.id.nv.name,
       );
-      clone_dir_recursive(&source_path, &package_path)?;
-      // write out a file that indicates this folder has been initialized
-      fs::write(initialized_file, "")?;
+      deno_core::unsync::spawn_blocking({
+        move || {
+          clone_dir_recursive(&source_path, &package_path)?;
+          // write out a file that indicates this folder has been initialized
+          fs::write(initialized_file, "")?;
+
+          Ok::<_, AnyError>(())
+        }
+      })
+      .await??;
     }
   }
 

--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -383,16 +383,10 @@ async fn sync_resolution_with_fs(
           .join("node_modules"),
         &package.id.nv.name,
       );
-      deno_core::unsync::spawn_blocking({
-        move || {
-          clone_dir_recursive(&source_path, &package_path)?;
-          // write out a file that indicates this folder has been initialized
-          fs::write(initialized_file, "")?;
 
-          Ok::<_, AnyError>(())
-        }
-      })
-      .await??;
+      clone_dir_recursive(&source_path, &package_path)?;
+      // write out a file that indicates this folder has been initialized
+      fs::write(initialized_file, "")?;
     }
   }
 


### PR DESCRIPTION
The same issue in two different places - doing blocking FS work in an async task, limiting the amount of work that happens concurrently.

- When setting up node_modules, where we try to set up entries concurrently but were blocking other tasks from actually running.
- When loading package info from the npm registry file cache, loading and deserializing is expensive and prevents concurrency. This was especially noticeable when loading an npm resolution snapshot from a lockfile (`snapshot_from_lockfile` in `deno_npm`).

Installing deps in `deno-docs`:

```
❯ hyperfine -i -p 'rm -rf node_modules/' '../d7/deno-main i' '../d7/target/release/deno i'
Benchmark 1: ../d7/deno-main i
  Time (mean ± σ):      2.193 s ±  0.027 s    [User: 0.589 s, System: 1.033 s]
  Range (min … max):    2.151 s …  2.242 s    10 runs

Benchmark 2: ../d7/target/release/deno i
  Time (mean ± σ):      1.597 s ±  0.021 s    [User: 0.977 s, System: 1.337 s]
  Range (min … max):    1.550 s …  1.627 s    10 runs

Summary
  ../d7/target/release/deno i ran
    1.37 ± 0.02 times faster than ../d7/deno-main i
```

Caching `npm:@11ty/eleventy`:
```
❯ hyperfine -i -p 'rm -rf node_modules/' --warmup 5 '../../d7/deno-main cache npm:@11ty/eleventy' '../../d7/target/release/deno cache npm:@11ty/eleventy'
Benchmark 1: ../../d7/deno-main cache npm:@11ty/eleventy
  Time (mean ± σ):     129.9 ms ±   2.2 ms    [User: 27.5 ms, System: 101.3 ms]
  Range (min … max):   127.5 ms … 135.8 ms    10 runs

Benchmark 2: ../../d7/target/release/deno cache npm:@11ty/eleventy
  Time (mean ± σ):     100.6 ms ±   1.3 ms    [User: 38.8 ms, System: 233.8 ms]
  Range (min … max):    99.3 ms … 103.2 ms    10 runs

Summary
  ../../d7/target/release/deno cache npm:@11ty/eleventy ran
    1.29 ± 0.03 times faster than ../../d7/deno-main cache npm:@11ty/eleventy
```