### PR TITLE
fix(cli): handle edge cases around `export`s in doc tests and default export

### DIFF
--- a/cli/util/extract.rs
+++ b/cli/util/extract.rs
@@ -1269,6 +1269,38 @@ foo();
           media_type: MediaType::TypeScript,
         }],
       },
+      // Unlike `extract_doc_tests`, `extract_snippet_files` does not remove
+      // the `export` keyword from the exported items.
+      Test {
+        input: Input {
+          source: r#"
+/**
+ * ```ts
+ * import { getLogger } from "@std/log";
+ *
+ * const logger = getLogger("my-awesome-module");
+ *
+ * export function foo() {
+ *   logger.debug("hello");
+ * }
+ * ```
+ *
+ * @module
+ */
+"#,
+          specifier: "file:///main.ts",
+        },
+        expected: vec![Expected {
+          source: r#"import { getLogger } from "@std/log";
+export function foo() {
+    logger.debug("hello");
+}
+const logger = getLogger("my-awesome-module");
+"#,
+          specifier: "file:///main.ts$3-12.ts",
+          media_type: MediaType::TypeScript,
+        }],
+      },
       Test {
         input: Input {
           source: r#"


### PR DESCRIPTION
This commit fixes issues with the pseudo test file generation logic, namely:

- `export`s declared in snippets
- auto import insertion for `default export`

## Case 1: `export`s declared in snippets

In the previous implementation, `export`s declared in snippets were moved to the top level of the module as a result of pseudo test file generation. This is required because `export` must be at the top level.

This becomes a problem if such a `export` has a body, containing a reference to a local variable. Suppose we extract this snippet from JSDoc:

```ts
const logger = createLogger("my-awesome-module");

export function sum(a: number, b: number): number {
  logger.debug("sum called");
  return a + b;
}
```

This gets converted into the following invalid code (note that `export function sum` is moved to the top level, but its body references `logger` variable which can't be referenced from here):

```ts
export function sum(a: number, b: number): number {
  logger.debug("sum called");
  return a + b;
}

Deno.test("./base.ts$1-7.ts", async () => {
  const logger = createLogger("my-awesome-module");
});
```

To resolve this issue, this commit adds a logic to remove the `export` keyword, allowing the exported items to stay in the `Deno.test` block scope, like so:

```ts
Deno.test("./base.ts$1-7.ts", async () => {
  const logger = createLogger("my-awesome-module");

  function sum(a: number, b: number): number {
    logger.debug("sum called");
    return a + b;
  }
});
```

## Case 2: default export

Previously `default export foo` was not captured by the export collector, so auto import insertion didn't work for this case. To put it concretely, the following code snippet didn't work when run with `deno test --doc` because `import foo from "file:///path/to/mod.ts"` didn't get inserted automatically:

```ts
/**
 * ```ts
 * console.log(foo);
 * ```
 * 
 * @module
 */

const foo = 42;
export default foo;
```

This commit fixes this issue and the above example works fine.

---

Fixes #25718
