### PR TITLE
build: Allow building 'rc' release from source

### DIFF
--- a/cli/version.rs
+++ b/cli/version.rs
@@ -10,7 +10,7 @@ const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 // TODO(bartlomieju): ideally we could remove this const.
 const IS_CANARY: bool = option_env!("DENO_CANARY").is_some();
 // TODO(bartlomieju): this is temporary, to allow Homebrew to cut RC releases as well
-const IS_RC: bool = option_env!("DENO_CANARY").is_some();
+const IS_RC: bool = option_env!("DENO_RC").is_some();
 
 pub static DENO_VERSION_INFO: Lazy<DenoVersionInfo> = Lazy::new(|| {
   let release_channel = libsui::find_section("denover")

--- a/cli/version.rs
+++ b/cli/version.rs
@@ -9,6 +9,8 @@ const TYPESCRIPT: &str = env!("TS_VERSION");
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 // TODO(bartlomieju): ideally we could remove this const.
 const IS_CANARY: bool = option_env!("DENO_CANARY").is_some();
+// TODO(bartlomieju): this is temporary, to allow Homebrew to cut RC releases as well
+const IS_RC: bool = option_env!("DENO_CANARY").is_some();
 
 pub static DENO_VERSION_INFO: Lazy<DenoVersionInfo> = Lazy::new(|| {
   let release_channel = libsui::find_section("denover")
@@ -17,6 +19,8 @@ pub static DENO_VERSION_INFO: Lazy<DenoVersionInfo> = Lazy::new(|| {
     .unwrap_or({
       if IS_CANARY {
         ReleaseChannel::Canary
+      } else if IS_RC {
+        ReleaseChannel::Rc
       } else {
         ReleaseChannel::Stable
       }


### PR DESCRIPTION
We're not gonna use it, but this might help distribution tools like
Homebrew to also release Deno 2.0 RC releases.