### PR TITLE
perf(repl): don't walk workspace in repl language server

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -226,7 +226,7 @@ fn get_maybe_test_module_fut(
   maybe_parsed_source: Option<&ParsedSourceResult>,
   config: &Config,
 ) -> Option<TestModuleFut> {
-  if !config.client_capabilities.testing_api {
+  if !config.testing_api_capable() {
     return None;
   }
   let parsed_source = maybe_parsed_source?.as_ref().ok()?.clone();

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -803,6 +803,7 @@ impl Inner {
 
   fn walk_workspace(config: &Config) -> (BTreeSet<ModuleSpecifier>, bool) {
     if !config.workspace_capable() {
+      log::debug!("Skipped workspace walk due to client incapability.");
       return (Default::default(), false);
     }
     let mut workspace_files = Default::default();

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -439,7 +439,7 @@ impl LanguageServer {
       (
         inner.client.clone(),
         inner.config.workspace_folders.clone(),
-        inner.config.client_capabilities.workspace_configuration,
+        inner.config.workspace_configuration_capable(),
       )
     };
     if capable {
@@ -769,7 +769,7 @@ impl Inner {
           vec![],
         );
       }
-      self.config.update_capabilities(&params.capabilities);
+      self.config.set_client_capabilities(params.capabilities);
     }
 
     self.diagnostics_server.start();
@@ -802,6 +802,9 @@ impl Inner {
   }
 
   fn walk_workspace(config: &Config) -> (BTreeSet<ModuleSpecifier>, bool) {
+    if !config.workspace_capable() {
+      return (Default::default(), false);
+    }
     let mut workspace_files = Default::default();
     let entry_limit = 1000;
     let mut pending = VecDeque::new();
@@ -1664,10 +1667,10 @@ impl Inner {
         .map(CodeActionOrCommand::CodeAction),
     );
 
-    let code_action_disabled_support =
-      self.config.client_capabilities.code_action_disabled_support;
+    let code_action_disabled_capable =
+      self.config.code_action_disabled_capable();
     let actions: Vec<CodeActionOrCommand> = all_actions.into_iter().filter(|ca| {
-      code_action_disabled_support
+      code_action_disabled_capable
         || matches!(ca, CodeActionOrCommand::CodeAction(ca) if ca.disabled.is_none())
     }).collect();
     let response = if actions.is_empty() {
@@ -2318,7 +2321,7 @@ impl Inner {
             span.to_folding_range(
               asset_or_doc.line_index(),
               asset_or_doc.text().as_bytes(),
-              self.config.client_capabilities.line_folding_only,
+              self.config.line_folding_only_capable(),
             )
           })
           .collect::<Vec<FoldingRange>>(),
@@ -2887,11 +2890,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
       inner.refresh_documents_config().await;
       inner.task_queue.start(self.clone());
       self.init_flag.raise();
-      if inner
-        .config
-        .client_capabilities
-        .workspace_did_change_watched_files
-      {
+      if inner.config.did_change_watched_files_capable() {
         // we are going to watch all the JSON files in the workspace, and the
         // notification handler will pick up any of the changes of those files we
         // are interested in.
@@ -2909,7 +2908,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
           register_options: Some(serde_json::to_value(options).unwrap()),
         });
       }
-      if inner.config.client_capabilities.workspace_will_rename_files {
+      if inner.config.will_rename_files_capable() {
         let options = FileOperationRegistrationOptions {
           filters: vec![FileOperationFilter {
             scheme: Some("file".to_string()),
@@ -2927,7 +2926,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
         });
       }
 
-      if inner.config.client_capabilities.testing_api {
+      if inner.config.testing_api_capable() {
         let test_server = testing::TestServer::new(
           inner.client.clone(),
           inner.performance.clone(),
@@ -3051,7 +3050,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
     };
     self.refresh_configuration().await;
     let mut inner = self.inner.write().await;
-    if !inner.config.client_capabilities.workspace_configuration {
+    if !inner.config.workspace_configuration_capable() {
       let config = params.settings.as_object().map(|settings| {
         let deno =
           serde_json::to_value(settings.get(SETTINGS_SECTION)).unwrap();

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -3725,6 +3725,10 @@ mod tests {
       temp_dir.uri().join("root2/").unwrap(),
       temp_dir.uri().join("root3/").unwrap(),
     ]);
+    config.set_client_capabilities(ClientCapabilities {
+      workspace: Some(Default::default()),
+      ..Default::default()
+    });
     config.set_workspace_settings(
       Default::default(),
       vec![

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4679,7 +4679,7 @@ impl UserPreferences {
       // TODO(nayeemrmn): Investigate why we use `Index` here.
       import_module_specifier_ending: Some(ImportModuleSpecifierEnding::Index),
       include_completions_with_snippet_text: Some(
-        config.client_capabilities.snippet_support,
+        config.snippet_support_capable(),
       ),
       provide_refactor_not_applicable_reason: Some(true),
       quote_preference: Some(fmt_config.into()),
@@ -4717,7 +4717,7 @@ impl UserPreferences {
       include_completions_with_class_member_snippets: Some(
         language_settings.suggest.enabled
           && language_settings.suggest.class_member_snippets.enabled
-          && config.client_capabilities.snippet_support,
+          && config.snippet_support_capable(),
       ),
       include_completions_with_insert_text: Some(
         language_settings.suggest.enabled,
@@ -4728,7 +4728,7 @@ impl UserPreferences {
             .suggest
             .object_literal_method_snippets
             .enabled
-          && config.client_capabilities.snippet_support,
+          && config.snippet_support_capable(),
       ),
       import_module_specifier_preference: Some(
         language_settings.preferences.import_module_specifier,

--- a/tests/integration/repl_tests.rs
+++ b/tests/integration/repl_tests.rs
@@ -1084,7 +1084,10 @@ fn closed_file_pre_load_does_not_occur() {
     .new_command()
     .args_vec(["repl", "-A", "--log-level=debug"])
     .with_pty(|console| {
-      assert_contains!(console.all_output(), "Skipped document preload.",);
+      assert_contains!(
+        console.all_output(),
+        "Skipped workspace walk due to client incapability.",
+      );
     });
 }
 


### PR DESCRIPTION
Fixes #24031. Don't walk the workspace if the workspace capability is `None`. Also refactor client capability storage to use the `lsp_types` field and not parsing it into our own struct. It had some unused fields.

We used to address this by passing `document_preload_limit: 0` from the repl, but the workspace walk was separated from that check as of #23123.