### PR TITLE
refactor: show release channel in `deno --version`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -36,7 +36,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::args::resolve_no_prompt;
-use crate::shared::ReleaseChannel;
 use crate::util::fs::canonicalize_path;
 
 use super::flags_net;
@@ -1333,27 +1332,10 @@ static UNSTABLE_HEADING: &str = "Unstable";
 
 pub fn clap_root() -> Command {
   let long_version = format!(
-    "{} ({}, {})\nv8 {}\ntypescript {}",
+    "{} ({}, {}, {})\nv8 {}\ntypescript {}",
     crate::version::DENO_VERSION_INFO.deno,
-    // TODO(bartlomieju): alter what's printed here.
-    // I think it's best if we print as follows:
-    // <version>(+<short_git_hash>) (<release_channel>, <profile>, <target>)
-    // For stable it would be:
-    //   v1.46.0 (stable, release, aarch64-apple-darwin)
-    // For rc it would be:
-    //   v1.46.0-rc.2 (release candidate, release, aarch64-apple-darwin)
-    // For lts it would be:
-    //   v2.1.13-lts (LTS (long term support), release, aarch64-apple-darwin)
-    // For canary it would be:
-    //   v1.46.0+25bb59d (canary, release, aarch64-apple-darwin)
-    if matches!(
-      crate::version::DENO_VERSION_INFO.release_channel,
-      ReleaseChannel::Canary
-    ) {
-      "canary"
-    } else {
-      env!("PROFILE")
-    },
+    crate::version::DENO_VERSION_INFO.release_channel.name(),
+    env!("PROFILE"),
     env!("TARGET"),
     deno_core::v8_version(),
     crate::version::DENO_VERSION_INFO.typescript

--- a/cli/shared.rs
+++ b/cli/shared.rs
@@ -16,14 +16,14 @@ pub enum ReleaseChannel {
   #[allow(unused)]
   Lts,
 
-  /// Release candidate, poiting to a git hash
+  /// Release candidate, eg. 1.46.0-rc.0, 2.0.0-rc.1
   Rc,
 }
 
 impl ReleaseChannel {
   pub fn name(&self) -> &str {
     match self {
-      Self::Stable => "latest",
+      Self::Stable => "stable",
       Self::Canary => "canary",
       Self::Rc => "release candidate",
       Self::Lts => "long term support",

--- a/cli/shared.rs
+++ b/cli/shared.rs
@@ -26,7 +26,7 @@ impl ReleaseChannel {
       Self::Stable => "latest",
       Self::Canary => "canary",
       Self::Rc => "release candidate",
-      Self::Lts => "LTS (long term support)",
+      Self::Lts => "long term support",
     }
   }
 

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -23,8 +23,7 @@ pub static DENO_VERSION_INFO: Lazy<DenoVersionInfo> = Lazy::new(|| {
     });
 
   DenoVersionInfo {
-    // TODO(bartlomieju): fix further for RC and LTS releases
-    deno: if IS_CANARY {
+    deno: if release_channel == ReleaseChannel::Canary {
       concat!(
         env!("CARGO_PKG_VERSION"),
         "+",
@@ -39,8 +38,7 @@ pub static DENO_VERSION_INFO: Lazy<DenoVersionInfo> = Lazy::new(|| {
     git_hash: GIT_COMMIT_HASH,
 
     // Keep in sync with `deno` field.
-    // TODO(bartlomieju): fix further for RC and LTS releases
-    user_agent: if IS_CANARY {
+    user_agent: if release_channel == ReleaseChannel::Canary {
       concat!(
         "Deno/",
         env!("CARGO_PKG_VERSION"),
@@ -77,7 +75,7 @@ impl DenoVersionInfo {
   /// For stable release, a semver like, eg. `v1.46.2`.
   /// For canary release a full git hash, eg. `9bdab6fb6b93eb43b1930f40987fa4997287f9c8`.
   pub fn version_or_git_hash(&self) -> &'static str {
-    if IS_CANARY {
+    if self.release_channel == ReleaseChannel::Canary {
       self.git_hash
     } else {
       CARGO_PKG_VERSION


### PR DESCRIPTION
Also simplifies handling of various release channels in `deno upgrade` subcommand.