### PR TITLE
fix(ext/node): do not expose `self` global in node

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -67,7 +67,7 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 
 // UTF-16 encodings of the managed globals. THIS LIST MUST BE SORTED.
 #[rustfmt::skip]
-const MANAGED_GLOBALS: [&[u16]; 12] = [
+const MANAGED_GLOBALS: [&[u16]; 13] = [
   &str_to_utf16::<6>("Buffer"),
   &str_to_utf16::<14>("clearImmediate"),
   &str_to_utf16::<13>("clearInterval"),
@@ -76,13 +76,14 @@ const MANAGED_GLOBALS: [&[u16]; 12] = [
   &str_to_utf16::<6>("global"),
   &str_to_utf16::<11>("performance"),
   &str_to_utf16::<7>("process"),
+  &str_to_utf16::<4>("self"),
   &str_to_utf16::<12>("setImmediate"),
   &str_to_utf16::<11>("setInterval"),
   &str_to_utf16::<10>("setTimeout"),
   &str_to_utf16::<6>("window"),
 ];
 
-const SHORTEST_MANAGED_GLOBAL: usize = 6;
+const SHORTEST_MANAGED_GLOBAL: usize = 4;
 const LONGEST_MANAGED_GLOBAL: usize = 14;
 
 #[derive(Debug, Clone, Copy)]

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -356,7 +356,7 @@ internals.__initWorkerThreads = (
       (ev: any) => any
     >();
 
-    parentPort = self as ParentPort;
+    parentPort = globalThis as ParentPort;
     threadId = workerId;
     if (maybeWorkerMetadata) {
       const { 0: metadata, 1: _ } = maybeWorkerMetadata;

--- a/tests/registry/npm/@denotest/globals/1.0.0/index.d.ts
+++ b/tests/registry/npm/@denotest/globals/1.0.0/index.d.ts
@@ -17,5 +17,6 @@ export function getSetTimeout(): typeof setTimeout;
 
 export function checkProcessGlobal(): void;
 export function checkWindowGlobal(): void;
+export function checkSelfGlobal(): void;
 
 export function getFoo(): string;

--- a/tests/registry/npm/@denotest/globals/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/globals/1.0.0/index.js
@@ -20,6 +20,11 @@ exports.checkWindowGlobal = function () {
   console.log(Object.getOwnPropertyDescriptor(globalThis, "window") !== undefined);
 }
 
+exports.checkSelfGlobal = function () {
+  console.log("self" in globalThis);
+  console.log(Object.getOwnPropertyDescriptor(globalThis, "self") !== undefined);
+}
+
 exports.getFoo = function () {
   return globalThis.foo;
 }

--- a/tests/testdata/npm/compare_globals/main.out
+++ b/tests/testdata/npm/compare_globals/main.out
@@ -21,6 +21,10 @@ true
 true
 true
 true
+true
+true
+false
+false
 false
 false
 bar

--- a/tests/testdata/npm/compare_globals/main.ts
+++ b/tests/testdata/npm/compare_globals/main.ts
@@ -37,12 +37,17 @@ console.log(
 );
 globals.checkProcessGlobal();
 
-// In Deno, the window global is defined, but in Node it is not.
+// In Deno, the window and self globals are defined, but in Node they are not.
 console.log("window" in globalThis);
+console.log("self" in globalThis);
 console.log(
   Object.getOwnPropertyDescriptor(globalThis, "window") !== undefined,
 );
+console.log(
+  Object.getOwnPropertyDescriptor(globalThis, "self") !== undefined,
+);
 globals.checkWindowGlobal();
+globals.checkSelfGlobal();
 
 // "Non-managed" globals are shared between Node and Deno.
 (globalThis as any).foo = "bar";


### PR DESCRIPTION
This PR hides `self` global in node compat runtime.

closes #23727
