### PR TITLE
feat: Deprecate --lock-write flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -546,6 +546,7 @@ pub struct Flags {
   pub inspect_wait: Option<SocketAddr>,
   pub inspect: Option<SocketAddr>,
   pub location: Option<Url>,
+  // TODO(bartlomieju): deprecated, to be removed in Deno 2.
   pub lock_write: bool,
   pub lock: Option<String>,
   pub log_level: Option<Level>,
@@ -3623,12 +3624,14 @@ If value is not provided, defaults to \"deno.lock\" in the current working direc
     .value_hint(ValueHint::FilePath)
 }
 
+// TODO(bartlomieju): deprecated, to be removed in Deno 2.
 fn lock_write_arg() -> Arg {
   Arg::new("lock-write")
     .action(ArgAction::SetTrue)
     .long("lock-write")
     .help("Force overwriting the lock file.")
     .conflicts_with("no-lock")
+    .hide(true)
 }
 
 fn no_lock_arg() -> Arg {
@@ -4747,6 +4750,7 @@ fn check_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 fn lock_args_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   lock_arg_parse(flags, matches);
   no_lock_arg_parse(flags, matches);
+  // TODO(bartlomieju): deprecated, to be removed in Deno 2.
   if matches.get_flag("lock-write") {
     flags.lock_write = true;
   }

--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -130,6 +130,10 @@ impl CliLockfile {
     };
 
     let lockfile = if flags.lock_write {
+      log::warn!(
+        "{} \"--lock-write\" flag is deprecated and will be removed in Deno 2.",
+        colors::yellow("Warning")
+      );
       CliLockfile::new(
         Lockfile::new_empty(filename, true),
         flags.frozen_lockfile,

--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -132,7 +132,7 @@ impl CliLockfile {
     let lockfile = if flags.lock_write {
       log::warn!(
         "{} \"--lock-write\" flag is deprecated and will be removed in Deno 2.",
-        colors::yellow("Warning")
+        crate::colors::yellow("Warning")
       );
       CliLockfile::new(
         Lockfile::new_empty(filename, true),

--- a/tests/testdata/lockfile/no_dts/main.cache.out
+++ b/tests/testdata/lockfile/no_dts/main.cache.out
@@ -1,2 +1,3 @@
+Warning "--lock-write" flag is deprecated and will be removed in Deno 2.
 Download http://localhost:4545/lockfile/no_dts/mod.js
 Download http://localhost:4545/lockfile/no_dts/mod.d.ts


### PR DESCRIPTION
This commit deprecates `--lock-write` flag by removing it from
the help output and printing a warning message when it's used.

Users should use `--frozen=false` instead which was added
in https://github.com/denoland/deno/pull/24355.

Towards https://github.com/denoland/deno/issues/24167.