### PR TITLE
fix(workspace): allow using --import-map flag with workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,8 +1309,7 @@ dependencies = [
 [[package]]
 name = "deno_config"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d457bbaff2200897ab1f635863c477f10524412a1f568535ea26763b96d5c9"
+source = "git+https://github.com/denoland/deno_config?branch=import_map_in_workspaces#5298f370b6fd31a0cda21f31acf42783ad53c07c"
 dependencies = [
  "anyhow",
  "deno_semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,8 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.21.0"
-source = "git+https://github.com/denoland/deno_config?branch=import_map_in_workspaces#5298f370b6fd31a0cda21f31acf42783ad53c07c"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2df23da1c85522dd6cb23372d7953ecf576ec416c5d517b046aeeca281ca5a4"
 dependencies = [
  "anyhow",
  "deno_semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,3 +377,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
+
+[patch.crates-io]
+deno_config = { git = "https://github.com/denoland/deno_config", branch = "import_map_in_workspaces" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ console_static_text = "=0.8.1"
 data-encoding = "2.3.3"
 data-url = "=0.3.0"
 deno_cache_dir = "=0.10.0"
-deno_config = { version = "=0.21.0", default-features = false }
+deno_config = { version = "=0.21.1", default-features = false }
 dlopen2 = "0.6.1"
 ecb = "=0.1.2"
 elliptic-curve = { version = "0.13.4", features = ["alloc", "arithmetic", "ecdh", "std", "pem"] }
@@ -377,6 +377,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
-
-[patch.crates-io]
-deno_config = { git = "https://github.com/denoland/deno_config", branch = "import_map_in_workspaces" }

--- a/tests/specs/run/workspaces/explicit_import_map/__test__.jsonc
+++ b/tests/specs/run/workspaces/explicit_import_map/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run -A --import-map=./import_map.json main.ts",
+  "output": "main.out",
+  "tempDir": true
+}

--- a/tests/specs/run/workspaces/explicit_import_map/import_map.json
+++ b/tests/specs/run/workspaces/explicit_import_map/import_map.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "chalk": "npm:chalk"
+  }
+}

--- a/tests/specs/run/workspaces/explicit_import_map/main.out
+++ b/tests/specs/run/workspaces/explicit_import_map/main.out
@@ -1,0 +1,2 @@
+[WILDCARD]
+hello

--- a/tests/specs/run/workspaces/explicit_import_map/main.ts
+++ b/tests/specs/run/workspaces/explicit_import_map/main.ts
@@ -1,0 +1,3 @@
+import chalk from "chalk";
+
+console.log(chalk.green("hello"));

--- a/tests/specs/run/workspaces/explicit_import_map/package.json
+++ b/tests/specs/run/workspaces/explicit_import_map/package.json
@@ -1,0 +1,3 @@
+{
+  "workspaces": ["packages/*"]
+}


### PR DESCRIPTION
This is a temporary fix, which is not perfect - specifying `--import-map`
will break resolution of packages defined in `workspace` setting, but
erroring on `--import-map` currently causes regression in code that
worked fine in v1.44.x.