### PR TITLE
fix(lockfile): use loose deserialization for version constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb68a4a666c69eabd8fe505d6fdc4ed4a2d962fe1680dbfa8b0c8a2975d58ed0"
+checksum = "579117d5815aa9bae0212637d6f4d5f45f9649bb2c8988dca434077545535039"
 dependencies = [
  "deno_semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ deno_ast = { version = "=0.42.0", features = ["transpiling"] }
 deno_core = { version = "0.308.0" }
 
 deno_bench_util = { version = "0.162.0", path = "./bench_util" }
-deno_lockfile = "=0.23.0"
+deno_lockfile = "=0.23.1"
 deno_media_type = { version = "0.1.4", features = ["module_specifier"] }
 deno_permissions = { version = "0.28.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.177.0", path = "./runtime" }


### PR DESCRIPTION
* https://github.com/denoland/deno_lockfile/pull/39

Closes https://github.com/denoland/deno/issues/25649