### PR TITLE
chore: tweak warning message for un-run install scripts

### DIFF
--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -721,7 +721,7 @@ async fn sync_resolution_with_fs(
     };
     let packages = packages_with_scripts_not_run
       .iter()
-      .map(|p| p.to_string())
+      .map(|p| format!("npm:{p}"))
       .collect::<Vec<_>>()
       .join(", ");
     log::warn!("{}: Packages contained npm lifecycle scripts (preinstall/install/postinstall) that were not executed.

--- a/tests/specs/npm/lifecycle_scripts/all_lifecycles_not_run.out
+++ b/tests/specs/npm/lifecycle_scripts/all_lifecycles_not_run.out
@@ -9,4 +9,4 @@ Initialize @denotest/bin@1.0.0
 warning: Packages contained npm lifecycle scripts (preinstall/install/postinstall) that were not executed.
     This may cause the packages to not work correctly. To run them, use the `--allow-scripts` flag with `deno cache`
     (e.g. `deno cache --allow-scripts=pkg1,pkg2 <entrypoint>`):
-      @denotest/node-lifecycle-scripts@1.0.0
+      npm:@denotest/node-lifecycle-scripts@1.0.0

--- a/tests/specs/npm/lifecycle_scripts/future_install_all_lifecycles_not_run.out
+++ b/tests/specs/npm/lifecycle_scripts/future_install_all_lifecycles_not_run.out
@@ -10,4 +10,4 @@ Initialize @denotest/bin@1.0.0
 warning: Packages contained npm lifecycle scripts (preinstall/install/postinstall) that were not executed.
     This may cause the packages to not work correctly. To run them, use the `--allow-scripts` flag with `deno cache` or `deno install`
     (e.g. `deno cache --allow-scripts=pkg1,pkg2 <entrypoint>` or `deno install --allow-scripts=pkg1,pkg2`):
-      @denotest/node-lifecycle-scripts@1.0.0
+      npm:@denotest/node-lifecycle-scripts@1.0.0

--- a/tests/specs/npm/lifecycle_scripts/node_gyp_not_run.out
+++ b/tests/specs/npm/lifecycle_scripts/node_gyp_not_run.out
@@ -4,6 +4,6 @@ Download http://localhost:4260/node-gyp
 warning: Packages contained npm lifecycle scripts (preinstall/install/postinstall) that were not executed.
     This may cause the packages to not work correctly. To run them, use the `--allow-scripts` flag with `deno cache`
     (e.g. `deno cache --allow-scripts=pkg1,pkg2 <entrypoint>`):
-      @denotest/node-addon@1.0.0
+      npm:@denotest/node-addon@1.0.0
 error: Uncaught (in promise) Error: Cannot find module './build/Release/node_addon'
 [WILDCARD]


### PR DESCRIPTION
Previously when we printed out the packages that skipped install scripts, we didn't prefix them with `npm:`. When you pass `--allow-scripts` though, we require `npm:`, which means you can't just copy paste the package name from the warning message.