### PR TITLE
build: remove --unstable flags from CI

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -649,7 +649,7 @@ const ci = {
           name: "test_format.js",
           if: "matrix.job == 'lint' && matrix.os == 'linux'",
           run:
-            "deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check",
+            "deno run --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check",
         },
         {
           name: "Lint PR title",
@@ -664,7 +664,7 @@ const ci = {
           name: "lint.js",
           if: "matrix.job == 'lint'",
           run:
-            "deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/lint.js",
+            "deno run --allow-write --allow-read --allow-run --allow-net ./tools/lint.js",
         },
         {
           name: "jsdoc_checker.js",
@@ -826,7 +826,7 @@ const ci = {
             "!startsWith(github.ref, 'refs/tags/')",
           ].join("\n"),
           run:
-            "target/release/deno run -A --unstable --config tests/config/deno.json ext/websocket/autobahn/fuzzingclient.js",
+            "target/release/deno run -A --config tests/config/deno.json ext/websocket/autobahn/fuzzingclient.js",
         },
         {
           name: "Test (full, debug)",
@@ -879,9 +879,9 @@ const ci = {
             DENO_BIN: "./target/debug/deno",
           },
           run: [
-            "deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\\",
+            "deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\\",
             "        ./tests/wpt/wpt.ts setup",
-            "deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\\",
+            "deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\\",
             '         ./tests/wpt/wpt.ts run --quiet --binary="$DENO_BIN"',
           ].join("\n"),
         },
@@ -892,9 +892,9 @@ const ci = {
             DENO_BIN: "./target/release/deno",
           },
           run: [
-            "deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\\",
+            "deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\\",
             "         ./tests/wpt/wpt.ts setup",
-            "deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\\",
+            "deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\\",
             "         ./tests/wpt/wpt.ts run --quiet --release         \\",
             '                            --binary="$DENO_BIN"          \\',
             "                            --json=wpt.json               \\",
@@ -958,8 +958,7 @@ const ci = {
             "git clone --depth 1 --branch gh-pages                             \\",
             "    https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git \\",
             "    gh-pages",
-            "./target/release/deno run --allow-all --unstable \\",
-            "    ./tools/build_benchmark_jsons.js --release",
+            "./target/release/deno run --allow-all ./tools/build_benchmark_jsons.js --release",
             "cd gh-pages",
             'git config user.email "propelml@gmail.com"',
             'git config user.name "denobot"',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
           cache-path: ./target
       - name: test_format.js
         if: '!(matrix.skip) && (matrix.job == ''lint'' && matrix.os == ''linux'')'
-        run: deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check
+        run: deno run --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check
       - name: Lint PR title
         if: '!(matrix.skip) && (matrix.job == ''lint'' && github.event_name == ''pull_request'' && matrix.os == ''linux'')'
         env:
@@ -397,7 +397,7 @@ jobs:
         run: deno run ./tools/verify_pr_title.js "$PR_TITLE"
       - name: lint.js
         if: '!(matrix.skip) && (matrix.job == ''lint'')'
-        run: deno run --unstable --allow-write --allow-read --allow-run --allow-net ./tools/lint.js
+        run: deno run --allow-write --allow-read --allow-run --allow-net ./tools/lint.js
       - name: jsdoc_checker.js
         if: '!(matrix.skip) && (matrix.job == ''lint'')'
         run: deno run --allow-read --allow-env --allow-sys ./tools/jsdoc_checker.js
@@ -494,7 +494,7 @@ jobs:
           matrix.job == 'test' &&
           matrix.profile == 'release' &&
           !startsWith(github.ref, 'refs/tags/'))
-        run: target/release/deno run -A --unstable --config tests/config/deno.json ext/websocket/autobahn/fuzzingclient.js
+        run: target/release/deno run -A --config tests/config/deno.json ext/websocket/autobahn/fuzzingclient.js
       - name: 'Test (full, debug)'
         if: |-
           !(matrix.skip) && (matrix.job == 'test' &&
@@ -531,18 +531,18 @@ jobs:
         env:
           DENO_BIN: ./target/debug/deno
         run: |-
-          deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\
+          deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\
                   ./tests/wpt/wpt.ts setup
-          deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\
+          deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\
                    ./tests/wpt/wpt.ts run --quiet --binary="$DENO_BIN"
       - name: Run web platform tests (release)
         if: '!(matrix.skip) && (matrix.wpt && matrix.profile == ''release'')'
         env:
           DENO_BIN: ./target/release/deno
         run: |-
-          deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\
+          deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\
                    ./tests/wpt/wpt.ts setup
-          deno run -A --unstable --lock=tools/deno.lock.json --config tests/config/deno.json\
+          deno run -A --lock=tools/deno.lock.json --config tests/config/deno.json\
                    ./tests/wpt/wpt.ts run --quiet --release         \
                                       --binary="$DENO_BIN"          \
                                       --json=wpt.json               \
@@ -590,8 +590,7 @@ jobs:
           git clone --depth 1 --branch gh-pages                             \
               https://${DENOBOT_PAT}@github.com/denoland/benchmark_data.git \
               gh-pages
-          ./target/release/deno run --allow-all --unstable \
-              ./tools/build_benchmark_jsons.js --release
+          ./target/release/deno run --allow-all ./tools/build_benchmark_jsons.js --release
           cd gh-pages
           git config user.email "propelml@gmail.com"
           git config user.name "denobot"

--- a/.github/workflows/wpt_epoch.yml
+++ b/.github/workflows/wpt_epoch.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Run web platform tests
         shell: bash
         run: |
-          deno run --unstable -A --lock=tools/deno.lock.json --config=tests/config/deno.json \
+          deno run -A --lock=tools/deno.lock.json --config=tests/config/deno.json \
             ./tests/wpt/wpt.ts setup
-          deno run --unstable -A --lock=tools/deno.lock.json --config=tests/config/deno.json \
+          deno run -A --lock=tools/deno.lock.json --config=tests/config/deno.json \
             ./tests/wpt/wpt.ts run                                             \                                                \
             --binary=$(which deno) --quiet --release --no-ignore --json=wpt.json --wptreport=wptreport.json --exit-zero
 

--- a/ext/websocket/autobahn/fuzzingclient.js
+++ b/ext/websocket/autobahn/fuzzingclient.js
@@ -11,7 +11,7 @@ const AUTOBAHN_TESTSUITE_DOCKER =
   "crossbario/autobahn-testsuite:0.8.2@sha256:5d4ba3aa7d6ab2fdbf6606f3f4ecbe4b66f205ce1cbc176d6cdf650157e52242";
 
 const self = Deno.execPath();
-$`${self} run -A --unstable --config ${pwd}/../../../tests/config/deno.json ${pwd}/autobahn_server.js`
+$`${self} run -A --config ${pwd}/../../../tests/config/deno.json ${pwd}/autobahn_server.js`
   .spawn();
 
 for (let i = 0; i < 6; i++) {


### PR DESCRIPTION
This commit removes usages of deprecated `--unstable` flag
from the CI scripts.