### PR TITLE
refactor: update deno_core for error rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,8 +1404,6 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.306.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7e5ec71a92ab026b997ac1315bdfb3eeac6cf89dd20f816c9c02baebccd066"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1428,6 +1426,7 @@ dependencies = [
  "smallvec",
  "sourcemap",
  "static_assertions",
+ "thiserror",
  "tokio",
  "url",
  "v8",
@@ -1902,8 +1901,6 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.182.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623fee81066617b7a706923bc6364cd4181d35e6438e69d30dc8dd9ec94936f7"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6304,8 +6301,6 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41001c84d438ec3ad2d86413993cd72cb00b4d47aad010fc562bfdbb9aeff71d"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.41.2", features = ["transpiling"] }
-deno_core = { version = "0.306.0" }
+deno_core = { path = "../deno_core/core" }
 
 deno_bench_util = { version = "0.160.0", path = "./bench_util" }
 deno_lockfile = "0.21.2"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -9,8 +9,8 @@ mod shared;
 
 mod ts {
   use super::*;
-  use deno_core::error::custom_error;
-  use deno_core::error::AnyError;
+  use deno_core::error::{AnyError};
+  use deno_core::error::{JsNativeError};
   use deno_core::op2;
   use deno_core::OpState;
   use deno_runtime::deno_node::SUPPORTED_BUILTIN_NODE_MODULES;
@@ -111,16 +111,16 @@ mod ts {
           script_kind: 3,
         })
       } else {
-        Err(custom_error(
+        Err(JsNativeError::new(
           "InvalidSpecifier",
           format!("An invalid specifier was requested: {}", load_specifier),
-        ))
+        ).into())
       }
     } else {
-      Err(custom_error(
+      Err(JsNativeError::new(
         "InvalidSpecifier",
         format!("An invalid specifier was requested: {}", load_specifier),
-      ))
+      ).into())
     }
   }
 

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -9,83 +9,11 @@
 //!   Diagnostics are compile-time type errors, whereas JsErrors are runtime
 //!   exceptions.
 
-use deno_ast::ParseDiagnostic;
 use deno_core::error::AnyError;
-use deno_graph::source::ResolveError;
-use deno_graph::ModuleError;
-use deno_graph::ModuleGraphError;
-use deno_graph::ModuleLoadError;
-use deno_graph::ResolutionError;
 use import_map::ImportMapError;
 
 fn get_import_map_error_class(_: &ImportMapError) -> &'static str {
   "URIError"
-}
-
-fn get_diagnostic_class(_: &ParseDiagnostic) -> &'static str {
-  "SyntaxError"
-}
-
-fn get_module_graph_error_class(err: &ModuleGraphError) -> &'static str {
-  use deno_graph::JsrLoadError;
-  use deno_graph::NpmLoadError;
-
-  match err {
-    ModuleGraphError::ResolutionError(err)
-    | ModuleGraphError::TypesResolutionError(err) => {
-      get_resolution_error_class(err)
-    }
-    ModuleGraphError::ModuleError(err) => match err {
-      ModuleError::InvalidTypeAssertion { .. } => "SyntaxError",
-      ModuleError::ParseErr(_, diagnostic) => get_diagnostic_class(diagnostic),
-      ModuleError::UnsupportedMediaType { .. }
-      | ModuleError::UnsupportedImportAttributeType { .. } => "TypeError",
-      ModuleError::Missing(_, _) | ModuleError::MissingDynamic(_, _) => {
-        "NotFound"
-      }
-      ModuleError::LoadingErr(_, _, err) => match err {
-        ModuleLoadError::Loader(err) => get_error_class_name(err.as_ref()),
-        ModuleLoadError::HttpsChecksumIntegrity(_)
-        | ModuleLoadError::TooManyRedirects => "Error",
-        ModuleLoadError::NodeUnknownBuiltinModule(_) => "NotFound",
-        ModuleLoadError::Decode(_) => "TypeError",
-        ModuleLoadError::Npm(err) => match err {
-          NpmLoadError::NotSupportedEnvironment
-          | NpmLoadError::PackageReqResolution(_)
-          | NpmLoadError::RegistryInfo(_) => "Error",
-          NpmLoadError::PackageReqReferenceParse(_) => "TypeError",
-        },
-        ModuleLoadError::Jsr(err) => match err {
-          JsrLoadError::UnsupportedManifestChecksum
-          | JsrLoadError::PackageFormat(_) => "TypeError",
-          JsrLoadError::ContentLoadExternalSpecifier
-          | JsrLoadError::ContentLoad(_)
-          | JsrLoadError::ContentChecksumIntegrity(_)
-          | JsrLoadError::PackageManifestLoad(_, _)
-          | JsrLoadError::PackageVersionManifestChecksumIntegrity(..)
-          | JsrLoadError::PackageVersionManifestLoad(_, _)
-          | JsrLoadError::RedirectInPackage(_) => "Error",
-          JsrLoadError::PackageNotFound(_)
-          | JsrLoadError::PackageReqNotFound(_)
-          | JsrLoadError::PackageVersionNotFound(_)
-          | JsrLoadError::UnknownExport { .. } => "NotFound",
-        },
-      },
-    },
-  }
-}
-
-fn get_resolution_error_class(err: &ResolutionError) -> &'static str {
-  match err {
-    ResolutionError::ResolverError { error, .. } => {
-      use ResolveError::*;
-      match error.as_ref() {
-        Specifier(_) => "TypeError",
-        Other(e) => get_error_class_name(e),
-      }
-    }
-    _ => "TypeError",
-  }
 }
 
 pub fn get_error_class_name(e: &AnyError) -> &'static str {
@@ -93,18 +21,6 @@ pub fn get_error_class_name(e: &AnyError) -> &'static str {
     .or_else(|| {
       e.downcast_ref::<ImportMapError>()
         .map(get_import_map_error_class)
-    })
-    .or_else(|| {
-      e.downcast_ref::<ParseDiagnostic>()
-        .map(get_diagnostic_class)
-    })
-    .or_else(|| {
-      e.downcast_ref::<ModuleGraphError>()
-        .map(get_module_graph_error_class)
-    })
-    .or_else(|| {
-      e.downcast_ref::<ResolutionError>()
-        .map(get_resolution_error_class)
     })
     .unwrap_or("Error")
 }

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -17,7 +17,7 @@ use deno_ast::SourceRange;
 use deno_ast::SourceRangedForSpanned;
 use deno_ast::SourceTextInfo;
 use deno_core::anyhow::anyhow;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::serde::Deserialize;
 use deno_core::serde::Serialize;
@@ -968,10 +968,10 @@ impl CodeActionCollection {
       // we wrap tsc, we can't handle the asynchronous response, so it is
       // actually easier to return errors if we ever encounter one of these,
       // which we really wouldn't expect from the Deno lsp.
-      return Err(custom_error(
+      return Err(JsNativeError::new(
         "UnsupportedFix",
         "The action returned from TypeScript is unsupported.",
-      ));
+      ).into());
     }
     let action = fix_ts_import_action(
       specifier,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -19,7 +19,7 @@ use deno_ast::swc::visit::VisitWith;
 use deno_ast::MediaType;
 use deno_ast::ParsedSource;
 use deno_ast::SourceTextInfo;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::future;
 use deno_core::futures::future::Shared;
@@ -1002,7 +1002,7 @@ impl Documents {
       .or_else(|| self.file_system_docs.remove_document(specifier))
       .map(Ok)
       .unwrap_or_else(|| {
-        Err(custom_error(
+        Err(JsNativeError::new(
           "NotFound",
           format!("The specifier \"{specifier}\" was not found."),
         ))

--- a/cli/lsp/text.rs
+++ b/cli/lsp/text.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use dissimilar::diff;
 use dissimilar::Chunk;
@@ -136,7 +136,7 @@ impl LineIndex {
     if let Some(line_offset) = self.utf8_offsets.get(position.line as usize) {
       Ok(line_offset + col)
     } else {
-      Err(custom_error("OutOfRange", "The position is out of range."))
+      Err(JsNativeError::new("OutOfRange", "The position is out of range.").into())
     }
   }
 
@@ -156,7 +156,7 @@ impl LineIndex {
     if let Some(line_offset) = self.utf16_offsets.get(position.line as usize) {
       Ok(line_offset + TextSize::from(position.character))
     } else {
-      Err(custom_error("OutOfRange", "The position is out of range."))
+      Err(JsNativeError::new("OutOfRange", "The position is out of range.").into())
     }
   }
 

--- a/cli/mainrt.rs
+++ b/cli/mainrt.rs
@@ -24,7 +24,6 @@ mod util;
 mod version;
 mod worker;
 
-use deno_core::error::generic_error;
 use deno_core::error::AnyError;
 use deno_core::error::JsError;
 use deno_runtime::fmt_errors::format_js_error;

--- a/cli/npm/managed/cache/registry_info.rs
+++ b/cli/npm/managed/cache/registry_info.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use deno_core::anyhow::anyhow;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::future::LocalBoxFuture;
 use deno_core::futures::FutureExt;
@@ -95,12 +95,12 @@ impl RegistryInfoDownloader {
     name: &str,
   ) -> Result<Option<Arc<NpmPackageInfo>>, AnyError> {
     if *self.cache.cache_setting() == CacheSetting::Only {
-      return Err(custom_error(
+      return Err(JsNativeError::new(
         "NotCached",
         format!(
           "An npm specifier not found in cache: \"{name}\", --cached-only is specified."
         )
-      ));
+      ).into());
     }
 
     let cache_item = {

--- a/cli/npm/managed/cache/tarball.rs
+++ b/cli/npm/managed/cache/tarball.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use deno_core::anyhow::anyhow;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::future::LocalBoxFuture;
 use deno_core::futures::FutureExt;
@@ -148,13 +148,13 @@ impl TarballCache {
       if should_use_cache && package_folder_exists {
         return Ok(());
       } else if tarball_cache.cache.cache_setting() == &CacheSetting::Only {
-        return Err(custom_error(
+        return Err(JsNativeError::new(
           "NotCached",
           format!(
             "An npm specifier not found in cache: \"{}\", --cached-only is specified.",
             &package_nv.name
           )
-        )
+        ).into()
         );
       }
 

--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -4,8 +4,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time;
 
-use deno_core::error::generic_error;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
@@ -95,7 +94,7 @@ pub fn op_restore_test_permissions(
     state.put::<PermissionsContainer>(permissions);
     Ok(())
   } else {
-    Err(generic_error("no permissions to restore"))
+    Err(JsNativeError::generic("no permissions to restore").into())
   }
 }
 
@@ -115,10 +114,10 @@ fn op_register_bench(
   #[buffer] ret_buf: &mut [u8],
 ) -> Result<(), AnyError> {
   if ret_buf.len() != 4 {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Invalid ret_buf length: {}",
       ret_buf.len()
-    )));
+    )).into());
   }
   let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
   let origin = state.borrow::<ModuleSpecifier>().to_string();

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -9,8 +9,7 @@ use crate::tools::test::TestLocation;
 use crate::tools::test::TestStepDescription;
 use crate::tools::test::TestStepResult;
 
-use deno_core::error::generic_error;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
@@ -89,7 +88,7 @@ pub fn op_restore_test_permissions(
     state.put::<PermissionsContainer>(permissions);
     Ok(())
   } else {
-    Err(generic_error("no permissions to restore"))
+    Err(JsNativeError::generic("no permissions to restore").into())
   }
 }
 
@@ -111,10 +110,10 @@ fn op_register_test(
   #[buffer] ret_buf: &mut [u8],
 ) -> Result<(), AnyError> {
   if ret_buf.len() != 4 {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Invalid ret_buf length: {}",
       ret_buf.len()
-    )));
+    )).into());
   }
   let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
   let origin = state.borrow::<ModuleSpecifier>().to_string();

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -16,7 +16,7 @@ use crate::util::path::matches_pattern_or_exact_path;
 use crate::worker::CliMainWorkerFactory;
 
 use deno_config::glob::WalkEntry;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::error::JsError;
 use deno_core::futures::future;
@@ -349,13 +349,13 @@ async fn bench_specifiers(
       reporter.report_end(&report);
 
       if used_only {
-        return Err(generic_error(
+        return Err(AnyError::new(JsNativeError::generic(
           "Bench failed because the \"only\" option was used",
-        ));
+        )));
       }
 
       if report.failed > 0 {
-        return Err(generic_error("Bench failed"));
+        return Err(JsNativeError::generic("Bench failed").into());
       }
 
       Ok(())
@@ -430,7 +430,7 @@ pub async fn run_benchmarks(
     .collect::<Vec<_>>();
 
   if specifiers.is_empty() {
-    return Err(generic_error("No bench modules found"));
+    return Err(JsNativeError::generic("No bench modules found").into());
   }
 
   let main_graph_container = factory.main_module_graph_container().await?;

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -8,7 +8,7 @@ use crate::standalone::is_standalone_binary;
 use deno_ast::ModuleSpecifier;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::resolve_url_or_path;
 use deno_graph::GraphKind;
@@ -257,9 +257,9 @@ async fn resolve_compile_executable_output_path(
       .map(PathBuf::from)
   }
 
-  output_path.ok_or_else(|| generic_error(
+  output_path.ok_or_else(|| JsNativeError::generic(
     "An executable name was not provided. One could not be inferred from the URL. Aborting.",
-  )).map(|output_path| {
+  ).into()).map(|output_path| {
     get_os_specific_filepath(output_path, &compile_flags.target)
   })
 }

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -19,7 +19,7 @@ use deno_config::glob::PathOrPattern;
 use deno_config::glob::PathOrPatternSet;
 use deno_core::anyhow::anyhow;
 use deno_core::anyhow::Context;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
 use deno_core::sourcemap::SourceMap;
@@ -478,7 +478,7 @@ pub async fn cover_files(
   coverage_flags: CoverageFlags,
 ) -> Result<(), AnyError> {
   if coverage_flags.files.include.is_empty() {
-    return Err(generic_error("No matching coverage profiles found"));
+    return Err(JsNativeError::generic("No matching coverage profiles found").into());
   }
 
   let factory = CliFactory::from_flags(flags);
@@ -499,7 +499,7 @@ pub async fn cover_files(
     cli_options.initial_cwd(),
   )?;
   if script_coverages.is_empty() {
-    return Err(generic_error("No coverage files found"));
+    return Err(JsNativeError::generic("No coverage files found").into());
   }
   let script_coverages = filter_coverages(
     script_coverages,
@@ -508,7 +508,7 @@ pub async fn cover_files(
     npm_resolver.as_ref(),
   );
   if script_coverages.is_empty() {
-    return Err(generic_error("No covered files included in the report"));
+    return Err(JsNativeError::generic("No covered files included in the report").into());
   }
 
   let proc_coverages: Vec<_> = script_coverages

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -28,7 +28,7 @@ use deno_config::glob::FilePatterns;
 use deno_core::anyhow::anyhow;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures;
 use deno_core::parking_lot::Mutex;
@@ -165,7 +165,7 @@ fn resolve_paths_with_options_batches(
     }
   }
   if paths_with_options_batches.is_empty() {
-    return Err(generic_error("No target files found."));
+    return Err(JsNativeError::generic("No target files found.").into());
   }
   Ok(paths_with_options_batches)
 }
@@ -628,9 +628,9 @@ impl Formatter for CheckFormatter {
       Ok(())
     } else {
       let not_formatted_files_str = files_str(not_formatted_files_count);
-      Err(generic_error(format!(
+      Err(JsNativeError::generic(format!(
         "Found {not_formatted_files_count} not formatted {not_formatted_files_str} in {checked_files_str}",
-      )))
+      )).into())
     }
   }
 }

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -15,7 +15,7 @@ use crate::tools::test::TestFailureFormatOptions;
 use crate::CliFactory;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::FutureExt;
 use deno_core::located_script_name;
@@ -136,7 +136,7 @@ pub async fn kernel(
   }
   let cwd_url =
     Url::from_directory_path(cli_options.initial_cwd()).map_err(|_| {
-      generic_error(format!(
+      JsNativeError::generic(format!(
         "Unable to construct URL from the path of cwd: {}",
         cli_options.initial_cwd().to_string_lossy(),
       ))

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -10,7 +10,7 @@ use deno_config::glob::FileCollector;
 use deno_config::glob::FilePatterns;
 use deno_config::workspace::WorkspaceDirectory;
 use deno_core::anyhow::anyhow;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::future::LocalBoxFuture;
 use deno_core::futures::FutureExt;
@@ -68,9 +68,9 @@ pub async fn lint(
 ) -> Result<(), AnyError> {
   if let Some(watch_flags) = &lint_flags.watch {
     if lint_flags.is_stdin() {
-      return Err(generic_error(
+      return Err(JsNativeError::generic(
         "Lint watch on standard input is not supported.",
-      ));
+      ).into());
     }
     file_watcher::watch_func(
       flags,
@@ -218,7 +218,7 @@ fn resolve_paths_with_options_batches(
     }
   }
   if paths_with_options_batches.is_empty() {
-    return Err(generic_error("No target files found."));
+    return Err(JsNativeError::generic("No target files found.").into());
   }
   Ok(paths_with_options_batches)
 }
@@ -482,7 +482,7 @@ fn lint_stdin(
 ) -> Result<(ParsedSource, Vec<LintDiagnostic>), AnyError> {
   let mut source_code = String::new();
   if stdin().read_to_string(&mut source_code).is_err() {
-    return Err(generic_error("Failed to read from stdin"));
+    return Err(JsNativeError::generic("Failed to read from stdin").into());
   }
 
   let linter = CliLinter::new(CliLinterOptions {

--- a/cli/tools/repl/channel.rs
+++ b/cli/tools/repl/channel.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::anyhow::anyhow;
-use deno_core::error::AnyError;
+use deno_core::error::{AnyError, CoreError};
 use deno_core::serde_json;
 use deno_core::serde_json::Value;
 use std::cell::RefCell;
@@ -46,7 +46,7 @@ pub enum RustylineSyncMessage {
 }
 
 pub enum RustylineSyncResponse {
-  PostMessage(Result<Value, AnyError>),
+  PostMessage(Result<Value, CoreError>),
   LspCompletions(Vec<ReplCompletionItem>),
 }
 
@@ -74,7 +74,7 @@ impl RustylineSyncMessageSender {
       Err(anyhow!("{}", err))
     } else {
       match self.response_rx.borrow_mut().blocking_recv().unwrap() {
-        RustylineSyncResponse::PostMessage(result) => result,
+        RustylineSyncResponse::PostMessage(result) => result.map_err(AnyError::new),
         RustylineSyncResponse::LspCompletions(_) => unreachable!(),
       }
     }

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -31,7 +31,8 @@ use deno_ast::ParsedSource;
 use deno_ast::SourcePos;
 use deno_ast::SourceRangedForSpanned;
 use deno_ast::SourceTextInfo;
-use deno_core::error::generic_error;
+use deno_core::error::{CoreError};
+use deno_core::error::{JsNativeError};
 use deno_core::error::AnyError;
 use deno_core::futures::channel::mpsc::UnboundedReceiver;
 use deno_core::futures::FutureExt;
@@ -249,7 +250,7 @@ impl ReplSession {
 
     let cwd_url =
       Url::from_directory_path(cli_options.initial_cwd()).map_err(|_| {
-        generic_error(format!(
+        JsNativeError::generic(format!(
           "Unable to construct URL from the path of cwd: {}",
           cli_options.initial_cwd().to_string_lossy(),
         ))
@@ -321,7 +322,7 @@ impl ReplSession {
     &mut self,
     method: &str,
     params: Option<T>,
-  ) -> Result<Value, AnyError> {
+  ) -> Result<Value, CoreError> {
     self
       .worker
       .js_runtime
@@ -338,7 +339,7 @@ impl ReplSession {
       .await
   }
 
-  pub async fn run_event_loop(&mut self) -> Result<(), AnyError> {
+  pub async fn run_event_loop(&mut self) -> Result<(), CoreError> {
     self.worker.run_event_loop(true).await
   }
 
@@ -735,7 +736,7 @@ impl ReplSession {
   async fn evaluate_expression(
     &mut self,
     expression: &str,
-  ) -> Result<cdp::EvaluateResponse, AnyError> {
+  ) -> Result<cdp::EvaluateResponse, CoreError> {
     self
       .post_message_with_event_loop(
         "Runtime.evaluate",
@@ -758,7 +759,7 @@ impl ReplSession {
         }),
       )
       .await
-      .and_then(|res| serde_json::from_value(res).map_err(|e| e.into()))
+      .and_then(|res| serde_json::from_value(res).map_err(|e| AnyError::new(e).into()))
   }
 }
 

--- a/cli/tools/run/hmr.rs
+++ b/cli/tools/run/hmr.rs
@@ -4,7 +4,7 @@ use crate::cdp;
 use crate::emit::Emitter;
 use crate::util::file_watcher::WatcherCommunicator;
 use crate::util::file_watcher::WatcherRestartMode;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::StreamExt;
 use deno_core::serde_json::json;
@@ -89,7 +89,7 @@ impl crate::worker::HmrRunner for HmrRunner {
           if notification.method == "Runtime.exceptionThrown" {
             let exception_thrown = serde_json::from_value::<cdp::ExceptionThrown>(notification.params)?;
             let (message, description) = exception_thrown.exception_details.get_message_and_description();
-            break Err(generic_error(format!("{} {}", message, description)));
+            break Err(JsNativeError::generic(format!("{} {}", message, description)).into());
           } else if notification.method == "Debugger.scriptParsed" {
             let params = serde_json::from_value::<cdp::ScriptParsed>(notification.params)?;
             if params.url.starts_with("file://") {

--- a/cli/tools/vendor/build.rs
+++ b/cli/tools/vendor/build.rs
@@ -1315,7 +1315,7 @@ mod test {
     assert_eq!(
       test_util::strip_ansi_codes(&err.to_string()),
       concat!(
-        "500 Internal Server Error\n",
+        "Error: 500 Internal Server Error\n",
         "    at https://localhost/mod.ts:1:14"
       )
     );

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::serde::Deserialize;
@@ -211,7 +211,7 @@ where
     state.put(cache);
     Ok(state.borrow::<CA>().clone())
   } else {
-    Err(type_error("CacheStorage is not available in this context."))
+    Err(JsNativeError::type_error("CacheStorage is not available in this context.").into())
   }
 }
 

--- a/ext/canvas/lib.rs
+++ b/ext/canvas/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::ToJsBuffer;
@@ -124,10 +124,10 @@ fn op_image_decode_png(#[buffer] buf: &[u8]) -> Result<DecodedPng, AnyError> {
 
   // TODO(@crowlKats): maybe use DynamicImage https://docs.rs/image/0.24.7/image/enum.DynamicImage.html ?
   if png.color_type() != ColorType::Rgba8 {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Color type '{:?}' not supported",
       png.color_type()
-    )));
+    )).into());
   }
 
   // read_image will assert that the buffer is the correct size, so we need to fill it with zeros

--- a/ext/cron/lib.rs
+++ b/ext/cron/lib.rs
@@ -7,8 +7,8 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use deno_core::error::get_custom_error_class;
-use deno_core::error::type_error;
+use deno_core::error::JsErrorClass;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -101,10 +101,10 @@ where
     let resource = match state.resource_table.get::<CronResource<C::EH>>(rid) {
       Ok(resource) => resource,
       Err(err) => {
-        if get_custom_error_class(&err) == Some("BadResource") {
+        if err.get_class() == "BadResource" {
           return Ok(false);
         } else {
-          return Err(err);
+          return Err(err.into());
         }
       }
     };
@@ -116,12 +116,12 @@ where
 
 fn validate_cron_name(name: &str) -> Result<(), AnyError> {
   if name.len() > 64 {
-    return Err(type_error("Cron name is too long"));
+    return Err(JsNativeError::type_error("Cron name is too long").into());
   }
   if !name.chars().all(|c| {
     c.is_ascii_whitespace() || c.is_ascii_alphanumeric() || c == '_' || c == '-'
   }) {
-    return Err(type_error("Invalid cron name. Only alphanumeric characters, whitespace, hyphens, and underscores are allowed"));
+    return Err(JsNativeError::type_error("Invalid cron name. Only alphanumeric characters, whitespace, hyphens, and underscores are allowed").into());
   }
   Ok(())
 }

--- a/ext/cron/local.rs
+++ b/ext/cron/local.rs
@@ -10,7 +10,7 @@ use std::rc::Weak;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures;
 use deno_core::futures::FutureExt;
@@ -208,17 +208,17 @@ impl CronHandler for LocalCronHandler {
     let mut runtime_state = self.runtime_state.borrow_mut();
 
     if runtime_state.crons.len() > MAX_CRONS {
-      return Err(type_error("Too many crons"));
+      return Err(JsNativeError::type_error("Too many crons").into());
     }
     if runtime_state.crons.contains_key(&spec.name) {
-      return Err(type_error("Cron with this name already exists"));
+      return Err(JsNativeError::type_error("Cron with this name already exists").into());
     }
 
     // Validate schedule expression.
     spec
       .cron_schedule
       .parse::<saffron::Cron>()
-      .map_err(|_| type_error("Invalid cron schedule"))?;
+      .map_err(|_| JsNativeError::type_error("Invalid cron schedule"))?;
 
     // Validate backoff_schedule.
     if let Some(backoff_schedule) = &spec.backoff_schedule {
@@ -320,10 +320,10 @@ fn compute_next_deadline(cron_expression: &str) -> Result<u64, AnyError> {
 
 fn validate_backoff_schedule(backoff_schedule: &[u32]) -> Result<(), AnyError> {
   if backoff_schedule.len() > MAX_BACKOFF_COUNT {
-    return Err(type_error("Invalid backoff schedule"));
+    return Err(JsNativeError::type_error("Invalid backoff schedule").into());
   }
   if backoff_schedule.iter().any(|s| *s > MAX_BACKOFF_MS) {
-    return Err(type_error("Invalid backoff schedule"));
+    return Err(JsNativeError::type_error("Invalid backoff schedule").into());
   }
   Ok(())
 }

--- a/ext/crypto/ed25519.rs
+++ b/ext/crypto/ed25519.rs
@@ -2,7 +2,7 @@
 
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::ToJsBuffer;
@@ -129,7 +129,7 @@ pub fn op_crypto_export_spki_ed25519(
     key_info
       .to_der()
       .map_err(|_| {
-        custom_error("DOMExceptionOperationError", "Failed to export key")
+        JsNativeError::new("DOMExceptionOperationError", "Failed to export key")
       })?
       .into(),
   )

--- a/ext/crypto/encrypt.rs
+++ b/ext/crypto/encrypt.rs
@@ -16,7 +16,7 @@ use aes_gcm::Nonce;
 use ctr::Ctr128BE;
 use ctr::Ctr32BE;
 use ctr::Ctr64BE;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::unsync::spawn_blocking;
@@ -175,7 +175,7 @@ fn encrypt_aes_cbc(
         .map_err(|_| operation_error("invalid key or iv".to_string()))?;
       cipher.encrypt_padded_vec_mut::<Pkcs7>(data)
     }
-    _ => return Err(type_error("invalid length")),
+    _ => return Err(JsNativeError::type_error("invalid length").into()),
   };
   Ok(ciphertext)
 }
@@ -210,7 +210,7 @@ fn encrypt_aes_gcm_general<N: ArrayLength<u8>>(
         .encrypt_in_place_detached(nonce, &additional_data, ciphertext)
         .map_err(|_| operation_error("Encryption failed"))?
     }
-    _ => return Err(type_error("invalid length")),
+    _ => return Err(JsNativeError::type_error("invalid length").into()),
   };
 
   Ok(tag)
@@ -244,7 +244,7 @@ fn encrypt_aes_gcm(
       &mut ciphertext,
       additional_data,
     )?,
-    _ => return Err(type_error("iv length not equal to 12 or 16")),
+    _ => return Err(JsNativeError::type_error("iv length not equal to 12 or 16").into()),
   };
 
   // Truncated tag to the specified tag length.
@@ -289,22 +289,22 @@ fn encrypt_aes_ctr(
       128 => encrypt_aes_ctr_gen::<Ctr32BE<aes::Aes128>>(key, counter, data),
       192 => encrypt_aes_ctr_gen::<Ctr32BE<aes::Aes192>>(key, counter, data),
       256 => encrypt_aes_ctr_gen::<Ctr32BE<aes::Aes256>>(key, counter, data),
-      _ => Err(type_error("invalid length")),
+      _ => Err(JsNativeError::type_error("invalid length").into()),
     },
     64 => match key_length {
       128 => encrypt_aes_ctr_gen::<Ctr64BE<aes::Aes128>>(key, counter, data),
       192 => encrypt_aes_ctr_gen::<Ctr64BE<aes::Aes192>>(key, counter, data),
       256 => encrypt_aes_ctr_gen::<Ctr64BE<aes::Aes256>>(key, counter, data),
-      _ => Err(type_error("invalid length")),
+      _ => Err(JsNativeError::type_error("invalid length").into()),
     },
     128 => match key_length {
       128 => encrypt_aes_ctr_gen::<Ctr128BE<aes::Aes128>>(key, counter, data),
       192 => encrypt_aes_ctr_gen::<Ctr128BE<aes::Aes192>>(key, counter, data),
       256 => encrypt_aes_ctr_gen::<Ctr128BE<aes::Aes256>>(key, counter, data),
-      _ => Err(type_error("invalid length")),
+      _ => Err(JsNativeError::type_error("invalid length").into()),
     },
-    _ => Err(type_error(
+    _ => Err(JsNativeError::type_error(
       "invalid counter length. Currently supported 32/64/128 bits",
-    )),
+    ).into()),
   }
 }

--- a/ext/crypto/export_key.rs
+++ b/ext/crypto/export_key.rs
@@ -4,7 +4,7 @@ use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
 use const_oid::AssociatedOid;
 use const_oid::ObjectIdentifier;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::ToJsBuffer;
@@ -182,7 +182,7 @@ fn export_key_rsa(
       let public_key = key_data.as_rsa_public_key()?;
       let public_key = rsa::pkcs1::RsaPublicKey::from_der(&public_key)
         .map_err(|_| {
-          custom_error(
+          JsNativeError::new(
             "DOMExceptionOperationError",
             "failed to decode public key",
           )
@@ -197,7 +197,7 @@ fn export_key_rsa(
       let private_key = key_data.as_rsa_private_key()?;
       let private_key = rsa::pkcs1::RsaPrivateKey::from_der(private_key)
         .map_err(|_| {
-          custom_error(
+          JsNativeError::new(
             "DOMExceptionOperationError",
             "failed to decode private key",
           )
@@ -327,10 +327,10 @@ fn export_key_ec(
             y: bytes_to_b64(y),
           })
         } else {
-          Err(custom_error(
+          Err(JsNativeError::new(
             "DOMExceptionOperationError",
             "failed to decode public key",
-          ))
+          ).into())
         }
       }
       EcNamedCurve::P384 => {
@@ -345,10 +345,10 @@ fn export_key_ec(
             y: bytes_to_b64(y),
           })
         } else {
-          Err(custom_error(
+          Err(JsNativeError::new(
             "DOMExceptionOperationError",
             "failed to decode public key",
-          ))
+          ).into())
         }
       }
       EcNamedCurve::P521 => Err(data_error("Unsupported named curve")),
@@ -360,7 +360,7 @@ fn export_key_ec(
         EcNamedCurve::P256 => {
           let ec_key =
             p256::SecretKey::from_pkcs8_der(private_key).map_err(|_| {
-              custom_error(
+              JsNativeError::new(
                 "DOMExceptionOperationError",
                 "failed to decode private key",
               )
@@ -383,7 +383,7 @@ fn export_key_ec(
         EcNamedCurve::P384 => {
           let ec_key =
             p384::SecretKey::from_pkcs8_der(private_key).map_err(|_| {
-              custom_error(
+              JsNativeError::new(
                 "DOMExceptionOperationError",
                 "failed to decode private key",
               )

--- a/ext/crypto/x25519.rs
+++ b/ext/crypto/x25519.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use curve25519_dalek::montgomery::MontgomeryPoint;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::ToJsBuffer;
@@ -126,7 +126,7 @@ pub fn op_crypto_export_spki_x25519(
     key_info
       .to_der()
       .map_err(|_| {
-        custom_error("DOMExceptionOperationError", "Failed to export key")
+        JsNativeError::new("DOMExceptionOperationError", "Failed to export key")
       })?
       .into(),
   )

--- a/ext/fetch/fs_fetch_handler.rs
+++ b/ext/fetch/fs_fetch_handler.rs
@@ -4,7 +4,7 @@ use crate::CancelHandle;
 use crate::CancelableResponseFuture;
 use crate::FetchHandler;
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::futures::FutureExt;
 use deno_core::futures::TryFutureExt;
 use deno_core::futures::TryStreamExt;
@@ -43,7 +43,7 @@ impl FetchHandler for FsFetchHandler {
       Ok::<_, ()>(response)
     }
     .map_err(move |_| {
-      type_error("NetworkError when attempting to fetch resource.")
+      JsNativeError::type_error("NetworkError when attempting to fetch resource.").into()
     })
     .or_cancel(&cancel_handle)
     .boxed_local();

--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -9,7 +9,7 @@ use crate::symbol::Symbol;
 use crate::FfiPermissions;
 use crate::ForeignFunction;
 use deno_core::anyhow::anyhow;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::serde_json::Value;
@@ -334,7 +334,7 @@ pub fn op_ffi_call_nonblocking(
     let symbols = &resource.symbols;
     *symbols
       .get(&symbol)
-      .ok_or_else(|| type_error("Invalid FFI symbol name"))?
+      .ok_or_else(|| JsNativeError::type_error("Invalid FFI symbol name"))?
       .clone()
   };
 

--- a/ext/ffi/ir.rs
+++ b/ext/ffi/ir.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use crate::symbol::NativeType;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::v8;
 use libffi::middle::Arg;
@@ -128,7 +128,7 @@ pub fn ffi_parse_bool_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let bool_value = v8::Local::<v8::Boolean>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI u8 type, expected boolean"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI u8 type, expected boolean"))?
     .is_true();
   Ok(NativeValue { bool_value })
 }
@@ -138,7 +138,7 @@ pub fn ffi_parse_u8_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let u8_value = v8::Local::<v8::Uint32>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI u8 type, expected unsigned integer"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI u8 type, expected unsigned integer"))?
     .value() as u8;
   Ok(NativeValue { u8_value })
 }
@@ -148,7 +148,7 @@ pub fn ffi_parse_i8_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let i8_value = v8::Local::<v8::Int32>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI i8 type, expected integer"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI i8 type, expected integer"))?
     .value() as i8;
   Ok(NativeValue { i8_value })
 }
@@ -158,7 +158,7 @@ pub fn ffi_parse_u16_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let u16_value = v8::Local::<v8::Uint32>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI u16 type, expected unsigned integer"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI u16 type, expected unsigned integer"))?
     .value() as u16;
   Ok(NativeValue { u16_value })
 }
@@ -168,7 +168,7 @@ pub fn ffi_parse_i16_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let i16_value = v8::Local::<v8::Int32>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI i16 type, expected integer"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI i16 type, expected integer"))?
     .value() as i16;
   Ok(NativeValue { i16_value })
 }
@@ -178,7 +178,7 @@ pub fn ffi_parse_u32_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let u32_value = v8::Local::<v8::Uint32>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI u32 type, expected unsigned integer"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI u32 type, expected unsigned integer"))?
     .value();
   Ok(NativeValue { u32_value })
 }
@@ -188,7 +188,7 @@ pub fn ffi_parse_i32_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let i32_value = v8::Local::<v8::Int32>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI i32 type, expected integer"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI i32 type, expected integer"))?
     .value();
   Ok(NativeValue { i32_value })
 }
@@ -207,9 +207,9 @@ pub fn ffi_parse_u64_arg(
   } else if let Ok(value) = v8::Local::<v8::Number>::try_from(arg) {
     value.integer_value(scope).unwrap() as u64
   } else {
-    return Err(type_error(
+    return Err(JsNativeError::type_error(
       "Invalid FFI u64 type, expected unsigned integer",
-    ));
+    ).into());
   };
   Ok(NativeValue { u64_value })
 }
@@ -228,7 +228,7 @@ pub fn ffi_parse_i64_arg(
   } else if let Ok(value) = v8::Local::<v8::Number>::try_from(arg) {
     value.integer_value(scope).unwrap()
   } else {
-    return Err(type_error("Invalid FFI i64 type, expected integer"));
+    return Err(JsNativeError::type_error("Invalid FFI i64 type, expected integer").into());
   };
   Ok(NativeValue { i64_value })
 }
@@ -247,7 +247,7 @@ pub fn ffi_parse_usize_arg(
     } else if let Ok(value) = v8::Local::<v8::Number>::try_from(arg) {
       value.integer_value(scope).unwrap() as usize
     } else {
-      return Err(type_error("Invalid FFI usize type, expected integer"));
+      return Err(JsNativeError::type_error("Invalid FFI usize type, expected integer").into());
     };
   Ok(NativeValue { usize_value })
 }
@@ -266,7 +266,7 @@ pub fn ffi_parse_isize_arg(
     } else if let Ok(value) = v8::Local::<v8::Number>::try_from(arg) {
       value.integer_value(scope).unwrap() as isize
     } else {
-      return Err(type_error("Invalid FFI isize type, expected integer"));
+      return Err(JsNativeError::type_error("Invalid FFI isize type, expected integer").into());
     };
   Ok(NativeValue { isize_value })
 }
@@ -276,7 +276,7 @@ pub fn ffi_parse_f32_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let f32_value = v8::Local::<v8::Number>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI f32 type, expected number"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI f32 type, expected number"))?
     .value() as f32;
   Ok(NativeValue { f32_value })
 }
@@ -286,7 +286,7 @@ pub fn ffi_parse_f64_arg(
   arg: v8::Local<v8::Value>,
 ) -> Result<NativeValue, AnyError> {
   let f64_value = v8::Local::<v8::Number>::try_from(arg)
-    .map_err(|_| type_error("Invalid FFI f64 type, expected number"))?
+    .map_err(|_| JsNativeError::type_error("Invalid FFI f64 type, expected number"))?
     .value();
   Ok(NativeValue { f64_value })
 }
@@ -301,9 +301,9 @@ pub fn ffi_parse_pointer_arg(
   } else if arg.is_null() {
     ptr::null_mut()
   } else {
-    return Err(type_error(
+    return Err(JsNativeError::type_error(
       "Invalid FFI pointer type, expected null, or External",
-    ));
+    ).into());
   };
   Ok(NativeValue { pointer })
 }
@@ -329,7 +329,7 @@ pub fn ffi_parse_buffer_arg(
     let pointer = value
       .buffer(scope)
       .ok_or_else(|| {
-        type_error("Invalid FFI ArrayBufferView, expected data in the buffer")
+        JsNativeError::type_error("Invalid FFI ArrayBufferView, expected data in the buffer")
       })?
       .data();
     if let Some(non_null) = pointer {
@@ -342,9 +342,9 @@ pub fn ffi_parse_buffer_arg(
   } else if arg.is_null() {
     ptr::null_mut()
   } else {
-    return Err(type_error(
+    return Err(JsNativeError::type_error(
       "Invalid FFI buffer type, expected null, ArrayBuffer, or ArrayBufferView",
-    ));
+    ).into());
   };
   Ok(NativeValue { pointer })
 }
@@ -362,16 +362,16 @@ pub fn ffi_parse_struct_arg(
     if let Some(non_null) = value.data() {
       non_null.as_ptr()
     } else {
-      return Err(type_error(
+      return Err(JsNativeError::type_error(
         "Invalid FFI ArrayBuffer, expected data in buffer",
-      ));
+      ).into());
     }
   } else if let Ok(value) = v8::Local::<v8::ArrayBufferView>::try_from(arg) {
     let byte_offset = value.byte_offset();
     let pointer = value
       .buffer(scope)
       .ok_or_else(|| {
-        type_error("Invalid FFI ArrayBufferView, expected data in the buffer")
+        JsNativeError::type_error("Invalid FFI ArrayBufferView, expected data in the buffer")
       })?
       .data();
     if let Some(non_null) = pointer {
@@ -379,14 +379,14 @@ pub fn ffi_parse_struct_arg(
       // is within the buffer backing store.
       unsafe { non_null.as_ptr().add(byte_offset) }
     } else {
-      return Err(type_error(
+      return Err(JsNativeError::type_error(
         "Invalid FFI ArrayBufferView, expected data in buffer",
-      ));
+      ).into());
     }
   } else {
-    return Err(type_error(
+    return Err(JsNativeError::type_error(
       "Invalid FFI struct type, expected ArrayBuffer, or ArrayBufferView",
-    ));
+    ).into());
   };
   Ok(NativeValue { pointer })
 }
@@ -401,9 +401,9 @@ pub fn ffi_parse_function_arg(
   } else if arg.is_null() {
     ptr::null_mut()
   } else {
-    return Err(type_error(
+    return Err(JsNativeError::type_error(
       "Invalid FFI function type, expected null, or External",
-    ));
+    ).into());
   };
   Ok(NativeValue { pointer })
 }

--- a/ext/ffi/repr.rs
+++ b/ext/ffi/repr.rs
@@ -2,8 +2,7 @@
 
 use crate::check_unstable;
 use crate::FfiPermissions;
-use deno_core::error::range_error;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
@@ -94,7 +93,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid pointer to offset, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid pointer to offset, pointer is null").into());
   }
 
   // TODO(mmastrac): Create a RawPointer that can safely do pointer math.
@@ -144,7 +143,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid ArrayBuffer pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid ArrayBuffer pointer, pointer is null").into());
   }
 
   // SAFETY: Trust the user to have provided a real pointer, offset, and a valid matching size to it. Since this is a foreign pointer, we should not do any deletion.
@@ -178,11 +177,11 @@ where
   permissions.check_partial(None)?;
 
   if src.is_null() {
-    Err(type_error("Invalid ArrayBuffer pointer, pointer is null"))
+    Err(JsNativeError::type_error("Invalid ArrayBuffer pointer, pointer is null").into())
   } else if dst.len() < len {
-    Err(range_error(
+    Err(JsNativeError::range_error(
       "Destination length is smaller than source length",
-    ))
+    ).into())
   } else {
     let src = src as *const c_void;
 
@@ -211,7 +210,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid CString pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid CString pointer, pointer is null").into());
   }
 
   let cstr =
@@ -219,7 +218,7 @@ where
     unsafe { CStr::from_ptr(ptr.offset(offset) as *const c_char) }.to_bytes();
   let value = v8::String::new_from_utf8(scope, cstr, v8::NewStringType::Normal)
     .ok_or_else(|| {
-      type_error("Invalid CString pointer, string exceeds max length")
+      JsNativeError::type_error("Invalid CString pointer, string exceeds max length")
     })?;
   Ok(value)
 }
@@ -239,7 +238,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid bool pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid bool pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -261,7 +260,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid u8 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid u8 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -285,7 +284,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid i8 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid i8 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -309,7 +308,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid u16 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid u16 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -333,7 +332,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid i16 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid i16 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -357,7 +356,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid u32 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid u32 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -379,7 +378,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid i32 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid i32 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -404,7 +403,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid u64 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid u64 pointer, pointer is null").into());
   }
 
   let value =
@@ -432,7 +431,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid i64 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid i64 pointer, pointer is null").into());
   }
 
   let value =
@@ -457,7 +456,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid f32 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid f32 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -479,7 +478,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid f64 pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid f64 pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.
@@ -501,7 +500,7 @@ where
   permissions.check_partial(None)?;
 
   if ptr.is_null() {
-    return Err(type_error("Invalid pointer pointer, pointer is null"));
+    return Err(JsNativeError::type_error("Invalid pointer pointer, pointer is null").into());
   }
 
   // SAFETY: ptr and offset are user provided.

--- a/ext/ffi/static.rs
+++ b/ext/ffi/static.rs
@@ -2,7 +2,7 @@
 
 use crate::dlfcn::DynamicLibraryResource;
 use crate::symbol::NativeType;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::v8;
@@ -35,7 +35,7 @@ pub fn op_ffi_get_static<'scope>(
 
   Ok(match static_type {
     NativeType::Void => {
-      return Err(type_error("Invalid FFI static type 'void'"));
+      return Err(JsNativeError::type_error("Invalid FFI static type 'void'").into());
     }
     NativeType::Bool => {
       // SAFETY: ptr is user provided
@@ -132,7 +132,7 @@ pub fn op_ffi_get_static<'scope>(
       external
     }
     NativeType::Struct(_) => {
-      return Err(type_error("Invalid FFI static type 'struct'"));
+      return Err(JsNativeError::type_error("Invalid FFI static type 'struct'").into());
     }
   })
 }

--- a/ext/ffi/symbol.rs
+++ b/ext/ffi/symbol.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 
 /// Defines the accepted types that can be used as
@@ -56,7 +56,7 @@ impl TryFrom<NativeType> for libffi::middle::Type {
             .map(|field| field.clone().try_into())
             .collect::<Result<Vec<_>, _>>()?,
           false => {
-            return Err(type_error("Struct must have at least one field"))
+            return Err(JsNativeError::type_error("Struct must have at least one field").into())
           }
         })
       }

--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -8,8 +8,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use deno_core::anyhow::bail;
-use deno_core::error::custom_error;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::CancelFuture;
@@ -74,7 +73,7 @@ fn map_permission_error(
         format!(
           "Requires {err} access to {path}{truncated}, run again with the --allow-{err} flag")
       };
-      custom_error("PermissionDenied", msg)
+      JsNativeError::new("PermissionDenied", msg).into()
     }
     err => Err::<(), _>(err)
       .context_path(operation, path)
@@ -1395,7 +1394,7 @@ fn to_seek_from(offset: i64, whence: i32) -> Result<SeekFrom, AnyError> {
     1 => SeekFrom::Current(offset),
     2 => SeekFrom::End(offset),
     _ => {
-      return Err(type_error(format!("Invalid seek mode: {whence}")));
+      return Err(JsNativeError::type_error(format!("Invalid seek mode: {whence}")).into());
     }
   };
   Ok(seek_from)
@@ -1715,7 +1714,7 @@ impl<T> MapErrContext for Result<T, FsError> {
 fn path_into_string(s: std::ffi::OsString) -> Result<String, AnyError> {
   s.into_string().map_err(|s| {
     let message = format!("File name or path {s:?} is not valid UTF-8");
-    custom_error("InvalidData", message)
+    JsNativeError::new("InvalidData", message).into()
   })
 }
 

--- a/ext/io/fs.rs
+++ b/ext/io/fs.rs
@@ -6,12 +6,11 @@ use std::rc::Rc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use deno_core::error::custom_error;
-use deno_core::error::not_supported;
-use deno_core::error::resource_unavailable;
+use deno_core::error::ResourceError;
 use deno_core::error::AnyError;
 use deno_core::BufMutView;
 use deno_core::BufView;
+use deno_core::error::JsNativeError;
 use deno_core::OpState;
 use deno_core::ResourceHandleFd;
 use deno_core::ResourceId;
@@ -63,10 +62,10 @@ impl From<FsError> for AnyError {
   fn from(err: FsError) -> Self {
     match err {
       FsError::Io(err) => AnyError::from(err),
-      FsError::FileBusy => resource_unavailable(),
-      FsError::NotSupported => not_supported(),
+      FsError::FileBusy => ResourceError::Unavailable.into(),
+      FsError::NotSupported => JsNativeError::not_supported().into(),
       FsError::PermissionDenied(err) => {
-        custom_error("PermissionDenied", format!("permission denied: {err}"))
+        JsNativeError::new("PermissionDenied", format!("permission denied: {err}")).into()
       }
     }
   }

--- a/ext/kv/dynamic.rs
+++ b/ext/kv/dynamic.rs
@@ -13,7 +13,7 @@ use crate::QueueMessageHandle;
 use crate::ReadRange;
 use crate::SnapshotReadOptions;
 use async_trait::async_trait;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::OpState;
 use denokv_proto::CommitResult;
@@ -76,10 +76,10 @@ impl DatabaseHandler for MultiBackendDbHandler {
         }
       }
     }
-    Err(type_error(format!(
+    Err(JsNativeError::type_error(format!(
       "No backend supports the given path: {:?}",
       path
-    )))
+    )).into())
   }
 }
 

--- a/ext/kv/remote.rs
+++ b/ext/kv/remote.rs
@@ -9,7 +9,7 @@ use crate::DatabaseHandler;
 use anyhow::Context;
 use async_trait::async_trait;
 use bytes::Bytes;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::futures::Stream;
 use deno_core::OpState;
@@ -162,11 +162,11 @@ impl<P: RemoteDbHandlerPermissions + 'static> DatabaseHandler
     const ENV_VAR_NAME: &str = "DENO_KV_ACCESS_TOKEN";
 
     let Some(url) = path else {
-      return Err(type_error("Missing database url"));
+      return Err(JsNativeError::type_error("Missing database url").into());
     };
 
     let Ok(parsed_url) = Url::parse(&url) else {
-      return Err(type_error(format!("Invalid database url: {}", url)));
+      return Err(JsNativeError::type_error(format!("Invalid database url: {}", url)).into());
     };
 
     {

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::AsyncMutFuture;
 use deno_core::AsyncRefCell;
@@ -133,7 +133,7 @@ impl TcpStreamResource {
       return map(socket);
     }
 
-    Err(generic_error("Unable to get resources"))
+    Err(JsNativeError::generic("Unable to get resources").into())
   }
 }
 

--- a/ext/net/raw.rs
+++ b/ext/net/raw.rs
@@ -1,8 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use crate::io::TcpStreamResource;
 use crate::ops_tls::TlsStreamResource;
-use deno_core::error::bad_resource;
-use deno_core::error::bad_resource_id;
+use deno_core::error::ResourceError;
 use deno_core::error::AnyError;
 use deno_core::AsyncRefCell;
 use deno_core::CancelHandle;
@@ -70,7 +69,7 @@ impl<T: NetworkStreamListenerTrait + 'static> NetworkListenerResource<T> {
   ) -> Result<Option<NetworkStreamListener>, AnyError> {
     if let Ok(resource_rc) = resource_table.take::<Self>(listener_rid) {
       let resource = Rc::try_unwrap(resource_rc)
-        .map_err(|_| bad_resource("Listener is currently in use"))?;
+        .map_err(|_| ResourceError::Other("Listener is currently in use".to_string()))?;
       return Ok(Some(resource.listener.into_inner().into()));
     }
     Ok(None)
@@ -247,7 +246,7 @@ macro_rules! network_stream {
             return Ok(resource)
           }
         )*
-        Err(bad_resource_id())
+        Err(ResourceError::BadResourceId.into())
       }
     }
   };
@@ -334,7 +333,7 @@ pub fn take_network_stream_resource(
   {
     // This TCP connection might be used somewhere else.
     let resource = Rc::try_unwrap(resource_rc)
-      .map_err(|_| bad_resource("TCP stream is currently in use"))?;
+      .map_err(|_| ResourceError::Other("TCP stream is currently in use".into()))?;
     let (read_half, write_half) = resource.into_inner();
     let tcp_stream = read_half.reunite(write_half)?;
     return Ok(NetworkStream::Tcp(tcp_stream));
@@ -344,7 +343,7 @@ pub fn take_network_stream_resource(
   {
     // This TLS connection might be used somewhere else.
     let resource = Rc::try_unwrap(resource_rc)
-      .map_err(|_| bad_resource("TLS stream is currently in use"))?;
+      .map_err(|_| ResourceError::Other("TLS stream is currently in use".into()))?;
     let (read_half, write_half) = resource.into_inner();
     let tls_stream = read_half.unsplit(write_half);
     return Ok(NetworkStream::Tls(tls_stream));
@@ -356,13 +355,13 @@ pub fn take_network_stream_resource(
   {
     // This UNIX socket might be used somewhere else.
     let resource = Rc::try_unwrap(resource_rc)
-      .map_err(|_| bad_resource("UNIX stream is currently in use"))?;
+      .map_err(|_| ResourceError::Other("UNIX stream is currently in use".to_string()))?;
     let (read_half, write_half) = resource.into_inner();
     let unix_stream = read_half.reunite(write_half)?;
     return Ok(NetworkStream::Unix(unix_stream));
   }
 
-  Err(bad_resource_id())
+  Err(ResourceError::BadResourceId.into())
 }
 
 /// In some cases it may be more efficient to extract the resource from the resource table and use it directly (for example, an HTTP server).

--- a/ext/node/ops/crypto/cipher.rs
+++ b/ext/node/ops/crypto/cipher.rs
@@ -4,7 +4,7 @@ use aes::cipher::block_padding::Pkcs7;
 use aes::cipher::BlockDecryptMut;
 use aes::cipher::BlockEncryptMut;
 use aes::cipher::KeyIvInit;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::Resource;
 use digest::generic_array::GenericArray;
@@ -75,7 +75,7 @@ impl CipherContext {
     output: &mut [u8],
   ) -> Result<Tag, AnyError> {
     Rc::try_unwrap(self.cipher)
-      .map_err(|_| type_error("Cipher context is already in use"))?
+      .map_err(|_| JsNativeError::type_error("Cipher context is already in use"))?
       .into_inner()
       .r#final(auto_pad, input, output)
   }
@@ -104,7 +104,7 @@ impl DecipherContext {
     auth_tag: &[u8],
   ) -> Result<(), AnyError> {
     Rc::try_unwrap(self.decipher)
-      .map_err(|_| type_error("Decipher context is already in use"))?
+      .map_err(|_| JsNativeError::type_error("Decipher context is already in use"))?
       .into_inner()
       .r#final(auto_pad, input, output, auth_tag)
   }
@@ -153,7 +153,7 @@ impl Cipher {
       "aes256" | "aes-256-cbc" => {
         Aes256Cbc(Box::new(cbc::Encryptor::new(key.into(), iv.into())))
       }
-      _ => return Err(type_error(format!("Unknown cipher {algorithm_name}"))),
+      _ => return Err(JsNativeError::type_error(format!("Unknown cipher {algorithm_name}")).into()),
     })
   }
 
@@ -228,7 +228,7 @@ impl Cipher {
       (Aes128Cbc(encryptor), true) => {
         let _ = (*encryptor)
           .encrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot pad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot pad the input data"))?;
         Ok(None)
       }
       (Aes128Cbc(mut encryptor), false) => {
@@ -241,7 +241,7 @@ impl Cipher {
       (Aes128Ecb(encryptor), true) => {
         let _ = (*encryptor)
           .encrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot pad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot pad the input data"))?;
         Ok(None)
       }
       (Aes128Ecb(mut encryptor), false) => {
@@ -254,7 +254,7 @@ impl Cipher {
       (Aes192Ecb(encryptor), true) => {
         let _ = (*encryptor)
           .encrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot pad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot pad the input data"))?;
         Ok(None)
       }
       (Aes192Ecb(mut encryptor), false) => {
@@ -267,7 +267,7 @@ impl Cipher {
       (Aes256Ecb(encryptor), true) => {
         let _ = (*encryptor)
           .encrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot pad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot pad the input data"))?;
         Ok(None)
       }
       (Aes256Ecb(mut encryptor), false) => {
@@ -282,7 +282,7 @@ impl Cipher {
       (Aes256Cbc(encryptor), true) => {
         let _ = (*encryptor)
           .encrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot pad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot pad the input data"))?;
         Ok(None)
       }
       (Aes256Cbc(mut encryptor), false) => {
@@ -336,7 +336,7 @@ impl Decipher {
       "aes256" | "aes-256-cbc" => {
         Aes256Cbc(Box::new(cbc::Decryptor::new(key.into(), iv.into())))
       }
-      _ => return Err(type_error(format!("Unknown cipher {algorithm_name}"))),
+      _ => return Err(JsNativeError::type_error(format!("Unknown cipher {algorithm_name}")).into()),
     })
   }
 
@@ -412,7 +412,7 @@ impl Decipher {
         assert!(input.len() == 16);
         let _ = (*decryptor)
           .decrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot unpad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot unpad the input data"))?;
         Ok(())
       }
       (Aes128Cbc(mut decryptor), false) => {
@@ -426,7 +426,7 @@ impl Decipher {
         assert!(input.len() == 16);
         let _ = (*decryptor)
           .decrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot unpad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot unpad the input data"))?;
         Ok(())
       }
       (Aes128Ecb(mut decryptor), false) => {
@@ -440,7 +440,7 @@ impl Decipher {
         assert!(input.len() == 16);
         let _ = (*decryptor)
           .decrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot unpad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot unpad the input data"))?;
         Ok(())
       }
       (Aes192Ecb(mut decryptor), false) => {
@@ -454,7 +454,7 @@ impl Decipher {
         assert!(input.len() == 16);
         let _ = (*decryptor)
           .decrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot unpad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot unpad the input data"))?;
         Ok(())
       }
       (Aes256Ecb(mut decryptor), false) => {
@@ -469,28 +469,28 @@ impl Decipher {
         if tag.as_slice() == auth_tag {
           Ok(())
         } else {
-          Err(type_error("Failed to authenticate data"))
+          Err(JsNativeError::type_error("Failed to authenticate data").into())
         }
       }
-      (Aes128Gcm(_), false) => Err(type_error(
+      (Aes128Gcm(_), false) => Err(JsNativeError::type_error(
         "setAutoPadding(false) not supported for Aes256Gcm yet",
-      )),
+      ).into()),
       (Aes256Gcm(decipher), true) => {
         let tag = decipher.finish();
         if tag.as_slice() == auth_tag {
           Ok(())
         } else {
-          Err(type_error("Failed to authenticate data"))
+          Err(JsNativeError::type_error("Failed to authenticate data").into())
         }
       }
-      (Aes256Gcm(_), false) => Err(type_error(
+      (Aes256Gcm(_), false) => Err(JsNativeError::type_error(
         "setAutoPadding(false) not supported for Aes256Gcm yet",
-      )),
+      ).into()),
       (Aes256Cbc(decryptor), true) => {
         assert!(input.len() == 16);
         let _ = (*decryptor)
           .decrypt_padded_b2b_mut::<Pkcs7>(input, output)
-          .map_err(|_| type_error("Cannot unpad the input data"))?;
+          .map_err(|_| JsNativeError::type_error("Cannot unpad the input data"))?;
         Ok(())
       }
       (Aes256Cbc(mut decryptor), false) => {

--- a/ext/node/ops/crypto/digest.rs
+++ b/ext/node/ops/crypto/digest.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::GarbageCollected;
 use digest::Digest;
@@ -197,17 +197,17 @@ impl Hash {
         let digest: D = Digest::new();
         if let Some(length) = output_length {
           if length != digest.output_size() {
-            return Err(generic_error(
+            return Err(JsNativeError::generic(
               "Output length mismatch for non-extendable algorithm",
-            ));
+            ).into());
           }
         }
         FixedSize(Box::new(digest))
       },
       _ => {
-        return Err(generic_error(format!(
+        return Err(JsNativeError::generic(format!(
           "Digest method not supported: {algorithm_name}"
-        )))
+        )).into())
       }
     );
 
@@ -244,9 +244,9 @@ impl Hash {
       FixedSize(context) => {
         if let Some(length) = output_length {
           if length != context.output_size() {
-            return Err(generic_error(
+            return Err(JsNativeError::generic(
               "Output length mismatch for non-extendable algorithm",
-            ));
+            ).into());
           }
         }
         FixedSize(context.box_clone())

--- a/ext/node/ops/os/mod.rs
+++ b/ext/node/ops/os/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use crate::NodePermissions;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -105,7 +105,7 @@ where
     permissions.check_sys("cpus", "node:os.cpus()")?;
   }
 
-  cpus::cpu_info().ok_or_else(|| type_error("Failed to get cpu info"))
+  cpus::cpu_info().ok_or_else(|| JsNativeError::type_error("Failed to get cpu info").into())
 }
 
 #[op2]

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::anyhow::Context;
-use deno_core::error::generic_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::normalize_path;
 use deno_core::op2;
@@ -319,12 +319,12 @@ pub fn op_require_path_resolve(#[serde] parts: Vec<String>) -> String {
 #[string]
 pub fn op_require_path_dirname(
   #[string] request: String,
-) -> Result<String, AnyError> {
+) -> Result<String, JsNativeError> {
   let p = PathBuf::from(request);
   if let Some(parent) = p.parent() {
     Ok(parent.to_string_lossy().to_string())
   } else {
-    Err(generic_error("Path doesn't have a parent"))
+    Err(JsNativeError::generic("Path doesn't have a parent"))
   }
 }
 
@@ -332,12 +332,12 @@ pub fn op_require_path_dirname(
 #[string]
 pub fn op_require_path_basename(
   #[string] request: String,
-) -> Result<String, AnyError> {
+) -> Result<String, JsNativeError> {
   let p = PathBuf::from(request);
   if let Some(path) = p.file_name() {
     Ok(path.to_string_lossy().to_string())
   } else {
-    Err(generic_error("Path doesn't have a file name"))
+    Err(JsNativeError::generic("Path doesn't have a file name"))
   }
 }
 

--- a/ext/node/ops/zlib/brotli.rs
+++ b/ext/node/ops/zlib/brotli.rs
@@ -9,7 +9,7 @@ use brotli::BrotliDecompressStream;
 use brotli::BrotliResult;
 use brotli::BrotliState;
 use brotli::Decompressor;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::JsBuffer;
@@ -28,7 +28,7 @@ fn encoder_mode(mode: u32) -> Result<BrotliEncoderMode, AnyError> {
     4 => BrotliEncoderMode::BROTLI_FORCE_MSB_PRIOR,
     5 => BrotliEncoderMode::BROTLI_FORCE_UTF8_PRIOR,
     6 => BrotliEncoderMode::BROTLI_FORCE_SIGNED_PRIOR,
-    _ => return Err(type_error("Invalid encoder mode")),
+    _ => return Err(JsNativeError::type_error("Invalid encoder mode").into()),
   })
 }
 
@@ -57,7 +57,7 @@ pub fn op_brotli_compress(
     &mut |_, _, _, _| (),
   );
   if result != 1 {
-    return Err(type_error("Failed to compress"));
+    return Err(JsNativeError::type_error("Failed to compress").into());
   }
 
   Ok(out_size)
@@ -107,7 +107,7 @@ pub async fn op_brotli_compress_async(
       &mut |_, _, _, _| (),
     );
     if result != 1 {
-      return Err(type_error("Failed to compress"));
+      return Err(JsNativeError::type_error("Failed to compress").into());
     }
 
     out.truncate(out_size);
@@ -168,7 +168,7 @@ pub fn op_brotli_compress_stream(
     &mut |_, _, _, _| (),
   );
   if !result {
-    return Err(type_error("Failed to compress"));
+    return Err(JsNativeError::type_error("Failed to compress").into());
   }
 
   Ok(output_offset)
@@ -197,7 +197,7 @@ pub fn op_brotli_compress_stream_end(
     &mut |_, _, _, _| (),
   );
   if !result {
-    return Err(type_error("Failed to compress"));
+    return Err(JsNativeError::type_error("Failed to compress").into());
   }
 
   Ok(output_offset)
@@ -268,7 +268,7 @@ pub fn op_brotli_decompress_stream(
     &mut inst,
   );
   if matches!(result, BrotliResult::ResultFailure) {
-    return Err(type_error("Failed to decompress"));
+    return Err(JsNativeError::type_error("Failed to decompress").into());
   }
 
   Ok(output_offset)
@@ -296,7 +296,7 @@ pub fn op_brotli_decompress_stream_end(
     &mut inst,
   );
   if matches!(result, BrotliResult::ResultFailure) {
-    return Err(type_error("Failed to decompress"));
+    return Err(JsNativeError::type_error("Failed to decompress").into());
   }
 
   Ok(output_offset)

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -10,7 +10,7 @@ pub use webpki;
 pub use webpki_roots;
 
 use deno_core::anyhow::anyhow;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 
 use rustls::client::danger::HandshakeSignatureValid;
@@ -259,7 +259,7 @@ pub fn load_certs(
   let certs: Result<Vec<_>, _> = certs(reader).collect();
 
   let certs = certs
-    .map_err(|_| custom_error("InvalidData", "Unable to decode certificate"))?;
+    .map_err(|_| JsNativeError::new("InvalidData", "Unable to decode certificate"))?;
 
   if certs.is_empty() {
     return Err(cert_not_found_err());
@@ -269,15 +269,15 @@ pub fn load_certs(
 }
 
 fn key_decode_err() -> AnyError {
-  custom_error("InvalidData", "Unable to decode key")
+  JsNativeError::new("InvalidData", "Unable to decode key").into()
 }
 
 fn key_not_found_err() -> AnyError {
-  custom_error("InvalidData", "No keys found in key data")
+  JsNativeError::new("InvalidData", "No keys found in key data").into()
 }
 
 fn cert_not_found_err() -> AnyError {
-  custom_error("InvalidData", "No certificates found in certificate data")
+  JsNativeError::new("InvalidData", "No certificates found in certificate data").into()
 }
 
 /// Starts with -----BEGIN RSA PRIVATE KEY-----

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -2,7 +2,7 @@
 
 mod urlpattern;
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::url::form_urlencoded;
@@ -228,7 +228,7 @@ pub fn op_url_parse_search_params(
       .into_iter()
       .map(|(k, v)| (k.as_ref().to_owned(), v.as_ref().to_owned()))
       .collect(),
-    _ => return Err(type_error("invalid parameters")),
+    _ => return Err(JsNativeError::type_error("invalid parameters").into()),
   };
   Ok(params)
 }

--- a/ext/url/urlpattern.rs
+++ b/ext/url/urlpattern.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
 use deno_core::error::AnyError;
 use deno_core::op2;
 
@@ -8,6 +7,8 @@ use urlpattern::quirks;
 use urlpattern::quirks::MatchInput;
 use urlpattern::quirks::StringOrInit;
 use urlpattern::quirks::UrlPattern;
+
+deno_core::js_error_wrapper!(urlpattern::Error, JsUrlPatternError, "TypeError");
 
 #[op2]
 #[serde]
@@ -20,10 +21,10 @@ pub fn op_urlpattern_parse(
     input,
     base_url.as_deref(),
   )
-  .map_err(|e| type_error(e.to_string()))?;
+  .map_err(JsUrlPatternError)?;
 
   let pattern = urlpattern::quirks::parse_pattern(init, options)
-    .map_err(|e| type_error(e.to_string()))?;
+    .map_err(JsUrlPatternError)?;
 
   Ok(pattern)
 }
@@ -35,7 +36,7 @@ pub fn op_urlpattern_process_match_input(
   #[string] base_url: Option<String>,
 ) -> Result<Option<(MatchInput, quirks::Inputs)>, AnyError> {
   let res = urlpattern::quirks::process_match_input(input, base_url.as_deref())
-    .map_err(|e| type_error(e.to_string()))?;
+    .map_err(JsUrlPatternError)?;
 
   let (input, inputs) = match res {
     Some((input, inputs)) => (input, inputs),

--- a/ext/web/blob.rs
+++ b/ext/web/blob.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::parking_lot::Mutex;
@@ -193,15 +193,15 @@ pub fn op_blob_slice_part(
   let blob_store = state.borrow::<Arc<BlobStore>>();
   let part = blob_store
     .get_part(&id)
-    .ok_or_else(|| type_error("Blob part not found"))?;
+    .ok_or_else(|| JsNativeError::type_error("Blob part not found"))?;
 
   let SliceOptions { start, len } = options;
 
   let size = part.size();
   if start + len > size {
-    return Err(type_error(
+    return Err(JsNativeError::type_error(
       "start + len can not be larger than blob part size",
-    ));
+    ).into());
   }
 
   let sliced_part = SlicedBlobPart { part, start, len };
@@ -221,7 +221,7 @@ pub async fn op_blob_read_part(
     let blob_store = state.borrow::<Arc<BlobStore>>();
     blob_store.get_part(&id)
   }
-  .ok_or_else(|| type_error("Blob part not found"))?;
+  .ok_or_else(|| JsNativeError::type_error("Blob part not found"))?;
   let buf = part.read().await?;
   Ok(ToJsBuffer::from(buf.to_vec()))
 }
@@ -244,7 +244,7 @@ pub fn op_blob_create_object_url(
   for part_id in part_ids {
     let part = blob_store
       .get_part(&part_id)
-      .ok_or_else(|| type_error("Blob part not found"))?;
+      .ok_or_else(|| JsNativeError::type_error("Blob part not found"))?;
     parts.push(part);
   }
 
@@ -294,7 +294,7 @@ pub fn op_blob_from_object_url(
   }
 
   let blob_store = state.try_borrow::<Arc<BlobStore>>().ok_or_else(|| {
-    type_error("Blob URLs are not supported in this context.")
+    JsNativeError::type_error("Blob URLs are not supported in this context.")
   })?;
   if let Some(blob) = blob_store.get_object_url(url) {
     let parts = blob

--- a/ext/web/compression.rs
+++ b/ext/web/compression.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use flate2::write::DeflateDecoder;
@@ -49,7 +49,7 @@ pub fn op_compression_new(
     ("gzip", false) => {
       Inner::GzEncoder(GzEncoder::new(w, Compression::default()))
     }
-    _ => return Err(type_error("Unsupported format")),
+    _ => return Err(JsNativeError::type_error("Unsupported format").into()),
   };
   Ok(CompressionResource(RefCell::new(Some(inner))))
 }
@@ -63,35 +63,35 @@ pub fn op_compression_write(
   let mut inner = resource.0.borrow_mut();
   let inner = inner
     .as_mut()
-    .ok_or_else(|| type_error("resource is closed"))?;
+    .ok_or_else(|| JsNativeError::type_error("resource is closed"))?;
   let out: Vec<u8> = match &mut *inner {
     Inner::DeflateDecoder(d) => {
-      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
+      d.write_all(input).map_err(|e| JsNativeError::type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::DeflateEncoder(d) => {
-      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
+      d.write_all(input).map_err(|e| JsNativeError::type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::DeflateRawDecoder(d) => {
-      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
+      d.write_all(input).map_err(|e| JsNativeError::type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::DeflateRawEncoder(d) => {
-      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
+      d.write_all(input).map_err(|e| JsNativeError::type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::GzDecoder(d) => {
-      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
+      d.write_all(input).map_err(|e| JsNativeError::type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
     Inner::GzEncoder(d) => {
-      d.write_all(input).map_err(|e| type_error(e.to_string()))?;
+      d.write_all(input).map_err(|e| JsNativeError::type_error(e.to_string()))?;
       d.flush()?;
       d.get_mut().drain(..)
     }
@@ -110,27 +110,27 @@ pub fn op_compression_finish(
     .0
     .borrow_mut()
     .take()
-    .ok_or_else(|| type_error("resource is closed"))?;
+    .ok_or_else(|| JsNativeError::type_error("resource is closed"))?;
   let out = match inner {
     Inner::DeflateDecoder(d) => {
-      d.finish().map_err(|e| type_error(e.to_string()))
+      d.finish().map_err(|e| JsNativeError::type_error(e.to_string()))
     }
     Inner::DeflateEncoder(d) => {
-      d.finish().map_err(|e| type_error(e.to_string()))
+      d.finish().map_err(|e| JsNativeError::type_error(e.to_string()))
     }
     Inner::DeflateRawDecoder(d) => {
-      d.finish().map_err(|e| type_error(e.to_string()))
+      d.finish().map_err(|e| JsNativeError::type_error(e.to_string()))
     }
     Inner::DeflateRawEncoder(d) => {
-      d.finish().map_err(|e| type_error(e.to_string()))
+      d.finish().map_err(|e| JsNativeError::type_error(e.to_string()))
     }
-    Inner::GzDecoder(d) => d.finish().map_err(|e| type_error(e.to_string())),
-    Inner::GzEncoder(d) => d.finish().map_err(|e| type_error(e.to_string())),
+    Inner::GzDecoder(d) => d.finish().map_err(|e| JsNativeError::type_error(e.to_string())),
+    Inner::GzEncoder(d) => d.finish().map_err(|e| JsNativeError::type_error(e.to_string())),
   };
   match out {
     Err(err) => {
       if report_errors {
-        Err(err)
+        Err(err.into())
       } else {
         Ok(Vec::with_capacity(0))
       }

--- a/ext/web/message_port.rs
+++ b/ext/web/message_port.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 
@@ -155,10 +155,10 @@ pub fn deserialize_js_transferables(
         let resource = state
           .resource_table
           .take::<MessagePortResource>(id)
-          .map_err(|_| type_error("Invalid message port transfer"))?;
+          .map_err(|_| JsNativeError::type_error("Invalid message port transfer"))?;
         resource.cancel.cancel();
         let resource = Rc::try_unwrap(resource)
-          .map_err(|_| type_error("Message port is not ready for transfer"))?;
+          .map_err(|_| JsNativeError::type_error("Message port is not ready for transfer"))?;
         transferables.push(Transferable::MessagePort(resource.port));
       }
       JsTransferable::ArrayBuffer(id) => {
@@ -206,7 +206,7 @@ pub fn op_message_port_post_message(
   for js_transferable in &data.transferables {
     if let JsTransferable::MessagePort(id) = js_transferable {
       if *id == rid {
-        return Err(type_error("Can not transfer self message port"));
+        return Err(JsNativeError::type_error("Can not transfer self message port").into());
       }
     }
   }

--- a/ext/web/stream_resource.rs
+++ b/ext/web/stream_resource.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use bytes::BytesMut;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::external;
 use deno_core::op2;
@@ -550,7 +550,7 @@ pub fn op_readable_stream_resource_write_error(
 ) -> bool {
   let sender = get_sender(sender);
   // We can always write an error, no polling required
-  sender.write_error(type_error(Cow::Owned(error)));
+  sender.write_error(JsNativeError::type_error(Cow::Owned(error)).into());
   !sender.closed()
 }
 

--- a/ext/webgpu/buffer.rs
+++ b/ext/webgpu/buffer.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -57,7 +57,7 @@ pub fn op_webgpu_create_buffer(
     label: Some(label),
     size,
     usage: wgpu_types::BufferUsages::from_bits(usage)
-      .ok_or_else(|| type_error("usage is not valid"))?,
+      .ok_or_else(|| JsNativeError::type_error("usage is not valid"))?,
     mapped_at_creation,
   };
 

--- a/ext/webgpu/bundle.rs
+++ b/ext/webgpu/bundle.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -276,7 +276,7 @@ pub fn op_webgpu_render_bundle_encoder_set_index_buffer(
       .get::<WebGpuRenderBundleEncoder>(render_bundle_encoder_rid)?;
   let size = Some(
     std::num::NonZeroU64::new(size)
-      .ok_or_else(|| type_error("size must be larger than 0"))?,
+      .ok_or_else(|| JsNativeError::type_error("size must be larger than 0"))?,
   );
 
   render_bundle_encoder_resource
@@ -307,7 +307,7 @@ pub fn op_webgpu_render_bundle_encoder_set_vertex_buffer(
   let size = if let Some(size) = size {
     Some(
       std::num::NonZeroU64::new(size)
-        .ok_or_else(|| type_error("size must be larger than 0"))?,
+        .ok_or_else(|| JsNativeError::type_error("size must be larger than 0"))?,
     )
   } else {
     None

--- a/ext/webgpu/byow.rs
+++ b/ext/webgpu/byow.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -25,7 +25,7 @@ pub fn op_webgpu_surface_create(
   p2: *const c_void,
 ) -> Result<ResourceId, AnyError> {
   let instance = state.try_borrow::<super::Instance>().ok_or_else(|| {
-    type_error("Cannot create surface outside of WebGPU context. Did you forget to call `navigator.gpu.requestAdapter()`?")
+    JsNativeError::type_error("Cannot create surface outside of WebGPU context. Did you forget to call `navigator.gpu.requestAdapter()`?")
   })?;
   // Security note:
   //
@@ -41,7 +41,7 @@ pub fn op_webgpu_surface_create(
   //
   // - Only FFI can export v8::External to user code.
   if p1.is_null() {
-    return Err(type_error("Invalid parameters"));
+    return Err(JsNativeError::type_error("Invalid parameters").into());
   }
 
   let (win_handle, display_handle) = raw_window(system, p1, p2)?;
@@ -68,13 +68,13 @@ fn raw_window(
   ns_view: *const c_void,
 ) -> Result<RawHandles, AnyError> {
   if system != "cocoa" {
-    return Err(type_error("Invalid system on macOS"));
+    return Err(JsNativeError::type_error("Invalid system on macOS").into());
   }
 
   let win_handle = raw_window_handle::RawWindowHandle::AppKit(
     raw_window_handle::AppKitWindowHandle::new(
       NonNull::new(ns_view as *mut c_void)
-        .ok_or(type_error("ns_view is null"))?,
+        .ok_or(JsNativeError::type_error("ns_view is null"))?,
     ),
   );
 
@@ -92,13 +92,13 @@ fn raw_window(
 ) -> Result<RawHandles, AnyError> {
   use raw_window_handle::WindowsDisplayHandle;
   if system != "win32" {
-    return Err(type_error("Invalid system on Windows"));
+    return Err(JsNativeError::type_error("Invalid system on Windows").into());
   }
 
   let win_handle = {
     let mut handle = raw_window_handle::Win32WindowHandle::new(
       std::num::NonZeroIsize::new(window as isize)
-        .ok_or(type_error("window is null"))?,
+        .ok_or(JsNativeError::type_error("window is null"))?,
     );
     handle.hinstance = std::num::NonZeroIsize::new(hinstance as isize);
 
@@ -132,18 +132,18 @@ fn raw_window(
     win_handle = raw_window_handle::RawWindowHandle::Wayland(
       raw_window_handle::WaylandWindowHandle::new(
         NonNull::new(window as *mut c_void)
-          .ok_or(type_error("window is null"))?,
+          .ok_or(JsNativeError::type_error("window is null"))?,
       ),
     );
 
     display_handle = raw_window_handle::RawDisplayHandle::Wayland(
       raw_window_handle::WaylandDisplayHandle::new(
         NonNull::new(display as *mut c_void)
-          .ok_or(type_error("display is null"))?,
+          .ok_or(JsNativeError::type_error("display is null"))?,
       ),
     );
   } else {
-    return Err(type_error("Invalid system on Linux/BSD"));
+    return Err(JsNativeError::type_error("Invalid system on Linux/BSD").into());
   }
 
   Ok((win_handle, display_handle))

--- a/ext/webgpu/error.rs
+++ b/ext/webgpu/error.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::AnyError;
 use deno_core::ResourceId;
 use serde::Serialize;
 use std::convert::From;
@@ -308,7 +307,8 @@ impl fmt::Display for DomExceptionOperationError {
 
 impl std::error::Error for DomExceptionOperationError {}
 
-pub fn get_error_class_name(e: &AnyError) -> Option<&'static str> {
-  e.downcast_ref::<DomExceptionOperationError>()
-    .map(|_| "DOMExceptionOperationError")
+impl deno_core::error::JsErrorClass for DomExceptionOperationError {
+  fn get_class(&self) -> &'static str {
+    "DOMExceptionOperationError"
+  }
 }

--- a/ext/webgpu/render_pass.rs
+++ b/ext/webgpu/render_pass.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -345,7 +345,7 @@ pub fn op_webgpu_render_pass_set_index_buffer(
   let size = if let Some(size) = size {
     Some(
       std::num::NonZeroU64::new(size)
-        .ok_or_else(|| type_error("size must be larger than 0"))?,
+        .ok_or_else(|| JsNativeError::type_error("size must be larger than 0"))?,
     )
   } else {
     None
@@ -381,7 +381,7 @@ pub fn op_webgpu_render_pass_set_vertex_buffer(
   let size = if let Some(size) = size {
     Some(
       std::num::NonZeroU64::new(size)
-        .ok_or_else(|| type_error("size must be larger than 0"))?,
+        .ok_or_else(|| JsNativeError::type_error("size must be larger than 0"))?,
     )
   } else {
     None

--- a/ext/webstorage/lib.rs
+++ b/ext/webstorage/lib.rs
@@ -254,9 +254,8 @@ impl fmt::Display for DomExceptionNotSupportedError {
 
 impl std::error::Error for DomExceptionNotSupportedError {}
 
-pub fn get_not_supported_error_class_name(
-  e: &AnyError,
-) -> Option<&'static str> {
-  e.downcast_ref::<DomExceptionNotSupportedError>()
-    .map(|_| "DOMExceptionNotSupportedError")
+impl deno_core::error::JsErrorClass for DomExceptionNotSupportedError {
+  fn get_class(&self) -> &'static str {
+    "DOMExceptionNotSupportedError"
+  }
 }

--- a/runtime/errors.rs
+++ b/runtime/errors.rs
@@ -10,86 +10,7 @@
 //!   exceptions.
 
 use deno_core::error::AnyError;
-use deno_core::serde_json;
-use deno_core::url;
-use deno_core::ModuleResolutionError;
-use std::env;
-use std::error::Error;
-use std::io;
 use std::sync::Arc;
-
-fn get_dlopen_error_class(error: &dlopen2::Error) -> &'static str {
-  use dlopen2::Error::*;
-  match error {
-    NullCharacter(_) => "InvalidData",
-    OpeningLibraryError(ref e) => get_io_error_class(e),
-    SymbolGettingError(ref e) => get_io_error_class(e),
-    AddrNotMatchingDll(ref e) => get_io_error_class(e),
-    NullSymbol => "NotFound",
-  }
-}
-
-fn get_env_var_error_class(error: &env::VarError) -> &'static str {
-  use env::VarError::*;
-  match error {
-    NotPresent => "NotFound",
-    NotUnicode(..) => "InvalidData",
-  }
-}
-
-fn get_io_error_class(error: &io::Error) -> &'static str {
-  use io::ErrorKind::*;
-  match error.kind() {
-    NotFound => "NotFound",
-    PermissionDenied => "PermissionDenied",
-    ConnectionRefused => "ConnectionRefused",
-    ConnectionReset => "ConnectionReset",
-    ConnectionAborted => "ConnectionAborted",
-    NotConnected => "NotConnected",
-    AddrInUse => "AddrInUse",
-    AddrNotAvailable => "AddrNotAvailable",
-    BrokenPipe => "BrokenPipe",
-    AlreadyExists => "AlreadyExists",
-    InvalidInput => "TypeError",
-    InvalidData => "InvalidData",
-    TimedOut => "TimedOut",
-    Interrupted => "Interrupted",
-    WriteZero => "WriteZero",
-    UnexpectedEof => "UnexpectedEof",
-    Other => "Error",
-    WouldBlock => "WouldBlock",
-    // Non-exhaustive enum - might add new variants
-    // in the future
-    kind => {
-      let kind_str = kind.to_string();
-      match kind_str.as_str() {
-        "FilesystemLoop" => "FilesystemLoop",
-        "IsADirectory" => "IsADirectory",
-        "NetworkUnreachable" => "NetworkUnreachable",
-        "NotADirectory" => "NotADirectory",
-        _ => "Error",
-      }
-    }
-  }
-}
-
-fn get_module_resolution_error_class(
-  _: &ModuleResolutionError,
-) -> &'static str {
-  "URIError"
-}
-
-fn get_notify_error_class(error: &notify::Error) -> &'static str {
-  use notify::ErrorKind::*;
-  match error.kind {
-    Generic(_) => "Error",
-    Io(ref e) => get_io_error_class(e),
-    PathNotFound => "NotFound",
-    WatchNotFound => "NotFound",
-    InvalidConfig(_) => "InvalidData",
-    MaxFilesWatch => "Error",
-  }
-}
 
 fn get_regex_error_class(error: &regex::Error) -> &'static str {
   use regex::Error::*;
@@ -98,26 +19,6 @@ fn get_regex_error_class(error: &regex::Error) -> &'static str {
     CompiledTooBig(_) => "RangeError",
     _ => "Error",
   }
-}
-
-fn get_serde_json_error_class(
-  error: &serde_json::error::Error,
-) -> &'static str {
-  use deno_core::serde_json::error::*;
-  match error.classify() {
-    Category::Io => error
-      .source()
-      .and_then(|e| e.downcast_ref::<io::Error>())
-      .map(get_io_error_class)
-      .unwrap(),
-    Category::Syntax => "SyntaxError",
-    Category::Data => "InvalidData",
-    Category::Eof => "UnexpectedEof",
-  }
-}
-
-fn get_url_parse_error_class(_error: &url::ParseError) -> &'static str {
-  "URIError"
 }
 
 fn get_hyper_error_class(_error: &hyper::Error) -> &'static str {
@@ -154,60 +55,16 @@ pub fn get_nix_error_class(error: &nix::Error) -> &'static str {
 }
 
 pub fn get_error_class_name(e: &AnyError) -> Option<&'static str> {
-  deno_core::error::get_custom_error_class(e)
-    .or_else(|| deno_webgpu::error::get_error_class_name(e))
-    .or_else(|| deno_web::get_error_class_name(e))
-    .or_else(|| deno_webstorage::get_not_supported_error_class_name(e))
-    .or_else(|| deno_websocket::get_network_error_class_name(e))
-    .or_else(|| {
-      e.downcast_ref::<dlopen2::Error>()
-        .map(get_dlopen_error_class)
-    })
-    .or_else(|| e.downcast_ref::<hyper::Error>().map(get_hyper_error_class))
+  e.downcast_ref::<hyper::Error>().map(get_hyper_error_class)
     .or_else(|| {
       e.downcast_ref::<hyper_util::client::legacy::Error>()
         .map(get_hyper_util_error_class)
     })
     .or_else(|| {
-      e.downcast_ref::<hyper_v014::Error>()
-        .map(get_hyper_v014_error_class)
-    })
-    .or_else(|| {
       e.downcast_ref::<Arc<hyper_v014::Error>>()
         .map(|e| get_hyper_v014_error_class(e))
     })
-    .or_else(|| {
-      e.downcast_ref::<deno_core::Canceled>().map(|e| {
-        let io_err: io::Error = e.to_owned().into();
-        get_io_error_class(&io_err)
-      })
-    })
-    .or_else(|| {
-      e.downcast_ref::<env::VarError>()
-        .map(get_env_var_error_class)
-    })
-    .or_else(|| e.downcast_ref::<io::Error>().map(get_io_error_class))
-    .or_else(|| {
-      e.downcast_ref::<ModuleResolutionError>()
-        .map(get_module_resolution_error_class)
-    })
-    .or_else(|| {
-      e.downcast_ref::<notify::Error>()
-        .map(get_notify_error_class)
-    })
     .or_else(|| e.downcast_ref::<regex::Error>().map(get_regex_error_class))
-    .or_else(|| {
-      e.downcast_ref::<serde_json::error::Error>()
-        .map(get_serde_json_error_class)
-    })
-    .or_else(|| {
-      e.downcast_ref::<url::ParseError>()
-        .map(get_url_parse_error_class)
-    })
-    .or_else(|| {
-      e.downcast_ref::<deno_kv::sqlite::SqliteBackendError>()
-        .map(|_| "TypeError")
-    })
     .or_else(|| {
       #[cfg(unix)]
       let maybe_get_nix_error_class =

--- a/runtime/fs_util.rs
+++ b/runtime/fs_util.rs
@@ -2,7 +2,7 @@
 
 use deno_ast::ModuleSpecifier;
 use deno_core::anyhow::Context;
-use deno_core::error::uri_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 pub use deno_core::normalize_path;
 use std::path::Path;
@@ -57,9 +57,9 @@ pub fn specifier_to_file_path(
   };
   match result {
     Ok(path) => Ok(path),
-    Err(()) => Err(uri_error(format!(
+    Err(()) => Err(JsNativeError::uri_error( format!(
       "Invalid file path.\n  Specifier: {specifier}"
-    ))),
+    )).into()),
   }
 }
 

--- a/runtime/ops/os/mod.rs
+++ b/runtime/ops/os/mod.rs
@@ -2,7 +2,7 @@
 
 use super::utils::into_string;
 use crate::worker::ExitCode;
-use deno_core::error::type_error;
+use deno_core::error::{JsNativeError};
 use deno_core::error::AnyError;
 use deno_core::normalize_path;
 use deno_core::op2;
@@ -94,17 +94,17 @@ fn op_set_env(
 ) -> Result<(), AnyError> {
   state.borrow_mut::<PermissionsContainer>().check_env(key)?;
   if key.is_empty() {
-    return Err(type_error("Key is an empty string."));
+    return Err(JsNativeError::type_error("Key is an empty string.").into());
   }
   if key.contains(&['=', '\0'] as &[char]) {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Key contains invalid characters: {key:?}"
-    )));
+    )).into());
   }
   if value.contains('\0') {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Value contains invalid characters: {value:?}"
-    )));
+    )).into());
   }
   env::set_var(key, value);
   Ok(())
@@ -130,13 +130,13 @@ fn op_get_env(
   }
 
   if key.is_empty() {
-    return Err(type_error("Key is an empty string."));
+    return Err(JsNativeError::type_error("Key is an empty string.").into());
   }
 
   if key.contains(&['=', '\0'] as &[char]) {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Key contains invalid characters: {key:?}"
-    )));
+    )).into());
   }
 
   let r = match env::var(key) {
@@ -153,7 +153,7 @@ fn op_delete_env(
 ) -> Result<(), AnyError> {
   state.borrow_mut::<PermissionsContainer>().check_env(&key)?;
   if key.is_empty() || key.contains(&['=', '\0'] as &[char]) {
-    return Err(type_error("Key contains invalid characters."));
+    return Err(JsNativeError::type_error("Key contains invalid characters.").into());
   }
   env::remove_var(key);
   Ok(())

--- a/runtime/ops/permissions.rs
+++ b/runtime/ops/permissions.rs
@@ -3,7 +3,7 @@
 use ::deno_permissions::parse_sys_kind;
 use ::deno_permissions::PermissionState;
 use ::deno_permissions::PermissionsContainer;
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::OpState;
@@ -75,10 +75,10 @@ pub fn op_query_permission(
     "ffi" => permissions.ffi.query(args.path.as_deref().map(Path::new)),
     "hrtime" => permissions.hrtime.query(),
     n => {
-      return Err(custom_error(
+      return Err(JsNativeError::new(
         "ReferenceError",
         format!("No such permission name: {n}"),
-      ))
+      ).into())
     }
   };
   Ok(PermissionStatus::from(perm))
@@ -110,10 +110,10 @@ pub fn op_revoke_permission(
     "ffi" => permissions.ffi.revoke(args.path.as_deref().map(Path::new)),
     "hrtime" => permissions.hrtime.revoke(),
     n => {
-      return Err(custom_error(
+      return Err(JsNativeError::new(
         "ReferenceError",
         format!("No such permission name: {n}"),
-      ))
+      ).into())
     }
   };
   Ok(PermissionStatus::from(perm))
@@ -145,10 +145,10 @@ pub fn op_request_permission(
     "ffi" => permissions.ffi.request(args.path.as_deref().map(Path::new)),
     "hrtime" => permissions.hrtime.request(),
     n => {
-      return Err(custom_error(
+      return Err(JsNativeError::new(
         "ReferenceError",
         format!("No such permission name: {n}"),
-      ))
+      ).into())
     }
   };
   Ok(PermissionStatus::from(perm))

--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -2,7 +2,7 @@
 
 use super::check_unstable;
 use deno_core::anyhow::Context;
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::serde_json;
@@ -579,7 +579,7 @@ fn op_spawn_kill(
     deprecated::kill(child_resource.1 as i32, &signal)?;
     return Ok(());
   }
-  Err(type_error("Child process has already terminated."))
+  Err(JsNativeError::type_error("Child process has already terminated.").into())
 }
 
 mod deprecated {
@@ -808,9 +808,9 @@ mod deprecated {
     use winapi::um::winnt::PROCESS_TERMINATE;
 
     if !matches!(signal, "SIGKILL" | "SIGTERM") {
-      Err(type_error(format!("Invalid signal: {signal}")))
+      Err(JsNativeError::type_error(format!("Invalid signal: {signal}")).into())
     } else if pid <= 0 {
-      Err(type_error("Invalid pid"))
+      Err(JsNativeError::type_error("Invalid pid").into())
     } else {
       let handle =
         // SAFETY: winapi call

--- a/runtime/ops/signal.rs
+++ b/runtime/ops/signal.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-use deno_core::error::type_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 use deno_core::op2;
 use deno_core::AsyncRefCell;
@@ -419,7 +419,7 @@ pub fn signal_str_to_int(s: &str) -> Result<libc::c_int, AnyError> {
     "SIGINFO" => Ok(29),
     "SIGUSR1" => Ok(30),
     "SIGUSR2" => Ok(31),
-    _ => Err(type_error(format!("Invalid signal: {s}"))),
+    _ => Err(JsNativeError::type_error(format!("Invalid signal: {s}")).into()),
   }
 }
 
@@ -457,7 +457,7 @@ pub fn signal_int_to_str(s: libc::c_int) -> Result<&'static str, AnyError> {
     29 => Ok("SIGINFO"),
     30 => Ok("SIGUSR1"),
     31 => Ok("SIGUSR2"),
-    _ => Err(type_error(format!("Invalid signal: {s}"))),
+    _ => Err(JsNativeError::type_error(format!("Invalid signal: {s}")).into()),
   }
 }
 
@@ -563,9 +563,9 @@ pub fn signal_str_to_int(s: &str) -> Result<libc::c_int, AnyError> {
   match s {
     "SIGINT" => Ok(2),
     "SIGBREAK" => Ok(21),
-    _ => Err(type_error(
+    _ => Err(JsNativeError::type_error(
       "Windows only supports ctrl-c (SIGINT) and ctrl-break (SIGBREAK).",
-    )),
+    ).into()),
   }
 }
 
@@ -574,9 +574,9 @@ pub fn signal_int_to_str(s: libc::c_int) -> Result<&'static str, AnyError> {
   match s {
     2 => Ok("SIGINT"),
     21 => Ok("SIGBREAK"),
-    _ => Err(type_error(
+    _ => Err(JsNativeError::type_error(
       "Windows only supports ctrl-c (SIGINT) and ctrl-break (SIGBREAK).",
-    )),
+    ).into()),
   }
 }
 
@@ -589,9 +589,9 @@ fn op_signal_bind(
 ) -> Result<ResourceId, AnyError> {
   let signo = signal_str_to_int(sig)?;
   if signal_hook_registry::FORBIDDEN.contains(&signo) {
-    return Err(type_error(format!(
+    return Err(JsNativeError::type_error(format!(
       "Binding to signal '{sig}' is not allowed",
-    )));
+    )).into());
   }
 
   let signal = AsyncRefCell::new(signal(SignalKind::from_raw(signo))?);

--- a/runtime/ops/utils.rs
+++ b/runtime/ops/utils.rs
@@ -1,12 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::error::custom_error;
+use deno_core::error::JsNativeError;
 use deno_core::error::AnyError;
 
 /// A utility function to map OsStrings to Strings
 pub fn into_string(s: std::ffi::OsString) -> Result<String, AnyError> {
   s.into_string().map_err(|s| {
     let message = format!("File name or path {s:?} is not valid UTF-8");
-    custom_error("InvalidData", message)
+    JsNativeError::new("InvalidData", message).into()
   })
 }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -12,7 +12,8 @@ use std::time::Instant;
 use deno_broadcast_channel::InMemoryBroadcastChannel;
 use deno_cache::CreateCache;
 use deno_cache::SqliteBackedCache;
-use deno_core::error::AnyError;
+use deno_core::error::{CoreError};
+use deno_core::error::{AnyError};
 use deno_core::error::JsError;
 use deno_core::merge_op_metrics;
 use deno_core::v8;
@@ -20,7 +21,6 @@ use deno_core::CompiledWasmModuleStore;
 use deno_core::Extension;
 use deno_core::FeatureChecker;
 use deno_core::FsModuleLoader;
-use deno_core::GetErrorClassFn;
 use deno_core::JsRuntime;
 use deno_core::LocalInspectorSession;
 use deno_core::ModuleCodeString;
@@ -59,7 +59,7 @@ pub fn import_meta_resolve_callback(
   loader: &dyn deno_core::ModuleLoader,
   specifier: String,
   referrer: String,
-) -> Result<ModuleSpecifier, AnyError> {
+) -> Result<ModuleSpecifier, deno_core::error::ModuleLoaderError> {
   loader.resolve(
     &specifier,
     &referrer,
@@ -172,9 +172,6 @@ pub struct WorkerOptions {
   /// If Some, print a low-level trace output for ops matching the given patterns.
   pub strace_ops: Option<Vec<String>>,
 
-  /// Allows to map error type to a string "class" used to represent
-  /// error in JavaScript.
-  pub get_error_class_fn: Option<GetErrorClassFn>,
   pub cache_storage_dir: Option<std::path::PathBuf>,
   pub origin_storage_dir: Option<std::path::PathBuf>,
   pub blob_store: Arc<BlobStore>,
@@ -219,7 +216,6 @@ impl Default for WorkerOptions {
       shared_array_buffer_store: Default::default(),
       maybe_inspector_server: Default::default(),
       format_js_error_fn: Default::default(),
-      get_error_class_fn: Default::default(),
       origin_storage_dir: Default::default(),
       cache_storage_dir: Default::default(),
       broadcast_channel: Default::default(),
@@ -489,7 +485,6 @@ impl MainWorker {
       startup_snapshot: options.startup_snapshot,
       create_params: options.create_params,
       skip_op_registration: options.skip_op_registration,
-      get_error_class_fn: options.get_error_class_fn,
       shared_array_buffer_store: options.shared_array_buffer_store.clone(),
       compiled_wasm_module_store: options.compiled_wasm_module_store.clone(),
       extensions,
@@ -701,7 +696,7 @@ impl MainWorker {
     &mut self,
     script_name: &'static str,
     source_code: ModuleCodeString,
-  ) -> Result<v8::Global<v8::Value>, AnyError> {
+  ) -> Result<v8::Global<v8::Value>, CoreError> {
     self.js_runtime.execute_script(script_name, source_code)
   }
 
@@ -709,7 +704,7 @@ impl MainWorker {
   pub async fn preload_main_module(
     &mut self,
     module_specifier: &ModuleSpecifier,
-  ) -> Result<ModuleId, AnyError> {
+  ) -> Result<ModuleId, CoreError> {
     self.js_runtime.load_main_es_module(module_specifier).await
   }
 
@@ -717,7 +712,7 @@ impl MainWorker {
   pub async fn preload_side_module(
     &mut self,
     module_specifier: &ModuleSpecifier,
-  ) -> Result<ModuleId, AnyError> {
+  ) -> Result<ModuleId, CoreError> {
     self.js_runtime.load_side_es_module(module_specifier).await
   }
 
@@ -725,7 +720,7 @@ impl MainWorker {
   pub async fn evaluate_module(
     &mut self,
     id: ModuleId,
-  ) -> Result<(), AnyError> {
+  ) -> Result<(), CoreError> {
     self.wait_for_inspector_session();
     let mut receiver = self.js_runtime.mod_evaluate(id);
     tokio::select! {
@@ -750,7 +745,7 @@ impl MainWorker {
   pub async fn run_up_to_duration(
     &mut self,
     duration: Duration,
-  ) -> Result<(), AnyError> {
+  ) -> Result<(), CoreError> {
     match tokio::time::timeout(
       duration,
       self
@@ -769,7 +764,7 @@ impl MainWorker {
   pub async fn execute_side_module(
     &mut self,
     module_specifier: &ModuleSpecifier,
-  ) -> Result<(), AnyError> {
+  ) -> Result<(), CoreError> {
     let id = self.preload_side_module(module_specifier).await?;
     self.evaluate_module(id).await
   }
@@ -780,7 +775,7 @@ impl MainWorker {
   pub async fn execute_main_module(
     &mut self,
     module_specifier: &ModuleSpecifier,
-  ) -> Result<(), AnyError> {
+  ) -> Result<(), CoreError> {
     let id = self.preload_main_module(module_specifier).await?;
     self.evaluate_module(id).await
   }
@@ -807,7 +802,7 @@ impl MainWorker {
   pub async fn run_event_loop(
     &mut self,
     wait_for_inspector: bool,
-  ) -> Result<(), AnyError> {
+  ) -> Result<(), CoreError> {
     self
       .js_runtime
       .run_event_loop(deno_core::PollEventLoopOptions {
@@ -826,7 +821,7 @@ impl MainWorker {
   /// Dispatches "load" event to the JavaScript runtime.
   ///
   /// Does not poll event loop, and thus not await any of the "load" event handlers.
-  pub fn dispatch_load_event(&mut self) -> Result<(), AnyError> {
+  pub fn dispatch_load_event(&mut self) -> Result<(), CoreError> {
     let scope = &mut self.js_runtime.handle_scope();
     let tc_scope = &mut v8::TryCatch::new(scope);
     let dispatch_load_event_fn =


### PR DESCRIPTION
First pass of the error rework. 
This PR will only serve to update the deno_core crate, not actually improve the error handling in the crates. This effort will be done separately as a follow-up with first the different exts being adapted to use proper errors.

still needs a few fixes related to the error wrappers.

deno_core PR: https://github.com/denoland/deno_core/pull/878