### PR TITLE
perf(ext/fetch): speed up `resp.clone()`

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -196,10 +196,23 @@ class InnerBody {
    * @returns {InnerBody}
    */
   clone() {
-    const { 0: out1, 1: out2 } = readableStreamTee(this.stream, true);
-    this.streamOrStatic = out1;
-    const second = new InnerBody(out2);
-    second.source = core.deserialize(core.serialize(this.source));
+    let second;
+    if (
+      !ObjectPrototypeIsPrototypeOf(
+        ReadableStreamPrototype,
+        this.streamOrStatic,
+      ) && !this.streamOrStatic.consumed
+    ) {
+      second = new InnerBody({
+        body: this.streamOrStatic.body,
+        consumed: false,
+      });
+    } else {
+      const { 0: out1, 1: out2 } = readableStreamTee(this.stream, true);
+      this.streamOrStatic = out1;
+      second = new InnerBody(out2);
+    }
+    second.source = this.source;
     second.length = this.length;
     return second;
   }


### PR DESCRIPTION
### main (before)

```
Running 10s test @ http://localhost:8000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   123.96us   57.25us   3.64ms   96.84%
    Req/Sec    41.15k     2.11k   42.76k    95.05%
  827087 requests in 10.10s, 125.41MB read
Requests/sec:  81895.64
Transfer/sec:     12.42MB
```

### this branch

```
Running 10s test @ http://localhost:8000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    66.91us   17.71us   2.03ms   95.91%
    Req/Sec    74.43k     2.52k   76.71k    92.57%
  1496402 requests in 10.10s, 199.79MB read
Requests/sec: 148170.16
Transfer/sec:     19.78MB
```

Fixes #24766
