### PR TITLE
fix: log current version when using deno upgrade

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -450,7 +450,7 @@ pub async fn upgrade(
   let requested_version =
     RequestedVersion::from_upgrade_flags(upgrade_flags.clone())?;
 
-  log::info!("Current version is {}", version::DENO_VERSION_INFO.deno);
+  log::info!("Current Deno version: v{}", version::DENO_VERSION_INFO.deno);
 
   let maybe_selected_version_to_upgrade = match &requested_version {
     RequestedVersion::Latest(channel) => {

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -450,6 +450,8 @@ pub async fn upgrade(
   let requested_version =
     RequestedVersion::from_upgrade_flags(upgrade_flags.clone())?;
 
+  log::info!("Current version is {}", version::DENO_VERSION_INFO.deno);
+
   let maybe_selected_version_to_upgrade = match &requested_version {
     RequestedVersion::Latest(channel) => {
       find_latest_version_to_upgrade(


### PR DESCRIPTION
This PR addresses a suggestion in issue #21417

**Changes**
Logged out current version when using deno upgrade.