### PR TITLE
fix: include already seen deps in lockfile dep tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.80.0"
+version = "0.80.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ec763fcd824d63cc056f153ba7fbf6254b515c347ec8b7d1a21515742547bb"
+checksum = "a71a3f1575d0309ac18ca2e7af88d64c15acd2c55d06fef0fbdfd7c69cecb09d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -69,7 +69,7 @@ deno_config = { workspace = true, features = ["workspace"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.142.0", features = ["html", "syntect"] }
 deno_emit = "=0.43.1"
-deno_graph = { version = "=0.80.0", features = ["tokio_executor"] }
+deno_graph = { version = "=0.80.1", features = ["tokio_executor"] }
 deno_lint = { version = "=0.60.1", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm = "=0.21.4"


### PR DESCRIPTION
Tests in https://github.com/denoland/deno_graph/pull/504

Closes #24536