### PR TITLE
test: make specs::test::doc_success less flaky

### DIFF
--- a/tests/specs/test/doc_success/main.out
+++ b/tests/specs/test/doc_success/main.out
@@ -15,5 +15,5 @@ running 1 test from ./main.ts$26-31.tsx
 running 1 test from ./main.ts$42-47.ts
 [WILDCARD]/main.ts$42-47.ts ... ok ([WILDCARD]s)
 
-ok | 5 passed | 0 failed ([WILDCARD]ms)
+ok | 5 passed | 0 failed ([WILDCARD]s)
 


### PR DESCRIPTION
Missed this line in https://github.com/denoland/deno/pull/25726