### PR TITLE
fix: panic when require(esm)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.310.0"
+version = "0.311.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40269d9035d16ea83335f87eab8014c6e73c5045a1f32a3cfae835b3efdd76b1"
+checksum = "5e09bd55da542fa1fde753aff617c355b5d782e763ab2a19e4371a56d7844cac"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.186.0"
+version = "0.187.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0c37f722813b9a9016f9d442e37bce0e30b97111a1690e70bab1057c03651d"
+checksum = "e040fd4def8a67538fe38c9955fd970efc9f44284bd69d44f8992a456afd665d"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6259,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.219.0"
+version = "0.220.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4de773ce668166fe0a77291cf90a7740be7997c954103c8125892597c0e98b"
+checksum = "6e7a65d91d79acc82aa229aeb084f4a39bda269069bc1520df40f679495388e4"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.42.0", features = ["transpiling"] }
-deno_core = { version = "0.310.0" }
+deno_core = { version = "0.311.0" }
 
 deno_bench_util = { version = "0.162.0", path = "./bench_util" }
 deno_lockfile = "=0.23.1"


### PR DESCRIPTION
Upgrades `deno_core`.

Closes https://github.com/denoland/deno/issues/25761
Closes https://github.com/denoland/deno/issues/25738