### PR TITLE
fix(ext/node): fix `Cipheriv#update(string, undefined)`

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -242,7 +242,7 @@ export class Cipheriv extends Transform implements Cipher {
   ): Buffer | string {
     // TODO(kt3k): throw ERR_INVALID_ARG_TYPE if data is not string, Buffer, or ArrayBufferView
     let buf = data;
-    if (typeof data === "string" && typeof inputEncoding === "string") {
+    if (typeof data === "string") {
       buf = Buffer.from(data, inputEncoding);
     }
 
@@ -396,7 +396,7 @@ export class Decipheriv extends Transform implements Cipher {
   ): Buffer | string {
     // TODO(kt3k): throw ERR_INVALID_ARG_TYPE if data is not string, Buffer, or ArrayBufferView
     let buf = data;
-    if (typeof data === "string" && typeof inputEncoding === "string") {
+    if (typeof data === "string") {
       buf = Buffer.from(data, inputEncoding);
     }
 

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -139,16 +139,32 @@ Deno.test({
 Deno.test({
   name: "createCipheriv - input encoding",
   fn() {
-    const cipher = crypto.createCipheriv(
-      "aes-128-cbc",
-      new Uint8Array(16),
-      new Uint8Array(16),
-    );
-    assertEquals(
-      cipher.update("hello, world! hello, world!", "utf-8", "hex"),
-      "ca7df4d74f51b77a7440ead38343ab0f",
-    );
-    assertEquals(cipher.final("hex"), "d0da733dec1fa61125c80a6f97e6166e");
+    {
+      const cipher = crypto.createCipheriv(
+        "aes-128-cbc",
+        new Uint8Array(16),
+        new Uint8Array(16),
+      );
+      assertEquals(
+        cipher.update("hello, world! hello, world!", "utf-8", "hex"),
+        "ca7df4d74f51b77a7440ead38343ab0f",
+      );
+      assertEquals(cipher.final("hex"), "d0da733dec1fa61125c80a6f97e6166e");
+    }
+
+    {
+      const cipher = crypto.createCipheriv(
+        "aes-128-cbc",
+        new Uint8Array(16),
+        new Uint8Array(16),
+      );
+      // update with string without input encoding
+      assertEquals(
+        cipher.update("hello, world! hello, world!").toString("hex"),
+        "ca7df4d74f51b77a7440ead38343ab0f",
+      );
+      assertEquals(cipher.final("hex"), "d0da733dec1fa61125c80a6f97e6166e");
+    }
   },
 });
 


### PR DESCRIPTION
This PR fixes the case when the `Cipheriv#update()` method is called with string without `inputEncoding` specified.

When the input is string and `inputEncoding` is not specified, the given string is directly passed to `op_node_cipheriv_encrypt`, and the encoding result becomes a wrong value.

This PR fixes it by always converting the input string with `Buffer.from` when the input is string. (ref: Node.js does the same https://github.com/nodejs/node/blob/123bb4cb22e739a039392d83d512601982f40fc0/lib/internal/crypto/cipher.js#L165-L166 )

closes #25279 