### PR TITLE
test: run specs::npm::exec_file_inside_npm_package with DENO_FUTURE=1

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1614,6 +1614,7 @@ impl CliOptions {
   pub fn use_byonm(&self) -> bool {
     if self.enable_future_features()
       && self.node_modules_dir_enablement().is_none()
+      && self.maybe_node_modules_folder.is_some()
       && self
         .workspace()
         .config_folders()

--- a/tests/specs/npm/exec_file_inside_npm_package/__test__.jsonc
+++ b/tests/specs/npm/exec_file_inside_npm_package/__test__.jsonc
@@ -1,4 +1,7 @@
 {
   "args": "run -A main.ts",
-  "output": "main.out"
+  "output": "main.out",
+  "envs": {
+    "DENO_FUTURE": "1"
+  }
 }


### PR DESCRIPTION
The test is failing if run with `DENO_FUTURE=1` which is blocking
https://github.com/denoland/deno/pull/25213.