### PR TITLE
fix: replace `npm install` hint with `deno install` hint

### DIFF
--- a/cli/npm/byonm.rs
+++ b/cli/npm/byonm.rs
@@ -307,14 +307,9 @@ impl CliNpmResolver for ByonmCliNpmResolver {
       concat!(
         "Could not find \"{}\" in a node_modules folder. ",
         "Deno expects the node_modules/ directory to be up to date. ",
-        "Did you forget to run `{}`?"
+        "Did you forget to run `deno install`?"
       ),
       alias,
-      if *crate::args::DENO_FUTURE {
-        "deno install"
-      } else {
-        "npm install"
-      }
     );
   }
 

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -146,7 +146,7 @@ impl CliNodeResolver {
                         concat!(
                         "Could not resolve \"{}\", but found it in a package.json. ",
                         "Deno expects the node_modules/ directory to be up to date. ",
-                        "Did you forget to run `npm install`?"
+                        "Did you forget to run `deno install`?"
                       ),
                         specifier
                       ));

--- a/tests/integration/npm_tests.rs
+++ b/tests/integration/npm_tests.rs
@@ -2404,7 +2404,7 @@ fn byonm_package_specifier_not_installed_and_invalid_subpath() {
   // no npm install has been run, so this should give an informative error
   let output = test_context.new_command().args("run main.ts").run();
   output.assert_matches_text(
-    r#"error: Could not resolve "chalk", but found it in a package.json. Deno expects the node_modules/ directory to be up to date. Did you forget to run `npm install`?
+    r#"error: Could not resolve "chalk", but found it in a package.json. Deno expects the node_modules/ directory to be up to date. Did you forget to run `deno install`?
     at file:///[WILDCARD]/main.ts:1:19
 "#,
   );

--- a/tests/specs/npm/byonm/not_installed.out
+++ b/tests/specs/npm/byonm/not_installed.out
@@ -1,2 +1,2 @@
-error: Could not find "chalk" in a node_modules folder. Deno expects the node_modules/ directory to be up to date. Did you forget to run `npm install`?
+error: Could not find "chalk" in a node_modules folder. Deno expects the node_modules/ directory to be up to date. Did you forget to run `deno install`?
     at file:///[WILDCARD]/not_installed.ts:1:19


### PR DESCRIPTION
Needed for https://github.com/denoland/deno/pull/25213.

With Deno 2, we should suggest using `deno install` instead of `npm install`.