### PR TITLE
perf(ext/websocket): avoid global interceptor overhead

### DIFF
--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -50,6 +50,7 @@ import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 import { HTTP_TOKEN_CODE_POINT_RE } from "ext:deno_web/00_infra.js";
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
+import { setTimeout, clearTimeout } from "ext:deno_web/02_timers.js";
 import {
   CloseEvent,
   defineEventHandler,

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -50,7 +50,7 @@ import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { createFilteredInspectProxy } from "ext:deno_console/01_console.js";
 import { HTTP_TOKEN_CODE_POINT_RE } from "ext:deno_web/00_infra.js";
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
-import { setTimeout, clearTimeout } from "ext:deno_web/02_timers.js";
+import { clearTimeout, setTimeout } from "ext:deno_web/02_timers.js";
 import {
   CloseEvent,
   defineEventHandler,


### PR DESCRIPTION
Improves echo server message throughput by ~40-50% (103k -> 146k msg/sec)


Before: https://share.firefox.dev/3Rzzez2
After: https://share.firefox.dev/3VzXAKn

![image](https://github.com/denoland/deno/assets/34997667/a4426c9f-2175-414a-930c-f837149d37e3)

