### PR TITLE
feat(cli): Add --env-file as alternative to --env

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3398,8 +3398,9 @@ fn import_map_arg() -> Arg {
 }
 
 fn env_file_arg() -> Arg {
-  Arg::new("env")
-    .long("env")
+  Arg::new("env-file")
+    .long("env-file")
+    .alias("env")
     .value_name("FILE")
     .help("Load .env file")
     .long_help("UNSTABLE: Load environment variables from local file. Only the first environment variable with a given key is used. Existing process environment variables are not overwritten.")
@@ -4792,7 +4793,7 @@ fn import_map_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 }
 
 fn env_file_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
-  flags.env_file = matches.remove_one::<String>("env");
+  flags.env_file = matches.remove_one::<String>("env-file");
 }
 
 fn reload_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
@@ -7570,8 +7571,24 @@ mod tests {
   }
 
   #[test]
-  fn run_env_file_default() {
+  fn run_env_default() {
     let r = flags_from_vec(svec!["deno", "run", "--env", "script.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run(RunFlags::new_default(
+          "script.ts".to_string(),
+        )),
+        env_file: Some(".env".to_owned()),
+        code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn run_env_file_default() {
+    let r = flags_from_vec(svec!["deno", "run", "--env-file", "script.ts"]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -7601,9 +7618,30 @@ mod tests {
   }
 
   #[test]
-  fn run_env_file_defined() {
+  fn run_env_defined() {
     let r =
       flags_from_vec(svec!["deno", "run", "--env=.another_env", "script.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run(RunFlags::new_default(
+          "script.ts".to_string(),
+        )),
+        env_file: Some(".another_env".to_owned()),
+        code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn run_env_file_defined() {
+    let r = flags_from_vec(svec![
+      "deno",
+      "run",
+      "--env-file=.another_env",
+      "script.ts"
+    ]);
     assert_eq!(
       r.unwrap(),
       Flags {

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1885,7 +1885,7 @@ fn load_env_variables_from_env_file(filename: Option<&String>) {
     Err(error) => {
       match error {
           dotenvy::Error::LineParse(line, index)=> log::info!("{} Parsing failed within the specified environment file: {} at index: {} of the value: {}",colors::yellow("Warning"), env_file_name, index, line),
-          dotenvy::Error::Io(_)=> log::info!("{} The `--env` flag was used, but the environment file specified '{}' was not found.",colors::yellow("Warning"),env_file_name),
+          dotenvy::Error::Io(_)=> log::info!("{} The `--env-file` flag was used, but the environment file specified '{}' was not found.",colors::yellow("Warning"),env_file_name),
           dotenvy::Error::EnvVar(_)=> log::info!("{} One or more of the environment variables isn't present or not unicode within the specified environment file: {}",colors::yellow("Warning"),env_file_name),
           _ => log::info!("{} Unknown failure occurred with the specified environment file: {}", colors::yellow("Warning"), env_file_name),
         }

--- a/tests/testdata/eval/env_file_missing.out
+++ b/tests/testdata/eval/env_file_missing.out
@@ -1,2 +1,2 @@
-Warning The `--env` flag was used, but the environment file specified 'missing' was not found.
+Warning The `--env-file` flag was used, but the environment file specified 'missing' was not found.
 undefined

--- a/tests/testdata/run/env_file_missing.out
+++ b/tests/testdata/run/env_file_missing.out
@@ -1,4 +1,4 @@
-Warning The `--env` flag was used, but the environment file specified 'missing' was not found.
+Warning The `--env-file` flag was used, but the environment file specified 'missing' was not found.
 undefined
 undefined
 undefined


### PR DESCRIPTION
Closes #24528, see comment [here](https://github.com/denoland/deno/pull/24166#issuecomment-2221817406) on Deno 2
- https://github.com/denoland/deno/issues/24528

This pr rename --env to --env-file for several reasons (see issue), but allow --env to keep working as an alias.

I've added 2 unit tests to make sure both --env and --env-file work