### PR TITLE
ci: error on `chore:` deno_core upgrade pr titles

### DIFF
--- a/tools/verify_pr_title.js
+++ b/tools/verify_pr_title.js
@@ -7,6 +7,21 @@ if (prTitle == null) {
 
 console.log("PR title:", prTitle);
 
+if (
+  prTitle.startsWith("chore:") && prTitle.contains("deno_core") &&
+  (prTitle.contains("upgrade") || prTitle.contains("update"))
+) {
+  console.error([
+    "Please categorize this deno_core upgrade as a 'feat:', 'fix:' or a ",
+    "'refactor:'. If your upgrade does not fall into either of these ",
+    "categories, wait until the next deno_core release.\n\n",
+    "For feats and fixes, please title your PR outlining the fixed issue ",
+    "rather than just `fix: upgrade deno_core` so that users understand the ",
+    "change that was made in the changelog.",
+  ].join(""));
+  Deno.exit(1);
+}
+
 // This is a release PR, so it's valid.
 if (/^[^\s]+\.[^\s]+\.[^\s]+$/.test(prTitle)) {
   console.log("Valid.");


### PR DESCRIPTION
Too many `chore: upgrade deno_core` PRs have landed that fix issues in the CLI. These PR titles should be descriptive of the bugs they fix.