### PR TITLE
feat(upgrade): support `deno upgrade 1.46.0`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3019,8 +3019,23 @@ The declaration file could be saved and used for typing information.",
 fn upgrade_subcommand() -> Command {
   command(
     "upgrade",
-    "Upgrade deno executable to the given version.
-Defaults to latest.
+    color_print::cstr!("<g>Upgrade</> deno executable to the given version.
+
+<g>Latest</>
+
+  deno upgrade
+
+<g>Specific version</>
+
+  deno upgrade <p(245)>1.45.0</>
+  deno upgrade <p(245)>1.46.0-rc.1</>
+  deno upgrade <p(245)>9bc2dd29ad6ba334fd57a20114e367d3c04763d4</>
+
+<g>Channel</>
+
+  deno upgrade <p(245)>stable</>
+  deno upgrade <p(245)>rc</>
+  deno upgrade <p(245)>canary</>
 
 The version is downloaded from
 https://github.com/denoland/deno/releases
@@ -3028,7 +3043,7 @@ and is used to replace the current executable.
 
 If you want to not replace the current Deno executable but instead download an
 update to a different location, use the --output flag:
-  deno upgrade --output $HOME/my_deno",
+  deno upgrade --output $HOME/my_deno"),
     UnstableArgsConfig::None,
   )
   .hide(cfg!(not(feature = "upgrade")))
@@ -3038,7 +3053,8 @@ update to a different location, use the --output flag:
         Arg::new("version")
           .long("version")
           .help("The version to upgrade to")
-          .help_heading(UPGRADE_HEADING),
+          .help_heading(UPGRADE_HEADING)// NOTE(bartlomieju): pre-v1.46 compat
+          .hide(true),
       )
       .arg(
         Arg::new("output")
@@ -3068,7 +3084,8 @@ update to a different location, use the --output flag:
           .long("canary")
           .help("Upgrade to canary builds")
           .action(ArgAction::SetTrue)
-          .help_heading(UPGRADE_HEADING),
+          .help_heading(UPGRADE_HEADING)// NOTE(bartlomieju): pre-v1.46 compat
+          .hide(true),
       )
       .arg(
         Arg::new("release-candidate")
@@ -3076,11 +3093,13 @@ update to a different location, use the --output flag:
           .help("Upgrade to a release candidate")
           .conflicts_with_all(["canary", "version"])
           .action(ArgAction::SetTrue)
-          .help_heading(UPGRADE_HEADING),
+          .help_heading(UPGRADE_HEADING)
+          // NOTE(bartlomieju): pre-v1.46 compat
+          .hide(true),
       )
       .arg(
         Arg::new("version-or-hash-or-channel")
-          .help("Version, channel or commit hash")
+          .help(color_print::cstr!("Version <p(245)>(v1.46.0)</>, channel <p(245)>(rc, canary)</> or commit hash <p(245)>(9bc2dd29ad6ba334fd57a20114e367d3c04763d4)</>"))
           .value_name("VERSION")
           .action(ArgAction::Append)
           .trailing_var_arg(true),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -412,6 +412,7 @@ pub struct UpgradeFlags {
   pub canary: bool,
   pub version: Option<String>,
   pub output: Option<String>,
+  pub version_or_hash_or_channel: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2983,6 +2984,13 @@ update to a different location, use the --output flag:
             .conflicts_with_all(["canary", "version"])
             .action(ArgAction::SetTrue),
         )
+        .arg(
+          Arg::new("version-or-hash-or-channel")
+            .help("Version, channel or commit hash")
+            .value_name("VERSION")
+            .action(ArgAction::Append)
+            .trailing_var_arg(true),
+        )
         .arg(ca_file_arg())
     })
 }
@@ -4668,6 +4676,8 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let release_candidate = matches.get_flag("release-candidate");
   let version = matches.remove_one::<String>("version");
   let output = matches.remove_one::<String>("output");
+  let version_or_hash_or_channel =
+    matches.remove_one::<String>("version-or-hash-or-channel");
   flags.subcommand = DenoSubcommand::Upgrade(UpgradeFlags {
     dry_run,
     force,
@@ -4675,6 +4685,7 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     canary,
     version,
     output,
+    version_or_hash_or_channel,
   });
 }
 

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -645,14 +645,9 @@ fn select_specific_version_for_upgrade(
       }))
     }
     ReleaseChannel::Rc => {
-      let current_is_passed = if version::DENO_VERSION_INFO.release_channel
+      let current_is_passed = version::DENO_VERSION_INFO.release_channel
         == ReleaseChannel::Rc
-        && version::DENO_VERSION_INFO.deno == version
-      {
-        true
-      } else {
-        false
-      };
+        && version::DENO_VERSION_INFO.deno == version;
 
       if !force && current_is_passed {
         log::info!(

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -570,6 +570,11 @@ impl RequestedVersion {
       if let Ok(channel) = ReleaseChannel::deserialize(&val.to_lowercase()) {
         // TODO(bartlomieju): print error if any other flags passed?
         return Ok(Self::Latest(channel));
+      } else if re_hash.is_match(val) {
+        return Ok(Self::SpecificVersion(
+          ReleaseChannel::Canary,
+          val.to_string(),
+        ));
       } else {
         maybe_passed_version = Some(val.to_string());
       }
@@ -1064,21 +1069,86 @@ mod test {
       RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
     assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
 
+    upgrade_flags.version = Some("1.46.0".to_string());
     let req_ver =
       RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
-    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+    assert_eq!(
+      req_ver,
+      RequestedVersion::SpecificVersion(
+        ReleaseChannel::Stable,
+        "1.46.0".to_string()
+      )
+    );
 
+    upgrade_flags.version = None;
+    upgrade_flags.canary = true;
     let req_ver =
       RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
-    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Canary));
 
+    upgrade_flags.version =
+      Some("5c69b4861b52ab406e73b9cd85c254f0505cb20f".to_string());
     let req_ver =
       RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
-    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+    assert_eq!(
+      req_ver,
+      RequestedVersion::SpecificVersion(
+        ReleaseChannel::Canary,
+        "5c69b4861b52ab406e73b9cd85c254f0505cb20f".to_string()
+      )
+    );
 
+    upgrade_flags.version = None;
+    upgrade_flags.canary = false;
+    upgrade_flags.release_candidate = true;
     let req_ver =
       RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
-    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Rc));
+
+    upgrade_flags.release_candidate = false;
+    upgrade_flags.version_or_hash_or_channel = Some("v1.46.5".to_string());
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(
+      req_ver,
+      RequestedVersion::SpecificVersion(
+        ReleaseChannel::Stable,
+        "1.46.5".to_string()
+      )
+    );
+
+    upgrade_flags.version_or_hash_or_channel = Some("2.0.0-rc.0".to_string());
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(
+      req_ver,
+      RequestedVersion::SpecificVersion(
+        ReleaseChannel::Rc,
+        "2.0.0-rc.0".to_string()
+      )
+    );
+
+    upgrade_flags.version_or_hash_or_channel = Some("canary".to_string());
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Canary,));
+
+    upgrade_flags.version_or_hash_or_channel = Some("rc".to_string());
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Rc,));
+
+    upgrade_flags.version_or_hash_or_channel =
+      Some("5c69b4861b52ab406e73b9cd85c254f0505cb20f".to_string());
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(
+      req_ver,
+      RequestedVersion::SpecificVersion(
+        ReleaseChannel::Canary,
+        "5c69b4861b52ab406e73b9cd85c254f0505cb20f".to_string()
+      )
+    );
   }
 
   #[test]

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -547,7 +547,7 @@ pub async fn upgrade(
   Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum RequestedVersion {
   Latest(ReleaseChannel),
   SpecificVersion(ReleaseChannel, String),
@@ -1047,6 +1047,39 @@ mod test {
   use std::rc::Rc;
 
   use super::*;
+
+  #[test]
+  fn test_requested_version() {
+    let mut upgrade_flags = UpgradeFlags {
+      dry_run: false,
+      force: false,
+      release_candidate: false,
+      canary: false,
+      version: None,
+      output: None,
+      version_or_hash_or_channel: None,
+    };
+
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+
+    let req_ver =
+      RequestedVersion::from_upgrade_flags(upgrade_flags.clone()).unwrap();
+    assert_eq!(req_ver, RequestedVersion::Latest(ReleaseChannel::Stable));
+  }
 
   #[test]
   fn test_parse_upgrade_check_file() {

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -380,13 +380,13 @@ async fn check_for_upgrades_for_lsp_with_provider(
         }
       }
       Ok(Some(LspVersionUpgradeInfo {
-        latest_version: latest_version.display,
+        latest_version: latest_version.version_or_hash,
         is_canary: false,
       }))
     }
 
     ReleaseChannel::Canary => Ok(Some(LspVersionUpgradeInfo {
-      latest_version: latest_version.display,
+      latest_version: latest_version.version_or_hash,
       is_canary: true,
     })),
 
@@ -488,7 +488,7 @@ pub async fn upgrade(
     "{}",
     colors::gray(format!(
       "Deno is upgrading to version {}",
-      &selected_version_to_upgrade.display
+      &selected_version_to_upgrade.version_or_hash
     ))
   );
 
@@ -533,7 +533,7 @@ pub async fn upgrade(
   if requested_version.release_channel() == ReleaseChannel::Stable {
     print_release_notes(
       version::DENO_VERSION_INFO.deno,
-      &selected_version_to_upgrade.display,
+      &selected_version_to_upgrade.version_or_hash,
     );
   }
 
@@ -574,10 +574,15 @@ impl RequestedVersion {
       }
       (ReleaseChannel::Canary, passed_version)
     } else {
-      if Version::parse_standard(&passed_version).is_err() {
+      let Ok(semver) = Version::parse_standard(&passed_version) else {
         bail!("Invalid version passed");
       };
-      (ReleaseChannel::Stable, passed_version)
+
+      if semver.pre.contains(&"rc".to_string()) {
+        (ReleaseChannel::Rc, passed_version)
+      } else {
+        (ReleaseChannel::Stable, passed_version)
+      }
     };
 
     Ok(RequestedVersion::SpecificVersion(channel, passed_version))
@@ -616,9 +621,8 @@ fn select_specific_version_for_upgrade(
       }
 
       Ok(Some(AvailableVersion {
-        version_or_hash: version.to_string(),
+        version_or_hash: version,
         release_channel,
-        display: version,
       }))
     }
     ReleaseChannel::Canary => {
@@ -632,13 +636,33 @@ fn select_specific_version_for_upgrade(
       }
 
       Ok(Some(AvailableVersion {
-        version_or_hash: version.to_string(),
+        version_or_hash: version,
         release_channel,
-        display: version,
       }))
     }
-    // TODO(bartlomieju)
-    ReleaseChannel::Rc => unreachable!(),
+    ReleaseChannel::Rc => {
+      let current_is_passed = if version::DENO_VERSION_INFO.release_channel
+        == ReleaseChannel::Rc
+        && version::DENO_VERSION_INFO.deno == version
+      {
+        true
+      } else {
+        false
+      };
+
+      if !force && current_is_passed {
+        log::info!(
+          "Version {} is already installed",
+          version::DENO_VERSION_INFO.deno
+        );
+        return Ok(None);
+      }
+
+      Ok(Some(AvailableVersion {
+        version_or_hash: version,
+        release_channel,
+      }))
+    }
     // TODO(bartlomieju)
     ReleaseChannel::Lts => unreachable!(),
   }
@@ -717,8 +741,6 @@ async fn find_latest_version_to_upgrade(
 struct AvailableVersion {
   version_or_hash: String,
   release_channel: ReleaseChannel,
-  // TODO(bartlomieju): remove this one
-  display: String,
 }
 
 impl AvailableVersion {
@@ -726,8 +748,8 @@ impl AvailableVersion {
   /// for non-canary releases.
   fn display(&self) -> Cow<str> {
     match self.release_channel {
-      ReleaseChannel::Canary => Cow::Borrowed(&self.display),
-      _ => Cow::Owned(format!("v{}", self.display)),
+      ReleaseChannel::Canary => Cow::Borrowed(&self.version_or_hash),
+      _ => Cow::Owned(format!("v{}", self.version_or_hash)),
     }
   }
 }
@@ -754,13 +776,11 @@ fn normalize_version_from_server(
       Ok(AvailableVersion {
         version_or_hash: v.to_string(),
         release_channel,
-        display: v.to_string(),
       })
     }
     ReleaseChannel::Canary => Ok(AvailableVersion {
       version_or_hash: text.to_string(),
       release_channel,
-      display: text.to_string(),
     }),
   }
 }
@@ -1087,7 +1107,6 @@ mod test {
         latest_version: Rc::new(RefCell::new(Ok(AvailableVersion {
           version_or_hash: "".to_string(),
           release_channel: ReleaseChannel::Stable,
-          display: "".to_string(),
         }))),
         time: Rc::new(RefCell::new(chrono::Utc::now())),
       }
@@ -1116,7 +1135,6 @@ mod test {
       *self.latest_version.borrow_mut() = Ok(AvailableVersion {
         version_or_hash: version.to_string(),
         release_channel,
-        display: version.to_string(),
       });
     }
 
@@ -1413,7 +1431,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "1.0.0".to_string(),
         release_channel: ReleaseChannel::Stable,
-        display: "1.0.0".to_string()
       },
     );
     // should not replace v after start
@@ -1426,7 +1443,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "1.0.0-test-v".to_string(),
         release_channel: ReleaseChannel::Stable,
-        display: "1.0.0-test-v".to_string()
       }
     );
     // should not strip v for canary
@@ -1439,7 +1455,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "v1452345asdf".to_string(),
         release_channel: ReleaseChannel::Canary,
-        display: "v1452345asdf".to_string()
       }
     );
     assert_eq!(
@@ -1448,7 +1463,6 @@ mod test {
       AvailableVersion {
         version_or_hash: "1.46.0-rc.0".to_string(),
         release_channel: ReleaseChannel::Rc,
-        display: "1.46.0-rc.0".to_string(),
       },
     );
   }

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -527,8 +527,12 @@ pub async fn upgrade(
   check_windows_access_denied_error(output_result, output_exe_path)?;
 
   log::info!(
-    "\nUpgraded successfully to Deno {}\n",
-    colors::green(selected_version_to_upgrade.display())
+    "\nUpgraded successfully to Deno {} {}\n",
+    colors::green(selected_version_to_upgrade.display()),
+    colors::gray(&format!(
+      "({})",
+      selected_version_to_upgrade.release_channel.name()
+    ))
   );
   if requested_version.release_channel() == ReleaseChannel::Stable {
     print_release_notes(


### PR DESCRIPTION
This commit changes `deno upgrade` subcommand to accept
a positional argument that can be either a version, release channel
name or a git hash, making invocations of `deno upgrade` much
more concise:

```
# before
$ deno upgrade --version 1.46.0
# after 
$ deno upgrade 1.46.0
```

```
# before
$ deno upgrade --canary
# after
$ deno upgrade canary
```

```
# specific canary version before
$ deno upgrade --canary --version f042c39180c1b345de8e7b5f0dfae5d0a49b161f
# after
$ deno upgrade f042c39180c1b345de8e7b5f0dfae5d0a49b161f
```

Old flags are still supported, but hidden from the help output.