### PR TITLE
fix(types): simplify mtls related types

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -6126,7 +6126,12 @@ declare namespace Deno {
 
   /** Create a custom HttpClient to use with {@linkcode fetch}. This is an
    * extension of the web platform Fetch API which allows Deno to use custom
-   * TLS certificates and connect via a proxy while using `fetch()`.
+   * TLS CA certificates and connect via a proxy while using `fetch()`.
+   *
+   * The `cert` and `key` options can be used to specify a client certificate
+   * and key to use when connecting to a server that requires client
+   * authentication (mutual TLS or mTLS). The `cert` and `key` options must be
+   * provided in PEM format.
    *
    * @example ```ts
    * const caCert = await Deno.readTextFile("./ca.pem");
@@ -6141,29 +6146,18 @@ declare namespace Deno {
    * const response = await fetch("https://myserver.com", { client });
    * ```
    *
-   * @category Fetch
-   */
-  export function createHttpClient(
-    options: CreateHttpClientOptions,
-  ): HttpClient;
-
-  /**
-   * Create a custom HttpClient to use with {@linkcode fetch}. This is an
-   * extension of the web platform Fetch API which allows Deno to use custom
-   * TLS certificates and connect via a proxy while using `fetch()`.
-   *
    * @example ```ts
-   * const caCert = await Deno.readTextFile("./ca.pem");
-   * // Load a client key and certificate that we'll use to connect
-   * const key = await Deno.readTextFile("./key.key");
-   * const cert = await Deno.readTextFile("./cert.crt");
-   * const client = Deno.createHttpClient({ caCerts: [ caCert ], key, cert });
+   * const key = "----BEGIN PRIVATE KEY----...";
+   * const cert = "----BEGIN CERTIFICATE----...";
+   * const client = Deno.createHttpClient({ key, cert });
    * const response = await fetch("https://myserver.com", { client });
    * ```
    *
    * @category Fetch
    */
   export function createHttpClient(
-    options: CreateHttpClientOptions & TlsCertifiedKeyPem,
+    options:
+      | CreateHttpClientOptions
+      | (CreateHttpClientOptions & TlsCertifiedKeyPem),
   ): HttpClient;
 }

--- a/ext/net/lib.deno_net.d.ts
+++ b/ext/net/lib.deno_net.d.ts
@@ -371,9 +371,14 @@ declare namespace Deno {
   }
 
   /** Establishes a secure connection over TLS (transport layer security) using
-   * an optional cert file, hostname (default is "127.0.0.1") and port.  The
-   * cert file is optional and if not included Mozilla's root certificates will
-   * be used (see also https://github.com/ctz/webpki-roots for specifics)
+   * an optional list of CA certs, hostname (default is "127.0.0.1") and port.
+   *
+   * The CA cert list is optional and if not included Mozilla's root
+   * certificates will be used (see also https://github.com/ctz/webpki-roots for
+   * specifics).
+   *
+   * Mutual TLS (mTLS or client certificates) are supported by providing a
+   * `key` and `cert` in the options as PEM-encoded strings.
    *
    * ```ts
    * const caCert = await Deno.readTextFile("./certs/my_custom_root_CA.pem");
@@ -381,28 +386,10 @@ declare namespace Deno {
    * const conn2 = await Deno.connectTls({ caCerts: [caCert], hostname: "192.0.2.1", port: 80 });
    * const conn3 = await Deno.connectTls({ hostname: "[2001:db8::1]", port: 80 });
    * const conn4 = await Deno.connectTls({ caCerts: [caCert], hostname: "golang.org", port: 80});
-   * ```
    *
-   * Requires `allow-net` permission.
-   *
-   * @tags allow-net
-   * @category Network
-   */
-  export function connectTls(options: ConnectTlsOptions): Promise<TlsConn>;
-
-  /** Establishes a secure connection over TLS (transport layer security) using
-   * an optional cert file, client certificate, hostname (default is "127.0.0.1") and
-   * port.  The cert file is optional and if not included Mozilla's root certificates will
-   * be used (see also https://github.com/ctz/webpki-roots for specifics)
-   *
-   * ```ts
-   * const caCert = await Deno.readTextFile("./certs/my_custom_root_CA.pem");
    * const key = "----BEGIN PRIVATE KEY----...";
    * const cert = "----BEGIN CERTIFICATE----...";
-   * const conn1 = await Deno.connectTls({ port: 80, key, cert });
-   * const conn2 = await Deno.connectTls({ caCerts: [caCert], hostname: "192.0.2.1", port: 80, key, cert });
-   * const conn3 = await Deno.connectTls({ hostname: "[2001:db8::1]", port: 80, key, cert });
-   * const conn4 = await Deno.connectTls({ caCerts: [caCert], hostname: "golang.org", port: 80, key, cert });
+   * const conn5 = await Deno.connectTls({ port: 80, key, cert });
    * ```
    *
    * Requires `allow-net` permission.
@@ -411,7 +398,7 @@ declare namespace Deno {
    * @category Network
    */
   export function connectTls(
-    options: ConnectTlsOptions & TlsCertifiedKeyPem,
+    options: ConnectTlsOptions | (ConnectTlsOptions & TlsCertifiedKeyPem),
   ): Promise<TlsConn>;
 
   /** @category Network */


### PR DESCRIPTION
Instead of two overloads for `Deno.connectTls` and `Deno.createHttpClient`, there is now just one.
