### PR TITLE
fix: FileFetcher correctly retries failed requests

### DIFF
--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -339,7 +339,7 @@ impl HttpClient {
     let response = match request.send().await {
       Ok(resp) => resp,
       Err(err) => {
-        if err.is_connect() || err.is_timeout() {
+        if err.is_connect() || err.is_timeout() || err.is_request() {
           return Ok(FetchOnceResult::RequestError(err.to_string()));
         }
         return Err(err.into());


### PR DESCRIPTION
It appears that during reqwest upgrade (https://github.com/denoland/deno/pull/24056) some
of the errors were reclassified and we no longer correctly retried failed requests.

I confirmed locally that the reproduction is now working correctly.

Closes https://github.com/denoland/deno/issues/24260.