### PR TITLE
fix(upgrade): support RC release with --version flag

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -645,14 +645,9 @@ fn select_specific_version_for_upgrade(
       }))
     }
     ReleaseChannel::Rc => {
-      let current_is_passed = if version::DENO_VERSION_INFO.release_channel
+      let current_is_passed = version::DENO_VERSION_INFO.release_channel
         == ReleaseChannel::Rc
-        && version::DENO_VERSION_INFO.deno == version
-      {
-        true
-      } else {
-        false
-      };
+        && version::DENO_VERSION_INFO.deno == version;
 
       if !force && current_is_passed {
         log::info!(

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -380,13 +380,13 @@ async fn check_for_upgrades_for_lsp_with_provider(
         }
       }
       Ok(Some(LspVersionUpgradeInfo {
-        latest_version: latest_version.display,
+        latest_version: latest_version.version_or_hash,
         is_canary: false,
       }))
     }
 
     ReleaseChannel::Canary => Ok(Some(LspVersionUpgradeInfo {
-      latest_version: latest_version.display,
+      latest_version: latest_version.version_or_hash,
       is_canary: true,
     })),
 
@@ -488,7 +488,7 @@ pub async fn upgrade(
     "{}",
     colors::gray(format!(
       "Deno is upgrading to version {}",
-      &selected_version_to_upgrade.display
+      &selected_version_to_upgrade.version_or_hash
     ))
   );
 
@@ -533,7 +533,7 @@ pub async fn upgrade(
   if requested_version.release_channel() == ReleaseChannel::Stable {
     print_release_notes(
       version::DENO_VERSION_INFO.deno,
-      &selected_version_to_upgrade.display,
+      &selected_version_to_upgrade.version_or_hash,
     );
   }
 
@@ -574,10 +574,15 @@ impl RequestedVersion {
       }
       (ReleaseChannel::Canary, passed_version)
     } else {
-      if Version::parse_standard(&passed_version).is_err() {
+      let Ok(semver) = Version::parse_standard(&passed_version) else {
         bail!("Invalid version passed");
       };
-      (ReleaseChannel::Stable, passed_version)
+
+      if semver.pre.contains(&"rc".to_string()) {
+        (ReleaseChannel::Rc, passed_version)
+      } else {
+        (ReleaseChannel::Stable, passed_version)
+      }
     };
 
     Ok(RequestedVersion::SpecificVersion(channel, passed_version))
@@ -616,9 +621,8 @@ fn select_specific_version_for_upgrade(
       }
 
       Ok(Some(AvailableVersion {
-        version_or_hash: version.to_string(),
+        version_or_hash: version,
         release_channel,
-        display: version,
       }))
     }
     ReleaseChannel::Canary => {
@@ -632,13 +636,33 @@ fn select_specific_version_for_upgrade(
       }
 
       Ok(Some(AvailableVersion {
-        version_or_hash: version.to_string(),
+        version_or_hash: version,
         release_channel,
-        display: version,
       }))
     }
-    // TODO(bartlomieju)
-    ReleaseChannel::Rc => unreachable!(),
+    ReleaseChannel::Rc => {
+      let current_is_passed = if version::DENO_VERSION_INFO.release_channel
+        == ReleaseChannel::Rc
+        && version::DENO_VERSION_INFO.deno == version
+      {
+        true
+      } else {
+        false
+      };
+
+      if !force && current_is_passed {
+        log::info!(
+          "Version {} is already installed",
+          version::DENO_VERSION_INFO.deno
+        );
+        return Ok(None);
+      }
+
+      Ok(Some(AvailableVersion {
+        version_or_hash: version,
+        release_channel,
+      }))
+    }
     // TODO(bartlomieju)
     ReleaseChannel::Lts => unreachable!(),
   }
@@ -717,8 +741,6 @@ async fn find_latest_version_to_upgrade(
 struct AvailableVersion {
   version_or_hash: String,
   release_channel: ReleaseChannel,
-  // TODO(bartlomieju): remove this one
-  display: String,
 }
 
 impl AvailableVersion {
@@ -726,8 +748,8 @@ impl AvailableVersion {
   /// for non-canary releases.
   fn display(&self) -> Cow<str> {
     match self.release_channel {
-      ReleaseChannel::Canary => Cow::Borrowed(&self.display),
-      _ => Cow::Owned(format!("v{}", self.display)),
+      ReleaseChannel::Canary => Cow::Borrowed(&self.version_or_hash),
+      _ => Cow::Owned(format!("v{}", self.version_or_hash)),
     }
   }
 }
@@ -754,13 +776,11 @@ fn normalize_version_from_server(
       Ok(AvailableVersion {
         version_or_hash: v.to_string(),
         release_channel,
-        display: v.to_string(),
       })
     }
     ReleaseChannel::Canary => Ok(AvailableVersion {
       version_or_hash: text.to_string(),
       release_channel,
-      display: text.to_string(),
     }),
   }
 }
@@ -1087,7 +1107,6 @@ mod test {
         latest_version: Rc::new(RefCell::new(Ok(AvailableVersion {
           version_or_hash: "".to_string(),
           release_channel: ReleaseChannel::Stable,
-          display: "".to_string(),
         }))),
         time: Rc::new(RefCell::new(chrono::Utc::now())),
       }
@@ -1116,7 +1135,6 @@ mod test {
       *self.latest_version.borrow_mut() = Ok(AvailableVersion {
         version_or_hash: version.to_string(),
         release_channel,
-        display: version.to_string(),
       });
     }
 
@@ -1413,7 +1431,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "1.0.0".to_string(),
         release_channel: ReleaseChannel::Stable,
-        display: "1.0.0".to_string()
       },
     );
     // should not replace v after start
@@ -1426,7 +1443,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "1.0.0-test-v".to_string(),
         release_channel: ReleaseChannel::Stable,
-        display: "1.0.0-test-v".to_string()
       }
     );
     // should not strip v for canary
@@ -1439,7 +1455,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "v1452345asdf".to_string(),
         release_channel: ReleaseChannel::Canary,
-        display: "v1452345asdf".to_string()
       }
     );
     assert_eq!(
@@ -1448,7 +1463,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "1.46.0-rc.0".to_string(),
         release_channel: ReleaseChannel::Rc,
-        display: "1.46.0-rc.0".to_string(),
       },
     );
   }

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -527,8 +527,12 @@ pub async fn upgrade(
   check_windows_access_denied_error(output_result, output_exe_path)?;
 
   log::info!(
-    "\nUpgraded successfully to Deno {}\n",
-    colors::green(selected_version_to_upgrade.display())
+    "\nUpgraded successfully to Deno {} {}\n",
+    colors::green(selected_version_to_upgrade.display()),
+    colors::gray(&format!(
+      "({})",
+      selected_version_to_upgrade.release_channel.name()
+    ))
   );
   if requested_version.release_channel() == ReleaseChannel::Stable {
     print_release_notes(


### PR DESCRIPTION
This commit fixes scenarios like:
```
$ deno upgrade --version=v1.46.0-rc.0
Downloading https://github.com/denoland/deno/releases/download/v1.46.0-rc.0/deno-aarch64-apple-darwin.zip
Download could not be found, aborting
```

Now:
```
$ target/debug/deno upgrade --version=v1.46.0-rc.0
Downloading https://dl.deno.land/release/v1.46.0-rc.0/deno-aarch64-apple-darwin.zip
Deno is upgrading to version 1.46.0-rc.0

Upgraded successfully to Deno v1.46.0-rc.0

```

Also some unneeded code was removed.