### PR TITLE
fix(ext/node): don't throw when calling PerformanceObserver.observe

### DIFF
--- a/ext/node/polyfills/perf_hooks.ts
+++ b/ext/node/polyfills/perf_hooks.ts
@@ -10,11 +10,12 @@ import {
 } from "ext:deno_web/15_performance.js";
 
 class PerformanceObserver {
+  static supportedEntryTypes: string[] = [];
   observe() {
-    notImplemented("PerformanceObserver.observe");
+    // todo(lucacasonato): actually implement this
   }
   disconnect() {
-    notImplemented("PerformanceObserver.disconnect");
+    // todo(lucacasonato): actually implement this
   }
 }
 


### PR DESCRIPTION
Towards #25034
