### PR TITLE
feat: support short flags for permissions

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3130,6 +3130,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-read")
         .long("allow-read")
+        .short("R")
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3152,6 +3153,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-write")
         .long("allow-write")
+        .short("W")
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3174,6 +3176,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-net")
         .long("allow-net")
+        .short("N")
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3195,6 +3198,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-env")
         .long("allow-env")
+        .short("E")
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3235,6 +3239,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-sys")
         .long("allow-sys")
+        .short("S")
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -5677,6 +5682,26 @@ mod tests {
         )),
         permissions: PermissionFlags {
           allow_read: Some(vec![]),
+          ..Default::default()
+        },
+        code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn short_permission_flags() {
+    let r = flags_from_vec(svec!["deno", "run", "-RW", "gist.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run(RunFlags::new_default(
+          "gist.ts".to_string()
+        )),
+        permissions: PermissionFlags {
+          allow_read: Some(vec![]),
+          allow_write: Some(vec![]),
           ..Default::default()
         },
         code_cache_enabled: true,

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3130,7 +3130,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-read")
         .long("allow-read")
-        .short("R")
+        .short('R')
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3153,7 +3153,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-write")
         .long("allow-write")
-        .short("W")
+        .short('W')
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3176,7 +3176,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-net")
         .long("allow-net")
-        .short("N")
+        .short('N')
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3198,7 +3198,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-env")
         .long("allow-env")
-        .short("E")
+        .short('E')
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)
@@ -3239,7 +3239,7 @@ fn permission_args(app: Command) -> Command {
     .arg(
       Arg::new("allow-sys")
         .long("allow-sys")
-        .short("S")
+        .short('S')
         .num_args(0..)
         .use_value_delimiter(true)
         .require_equals(true)


### PR DESCRIPTION
This commit adds short CLI flags for following permission flags:
- "-R" for "--allow-read"
- "-W" for "--allow-write"
- "-E" for "--allow-env"
- "-N" for "--allow-net"
- "-S" for "--allow-sys"