### PR TITLE
chore(tests): reduce the use of `--unstable` flag in test util

### DIFF
--- a/tests/unit/test_util.ts
+++ b/tests/unit/test_util.ts
@@ -81,7 +81,7 @@ export function execCode3(cmd: string, args: string[]) {
 }
 
 export function execCode2(code: string) {
-  return execCode3(Deno.execPath(), ["eval", "--unstable", "--no-check", code]);
+  return execCode3(Deno.execPath(), ["eval", code]);
 }
 
 export function tmpUnixSocketPath(): string {


### PR DESCRIPTION
This PR removes unnecessary use of `--unstable` flag in test util, and reduces the warning during test.