### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/_fs/_fs_cp.js`

### DIFF
--- a/ext/node/polyfills/_fs/_fs_cp.js
+++ b/ext/node/polyfills/_fs/_fs_cp.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-
-import { op_node_cp, op_node_cp_sync, primordials } from "ext:core/ops";
+import { primordials } from "ext:core/mod.js";
+import { op_node_cp, op_node_cp_sync } from "ext:core/ops";
 import {
   getValidatedPath,
   validateCpOptions,

--- a/ext/node/polyfills/_fs/_fs_cp.js
+++ b/ext/node/polyfills/_fs/_fs_cp.js
@@ -1,14 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-// deno-lint-ignore-file prefer-primordials
-
-import { op_node_cp, op_node_cp_sync } from "ext:core/ops";
-
+import { op_node_cp, op_node_cp_sync, primordials } from "ext:core/ops";
 import {
   getValidatedPath,
   validateCpOptions,
 } from "ext:deno_node/internal/fs/utils.mjs";
 import { promisify } from "ext:deno_node/internal/util.mjs";
+
+const { PromisePrototypeThen } = primordials;
 
 export function cpSync(src, dest, options) {
   validateCpOptions(options);
@@ -27,10 +26,11 @@ export function cp(src, dest, options, callback) {
   const srcPath = getValidatedPath(src, "src");
   const destPath = getValidatedPath(dest, "dest");
 
-  op_node_cp(
-    srcPath,
-    destPath,
-  ).then(
+  PromisePrototypeThen(
+    op_node_cp(
+      srcPath,
+      destPath,
+    ),
     (res) => callback(null, res),
     (err) => callback(err, null),
   );


### PR DESCRIPTION
Towards #24236