### PR TITLE
fix(compile): adhoc codesign mach-o by default

### DIFF
--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -183,7 +183,7 @@ fn write_binary_bytes(
   } else if target.contains("darwin") {
     libsui::Macho::from(original_bin)?
       .write_section("d3n0l4nd", writer)?
-      .build(&mut file_writer)?;
+      .build_and_sign(&mut file_writer)?;
   }
   Ok(())
 }
@@ -194,8 +194,8 @@ pub fn is_standalone_binary(exe_path: &Path) -> bool {
   };
 
   libsui::utils::is_elf(&data)
-    | libsui::utils::is_pe(&data)
-    | libsui::utils::is_macho(&data)
+    || libsui::utils::is_pe(&data)
+    || libsui::utils::is_macho(&data)
 }
 
 /// This function will try to run this binary as a standalone binary

--- a/tests/integration/compile_tests.rs
+++ b/tests/integration/compile_tests.rs
@@ -34,6 +34,17 @@ fn compile_basic() {
     output.assert_matches_text("Welcome to Deno!\n");
   }
 
+  // On arm64 macOS, check if `codesign -v` passes
+  #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+  {
+    let output = std::process::Command::new("codesign")
+      .arg("-v")
+      .arg(&exe)
+      .output()
+      .unwrap();
+    assert!(output.status.success());
+  }
+
   // now ensure this works when the deno_dir is readonly
   let readonly_dir = dir.path().join("readonly");
   readonly_dir.make_dir_readonly();


### PR DESCRIPTION
Missed to add this in #24604 