### PR TITLE
fix: error on unsupported compiler options

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -9,6 +9,7 @@
     "compilerOptions": {
       "type": "object",
       "description": "Instructs the TypeScript compiler how to compile .ts files.",
+      "additionalProperties": false,
       "properties": {
         "allowJs": {
           "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",


### PR DESCRIPTION
Update the config schema to error when adding unsupported `compilerOptions`.

Fixes https://github.com/denoland/deno/issues/25696