### PR TITLE
feat(lint): Add lint for usage of node globals (with autofix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69bb0887acec1830cac1a325ebe5cec96fdc41f61ee50e7b25447741007757b6"
+checksum = "267c773673e6b00d1acfff9b78df679282c431969531e6cb2786dc55b8f9af1b"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -1702,6 +1702,7 @@ dependencies = [
  "if_chain",
  "log",
  "once_cell",
+ "phf 0.11.2",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.63.0"
+version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267c773673e6b00d1acfff9b78df679282c431969531e6cb2786dc55b8f9af1b"
+checksum = "e0e6cc8fcb4819dd5e12d640d6fc455217c66bda00e30fd6d46d2844e3e1bdcf"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,7 +70,7 @@ deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"]
 deno_doc = { version = "0.146.0", features = ["html", "syntect"] }
 deno_emit = "=0.44.0"
 deno_graph = { version = "=0.81.2" }
-deno_lint = { version = "=0.63.0", features = ["docs"] }
+deno_lint = { version = "=0.63.1", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm = "=0.21.4"
 deno_package_json.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,7 +70,7 @@ deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"]
 deno_doc = { version = "0.146.0", features = ["html", "syntect"] }
 deno_emit = "=0.44.0"
 deno_graph = { version = "=0.81.2" }
-deno_lint = { version = "=0.62.0", features = ["docs"] }
+deno_lint = { version = "=0.63.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm = "=0.21.4"
 deno_package_json.workspace = true

--- a/cli/tools/lint/linter.rs
+++ b/cli/tools/lint/linter.rs
@@ -231,7 +231,7 @@ fn apply_lint_fixes(
   for i in (1..quick_fixes.len()).rev() {
     let cur = &quick_fixes[i];
     let previous = &quick_fixes[i - 1];
-    let is_overlapping = cur.range.start < previous.range.end;
+    let is_overlapping = cur.range.start <= previous.range.end;
     if is_overlapping {
       quick_fixes.remove(i);
     }

--- a/tests/specs/lint/node_globals_no_duplicate_imports/__test__.jsonc
+++ b/tests/specs/lint/node_globals_no_duplicate_imports/__test__.jsonc
@@ -1,0 +1,23 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "run main.ts",
+      "output": "error.out",
+      "exitCode": 1
+    },
+    {
+      "args": "lint main.ts",
+      "output": "lint.out",
+      "exitCode": 1
+    },
+    {
+      "args": "lint --fix main.ts",
+      "output": "Checked 1 file\n"
+    },
+    {
+      "args": "run --allow-env main.ts",
+      "output": ""
+    }
+  ]
+}

--- a/tests/specs/lint/node_globals_no_duplicate_imports/error.out
+++ b/tests/specs/lint/node_globals_no_duplicate_imports/error.out
@@ -1,0 +1,4 @@
+error: Uncaught (in promise) ReferenceError: process is not defined
+const _foo = process.env.FOO;
+             ^
+    at [WILDCARD]main.ts:3:14

--- a/tests/specs/lint/node_globals_no_duplicate_imports/lint.out
+++ b/tests/specs/lint/node_globals_no_duplicate_imports/lint.out
@@ -1,0 +1,22 @@
+error[no-node-globals]: NodeJS globals are not available in Deno
+ --> [WILDCARD]main.ts:3:14
+  | 
+3 | const _foo = process.env.FOO;
+  |              ^^^^^^^
+  = hint: Import from the appropriate module instead
+
+  docs: https://lint.deno.land/rules/no-node-globals
+
+
+error[no-node-globals]: NodeJS globals are not available in Deno
+ --> [WILDCARD]main.ts:7:14
+  | 
+7 | const _bar = process.env.BAR;
+  |              ^^^^^^^
+  = hint: Import from the appropriate module instead
+
+  docs: https://lint.deno.land/rules/no-node-globals
+
+
+Found 2 problems (2 fixable via --fix)
+Checked 1 file

--- a/tests/specs/lint/node_globals_no_duplicate_imports/lint.out
+++ b/tests/specs/lint/node_globals_no_duplicate_imports/lint.out
@@ -3,7 +3,7 @@ error[no-node-globals]: NodeJS globals are not available in Deno
   | 
 3 | const _foo = process.env.FOO;
   |              ^^^^^^^
-  = hint: Import from the appropriate module instead
+  = hint: Add `import process from "node:process";`
 
   docs: https://lint.deno.land/rules/no-node-globals
 
@@ -13,7 +13,7 @@ error[no-node-globals]: NodeJS globals are not available in Deno
   | 
 7 | const _bar = process.env.BAR;
   |              ^^^^^^^
-  = hint: Import from the appropriate module instead
+  = hint: Add `import process from "node:process";`
 
   docs: https://lint.deno.land/rules/no-node-globals
 

--- a/tests/specs/lint/node_globals_no_duplicate_imports/main.ts
+++ b/tests/specs/lint/node_globals_no_duplicate_imports/main.ts
@@ -1,0 +1,7 @@
+import {} from "node:console";
+
+const _foo = process.env.FOO;
+
+import {} from "node:assert";
+
+const _bar = process.env.BAR;


### PR DESCRIPTION
From upgrading `deno_lint`.

Previously if you had a node project that used a bunch of node globals (`process.env`, etc), you would have to fix the errors by hand. This PR includes a new lint that detects usages of node globals (`process`, `setImmediate`, `Buffer`, etc.) and provides an autofix to import the correct value. For instance:

```ts
// main.ts
const _foo = process.env.FOO;
```

`deno lint` gives you

```ts
error[no-node-globals]: NodeJS globals are not available in Deno
 --> /home/foo.ts:1:14
  |
1 | const _foo = process.env.FOO;
  |              ^^^^^^^
  = hint: Add `import process from "node:process";`

  docs: https://lint.deno.land/rules/no-node-globals


Found 1 problem (1 fixable via --fix)
Checked 1 file
```
And `deno lint --fix` adds the import for you:

```ts
// main.ts
import process from "node:process";
const _foo = process.env.FOO;
```