### PR TITLE
fix(task): support tasks with colons in name in `deno run`

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -53,6 +53,7 @@ use deno_runtime::tokio_util::create_and_run_current_thread_with_maybe_metrics;
 use deno_terminal::colors;
 use factory::CliFactory;
 use standalone::MODULE_NOT_FOUND;
+use standalone::UNSUPPORTED_SCHEME;
 use std::env;
 use std::future::Future;
 use std::ops::Deref;
@@ -196,7 +197,8 @@ async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
         match result {
           Ok(v) => Ok(v),
           Err(script_err) => {
-            if script_err.to_string().starts_with(MODULE_NOT_FOUND) {
+            let script_err_msg = script_err.to_string();
+            if script_err_msg.starts_with(MODULE_NOT_FOUND) || script_err_msg.starts_with(UNSUPPORTED_SCHEME) {
               if run_flags.bare {
                 let mut cmd = args::clap_root();
                 cmd.build();

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -133,6 +133,7 @@ struct EmbeddedModuleLoader {
 }
 
 pub const MODULE_NOT_FOUND: &str = "Module not found";
+pub const UNSUPPORTED_SCHEME: &str = "Unsupported scheme";
 
 impl ModuleLoader for EmbeddedModuleLoader {
   fn resolve(

--- a/tests/specs/run/run_task/__test__.jsonc
+++ b/tests/specs/run/run_task/__test__.jsonc
@@ -8,6 +8,10 @@
       "args": "run not_found",
       "output": "not_found.out",
       "exitCode": 1
+    },
+    "deno_run_task_colon": {
+      "args": "run main:foo",
+      "output": "main_foo.out"
     }
   }
 }

--- a/tests/specs/run/run_task/deno.json
+++ b/tests/specs/run/run_task/deno.json
@@ -1,5 +1,6 @@
 {
   "tasks": {
-    "main": "deno run main.ts"
+    "main": "deno run main.ts",
+    "main:foo": "deno run main.ts"
   }
 }

--- a/tests/specs/run/run_task/main_foo.out
+++ b/tests/specs/run/run_task/main_foo.out
@@ -1,0 +1,2 @@
+Task main:foo deno run main.ts
+main


### PR DESCRIPTION
Fix task names containing a colon not being found with `deno run`. We were only checking for a `module not found` error message, but strings containing a colon throw a different error.

Fixes https://github.com/denoland/deno/issues/25232