### PR TITLE
fix(node/inspector): Session constructor should not throw

### DIFF
--- a/ext/node/polyfills/inspector.ts
+++ b/ext/node/polyfills/inspector.ts
@@ -1,26 +1,18 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { EventEmitter } from "node:events";
 import { notImplemented } from "ext:deno_node/_utils.ts";
+import { primordials } from "ext:core/mod.js";
 
-const connectionSymbol = Symbol("connectionProperty");
-const messageCallbacksSymbol = Symbol("messageCallbacks");
-const nextIdSymbol = Symbol("nextId");
-const onMessageSymbol = Symbol("onMessage");
+const {
+  SafeMap,
+} = primordials;
 
 class Session extends EventEmitter {
-  [connectionSymbol]: null;
-  [nextIdSymbol]: number;
-  [messageCallbacksSymbol]: Map<string, (e: Error) => void>;
-
-  constructor() {
-    super();
-    notImplemented("inspector.Session.prototype.constructor");
-  }
+  #connection = null;
+  #nextId = 1;
+  #messageCallbacks = new SafeMap();
 
   /** Connects the session to the inspector back-end. */
   connect() {
@@ -31,10 +23,6 @@ class Session extends EventEmitter {
    * inspector back-end. */
   connectToMainThread() {
     notImplemented("inspector.Session.prototype.connectToMainThread");
-  }
-
-  [onMessageSymbol](_message: string) {
-    notImplemented("inspector.Session.prototype[Symbol('onMessage')]");
   }
 
   /** Posts a message to the inspector back-end. */

--- a/tests/unit_node/inspector_test.ts
+++ b/tests/unit_node/inspector_test.ts
@@ -1,7 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import inspector from "node:inspector";
+import inspector, { Session } from "node:inspector";
 import { assertEquals } from "@std/assert/equals";
 
 Deno.test("[node/inspector] - importing inspector works", () => {
   assertEquals(typeof inspector.open, "function");
+});
+
+Deno.test("[node/inspector] - Session constructor should not throw", () => {
+  new Session();
 });


### PR DESCRIPTION
There is no constructor code when creating an inspector `Session` instance in Node. Also get rid of some symbols which should've been private properties. This PR doesn't yet add any new implementations though as these are mostly cosmetic changes.