### PR TITLE
chore: mark upgrade invalid lockfile as flaky

### DIFF
--- a/tests/integration/upgrade_tests.rs
+++ b/tests/integration/upgrade_tests.rs
@@ -213,6 +213,7 @@ fn upgrade_invalid_lockfile() {
     .arg("upgrade")
     .arg("--version")
     .arg("foobar")
+    .arg("--dry-run")
     .stderr(Stdio::piped())
     .spawn()
     .unwrap()

--- a/tests/integration/upgrade_tests.rs
+++ b/tests/integration/upgrade_tests.rs
@@ -194,7 +194,7 @@ fn upgrade_invalid_canary_version() {
   );
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn upgrade_invalid_lockfile() {
   let context = upgrade_context();
   let temp_dir = context.temp_dir();


### PR DESCRIPTION
Closes #24759