### PR TITLE
chore: fix WPT epoch

### DIFF
--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Run web platform tests
         shell: bash
         run: |
-          deno run --unstable -A --lock=tools/deno.lock.json                   \
+          deno run --unstable -A --lock=tools/deno.lock.json --config=tests/config/deno.json \
             ./tests/wpt/wpt.ts setup
-          deno run --unstable -A --lock=tools/deno.lock.json                   \
+          deno run --unstable -A --lock=tools/deno.lock.json --config=tests/config/deno.json \
             ./tests/wpt/wpt.ts run                                             \                                                \
             --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json --exit-zero
 


### PR DESCRIPTION
This was missed in the previous `std` updates.