### PR TITLE
fix(node/http): don't throw on .address() before .listen()

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1657,7 +1657,7 @@ export class ServerImpl extends EventEmitter {
   #httpConnections: Set<Deno.HttpConn> = new Set();
   #listener?: Deno.Listener;
 
-  #addr: Deno.NetAddr;
+  #addr: Deno.NetAddr | null = null;
   #hasClosed = false;
   #server: Deno.HttpServer;
   #unref = false;
@@ -1843,6 +1843,7 @@ export class ServerImpl extends EventEmitter {
   }
 
   address() {
+    if (this.#addr === null) return null;
     return {
       port: this.#addr.port,
       address: this.#addr.hostname,

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1251,3 +1251,8 @@ Deno.test("[node/http] http.request() post streaming body works", async () => {
   clearTimeout(timeout);
   assertEquals(server.listening, false);
 });
+
+Deno.test("[node/http] Server.address() can be null", () => {
+  const server = http.createServer((req, res) => res.end("it works"));
+  assertEquals(server.address(), null);
+});

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1253,6 +1253,6 @@ Deno.test("[node/http] http.request() post streaming body works", async () => {
 });
 
 Deno.test("[node/http] Server.address() can be null", () => {
-  const server = http.createServer((req, res) => res.end("it works"));
+  const server = http.createServer((_req, res) => res.end("it works"));
   assertEquals(server.address(), null);
 });


### PR DESCRIPTION
It's perfectly valid to access `server.address()` before calling `.listen()`. Until a server actively listens on a socket Node will return `null` here, but we threw a "Cannot access property 'port' of undefined" instead.

This was discovered when inspecting failures in Koa's test suite with Deno.