### PR TITLE
BREAKING: remove "emit" and "map" from deno info output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.82.0"
+version = "0.82.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646757b109993751f618d20de9bafc17f8f886fa910fb82c2c89b9e1df220ac6"
+checksum = "78b63015c73aa203da206b5d35b4c1eaa23bc7fed37ab325da62d525a5524a04"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -68,7 +68,7 @@ deno_cache_dir = { workspace = true }
 deno_config = { version = "=0.33.2", features = ["workspace", "sync"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "0.148.0", features = ["html", "syntect"] }
-deno_graph = { version = "=0.82.0" }
+deno_graph = { version = "=0.82.1" }
 deno_lint = { version = "=0.64.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm = "=0.25.0"

--- a/cli/cache/emit.rs
+++ b/cli/cache/emit.rs
@@ -82,19 +82,6 @@ impl EmitCache {
     Ok(())
   }
 
-  /// Gets the filepath which stores the emit.
-  pub fn get_emit_filepath(
-    &self,
-    specifier: &ModuleSpecifier,
-  ) -> Option<PathBuf> {
-    Some(
-      self
-        .disk_cache
-        .location
-        .join(self.get_emit_filename(specifier)?),
-    )
-  }
-
   fn get_emit_filename(&self, specifier: &ModuleSpecifier) -> Option<PathBuf> {
     self
       .disk_cache

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -616,7 +616,6 @@ impl CliFactory {
           self.parsed_source_cache().clone(),
           cli_options.maybe_lockfile().cloned(),
           self.maybe_file_watcher_reporter().clone(),
-          self.emit_cache()?.clone(),
           self.file_fetcher()?.clone(),
           self.global_http_cache()?.clone(),
         )))

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -368,7 +368,6 @@ pub struct ModuleGraphBuilder {
   parsed_source_cache: Arc<ParsedSourceCache>,
   lockfile: Option<Arc<CliLockfile>>,
   maybe_file_watcher_reporter: Option<FileWatcherReporter>,
-  emit_cache: Arc<cache::EmitCache>,
   file_fetcher: Arc<FileFetcher>,
   global_http_cache: Arc<GlobalHttpCache>,
 }
@@ -385,7 +384,6 @@ impl ModuleGraphBuilder {
     parsed_source_cache: Arc<ParsedSourceCache>,
     lockfile: Option<Arc<CliLockfile>>,
     maybe_file_watcher_reporter: Option<FileWatcherReporter>,
-    emit_cache: Arc<cache::EmitCache>,
     file_fetcher: Arc<FileFetcher>,
     global_http_cache: Arc<GlobalHttpCache>,
   ) -> Self {
@@ -399,7 +397,6 @@ impl ModuleGraphBuilder {
       parsed_source_cache,
       lockfile,
       maybe_file_watcher_reporter,
-      emit_cache,
       file_fetcher,
       global_http_cache,
     }
@@ -681,7 +678,6 @@ impl ModuleGraphBuilder {
     permissions: PermissionsContainer,
   ) -> cache::FetchCacher {
     cache::FetchCacher::new(
-      self.emit_cache.clone(),
       self.file_fetcher.clone(),
       self.options.resolve_file_header_overrides(),
       self.global_http_cache.clone(),

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1524,12 +1524,16 @@ impl<'a> deno_graph::source::Loader for OpenDocumentsGraphLoader<'a> {
   fn cache_module_info(
     &self,
     specifier: &deno_ast::ModuleSpecifier,
+    media_type: MediaType,
     source: &Arc<[u8]>,
     module_info: &deno_graph::ModuleInfo,
   ) {
-    self
-      .inner_loader
-      .cache_module_info(specifier, source, module_info)
+    self.inner_loader.cache_module_info(
+      specifier,
+      media_type,
+      source,
+      module_info,
+    )
   }
 }
 

--- a/cli/schemas/module-graph.json
+++ b/cli/schemas/module-graph.json
@@ -83,14 +83,6 @@
           "type": "string",
           "description": "The checksum of the local source file. This can be used to validate if the current on disk version matches the version described here."
         },
-        "emit": {
-          "type": "string",
-          "description": "The path to an emitted version of the module, if the module requires transpilation to be loaded into the Deno runtime."
-        },
-        "map": {
-          "type": "string",
-          "description": "The path to an optionally emitted source map between the original and emitted version of the file."
-        },
         "error": {
           "type": "string",
           "description": "If when resolving the module, Deno encountered an error and the module is unavailable, the text of that error will be indicated here."

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -461,22 +461,6 @@ impl<'a> GraphDisplayContext<'a> {
               local.to_string_lossy()
             )?;
           }
-          if let Some(emit) = &cache_info.emit {
-            writeln!(
-              writer,
-              "{} {}",
-              colors::bold("emit:"),
-              emit.to_string_lossy()
-            )?;
-          }
-          if let Some(map) = &cache_info.map {
-            writeln!(
-              writer,
-              "{} {}",
-              colors::bold("map:"),
-              map.to_string_lossy()
-            )?;
-          }
         }
         if let Some(module) = root.js() {
           writeln!(writer, "{} {}", colors::bold("type:"), module.media_type)?;

--- a/tests/integration/info_tests.rs
+++ b/tests/integration/info_tests.rs
@@ -6,31 +6,6 @@ use test_util::itest;
 use util::TestContextBuilder;
 
 #[test]
-fn info_with_compiled_source() {
-  let context = TestContextBuilder::new().use_http_server().build();
-  let module_path = "http://127.0.0.1:4545/run/048_media_types_jsx.ts";
-
-  let output = context
-    .new_command()
-    .current_dir(util::testdata_path())
-    .args_vec(["cache", module_path])
-    .run();
-  output.assert_exit_code(0);
-  output.skip_output_check();
-
-  let output = context
-    .new_command()
-    .current_dir(util::testdata_path())
-    .args_vec(["info", module_path])
-    .split_output()
-    .run();
-
-  // check the output of the test.ts program.
-  assert!(output.stdout().trim().contains("emit: "));
-  assert_eq!(output.stderr(), "");
-}
-
-#[test]
 fn info_lock_write() {
   let context = TestContextBuilder::new().use_http_server().build();
 

--- a/tests/specs/info/multiple_redirects/main.out
+++ b/tests/specs/info/multiple_redirects/main.out
@@ -27,8 +27,6 @@ Download http://localhost:4545/subdir/redirects/redirect1.js
         }
       ],
       "local": "[WILDLINE]main.ts",
-      "emit": null,
-      "map": null,
       "size": 97,
       "mediaType": "TypeScript",
       "specifier": "file:///[WILDLINE]/multiple_redirects/main.ts"
@@ -36,8 +34,6 @@ Download http://localhost:4545/subdir/redirects/redirect1.js
     {
       "kind": "esm",
       "local": "[WILDLINE]",
-      "emit": null,
-      "map": null,
       "size": 27,
       "mediaType": "JavaScript",
       "specifier": "http://localhost:4545/subdir/redirects/redirect1.js"

--- a/tests/testdata/npm/cjs_with_deps/main_info_json.out
+++ b/tests/testdata/npm/cjs_with_deps/main_info_json.out
@@ -42,8 +42,6 @@
         }
       ],
       "local": "[WILDCARD]main.js",
-      "emit": null,
-      "map": null,
       "size": 325,
       "mediaType": "JavaScript",
       "specifier": "[WILDCARD]/main.js"

--- a/tests/testdata/npm/peer_deps_with_copied_folders/main_info_json.out
+++ b/tests/testdata/npm/peer_deps_with_copied_folders/main_info_json.out
@@ -42,8 +42,6 @@
         }
       ],
       "local": "[WILDCARD]main.ts",
-      "emit": null,
-      "map": null,
       "size": 171,
       "mediaType": "TypeScript",
       "specifier": "file://[WILDCARD]/main.ts"


### PR DESCRIPTION
The map field has been empty for years now and we don't want the emit file to be exposed so it allows us to iterate on making the cache faster. Additionally, it's racy/unreliable to rely on this information. Instead, people should emit the TS files themselves using tools like deno_emit, typescript, esbuild, etc.

Closes https://github.com/denoland/deno/issues/17703