### PR TITLE
fix: correct JSON config schema to show vendor option as stable

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -434,7 +434,7 @@
       "type": "boolean"
     },
     "vendor": {
-      "description": "UNSTABLE: Enables or disables the use of a local vendor folder as a local cache for remote modules and node_modules folder for npm packages. Alternatively, use the `--vendor` flag or override the config via `--vendor=false`. Requires Deno 1.36.1 or later.",
+      "description": "Enables or disables the use of a local vendor folder as a local cache for remote modules and node_modules folder for npm packages. Alternatively, use the `--vendor` flag or override the config via `--vendor=false`. Requires Deno 1.36.1 or later.",
       "type": "boolean"
     },
     "tasks": {


### PR DESCRIPTION
This has been considered stable for some time now.

https://docs.deno.com/runtime/manual/basics/vendoring/