### PR TITLE
Revert "feat: `deno upgrade --rc` (#24905)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "1.46.0-rc.0"
+version = "1.45.5"
 dependencies = [
  "async-trait",
  "base32",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "1.46.0-rc.0"
+version = "1.45.5"
 authors.workspace = true
 default-run = "deno"
 edition.workspace = true

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -403,7 +403,6 @@ pub struct TestFlags {
 pub struct UpgradeFlags {
   pub dry_run: bool,
   pub force: bool,
-  pub release_candidate: bool,
   pub canary: bool,
   pub version: Option<String>,
   pub output: Option<String>,
@@ -2942,13 +2941,6 @@ update to a different location, use the --output flag:
             .help("Upgrade to canary builds")
             .action(ArgAction::SetTrue),
         )
-        .arg(
-          Arg::new("release-candidate")
-            .long("rc")
-            .help("Upgrade to a release candidate")
-            .conflicts_with_all(["canary", "version"])
-            .action(ArgAction::SetTrue),
-        )
         .arg(ca_file_arg())
     })
 }
@@ -4615,13 +4607,11 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let dry_run = matches.get_flag("dry-run");
   let force = matches.get_flag("force");
   let canary = matches.get_flag("canary");
-  let release_candidate = matches.get_flag("release-candidate");
   let version = matches.remove_one::<String>("version");
   let output = matches.remove_one::<String>("output");
   flags.subcommand = DenoSubcommand::Upgrade(UpgradeFlags {
     dry_run,
     force,
-    release_candidate,
     canary,
     version,
     output,
@@ -5106,7 +5096,6 @@ mod tests {
           force: true,
           dry_run: true,
           canary: false,
-          release_candidate: false,
           version: None,
           output: None,
         }),
@@ -5125,7 +5114,6 @@ mod tests {
           force: false,
           dry_run: false,
           canary: false,
-          release_candidate: false,
           version: None,
           output: Some(String::from("example.txt")),
         }),
@@ -9090,7 +9078,6 @@ mod tests {
           force: false,
           dry_run: false,
           canary: false,
-          release_candidate: false,
           version: None,
           output: None,
         }),
@@ -9098,31 +9085,6 @@ mod tests {
         ..Flags::default()
       }
     );
-  }
-
-  #[test]
-  fn upgrade_release_candidate() {
-    let r = flags_from_vec(svec!["deno", "upgrade", "--rc"]);
-    assert_eq!(
-      r.unwrap(),
-      Flags {
-        subcommand: DenoSubcommand::Upgrade(UpgradeFlags {
-          force: false,
-          dry_run: false,
-          canary: false,
-          release_candidate: true,
-          version: None,
-          output: None,
-        }),
-        ..Flags::default()
-      }
-    );
-
-    let r = flags_from_vec(svec!["deno", "upgrade", "--rc", "--canary"]);
-    assert!(r.is_err());
-
-    let r = flags_from_vec(svec!["deno", "upgrade", "--rc", "--version"]);
-    assert!(r.is_err());
   }
 
   #[test]


### PR DESCRIPTION
This reverts commit 3c70b9435a649a53614bd3ae6f434c2a455d575a.

Reverting because CI is getting failures like this one:
```
---- upgrade::upgrade_prompt stdout ----
command /home/runner/work/deno/deno/target/release/deno run --log-level=debug main.js
command cwd /tmp/deno-cli-testqDw5UR
command /home/runner/work/deno/deno/target/release/deno run --log-level=debug main.js
command cwd /tmp/deno-cli-testqDw5UR
------ Start Full Text ------
"DEBUG RS - deno::args:620 - No .npmrc file found\r\nDEBUG RS - deno::args:909 - Finished config loading.\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/dep_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/node_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/v8_code_cache_v2...\r\nDEBUG RS - deno::js:10 - Deno isolate init with snapshots.\r\nDEBUG RS - deno::worker:183 - main_module file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:158 - Preparing module load.\r\nDEBUG RS - deno::module_loader:162 - Building module graph.\r\nDEBUG RS - deno::file_fetcher:573 - FileFetcher::fetch_no_follow_with_options - specifier: file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:208 - Prepared module load.\r\nDEBUG RS - deno_runtime::worker:739 - received module evaluate Ok(\r\n    (),\r\n)\r\nDEBUG RS - deno::module_loader:831 - Updating V8 code cache for ES module: file:///tmp/deno-cli-testqDw5UR/main.js, [1577979522354460122]\r\n"
------- End Full Text -------
Next text: "DEBUG RS - deno::args:620 - No .npmrc file found\r\nDEBUG RS - deno::args:909 - Finished config loading.\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/dep_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/node_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/v8_code_cache_v2...\r\nDEBUG RS - deno::js:10 - Deno isolate init with snapshots.\r\nDEBUG RS - deno::worker:183 - main_module file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:158 - Preparing module load.\r\nDEBUG RS - deno::module_loader:162 - Building module graph.\r\nDEBUG RS - deno::file_fetcher:573 - FileFetcher::fetch_no_follow_with_options - specifier: file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:208 - Prepared module load.\r\nDEBUG RS - deno_runtime::worker:739 - received module evaluate Ok(\r\n    (),\r\n)\r\nDEBUG RS - deno::module_loader:831 - Updating V8 code cache for ES module: file:///tmp/deno-cli-testqDw5UR/main.js, [1577979522354460122]\r\n"
thread 'upgrade::upgrade_prompt' panicked at tests/integration/upgrade_tests.rs:251:9:
Timed out.
```