### PR TITLE
BREAKING(unstable/webgpu): Replace async .requestAdapterInfo() with sync .info

### DIFF
--- a/cli/tsc/dts/lib.deno_webgpu.d.ts
+++ b/cli/tsc/dts/lib.deno_webgpu.d.ts
@@ -123,10 +123,10 @@ declare type GPUPowerPreference = "low-power" | "high-performance";
 declare class GPUAdapter {
   readonly features: GPUSupportedFeatures;
   readonly limits: GPUSupportedLimits;
+  readonly info: GPUAdapterInfo;
   readonly isFallbackAdapter: boolean;
 
   requestDevice(descriptor?: GPUDeviceDescriptor): Promise<GPUDevice>;
-  requestAdapterInfo(): Promise<GPUAdapterInfo>;
 }
 
 /**

--- a/ext/webgpu/01_webgpu.js
+++ b/ext/webgpu/01_webgpu.js
@@ -502,9 +502,9 @@ class GPUAdapter {
   }
 
   /**
-   * @returns {Promise<GPUAdapterInfo>}
+   * @returns {GPUAdapterInfo}
    */
-  requestAdapterInfo() {
+  get info() {
     webidl.assertBranded(this, GPUAdapterPrototype);
 
     if (this[_invalid]) {
@@ -525,7 +525,7 @@ class GPUAdapter {
     adapterInfo[_architecture] = architecture;
     adapterInfo[_device] = device;
     adapterInfo[_description] = description;
-    return PromiseResolve(adapterInfo);
+    return adapterInfo;
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {

--- a/ext/webgpu/webgpu.idl
+++ b/ext/webgpu/webgpu.idl
@@ -78,11 +78,11 @@ enum GPUPowerPreference {
 [Exposed=(Window, Worker), SecureContext]
 interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
+    [SameObject] readonly attribute GPUAdapterInfo info;
     [SameObject] readonly attribute GPUSupportedLimits limits;
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    Promise<GPUAdapterInfo> requestAdapterInfo();
 };
 
 dictionary GPUDeviceDescriptor


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/24779

Ref https://github.com/gpuweb/gpuweb/pull/4662
