### PR TITLE
feat(workspace): support object config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd69b394ee336e02ac28cf412a543f9e83d79c8e6584a530940712fa6c01885"
+checksum = "96119386ea33783e2a35a3f0c5a960f88edda53f34df9594c9bb8017dcae2367"
 dependencies = [
  "anyhow",
  "deno_semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ console_static_text = "=0.8.1"
 data-encoding = "2.3.3"
 data-url = "=0.3.0"
 deno_cache_dir = "=0.10.0"
-deno_config = { version = "=0.20.2", default-features = false }
+deno_config = { version = "=0.20.4", default-features = false }
 dlopen2 = "0.6.1"
 ecb = "=0.1.2"
 elliptic-curve = { version = "0.13.4", features = ["alloc", "arithmetic", "ecdh", "std", "pem"] }

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1534,11 +1534,12 @@ impl ConfigData {
 
     let workspace = config_file
       .as_ref()
-      .and_then(|c| c.json.workspace.as_ref().map(|w| (c, w)));
+      .and_then(|c| c.to_workspace_config().ok().flatten().map(|w| (c, w)));
     let is_workspace_root = workspace.is_some();
     let workspace_members = if let Some((config, workspace)) = workspace {
       Arc::new(
         workspace
+          .members
           .iter()
           .flat_map(|p| {
             let dir_specifier = config.specifier.join(p).ok()?;

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -605,11 +605,27 @@
       ]
     },
     "workspace": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "The members of this workspace."
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The members of this workspace."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The members of this workspace."
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This adds object config for the workspace config:

```json
{
  "workspace": {
    "members": ["./member-1", "./member-2"]
  }
}
```

This is a more verbose version of `"workspace": ["./member-1", "./member-2"]`. Although we don't need it at the moment, it makes the naming of `"workspace"` more clear and leaves the object open for more config in the future.

Closes https://github.com/denoland/deno/issues/24456