### PR TITLE
fix(ext/node): make process.versions own property

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -731,6 +731,9 @@ if (isWindows) {
 // @ts-ignore TS doesn't work well with ES5 classes
 const process = new Process();
 
+/* Set owned property */
+process.versions = versions;
+
 Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,
   writable: true,

--- a/tests/unit/process_test.ts
+++ b/tests/unit/process_test.ts
@@ -699,4 +699,3 @@ Deno.test(
     assertStringIncludes(stderr, "Failed getting cwd.");
   },
 );
-

--- a/tests/unit/process_test.ts
+++ b/tests/unit/process_test.ts
@@ -699,3 +699,4 @@ Deno.test(
     assertStringIncludes(stderr, "Failed getting cwd.");
   },
 );
+

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1116,3 +1116,7 @@ Deno.test("process.listeners - include SIG* events", () => {
   process.off("SIGINT", listener2);
   assertEquals(process.listeners("SIGINT").length, 0);
 });
+
+Deno.test(function processVersionsOwnProperty() {
+  assert(Object.prototype.hasOwnProperty.call(process, "versions"));
+});


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/24233

This is a quick fix. There are some more properties that should be on the object rather than the class, this'll do for now

```
[divy@divy deno]$ target/debug/deno
Deno 1.44.2
exit using ctrl+d, ctrl+c, or close()
REPL is running with all permissions allowed.
To specify permissions, run `deno repl` with allow flags.
> import { ClientSecretCredential } from "npm:@azure/identity";
const test = new ClientSecretCredential("a","b","c",);
console.log(test);
ClientSecretCredential {
  clientSecret: "c",
  tenantId: "a",
  additionallyAllowedTenantIds: [],
  msalClient: {
    getTokenByClientSecret: [AsyncFunction: getTokenByClientSecret],
    getTokenByClientAssertion: [AsyncFunction: getTokenByClientAssertion],
    getTokenByClientCertificate: [AsyncFunction: getTokenByClientCertificate]
  }
}
```