### PR TITLE
fix: upgrade deno_core to 0.298.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.297.0"
+version = "0.298.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f288b405f91af8ea45dc74ce4391fc5f390531947e9fc8630fb0206d3f2c93"
+checksum = "54fb4db0174c7130b3a8a90ed6aefb3b42a8acd6b75ea9a5a0c7c4d02993cd61"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1359,6 +1359,7 @@ dependencies = [
  "libc",
  "memoffset 0.9.1",
  "parking_lot 0.12.3",
+ "percent-encoding",
  "pin-project",
  "serde",
  "serde_json",
@@ -1822,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.173.0"
+version = "0.174.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c1e18b32543405cde22a2b04b4d108c2f129cc2d34db0872d4a5bb378b43af"
+checksum = "cdacbea7e6c459f0bcb48cdb0c7ce8ca6ece53645385fe98cf38e7242b2c5809"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -5939,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.206.0"
+version = "0.207.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517f37bd74d2287bd9b5197f7dff77d1f1f960a7a1f6557b55dc39423e0372a8"
+checksum = "a442f2e04f8367eb99982beb6733fb88df666da9379f937552d67ca060de6e80"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7559,9 +7560,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.98.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b8009c63eec162cbcc41aa4db66b81974f641d32a35b1a3198ec2ce4712d6b"
+checksum = "fa3fc0608a78f0c7d4ec88025759cb78c90a29984b48540060355a626ae329c1"
 dependencies = [
  "bindgen",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
-deno_core = { version = "0.297.0" }
+deno_core = { version = "0.298.0" }
 
 deno_bench_util = { version = "0.156.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -93,7 +93,7 @@ test 0 => ./fail_with_contain_unicode_filename🦕.ts:[WILDCARD]
 error: Error
   throw new Error();
         ^
-    at [WILDCARD]/fail_with_contain_unicode_filename%F0%9F%A6%95.ts:[WILDCARD]
+    at [WILDCARD]/fail_with_contain_unicode_filename🦕.ts:[WILDCARD]
 
  FAILURES 
 


### PR DESCRIPTION
Fixes percent-encoded filenames in stack traces:
- https://github.com/denoland/deno_core/pull/759

Closes #18983