### PR TITLE
fix(ext/node): fix Decipheriv when autoPadding disabled

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -306,6 +306,10 @@ class BlockModeCache {
     this.cache = this.cache.subarray(len);
     return out;
   }
+
+  set lastChunkIsNonZero(value: boolean) {
+    this.#lastChunkIsNonZero = value;
+  }
 }
 
 export class Decipheriv extends Transform implements Cipher {
@@ -338,7 +342,7 @@ export class Decipheriv extends Transform implements Cipher {
       },
       ...options,
     });
-    this.#cache = new BlockModeCache(true);
+    this.#cache = new BlockModeCache(this.#autoPadding);
     this.#context = op_node_create_decipheriv(cipher, toU8(key), toU8(iv));
     this.#needsBlockCache =
       !(cipher == "aes-128-gcm" || cipher == "aes-256-gcm");
@@ -386,6 +390,7 @@ export class Decipheriv extends Transform implements Cipher {
 
   setAutoPadding(autoPadding?: boolean): this {
     this.#autoPadding = Boolean(autoPadding);
+    this.#cache.lastChunkIsNonZero = this.#autoPadding;
     return this;
   }
 

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -378,3 +378,41 @@ Deno.test({
     assertEquals(info2.ivLength, 16);
   },
 });
+
+Deno.test({
+  name:
+    "createDecipheriv - handling of the last chunk when auto padding enabled/disabled",
+  fn() {
+    const algorithm = "aes-256-cbc";
+    const key = Buffer.from(
+      "84dcdd964968734fdf0de4a2cba471c2e0a753930b841c014b1e77f456b5797b",
+      "hex",
+    );
+    const val = Buffer.from(
+      "feabbdf66e2c71cc780d0cd2765dcce283e8ae7e58fcc1a9acafc678581e0e06",
+      "hex",
+    );
+    const iv = Buffer.alloc(16, 0);
+
+    {
+      const decipher = crypto.createDecipheriv(algorithm, key, iv);
+      decipher.setAutoPadding(false);
+      assertEquals(
+        decipher.update(val, undefined, "hex"),
+        "ed2c908f26571bf8e50d60b77fb9c25f95b933b59111543c6fac41ad6b47e681",
+      );
+      assertEquals(decipher.final("hex"), "");
+    }
+
+    {
+      const decipher = crypto.createDecipheriv(algorithm, key, iv);
+      assertEquals(
+        decipher.update(val, undefined, "hex"),
+        "ed2c908f26571bf8e50d60b77fb9c25f",
+      );
+      assertThrows(() => {
+        decipher.final();
+      });
+    }
+  },
+});


### PR DESCRIPTION
This PR fixes Decipheriv behavior when autoPadding disabled and enabled.

By this change, the example given in [this comment](https://github.com/denoland/deno/issues/20924#issuecomment-2345931295) works in the same way as Node.

closes #20924