### PR TITLE
fix: support `npm:bindings` and `npm:callsites` packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.298.0"
+version = "0.299.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fb4db0174c7130b3a8a90ed6aefb3b42a8acd6b75ea9a5a0c7c4d02993cd61"
+checksum = "428488cc6b392a199a159054da754f56a1fdc63ee03f16be2c21cbd22e936e7b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1354,7 +1354,7 @@ dependencies = [
  "cooked-waker",
  "deno_core_icudata",
  "deno_ops",
- "deno_unsync",
+ "deno_unsync 0.4.0",
  "futures",
  "libc",
  "memoffset 0.9.1",
@@ -1544,7 +1544,7 @@ dependencies = [
  "data-url",
  "deno_ast",
  "deno_semver",
- "deno_unsync",
+ "deno_unsync 0.3.10",
  "encoding_rs",
  "futures",
  "import_map",
@@ -1823,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.174.0"
+version = "0.175.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacbea7e6c459f0bcb48cdb0c7ce8ca6ece53645385fe98cf38e7242b2c5809"
+checksum = "2d2b71759647722be6ae051919b75cb66b3dccafe61b53c75ad5a6fad9d0ee4a"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -1997,6 +1997,16 @@ name = "deno_unsync"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8b95582c2023dbb66fccc37421b374026f5915fa507d437cb566904db9a3a"
+dependencies = [
+ "parking_lot 0.12.3",
+ "tokio",
+]
+
+[[package]]
+name = "deno_unsync"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ee1607db298c8f12124b345a52d5f2f504a7504c9d535f1d8f07127b237010"
 dependencies = [
  "parking_lot 0.12.3",
  "tokio",
@@ -5940,9 +5950,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.207.0"
+version = "0.208.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a442f2e04f8367eb99982beb6733fb88df666da9379f937552d67ca060de6e80"
+checksum = "583f3c71a6f7acc1711ad718a33f6e799bacdc711d297b15bb28533f32264c58"
 dependencies = [
  "num-bigint",
  "serde",
@@ -6867,7 +6877,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "console_static_text",
- "deno_unsync",
+ "deno_unsync 0.3.10",
  "denokv_proto",
  "fastwebsockets",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
-deno_core = { version = "0.298.0" }
+deno_core = { version = "0.299.0" }
 
 deno_bench_util = { version = "0.156.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/cli/util/sync/mod.rs
+++ b/cli/util/sync/mod.rs
@@ -6,9 +6,8 @@ mod task_queue;
 mod value_creator;
 
 pub use async_flag::AsyncFlag;
+pub use deno_core::unsync::sync::AtomicFlag;
 pub use sync_read_async_write_lock::SyncReadAsyncWriteLock;
 pub use task_queue::TaskQueue;
 pub use task_queue::TaskQueuePermit;
 pub use value_creator::MultiRuntimeAsyncValueCreator;
-// todo(dsherret): this being in the unsync module is slightly confusing, but it's Sync
-pub use deno_core::unsync::AtomicFlag;


### PR DESCRIPTION
Adds support for `npm:bindings` and `npm:callsites` packages because of changes in
https://github.com/denoland/deno_core/pull/838.

This `deno_core` bump causes us to stop prepending `file://` scheme for locations
in stack traces that are for local files.

Fixes https://github.com/denoland/deno/issues/24462 , fixes https://github.com/denoland/deno/issues/22671 , fixes https://github.com/denoland/deno/issues/15717 , fixes https://github.com/denoland/deno/issues/19130 , fixes https://github.com/WiseLibs/better-sqlite3/issues/1205 , fixes https://github.com/WiseLibs/better-sqlite3/issues/1034 , fixes https://github.com/denoland/deno/issues/20936