### PR TITLE
fix(unstable): panic when running deno install with DENO_FUTURE=1

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -355,7 +355,7 @@ impl CliFactory {
         let fs = self.fs();
         let cli_options = self.cli_options()?;
         // For `deno install` we want to force the managed resolver so it can set up `node_modules/` directory.
-        create_cli_npm_resolver(if cli_options.use_byonm() && !matches!(cli_options.sub_command(), DenoSubcommand::Install(_)) {
+        create_cli_npm_resolver(if cli_options.use_byonm() && !matches!(cli_options.sub_command(), DenoSubcommand::Install(_) | DenoSubcommand::Add(_)) {
           CliNpmResolverCreateOptions::Byonm(CliNpmResolverByonmCreateOptions {
             fs: fs.clone(),
             root_node_modules_dir: Some(match cli_options.node_modules_dir_path() {


### PR DESCRIPTION
Not bothering to add a test for this because we're going to change this to be the default in a couple weeks.