### PR TITLE
chore: remove deno_core patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,8 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.289.0"
-source = "git+https://github.com/denoland/deno_core#e0f203688ad98dd18cc079e48e9f2c318899519f"
+version = "0.290.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba7176428b2dd879e8bdb38075c0e355f7e6b6280d0d11591e14c2e092edc5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1761,8 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.165.0"
-source = "git+https://github.com/denoland/deno_core#e0f203688ad98dd18cc079e48e9f2c318899519f"
+version = "0.166.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4e924b7703ff1ec71b38d0c2b09efcd7ff19a2a8ce5be11b712c22ea9fd1ba"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5782,8 +5784,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.198.0"
-source = "git+https://github.com/denoland/deno_core#e0f203688ad98dd18cc079e48e9f2c318899519f"
+version = "0.199.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467186012b61a4754390c7a4304db281ee91f5686210584ea0c09894497d27f"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.39.2", features = ["transpiling"] }
-deno_core = { version = "0.289.0" }
+deno_core = { version = "0.290.0" }
 
 deno_bench_util = { version = "0.150.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"
@@ -368,6 +368,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.base64-simd]
 opt-level = 3
-
-[patch.crates-io]
-deno_core = { git = "https://github.com/denoland/deno_core" }


### PR DESCRIPTION
A PR was landed by mistake that used `[patch.crates-io]` instead
of released `deno_core` version: https://github.com/denoland/deno/pull/23842#discussion_r1645170369