### PR TITLE
fix(napi): Don't run microtasks in napi_resolve_deferred

### DIFF
--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -3307,6 +3307,11 @@ fn napi_resolve_deferred(
   check_arg!(env, result);
   check_arg!(env, deferred);
 
+  // Make sure microtasks don't run and call back into JS
+  env
+    .scope()
+    .set_microtasks_policy(v8::MicrotasksPolicy::Explicit);
+
   let deferred_ptr =
     unsafe { NonNull::new_unchecked(deferred as *mut v8::PromiseResolver) };
   let global = unsafe { v8::Global::from_raw(env.isolate(), deferred_ptr) };

--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -3321,9 +3321,15 @@ fn napi_resolve_deferred(
     .resolve(&mut env.scope(), result.unwrap())
     .unwrap_or(false)
   {
+    env
+      .scope()
+      .set_microtasks_policy(v8::MicrotasksPolicy::Auto);
     return napi_generic_failure;
   }
 
+  env
+    .scope()
+    .set_microtasks_policy(v8::MicrotasksPolicy::Auto);
   napi_ok
 }
 

--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -3317,20 +3317,20 @@ fn napi_resolve_deferred(
   let global = unsafe { v8::Global::from_raw(env.isolate(), deferred_ptr) };
   let resolver = v8::Local::new(&mut env.scope(), global);
 
-  if !resolver
+  let success = resolver
     .resolve(&mut env.scope(), result.unwrap())
-    .unwrap_or(false)
-  {
-    env
-      .scope()
-      .set_microtasks_policy(v8::MicrotasksPolicy::Auto);
-    return napi_generic_failure;
-  }
+    .unwrap_or(false);
 
+  // Restore policy
   env
     .scope()
     .set_microtasks_policy(v8::MicrotasksPolicy::Auto);
-  napi_ok
+
+  if success {
+    napi_ok
+  } else {
+    napi_generic_failure
+  }
 }
 
 #[napi_sym]


### PR DESCRIPTION
Fixes an incredibly obscure bug that causes parcel's file watcher to not get any file update notifications on macOS.

The issue was that the native addon was calling `napi_resolve_deferred`, but when we resolved the promise, v8 was running microtasks automatically. That executed JS, which called back into the native addon and broke the addon's assumption that the call wouldn't be reentrant.