### PR TITLE
feat: Add better error messages for unstable APIs

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -352,35 +352,35 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
       ];
     } else if msg.contains("openKv is not a function") {
       return vec![
-        FixSuggestion::info("Deno.openKv() is an unstable API"),
+        FixSuggestion::info("Deno.openKv() is an unstable API."),
         FixSuggestion::hint(
           "Run again with `--unstable-kv` flag to enable this API.",
         ),
       ];
     } else if msg.contains("cron is not a function") {
       return vec![
-        FixSuggestion::info("Deno.cron() is an unstable API"),
+        FixSuggestion::info("Deno.cron() is an unstable API."),
         FixSuggestion::hint(
           "Run again with `--unstable-cron` flag to enable this API.",
         ),
       ];
     } else if msg.contains("createHttpClient is not a function") {
       return vec![
-        FixSuggestion::info("Deno.createHttpClient() is an unstable API"),
+        FixSuggestion::info("Deno.createHttpClient() is an unstable API."),
         FixSuggestion::hint(
           "Run again with `--unstable-http` flag to enable this API.",
         ),
       ];
     } else if msg.contains("Temporal is not defined") {
       return vec![
-        FixSuggestion::info("Temporal is an unstable API"),
+        FixSuggestion::info("Temporal is an unstable API."),
         FixSuggestion::hint(
           "Run again with `--unstable-temporal` flag to enable this API.",
         ),
       ];
     } else if msg.contains("BroadcastChannel is not defined") {
       return vec![
-        FixSuggestion::info("BroadcastChannel is an unstable API"),
+        FixSuggestion::info("BroadcastChannel is an unstable API."),
         FixSuggestion::hint(
           "Run again with `--unstable-broadcast-channel` flag to enable this API.",
         ),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -371,6 +371,13 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
           "Run again with `--unstable-http` flag to enable this API.",
         ),
       ];
+    } else if msg.contains("WebSocketStream is not defined") {
+      return vec![
+        FixSuggestion::info("new WebSocketStream() is an unstable API."),
+        FixSuggestion::hint(
+          "Run again with `--unstable-http` flag to enable this API.",
+        ),
+      ];
     } else if msg.contains("Temporal is not defined") {
       return vec![
         FixSuggestion::info("Temporal is an unstable API."),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -337,17 +337,54 @@ fn exit_with_message(message: &str, code: i32) -> ! {
   std::process::exit(code);
 }
 
-fn get_suggestions_for_commonjs_error(e: &JsError) -> Vec<FixSuggestion> {
-  if e.name.as_deref() == Some("ReferenceError") {
-    if let Some(msg) = &e.message {
-      if msg.contains("module is not defined")
-        || msg.contains("exports is not defined")
-      {
-        return vec![
-          FixSuggestion::info("Deno does not support CommonJS modules without `.cjs` extension."),
-          FixSuggestion::hint("Rewrite this module to ESM or change the file extension to `.cjs`."),
-        ];
-      }
+fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
+  if let Some(msg) = &e.message {
+    if msg.contains("module is not defined")
+      || msg.contains("exports is not defined")
+    {
+      return vec![
+        FixSuggestion::info(
+          "Deno does not support CommonJS modules without `.cjs` extension.",
+        ),
+        FixSuggestion::hint(
+          "Rewrite this module to ESM or change the file extension to `.cjs`.",
+        ),
+      ];
+    } else if msg.contains("openKv is not a function") {
+      return vec![
+        FixSuggestion::info("Deno.openKv() is an unstable API"),
+        FixSuggestion::hint(
+          "Run again with `--unstable-kv` flag to enable this API.",
+        ),
+      ];
+    } else if msg.contains("cron is not a function") {
+      return vec![
+        FixSuggestion::info("Deno.cron() is an unstable API"),
+        FixSuggestion::hint(
+          "Run again with `--unstable-cron` flag to enable this API.",
+        ),
+      ];
+    } else if msg.contains("createHttpClient is not a function") {
+      return vec![
+        FixSuggestion::info("Deno.createHttpClient() is an unstable API"),
+        FixSuggestion::hint(
+          "Run again with `--unstable-http` flag to enable this API.",
+        ),
+      ];
+    } else if msg.contains("Temporal is not defined") {
+      return vec![
+        FixSuggestion::info("Temporal is an unstable API"),
+        FixSuggestion::hint(
+          "Run again with `--unstable-temporal` flag to enable this API.",
+        ),
+      ];
+    } else if msg.contains("BroadcastChannel is not defined") {
+      return vec![
+        FixSuggestion::info("BroadcastChannel is an unstable API"),
+        FixSuggestion::hint(
+          "Run again with `--unstable-broadcast-channel` flag to enable this API.",
+        ),
+      ];
     }
   }
 
@@ -359,7 +396,7 @@ fn exit_for_error(error: AnyError) -> ! {
   let mut error_code = 1;
 
   if let Some(e) = error.downcast_ref::<JsError>() {
-    let suggestions = get_suggestions_for_commonjs_error(e);
+    let suggestions = get_suggestions_for_terminal_errors(e);
     error_string = format_js_error_with_suggestions(e, suggestions);
   } else if let Some(SnapshotFromLockfileError::IntegrityCheckFailed(e)) =
     error.downcast_ref::<SnapshotFromLockfileError>()

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -375,7 +375,7 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
       return vec![
         FixSuggestion::info("new WebSocketStream() is an unstable API."),
         FixSuggestion::hint(
-          "Run again with `--unstable-http` flag to enable this API.",
+          "Run again with `--unstable-net` flag to enable this API.",
         ),
       ];
     } else if msg.contains("Temporal is not defined") {

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -4811,13 +4811,6 @@ itest!(unstable_temporal_api_config_file {
   exit_code: 0,
 });
 
-itest!(unstable_temporal_api_missing_flag {
-  args: "run --no-config run/unstable_temporal_api/missing_flag.js",
-  output: "run/unstable_temporal_api/missing_flag.out",
-  http_server: false,
-  exit_code: 1,
-});
-
 // TODO(bartlomieju): temporary disabled
 // itest!(warn_on_deprecated_api {
 //   args: "run -A run/warn_on_deprecated_api/main.js",

--- a/tests/specs/run/unstable/__test__.jsonc
+++ b/tests/specs/run/unstable/__test__.jsonc
@@ -15,6 +15,11 @@
       "exitCode": 1,
       "output": "http.out"
     },
+    "http_wss": {
+      "args": "run http_wss.ts",
+      "exitCode": 1,
+      "output": "http_wss.out"
+    },
     "kv": {
       "args": "run kv.ts",
       "exitCode": 1,

--- a/tests/specs/run/unstable/__test__.jsonc
+++ b/tests/specs/run/unstable/__test__.jsonc
@@ -1,0 +1,29 @@
+{
+  "tests": {
+    "broadcast_channel": {
+      "args": "run broadcast_channel.ts",
+      "exitCode": 1,
+      "output": "broadcast_channel.out"
+    },
+    "cron": {
+      "args": "run cron.ts",
+      "exitCode": 1,
+      "output": "cron.out"
+    },
+    "http": {
+      "args": "run http.ts",
+      "exitCode": 1,
+      "output": "http.out"
+    },
+    "kv": {
+      "args": "run kv.ts",
+      "exitCode": 1,
+      "output": "kv.out"
+    },
+    "temporal": {
+      "args": "run temporal.ts",
+      "exitCode": 1,
+      "output": "temporal.out"
+    }
+  }
+}

--- a/tests/specs/run/unstable/broadcast_channel.out
+++ b/tests/specs/run/unstable/broadcast_channel.out
@@ -1,7 +1,7 @@
 error: Uncaught (in promise) ReferenceError: BroadcastChannel is not defined
 new BroadcastChannel("hello");
 ^
-    at file:///Users/ib/dev/deno/tests/specs/run/unstable/broadcast_channel.ts:1:1
+    at [WILDCARD]broadcast_channel.ts:1:1
 
     info: BroadcastChannel is an unstable API.
     hint: Run again with `--unstable-broadcast-channel` flag to enable this API.

--- a/tests/specs/run/unstable/broadcast_channel.out
+++ b/tests/specs/run/unstable/broadcast_channel.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) ReferenceError: BroadcastChannel is not defined
+new BroadcastChannel("hello");
+^
+    at file:///Users/ib/dev/deno/tests/specs/run/unstable/broadcast_channel.ts:1:1
+
+    info: BroadcastChannel is an unstable API
+    hint: Run again with `--unstable-broadcast-channel` flag to enable this API.

--- a/tests/specs/run/unstable/broadcast_channel.out
+++ b/tests/specs/run/unstable/broadcast_channel.out
@@ -3,5 +3,5 @@ new BroadcastChannel("hello");
 ^
     at file:///Users/ib/dev/deno/tests/specs/run/unstable/broadcast_channel.ts:1:1
 
-    info: BroadcastChannel is an unstable API
+    info: BroadcastChannel is an unstable API.
     hint: Run again with `--unstable-broadcast-channel` flag to enable this API.

--- a/tests/specs/run/unstable/broadcast_channel.ts
+++ b/tests/specs/run/unstable/broadcast_channel.ts
@@ -1,0 +1,1 @@
+new BroadcastChannel("hello");

--- a/tests/specs/run/unstable/cron.out
+++ b/tests/specs/run/unstable/cron.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) TypeError: Deno.cron is not a function
+Deno.cron();
+     ^
+    at file:///Users/ib/dev/deno/tests/specs/run/unstable/cron.ts:1:6
+
+    info: Deno.cron() is an unstable API
+    hint: Run again with `--unstable-cron` flag to enable this API.

--- a/tests/specs/run/unstable/cron.out
+++ b/tests/specs/run/unstable/cron.out
@@ -3,5 +3,5 @@ Deno.cron();
      ^
     at file:///Users/ib/dev/deno/tests/specs/run/unstable/cron.ts:1:6
 
-    info: Deno.cron() is an unstable API
+    info: Deno.cron() is an unstable API.
     hint: Run again with `--unstable-cron` flag to enable this API.

--- a/tests/specs/run/unstable/cron.out
+++ b/tests/specs/run/unstable/cron.out
@@ -1,7 +1,7 @@
 error: Uncaught (in promise) TypeError: Deno.cron is not a function
 Deno.cron();
      ^
-    at file:///Users/ib/dev/deno/tests/specs/run/unstable/cron.ts:1:6
+    at [WILDCARD]cron.ts:1:6
 
     info: Deno.cron() is an unstable API.
     hint: Run again with `--unstable-cron` flag to enable this API.

--- a/tests/specs/run/unstable/cron.ts
+++ b/tests/specs/run/unstable/cron.ts
@@ -1,0 +1,1 @@
+Deno.cron();

--- a/tests/specs/run/unstable/http.out
+++ b/tests/specs/run/unstable/http.out
@@ -3,5 +3,5 @@ Deno.createHttpClient();
      ^
     at file:///Users/ib/dev/deno/tests/specs/run/unstable/http.ts:1:6
 
-    info: Deno.createHttpClient() is an unstable API
+    info: Deno.createHttpClient() is an unstable API.
     hint: Run again with `--unstable-http` flag to enable this API.

--- a/tests/specs/run/unstable/http.out
+++ b/tests/specs/run/unstable/http.out
@@ -1,7 +1,7 @@
 error: Uncaught (in promise) TypeError: Deno.createHttpClient is not a function
 Deno.createHttpClient();
      ^
-    at file:///Users/ib/dev/deno/tests/specs/run/unstable/http.ts:1:6
+    at [WILDCARD]http.ts:1:6
 
     info: Deno.createHttpClient() is an unstable API.
     hint: Run again with `--unstable-http` flag to enable this API.

--- a/tests/specs/run/unstable/http.out
+++ b/tests/specs/run/unstable/http.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) TypeError: Deno.createHttpClient is not a function
+Deno.createHttpClient();
+     ^
+    at file:///Users/ib/dev/deno/tests/specs/run/unstable/http.ts:1:6
+
+    info: Deno.createHttpClient() is an unstable API
+    hint: Run again with `--unstable-http` flag to enable this API.

--- a/tests/specs/run/unstable/http.ts
+++ b/tests/specs/run/unstable/http.ts
@@ -1,0 +1,1 @@
+Deno.createHttpClient();

--- a/tests/specs/run/unstable/http_wss.out
+++ b/tests/specs/run/unstable/http_wss.out
@@ -4,4 +4,4 @@ const wss = new WebSocketStream("ws://127.0.0.1:4513");
     at [WILDCARD]http_wss.ts:1:13
 
     info: new WebSocketStream() is an unstable API.
-    hint: Run again with `--unstable-http` flag to enable this API.
+    hint: Run again with `--unstable-net` flag to enable this API.

--- a/tests/specs/run/unstable/http_wss.out
+++ b/tests/specs/run/unstable/http_wss.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) ReferenceError: WebSocketStream is not defined
+const wss = new WebSocketStream("ws://127.0.0.1:4513");
+            ^
+    at [WILDCARD]http_wss.ts:1:13
+
+    info: new WebSocketStream() is an unstable API.
+    hint: Run again with `--unstable-http` flag to enable this API.

--- a/tests/specs/run/unstable/http_wss.ts
+++ b/tests/specs/run/unstable/http_wss.ts
@@ -1,0 +1,1 @@
+const wss = new WebSocketStream("ws://127.0.0.1:4513");

--- a/tests/specs/run/unstable/kv.out
+++ b/tests/specs/run/unstable/kv.out
@@ -3,5 +3,5 @@ const db = await Deno.openKv();
                       ^
     at file:///Users/ib/dev/deno/tests/specs/run/unstable/kv.ts:1:23
 
-    info: Deno.openKv() is an unstable API
+    info: Deno.openKv() is an unstable API.
     hint: Run again with `--unstable-kv` flag to enable this API.

--- a/tests/specs/run/unstable/kv.out
+++ b/tests/specs/run/unstable/kv.out
@@ -1,7 +1,7 @@
 error: Uncaught (in promise) TypeError: Deno.openKv is not a function
 const db = await Deno.openKv();
                       ^
-    at file:///Users/ib/dev/deno/tests/specs/run/unstable/kv.ts:1:23
+    at [WILDCARD]kv.ts:1:23
 
     info: Deno.openKv() is an unstable API.
     hint: Run again with `--unstable-kv` flag to enable this API.

--- a/tests/specs/run/unstable/kv.out
+++ b/tests/specs/run/unstable/kv.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) TypeError: Deno.openKv is not a function
+const db = await Deno.openKv();
+                      ^
+    at file:///Users/ib/dev/deno/tests/specs/run/unstable/kv.ts:1:23
+
+    info: Deno.openKv() is an unstable API
+    hint: Run again with `--unstable-kv` flag to enable this API.

--- a/tests/specs/run/unstable/kv.ts
+++ b/tests/specs/run/unstable/kv.ts
@@ -1,0 +1,1 @@
+const db = await Deno.openKv();

--- a/tests/specs/run/unstable/temporal.out
+++ b/tests/specs/run/unstable/temporal.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) ReferenceError: Temporal is not defined
+Temporal.Now.instant();
+^
+    at file:///Users/ib/dev/deno/tests/specs/run/unstable/temporal.ts:1:1
+
+    info: Temporal is an unstable API
+    hint: Run again with `--unstable-temporal` flag to enable this API.

--- a/tests/specs/run/unstable/temporal.out
+++ b/tests/specs/run/unstable/temporal.out
@@ -3,5 +3,5 @@ Temporal.Now.instant();
 ^
     at file:///Users/ib/dev/deno/tests/specs/run/unstable/temporal.ts:1:1
 
-    info: Temporal is an unstable API
+    info: Temporal is an unstable API.
     hint: Run again with `--unstable-temporal` flag to enable this API.

--- a/tests/specs/run/unstable/temporal.out
+++ b/tests/specs/run/unstable/temporal.out
@@ -1,7 +1,7 @@
 error: Uncaught (in promise) ReferenceError: Temporal is not defined
 Temporal.Now.instant();
 ^
-    at file:///Users/ib/dev/deno/tests/specs/run/unstable/temporal.ts:1:1
+    at [WILDCARD]temporal.ts:1:1
 
     info: Temporal is an unstable API.
     hint: Run again with `--unstable-temporal` flag to enable this API.

--- a/tests/specs/run/unstable/temporal.ts
+++ b/tests/specs/run/unstable/temporal.ts
@@ -1,0 +1,1 @@
+Temporal.Now.instant();

--- a/tests/testdata/run/unstable_temporal_api/missing_flag.js
+++ b/tests/testdata/run/unstable_temporal_api/missing_flag.js
@@ -1,1 +1,0 @@
-Temporal.Now.instant();

--- a/tests/testdata/run/unstable_temporal_api/missing_flag.out
+++ b/tests/testdata/run/unstable_temporal_api/missing_flag.out
@@ -1,4 +1,0 @@
-error: Uncaught (in promise) ReferenceError: Temporal is not defined
-Temporal.Now.instant();
-^
-    at [WILDCARD]missing_flag.js:1:1

--- a/tools/lint.js
+++ b/tools/lint.js
@@ -220,7 +220,7 @@ async function ensureNoNewITests() {
     "pm_tests.rs": 0,
     "publish_tests.rs": 0,
     "repl_tests.rs": 0,
-    "run_tests.rs": 348,
+    "run_tests.rs": 347,
     "shared_library_tests.rs": 0,
     "task_tests.rs": 30,
     "test_tests.rs": 75,


### PR DESCRIPTION
This commit improves error messages for unstable APIs:
- `--unstable-broadcast-channel`
- `--unstable-cron`
- `--unstable-http`
- `--unstable-kv`
- `--unstable-temporal`

By providing information and hints what went wrong and how the
error can be fixed. It reuses the same infra that was added in 
https://github.com/denoland/deno/pull/21764.