### PR TITLE
BREAKING(config): make supported compilerOptions an allow list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.32.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c774f2e49b4ca47f1fe5c39e1775d1434280a4f168252fed8f4a3f2230868448"
+checksum = "495df7ebed4feee5c0eb7631b0b86432bb6370638cf81d5eeb5769aab55fb2de"
 dependencies = [
  "anyhow",
  "deno_package_json",
@@ -1388,6 +1388,7 @@ dependencies = [
  "jsonc-parser",
  "log",
  "percent-encoding",
+ "phf 0.11.2",
  "serde",
  "serde_json",
  "thiserror",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,7 +65,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = { workspace = true }
-deno_config = { version = "=0.32.0", features = ["workspace", "sync"] }
+deno_config = { version = "=0.33.1", features = ["workspace", "sync"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "0.148.0", features = ["html", "syntect"] }
 deno_graph = { version = "=0.82.0" }

--- a/cli/args/deno_json.rs
+++ b/cli/args/deno_json.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use deno_config::deno_json::TsConfigForEmit;
 use deno_core::serde_json;
 use deno_semver::jsr::JsrDepPackageReq;
 use deno_semver::jsr::JsrPackageReqReference;
@@ -104,4 +105,19 @@ fn values_to_set<'a>(
     }
   }
   entries
+}
+
+pub fn check_warn_tsconfig(ts_config: &TsConfigForEmit) {
+  if let Some(ignored_options) = &ts_config.maybe_ignored_options {
+    log::warn!("{}", ignored_options);
+  }
+  let serde_json::Value::Object(obj) = &ts_config.ts_config.0 else {
+    return;
+  };
+  if obj.get("experimentalDecorators") == Some(&serde_json::Value::Bool(true)) {
+    log::warn!(
+      "{} experimentalDecorators compiler option is deprecated and may be removed at any time",
+      deno_runtime::colors::yellow("Warning"),
+    );
+  }
 }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1220,7 +1220,7 @@ impl CliOptions {
     if let Some(flag) = self.flags.node_modules_dir {
       return Ok(Some(flag));
     }
-    self.workspace().node_modules_dir_mode().map_err(Into::into)
+    self.workspace().node_modules_dir().map_err(Into::into)
   }
 
   pub fn vendor_dir_path(&self) -> Option<&PathBuf> {
@@ -1731,7 +1731,7 @@ fn resolve_node_modules_folder(
     Some(mode.uses_node_modules_dir())
   } else {
     workspace
-      .node_modules_dir_mode()?
+      .node_modules_dir()?
       .map(|m| m.uses_node_modules_dir())
       .or(flags.vendor)
       .or_else(|| root_folder.deno_json.as_ref().and_then(|c| c.json.vendor))

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -42,6 +42,7 @@ pub use deno_config::deno_json::TsConfigForEmit;
 pub use deno_config::deno_json::TsConfigType;
 pub use deno_config::deno_json::TsTypeLib;
 pub use deno_config::glob::FilePatterns;
+pub use deno_json::check_warn_tsconfig;
 pub use flags::*;
 pub use lockfile::CliLockfile;
 pub use package_json::PackageJsonInstallDepsProvider;

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use crate::args::check_warn_tsconfig;
 use crate::args::get_root_cert_store;
 use crate::args::CaData;
 use crate::args::CliOptions;
@@ -522,9 +523,7 @@ impl CliFactory {
       let cli_options = self.cli_options()?;
       let ts_config_result =
         cli_options.resolve_ts_config_for_emit(TsConfigType::Emit)?;
-      if let Some(ignored_options) = ts_config_result.maybe_ignored_options {
-        warn!("{}", ignored_options);
-      }
+      check_warn_tsconfig(&ts_config_result);
       let (transpile_options, emit_options) =
         crate::args::ts_config_to_transpile_and_emit_options(
           ts_config_result.ts_config,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1387,10 +1387,8 @@ impl ConfigData {
       }
     }
 
-    let node_modules_dir = member_dir
-      .workspace
-      .node_modules_dir_mode()
-      .unwrap_or_default();
+    let node_modules_dir =
+      member_dir.workspace.node_modules_dir().unwrap_or_default();
     let byonm = match node_modules_dir {
       Some(mode) => mode == NodeModulesDirMode::Manual,
       None => member_dir.workspace.root_pkg_json().is_some(),
@@ -1873,7 +1871,7 @@ fn resolve_node_modules_dir(
   // `nodeModulesDir: true` setting in the deno.json file. This is to
   // reduce the chance of modifying someone's node_modules directory
   // without them having asked us to do so.
-  let node_modules_mode = workspace.node_modules_dir_mode().ok().flatten();
+  let node_modules_mode = workspace.node_modules_dir().ok().flatten();
   let explicitly_disabled = node_modules_mode == Some(NodeModulesDirMode::None);
   if explicitly_disabled {
     return None;

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -966,9 +966,8 @@ impl Inner {
       .await;
     for config_file in self.config.tree.config_files() {
       (|| {
-        let compiler_options = config_file.to_compiler_options().ok()?.0;
-        let compiler_options_obj = compiler_options.as_object()?;
-        let jsx_import_source = compiler_options_obj.get("jsxImportSource")?;
+        let compiler_options = config_file.to_compiler_options().ok()?.options;
+        let jsx_import_source = compiler_options.get("jsxImportSource")?;
         let jsx_import_source = jsx_import_source.as_str()?;
         let referrer = config_file.specifier.clone();
         let specifier = Url::parse(&format!(

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -14,6 +14,7 @@ use deno_terminal::colors;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use crate::args::check_warn_tsconfig;
 use crate::args::CliOptions;
 use crate::args::TsConfig;
 use crate::args::TsConfigType;
@@ -118,9 +119,7 @@ impl TypeChecker {
       .cli_options
       .resolve_ts_config_for_emit(TsConfigType::Check { lib: options.lib })?;
     if options.log_ignored_options {
-      if let Some(ignored_options) = ts_config_result.maybe_ignored_options {
-        log::warn!("{}", ignored_options);
-      }
+      check_warn_tsconfig(&ts_config_result);
     }
 
     let type_check_mode = options.type_check_mode;

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use crate::args::check_warn_tsconfig;
 use crate::args::CompileFlags;
 use crate::args::Flags;
 use crate::factory::CliFactory;
@@ -79,6 +80,7 @@ pub async fn compile(
 
   let ts_config_for_emit = cli_options
     .resolve_ts_config_for_emit(deno_config::deno_json::TsConfigType::Emit)?;
+  check_warn_tsconfig(&ts_config_for_emit);
   let (transpile_options, emit_options) =
     crate::args::ts_config_to_transpile_and_emit_options(
       ts_config_for_emit.ts_config,

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -483,11 +483,6 @@ itest!(dynamic_import_concurrent_non_statically_analyzable {
   http_server: true,
 });
 
-itest!(no_check_imports_not_used_as_values {
-    args: "run --config run/no_check_imports_not_used_as_values/preserve_imports.tsconfig.json --no-check run/no_check_imports_not_used_as_values/main.ts",
-    output: "run/no_check_imports_not_used_as_values/main.out",
-  });
-
 itest!(_088_dynamic_import_already_evaluating {
   args: "run --allow-read run/088_dynamic_import_already_evaluating.ts",
   output: "run/088_dynamic_import_already_evaluating.ts.out",

--- a/tests/testdata/run/checkjs.tsconfig.json
+++ b/tests/testdata/run/checkjs.tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "checkJs": true
   }
 }

--- a/tests/testdata/run/decorators/experimental/ts/main.out
+++ b/tests/testdata/run/decorators/experimental/ts/main.out
@@ -1,2 +1,3 @@
+Warning experimentalDecorators compiler option is deprecated and may be removed at any time
 Check [WILDCARD]
 SomeClass { someField: "asdf" }

--- a/tests/testdata/run/no_check_imports_not_used_as_values/hello.ts
+++ b/tests/testdata/run/no_check_imports_not_used_as_values/hello.ts
@@ -1,2 +1,0 @@
-export type SomeType = unknown;
-console.log("Hello, world!");

--- a/tests/testdata/run/no_check_imports_not_used_as_values/main.out
+++ b/tests/testdata/run/no_check_imports_not_used_as_values/main.out
@@ -1,2 +1,0 @@
-[WILDCARD]Hello, world!
-Hi!

--- a/tests/testdata/run/no_check_imports_not_used_as_values/main.ts
+++ b/tests/testdata/run/no_check_imports_not_used_as_values/main.ts
@@ -1,4 +1,0 @@
-import { SomeType } from "./hello.ts";
-
-const string: SomeType = "Hi!";
-console.log(string);

--- a/tests/testdata/run/no_check_imports_not_used_as_values/preserve_imports.tsconfig.json
+++ b/tests/testdata/run/no_check_imports_not_used_as_values/preserve_imports.tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "importsNotUsedAsValues": "preserve"
-  }
-}

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -221,7 +221,7 @@ async function ensureNoNewITests() {
     "pm_tests.rs": 0,
     "publish_tests.rs": 0,
     "repl_tests.rs": 0,
-    "run_tests.rs": 350,
+    "run_tests.rs": 349,
     "shared_library_tests.rs": 0,
     "task_tests.rs": 30,
     "test_tests.rs": 75,


### PR DESCRIPTION
Deno has been using a deny list, which doesn't make sense because a lot of these options don't even work.

Closes #25363