### PR TITLE
fix(ext/web): propagate aborted state to dependent signals before firing events

### DIFF
--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -160,7 +160,7 @@ class AbortSignal extends EventTarget {
 
         if (!dependentSignal.aborted) {
           dependentSignal[setAbortReason](reason);
-          dependentSignalsToAbort.push(dependentSignal);
+          ArrayPrototypePush(dependentSignalsToAbortm, dependentSignal);
         }
       }
     }

--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -160,7 +160,7 @@ class AbortSignal extends EventTarget {
 
         if (!dependentSignal.aborted) {
           dependentSignal[setAbortReason](reason);
-          ArrayPrototypePush(dependentSignalsToAbortm, dependentSignal);
+          ArrayPrototypePush(dependentSignalsToAbort, dependentSignal);
         }
       }
     }

--- a/tests/unit/abort_controller_test.ts
+++ b/tests/unit/abort_controller_test.ts
@@ -62,3 +62,22 @@ Deno.test(function abortReason() {
   assertEquals(signal.aborted, true);
   assertEquals(signal.reason, "hey!");
 });
+
+Deno.test(function dependentSignalsAborted() {
+  const controller = new AbortController();
+  const signal1 = AbortSignal.any([controller.signal]);
+  const signal2 = AbortSignal.any([signal1]);
+  let eventFired = false;
+
+  controller.signal.addEventListener("abort", () => {
+    const signal3 = AbortSignal.any([signal2]);
+    assert(controller.signal.aborted);
+    assert(signal1.aborted);
+    assert(signal2.aborted);
+    assert(signal3.aborted);
+    eventFired = true;
+  });
+
+  controller.abort();
+  assert(eventFired, "event fired");
+});


### PR DESCRIPTION
Ref https://github.com/whatwg/dom/pull/1295

Fixes https://github.com/denoland/deno/issues/25118

