### PR TITLE
fix: do not return undefined for missing global properties

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -305,6 +305,10 @@ pub fn getter<'s>(
   let reflect_get = v8::Local::new(scope, reflect_get);
   let inner = v8::Local::new(scope, inner);
 
+  if !inner.has_own_property(scope, key).unwrap_or(false) {
+    return v8::Intercepted::No;
+  }
+
   let undefined = v8::undefined(scope);
   let Some(value) = reflect_get.call(
     scope,

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -35,7 +35,7 @@ function checkThis(thisArg) {
 function setImmediate(callback, ...args) {
   if (args.length > 0) {
     const unboundCallback = callback;
-    callback = () => ReflectApply(unboundCallback, window, args);
+    callback = () => ReflectApply(unboundCallback, globalThis, args);
   }
 
   return core.queueImmediate(
@@ -55,7 +55,7 @@ function setTimeout(callback, timeout = 0, ...args) {
   }
   if (args.length > 0) {
     const unboundCallback = callback;
-    callback = () => ReflectApply(unboundCallback, window, args);
+    callback = () => ReflectApply(unboundCallback, globalThis, args);
   }
   timeout = webidl.converters.long(timeout);
   return core.queueUserTimer(
@@ -77,7 +77,7 @@ function setInterval(callback, timeout = 0, ...args) {
   }
   if (args.length > 0) {
     const unboundCallback = callback;
-    callback = () => ReflectApply(unboundCallback, window, args);
+    callback = () => ReflectApply(unboundCallback, globalThis, args);
   }
   timeout = webidl.converters.long(timeout);
   return core.queueUserTimer(

--- a/tests/node_compat/test/common/index.js
+++ b/tests/node_compat/test/common/index.js
@@ -62,7 +62,6 @@ let knownGlobals = [
   self,
   sessionStorage,
   setImmediate,
-  window,
 ];
 
 if (global.AbortController)

--- a/tests/unit/globals_test.ts
+++ b/tests/unit/globals_test.ts
@@ -1,7 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 // deno-lint-ignore-file no-window-prefix no-window
-import { assert, assertEquals, assertRejects } from "./test_util.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "./test_util.ts";
 
 Deno.test(function globalThisExists() {
   assert(globalThis != null);
@@ -223,4 +228,10 @@ Deno.test(function mapGroupBy() {
     type: "fruit",
     quantity: 5,
   }]);
+});
+
+Deno.test(function nodeGlobalsRaise() {
+  assertThrows(() => {
+    Buffer;
+  }, ReferenceError);
 });

--- a/tests/unit/globals_test.ts
+++ b/tests/unit/globals_test.ts
@@ -232,6 +232,7 @@ Deno.test(function mapGroupBy() {
 
 Deno.test(function nodeGlobalsRaise() {
   assertThrows(() => {
+    // @ts-ignore yes that's the point
     Buffer;
   }, ReferenceError);
 });


### PR DESCRIPTION
accessing e.g. `Buffer` in `Mode::Deno` mode should throw, not return undefined.