### PR TITLE
feat: support DENO_LOG env var instead of RUST_LOG

### DIFF
--- a/cli/util/logger.rs
+++ b/cli/util/logger.rs
@@ -43,9 +43,8 @@ pub fn init(maybe_level: Option<log::Level>) {
   let logger = env_logger::Builder::from_env(
     env_logger::Env::new()
       // Use `DENO_LOG` and `DENO_LOG_STYLE` instead of `RUST_` prefix
-      .filter("DENO_LOG")
-      .write_style("DENO_LOG_STYLE")
-      .default_filter_or(log_level.to_level_filter().to_string()),
+      .filter_or("DENO_LOG", log_level.to_level_filter().to_string())
+      .write_style("DENO_LOG_STYLE"),
   )
   // https://github.com/denoland/deno/issues/6641
   .filter_module("rustyline", log::LevelFilter::Off)

--- a/cli/util/logger.rs
+++ b/cli/util/logger.rs
@@ -41,7 +41,10 @@ impl log::Log for CliLogger {
 pub fn init(maybe_level: Option<log::Level>) {
   let log_level = maybe_level.unwrap_or(log::Level::Info);
   let logger = env_logger::Builder::from_env(
-    env_logger::Env::default()
+    env_logger::Env::new()
+      // Use `DENO_LOG` and `DENO_LOG_STYLE` instead of `RUST_` prefix
+      .filter("DENO_LOG")
+      .write_style("DENO_LOG_STYLE")
       .default_filter_or(log_level.to_level_filter().to_string()),
   )
   // https://github.com/denoland/deno/issues/6641

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -2499,8 +2499,8 @@ fn should_not_panic_on_undefined_deno_dir_and_home_environment_variables() {
 }
 
 #[test]
-fn rust_log() {
-  // Without RUST_LOG the stderr is empty.
+fn deno_log() {
+  // Without DENO_LOG the stderr is empty.
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
@@ -2513,12 +2513,12 @@ fn rust_log() {
   assert!(output.status.success());
   assert!(output.stderr.is_empty());
 
-  // With RUST_LOG the stderr is not empty.
+  // With DENO_LOG the stderr is not empty.
   let output = util::deno_cmd()
     .current_dir(util::testdata_path())
     .arg("run")
     .arg("run/001_hello.js")
-    .env("RUST_LOG", "debug")
+    .env("DENO_LOG", "debug")
     .stderr_piped()
     .spawn()
     .unwrap()


### PR DESCRIPTION
Instead of `RUST_LOG` env var, we now support `DENO_LOG` env var.
This is done to be able to set a setting specific to `deno` that wouldn't impact
other binaries written in Rust.

Ref https://github.com/denoland/deno/issues/10558#issuecomment-2324300211

