### PR TITLE
fix(node/perf_hooks): stub eventLoopUtilization to make hapi tests work

### DIFF
--- a/ext/node/polyfills/perf_hooks.ts
+++ b/ext/node/polyfills/perf_hooks.ts
@@ -26,8 +26,11 @@ const performance:
     "clearMeasures" | "getEntries"
   >
   & {
-    // deno-lint-ignore no-explicit-any
-    eventLoopUtilization: any;
+    eventLoopUtilization(): {
+      idle: number;
+      active: number;
+      utilization: number;
+    };
     nodeTiming: Record<string, string>;
     // deno-lint-ignore no-explicit-any
     timerify: any;
@@ -37,8 +40,10 @@ const performance:
     markResourceTiming: any;
   } = {
     clearMarks: (markName: string) => shimPerformance.clearMarks(markName),
-    eventLoopUtilization: () =>
-      notImplemented("eventLoopUtilization from performance"),
+    eventLoopUtilization: () => {
+      // TODO(@marvinhagemeister): Return actual non-stubbed values
+      return { idle: 0, active: 0, utilization: 0 };
+    },
     mark: (markName: string) => shimPerformance.mark(markName),
     measure: (
       measureName: string,

--- a/tests/unit_node/perf_hooks_test.ts
+++ b/tests/unit_node/perf_hooks_test.ts
@@ -61,3 +61,10 @@ Deno.test({
     });
   },
 });
+
+Deno.test("[perf_hooks]: eventLoopUtilization", () => {
+  const obj = performance.eventLoopUtilization();
+  assertEquals(typeof obj.idle, "number");
+  assertEquals(typeof obj.active, "number");
+  assertEquals(typeof obj.utilization, "number");
+});


### PR DESCRIPTION
This PR stubs `perf_hooks.eventLoopUtilization` to make the tests of [hapi](https://github.com/hapijs/hapi) start. Previously, they'd all error because of this function throwing a not implemented error. This brings down the test failures in their suite from 982 to 68 failures.