### PR TITLE
chore(fs): undeprecate `Deno.FsWatcher.prototype.return()`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3496,10 +3496,6 @@ declare namespace Deno {
     close(): void;
     /**
      * Stops watching the file system and closes the watcher resource.
-     *
-     * @deprecated This will be removed in Deno 2.0. See the
-     * {@link https://docs.deno.com/runtime/manual/advanced/migrate_deprecations | Deno 1.x to 2.x Migration Guide}
-     * for migration instructions.
      */
     return?(value?: any): Promise<IteratorResult<FsEvent>>;
     [Symbol.asyncIterator](): AsyncIterableIterator<FsEvent>;

--- a/runtime/js/40_fs_events.js
+++ b/runtime/js/40_fs_events.js
@@ -57,10 +57,7 @@ class FsWatcher {
     }
   }
 
-  // TODO(kt3k): This is deprecated. Will be removed in v2.0.
-  // See https://github.com/denoland/deno/issues/10577 for details
   return(value) {
-    internals.warnOnDeprecatedApi("Deno.FsWatcher.return()", new Error().stack);
     core.close(this.#rid);
     return PromiseResolve({ value, done: true });
   }

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -90,8 +90,6 @@ Deno.test(
   },
 );
 
-// TODO(kt3k): This test is for the backward compatibility of `.return` method.
-// This should be removed at 2.0
 Deno.test(
   { permissions: { read: true, write: true } },
   async function watchFsReturn() {


### PR DESCRIPTION
The opposite of #25445