### PR TITLE
fix(node): Rework node:child_process IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ dependencies = [
  "libz-sys",
  "md-5",
  "md4",
+ "memchr",
  "node_resolver",
  "num-bigint",
  "num-bigint-dig",
@@ -4150,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1050,10 +1050,10 @@ impl CliOptions {
   }
 
   pub fn node_ipc_fd(&self) -> Option<i64> {
-    let maybe_node_channel_fd = std::env::var("DENO_CHANNEL_FD").ok();
+    let maybe_node_channel_fd = std::env::var("NODE_CHANNEL_FD").ok();
     if let Some(node_channel_fd) = maybe_node_channel_fd {
       // Remove so that child processes don't inherit this environment variable.
-      std::env::remove_var("DENO_CHANNEL_FD");
+      std::env::remove_var("NODE_CHANNEL_FD");
       node_channel_fd.parse::<i64>().ok()
     } else {
       None

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -56,6 +56,7 @@ libz-sys.workspace = true
 md-5 = { version = "0.10.5", features = ["oid"] }
 md4 = "0.10.2"
 node_resolver.workspace = true
+memchr = "2.7.4"
 num-bigint.workspace = true
 num-bigint-dig = "0.8.2"
 num-integer = "0.1.45"

--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -55,8 +55,8 @@ libc.workspace = true
 libz-sys.workspace = true
 md-5 = { version = "0.10.5", features = ["oid"] }
 md4 = "0.10.2"
-node_resolver.workspace = true
 memchr = "2.7.4"
+node_resolver.workspace = true
 num-bigint.workspace = true
 num-bigint-dig = "0.8.2"
 num-integer = "0.1.45"

--- a/ext/node/benchmarks/child_process_ipc.mjs
+++ b/ext/node/benchmarks/child_process_ipc.mjs
@@ -10,7 +10,7 @@ if (process.env.CHILD) {
     while (process.send(msg, undefined, undefined, (_e) => {
       if (waiting) {
         waiting = false;
-        send();
+        setImmediate(send);
       }
     }));
     // Wait: backlog of unsent messages exceeds threshold

--- a/ext/node/benchmarks/child_process_ipc.mjs
+++ b/ext/node/benchmarks/child_process_ipc.mjs
@@ -5,10 +5,18 @@ import { setImmediate } from "node:timers";
 if (process.env.CHILD) {
   const len = +process.env.CHILD;
   const msg = ".".repeat(len);
+  let waiting = false;
   const send = () => {
-    while (process.send(msg));
+    while (process.send(msg, undefined, undefined, (_e) => {
+      if (waiting) {
+        waiting = false;
+        send();
+      }
+    }));
     // Wait: backlog of unsent messages exceeds threshold
-    setImmediate(send);
+    // once the message is sent, the callback will be called
+    // and we'll resume
+    waiting = true;
   };
   send();
 } else {

--- a/ext/node/benchmarks/child_process_ipc.mjs
+++ b/ext/node/benchmarks/child_process_ipc.mjs
@@ -7,12 +7,14 @@ if (process.env.CHILD) {
   const msg = ".".repeat(len);
   let waiting = false;
   const send = () => {
-    while (process.send(msg, undefined, undefined, (_e) => {
-      if (waiting) {
-        waiting = false;
-        setImmediate(send);
-      }
-    }));
+    while (
+      process.send(msg, undefined, undefined, (_e) => {
+        if (waiting) {
+          waiting = false;
+          setImmediate(send);
+        }
+      })
+    );
     // Wait: backlog of unsent messages exceeds threshold
     // once the message is sent, the callback will be called
     // and we'll resume

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -30,6 +30,7 @@ pub use deno_package_json::PackageJson;
 pub use node_resolver::PathClean;
 pub use ops::ipc::ChildPipeFd;
 pub use ops::ipc::IpcJsonStreamResource;
+pub use ops::ipc::IpcRefTracker;
 use ops::vm;
 pub use ops::vm::create_v8_context;
 pub use ops::vm::init_global_template;
@@ -378,6 +379,8 @@ deno_core::extension!(deno_node,
     ops::ipc::op_node_child_ipc_pipe,
     ops::ipc::op_node_ipc_write,
     ops::ipc::op_node_ipc_read,
+    ops::ipc::op_node_ipc_ref,
+    ops::ipc::op_node_ipc_unref,
     ops::process::op_node_process_kill,
     ops::process::op_process_abort,
   ],

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -71,8 +71,8 @@ mod impl_ {
   /// Serialize a v8 value directly into a serde serializer.
   /// This allows us to go from v8 values to JSON without having to
   /// deserialize into a `serde_json::Value` and then reserialize to JSON
-  fn serialize_v8_value<'a, 'b, S: Serializer>(
-    scope: &'b mut v8::HandleScope<'a>,
+  fn serialize_v8_value<'a, S: Serializer>(
+    scope: &mut v8::HandleScope<'a>,
     value: v8::Local<'a, v8::Value>,
     ser: S,
   ) -> Result<S::Ok, S::Error> {
@@ -102,7 +102,7 @@ mod impl_ {
       use serde::ser::SerializeMap;
       if value.is_array_buffer_view() {
         let buffer = v8::Local::<v8::ArrayBufferView>::try_from(value).unwrap();
-        let mut buf = vec![0u8; buffer.byte_length() as usize];
+        let mut buf = vec![0u8; buffer.byte_length()];
         let copied = buffer.copy_contents(&mut buf);
         assert_eq!(copied, buf.len());
         return ser.serialize_bytes(&buf);

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -842,7 +842,6 @@ mod impl_ {
 
     #[test]
     fn ipc_serialization() {
-      deno_core::JsRuntime::init_platform(None);
       let mut runtime = JsRuntime::new(RuntimeOptions::default());
 
       let cases = [

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -409,10 +409,7 @@ mod impl_ {
     }
 
     #[cfg(all(windows, test))]
-    fn from_stream(
-      pipe: NamedPipeClient,
-      ref_tracker: ExternalOpsTracker,
-    ) -> Self {
+    fn from_stream(pipe: NamedPipeClient, ref_tracker: IpcRefTracker) -> Self {
       let (read_half, write_half) = tokio::io::split(pipe);
       Self {
         read_half: AsyncRefCell::new(IpcJsonStream::new(read_half)),
@@ -679,7 +676,10 @@ mod impl_ {
 
       server.connect().await.unwrap();
       /* Similar to how ops would use the resource */
-      let client = Rc::new(IpcJsonStreamResource::from_stream(client));
+      let client = Rc::new(IpcJsonStreamResource::from_stream(
+        client,
+        super::IpcRefTracker::new_test(),
+      ));
       (client, server)
     }
 

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -842,6 +842,7 @@ mod impl_ {
 
     #[test]
     fn ipc_serialization() {
+      deno_core::JsRuntime::init_platform(None);
       let mut runtime = JsRuntime::new(RuntimeOptions::default());
 
       let cases = [

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -181,6 +181,7 @@ mod impl_ {
         "failed to serialize json value: {e}"
       ))
     })?;
+    serialized.push(b'\n');
 
     let stream = state
       .borrow()
@@ -196,7 +197,6 @@ mod impl_ {
       queue_ok.set_index(scope, 0, v);
     }
     Ok(async move {
-      serialized.push(b'\n');
       stream.clone().write_msg_bytes(&serialized).await?;
       stream
         .queued_bytes

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -416,7 +416,6 @@ mod impl_ {
         write_half: AsyncRefCell::new(write_half),
         cancel: Default::default(),
         queued_bytes: Default::default(),
-        refed: AtomicBool::new(false),
         ref_tracker,
       }
     }

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -509,6 +509,7 @@ mod impl_ {
       Self {
         pipe,
         buffer: Vec::with_capacity(INITIAL_CAPACITY),
+        read_buffer: ReadBuffer::new(),
       }
     }
 

--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -140,8 +140,7 @@ mod tests {
   #[test]
   fn test_run_in_this_context() {
     let platform = v8::new_default_platform(0, false).make_shared();
-    v8::V8::initialize_platform(platform);
-    v8::V8::initialize();
+    deno_core::JsRuntime::init_platform(Some(platform));
 
     let isolate = &mut v8::Isolate::new(Default::default());
 

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -126,7 +126,7 @@ export function fork(
         execArgv.splice(index, 1);
       } else if (flag.startsWith("-C") || flag.startsWith("--conditions")) {
         let rm = 1;
-        if (flag.indexOf("=") === -1) {
+        if (flag.indexOf("=") !== -1) {
           rm = 2;
         }
         execArgv.splice(index, rm);

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -115,7 +115,8 @@ export function fork(
   // more
   const v8Flags: string[] = [];
   if (Array.isArray(execArgv)) {
-    for (let index = 0; index < execArgv.length; index++) {
+    let index = 0;
+    while (index < execArgv.length) {
       const flag = execArgv[index];
       if (flag.startsWith("--max-old-space-size")) {
         execArgv.splice(index, 1);
@@ -123,6 +124,14 @@ export function fork(
       } else if (flag.startsWith("--enable-source-maps")) {
         // https://github.com/denoland/deno/issues/21750
         execArgv.splice(index, 1);
+      } else if (flag.startsWith("-C") || flag.startsWith("--conditions")) {
+        let rm = 1;
+        if (flag.indexOf("=") === -1) {
+          rm = 2;
+        }
+        execArgv.splice(index, rm);
+      } else {
+        index++;
       }
     }
   }

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -126,7 +126,9 @@ export function fork(
         execArgv.splice(index, 1);
       } else if (flag.startsWith("-C") || flag.startsWith("--conditions")) {
         let rm = 1;
-        if (flag.indexOf("=") !== -1) {
+        if (flag.indexOf("=") === -1) {
+          // --conditions foo
+          // so remove the next argument as well.
           rm = 2;
         }
         execArgv.splice(index, rm);

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -834,7 +834,17 @@ export function execFileSync(
 function setupChildProcessIpcChannel() {
   const fd = op_node_child_ipc_pipe();
   if (typeof fd != "number" || fd < 0) return;
-  setupChannel(process, fd);
+  const control = setupChannel(process, fd);
+  process.on("newListener", (name: string) => {
+    if (name === "message" || name === "disconnect") {
+      control.refCounted();
+    }
+  });
+  process.on("removeListener", (name: string) => {
+    if (name === "message" || name === "disconnect") {
+      control.unrefCounted();
+    }
+  });
 }
 
 internals.__setupChildProcessIpcChannel = setupChildProcessIpcChannel;

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -304,7 +304,7 @@ export class ChildProcess extends EventEmitter {
     }
 
     /* Cancel any pending IPC I/O */
-    if (this.implementsDisconnect) {
+    if (this.canDisconnect) {
       this.disconnect?.();
     }
 
@@ -1169,12 +1169,13 @@ export function setupChannel(target, ipc) {
     }
 
     this.connected = false;
+    target.canDisconnect = false;
     process.nextTick(() => {
       core.close(ipc);
       target.emit("disconnect");
     });
   };
-  target.implementsDisconnect = true;
+  target.canDisconnect = true;
 
   // Start reading messages from the channel.
   readLoop();

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1172,8 +1172,8 @@ export function setupChannel(target, ipc) {
         // there will always be a pending read promise,
         // but it shouldn't keep the event loop from exiting
         core.unrefOpPromise(prom);
-        const [msg, stillOpen] = await prom;
-        if (stillOpen == false) {
+        const msg = await prom;
+        if (msg && typeof msg === "object" && msg["cmd"] === "NODE_CLOSE") {
           // Channel closed.
           target.disconnect();
           return;

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1106,8 +1106,8 @@ export function setupChannel(target, ipc) {
         if (!target.connected || target.killed) {
           return;
         }
-        const msg = await op_node_ipc_read(ipc);
-        if (msg == null) {
+        const [msg, stillOpen] = await op_node_ipc_read(ipc);
+        if (stillOpen == false) {
           // Channel closed.
           target.disconnect();
           return;

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1152,12 +1152,15 @@ export function setupChannel(target, ipc) {
     if (handle !== undefined) {
       notImplemented("ChildProcess.send with handle");
     }
-    op_node_ipc_write(ipc, message)
+
+    const queueOk = [true];
+    op_node_ipc_write(ipc, message, queueOk)
       .then(() => {
         if (callback) {
           process.nextTick(callback, null);
         }
       });
+    return queueOk[0];
   };
 
   target.connected = true;

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1106,7 +1106,9 @@ export function setupChannel(target, ipc) {
         if (!target.connected || target.killed) {
           return;
         }
-        const [msg, stillOpen] = await op_node_ipc_read(ipc);
+        const prom = op_node_ipc_read(ipc);
+        core.unrefOpPromise(prom);
+        const [msg, stillOpen] = await prom;
         if (stillOpen == false) {
           // Channel closed.
           target.disconnect();

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1150,7 +1150,7 @@ export function setupChannel(target, ipc) {
     if (handle !== undefined) {
       notImplemented("ChildProcess.send with handle");
     }
-    op_node_ipc_write(ipc, core.encode(JSON.stringify(message)))
+    op_node_ipc_write(ipc, message)
       .then(() => {
         if (callback) {
           process.nextTick(callback, null);

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -339,7 +339,7 @@ export class ChildProcess extends EventEmitter {
 
     /* Cancel any pending IPC I/O */
     if (this.canDisconnect) {
-      this.disconnect();
+      this.disconnect?.();
     }
 
     this.killed = true;
@@ -354,8 +354,6 @@ export class ChildProcess extends EventEmitter {
   unref() {
     this.#process.unref();
   }
-
-  disconnect() {}
 
   async #_waitForChildStreamsToClose() {
     const promises = [] as Array<Promise<void>>;

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1150,8 +1150,7 @@ export function setupChannel(target, ipc) {
     if (handle !== undefined) {
       notImplemented("ChildProcess.send with handle");
     }
-
-    op_node_ipc_write(ipc, message)
+    op_node_ipc_write(ipc, core.encode(JSON.stringify(message)))
       .then(() => {
         if (callback) {
           process.nextTick(callback, null);

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1153,6 +1153,9 @@ export function setupChannel(target, ipc) {
       notImplemented("ChildProcess.send with handle");
     }
 
+    // signals whether the queue is within the limit.
+    // if false, the sender should slow down.
+    // this acts as a backpressure mechanism.
     const queueOk = [true];
     op_node_ipc_write(ipc, message, queueOk)
       .then(() => {

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -173,10 +173,13 @@ export class ChildProcess extends EventEmitter {
     null,
   ];
 
+  disconnect?: () => void;
+
   #process!: Deno.ChildProcess;
   #spawned = Promise.withResolvers<void>();
   [kClosesNeeded] = 1;
   [kClosesReceived] = 0;
+  canDisconnect = false;
 
   constructor(
     command: string,
@@ -391,6 +394,16 @@ export class ChildProcess extends EventEmitter {
     if (this.stdin) {
       assert(this.stdin);
       this.stdin.destroy();
+    }
+    /// TODO(nathanwhit): for some reason when the child process exits
+    /// and the child end of the named pipe closes, reads still just return `Pending`
+    /// instead of returning that 0 bytes were read (to signal the pipe died).
+    /// For now, just forcibly disconnect, but in theory I think we could miss messages
+    /// that haven't been read yet.
+    if (Deno.build.os === "windows") {
+      if (this.canDisconnect) {
+        this.disconnect?.();
+      }
     }
   }
 }

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -28,7 +28,7 @@ import {
 import { assert } from "ext:deno_node/_util/asserts.ts";
 import { EventEmitter } from "node:events";
 import { os } from "ext:deno_node/internal_binding/constants.ts";
-import { notImplemented, warnNotImplemented } from "ext:deno_node/_utils.ts";
+import { notImplemented } from "ext:deno_node/_utils.ts";
 import { Readable, Stream, Writable } from "node:stream";
 import { isWindows } from "ext:deno_node/_util/os.ts";
 import { nextTick } from "ext:deno_node/_next_tick.ts";
@@ -253,7 +253,7 @@ export class ChildProcess extends EventEmitter {
           maybeClose(this);
         });
       }
-      // TODO: once we impl > 3 stdio pipes make sure we also listen for their
+      // TODO(nathanwhit): once we impl > 3 stdio pipes make sure we also listen for their
       // close events (like above)
 
       this.stdio[0] = this.stdin;

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -352,8 +352,8 @@ fn create_command(
         )?,
       ));
 
-      /* The other end passed to child process via DENO_CHANNEL_FD */
-      command.env("DENO_CHANNEL_FD", format!("{}", ipc));
+      /* The other end passed to child process via NODE_CHANNEL_FD */
+      command.env("NODE_CHANNEL_FD", format!("{}", ipc));
 
       return Ok((command, pipe_rid));
     }
@@ -477,8 +477,8 @@ fn create_command(
           .add(deno_node::IpcJsonStreamResource::new(hd1 as i64)?),
       );
 
-      /* The other end passed to child process via DENO_CHANNEL_FD */
-      command.env("DENO_CHANNEL_FD", format!("{}", hd2 as i64));
+      /* The other end passed to child process via NODE_CHANNEL_FD */
+      command.env("NODE_CHANNEL_FD", format!("{}", hd2 as i64));
 
       return Ok((command, pipe_fd));
     }

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -471,11 +471,12 @@ fn create_command(
       }
 
       /* One end returned to parent process (this) */
-      let pipe_fd = Some(
-        state
-          .resource_table
-          .add(deno_node::IpcJsonStreamResource::new(hd1 as i64)?),
-      );
+      let pipe_fd = Some(state.resource_table.add(
+        deno_node::IpcJsonStreamResource::new(
+          hd1 as i64,
+          deno_node::IpcRefTracker::new(state.external_ops_tracker.clone()),
+        )?,
+      ));
 
       /* The other end passed to child process via NODE_CHANNEL_FD */
       command.env("NODE_CHANNEL_FD", format!("{}", hd2 as i64));

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -345,11 +345,12 @@ fn create_command(
       });
 
       /* One end returned to parent process (this) */
-      let pipe_rid = Some(
-        state
-          .resource_table
-          .add(deno_node::IpcJsonStreamResource::new(fd1 as _)?),
-      );
+      let pipe_rid = Some(state.resource_table.add(
+        deno_node::IpcJsonStreamResource::new(
+          fd1 as _,
+          deno_node::IpcRefTracker::new(state.external_ops_tracker.clone()),
+        )?,
+      ));
 
       /* The other end passed to child process via DENO_CHANNEL_FD */
       command.env("DENO_CHANNEL_FD", format!("{}", ipc));

--- a/tests/node_compat/runner.ts
+++ b/tests/node_compat/runner.ts
@@ -2,8 +2,6 @@
 import "./polyfill_globals.js";
 import { createRequire } from "node:module";
 import { toFileUrl } from "@std/path/to-file-url";
-import process from "node:process";
-
 const file = Deno.args[0];
 if (!file) {
   throw new Error("No file provided");

--- a/tests/node_compat/runner.ts
+++ b/tests/node_compat/runner.ts
@@ -2,10 +2,27 @@
 import "./polyfill_globals.js";
 import { createRequire } from "node:module";
 import { toFileUrl } from "@std/path/to-file-url";
+import process from "node:process";
+
+// exclude argv[1], which is the path to this runner script.
+// some tests expect that argv[1] is the path to the test file.
+function patchArgv() {
+  const out = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (i === 1) {
+      continue;
+    }
+    out.push(process.argv[i]);
+  }
+  process.argv = out;
+}
+
 const file = Deno.args[0];
 if (!file) {
   throw new Error("No file provided");
 }
+
+patchArgv();
 
 if (file.endsWith(".mjs")) {
   await import(toFileUrl(file).href);

--- a/tests/node_compat/runner.ts
+++ b/tests/node_compat/runner.ts
@@ -4,25 +4,10 @@ import { createRequire } from "node:module";
 import { toFileUrl } from "@std/path/to-file-url";
 import process from "node:process";
 
-// exclude argv[1], which is the path to this runner script.
-// some tests expect that argv[1] is the path to the test file.
-function patchArgv() {
-  const out = [];
-  for (let i = 0; i < process.argv.length; i++) {
-    if (i === 1) {
-      continue;
-    }
-    out.push(process.argv[i]);
-  }
-  process.argv = out;
-}
-
 const file = Deno.args[0];
 if (!file) {
   throw new Error("No file provided");
 }
-
-patchArgv();
 
 if (file.endsWith(".mjs")) {
   await import(toFileUrl(file).href);

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -9,6 +9,7 @@ import {
   assertNotStrictEquals,
   assertStrictEquals,
   assertStringIncludes,
+  assertThrows,
 } from "@std/assert";
 import * as path from "@std/path";
 
@@ -979,11 +980,5 @@ Deno.test(async function killMultipleTimesNoError() {
   child.kill();
 
   // explicitly calling disconnect after kill should throw
-  let threw = false;
-  try {
-    child.disconnect();
-  } catch (_) {
-    threw = true;
-  }
-  assert(threw);
+  assertThrows(() => child.disconnect());
 });

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -935,9 +935,6 @@ Deno.test(
     child.on("message", (message) => {
       assertEquals(message, expect[i]);
       i++;
-      if (i === expect.length) {
-        child.kill();
-      }
     });
     child.on("close", () => p.resolve());
     await Promise.race([p.promise, timeout.promise]);

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -67,6 +67,7 @@ Deno.test("[node/child_process disconnect] the method exists", async () => {
   const deferred = withTimeout<void>();
   const childProcess = spawn(Deno.execPath(), ["--help"], {
     env: { NO_COLOR: "true" },
+    stdio: ["pipe", "pipe", "pipe", "ipc"],
   });
   try {
     childProcess.disconnect();


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/24756. Fixes https://github.com/denoland/deno/issues/24796.

This also gets vitest working when using [`--pool=forks`](https://vitest.dev/guide/improving-performance#pool) (which is the default as of vitest 2.0). Ref https://github.com/denoland/deno/issues/23882.

---

This PR resolves a handful of issues with child_process IPC. In particular:

- We didn't support sending typed array views over IPC
- Opening an IPC channel resulted in the event loop never exiting
- Sending a `null` over IPC would terminate the channel
- There was some UB in the read implementation (transmuting an `&[u8]` to `&mut [u8]`)
- The `send` method wasn't returning anything, so there was no way to signal backpressure (this also resulted in the benchmark `child_process_ipc.mjs` being misleading, as it tried to respect backpressure. That gave node much worse results at larger message sizes, and gave us much worse results at smaller message sizes).
- We weren't setting up the `channel` property on the `process` global (or on the `ChildProcess` object), and also didn't have a way to ref/unref the channel
- Calling `kill` multiple times (or disconnecting the channel, then calling kill) would throw an error
- Node couldn't spawn a deno subprocess and communicate with it over IPC

