### PR TITLE
refactor(cli/js): align error messages

### DIFF
--- a/cli/js/40_bench.js
+++ b/cli/js/40_bench.js
@@ -104,12 +104,12 @@ function bench(
       }
       if (optionsOrFn.fn != undefined) {
         throw new TypeError(
-          "Unexpected 'fn' field in options, bench function is already provided as the third argument.",
+          "Unexpected 'fn' field in options, bench function is already provided as the third argument",
         );
       }
       if (optionsOrFn.name != undefined) {
         throw new TypeError(
-          "Unexpected 'name' field in options, bench name is already provided as the first argument.",
+          "Unexpected 'name' field in options, bench name is already provided as the first argument",
         );
       }
       benchDesc = {
@@ -141,7 +141,7 @@ function bench(
       fn = optionsOrFn;
       if (nameOrFnOrOptions.fn != undefined) {
         throw new TypeError(
-          "Unexpected 'fn' field in options, bench function is already provided as the second argument.",
+          "Unexpected 'fn' field in options, bench function is already provided as the second argument",
         );
       }
       name = nameOrFnOrOptions.name ?? fn.name;
@@ -150,7 +150,7 @@ function bench(
         !nameOrFnOrOptions.fn || typeof nameOrFnOrOptions.fn !== "function"
       ) {
         throw new TypeError(
-          "Expected 'fn' field in the first argument to be a bench function.",
+          "Expected 'fn' field in the first argument to be a bench function",
         );
       }
       fn = nameOrFnOrOptions.fn;
@@ -385,12 +385,12 @@ function createBenchContext(desc) {
     start() {
       if (currentBenchId !== desc.id) {
         throw new TypeError(
-          "The benchmark which this context belongs to is not being executed.",
+          "The benchmark which this context belongs to is not being executed",
         );
       }
       if (currentBenchUserExplicitStart != null) {
         throw new TypeError(
-          "BenchContext::start() has already been invoked.",
+          "BenchContext::start() has already been invoked",
         );
       }
       currentBenchUserExplicitStart = benchNow();
@@ -399,11 +399,11 @@ function createBenchContext(desc) {
       const end = benchNow();
       if (currentBenchId !== desc.id) {
         throw new TypeError(
-          "The benchmark which this context belongs to is not being executed.",
+          "The benchmark which this context belongs to is not being executed",
         );
       }
       if (currentBenchUserExplicitEnd != null) {
-        throw new TypeError("BenchContext::end() has already been invoked.");
+        throw new TypeError("BenchContext::end() has already been invoked");
       }
       currentBenchUserExplicitEnd = end;
     },

--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -113,7 +113,7 @@ function assertExit(fn, isTest) {
         throw new Error(
           `${
             isTest ? "Test case" : "Bench"
-          } finished with exit code set to ${exitCode}.`,
+          } finished with exit code set to ${exitCode}`,
         );
       }
       if (innerResult) {
@@ -242,12 +242,12 @@ function testInner(
       }
       if (optionsOrFn.fn != undefined) {
         throw new TypeError(
-          "Unexpected 'fn' field in options, test function is already provided as the third argument.",
+          "Unexpected 'fn' field in options, test function is already provided as the third argument",
         );
       }
       if (optionsOrFn.name != undefined) {
         throw new TypeError(
-          "Unexpected 'name' field in options, test name is already provided as the first argument.",
+          "Unexpected 'name' field in options, test name is already provided as the first argument",
         );
       }
       testDesc = {
@@ -279,7 +279,7 @@ function testInner(
       fn = optionsOrFn;
       if (nameOrFnOrOptions.fn != undefined) {
         throw new TypeError(
-          "Unexpected 'fn' field in options, test function is already provided as the second argument.",
+          "Unexpected 'fn' field in options, test function is already provided as the second argument",
         );
       }
       name = nameOrFnOrOptions.name ?? fn.name;
@@ -288,7 +288,7 @@ function testInner(
         !nameOrFnOrOptions.fn || typeof nameOrFnOrOptions.fn !== "function"
       ) {
         throw new TypeError(
-          "Expected 'fn' field in the first argument to be a test function.",
+          "Expected 'fn' field in the first argument to be a test function",
         );
       }
       fn = nameOrFnOrOptions.fn;
@@ -426,7 +426,7 @@ function createTestContext(desc) {
       let stepDesc;
       if (typeof nameOrFnOrOptions === "string") {
         if (typeof maybeFn !== "function") {
-          throw new TypeError("Expected function for second argument.");
+          throw new TypeError("Expected function for second argument");
         }
         stepDesc = {
           name: nameOrFnOrOptions,
@@ -434,7 +434,7 @@ function createTestContext(desc) {
         };
       } else if (typeof nameOrFnOrOptions === "function") {
         if (!nameOrFnOrOptions.name) {
-          throw new TypeError("The step function must have a name.");
+          throw new TypeError("The step function must have a name");
         }
         if (maybeFn != undefined) {
           throw new TypeError(
@@ -449,7 +449,7 @@ function createTestContext(desc) {
         stepDesc = nameOrFnOrOptions;
       } else {
         throw new TypeError(
-          "Expected a test definition or name and function.",
+          "Expected a test definition or name and function",
         );
       }
       stepDesc.ignore ??= false;

--- a/tests/specs/bench/bench_explicit_start_end/explicit_start_and_end.out
+++ b/tests/specs/bench/bench_explicit_start_end/explicit_start_and_end.out
@@ -8,17 +8,17 @@ benchmark       time/iter (avg)        iter/s      (min … max)           p75  
 start and end  [WILDCARD] [WILDCARD] [WILDCARD] ([WILDCARD] … [WILDCARD]) [WILDCARD]
 start only     [WILDCARD] [WILDCARD] [WILDCARD] ([WILDCARD] … [WILDCARD]) [WILDCARD]
 end only       [WILDCARD] [WILDCARD] [WILDCARD] ([WILDCARD] … [WILDCARD]) [WILDCARD]
-double start    error: TypeError: BenchContext::start() has already been invoked.
+double start    error: TypeError: BenchContext::start() has already been invoked
   t.start();
     ^
     at BenchContext.start ([WILDCARD])
     at [WILDCARD]/explicit_start_and_end.ts:[WILDCARD]
-double end      error: TypeError: BenchContext::end() has already been invoked.
+double end      error: TypeError: BenchContext::end() has already been invoked
   t.end();
     ^
     at BenchContext.end ([WILDCARD])
     at [WILDCARD]/explicit_start_and_end.ts:[WILDCARD]
-captured        error: TypeError: The benchmark which this context belongs to is not being executed.
+captured        error: TypeError: The benchmark which this context belongs to is not being executed
   captured!.start();
             ^
     at BenchContext.start ([WILDCARD])

--- a/tests/specs/test/exit_code/main.out
+++ b/tests/specs/test/exit_code/main.out
@@ -4,7 +4,7 @@ Deno.exitCode ... FAILED ([WILDCARD])
  ERRORS 
 
 Deno.exitCode => ./main.js:1:6
-error: Error: Test case finished with exit code set to 42.
+error: Error: Test case finished with exit code set to 42
     at exitSanitizer (ext:cli/40_test.js:113:15)
     at async outerWrapped (ext:cli/40_test.js:134:14)
 

--- a/tests/specs/test/exit_code2/main.out
+++ b/tests/specs/test/exit_code2/main.out
@@ -11,7 +11,7 @@ error: Error
     at [WILDCARD]/exit_code2/main.js:3:9
 
 success => ./main.js:6:6
-error: Error: Test case finished with exit code set to 5.
+error: Error: Test case finished with exit code set to 5
     at exitSanitizer (ext:cli/40_test.js:113:15)
     at async outerWrapped (ext:cli/40_test.js:134:14)
 

--- a/tests/specs/test/exit_code3/main.out
+++ b/tests/specs/test/exit_code3/main.out
@@ -5,7 +5,7 @@ success ... ok ([WILDCARD])
  ERRORS 
 
 Deno.exitCode => ./main.js:1:6
-error: Error: Test case finished with exit code set to 42.
+error: Error: Test case finished with exit code set to 42
     at exitSanitizer (ext:cli/40_test.js:113:15)
     at async outerWrapped (ext:cli/40_test.js:134:14)
 

--- a/tests/testdata/bench/explicit_start_and_end.out
+++ b/tests/testdata/bench/explicit_start_and_end.out
@@ -8,17 +8,17 @@ benchmark       time/iter (avg)        iter/s      (min … max)           p75  
 start and end  [WILDCARD] [WILDCARD] [WILDCARD] ([WILDCARD] … [WILDCARD]) [WILDCARD]
 start only     [WILDCARD] [WILDCARD] [WILDCARD] ([WILDCARD] … [WILDCARD]) [WILDCARD]
 end only       [WILDCARD] [WILDCARD] [WILDCARD] ([WILDCARD] … [WILDCARD]) [WILDCARD]
-double start    error: Type error: BenchContext::start() has already been invoked.
+double start    error: Type error: BenchContext::start() has already been invoked
   t.start();
     ^
     at BenchContext.start ([WILDCARD])
     at [WILDCARD]/explicit_start_and_end.ts:[WILDCARD]
-double end      error: Type error: BenchContext::end() has already been invoked.
+double end      error: Type error: BenchContext::end() has already been invoked
   t.end();
     ^
     at BenchContext.end ([WILDCARD])
     at [WILDCARD]/explicit_start_and_end.ts:[WILDCARD]
-captured        error: Type error: The benchmark which this context belongs to is not being executed.
+captured        error: Type error: The benchmark which this context belongs to is not being executed
   captured!.start();
             ^
     at BenchContext.start ([WILDCARD])

--- a/tests/unit/testing_test.ts
+++ b/tests/unit/testing_test.ts
@@ -8,7 +8,7 @@ Deno.test(function testWrongOverloads() {
       Deno.test("some name", { fn: () => {} }, () => {});
     },
     TypeError,
-    "Unexpected 'fn' field in options, test function is already provided as the third argument.",
+    "Unexpected 'fn' field in options, test function is already provided as the third argument",
   );
   assertThrows(
     () => {
@@ -16,7 +16,7 @@ Deno.test(function testWrongOverloads() {
       Deno.test("some name", { name: "some name2" }, () => {});
     },
     TypeError,
-    "Unexpected 'name' field in options, test name is already provided as the first argument.",
+    "Unexpected 'name' field in options, test name is already provided as the first argument",
   );
   assertThrows(
     () => {
@@ -40,7 +40,7 @@ Deno.test(function testWrongOverloads() {
       Deno.test({ fn: () => {} }, function foo() {});
     },
     TypeError,
-    "Unexpected 'fn' field in options, test function is already provided as the second argument.",
+    "Unexpected 'fn' field in options, test function is already provided as the second argument",
   );
   assertThrows(
     () => {
@@ -48,7 +48,7 @@ Deno.test(function testWrongOverloads() {
       Deno.test({});
     },
     TypeError,
-    "Expected 'fn' field in the first argument to be a test function.",
+    "Expected 'fn' field in the first argument to be a test function",
   );
   assertThrows(
     () => {
@@ -56,7 +56,7 @@ Deno.test(function testWrongOverloads() {
       Deno.test({ fn: "boo!" });
     },
     TypeError,
-    "Expected 'fn' field in the first argument to be a test function.",
+    "Expected 'fn' field in the first argument to be a test function",
   );
 });
 
@@ -87,7 +87,7 @@ Deno.test(async function invalidStepArguments(t) {
       await (t as any).step("test");
     },
     TypeError,
-    "Expected function for second argument.",
+    "Expected function for second argument",
   );
 
   await assertRejects(
@@ -96,7 +96,7 @@ Deno.test(async function invalidStepArguments(t) {
       await (t as any).step("test", "not a function");
     },
     TypeError,
-    "Expected function for second argument.",
+    "Expected function for second argument",
   );
 
   await assertRejects(
@@ -105,7 +105,7 @@ Deno.test(async function invalidStepArguments(t) {
       await (t as any).step();
     },
     TypeError,
-    "Expected a test definition or name and function.",
+    "Expected a test definition or name and function",
   );
 
   await assertRejects(
@@ -114,7 +114,7 @@ Deno.test(async function invalidStepArguments(t) {
       await (t as any).step(() => {});
     },
     TypeError,
-    "The step function must have a name.",
+    "The step function must have a name",
   );
 });
 


### PR DESCRIPTION
Aligns the error messages in the cli/js folder to be in-line with the Deno style guide.

https://github.com/denoland/deno/issues/25269

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
