### PR TITLE
fix(cli): `deno task` exit with status 0

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -75,7 +75,7 @@ See https://docs.deno.com/go/config"#
         &cli_options.start_dir,
         &tasks_config,
       )?;
-      return Ok(1);
+      return Ok(0);
     }
   };
 

--- a/tests/specs/task/both_no_arg/__test__.jsonc
+++ b/tests/specs/task/both_no_arg/__test__.jsonc
@@ -4,5 +4,5 @@
   "envs": {
     "NO_COLOR": "1"
   },
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/tests/specs/task/cwd_resolves_config_from_specified_dir/__test__.jsonc
+++ b/tests/specs/task/cwd_resolves_config_from_specified_dir/__test__.jsonc
@@ -4,5 +4,5 @@
   "envs": {
     "NO_COLOR": "1"
   },
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/tests/specs/task/doc_comments_no_args/__test__.jsonc
+++ b/tests/specs/task/doc_comments_no_args/__test__.jsonc
@@ -2,5 +2,5 @@
   "args": "task",
   "envs": { "NO_COLOR": "1" },
   "output": "task.out",
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/tests/specs/task/no_args/__test__.jsonc
+++ b/tests/specs/task/no_args/__test__.jsonc
@@ -4,5 +4,5 @@
   "envs": {
     "NO_COLOR": "1"
   },
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/tests/specs/task/package_json_no_arg/__test__.jsonc
+++ b/tests/specs/task/package_json_no_arg/__test__.jsonc
@@ -4,5 +4,5 @@
   "envs": {
     "NO_COLOR": "1"
   },
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/tests/specs/task/pre_post/__test__.jsonc
+++ b/tests/specs/task/pre_post/__test__.jsonc
@@ -4,5 +4,5 @@
   "envs": {
     "NO_COLOR": "1"
   },
-  "exitCode": 1
+  "exitCode": 0
 }

--- a/tests/specs/task/pre_post/__test__.jsonc
+++ b/tests/specs/task/pre_post/__test__.jsonc
@@ -4,5 +4,5 @@
   "envs": {
     "NO_COLOR": "1"
   },
-  "exitCode": 0
+  "exitCode": 1
 }

--- a/tests/specs/task/workspace/__test__.jsonc
+++ b/tests/specs/task/workspace/__test__.jsonc
@@ -3,25 +3,25 @@
     "root": {
       "args": "task",
       "output": "root.out",
-      "exitCode": 1
+      "exitCode": 0
     },
     "package_a": {
       "args": "task",
       "cwd": "package-a",
       "output": "package-a.out",
-      "exitCode": 1
+      "exitCode": 0
     },
     "package_b": {
       "args": "task",
       "cwd": "package-b",
       "output": "package-b.out",
-      "exitCode": 1
+      "exitCode": 0
     },
     "scripts": {
       "args": "task",
       "cwd": "scripts",
       "output": "scripts.out",
-      "exitCode": 1
+      "exitCode": 0
     },
     "package_b_tasks": {
       "steps": [{


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/25632

Exit code 1 indiciates some sort of failure but `deno task` (without arguments) is used to list available commands.

