### PR TITLE
fix(ext/node): use primordials in ext/node/polyfills/wasi.ts

### DIFF
--- a/ext/node/polyfills/wasi.ts
+++ b/ext/node/polyfills/wasi.ts
@@ -1,7 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
+import { primordials } from "ext:core/mod.js";
+
+const { Error } = primordials;
 
 class Context {
   constructor() {


### PR DESCRIPTION
Contributing toward #24236 

- Removed referencing TODO comment.
- Add Error primordial.

More coming; working my way up in comfort with the codebase and contribution flow :)
