### PR TITLE
fix(node/tty): fix `tty.WriteStream.hasColor` with different args

### DIFF
--- a/ext/node/polyfills/tty.js
+++ b/ext/node/polyfills/tty.js
@@ -113,7 +113,10 @@ export class WriteStream extends Socket {
    * @returns {boolean}
    */
   hasColors(count, env) {
-    if (env === undefined && typeof count === "object") {
+    if (
+      env === undefined &&
+      (count === undefined || typeof count === "object" && count !== null)
+    ) {
       env = count;
       count = 16;
     }

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -38,6 +38,9 @@ Deno.test("[node/tty WriteStream.isTTY] returns true when fd is a tty", () => {
 
 Deno.test("[node/tty WriteStream.hasColors] returns true when colors are supported", () => {
   assert(tty.WriteStream.prototype.hasColors() === !Deno.noColor);
+  assert(tty.WriteStream.prototype.hasColors({}) === !Deno.noColor);
+  assert(tty.WriteStream.prototype.hasColors(2) === !Deno.noColor);
+  assert(tty.WriteStream.prototype.hasColors(2, {}) === !Deno.noColor);
 });
 
 Deno.test("[node/tty WriteStream.getColorDepth] returns current terminal color depth", () => {

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -40,9 +40,8 @@ Deno.test("[node/tty WriteStream.hasColors] returns true when colors are support
   assert(tty.WriteStream.prototype.hasColors() === !Deno.noColor);
   assert(tty.WriteStream.prototype.hasColors({}) === !Deno.noColor);
 
-  const depth = tty.WriteStream.prototype.getColorDepth();
-  assert(tty.WriteStream.prototype.hasColors(depth) === !Deno.noColor);
-  assert(tty.WriteStream.prototype.hasColors(depth, {}) === !Deno.noColor);
+  assert(tty.WriteStream.prototype.hasColors(1));
+  assert(tty.WriteStream.prototype.hasColors(1, {}));
 });
 
 Deno.test("[node/tty WriteStream.getColorDepth] returns current terminal color depth", () => {

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -39,8 +39,10 @@ Deno.test("[node/tty WriteStream.isTTY] returns true when fd is a tty", () => {
 Deno.test("[node/tty WriteStream.hasColors] returns true when colors are supported", () => {
   assert(tty.WriteStream.prototype.hasColors() === !Deno.noColor);
   assert(tty.WriteStream.prototype.hasColors({}) === !Deno.noColor);
-  assert(tty.WriteStream.prototype.hasColors(2) === !Deno.noColor);
-  assert(tty.WriteStream.prototype.hasColors(2, {}) === !Deno.noColor);
+
+  const depth = tty.WriteStream.prototype.getColorDepth();
+  assert(tty.WriteStream.prototype.hasColors(depth) === !Deno.noColor);
+  assert(tty.WriteStream.prototype.hasColors(depth, {}) === !Deno.noColor);
 });
 
 Deno.test("[node/tty WriteStream.getColorDepth] returns current terminal color depth", () => {


### PR DESCRIPTION
The check in `tty.WriteStream.prototype.hasColors()` was incorrect leading to the [`yoctocolors`](https://github.com/sindresorhus/yoctocolors) package not printing any colors.

Fixes https://github.com/denoland/deno/issues/24407