### PR TITLE
perf(crypto): Enable `asm` cargo feature for sha1/sha2 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5873,6 +5873,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -5890,6 +5900,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,8 +160,8 @@ serde = { version = "1.0.149", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0.85"
 serde_repr = "=0.1.16"
-sha1 = { version = "0.10.6", features = ["oid"] }
-sha2 = { version = "0.10.8", features = ["oid"] }
+sha1 = { version = "0.10.6", features = ["oid", "asm"] }
+sha2 = { version = "0.10.8", features = ["oid", "asm"] }
 signature = "2.1"
 slab = "0.4"
 smallvec = "1.8"


### PR DESCRIPTION
It's an easy perf win, especially on aarch64, where if the `asm` feature is disabled it falls back to a [soft implementation](https://github.com/RustCrypto/hashes/blob/28a7b0da94a581e71e85d264836e1c3f8343338e/sha2/src/sha256.rs#L16-L26).

```
// main.ts
import { createHmac } from "node:crypto";

const alg = Deno.args[0] ? Deno.args[0].trim() : "sha256";

const input = "a".repeat(300);

for (let i = 0; i < 100_000; i++) {
  const hash = createHmac(alg, input).update(input).digest();
}
```

```
❯ hyperfine --warmup 5 './deno-canary run -A main.ts sha256' './deno-this-pr run -A main.ts sha256'
Benchmark 1: ./deno-canary run -A main.ts sha256
  Time (mean ± σ):     684.7 ms ±   2.5 ms    [User: 771.0 ms, System: 16.2 ms]
  Range (min … max):   680.4 ms … 688.2 ms    10 runs

Benchmark 2: ./deno-this-pr run -A main.ts sha256
  Time (mean ± σ):     414.2 ms ±   4.1 ms    [User: 500.4 ms, System: 16.3 ms]
  Range (min … max):   409.2 ms … 421.5 ms    10 runs

Summary
  ./deno-this-pr run -A main.ts sha256 ran
    1.65 ± 0.02 times faster than ./deno-canary run -A main.ts sha256

❯ hyperfine --warmup 5 './deno-canary run -A main.ts sha1' './deno-this-pr run -A main.ts sha1'
Benchmark 1: ./deno-canary run -A main.ts sha1
  Time (mean ± σ):     597.4 ms ±  15.7 ms    [User: 682.8 ms, System: 18.3 ms]
  Range (min … max):   581.6 ms … 634.0 ms    10 runs

Benchmark 2: ./deno-this-pr run -A main.ts sha1
  Time (mean ± σ):     404.4 ms ±   3.3 ms    [User: 493.0 ms, System: 17.6 ms]
  Range (min … max):   400.0 ms … 411.1 ms    10 runs

Summary
  ./deno-this-pr run -A main.ts sha1 ran
    1.48 ± 0.04 times faster than ./deno-canary run -A main.ts sha1
```