### PR TITLE
docs: document `cli/tsc/dts/lib.deno.ns.d.ts`

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -667,6 +667,11 @@ const ci = {
             "deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/lint.js",
         },
         {
+          name: "deno doc --lint",
+          if: "matrix.job == 'lint'",
+          run: "deno doc --lint cli/tsc/dts/lib.deno.ns.d.ts",
+        },
+        {
           name: "jsdoc_checker.js",
           if: "matrix.job == 'lint'",
           run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,9 @@ jobs:
       - name: lint.js
         if: '!(matrix.skip) && (matrix.job == ''lint'')'
         run: deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/lint.js
+      - name: deno doc --lint
+        if: '!(matrix.skip) && (matrix.job == ''lint'')'
+        run: deno doc --lint cli/tsc/dts/lib.deno.ns.d.ts
       - name: jsdoc_checker.js
         if: '!(matrix.skip) && (matrix.job == ''lint'')'
         run: deno run --allow-read --allow-env --allow-sys ./tools/jsdoc_checker.js


### PR DESCRIPTION
Ensures that `deno doc --lint cli/tsc/dts/lib.deno.ns.d.ts` passes.

Towards #24941