### PR TITLE
fix(workspace): support resolving bare specifiers to npm pkgs within a workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.22.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83df0c14d89f4e6e7ff91bfea0b4d5a0a33b4385c517ff4d8b4236d9834561e3"
+checksum = "90684d387a893a3318569b8bb548e2f9291f86f2909f5349dd9d2b97c83fdb18"
 dependencies = [
  "anyhow",
  "deno_semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ console_static_text = "=0.8.1"
 data-encoding = "2.3.3"
 data-url = "=0.3.0"
 deno_cache_dir = "=0.10.0"
-deno_config = { version = "=0.22.2", default-features = false }
+deno_config = { version = "=0.23.0", default-features = false }
 dlopen2 = "0.6.1"
 ecb = "=0.1.2"
 elliptic-curve = { version = "0.13.4", features = ["alloc", "arithmetic", "ecdh", "std", "pem"] }

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -533,7 +533,7 @@ fn create_graph_resolver(
         // todo(dsherret): we need a better way of determining the workspace
         // root for this config data, but this is fine for now because this
         // value is only used for determining if a specifier is in the workspace
-        // in order to resolve bare specifiers to deno.json files.
+        // in order to resolve bare specifiers to workspace npm packages
         npm_resolver
           .and_then(|r| r.root_node_modules_path())
           .and_then(|p| p.parent())

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -529,6 +529,17 @@ fn create_graph_resolver(
     node_resolver: node_resolver.cloned(),
     npm_resolver: npm_resolver.cloned(),
     workspace_resolver: Arc::new(WorkspaceResolver::new_raw(
+      Arc::new(
+        // todo(dsherret): we need a better way of determining the workspace
+        // root for this config data, but this is fine for now because this
+        // value is only used for determining if a specifier is in the workspace
+        // in order to resolve bare specifiers to deno.json files.
+        npm_resolver
+          .and_then(|r| r.root_node_modules_path())
+          .and_then(|p| p.parent())
+          .and_then(|p| ModuleSpecifier::from_directory_path(p).ok())
+          .unwrap_or_else(|| ModuleSpecifier::parse("file:///").unwrap()),
+      ),
       config_data.and_then(|d| d.import_map.as_ref().map(|i| (**i).clone())),
       config_data
         .and_then(|d| d.package_json.clone())

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -530,14 +530,10 @@ fn create_graph_resolver(
     npm_resolver: npm_resolver.cloned(),
     workspace_resolver: Arc::new(WorkspaceResolver::new_raw(
       Arc::new(
-        // todo(dsherret): we need a better way of determining the workspace
-        // root for this config data, but this is fine for now because this
-        // value is only used for determining if a specifier is in the workspace
-        // in order to resolve bare specifiers to workspace npm packages
-        npm_resolver
-          .and_then(|r| r.root_node_modules_path())
-          .and_then(|p| p.parent())
-          .and_then(|p| ModuleSpecifier::from_directory_path(p).ok())
+        config_data
+          .map(|d| d.workspace_root_dir.clone())
+          // this is fine because this value is only used to filter bare
+          // specifier resolution to workspace npm packages when in a workspace
           .unwrap_or_else(|| ModuleSpecifier::parse("file:///").unwrap()),
       ),
       config_data.and_then(|d| d.import_map.as_ref().map(|i| (**i).clone())),

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -542,6 +542,22 @@ impl Resolver for CliGraphResolver {
       Ok(resolution) => match resolution {
         MappedResolution::Normal(specifier)
         | MappedResolution::ImportMap(specifier) => Ok(specifier),
+        MappedResolution::WorkspaceNpmPackage {
+          target_pkg_json: pkg_json,
+          sub_path,
+          ..
+        } => self
+          .node_resolver
+          .as_ref()
+          .unwrap()
+          .resolve_package_sub_path_from_deno_module(
+            pkg_json.dir_path(),
+            sub_path.as_deref(),
+            Some(referrer),
+            to_node_mode(mode),
+          )
+          .map_err(ResolveError::Other)
+          .map(|res| res.into_url()),
         // todo(dsherret): for byonm it should do resolution solely based on
         // the referrer and not the package.json
         MappedResolution::PackageJson {

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -88,7 +88,7 @@ struct WorkspaceEszipModule {
 
 struct WorkspaceEszip {
   eszip: eszip::EszipV2,
-  root_dir_url: ModuleSpecifier,
+  root_dir_url: Arc<ModuleSpecifier>,
 }
 
 impl WorkspaceEszip {
@@ -166,6 +166,22 @@ impl ModuleLoader for EmbeddedModuleLoader {
       self.shared.workspace_resolver.resolve(specifier, &referrer);
 
     match mapped_resolution {
+      Ok(MappedResolution::WorkspaceNpmPackage {
+        target_pkg_json: pkg_json,
+        sub_path,
+        ..
+      }) => Ok(
+        self
+          .shared
+          .node_resolver
+          .resolve_package_sub_path_from_deno_module(
+            pkg_json.dir_path(),
+            sub_path.as_deref(),
+            Some(&referrer),
+            NodeResolutionMode::Execution,
+          )?
+          .into_url(),
+      ),
       Ok(MappedResolution::PackageJson {
         dep_result,
         sub_path,
@@ -427,7 +443,8 @@ pub async fn run(
   let npm_registry_url = ModuleSpecifier::parse("https://localhost/").unwrap();
   let root_path =
     std::env::temp_dir().join(format!("deno-compile-{}", current_exe_name));
-  let root_dir_url = ModuleSpecifier::from_directory_path(&root_path).unwrap();
+  let root_dir_url =
+    Arc::new(ModuleSpecifier::from_directory_path(&root_path).unwrap());
   let main_module = root_dir_url.join(&metadata.entrypoint_key).unwrap();
   let root_node_modules_path = root_path.join("node_modules");
   let npm_cache_dir = NpmCacheDir::new(
@@ -579,6 +596,7 @@ pub async fn run(
       })
       .collect();
     WorkspaceResolver::new_raw(
+      root_dir_url.clone(),
       import_map,
       pkg_jsons,
       metadata.workspace_resolver.pkg_json_resolution,

--- a/cli/tools/registry/unfurl.rs
+++ b/cli/tools/registry/unfurl.rs
@@ -119,7 +119,7 @@ impl SpecifierUnfurler {
             PackageJsonDepValue::Workspace(version_req) => {
               // todo(#24612): consider warning or error when this is also a jsr package?
               ModuleSpecifier::parse(&format!(
-                "npm:{}{}{}",
+                "npm:{}@{}{}",
                 alias,
                 version_req,
                 sub_path

--- a/cli/tools/registry/unfurl.rs
+++ b/cli/tools/registry/unfurl.rs
@@ -79,20 +79,23 @@ impl SpecifierUnfurler {
           target_pkg_json: pkg_json,
           pkg_name,
           sub_path,
-        } => ModuleSpecifier::parse(&format!(
-          "npm:{}{}{}",
-          pkg_name,
-          pkg_json
-            .version
-            .as_ref()
-            .map(|v| format!("@^{}", v))
-            .unwrap_or_default(),
-          sub_path
-            .as_ref()
-            .map(|s| format!("/{}", s))
-            .unwrap_or_default()
-        ))
-        .ok(),
+        } => {
+          // todo(#24612): consider warning or error when this is also a jsr package?
+          ModuleSpecifier::parse(&format!(
+            "npm:{}{}{}",
+            pkg_name,
+            pkg_json
+              .version
+              .as_ref()
+              .map(|v| format!("@^{}", v))
+              .unwrap_or_default(),
+            sub_path
+              .as_ref()
+              .map(|s| format!("/{}", s))
+              .unwrap_or_default()
+          ))
+          .ok()
+        }
         MappedResolution::PackageJson {
           alias,
           sub_path,
@@ -101,6 +104,8 @@ impl SpecifierUnfurler {
         } => match dep_result {
           Ok(dep) => match dep {
             PackageJsonDepValue::Req(pkg_req) => {
+              // todo(#24612): consider warning or error when this is an npm workspace
+              // member that's also a jsr package?
               ModuleSpecifier::parse(&format!(
                 "npm:{}{}",
                 pkg_req,
@@ -112,6 +117,7 @@ impl SpecifierUnfurler {
               .ok()
             }
             PackageJsonDepValue::Workspace(version_req) => {
+              // todo(#24612): consider warning or error when this is also a jsr package?
               ModuleSpecifier::parse(&format!(
                 "npm:{}{}{}",
                 alias,

--- a/cli/tools/registry/unfurl.rs
+++ b/cli/tools/registry/unfurl.rs
@@ -75,26 +75,53 @@ impl SpecifierUnfurler {
       match resolved {
         MappedResolution::Normal(specifier)
         | MappedResolution::ImportMap(specifier) => Some(specifier),
+        MappedResolution::WorkspaceNpmPackage {
+          target_pkg_json: pkg_json,
+          pkg_name,
+          sub_path,
+        } => ModuleSpecifier::parse(&format!(
+          "npm:{}{}{}",
+          pkg_name,
+          pkg_json
+            .version
+            .as_ref()
+            .map(|v| format!("@^{}", v))
+            .unwrap_or_default(),
+          sub_path
+            .as_ref()
+            .map(|s| format!("/{}", s))
+            .unwrap_or_default()
+        ))
+        .ok(),
         MappedResolution::PackageJson {
+          alias,
           sub_path,
           dep_result,
           ..
         } => match dep_result {
           Ok(dep) => match dep {
-            PackageJsonDepValue::Req(req) => ModuleSpecifier::parse(&format!(
-              "npm:{}{}",
-              req,
-              sub_path
-                .as_ref()
-                .map(|s| format!("/{}", s))
-                .unwrap_or_default()
-            ))
-            .ok(),
-            PackageJsonDepValue::Workspace(_) => {
-              log::warn!(
-                "package.json workspace entries are not implemented yet for publishing."
-              );
-              None
+            PackageJsonDepValue::Req(pkg_req) => {
+              ModuleSpecifier::parse(&format!(
+                "npm:{}{}",
+                pkg_req,
+                sub_path
+                  .as_ref()
+                  .map(|s| format!("/{}", s))
+                  .unwrap_or_default()
+              ))
+              .ok()
+            }
+            PackageJsonDepValue::Workspace(version_req) => {
+              ModuleSpecifier::parse(&format!(
+                "npm:{}{}{}",
+                alias,
+                version_req,
+                sub_path
+                  .as_ref()
+                  .map(|s| format!("/{}", s))
+                  .unwrap_or_default()
+              ))
+              .ok()
             }
           },
           Err(err) => {
@@ -401,6 +428,7 @@ mod tests {
       }),
     );
     let workspace_resolver = WorkspaceResolver::new_raw(
+      Arc::new(ModuleSpecifier::from_directory_path(&cwd).unwrap()),
       Some(import_map),
       vec![Arc::new(package_json)],
       deno_config::workspace::PackageJsonDepResolution::Enabled,

--- a/cli/tools/vendor/test.rs
+++ b/cli/tools/vendor/test.rs
@@ -234,6 +234,7 @@ impl VendorTestBuilder {
     let loader = self.loader.clone();
     let parsed_source_cache = ParsedSourceCache::default();
     let resolver = Arc::new(build_resolver(
+      output_dir.parent().unwrap(),
       self.jsx_import_source_config.clone(),
       self.maybe_original_import_map.clone(),
     ));
@@ -287,6 +288,7 @@ impl VendorTestBuilder {
 }
 
 fn build_resolver(
+  root_dir: &Path,
   maybe_jsx_import_source_config: Option<JsxImportSourceConfig>,
   maybe_original_import_map: Option<ImportMap>,
 ) -> CliGraphResolver {
@@ -295,6 +297,7 @@ fn build_resolver(
     npm_resolver: None,
     sloppy_imports_resolver: None,
     workspace_resolver: Arc::new(WorkspaceResolver::new_raw(
+      Arc::new(ModuleSpecifier::from_directory_path(root_dir).unwrap()),
       maybe_original_import_map,
       Vec::new(),
       deno_config::workspace::PackageJsonDepResolution::Enabled,

--- a/tests/specs/npm/workspace_basic/__test__.jsonc
+++ b/tests/specs/npm/workspace_basic/__test__.jsonc
@@ -5,6 +5,10 @@
       "args": "run --node-modules-dir=false b/main.ts",
       "output": "b/main_global_cache.out"
     },
+    "global_cache_bare_specifier_not_in_pkg": {
+      "args": "run --node-modules-dir=false main.ts",
+      "output": "main.out"
+    },
     "node_modules_dir": {
       "args": "run --node-modules-dir=true b/main.ts",
       "output": "b/main_node_modules_dir.out"

--- a/tests/specs/npm/workspace_basic/b/main.ts
+++ b/tests/specs/npm/workspace_basic/b/main.ts
@@ -1,9 +1,7 @@
 import * as a1 from "@denotest/a";
 import * as a2 from "npm:@denotest/a@1";
-import * as a3 from "npm:@denotest/a@workspace";
 import * as c from "@denotest/c";
 
 a1.sayHello();
 a2.sayHello();
-a3.sayHello();
 c.sayHello();

--- a/tests/specs/npm/workspace_basic/b/main_byonm.out
+++ b/tests/specs/npm/workspace_basic/b/main_byonm.out
@@ -1,4 +1,3 @@
 Hello 5
 Hello 5
-Hello 5
 C: Hi!

--- a/tests/specs/npm/workspace_basic/b/main_node_modules_dir.out
+++ b/tests/specs/npm/workspace_basic/b/main_node_modules_dir.out
@@ -3,5 +3,4 @@ Download http://localhost:4260/@denotest/esm-basic/1.0.0.tgz
 Initialize @denotest/esm-basic@1.0.0
 Hello 5
 Hello 5
-Hello 5
 C: Hi!

--- a/tests/specs/npm/workspace_basic/main.out
+++ b/tests/specs/npm/workspace_basic/main.out
@@ -1,5 +1,4 @@
 Download http://localhost:4260/@denotest/esm-basic
 Download http://localhost:4260/@denotest/esm-basic/1.0.0.tgz
 Hello 5
-Hello 5
 C: Hi!

--- a/tests/specs/npm/workspace_basic/main.ts
+++ b/tests/specs/npm/workspace_basic/main.ts
@@ -1,0 +1,6 @@
+// should resolve these as bare specifiers within the workspace
+import * as a from "@denotest/a";
+import * as c from "@denotest/c";
+
+a.sayHello();
+c.sayHello();

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/__test__.jsonc
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/__test__.jsonc
@@ -1,4 +1,14 @@
 {
-  "args": "publish --dry-run --no-check --log-level=debug",
-  "output": "publish.out"
+  "tests": {
+    "dep_and_workspace_dep": {
+      "args": "publish --dry-run --no-check --log-level=debug",
+      "cwd": "subtract",
+      "output": "publish-subtract.out"
+    },
+    "bare_specifier": {
+      "args": "publish --dry-run --no-check --log-level=debug",
+      "cwd": "subtract-2",
+      "output": "publish-subtract2.out"
+    }
+  }
 }

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/__test__.jsonc
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "publish --dry-run --no-check --log-level=debug",
+  "output": "publish.out"
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/add/index.js
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/add/index.js
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b;
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/add/package.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/add/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "add",
+  "type": "module",
+  "version": "1.0.0",
+  "exports": "./index.js"
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/package.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/package.json
@@ -1,0 +1,3 @@
+{
+  "workspaces": ["./add", "./subtract"]
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/package.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/package.json
@@ -1,3 +1,3 @@
 {
-  "workspaces": ["./add", "./subtract"]
+  "workspaces": ["./add", "./subtract", "./subtract-2"]
 }

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish-subtract.out
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish-subtract.out
@@ -1,0 +1,3 @@
+[WILDCARD]Unfurled specifier: add-dep from file:///[WILDLINE]/subtract/index.ts -> npm:add@1.0.0
+[WILDCARD]Unfurled specifier: add from file:///[WILDLINE]/subtract/index.ts -> npm:add@^1.0.0
+[WILDCARD]

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish-subtract2.out
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish-subtract2.out
@@ -1,0 +1,2 @@
+[WILDCARD]Unfurled specifier: add from file:///[WILDLINE]/subtract-2/index.ts -> npm:add@^1.0.0
+[WILDCARD]

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish.out
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish.out
@@ -1,4 +1,0 @@
-[WILDCARD]Unfurled specifier: add-dep from file:///[WILDLINE]/subtract/index.ts -> npm:add@1.0.0
-[WILDCARD]Unfurled specifier: add from file:///[WILDLINE]/subtract/index.ts -> npm:add^1.0.0
-[WILDCARD]Unfurled specifier: add from file:///[WILDLINE]/subtract-2/index.ts -> npm:add^1.0.0
-[WILDCARD]

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish.out
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/publish.out
@@ -1,0 +1,4 @@
+[WILDCARD]Unfurled specifier: add-dep from file:///[WILDLINE]/subtract/index.ts -> npm:add@1.0.0
+[WILDCARD]Unfurled specifier: add from file:///[WILDLINE]/subtract/index.ts -> npm:add^1.0.0
+[WILDCARD]Unfurled specifier: add from file:///[WILDLINE]/subtract-2/index.ts -> npm:add^1.0.0
+[WILDCARD]

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract-2/deno.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract-2/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/subtract2",
+  "version": "1.0.0",
+  "exports": "./index.ts"
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract-2/index.ts
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract-2/index.ts
@@ -1,0 +1,6 @@
+// test using a bare specifier to a pkg.json dep
+import { add } from "add";
+
+export function subtract(a: number, b: number): number {
+  return add(a, -b);
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract-2/package.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "subtract2",
+  "version": "1.0.0"
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract/deno.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/subtract",
+  "version": "1.0.0",
+  "exports": "./index.ts"
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract/index.ts
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract/index.ts
@@ -1,0 +1,7 @@
+// test using a pkg.json dep and a workspace dep
+import * as addDep from "add-dep";
+import * as addWorkspaceDep from "add";
+
+export function subtract(a: number, b: number): number {
+  return addWorkspaceDep.add(addDep.add(a, -b), 1 - 1);
+}

--- a/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract/package.json
+++ b/tests/specs/publish/npm_workspace_jsr_pkg_with_npm_dep/subtract/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "subtract",
+  "version": "1.0.0",
+  "dependencies": {
+    "add-dep": "npm:add@1.0.0",
+    "add": "workspace:^1.0.0"
+  }
+}


### PR DESCRIPTION
This makes bare specifiers for npm packages work when inside a workspace, which emulates the same behaviour as when there's a node_modules directory. The bare specifier can be overwritten by specifying an import map entry or package.json dependency entry.

* https://github.com/denoland/deno_config/pull/88

Closes #24605