### PR TITLE
fix(upgrade): more informative information on invalid version

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1173,7 +1173,7 @@ static DENO_HELP: &str = cstr!(
                   <p(245)>deno test  |  deno test test.ts</>
     <g>publish</>      Publish the current working directory's package or workspace
     <g>upgrade</>      Upgrade deno executable to given version
-                  <p(245)>deno upgrade  |  deno upgrade --version=1.45.0  |  deno upgrade --canary</>
+                  <p(245)>deno upgrade  |  deno upgrade 1.45.0  |  deno upgrade canary</>
 {after-help}
 
 <y>Docs:</> https://docs.deno.com

--- a/tests/integration/upgrade_tests.rs
+++ b/tests/integration/upgrade_tests.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use std::process::Stdio;
 use std::time::Instant;
 use test_util as util;
+use test_util::assert_starts_with;
 use test_util::TempDir;
 use test_util::TestContext;
 use util::TestContextBuilder;
@@ -163,9 +164,10 @@ fn upgrade_invalid_stable_version() {
     .wait_with_output()
     .unwrap();
   assert!(!output.status.success());
-  assert_eq!(
-    "error: Invalid version passed\n",
-    util::strip_ansi_codes(&String::from_utf8(output.stderr).unwrap())
+  assert_starts_with!(
+    &util::strip_ansi_codes(&String::from_utf8(output.stderr.clone()).unwrap())
+      .to_string(),
+    "error: Invalid version passed (foobar)"
   );
 }
 
@@ -188,9 +190,10 @@ fn upgrade_invalid_canary_version() {
     .wait_with_output()
     .unwrap();
   assert!(!output.status.success());
-  assert_eq!(
-    "error: Invalid commit hash passed\n",
-    util::strip_ansi_codes(&String::from_utf8(output.stderr).unwrap())
+  assert_starts_with!(
+    &util::strip_ansi_codes(&String::from_utf8(output.stderr.clone()).unwrap())
+      .to_string(),
+    "error: Invalid commit hash passed (foobar)"
   );
 }
 
@@ -221,9 +224,10 @@ fn upgrade_invalid_lockfile() {
     .unwrap();
   assert!(!output.status.success());
   // should make it here instead of erroring on an invalid lockfile
-  assert_eq!(
-    "error: Invalid version passed\n",
-    util::strip_ansi_codes(&String::from_utf8(output.stderr).unwrap())
+  assert_starts_with!(
+    &util::strip_ansi_codes(&String::from_utf8(output.stderr.clone()).unwrap())
+      .to_string(),
+    "error: Invalid version passed (foobar)"
   );
 }
 

--- a/tests/integration/upgrade_tests.rs
+++ b/tests/integration/upgrade_tests.rs
@@ -251,7 +251,7 @@ fn upgrade_prompt() {
     pty.expect_any(&[
       " 99999.99.99 Run `deno upgrade` to install it.",
       // it builds canary releases on main, so check for this in that case
-      "Run `deno upgrade --canary` to install it.",
+      "Run `deno upgrade canary` to install it.",
     ]);
   });
 }


### PR DESCRIPTION
Before:
```
$ deno upgrade v1.xx
error: Invalid version passed
```

After:
```
$ deno upgrade v1.xx
error: Invalid version passed (v1.xx)

Example usage:
  deno upgrade | deno upgrade 1.46 | deno upgrade canary
```

![Screenshot 2024-08-31 at 01 21 30](https://github.com/user-attachments/assets/b7439ac9-593e-4454-9c82-395bd85b013c)

Also updates help text to use "shorthand version" without flags, but a positional arg.