### PR TITLE
feat(flags): improve help output and make `deno run` list tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,15 +152,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -1146,6 +1147,7 @@ dependencies = [
 name = "deno"
 version = "1.46.0-rc.1"
 dependencies = [
+ "anstream",
  "async-trait",
  "base32",
  "base64 0.21.7",
@@ -3870,6 +3872,12 @@ dependencies = [
  "is-docker",
  "once_cell",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -83,6 +83,7 @@ libsui = "0.3.0"
 napi_sym.workspace = true
 node_resolver.workspace = true
 
+anstream = "0.6.14"
 async-trait.workspace = true
 base32.workspace = true
 base64.workspace = true

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2279,14 +2279,16 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
           .long("unstable-html")
           .help("Enable formatting HTML files")
           .value_parser(FalseyValueParser::new())
-          .action(ArgAction::SetTrue),
+          .action(ArgAction::SetTrue)
+          .help_heading(FMT_HEADING),
       )
       .arg(
         Arg::new("unstable-component")
           .long("unstable-component")
           .help("Enable formatting Svelte, Vue, Astro and Angular files")
           .value_parser(FalseyValueParser::new())
-          .action(ArgAction::SetTrue),
+          .action(ArgAction::SetTrue)
+          .help_heading(FMT_HEADING),
       )
       .arg(
         Arg::new("unstable-yaml")

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -376,6 +376,7 @@ pub struct WatchFlagsWithPaths {
 pub struct TaskFlags {
   pub cwd: Option<String>,
   pub task: Option<String>,
+  pub is_run: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3210,7 +3211,7 @@ fn compile_args_without_check_args(app: Command) -> Command {
 fn permission_args(app: Command) -> Command {
   app
     .after_help(cstr!(r#"<y>Permission options:</>
-Docs: https://docs.deno.com/go/permissions
+Docs: <c>https://docs.deno.com/go/permissions</>
 
   <g>-A, --allow-all</>                        Allow all permissions.
   <g>--no-prompt</>                        Always throw if required permission wasn't passed.
@@ -3230,6 +3231,7 @@ Docs: https://docs.deno.com/go/permissions
       <g>--allow-ffi[=<<PATH>...]</>            (Unstable) Allow loading dynamic libraries. Optionally specify allowed directories or files.
                                            <p(245)>--allow-ffi  |  --allow-ffi="./libfoo.so"</>
       <g>--allow-hrtime</>                     Allow high-resolution time measurement. Note: this can enable timing attacks and fingerprinting.
+                                           <p(245)>--allow-hrtime</>
   <g>    --deny-read[=<<PATH>...]</>            Deny file system read access. Optionally specify denied paths.
                                            <p(245)>--deny-read  |  --deny-read="/etc,/var/log.txt"</>
   <g>    --deny-write[=<<PATH>...]</>           Deny file system write access. Optionally specify denied paths.
@@ -3245,6 +3247,7 @@ Docs: https://docs.deno.com/go/permissions
       <g>--deny-ffi[=<<PATH>...]</>             (Unstable) Deny loading dynamic libraries. Optionally specify denied directories or files.
                                            <p(245)>--deny-ffi  |  --deny-ffi="./libfoo.so"</>
       <g>--deny-hrtime</>                      Deny high-resolution time measurement.
+                                           <p(245)>--deny-hrtime</>
 "#))
     .arg(
       Arg::new("allow-all")
@@ -4671,6 +4674,7 @@ fn run_parse(
     flags.subcommand = DenoSubcommand::Task(TaskFlags {
       cwd: None,
       task: None,
+      is_run: true,
     });
   }
 
@@ -4746,6 +4750,7 @@ fn task_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let mut task_flags = TaskFlags {
     cwd: matches.remove_one::<String>("cwd"),
     task: None,
+    is_run: false,
   };
 
   if let Some((task, mut matches)) = matches.remove_subcommand() {
@@ -10060,6 +10065,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         argv: svec!["hello", "world"],
         ..Flags::default()
@@ -10073,6 +10079,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         ..Flags::default()
       }
@@ -10085,6 +10092,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: Some("foo".to_string()),
           task: Some("build".to_string()),
+          is_run: false,
         }),
         ..Flags::default()
       }
@@ -10109,6 +10117,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         argv: svec!["--", "hello", "world"],
         config_flag: ConfigFlag::Path("deno.json".to_owned()),
@@ -10125,6 +10134,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: Some("foo".to_string()),
           task: Some("build".to_string()),
+          is_run: false,
         }),
         argv: svec!["--", "hello", "world"],
         ..Flags::default()
@@ -10142,6 +10152,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         argv: svec!["--"],
         ..Flags::default()
@@ -10158,6 +10169,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         argv: svec!["-1", "--test"],
         ..Flags::default()
@@ -10174,6 +10186,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         argv: svec!["--test"],
         ..Flags::default()
@@ -10191,6 +10204,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: Some("build".to_string()),
+          is_run: false,
         }),
         log_level: Some(log::Level::Error),
         ..Flags::default()
@@ -10207,6 +10221,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: None,
+          is_run: false,
         }),
         ..Flags::default()
       }
@@ -10222,6 +10237,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: None,
+          is_run: false,
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ..Flags::default()
@@ -10238,6 +10254,7 @@ mod tests {
         subcommand: DenoSubcommand::Task(TaskFlags {
           cwd: None,
           task: None,
+          is_run: false,
         }),
         config_flag: ConfigFlag::Path("deno.jsonc".to_string()),
         ..Flags::default()

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -218,9 +218,10 @@ async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
                 let task_flags = TaskFlags {
                   cwd: None,
                   task: Some(run_flags.script.clone()),
+                  is_run: true,
                 };
                 new_flags.subcommand = DenoSubcommand::Task(task_flags.clone());
-                let result = tools::task::execute_script(Arc::new(new_flags), task_flags.clone(), true).await;
+                let result = tools::task::execute_script(Arc::new(new_flags), task_flags.clone()).await;
                 match result {
                   Ok(v) => Ok(v),
                   Err(_) => {
@@ -240,7 +241,7 @@ async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
       tools::serve::serve(flags, serve_flags).await
     }),
     DenoSubcommand::Task(task_flags) => spawn_subcommand(async {
-      tools::task::execute_script(flags, task_flags, false).await
+      tools::task::execute_script(flags, task_flags).await
     }),
     DenoSubcommand::Test(test_flags) => {
       spawn_subcommand(async {

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -35,7 +35,17 @@ pub async fn execute_script(
   let cli_options = factory.cli_options()?;
   let start_dir = &cli_options.start_dir;
   if !start_dir.has_deno_or_pkg_json() {
-    bail!("deno task couldn't find deno.json(c). See https://docs.deno.com/go/config")
+    if task_flags.is_run {
+      bail!(r#"deno run couldn't find deno.json(c).
+If you meant to run a script, specify it, e.g., `deno run ./script.ts`.
+To run a task, ensure the config file exists.
+Examples:
+- Script: `deno run ./script.ts`
+- Task: `deno run dev`
+See https://docs.deno.com/go/config"#)
+    } else {
+      bail!("deno task couldn't find deno.json(c). See https://docs.deno.com/go/config")
+    }
   }
   let force_use_pkg_json =
     std::env::var_os(crate::task_runner::USE_PKG_JSON_HIDDEN_ENV_VAR_NAME)

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 pub async fn execute_script(
   flags: Arc<Flags>,
   task_flags: TaskFlags,
-  using_run: bool,
 ) -> Result<i32, AnyError> {
   let factory = CliFactory::from_flags(flags);
   let cli_options = factory.cli_options()?;
@@ -154,7 +153,7 @@ See https://docs.deno.com/go/config"#
       }
     },
     None => {
-      if using_run {
+      if task_flags.is_run {
         return Err(anyhow!("Task not found: {}", task_name));
       }
       log::error!("Task not found: {}", task_name);

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -36,13 +36,15 @@ pub async fn execute_script(
   let start_dir = &cli_options.start_dir;
   if !start_dir.has_deno_or_pkg_json() {
     if task_flags.is_run {
-      bail!(r#"deno run couldn't find deno.json(c).
+      bail!(
+        r#"deno run couldn't find deno.json(c).
 If you meant to run a script, specify it, e.g., `deno run ./script.ts`.
 To run a task, ensure the config file exists.
 Examples:
 - Script: `deno run ./script.ts`
 - Task: `deno run dev`
-See https://docs.deno.com/go/config"#)
+See https://docs.deno.com/go/config"#
+      )
     } else {
       bail!("deno task couldn't find deno.json(c). See https://docs.deno.com/go/config")
     }


### PR DESCRIPTION
- rewrite flag help
- use gray for indentation
- reorganize permission flags and split them up
- make help subcommand act like help flag
- `deno run` outputs list of tasks
- Fixes #25120

error handling for `deno run` in case of no config file being found needs to be improved