### PR TITLE
BREAKING(buffer): remove `Deno.writeAll[Sync]()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2994,29 +2994,6 @@ declare namespace Deno {
   export function readAllSync(r: ReaderSync): Uint8Array;
 
   /**
-   * Write all the content of the array buffer (`arr`) to the writer (`w`).
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function writeAll(w: Writer, arr: Uint8Array): Promise<void>;
-
-  /**
-   * Synchronously write all the content of the array buffer (`arr`) to the
-   * writer (`w`).
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   *
-   * @category I/O
-   */
-  export function writeAllSync(w: WriterSync, arr: Uint8Array): void;
-
-  /**
    * Options which can be set when using {@linkcode Deno.mkdir} and
    * {@linkcode Deno.mkdirSync}.
    *

--- a/runtime/js/13_buffer.js
+++ b/runtime/js/13_buffer.js
@@ -256,28 +256,4 @@ function readAllSync(r) {
   return buf.bytes();
 }
 
-async function writeAll(w, arr) {
-  internals.warnOnDeprecatedApi(
-    "Deno.writeAll()",
-    new Error().stack,
-    "Use `writeAll()` from `https://jsr.io/@std/io/doc/write-all/~` instead.",
-  );
-  let nwritten = 0;
-  while (nwritten < arr.length) {
-    nwritten += await w.write(TypedArrayPrototypeSubarray(arr, nwritten));
-  }
-}
-
-function writeAllSync(w, arr) {
-  internals.warnOnDeprecatedApi(
-    "Deno.writeAllSync()",
-    new Error().stack,
-    "Use `writeAllSync()` from `https://jsr.io/@std/io/doc/write-all/~` instead.",
-  );
-  let nwritten = 0;
-  while (nwritten < arr.length) {
-    nwritten += w.writeSync(TypedArrayPrototypeSubarray(arr, nwritten));
-  }
-}
-
-export { Buffer, readAll, readAllSync, writeAll, writeAllSync };
+export { Buffer, readAll, readAllSync };

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -101,8 +101,6 @@ const denoNs = {
   Buffer: buffer.Buffer,
   readAll: buffer.readAll,
   readAllSync: buffer.readAllSync,
-  writeAll: buffer.writeAll,
-  writeAllSync: buffer.writeAllSync,
   copy: io.copy,
   SeekMode: io.SeekMode,
   read(rid, buffer) {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -815,8 +815,6 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       delete Deno.readSync;
       delete Deno.seek;
       delete Deno.seekSync;
-      delete Deno.writeAll;
-      delete Deno.writeAllSync;
       delete Deno.write;
       delete Deno.writeSync;
     }
@@ -992,8 +990,6 @@ function bootstrapWorkerRuntime(
       delete Deno.readSync;
       delete Deno.seek;
       delete Deno.seekSync;
-      delete Deno.writeAll;
-      delete Deno.writeAllSync;
       delete Deno.write;
       delete Deno.writeSync;
     }

--- a/tests/specs/future/runtime_api/main.js
+++ b/tests/specs/future/runtime_api/main.js
@@ -17,8 +17,6 @@ console.log("Deno.read is", Deno.read);
 console.log("Deno.readSync is", Deno.readSync);
 console.log("Deno.seek is", Deno.seek);
 console.log("Deno.seekSync is", Deno.seekSync);
-console.log("Deno.writeAll is", Deno.writeAll);
-console.log("Deno.writeAllSync is", Deno.writeAllSync);
 console.log("Deno.write is", Deno.write);
 console.log("Deno.writeSync is", Deno.writeSync);
 

--- a/tests/specs/future/runtime_api/main.out
+++ b/tests/specs/future/runtime_api/main.out
@@ -14,8 +14,6 @@ Deno.read is undefined
 Deno.readSync is undefined
 Deno.seek is undefined
 Deno.seekSync is undefined
-Deno.writeAll is undefined
-Deno.writeAllSync is undefined
 Deno.write is undefined
 Deno.writeSync is undefined
 Deno.Listener.prototype.rid is undefined

--- a/tests/unit/buffer_test.ts
+++ b/tests/unit/buffer_test.ts
@@ -376,30 +376,6 @@ Deno.test({ ignore: DENO_FUTURE }, function testReadAllSync() {
   }
 });
 
-Deno.test({ ignore: DENO_FUTURE }, async function testWriteAll() {
-  init();
-  assert(testBytes);
-  const writer = new Deno.Buffer();
-  await Deno.writeAll(writer, testBytes);
-  const actualBytes = writer.bytes();
-  assertEquals(testBytes.byteLength, actualBytes.byteLength);
-  for (let i = 0; i < testBytes.length; ++i) {
-    assertEquals(testBytes[i], actualBytes[i]);
-  }
-});
-
-Deno.test({ ignore: DENO_FUTURE }, function testWriteAllSync() {
-  init();
-  assert(testBytes);
-  const writer = new Deno.Buffer();
-  Deno.writeAllSync(writer, testBytes);
-  const actualBytes = writer.bytes();
-  assertEquals(testBytes.byteLength, actualBytes.byteLength);
-  for (let i = 0; i < testBytes.length; ++i) {
-    assertEquals(testBytes[i], actualBytes[i]);
-  }
-});
-
 Deno.test({ ignore: DENO_FUTURE }, function testBufferBytesArrayBufferLength() {
   // defaults to copy
   const args = [{}, { copy: undefined }, undefined, { copy: true }];


### PR DESCRIPTION
Towards #22079