### PR TITLE
refactor(ext/webidl): align error messages

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -712,7 +712,7 @@ function requiredArguments(length, required, prefix) {
   if (length < required) {
     const errMsg = `${prefix ? prefix + ": " : ""}${required} argument${
       required === 1 ? "" : "s"
-    } required, but only ${length} present.`;
+    } required, but only ${length} present`;
     throw new TypeError(errMsg);
   }
 }
@@ -818,7 +818,7 @@ function createDictionaryConverter(name, ...dictionaries) {
       } else if (member.required) {
         throw makeException(
           TypeError,
-          `can not be converted to '${name}' because '${key}' is required in '${name}'.`,
+          `can not be converted to '${name}' because '${key}' is required in '${name}'`,
           prefix,
           context,
         );
@@ -845,7 +845,7 @@ function createEnumConverter(name, values) {
       throw new TypeError(
         `${
           prefix ? prefix + ": " : ""
-        }The provided value '${S}' is not a valid enum value of type ${name}.`,
+        }The provided value '${S}' is not a valid enum value of type ${name}`,
       );
     }
 
@@ -925,7 +925,7 @@ function createRecordConverter(keyConverter, valueConverter) {
     if (type(V) !== "Object") {
       throw makeException(
         TypeError,
-        "can not be converted to dictionary.",
+        "can not be converted to dictionary",
         prefix,
         context,
       );
@@ -996,7 +996,7 @@ function createInterfaceConverter(name, prototype) {
     if (!ObjectPrototypeIsPrototypeOf(prototype, V) || V[brand] !== brand) {
       throw makeException(
         TypeError,
-        `is not of type ${name}.`,
+        `is not of type ${name}`,
         prefix,
         context,
       );

--- a/tests/testdata/run/error_009_extensions_error.js.out
+++ b/tests/testdata/run/error_009_extensions_error.js.out
@@ -1,4 +1,4 @@
-[WILDCARD]error: Uncaught (in promise) TypeError: Failed to construct 'Event': 1 argument required, but only 0 present.
+[WILDCARD]error: Uncaught (in promise) TypeError: Failed to construct 'Event': 1 argument required, but only 0 present
 new Event();
 ^
     at [WILDCARD]


### PR DESCRIPTION
Aligns the error messages in the ext/webidl folder to be in-line with the Deno style guide.

https://github.com/denoland/deno/issues/25269

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
