### PR TITLE
perf: improve Buffer.from(buf, 'base64') performance

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -103,6 +103,12 @@ function createBuffer(length) {
   return buf;
 }
 
+function createBufferFromAb(ab) {
+  const buf = new Uint8Array(ab);
+  Object.setPrototypeOf(buf, Buffer.prototype);
+  return buf;
+}
+
 export function Buffer(arg, encodingOrOffset, length) {
   if (typeof arg === "number") {
     if (typeof encodingOrOffset === "string") {
@@ -229,11 +235,20 @@ function fromArrayLike(array) {
   return buf;
 }
 
+function fromAnyArrayBuffer(ab) {
+  return createBufferFromAb(ab).slice();
+}
+
 function fromObject(obj) {
-  if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
+  if (obj.length !== undefined) {
     if (typeof obj.length !== "number") {
       return createBuffer(0);
     }
+
+    if (isAnyArrayBuffer(obj.buffer)) {
+      return fromAnyArrayBuffer(obj.buffer);
+    }
+
     return fromArrayLike(obj);
   }
 


### PR DESCRIPTION
Improve `Buffer.from(buffer, "base64")` performance by ~29x

```
$ deno run -A bench.mjs
7987.390458 ms

$ node bench.mjs
773.420042 ms

$ bun bench.mjs
737.7943750 ms

$ target/release/deno run -A bench.mjs
275.3805 ms
```

```js
import { Buffer } from "node:buffer";

const buffer = Buffer.alloc(1024 * 10, "latin1");

const start = performance.now();
for (let i = 0; i < 1000000; i++) {
  Buffer.from(buffer, "base64");
}
console.log(performance.now() - start);
```