### PR TITLE
fix(node/timers/promises): add scheduler APIs

### DIFF
--- a/ext/node/polyfills/timers/promises.ts
+++ b/ext/node/polyfills/timers/promises.ts
@@ -6,6 +6,13 @@ export const setTimeout = promisify(timers.setTimeout),
   setImmediate = promisify(timers.setImmediate),
   setInterval = promisify(timers.setInterval);
 
+export const scheduler = {
+  async wait(delay: number, options?: { signal?: AbortSignal }): Promise<void> {
+    return await setTimeout(delay, undefined, options);
+  },
+  yield: setImmediate,
+};
+
 export default {
   setTimeout,
   setImmediate,

--- a/tests/unit_node/timers_test.ts
+++ b/tests/unit_node/timers_test.ts
@@ -66,6 +66,29 @@ Deno.test("[node/timers/promises setTimeout]", () => {
   return p;
 });
 
+Deno.test("[node/timers/promises scheduler.wait]", async () => {
+  const { scheduler } = timersPromises;
+  let resolved = false;
+  timers.setTimeout(() => (resolved = true), 20);
+  const p = scheduler.wait(20);
+
+  assert(p instanceof Promise);
+  await p;
+  assert(resolved);
+});
+
+Deno.test("[node/timers/promises scheduler.yield]", async () => {
+  const { scheduler } = timersPromises;
+  let resolved = false;
+  timers.setImmediate(() => resolved = true);
+
+  const p = scheduler.yield();
+  assert(p instanceof Promise);
+  await p;
+
+  assert(resolved);
+});
+
 // Regression test for https://github.com/denoland/deno/issues/17981
 Deno.test("[node/timers refresh cancelled timer]", () => {
   const { setTimeout, clearTimeout } = timers;


### PR DESCRIPTION
This PR adds the experimental `scheduler` APIs in Node's `timers/promises` module. See https://nodejs.org/api/timers.html#timerspromisesschedulerwaitdelay-options

Fixes https://github.com/denoland/deno/issues/24800