### PR TITLE
fix: don't include extensionless files in file collection for lint & fmt by default

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -221,10 +221,8 @@ fn collect_fmt_files(
   files: FilePatterns,
 ) -> Result<Vec<PathBuf>, AnyError> {
   FileCollector::new(|e| {
-    cli_options.ext_flag().as_ref().is_some_and(|ext| {
-      is_supported_ext_fmt(Path::new(&format!("placeholder.{ext}")))
-    }) || is_supported_ext_fmt(e.path)
-      || e.path.extension().is_none()
+    is_supported_ext_fmt(e.path)
+      || (e.path.extension().is_none() && cli_options.ext_flag().is_some())
   })
   .ignore_git_folder()
   .ignore_node_modules()

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -430,10 +430,8 @@ fn collect_lint_files(
   files: FilePatterns,
 ) -> Result<Vec<PathBuf>, AnyError> {
   FileCollector::new(|e| {
-    cli_options.ext_flag().as_ref().is_some_and(|ext| {
-      is_script_ext(Path::new(&format!("placeholder.{ext}")))
-    }) || is_script_ext(e.path)
-      || e.path.extension().is_none()
+    is_script_ext(e.path)
+      || (e.path.extension().is_none() && cli_options.ext_flag().is_some())
   })
   .ignore_git_folder()
   .ignore_node_modules()

--- a/tests/specs/fmt/default_ts/__test__.jsonc
+++ b/tests/specs/fmt/default_ts/__test__.jsonc
@@ -12,6 +12,11 @@
     },
     "extensionless": {
       "args": "fmt extensionless",
+      "output": "error: No target files found.\n",
+      "exitCode": 1
+    },
+    "extensionless_with_flag": {
+      "args": "fmt --ext=ts extensionless",
       "output": "Checked 1 file\n"
     }
   }

--- a/tests/specs/lint/default_ts/__test__.jsonc
+++ b/tests/specs/lint/default_ts/__test__.jsonc
@@ -12,6 +12,11 @@
     },
     "extensionless": {
       "args": "lint extensionless",
+      "output": "error: No target files found.\n",
+      "exitCode": 1
+    },
+    "extensionless_with_flag": {
+      "args": "lint --ext=ts extensionless",
       "output": "Checked 1 file\n"
     }
   }


### PR DESCRIPTION
Fixes #25717

When using the `ext` flag, it will still attempt formatting them with the provided extension