### PR TITLE
ci: bump fetch depth to unblock canary uploads

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -158,7 +158,7 @@ const cloneRepoStep = [{
     // Use depth > 1, because sometimes we need to rebuild main and if
     // other commits have landed it will become impossible to rebuild if
     // the checkout is too shallow.
-    "fetch-depth": 5,
+    "fetch-depth": 50,
     submodules: false,
   },
 }];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 5
+          fetch-depth: 50
           submodules: false
         if: github.event.pull_request.draft == true
       - id: check
@@ -148,7 +148,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 5
+          fetch-depth: 50
           submodules: false
         if: '!(matrix.skip)'
       - name: Clone submodule ./tests/util/std


### PR DESCRIPTION
Current mac arm canaries are failing to upload because the existing latest commit hash
is more that 5 commits behind and it's not in the git history.