### PR TITLE
build: update wgpu-core to unblock release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7657,9 +7657,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6a86eaa5e763e59c73cf9e97d55fffd4dfda69fd8bda19589fcf851ddfef1f"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -7686,9 +7686,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d71c8ae05170583049b65ee562fd839fdc0b3e9ddb84f4e40c9d5f8ea0d4c8c"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ rsa = { version = "0.9.3", default-features = false, features = ["std", "pem", "
 
 # webgpu
 raw-window-handle = "0.6.0"
-wgpu-core = "0.20"
+wgpu-core = "0.21.1"
 wgpu-types = "0.20"
 
 # macros


### PR DESCRIPTION
`wgpu-core` version 0.20 was yanked and it caused failure to
publish `deno_webgpu`. I bumped and published locally to
unblock the release.