### PR TITLE
fix(node/assert): throws not checking error instance

### DIFF
--- a/ext/node/polyfills/assert.ts
+++ b/ext/node/polyfills/assert.ts
@@ -17,6 +17,9 @@ import {
   ERR_MISSING_ARGS,
 } from "ext:deno_node/internal/errors.ts";
 import { isDeepEqual } from "ext:deno_node/internal/util/comparisons.ts";
+import { primordials } from "ext:core/mod.js";
+
+const { ObjectPrototypeIsPrototypeOf } = primordials;
 
 function innerFail(obj: {
   actual?: unknown;
@@ -744,8 +747,8 @@ function validateThrownError(
     error = undefined;
   }
   if (
-    error instanceof Function && error.prototype !== undefined &&
-    error.prototype instanceof Error
+    typeof error === "function" &&
+    (error === Error || ObjectPrototypeIsPrototypeOf(Error, error))
   ) {
     // error is a constructor
     if (e instanceof error) {

--- a/tests/integration/node_unit_tests.rs
+++ b/tests/integration/node_unit_tests.rs
@@ -53,6 +53,7 @@ util::unit_test_factory!(
     _fs_writeFile_test = _fs / _fs_writeFile_test,
     _fs_write_test = _fs / _fs_write_test,
     async_hooks_test,
+    assert_test,
     assertion_error_test,
     buffer_test,
     child_process_test,

--- a/tests/unit_node/assert_test.ts
+++ b/tests/unit_node/assert_test.ts
@@ -1,0 +1,18 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import * as assert from "node:assert";
+
+Deno.test("[node/assert] .throws() compares Error instance", () => {
+  assert.throws(
+    () => {
+      throw new Error("FAIL");
+    },
+    Error,
+  );
+
+  assert.throws(
+    () => {
+      throw new TypeError("FAIL");
+    },
+    TypeError,
+  );
+});


### PR DESCRIPTION
The implementation for `assert.throws()` from `node:assert` didn't work when the expected value was an `Error` constructor. In this case the thrown error should checked if it's an instance of said constructor.

Fixes https://github.com/denoland/deno/issues/24464