### PR TITLE
perf(ext/fetch): improve decompression throughput by not using `tower_http::decompression`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,7 @@ dependencies = [
 name = "deno_fetch"
 version = "0.192.0"
 dependencies = [
+ "async-compression",
  "base64 0.21.7",
  "bytes",
  "data-url",
@@ -1540,7 +1541,6 @@ dependencies = [
  "tokio-socks",
  "tokio-util",
  "tower",
- "tower-http",
  "tower-service",
 ]
 
@@ -7534,26 +7534,6 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "async-compression",
- "bitflags 2.6.0",
- "bytes",
- "futures-core",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-body-util",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ node_resolver = { version = "0.7.0", path = "./ext/node_resolver" }
 
 aes = "=0.8.3"
 anyhow = "1.0.57"
+async-compression = { version = "0.4", features = ["tokio", "brotli", "gzip"] }
 async-trait = "0.1.73"
 base32 = "=0.5.1"
 base64 = "0.21.7"
@@ -184,7 +185,6 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = ["ring
 tokio-socks = "0.5.1"
 tokio-util = "0.7.4"
 tower = { version = "0.4.13", default-features = false, features = ["util"] }
-tower-http = { version = "0.5.2", features = ["decompression-br", "decompression-gzip"] }
 tower-lsp = { package = "deno_tower_lsp", version = "0.1.0", features = ["proposed"] }
 tower-service = "0.3.2"
 twox-hash = "=1.6.3"

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -14,6 +14,7 @@ description = "Fetch API implementation for Deno"
 path = "lib.rs"
 
 [dependencies]
+async-compression.workspace = true
 base64.workspace = true
 bytes.workspace = true
 data-url.workspace = true
@@ -37,7 +38,6 @@ tokio-rustls.workspace = true
 tokio-socks.workspace = true
 tokio-util = { workspace = true, features = ["io"] }
 tower.workspace = true
-tower-http.workspace = true
 tower-service.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
This commit improves the throughput when a Deno process is running as a proxy server that deals with compressed data from the upstream server.

We have seen a performance degradation since v1.45.2 when we run a HTTP server with Deno with a particular setting where it fetches _compressed_ data from the upstream server and forwards it to the end client. After some investigation, it's turned out that [tower_http::decompression](https://docs.rs/tower-http/0.6.0/tower_http/decompression/index.html) causes this issue, and that this issue is resolved if we manually implement decompression logic using `async-compression` directly.

This figure shows how the performance changes for different versions (lower is better), and verifies this patch fixes the issue:

![perf comparison](https://github.com/user-attachments/assets/2e72e72f-deb2-406d-9f8f-d0c6da8e89bf)

(See also https://github.com/magurotuna/deno_fetch_decompression_throughput for how this result was obtained)

Probably we could discover a potential bottleneck in `tower_http`, but given that manual implementation just takes less than 100 lines of code, it makes more sense to maintain our own code rather than depending on the third party, in my opinion.

Fixes #25798 
