### PR TITLE
fix: cache bust jsr meta file when version not found in dynamic branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.81.1"
+version = "0.81.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cada0d9fd56536d3208cff2b130096e396ee2716466850cf0b7927249e40a0"
+checksum = "beccc9d4007be8b85299f696a412f38912fc304cf9519092b47531319ef8a92f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -69,7 +69,7 @@ deno_config = { version = "=0.28.0", features = ["workspace", "sync"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "0.145.0", features = ["html", "syntect"] }
 deno_emit = "=0.44.0"
-deno_graph = { version = "=0.81.1" }
+deno_graph = { version = "=0.81.2" }
 deno_lint = { version = "=0.62.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm = "=0.21.4"


### PR DESCRIPTION
Test and code change in deno_graph.

* https://github.com/denoland/deno_graph/pull/511

Closes https://github.com/denoland/deno/issues/23965