### PR TITLE
fix(cli): use correct cfg name for debug builds

### DIFF
--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -113,7 +113,7 @@ pub fn get_error_class_name(e: &AnyError) -> &'static str {
         .map(get_resolution_error_class)
     })
     .unwrap_or_else(|| {
-      if cfg!(debug) {
+      if cfg!(debug_assertions) {
         log::warn!(
           "Error '{}' contains boxed error of unknown type:{}",
           e,

--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -1048,7 +1048,7 @@ fn junction_or_symlink_dir(
   match junction::create(old_path, new_path) {
     Ok(()) => Ok(()),
     Err(junction_err) => {
-      if cfg!(debug) {
+      if cfg!(debug_assertions) {
         // When running the tests, junctions should be created, but if not then
         // surface this error.
         log::warn!("Error creating junction. {:#}", junction_err);


### PR DESCRIPTION
Motivated by https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#checked-cfg-names-and-values

```
❯ rg -t rust 'cfg!\(debug\)'
cli/npm/managed/resolvers/local.rs
1051:      if cfg!(debug) {

cli/errors.rs
116:      if cfg!(debug) {
```