### PR TITLE
fix: removed unstable-htttp from deno help

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4050,9 +4050,15 @@ impl Iterator for UnstableArgsIter {
         .hide(true)
         .help_heading(UNSTABLE_HEADING)
         // we don't render long help, so using it here as a sort of metadata
-        .long_help(match self.cfg {
-          UnstableArgsConfig::None | UnstableArgsConfig::ResolutionOnly => None,
-          UnstableArgsConfig::ResolutionAndRuntime => Some("true"),
+        .long_help(if granular_flag.show_in_help {
+          match self.cfg {
+            UnstableArgsConfig::None | UnstableArgsConfig::ResolutionOnly => {
+              None
+            }
+            UnstableArgsConfig::ResolutionAndRuntime => Some("true"),
+          }
+        } else {
+          None
         })
     } else {
       return None;

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4042,11 +4042,10 @@ impl Iterator for UnstableArgsIter {
       })
       .help_heading(UNSTABLE_HEADING)
     } else if self.idx > 3 {
-      let (flag_name, help, _) =
-        crate::UNSTABLE_GRANULAR_FLAGS.get(self.idx - 4)?;
-      Arg::new(format!("unstable-{}", flag_name))
-        .long(format!("unstable-{}", flag_name))
-        .help(help)
+      let granular_flag = crate::UNSTABLE_GRANULAR_FLAGS.get(self.idx - 4)?;
+      Arg::new(format!("unstable-{}", granular_flag.name))
+        .long(format!("unstable-{}", granular_flag.name))
+        .help(granular_flag.help_text)
         .action(ArgAction::SetTrue)
         .hide(true)
         .help_heading(UNSTABLE_HEADING)
@@ -5405,9 +5404,12 @@ fn unstable_args_parse(
     matches.get_flag("unstable-sloppy-imports");
 
   if matches!(cfg, UnstableArgsConfig::ResolutionAndRuntime) {
-    for (name, _, _) in crate::UNSTABLE_GRANULAR_FLAGS {
-      if matches.get_flag(&format!("unstable-{}", name)) {
-        flags.unstable_config.features.push(name.to_string());
+    for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS {
+      if matches.get_flag(&format!("unstable-{}", granular_flag.name)) {
+        flags
+          .unstable_config
+          .features
+          .push(granular_flag.name.to_string());
       }
     }
   }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1669,7 +1669,7 @@ impl CliOptions {
       let mut all_valid_unstable_flags: Vec<&str> =
         crate::UNSTABLE_GRANULAR_FLAGS
           .iter()
-          .map(|granular_flag| granular_flag.0)
+          .map(|granular_flag| granular_flag.name)
           .collect();
 
       let mut another_unstable_flags = Vec::from([

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -720,9 +720,9 @@ impl CliFactory {
         checker.warn_on_legacy_unstable();
       }
       let unstable_features = cli_options.unstable_features();
-      for (flag_name, _, _) in crate::UNSTABLE_GRANULAR_FLAGS {
-        if unstable_features.contains(&flag_name.to_string()) {
-          checker.enable_feature(flag_name);
+      for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS {
+        if unstable_features.contains(&granular_flag.name.to_string()) {
+          checker.enable_feature(granular_flag.name);
         }
       }
 

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -573,9 +573,9 @@ impl CliMainWorkerFactory {
     let feature_checker = shared.feature_checker.clone();
     let mut unstable_features =
       Vec::with_capacity(crate::UNSTABLE_GRANULAR_FLAGS.len());
-    for (feature_name, _, id) in crate::UNSTABLE_GRANULAR_FLAGS {
-      if feature_checker.check(feature_name) {
-        unstable_features.push(*id);
+    for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS {
+      if feature_checker.check(granular_flag.name) {
+        unstable_features.push(granular_flag.id);
       }
     }
 
@@ -771,9 +771,9 @@ fn create_web_worker_callback(
     let feature_checker = shared.feature_checker.clone();
     let mut unstable_features =
       Vec::with_capacity(crate::UNSTABLE_GRANULAR_FLAGS.len());
-    for (feature_name, _, id) in crate::UNSTABLE_GRANULAR_FLAGS {
-      if feature_checker.check(feature_name) {
-        unstable_features.push(*id);
+    for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS {
+      if feature_checker.check(granular_flag.name) {
+        unstable_features.push(granular_flag.id);
       }
     }
 

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -47,73 +47,90 @@ mod shared;
 pub use shared::import_assertion_callback;
 pub use shared::runtime;
 
-// NOTE(bartlomieju): keep IDs in sync with `runtime/90_deno_ns.js` (search for `unstableFeatures`)
-pub static UNSTABLE_GRANULAR_FLAGS: &[(
-  // flag name
-  &str,
-  // help text
-  &str,
+pub struct UnstableGranularFlag {
+  pub name: &'static str,
+  pub help_text: &'static str,
+  pub show_in_help: bool,
   // id to enable it in runtime/99_main.js
-  i32,
-)] = &[
-  (
-    deno_broadcast_channel::UNSTABLE_FEATURE_NAME,
-    "Enable unstable `BroadcastChannel` API",
-    1,
-  ),
-  (
-    deno_cron::UNSTABLE_FEATURE_NAME,
-    "Enable unstable Deno.cron API",
-    2,
-  ),
-  (
-    deno_ffi::UNSTABLE_FEATURE_NAME,
-    "Enable unstable FFI APIs",
-    3,
-  ),
-  (
-    deno_fs::UNSTABLE_FEATURE_NAME,
-    "Enable unstable file system APIs",
-    4,
-  ),
-  (
-    ops::http::UNSTABLE_FEATURE_NAME,
-    "Enable unstable HTTP APIs",
-    5,
-  ),
-  (
-    deno_kv::UNSTABLE_FEATURE_NAME,
-    "Enable unstable Key-Value store APIs",
-    6,
-  ),
-  (
-    deno_net::UNSTABLE_FEATURE_NAME,
-    "Enable unstable net APIs",
-    7,
-  ),
-  (
-    ops::process::UNSTABLE_FEATURE_NAME,
-    "Enable unstable process APIs",
-    8,
-  ),
-  ("temporal", "Enable unstable Temporal API", 9),
-  (
-    "unsafe-proto",
-    "Enable unsafe __proto__ support. This is a security risk.",
+  pub id: i32,
+}
+
+// NOTE(bartlomieju): keep IDs in sync with `runtime/90_deno_ns.js` (search for `unstableFeatures`)
+pub static UNSTABLE_GRANULAR_FLAGS: &[UnstableGranularFlag] = &[
+  UnstableGranularFlag {
+    name: deno_broadcast_channel::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable `BroadcastChannel` API",
+    show_in_help: true,
+    id: 1,
+  },
+  UnstableGranularFlag {
+    name: deno_cron::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable Deno.cron API",
+    show_in_help: true,
+    id: 2,
+  },
+  UnstableGranularFlag {
+    name: deno_ffi::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable FFI APIs",
+    show_in_help: true,
+    id: 3,
+  },
+  UnstableGranularFlag {
+    name: deno_fs::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable file system APIs",
+    show_in_help: true,
+    id: 4,
+  },
+  UnstableGranularFlag {
+    name: ops::http::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable HTTP APIs",
+    show_in_help: false,
+    id: 5,
+  },
+  UnstableGranularFlag {
+    name: deno_kv::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable Key-Value store APIs",
+    show_in_help: true,
+    id: 6,
+  },
+  UnstableGranularFlag {
+    name: deno_net::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable net APIs",
+    show_in_help: true,
+    id: 7,
+  },
+  UnstableGranularFlag {
+    name: ops::process::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable process APIs",
+    show_in_help: true,
+    id: 8,
+  },
+  UnstableGranularFlag {
+    name: "temporal",
+    help_text: "Enable unstable Temporal API",
+    show_in_help: true,
+    id: 9,
+  },
+  UnstableGranularFlag {
+    name: "unsafe-proto",
+    help_text: "Enable unsafe __proto__ support. This is a security risk.",
+    show_in_help: true,
     // This number is used directly in the JS code. Search
     // for "unstableIds" to see where it's used.
-    10,
-  ),
-  (
-    deno_webgpu::UNSTABLE_FEATURE_NAME,
-    "Enable unstable `WebGPU` API",
-    11,
-  ),
-  (
-    ops::worker_host::UNSTABLE_FEATURE_NAME,
-    "Enable unstable Web Worker APIs",
-    12,
-  ),
+    id: 10,
+  },
+  UnstableGranularFlag {
+    name: deno_webgpu::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable `WebGPU` API",
+    show_in_help: true,
+    id: 11,
+  },
+  UnstableGranularFlag {
+    name: ops::worker_host::UNSTABLE_FEATURE_NAME,
+    help_text: "Enable unstable Web Worker APIs",
+    show_in_help: true,
+    id: 12,
+  },
 ];
 
 #[cfg(test)]
@@ -124,7 +141,7 @@ mod test {
   fn unstable_granular_flag_names_sorted() {
     let flags = UNSTABLE_GRANULAR_FLAGS
       .iter()
-      .map(|(name, _, _)| name.to_string())
+      .map(|granular_flag| granular_flag.name.to_string())
       .collect::<Vec<_>>();
     let mut sorted_flags = flags.clone();
     sorted_flags.sort();

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -77,6 +77,11 @@ pub static UNSTABLE_GRANULAR_FLAGS: &[(
     4,
   ),
   (
+    ops::http::UNSTABLE_FEATURE_NAME,
+    "Enable unstable HTTP APIs",
+    5,
+  ),
+  (
     deno_kv::UNSTABLE_FEATURE_NAME,
     "Enable unstable Key-Value store APIs",
     6,

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -77,11 +77,6 @@ pub static UNSTABLE_GRANULAR_FLAGS: &[(
     4,
   ),
   (
-    ops::http::UNSTABLE_FEATURE_NAME,
-    "Enable unstable HTTP APIs",
-    5,
-  ),
-  (
     deno_kv::UNSTABLE_FEATURE_NAME,
     "Enable unstable Key-Value store APIs",
     6,

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -100,9 +100,9 @@ pub fn op_bootstrap_unstable_args(state: &mut OpState) -> Vec<String> {
   }
 
   let mut flags = Vec::new();
-  for (name, _, id) in crate::UNSTABLE_GRANULAR_FLAGS.iter() {
-    if options.unstable_features.contains(id) {
-      flags.push(format!("--unstable-{}", name));
+  for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS.iter() {
+    if options.unstable_features.contains(&granular_flag.id) {
+      flags.push(format!("--unstable-{}", granular_flag.name));
     }
   }
   flags


### PR DESCRIPTION
Closes #25210 .

Removed --unstable-http from being displayed on deno run --help=unstable