### PR TITLE
fix(node/http): don't error if request destroyed before send

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -322,6 +322,7 @@ class ClientRequest extends OutgoingMessage {
   insecureHTTPParser: boolean;
   useChunkedEncodingByDefault: boolean;
   path: string;
+  _req: { requestRid: number; cancelHandleRid: number } | undefined;
 
   constructor(
     input: string | URL,
@@ -819,7 +820,9 @@ class ClientRequest extends OutgoingMessage {
     if (rid) {
       core.tryClose(rid);
     }
-    if (this._req.cancelHandleRid !== null) {
+
+    // Request might be closed before we actually made it
+    if (this._req !== undefined && this._req.cancelHandleRid !== null) {
       core.tryClose(this._req.cancelHandleRid);
     }
     // If we're aborting, we don't care about any more response data.

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -322,7 +322,7 @@ class ClientRequest extends OutgoingMessage {
   insecureHTTPParser: boolean;
   useChunkedEncodingByDefault: boolean;
   path: string;
-  _req: { requestRid: number; cancelHandleRid: number } | undefined;
+  _req: { requestRid: number; cancelHandleRid: number | null } | undefined;
 
   constructor(
     input: string | URL,

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -994,6 +994,15 @@ Deno.test(
   },
 );
 
+Deno.test(
+  "[node/http] client destroy before sending request should not error",
+  () => {
+    const request = http.request("http://localhost:5929/");
+    // Calling this would throw
+    request.destroy();
+  },
+);
+
 Deno.test("[node/http] node:http exports globalAgent", async () => {
   const http = await import("node:http");
   assert(


### PR DESCRIPTION
A request can be destroyed before it was even made in the Node http API. We errored on that.

This issue was discovered in the JSDOM test suite.