### PR TITLE
chore: enable no-console dlint rule

### DIFF
--- a/.dlint.json
+++ b/.dlint.json
@@ -4,6 +4,7 @@
     "include": [
       "ban-untagged-todo",
       "camelcase",
+      "no-console",
       "guard-for-in"
     ],
     "exclude": [

--- a/cli/bench/console.js
+++ b/cli/bench/console.js
@@ -1,3 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 const count = 100000;
 for (let i = 0; i < count; i++) console.log("Hello World");

--- a/cli/bench/encode_into.js
+++ b/cli/bench/encode_into.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args
   : [process.argv[2], process.argv[3]];

--- a/cli/bench/getrandom.js
+++ b/cli/bench/getrandom.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args
   : [process.argv[2], process.argv[3]];

--- a/cli/bench/http/deno_tcp.ts
+++ b/cli/bench/http/deno_tcp.ts
@@ -3,6 +3,7 @@
 // TODO(bartlomieju): Replace this with a real HTTP server once
 // https://github.com/denoland/deno/issues/726 is completed.
 // Note: this is a keep-alive server.
+// deno-lint-ignore-file no-console
 const addr = Deno.args[0] || "127.0.0.1:4500";
 const [hostname, port] = addr.split(":");
 const listener = Deno.listen({ hostname, port: Number(port) });

--- a/cli/bench/op_now.js
+++ b/cli/bench/op_now.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args

--- a/cli/bench/secure_curves.js
+++ b/cli/bench/secure_curves.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args
   : [process.argv[2], process.argv[3]];

--- a/cli/bench/stdio/stdio.js
+++ b/cli/bench/stdio/stdio.js
@@ -2,6 +2,8 @@
 //
 // From https://github.com/just-js/benchmarks/tree/main/01-stdio
 
+// deno-lint-ignore-file no-console
+
 const blocksize = parseInt(Deno.args[0] || 65536);
 const buf = new Uint8Array(blocksize);
 let size = 0;

--- a/cli/bench/tty.js
+++ b/cli/bench/tty.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args

--- a/cli/bench/url_parse.js
+++ b/cli/bench/url_parse.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args

--- a/cli/bench/webstorage.js
+++ b/cli/bench/webstorage.js
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 // Note: when benchmarking across different Deno version, make sure to clear
 // the DENO_DIR cache.
 let [total, count] = typeof Deno !== "undefined" ? Deno.args : [];

--- a/cli/bench/write_file.js
+++ b/cli/bench/write_file.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 const queueMicrotask = globalThis.queueMicrotask || process.nextTick;
 let [total, count] = typeof Deno !== "undefined"
   ? Deno.args

--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -157,6 +157,7 @@ function cron(
         const _res = isPromise(result) ? (await result) : result;
         success = true;
       } catch (error) {
+        // deno-lint-ignore no-console
         console.error(`Exception in cron handler ${name}`, error);
         success = false;
       }

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -525,6 +525,7 @@ function mapToCallback(context, callback, onError) {
           );
         }
       } catch (error) {
+        // deno-lint-ignore no-console
         console.error("Exception in onError while handling exception", error);
         response = internalServerError();
       }
@@ -533,6 +534,7 @@ function mapToCallback(context, callback, onError) {
     if (innerRequest?.[_upgraded]) {
       // We're done here as the connection has been upgraded during the callback and no longer requires servicing.
       if (response !== UPGRADE_RESPONSE_SENTINEL) {
+        // deno-lint-ignore no-console
         console.error("Upgrade response was not returned from callback");
         context.close();
       }
@@ -612,6 +614,7 @@ function serve(arg1, arg2) {
   const wantsUnix = ObjectHasOwn(options, "path");
   const signal = options.signal;
   const onError = options.onError ?? function (error) {
+    // deno-lint-ignore no-console
     console.error(error);
     return internalServerError();
   };
@@ -627,6 +630,7 @@ function serve(arg1, arg2) {
       if (options.onListen) {
         options.onListen(listener.addr);
       } else {
+        // deno-lint-ignore no-console
         console.log(`Listening on ${path}`);
       }
     });
@@ -684,6 +688,7 @@ function serve(arg1, arg2) {
       const host = StringPrototypeIncludes(addr.hostname, ":")
         ? `[${addr.hostname}]`
         : addr.hostname;
+      // deno-lint-ignore no-console
       console.log(`Listening on ${scheme}${host}:${addr.port}/`);
     }
   };
@@ -729,6 +734,7 @@ function serveHttpOn(context, addr, callback) {
 
   const promiseErrorHandler = (error) => {
     // Abnormal exit
+    // deno-lint-ignore no-console
     console.error(
       "Terminating Deno.serve loop due to unexpected error",
       error,
@@ -856,6 +862,7 @@ function registerDeclarativeServer(exports) {
             const nThreads = serveWorkerCount > 1
               ? ` with ${serveWorkerCount} threads`
               : "";
+            // deno-lint-ignore no-console
             console.debug(
               `%cdeno serve%c: Listening on %chttp://${hostname}:${port}/%c${nThreads}`,
               "color: green",

--- a/ext/kv/01_db.ts
+++ b/ext/kv/01_db.ts
@@ -318,6 +318,7 @@ class Kv {
           const _res = isPromise(result) ? (await result) : result;
           success = true;
         } catch (error) {
+          // deno-lint-ignore no-console
           console.error("Exception in queue handler", error);
         } finally {
           const promise: Promise<void> = op_kv_finish_dequeued_message(

--- a/ext/node/polyfills/_utils.ts
+++ b/ext/node/polyfills/_utils.ts
@@ -42,6 +42,7 @@ export function warnNotImplemented(msg?: string) {
   const message = msg
     ? `Warning: Not implemented: ${msg}`
     : "Warning: Not implemented";
+  // deno-lint-ignore no-console
   console.warn(message);
 }
 

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1836,6 +1836,7 @@ export class ServerImpl extends EventEmitter {
   }
 
   setTimeout() {
+    // deno-lint-ignore no-console
     console.error("Not implemented: Server.setTimeout()");
   }
 

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -127,6 +127,7 @@ type Http2Headers = Record<string, string | string[]>;
 const debugHttp2Enabled = false;
 function debugHttp2(...args) {
   if (debugHttp2Enabled) {
+    // deno-lint-ignore no-console
     console.log(...args);
   }
 }
@@ -1636,16 +1637,19 @@ export class Http2Server extends Server {
                 this.emit("stream", stream, headers);
                 return await stream._deferred.promise;
               } catch (e) {
+                // deno-lint-ignore no-console
                 console.log(">>> Error in serveHttpOnConnection", e);
               }
               return new Response("");
             },
             () => {
+              // deno-lint-ignore no-console
               console.log(">>> error");
             },
             () => {},
           );
         } catch (e) {
+          // deno-lint-ignore no-console
           console.log(">>> Error in Http2Server", e);
         }
       },

--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -30,6 +30,7 @@ export function initializeDebugEnv(debugEnv: string) {
 // NODE_DEBUG=http or NODE_DEBUG=http2.
 function emitWarningIfNeeded(set: string) {
   if ("HTTP" === set || "HTTP2" === set) {
+    // deno-lint-ignore no-console
     console.warn(
       "Setting the NODE_DEBUG environment variable " +
         "to '" + set.toLowerCase() + "' can expose sensitive " +
@@ -50,6 +51,7 @@ function debuglogImpl(
       emitWarningIfNeeded(set);
       debugImpls[set] = function debug(...args: unknown[]) {
         const msg = args.map((arg) => inspect(arg)).join(" ");
+        // deno-lint-ignore no-console
         console.error("%s %s: %s", set, String(Deno.pid), msg);
       };
     } else {

--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -28,6 +28,7 @@ class NodeTestContext {
   }
 
   diagnostic(message) {
+    // deno-lint-ignore no-console
     console.log("DIAGNOSTIC:", message);
   }
 

--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -234,6 +234,7 @@ function timestamp(): string {
  */
 // deno-lint-ignore no-explicit-any
 export function log(...args: any[]) {
+  // deno-lint-ignore no-console
   console.log("%s - %s", timestamp(), ReflectApply(format, undefined, args));
 }
 

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -47,7 +47,7 @@ const {
 const debugWorkerThreads = false;
 function debugWT(...args) {
   if (debugWorkerThreads) {
-    // deno-lint-ignore prefer-primordials
+    // deno-lint-ignore prefer-primordials no-console
     console.log(...args);
   }
 }

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -164,6 +164,7 @@ function resolvePromiseWith(value) {
 function rethrowAssertionErrorRejection(e) {
   if (e && ObjectPrototypeIsPrototypeOf(AssertionError.prototype, e)) {
     queueMicrotask(() => {
+      // deno-lint-ignore no-console
       console.error(`Internal Error: ${e.stack}`);
     });
   }

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -125,12 +125,15 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
     return;
   }
 
+  // deno-lint-ignore no-console
+  const logError = console.error;
+
   if (!verboseDeprecatedApiWarning) {
     if (ALREADY_WARNED_DEPRECATED.has(apiName)) {
       return;
     }
     ALREADY_WARNED_DEPRECATED.add(apiName);
-    console.error(
+    logError(
       `%cwarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2. Run again with DENO_VERBOSE_WARNINGS=1 to get more details.`,
       "color: yellow;",
       "font-weight: bold;",
@@ -176,40 +179,40 @@ function warnOnDeprecatedApi(apiName, stack, ...suggestions) {
   }
 
   ALREADY_WARNED_DEPRECATED.add(apiName + stack);
-  console.error(
+  logError(
     `%cwarning: %cUse of deprecated "${apiName}" API. This API will be removed in Deno 2.`,
     "color: yellow;",
     "font-weight: bold;",
   );
 
-  console.error();
-  console.error(
+  logError();
+  logError(
     "See the Deno 1 to 2 Migration Guide for more information at https://docs.deno.com/runtime/manual/advanced/migrate_deprecations",
   );
-  console.error();
+  logError();
   if (stackLines.length > 0) {
-    console.error("Stack trace:");
+    logError("Stack trace:");
     for (let i = 0; i < stackLines.length; i++) {
-      console.error(`  ${StringPrototypeTrim(stackLines[i])}`);
+      logError(`  ${StringPrototypeTrim(stackLines[i])}`);
     }
-    console.error();
+    logError();
   }
 
   for (let i = 0; i < suggestions.length; i++) {
     const suggestion = suggestions[i];
-    console.error(
+    logError(
       `%chint: ${suggestion}`,
       "font-weight: bold;",
     );
   }
 
   if (isFromRemoteDependency) {
-    console.error(
+    logError(
       `%chint: It appears this API is used by a remote dependency. Try upgrading to the latest version of that dependency.`,
       "font-weight: bold;",
     );
   }
-  console.error();
+  logError();
 }
 
 function windowClose() {
@@ -716,25 +719,33 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
 
     if (mode === executionModes.serve) {
       if (serveIsMain && serveWorkerCount) {
+        // deno-lint-ignore no-console
         const origLog = console.log;
+        // deno-lint-ignore no-console
         const origError = console.error;
         const prefix = `[serve-worker-0 ]`;
+        // deno-lint-ignore no-console
         console.log = (...args) => {
           return origLog(prefix, ...new primordials.SafeArrayIterator(args));
         };
+        // deno-lint-ignore no-console
         console.error = (...args) => {
           return origError(prefix, ...new primordials.SafeArrayIterator(args));
         };
       } else if (serveWorkerCount !== null) {
+        // deno-lint-ignore no-console
         const origLog = console.log;
+        // deno-lint-ignore no-console
         const origError = console.error;
         const base = `serve-worker-${serveWorkerCount + 1}`;
         // 15 = "serve-worker-nn".length, assuming
         // serveWorkerCount < 100
         const prefix = `[${StringPrototypePadEnd(base, 15, " ")}]`;
+        // deno-lint-ignore no-console
         console.log = (...args) => {
           return origLog(prefix, ...new primordials.SafeArrayIterator(args));
         };
+        // deno-lint-ignore no-console
         console.error = (...args) => {
           return origError(prefix, ...new primordials.SafeArrayIterator(args));
         };
@@ -757,6 +768,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
         if (mode === executionModes.serve && !serve) {
           if (serveIsMain) {
             // Only error if main worker
+            // deno-lint-ignore no-console
             console.error(
               `%cerror: %cdeno serve requires %cexport default { fetch }%c in the main module, did you mean to run \"deno run\"?`,
               "color: yellow;",
@@ -770,6 +782,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
 
         if (serve) {
           if (mode === executionModes.run) {
+            // deno-lint-ignore no-console
             console.error(
               `%cwarning: %cDetected %cexport default { fetch }%c, did you mean to run \"deno serve\"?`,
               "color: yellow;",

--- a/tests/ffi/tests/event_loop_integration.ts
+++ b/tests/ffi/tests/event_loop_integration.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 const targetDir = Deno.execPath().replace(/[^\/\\]+$/, "");
 const [libPrefix, libSuffix] = {
   darwin: ["lib", "dylib"],

--- a/tests/ffi/tests/ffi_callback_errors.ts
+++ b/tests/ffi/tests/ffi_callback_errors.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 const targetDir = Deno.execPath().replace(/[^\/\\]+$/, "");
 const [libPrefix, libSuffix] = {
   darwin: ["lib", "dylib"],

--- a/tests/napi/cleanup_hook_test.js
+++ b/tests/napi/cleanup_hook_test.js
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import { assertEquals, loadTestLibrary } from "./common.js";
 
 const properties = loadTestLibrary();

--- a/tests/node_compat/runner/setup.ts
+++ b/tests/node_compat/runner/setup.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S deno run --allow-read=. --allow-write=. --allow-run=git --config=tests/config/deno.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 /** This copies the test files according to the config file `tests/node_compat/config.jsonc` */
 
 import { walk } from "@std/fs/walk";

--- a/tests/node_compat/test.ts
+++ b/tests/node_compat/test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 /**
  * This script will run the test files specified in the configuration file.
  *

--- a/tests/node_compat/test/fixtures/child-process-spawn-node.js
+++ b/tests/node_compat/test/fixtures/child-process-spawn-node.js
@@ -1,7 +1,5 @@
 const assert = require("assert");
-// TODO(kt3k): Uncomment this when util.debuglog is added
-// const debug = require('util').debuglog('test');
-const debug = console.log;
+const debug = require('util').debuglog('test');
 
 function onmessage(m) {
   debug("CHILD got message:", m);

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -8,6 +8,8 @@
 // std/fmt/colors auto determines whether to put colors in or not. We need
 // better infrastructure here so we can properly test the colors.
 
+// deno-lint-ignore-file no-console
+
 import {
   assert,
   assertEquals,

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import {
   assert,
   assertEquals,
@@ -2030,7 +2033,6 @@ Deno.test(
         try {
           controller.abort();
         } catch (e) {
-          // deno-lint-ignore no-console
           console.log(e);
           fail("abort should not throw");
         }

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2030,6 +2030,7 @@ Deno.test(
         try {
           controller.abort();
         } catch (e) {
+          // deno-lint-ignore no-console
           console.log(e);
           fail("abort should not throw");
         }

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import { assertMatch, assertRejects } from "@std/assert";
 import { Buffer, BufReader, BufWriter } from "@std/io";
 import { TextProtoReader } from "../testdata/run/textproto.ts";

--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import {
   assert,
   assertEquals,

--- a/tests/unit/worker_test.ts
+++ b/tests/unit/worker_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 // Requires to be run with `--allow-net` flag
 
 import { assert, assertEquals, assertMatch, assertThrows } from "@std/assert";

--- a/tests/unit_node/_fs/_fs_write_test.ts
+++ b/tests/unit_node/_fs/_fs_write_test.ts
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import { write, writeSync } from "node:fs";
 import { assertEquals } from "@std/assert";
 import { Buffer } from "node:buffer";

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import * as http2 from "node:http2";
 import { Buffer } from "node:buffer";
 import { readFile } from "node:fs/promises";

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import EventEmitter from "node:events";
 import http, { type RequestOptions, type ServerResponse } from "node:http";
 import url from "node:url";

--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import * as net from "node:net";
 import { assert, assertEquals } from "@std/assert";
 import * as path from "@std/path";

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1,5 +1,6 @@
-// deno-lint-ignore-file no-undef
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-undef no-console
 
 import process, {
   arch as importedArch,

--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S deno run --allow-write --allow-read --allow-net --allow-env --allow-run --config=tests/config/deno.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 // This script is used to run WPT tests for Deno.
 
 import {

--- a/tools/copyright_checker.js
+++ b/tools/copyright_checker.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S deno run --allow-read=. --allow-run=git --config=tests/config/deno.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import { getSources, ROOT_PATH } from "./util.js";
 
 const copyrightYear = 2024;

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env -S deno run --allow-write --allow-read --allow-run --allow-net --config=tests/config/deno.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import { buildMode, getPrebuilt, getSources, join, ROOT_PATH } from "./util.js";
 import { checkCopyright } from "./copyright_checker.js";
 import * as ciFile from "../.github/workflows/ci.generate.ts";
@@ -44,27 +47,19 @@ async function dlint() {
     "*.js",
     "*.ts",
     ":!:.github/mtime_cache/action.js",
-    ":!:tests/testdata/swc_syntax_error.ts",
-    ":!:tests/testdata/error_008_checkjs.js",
     ":!:cli/bench/testdata/npm/*",
     ":!:cli/bench/testdata/express-router.js",
     ":!:cli/bench/testdata/react-dom.js",
     ":!:cli/compilers/wasm_wrap.js",
     ":!:cli/tsc/dts/**",
+    ":!:cli/tsc/*typescript.js",
+    ":!:cli/tsc/compiler.d.ts",
+    ":!:runtime/examples/",
     ":!:target/",
     ":!:tests/registry/**",
     ":!:tests/specs/**",
-    ":!:tests/testdata/encoding/**",
-    ":!:tests/testdata/error_syntax.js",
-    ":!:tests/testdata/file_extensions/ts_with_js_extension.js",
-    ":!:tests/testdata/fmt/**",
-    ":!:tests/testdata/lint/**",
-    ":!:tests/testdata/npm/**",
-    ":!:tests/testdata/run/**",
-    ":!:tests/testdata/tsc/**",
-    ":!:tests/testdata/test/glob/**",
-    ":!:cli/tsc/*typescript.js",
-    ":!:cli/tsc/compiler.d.ts",
+    ":!:tests/testdata/**",
+    ":!:tests/unit_node/testdata/**",
     ":!:tests/wpt/suite/**",
     ":!:tests/wpt/runner/**",
   ]);
@@ -93,7 +88,7 @@ async function dlint() {
       }),
     );
   }
-  await Promise.all(pending);
+  await Promise.allSettled(pending);
 }
 
 // `prefer-primordials` has to apply only to files related to bootstrapping,

--- a/tools/release/00_start_release.ts
+++ b/tools/release/00_start_release.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env -S deno run -A --quiet --lock=tools/deno.lock.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import { $, createOctoKit, semver } from "./deps.ts";
 
 const currentDirPath = $.path(import.meta).parentOrThrow();

--- a/tools/release/03_publish_crates.ts
+++ b/tools/release/03_publish_crates.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import { DenoWorkspace } from "./deno_workspace.ts";
 import { $, getCratesPublishOrder } from "./deps.ts";
 

--- a/tools/release/promote_to_rc.ts
+++ b/tools/release/promote_to_rc.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+// deno-lint-ignore-file no-console
+
 import { $ } from "jsr:@david/dax@0.41.0";
 import { gray } from "jsr:@std/fmt@1/colors";
 import { patchver } from "jsr:@deno/patchver@0.1.0";

--- a/tools/upload_wptfyi.js
+++ b/tools/upload_wptfyi.js
@@ -4,6 +4,8 @@
 // passed, will automatically add a status check to the commit with a link to
 // the wpt.fyi page.
 
+// deno-lint-ignore-file no-console
+
 import { gzip } from "https://deno.land/x/compress@v0.4.1/gzip/mod.ts";
 
 const user = Deno.env.get("WPT_FYI_USER");

--- a/tools/util.js
+++ b/tools/util.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 import { dirname, fromFileUrl, join, resolve, toFileUrl } from "@std/path";
 import { wait } from "https://deno.land/x/wait@0.1.13/mod.ts";
 export { dirname, fromFileUrl, join, resolve, toFileUrl };

--- a/tools/verify_pr_title.js
+++ b/tools/verify_pr_title.js
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore-file no-console
+
 const prTitle = Deno.args[0];
 
 if (prTitle == null) {


### PR DESCRIPTION
Helps prevent https://github.com/denoland/deno/pull/25111 in JS code, though there is a bug that doesn't catch that specific issue. I opened https://github.com/denoland/deno_lint/issues/1316 for that.