### PR TITLE
feat(add): strip package subpath when adding a package

### DIFF
--- a/cli/tools/registry/pm.rs
+++ b/cli/tools/registry/pm.rs
@@ -512,9 +512,9 @@ impl AddPackageReq {
         })
       }
       Prefix::Npm => {
-        let npm_package_req =
+        let req_ref =
           NpmPackageReqReference::from_str(&format!("npm:{}", entry_text))?;
-        let package_req = npm_package_req.req().clone();
+        let package_req = req_ref.into_inner().req;
         Ok(AddPackageReq {
           alias: maybe_alias.unwrap_or_else(|| package_req.name.to_string()),
           value: AddPackageReqValue::Npm(package_req),

--- a/cli/tools/registry/pm.rs
+++ b/cli/tools/registry/pm.rs
@@ -3,6 +3,8 @@
 mod cache_deps;
 
 pub use cache_deps::cache_top_level_deps;
+use deno_semver::jsr::JsrPackageReqReference;
+use deno_semver::npm::NpmPackageReqReference;
 
 use std::borrow::Cow;
 use std::path::Path;
@@ -501,14 +503,18 @@ impl AddPackageReq {
 
     match prefix {
       Prefix::Jsr => {
-        let package_req = PackageReq::from_str(entry_text)?;
+        let jsr_package_req =
+          JsrPackageReqReference::from_str(&format!("jsr:{}", entry_text))?;
+        let package_req = jsr_package_req.req().clone();
         Ok(AddPackageReq {
           alias: maybe_alias.unwrap_or_else(|| package_req.name.to_string()),
           value: AddPackageReqValue::Jsr(package_req),
         })
       }
       Prefix::Npm => {
-        let package_req = PackageReq::from_str(entry_text)?;
+        let npm_package_req =
+          NpmPackageReqReference::from_str(&format!("npm:{}", entry_text))?;
+        let package_req = npm_package_req.req().clone();
         Ok(AddPackageReq {
           alias: maybe_alias.unwrap_or_else(|| package_req.name.to_string()),
           value: AddPackageReqValue::Npm(package_req),

--- a/cli/tools/registry/pm.rs
+++ b/cli/tools/registry/pm.rs
@@ -503,9 +503,9 @@ impl AddPackageReq {
 
     match prefix {
       Prefix::Jsr => {
-        let jsr_package_req =
+        let req_ref =
           JsrPackageReqReference::from_str(&format!("jsr:{}", entry_text))?;
-        let package_req = jsr_package_req.req().clone();
+        let package_req = req_ref.into_inner().req;
         Ok(AddPackageReq {
           alias: maybe_alias.unwrap_or_else(|| package_req.name.to_string()),
           value: AddPackageReqValue::Jsr(package_req),

--- a/tests/specs/add/add_with_subpath/__test__.jsonc
+++ b/tests/specs/add/add_with_subpath/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "add @std/testing/bdd npm:preact/hooks",
+      "output": "add.out"
+    },
+    {
+      "args": "add @std/testing/bdd@1 npm:preact/hooks@10",
+      "output": "wrong_constraint_jsr.out",
+      "exitCode": 1
+    },
+    {
+      "args": "add npm:preact/hooks@10",
+      "output": "wrong_constraint_npm.out",
+      "exitCode": 1
+    }
+  ]
+}

--- a/tests/specs/add/add_with_subpath/add.out
+++ b/tests/specs/add/add_with_subpath/add.out
@@ -1,0 +1,8 @@
+[UNORDERED_START]
+Add jsr:@std/testing@1.0.0
+Add npm:preact@10.19.6
+Download http://127.0.0.1:4250/@std/testing/1.0.0/bdd.ts
+Download http://127.0.0.1:4250/@std/testing/1.0.0/types.ts
+Download http://localhost:4260/preact
+Download http://localhost:4260/preact/preact-10.19.6.tgz
+[UNORDERED_END]

--- a/tests/specs/add/add_with_subpath/wrong_constraint_jsr.out
+++ b/tests/specs/add/add_with_subpath/wrong_constraint_jsr.out
@@ -1,0 +1,4 @@
+error: Failed to parse package required: @std/testing/bdd@1
+
+Caused by:
+    Invalid package specifier 'jsr:@std/testing/bdd@1'. Did you mean to write 'jsr:@std/testing@1/bdd'?

--- a/tests/specs/add/add_with_subpath/wrong_constraint_npm.out
+++ b/tests/specs/add/add_with_subpath/wrong_constraint_npm.out
@@ -1,0 +1,4 @@
+error: Failed to parse package required: npm:preact/hooks@10
+
+Caused by:
+    Invalid package specifier 'npm:preact/hooks@10'. Did you mean to write 'npm:preact@10/hooks'?


### PR DESCRIPTION
These now works:
```
$ deno add @std/dotenv/load
$ deno add npm:preact/hooks
```
Previously we were erroring out, because this is a "package reference" including
a subpath.

Closes https://github.com/denoland/deno/issues/25385