### PR TITLE
Revert "feat(fmt): sort type-only named import/exports last"

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -64,7 +64,7 @@
     "third_party"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.92.0.wasm",
+    "https://plugins.dprint.dev/typescript-0.93.0.wasm",
     "https://plugins.dprint.dev/json-0.19.3.wasm",
     "https://plugins.dprint.dev/markdown-0.17.8.wasm",
     "https://plugins.dprint.dev/toml-0.6.2.wasm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.92.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e454b93b06b61a6cf76b921906074616052a29a16dba8119947669121283fc3"
+checksum = "e9308d98b923b7c0335c2ee1560199e3f2321b1be82803107b4ba4ed5dac46cc"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -102,7 +102,7 @@ dotenvy = "0.15.7"
 dprint-plugin-json = "=0.19.3"
 dprint-plugin-jupyter = "=0.1.3"
 dprint-plugin-markdown = "=0.17.8"
-dprint-plugin-typescript = "=0.92.0"
+dprint-plugin-typescript = "=0.93.0"
 env_logger = "=0.10.0"
 fancy-regex = "=0.10.0"
 faster-hex.workspace = true

--- a/ext/node/polyfills/_fs/_fs_access.ts
+++ b/ext/node/polyfills/_fs/_fs_access.ts
@@ -4,8 +4,8 @@
 // deno-lint-ignore-file prefer-primordials
 
 import {
-  makeCallback,
   type CallbackWithError,
+  makeCallback,
 } from "ext:deno_node/_fs/_fs_common.ts";
 import { fs } from "ext:deno_node/internal_binding/constants.ts";
 import { codeMap } from "ext:deno_node/internal_binding/uv.ts";

--- a/ext/node/polyfills/_fs/_fs_chown.ts
+++ b/ext/node/polyfills/_fs/_fs_chown.ts
@@ -4,8 +4,8 @@
 // deno-lint-ignore-file prefer-primordials
 
 import {
-  makeCallback,
   type CallbackWithError,
+  makeCallback,
 } from "ext:deno_node/_fs/_fs_common.ts";
 import {
   getValidatedPath,

--- a/ext/node/polyfills/_fs/_fs_lchown.ts
+++ b/ext/node/polyfills/_fs/_fs_lchown.ts
@@ -4,8 +4,8 @@
 // deno-lint-ignore-file prefer-primordials
 
 import {
-  makeCallback,
   type CallbackWithError,
+  makeCallback,
 } from "ext:deno_node/_fs/_fs_common.ts";
 import {
   getValidatedPath,

--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -18,11 +18,11 @@ import {
   ChildProcessOptions,
   normalizeSpawnArguments,
   setupChannel,
-  spawnSync as _spawnSync,
-  stdioStringToArray,
   type SpawnOptions,
+  spawnSync as _spawnSync,
   type SpawnSyncOptions,
   type SpawnSyncResult,
+  stdioStringToArray,
 } from "ext:deno_node/internal/child_process.ts";
 import {
   validateAbortSignal,

--- a/ext/node/polyfills/https.ts
+++ b/ext/node/polyfills/https.ts
@@ -13,7 +13,7 @@ import {
 } from "node:http";
 import { Agent as HttpAgent } from "node:_http_agent";
 import { createHttpClient } from "ext:deno_fetch/22_http_client.js";
-import { ServerImpl as HttpServer, type ServerHandler } from "node:http";
+import { type ServerHandler, ServerImpl as HttpServer } from "node:http";
 import { validateObject } from "ext:deno_node/internal/validators.mjs";
 import { kEmptyObject } from "ext:deno_node/internal/util.mjs";
 import { Buffer } from "node:buffer";

--- a/tests/testdata/repl/import_type.ts
+++ b/tests/testdata/repl/import_type.ts
@@ -1,4 +1,4 @@
-import { create, type B } from "./subdir/export_types.ts";
+import { type B, create } from "./subdir/export_types.ts";
 
 const b: B = create();
 

--- a/tests/testdata/run/import_type.ts
+++ b/tests/testdata/run/import_type.ts
@@ -1,4 +1,4 @@
-import { create, type B } from "../subdir/export_types.ts";
+import { type B, create } from "../subdir/export_types.ts";
 
 const b: B = create();
 


### PR DESCRIPTION
Reverts #25690

This was not an issue with the ts compiler anymore. Discussion here: https://github.com/dprint/dprint-plugin-typescript/pull/664#issuecomment-2357000053