### PR TITLE
refactor: don't virtualize the `console` global for node mode

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -52,7 +52,6 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 // - clearImmediate (node only)
 // - clearInterval (both, but different implementation)
 // - clearTimeout (both, but different implementation)
-// - console (both, but different implementation)
 // - global (node only)
 // - performance (both, but different implementation)
 // - process (node only)
@@ -63,13 +62,12 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 
 // UTF-16 encodings of the managed globals. THIS LIST MUST BE SORTED.
 #[rustfmt::skip]
-const MANAGED_GLOBALS: [&[u16]; 14] = [
+const MANAGED_GLOBALS: [&[u16]; 13] = [
   &str_to_utf16::<6>("Buffer"),
   &str_to_utf16::<17>("WorkerGlobalScope"),
   &str_to_utf16::<14>("clearImmediate"),
   &str_to_utf16::<13>("clearInterval"),
   &str_to_utf16::<12>("clearTimeout"),
-  &str_to_utf16::<7>("console"),
   &str_to_utf16::<6>("global"),
   &str_to_utf16::<11>("performance"),
   &str_to_utf16::<7>("process"),

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -945,7 +945,7 @@ Module.prototype.require = function (id) {
 // The only observable difference is that in Deno `arguments.callee` is not
 // null.
 Module.wrapper = [
-  "(function (exports, require, module, __filename, __dirname, Buffer, clearImmediate, clearInterval, clearTimeout, console, global, process, setImmediate, setInterval, setTimeout, performance) { (function (exports, require, module, __filename, __dirname) {",
+  "(function (exports, require, module, __filename, __dirname, Buffer, clearImmediate, clearInterval, clearTimeout, global, process, setImmediate, setInterval, setTimeout, performance) { (function (exports, require, module, __filename, __dirname) {",
   "\n}).call(this, exports, require, module, __filename, __dirname); })",
 ];
 Module.wrap = function (script) {
@@ -1029,7 +1029,6 @@ Module.prototype._compile = function (content, filename, format) {
     clearImmediate,
     clearInterval,
     clearTimeout,
-    console,
     global,
     process,
     setImmediate,
@@ -1049,7 +1048,6 @@ Module.prototype._compile = function (content, filename, format) {
     clearImmediate,
     clearInterval,
     clearTimeout,
-    console,
     global,
     process,
     setImmediate,

--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -76,7 +76,6 @@ nodeGlobals.Buffer = nativeModuleExports["buffer"].Buffer;
 nodeGlobals.clearImmediate = nativeModuleExports["timers"].clearImmediate;
 nodeGlobals.clearInterval = nativeModuleExports["timers"].clearInterval;
 nodeGlobals.clearTimeout = nativeModuleExports["timers"].clearTimeout;
-nodeGlobals.console = nativeModuleExports["console"];
 nodeGlobals.global = globalThis;
 nodeGlobals.process = nativeModuleExports["process"];
 nodeGlobals.setImmediate = nativeModuleExports["timers"].setImmediate;

--- a/ext/node/polyfills/console.ts
+++ b/ext/node/polyfills/console.ts
@@ -9,7 +9,9 @@ import { windowOrWorkerGlobalScope } from "ext:runtime/98_global_scope_shared.js
 // to native `console` object provided by V8.
 const console = windowOrWorkerGlobalScope.console.value;
 
-export default Object.assign({}, console, { Console });
+Object.assign(console, { Console });
+
+export default console;
 
 export { Console };
 export const {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -536,10 +536,6 @@ function dispatchUnloadEvent() {
 }
 
 let hasBootstrapped = false;
-// Delete the `console` object that V8 automatically adds onto the global wrapper
-// object on context creation. We don't want this console object to shadow the
-// `console` object exposed by the ext/node globalThis proxy.
-delete globalThis.console;
 // Set up global properties shared by main and worker runtime.
 ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
 

--- a/tests/registry/npm/@denotest/cjs-local-global-decls/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/cjs-local-global-decls/1.0.0/index.js
@@ -1,3 +1,3 @@
 // package that has all the locals defined
-const Buffer = 1, clearImmediate = 1, clearInterval = 1, clearTimeout = 1, console = 1, global = 1, process = 1, setImmediate = 1, setInterval = 1, setTimeout = 1, globalThis = 1;
+const Buffer = 1, clearImmediate = 1, clearInterval = 1, clearTimeout = 1, global = 1, process = 1, setImmediate = 1, setInterval = 1, setTimeout = 1, globalThis = 1;
 require("./other.js");


### PR DESCRIPTION
Turns out we only virtualized it so one could have a `Console` property, and the other one not. We can just make this `console.Console` available everywhere?