### PR TITLE
feat: do not require `DENO_FUTURE=1` for npmrc support

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -558,10 +558,6 @@ pub fn discover_npmrc(
   maybe_package_json_path: Option<PathBuf>,
   maybe_deno_json_path: Option<PathBuf>,
 ) -> Result<(Arc<ResolvedNpmRc>, Option<PathBuf>), AnyError> {
-  if !*DENO_FUTURE {
-    return Ok((create_default_npmrc(), None));
-  }
-
   const NPMRC_NAME: &str = ".npmrc";
 
   fn get_env_var(var_name: &str) -> Option<String> {

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8866,7 +8866,6 @@ fn lsp_npmrc() {
     .use_http_server()
     .use_temp_cwd()
     .add_npm_env_vars()
-    .env("DENO_FUTURE", "1")
     .build();
   let temp_dir = context.temp_dir();
   temp_dir.write(

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8861,6 +8861,83 @@ fn lsp_tls_cert() {
 }
 
 #[test]
+fn lsp_npmrc() {
+  let context = TestContextBuilder::new()
+    .use_http_server()
+    .use_temp_cwd()
+    .add_npm_env_vars()
+    .env("DENO_FUTURE", "1")
+    .build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write(
+    temp_dir.path().join("deno.json"),
+    json!({
+      "nodeModulesDir": true,
+    })
+    .to_string(),
+  );
+  temp_dir.write(
+    temp_dir.path().join("package.json"),
+    json!({
+      "name": "npmrc_test",
+      "version": "0.0.1",
+      "dependencies": {
+        "@denotest/basic": "1.0.0",
+      },
+    })
+    .to_string(),
+  );
+  temp_dir.write(
+    temp_dir.path().join(".npmrc"),
+    "\
+@denotest:registry=http://127.0.0.1:4261/
+//127.0.0.1:4261/denotest/:_authToken=private-reg-token
+",
+  );
+  let file = source_file(
+    temp_dir.path().join("main.ts"),
+    r#"
+      import { getValue, setValue } from "@denotest/basic";
+      setValue(42);
+      const n: string = getValue();
+      console.log(n);
+    "#,
+  );
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.write_request(
+    "workspace/executeCommand",
+    json!({
+      "command": "deno.cache",
+      "arguments": [[], file.uri()],
+    }),
+  );
+  let diagnostics = client.did_open_file(&file);
+  assert_eq!(
+    json!(diagnostics.all()),
+    json!([
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 12,
+          },
+          "end": {
+            "line": 3,
+            "character": 13,
+          },
+        },
+        "severity": 1,
+        "code": 2322,
+        "source": "deno-ts",
+        "message": "Type 'number' is not assignable to type 'string'.",
+      },
+    ]),
+  );
+  client.shutdown();
+}
+
+#[test]
 fn lsp_diagnostics_warn_redirect() {
   let context = TestContextBuilder::new()
     .use_http_server()

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8870,6 +8870,13 @@ fn lsp_npmrc() {
     .build();
   let temp_dir = context.temp_dir();
   temp_dir.write(
+    temp_dir.path().join("deno.json"),
+    json!({
+      "nodeModulesDir": true,
+    })
+    .to_string(),
+  );
+  temp_dir.write(
     temp_dir.path().join("package.json"),
     json!({
       "name": "npmrc_test",
@@ -8884,10 +8891,9 @@ fn lsp_npmrc() {
     temp_dir.path().join(".npmrc"),
     "\
 @denotest:registry=http://127.0.0.1:4261/
-//127.0.0.1:4261/:_authToken=private-reg-token
+//127.0.0.1:4261/denotest/:_authToken=private-reg-token
 ",
   );
-  context.run_npm("install");
   let file = source_file(
     temp_dir.path().join("main.ts"),
     r#"

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8870,13 +8870,6 @@ fn lsp_npmrc() {
     .build();
   let temp_dir = context.temp_dir();
   temp_dir.write(
-    temp_dir.path().join("deno.json"),
-    json!({
-      "nodeModulesDir": true,
-    })
-    .to_string(),
-  );
-  temp_dir.write(
     temp_dir.path().join("package.json"),
     json!({
       "name": "npmrc_test",
@@ -8891,9 +8884,10 @@ fn lsp_npmrc() {
     temp_dir.path().join(".npmrc"),
     "\
 @denotest:registry=http://127.0.0.1:4261/
-//127.0.0.1:4261/denotest/:_authToken=private-reg-token
+//127.0.0.1:4261/:_authToken=private-reg-token
 ",
   );
+  context.run_npm("install");
   let file = source_file(
     temp_dir.path().join("main.ts"),
     r#"

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8891,7 +8891,7 @@ fn lsp_npmrc() {
     temp_dir.path().join(".npmrc"),
     "\
 @denotest:registry=http://127.0.0.1:4261/
-//127.0.0.1:4261/denotest/:_authToken=private-reg-token
+//127.0.0.1:4261/:_authToken=private-reg-token
 ",
   );
   let file = source_file(

--- a/tests/specs/npm/npmrc/__test__.jsonc
+++ b/tests/specs/npm/npmrc/__test__.jsonc
@@ -1,13 +1,21 @@
 {
-  "envs": {
-    "DENO_FUTURE": "1"
-  },
   "tempDir": true,
-  "steps": [{
-    "args": "install",
-    "output": "install.out"
-  }, {
-    "args": "run -A main.js",
-    "output": "main.out"
-  }]
+  "tests": {
+    "deno_install": {
+      "envs": {
+        "DENO_FUTURE": "1"
+      },
+      "steps": [{
+        "args": "install",
+        "output": "install.out"
+      }, {
+        "args": "run -A main.js",
+        "output": "main.out"
+      }]
+    },
+    "run_node_modules_dir": {
+      "args": "run --node-modules-dir -A --quiet main.js",
+      "output": "main.out"
+    }
+  }
 }


### PR DESCRIPTION
We were initially only adding this to deno_future because it was going to land in a patch release. We can remove this now though.