### PR TITLE
fix: `rename` watch event missing

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4149,7 +4149,14 @@ declare namespace Deno {
    * @category File System */
   export interface FsEvent {
     /** The kind/type of the file system event. */
-    kind: "any" | "access" | "create" | "modify" | "remove" | "other";
+    kind:
+      | "any"
+      | "access"
+      | "create"
+      | "modify"
+      | "rename"
+      | "remove"
+      | "other";
     /** An array of paths that are associated with the file system event. */
     paths: string[];
     /** Any additional flags associated with the event. */

--- a/ext/node/polyfills/_fs/_fs_watch.ts
+++ b/ext/node/polyfills/_fs/_fs_watch.ts
@@ -361,7 +361,7 @@ class FSWatcher extends EventEmitter {
   }
 }
 
-type NodeFsEventType = "rename" | "change" | "rename";
+type NodeFsEventType = "rename" | "change";
 
 function convertDenoFsEventToNodeFsEvent(
   kind: Deno.FsEvent["kind"],

--- a/ext/node/polyfills/_fs/_fs_watch.ts
+++ b/ext/node/polyfills/_fs/_fs_watch.ts
@@ -361,12 +361,14 @@ class FSWatcher extends EventEmitter {
   }
 }
 
-type NodeFsEventType = "rename" | "change";
+type NodeFsEventType = "rename" | "change" | "rename";
 
 function convertDenoFsEventToNodeFsEvent(
   kind: Deno.FsEvent["kind"],
 ): NodeFsEventType {
   if (kind === "create" || kind === "remove") {
+    return "rename";
+  } else if (kind === "rename") {
     return "rename";
   } else {
     return "change";

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -14,6 +14,7 @@ use deno_core::op2;
 
 use deno_permissions::PermissionsContainer;
 use notify::event::Event as NotifyEvent;
+use notify::event::ModifyKind;
 use notify::Error as NotifyError;
 use notify::EventKind;
 use notify::RecommendedWatcher;
@@ -71,7 +72,13 @@ impl From<NotifyEvent> for FsEvent {
       EventKind::Any => "any",
       EventKind::Access(_) => "access",
       EventKind::Create(_) => "create",
-      EventKind::Modify(_) => "modify",
+      EventKind::Modify(modify_event) => match modify_event {
+        ModifyKind::Name(_) => "rename",
+        ModifyKind::Any
+        | ModifyKind::Data(_)
+        | ModifyKind::Metadata(_)
+        | ModifyKind::Other => "modify",
+      },
       EventKind::Remove(_) => "remove",
       EventKind::Other => "other",
     };

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -72,7 +72,7 @@ impl From<NotifyEvent> for FsEvent {
       EventKind::Any => "any",
       EventKind::Access(_) => "access",
       EventKind::Create(_) => "create",
-      EventKind::Modify(modify_event) => match modify_event {
+      EventKind::Modify(modify_kind) => match modify_kind {
         ModifyKind::Name(_) => "rename",
         ModifyKind::Any
         | ModifyKind::Data(_)

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -88,11 +88,11 @@ Deno.test(
     // We should have gotten two fs events.
     const events = await eventsPromise;
     assert(events.length >= 2);
-    assert(events[0].kind == "create");
+    assertEquals(events[0].kind, "create");
     assert(events[0].paths[0].includes(testDir));
-    assert(events[1].kind == "rename");
+    assertEquals(events[1].kind, "rename");
     assert(events[1].paths[0].includes(testDir));
-    assert(events[2].kind == "modify");
+    assertEquals(events[2].kind, "modify");
     assert(events[2].paths[0].includes(testDir));
   },
 );

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+import console from "node:console";
 import { assert, assertEquals, assertThrows, delay } from "./test_util.ts";
 
 // TODO(ry) Add more tests to specify format.
@@ -87,6 +88,7 @@ Deno.test(
 
     // We should have gotten two fs events.
     const events = await eventsPromise;
+    console.log(events);
     assert(events.length >= 2);
     assertEquals(events[0].kind, "create");
     assert(events[0].paths[0].includes(testDir));

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import console from "node:console";
 import { assert, assertEquals, assertThrows, delay } from "./test_util.ts";
 
 // TODO(ry) Add more tests to specify format.


### PR DESCRIPTION
This PR ensures that we forward a `rename` event in our file watcher. The rust lib we use combines that with the `modify` event.

This fixes a compatibility issue with Node too, which sends the `rename` event as well.

Fixes https://github.com/denoland/deno/issues/24880