### PR TITLE
fix(jupyter): Avoid panicking when `DEBUG` env var is set

### DIFF
--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -7,7 +7,6 @@ use crate::tools::repl;
 use crate::tools::test::create_single_test_event_channel;
 use crate::tools::test::reporters::PrettyTestReporter;
 use crate::tools::test::TestEventWorkerSender;
-use crate::util::logger;
 use crate::CliFactory;
 use deno_core::anyhow::Context;
 use deno_core::error::generic_error;
@@ -51,11 +50,6 @@ pub async fn kernel(
   }
 
   let connection_filepath = jupyter_flags.conn_file.unwrap();
-
-  // This env var might be set by notebook
-  if std::env::var("DEBUG").is_ok() {
-    logger::init(Some(log::Level::Debug));
-  }
 
   let factory = CliFactory::from_flags(flags)?;
   let cli_options = factory.cli_options();


### PR DESCRIPTION
Fixes #22050.

It seems very unlikely that a user would be intending to enable deno's internal debug logs by setting the DEBUG env var. If they really want that, they can set `RUST_LOG=debug` instead.