### PR TITLE
fix: delete old Deno 1.x headers file when loading cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "405790fa1fa5f05c2e7dca817f820dc1c950ea846f47212ed6d670a3023cb4fe"
+checksum = "6df43311cb7703fa3242c282823a850e4c8d0c06b9527d8209b55bd695452ea5"
 dependencies = [
  "deno_media_type",
  "indexmap",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef522937758930b9d6897631fa94bc69bcbbe78613c939ab2054ca96191afbd"
+checksum = "6657fecb9ac6a7a71f552c95e8cc492466a75f5660224577e2226bcf30db9768"
 dependencies = [
  "monch",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ deno_lockfile = "=0.23.0"
 deno_media_type = { version = "0.1.4", features = ["module_specifier"] }
 deno_permissions = { version = "0.26.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.175.0", path = "./runtime" }
-deno_semver = "=0.5.12"
+deno_semver = "=0.5.13"
 deno_terminal = "0.2.0"
 napi_sym = { version = "0.96.0", path = "./cli/napi/sym" }
 test_util = { package = "test_server", path = "./tests/util/server" }
@@ -103,7 +103,7 @@ chrono = { version = "0.4", default-features = false, features = ["std", "serde"
 console_static_text = "=0.8.1"
 data-encoding = "2.3.3"
 data-url = "=0.3.0"
-deno_cache_dir = "=0.11.0"
+deno_cache_dir = "=0.11.1"
 deno_package_json = { version = "=0.1.1", default-features = false }
 dlopen2 = "0.6.1"
 ecb = "=0.1.2"

--- a/cli/cache/mod.rs
+++ b/cli/cache/mod.rs
@@ -74,6 +74,10 @@ impl deno_cache_dir::DenoCacheEnv for RealDenoCacheEnv {
     atomic_write_file_with_retries(path, bytes, CACHE_PERM)
   }
 
+  fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+    std::fs::remove_file(path)
+  }
+
   fn modified(&self, path: &Path) -> std::io::Result<Option<SystemTime>> {
     match std::fs::metadata(path) {
       Ok(metadata) => Ok(Some(


### PR DESCRIPTION
* https://github.com/denoland/deno_cache_dir/pull/59

Reasons listed in that deno_cache_dir PR.

Note: we could make this a bit better by upgrading the cache, but I'm not sure it's worth the effort. We'll see what feedback we get.