### PR TITLE
fix: deserialize lockfile v3 straight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01138860cdf20cfca4c9e6bcda2bbe577f0c784f6f6938205d522ee2b6327ed"
+checksum = "04beb67705d894d688e818870a701829223f6f485ef3ce0b8b2a7adac98d9583"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ deno_ast = { version = "=0.41.2", features = ["transpiling"] }
 deno_core = { version = "0.304.0" }
 
 deno_bench_util = { version = "0.158.0", path = "./bench_util" }
-deno_lockfile = "0.21.1"
+deno_lockfile = "0.21.2"
 deno_media_type = { version = "0.1.4", features = ["module_specifier"] }
 deno_permissions = { version = "0.24.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.173.0", path = "./runtime" }


### PR DESCRIPTION
v4 is a somewhat lossy format and so we can't actually work with v3 by upgrading to v4 and then downgrading.

* https://github.com/denoland/deno_lockfile/pull/34