### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/console.ts`

### DIFF
--- a/ext/node/polyfills/console.ts
+++ b/ext/node/polyfills/console.ts
@@ -1,15 +1,15 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
+import { primordials } from "ext:core/mod.js";
 import { Console } from "ext:deno_node/internal/console/constructor.mjs";
 import { windowOrWorkerGlobalScope } from "ext:runtime/98_global_scope_shared.js";
 // Don't rely on global `console` because during bootstrapping, it is pointing
 // to native `console` object provided by V8.
 const console = windowOrWorkerGlobalScope.console.value;
 
-Object.assign(console, { Console });
+const { ObjectAssign } = primordials;
+
+ObjectAssign(console, { Console });
 
 export default console;
 


### PR DESCRIPTION
Contributing toward #24236

- Swapped `Object.assign` for `ObjectAssign` primordial.
- Removed referencing TODO comment.

Please disregard if no longer desired.