### PR TITLE
fix(http): make `info` parameter in `Deno.serve()` optional

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -6253,7 +6253,7 @@ declare namespace Deno {
    */
   export type ServeHandler = (
     request: Request,
-    info: ServeHandlerInfo,
+    info?: ServeHandlerInfo,
   ) => Response | Promise<Response>;
 
   /** Options which can be set when calling {@linkcode Deno.serve}.


### PR DESCRIPTION
This change makes handlers compatible with both `Deno.serve()` and `Deno.ServeDefaultExport`.