### PR TITLE
feat: Allow importing .cjs files

### DIFF
--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -327,7 +327,9 @@ impl NpmModuleLoader {
     specifier: &ModuleSpecifier,
     maybe_referrer: Option<&ModuleSpecifier>,
   ) -> Option<Result<ModuleCodeStringSource, AnyError>> {
-    if self.node_resolver.in_npm_package(specifier) {
+    if self.node_resolver.in_npm_package(specifier)
+      || specifier.path().ends_with(".cjs")
+    {
       Some(self.load(specifier, maybe_referrer).await)
     } else {
       None
@@ -376,7 +378,9 @@ impl NpmModuleLoader {
         }
       })?;
 
-    let code = if self.cjs_resolutions.contains(specifier) {
+    let code = if self.cjs_resolutions.contains(specifier)
+      || specifier.path().ends_with(".cjs")
+    {
       // translate cjs to esm if it's cjs and inject node globals
       let code = match String::from_utf8_lossy(&code) {
         Cow::Owned(code) => code,

--- a/tests/specs/run/import_common_js/__test__.jsonc
+++ b/tests/specs/run/import_common_js/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "steps": [
+    { "args": "run -R index.cjs", "output": "index.out" },
+    { "args": "run -R main.ts", "output": "main.out" }
+  ]
+}

--- a/tests/specs/run/import_common_js/a.js
+++ b/tests/specs/run/import_common_js/a.js
@@ -1,0 +1,7 @@
+function foobar() {
+  console.log("foobar");
+}
+
+module.exports = {
+  foobar,
+};

--- a/tests/specs/run/import_common_js/index.cjs
+++ b/tests/specs/run/import_common_js/index.cjs
@@ -1,0 +1,9 @@
+const process = require("process");
+const a = require("./a");
+
+console.log(process.cwd());
+
+module.exports = {
+  cwd: process.cwd,
+  foobar: a.foobar,
+};

--- a/tests/specs/run/import_common_js/index.out
+++ b/tests/specs/run/import_common_js/index.out
@@ -1,0 +1,1 @@
+[WILDCARD]/import_common_js

--- a/tests/specs/run/import_common_js/main.out
+++ b/tests/specs/run/import_common_js/main.out
@@ -1,0 +1,5 @@
+hello from foo node module
+[WILDCARD]import_common_js
+cjsModule.cwd() [WILDCARD]import_common_js
+foobar
+cjsModule.foobar() undefined

--- a/tests/specs/run/import_common_js/main.ts
+++ b/tests/specs/run/import_common_js/main.ts
@@ -1,0 +1,3 @@
+import foo from "foo";
+
+foo();

--- a/tests/specs/run/import_common_js/node_modules/foo/index.mjs
+++ b/tests/specs/run/import_common_js/node_modules/foo/index.mjs
@@ -1,0 +1,14 @@
+import process from "node:process";
+import path from "node:path";
+
+
+export default async function () {
+    console.log("hello from foo node module");
+
+    const cjsFileToImport = path.join(process.cwd(), "index.cjs");
+
+    const cjsModule = await import(cjsFileToImport);
+
+    console.log("cjsModule.cwd()", cjsModule.cwd());
+    console.log("cjsModule.foobar()", cjsModule.foobar());
+}

--- a/tests/specs/run/import_common_js/node_modules/foo/package.json
+++ b/tests/specs/run/import_common_js/node_modules/foo/package.json
@@ -1,0 +1,3 @@
+{
+    "main": "./index.mjs"
+}

--- a/tests/specs/run/import_common_js/package.json
+++ b/tests/specs/run/import_common_js/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "foo": "npm:foo"
+  }
+}


### PR DESCRIPTION
This commit adds support for executing top-level `.cjs` files, 
as well as import `.cjs` files from within npm packages.

This works only for `.cjs` files, the contents of sibling `package.json`
are not consulted for the `"type"` field.

Closes https://github.com/denoland/deno/issues/25384