### PR TITLE
fix(ext/cache): set content-length header for string and Uint8Array response body types

### DIFF
--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -135,7 +135,7 @@ class Cache {
     }
 
     // If response body is a string or Uint8Array, attempt to auto-detect content-length
-    const headerList = [...innerResponse.headerList];
+    let headerList = innerResponse.headerList;
     if (
       innerResponse.body !== null &&
       !getHeader(headerList, "content-length")
@@ -146,7 +146,7 @@ class Cache {
         ? innerResponse.body.source.length
         : undefined;
       if (typeof byteLength === "number") {
-        headerList.push(["content-length", "" + byteLength]);
+        headerList = [...headerList, ["content-length", "" + byteLength]];
       }
     }
 

--- a/tests/unit/cache_api_test.ts
+++ b/tests/unit/cache_api_test.ts
@@ -92,6 +92,26 @@ Deno.test(async function cacheApi() {
     assertEquals(await res3?.json(), { msg: "hello world" });
   }
 
+  // Test that cache.put() sets content-length for UTF-8 string bodies.
+  {
+    const req = "https://deno.com";
+    await cache.put(req, new Response("some string 中文"));
+    const res = await cache.match(req);
+    assertEquals(res?.headers.get("content-length"), "18");
+    assertEquals(await res?.text(), "some string 中文");
+    assert(await cache.delete(req));
+  }
+
+  // Test that cache.put() sets content-length for Uint8Array bodies.
+  {
+    const req = "https://deno.com";
+    await cache.put(req, new Response(new TextEncoder().encode("some bytes")));
+    const res = await cache.match(req);
+    assertEquals(res?.headers.get("content-length"), "10");
+    assertEquals(await res?.text(), "some bytes");
+    assert(await cache.delete(req));
+  }
+
   assert(await caches.delete(cacheName));
   assertFalse(await caches.has(cacheName));
 });


### PR DESCRIPTION
In `cache.put()`, if `innerResponse.body.source` is a `string` or `Uint8Array` and the `content-length` header is not already set, calculate and set the `content-length` header.