### PR TITLE
refactor(ext): throw new error instead of throw error

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -145,7 +145,7 @@ async function mainFetch(req, recursive, terminator) {
         reqRid = resourceForReadableStream(stream, req.body.length);
       }
     } else {
-      throw TypeError("invalid body");
+      throw new TypeError("invalid body");
     }
   }
 

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -457,7 +457,7 @@ function fastSyncResponseOrStream(
   // At this point in the response it needs to be a stream
   if (!ObjectPrototypeIsPrototypeOf(ReadableStreamPrototype, stream)) {
     innerRequest?.close();
-    throw TypeError("invalid response");
+    throw new TypeError("invalid response");
   }
   const resourceBacking = getReadableStreamResourceBacking(stream);
   let rid, autoClose;
@@ -506,13 +506,13 @@ function mapToCallback(context, callback, onError) {
 
       // Throwing Error if the handler return value is not a Response class
       if (!ObjectPrototypeIsPrototypeOf(ResponsePrototype, response)) {
-        throw TypeError(
+        throw new TypeError(
           "Return value from serve handler must be a response or a promise resolving to a response",
         );
       }
 
       if (response.bodyUsed) {
-        throw TypeError(
+        throw new TypeError(
           "The body of the Response returned from the serve handler has already been consumed.",
         );
       }
@@ -520,7 +520,7 @@ function mapToCallback(context, callback, onError) {
       try {
         response = await onError(error);
         if (!ObjectPrototypeIsPrototypeOf(ResponsePrototype, response)) {
-          throw TypeError(
+          throw new TypeError(
             "Return value from onError handler must be a response or a promise resolving to a response",
           );
         }

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -890,7 +890,7 @@ Module._preloadModules = function (requests) {
 
 Module.prototype.load = function (filename) {
   if (this.loaded) {
-    throw Error("Module already loaded");
+    throw new Error("Module already loaded");
   }
 
   // Canonicalize the path so it's not pointing to the symlinked directory

--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -22,7 +22,7 @@ function initialize(args) {
   } = args;
   if (!warmup) {
     if (initialized) {
-      throw Error("Node runtime already initialized");
+      throw new Error("Node runtime already initialized");
     }
     initialized = true;
     if (usesLocalNodeModulesDir) {

--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -32,7 +32,7 @@ export function arch(): string {
   } else if (build.arch == "riscv64gc") {
     return "riscv64";
   } else {
-    throw Error("unreachable");
+    throw new Error("unreachable");
   }
 }
 

--- a/ext/node/polyfills/internal/util/comparisons.ts
+++ b/ext/node/polyfills/internal/util/comparisons.ts
@@ -432,7 +432,7 @@ function isEqualBoxedPrimitive(a: any, b: any): boolean {
   }
   // assert.fail(`Unknown boxed type ${val1}`);
   // return false;
-  throw Error(`Unknown boxed type`);
+  throw new Error(`Unknown boxed type`);
 }
 
 function getEnumerables(val: any, keys: any) {

--- a/ext/node/polyfills/os.ts
+++ b/ext/node/polyfills/os.ts
@@ -311,7 +311,7 @@ export function type(): string {
     case "openbsd":
       return "OpenBSD";
     default:
-      throw Error("unreachable");
+      throw new Error("unreachable");
   }
 }
 

--- a/ext/web/00_infra.js
+++ b/ext/web/00_infra.js
@@ -133,7 +133,7 @@ function regexMatcher(chars) {
       );
       return `\\u${a}-\\u${b}`;
     } else {
-      throw TypeError("unreachable");
+      throw new TypeError("unreachable");
     }
   });
   return ArrayPrototypeJoin(matchers, "");

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -524,10 +524,10 @@ function dequeueValue(container) {
 function enqueueValueWithSize(container, value, size) {
   assert(container[_queue] && typeof container[_queueTotalSize] === "number");
   if (isNonNegativeNumber(size) === false) {
-    throw RangeError("chunk size isn't a positive number");
+    throw new RangeError("chunk size isn't a positive number");
   }
   if (size === Infinity) {
-    throw RangeError("chunk size is invalid");
+    throw new RangeError("chunk size is invalid");
   }
   container[_queue].enqueue({ value, size });
   container[_queueTotalSize] += size;
@@ -543,7 +543,7 @@ function extractHighWaterMark(strategy, defaultHWM) {
   }
   const highWaterMark = strategy.highWaterMark;
   if (NumberIsNaN(highWaterMark) || highWaterMark < 0) {
-    throw RangeError(
+    throw new RangeError(
       `Expected highWaterMark to be a positive number or Infinity, got "${highWaterMark}".`,
     );
   }

--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -95,7 +95,7 @@ function makeException(ErrorType, message, prefix, context) {
 
 function toNumber(value) {
   if (typeof value === "bigint") {
-    throw TypeError("Cannot convert a BigInt value to a number");
+    throw new TypeError("Cannot convert a BigInt value to a number");
   }
   return Number(value);
 }


### PR DESCRIPTION
To ensure consistency across the codebase, this commit refactors the code in the `ext` folder to use `throw new Error`` instead of `throw` for throwing errors.

https://github.com/denoland/deno/issues/25270

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
