### PR TITLE
fix(cli): Explicitly cache NPM packages during `deno install`

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -75,6 +75,7 @@ pub async fn load_top_level_deps(factory: &CliFactory) -> Result<(), AnyError> {
   let npm_resolver = factory.npm_resolver().await?;
   if let Some(npm_resolver) = npm_resolver.as_managed() {
     npm_resolver.ensure_top_level_package_json_install().await?;
+    npm_resolver.cache_packages().await?;
   }
   // cache as many entries in the import map as we can
   if let Some(import_map) = factory.maybe_import_map().await? {

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -75,6 +75,8 @@ pub async fn load_top_level_deps(factory: &CliFactory) -> Result<(), AnyError> {
   let npm_resolver = factory.npm_resolver().await?;
   if let Some(npm_resolver) = npm_resolver.as_managed() {
     npm_resolver.ensure_top_level_package_json_install().await?;
+    // TODO(nathanwhit): we call `cache_packages` if the lockfile is modified,
+    // so by calling it here it's possible we end up calling it twice
     npm_resolver.cache_packages().await?;
   }
   // cache as many entries in the import map as we can

--- a/tests/specs/install/future_install_node_modules/__test__.jsonc
+++ b/tests/specs/install/future_install_node_modules/__test__.jsonc
@@ -45,7 +45,10 @@
         },
         {
           // remove the lockfile
-          "args": ["eval", "Deno.removeSync('node_modules', {recursive: true});"],
+          "args": [
+            "eval",
+            "Deno.removeSync('node_modules', {recursive: true});"
+          ],
           "output": ""
         },
         {

--- a/tests/specs/install/future_install_node_modules/__test__.jsonc
+++ b/tests/specs/install/future_install_node_modules/__test__.jsonc
@@ -25,6 +25,41 @@
         }
       ]
     },
+    "install_sets_up_node_modules_with_lockfile": {
+      "tempDir": true,
+      "envs": {
+        "DENO_FUTURE": "1"
+      },
+      "steps": [
+        {
+          "args": "install",
+          "output": "install.out"
+        },
+        {
+          // check for lockfile
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('./deno.lock').trim())"
+          ],
+          "output": "deno.lock.out"
+        },
+        {
+          // remove the lockfile
+          "args": ["eval", "Deno.removeSync('node_modules', {recursive: true});"],
+          "output": ""
+        },
+        {
+          // install, this time should use the lockfile
+          "args": "install",
+          "output": "install_lockfile.out"
+        },
+        {
+          // make sure we created the node_modules dir
+          "args": ["eval", "Deno.statSync('node_modules')"],
+          "output": ""
+        }
+      ]
+    },
     "install_errors_corrupted_lockfile": {
       "tempDir": true,
       "envs": {

--- a/tests/specs/install/future_install_node_modules/install_lockfile.out
+++ b/tests/specs/install/future_install_node_modules/install_lockfile.out
@@ -1,0 +1,2 @@
+⚠️ `deno install` behavior will change in Deno 2. To preserve the current behavior use the `-g` or `--global` flag.
+Initialize @denotest/esm-basic@1.0.0

--- a/tests/specs/npm/npmrc_not_next_to_package_json/main.out
+++ b/tests/specs/npm/npmrc_not_next_to_package_json/main.out
@@ -4,3 +4,4 @@
 [WILDCARD]
 Download http://localhost:4260/@denotest/esm-basic/1.0.0.tgz
 Initialize @denotest/esm-basic@1.0.0
+[WILDCARD]


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/denoland/deno/pull/24170, where we wouldn't actually set up the node modules dir on `deno install` if there was an up to date deno lockfile present. 

Previously we were relying on the fact that resolving pending module resolution called `cache_packages` (which sets up the node modules dir). When pending resolutions were removed, and the `resolve_pending` function with it, we also removed the `cache_packages` call needed to set up node modules.