### PR TITLE
fix(ext/node): export request and response clases from `http2` module

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -2295,7 +2295,7 @@ function onStreamTimeout(kind) {
   };
 }
 
-class Http2ServerRequest extends Readable {
+export class Http2ServerRequest extends Readable {
   readableEnded = false;
 
   constructor(stream, headers, options, rawHeaders) {
@@ -2523,7 +2523,7 @@ function isConnectionHeaderAllowed(name, value) {
     value === "trailers";
 }
 
-class Http2ServerResponse extends Stream {
+export class Http2ServerResponse extends Stream {
   writable = false;
   req = null;
 

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -378,3 +378,8 @@ Deno.test("[node/http2 client] connection states", async () => {
 
   assertEquals(actual, expected);
 });
+
+Deno.test("request and response exports", () => {
+  assert(http2.Http2ServerRequest);
+  assert(http2.Http2ServerResponse);
+});


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/20612
Closes https://github.com/denoland/deno/issues/23326

This makes `qwik` work.


https://github.com/user-attachments/assets/c09df01a-a793-40dd-bdd2-aee21cb1ae11

