### PR TITLE
fix: Don't panic if failed to add system certificate

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -623,6 +623,8 @@ pub enum RootCertStoreLoadError {
   UnknownStore(String),
   #[error("Unable to add pem file to certificate store: {0}")]
   FailedAddPemFile(String),
+  #[error("Unable to add system certificate to certificate store: {0}")]
+  FailedAddSystemCert(String),
   #[error("Failed opening CA file: {0}")]
   CaFileOpenError(String),
 }
@@ -658,7 +660,7 @@ pub fn get_root_cert_store(
         for root in roots {
           root_cert_store
             .add(rustls::pki_types::CertificateDer::from(root.0))
-            .expect("Failed to add platform cert to root cert store");
+            .map_err(|e| RootCertStoreLoadError::FailedAddSystemCert(e.to_string()))?;
         }
       }
       _ => {


### PR DESCRIPTION
This commit fixes the panic from https://github.com/denoland/deno/issues/24137.

I'm not sure if we want to hard error or maybe instead skip with a warning
and continue execution.