### PR TITLE
feat: upgrade V8 to 12.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,8 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.299.0"
-source = "git+https://github.com/denoland/deno_core.git?rev=4fe63c9#4fe63c9dd2b4a3ed8e232fb3044eef4e65e9a59e"
+version = "0.300.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb79d0494b8c15f97761645f4afca5d52a414d4dc8f8aef8ca3b3ca82240ab55"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1827,8 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.175.0"
-source = "git+https://github.com/denoland/deno_core.git?rev=4fe63c9#4fe63c9dd2b4a3ed8e232fb3044eef4e65e9a59e"
+version = "0.176.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb75c43c9441f413f0595f694746f90d8ffd292337287da309dbd93773928c"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5985,8 +5987,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.208.0"
-source = "git+https://github.com/denoland/deno_core.git?rev=4fe63c9#4fe63c9dd2b4a3ed8e232fb3044eef4e65e9a59e"
+version = "0.209.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d9095a8a725125fff1706f940af182e2a8ca01da8b0cd019aa47da93b28b94"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,8 +1344,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.299.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428488cc6b392a199a159054da754f56a1fdc63ee03f16be2c21cbd22e936e7b"
+source = "git+https://github.com/denoland/deno_core.git?rev=4fe63c9#4fe63c9dd2b4a3ed8e232fb3044eef4e65e9a59e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1829,8 +1828,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.175.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2b71759647722be6ae051919b75cb66b3dccafe61b53c75ad5a6fad9d0ee4a"
+source = "git+https://github.com/denoland/deno_core.git?rev=4fe63c9#4fe63c9dd2b4a3ed8e232fb3044eef4e65e9a59e"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5988,8 +5986,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.208.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583f3c71a6f7acc1711ad718a33f6e799bacdc711d297b15bb28533f32264c58"
+source = "git+https://github.com/denoland/deno_core.git?rev=4fe63c9#4fe63c9dd2b4a3ed8e232fb3044eef4e65e9a59e"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7622,9 +7619,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.99.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3fc0608a78f0c7d4ec88025759cb78c90a29984b48540060355a626ae329c1"
+checksum = "06bc034c7b5e85fac85d2c6f181878266dd344790702d03e946c25cba78646a9"
 dependencies = [
  "bindgen",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.41.2", features = ["transpiling"] }
-deno_core = { version = "0.299.0" }
+deno_core = { version = "0.300.0" }
 
 deno_bench_util = { version = "0.158.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -63,7 +63,7 @@ use deno_graph::Module;
 use deno_graph::ModuleGraph;
 use deno_graph::Resolution;
 use deno_runtime::code_cache;
-use deno_runtime::deno_node::get_host_defined_options;
+use deno_runtime::deno_node::create_host_defined_options;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_semver::npm::NpmPackageReqReference;
 use node_resolver::NodeResolutionMode;
@@ -732,7 +732,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
   ) -> Option<deno_core::v8::Local<'s, deno_core::v8::Data>> {
     let name = deno_core::ModuleSpecifier::parse(name).ok()?;
     if self.0.shared.node_resolver.in_npm_package(&name) {
-      Some(get_host_defined_options(scope))
+      Some(create_host_defined_options(scope))
     } else {
       None
     }

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -25,7 +25,7 @@ use deno_core::ResolutionKind;
 use deno_npm::npm_rc::ResolvedNpmRc;
 use deno_package_json::PackageJsonDepValue;
 use deno_runtime::deno_fs;
-use deno_runtime::deno_node::get_host_defined_options;
+use deno_runtime::deno_node::create_host_defined_options;
 use deno_runtime::deno_node::NodeResolver;
 use deno_runtime::deno_permissions::Permissions;
 use deno_runtime::deno_permissions::PermissionsContainer;
@@ -275,7 +275,7 @@ impl ModuleLoader for EmbeddedModuleLoader {
   ) -> Option<deno_core::v8::Local<'s, deno_core::v8::Data>> {
     let name = deno_core::ModuleSpecifier::parse(name).ok()?;
     if self.shared.node_resolver.in_npm_package(&name) {
-      Some(get_host_defined_options(scope))
+      Some(create_host_defined_options(scope))
     } else {
       None
     }

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -25,6 +25,7 @@ use deno_core::ResolutionKind;
 use deno_npm::npm_rc::ResolvedNpmRc;
 use deno_package_json::PackageJsonDepValue;
 use deno_runtime::deno_fs;
+use deno_runtime::deno_node::get_host_defined_options;
 use deno_runtime::deno_node::NodeResolver;
 use deno_runtime::deno_permissions::Permissions;
 use deno_runtime::deno_permissions::PermissionsContainer;
@@ -264,6 +265,19 @@ impl ModuleLoader for EmbeddedModuleLoader {
         Err(err.into())
       }
       Err(err) => Err(err.into()),
+    }
+  }
+
+  fn get_host_defined_options<'s>(
+    &self,
+    scope: &mut deno_core::v8::HandleScope<'s>,
+    name: &str,
+  ) -> Option<deno_core::v8::Local<'s, deno_core::v8::Data>> {
+    let name = deno_core::ModuleSpecifier::parse(name).ok()?;
+    if self.shared.node_resolver.in_npm_package(&name) {
+      Some(get_host_defined_options(scope))
+    } else {
+      None
     }
   }
 

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -1,12 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use std::mem::MaybeUninit;
-
 use deno_core::v8;
 use deno_core::v8::GetPropertyNamesArgs;
 use deno_core::v8::MapFnTo;
-
-use crate::NodeResolverRc;
 
 // NOTE(bartlomieju): somehow calling `.map_fn_to()` multiple times on a function
 // returns two different pointers. That shouldn't be the case as `.map_fn_to()`
@@ -239,19 +235,19 @@ fn is_managed_key(
 }
 
 fn current_mode(scope: &mut v8::HandleScope) -> Mode {
-  let Some(v8_string) =
-    v8::StackTrace::current_script_name_or_source_url(scope)
+  let Some(host_defined_options) = scope.get_current_host_defined_options()
   else {
     return Mode::Deno;
   };
-  let op_state = deno_core::JsRuntime::op_state_from(scope);
-  let op_state = op_state.borrow();
-  let Some(node_resolver) = op_state.try_borrow::<NodeResolverRc>() else {
-    return Mode::Deno;
+  // SAFETY: host defined options must always be a PrimitiveArray in current V8.
+  let host_defined_options = unsafe {
+    v8::Local::<v8::PrimitiveArray>::cast_unchecked(host_defined_options)
   };
-  let mut buffer = [MaybeUninit::uninit(); 2048];
-  let str = v8_string.to_rust_cow_lossy(scope, &mut buffer);
-  if str.starts_with("node:") || node_resolver.in_npm_package_with_cache(str) {
+  if host_defined_options.length() < 1 {
+    return Mode::Deno;
+  }
+  let is_node = host_defined_options.get(scope, 0).is_true();
+  if is_node {
     Mode::Node
   } else {
     Mode::Deno

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -842,3 +842,12 @@ impl<'a> deno_package_json::fs::DenoPkgJsonFs for DenoPkgJsonFsAdapter<'a> {
       .map_err(|err| err.into_io_error())
   }
 }
+
+pub fn get_host_defined_options<'s>(
+  scope: &mut v8::HandleScope<'s>,
+) -> v8::Local<'s, v8::Data> {
+  let host_defined_options = v8::PrimitiveArray::new(scope, 1);
+  let value = v8::Boolean::new(scope, true);
+  host_defined_options.set(scope, 0, value.into());
+  host_defined_options.into()
+}

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -655,8 +655,8 @@ deno_core::extension!(deno_node,
     });
     vm::DELETER_MAP_FN.with(|deleter| {
       external_references.push(ExternalReference {
-        named_getter: *deleter,
-      },);
+        named_deleter: *deleter,
+      });
     });
     vm::ENUMERATOR_MAP_FN.with(|enumerator| {
       external_references.push(ExternalReference {
@@ -686,7 +686,7 @@ deno_core::extension!(deno_node,
     });
     vm::INDEXED_DELETER_MAP_FN.with(|deleter| {
       external_references.push(ExternalReference {
-        indexed_getter: *deleter,
+        indexed_deleter: *deleter,
       });
     });
     vm::INDEXED_DEFINER_MAP_FN.with(|definer| {
@@ -712,13 +712,13 @@ deno_core::extension!(deno_node,
     });
     global::QUERY_MAP_FN.with(|query| {
       external_references.push(ExternalReference {
-        named_getter: *query,
+        named_query: *query,
       });
     });
     global::DELETER_MAP_FN.with(|deleter| {
       external_references.push(ExternalReference {
-        named_getter: *deleter,
-      },);
+        named_deleter: *deleter,
+      });
     });
     global::ENUMERATOR_MAP_FN.with(|enumerator| {
       external_references.push(ExternalReference {

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -843,7 +843,7 @@ impl<'a> deno_package_json::fs::DenoPkgJsonFs for DenoPkgJsonFsAdapter<'a> {
   }
 }
 
-pub fn get_host_defined_options<'s>(
+pub fn create_host_defined_options<'s>(
   scope: &mut v8::HandleScope<'s>,
 ) -> v8::Local<'s, v8::Data> {
   let host_defined_options = v8::PrimitiveArray::new(scope, 1);

--- a/ext/node/ops/vm_internal.rs
+++ b/ext/node/ops/vm_internal.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use crate::get_host_defined_options;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::v8;
@@ -19,7 +20,22 @@ impl ContextifyScript {
     scope: &mut v8::HandleScope,
     source_str: v8::Local<v8::String>,
   ) -> Result<Self, AnyError> {
-    let source = v8::script_compiler::Source::new(source_str, None);
+    let resource_name = v8::undefined(scope);
+    let host_defined_options = get_host_defined_options(scope);
+    let origin = v8::ScriptOrigin::new(
+      scope,
+      resource_name.into(),
+      0,
+      0,
+      false,
+      0,
+      None,
+      false,
+      false,
+      false,
+      Some(host_defined_options),
+    );
+    let source = v8::script_compiler::Source::new(source_str, Some(&origin));
 
     let unbound_script = v8::script_compiler::compile_unbound_script(
       scope,

--- a/ext/node/ops/vm_internal.rs
+++ b/ext/node/ops/vm_internal.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use crate::get_host_defined_options;
+use crate::create_host_defined_options;
 use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::v8;
@@ -21,7 +21,7 @@ impl ContextifyScript {
     source_str: v8::Local<v8::String>,
   ) -> Result<Self, AnyError> {
     let resource_name = v8::undefined(scope);
-    let host_defined_options = get_host_defined_options(scope);
+    let host_defined_options = create_host_defined_options(scope);
     let origin = v8::ScriptOrigin::new(
       scope,
       resource_name.into(),

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -976,9 +976,14 @@ function wrapSafe(
   filename,
   content,
   cjsModuleInstance,
+  format,
 ) {
   const wrapper = Module.wrap(content);
-  const [f, err] = core.evalContext(wrapper, `file://${filename}`);
+  const [f, err] = core.evalContext(
+    wrapper,
+    url.pathToFileURL(filename).toString(),
+    [format !== "module"],
+  );
   if (err) {
     if (process.mainModule === cjsModuleInstance) {
       enrichCJSError(err.thrown);
@@ -995,8 +1000,16 @@ function wrapSafe(
   return f;
 }
 
-Module.prototype._compile = function (content, filename) {
-  const compiledWrapper = wrapSafe(filename, content, this);
+Module.prototype._compile = function (content, filename, format) {
+  const compiledWrapper = wrapSafe(filename, content, this, format);
+
+  if (format === "module") {
+    // TODO: implement require esm
+    throw createRequireEsmError(
+      filename,
+      moduleParentCache.get(module)?.filename,
+    );
+  }
 
   const dirname = pathDirname(filename);
   const require = makeRequireFunction(this);
@@ -1053,17 +1066,24 @@ Module.prototype._compile = function (content, filename) {
 Module._extensions[".js"] = function (module, filename) {
   const content = op_require_read_file(filename);
 
+  let format;
   if (StringPrototypeEndsWith(filename, ".js")) {
     const pkg = op_require_read_closest_package_json(filename);
-    if (pkg && pkg.typ === "module") {
+    if (pkg?.typ === "module") {
+      // TODO: implement require esm
+      format = "module";
       throw createRequireEsmError(
         filename,
         moduleParentCache.get(module)?.filename,
       );
+    } else if (pkg?.type === "commonjs") {
+      format = "commonjs";
     }
+  } else if (StringPrototypeEndsWith(filename, ".cjs")) {
+    format = "commonjs";
   }
 
-  module._compile(content, filename);
+  module._compile(content, filename, format);
 };
 
 function createRequireEsmError(filename, parent) {

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1004,7 +1004,7 @@ Module.prototype._compile = function (content, filename, format) {
   const compiledWrapper = wrapSafe(filename, content, this, format);
 
   if (format === "module") {
-    // TODO: implement require esm
+    // TODO(https://github.com/denoland/deno/issues/24822): implement require esm
     throw createRequireEsmError(
       filename,
       moduleParentCache.get(module)?.filename,
@@ -1070,7 +1070,7 @@ Module._extensions[".js"] = function (module, filename) {
   if (StringPrototypeEndsWith(filename, ".js")) {
     const pkg = op_require_read_closest_package_json(filename);
     if (pkg?.typ === "module") {
-      // TODO: implement require esm
+      // TODO(https://github.com/denoland/deno/issues/24822): implement require esm
       format = "module";
       throw createRequireEsmError(
         filename,

--- a/ext/node_resolver/resolution.rs
+++ b/ext/node_resolver/resolution.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -138,36 +137,15 @@ pub type NodeResolverRc<TEnv> = crate::sync::MaybeArc<NodeResolver<TEnv>>;
 pub struct NodeResolver<TEnv: NodeResolverEnv> {
   env: TEnv,
   npm_resolver: NpmResolverRc,
-  in_npm_package_cache: crate::sync::MaybeArcMutex<HashMap<String, bool>>,
 }
 
 impl<TEnv: NodeResolverEnv> NodeResolver<TEnv> {
   pub fn new(env: TEnv, npm_resolver: NpmResolverRc) -> Self {
-    Self {
-      env,
-      npm_resolver,
-      in_npm_package_cache: crate::sync::MaybeArcMutex::new(HashMap::new()),
-    }
+    Self { env, npm_resolver }
   }
 
   pub fn in_npm_package(&self, specifier: &Url) -> bool {
     self.npm_resolver.in_npm_package(specifier)
-  }
-
-  pub fn in_npm_package_with_cache(&self, specifier: Cow<str>) -> bool {
-    let mut cache = self.in_npm_package_cache.lock();
-
-    if let Some(result) = cache.get(specifier.as_ref()) {
-      return *result;
-    }
-
-    let result = if let Ok(specifier) = Url::parse(&specifier) {
-      self.npm_resolver.in_npm_package(&specifier)
-    } else {
-      false
-    };
-    cache.insert(specifier.into_owned(), result);
-    result
   }
 
   /// This function is an implementation of `defaultResolve` in

--- a/ext/node_resolver/sync.rs
+++ b/ext/node_resolver/sync.rs
@@ -6,38 +6,7 @@ pub use inner::*;
 mod inner {
   #![allow(clippy::disallowed_types)]
 
-  use std::ops::Deref;
-  use std::ops::DerefMut;
   pub use std::sync::Arc as MaybeArc;
-
-  pub struct MaybeArcMutexGuard<'lock, T>(std::sync::MutexGuard<'lock, T>);
-
-  impl<'lock, T> Deref for MaybeArcMutexGuard<'lock, T> {
-    type Target = std::sync::MutexGuard<'lock, T>;
-    fn deref(&self) -> &std::sync::MutexGuard<'lock, T> {
-      &self.0
-    }
-  }
-
-  impl<'lock, T> DerefMut for MaybeArcMutexGuard<'lock, T> {
-    fn deref_mut(&mut self) -> &mut std::sync::MutexGuard<'lock, T> {
-      &mut self.0
-    }
-  }
-
-  #[derive(Debug)]
-  pub struct MaybeArcMutex<T>(std::sync::Arc<std::sync::Mutex<T>>);
-  impl<T> MaybeArcMutex<T> {
-    pub fn new(val: T) -> Self {
-      Self(std::sync::Arc::new(std::sync::Mutex::new(val)))
-    }
-  }
-
-  impl<'lock, T> MaybeArcMutex<T> {
-    pub fn lock(&'lock self) -> MaybeArcMutexGuard<'lock, T> {
-      MaybeArcMutexGuard(self.0.lock().unwrap())
-    }
-  }
 
   pub use core::marker::Send as MaybeSend;
   pub use core::marker::Sync as MaybeSync;
@@ -45,42 +14,5 @@ mod inner {
 
 #[cfg(not(feature = "sync"))]
 mod inner {
-  use std::ops::Deref;
-  use std::ops::DerefMut;
-
   pub use std::rc::Rc as MaybeArc;
-
-  pub struct MaybeArcMutexGuard<'lock, T>(std::cell::RefMut<'lock, T>);
-
-  impl<'lock, T> Deref for MaybeArcMutexGuard<'lock, T> {
-    type Target = std::cell::RefMut<'lock, T>;
-    fn deref(&self) -> &std::cell::RefMut<'lock, T> {
-      &self.0
-    }
-  }
-
-  impl<'lock, T> DerefMut for MaybeArcMutexGuard<'lock, T> {
-    fn deref_mut(&mut self) -> &mut std::cell::RefMut<'lock, T> {
-      &mut self.0
-    }
-  }
-
-  #[derive(Debug)]
-  pub struct MaybeArcMutex<T>(std::rc::Rc<std::cell::RefCell<T>>);
-  impl<T> MaybeArcMutex<T> {
-    pub fn new(val: T) -> Self {
-      Self(std::rc::Rc::new(std::cell::RefCell::new(val)))
-    }
-  }
-
-  impl<'lock, T> MaybeArcMutex<T> {
-    pub fn lock(&'lock self) -> MaybeArcMutexGuard<'lock, T> {
-      MaybeArcMutexGuard(self.0.borrow_mut())
-    }
-  }
-
-  pub trait MaybeSync {}
-  impl<T> MaybeSync for T where T: ?Sized {}
-  pub trait MaybeSend {}
-  impl<T> MaybeSend for T where T: ?Sized {}
 }

--- a/ext/node_resolver/sync.rs
+++ b/ext/node_resolver/sync.rs
@@ -15,4 +15,9 @@ mod inner {
 #[cfg(not(feature = "sync"))]
 mod inner {
   pub use std::rc::Rc as MaybeArc;
+
+  pub trait MaybeSync {}
+  impl<T> MaybeSync for T where T: ?Sized {}
+  pub trait MaybeSend {}
+  impl<T> MaybeSend for T where T: ?Sized {}
 }

--- a/tests/node_compat/test/common/index.js
+++ b/tests/node_compat/test/common/index.js
@@ -59,7 +59,6 @@ let knownGlobals = [
   queueMicrotask,
   removeEventListener,
   reportError,
-  self,
   sessionStorage,
   setImmediate,
 ];

--- a/tests/testdata/run/worker_close_in_wasm_reactions.js.out
+++ b/tests/testdata/run/worker_close_in_wasm_reactions.js.out
@@ -1,2 +1,2 @@
-Error: CompileError: WebAssembly.compile(): reached end while decoding  length: @+10
+Error: CompileError: WebAssembly.compile(): reached end while decoding length @+10
     at file:///[WILDCARD]/close_in_wasm_reactions.js:18:13

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -518,8 +518,8 @@ Deno.test(function consoleTestStringifyFunctionWithProperties() {
   ],
   [isArray]: [Function: isArray] { [length]: 1, [name]: "isArray" },
   [from]: [Function: from] { [length]: 1, [name]: "from" },
-  [of]: [Function: of] { [length]: 0, [name]: "of" },
   [fromAsync]: [Function: fromAsync] { [length]: 1, [name]: "fromAsync" },
+  [of]: [Function: of] { [length]: 0, [name]: "of" },
   [Symbol(Symbol.species)]: [Getter]
 }`,
   );


### PR DESCRIPTION
- upgrade to v8 12.8
  - optimizes DataView bigint methods
  - fixes global interceptors
  - includes CPED methods for ALS
- fix global resolution
  - makes global resolution consistent using host_defined_options. originally a separate patch but due to the global interceptor bug it needs to be included in this pr for all tests to pass.