### PR TITLE
perf(lsp): store settings in Arc

### DIFF
--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1611,21 +1611,21 @@ mod tests {
   fn mock_config() -> Config {
     let root_uri = resolve_url("file:///").unwrap();
     Config {
-      settings: Settings {
-        unscoped: WorkspaceSettings {
+      settings: Arc::new(Settings {
+        unscoped: Arc::new(WorkspaceSettings {
           enable: Some(true),
           lint: true,
           ..Default::default()
-        },
+        }),
         ..Default::default()
-      },
-      workspace_folders: vec![(
+      }),
+      workspace_folders: Arc::new(vec![(
         root_uri.clone(),
         lsp::WorkspaceFolder {
           uri: root_uri,
           name: "".to_string(),
         },
-      )],
+      )]),
       ..Default::default()
     }
   }
@@ -1719,10 +1719,13 @@ let c: number = "a";
     // now test disabled specifier
     {
       let mut disabled_config = mock_config();
-      disabled_config.settings.unscoped = WorkspaceSettings {
-        enable: Some(false),
-        ..Default::default()
-      };
+      disabled_config.set_workspace_settings(
+        WorkspaceSettings {
+          enable: Some(false),
+          ..Default::default()
+        },
+        vec![],
+      );
 
       let diagnostics = generate_lint_diagnostics(
         &snapshot,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -446,7 +446,7 @@ impl LanguageServer {
     if capable {
       let mut scopes = Vec::with_capacity(folders.len() + 1);
       scopes.push(None);
-      for (_, folder) in &folders {
+      for (_, folder) in folders.as_ref() {
         scopes.push(Some(folder.uri.clone()));
       }
       let configs = client
@@ -461,7 +461,7 @@ impl LanguageServer {
         let mut configs = configs.into_iter();
         let unscoped = configs.next().unwrap();
         let mut folder_settings = Vec::with_capacity(folders.len());
-        for (folder_uri, _) in &folders {
+        for (folder_uri, _) in folders.as_ref() {
           folder_settings.push((folder_uri.clone(), configs.next().unwrap()));
         }
         let mut inner = self.inner.write().await;
@@ -3146,7 +3146,7 @@ impl tower_lsp::LanguageServer for LanguageServer {
           )
         })
         .collect::<Vec<(ModuleSpecifier, WorkspaceFolder)>>();
-      for (specifier, folder) in &inner.config.workspace_folders {
+      for (specifier, folder) in inner.config.workspace_folders.as_ref() {
         if !params.event.removed.is_empty()
           && params.event.removed.iter().any(|f| f.uri == folder.uri)
         {


### PR DESCRIPTION
Namely `Config::{settings,client_capabilities,workspace_folders}` and some nested `WorkspaceSettings`. These are large and cloned often.