### PR TITLE
test(ext/node): check hostname option has precedence over host option

### DIFF
--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1597,9 +1597,8 @@ Deno.test("[node/http] In ClientRequest, option.hostname has precedence over opt
     port: 4545,
     path: "/http_version",
   }).on("response", async (res) => {
-    const resText = await text(res)
     assertEquals(res.statusCode, 200);
-    assertEquals(resText, "HTTP/1.1");
+    assertEquals(await text(res), "HTTP/1.1");
     responseReceived.resolve();
   }).end();
 


### PR DESCRIPTION
This PR adds a test case which checks that the issue #18154 is already resolved in main.

The `hostname` option has more precedence over `host` option in `ClientRequest` options. This behavior was fixed in [this commit](https://github.com/denoland/deno/commit/867a6d303285cdffd060e6bb4b0e97de73925cfe).

closes #18154