### PR TITLE
chore: Remove stray `console.error` log in `node:child_process`

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -55,7 +55,6 @@ import process from "node:process";
 import { StringPrototypeSlice } from "ext:deno_node/internal/primordials.mjs";
 import { StreamBase } from "ext:deno_node/internal_binding/stream_wrap.ts";
 import { Pipe, socketType } from "ext:deno_node/internal_binding/pipe_wrap.ts";
-import console from "node:console";
 import { Socket } from "node:net";
 
 export function mapValues<T, O>(

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1387,7 +1387,6 @@ export function setupChannel(target: any, ipc: number) {
     if (!target.connected) {
       const err = new ERR_IPC_CHANNEL_CLOSED();
       if (typeof callback === "function") {
-        console.error("ChildProcess.send with callback");
         process.nextTick(callback, err);
       } else {
         nextTick(() => target.emit("error", err));


### PR DESCRIPTION
Missed removing it before committing