### PR TITLE
Fix: Update permission prompt message for compiled binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "fs3",
  "glibc_version",
  "glob",
+ "global_flags",
  "ignore",
  "import_map",
  "indexmap",
@@ -1467,6 +1468,7 @@ dependencies = [
  "deno_core",
  "deno_io",
  "filetime",
+ "global_flags",
  "junction",
  "libc",
  "nix 0.26.2",
@@ -1773,6 +1775,7 @@ dependencies = [
  "deno_core",
  "deno_terminal",
  "fqdn",
+ "global_flags",
  "libc",
  "log",
  "once_cell",
@@ -1815,6 +1818,7 @@ dependencies = [
  "encoding_rs",
  "fastwebsockets",
  "flate2",
+ "global_flags",
  "http 1.1.0",
  "http-body-util",
  "hyper 0.14.28",
@@ -2972,6 +2976,13 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "global_flags"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "globset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "ext/webstorage",
   "runtime",
   "runtime/permissions",
+  "global_flags",
   "tests",
   "tests/ffi",
   "tests/napi",
@@ -112,6 +113,7 @@ flate2 = { version = "1.0.26", default-features = false }
 fs3 = "0.5.0"
 futures = "0.3.21"
 glob = "0.3.1"
+global_flags = { path = "global_flags" }
 h2 = "0.4.4"
 http = "1.0"
 http-body-util = "0.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -107,6 +107,7 @@ faster-hex.workspace = true
 flate2.workspace = true
 fs3.workspace = true
 glob = "0.3.1"
+global_flags.workspace = true
 ignore = "0.4"
 import_map = { version = "=0.19.0", features = ["ext"] }
 indexmap.workspace = true

--- a/cli/mainrt.rs
+++ b/cli/mainrt.rs
@@ -30,6 +30,7 @@ use deno_runtime::tokio_util::create_and_run_current_thread_with_maybe_metrics;
 pub use deno_runtime::UNSTABLE_GRANULAR_FLAGS;
 use deno_terminal::colors;
 
+use global_flags::global_flags::set_running_from_binary;
 use std::borrow::Cow;
 use std::env;
 use std::env::current_exe;
@@ -71,6 +72,8 @@ fn unwrap_or_exit<T>(result: Result<T, AnyError>) -> T {
 }
 
 fn main() {
+  let running_from_binary = true;
+  set_running_from_binary(running_from_binary);
   let args: Vec<_> = env::args_os().collect();
   let current_exe_path = current_exe().unwrap();
   let standalone =

--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -22,6 +22,7 @@ base32.workspace = true
 deno_core.workspace = true
 deno_io.workspace = true
 filetime.workspace = true
+global_flags.workspace = true
 libc.workspace = true
 rand.workspace = true
 rayon = "1.8.0"

--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -22,6 +22,7 @@ use deno_core::ToJsBuffer;
 use deno_io::fs::FileResource;
 use deno_io::fs::FsError;
 use deno_io::fs::FsStat;
+use global_flags::global_flags::is_running_from_binary;
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;
@@ -68,7 +69,14 @@ fn map_permission_error(
       } else {
         (path.as_str(), "")
       };
-      custom_error("PermissionDenied", format!("Requires {err} access to {path}{truncated}, run again with the --allow-{err} flag"))
+      let msg = if !is_running_from_binary() {
+        format!(
+          "Requires {err} access to {path}{truncated}, run again with the --allow-{err} flag")
+      } else {
+        format!(
+          "Requires {err} access to {path}{truncated}, specify the required permissions during compilation using `deno compile --allow-{err}`")
+      };
+      custom_error("PermissionDenied", msg)
     }
     err => Err::<(), _>(err)
       .context_path(operation, path)

--- a/global_flags/Cargo.toml
+++ b/global_flags/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "global_flags"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+lazy_static = "1.4.0"

--- a/global_flags/global_flags.rs
+++ b/global_flags/global_flags.rs
@@ -1,0 +1,15 @@
+use lazy_static::lazy_static;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+lazy_static! {
+  pub static ref RUNNING_FROM_BINARY: AtomicBool = AtomicBool::new(false);
+}
+
+pub fn set_running_from_binary(value: bool) {
+  RUNNING_FROM_BINARY.store(value, Ordering::SeqCst);
+}
+
+pub fn is_running_from_binary() -> bool {
+  RUNNING_FROM_BINARY.load(Ordering::SeqCst)
+}

--- a/global_flags/lib.rs
+++ b/global_flags/lib.rs
@@ -1,0 +1,1 @@
+pub mod global_flags;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -98,6 +98,7 @@ deno_webstorage.workspace = true
 dlopen2.workspace = true
 encoding_rs.workspace = true
 fastwebsockets.workspace = true
+global_flags.workspace = true
 http.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true

--- a/runtime/permissions/Cargo.toml
+++ b/runtime/permissions/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 deno_core.workspace = true
 deno_terminal.workspace = true
 fqdn = "0.3.4"
+global_flags.workspace = true
 libc.workspace = true
 log.workspace = true
 once_cell.workspace = true

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -18,6 +18,7 @@ use deno_core::ModuleSpecifier;
 use deno_terminal::colors;
 use fqdn::fqdn;
 use fqdn::FQDN;
+use global_flags::global_flags::is_running_from_binary;
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -131,14 +132,20 @@ impl PermissionState {
   }
 
   fn error(name: &str, info: impl FnOnce() -> Option<String>) -> AnyError {
-    custom_error(
-      "PermissionDenied",
+    let msg = if is_running_from_binary() {
       format!(
         "Requires {}, run again with the --allow-{} flag",
         Self::fmt_access(name, info),
         name
-      ),
-    )
+      )
+    } else {
+      format!(
+        "Requires {}, specify the required permissions during compilation using `deno compile --allow-{}`",
+        Self::fmt_access(name, info),
+        name
+      )
+    };
+    custom_error("PermissionDenied", msg)
   }
 
   /// Check the permission state. bool is whether a prompt was issued.


### PR DESCRIPTION
When running a compiled Deno program that requires permissions, the prompt message previously instructed users to rerun with `--allow-*` flags, which is incorrect for binaries.

Changes:
- Updated the permission prompt message to instruct users to specify required permissions during the compilation step using `deno compile --allow-*`.
- Adjusted `PermissionDenied` error messages to reflect the correct instructions for binaries.

This fix ensures that users are correctly informed about how to handle permissions for compiled Deno binaries.

Resolves #23250.
