### PR TITLE
chore(ext/node): bump minimum required version of `dsa` to 0.6.3

### DIFF
--- a/ext/node/Cargo.toml
+++ b/ext/node/Cargo.toml
@@ -38,7 +38,7 @@ deno_permissions.workspace = true
 deno_whoami = "0.1.0"
 der = { version = "0.7.9", features = ["derive"] }
 digest = { version = "0.10.5", features = ["core-api", "std"] }
-dsa = "0.6.1"
+dsa = "0.6.3"
 ecb.workspace = true
 ecdsa = "0.16.9"
 ed25519-dalek = { version = "2.1.1", features = ["digest", "pkcs8", "rand_core", "signature"] }


### PR DESCRIPTION
This commit bumps the minimum required version of `dsa` crate to 0.6.3. This is preferable because `SigningKey::sign_prehashed_rfc6979` function we use in `deno_node` is available from this version.

https://github.com/denoland/deno/blob/e7026c5ee8ac6780391b2169e338ca5fb5bbac70/ext/node/ops/crypto/sign.rs#L127-L138

Ref: [dsa's CHANGELOG.md](https://github.com/RustCrypto/signatures/blob/132b04631409db1ca805aba2f62830c8e359b29f/dsa/CHANGELOG.md#063-2024-01-28)
