### PR TITLE
feat(ext/crypto): make deriveBits length parameter optional and nullable

### DIFF
--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -1131,10 +1131,10 @@ class SubtleCrypto {
    * @param {number | null} length
    * @returns {Promise<ArrayBuffer>}
    */
-  async deriveBits(algorithm, baseKey, length) {
+  async deriveBits(algorithm, baseKey, length = null) {
     webidl.assertBranded(this, SubtleCryptoPrototype);
     const prefix = "Failed to execute 'deriveBits' on 'SubtleCrypto'";
-    webidl.requiredArguments(arguments.length, 3, prefix);
+    webidl.requiredArguments(arguments.length, 2, prefix);
     algorithm = webidl.converters.AlgorithmIdentifier(
       algorithm,
       prefix,

--- a/tests/wpt/runner/expectation.json
+++ b/tests/wpt/runner/expectation.json
@@ -909,10 +909,12 @@
     "historical.any.html": false,
     "historical.any.worker.html": false,
     "idlharness.https.any.html": [
-      "Window interface: attribute crypto"
+      "Window interface: attribute crypto",
+      "SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)"
     ],
     "idlharness.https.any.worker.html": [
-      "WorkerGlobalScope interface: attribute crypto"
+      "WorkerGlobalScope interface: attribute crypto",
+      "SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)"
     ],
     "import_export": {
       "ec_importKey.https.any.html": [


### PR DESCRIPTION
Updates SubtleCrypto.prototype.deriveBits as per https://github.com/w3c/webcrypto/pull/345

(WPT update in https://github.com/web-platform-tests/wpt/pull/43400)