### PR TITLE
fix(ext/permissions): add correct feature flags to winapi

### DIFF
--- a/runtime/permissions/Cargo.toml
+++ b/runtime/permissions/Cargo.toml
@@ -24,4 +24,4 @@ serde.workspace = true
 which = "4.2.5"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "tlhelp32", "winbase", "winerror", "winuser", "winsock2"] }
+winapi = { workspace = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "tlhelp32", "winbase", "winerror", "winuser", "winsock2", "processenv", "wincon", "wincontypes"] }


### PR DESCRIPTION
Adds 3 new feature flags to `runtime/permissions/winapi` to close issue #24212