### PR TITLE
test: replace usage of `window` with `globalThis`

### DIFF
--- a/tests/testdata/import_attributes/dynamic_import.out
+++ b/tests/testdata/import_attributes/dynamic_import.out
@@ -1,3 +1,2 @@
 [WILDCARD]
 [Module: null prototype] { default: { a: "b", c: { d: 10 } } }
-[Module: null prototype] { default: { a: "b", c: { d: 10 } } }

--- a/tests/testdata/import_attributes/dynamic_import.ts
+++ b/tests/testdata/import_attributes/dynamic_import.ts
@@ -1,6 +1,3 @@
 const data1 = await import("./data.json", { with: { type: "json" } });
-// deno-lint-ignore no-import-assertions
-const data2 = await import("./data.json", { assert: { type: "json" } });
 
 console.log(data1);
-console.log(data2);

--- a/tests/testdata/run/025_hrtime.ts
+++ b/tests/testdata/run/025_hrtime.ts
@@ -1,4 +1,4 @@
-window.onload = async () => {
+globalThis.onload = async () => {
   console.log(performance.now() % 2 !== 0);
   await Deno.permissions.revoke({ name: "hrtime" });
   console.log(performance.now() % 2 === 0);

--- a/tests/testdata/run/025_reload_js_type_error.js
+++ b/tests/testdata/run/025_reload_js_type_error.js
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file
 // There was a bug where if this was executed with --reload it would throw a
 // type error.
-window.test = null;
+globalThis.test = null;
 test = console;
 test.log("hello");

--- a/tests/testdata/run/058_tasks_microtasks_close.ts
+++ b/tests/testdata/run/058_tasks_microtasks_close.ts
@@ -9,7 +9,7 @@ setTimeout(() => {
 Promise.resolve().then(() => {
   console.log("promise 1");
 });
-window.close();
+globalThis.close();
 console.log("sync 2");
 setTimeout(() => {
   console.log("setTimeout 2");

--- a/tests/testdata/run/078_unload_on_exit.ts
+++ b/tests/testdata/run/078_unload_on_exit.ts
@@ -1,4 +1,4 @@
-window.onunload = () => {
+globalThis.onunload = () => {
   console.log("onunload is called");
   // This second exit call doesn't trigger unload event,
   // and therefore actually stops the process.

--- a/tests/testdata/run/onload/imported.ts
+++ b/tests/testdata/run/onload/imported.ts
@@ -1,4 +1,3 @@
-// deno-lint-ignore-file no-window-prefix
 import { assert } from "@std/assert";
 import "./nest_imported.ts";
 
@@ -7,7 +6,7 @@ const handler = (e: Event) => {
   console.log(`got ${e.type} event in event handler (imported)`);
 };
 
-window.addEventListener("load", handler);
-window.addEventListener("beforeunload", handler);
-window.addEventListener("unload", handler);
+globalThis.addEventListener("load", handler);
+globalThis.addEventListener("beforeunload", handler);
+globalThis.addEventListener("unload", handler);
 console.log("log from imported script");

--- a/tests/testdata/run/onload/main.ts
+++ b/tests/testdata/run/onload/main.ts
@@ -1,32 +1,32 @@
-// deno-lint-ignore-file no-window-prefix no-prototype-builtins
+// deno-lint-ignore-file no-prototype-builtins
 import { assert } from "@std/assert";
 import "./imported.ts";
 
-assert(window.hasOwnProperty("onload"));
-assert(window.onload === null);
+assert(globalThis.hasOwnProperty("onload"));
+assert(globalThis.onload === null);
 
 const eventHandler = (e: Event) => {
   assert(e.type === "beforeunload" ? e.cancelable : !e.cancelable);
   console.log(`got ${e.type} event in event handler (main)`);
 };
 
-window.addEventListener("load", eventHandler);
+globalThis.addEventListener("load", eventHandler);
 
-window.addEventListener("beforeunload", eventHandler);
+globalThis.addEventListener("beforeunload", eventHandler);
 
-window.addEventListener("unload", eventHandler);
+globalThis.addEventListener("unload", eventHandler);
 
-window.onload = (e: Event) => {
+globalThis.onload = (e: Event) => {
   assert(!e.cancelable);
   console.log(`got ${e.type} event in onload function`);
 };
 
-window.onbeforeunload = (e: BeforeUnloadEvent) => {
+globalThis.onbeforeunload = (e: BeforeUnloadEvent) => {
   assert(e.cancelable);
   console.log(`got ${e.type} event in onbeforeunload function`);
 };
 
-window.onunload = (e: Event) => {
+globalThis.onunload = (e: Event) => {
   assert(!e.cancelable);
   console.log(`got ${e.type} event in onunload function`);
 };

--- a/tests/testdata/run/onload/nest_imported.ts
+++ b/tests/testdata/run/onload/nest_imported.ts
@@ -1,4 +1,3 @@
-// deno-lint-ignore-file no-window-prefix
 import { assert } from "@std/assert";
 
 const handler = (e: Event) => {
@@ -6,7 +5,7 @@ const handler = (e: Event) => {
   console.log(`got ${e.type} event in event handler (nest_imported)`);
 };
 
-window.addEventListener("load", handler);
-window.addEventListener("beforeunload", handler);
-window.addEventListener("unload", handler);
+globalThis.addEventListener("load", handler);
+globalThis.addEventListener("beforeunload", handler);
+globalThis.addEventListener("unload", handler);
 console.log("log from nest_imported script");

--- a/tests/testdata/run/rejection_handled.ts
+++ b/tests/testdata/run/rejection_handled.ts
@@ -1,9 +1,9 @@
-window.addEventListener("unhandledrejection", (event) => {
+globalThis.addEventListener("unhandledrejection", (event) => {
   console.log("unhandledrejection", event.reason, event.promise);
   event.preventDefault();
 });
 
-window.addEventListener("rejectionhandled", (event) => {
+globalThis.addEventListener("rejectionhandled", (event) => {
   console.log("rejectionhandled", event.reason, event.promise);
 });
 

--- a/tests/testdata/run/tls_connecttls.js
+++ b/tests/testdata/run/tls_connecttls.js
@@ -37,7 +37,6 @@ const conn = await Deno.connectTls({
   hostname,
   port,
 });
-assert(conn.rid > 0);
 const w = new BufWriter(conn);
 const r = new BufReader(conn);
 const body = `GET / HTTP/1.1\r\nHost: ${hostname}:${port}\r\n\r\n`;

--- a/tests/testdata/run/tls_starttls.js
+++ b/tests/testdata/run/tls_starttls.js
@@ -36,7 +36,6 @@ listener.accept().then(
 
 let conn = await Deno.connect({ hostname, port });
 conn = await Deno.startTls(conn, { hostname });
-assert(conn.rid > 0);
 const w = new BufWriter(conn);
 const r = new BufReader(conn);
 const body = `GET / HTTP/1.1\r\nHost: ${hostname}:${port}\r\n\r\n`;

--- a/tests/testdata/run/webstorage/logger.ts
+++ b/tests/testdata/run/webstorage/logger.ts
@@ -1,1 +1,1 @@
-console.log(window.localStorage);
+console.log(globalThis.localStorage);

--- a/tests/testdata/run/webstorage/serialization.ts
+++ b/tests/testdata/run/webstorage/serialization.ts
@@ -1,4 +1,4 @@
-window.sessionStorage.setItem("hello", "deno");
+globalThis.sessionStorage.setItem("hello", "deno");
 
-console.log(window.localStorage);
-console.log(window.sessionStorage);
+console.log(globalThis.localStorage);
+console.log(globalThis.sessionStorage);

--- a/tests/testdata/run/webstorage/setter.ts
+++ b/tests/testdata/run/webstorage/setter.ts
@@ -1,1 +1,1 @@
-window.localStorage.setItem("hello", "deno");
+globalThis.localStorage.setItem("hello", "deno");


### PR DESCRIPTION
Fixes several tests blocking https://github.com/denoland/deno/pull/25213
by replacing `window` global that is gone in Deno 2 with `globalThis`.

Also adjusted a few tests using deprecated `rid` field.