### PR TITLE
refactor(ext/fs): align error messages

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -631,7 +631,7 @@ class FsFile {
       );
       if (internals.future) {
         throw new TypeError(
-          "`Deno.FsFile` cannot be constructed, use `Deno.open()` or `Deno.openSync()` instead.",
+          "`Deno.FsFile` cannot be constructed, use `Deno.open()` or `Deno.openSync()` instead",
         );
       }
     }
@@ -776,11 +776,15 @@ function checkOpenOptions(options) {
       (val) => val === true,
     ).length === 0
   ) {
-    throw new Error("OpenOptions requires at least one option to be true");
+    throw new Error(
+      "Cannot open file: `options` requires at least one option to be true",
+    );
   }
 
   if (options.truncate && !options.write) {
-    throw new Error("'truncate' option requires 'write' option");
+    throw new Error(
+      "Cannot open file: 'truncate' option requires 'write' to be true",
+    );
   }
 
   const createOrCreateNewWithoutWriteOrAppend =
@@ -789,7 +793,7 @@ function checkOpenOptions(options) {
 
   if (createOrCreateNewWithoutWriteOrAppend) {
     throw new Error(
-      "'create' or 'createNew' options require 'write' or 'append' option",
+      "Cannot open file: 'create' or 'createNew' options require 'write' or 'append' to be true",
     );
   }
 }

--- a/tests/specs/future/runtime_api/main.js
+++ b/tests/specs/future/runtime_api/main.js
@@ -74,7 +74,7 @@ try {
   if (
     error instanceof TypeError &&
     error.message ===
-      "`Deno.FsFile` cannot be constructed, use `Deno.open()` or `Deno.openSync()` instead."
+      "`Deno.FsFile` cannot be constructed, use `Deno.open()` or `Deno.openSync()` instead"
   ) {
     console.log("Deno.FsFile constructor is illegal");
   }

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -139,7 +139,7 @@ Deno.test(async function openOptions() {
       await Deno.open(filename, { write: false });
     },
     Error,
-    "OpenOptions requires at least one option to be true",
+    "Cannot open file: `options` requires at least one option to be true",
   );
 
   await assertRejects(
@@ -147,7 +147,7 @@ Deno.test(async function openOptions() {
       await Deno.open(filename, { truncate: true, write: false });
     },
     Error,
-    "'truncate' option requires 'write' option",
+    "Cannot open file: 'truncate' option requires 'write' to be true",
   );
 
   await assertRejects(
@@ -155,7 +155,7 @@ Deno.test(async function openOptions() {
       await Deno.open(filename, { create: true, write: false });
     },
     Error,
-    "'create' or 'createNew' options require 'write' or 'append' option",
+    "Cannot open file: 'create' or 'createNew' options require 'write' or 'append' to be true",
   );
 
   await assertRejects(
@@ -163,7 +163,7 @@ Deno.test(async function openOptions() {
       await Deno.open(filename, { createNew: true, append: false });
     },
     Error,
-    "'create' or 'createNew' options require 'write' or 'append' option",
+    "Cannot open file: 'create' or 'createNew' options require 'write' or 'append' to be true",
   );
 });
 


### PR DESCRIPTION
Aligns the error messages in the ext/fs folder to be in-line with the Deno style guide.

https://github.com/denoland/deno/issues/25269

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
