### PR TITLE
ci: increase timeout to 180 minutes

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -354,7 +354,7 @@ const ci = {
       needs: ["pre_build"],
       if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
       "runs-on": "${{ matrix.runner }}",
-      "timeout-minutes": 150,
+      "timeout-minutes": 180,
       defaults: {
         run: {
           // GH actions does not fail fast by default on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - pre_build
     if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
     runs-on: '${{ matrix.runner }}'
-    timeout-minutes: 150
+    timeout-minutes: 180
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Mac aarch64 is failing with timeout after 150 minutes :( we'll address it
after Deno 2 is released but for now just increase the timeout.