### PR TITLE
fix(cli): Overwrite existing bin entries in `node_modules`

### DIFF
--- a/tests/specs/task/bin_package/__test__.jsonc
+++ b/tests/specs/task/bin_package/__test__.jsonc
@@ -27,17 +27,16 @@
         }
       ]
     },
-    "warns_if_already_setup": {
+    "clobbers_if_already_setup": {
       "tempDir": true,
       "steps": [{
-        "if": "unix",
         "commandName": "npm",
         "args": "install",
         "output": "\nadded 1 package in [WILDCARD]\n"
       }, {
         "if": "unix",
         "args": "task sayhi",
-        "output": "already-set-up.out"
+        "output": "task.out"
       }]
     }
   }

--- a/tests/specs/task/bin_package/already-set-up.out
+++ b/tests/specs/task/bin_package/already-set-up.out
@@ -1,9 +1,0 @@
-Download http://localhost:4260/@denotest/bin
-Download http://localhost:4260/@denotest/bin/1.0.0.tgz
-Initialize @denotest/bin@1.0.0
-Warning Trying to set up [WILDCARD] bin for [WILDCARD], but an entry pointing to [WILDCARD] already exists. Skipping...
-Warning Trying to set up [WILDCARD] bin for [WILDCARD] but an entry pointing to [WILDCARD] already exists. Skipping...
-Warning Trying to set up [WILDCARD] bin for [WILDCARD], but an entry pointing to [WILDCARD] already exists. Skipping...
-Task sayhi cli-esm hi hello
-hi
-hello


### PR DESCRIPTION
Previously we warned on unix and didn't touch them on windows, now we unconditionally overwrite them. This matches what npm does.