### PR TITLE
BREAKING(unstable/ffi): remove callback reentrant flag

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -371,11 +371,6 @@ declare namespace Deno {
     /** When `true`, function calls will run on a dedicated blocking thread and
      * will return a `Promise` resolving to the `result`. */
     nonblocking?: NonBlocking;
-    /** When `true`, function calls can safely callback into JavaScript or
-     * trigger a garbage collection event.
-     *
-     * @default {false} */
-    callback?: boolean;
     /** When `true`, dlopen will not fail if the symbol is not found.
      * Instead, the symbol will be set to `null`.
      *

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -60,16 +60,9 @@ pub struct ForeignFunction {
   pub result: NativeType,
   #[serde(rename = "nonblocking")]
   non_blocking: Option<bool>,
-  #[serde(rename = "callback")]
-  #[serde(default = "default_callback")]
-  callback: bool,
   #[serde(rename = "optional")]
   #[serde(default = "default_optional")]
   optional: bool,
-}
-
-fn default_callback() -> bool {
-  false
 }
 
 fn default_optional() -> bool {
@@ -191,7 +184,6 @@ where
           ptr,
           parameter_types: foreign_fn.parameters,
           result_type: foreign_fn.result,
-          can_callback: foreign_fn.callback,
         });
 
         resource.symbols.insert(symbol_key, sym.clone());

--- a/ext/ffi/symbol.rs
+++ b/ext/ffi/symbol.rs
@@ -70,7 +70,6 @@ pub struct Symbol {
   pub ptr: libffi::middle::CodePtr,
   pub parameter_types: Vec<NativeType>,
   pub result_type: NativeType,
-  pub can_callback: bool,
 }
 
 #[allow(clippy::non_send_fields_in_send_ty)]

--- a/ext/ffi/turbocall.rs
+++ b/ext/ffi/turbocall.rs
@@ -18,8 +18,7 @@ pub(crate) fn is_compatible(sym: &Symbol) -> bool {
     all(target_arch = "x86_64", target_family = "unix"),
     all(target_arch = "x86_64", target_family = "windows"),
     all(target_arch = "aarch64", target_vendor = "apple")
-  )) && !sym.can_callback
-    && !matches!(sym.result_type, NativeType::Struct(_))
+  )) && !matches!(sym.result_type, NativeType::Struct(_))
     && !sym
       .parameter_types
       .iter()
@@ -1437,7 +1436,6 @@ mod tests {
       ptr: libffi::middle::CodePtr(null_mut()),
       parameter_types: parameters,
       result_type: ret,
-      can_callback: false,
     }
   }
 

--- a/tests/ffi/tests/ffi_types.ts
+++ b/tests/ffi/tests/ffi_types.ts
@@ -5,7 +5,7 @@
 const remote = Deno.dlopen(
   "dummy_lib.so",
   {
-    method1: { parameters: ["usize", "bool"], result: "void", callback: true },
+    method1: { parameters: ["usize", "bool"], result: "void" },
     method2: { parameters: [], result: "void" },
     method3: { parameters: ["usize"], result: "void" },
     method4: { parameters: ["isize"], result: "void" },

--- a/tests/ffi/tests/test.js
+++ b/tests/ffi/tests/test.js
@@ -214,12 +214,10 @@ const dylib = Deno.dlopen(libPath, {
   call_stored_function: {
     parameters: [],
     result: "void",
-    callback: true,
   },
   call_stored_function_2: {
     parameters: ["u8"],
     result: "void",
-    callback: true,
   },
   log_many_parameters: {
     parameters: ["u8", "u16", "u32", "u64", "f64", "f32", "i64", "i32", "i16", "i8", "isize", "usize", "f64", "f32", "f64", "f32", "f64", "f32", "f64"],


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/22947

This option is no longer needed as fast calls are now allowed to re-enter the isolate