### PR TITLE
fix(docs): fix some deno.land/manual broken urls

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4979,7 +4979,7 @@ declare namespace Deno {
 
   /** The permission descriptor for the `allow-ffi` and `deny-ffi` permissions, which controls
    * access to loading _foreign_ code and interfacing with it via the
-   * [Foreign Function Interface API](https://deno.land/manual/runtime/ffi_api)
+   * [Foreign Function Interface API](https://docs.deno.com/runtime/manual/runtime/ffi_api)
    * available in Deno.  The option `path` allows scoping the permission to a
    * specific path on the host.
    *

--- a/ext/kv/README.md
+++ b/ext/kv/README.md
@@ -1,7 +1,7 @@
 # deno_kv
 
 This crate provides a key/value store for Deno. For an overview of Deno KV,
-please read the [manual](https://deno.land/manual/runtime/kv).
+please read the [manual](https://docs.deno.com/deploy/kv/manual).
 
 ## Storage Backends
 

--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -94,7 +94,7 @@ switch (command) {
     update
       Update the \`expectation.json\` to match the current reality.
 
-More details at https://deno.land/manual@main/contributing/web_platform_tests
+More details at https://docs.deno.com/runtime/manual/references/contributing/web_platform_tests
 
     `);
     break;


### PR DESCRIPTION
Fixing some broken urls found after the docs migration