### PR TITLE
fix(upgrade): return no RC versions if fetching fails

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -147,11 +147,14 @@ impl VersionProvider for RealVersionProvider {
     &self,
   ) -> Result<ReleaseChannel, AnyError> {
     if version::is_canary() {
+      // If this fails for whatever reason, just return an empty vector.
+      // It's better to miss that than throw error here.
       let rc_versions = get_rc_versions(
         &self.http_client_provider.get_or_create()?,
         self.check_kind,
       )
-      .await?;
+      .await
+      .unwrap_or_else(|_| vec![]);
 
       let is_current_exe_an_rc = rc_versions
         .iter()


### PR DESCRIPTION
Supersedes https://github.com/denoland/deno/pull/25012

This commit fixes errors on CI like this:
```
---- upgrade::upgrade_prompt stdout ----
command /home/runner/work/deno/deno/target/release/deno run --log-level=debug main.js
command cwd /tmp/deno-cli-testqDw5UR
command /home/runner/work/deno/deno/target/release/deno run --log-level=debug main.js
command cwd /tmp/deno-cli-testqDw5UR
------ Start Full Text ------
"DEBUG RS - deno::args:620 - No .npmrc file found\r\nDEBUG RS - deno::args:909 - Finished config loading.\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/dep_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/node_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/v8_code_cache_v2...\r\nDEBUG RS - deno::js:10 - Deno isolate init with snapshots.\r\nDEBUG RS - deno::worker:183 - main_module file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:158 - Preparing module load.\r\nDEBUG RS - deno::module_loader:162 - Building module graph.\r\nDEBUG RS - deno::file_fetcher:573 - FileFetcher::fetch_no_follow_with_options - specifier: file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:208 - Prepared module load.\r\nDEBUG RS - deno_runtime::worker:739 - received module evaluate Ok(\r\n    (),\r\n)\r\nDEBUG RS - deno::module_loader:831 - Updating V8 code cache for ES module: file:///tmp/deno-cli-testqDw5UR/main.js, [1577979522354460122]\r\n"
------- End Full Text -------
Next text: "DEBUG RS - deno::args:620 - No .npmrc file found\r\nDEBUG RS - deno::args:909 - Finished config loading.\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/dep_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/node_analysis_cache_v2...\r\nDEBUG RS - deno::cache::cache_db:168 - Opening cache /tmp/deno-cli-testMKnYXP/v8_code_cache_v2...\r\nDEBUG RS - deno::js:10 - Deno isolate init with snapshots.\r\nDEBUG RS - deno::worker:183 - main_module file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:158 - Preparing module load.\r\nDEBUG RS - deno::module_loader:162 - Building module graph.\r\nDEBUG RS - deno::file_fetcher:573 - FileFetcher::fetch_no_follow_with_options - specifier: file:///tmp/deno-cli-testqDw5UR/main.js\r\nDEBUG RS - deno::module_loader:208 - Prepared module load.\r\nDEBUG RS - deno_runtime::worker:739 - received module evaluate Ok(\r\n    (),\r\n)\r\nDEBUG RS - deno::module_loader:831 - Updating V8 code cache for ES module: file:///tmp/deno-cli-testqDw5UR/main.js, [1577979522354460122]\r\n"
thread 'upgrade::upgrade_prompt' panicked at tests/integration/upgrade_tests.rs:251:9:
Timed out.
```

These errors are caused by the fact that the test server doesn't have an endpoint to return
RC releases. Which in turn causes an error to be raised which later just short-circuits logic
for checking the version and storing it in file. Since fetching from a remote host is always
fallible I elected to just return an empty vec of "rc" versions instead of erroring. This might
lead to a slight mismatch in some situation when the request actually failed and user is
prompted that there's a new canary version, but that is better than not displaying
prompt at all. This issue will be fixed more robustly once we move to using SUI for
specifying version of the binary.