### PR TITLE
fix(node/fs/promises): watch should be async iterable

### DIFF
--- a/ext/node/polyfills/_fs/_fs_watch.ts
+++ b/ext/node/polyfills/_fs/_fs_watch.ts
@@ -12,7 +12,6 @@ import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import { stat, Stats } from "ext:deno_node/_fs/_fs_stat.ts";
 import { Buffer } from "node:buffer";
 import { delay } from "ext:deno_node/_util/async.ts";
-import console from "node:console";
 
 const statPromisified = promisify(stat);
 const statAsync = async (filename: string): Promise<Stats | null> => {

--- a/ext/node/polyfills/_fs/_fs_watch.ts
+++ b/ext/node/polyfills/_fs/_fs_watch.ts
@@ -12,6 +12,7 @@ import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import { stat, Stats } from "ext:deno_node/_fs/_fs_stat.ts";
 import { Buffer } from "node:buffer";
 import { delay } from "ext:deno_node/_util/async.ts";
+import console from "node:console";
 
 const statPromisified = promisify(stat);
 const statAsync = async (filename: string): Promise<Stats | null> => {
@@ -155,22 +156,43 @@ export function watch(
   return fsWatcher;
 }
 
-export const watchPromise = promisify(watch) as (
-  & ((
-    filename: string | URL,
-    options: watchOptions,
-    listener: watchListener,
-  ) => Promise<FSWatcher>)
-  & ((
-    filename: string | URL,
-    listener: watchListener,
-  ) => Promise<FSWatcher>)
-  & ((
-    filename: string | URL,
-    options: watchOptions,
-  ) => Promise<FSWatcher>)
-  & ((filename: string | URL) => Promise<FSWatcher>)
-);
+export function watchPromise(
+  filename: string | Buffer | URL,
+  options?: {
+    persistent?: boolean;
+    recursive?: boolean;
+    encoding?: string;
+    signal?: AbortSignal;
+  },
+): AsyncIterable<{ eventType: string; filename: string | Buffer | null }> {
+  const watchPath = getValidatedPath(filename).toString();
+
+  const watcher = Deno.watchFs(watchPath, {
+    recursive: options?.recursive ?? false,
+  });
+
+  if (options?.signal) {
+    options?.signal.addEventListener("abort", () => watcher.close());
+  }
+
+  const fsIterable = watcher[Symbol.asyncIterator]();
+  const iterable = {
+    async next() {
+      const result = await fsIterable.next();
+      if (result.done) return result;
+
+      const eventType = convertDenoFsEventToNodeFsEvent(result.value.kind);
+      return {
+        value: { eventType, filename: basename(result.value.paths[0]) },
+        done: result.done,
+      };
+    },
+  };
+
+  return {
+    [Symbol.asyncIterator]: () => iterable,
+  };
+}
 
 type WatchFileListener = (curr: Stats, prev: Stats) => void;
 type WatchFileOptions = {

--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -62,8 +62,7 @@ Deno.test({
     const file = Deno.makeTempFileSync();
     Deno.writeTextFileSync(file, "foo");
 
-    // deno-lint-ignore no-explicit-any
-    const result: any[] = [];
+    const result: { eventType: string; filename: string | null }[] = [];
 
     const controller = new AbortController();
     const watcher = watchPromise(file, {

--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -3,7 +3,6 @@ import { unwatchFile, watch, watchFile } from "node:fs";
 import { watch as watchPromise } from "node:fs/promises";
 import { assert, assertEquals } from "@std/assert";
 import { setTimeout } from "node:timers";
-import console from "node:console";
 
 function wait(time: number) {
   return new Promise((resolve) => {

--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -2,7 +2,6 @@
 import { unwatchFile, watch, watchFile } from "node:fs";
 import { watch as watchPromise } from "node:fs/promises";
 import { assert, assertEquals } from "@std/assert";
-import { setTimeout } from "node:timers";
 
 function wait(time: number) {
   return new Promise((resolve) => {


### PR DESCRIPTION
The way `fs.watch` works is different in `node:fs/promises` than `node:fs`. It has a different function signature and it returns an async iterable instead, see https://nodejs.org/api/fs.html#fspromiseswatchfilename-options

Fixes https://github.com/denoland/deno/issues/24661