### PR TITLE
chore: rename `__runtime_js_source` to `hmr`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,7 +44,7 @@ default = ["upgrade", "__vendored_zlib_ng"]
 upgrade = []
 # A dev feature to disable creations and loading of snapshots in favor of
 # loading JS sources at runtime.
-__runtime_js_sources = ["deno_runtime/__runtime_js_sources"]
+hmr = ["deno_runtime/hmr"]
 # Vendor zlib as zlib-ng
 __vendored_zlib_ng = ["flate2/zlib-ng-compat", "libz-sys/zlib-ng"]
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -325,7 +325,7 @@ mod ts {
   }
 }
 
-#[cfg(not(feature = "__runtime_js_sources"))]
+#[cfg(not(feature = "hmr"))]
 fn create_cli_snapshot(snapshot_path: PathBuf) {
   use deno_runtime::ops::bootstrap::SnapshotOptions;
 
@@ -469,7 +469,7 @@ fn main() {
   let compiler_snapshot_path = o.join("COMPILER_SNAPSHOT.bin");
   ts::create_compiler_snapshot(compiler_snapshot_path, &c);
 
-  #[cfg(not(feature = "__runtime_js_sources"))]
+  #[cfg(not(feature = "hmr"))]
   {
     let cli_snapshot_path = o.join("CLI_SNAPSHOT.bin");
     create_cli_snapshot(cli_snapshot_path);

--- a/cli/js.rs
+++ b/cli/js.rs
@@ -2,17 +2,17 @@
 
 use log::debug;
 
-#[cfg(not(feature = "__runtime_js_sources"))]
+#[cfg(not(feature = "hmr"))]
 static CLI_SNAPSHOT: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/CLI_SNAPSHOT.bin"));
 
 pub fn deno_isolate_init() -> Option<&'static [u8]> {
   debug!("Deno isolate init with snapshots.");
-  #[cfg(not(feature = "__runtime_js_sources"))]
+  #[cfg(not(feature = "hmr"))]
   {
     Some(CLI_SNAPSHOT)
   }
-  #[cfg(feature = "__runtime_js_sources")]
+  #[cfg(feature = "hmr")]
   {
     None
   }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,7 +22,7 @@ include_js_files_for_snapshotting = [
 ]
 # A dev feature to disable creations and loading of snapshots in favor of
 # loading JS sources at runtime.
-__runtime_js_sources = ["include_js_files_for_snapshotting"]
+hmr = ["include_js_files_for_snapshotting"]
 # Signal that only snapshotted JS sources should be used. This will
 # conditionally exclude the runtime source transpilation logic, and add an
 # assertion that a snapshot is provided.

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -518,8 +518,11 @@ impl WebWorker {
       ops::web_worker::deno_web_worker::init_ops_and_esm(),
     ];
 
-    #[cfg(__runtime_js_sources)]
-    assert!(cfg!(not(feature = "only_snapshotted_js_sources")), "'__runtime_js_sources' is incompatible with 'only_snapshotted_js_sources'.");
+    #[cfg(hmr)]
+    assert!(
+      cfg!(not(feature = "only_snapshotted_js_sources")),
+      "'hmr' is incompatible with 'only_snapshotted_js_sources'."
+    );
 
     for extension in &mut extensions {
       if options.startup_snapshot.is_some() {

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -454,8 +454,11 @@ impl MainWorker {
       ops::web_worker::deno_web_worker::init_ops_and_esm().disable(),
     ];
 
-    #[cfg(__runtime_js_sources)]
-    assert!(cfg!(not(feature = "only_snapshotted_js_sources")), "'__runtime_js_sources' is incompatible with 'only_snapshotted_js_sources'.");
+    #[cfg(hmr)]
+    assert!(
+      cfg!(not(feature = "only_snapshotted_js_sources")),
+      "'hmr' is incompatible with 'only_snapshotted_js_sources'."
+    );
 
     for extension in &mut extensions {
       if options.startup_snapshot.is_some() {


### PR DESCRIPTION
Saves some keystrokes and easy to remember

```
cargo b --features hmr
```
