### PR TITLE
fix(ext/node): attach console stream properties

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -128,6 +128,7 @@ import internalTestBinding from "ext:deno_node/internal/test/binding.ts";
 import internalTimers from "ext:deno_node/internal/timers.mjs";
 import internalUtil from "ext:deno_node/internal/util.mjs";
 import internalUtilInspect from "ext:deno_node/internal/util/inspect.mjs";
+import internalConsole from "ext:deno_node/internal/console/constructor.mjs";
 import net from "node:net";
 import os from "node:os";
 import pathPosix from "node:path/posix";
@@ -198,6 +199,7 @@ function setupBuiltinModules() {
     http2,
     https,
     inspector,
+    "internal/console/constructor": internalConsole,
     "internal/child_process": internalCp,
     "internal/crypto/certificate": internalCryptoCertificate,
     "internal/crypto/cipher": internalCryptoCipher,

--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -82,3 +82,8 @@ nodeGlobals.setImmediate = nativeModuleExports["timers"].setImmediate;
 nodeGlobals.setInterval = nativeModuleExports["timers"].setInterval;
 nodeGlobals.setTimeout = nativeModuleExports["timers"].setTimeout;
 nodeGlobals.performance = nativeModuleExports["perf_hooks"].performance;
+
+nativeModuleExports["internal/console/constructor"].bindStreamsLazy(
+  nativeModuleExports["console"],
+  nativeModuleExports["process"],
+);

--- a/ext/node/polyfills/internal/console/constructor.mjs
+++ b/ext/node/polyfills/internal/console/constructor.mjs
@@ -667,10 +667,15 @@ Console.prototype.dirxml = Console.prototype.log;
 Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
+export function bindStreamsLazy(console, object) {
+  Console.prototype[kBindStreamsLazy].call(console, object);
+}
+
 export { Console, formatTime, kBindProperties, kBindStreamsLazy };
 export default {
   Console,
   kBindStreamsLazy,
   kBindProperties,
   formatTime,
+  bindStreamsLazy,
 };


### PR DESCRIPTION
`kBindStreamsLazy` should be called with `process` during init, but it never was.