### PR TITLE
feat: add preventCloseOnEOF option

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1964,7 +1964,10 @@ declare namespace Deno {
    * @tags allow-read, allow-write
    * @category File System
    */
-  export function create(path: string | URL): Promise<FsFile>;
+  export function create(
+    path: string | URL,
+    options?: CreateOptions,
+  ): Promise<FsFile>;
 
   /** Creates a file if none exists or truncates an existing file and returns
    *  an instance of {@linkcode Deno.FsFile}.
@@ -1978,7 +1981,10 @@ declare namespace Deno {
    * @tags allow-read, allow-write
    * @category File System
    */
-  export function createSync(path: string | URL): FsFile;
+  export function createSync(
+    path: string | URL,
+    options?: CreateOptions,
+  ): FsFile;
 
   /** Read from a resource ID (`rid`) into an array buffer (`buffer`).
    *
@@ -2329,9 +2335,24 @@ declare namespace Deno {
      */
     readonly rid: number;
     /** A {@linkcode ReadableStream} instance representing to the byte contents
-     * of the file. This makes it easy to interoperate with other web streams
-     * based APIs.
+     * of the file.
      *
+     * When the readable stream hits the end of the file (EOF), the stream will
+     * end. Additionally, the underlying file handle is automatically closed.
+     * This means that other APIs on this file handle will no longer work after
+     * the stream ends and the end of file (EOF) is reached. In particular, the
+     * writable stream will no longer work after EOF is reached.
+     *
+     * This behavior can be changed by setting the `preventCloseOnEOF` to `true`
+     * when creating the `FsFile` instance with {@linkcode Deno.open} or
+     * similar. This will prevent the file handle from being closed
+     * automatically when the stream reaches EOF.
+     *
+     * You do not need to manually close the file handle with `file.close()`
+     * when using the readable stream. The file handle is automatically closed
+     * when the stream ends.
+     *
+     * @example Read the contents of a file using a readable stream:
      * ```ts
      * using file = await Deno.open("my_file.txt", { read: true });
      * const decoder = new TextDecoder();
@@ -2339,12 +2360,32 @@ declare namespace Deno {
      *   console.log(decoder.decode(chunk));
      * }
      * ```
+     *
+     * @example Respond to a HTTP request with the contents of a file:
+     * ```ts
+     * Deno.serve(() => {
+     *   const file = await Deno.open("my_file.txt", { read: true });
+     *   return new Response(file.readable);
+     * });
+     * ```
      */
     readonly readable: ReadableStream<Uint8Array>;
     /** A {@linkcode WritableStream} instance to write the contents of the
-     * file. This makes it easy to interoperate with other web streams based
-     * APIs.
+     * file.
      *
+     * When the writable stream is closed, the underlying file handle is also
+     * closed automatically. This means that APIs on this file handle will no
+     * longer work after the stream is closed.
+     *
+     * This means that other APIs on this file handle will no longer work after
+     * the stream is closed.
+     *
+     * To not close the file handle automatically, for example when wanting
+     * reusing the file handle, one should not close the writable stream. When
+     * using `.pipeTo()` to write to this writable, this can be done by setting
+     * the `preventClose` option in `PipeOptions` to `true`.
+     *
+     * @example Write to a file using a writable stream:
      * ```ts
      * const items = ["hello", "world"];
      * using file = await Deno.open("my_file.txt", { write: true });
@@ -2353,6 +2394,15 @@ declare namespace Deno {
      * for (const item of items) {
      *   await writer.write(encoder.encode(item));
      * }
+     * ```
+     *
+     * @example Write a HTTP request body to a file:
+     * ```ts
+     * Deno.serve(async (req) => {
+     *   const file = await Deno.open("my_file.txt", { write: true });
+     *   await req.body.pipeTo(file.writable);
+     *   return new Response();
+     * });
      * ```
      */
     readonly writable: WritableStream<Uint8Array>;
@@ -2798,7 +2848,13 @@ declare namespace Deno {
      * for migration instructions.
      */
     readonly rid: number;
-    /** A readable stream interface to `stdin`. */
+    /**
+     * A readable stream interface to `stdin`.
+     *
+     * When the readable stream hits the end of the file (EOF), the stream will
+     * be closed. This means that stdin can then not be used for any other
+     * file operations.
+     */
     readonly readable: ReadableStream<Uint8Array>;
     /**
      * Set TTY to be under raw mode or not. In raw mode, characters are read and
@@ -2846,7 +2902,26 @@ declare namespace Deno {
      * for migration instructions.
      */
     readonly rid: number;
-    /** A writable stream interface to `stdout`. */
+    /**
+     * A writable stream interface to `stdout`.
+     *
+     * When the writable stream is closed, stdout is also closed automatically.
+     * This means that other APIs operating on stdout will no longer work after
+     * the stream is closed. In particular, `console.log` will no longer work
+     * after the stream is closed.
+     *
+     * When wanting to write to `stdout` without closing the file handle, for
+     * example when wanting to write multiple times to `stdout`, one should not
+     * close the writable stream. When using `ReadableStream#pipeTo()` to write
+     * to this writable, this can be done by setting the `preventClose` option
+     * in `PipeOptions` to `true`.
+     *
+     * @example Writing a file to `stdout`:
+     * ```ts
+     * const file = await Deno.open("my_file.txt");
+     * await file.readable.pipeTo(Deno.stdout.writable, { preventClose: true }); // do not close stdout after finishing writing
+     * ```
+     */
     readonly writable: WritableStream<Uint8Array>;
     /**
      * Checks if `stdout` is a TTY (terminal).
@@ -2880,7 +2955,26 @@ declare namespace Deno {
      * for migration instructions.
      */
     readonly rid: number;
-    /** A writable stream interface to `stderr`. */
+    /**
+     * A writable stream interface to `stderr`.
+     *
+     * When the writable stream is closed, stderr is also closed automatically.
+     * This means that other APIs operating on stderr will no longer work after
+     * the stream is closed. In particular, `console.error` will no longer work
+     * after the stream is closed.
+     *
+     * When wanting to write to `stderr` without closing the file handle, for
+     * example when wanting to write multiple times to `stderr`, one should not
+     * close the writable stream. When using `ReadableStream#pipeTo()` to write
+     * to this writable, this can be done by setting the `preventClose` option
+     * in `PipeOptions` to `true`.
+     *
+     * @example Writing a file to `stderr`:
+     * ```ts
+     * const file = await Deno.open("my_file.txt");
+     * await file.readable.pipeTo(Deno.stderr.writable, { preventClose: true }); // do not close stderr after finishing writing
+     * ```
+     */
     readonly writable: WritableStream<Uint8Array>;
     /**
      * Checks if `stderr` is a TTY (terminal).
@@ -2946,6 +3040,31 @@ declare namespace Deno {
      *
      * Ignored on Windows. */
     mode?: number;
+    /** Prevent the file from being closed automatically when the readable
+     * stream reaches EOF. This allows the file to be reused for further writes
+     * or reads.
+     *
+     * @default {false} */
+    preventCloseOnEOF?: boolean;
+  }
+
+  /*
+   * Options which can be set when doing {@linkcode Deno.create} and
+   * {@linkcode Deno.createSync}.
+   *
+   * @category File System */
+  export interface CreateOptions {
+    /** Permissions to use when creating the file (defaults to `0o666`, before
+     * the process's umask).
+     *
+     * Ignored on Windows. */
+    mode?: number;
+    /** Prevent the file from being closed automatically when the readable
+     * stream reaches EOF. This allows the file to be reused for further writes
+     * or reads.
+     *
+     * @default {false} */
+    preventCloseOnEOF?: boolean;
   }
 
   /**
@@ -4634,8 +4753,54 @@ declare namespace Deno {
    * @category Sub Process
    */
   export class ChildProcess implements AsyncDisposable {
+    /**
+     * The `stdin` of the child process, when `stdin` is set to `"piped"`.
+     *
+     * This writable stream can be used to write data to the child process.
+     *
+     * When closing the writable stream, the underlying stdin pipe will be
+     * closed. This means that the child process will receive an EOF on its
+     * stdin.
+     *
+     * To write multiple times to stdin, one must not close the writable stream
+     * after each write. Instead, the writable stream should be closed after all
+     * writes are done. To not close a writable stream when writing with
+     * `ReadableStream#pipeTo`, set the `preventClose` option to `true` in the
+     * `PipeOptions`.
+     *
+     * If `stdin` is not set to `"piped"`, accessing this field will throw a
+     * `TypeError`.
+     */
     get stdin(): WritableStream<Uint8Array>;
+    /**
+     * The `stdout` of the child process, when `stdout` is set to `"piped"`.
+     *
+     * This readable stream can be used to read data from the child process.
+     * When the child process writes data to its stdout, it can be read from
+     * this stream.
+     *
+     * When the child process closes its stdout, the readable stream will be
+     * closed too once it has read all the data written by the child process
+     * before the stdout was closed.
+     *
+     * If `stdout` is not set to `"piped"`, accessing this field will throw a
+     * `TypeError`.
+     */
     get stdout(): ReadableStream<Uint8Array>;
+    /**
+     * The `stderr` of the child process, when `stderr` is set to `"piped"`.
+     *
+     * This readable stream can be used to read data from the child process.
+     * When the child process writes data to its stderr, it can be read from
+     * this stream.
+     *
+     * When the child process closes its stderr, the readable stream will be
+     * closed too once it has read all the data written by the child process
+     * before the stderr was closed.
+     *
+     * If `stderr` is not set to `"piped"`, accessing this field will throw a
+     * `TypeError`.
+     */
     get stderr(): ReadableStream<Uint8Array>;
     readonly pid: number;
     /** Get the status of the child. */
@@ -4644,7 +4809,20 @@ declare namespace Deno {
     /** Waits for the child to exit completely, returning all its output and
      * status. */
     output(): Promise<CommandOutput>;
-    /** Kills the process with given {@linkcode Deno.Signal}.
+    /** Sends the given {@linkcode Deno.Signal} to the child process.
+     *
+     * Process shutdown is asynchronous, so the process may still be running
+     * when this function returns. To wait for the process to exit, use
+     * {@linkcode Deno.ChildProcess.status}.
+     *
+     * Some signals may not result in the subprocess exiting at all - this is
+     * generally dependent on the subprocess itself. Some signals, like
+     * `SIGTERM` will usually cause the subprocess to exit after a short time,
+     * but badly behaved subprocesses may ignore the signal entirely. To
+     * forcibly terminate a subprocess, use `SIGKILL`. Even when using
+     * `SIGKILL`, the subprocess may take a while to actually exit - always
+     * use {@linkcode Deno.ChildProcess.status} to wait for the subprocess to
+     * exit.
      *
      * Defaults to `SIGTERM` if no signal is provided.
      *

--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -622,7 +622,11 @@ function openSync(
     options,
   );
 
-  return new FsFile(rid, SymbolFor("Deno.internal.FsFile"));
+  return new FsFile(
+    rid,
+    options.preventCloseOnEOF ?? false,
+    SymbolFor("Deno.internal.FsFile"),
+  );
 }
 
 async function open(
@@ -635,39 +639,50 @@ async function open(
     options,
   );
 
-  return new FsFile(rid, SymbolFor("Deno.internal.FsFile"));
+  return new FsFile(
+    rid,
+    options.preventCloseOnEOF ?? false,
+    SymbolFor("Deno.internal.FsFile"),
+  );
 }
 
-function createSync(path) {
+function createSync(path, options) {
   return openSync(path, {
     read: true,
     write: true,
     truncate: true,
     create: true,
+    mode: options?.mode,
+    preventCloseOnEOF: options?.preventCloseOnEOF,
   });
 }
 
-function create(path) {
+function create(path, options) {
   return open(path, {
     read: true,
     write: true,
     truncate: true,
     create: true,
+    mode: options?.mode,
+    preventCloseOnEOF: options?.preventCloseOnEOF,
   });
 }
 
 class FsFile {
   #rid = 0;
 
+  #preventCloseOnEOF;
+
   #readable;
   #writable;
 
-  constructor(rid, symbol) {
+  constructor(rid, preventCloseOnEOF, symbol) {
     ObjectDefineProperty(this, internalRidSymbol, {
       enumerable: false,
       value: rid,
     });
     this.#rid = rid;
+    this.#preventCloseOnEOF = preventCloseOnEOF;
     if (!symbol || symbol !== SymbolFor("Deno.internal.FsFile")) {
       internals.warnOnDeprecatedApi(
         "new Deno.FsFile()",
@@ -745,7 +760,7 @@ class FsFile {
 
   get readable() {
     if (this.#readable === undefined) {
-      this.#readable = readableStreamForRid(this.#rid);
+      this.#readable = readableStreamForRid(this.#rid, this.#preventCloseOnEOF);
     }
     return this.#readable;
   }

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -193,6 +193,7 @@ class InnerRequest {
         upgradeRid,
         underlyingConn?.remoteAddr,
         underlyingConn?.localAddr,
+        false,
       );
 
       return { response: UPGRADE_RESPONSE_SENTINEL, conn };

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -104,7 +104,35 @@ declare namespace Deno {
     /** Make the connection not block the event loop from finishing. */
     unref(): void;
 
+    /**
+     * A readable stream representing the data on the connection.
+     *
+     * When the connection is closed (EOF is encountered), the stream will also
+     * be closed. By default, when the stream is closed, the underlying
+     * network connection will also be closed. This means in particular that if
+     * `readable` is closed due to an EOF, the entire connection will be closed
+     * and this the `writable` end of the stream will also be closed.
+     *
+     * To prevent this behavior, you can set the `preventCloseOnEOF` option to
+     * `true` when creating the connection. This will prevent the connection
+     * from being closed when the stream is closed due to an EOF.
+     */
     readonly readable: ReadableStream<Uint8Array>;
+    /**
+     * A writable stream representing the data on the connection.
+     *
+     * When the connection is closed, the stream will also be closed. When the
+     * stream is closed, the underlying network connection will also be closed.
+     * This means in particular that if `writable` is closed, the entire
+     * connection will be closed and thus the `readable` end of the stream will
+     * also be closed.
+     *
+     * In cases where one wants to keep the connection open after writing to the
+     * writable, do not close the writable stream. For example, when using
+     * `ReadableStream#pipeTo()` to pipe a readable stream to the writable
+     * stream, pass the `preventClose` option with a value of `true` to prevent
+     * the writable stream from being closed when the readable stream is closed.
+     */
     readonly writable: WritableStream<Uint8Array>;
   }
 
@@ -326,6 +354,12 @@ declare namespace Deno {
      * @default {"127.0.0.1"} */
     hostname?: string;
     transport?: "tcp";
+    /** Prevent the connection from being closed automatically when the readable
+     * stream reaches EOF. This allows the connection to be reused for further
+     * writes or reads.
+     *
+     * @default {false} */
+    preventCloseOnEOF?: boolean;
   }
 
   /**
@@ -369,7 +403,16 @@ declare namespace Deno {
   /** @category Network */
   export interface UnixConnectOptions {
     transport: "unix";
+    /**
+     * The path to the Unix Socket to connect to.
+     */
     path: string;
+    /** Prevent the connection from being closed automatically when the readable
+     * stream reaches EOF. This allows the connection to be reused for further
+     * writes or reads.
+     *
+     * @default {false} */
+    preventCloseOnEOF?: boolean;
   }
 
   /** @category Network */
@@ -431,6 +474,12 @@ declare namespace Deno {
      * TLS handshake.
      */
     alpnProtocols?: string[];
+    /** Prevent the connection from being closed automatically when the readable
+     * stream reaches EOF. This allows the connection to be reused for further
+     * writes or reads.
+     *
+     * @default {false} */
+    preventCloseOnEOF?: boolean;
   }
 
   /** Establishes a secure connection over TLS (transport layer security) using
@@ -493,6 +542,12 @@ declare namespace Deno {
      * TLS handshake.
      */
     alpnProtocols?: string[];
+    /** Prevent the connection from being closed automatically when the readable
+     * stream reaches EOF. This allows the connection to be reused for further
+     * writes or reads.
+     *
+     * @default {false} */
+    preventCloseOnEOF?: boolean;
   }
 
   /** Start TLS handshake from an existing connection using an optional list of

--- a/ext/node/polyfills/_fs/_fs_fdatasync.ts
+++ b/ext/node/polyfills/_fs/_fs_fdatasync.ts
@@ -10,12 +10,12 @@ export function fdatasync(
   fd: number,
   callback: CallbackWithError,
 ) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).syncData().then(
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).syncData().then(
     () => callback(null),
     callback,
   );
 }
 
 export function fdatasyncSync(fd: number) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).syncDataSync();
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).syncDataSync();
 }

--- a/ext/node/polyfills/_fs/_fs_fstat.ts
+++ b/ext/node/polyfills/_fs/_fs_fstat.ts
@@ -41,7 +41,7 @@ export function fstat(
 
   if (!callback) throw new Error("No callback function supplied");
 
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).stat().then(
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).stat().then(
     (stat) => callback(null, CFISBIS(stat, options.bigint)),
     (err) => callback(err),
   );
@@ -60,6 +60,7 @@ export function fstatSync(
   fd: number,
   options?: statOptions,
 ): Stats | BigIntStats {
-  const origin = new FsFile(fd, Symbol.for("Deno.internal.FsFile")).statSync();
+  const origin = new FsFile(fd, false, Symbol.for("Deno.internal.FsFile"))
+    .statSync();
   return CFISBIS(origin, options?.bigint || false);
 }

--- a/ext/node/polyfills/_fs/_fs_fsync.ts
+++ b/ext/node/polyfills/_fs/_fs_fsync.ts
@@ -10,12 +10,12 @@ export function fsync(
   fd: number,
   callback: CallbackWithError,
 ) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).sync().then(
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).sync().then(
     () => callback(null),
     callback,
   );
 }
 
 export function fsyncSync(fd: number) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).syncSync();
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).syncSync();
 }

--- a/ext/node/polyfills/_fs/_fs_ftruncate.ts
+++ b/ext/node/polyfills/_fs/_fs_ftruncate.ts
@@ -20,12 +20,12 @@ export function ftruncate(
 
   if (!callback) throw new Error("No callback function supplied");
 
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).truncate(len).then(
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).truncate(len).then(
     () => callback(null),
     callback,
   );
 }
 
 export function ftruncateSync(fd: number, len?: number) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).truncateSync(len);
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).truncateSync(len);
 }

--- a/ext/node/polyfills/_fs/_fs_futimes.ts
+++ b/ext/node/polyfills/_fs/_fs_futimes.ts
@@ -40,10 +40,11 @@ export function futimes(
   mtime = getValidTime(mtime, "mtime");
 
   // TODO(@littledivy): Treat `fd` as real file descriptor.
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).utime(atime, mtime).then(
-    () => callback(null),
-    callback,
-  );
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).utime(atime, mtime)
+    .then(
+      () => callback(null),
+      callback,
+    );
 }
 
 export function futimesSync(
@@ -55,5 +56,8 @@ export function futimesSync(
   mtime = getValidTime(mtime, "mtime");
 
   // TODO(@littledivy): Treat `fd` as real file descriptor.
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).utimeSync(atime, mtime);
+  new FsFile(fd, false, Symbol.for("Deno.internal.FsFile")).utimeSync(
+    atime,
+    mtime,
+  );
 }

--- a/ext/node/polyfills/_fs/_fs_readFile.ts
+++ b/ext/node/polyfills/_fs/_fs_readFile.ts
@@ -73,7 +73,11 @@ export function readFile(
 
   let p: Promise<Uint8Array>;
   if (path instanceof FileHandle) {
-    const fsFile = new FsFile(path.fd, Symbol.for("Deno.internal.FsFile"));
+    const fsFile = new FsFile(
+      path.fd,
+      false,
+      Symbol.for("Deno.internal.FsFile"),
+    );
     p = readAll(fsFile);
   } else {
     p = Deno.readFile(path);

--- a/ext/node/polyfills/_fs/_fs_writeFile.ts
+++ b/ext/node/polyfills/_fs/_fs_writeFile.ts
@@ -69,7 +69,11 @@ export function writeFile(
   (async () => {
     try {
       file = isRid
-        ? new FsFile(pathOrRid as number, Symbol.for("Deno.internal.FsFile"))
+        ? new FsFile(
+          pathOrRid as number,
+          false,
+          Symbol.for("Deno.internal.FsFile"),
+        )
         : await Deno.open(pathOrRid as string, openOptions);
 
       // ignore mode because it's not supported on windows
@@ -129,7 +133,11 @@ export function writeFileSync(
   let error: Error | null = null;
   try {
     file = isRid
-      ? new FsFile(pathOrRid as number, Symbol.for("Deno.internal.FsFile"))
+      ? new FsFile(
+        pathOrRid as number,
+        false,
+        Symbol.for("Deno.internal.FsFile"),
+      )
       : Deno.openSync(pathOrRid as string, openOptions);
 
     // ignore mode because it's not supported on windows

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -77,12 +77,17 @@ class Process {
     this.pid = res.pid;
 
     if (res.stdinRid && res.stdinRid > 0) {
-      this.stdin = new FsFile(res.stdinRid, SymbolFor("Deno.internal.FsFile"));
+      this.stdin = new FsFile(
+        res.stdinRid,
+        false,
+        SymbolFor("Deno.internal.FsFile"),
+      );
     }
 
     if (res.stdoutRid && res.stdoutRid > 0) {
       this.stdout = new FsFile(
         res.stdoutRid,
+        false,
         SymbolFor("Deno.internal.FsFile"),
       );
     }
@@ -90,6 +95,7 @@ class Process {
     if (res.stderrRid && res.stderrRid > 0) {
       this.stderr = new FsFile(
         res.stderrRid,
+        false,
         SymbolFor("Deno.internal.FsFile"),
       );
     }


### PR DESCRIPTION
This commit adds a `preventCloseOnEOF` option to `Deno.open`, `Deno.create`,
`Deno.connect`, `Deno.connectTls`, and `Deno.startTls`. It ensures that readable
streams returned from the objects' `readable` properties do not automatically
close the underlying resource when EOF is reached.

This option is described here: https://github.com/denoland/deno/issues/22258#issuecomment-2176162803

Additionally it adds a bunch of docs for `readable` and `writable`, also
outlining some common footguns.

As a drive by fix, one can now also pass `mode` to `Deno.create`, like you
already can for `Deno.open`.

Fixes #22258
Fixes #15442 (by adding docs)
And helps with #17828