### PR TITLE
fix(ext/node): Add missing `node:path` exports

### DIFF
--- a/ext/node/polyfills/path/_posix.ts
+++ b/ext/node/polyfills/path/_posix.ts
@@ -478,6 +478,9 @@ export function parse(path: string): ParsedPath {
 
   return ret;
 }
+
+export const _makeLong = toNamespacedPath;
+
 export default {
   basename,
   delimiter,
@@ -492,4 +495,5 @@ export default {
   resolve,
   sep,
   toNamespacedPath,
+  _makeLong,
 };

--- a/ext/node/polyfills/path/_win32.ts
+++ b/ext/node/polyfills/path/_win32.ts
@@ -953,6 +953,8 @@ export function parse(path: string): ParsedPath {
   return ret;
 }
 
+export const _makeLong = toNamespacedPath;
+
 export default {
   basename,
   delimiter,
@@ -967,4 +969,5 @@ export default {
   resolve,
   sep,
   toNamespacedPath,
+  _makeLong,
 };

--- a/ext/node/polyfills/path/mod.ts
+++ b/ext/node/polyfills/path/mod.ts
@@ -36,6 +36,7 @@ export const {
   resolve,
   sep,
   toNamespacedPath,
+  _makeLong,
 } = path;
 export default path;
 export * from "ext:deno_node/path/common.ts";

--- a/ext/node/polyfills/path/posix.ts
+++ b/ext/node/polyfills/path/posix.ts
@@ -18,6 +18,9 @@ export const {
   resolve,
   sep,
   toNamespacedPath,
+  _makeLong,
 } = path.posix;
 
+export const posix = path.posix;
+export const win32 = path.win32;
 export default path.posix;

--- a/ext/node/polyfills/path/win32.ts
+++ b/ext/node/polyfills/path/win32.ts
@@ -18,6 +18,9 @@ export const {
   resolve,
   sep,
   toNamespacedPath,
+  _makeLong,
 } = path.win32;
 
+export const posix = path.posix;
+export const win32 = path.win32;
 export default path.win32;


### PR DESCRIPTION
Apparently `path/posix` and `path/win32` have circular exports. I do not know why.

Additionally there's a deprecated function `_makeLong` which is just `toNamespacedPath`