### PR TITLE
fix: update malva in deno to support astro css comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "malva"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e9f16e424a6672f6726daf965333952dece79ef3d17aac712b92b3b72d0a8"
+checksum = "484beda6e5d775ed06a8ec0fce79e51d39f49d834ed2a29da3f437079321804f"
 dependencies = [
  "aho-corasick",
  "itertools 0.13.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -123,7 +123,7 @@ libc.workspace = true
 libz-sys.workspace = true
 log = { workspace = true, features = ["serde"] }
 lsp-types.workspace = true
-malva = "=0.9.0"
+malva = "=0.10.1"
 markup_fmt = "=0.12.0"
 memmem.workspace = true
 monch.workspace = true

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -907,6 +907,7 @@ fn get_resolved_malva_config(
   };
 
   let language_options = LanguageOptions {
+    align_comments: true,
     hex_case: HexCase::Lower,
     hex_color_length: None,
     quotes: if let Some(true) = options.single_quote {

--- a/tests/specs/fmt/astro_file_with_css_comment/__test__.jsonc
+++ b/tests/specs/fmt/astro_file_with_css_comment/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "fmt --unstable-component",
+  "output": "fmt.out"
+}

--- a/tests/specs/fmt/astro_file_with_css_comment/fmt.out
+++ b/tests/specs/fmt/astro_file_with_css_comment/fmt.out
@@ -1,0 +1,2 @@
+[WILDCARD]\main.astro
+Checked 1 file

--- a/tests/specs/fmt/astro_file_with_css_comment/main.astro
+++ b/tests/specs/fmt/astro_file_with_css_comment/main.astro
@@ -1,0 +1,8 @@
+<style>
+  /* 
+      CSS 
+  */
+    body {
+        font-family: 'Arial', sans-serif;
+    }
+</style>


### PR DESCRIPTION
This PR addresses issue #25534 

**Code Changes**
- Updated malva version to the latest in cli/Cargo.toml.
- Updated LanguageOptions to match new Malva config.
- Added test case same as the issue to assure changes success.