### PR TITLE
perf: optimize Buffer.from("base64") for forgiving-base64 conforming input

### DIFF
--- a/ext/node/polyfills/internal_binding/_utils.ts
+++ b/ext/node/polyfills/internal_binding/_utils.ts
@@ -18,9 +18,13 @@ export function asciiToBytes(str: string) {
 }
 
 export function base64ToBytes(str: string) {
-  str = base64clean(str);
-  str = str.replaceAll("-", "+").replaceAll("_", "/");
-  return forgivingBase64Decode(str);
+  try {
+    return forgivingBase64Decode(str);
+  } catch {
+    str = base64clean(str);
+    str = str.replaceAll("-", "+").replaceAll("_", "/");
+    return forgivingBase64Decode(str);
+  }
 }
 
 const INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;


### PR DESCRIPTION
Don't try to clean the input unless decoding fails at first. A ~3x improvement for forgiving-base64 conforming input.

```
$ target/release/deno run  -A ./bench.mjs
593.3049169
$ deno run -A ./bench.mjs
1912.209888
$ node bench.mjs
989.406209
```

```js
import { Buffer } from "node:buffer";

const buffer = Buffer.alloc(1024 * 10, "latin1");
const input = buffer.toString("base64");
const start = performance.now();
for (let i = 0; i < 100000; i++) {
	Buffer.from(input, "base64");
}

console.log(performance.now() - start);
```

Ref #24323 