### PR TITLE
feat(cli) Add CSV Benchmark reporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1138,7 @@ dependencies = [
  "clap_complete_fig",
  "color-print",
  "console_static_text",
+ "csv",
  "dashmap",
  "data-encoding",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -150,6 +150,7 @@ typed-arena = "=2.0.1"
 uuid = { workspace = true, features = ["serde"] }
 zeromq.workspace = true
 zstd.workspace = true
+csv = "1.3.0"
 
 [target.'cfg(windows)'.dependencies]
 junction.workspace = true

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -254,7 +254,7 @@ impl CacheSetting {
 
 pub struct WorkspaceBenchOptions {
   pub filter: Option<String>,
-  pub json: bool,
+  pub format: BenchReporterFormat,
   pub no_run: bool,
 }
 
@@ -262,7 +262,7 @@ impl WorkspaceBenchOptions {
   pub fn resolve(bench_flags: &BenchFlags) -> Self {
     Self {
       filter: bench_flags.filter.clone(),
-      json: bench_flags.json,
+      format: bench_flags.format.clone(),
       no_run: bench_flags.no_run,
     }
   }

--- a/cli/tools/bench/reporters.rs
+++ b/cli/tools/bench/reporters.rs
@@ -299,3 +299,47 @@ impl BenchReporter for ConsoleReporter {
     println!();
   }
 }
+
+pub struct CsvReporter(Vec<CsvReporterOutput>);
+
+impl CsvReporter {
+  pub fn new() -> Self {
+    Self(Vec::new())
+  }
+}
+
+pub struct CsvReporterOutput;
+
+impl BenchReporter for CsvReporter {
+  fn report_group_summary(&mut self) {
+    println!("Report Group Summary")
+  }
+
+  fn report_plan(&mut self, plan: &BenchPlan) {
+    println!("Bench plan: {plan:?}");
+  }
+
+  fn report_end(&mut self, report: &BenchReport) {
+    println!("Report end: {report:?}")
+  }
+
+  fn report_register(&mut self, desc: &BenchDescription) {
+    println!("Report register: {desc:?}")
+  }
+
+  fn report_wait(&mut self, desc: &BenchDescription) {
+    println!("Report wait: {desc:?}")
+  }
+
+  fn report_output(&mut self, output: &str) {
+    println!("Report output: {output}")
+  }
+
+  fn report_result(&mut self, desc: &BenchDescription, result: &BenchResult) {
+    println!("Report result: {desc:?}");
+  }
+
+  fn report_uncaught_error(&mut self, origin: &str, error: Box<JsError>) {
+    println!("Uncaught error. Origin: {origin}, error: {error}")
+  }
+}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Closes #22528

- Changes CLI bench options, removing `--json` flag and replacing it with `--format json`, `--format csv` etc.
- Adds a CSV benchmark formatter.
