### PR TITLE
ci: upgrade release template

### DIFF
--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -151,13 +151,6 @@ verify on GitHub that everything looks correct.
 - [ ] This will open a PR. Review and merge it.
 - [ ] Create a `$VERSION` tag (_without_ `v` prefix).
 
-## Updating `deno-lambda`
-
-- [ ] Run the version bump workflow:
-      https://github.com/denoland/deno-lambda/actions/workflows/bump.yml
-- [ ] This will open a PR. Review and merge it.
-- [ ] Create a `$VERSION` tag (_without_ `v` prefix).
-
 ## All done!
 
 - [ ] Write a message in company's #cli channel:


### PR DESCRIPTION
Removes `deno-lambda` section that is now deprecated: https://github.com/denoland/deno-lambda/pull/307