### PR TITLE
fix(node): revert invalid package target change

### DIFF
--- a/ext/node/resolution.rs
+++ b/ext/node/resolution.rs
@@ -878,15 +878,15 @@ impl NodeResolver {
             last_error = None;
             continue;
           }
-          Err(e) => match e.as_kind() {
-            PackageTargetResolveErrorKind::InvalidPackageTarget(_) => {
+          Err(e) => {
+            // todo(dsherret): add codes to each error and match on that instead
+            if e.to_string().starts_with("[ERR_INVALID_PACKAGE_TARGET]") {
               last_error = Some(e);
               continue;
-            }
-            _ => {
+            } else {
               return Err(e);
             }
-          },
+          }
         }
       }
       if last_error.is_none() {


### PR DESCRIPTION
Reverts this change (I'm not sure it causes a bug, but I thought about this in the morning):

https://github.com/denoland/deno/pull/24470/files/18cd4ff3ff5050e18647c781011a2bc3099cab5c..ac3e42eaaecc6cf89300b39c270029da3ecc1e63?diff=split&w=0

Reason is that `e` may contain an invalid package target nested deeply in the returned errors. We should probably add a `.code()` to all errors to make matching easier or make the errors flatter.