### PR TITLE
fix(ext/node): throw when loading `cpu-features` module

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1121,6 +1121,9 @@ Module._extensions[".json"] = function (module, filename) {
 
 // Native extension for .node
 Module._extensions[".node"] = function (module, filename) {
+  if (filename.endsWith("cpufeatures.node")) {
+    throw new Error("Using cpu-features module is currently not supported");
+  }
   module.exports = op_napi_open(
     filename,
     globalThis,


### PR DESCRIPTION
It crashes because of NAN usage, we want to trigger the fallback case in ssh2 by throwing an error.

Fixes https://github.com/denoland/deno/issues/25236
