### PR TITLE
fix(ext/node): emit `online` event after worker thread is initialized

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -57,8 +57,9 @@ interface WorkerOnlineMsg {
 }
 
 function isWorkerOnlineMsg(data: unknown): data is WorkerOnlineMsg {
-  return typeof data === "object" && data !== null && "type" in data &&
-    data["type"] === "WORKER_ONLINE";
+  return typeof data === "object" && data !== null &&
+    ObjectHasOwn(data, "type") &&
+    (data as { "type": unknown })["type"] === "WORKER_ONLINE";
 }
 
 export interface WorkerOptions {

--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -151,6 +151,7 @@ class NodeWorker extends EventEmitter {
       workerData: options?.workerData,
       environmentData: environmentData,
       env: env_,
+      isWorkerThread: true,
     }, options?.transferList ?? []);
     const id = op_create_worker(
       {
@@ -376,10 +377,12 @@ internals.__initWorkerThreads = (
 
     parentPort = globalThis as ParentPort;
     threadId = workerId;
+    let isWorkerThread = false;
     if (maybeWorkerMetadata) {
       const { 0: metadata, 1: _ } = maybeWorkerMetadata;
       workerData = metadata.workerData;
       environmentData = metadata.environmentData;
+      isWorkerThread = metadata.isWorkerThread;
       const env = metadata.env;
       if (env) {
         process.env = env;
@@ -444,11 +447,14 @@ internals.__initWorkerThreads = (
       parentPort[unrefPollForMessages] = false;
     };
 
-    parentPort.postMessage(
-      {
-        type: "WORKER_ONLINE",
-      } satisfies WorkerOnlineMsg,
-    );
+    if (isWorkerThread) {
+      // Notify the host that the worker is online
+      parentPort.postMessage(
+        {
+          type: "WORKER_ONLINE",
+        } satisfies WorkerOnlineMsg,
+      );
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #23281. Part of #20613.

We were emitting the `online` event in the constructor, so the caller could never receive it (since there was no time for them to add a listener). Instead, emit the event where it's intended – after the worker is initialized.

---

After this parcel no longer freezes, but still will fail due to other bugs (which will be fixed in other PRs)