### PR TITLE
fix: stub `node:module.register()`

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1293,6 +1293,19 @@ export function findSourceMap(_path) {
   return undefined;
 }
 
+/**
+ * @param {string | URL} _specifier
+ * @param {string | URL} _parentUrl
+ * @param {{ parentURL: string | URL, data: any, transferList: any[] }} [_options]
+ */
+export function register(_specifier, _parentUrl, _options) {
+  // TODO(@marvinhagemeister): Stub implementation for programs registering
+  // TypeScript loaders. We don't support registering loaders for file
+  // types that Deno itself doesn't support at the moment.
+
+  return undefined;
+}
+
 export { builtinModules, createRequire, isBuiltin, Module };
 export const _cache = Module._cache;
 export const _extensions = Module._extensions;

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -6,6 +6,10 @@ import {
   findSourceMap,
   isBuiltin,
   Module,
+  // @ts-ignore Our internal @types/node is at v18.16.19 which predates
+  // this change. Updating it is difficult due to different types in Node
+  // for `import.meta.filename` and `import.meta.dirname` that Deno
+  // provides.
   register,
 } from "node:module";
 import { assert, assertEquals } from "@std/assert";

--- a/tests/unit_node/module_test.ts
+++ b/tests/unit_node/module_test.ts
@@ -6,6 +6,7 @@ import {
   findSourceMap,
   isBuiltin,
   Module,
+  register,
 } from "node:module";
 import { assert, assertEquals } from "@std/assert";
 import process from "node:process";
@@ -98,4 +99,9 @@ Deno.test("[node/module builtinModules] has 'module' in builtins", () => {
 // https://github.com/denoland/deno/issues/18666
 Deno.test("[node/module findSourceMap] is a function", () => {
   assertEquals(findSourceMap("foo"), undefined);
+});
+
+// https://github.com/denoland/deno/issues/24902
+Deno.test("[node/module register] is a function", () => {
+  assertEquals(register("foo"), undefined);
 });


### PR DESCRIPTION
This is commonly used to register loading non standard file types. But some libs also register TS loaders which Deno supports natively, like the npm `payload` package. This PR unblocks those.

Fixes https://github.com/denoland/deno/issues/24902