### PR TITLE
fix(node/crypto): Assign publicKey and privateKey with let instead of const

### DIFF
--- a/ext/node/polyfills/internal/crypto/keygen.ts
+++ b/ext/node/polyfills/internal/crypto/keygen.ts
@@ -573,8 +573,8 @@ export function generateKeyPair(
     const privateKeyHandle = op_node_get_private_key_from_pair(pair);
     const publicKeyHandle = op_node_get_public_key_from_pair(pair);
 
-    const privateKey = new PrivateKeyObject(privateKeyHandle);
-    const publicKey = new PublicKeyObject(publicKeyHandle);
+    let privateKey = new PrivateKeyObject(privateKeyHandle);
+    let publicKey = new PublicKeyObject(publicKeyHandle);
 
     if (typeof options === "object" && options !== null) {
       const { publicKeyEncoding, privateKeyEncoding } = options as any;


### PR DESCRIPTION
Because public/private key are reassigned, they should be `let` instead of `const`.

```ts
  const privateKey = new PrivateKeyObject(privateKeyHandle);  // <- Const here
  const publicKey = new PublicKeyObject(publicKeyHandle); // <- Const here

  if (typeof options === "object" && options !== null) {
    const { publicKeyEncoding, privateKeyEncoding } = options as any;


    if (publicKeyEncoding) {
      publicKey = publicKey.export(publicKeyEncoding); // <- Reassigned here
    }

    if (privateKeyEncoding) {
      privateKey = privateKey.export(privateKeyEncoding);  // <- Reassigned here
    }
  }
```

This gives an error:

`ERROR  Assignment to constant variable.`

Related to
- #23471 