### PR TITLE
fix(config): validate export names

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -622,6 +622,11 @@
         {
           "type": "object",
           "description": "A map of package exports to files in this JSR package.",
+          "propertyNames": {
+            "description": "Package export name",
+            "examples": [".", "./foo", "./bar"],
+            "pattern": "^\\.(/.*)?$"
+          },
           "patternProperties": {
             "^\\.(/.*)?$": {
               "type": "string",


### PR DESCRIPTION
The property names of the `exports` field in `deno.json` was never validated. The `patternProperties` only validates values, whose property name matches the regex. It doesn't validate the property names themselves. That's what `propertyNames` is for.

Related https://github.com/denoland/deno/issues/25435