### PR TITLE
feat(serve): env var `DENO_SERVE_ADDRESS` for configuring default listener address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "serde",
+ "tempfile",
  "test_server",
  "tokio",
  "tower-lsp",

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1100,6 +1100,8 @@ static ENV_VARIABLES_HELP: &str = color_print::cstr!(
     <g>DENO_NO_UPDATE_CHECK</> Set to disable checking if a newer Deno version is
                          available
 
+    <g>DENO_SERVE_ADDRESS</>   Default listening address for `Deno.serve()`
+
     <g>DENO_TLS_CA_STORE</>    Comma-separated list of order dependent certificate
                          stores. Possible values: "system", "mozilla".
                          Defaults to "mozilla".

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -54,6 +54,7 @@ os_pipe.workspace = true
 pretty_assertions.workspace = true
 regex.workspace = true
 serde.workspace = true
+tempfile.workspace = true
 test_util.workspace = true
 tokio.workspace = true
 tower-lsp.workspace = true

--- a/tests/integration/serve_tests.rs
+++ b/tests/integration/serve_tests.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use std::io::BufRead;
+use std::io::BufReader;
 use std::io::Read;
 
 use deno_fetch::reqwest;
@@ -88,6 +90,79 @@ async fn deno_serve_no_args() {
 
   let body = res.text().await.unwrap();
   assert_eq!(body, "deno serve with no args in fetch() works!");
+
+  child.kill().unwrap();
+  child.wait().unwrap();
+}
+
+#[tokio::test]
+async fn deno_run_serve_with_tcp_from_env() {
+  let mut child = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("run")
+    .arg("--allow-env=DENO_SERVE_ADDRESS")
+    .arg("--allow-net")
+    .arg("./serve/run_serve.ts")
+    .env("DENO_SERVE_ADDRESS", format!("tcp/127.0.0.1:0"))
+    .stdout_piped()
+    .spawn()
+    .unwrap();
+  let stdout = BufReader::new(child.stdout.as_mut().unwrap());
+  let msg = stdout.lines().next().unwrap().unwrap();
+
+  // Deno.serve() listens on 0.0.0.0 by default. This checks DENO_SERVE_ADDRESS
+  // is not ignored by ensuring it's listening on 127.0.0.1.
+  let port_regex = Regex::new(r"http:\/\/127\.0\.0\.1:(\d+)").unwrap();
+  let port = port_regex.captures(&msg).unwrap().get(1).unwrap().as_str();
+
+  let client = reqwest::Client::builder().build().unwrap();
+
+  let res = client
+    .get(&format!("http://127.0.0.1:{port}"))
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(200, res.status());
+
+  let body = res.text().await.unwrap();
+  assert_eq!(body, "Deno.serve() works!");
+
+  child.kill().unwrap();
+  child.wait().unwrap();
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn deno_run_serve_with_unix_socket_from_env() {
+  use tokio::io::AsyncReadExt;
+  use tokio::io::AsyncWriteExt;
+  use tokio::net::UnixStream;
+
+  let dir = tempfile::TempDir::new().unwrap();
+  let sock = dir.path().join("listen.sock");
+  let mut child = util::deno_cmd()
+    .current_dir(util::testdata_path())
+    .arg("run")
+    .arg("--allow-env=DENO_SERVE_ADDRESS")
+    .arg(format!("--allow-read={}", sock.display()))
+    .arg(format!("--allow-write={}", sock.display()))
+    .arg("./serve/run_serve.ts")
+    .env("DENO_SERVE_ADDRESS", format!("unix/{}", sock.display()))
+    .stdout_piped()
+    .spawn()
+    .unwrap();
+  let stdout = BufReader::new(child.stdout.as_mut().unwrap());
+  stdout.lines().next().unwrap().unwrap();
+
+  // reqwest does not support connecting to unix sockets yet, so here we send the http
+  // payload directly
+  let mut conn = UnixStream::connect(dir.path().join("listen.sock"))
+    .await
+    .unwrap();
+  conn.write_all(b"GET / HTTP/1.0\r\n\r\n").await.unwrap();
+  let mut response = String::new();
+  conn.read_to_string(&mut response).await.unwrap();
+  assert!(response.ends_with("\r\nDeno.serve() works!"));
 
   child.kill().unwrap();
   child.wait().unwrap();

--- a/tests/testdata/serve/run_serve.ts
+++ b/tests/testdata/serve/run_serve.ts
@@ -1,0 +1,3 @@
+Deno.serve((_req: Request) => {
+  return new Response("Deno.serve() works!");
+})


### PR DESCRIPTION
This patch adds support for configuring a default listen address for `Deno.serve()` with the `DENO_SERVE_ADDRESS` environment variable. If none of `options.{hostname,port,path}` is set, the listener will attempt to parse `DENO_SERVE_ADDRESS` and listen on the specified endpoint.

The listen address is specified in a `network/address` format. For example:

- `tcp/0.0.0.0:8080`
- `unix//var/run/http.sock`
