### PR TITLE
refactor(ext): align error messages

### DIFF
--- a/ext/cache/01_cache.js
+++ b/ext/cache/01_cache.js
@@ -105,7 +105,7 @@ class Cache {
     const reqUrl = new URL(innerRequest.url());
     if (reqUrl.protocol !== "http:" && reqUrl.protocol !== "https:") {
       throw new TypeError(
-        "Request url protocol must be 'http:' or 'https:'",
+        `Request url protocol must be 'http:' or 'https:': received '${reqUrl.protocol}'`,
       );
     }
     if (innerRequest.method !== "GET") {

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -211,7 +211,7 @@ where
     state.put(cache);
     Ok(state.borrow::<CA>().clone())
   } else {
-    Err(type_error("CacheStorage is not available in this context."))
+    Err(type_error("CacheStorage is not available in this context"))
   }
 }
 

--- a/ext/canvas/01_image.js
+++ b/ext/canvas/01_image.js
@@ -307,7 +307,9 @@ function processImage(input, width, height, sx, sy, sw, sh, options) {
   }
 
   if (options.colorSpaceConversion === "none") {
-    throw new TypeError("options.colorSpaceConversion 'none' is not supported");
+    throw new TypeError(
+      "Cannot create image: invalid colorSpaceConversion option, 'none' is not supported",
+    );
   }
 
   /*

--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -250,7 +250,7 @@ class UnsafePointer {
       }
     } else {
       throw new TypeError(
-        "Expected ArrayBuffer, ArrayBufferView or UnsafeCallbackPrototype",
+        `Cannot access pointer: expected 'ArrayBuffer', 'ArrayBufferView' or 'UnsafeCallbackPrototype', received ${typeof value}`,
       );
     }
     if (pointer) {
@@ -335,7 +335,9 @@ function getTypeSizeAndAlignment(type, cache = new SafeMap()) {
     const cached = cache.get(type);
     if (cached !== undefined) {
       if (cached === null) {
-        throw new TypeError("Recursive struct definition");
+        throw new TypeError(
+          "Cannot get pointer size: found recursive struct",
+        );
       }
       return cached;
     }
@@ -379,7 +381,7 @@ function getTypeSizeAndAlignment(type, cache = new SafeMap()) {
     case "isize":
       return [8, 8];
     default:
-      throw new TypeError(`Unsupported type: ${type}`);
+      throw new TypeError(`Cannot get pointer size, unsupported type: ${type}`);
   }
 }
 
@@ -395,7 +397,7 @@ class UnsafeCallback {
   constructor(definition, callback) {
     if (definition.nonblocking) {
       throw new TypeError(
-        "Invalid UnsafeCallback, cannot be nonblocking",
+        "Cannot construct UnsafeCallback: cannot be nonblocking",
       );
     }
     const { 0: rid, 1: pointer } = op_ffi_unsafe_callback_create(
@@ -467,7 +469,7 @@ class DynamicLibrary {
         const type = symbols[symbol].type;
         if (type === "void") {
           throw new TypeError(
-            "Foreign symbol of type 'void' is not supported.",
+            "Foreign symbol of type 'void' is not supported",
           );
         }
 

--- a/ext/ffi/call.rs
+++ b/ext/ffi/call.rs
@@ -334,7 +334,9 @@ pub fn op_ffi_call_nonblocking(
     let symbols = &resource.symbols;
     *symbols
       .get(&symbol)
-      .ok_or_else(|| type_error("Invalid FFI symbol name"))?
+      .ok_or_else(|| {
+        type_error(format!("Invalid FFI symbol name: '{symbol}'"))
+      })?
       .clone()
   };
 

--- a/ext/ffi/callback.rs
+++ b/ext/ffi/callback.rs
@@ -174,7 +174,7 @@ unsafe extern "C" fn deno_ffi_callback(
         let tc_scope = &mut TryCatch::new(scope);
         args.run(tc_scope);
         if tc_scope.exception().is_some() {
-          log::error!("Illegal unhandled exception in nonblocking callback.");
+          log::error!("Illegal unhandled exception in nonblocking callback");
         }
       });
     }

--- a/tests/ffi/tests/integration_tests.rs
+++ b/tests/ffi/tests/integration_tests.rs
@@ -300,6 +300,6 @@ fn ffi_callback_errors_test() {
   assert_eq!(stdout, expected);
   assert_eq!(
     stderr,
-    "Illegal unhandled exception in nonblocking callback.\n".repeat(3)
+    "Illegal unhandled exception in nonblocking callback\n".repeat(3)
   );
 }


### PR DESCRIPTION
Aligns the error messages in the console extension to be in-line with the Deno style guide. This change-set aligns the messages in:
 - ext/cache
 - ext/canvas
 - ext/ffi

https://github.com/denoland/deno/issues/25269

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
