### PR TITLE
fix(workspaces/publish): include the license file from the workspace root if not in pkg

### DIFF
--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -1215,9 +1215,9 @@ static SUPPORTED_LICENSE_FILE_NAMES: [&str; 6] = [
   "LICENSE",
   "LICENSE.md",
   "LICENSE.txt",
-  "LICENSE",
-  "LICENSE.md",
-  "LICENSE.txt",
+  "LICENCE",
+  "LICENCE.md",
+  "LICENCE.txt",
 ];
 
 fn resolve_license_file(

--- a/cli/tools/registry/paths.rs
+++ b/cli/tools/registry/paths.rs
@@ -214,7 +214,10 @@ pub enum PackagePathValidationError {
 pub struct CollectedPublishPath {
   pub specifier: ModuleSpecifier,
   pub path: PathBuf,
+  /// Relative path to use in the tarball.
   pub relative_path: String,
+  /// Specify the contents for any injected paths.
+  pub maybe_content: Option<Vec<u8>>,
 }
 
 pub struct CollectPublishPathsOptions<'a> {
@@ -307,6 +310,7 @@ pub fn collect_publish_paths(
       specifier,
       path,
       relative_path,
+      maybe_content: None,
     });
   }
 

--- a/cli/tools/registry/tar.rs
+++ b/cli/tools/registry/tar.rs
@@ -34,7 +34,7 @@ pub struct PublishableTarball {
 }
 
 pub fn create_gzipped_tarball(
-  publish_paths: &[CollectedPublishPath],
+  publish_paths: Vec<CollectedPublishPath>,
   source_parser: LazyGraphSourceParser,
   diagnostics_collector: &PublishDiagnosticsCollector,
   unfurler: &SpecifierUnfurler,
@@ -45,15 +45,17 @@ pub fn create_gzipped_tarball(
   for path in publish_paths {
     let path_str = &path.relative_path;
     let specifier = &path.specifier;
-    let path = &path.path;
 
-    let content = resolve_content_maybe_unfurling(
-      path,
-      specifier,
-      unfurler,
-      source_parser,
-      diagnostics_collector,
-    )?;
+    let content = match path.maybe_content {
+      Some(content) => content.clone(),
+      None => resolve_content_maybe_unfurling(
+        &path.path,
+        specifier,
+        unfurler,
+        source_parser,
+        diagnostics_collector,
+      )?,
+    };
 
     files.push(PublishableTarballFile {
       path_str: path_str.clone(),
@@ -65,7 +67,7 @@ pub fn create_gzipped_tarball(
     tar
       .add_file(format!(".{}", path_str), &content)
       .with_context(|| {
-        format!("Unable to add file to tarball '{}'", path.display())
+        format!("Unable to add file to tarball '{}'", path.path.display())
       })?;
   }
 

--- a/tests/specs/publish/workspace/__test__.jsonc
+++ b/tests/specs/publish/workspace/__test__.jsonc
@@ -4,6 +4,10 @@
       "args": "publish --token 'sadfasdf'",
       "output": "workspace.out"
     },
+    "workspace_dry_run": {
+      "args": "publish --token 'sadfasdf' --dry-run",
+      "output": "workspace_dry_run.out"
+    },
     "individual": {
       "cwd": "./bar",
       "args": "publish --token 'sadfasdf'",

--- a/tests/specs/publish/workspace/__test__.jsonc
+++ b/tests/specs/publish/workspace/__test__.jsonc
@@ -8,6 +8,11 @@
       "args": "publish --token 'sadfasdf' --dry-run",
       "output": "workspace_dry_run.out"
     },
+    "individual_dry_run": {
+      "cwd": "./foo",
+      "args": "publish --token 'sadfasdf' --dry-run",
+      "output": "foo_dry_run.out"
+    },
     "individual": {
       "cwd": "./bar",
       "args": "publish --token 'sadfasdf'",

--- a/tests/specs/publish/workspace/foo_dry_run.out
+++ b/tests/specs/publish/workspace/foo_dry_run.out
@@ -1,0 +1,9 @@
+Check file:///[WILDLINE]/foo/mod.ts
+Checking for slow types in the public API...
+Check file:///[WILDLINE]/foo/mod.ts
+Simulating publish of @foo/foo@1.0.0 with files:
+[# notice how this line is including the LICENSE from the root directory]
+   file:///[WILDLINE]/workspace/LICENSE (0B)
+   file:///[WILDLINE]/workspace/foo/deno.json (135B)
+   file:///[WILDLINE]/workspace/foo/mod.ts (118B)
+Warning Aborting due to --dry-run

--- a/tests/specs/publish/workspace/workspace_dry_run.out
+++ b/tests/specs/publish/workspace/workspace_dry_run.out
@@ -4,8 +4,8 @@ Check file:///[WILDLINE]/workspace/foo/mod.ts
 Checking for slow types in the public API...
 Check file:///[WILDLINE]/workspace/bar/mod.ts
 Check file:///[WILDLINE]/workspace/foo/mod.ts
+[UNORDERED_START]
 Simulating publish of @foo/foo@1.0.0 with files:
-[# notice how this line is including the LICENSE from the root directory]
    file:///[WILDLINE]/workspace/LICENSE (0B)
    file:///[WILDLINE]/workspace/foo/deno.json (135B)
    file:///[WILDLINE]/workspace/foo/mod.ts (118B)
@@ -13,4 +13,5 @@ Simulating publish of @foo/bar@1.0.0 with files:
    file:///[WILDLINE]/workspace/bar/LICENSE (0B)
    file:///[WILDLINE]/workspace/bar/deno.json (87B)
    file:///[WILDLINE]/workspace/bar/mod.ts (70B)
+[UNORDERED_END]
 Warning Aborting due to --dry-run

--- a/tests/specs/publish/workspace/workspace_dry_run.out
+++ b/tests/specs/publish/workspace/workspace_dry_run.out
@@ -1,0 +1,16 @@
+Publishing a workspace...
+Check file:///[WILDLINE]/workspace/bar/mod.ts
+Check file:///[WILDLINE]/workspace/foo/mod.ts
+Checking for slow types in the public API...
+Check file:///[WILDLINE]/workspace/bar/mod.ts
+Check file:///[WILDLINE]/workspace/foo/mod.ts
+Simulating publish of @foo/foo@1.0.0 with files:
+[# notice how this line is including the LICENSE from the root directory]
+   file:///[WILDLINE]/workspace/LICENSE (0B)
+   file:///[WILDLINE]/workspace/foo/deno.json (135B)
+   file:///[WILDLINE]/workspace/foo/mod.ts (118B)
+Simulating publish of @foo/bar@1.0.0 with files:
+   file:///[WILDLINE]/workspace/bar/LICENSE (0B)
+   file:///[WILDLINE]/workspace/bar/deno.json (87B)
+   file:///[WILDLINE]/workspace/bar/mod.ts (70B)
+Warning Aborting due to --dry-run


### PR DESCRIPTION
This includes the license file from the workspace root in the package if the package doesn't have a license file.

This is to support scenarios like deno_std.