### PR TITLE
fix(node): Fix node IPC serialization for objects with undefined values

### DIFF
--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -149,6 +149,9 @@ mod impl_ {
         let key = keys.get_index(scope, i).unwrap();
         let key_str = key.to_rust_string_lossy(scope);
         let value = object.get(scope, key).unwrap();
+        if value.is_undefined() {
+          continue;
+        }
         map.serialize_entry(
           &key_str,
           &SerializeWrapper(RefCell::new(scope), value),

--- a/ext/node/ops/ipc.rs
+++ b/ext/node/ops/ipc.rs
@@ -165,9 +165,10 @@ mod impl_ {
       map.end()
     } else {
       // TODO(nathanwhit): better error message
-      Err(S::Error::custom(deno_core::error::type_error(
-        "Unsupported type",
-      )))
+      Err(S::Error::custom(deno_core::error::type_error(format!(
+        "Unsupported type: {}",
+        value.type_repr()
+      ))))
     }
   }
 


### PR DESCRIPTION
We were serializing `{ a: undefined }` to `{ a: null }` instead of `{}`