### PR TITLE
chore: upgrade jupyter runtimelib to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,7 +5356,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.10.0"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f4969d577fe13ef40c8eb6fad2ccc66c26c800410672c847f5397699240b9d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,9 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300b46ab6f2970f81c176f4f2f7ff0a48809f52be7a8fd4ca5a32e9002f6e8f"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -130,7 +130,7 @@ rand = { workspace = true, features = ["small_rng"] }
 regex.workspace = true
 reqwest.workspace = true
 ring.workspace = true
-runtimelib = "=0.9.0"
+runtimelib = "=0.11.0"
 rustyline.workspace = true
 rustyline-derive = "=0.7.0"
 serde.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -111,6 +111,7 @@ ignore = "0.4"
 import_map = { version = "=0.19.0", features = ["ext"] }
 indexmap.workspace = true
 jsonc-parser.workspace = true
+jupyter_runtime = { package = "runtimelib", version = "=0.11.0" }
 lazy-regex.workspace = true
 libc.workspace = true
 libz-sys.workspace = true
@@ -130,7 +131,6 @@ rand = { workspace = true, features = ["small_rng"] }
 regex.workspace = true
 reqwest.workspace = true
 ring.workspace = true
-runtimelib = "=0.11.0"
 rustyline.workspace = true
 rustyline-derive = "=0.7.0"
 serde.workspace = true

--- a/cli/ops/jupyter.rs
+++ b/cli/ops/jupyter.rs
@@ -65,12 +65,9 @@ pub async fn op_jupyter_broadcast(
       err
     })?;
 
-    let mut jupyter_message = JupyterMessage::new(content, Some(&last_request));
-
-    jupyter_message.metadata = metadata;
-    jupyter_message.buffers =
-      buffers.into_iter().map(|b| b.to_vec().into()).collect();
-    jupyter_message.set_parent(last_request);
+    let jupyter_message = JupyterMessage::new(content, Some(&last_request))
+      .with_metadata(metadata)
+      .with_buffers(buffers.into_iter().map(|b| b.to_vec().into()).collect());
 
     (iopub_connection.lock().await)
       .send(jupyter_message)

--- a/cli/ops/jupyter.rs
+++ b/cli/ops/jupyter.rs
@@ -4,10 +4,10 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use runtimelib::JupyterMessage;
-use runtimelib::JupyterMessageContent;
-use runtimelib::KernelIoPubConnection;
-use runtimelib::StreamContent;
+use jupyter_runtime::JupyterMessage;
+use jupyter_runtime::JupyterMessageContent;
+use jupyter_runtime::KernelIoPubConnection;
+use jupyter_runtime::StreamContent;
 
 use deno_core::error::AnyError;
 use deno_core::op2;

--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -7,7 +7,7 @@ use std::env::current_exe;
 use std::io::Write;
 use std::path::Path;
 
-use runtimelib::dirs::user_data_dir;
+use jupyter_runtime::dirs::user_data_dir;
 
 const DENO_ICON_32: &[u8] = include_bytes!("./resources/deno-logo-32x32.png");
 const DENO_ICON_64: &[u8] = include_bytes!("./resources/deno-logo-64x64.png");

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -23,8 +23,8 @@ use deno_runtime::permissions::PermissionsContainer;
 use deno_runtime::WorkerExecutionMode;
 use deno_terminal::colors;
 
-use runtimelib::jupyter::ConnectionInfo;
-use runtimelib::messaging::StreamContent;
+use jupyter_runtime::jupyter::ConnectionInfo;
+use jupyter_runtime::messaging::StreamContent;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -19,19 +19,18 @@ use deno_core::CancelHandle;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 
-use runtimelib::ConnectionInfo;
-use runtimelib::KernelControlConnection;
-use runtimelib::KernelHeartbeatConnection;
-use runtimelib::KernelIoPubConnection;
-use runtimelib::KernelShellConnection;
-
-use runtimelib::messaging;
-use runtimelib::AsChildOf;
-use runtimelib::JupyterMessage;
-use runtimelib::JupyterMessageContent;
-use runtimelib::ReplyError;
-use runtimelib::ReplyStatus;
-use runtimelib::StreamContent;
+use jupyter_runtime::messaging;
+use jupyter_runtime::AsChildOf;
+use jupyter_runtime::ConnectionInfo;
+use jupyter_runtime::JupyterMessage;
+use jupyter_runtime::JupyterMessageContent;
+use jupyter_runtime::KernelControlConnection;
+use jupyter_runtime::KernelHeartbeatConnection;
+use jupyter_runtime::KernelIoPubConnection;
+use jupyter_runtime::KernelShellConnection;
+use jupyter_runtime::ReplyError;
+use jupyter_runtime::ReplyStatus;
+use jupyter_runtime::StreamContent;
 
 pub struct JupyterServer {
   execution_count: usize,

--- a/cli/tools/jupyter/server.rs
+++ b/cli/tools/jupyter/server.rs
@@ -455,7 +455,7 @@ impl JupyterServer {
             messaging::ExecuteReply {
               execution_count: self.execution_count,
               status: ReplyStatus::Error,
-              payload: None,
+              payload: Default::default(),
               user_expressions: None,
               error: None,
             }
@@ -481,7 +481,7 @@ impl JupyterServer {
             execution_count: self.execution_count,
             status: ReplyStatus::Ok,
             user_expressions: None,
-            payload: None,
+            payload: Default::default(),
             error: None,
           }
           .as_child_of(parent_message),
@@ -586,7 +586,7 @@ impl JupyterServer {
               traceback,
             }),
             user_expressions: None,
-            payload: None,
+            payload: Default::default(),
           }
           .as_child_of(parent_message),
         )


### PR DESCRIPTION
Brings in:

* More fully typed structures (for when we get to implementing more)
* `with_metadata`, `with_buffers`, etc. from https://github.com/runtimed/runtimed/pull/99