### PR TITLE
feat(unstable/fmt): move yaml formatting behind unstable flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -200,6 +200,7 @@ pub struct FmtFlags {
   pub prose_wrap: Option<String>,
   pub no_semicolons: Option<bool>,
   pub watch: Option<WatchFlags>,
+  pub unstable_yaml: bool,
 }
 
 impl FmtFlags {
@@ -2079,6 +2080,14 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
             .help(
               "Don't use semicolons except where necessary. Defaults to false.",
             ),
+        )
+        .arg(
+          Arg::new("unstable-yaml")
+            .long("unstable-yaml")
+            .help("Enable formatting YAML files.")
+            .value_parser(FalseyValueParser::new())
+            .action(ArgAction::SetTrue)
+            .global(true),
         )
     })
 }
@@ -4085,6 +4094,7 @@ fn fmt_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let single_quote = matches.remove_one::<bool>("single-quote");
   let prose_wrap = matches.remove_one::<String>("prose-wrap");
   let no_semicolons = matches.remove_one::<bool>("no-semicolons");
+  let unstable_yaml = matches.get_flag("unstable-yaml");
 
   flags.subcommand = DenoSubcommand::Fmt(FmtFlags {
     check: matches.get_flag("check"),
@@ -4096,6 +4106,7 @@ fn fmt_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     prose_wrap,
     no_semicolons,
     watch: watch_arg_parse(matches),
+    unstable_yaml,
   });
 }
 
@@ -5768,6 +5779,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
@@ -5791,6 +5803,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
@@ -5814,6 +5827,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
@@ -5837,6 +5851,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Some(Default::default()),
         }),
         ext: Some("ts".to_string()),
@@ -5844,8 +5859,13 @@ mod tests {
       }
     );
 
-    let r =
-      flags_from_vec(svec!["deno", "fmt", "--watch", "--no-clear-screen"]);
+    let r = flags_from_vec(svec![
+      "deno",
+      "fmt",
+      "--watch",
+      "--no-clear-screen",
+      "--unstable-yaml"
+    ]);
     assert_eq!(
       r.unwrap(),
       Flags {
@@ -5861,6 +5881,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: true,
           watch: Some(WatchFlags {
             hmr: false,
             no_clear_screen: true,
@@ -5895,6 +5916,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Some(Default::default()),
         }),
         ext: Some("ts".to_string()),
@@ -5918,6 +5940,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
@@ -5949,6 +5972,7 @@ mod tests {
           single_quote: None,
           prose_wrap: None,
           no_semicolons: None,
+          unstable_yaml: false,
           watch: Some(Default::default()),
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
@@ -5985,6 +6009,7 @@ mod tests {
           single_quote: Some(true),
           prose_wrap: Some("never".to_string()),
           no_semicolons: Some(true),
+          unstable_yaml: false,
           watch: Default::default(),
         }),
         ext: Some("ts".to_string()),
@@ -6015,6 +6040,7 @@ mod tests {
           single_quote: Some(false),
           prose_wrap: None,
           no_semicolons: Some(false),
+          unstable_yaml: false,
           watch: Default::default(),
         }),
         ext: Some("ts".to_string()),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2086,8 +2086,7 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
             .long("unstable-yaml")
             .help("Enable formatting YAML files.")
             .value_parser(FalseyValueParser::new())
-            .action(ArgAction::SetTrue)
-            .global(true),
+            .action(ArgAction::SetTrue),
         )
     })
 }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -92,6 +92,7 @@ use crate::args::CaData;
 use crate::args::CacheSetting;
 use crate::args::CliOptions;
 use crate::args::Flags;
+use crate::args::UnstableFmtOptions;
 use crate::factory::CliFactory;
 use crate::file_fetcher::FileFetcher;
 use crate::graph_util;
@@ -1361,6 +1362,16 @@ impl Inner {
         .clone();
       fmt_options.use_tabs = Some(!params.options.insert_spaces);
       fmt_options.indent_width = Some(params.options.tab_size as u8);
+      let maybe_workspace = self
+        .config
+        .tree
+        .data_for_specifier(&specifier)
+        .map(|d| &d.member_dir.workspace);
+      let unstable_options = UnstableFmtOptions {
+        yaml: maybe_workspace
+          .map(|w| w.has_unstable("fmt-yaml"))
+          .unwrap_or(false),
+      };
       let document = document.clone();
       move || {
         let format_result = match document.maybe_parsed_source() {
@@ -1378,7 +1389,12 @@ impl Inner {
               .map(|ext| file_path.with_extension(ext))
               .unwrap_or(file_path);
             // it's not a js/ts file, so attempt to format its contents
-            format_file(&file_path, document.content(), &fmt_options)
+            format_file(
+              &file_path,
+              document.content(),
+              &fmt_options,
+              &unstable_options,
+            )
           }
         };
         match format_result {

--- a/tests/integration/fmt_tests.rs
+++ b/tests/integration/fmt_tests.rs
@@ -49,6 +49,7 @@ fn fmt_test() {
     .current_dir(&testdata_fmt_dir)
     .args_vec(vec![
       "fmt".to_string(),
+      "--unstable-yaml".to_string(),
       format!(
         "--ignore={badly_formatted_js},{badly_formatted_md},{badly_formatted_json},{badly_formatted_yaml},{badly_formatted_ipynb}",
       ),
@@ -69,6 +70,7 @@ fn fmt_test() {
     .args_vec(vec![
       "fmt".to_string(),
       "--check".to_string(),
+      "--unstable-yaml".to_string(),
       badly_formatted_js.to_string(),
       badly_formatted_md.to_string(),
       badly_formatted_json.to_string(),
@@ -86,6 +88,7 @@ fn fmt_test() {
     .current_dir(&testdata_fmt_dir)
     .args_vec(vec![
       "fmt".to_string(),
+      "--unstable-yaml".to_string(),
       badly_formatted_js.to_string(),
       badly_formatted_md.to_string(),
       badly_formatted_json.to_string(),

--- a/tests/integration/upgrade_tests.rs
+++ b/tests/integration/upgrade_tests.rs
@@ -145,7 +145,7 @@ fn upgrade_with_out_in_tmpdir() {
   assert!(v.contains("1.11.5"));
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn upgrade_invalid_stable_version() {
   let context = upgrade_context();
   let temp_dir = context.temp_dir();

--- a/tests/specs/fmt/unstable_yaml/__test__.jsonc
+++ b/tests/specs/fmt/unstable_yaml/__test__.jsonc
@@ -1,0 +1,25 @@
+{
+  "tempDir": true,
+  "tests": {
+    "nothing": {
+      "args": "fmt",
+      "output": "Checked 1 file\n"
+    },
+    "flag": {
+      "args": "fmt --unstable-yaml",
+      "output": "[WILDLINE]badly_formatted.yml\nChecked 1 file\n"
+    },
+    "config_file": {
+      "steps": [{
+        "args": [
+          "eval",
+          "Deno.writeTextFile('deno.json', '{\\n  \"unstable\": [\"fmt-yaml\"]\\n}\\n')"
+        ],
+        "output": "[WILDCARD]"
+      }, {
+        "args": "fmt",
+        "output": "[WILDLINE]badly_formatted.yml\nChecked 2 files\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/fmt/unstable_yaml/badly_formatted.yml
+++ b/tests/specs/fmt/unstable_yaml/badly_formatted.yml
@@ -1,0 +1,3 @@
+- Test
+ - Test
+  - Test


### PR DESCRIPTION
This moves YAML formatting behind an unstable flag for Deno 1.46. This will make it opt-in to start and then we can remove the flag to make it on by default in version of Deno after that.

This can be specified by doing `deno fmt --unstable-yaml` or by specifying the following in a deno.json file:

```json
{
  "unstable": ["fmt-yaml"]
}
```

cc @g-plane - It would be good to do the same for other languages.

Part of #12217