### PR TITLE
fix(ext/node): don't throw error for unsupported signal binding on windows

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -521,6 +521,7 @@ Process.prototype.on = function (
       event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows"
     ) {
       // Ignores all signals except SIGBREAK and SIGINT on windows.
+      // deno-lint-ignore no-console
       console.warn(`Ignoring signal "${event}" on Windows`);
     } else {
       EventEmitter.prototype.on.call(this, event, listener);

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -517,7 +517,9 @@ Process.prototype.on = function (
       // Ignores SIGBREAK if the platform is not windows.
     } else if (event === "SIGTERM" && Deno.build.os === "windows") {
       // Ignores SIGTERM on windows.
-    } else if (event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows") {
+    } else if (
+      event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows"
+    ) {
       // Ignores all signals except SIGBREAK and SIGINT on windows.
       console.warn(`Ignoring signal "${event}" on Windows`);
     } else {
@@ -544,7 +546,9 @@ Process.prototype.off = function (
   } else if (event.startsWith("SIG")) {
     if (event === "SIGBREAK" && Deno.build.os !== "windows") {
       // Ignores SIGBREAK if the platform is not windows.
-    } else if (event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows") {
+    } else if (
+      event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows"
+    ) {
       // Ignores all signals except SIGBREAK and SIGINT on windows.
     } else {
       EventEmitter.prototype.off.call(this, event, listener);

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -517,6 +517,9 @@ Process.prototype.on = function (
       // Ignores SIGBREAK if the platform is not windows.
     } else if (event === "SIGTERM" && Deno.build.os === "windows") {
       // Ignores SIGTERM on windows.
+    } else if (event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows") {
+      // Ignores all signals except SIGBREAK and SIGINT on windows.
+      console.warn(`Ignoring signal "${event}" on Windows`);
     } else {
       EventEmitter.prototype.on.call(this, event, listener);
       Deno.addSignalListener(event as Deno.Signal, listener);
@@ -541,8 +544,8 @@ Process.prototype.off = function (
   } else if (event.startsWith("SIG")) {
     if (event === "SIGBREAK" && Deno.build.os !== "windows") {
       // Ignores SIGBREAK if the platform is not windows.
-    } else if (event === "SIGTERM" && Deno.build.os === "windows") {
-      // Ignores SIGTERM on windows.
+    } else if (event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows") {
+      // Ignores all signals except SIGBREAK and SIGINT on windows.
     } else {
       EventEmitter.prototype.off.call(this, event, listener);
       Deno.removeSignalListener(event as Deno.Signal, listener);

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -25,7 +25,7 @@ import {
   assertThrows,
   fail,
 } from "@std/assert";
-import { spy, assertSpyCall, assertSpyCalls } from "@std/testing/mock"
+import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
 import { stripAnsiCode } from "@std/fmt/colors";
 import * as path from "@std/path";
 import { delay } from "@std/async/delay";
@@ -247,24 +247,24 @@ Deno.test({
 
     for (const signal of ignoredSignals) {
       using consoleSpy = spy(console, "warn");
-      const handler = () => {}
+      const handler = () => {};
       process.on(signal, handler);
       process.off(signal, handler);
       assertSpyCall(consoleSpy, 0, {
-        args: [`Ignoring signal "${signal}" on Windows`]
+        args: [`Ignoring signal "${signal}" on Windows`],
       });
     }
 
     {
       using consoleSpy = spy(console, "warn");
-      const handler = () => {}
+      const handler = () => {};
       process.on("SIGTERM", handler);
       process.off("SIGTERM", handler);
       // No warning is made for SIGTERM
       assertSpyCalls(consoleSpy, 0);
     }
   },
-})
+});
 
 Deno.test(
   { permissions: { run: true, read: true } },

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -25,6 +25,7 @@ import {
   assertThrows,
   fail,
 } from "@std/assert";
+import { spy, assertSpyCall, assertSpyCalls } from "@std/testing/mock"
 import { stripAnsiCode } from "@std/fmt/colors";
 import * as path from "@std/path";
 import { delay } from "@std/async/delay";
@@ -237,6 +238,33 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "process.on - ignored signals on windows",
+  ignore: Deno.build.os !== "windows",
+  fn() {
+    const ignoredSignals = ["SIGHUP", "SIGUSR1", "SIGUSR2"];
+
+    for (const signal of ignoredSignals) {
+      using consoleSpy = spy(console, "warn");
+      const handler = () => {}
+      process.on(signal, handler);
+      process.off(signal, handler);
+      assertSpyCall(consoleSpy, 0, {
+        args: [`Ignoring signal "${signal}" on Windows`]
+      });
+    }
+
+    {
+      using consoleSpy = spy(console, "warn");
+      const handler = () => {}
+      process.on("SIGTERM", handler);
+      process.off("SIGTERM", handler);
+      // No warning is made for SIGTERM
+      assertSpyCalls(consoleSpy, 0);
+    }
+  },
+})
 
 Deno.test(
   { permissions: { run: true, read: true } },


### PR DESCRIPTION
This PR changes the handling of unsupported signals on windows. Currently it throws an error if `process.on` is called with unsupported signal (ex. SIGHUP) on windows. That causes #25675 for example.

This PR changes it to not throw the error instead let it only print the warning messages.

closes #25675