### PR TITLE
refactor(ext/webgpu): align error messages

### DIFF
--- a/ext/webgpu/01_webgpu.js
+++ b/ext/webgpu/01_webgpu.js
@@ -175,7 +175,7 @@ function assertDevice(self, prefix, context) {
   const deviceRid = device?.rid;
   if (deviceRid === undefined) {
     throw new DOMException(
-      `${prefix}: ${context} references an invalid or destroyed device.`,
+      `${prefix}: ${context} references an invalid or destroyed device`,
       "OperationError",
     );
   }
@@ -196,7 +196,7 @@ function assertDeviceMatch(
   const resourceDevice = assertDevice(resource, prefix, resourceContext);
   if (resourceDevice.rid !== self.rid) {
     throw new DOMException(
-      `${prefix}: ${resourceContext} belongs to a different device than ${selfContext}.`,
+      `${prefix}: ${resourceContext} belongs to a different device than ${selfContext}`,
       "OperationError",
     );
   }
@@ -213,7 +213,7 @@ function assertResource(self, prefix, context) {
   const rid = self[_rid];
   if (rid === undefined) {
     throw new DOMException(
-      `${prefix}: ${context} an invalid or destroyed resource.`,
+      `${prefix}: ${context} an invalid or destroyed resource`,
       "OperationError",
     );
   }
@@ -469,7 +469,7 @@ class GPUAdapter {
         !SetPrototypeHas(this[_adapter].features[webidl.setlikeInner], feature)
       ) {
         throw new TypeError(
-          `${prefix}: requiredFeatures must be a subset of the adapter features.`,
+          `${prefix}: requiredFeatures must be a subset of the adapter features`,
         );
       }
     }
@@ -1819,12 +1819,12 @@ class GPUDevice extends EventTarget {
     const prefix = "Failed to execute 'popErrorScope' on 'GPUDevice'";
     const device = assertDevice(this, prefix, "this");
     if (device.isLost) {
-      throw new DOMException("Device has been lost.", "OperationError");
+      throw new DOMException("Device has been lost", "OperationError");
     }
     const scope = ArrayPrototypePop(device.errorScopeStack);
     if (!scope) {
       throw new DOMException(
-        "There are no error scopes on the error scope stack.",
+        "There are no error scopes on the error scope stack",
         "OperationError",
       );
     }
@@ -2195,25 +2195,25 @@ class GPUBuffer {
     }
     if ((offset % 8) !== 0) {
       throw new DOMException(
-        `${prefix}: offset must be a multiple of 8.`,
+        `${prefix}: offset must be a multiple of 8, received ${offset}`,
         "OperationError",
       );
     }
     if ((rangeSize % 4) !== 0) {
       throw new DOMException(
-        `${prefix}: rangeSize must be a multiple of 4.`,
+        `${prefix}: rangeSize must be a multiple of 4, received ${rangeSize}`,
         "OperationError",
       );
     }
     if ((offset + rangeSize) > this[_size]) {
       throw new DOMException(
-        `${prefix}: offset + rangeSize must be less than or equal to buffer size.`,
+        `${prefix}: offset + rangeSize must be less than or equal to buffer size`,
         "OperationError",
       );
     }
     if (this[_state] !== "unmapped") {
       throw new DOMException(
-        `${prefix}: GPUBuffer is not currently unmapped.`,
+        `${prefix}: GPUBuffer is not currently unmapped`,
         "OperationError",
       );
     }
@@ -2221,19 +2221,19 @@ class GPUBuffer {
     const writeMode = (mode & 0x0002) === 0x0002;
     if ((readMode && writeMode) || (!readMode && !writeMode)) {
       throw new DOMException(
-        `${prefix}: exactly one of READ or WRITE map mode must be set.`,
+        `${prefix}: exactly one of READ or WRITE map mode must be set`,
         "OperationError",
       );
     }
     if (readMode && !((this[_usage] && 0x0001) === 0x0001)) {
       throw new DOMException(
-        `${prefix}: READ map mode not valid because buffer does not have MAP_READ usage.`,
+        `${prefix}: READ map mode not valid because buffer does not have MAP_READ usage`,
         "OperationError",
       );
     }
     if (writeMode && !((this[_usage] && 0x0002) === 0x0002)) {
       throw new DOMException(
-        `${prefix}: WRITE map mode not valid because buffer does not have MAP_WRITE usage.`,
+        `${prefix}: WRITE map mode not valid because buffer does not have MAP_WRITE usage`,
         "OperationError",
       );
     }
@@ -2280,7 +2280,7 @@ class GPUBuffer {
 
     const mappedRanges = this[_mappedRanges];
     if (!mappedRanges) {
-      throw new DOMException(`${prefix}: invalid state.`, "OperationError");
+      throw new DOMException(`${prefix}: invalid state`, "OperationError");
     }
     for (let i = 0; i < mappedRanges.length; ++i) {
       const { 0: buffer, 1: _rid, 2: start } = mappedRanges[i];
@@ -2291,7 +2291,7 @@ class GPUBuffer {
         (end >= offset && end < (offset + rangeSize))
       ) {
         throw new DOMException(
-          `${prefix}: requested buffer overlaps with another mapped range.`,
+          `${prefix}: requested buffer overlaps with another mapped range`,
           "OperationError",
         );
       }
@@ -2317,14 +2317,14 @@ class GPUBuffer {
     const bufferRid = assertResource(this, prefix, "this");
     if (this[_state] === "unmapped" || this[_state] === "destroyed") {
       throw new DOMException(
-        `${prefix}: buffer is not ready to be unmapped.`,
+        `${prefix}: buffer is not ready to be unmapped`,
         "OperationError",
       );
     }
     if (this[_state] === "pending") {
       // TODO(lucacasonato): this is not spec compliant.
       throw new DOMException(
-        `${prefix}: can not unmap while mapping. This is a Deno limitation.`,
+        `${prefix}: can not unmap while mapping, this is a Deno limitation`,
         "OperationError",
       );
     } else if (
@@ -2338,7 +2338,7 @@ class GPUBuffer {
         const mapMode = this[_mapMode];
         if (mapMode === undefined) {
           throw new DOMException(
-            `${prefix}: invalid state.`,
+            `${prefix}: invalid state`,
             "OperationError",
           );
         }
@@ -2349,7 +2349,7 @@ class GPUBuffer {
 
       const mappedRanges = this[_mappedRanges];
       if (!mappedRanges) {
-        throw new DOMException(`${prefix}: invalid state.`, "OperationError");
+        throw new DOMException(`${prefix}: invalid state`, "OperationError");
       }
       for (let i = 0; i < mappedRanges.length; ++i) {
         const { 0: buffer, 1: mappedRid } = mappedRanges[i];
@@ -5540,7 +5540,7 @@ webidl.converters["GPUExtent3D"] = (V, opts) => {
       if (V.length < min || V.length > max) {
         throw webidl.makeException(
           TypeError,
-          `A sequence of number used as a GPUExtent3D must have between ${min} and ${max} elements.`,
+          `A sequence of number used as a GPUExtent3D must have between ${min} and ${max} elements, received ${V.length} elements`,
           opts,
         );
       }
@@ -5550,7 +5550,7 @@ webidl.converters["GPUExtent3D"] = (V, opts) => {
   }
   throw webidl.makeException(
     TypeError,
-    "can not be converted to sequence<GPUIntegerCoordinate> or GPUExtent3DDict.",
+    "can not be converted to sequence<GPUIntegerCoordinate> or GPUExtent3DDict",
     opts,
   );
 };
@@ -6884,7 +6884,7 @@ webidl.converters["GPUOrigin3D"] = (V, opts) => {
       if (V.length > length) {
         throw webidl.makeException(
           TypeError,
-          `A sequence of number used as a GPUOrigin3D must have at most ${length} elements.`,
+          `A sequence of number used as a GPUOrigin3D must have at most ${length} elements, received ${V.length} elements`,
           opts,
         );
       }
@@ -6894,7 +6894,7 @@ webidl.converters["GPUOrigin3D"] = (V, opts) => {
   }
   throw webidl.makeException(
     TypeError,
-    "can not be converted to sequence<GPUIntegerCoordinate> or GPUOrigin3DDict.",
+    "can not be converted to sequence<GPUIntegerCoordinate> or GPUOrigin3DDict",
     opts,
   );
 };
@@ -6961,7 +6961,7 @@ webidl.converters["GPUOrigin2D"] = (V, opts) => {
       if (V.length > length) {
         throw webidl.makeException(
           TypeError,
-          `A sequence of number used as a GPUOrigin2D must have at most ${length} elements.`,
+          `A sequence of number used as a GPUOrigin2D must have at most ${length} elements, received ${V.length} elements`,
           opts,
         );
       }
@@ -6971,7 +6971,7 @@ webidl.converters["GPUOrigin2D"] = (V, opts) => {
   }
   throw webidl.makeException(
     TypeError,
-    "can not be converted to sequence<GPUIntegerCoordinate> or GPUOrigin2DDict.",
+    "can not be converted to sequence<GPUIntegerCoordinate> or GPUOrigin2DDict",
     opts,
   );
 };
@@ -7055,7 +7055,7 @@ webidl.converters["GPUColor"] = (V, opts) => {
       if (V.length !== length) {
         throw webidl.makeException(
           TypeError,
-          `A sequence of number used as a GPUColor must have exactly ${length} elements.`,
+          `A sequence of number used as a GPUColor must have exactly ${length} elements, received ${V.length} elements`,
           opts,
         );
       }
@@ -7065,7 +7065,7 @@ webidl.converters["GPUColor"] = (V, opts) => {
   }
   throw webidl.makeException(
     TypeError,
-    "can not be converted to sequence<double> or GPUColorDict.",
+    "can not be converted to sequence<double> or GPUColorDict",
     opts,
   );
 };

--- a/ext/webgpu/02_surface.js
+++ b/ext/webgpu/02_surface.js
@@ -92,7 +92,7 @@ class GPUCanvasContext {
       "Failed to execute 'getCurrentTexture' on 'GPUCanvasContext'";
 
     if (this[_configuration] === null) {
-      throw new DOMException("context is not configured.", "InvalidStateError");
+      throw new DOMException("Context is not configured", "InvalidStateError");
     }
     const { createGPUTexture, assertDevice } = loadWebGPU();
 
@@ -179,7 +179,7 @@ class UnsafeWindowSurface {
 
   getContext(context) {
     if (context !== "webgpu") {
-      throw new TypeError("Only 'webgpu' context is supported.");
+      throw new TypeError("Only 'webgpu' context is supported");
     }
     this.#ctx = createCanvasContext({ surfaceRid: this.#surfaceRid });
     return this.#ctx;

--- a/tests/unit/webgpu_test.ts
+++ b/tests/unit/webgpu_test.ts
@@ -271,7 +271,7 @@ Deno.test({
   const invalidSize = [0, 0, 0];
 
   const msgIncludes =
-    "A sequence of number used as a GPUColor must have exactly 4 elements.";
+    "A sequence of number used as a GPUColor must have exactly 4 elements, received 3 elements";
 
   // validate the argument of descriptor.colorAttachments[@@iterator].clearValue property's length of GPUCommandEncoder.beginRenderPass when its a sequence
   // https://www.w3.org/TR/2024/WD-webgpu-20240409/#dom-gpucommandencoder-beginrenderpass
@@ -337,7 +337,7 @@ Deno.test({
   const overSize = [256, 256, 1, 1];
 
   const msgIncludes =
-    "A sequence of number used as a GPUExtent3D must have between 1 and 3 elements.";
+    "A sequence of number used as a GPUExtent3D must have between 1 and 3 elements";
 
   // validate the argument of descriptor.size property's length of GPUDevice.createTexture when its a sequence
   // https://www.w3.org/TR/2024/WD-webgpu-20240409/#dom-gpudevice-createtexture
@@ -437,7 +437,7 @@ Deno.test({
   const overSize = [256, 256, 1, 1];
 
   const msgIncludes =
-    "A sequence of number used as a GPUOrigin3D must have at most 3 elements.";
+    "A sequence of number used as a GPUOrigin3D must have at most 3 elements, received 4 elements";
 
   // validate the argument of destination.origin property's length of GPUCommandEncoder.copyBufferToTexture when its a sequence
   // https://www.w3.org/TR/2024/WD-webgpu-20240409/#dom-gpucommandencoder-copybuffertotexture


### PR DESCRIPTION
Aligns the error messages in the ext/webgpu folder to be in-line with the Deno style guide.

https://github.com/denoland/deno/issues/25269

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
