### PR TITLE
test: add supporting for ignoring spec tests

### DIFF
--- a/tests/specs/schema.json
+++ b/tests/specs/schema.json
@@ -50,6 +50,9 @@
         },
         "exitCode": {
           "type": "integer"
+        },
+        "ignore": {
+          "type": "boolean"
         }
       }
     },
@@ -77,6 +80,9 @@
             "items": {
               "$ref": "#/definitions/single_test"
             }
+          },
+          "ignore": {
+            "type": "boolean"
           }
         }
       }, {
@@ -126,6 +132,9 @@
           "additionalProperties": {
             "$ref": "#/definitions/single_or_multi_step_test"
           }
+        },
+        "ignore": {
+          "type": "boolean"
         }
       }
     }


### PR DESCRIPTION
You can now specify `"ignore": true` for either the whole file,
concrete test, or concrete step.