### PR TITLE
fix(ext/node): delay accept() call 2 ticks in net.Server#listen

### DIFF
--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -236,13 +236,14 @@ Deno.test("[node/net] net.Server can listen on the same port immediately after i
     console.error(e);
   });
   server.listen(0, () => {
-    const port = (server.address() as any).port;
+    // deno-lint-ignore no-explicit-any
+    const { port } = server.address() as any;
     server.close();
     server.listen(port, () => {
       server.close(() => {
         serverClosed.resolve();
       });
     });
-  })
+  });
   await serverClosed.promise;
 });

--- a/tests/unit_node/net_test.ts
+++ b/tests/unit_node/net_test.ts
@@ -228,3 +228,21 @@ Deno.test("[node/net] BlockList doesn't leak resources", () => {
   blockList.addAddress("1.1.1.1");
   assert(blockList.check("1.1.1.1"));
 });
+
+Deno.test("[node/net] net.Server can listen on the same port immediately after it's closed", async () => {
+  const serverClosed = Promise.withResolvers<void>();
+  const server = net.createServer();
+  server.on("error", (e) => {
+    console.error(e);
+  });
+  server.listen(0, () => {
+    const port = (server.address() as any).port;
+    server.close();
+    server.listen(port, () => {
+      server.close(() => {
+        serverClosed.resolve();
+      });
+    });
+  })
+  await serverClosed.promise;
+});


### PR DESCRIPTION
A workaround for the issue #25480

`Deno.Listener` can't be closed synchronously after `accept()` is called. This PR delays the `accept` call 2 ticks (The listener callback is called 1 tick later. So the 1 tick delay is not enough), and makes `net.Server` capable of being closed synchronously.

This unblocks `npm:detect-port` and `npm:portfinder`

closes #18301 
closes #25175 