### PR TITLE
fix(ext/node): add Symbol.toStringTag to KeyObject instances

### DIFF
--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -4,6 +4,13 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
+import { primordials } from "ext:core/mod.js";
+
+const {
+  ObjectDefineProperties,
+  SymbolToStringTag,
+} = primordials;
+
 import {
   op_node_create_private_key,
   op_node_create_public_key,
@@ -208,6 +215,14 @@ export class KeyObject {
     notImplemented("crypto.KeyObject.prototype.asymmetricKeyType");
   }
 }
+
+ObjectDefineProperties(KeyObject.prototype, {
+  [SymbolToStringTag]: {
+    __proto__: null,
+    configurable: true,
+    value: "KeyObject",
+  },
+});
 
 export interface JsonWebKeyInput {
   key: JsonWebKey;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

As per https://github.com/nodejs/node/pull/46043, this adds Symbol.toStringTag getter to KeyObject.