### PR TITLE
feat: `deno upgrade --list`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -390,6 +390,7 @@ pub struct UpgradeFlags {
   pub dry_run: bool,
   pub force: bool,
   pub canary: bool,
+  pub list: bool,
   pub version: Option<String>,
   pub output: Option<String>,
 }
@@ -2833,6 +2834,15 @@ update to a different location, use the --output flag
             .action(ArgAction::SetTrue),
         )
         .arg(
+          Arg::new("list")
+            .long("list")
+            .help("List all available Deno versions")
+            .conflicts_with_all([
+              "output", "dry-run", "version", "canary", "force",
+            ])
+            .action(ArgAction::SetTrue),
+        )
+        .arg(
           Arg::new("force")
             .long("force")
             .short('f')
@@ -4572,6 +4582,7 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let dry_run = matches.get_flag("dry-run");
   let force = matches.get_flag("force");
   let canary = matches.get_flag("canary");
+  let list = matches.get_flag("list");
   let version = matches.remove_one::<String>("version");
   let output = matches.remove_one::<String>("output");
   flags.subcommand = DenoSubcommand::Upgrade(UpgradeFlags {
@@ -4580,6 +4591,7 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     canary,
     version,
     output,
+    list,
   });
 }
 

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -384,19 +384,15 @@ pub async fn upgrade(
   if upgrade_flags.list {
     let response = client
       .get(Url::parse("https://deno.com/versions.json").unwrap())?
-      // .header(
-      //   http::HeaderName::from_static("accept"),
-      //   http::HeaderValue::from_static("application/json"),
-      // )
       .send()
       .await?;
     let body = response.collect().await?.to_bytes();
     let json_body: serde_json::Value = serde_json::from_slice(&body)?;
     if let Some(cli_versions) = json_body.get("cli") {
       if let Some(versions) = cli_versions.as_array() {
-        log::info!("Available versions:");
-        for version in versions {
-          log::info!(" - {}", colors::green(version));
+        log::info!("{}", colors::bold("Available recent versions:"));
+        for version in versions.iter().take(10) {
+          log::info!(" - {}", colors::green(version.as_str().unwrap()));
         }
       }
     }


### PR DESCRIPTION
List last 10 release of Deno:
```
$ deno upgrade --list
Available recent versions:
 - v1.45.5
 - v1.45.4
 - v1.45.3
 - v1.45.2
 - v1.45.1
 - v1.45.0
 - v1.44.4
 - v1.44.3
 - v1.44.2
 - v1.44.1
```

![Screenshot 2024-08-05 at 16 56 32](https://github.com/user-attachments/assets/de8ff5f0-4f77-43e1-8791-94274c4714bf)
