### PR TITLE
fix(cli/init): broken link in deno init sample template

### DIFF
--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -68,7 +68,7 @@ Deno.test(function addTest() {
   return a + b;
 }
 
-// Learn more at https://deno.land/manual/examples/module_metadata#concepts
+// Learn more at https://docs.deno.com/runtime/manual/examples/module_metadata#concepts
 if (import.meta.main) {
   console.log("Add 2 + 3 =", add(2, 3));
 }


### PR DESCRIPTION
This commit fixes the broken link in the sample template provided by the deno init command.
