### PR TITLE
fix(node/fs): node:fs.read and write should accept typed arrays other than Uint8Array

### DIFF
--- a/ext/node/polyfills/_fs/_fs_common.ts
+++ b/ext/node/polyfills/_fs/_fs_common.ts
@@ -38,7 +38,7 @@ export type BinaryOptionsArgument =
 export type FileOptionsArgument = Encodings | FileOptions;
 
 export type ReadOptions = {
-  buffer: Buffer | Uint8Array;
+  buffer: Buffer | ArrayBufferView;
   offset: number;
   length: number;
   position: number | null;

--- a/ext/node/polyfills/_fs/_fs_read.ts
+++ b/ext/node/polyfills/_fs/_fs_read.ts
@@ -88,22 +88,20 @@ export function read(
   } else {
     const opt = optOrBufferOrCb as ReadOptions;
     if (
-      opt.buffer !== null &&
       !isArrayBufferView(opt.buffer)
     ) {
       throw new ERR_INVALID_ARG_TYPE("buffer", [
         "Buffer",
         "TypedArray",
         "DataView",
-      ], opt.buffer);
+      ], optOrBufferOrCb);
     }
-    if (opt.buffer === null) {
+    if (opt.buffer === undefined) {
       buffer = Buffer.alloc(16384);
     } else {
       buffer = arrayBufferViewToUint8Array(opt.buffer);
     }
     offset = opt.offset ?? 0;
-    buffer = opt.buffer ?? Buffer.alloc(16384);
     length = opt.length ?? buffer.byteLength;
     position = opt.position ?? null;
   }

--- a/ext/node/polyfills/_fs/_fs_write.mjs
+++ b/ext/node/polyfills/_fs/_fs_write.mjs
@@ -12,6 +12,7 @@ import {
 import * as io from "ext:deno_io/12_io.js";
 import * as fs from "ext:deno_fs/30_fs.js";
 import {
+  arrayBufferViewToUint8Array,
   getValidatedFd,
   validateOffsetLengthWrite,
   validateStringAfterArrayBufferView,
@@ -23,9 +24,7 @@ export function writeSync(fd, buffer, offset, length, position) {
   fd = getValidatedFd(fd);
 
   const innerWriteSync = (fd, buffer, offset, length, position) => {
-    if (buffer instanceof DataView) {
-      buffer = new Uint8Array(buffer.buffer);
-    }
+    buffer = arrayBufferViewToUint8Array(buffer);
     if (typeof position === "number") {
       fs.seekSync(fd, position, io.SeekMode.Start);
     }
@@ -69,9 +68,7 @@ export function write(fd, buffer, offset, length, position, callback) {
   fd = getValidatedFd(fd);
 
   const innerWrite = async (fd, buffer, offset, length, position) => {
-    if (buffer instanceof DataView) {
-      buffer = new Uint8Array(buffer.buffer);
-    }
+    buffer = arrayBufferViewToUint8Array(buffer);
     if (typeof position === "number") {
       await fs.seek(fd, position, io.SeekMode.Start);
     }

--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -986,6 +986,16 @@ export const validatePosition = hideStackFrames((position) => {
   }
 });
 
+/** @type {(buffer: ArrayBufferView) => Uint8Array} */
+export const arrayBufferViewToUint8Array = hideStackFrames(
+  (buffer) => {
+    if (!(buffer instanceof Uint8Array)) {
+      return new Uint8Array(buffer.buffer);
+    }
+    return buffer;
+  },
+);
+
 export const realpathCacheKey = Symbol("realpathCacheKey");
 export const constants = {
   kIoMaxLength,


### PR DESCRIPTION
Part of #25028.

Our underlying read/write operations in `io` assume the buffer is a Uint8Array, but we were passing in other typed arrays (in the case above it was `Int8Array`).