### PR TITLE
BREAKING(fs): remove `Deno.FsWatcher.prototype.return()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3870,14 +3870,6 @@ declare namespace Deno {
     readonly rid: number;
     /** Stops watching the file system and closes the watcher resource. */
     close(): void;
-    /**
-     * Stops watching the file system and closes the watcher resource.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
-     */
-    return?(value?: any): Promise<IteratorResult<FsEvent>>;
     [Symbol.asyncIterator](): AsyncIterableIterator<FsEvent>;
   }
 

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -9,7 +9,6 @@ const {
 const {
   ArrayIsArray,
   ObjectPrototypeIsPrototypeOf,
-  PromiseResolve,
   SymbolAsyncIterator,
   ObjectDefineProperty,
 } = primordials;
@@ -63,14 +62,6 @@ class FsWatcher {
       }
       throw error;
     }
-  }
-
-  // TODO(kt3k): This is deprecated. Will be removed in v2.0.
-  // See https://github.com/denoland/deno/issues/10577 for details
-  return(value) {
-    internals.warnOnDeprecatedApi("Deno.FsWatcher.return()", new Error().stack);
-    core.close(this.#rid);
-    return PromiseResolve({ value, done: true });
   }
 
   close() {

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -49,7 +49,7 @@ Deno.test(
   { permissions: { read: true, write: true } },
   async function watchFsBasic() {
     const testDir = await makeTempDir();
-    const iter = Deno.watchFs(testDir);
+    using iter = Deno.watchFs(testDir);
 
     // Asynchronously capture two fs events.
     const eventsPromise = getTwoEvents(iter);
@@ -74,7 +74,7 @@ Deno.test(
   { permissions: { read: true, write: true } },
   async function watchFsRename() {
     const testDir = await makeTempDir();
-    const watcher = Deno.watchFs(testDir);
+    using watcher = Deno.watchFs(testDir);
     async function waitForRename() {
       for await (const event of watcher) {
         if (event.kind === "rename") {

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -90,26 +90,6 @@ Deno.test(
   },
 );
 
-// TODO(kt3k): This test is for the backward compatibility of `.return` method.
-// This should be removed at 2.0
-Deno.test(
-  { permissions: { read: true, write: true } },
-  async function watchFsReturn() {
-    const testDir = await makeTempDir();
-    const iter = Deno.watchFs(testDir);
-
-    // Asynchronously loop events.
-    const eventsPromise = getTwoEvents(iter);
-
-    // Close the watcher.
-    await iter.return!();
-
-    // Expect zero events.
-    const events = await eventsPromise;
-    assertEquals(events, []);
-  },
-);
-
 Deno.test(
   { permissions: { read: true, write: true } },
   async function watchFsClose() {


### PR DESCRIPTION
Towards #22079