### PR TITLE
Revert "fix: CFunctionInfo and CTypeInfo leaks (#24634)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.296.0"
+version = "0.294.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c980bc491eac03722a67eb8c1345152216b3b5f781ee4bbc053863f91ca81b"
+checksum = "8e3e1883573cace82d1e826096c8c06bd5e4310ca3a4dba0eb1bf67468719c01"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.172.0"
+version = "0.170.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b5e85887cd447ee47643c27c1b1991c3d8e3562ced9777388ff1febd7945c7"
+checksum = "c2534bce0346a6dbd6f892066b941a48297687d8755de135cef5dc15bed83214"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5921,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.205.0"
+version = "0.203.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e5b49b3c13594f38a8b880bcaf8fbec2b6b05e5621931e71b701e6e6daeca2"
+checksum = "5edf75e70aeb4c6f14c606cfe2fc8b3bd43d4f79c781365c3f336f1fe4be508a"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7541,9 +7541,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.98.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03f42deef61349d31ae100e7bcdcc5d9293c1126cb8aff8fd56ba3cba18340b"
+checksum = "feb252d5be11c32cb4755d66d58db30ff30af5f1f17183e83ff54383a402c5f6"
 dependencies = [
  "bindgen",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
-deno_core = { version = "0.296.0" }
+deno_core = { version = "0.294.0" }
 
 deno_bench_util = { version = "0.155.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -55,6 +55,7 @@ use deno_core::ModuleType;
 use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 use deno_core::SourceCodeCacheInfo;
+use deno_core::SourceMapGetter;
 use deno_graph::source::ResolutionMode;
 use deno_graph::source::Resolver;
 use deno_graph::GraphKind;
@@ -292,7 +293,8 @@ impl CliModuleLoaderFactory {
       shared: self.shared.clone(),
     })));
     ModuleLoaderAndSourceMapGetter {
-      module_loader: loader,
+      module_loader: loader.clone(),
+      source_map_getter: Some(loader),
     }
   }
 }
@@ -826,7 +828,11 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     }
     std::future::ready(()).boxed_local()
   }
+}
 
+impl<TGraphContainer: ModuleGraphContainer> SourceMapGetter
+  for CliModuleLoader<TGraphContainer>
+{
   fn get_source_map(&self, file_name: &str) -> Option<Vec<u8>> {
     let specifier = resolve_url(file_name).ok()?;
     match specifier.scheme() {
@@ -839,7 +845,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     source_map_from_code(source.code.as_bytes())
   }
 
-  fn get_source_mapped_source_line(
+  fn get_source_line(
     &self,
     file_name: &str,
     line_number: usize,

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -385,6 +385,7 @@ impl ModuleLoaderFactory for StandaloneModuleLoaderFactory {
         root_permissions,
         dynamic_permissions,
       }),
+      source_map_getter: None,
     }
   }
 
@@ -399,6 +400,7 @@ impl ModuleLoaderFactory for StandaloneModuleLoaderFactory {
         root_permissions,
         dynamic_permissions,
       }),
+      source_map_getter: None,
     }
   }
 }

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -18,6 +18,7 @@ use deno_core::ModuleId;
 use deno_core::ModuleLoader;
 use deno_core::PollEventLoopOptions;
 use deno_core::SharedArrayBufferStore;
+use deno_core::SourceMapGetter;
 use deno_runtime::code_cache;
 use deno_runtime::deno_broadcast_channel::InMemoryBroadcastChannel;
 use deno_runtime::deno_fs;
@@ -54,6 +55,7 @@ use crate::version;
 
 pub struct ModuleLoaderAndSourceMapGetter {
   pub module_loader: Rc<dyn ModuleLoader>,
+  pub source_map_getter: Option<Rc<dyn SourceMapGetter>>,
 }
 
 pub trait ModuleLoaderFactory: Send + Sync {
@@ -514,7 +516,10 @@ impl CliMainWorkerFactory {
       (main_module, false)
     };
 
-    let ModuleLoaderAndSourceMapGetter { module_loader } = shared
+    let ModuleLoaderAndSourceMapGetter {
+      module_loader,
+      source_map_getter,
+    } = shared
       .module_loader_factory
       .create_for_main(PermissionsContainer::allow_all(), permissions.clone());
     let maybe_inspector_server = shared.maybe_inspector_server.clone();
@@ -591,6 +596,7 @@ impl CliMainWorkerFactory {
         .clone(),
       root_cert_store_provider: Some(shared.root_cert_store_provider.clone()),
       seed: shared.options.seed,
+      source_map_getter,
       format_js_error_fn: Some(Arc::new(format_js_error)),
       create_web_worker_cb,
       maybe_inspector_server,
@@ -724,11 +730,13 @@ fn create_web_worker_callback(
   Arc::new(move |args| {
     let maybe_inspector_server = shared.maybe_inspector_server.clone();
 
-    let ModuleLoaderAndSourceMapGetter { module_loader } =
-      shared.module_loader_factory.create_for_worker(
-        args.parent_permissions.clone(),
-        args.permissions.clone(),
-      );
+    let ModuleLoaderAndSourceMapGetter {
+      module_loader,
+      source_map_getter,
+    } = shared.module_loader_factory.create_for_worker(
+      args.parent_permissions.clone(),
+      args.permissions.clone(),
+    );
     let create_web_worker_cb =
       create_web_worker_callback(mode, shared.clone(), stdio.clone());
 
@@ -794,6 +802,7 @@ fn create_web_worker_callback(
       seed: shared.options.seed,
       create_web_worker_cb,
       format_js_error_fn: Some(Arc::new(format_js_error)),
+      source_map_getter,
       module_loader,
       fs: shared.fs.clone(),
       node_resolver: Some(shared.node_resolver.clone()),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -38,6 +38,7 @@ use deno_core::ModuleSpecifier;
 use deno_core::PollEventLoopOptions;
 use deno_core::RuntimeOptions;
 use deno_core::SharedArrayBufferStore;
+use deno_core::SourceMapGetter;
 use deno_cron::local::LocalCronHandler;
 use deno_fs::FileSystem;
 use deno_http::DefaultHttpPropertyExtractor;
@@ -368,6 +369,7 @@ pub struct WebWorkerOptions {
   pub npm_resolver: Option<Arc<dyn deno_node::NpmResolver>>,
   pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
   pub format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
+  pub source_map_getter: Option<Rc<dyn SourceMapGetter>>,
   pub worker_type: WebWorkerType,
   pub maybe_inspector_server: Option<Arc<InspectorServer>>,
   pub get_error_class_fn: Option<GetErrorClassFn>,
@@ -544,6 +546,7 @@ impl WebWorker {
     let mut js_runtime = JsRuntime::new(RuntimeOptions {
       module_loader: Some(options.module_loader.clone()),
       startup_snapshot: options.startup_snapshot,
+      source_map_getter: options.source_map_getter,
       get_error_class_fn: options.get_error_class_fn,
       shared_array_buffer_store: options.shared_array_buffer_store.clone(),
       compiled_wasm_module_store: options.compiled_wasm_module_store.clone(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -33,6 +33,7 @@ use deno_core::PollEventLoopOptions;
 use deno_core::RuntimeOptions;
 use deno_core::SharedArrayBufferStore;
 use deno_core::SourceCodeCacheInfo;
+use deno_core::SourceMapGetter;
 use deno_cron::local::LocalCronHandler;
 use deno_fs::FileSystem;
 use deno_http::DefaultHttpPropertyExtractor;
@@ -161,6 +162,8 @@ pub struct WorkerOptions {
   pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
   pub format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
 
+  /// Source map reference for errors.
+  pub source_map_getter: Option<Rc<dyn SourceMapGetter>>,
   pub maybe_inspector_server: Option<Arc<InspectorServer>>,
   // If true, the worker will wait for inspector session and break on first
   // statement of user code. Takes higher precedence than
@@ -223,6 +226,7 @@ impl Default for WorkerOptions {
       origin_storage_dir: Default::default(),
       cache_storage_dir: Default::default(),
       broadcast_channel: Default::default(),
+      source_map_getter: Default::default(),
       root_cert_store_provider: Default::default(),
       node_resolver: Default::default(),
       npm_resolver: Default::default(),
@@ -482,6 +486,7 @@ impl MainWorker {
       module_loader: Some(options.module_loader.clone()),
       startup_snapshot: options.startup_snapshot,
       create_params: options.create_params,
+      source_map_getter: options.source_map_getter,
       skip_op_registration: options.skip_op_registration,
       get_error_class_fn: options.get_error_class_fn,
       shared_array_buffer_store: options.shared_array_buffer_store.clone(),

--- a/tests/integration/compile_tests.rs
+++ b/tests/integration/compile_tests.rs
@@ -107,6 +107,7 @@ fn standalone_error() {
   // On Windows, we cannot assert the file path (because '\').
   // Instead we just check for relevant output.
   assert_contains!(stderr, "error: Uncaught (in promise) Error: boom!");
+  assert_contains!(stderr, "throw new Error(\"boom!\");");
   assert_contains!(stderr, "\n    at boom (file://");
   assert_contains!(stderr, "standalone_error.ts:2:9");
   assert_contains!(stderr, "at foo (file://");
@@ -146,6 +147,7 @@ fn standalone_error_module_with_imports() {
   // On Windows, we cannot assert the file path (because '\').
   // Instead we just check for relevant output.
   assert_contains!(stderr, "error: Uncaught (in promise) Error: boom!");
+  assert_contains!(stderr, "throw new Error(\"boom!\");");
   assert_contains!(stderr, "\n    at file://");
   assert_contains!(stderr, "standalone_error_module_with_imports_2.ts:2:7");
   output.assert_exit_code(1);


### PR DESCRIPTION
This reverts commit 6c5905dbc354ae701f06c734608af834a0ba844c.

Reverting because of errors like this in CI:
```
#
# Fatal error in , line 0
# Check failed: FastApiCallNode::ArityForArgc(c_arg_count, slow_arg_count) == value_input_count.
#
#
#
#FailureMessage Object: 0x7fd5b3ffd9d0
==== C stack trace ===============================

    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1111883) [0x55b8d2107883]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1110b6b) [0x55b8d2106b6b]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x110c6f9) [0x55b8d21026f9]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x20413cd) [0x55b8d30373cd]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x2034222) [0x55b8d302a222]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x202ff44) [0x55b8d3025f44]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1e0b253) [0x55b8d2e01253]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1dfcd96) [0x55b8d2df2d96]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1df92aa) [0x55b8d2def2aa]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1df8b71) [0x55b8d2deeb71]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x11ce49b) [0x55b8d21c449b]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x121fb23) [0x55b8d2215b23]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1221359) [0x55b8d2217359]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x1112f3b) [0x55b8d2108f3b]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x111792b) [0x55b8d210d92b]
    /home/runner/work/deno/deno/target/release/deps/url_ops-e4068c650cedb9fa(+0x110df0f) [0x55b8d2103f0f]
    /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7fd5cb294ac3]
    /lib/x86_64-linux-gnu/libc.so.6(+0x126850) [0x7fd5cb326850]
```