### PR TITLE
fix: invalid ipv6 hostname on `deno serve`

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -691,15 +691,23 @@ function serve(arg1, arg2) {
       options.onListen(addr);
     } else {
       const hostname = mapAnyAddrToLocalhostForWindows(addr.hostname);
-      const host = StringPrototypeIncludes(hostname, ":")
-        ? `[${hostname}]`
-        : hostname;
+      const host = formatHostName(hostname);
+
       // deno-lint-ignore no-console
       console.log(`Listening on ${scheme}${host}:${addr.port}/`);
     }
   };
 
   return serveHttpOnListener(listener, signal, handler, onError, onListen);
+}
+
+/**
+ * @param {string} received
+ * @returns {string}
+ */
+function formatHostName(received) {
+  // Add brackets around ipv6 host
+  return StringPrototypeIncludes(received, ":") ? `[${received}]` : received;
 }
 
 /**
@@ -869,9 +877,11 @@ function registerDeclarativeServer(exports) {
               ? ` with ${serveWorkerCount} threads`
               : "";
             const hostname_ = mapAnyAddrToLocalhostForWindows(hostname);
+            const host = formatHostName(hostname_);
+
             // deno-lint-ignore no-console
             console.debug(
-              `%cdeno serve%c: Listening on %chttp://${hostname_}:${port}/%c${nThreads}`,
+              `%cdeno serve%c: Listening on %chttp://${host}:${port}/%c${nThreads}`,
               "color: green",
               "color: inherit",
               "color: yellow",

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -564,21 +564,6 @@ function mapToCallback(context, callback, onError) {
   };
 }
 
-function formatHostName(hostname: string): string {
-  // If the hostname is "0.0.0.0", we display "localhost" in console
-  // because browsers in Windows don't resolve "0.0.0.0".
-  // See the discussion in https://github.com/denoland/deno_std/issues/1165
-  if (
-    (Deno.build.os === "windows") &&
-    (hostname == "0.0.0.0" || hostname == "::")
-  ) {
-    return "localhost";
-  }
-
-  // Add brackets around ipv6 hostname
-  return StringPrototypeIncludes(hostname, ":") ? `[${hostname}]` : hostname;
-}
-
 type RawHandler = (
   request: Request,
   info: ServeHandlerInfo,
@@ -597,6 +582,21 @@ type RawServeOptions = {
 };
 
 const kLoadBalanced = Symbol("kLoadBalanced");
+
+function formatHostName(hostname: string): string {
+  // If the hostname is "0.0.0.0", we display "localhost" in console
+  // because browsers in Windows don't resolve "0.0.0.0".
+  // See the discussion in https://github.com/denoland/deno_std/issues/1165
+  if (
+    (Deno.build.os === "windows") &&
+    (hostname == "0.0.0.0" || hostname == "::")
+  ) {
+    return "localhost";
+  }
+
+  // Add brackets around ipv6 hostname
+  return StringPrototypeIncludes(hostname, ":") ? `[${hostname}]` : hostname;
+}
 
 function serve(arg1, arg2) {
   let options: RawServeOptions | undefined;

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -564,6 +564,25 @@ function mapToCallback(context, callback, onError) {
   };
 }
 
+/**
+ * @param {string} hostname
+ * @returns {string}
+ */
+function formatHostName(hostname) {
+  // If the hostname is "0.0.0.0", we display "localhost" in console
+  // because browsers in Windows don't resolve "0.0.0.0".
+  // See the discussion in https://github.com/denoland/deno_std/issues/1165
+  if (
+    (Deno.build.os === "windows") &&
+    (hostname == "0.0.0.0" || hostname == "::")
+  ) {
+    return "localhost";
+  }
+
+  // Add brackets around ipv6 hostname
+  return StringPrototypeIncludes(hostname, ":") ? `[${hostname}]` : hostname;
+}
+
 type RawHandler = (
   request: Request,
   info: ServeHandlerInfo,
@@ -685,25 +704,6 @@ function serve(arg1, arg2) {
   };
 
   return serveHttpOnListener(listener, signal, handler, onError, onListen);
-}
-
-/**
- * @param {string} hostname
- * @returns {string}
- */
-function formatHostName(hostname) {
-  // If the hostname is "0.0.0.0", we display "localhost" in console
-  // because browsers in Windows don't resolve "0.0.0.0".
-  // See the discussion in https://github.com/denoland/deno_std/issues/1165
-  if (
-    (Deno.build.os === "windows") &&
-    (hostname == "0.0.0.0" || hostname == "::")
-  ) {
-    return "localhost";
-  }
-
-  // Add brackets around ipv6 hostname
-  return StringPrototypeIncludes(hostname, ":") ? `[${hostname}]` : hostname;
 }
 
 /**

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -564,11 +564,7 @@ function mapToCallback(context, callback, onError) {
   };
 }
 
-/**
- * @param {string} hostname
- * @returns {string}
- */
-function formatHostName(hostname) {
+function formatHostName(hostname: string): string {
   // If the hostname is "0.0.0.0", we display "localhost" in console
   // because browsers in Windows don't resolve "0.0.0.0".
   // See the discussion in https://github.com/denoland/deno_std/issues/1165

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -872,6 +872,36 @@ Deno.test({ permissions: { net: true } }, async function validPortString() {
   await server.shutdown();
 });
 
+Deno.test({ permissions: { net: true } }, async function ipv6Hostname() {
+  const ac = new AbortController();
+  let url = "";
+
+  const consoleLog = console.log;
+  console.log = (msg) => {
+    try {
+      const match = msg.match(/Listening on (http:\/\/(.*?):(\d+)\/)/);
+      assert(!!match, `Didn't match ${msg}`);
+      url = match[1];
+    } finally {
+      ac.abort();
+    }
+  };
+
+  try {
+    const server = Deno.serve({
+      handler: () => new Response(),
+      hostname: "::1",
+      port: 0,
+      signal: ac.signal,
+    });
+    assertEquals(server.addr.transport, "tcp");
+    assert(new URL(url), `Not a valid URL "${url}"`);
+    await server.shutdown();
+  } finally {
+    console.log = consoleLog;
+  }
+});
+
 Deno.test({ permissions: { net: true } }, function invalidPortFloat() {
   assertThrows(
     () =>


### PR DESCRIPTION
This PR fixes an invalid URL being printed when running `deno serve`

Before: invalid URL

```sh
$ deno serve --host localhost
deno serve: Listening on http://::1:8000/
```

After: valid URL

```sh
$ deno serve --host localhost
deno serve: Listening on http://[::1]:8000/
```