### PR TITLE
chore: remove unused class private properties

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1650,9 +1650,6 @@ export function Server(opts, requestListener?: ServerHandler): ServerImpl {
 }
 
 export class ServerImpl extends EventEmitter {
-  #httpConnections: Set<Deno.HttpConn> = new Set();
-  #listener?: Deno.Listener;
-
   #addr: Deno.NetAddr | null = null;
   #hasClosed = false;
   #server: Deno.HttpServer;


### PR DESCRIPTION
Noticed that these private class properties are never used. Maybe a leftover from an earlier implementation.