### PR TITLE
fix(node/v8): stub serializer methods

### DIFF
--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -14,7 +14,7 @@ import {
 
 import { Buffer } from "node:buffer";
 
-import { notImplemented } from "ext:deno_node/_utils.ts";
+import { notImplemented, warnNotImplemented } from "ext:deno_node/_utils.ts";
 
 export function cachedDataVersionTag() {
   return op_v8_cached_data_version_tag();
@@ -79,7 +79,41 @@ export function deserialize(data) {
 }
 export class Serializer {
   constructor() {
-    notImplemented("v8.Serializer.prototype.constructor");
+    warnNotImplemented("v8.Serializer.prototype.constructor");
+  }
+
+  releaseBuffer(): Buffer {
+    warnNotImplemented("v8.DefaultSerializer.prototype.releaseBuffer");
+    return Buffer.from("");
+  }
+
+  transferArrayBuffer(_id: number, _arrayBuffer: ArrayBuffer): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.transferArrayBuffer");
+  }
+
+  writeDouble(_value: number): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.writeDouble");
+  }
+
+  writeHeader(): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.writeHeader");
+  }
+
+  writeRawBytes(_value: ArrayBufferView): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.writeRawBytes");
+  }
+
+  writeUint32(_value: number): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.writeUint32");
+  }
+
+  writeUint64(_hi: number, _lo: number): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.writeUint64");
+  }
+
+  // deno-lint-ignore no-explicit-any
+  writeValue(_value: any): void {
+    warnNotImplemented("v8.DefaultSerializer.prototype.writeValue");
   }
 }
 export class Deserializer {
@@ -87,9 +121,10 @@ export class Deserializer {
     notImplemented("v8.Deserializer.prototype.constructor");
   }
 }
-export class DefaultSerializer {
+export class DefaultSerializer extends Serializer {
   constructor() {
-    notImplemented("v8.DefaultSerializer.prototype.constructor");
+    warnNotImplemented("v8.DefaultSerializer.prototype.constructor");
+    super();
   }
 }
 export class DefaultDeserializer {


### PR DESCRIPTION
Stubbing a few of Node's `v8` serializer methods makes the `tap` test runner at least start. Previously, it would fail to boot up as some instances of `DefaultSerializer` are constructed eagerly :tada:

Before:
<img width="1041" alt="Screenshot 2024-07-10 at 16 41 30" src="https://github.com/denoland/deno/assets/1062408/58f1157f-cef8-4176-9239-9d724ca0a677">


After:

<img width="830" alt="Screenshot 2024-07-10 at 16 39 35" src="https://github.com/denoland/deno/assets/1062408/710ef673-8120-405a-b9d3-a5ca826b4829">


Fixes https://github.com/denoland/deno/issues/24409 