### PR TITLE
fix(tsc/dts): add missing generics for AsyncIterable type

### DIFF
--- a/cli/tsc/dts/lib.es2018.asynciterable.d.ts
+++ b/cli/tsc/dts/lib.es2018.asynciterable.d.ts
@@ -34,10 +34,10 @@ interface AsyncIterator<T, TReturn = any, TNext = undefined> {
     throw?(e?: any): Promise<IteratorResult<T, TReturn>>;
 }
 
-interface AsyncIterable<T> {
-    [Symbol.asyncIterator](): AsyncIterator<T>;
+interface AsyncIterable<T, TReturn = any, TNext = undefined> {
+    [Symbol.asyncIterator](): AsyncIterator<T, TReturn, TNext>;
 }
 
-interface AsyncIterableIterator<T> extends AsyncIterator<T> {
+interface AsyncIterableIterator<T extends AsyncIterator<T> {
     [Symbol.asyncIterator](): AsyncIterableIterator<T>;
 }


### PR DESCRIPTION
Related issue https://github.com/denoland/deno/issues/24837
