### PR TITLE
fix(ext/node): fix prismjs compatibiliy in Web Worker

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -65,6 +65,7 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 #[rustfmt::skip]
 const MANAGED_GLOBALS: [&[u16]; 13] = [
   &str_to_utf16::<6>("Buffer"),
+  &str_to_utf16::<17>("WorkerGlobalScope"),
   &str_to_utf16::<14>("clearImmediate"),
   &str_to_utf16::<13>("clearInterval"),
   &str_to_utf16::<12>("clearTimeout"),
@@ -76,11 +77,10 @@ const MANAGED_GLOBALS: [&[u16]; 13] = [
   &str_to_utf16::<12>("setImmediate"),
   &str_to_utf16::<11>("setInterval"),
   &str_to_utf16::<10>("setTimeout"),
-  &str_to_utf16::<6>("window"),
 ];
 
 const SHORTEST_MANAGED_GLOBAL: usize = 4;
-const LONGEST_MANAGED_GLOBAL: usize = 14;
+const LONGEST_MANAGED_GLOBAL: usize = 17;
 
 #[derive(Debug, Clone, Copy)]
 enum Mode {

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -80,8 +80,25 @@ const MANAGED_GLOBALS: [&[u16]; 14] = [
   &str_to_utf16::<6>("window"),
 ];
 
-const SHORTEST_MANAGED_GLOBAL: usize = 4;
-const LONGEST_MANAGED_GLOBAL: usize = 17;
+// Calculates the shortest & longest length of global var names
+const MANAGED_GLOBALS_INFO: (usize, usize) = {
+  let l = MANAGED_GLOBALS[0].len();
+  let (mut longest, mut shortest, mut i) = (l, l, 1);
+  while i < MANAGED_GLOBALS.len() {
+    let l = MANAGED_GLOBALS[i].len();
+    if l > longest {
+      longest = l
+    }
+    if l < shortest {
+      shortest = l
+    }
+    i += 1;
+  }
+  (shortest, longest)
+};
+
+const SHORTEST_MANAGED_GLOBAL: usize = MANAGED_GLOBALS_INFO.0;
+const LONGEST_MANAGED_GLOBAL: usize = MANAGED_GLOBALS_INFO.1;
 
 #[derive(Debug, Clone, Copy)]
 enum Mode {

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -63,7 +63,7 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 
 // UTF-16 encodings of the managed globals. THIS LIST MUST BE SORTED.
 #[rustfmt::skip]
-const MANAGED_GLOBALS: [&[u16]; 13] = [
+const MANAGED_GLOBALS: [&[u16]; 14] = [
   &str_to_utf16::<6>("Buffer"),
   &str_to_utf16::<17>("WorkerGlobalScope"),
   &str_to_utf16::<14>("clearImmediate"),
@@ -77,6 +77,7 @@ const MANAGED_GLOBALS: [&[u16]; 13] = [
   &str_to_utf16::<12>("setImmediate"),
   &str_to_utf16::<11>("setInterval"),
   &str_to_utf16::<10>("setTimeout"),
+  &str_to_utf16::<6>("window"),
 ];
 
 const SHORTEST_MANAGED_GLOBAL: usize = 4;

--- a/tests/registry/npm/@denotest/check-worker-globals/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/check-worker-globals/1.0.0/index.js
@@ -1,0 +1,7 @@
+if (typeof self !== "undefined") {
+  throw new Error("self is defined");
+}
+
+if (typeof WorkerGlobalScope !== "undefined") {
+  throw new Error("WorkerGlobalScope is defined");
+}

--- a/tests/registry/npm/@denotest/check-worker-globals/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/check-worker-globals/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/check-worker-globals",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/specs/npm/workers/main.out
+++ b/tests/specs/npm/workers/main.out
@@ -2,4 +2,5 @@
 1
 2
 3
+4
 [UNORDERED_END]

--- a/tests/specs/npm/workers/main.ts
+++ b/tests/specs/npm/workers/main.ts
@@ -7,3 +7,6 @@ new Worker(new URL("./worker2.ts", import.meta.url), {
 new Worker(new URL("./worker3.ts", import.meta.url), {
   type: "module",
 });
+new Worker(new URL("./worker4.ts", import.meta.url), {
+  type: "module",
+});

--- a/tests/specs/npm/workers/worker4.ts
+++ b/tests/specs/npm/workers/worker4.ts
@@ -1,0 +1,4 @@
+import "npm:@denotest/check-worker-globals";
+
+console.log(4);
+self.close();


### PR DESCRIPTION
PrismJS uses `WorkerGlobalScope` and `self` for detecting browser's Web Worker context:

https://github.com/PrismJS/prism/blob/59e5a3471377057de1f401ba38337aca27b80e03/prism.js#L11

Now the detection logic above is broken when it's imported from Deno's Web Worker context because we only hide `self` (Prism assumes when `WorkerGlobalScope` is available, `self` is also available).

This PR fixes the above by also hiding `WorkerGlobalScope` global in Node compat mode.

closes #25008
