### PR TITLE
fix(node/fs): Use correct offset and length in node:fs.read and write

### DIFF
--- a/ext/node/polyfills/_fs/_fs_read.ts
+++ b/ext/node/polyfills/_fs/_fs_read.ts
@@ -125,13 +125,13 @@ export function read(
         fs.seekSync(fd, position, io.SeekMode.Start);
         nread = io.readSync(
           fd,
-          arrayBufferViewToUint8Array(buffer, offset, length),
+          arrayBufferViewToUint8Array(buffer).subarray(offset, offset + length),
         );
         fs.seekSync(fd, currentPosition, io.SeekMode.Start);
       } else {
         nread = await io.read(
           fd,
-          arrayBufferViewToUint8Array(buffer, offset, length),
+          arrayBufferViewToUint8Array(buffer).subarray(offset, offset + length),
         );
       }
       cb(null, nread ?? 0, buffer);
@@ -197,7 +197,7 @@ export function readSync(
 
   const numberOfBytesRead = io.readSync(
     fd,
-    arrayBufferViewToUint8Array(buffer, offset, length),
+    arrayBufferViewToUint8Array(buffer).subarray(offset, offset + length),
   );
 
   if (typeof position === "number" && position >= 0) {

--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -988,12 +988,12 @@ export const validatePosition = hideStackFrames((position) => {
 
 /** @type {(buffer: ArrayBufferView, offset = 0, length?: number) => Uint8Array} */
 export const arrayBufferViewToUint8Array = hideStackFrames(
-  (buffer, offset = 0, length) => {
+  (buffer) => {
     if (!(buffer instanceof Uint8Array)) {
       return new Uint8Array(
         buffer.buffer,
-        buffer.byteOffset + offset,
-        length ?? buffer.byteLength - offset,
+        buffer.byteOffset,
+        buffer.byteLength,
       );
     }
     return buffer;

--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -990,7 +990,11 @@ export const validatePosition = hideStackFrames((position) => {
 export const arrayBufferViewToUint8Array = hideStackFrames(
   (buffer) => {
     if (!(buffer instanceof Uint8Array)) {
-      return new Uint8Array(buffer.buffer);
+      return new Uint8Array(
+        buffer.buffer,
+        buffer.byteOffset,
+        buffer.byteLength,
+      );
     }
     return buffer;
   },

--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -986,7 +986,7 @@ export const validatePosition = hideStackFrames((position) => {
   }
 });
 
-/** @type {(buffer: ArrayBufferView, offset = 0, length?: number) => Uint8Array} */
+/** @type {(buffer: ArrayBufferView) => Uint8Array} */
 export const arrayBufferViewToUint8Array = hideStackFrames(
   (buffer) => {
     if (!(buffer instanceof Uint8Array)) {

--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -986,14 +986,14 @@ export const validatePosition = hideStackFrames((position) => {
   }
 });
 
-/** @type {(buffer: ArrayBufferView) => Uint8Array} */
+/** @type {(buffer: ArrayBufferView, offset = 0, length?: number) => Uint8Array} */
 export const arrayBufferViewToUint8Array = hideStackFrames(
-  (buffer) => {
+  (buffer, offset = 0, length) => {
     if (!(buffer instanceof Uint8Array)) {
       return new Uint8Array(
         buffer.buffer,
-        buffer.byteOffset,
-        buffer.byteLength,
+        buffer.byteOffset + offset,
+        length ?? buffer.byteLength - offset,
       );
     }
     return buffer;

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -38,10 +38,11 @@ Deno.test("read specify opt", async function () {
     buffer: new Buffer(byteLength),
     offset: 6,
     length: 5,
+    position: 6,
   };
   let res = await fileHandle.read(opt);
 
-  assertEquals(res.bytesRead, byteLength);
+  assertEquals(res.bytesRead, 5);
   assertEquals(
     new TextDecoder().decode(res.buffer.subarray(6) as Uint8Array),
     "world",
@@ -54,7 +55,7 @@ Deno.test("read specify opt", async function () {
   };
   res = await fileHandle.read(opt2);
 
-  assertEquals(res.bytesRead, byteLength);
+  assertEquals(res.bytesRead, 5);
   assertEquals(
     decoder.decode(res.buffer.subarray(0, 5) as Uint8Array),
     "hello",

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -42,7 +42,10 @@ Deno.test("read specify opt", async function () {
   let res = await fileHandle.read(opt);
 
   assertEquals(res.bytesRead, byteLength);
-  assertEquals(new TextDecoder().decode(res.buffer as Uint8Array), "world");
+  assertEquals(
+    new TextDecoder().decode(res.buffer.subarray(6) as Uint8Array),
+    "world",
+  );
 
   const opt2 = {
     buffer: new Buffer(byteLength),
@@ -52,7 +55,10 @@ Deno.test("read specify opt", async function () {
   res = await fileHandle.read(opt2);
 
   assertEquals(res.bytesRead, byteLength);
-  assertEquals(decoder.decode(res.buffer as Uint8Array), "hello");
+  assertEquals(
+    decoder.decode(res.buffer.subarray(0, 5) as Uint8Array),
+    "hello",
+  );
 
   await fileHandle.close();
 });

--- a/tests/unit_node/_fs/_fs_write_test.ts
+++ b/tests/unit_node/_fs/_fs_write_test.ts
@@ -75,7 +75,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Accepts non Uint8Array buffer",
+  name: "write with offset TypedArray buffers",
   async fn() {
     const tempFile: string = Deno.makeTempFileSync();
     using file = Deno.openSync(tempFile, {
@@ -83,32 +83,56 @@ Deno.test({
       write: true,
       read: true,
     });
+    const arrayBuffer = new ArrayBuffer(128);
+    const resetBuffer = () => {
+      new Uint8Array(arrayBuffer).fill(0);
+    };
+    const bufConstructors = [
+      Int8Array,
+      Uint8Array,
+    ];
+    const offsets = [0, 24, 48];
     const bytes = [0, 1, 2, 3, 4];
-    const buffer = new Int8Array(bytes);
-    for (let i = 0; i < buffer.length; i++) {
-      buffer[i] = i;
+    for (const constr of bufConstructors) {
+      // test combinations of buffers internally offset from their backing array buffer,
+      // and also offset in the write call
+      for (const innerOffset of offsets) {
+        for (const offset of offsets) {
+          resetBuffer();
+          const buffer = new constr(
+            arrayBuffer,
+            innerOffset,
+            offset + bytes.length,
+          );
+          for (let i = 0; i < bytes.length; i++) {
+            buffer[offset + i] = i;
+          }
+          let nWritten = writeSync(file.rid, buffer, offset, bytes.length, 0);
+
+          let data = Deno.readFileSync(tempFile);
+
+          assertEquals(nWritten, bytes.length);
+          console.log(constr, innerOffset, offset);
+          assertEquals(data, new Uint8Array(bytes));
+          nWritten = await new Promise((resolve, reject) =>
+            write(
+              file.rid,
+              buffer,
+              offset,
+              bytes.length,
+              0,
+              (err: unknown, nwritten: number) => {
+                if (err) return reject(err);
+                resolve(nwritten);
+              },
+            )
+          );
+
+          data = Deno.readFileSync(tempFile);
+          assertEquals(nWritten, 5);
+          assertEquals(data, new Uint8Array(bytes));
+        }
+      }
     }
-    let nWritten = writeSync(file.rid, buffer);
-
-    const data = Deno.readFileSync(tempFile);
-
-    assertEquals(nWritten, 5);
-    assertEquals(data, new Uint8Array(bytes));
-
-    nWritten = await new Promise((resolve, reject) =>
-      write(
-        file.rid,
-        buffer,
-        0,
-        5,
-        (err: unknown, nwritten: number) => {
-          if (err) return reject(err);
-          resolve(nwritten);
-        },
-      )
-    );
-
-    assertEquals(nWritten, 5);
-    assertEquals(data, new Uint8Array(bytes));
   },
 });


### PR DESCRIPTION
My fix in #25030 was buggy, I forgot to pass the `byteOffset` and `byteLength`. Whoops.

I also discovered that fs.read was not respecting the `offset` argument, and we were constructing a new `Buffer` for the callback instead of just passing the original one (which is what node does, and the @types/node definitions also indicate the callback should get the same type).
Fixes #25028.