### PR TITLE
feat: upgrade deno_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.303.0"
+version = "0.304.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cd2cc931f61dee2db67ce9d032d229dda981be29d68dfd530a3dc1187ddd6b"
+checksum = "bcb02f25a743fe58a117ed5cfd47c4e640761926e294a1f4ba964a0e2c68b4dc"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.179.0"
+version = "0.180.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbb9802b8b976e73872ae6e03303532e6056236467053aa6df02f7deb33488c"
+checksum = "8bbba184551dfe009836a42c0268fea6b4ad036b5154aec5a7625e7a7ce4e315"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6252,9 +6252,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.212.0"
+version = "0.213.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9a8693e4e54bf21fe51b953b10f98a0e32040671f18c4065f6014f0317ae80"
+checksum = "1831a65bad8086cfc993eaead4cbcb00579c085e43b4952a90024e1243f23b4e"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7910,9 +7910,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a710d5b95bff79a90708203cf9f74384e080d21fc6664aa4df463f2c66ac83"
+checksum = "56d72310e5b559c0a8165a5d6bdf4c975ba77c61461039ccf615ce3bbe489ca5"
 dependencies = [
  "bindgen",
  "bitflags 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.41.2", features = ["transpiling"] }
-deno_core = { version = "0.303.0" }
+deno_core = { version = "0.304.0" }
 
 deno_bench_util = { version = "0.158.0", path = "./bench_util" }
 deno_lockfile = "0.20.0"

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1337,7 +1337,7 @@ pub fn clap_root() -> Command {
     crate::version::DENO_VERSION_INFO.release_channel.name(),
     env!("PROFILE"),
     env!("TARGET"),
-    deno_core::v8_version(),
+    deno_core::v8::VERSION_STRING,
     crate::version::DENO_VERSION_INFO.typescript
   );
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -332,7 +332,7 @@ fn create_cli_snapshot(snapshot_path: PathBuf) {
 
   let snapshot_options = SnapshotOptions {
     ts_version: ts::version(),
-    v8_version: deno_core::v8_version(),
+    v8_version: deno_core::v8::VERSION_STRING,
     target: std::env::var("TARGET").unwrap(),
   };
 

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -5,11 +5,13 @@ use crate::ir::out_buffer_as_ptr;
 use crate::symbol::NativeType;
 use crate::symbol::Symbol;
 use crate::turbocall;
+use crate::turbocall::Turbocall;
 use crate::FfiPermissions;
 use deno_core::error::generic_error;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
+use deno_core::GarbageCollected;
 use deno_core::OpState;
 use deno_core::Resource;
 use dlopen2::raw::Library;
@@ -208,84 +210,84 @@ where
   Ok(out.into())
 }
 
+struct FunctionData {
+  // Held in a box to keep memory while function is alive.
+  #[allow(unused)]
+  symbol: Box<Symbol>,
+  // Held in a box to keep inner data alive while function is alive.
+  #[allow(unused)]
+  turbocall: Option<Turbocall>,
+}
+
+impl GarbageCollected for FunctionData {}
+
 // Create a JavaScript function for synchronous FFI call to
 // the given symbol.
 fn make_sync_fn<'s>(
   scope: &mut v8::HandleScope<'s>,
-  sym: Box<Symbol>,
+  symbol: Box<Symbol>,
 ) -> v8::Local<'s, v8::Function> {
-  let sym = Box::leak(sym);
-  let builder = v8::FunctionTemplate::builder(
-    |scope: &mut v8::HandleScope,
-     args: v8::FunctionCallbackArguments,
-     mut rv: v8::ReturnValue| {
-      let external: v8::Local<v8::External> = args.data().try_into().unwrap();
-      // SAFETY: The pointer will not be deallocated until the function is
-      // garbage collected.
-      let symbol = unsafe { &*(external.value() as *const Symbol) };
-      let out_buffer = match symbol.result_type {
-        NativeType::Struct(_) => {
-          let argc = args.length();
-          out_buffer_as_ptr(
-            scope,
-            Some(
-              v8::Local::<v8::TypedArray>::try_from(args.get(argc - 1))
-                .unwrap(),
-            ),
-          )
-        }
-        _ => None,
-      };
-      match crate::call::ffi_call_sync(scope, args, symbol, out_buffer) {
-        Ok(result) => {
-          let result =
-            // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
-            unsafe { result.to_v8(scope, symbol.result_type.clone()) };
-          rv.set(result);
-        }
-        Err(err) => {
-          deno_core::_ops::throw_type_error(scope, err.to_string());
-        }
-      };
-    },
-  )
-  .data(v8::External::new(scope, sym as *mut Symbol as *mut _).into());
+  let turbocall = if turbocall::is_compatible(&symbol) {
+    let trampoline = turbocall::compile_trampoline(&symbol);
+    let turbocall = turbocall::make_template(&symbol, trampoline);
+    Some(turbocall)
+  } else {
+    None
+  };
 
-  let mut fast_call_alloc = None;
+  let c_function = turbocall.as_ref().map(|turbocall| {
+    v8::fast_api::CFunction::new(
+      turbocall.trampoline.ptr(),
+      &turbocall.c_function_info,
+    )
+  });
 
-  let func = if turbocall::is_compatible(sym) {
-    let trampoline = turbocall::compile_trampoline(sym);
-    let func = builder.build_fast(
-      scope,
-      &turbocall::make_template(sym, &trampoline),
-      None,
-      None,
-      None,
-    );
-    fast_call_alloc = Some(Box::into_raw(Box::new(trampoline)));
-    func
+  let data = FunctionData { symbol, turbocall };
+  let data = deno_core::cppgc::make_cppgc_object(scope, data);
+
+  let builder = v8::FunctionTemplate::builder(sync_fn_impl).data(data.into());
+
+  let func = if let Some(c_function) = c_function {
+    builder.build_fast(scope, &[c_function])
   } else {
     builder.build(scope)
   };
-  let func = func.get_function(scope).unwrap();
+  func.get_function(scope).unwrap()
+}
 
-  let weak = v8::Weak::with_finalizer(
+fn sync_fn_impl<'s>(
+  scope: &mut v8::HandleScope<'s>,
+  args: v8::FunctionCallbackArguments<'s>,
+  mut rv: v8::ReturnValue,
+) {
+  let data = deno_core::cppgc::try_unwrap_cppgc_object::<FunctionData>(
     scope,
-    func,
-    Box::new(move |_| {
-      // SAFETY: This is never called twice. pointer obtained
-      // from Box::into_raw, hence, satisfies memory layout requirements.
-      let _ = unsafe { Box::from_raw(sym) };
-      if let Some(fast_call_ptr) = fast_call_alloc {
-        // fast-call compiled trampoline is unmapped when the MMAP handle is dropped
-        // SAFETY: This is never called twice. pointer obtained
-        // from Box::into_raw, hence, satisfies memory layout requirements.
-        let _ = unsafe { Box::from_raw(fast_call_ptr) };
-      }
-    }),
-  );
-
-  weak.to_local(scope).unwrap()
+    args.data(),
+  )
+  .unwrap();
+  let out_buffer = match data.symbol.result_type {
+    NativeType::Struct(_) => {
+      let argc = args.length();
+      out_buffer_as_ptr(
+        scope,
+        Some(
+          v8::Local::<v8::TypedArray>::try_from(args.get(argc - 1)).unwrap(),
+        ),
+      )
+    }
+    _ => None,
+  };
+  match crate::call::ffi_call_sync(scope, args, &data.symbol, out_buffer) {
+    Ok(result) => {
+      let result =
+            // SAFETY: Same return type declared to libffi; trust user to have it right beyond that.
+            unsafe { result.to_v8(scope, data.symbol.result_type.clone()) };
+      rv.set(result);
+    }
+    Err(err) => {
+      deno_core::_ops::throw_type_error(scope, err.to_string());
+    }
+  };
 }
 
 // `path` is only used on Windows.

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -345,7 +345,7 @@ impl EnvShared {
 #[repr(C)]
 pub struct Env {
   context: NonNull<v8::Context>,
-  pub isolate_ptr: *mut v8::OwnedIsolate,
+  pub isolate_ptr: *mut v8::Isolate,
   pub open_handle_scopes: usize,
   pub shared: *mut EnvShared,
   pub async_work_sender: V8CrossThreadTaskSpawner,
@@ -364,7 +364,7 @@ unsafe impl Sync for Env {}
 impl Env {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
-    isolate_ptr: *mut v8::OwnedIsolate,
+    isolate_ptr: *mut v8::Isolate,
     context: v8::Global<v8::Context>,
     global: v8::Global<v8::Object>,
     buffer_constructor: v8::Global<v8::Function>,
@@ -409,8 +409,8 @@ impl Env {
   }
 
   #[inline]
-  pub fn isolate(&mut self) -> &mut v8::OwnedIsolate {
-    // SAFETY: Lifetime of `OwnedIsolate` is longer than `Env`.
+  pub fn isolate(&mut self) -> &mut v8::Isolate {
+    // SAFETY: Lifetime of `Isolate` is longer than `Env`.
     unsafe { &mut *self.isolate_ptr }
   }
 
@@ -496,6 +496,7 @@ impl NapiPermissions for deno_permissions::PermissionsContainer {
 #[op2(reentrant)]
 fn op_napi_open<NP, 'scope>(
   scope: &mut v8::HandleScope<'scope>,
+  isolate: *mut v8::Isolate,
   op_state: Rc<RefCell<OpState>>,
   #[string] path: String,
   global: v8::Local<'scope, v8::Object>,
@@ -507,15 +508,13 @@ where
 {
   // We must limit the OpState borrow because this function can trigger a
   // re-borrow through the NAPI module.
-  let (async_work_sender, isolate_ptr, cleanup_hooks, external_ops_tracker) = {
+  let (async_work_sender, cleanup_hooks, external_ops_tracker) = {
     let mut op_state = op_state.borrow_mut();
     let permissions = op_state.borrow_mut::<NP>();
     permissions.check(Some(&PathBuf::from(&path)))?;
     let napi_state = op_state.borrow::<NapiState>();
-    let isolate_ptr = op_state.borrow::<*mut v8::OwnedIsolate>();
     (
       op_state.borrow::<V8CrossThreadTaskSpawner>().clone(),
-      *isolate_ptr,
       napi_state.env_cleanup_hooks.clone(),
       op_state.external_ops_tracker.clone(),
     )
@@ -536,7 +535,7 @@ where
 
   let ctx = scope.get_current_context();
   let mut env = Env::new(
-    isolate_ptr,
+    isolate,
     v8::Global::new(scope, ctx),
     v8::Global::new(scope, global),
     v8::Global::new(scope, buffer_constructor),

--- a/runtime/inspector_server.rs
+++ b/runtime/inspector_server.rs
@@ -270,7 +270,7 @@ async fn server(
   let json_version_response = json!({
     "Browser": name,
     "Protocol-Version": "1.3",
-    "V8-Version": deno_core::v8_version(),
+    "V8-Version": deno_core::v8::VERSION_STRING,
   });
 
   // Create the server manually so it can use the Local Executor

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -54,7 +54,7 @@ impl Default for SnapshotOptions {
 
     Self {
       ts_version: "n/a".to_owned(),
-      v8_version: deno_core::v8_version(),
+      v8_version: deno_core::v8::VERSION_STRING,
       target,
     }
   }


### PR DESCRIPTION
- Update ffi turbocall to use revised fast call api
- Remove `v8_version` function calls
- `*mut OwnedIsolate` is no longer stored in OpCtx gotham store