### PR TITLE
fix(node): Include "node" condition during CJS re-export analysis

### DIFF
--- a/ext/node_resolver/analyze.rs
+++ b/ext/node_resolver/analyze.rs
@@ -196,7 +196,7 @@ impl<TCjsCodeAnalyzer: CjsCodeAnalyzer, TNodeResolverEnv: NodeResolverEnv>
             &referrer,
             // FIXME(bartlomieju): check if these conditions are okay, probably
             // should be `deno-require`, because `deno` is already used in `esm_resolver.rs`
-            &["deno", "require", "default"],
+            &["deno", "node", "require", "default"],
             NodeResolutionMode::Execution,
           );
           let reexport_specifier = match result {

--- a/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/bad.js
+++ b/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/bad.js
@@ -1,0 +1,3 @@
+module.exports = {
+  hello: "bad"
+};

--- a/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/good.cjs
+++ b/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/good.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+    hello: "from node"
+};

--- a/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/index.js
@@ -1,0 +1,3 @@
+export default {
+  hello: "default export"
+}

--- a/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/conditional-exports-node/1.0.0/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@denotest/conditional-exports",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "node": "./good.cjs",
+      "require": "./bad.js",
+      "default": "./index.js"
+    },
+    "./*": "./*"
+  }
+}

--- a/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/dist/package.cjs.js
+++ b/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/dist/package.cjs.js
@@ -1,0 +1,7 @@
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const pkg = require("@denotest/conditional-exports-node");
+
+Object.keys(pkg).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) exports[k] = pkg[k];
+});

--- a/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/package.cjs.js')

--- a/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/index.mjs
+++ b/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/index.mjs
@@ -1,0 +1,1 @@
+export * from "./index.js";

--- a/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/mjs-reexport-cjs/1.0.0/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@denotest/mjs-reexport-cjs",
+  "version": "1.0.0",
+  "dependencies": {
+    "@denotest/conditional-exports-node": "*"
+  },
+  "exports": {
+    "node": "./index.mjs",
+    "default": "./index.js"
+  }
+}

--- a/tests/specs/node/cjs_reexport_node_condition/__test__.jsonc
+++ b/tests/specs/node/cjs_reexport_node_condition/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run -A ./main.ts",
+      "output": "from node\n"
+    }
+  ]
+}

--- a/tests/specs/node/cjs_reexport_node_condition/deno.json
+++ b/tests/specs/node/cjs_reexport_node_condition/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "manual"
+}

--- a/tests/specs/node/cjs_reexport_node_condition/main.ts
+++ b/tests/specs/node/cjs_reexport_node_condition/main.ts
@@ -1,0 +1,3 @@
+import { hello } from "@denotest/mjs-reexport-cjs";
+
+console.log(hello);

--- a/tests/specs/node/cjs_reexport_node_condition/package.json
+++ b/tests/specs/node/cjs_reexport_node_condition/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/mjs-reexport-cjs": "*"
+  }
+}


### PR DESCRIPTION
Fixes #25777.

We were missing the "node" condition, so we were resolving to the wrong conditional export, causing our analysis to be incorrect.