### PR TITLE
fix(permissions): disallow any `LD_` prefixed env var without full --allow-run permissions

### DIFF
--- a/runtime/ops/process.rs
+++ b/runtime/ops/process.rs
@@ -234,15 +234,15 @@ fn create_command(
     permissions.check_run(&args.cmd, api_name)?;
     // error the same on all platforms
     if permissions.check_run_all(api_name).is_err()
-      && (args.env.iter().any(|(k, _)| k.trim() == "LD_PRELOAD")
+      && (args.env.iter().any(|(k, _)| k.trim().starts_with("LD_"))
         || !args.clear_env
-          && std::env::vars().any(|(k, _)| k.trim() == "LD_PRELOAD"))
+          && std::env::vars().any(|(k, _)| k.trim().starts_with("LD_")))
     {
-      // we don't allow users to launch subprocesses with the LD_PRELOAD
-      // env var set because this allows executing any code
+      // we don't allow users to launch subprocesses with any LD_ env var set
+      // because this allows executing code (ex. LD_PRELOAD)
       return Err(deno_core::error::custom_error(
           "PermissionDenied",
-          "Requires --allow-all permissions to spawn subprocess with LD_PRELOAD environment variable."
+          "Requires --allow-all permissions to spawn subprocess with any LD_* environment variable."
         ));
     }
   }

--- a/tests/specs/run/ld_preload/env_arg.out
+++ b/tests/specs/run/ld_preload/env_arg.out
@@ -1,4 +1,4 @@
-error: Uncaught (in promise) PermissionDenied: Requires --allow-all permissions to spawn subprocess with LD_PRELOAD environment variable.
+error: Uncaught (in promise) PermissionDenied: Requires --allow-all permissions to spawn subprocess with any LD_* environment variable.
 }).spawn();
    ^
     at [WILDCARD]

--- a/tests/specs/run/ld_preload/set_with_allow_env.out
+++ b/tests/specs/run/ld_preload/set_with_allow_env.out
@@ -1,4 +1,4 @@
-error: Uncaught (in promise) PermissionDenied: Requires --allow-all permissions to spawn subprocess with LD_PRELOAD environment variable.
+error: Uncaught (in promise) PermissionDenied: Requires --allow-all permissions to spawn subprocess with any LD_* environment variable.
 const output = new Deno.Command("echo").spawn();
                                         ^
     at [WILDCARD]


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/25221

I looked into what the list was and it was quite extensive, so I think as suggested in https://github.com/denoland/deno/issues/11964#issuecomment-2314585135 we should disallow this for any `LD_` prefixed env var.