### PR TITLE
feat(fmt): add HTML formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "css_dataset"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ed4c49b3d82ab5e2a0167f0d24d30872cbd8526b54fb060c84295ad7b6d71d"
+dependencies = [
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1211,7 @@ dependencies = [
  "log",
  "lsp-types",
  "malva",
+ "markup_fmt",
  "memmem",
  "monch",
  "napi_sym",
@@ -4287,10 +4300,24 @@ checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
  "phf 0.10.1",
- "phf_codegen",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "markup_fmt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29853cad9bee301eba8aa6b805bc849eef314447191fd77bc1f71b12911838fb"
+dependencies = [
+ "aho-corasick",
+ "css_dataset",
+ "itertools 0.13.0",
+ "memchr",
+ "once_cell",
+ "tiny_pretty",
 ]
 
 [[package]]
@@ -5026,6 +5053,16 @@ checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -7305,6 +7342,9 @@ name = "tiny_pretty"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3f46f0549180b9c6f7f76270903f1a06867c43a03998b99dce81aa1760c3b2"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "tinyvec"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -124,6 +124,7 @@ libz-sys.workspace = true
 log = { workspace = true, features = ["serde"] }
 lsp-types.workspace = true
 malva = "=0.8.0"
+markup_fmt = "0.11.0"
 memmem.workspace = true
 monch.workspace = true
 notify.workspace = true

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -206,6 +206,7 @@ pub struct FmtFlags {
   pub no_semicolons: Option<bool>,
   pub watch: Option<WatchFlags>,
   pub unstable_css: bool,
+  pub unstable_html: bool,
   pub unstable_yaml: bool,
 }
 
@@ -2189,6 +2190,13 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
             .action(ArgAction::SetTrue),
         )
         .arg(
+          Arg::new("unstable-html")
+            .long("unstable-html")
+            .help("Enable formatting HTML files.")
+            .value_parser(FalseyValueParser::new())
+            .action(ArgAction::SetTrue),
+        )
+        .arg(
           Arg::new("unstable-yaml")
             .long("unstable-yaml")
             .help("Enable formatting YAML files.")
@@ -4058,6 +4066,7 @@ fn fmt_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let prose_wrap = matches.remove_one::<String>("prose-wrap");
   let no_semicolons = matches.remove_one::<bool>("no-semicolons");
   let unstable_css = matches.get_flag("unstable-css");
+  let unstable_html = matches.get_flag("unstable-html");
   let unstable_yaml = matches.get_flag("unstable-yaml");
 
   flags.subcommand = DenoSubcommand::Fmt(FmtFlags {
@@ -4071,6 +4080,7 @@ fn fmt_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     no_semicolons,
     watch: watch_arg_parse(matches),
     unstable_css,
+    unstable_html,
     unstable_yaml,
   });
 }
@@ -5891,6 +5901,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Default::default(),
         }),
@@ -5916,6 +5927,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Default::default(),
         }),
@@ -5941,6 +5953,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Default::default(),
         }),
@@ -5966,6 +5979,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Some(Default::default()),
         }),
@@ -5980,6 +5994,7 @@ mod tests {
       "--watch",
       "--no-clear-screen",
       "--unstable-css",
+      "--unstable-html",
       "--unstable-yaml"
     ]);
     assert_eq!(
@@ -5998,6 +6013,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: true,
+          unstable_html: true,
           unstable_yaml: true,
           watch: Some(WatchFlags {
             hmr: false,
@@ -6034,6 +6050,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Some(Default::default()),
         }),
@@ -6059,6 +6076,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Default::default(),
         }),
@@ -6092,6 +6110,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: None,
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Some(Default::default()),
         }),
@@ -6130,6 +6149,7 @@ mod tests {
           prose_wrap: Some("never".to_string()),
           no_semicolons: Some(true),
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Default::default(),
         }),
@@ -6162,6 +6182,7 @@ mod tests {
           prose_wrap: None,
           no_semicolons: Some(false),
           unstable_css: false,
+          unstable_html: false,
           unstable_yaml: false,
           watch: Default::default(),
         }),

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -282,6 +282,7 @@ impl BenchOptions {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct UnstableFmtOptions {
   pub css: bool,
+  pub html: bool,
   pub yaml: bool,
 }
 
@@ -316,6 +317,7 @@ impl FmtOptions {
       options: resolve_fmt_options(fmt_flags, fmt_config.options),
       unstable: UnstableFmtOptions {
         css: unstable.css || fmt_flags.unstable_css,
+        html: unstable.html || fmt_flags.unstable_html,
         yaml: unstable.yaml || fmt_flags.unstable_yaml,
       },
       files: fmt_config.files,
@@ -1335,6 +1337,7 @@ impl CliOptions {
     let workspace = self.workspace();
     UnstableFmtOptions {
       css: workspace.has_unstable("fmt-css"),
+      html: workspace.has_unstable("fmt-html"),
       yaml: workspace.has_unstable("fmt-yaml"),
     }
   }

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1372,6 +1372,9 @@ impl Inner {
         css: maybe_workspace
           .map(|w| w.has_unstable("fmt-css"))
           .unwrap_or(false),
+        html: maybe_workspace
+          .map(|w| w.has_unstable("fmt-html"))
+          .unwrap_or(false),
         yaml: maybe_workspace
           .map(|w| w.has_unstable("fmt-yaml"))
           .unwrap_or(false),

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -250,6 +250,7 @@ fn format_markdown(
           | "less"
           | "yml"
           | "yaml"
+          | "html"
       ) {
         // It's important to tell dprint proper file extension, otherwise
         // it might parse the file twice.
@@ -270,6 +271,13 @@ fn format_markdown(
           "css" | "scss" | "sass" | "less" => {
             if unstable_options.css {
               format_css(&fake_filename, text, fmt_options)
+            } else {
+              Ok(None)
+            }
+          }
+          "html" => {
+            if unstable_options.html {
+              format_html(&fake_filename, text, fmt_options)
             } else {
               Ok(None)
             }
@@ -316,6 +324,21 @@ pub fn format_json(
   dprint_plugin_json::format_text(file_path, file_text, &config)
 }
 
+pub fn format_html(
+  _file_path: &Path,
+  file_text: &str,
+  _fmt_options: &FmtOptionsConfig,
+) -> Result<Option<String>, AnyError> {
+  markup_fmt::format_text(
+    file_text,
+    markup_fmt::Language::Html,
+    &Default::default(),
+    |_, code, _| Ok::<_, std::convert::Infallible>(code.into()),
+  )
+  .map(Some)
+  .map_err(AnyError::from)
+}
+
 pub fn format_css(
   file_path: &Path,
   file_text: &str,
@@ -347,6 +370,13 @@ pub fn format_file(
     "css" | "scss" | "sass" | "less" => {
       if unstable_options.css {
         format_css(file_path, file_text, fmt_options)
+      } else {
+        Ok(None)
+      }
+    }
+    "html" => {
+      if unstable_options.html {
+        format_html(file_path, file_text, fmt_options)
       } else {
         Ok(None)
       }
@@ -961,6 +991,7 @@ fn is_supported_ext_fmt(path: &Path) -> bool {
         | "yml"
         | "yaml"
         | "ipynb"
+        | "html"
     )
   })
 }
@@ -1007,6 +1038,9 @@ mod test {
     assert!(is_supported_ext_fmt(Path::new("foo.yaml")));
     assert!(is_supported_ext_fmt(Path::new("foo.YaML")));
     assert!(is_supported_ext_fmt(Path::new("foo.ipynb")));
+    assert!(is_supported_ext_fmt(Path::new("foo.html")));
+    assert!(is_supported_ext_fmt(Path::new("foo.HTML")));
+    assert!(is_supported_ext_fmt(Path::new("foo.Html")));
   }
 
   #[test]

--- a/tests/specs/fmt/unstable_html/__test__.jsonc
+++ b/tests/specs/fmt/unstable_html/__test__.jsonc
@@ -1,0 +1,25 @@
+{
+  "tempDir": true,
+  "tests": {
+    "nothing": {
+      "args": "fmt",
+      "output": "Checked 1 file\n"
+    },
+    "flag": {
+      "args": "fmt --unstable-html",
+      "output": "[WILDLINE]badly_formatted.html\nChecked 1 file\n"
+    },
+    "config_file": {
+      "steps": [{
+        "args": [
+          "eval",
+          "Deno.writeTextFile('deno.json', '{\\n  \"unstable\": [\"fmt-html\"]\\n}\\n')"
+        ],
+        "output": "[WILDCARD]"
+      }, {
+        "args": "fmt",
+        "output": "[WILDLINE]badly_formatted.html\nChecked 2 files\n"
+      }]
+    }
+  }
+}

--- a/tests/specs/fmt/unstable_html/badly_formatted.html
+++ b/tests/specs/fmt/unstable_html/badly_formatted.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+        <h1>
+            
+                My First Heading</h1>
+<p>My first paragraph.
+
+
+</p>
+
+    </body>
+        </html>


### PR DESCRIPTION
This commits adds an HTML formatter to `deno fmt`.

To enable it the `--unstable-html` flag needs to be passed
to `deno fmt` or `fmt-html` option in the `unstable` config
in the config file.

[`markup_fmt`](https://docs.rs/markup_fmt/latest/markup_fmt/) crate
is used for this purpose. The crate has ability to format other markup formats
like Vue, Svelte, Astro or Angular; but for now we are only enabling it for
HTML files.

Currently, no options are exposed to customize the formatting.

On `main` Deno weighs about 108.2Mb:
```
$ ls -la ./target/release/deno
-rwxr-xr-x@ 1 ib  staff  108228376 Aug 13 03:45 ./target/release/deno*
```

This PR weighs at about 108.3Mb
```
$ ls -la ./target/release/deno
-rwxr-xr-x@ 1 ib  staff  108354152 Aug 13 03:35 ./target/release/deno*
```