### PR TITLE
fix(node/util): add missing `debug` alias of `debuglog`

### DIFF
--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -47,6 +47,7 @@ import { parseArgs } from "ext:deno_node/internal/util/parse_args/parse_args.js"
 export {
   callbackify,
   debuglog,
+  debuglog as debug,
   format,
   formatWithOptions,
   inspect,
@@ -179,6 +180,7 @@ import {
   _TextEncoder,
   getSystemErrorName,
 } from "ext:deno_node/_utils.ts";
+import { debug } from "node:console";
 
 /** The global TextDecoder */
 export type TextDecoder = import("./_utils.ts")._TextDecoder;
@@ -321,5 +323,6 @@ export default {
   toUSVString,
   log,
   debuglog,
+  debug: debuglog,
   isDeepStrictEqual,
 };

--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -180,7 +180,6 @@ import {
   _TextEncoder,
   getSystemErrorName,
 } from "ext:deno_node/_utils.ts";
-import { debug } from "node:console";
 
 /** The global TextDecoder */
 export type TextDecoder = import("./_utils.ts")._TextDecoder;

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -8,6 +8,7 @@ import {
 } from "@std/assert";
 import { stripAnsiCode } from "@std/fmt/colors";
 import * as util from "node:util";
+import utilDefault from "node:util";
 import { Buffer } from "node:buffer";
 
 Deno.test({
@@ -321,4 +322,11 @@ Deno.test({
   fn() {
     util.parseArgs({});
   },
+});
+
+Deno.test("[util] debuglog() and debug()", () => {
+  assert(typeof util.debug === "function");
+  assert(typeof util.debuglog === "function");
+  assertEquals(util.debuglog, util.debug);
+  assertEquals(utilDefault.debuglog, utilDefault.debug);
 });


### PR DESCRIPTION
Add the missing `node:util.debug` export which is an alias of `node:util.debuglog`, see https://nodejs.org/api/util.html#utildebugsection