### PR TITLE
chore: Revert child_process close ordering change

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -391,8 +391,8 @@ export class ChildProcess extends EventEmitter {
           this.emit("exit", exitCode, signalCode);
           await this.#_waitForChildStreamsToClose();
           this.#closePipes();
-          nextTick(flushStdio, this);
           maybeClose(this);
+          nextTick(flushStdio, this);
         });
       })();
     } catch (err) {


### PR DESCRIPTION
From https://github.com/denoland/deno/commit/18b89d948dcb849c4dc577478794c3d5fb23b59

May have caused the recent flakiness of parallel/test-child-process-ipc-next-tick.js