### PR TITLE
chore: ignore lint warning in test

### DIFF
--- a/tests/unit/process_test.ts
+++ b/tests/unit/process_test.ts
@@ -397,6 +397,7 @@ Deno.test(
 
     assertStringIncludes(text, "error");
     assertStringIncludes(text, "output");
+    // deno-lint-ignore no-console
     console.log("finished tgis test");
   },
 );


### PR DESCRIPTION
Noticed this when working on another PR. The test code predates the addition of our `no-console` rule.