### PR TITLE
feat: Deprecate 'deno vendor' subcommand

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2800,7 +2800,10 @@ fn vendor_subcommand() -> Command {
   Command::new("vendor")
       .about("Vendor remote modules into a local directory")
       .long_about(
-        "Vendor remote modules into a local directory.
+        "⚠️ Warning: `deno vendor` is deprecated and will be removed in Deno 2.0.
+Use `--vendor` flag with subcommands or place `\"vendor\": true` in your config file.
+
+Vendor remote modules into a local directory.
 
 Analyzes the provided modules along with their dependencies, downloads
 remote modules to the output directory, and produces an import map that

--- a/cli/tools/vendor/mod.rs
+++ b/cli/tools/vendor/mod.rs
@@ -38,6 +38,11 @@ pub async fn vendor(
   flags: Flags,
   vendor_flags: VendorFlags,
 ) -> Result<(), AnyError> {
+  log::info!(
+    "{}",
+    colors::yellow("⚠️ Warning: `deno vendor` is deprecated and will be removed in Deno 2.0.\nUse `--vendor` flag with subcommands or place `\"vendor\": true` in your config file."),
+  );
+
   let mut cli_options = CliOptions::from_flags(flags)?;
   let raw_output_dir = match &vendor_flags.output_path {
     Some(output_path) => PathBuf::from(output_path).to_owned(),

--- a/cli/tools/vendor/mod.rs
+++ b/cli/tools/vendor/mod.rs
@@ -40,7 +40,7 @@ pub async fn vendor(
 ) -> Result<(), AnyError> {
   log::info!(
     "{}",
-    colors::yellow("⚠️ Warning: `deno vendor` is deprecated and will be removed in Deno 2.0.\nUse `--vendor` flag with subcommands or place `\"vendor\": true` in your config file."),
+    crate::colors::yellow("⚠️ Warning: `deno vendor` is deprecated and will be removed in Deno 2.0.\nUse `--vendor` flag with subcommands or place `\"vendor\": true` in your config file."),
   );
 
   let mut cli_options = CliOptions::from_flags(flags)?;


### PR DESCRIPTION
This commit deprecated `deno vendor` subcommand, in favor
of using `--vendor` flag or `"vendor": true` setting in the config
file.