### PR TITLE
fix(ext/node): Add Dirent.path and Dirent.parentPath

### DIFF
--- a/cli/standalone/virtual_fs.rs
+++ b/cli/standalone/virtual_fs.rs
@@ -764,6 +764,7 @@ impl FileBackedVfs {
         .entries
         .iter()
         .map(|entry| FsDirEntry {
+          parent_path: path.to_string_lossy().into_owned(),
           name: entry.name().to_string(),
           is_file: matches!(entry, VfsEntry::File(_)),
           is_directory: matches!(entry, VfsEntry::Dir(_)),

--- a/ext/fs/interface.rs
+++ b/ext/fs/interface.rs
@@ -72,6 +72,7 @@ pub enum FsFileType {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FsDirEntry {
+  pub parent_path: String,
   pub name: String,
   pub is_file: bool,
   pub is_directory: bool,

--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -785,6 +785,7 @@ fn read_dir(path: &Path) -> FsResult<Vec<FsDirEntry>> {
         };
       }
       Some(FsDirEntry {
+        parent_path: path.to_string_lossy().to_string(),
         name,
         is_file: method_or_false!(is_file),
         is_directory: method_or_false!(is_dir),

--- a/ext/node/polyfills/_fs/_fs_dirent.ts
+++ b/ext/node/polyfills/_fs/_fs_dirent.ts
@@ -43,4 +43,13 @@ export default class Dirent {
   get name(): string | null {
     return this.entry.name;
   }
+
+  get parentPath(): string {
+    return this.entry.parentPath;
+  }
+
+  /** @deprecated */
+  get path(): string {
+    return this.parentPath;
+  }
 }

--- a/test.mjs
+++ b/test.mjs
@@ -1,3 +1,0 @@
-import vm from "node:vm";
-const result = vm.runInThisContext(`global.foo = 1`);
-console.log(result);

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,3 @@
+import vm from "node:vm";
+const result = vm.runInThisContext(`global.foo = 1`);
+console.log(result);

--- a/tests/unit_node/_fs/_fs_dirent_test.ts
+++ b/tests/unit_node/_fs/_fs_dirent_test.ts
@@ -6,6 +6,7 @@ import { Dirent as Dirent_ } from "node:fs";
 const Dirent = Dirent_ as any;
 
 class DirEntryMock implements Deno.DirEntry {
+  parentPath = "";
   name = "";
   isFile = false;
   isDirectory = false;
@@ -78,5 +79,17 @@ Deno.test({
       Error,
       "does not yet support",
     );
+  },
+});
+
+Deno.test({
+  name: "Path and parent path is correct",
+  fn() {
+    const entry: DirEntryMock = new DirEntryMock();
+    entry.name = "my_file";
+    entry.parentPath = "/home/user";
+    assertEquals(new Dirent(entry).name, "my_file");
+    assertEquals(new Dirent(entry).path, "/home/user");
+    assertEquals(new Dirent(entry).parentPath, "/home/user");
   },
 });


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/24227

Adds `parentPath` field Deno.DirEntry for use in node:fs