### PR TITLE
fix(upgrade): better error message when check_exe fails

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -972,8 +972,13 @@ fn check_exe(exe_path: &Path) -> Result<(), AnyError> {
     .arg("-V")
     .stderr(std::process::Stdio::inherit())
     .output()?;
-  assert!(output.status.success());
-  Ok(())
+  if !output.status.success() {
+    bail!(
+      "Failed to validate Deno executable. This may be because your OS is unsupported or the executable is corrupted"
+    )
+  } else {
+    Ok(())
+  }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/24971

Fixes the panic. We can give a more personalized error by checking the macOS version but probably not worth the effort.
