### PR TITLE
chore(net): soft-remove `Deno.serveHttp()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4894,110 +4894,6 @@ declare namespace Deno {
     mtime: number | Date,
   ): Promise<void>;
 
-  /** The event yielded from an {@linkcode HttpConn} which represents an HTTP
-   * request from a remote client.
-   *
-   * @category HTTP Server
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   */
-  export interface RequestEvent {
-    /** The request from the client in the form of the web platform
-     * {@linkcode Request}. */
-    readonly request: Request;
-    /** The method to be used to respond to the event. The response needs to
-     * either be an instance of {@linkcode Response} or a promise that resolves
-     * with an instance of `Response`.
-     *
-     * When the response is successfully processed then the promise returned
-     * will be resolved. If there are any issues with sending the response,
-     * the promise will be rejected. */
-    respondWith(r: Response | PromiseLike<Response>): Promise<void>;
-  }
-
-  /**
-   * The async iterable that is returned from {@linkcode serveHttp} which
-   * yields up {@linkcode RequestEvent} events, representing individual
-   * requests on the HTTP server connection.
-   *
-   * @category HTTP Server
-   *
-   * @deprecated This will be removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   */
-  export interface HttpConn extends AsyncIterable<RequestEvent>, Disposable {
-    /** The resource ID associated with this connection. Generally users do not
-     * need to be aware of this identifier. */
-    readonly rid: number;
-
-    /** An alternative to the async iterable interface which provides promises
-     * which resolve with either a {@linkcode RequestEvent} when there is
-     * another request or `null` when the client has closed the connection. */
-    nextRequest(): Promise<RequestEvent | null>;
-    /** Initiate a server side closure of the connection, indicating to the
-     * client that you refuse to accept any more requests on this connection.
-     *
-     * Typically the client closes the connection, which will result in the
-     * async iterable terminating or the `nextRequest()` method returning
-     * `null`. */
-    close(): void;
-  }
-
-  /**
-   * Provides an interface to handle HTTP request and responses over TCP or TLS
-   * connections. The method returns an {@linkcode HttpConn} which yields up
-   * {@linkcode RequestEvent} events, which utilize the web platform standard
-   * {@linkcode Request} and {@linkcode Response} objects to handle the request.
-   *
-   * ```ts
-   * const conn = Deno.listen({ port: 80 });
-   * const httpConn = Deno.serveHttp(await conn.accept());
-   * const e = await httpConn.nextRequest();
-   * if (e) {
-   *   e.respondWith(new Response("Hello World"));
-   * }
-   * ```
-   *
-   * Alternatively, you can also use the async iterator approach:
-   *
-   * ```ts
-   * async function handleHttp(conn: Deno.Conn) {
-   *   for await (const e of Deno.serveHttp(conn)) {
-   *     e.respondWith(new Response("Hello World"));
-   *   }
-   * }
-   *
-   * for await (const conn of Deno.listen({ port: 80 })) {
-   *   handleHttp(conn);
-   * }
-   * ```
-   *
-   * If `httpConn.nextRequest()` encounters an error or returns `null` then the
-   * underlying {@linkcode HttpConn} resource is closed automatically.
-   *
-   * Also see the experimental Flash HTTP server {@linkcode Deno.serve} which
-   * provides a ground up rewrite of handling of HTTP requests and responses
-   * within the Deno CLI.
-   *
-   * Note that this function *consumes* the given connection passed to it, thus
-   * the original connection will be unusable after calling this. Additionally,
-   * you need to ensure that the connection is not being used elsewhere when
-   * calling this function in order for the connection to be consumed properly.
-   *
-   * For instance, if there is a `Promise` that is waiting for read operation on
-   * the connection to complete, it is considered that the connection is being
-   * used elsewhere. In such a case, this function will fail.
-   *
-   * @category HTTP Server
-   * @deprecated This will be soft-removed in Deno 2.0. See the
-   * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-   * for migration instructions.
-   */
-  export function serveHttp(conn: Conn): HttpConn;
-
   /** The object that is returned from a {@linkcode Deno.upgradeWebSocket}
    * request.
    *
@@ -5040,22 +4936,21 @@ declare namespace Deno {
    * with the returned response for the websocket upgrade to be successful.
    *
    * ```ts
-   * const conn = Deno.listen({ port: 80 });
-   * const httpConn = Deno.serveHttp(await conn.accept());
-   * const e = await httpConn.nextRequest();
-   * if (e) {
-   *   const { socket, response } = Deno.upgradeWebSocket(e.request);
-   *   socket.onopen = () => {
-   *     socket.send("Hello World!");
-   *   };
-   *   socket.onmessage = (e) => {
-   *     console.log(e.data);
-   *     socket.close();
-   *   };
-   *   socket.onclose = () => console.log("WebSocket has been closed.");
-   *   socket.onerror = (e) => console.error("WebSocket error:", e);
-   *   e.respondWith(response);
-   * }
+   * Deno.serve((req) => {
+   *   if (req.headers.get("upgrade") !== "websocket") {
+   *     return new Response(null, { status: 501 });
+   *   }
+   *   const { socket, response } = Deno.upgradeWebSocket(req);
+   *   socket.addEventListener("open", () => {
+   *     console.log("a client connected!");
+   *   });
+   *   socket.addEventListener("message", (event) => {
+   *     if (event.data === "ping") {
+   *       socket.send("pong");
+   *     }
+   *   });
+   *   return response;
+   * });
    * ```
    *
    * If the request body is disturbed (read from) before the upgrade is

--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { core, internals, primordials } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
 const {
   BadResourcePrototype,
   InterruptedPrototype,
@@ -396,11 +396,6 @@ function createRespondWith(
 }
 
 function serveHttp(conn) {
-  internals.warnOnDeprecatedApi(
-    "Deno.serveHttp()",
-    new Error().stack,
-    "Use `Deno.serve()` instead.",
-  );
   const rid = op_http_start(conn[internalRidSymbol]);
   return new HttpConn(rid, conn.remoteAddr, conn.localAddr);
 }

--- a/tests/testdata/run/error_for_await.ts
+++ b/tests/testdata/run/error_for_await.ts
@@ -5,7 +5,7 @@ for await (const conn of listener) {
 }
 
 function handleConn(conn: Deno.Conn) {
-  const httpConn = Deno.serveHttp(conn);
+  const httpConn = (Deno as any).serveHttp(conn);
   for await (const event of httpConn) {
     event.respondWith(new Response("html", { status: 200 }));
   }

--- a/tests/testdata/run/error_for_await.ts
+++ b/tests/testdata/run/error_for_await.ts
@@ -5,7 +5,6 @@ for await (const conn of listener) {
 }
 
 function handleConn(conn: Deno.Conn) {
-  // @ts-ignore `Deno.serveHttp()` was soft-removed in Deno 2.
   const httpConn = Deno.serveHttp(conn);
   for await (const event of httpConn) {
     event.respondWith(new Response("html", { status: 200 }));

--- a/tests/testdata/run/error_for_await.ts
+++ b/tests/testdata/run/error_for_await.ts
@@ -5,6 +5,7 @@ for await (const conn of listener) {
 }
 
 function handleConn(conn: Deno.Conn) {
+  // @ts-ignore `Deno.serveHttp()` was soft-removed in Deno 2.
   const httpConn = Deno.serveHttp(conn);
   for await (const event of httpConn) {
     event.respondWith(new Response("html", { status: 200 }));

--- a/tests/testdata/run/http2_request_url.ts
+++ b/tests/testdata/run/http2_request_url.ts
@@ -5,6 +5,7 @@ const listener = Deno.listen({
 console.log("READY");
 
 for await (const conn of listener) {
+  // @ts-ignore `Deno.serveHttp()` was soft-removed in Deno 2.
   for await (const { request, respondWith } of Deno.serveHttp(conn)) {
     const href = new URL(request.url).href;
     respondWith(new Response(href));

--- a/tests/testdata/run/websocket_server_idletimeout.ts
+++ b/tests/testdata/run/websocket_server_idletimeout.ts
@@ -5,6 +5,7 @@ const closeDeferred = Promise.withResolvers<void>();
 
 const listener = Deno.listen({ port: 4509 });
 console.log("READY");
+// @ts-ignore `Deno.serveHttp()` was soft-removed in Deno 2.
 const httpConn = Deno.serveHttp(await listener.accept());
 const { request, respondWith } = (await httpConn.nextRequest())!;
 const { response, socket } = Deno.upgradeWebSocket(request, {

--- a/tests/testdata/run/websocket_server_multi_field_connection_header_test.ts
+++ b/tests/testdata/run/websocket_server_multi_field_connection_header_test.ts
@@ -2,6 +2,7 @@ const { promise, resolve } = Promise.withResolvers<void>();
 const listener = Deno.listen({ port: 4319 });
 console.log("READY");
 const conn = await listener.accept();
+// @ts-ignore `Deno.serveHttp()` was soft-removed in Deno 2.
 const httpConn = Deno.serveHttp(conn);
 const { request, respondWith } = (await httpConn.nextRequest())!;
 const {

--- a/tests/testdata/workers/http_worker.js
+++ b/tests/testdata/workers/http_worker.js
@@ -6,6 +6,7 @@ const listener = Deno.listen({ hostname: "127.0.0.1", port: 4506 });
 postMessage("ready");
 for await (const conn of listener) {
   (async () => {
+    // @ts-ignore `Deno.serveHttp()` was soft-removed in Deno 2.
     const requests = Deno.serveHttp(conn);
     for await (const { respondWith } of requests) {
       respondWith(new Response("Hello world"));

--- a/tests/unit/http_test.ts
+++ b/tests/unit/http_test.ts
@@ -1,4 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// @ts-nocheck `Deno.serveHttp()` was soft-removed in Deno 2.
 
 // deno-lint-ignore-file no-deprecated-deno-api
 
@@ -51,7 +52,8 @@ async function writeRequestAndReadResponse(conn: Deno.Conn): Promise<string> {
 }
 
 Deno.test({ permissions: { net: true } }, async function httpServerBasic() {
-  let httpConn: Deno.HttpConn;
+  // deno-lint-ignore no-explicit-any
+  let httpConn: any;
   const promise = (async () => {
     const listener = Deno.listen({ port: listenPort });
     const conn = await listener.accept();
@@ -146,7 +148,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerGetRequestBody() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
@@ -187,7 +190,8 @@ Deno.test(
     writer.write(new TextEncoder().encode("world"));
     writer.close();
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -250,7 +254,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerStreamDuplex() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -363,7 +368,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerRegressionHang() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -482,7 +488,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerEmptyBlobResponse() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -505,7 +512,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerNextRequestResolvesOnClose() {
-    const httpConnList: Deno.HttpConn[] = [];
+    // deno-lint-ignore no-explicit-any
+    const httpConnList: any[] = [];
 
     async function serve(l: Deno.Listener) {
       for await (const conn of l) {
@@ -544,7 +552,8 @@ Deno.test(
       return new Response(s).body!;
     }
 
-    const httpConns: Deno.HttpConn[] = [];
+    // deno-lint-ignore no-explicit-any
+    const httpConns: any[] = [];
     const promise = (async () => {
       let count = 0;
       const listener = Deno.listen({ port: listenPort });
@@ -648,7 +657,8 @@ Deno.test(
       }).pipeThrough(new TextEncoderStream());
     }
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const finished = (async () => {
       const conn = await listener.accept();
@@ -675,7 +685,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpRequestLatin1Headers() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
@@ -724,7 +735,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerRequestWithoutPath() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -896,7 +908,8 @@ Deno.test(function httpUpgradeWebSocketWithoutUpgradeHeader() {
 Deno.test(
   { permissions: { net: true } },
   async function httpCookieConcatenation() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
@@ -955,7 +968,8 @@ Deno.test(
     using file = await Deno.open(tmpFile, { write: true, read: true });
     await file.write(new Uint8Array(70 * 1024).fill(1)); // 70kb sent in 64kb + 6kb chunks
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -1094,7 +1108,8 @@ Deno.test(
   { permissions: { net: true } },
   async function httpServerDoesntLeakResources2() {
     let listener: Deno.Listener;
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
 
     const promise = (async () => {
       listener = Deno.listen({ port: listenPort });
@@ -1161,7 +1176,8 @@ Deno.test(
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ hostname, port });
     async function server() {
       const tcpConn = await listener.accept();
@@ -1248,7 +1264,8 @@ Deno.test(
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ hostname, port });
     async function server() {
       const tcpConn = await listener.accept();
@@ -1279,7 +1296,8 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function httpServerRespondNonAsciiUint8Array() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -1318,7 +1336,8 @@ Deno.test(
   async function httpServerOnUnixSocket() {
     const filePath = tmpUnixSocketPath();
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ path: filePath, transport: "unix" });
       const conn = await listener.accept();
@@ -1367,7 +1386,8 @@ Deno.test({
 
     const data = { hello: "deno", now: "with", compressed: "body" };
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const tcpConn = await listener.accept();
       httpConn = Deno.serveHttp(tcpConn);
@@ -1419,7 +1439,8 @@ Deno.test({
 
     const data = { hello: "deno", now: "with", compressed: "body" };
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const tcpConn = await listener.accept();
       httpConn = Deno.serveHttp(tcpConn);
@@ -1473,7 +1494,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1526,7 +1548,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1582,7 +1605,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1635,7 +1659,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1695,7 +1720,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1754,7 +1780,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1810,7 +1837,8 @@ Deno.test({
     const hostname = "localhost";
     const port = listenPort;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -1871,7 +1899,8 @@ Deno.test({
 
     const data = { hello: "deno", now: "with", compressed: "body" };
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const tcpConn = await listener.accept();
       httpConn = Deno.serveHttp(tcpConn);
@@ -1933,7 +1962,8 @@ Deno.test({
 
     const data = { hello: "deno", now: "with", compressed: "body" };
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const tcpConn = await listener.accept();
       httpConn = Deno.serveHttp(tcpConn);
@@ -1995,7 +2025,8 @@ Deno.test({
     const port = listenPort;
     let contentLength: string;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -2061,7 +2092,8 @@ Deno.test({
     const port = listenPort;
     let contentLength: string;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -2122,7 +2154,8 @@ Deno.test({
     const port = listenPort;
     let contentLength: string;
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const listener = Deno.listen({ hostname, port });
       const tcpConn = await listener.accept();
@@ -2182,7 +2215,8 @@ Deno.test(
     const body = "aa\n" + "deno.land large body\n".repeat(TLS_PACKET_SIZE) +
       "zz";
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
@@ -2229,7 +2263,8 @@ Deno.test(
     }
     writer.close();
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
@@ -2339,7 +2374,8 @@ Deno.test(
   { permissions: { net: true } },
   async function httpServerRequestResponseClone() {
     const body = "deno".repeat(64 * 1024);
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const listener = Deno.listen({ port: listenPort });
     const promise = (async () => {
       const conn = await listener.accept();
@@ -2403,7 +2439,8 @@ Deno.test({
     const listener = Deno.listen({ hostname, port });
     const listener2 = Deno.listen({ hostname, port: port2 });
 
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     async function server() {
       const tcpConn = await listener.accept();
       httpConn = Deno.serveHttp(tcpConn);
@@ -2420,7 +2457,8 @@ Deno.test({
     const writer = ts.writable.getWriter();
     writer.write(encoder.encode("hello"));
 
-    let httpConn2: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn2: any;
     async function server2() {
       const tcpConn = await listener2.accept();
       httpConn2 = Deno.serveHttp(tcpConn);
@@ -2499,7 +2537,8 @@ Deno.test("case insensitive comma value finder", async (t) => {
 async function httpServerWithErrorBody(
   listener: Deno.Listener,
   compression: boolean,
-): Promise<Deno.HttpConn> {
+  // deno-lint-ignore no-explicit-any
+): Promise<any> {
   const conn = await listener.accept();
   listener.close();
   const httpConn = Deno.serveHttp(conn);
@@ -2627,7 +2666,8 @@ Deno.test({
   name: "request signal is aborted when response errors",
   permissions: { net: true },
   async fn() {
-    let httpConn: Deno.HttpConn;
+    // deno-lint-ignore no-explicit-any
+    let httpConn: any;
     const promise = (async () => {
       const listener = Deno.listen({ port: listenPort });
       const conn = await listener.accept();
@@ -2682,7 +2722,8 @@ Deno.test("proxy with fetch", async () => {
     return new Response("Hello world");
   });
 
-  let httpConn: Deno.HttpConn;
+  // deno-lint-ignore no-explicit-any
+  let httpConn: any;
   async function handleHttp(conn: Deno.Conn) {
     httpConn = Deno.serveHttp(conn);
     for await (const e of httpConn) {


### PR DESCRIPTION
Towards #22079