### PR TITLE
fix(dts): stabilize `fetch` declaration for use with `Deno.HttpClient`

### DIFF
--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -13,6 +13,7 @@
 /// <reference lib="deno.fetch" />
 /// <reference lib="deno.websocket" />
 /// <reference lib="deno.crypto" />
+/// <reference lib="deno.ns" />
 
 /** @category WASM */
 declare namespace WebAssembly {
@@ -740,3 +741,15 @@ declare interface ErrorConstructor {
   // TODO(nayeemrmn): Support `Error.prepareStackTrace()`. We currently use this
   // internally in a way that makes it unavailable for users.
 }
+
+/** The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+ * which also supports setting a {@linkcode Deno.HttpClient} which provides a
+ * way to connect via proxies and use custom TLS certificates.
+ *
+ * @tags allow-net, allow-read
+ * @category Fetch
+ */
+declare function fetch(
+  input: Request | URL | string,
+  init?: RequestInit & { client: Deno.HttpClient },
+): Promise<Response>;

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1218,21 +1218,6 @@ declare namespace Deno {
 
 /** **UNSTABLE**: New API, yet to be vetted.
  *
- * The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
- * which also supports setting a {@linkcode Deno.HttpClient} which provides a
- * way to connect via proxies and use custom TLS certificates.
- *
- * @tags allow-net, allow-read
- * @category Fetch
- * @experimental
- */
-declare function fetch(
-  input: Request | URL | string,
-  init?: RequestInit & { client: Deno.HttpClient },
-): Promise<Response>;
-
-/** **UNSTABLE**: New API, yet to be vetted.
- *
  * @category Workers
  * @experimental
  */


### PR DESCRIPTION
This commit stabilizes the `fetch` function declaration for use with `Deno.HttpClient` and moves it from `lib.deno.unstable.d.ts` to `lib.deno.shared_globals.d.ts`.

`Deno.HttpClient` was stabilized in #25569, but the associated override declaration for `fetch` is still marked as experimental. This should also be stabilized now and moved to a different d.ts file.
