### PR TITLE
fix: restore reference to dom.extras in lib.dom.d.ts

### DIFF
--- a/cli/tsc/dts/lib.dom.d.ts
+++ b/cli/tsc/dts/lib.dom.d.ts
@@ -15,6 +15,7 @@ and limitations under the License.
 
 
 /// <reference no-default-lib="true"/>
+/// <reference lib="dom.extras" />
 
 /////////////////////////////
 /// Window APIs

--- a/tests/specs/run/dom_extras_dts/__test__.jsonc
+++ b/tests/specs/run/dom_extras_dts/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run --check dom_extras_dts.ts",
+  "output": "dom_extras_dts.out"
+}

--- a/tests/specs/run/dom_extras_dts/deno.json
+++ b/tests/specs/run/dom_extras_dts/deno.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "deno.ns",
+      "dom"
+    ]
+  }
+}

--- a/tests/specs/run/dom_extras_dts/dom_extras_dts.out
+++ b/tests/specs/run/dom_extras_dts/dom_extras_dts.out
@@ -1,0 +1,3 @@
+Check [WILDCARD]dom_extras_dts.ts
+URLPattern[WILDCARD]
+function

--- a/tests/specs/run/dom_extras_dts/dom_extras_dts.ts
+++ b/tests/specs/run/dom_extras_dts/dom_extras_dts.ts
@@ -1,0 +1,2 @@
+console.log(new URLPattern({ pathname: "/:foo/:bar/c" }));
+console.log(typeof Deno.serve);


### PR DESCRIPTION
This was changed by mistake in #24326.

Closes https://github.com/denoland/deno/issues/24459.