### PR TITLE
feat(upgrade): better error message on failure

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2983,8 +2983,8 @@ The declaration file could be saved and used for typing information.",
   )
 }
 
-
-pub static UPGRADE_USAGE: &str = cstr!("<g>Latest</>
+pub static UPGRADE_USAGE: &str = cstr!(
+  "<g>Latest</>
   <bold>deno upgrade</>
 
 <g>Specific version</>
@@ -2995,8 +2995,8 @@ pub static UPGRADE_USAGE: &str = cstr!("<g>Latest</>
 <g>Channel</>
   <bold>deno upgrade</> <p(245)>stable</>
   <bold>deno upgrade</> <p(245)>rc</>
-  <bold>deno upgrade</> <p(245)>canary</>");
-
+  <bold>deno upgrade</> <p(245)>canary</>"
+);
 
 fn upgrade_subcommand() -> Command {
   command(

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2983,12 +2983,8 @@ The declaration file could be saved and used for typing information.",
   )
 }
 
-fn upgrade_subcommand() -> Command {
-  command(
-    "upgrade",
-    cstr!("Upgrade deno executable to the given version.
 
-<g>Latest</>
+pub static UPGRADE_USAGE: &str = cstr!("<g>Latest</>
   <bold>deno upgrade</>
 
 <g>Specific version</>
@@ -2999,7 +2995,15 @@ fn upgrade_subcommand() -> Command {
 <g>Channel</>
   <bold>deno upgrade</> <p(245)>stable</>
   <bold>deno upgrade</> <p(245)>rc</>
-  <bold>deno upgrade</> <p(245)>canary</>
+  <bold>deno upgrade</> <p(245)>canary</>");
+
+
+fn upgrade_subcommand() -> Command {
+  command(
+    "upgrade",
+    color_print::cformat!("Upgrade deno executable to the given version.
+
+{}
 
 The version is downloaded from <p(245)>https://dl.deno.land</> and is used to replace the current executable.
 
@@ -3007,7 +3011,7 @@ If you want to not replace the current Deno executable but instead download an u
 different location, use the <c>--output</> flag:
   <p(245)>deno upgrade --output $HOME/my_deno</>
 
-<y>Read more:</> <c>https://docs.deno.com/go/cmd/upgrade</>"),
+<y>Read more:</> <c>https://docs.deno.com/go/cmd/upgrade</>", UPGRADE_USAGE),
     UnstableArgsConfig::None,
   )
   .hide(cfg!(not(feature = "upgrade")))

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -4,6 +4,7 @@
 
 use crate::args::Flags;
 use crate::args::UpgradeFlags;
+use crate::args::UPGRADE_USAGE;
 use crate::colors;
 use crate::factory::CliFactory;
 use crate::http_util::HttpClient;
@@ -13,7 +14,6 @@ use crate::util::archive;
 use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;
 use crate::version;
-use crate::args::UPGRADE_USAGE;
 
 use async_trait::async_trait;
 use deno_core::anyhow::bail;

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -38,10 +38,12 @@ const RELEASE_URL: &str = "https://github.com/denoland/deno/releases";
 const CANARY_URL: &str = "https://dl.deno.land/canary";
 const RC_URL: &str = "https://dl.deno.land/release";
 
-static EXAMPLE_USAGE: &str = cstr!("Example usage:
+static EXAMPLE_USAGE: &str = cstr!("Usage:
   Latest version:    <p(245)>deno upgrade</>
   Specific version:  <p(245)>deno upgrade 1.46.3</>
-  Release Candidate: <p(245)>deno upgrade rc</>
+
+  Release candidate: <p(245)>deno upgrade rc</>
+
   Canary:            <p(245)>deno upgrade canary</>
   Specific canary:   <p(245)>deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f</>");
 

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -650,7 +650,7 @@ impl RequestedVersion {
     let (channel, passed_version) = if is_canary {
       if !re_hash.is_match(&passed_version) {
         bail!(
-          "Invalid commit hash passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
+          "Invalid commit hash passed ({})\n\nPass a semver version, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
           colors::gray(passed_version),
           UPGRADE_USAGE
         );
@@ -660,7 +660,7 @@ impl RequestedVersion {
     } else {
       let Ok(semver) = Version::parse_standard(&passed_version) else {
         bail!(
-          "Invalid version passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
+          "Invalid version passed ({})\n\nPass a semver version, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
           colors::gray(passed_version),
           UPGRADE_USAGE
         );

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -38,7 +38,12 @@ const RELEASE_URL: &str = "https://github.com/denoland/deno/releases";
 const CANARY_URL: &str = "https://dl.deno.land/canary";
 const RC_URL: &str = "https://dl.deno.land/release";
 
-static EXAMPLE_USAGE: &str = cstr!("Example usage:\n  <p(245)>deno upgrade | deno upgrade 1.46 | deno upgrade canary</>");
+static EXAMPLE_USAGE: &str = cstr!("Example usage:
+  Latest version:    <p(245)>deno upgrade</>
+  Specific version:  <p(245)>deno upgrade 1.46.3</>
+  Release Candidate: <p(245)>deno upgrade rc</>
+  Canary:            <p(245)>deno upgrade canary</>
+  Specific canary:   <p(245)>deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f</>");
 
 pub static ARCHIVE_NAME: Lazy<String> =
   Lazy::new(|| format!("deno-{}.zip", env!("TARGET")));
@@ -625,6 +630,7 @@ impl RequestedVersion {
     };
     let mut maybe_passed_version = upgrade_flags.version.clone();
 
+    // TODO(bartlomieju): prefer flags first? This whole logic could be cleaned up...
     if let Some(val) = &upgrade_flags.version_or_hash_or_channel {
       if let Ok(channel) = ReleaseChannel::deserialize(&val.to_lowercase()) {
         // TODO(bartlomieju): print error if any other flags passed?
@@ -651,7 +657,7 @@ impl RequestedVersion {
     let (channel, passed_version) = if is_canary {
       if !re_hash.is_match(&passed_version) {
         bail!(
-          "Invalid commit hash passed ({})\n\n{}",
+          "Invalid commit hash passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\n{}",
           colors::gray(passed_version),
           EXAMPLE_USAGE
         );
@@ -660,7 +666,7 @@ impl RequestedVersion {
     } else {
       let Ok(semver) = Version::parse_standard(&passed_version) else {
         bail!(
-          "Invalid version passed ({})\n\n{}",
+          "Invalid version passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\n{}",
           colors::gray(passed_version),
           EXAMPLE_USAGE
         );
@@ -1123,6 +1129,8 @@ mod test {
   use std::cell::RefCell;
   use std::rc::Rc;
 
+  use test_util::assert_contains;
+
   use super::*;
 
   #[test]
@@ -1220,6 +1228,27 @@ mod test {
         ReleaseChannel::Canary,
         "5c69b4861b52ab406e73b9cd85c254f0505cb20f".to_string()
       )
+    );
+
+    upgrade_flags.version_or_hash_or_channel =
+      Some("5c69b4861b52a".to_string());
+    let err = RequestedVersion::from_upgrade_flags(upgrade_flags.clone())
+      .unwrap_err()
+      .to_string();
+    assert_contains!(err, "Invalid version passed");
+    assert_contains!(
+      err,
+      "Pass a semver version, or a full 40 character git commit hash, or a release channel name."
+    );
+
+    upgrade_flags.version_or_hash_or_channel = Some("11.asd.1324".to_string());
+    let err = RequestedVersion::from_upgrade_flags(upgrade_flags.clone())
+      .unwrap_err()
+      .to_string();
+    assert_contains!(err, "Invalid version passed");
+    assert_contains!(
+      err,
+      "Pass a semver version, or a full 40 character git commit hash, or a release channel name."
     );
   }
 

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -650,7 +650,7 @@ impl RequestedVersion {
     let (channel, passed_version) = if is_canary {
       if !re_hash.is_match(&passed_version) {
         bail!(
-          "Invalid commit hash passed ({})\n\nPass a semver version, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
+          "Invalid commit hash passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
           colors::gray(passed_version),
           UPGRADE_USAGE
         );
@@ -660,7 +660,7 @@ impl RequestedVersion {
     } else {
       let Ok(semver) = Version::parse_standard(&passed_version) else {
         bail!(
-          "Invalid version passed ({})\n\nPass a semver version, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
+          "Invalid version passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
           colors::gray(passed_version),
           UPGRADE_USAGE
         );
@@ -1232,7 +1232,7 @@ mod test {
     assert_contains!(err, "Invalid version passed");
     assert_contains!(
       err,
-      "Pass a semver version, or a full 40 character git commit hash, or a release channel name."
+      "Pass a semver, or a full 40 character git commit hash, or a release channel name."
     );
 
     upgrade_flags.version_or_hash_or_channel = Some("11.asd.1324".to_string());
@@ -1242,7 +1242,7 @@ mod test {
     assert_contains!(err, "Invalid version passed");
     assert_contains!(
       err,
-      "Pass a semver version, or a full 40 character git commit hash, or a release channel name."
+      "Pass a semver, or a full 40 character git commit hash, or a release channel name."
     );
   }
 

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -13,9 +13,9 @@ use crate::util::archive;
 use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;
 use crate::version;
+use crate::args::UPGRADE_USAGE;
 
 use async_trait::async_trait;
-use color_print::cstr;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
@@ -37,15 +37,6 @@ use std::time::Duration;
 const RELEASE_URL: &str = "https://github.com/denoland/deno/releases";
 const CANARY_URL: &str = "https://dl.deno.land/canary";
 const RC_URL: &str = "https://dl.deno.land/release";
-
-static EXAMPLE_USAGE: &str = cstr!("Usage:
-  Latest version:    <p(245)>deno upgrade</>
-  Specific version:  <p(245)>deno upgrade 1.46.3</>
-
-  Release candidate: <p(245)>deno upgrade rc</>
-
-  Canary:            <p(245)>deno upgrade canary</>
-  Specific canary:   <p(245)>deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f</>");
 
 pub static ARCHIVE_NAME: Lazy<String> =
   Lazy::new(|| format!("deno-{}.zip", env!("TARGET")));
@@ -659,18 +650,19 @@ impl RequestedVersion {
     let (channel, passed_version) = if is_canary {
       if !re_hash.is_match(&passed_version) {
         bail!(
-          "Invalid commit hash passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\n{}",
+          "Invalid commit hash passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
           colors::gray(passed_version),
-          EXAMPLE_USAGE
+          UPGRADE_USAGE
         );
       }
+
       (ReleaseChannel::Canary, passed_version)
     } else {
       let Ok(semver) = Version::parse_standard(&passed_version) else {
         bail!(
-          "Invalid version passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\n{}",
+          "Invalid version passed ({})\n\nPass a semver, or a full 40 character git commit hash, or a release channel name.\n\nUsage:\n{}",
           colors::gray(passed_version),
-          EXAMPLE_USAGE
+          UPGRADE_USAGE
         );
       };
 

--- a/tests/specs/upgrade/invalid_version/__test__.jsonc
+++ b/tests/specs/upgrade/invalid_version/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tests": {
+    "canary": {
+      "args": "upgrade --canary asdfasdf",
+      "output": "canary.out",
+      "exitCode": 1
+    },
+    "version": {
+      "args": "upgrade --version asdfasdf",
+      "output": "version.out",
+      "exitCode": 1
+    },
+    "shorthand": {
+      "args": "upgrade asdfasdf",
+      "output": "shorthand.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/upgrade/invalid_version/canary.out
+++ b/tests/specs/upgrade/invalid_version/canary.out
@@ -1,0 +1,10 @@
+error: Invalid commit hash passed (asdfasdf)
+
+Pass a semver, or a full 40 character git commit hash, or a release channel name.
+
+Example usage:
+  Latest version:    deno upgrade
+  Specific version:  deno upgrade 1.46.3
+  Release Candidate: deno upgrade rc
+  Canary:            deno upgrade canary
+  Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f

--- a/tests/specs/upgrade/invalid_version/canary.out
+++ b/tests/specs/upgrade/invalid_version/canary.out
@@ -2,9 +2,11 @@ error: Invalid commit hash passed (asdfasdf)
 
 Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
-Example usage:
+Usage:
   Latest version:    deno upgrade
   Specific version:  deno upgrade 1.46.3
-  Release Candidate: deno upgrade rc
+
+  Release candidate: deno upgrade rc
+
   Canary:            deno upgrade canary
   Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f

--- a/tests/specs/upgrade/invalid_version/canary.out
+++ b/tests/specs/upgrade/invalid_version/canary.out
@@ -1,6 +1,6 @@
 error: Invalid commit hash passed (asdfasdf)
 
-Pass a semver version, or a full 40 character git commit hash, or a release channel name.
+Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
 Latest

--- a/tests/specs/upgrade/invalid_version/canary.out
+++ b/tests/specs/upgrade/invalid_version/canary.out
@@ -3,10 +3,15 @@ error: Invalid commit hash passed (asdfasdf)
 Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
-  Latest version:    deno upgrade
-  Specific version:  deno upgrade 1.46.3
+Latest
+  deno upgrade
 
-  Release candidate: deno upgrade rc
+Specific version
+  deno upgrade 1.45.0
+  deno upgrade 1.46.0-rc.1
+  deno upgrade 9bc2dd29ad6ba334fd57a20114e367d3c04763d4
 
-  Canary:            deno upgrade canary
-  Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f
+Channel
+  deno upgrade stable
+  deno upgrade rc
+  deno upgrade canary

--- a/tests/specs/upgrade/invalid_version/canary.out
+++ b/tests/specs/upgrade/invalid_version/canary.out
@@ -1,6 +1,6 @@
 error: Invalid commit hash passed (asdfasdf)
 
-Pass a semver, or a full 40 character git commit hash, or a release channel name.
+Pass a semver version, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
 Latest

--- a/tests/specs/upgrade/invalid_version/shorthand.out
+++ b/tests/specs/upgrade/invalid_version/shorthand.out
@@ -1,6 +1,6 @@
 error: Invalid version passed (asdfasdf)
 
-Pass a semver, or a full 40 character git commit hash, or a release channel name.
+Pass a semver version, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
 Latest

--- a/tests/specs/upgrade/invalid_version/shorthand.out
+++ b/tests/specs/upgrade/invalid_version/shorthand.out
@@ -1,0 +1,10 @@
+error: Invalid version passed (asdfasdf)
+
+Pass a semver, or a full 40 character git commit hash, or a release channel name.
+
+Example usage:
+  Latest version:    deno upgrade
+  Specific version:  deno upgrade 1.46.3
+  Release Candidate: deno upgrade rc
+  Canary:            deno upgrade canary
+  Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f

--- a/tests/specs/upgrade/invalid_version/shorthand.out
+++ b/tests/specs/upgrade/invalid_version/shorthand.out
@@ -2,9 +2,11 @@ error: Invalid version passed (asdfasdf)
 
 Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
-Example usage:
+Usage:
   Latest version:    deno upgrade
   Specific version:  deno upgrade 1.46.3
-  Release Candidate: deno upgrade rc
+
+  Release candidate: deno upgrade rc
+
   Canary:            deno upgrade canary
   Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f

--- a/tests/specs/upgrade/invalid_version/shorthand.out
+++ b/tests/specs/upgrade/invalid_version/shorthand.out
@@ -1,6 +1,6 @@
 error: Invalid version passed (asdfasdf)
 
-Pass a semver version, or a full 40 character git commit hash, or a release channel name.
+Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
 Latest

--- a/tests/specs/upgrade/invalid_version/shorthand.out
+++ b/tests/specs/upgrade/invalid_version/shorthand.out
@@ -3,10 +3,15 @@ error: Invalid version passed (asdfasdf)
 Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
-  Latest version:    deno upgrade
-  Specific version:  deno upgrade 1.46.3
+Latest
+  deno upgrade
 
-  Release candidate: deno upgrade rc
+Specific version
+  deno upgrade 1.45.0
+  deno upgrade 1.46.0-rc.1
+  deno upgrade 9bc2dd29ad6ba334fd57a20114e367d3c04763d4
 
-  Canary:            deno upgrade canary
-  Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f
+Channel
+  deno upgrade stable
+  deno upgrade rc
+  deno upgrade canary

--- a/tests/specs/upgrade/invalid_version/version.out
+++ b/tests/specs/upgrade/invalid_version/version.out
@@ -1,6 +1,6 @@
 error: Invalid version passed (asdfasdf)
 
-Pass a semver, or a full 40 character git commit hash, or a release channel name.
+Pass a semver version, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
 Latest

--- a/tests/specs/upgrade/invalid_version/version.out
+++ b/tests/specs/upgrade/invalid_version/version.out
@@ -1,0 +1,10 @@
+error: Invalid version passed (asdfasdf)
+
+Pass a semver, or a full 40 character git commit hash, or a release channel name.
+
+Example usage:
+  Latest version:    deno upgrade
+  Specific version:  deno upgrade 1.46.3
+  Release Candidate: deno upgrade rc
+  Canary:            deno upgrade canary
+  Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f

--- a/tests/specs/upgrade/invalid_version/version.out
+++ b/tests/specs/upgrade/invalid_version/version.out
@@ -2,9 +2,11 @@ error: Invalid version passed (asdfasdf)
 
 Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
-Example usage:
+Usage:
   Latest version:    deno upgrade
   Specific version:  deno upgrade 1.46.3
-  Release Candidate: deno upgrade rc
+
+  Release candidate: deno upgrade rc
+
   Canary:            deno upgrade canary
   Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f

--- a/tests/specs/upgrade/invalid_version/version.out
+++ b/tests/specs/upgrade/invalid_version/version.out
@@ -1,6 +1,6 @@
 error: Invalid version passed (asdfasdf)
 
-Pass a semver version, or a full 40 character git commit hash, or a release channel name.
+Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
 Latest

--- a/tests/specs/upgrade/invalid_version/version.out
+++ b/tests/specs/upgrade/invalid_version/version.out
@@ -3,10 +3,15 @@ error: Invalid version passed (asdfasdf)
 Pass a semver, or a full 40 character git commit hash, or a release channel name.
 
 Usage:
-  Latest version:    deno upgrade
-  Specific version:  deno upgrade 1.46.3
+Latest
+  deno upgrade
 
-  Release candidate: deno upgrade rc
+Specific version
+  deno upgrade 1.45.0
+  deno upgrade 1.46.0-rc.1
+  deno upgrade 9bc2dd29ad6ba334fd57a20114e367d3c04763d4
 
-  Canary:            deno upgrade canary
-  Specific canary:   deno upgrade 30687c786c37090ac0e4e2c3824b1b5cf313599f
+Channel
+  deno upgrade stable
+  deno upgrade rc
+  deno upgrade canary


### PR DESCRIPTION
When passing a wrong version here's the new message:

![Screenshot 2024-09-07 at 14 18 12](https://github.com/user-attachments/assets/56c49407-aec0-4fe2-a163-2956562fbc41)


Ideas for better coloring are welcome