### PR TITLE
fix(ext/fetch): respect authority from URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "ipnet",
+ "percent-encoding",
  "rustls-webpki",
  "serde",
  "serde_json",

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -27,6 +27,7 @@ hyper.workspace = true
 hyper-rustls.workspace = true
 hyper-util.workspace = true
 ipnet.workspace = true
+percent-encoding.workspace = true
 rustls-webpki.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -78,6 +78,7 @@ use tower_http::decompression::Decompression;
 
 // Re-export data_url
 pub use data_url;
+pub use proxy::basic_auth;
 
 pub use fs_fetch_handler::FsFetchHandler;
 
@@ -391,8 +392,7 @@ where
         .as_str()
         .parse::<Uri>()
         .map_err(|_| type_error("Invalid URL"))?;
-      eprintln!("url {}", url.as_str());
-      eprintln!("uri {}", uri.to_string());
+
       let mut con_len = None;
       let body = if has_body {
         match (data, resource) {

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -432,11 +432,10 @@ where
       *request.uri_mut() = uri;
 
       if let Some((username, password)) = maybe_authority {
-        let value =
-          proxy::basic_auth(&username, password.as_ref().map(|x| x.as_str()));
-        let mut header_value = HeaderValue::try_from(value)?;
-        header_value.set_sensitive(true);
-        request.headers_mut().insert(AUTHORIZATION, header_value);
+        request.headers_mut().insert(
+          AUTHORIZATION,
+          proxy::basic_auth(&username, password.as_deref()),
+        );
       }
       if let Some(len) = con_len {
         request.headers_mut().insert(CONTENT_LENGTH, len.into());

--- a/ext/fetch/proxy.rs
+++ b/ext/fetch/proxy.rs
@@ -106,7 +106,7 @@ pub(crate) fn from_env() -> Proxies {
   Proxies { intercepts, no }
 }
 
-pub(crate) fn basic_auth(user: &str, pass: Option<&str>) -> HeaderValue {
+pub fn basic_auth(user: &str, pass: Option<&str>) -> HeaderValue {
   use base64::prelude::BASE64_STANDARD;
   use base64::write::EncoderWriter;
   use std::io::Write;

--- a/ext/fetch/proxy.rs
+++ b/ext/fetch/proxy.rs
@@ -106,7 +106,7 @@ pub(crate) fn from_env() -> Proxies {
   Proxies { intercepts, no }
 }
 
-pub(crate) fn basic_auth(user: &str, pass: &str) -> HeaderValue {
+pub(crate) fn basic_auth(user: &str, pass: Option<&str>) -> HeaderValue {
   use base64::prelude::BASE64_STANDARD;
   use base64::write::EncoderWriter;
   use std::io::Write;
@@ -114,7 +114,10 @@ pub(crate) fn basic_auth(user: &str, pass: &str) -> HeaderValue {
   let mut buf = b"Basic ".to_vec();
   {
     let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
-    let _ = write!(encoder, "{user}:{pass}");
+    let _ = write!(encoder, "{user}:");
+    if let Some(password) = pass {
+      let _ = write!(encoder, "{password}");
+    }
   }
   let mut header =
     HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
@@ -140,10 +143,10 @@ impl Intercept {
   pub(crate) fn set_auth(&mut self, user: &str, pass: &str) {
     match self.target {
       Target::Http { ref mut auth, .. } => {
-        *auth = Some(basic_auth(user, pass));
+        *auth = Some(basic_auth(user, Some(pass)));
       }
       Target::Https { ref mut auth, .. } => {
-        *auth = Some(basic_auth(user, pass));
+        *auth = Some(basic_auth(user, Some(pass)));
       }
       Target::Socks { ref mut auth, .. } => {
         *auth = Some((user.into(), pass.into()));
@@ -192,7 +195,7 @@ impl Target {
       if is_socks {
         socks_auth = Some((user.into(), pass.into()));
       } else {
-        http_auth = Some(basic_auth(user, pass));
+        http_auth = Some(basic_auth(user, Some(pass)));
       }
       builder = builder.authority(host_port);
     } else {

--- a/ext/node/ops/http.rs
+++ b/ext/node/ops/http.rs
@@ -92,11 +92,10 @@ where
   *request.headers_mut() = header_map;
 
   if let Some((username, password)) = maybe_authority {
-    let value =
-      deno_fetch::basic_auth(&username, password.as_ref().map(|x| x.as_str()));
-    let mut header_value = HeaderValue::try_from(value)?;
-    header_value.set_sensitive(true);
-    request.headers_mut().insert(AUTHORIZATION, header_value);
+    request.headers_mut().insert(
+      AUTHORIZATION,
+      deno_fetch::basic_auth(&username, password.as_deref()),
+    );
   }
   if let Some(len) = con_len {
     request.headers_mut().insert(CONTENT_LENGTH, len.into());

--- a/ext/node/ops/http.rs
+++ b/ext/node/ops/http.rs
@@ -18,6 +18,7 @@ use deno_fetch::ResourceToBodyAdapter;
 use http::header::HeaderMap;
 use http::header::HeaderName;
 use http::header::HeaderValue;
+use http::header::AUTHORIZATION;
 use http::header::CONTENT_LENGTH;
 use http::Method;
 use http_body_util::BodyExt;
@@ -43,7 +44,8 @@ where
   };
 
   let method = Method::from_bytes(&method)?;
-  let url = Url::parse(&url)?;
+  let mut url = Url::parse(&url)?;
+  let maybe_authority = deno_fetch::extract_authority(&mut url);
 
   {
     let permissions = state.borrow_mut::<P>();
@@ -89,6 +91,13 @@ where
     .map_err(|_| type_error("Invalid URL"))?;
   *request.headers_mut() = header_map;
 
+  if let Some((username, password)) = maybe_authority {
+    let value =
+      deno_fetch::basic_auth(&username, password.as_ref().map(|x| x.as_str()));
+    let mut header_value = HeaderValue::try_from(value)?;
+    header_value.set_sensitive(true);
+    request.headers_mut().insert(AUTHORIZATION, header_value);
+  }
   if let Some(len) = con_len {
     request.headers_mut().insert(CONTENT_LENGTH, len.into());
   }


### PR DESCRIPTION
This commit fixes handling of "authority" in the URL by properly
sending "Authorization Basic..." header in `fetch` API.

This is a regression from https://github.com/denoland/deno/pull/24593
Fixes https://github.com/denoland/deno/issues/24697

CC @seanmonstar 