### PR TITLE
fix(ext/node): stub `process.cpuUsage()`

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -430,6 +430,14 @@ Process.prototype.config = {
   },
 };
 
+Process.prototype.cpuUsage = function () {
+  console.warn("Warning: process.cpuUsage() is not implemented yet");
+  return {
+    user: 0,
+    system: 0,
+  };
+};
+
 /** https://nodejs.org/api/process.html#process_process_cwd */
 Process.prototype.cwd = cwd;
 

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -431,7 +431,7 @@ Process.prototype.config = {
 };
 
 Process.prototype.cpuUsage = function () {
-  console.warn("Warning: process.cpuUsage() is not implemented yet");
+  warnNotImplemented("process.cpuUsage()");
   return {
     user: 0,
     system: 0,

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1136,4 +1136,4 @@ Deno.test("process.cpuUsage()", () => {
   const cpuUsage = process.cpuUsage();
   assert(typeof cpuUsage.user === "number");
   assert(typeof cpuUsage.system === "number");
-})
+});

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1131,3 +1131,9 @@ Deno.test(function importedExecArgvTest() {
 Deno.test(function importedExecPathTest() {
   assertEquals(importedExecPath, Deno.execPath());
 });
+
+Deno.test("process.cpuUsage()", () => {
+  const cpuUsage = process.cpuUsage();
+  assert(typeof cpuUsage.user === "number");
+  assert(typeof cpuUsage.system === "number");
+})


### PR DESCRIPTION
This PR adds a stub implementation of `process.cpuUsage()`. This unblocks `npm:elastic-apm-node` package working

closes #23401