### PR TITLE
docs(cli): remove trailing slash from `import.meta.dirname` expected output

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -50,10 +50,10 @@ declare interface ImportMeta {
    * * Example:
    * ```
    * // Unix
-   * console.log(import.meta.dirname); // /home/alice/
+   * console.log(import.meta.dirname); // /home/alice
    *
    * // Windows
-   * console.log(import.meta.dirname); // C:\alice\
+   * console.log(import.meta.dirname); // C:\alice
    * ```
    */
   dirname?: string;


### PR DESCRIPTION
`import.meta.dirname` behaves correctly, according to [Node's implementation](https://nodejs.org/api/esm.html#importmetadirname). Rather, the documentation simply had a typo.

Closes #24278