### PR TITLE
fix(runtime): don't error `child.output()` on consumed stream

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -1054,7 +1054,7 @@ async function readableStreamCollectIntoUint8Array(stream) {
     getReadableStreamResourceBackingUnrefable(stream);
   const reader = acquireReadableStreamDefaultReader(stream);
 
-  if (resourceBacking) {
+  if (resourceBacking && !isReadableStreamDisturbed(stream)) {
     // fast path, read whole body in a single op call
     try {
       readableStreamDisturb(stream);

--- a/tests/unit/command_test.ts
+++ b/tests/unit/command_test.ts
@@ -1043,3 +1043,24 @@ Deno.test(
     }
   },
 );
+
+Deno.test(async function outputWhenManuallyConsumingStreams() {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["eval", "console.log('hello world')"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const child = command.spawn();
+  for await (const _ of child.stdout) {
+    // consume stdout
+  }
+  for await (const _ of child.stderr) {
+    // consume stderr
+  }
+  const status = await child.output();
+  assertEquals(status.success, true);
+  assertEquals(status.code, 0);
+  assertEquals(status.signal, null);
+  assertEquals(status.stdout, new Uint8Array());
+  assertEquals(status.stderr, new Uint8Array());
+});


### PR DESCRIPTION
This fixes the fast path for `readableStreamCollectIntoUint8Array` to only
trigger if the readable stream has not yet been disturbed - because otherwise we
may not be able to close it if the read errors.

Fixes #22621