### PR TITLE
fix(cli/tools): correct `deno init --serve` template behavior

### DIFF
--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -37,7 +37,7 @@ const routes: Route[] = [
   },
   {
     pattern: new URLPattern({ pathname: "/static/*" }),
-    handler: (req) => serveDir(req, { urlRoot: "./" }),
+    handler: (req) => serveDir(req),
   },
 ];
 
@@ -52,7 +52,6 @@ export default {
     return handler(req);
   },
 } satisfies Deno.ServeDefaultExport;
- 
 "#,
     )?;
     create_file(
@@ -80,10 +79,19 @@ Deno.test(async function serverFetchUsers() {
 });
 
 Deno.test(async function serverFetchStatic() {
-  const req = new Request("https://deno.land/static/main.ts");
+  const req = new Request("https://deno.land/static/hello.js");
   const res = await server.fetch(req);
-  assertEquals(res.headers.get("content-type"), "text/plain;charset=UTF-8");
+  assertEquals(await res.text(), 'console.log("Hello, world!");\n');
 });
+"#,
+    )?;
+
+    let static_dir = dir.join("static");
+    std::fs::create_dir_all(&static_dir)?;
+    create_file(
+      &static_dir,
+      "hello.js",
+      r#"console.log("Hello, world!");
 "#,
     )?;
 
@@ -203,7 +211,7 @@ Deno.test(function addTest() {
     info!("  deno task dev");
     info!("");
     info!("  {}", colors::gray("# Run the tests"));
-    info!("  deno -R test");
+    info!("  deno test -R");
   } else if init_flags.lib {
     info!("  {}", colors::gray("# Run the tests"));
     info!("  deno test");

--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -82,6 +82,7 @@ Deno.test(async function serverFetchStatic() {
   const req = new Request("https://deno.land/static/hello.js");
   const res = await server.fetch(req);
   assertEquals(await res.text(), 'console.log("Hello, world!");\n');
+  assertEquals(res.headers.get("content-type"), "text/javascript; charset=UTF-8");
 });
 "#,
     )?;

--- a/tests/integration/init_tests.rs
+++ b/tests/integration/init_tests.rs
@@ -188,7 +188,7 @@ async fn init_subcommand_serve() {
   assert_contains!(stderr, "Project initialized");
   assert_contains!(stderr, "deno serve -R main.ts");
   assert_contains!(stderr, "deno task dev");
-  assert_contains!(stderr, "deno -R test");
+  assert_contains!(stderr, "deno test -R");
 
   assert!(cwd.join("deno.json").exists());
 
@@ -209,7 +209,7 @@ async fn init_subcommand_serve() {
   let output = context
     .new_command()
     .env("NO_COLOR", "1")
-    .args("-R test")
+    .args("test -R")
     .split_output()
     .run();
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

fix #25305

- adds static folder and asset
- makes the static server test in the template more meaningful
- reorders args in help message
- fixes output to conform to default `deno fmt`
