### PR TITLE
feat: hide several --unstable-* flags

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3848,15 +3848,9 @@ impl Iterator for UnstableArgsIter {
     } else if self.idx == 2 {
       Arg::new("unstable-byonm")
         .long("unstable-byonm")
-        .help("Enable unstable 'bring your own node_modules' feature")
         .value_parser(FalseyValueParser::new())
         .action(ArgAction::SetTrue)
         .hide(true)
-        .long_help(match self.cfg {
-          UnstableArgsConfig::None => None,
-          UnstableArgsConfig::ResolutionOnly
-          | UnstableArgsConfig::ResolutionAndRuntime => Some("true"),
-        })
         .help_heading(UNSTABLE_HEADING)
     } else if self.idx == 3 {
       Arg::new("unstable-sloppy-imports")

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -72,13 +72,13 @@ pub static UNSTABLE_GRANULAR_FLAGS: &[UnstableGranularFlag] = &[
   UnstableGranularFlag {
     name: deno_ffi::UNSTABLE_FEATURE_NAME,
     help_text: "Enable unstable FFI APIs",
-    show_in_help: true,
+    show_in_help: false,
     id: 3,
   },
   UnstableGranularFlag {
     name: deno_fs::UNSTABLE_FEATURE_NAME,
     help_text: "Enable unstable file system APIs",
-    show_in_help: true,
+    show_in_help: false,
     id: 4,
   },
   UnstableGranularFlag {
@@ -102,7 +102,7 @@ pub static UNSTABLE_GRANULAR_FLAGS: &[UnstableGranularFlag] = &[
   UnstableGranularFlag {
     name: ops::process::UNSTABLE_FEATURE_NAME,
     help_text: "Enable unstable process APIs",
-    show_in_help: true,
+    show_in_help: false,
     id: 8,
   },
   UnstableGranularFlag {
@@ -122,7 +122,7 @@ pub static UNSTABLE_GRANULAR_FLAGS: &[UnstableGranularFlag] = &[
   UnstableGranularFlag {
     name: deno_webgpu::UNSTABLE_FEATURE_NAME,
     help_text: "Enable unstable `WebGPU` API",
-    show_in_help: true,
+    show_in_help: false,
     id: 11,
   },
   UnstableGranularFlag {


### PR DESCRIPTION
This commit hides following unstable flags:
- `--unstable-ffi` (the API is now stable)
- `--unstable-webgpu` (this API is now stable)
- `--unstable-fs` (no more unstable APIs)
- `--unstable-byonm` (BYONM is on by default)


The flags are still parseable, but they are not used. Concrete cleanup
will be done in a follow up PR.