### PR TITLE
fix(publish): workspace included license file had incorrect path

### DIFF
--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -473,7 +473,7 @@ impl PublishPreparer {
             publish_paths.push(CollectedPublishPath {
               specifier: ModuleSpecifier::from_file_path(&license_path)
                 .unwrap(),
-              relative_path: "LICENSE".to_string(),
+              relative_path: "/LICENSE".to_string(),
               maybe_content: Some(std::fs::read(&license_path).with_context(
                 || format!("failed reading '{}'.", license_path.display()),
               )?),
@@ -1014,14 +1014,6 @@ async fn publish_package(
     );
   }
 
-  log::info!(
-    "{} @{}/{}@{}",
-    colors::green("Successfully published"),
-    package.scope,
-    package.package,
-    package.version
-  );
-
   let enable_provenance = std::env::var("DISABLE_JSR_PROVENANCE").is_err()
     && (auth::is_gha() && auth::gha_oidc_token().is_some() && provenance);
 
@@ -1070,6 +1062,14 @@ async fn publish_package(
       .send()
       .await?;
   }
+
+  log::info!(
+    "{} @{}/{}@{}",
+    colors::green("Successfully published"),
+    package.scope,
+    package.package,
+    package.version
+  );
 
   log::info!(
     "{}",

--- a/cli/tools/registry/paths.rs
+++ b/cli/tools/registry/paths.rs
@@ -214,7 +214,7 @@ pub enum PackagePathValidationError {
 pub struct CollectedPublishPath {
   pub specifier: ModuleSpecifier,
   pub path: PathBuf,
-  /// Relative path to use in the tarball.
+  /// Relative path to use in the tarball. This should be prefixed with a `/`.
   pub relative_path: String,
   /// Specify the contents for any injected paths.
   pub maybe_content: Option<Vec<u8>>,

--- a/cli/tools/registry/tar.rs
+++ b/cli/tools/registry/tar.rs
@@ -64,6 +64,7 @@ pub fn create_gzipped_tarball(
       hash: format!("sha256-{:x}", sha2::Sha256::digest(&content)),
       size: content.len(),
     });
+    assert!(path_str.starts_with("/"));
     tar
       .add_file(format!(".{}", path_str), &content)
       .with_context(|| {

--- a/cli/tools/registry/tar.rs
+++ b/cli/tools/registry/tar.rs
@@ -64,7 +64,7 @@ pub fn create_gzipped_tarball(
       hash: format!("sha256-{:x}", sha2::Sha256::digest(&content)),
       size: content.len(),
     });
-    assert!(path_str.starts_with("/"));
+    assert!(path_str.starts_with('/'));
     tar
       .add_file(format!(".{}", path_str), &content)
       .with_context(|| {

--- a/tests/testdata/publish/successful_provenance.out
+++ b/tests/testdata/publish/successful_provenance.out
@@ -2,6 +2,6 @@ Check file:///[WILDCARD]/publish/successful/mod.ts
 Checking for slow types in the public API...
 Check file:///[WILDCARD]/publish/successful/mod.ts
 Publishing @foo/bar@1.0.0 ...
-Successfully published @foo/bar@1.0.0
 Provenance transparency log available at https://search.sigstore.dev/?logIndex=42069
+Successfully published @foo/bar@1.0.0
 Visit http://127.0.0.1:4250/@foo/bar@1.0.0 for details


### PR DESCRIPTION
Also fixes the issue where we say a package was successfully published before it wasn't.

Bug in https://github.com/denoland/deno/pull/24714