### PR TITLE
feat: new global mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,9 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.298.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fb4db0174c7130b3a8a90ed6aefb3b42a8acd6b75ea9a5a0c7c4d02993cd61"
+version = "0.299.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1354,7 +1352,7 @@ dependencies = [
  "cooked-waker",
  "deno_core_icudata",
  "deno_ops",
- "deno_unsync",
+ "deno_unsync 0.4.0",
  "futures",
  "libc",
  "memoffset 0.9.1",
@@ -1544,7 +1542,7 @@ dependencies = [
  "data-url",
  "deno_ast",
  "deno_semver",
- "deno_unsync",
+ "deno_unsync 0.3.10",
  "encoding_rs",
  "futures",
  "import_map",
@@ -1823,9 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.174.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacbea7e6c459f0bcb48cdb0c7ce8ca6ece53645385fe98cf38e7242b2c5809"
+version = "0.175.0"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -1997,6 +1993,16 @@ name = "deno_unsync"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8b95582c2023dbb66fccc37421b374026f5915fa507d437cb566904db9a3a"
+dependencies = [
+ "parking_lot 0.12.3",
+ "tokio",
+]
+
+[[package]]
+name = "deno_unsync"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ee1607db298c8f12124b345a52d5f2f504a7504c9d535f1d8f07127b237010"
 dependencies = [
  "parking_lot 0.12.3",
  "tokio",
@@ -5940,9 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a442f2e04f8367eb99982beb6733fb88df666da9379f937552d67ca060de6e80"
+version = "0.208.0"
 dependencies = [
  "num-bigint",
  "serde",
@@ -6867,7 +6871,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "console_static_text",
- "deno_unsync",
+ "deno_unsync 0.3.10",
  "denokv_proto",
  "fastwebsockets",
  "flate2",
@@ -7560,9 +7564,7 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.99.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3fc0608a78f0c7d4ec88025759cb78c90a29984b48540060355a626ae329c1"
+version = "0.100.0"
 dependencies = [
  "bindgen",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
-deno_core = { version = "0.298.0" }
+deno_core = { path = "../deno_core/core" }
 
 deno_bench_util = { version = "0.156.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/cli/util/sync/mod.rs
+++ b/cli/util/sync/mod.rs
@@ -11,4 +11,4 @@ pub use task_queue::TaskQueue;
 pub use task_queue::TaskQueuePermit;
 pub use value_creator::MultiRuntimeAsyncValueCreator;
 // todo(dsherret): this being in the unsync module is slightly confusing, but it's Sync
-pub use deno_core::unsync::AtomicFlag;
+pub use deno_core::unsync::sync::AtomicFlag;

--- a/ext/node/ops/vm_internal.rs
+++ b/ext/node/ops/vm_internal.rs
@@ -19,7 +19,24 @@ impl ContextifyScript {
     scope: &mut v8::HandleScope,
     source_str: v8::Local<v8::String>,
   ) -> Result<Self, AnyError> {
-    let source = v8::script_compiler::Source::new(source_str, None);
+    let resource_name = v8::undefined(scope);
+    let host_defined_options = v8::PrimitiveArray::new(scope, 1);
+    let value = v8::Boolean::new(scope, true);
+    host_defined_options.set(scope, 0, value.into());
+    let origin = v8::ScriptOrigin::new(
+      scope,
+      resource_name.into(),
+      0,
+      0,
+      false,
+      0,
+      None,
+      false,
+      false,
+      false,
+      Some(host_defined_options.into()),
+    );
+    let source = v8::script_compiler::Source::new(source_str, Some(&origin));
 
     let unbound_script = v8::script_compiler::compile_unbound_script(
       scope,

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -976,9 +976,14 @@ function wrapSafe(
   filename,
   content,
   cjsModuleInstance,
+  format,
 ) {
   const wrapper = Module.wrap(content);
-  const [f, err] = core.evalContext(wrapper, `file://${filename}`);
+  const [f, err] = core.evalContext(
+    wrapper,
+    url.pathToFileURL(filename).toString(),
+    [format !== "module"],
+  );
   if (err) {
     if (process.mainModule === cjsModuleInstance) {
       enrichCJSError(err.thrown);
@@ -995,8 +1000,16 @@ function wrapSafe(
   return f;
 }
 
-Module.prototype._compile = function (content, filename) {
-  const compiledWrapper = wrapSafe(filename, content, this);
+Module.prototype._compile = function (content, filename, format) {
+  const compiledWrapper = wrapSafe(filename, content, this, format);
+
+  if (format === "module") {
+    // TODO: implement require esm
+    throw createRequireEsmError(
+      filename,
+      moduleParentCache.get(module)?.filename,
+    );
+  }
 
   const dirname = pathDirname(filename);
   const require = makeRequireFunction(this);
@@ -1053,17 +1066,24 @@ Module.prototype._compile = function (content, filename) {
 Module._extensions[".js"] = function (module, filename) {
   const content = op_require_read_file(filename);
 
+  let format;
   if (StringPrototypeEndsWith(filename, ".js")) {
     const pkg = op_require_read_closest_package_json(filename);
-    if (pkg && pkg.typ === "module") {
+    if (pkg?.typ === "module") {
+      // TODO: implement require esm
+      format = "module";
       throw createRequireEsmError(
         filename,
         moduleParentCache.get(module)?.filename,
       );
+    } else if (pkg?.typ === "commonjs") {
+      format = "commonjs";
     }
+  } else if (StringPrototypeEndsWith(filename, ".cjs")) {
+    format = "commonjs";
   }
 
-  module._compile(content, filename);
+  module._compile(content, filename, format);
 };
 
 function createRequireEsmError(filename, parent) {


### PR DESCRIPTION
Global mode is now determined via host defined options set on scripts at compilation time. For `npm` modules this causes no change, but for `vm` and `require` this ensures the modes are aligned.

Note that there is a pre-existing bug where doing `import('file.js'); require('file.js')` can cause the same `file.js` to be loaded and evaluated as both esm and cjs. This PR does not change the circumstances of that bug, it just aligns the behavior of commonjs modules with their wrapper behavior.