### PR TITLE
fix(node/http): wrong `req.url` value

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1781,7 +1781,7 @@ export class ServerImpl extends EventEmitter {
       });
 
       const req = new IncomingMessageForServer(socket);
-      // Slice of the origin
+      // Slice off the origin so that we only have pathname + search
       req.url = request.url?.slice(request.url.indexOf("/", 8));
       req.method = request.method;
       req.upgrade =

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1781,7 +1781,8 @@ export class ServerImpl extends EventEmitter {
       });
 
       const req = new IncomingMessageForServer(socket);
-      req.url = request.url?.slice(req.url.indexOf("/", 8));
+      // Slice of the origin
+      req.url = request.url?.slice(request.url.indexOf("/", 8));
       req.method = request.method;
       req.upgrade =
         request.headers.get("connection")?.toLowerCase().includes("upgrade") &&

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1539,3 +1539,21 @@ Deno.test("[node/http] ClientRequest PUT subarray", async () => {
   await promise;
   assertEquals(body, "world");
 });
+
+Deno.test("[node/http] req.url equals pathname + search", async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  const server = http.createServer((req, res) => res.end(req.url));
+  server.listen(async () => {
+    const { port } = server.address() as net.AddressInfo;
+    const res = await fetch(`http://localhost:${port}/foo/bar?baz=1`);
+    const text = await res.text();
+    assertEquals(text, "/foo/bar?baz=1");
+
+    server.close(() => {
+      resolve();
+    });
+  });
+
+  await promise;
+});


### PR DESCRIPTION
This PR addresses a regression introduced in https://github.com/denoland/deno/pull/25021 that would cause the `req.url` parameter in Node's http server to always be a single character instead of the expected value. The regression was caused by effectively calling `.indexOf()` on an empty string and thus passing the wrong index for slicing.

```js
"".indexOf("/") // -> -1
request.url.slice(-1) // effectively only giving us the last character
```

Fixes https://github.com/denoland/deno/issues/25080