### PR TITLE
fix(node/http): don't send destroyed requests

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -765,6 +765,9 @@ class ClientRequest extends OutgoingMessage {
 
   // deno-lint-ignore no-explicit-any
   end(chunk?: any, encoding?: any, cb?: any): this {
+    // Do nothing if request is already destroyed.
+    if (this.destroyed) return this;
+
     if (typeof chunk === "function") {
       cb = chunk;
       chunk = null;
@@ -797,6 +800,8 @@ class ClientRequest extends OutgoingMessage {
         //
       }
     })();
+
+    return this;
   }
 
   abort() {
@@ -1782,6 +1787,7 @@ export class ServerImpl extends EventEmitter {
       } else {
         return new Promise<Response>((resolve): void => {
           const res = new ServerResponse(resolve, socket);
+          console.log("EMITTING", res, req);
           this.emit("request", req, res);
         });
       }

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1787,7 +1787,6 @@ export class ServerImpl extends EventEmitter {
       } else {
         return new Promise<Response>((resolve): void => {
           const res = new ServerResponse(resolve, socket);
-          console.log("EMITTING", res, req);
           this.emit("request", req, res);
         });
       }

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1003,6 +1003,25 @@ Deno.test(
   },
 );
 
+Deno.test(
+  "[node/http] destroyed requests should not be sent",
+  async () => {
+    let receivedRequest = false;
+    const server = Deno.serve(() => {
+      receivedRequest = true;
+      return new Response(null);
+    });
+    const request = http.request(`http://localhost:${server.addr.port}/`);
+    // Calling this would throw
+    request.destroy();
+    request.end("hello");
+
+    await new Promise((r) => setTimeout(r, 500));
+    assertEquals(receivedRequest, false);
+    await server.shutdown();
+  },
+);
+
 Deno.test("[node/http] node:http exports globalAgent", async () => {
   const http = await import("node:http");
   assert(

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1012,7 +1012,6 @@ Deno.test(
       return new Response(null);
     });
     const request = http.request(`http://localhost:${server.addr.port}/`);
-    // Calling this would throw
     request.destroy();
     request.end("hello");
 


### PR DESCRIPTION
Make sure that already destroyed requests are not actually sent.

This error was discovered in jsdom's test suite.