### PR TITLE
fix(ext/node): avoid showing `UNKNOWN` error from TCP handle

### DIFF
--- a/ext/node/polyfills/internal_binding/stream_wrap.ts
+++ b/ext/node/polyfills/internal_binding/stream_wrap.ts
@@ -345,7 +345,7 @@ export class LibuvStreamWrap extends HandleWrap {
         nread = codeMap.get("ECONNRESET")!;
       } else {
         this[ownerSymbol].destroy(e);
-        return
+        return;
       }
     }
 

--- a/ext/node/polyfills/internal_binding/stream_wrap.ts
+++ b/ext/node/polyfills/internal_binding/stream_wrap.ts
@@ -38,6 +38,7 @@ import { TextEncoder } from "ext:deno_web/08_text_encoding.js";
 import { Buffer } from "node:buffer";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { HandleWrap } from "ext:deno_node/internal_binding/handle_wrap.ts";
+import { ownerSymbol } from "ext:deno_node/internal/async_hooks.ts";
 import {
   AsyncWrap,
   providerType,
@@ -343,7 +344,8 @@ export class LibuvStreamWrap extends HandleWrap {
       ) {
         nread = codeMap.get("ECONNRESET")!;
       } else {
-        nread = codeMap.get("UNKNOWN")!;
+        this[ownerSymbol].destroy(e);
+        return
       }
     }
 

--- a/tests/unit/test_util.ts
+++ b/tests/unit/test_util.ts
@@ -34,7 +34,7 @@ export function pathToAbsoluteFileUrl(path: string): URL {
   return new URL(`file://${Deno.build.os === "windows" ? "/" : ""}${path}`);
 }
 
-export function execCode(code: string): Promise<readonly [status: number, output: string]> {
+export function execCode(code: string): Promise<readonly [number, string]> {
   return execCode2(code).finished();
 }
 

--- a/tests/unit/test_util.ts
+++ b/tests/unit/test_util.ts
@@ -34,7 +34,7 @@ export function pathToAbsoluteFileUrl(path: string): URL {
   return new URL(`file://${Deno.build.os === "windows" ? "/" : ""}${path}`);
 }
 
-export function execCode(code: string): Promise<readonly [number, string]> {
+export function execCode(code: string): Promise<readonly [status: number, output: string]> {
   return execCode2(code).finished();
 }
 

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -1,11 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertInstanceOf } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertInstanceOf } from "@std/assert";
 import { delay } from "@std/async/delay";
 import { fromFileUrl, join } from "@std/path";
 import * as tls from "node:tls";
 import * as net from "node:net";
 import * as stream from "node:stream";
+import { execCode } from "../unit/test_util.ts";
 
 const tlsTestdataDir = fromFileUrl(
   new URL("../testdata/tls", import.meta.url),
@@ -190,4 +191,22 @@ Deno.test("tlssocket._handle._parentWrap is set", () => {
       ._handle as any)!
       ._parentWrap;
   assertInstanceOf(parentWrap, stream.PassThrough);
+});
+
+Deno.test("tls.connect() throws InvalidData when there's error in certificate", async () => {
+  // Uses execCode to avoid `--unsafely-ignore-certificate-errors` option applied
+  const [status, output] = await execCode(`
+    import tls from "node:tls";
+    const conn = tls.connect({
+      host: "localhost",
+      port: 4557,
+    });
+
+    conn.on("error", (err) => {
+      console.log(err);
+    });
+  `);
+
+  assertEquals(status, 0);
+  assertStringIncludes(output, "InvalidData: invalid peer certificate: UnknownIssuer");
 });

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertStringIncludes, assertInstanceOf } from "@std/assert";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+} from "@std/assert";
 import { delay } from "@std/async/delay";
 import { fromFileUrl, join } from "@std/path";
 import * as tls from "node:tls";
@@ -208,5 +212,8 @@ Deno.test("tls.connect() throws InvalidData when there's error in certificate", 
   `);
 
   assertEquals(status, 0);
-  assertStringIncludes(output, "InvalidData: invalid peer certificate: UnknownIssuer");
+  assertStringIncludes(
+    output,
+    "InvalidData: invalid peer certificate: UnknownIssuer",
+  );
 });


### PR DESCRIPTION
This PR destroys Node.js stream with Deno's original error instead of `UNKNOWN` error from handle object.

In `ext/node/polyfills/internal_binding/stream_wrap.ts`, we try to simulate the system call error when reading from the internal `Deno.Conn`, however when it's used with `tls.connect` and the thrown error is a cert error (like `InvalidData: invalid peer certificate: UnknownIssuer`), then that error can't be mapped using [this list of errors](https://github.com/denoland/deno/blob/c4d088863e93b70fa0729f326ad14376ca90b0a6/ext/node/polyfills/internal_binding/uv.ts) and it becomes `UNKNOWN` error.

This PR stops that mapping to UNKNOWN error (because it just obscures the actual reason and leads to the confusion like #20293), and instead destroys the stream with the Deno's original error (This is not ideal for the compatibility, but at least it's better than obscuring the error reason with 'UNKNOWN' error in my view).

related #20293