### PR TITLE
fix(tls): print a warning if a system certificate can't be loaded

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -640,8 +640,6 @@ pub enum RootCertStoreLoadError {
   UnknownStore(String),
   #[error("Unable to add pem file to certificate store: {0}")]
   FailedAddPemFile(String),
-  #[error("Unable to add system certificate to certificate store: {0}")]
-  FailedAddSystemCert(String),
   #[error("Failed opening CA file: {0}")]
   CaFileOpenError(String),
 }
@@ -681,7 +679,7 @@ pub fn get_root_cert_store(
             log::error!(
               "{}",
               colors::yellow(&format!(
-                "Failed to load system certificate: {:?}",
+                "Unable to add system certificate to certificate store: {:?}",
                 err
               ))
             );

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -675,11 +675,19 @@ pub fn get_root_cert_store(
       "system" => {
         let roots = load_native_certs().expect("could not load platform certs");
         for root in roots {
-          root_cert_store
-            .add(rustls::pki_types::CertificateDer::from(root.0))
-            .map_err(|e| {
-              RootCertStoreLoadError::FailedAddSystemCert(e.to_string())
-            })?;
+          if let Err(err) = root_cert_store
+            .add(rustls::pki_types::CertificateDer::from(root.0.clone()))
+          {
+            log::error!(
+              "{}",
+              colors::yellow(&format!(
+                "Failed to load system certificate: {:?}",
+                err
+              ))
+            );
+            let hex_encoded_root = faster_hex::hex_string(&root.0);
+            log::error!("{}", colors::gray(&hex_encoded_root));
+          }
         }
       }
       _ => {


### PR DESCRIPTION
This commit changes how system certificates are loaded on startup.

Instead of hard erroring if a certificate can't be decoded, we are now
printing a warning and bumping a hex representation of the certificate
and continue execution.

Ref https://github.com/denoland/deno/issues/24137