### PR TITLE
fix: make `deno add` output more deterministic

### DIFF
--- a/cli/tools/registry/pm.rs
+++ b/cli/tools/registry/pm.rs
@@ -247,7 +247,7 @@ pub async fn add(
     .collect::<Vec<_>>();
 
   let stream_of_futures = deno_core::futures::stream::iter(package_futures);
-  let mut buffered = stream_of_futures.buffer_unordered(10);
+  let mut buffered = stream_of_futures.buffered(10);
 
   while let Some(package_and_version_result) = buffered.next().await {
     let package_and_version = package_and_version_result?;


### PR DESCRIPTION
Will fix some flaky tests.

```
---- specs::remove::basic ----
command /Users/runner/work/deno/deno/target/debug/deno add @std/assert @std/http
command cwd /var/folders/cy/09t6wxdj6qn64c5q9_kr6czr0000gn/T/deno-cli-testKwb00C
output path /Users/runner/work/deno/deno/tests/specs/remove/basic/add.out
-- OUTPUT START --
Created deno.json configuration file.
Add jsr:@std/http@1.0.0
Add jsr:@std/assert@1.0.0
Download http://127.0.0.1:4250/@std/http/1.0.0_meta.json
Download http://127.0.0.1:4250/@std/assert/1.0.0_meta.json
Download http://127.0.0.1:4250/@std/http/1.0.0/mod.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/mod.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/assert_equals.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/assert.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/fail.ts

-- OUTPUT END --
-- EXPECTED START --
Created deno.json configuration file.
Add jsr:@std/assert@1.0.0
Add jsr:@std/http@1.0.0
[UNORDERED_START]
Download http://127.0.0.1:4250/@std/http/1.0.0_meta.json
Download http://127.0.0.1:4250/@std/assert/1.0.0_meta.json
Download http://127.0.0.1:4250/@std/http/1.0.0/mod.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/mod.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/assert_equals.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/assert.ts
Download http://127.0.0.1:4250/@std/assert/1.0.0/fail.ts
[UNORDERED_END]
```