### PR TITLE
fix(ext/node): send data frame with end_stream flag on _final call

### DIFF
--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -344,6 +344,7 @@ pub async fn op_http2_client_send_data(
   state: Rc<RefCell<OpState>>,
   #[smi] stream_rid: ResourceId,
   #[buffer] data: JsBuffer,
+  end_of_stream: bool,
 ) -> Result<(), AnyError> {
   let resource = state
     .borrow()
@@ -351,8 +352,7 @@ pub async fn op_http2_client_send_data(
     .get::<Http2ClientStream>(stream_rid)?;
   let mut stream = RcRef::map(&resource, |r| &r.stream).borrow_mut().await;
 
-  // TODO(bartlomieju): handle end of stream
-  stream.send_data(data.to_vec().into(), false)?;
+  stream.send_data(data.to_vec().into(), end_of_stream)?;
   Ok(())
 }
 


### PR DESCRIPTION
We previously ended the http2 stream by sending trailers which should have been only used if waitForTrailers option is set on the http2session. This patch updates it and ends the stream by sending an empty data frame with end_stream flag set or by emitting 'wantTrailers' event if waitForTrailers option is set.

Hard to create an unit test as this requires that a test server needs to ack end of stream flag and then process a request. The example from #24058 works.

Closes https://github.com/denoland/deno/issues/24058