### PR TITLE
fix(std/http2): Release window capacity back to remote stream

### DIFF
--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -456,26 +456,21 @@ fn poll_data_or_trailers(
   cx: &mut std::task::Context,
   body: &mut RecvStream,
 ) -> Poll<Result<DataOrTrailers, h2::Error>> {
-  loop {
-    if let Poll::Ready(trailers) = body.poll_trailers(cx) {
-      if let Some(trailers) = trailers? {
-        return Poll::Ready(Ok(DataOrTrailers::Trailers(trailers)));
-      } else {
-        return Poll::Ready(Ok(DataOrTrailers::Eof));
-      }
+  if let Poll::Ready(trailers) = body.poll_trailers(cx) {
+    if let Some(trailers) = trailers? {
+      return Poll::Ready(Ok(DataOrTrailers::Trailers(trailers)));
+    } else {
+      return Poll::Ready(Ok(DataOrTrailers::Eof));
     }
-    if let Poll::Ready(data) = body.poll_data(cx) {
-      if let Some(data) = data {
-        let data = data?;
-        body.flow_control().release_capacity(data.len())?;
-        return Poll::Ready(Ok(DataOrTrailers::Data(data)));
-      }
-      // If data is None, loop one more time to check for trailers
-      continue;
-    }
-    // Return pending here as poll_data will keep the waker
-    return Poll::Pending;
   }
+  if let Poll::Ready(Some(data)) = body.poll_data(cx) {
+    let data = data?;
+    body.flow_control().release_capacity(data.len())?;
+    return Poll::Ready(Ok(DataOrTrailers::Data(data)));
+    // If data is None, we need to poll one more time to check for trailers
+  }
+  // Return pending here as poll_data will keep the waker
+  Poll::Pending
 }
 
 #[op2(async)]

--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -467,7 +467,7 @@ fn poll_data_or_trailers(
     let data = data?;
     body.flow_control().release_capacity(data.len())?;
     return Poll::Ready(Ok(DataOrTrailers::Data(data)));
-    // If data is None, we need to poll one more time to check for trailers
+    // If `poll_data` returns `Ready(None)`, poll one more time to check for trailers
   }
   // Return pending here as poll_data will keep the waker
   Poll::Pending

--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -466,7 +466,9 @@ fn poll_data_or_trailers(
     }
     if let Poll::Ready(data) = body.poll_data(cx) {
       if let Some(data) = data {
-        return Poll::Ready(Ok(DataOrTrailers::Data(data?)));
+        let data = data?;
+        body.flow_control().release_capacity(data.len())?;
+        return Poll::Ready(Ok(DataOrTrailers::Data(data)));
       }
       // If data is None, loop one more time to check for trailers
       continue;


### PR DESCRIPTION
This PR adds logic to release window capacity after reading the chunks from the stream. Without it, large response (more than `u16::MAX`) may fill up the capacity and the whole response can't be read.

Closes #24552
Closes https://github.com/denoland/deno/issues/24305