### PR TITLE
perf: avoid building module graph if dynamic specifier already in graph

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -171,7 +171,7 @@ impl ModuleLoadPreparer {
       )
       .await?;
 
-    self.module_graph_builder.graph_roots_valid(graph, roots)?;
+    self.graph_roots_valid(graph, roots)?;
 
     // write the lockfile if there is one
     if let Some(lockfile) = &self.lockfile {
@@ -204,6 +204,14 @@ impl ModuleLoadPreparer {
     log::debug!("Prepared module load.");
 
     Ok(())
+  }
+
+  pub fn graph_roots_valid(
+    &self,
+    graph: &ModuleGraph,
+    roots: &[ModuleSpecifier],
+  ) -> Result<(), AnyError> {
+    self.module_graph_builder.graph_roots_valid(graph, roots)
   }
 }
 
@@ -804,8 +812,25 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     let inner = self.0.clone();
 
     async move {
-      let graph_container = inner.graph_container.clone();
-      let module_load_preparer = inner.shared.module_load_preparer.clone();
+      let graph_container = &inner.graph_container;
+      let module_load_preparer = &inner.shared.module_load_preparer;
+
+      if is_dynamic {
+        // When the specifier is already in the graph then it means it
+        // was previously loaded, so we can skip that and only check if
+        // this part of the graph is valid. This doesn't acquire a graph
+        // update permit because that will clone the graph which is a
+        // bit slow.
+        let graph = graph_container.graph();
+        if !graph.roots.is_empty() && graph.get(&specifier).is_some() {
+          log::debug!("Skipping prepare module load.");
+          // roots were already checked
+          if !graph.roots.contains(&specifier) {
+            module_load_preparer.graph_roots_valid(&graph, &[specifier])?;
+          }
+          return Ok(());
+        }
+      }
 
       let root_permissions = if is_dynamic {
         inner.dynamic_permissions.clone()

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -818,13 +818,14 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
       if is_dynamic {
         // When the specifier is already in the graph then it means it
         // was previously loaded, so we can skip that and only check if
-        // this part of the graph is valid. This doesn't acquire a graph
-        // update permit because that will clone the graph which is a
-        // bit slow.
+        // this part of the graph is valid.
+        //
+        // This doesn't acquire a graph update permit because that will
+        // clone the graph which is a bit slow.
         let graph = graph_container.graph();
         if !graph.roots.is_empty() && graph.get(&specifier).is_some() {
           log::debug!("Skipping prepare module load.");
-          // roots were already checked
+          // roots are already validated so we can skip those
           if !graph.roots.contains(&specifier) {
             module_load_preparer.graph_roots_valid(&graph, &[specifier])?;
           }

--- a/tests/specs/run/dynamic_already_prepared/__test__.jsonc
+++ b/tests/specs/run/dynamic_already_prepared/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "skips_prepare_module_load": {
+      "args": "run -A --log-level=debug main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/run/dynamic_already_prepared/dynamic.ts
+++ b/tests/specs/run/dynamic_already_prepared/dynamic.ts
@@ -1,0 +1,1 @@
+console.log(1);

--- a/tests/specs/run/dynamic_already_prepared/dynamic2.ts
+++ b/tests/specs/run/dynamic_already_prepared/dynamic2.ts
@@ -1,0 +1,1 @@
+await import("./dynamic3.ts");

--- a/tests/specs/run/dynamic_already_prepared/dynamic3.ts
+++ b/tests/specs/run/dynamic_already_prepared/dynamic3.ts
@@ -1,0 +1,1 @@
+await import("./dynamic.ts");

--- a/tests/specs/run/dynamic_already_prepared/main.out
+++ b/tests/specs/run/dynamic_already_prepared/main.out
@@ -1,0 +1,1 @@
+[WILDCARD]Prepared module load.[WILDCARD]Skipping prepare module load.[WILDCARD]Skipping prepare module load.[WILDCARD]Skipping prepare module load.[WILDCARD]

--- a/tests/specs/run/dynamic_already_prepared/main.ts
+++ b/tests/specs/run/dynamic_already_prepared/main.ts
@@ -1,0 +1,2 @@
+await import("./dynamic.ts");
+await import("./dynamic2.ts");


### PR DESCRIPTION
Real fix instead of https://github.com/denoland/deno/pull/24020

```
Benchmark 1: ../../deno/deno_old run -A repro.ts
  Time (mean ± σ):     272.0 ms ±   5.4 ms    [User: 267.9 ms, System: 95.2 ms]
  Range (min … max):   267.1 ms … 287.0 ms    11 runs
 
Benchmark 2: ../../deno/target/release/deno run -A repro.ts
  Time (mean ± σ):     237.2 ms ±   2.0 ms    [User: 236.0 ms, System: 93.1 ms]
  Range (min … max):   235.6 ms … 243.0 ms    12 runs
 
Summary
  ../../deno/target/release/deno run -A repro.ts ran
    1.15 ± 0.02 times faster than ../../deno/deno_old run -A repro.ts
```

```
Benchmark 1: ../../deno/deno_old run -A repro2.ts
  Time (mean ± σ):     202.2 ms ±   3.4 ms    [User: 233.0 ms, System: 61.3 ms]
  Range (min … max):   199.1 ms … 211.7 ms    14 runs
 
Benchmark 2: ../../deno/target/release/deno run -A repro2.ts
  Time (mean ± σ):     175.8 ms ±   1.8 ms    [User: 207.7 ms, System: 59.7 ms]
  Range (min … max):   173.8 ms … 179.9 ms    16 runs
 
Summary
  ../../deno/target/release/deno run -A repro2.ts ran
    1.15 ± 0.02 times faster than ../../deno/deno_old run -A repro2.ts
```