### PR TITLE
perf(ext/fetch): improve decompression throughput by upgrading `tower_http`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7541,8 +7541,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.0"
-source = "git+https://github.com/magurotuna/tower-http.git?rev=d84e6c0b0d1427edb366704b9a3bfd7e48f9d3d4#d84e6c0b0d1427edb366704b9a3bfd7e48f9d3d4"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
  "async-compression",
  "bitflags 2.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7541,9 +7541,8 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+version = "0.6.0"
+source = "git+https://github.com/magurotuna/tower-http.git?rev=d84e6c0b0d1427edb366704b9a3bfd7e48f9d3d4#d84e6c0b0d1427edb366704b9a3bfd7e48f9d3d4"
 dependencies = [
  "async-compression",
  "bitflags 2.6.0",
@@ -7561,9 +7560,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = ["ring
 tokio-socks = "0.5.1"
 tokio-util = "0.7.4"
 tower = { version = "0.4.13", default-features = false, features = ["util"] }
-tower-http = { version = "0.5.2", features = ["decompression-br", "decompression-gzip"] }
+tower-http = { version = "0.6.0", features = ["decompression-br", "decompression-gzip"] }
 tower-lsp = { package = "deno_tower_lsp", version = "0.1.0", features = ["proposed"] }
 tower-service = "0.3.2"
 twox-hash = "=1.6.3"
@@ -398,3 +398,7 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
+
+[patch.crates-io]
+# Until https://github.com/tower-rs/tower-http/pull/521 is merged and released
+tower-http = { git = "https://github.com/magurotuna/tower-http.git", rev = "d84e6c0b0d1427edb366704b9a3bfd7e48f9d3d4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ tokio-rustls = { version = "0.26.0", default-features = false, features = ["ring
 tokio-socks = "0.5.1"
 tokio-util = "0.7.4"
 tower = { version = "0.4.13", default-features = false, features = ["util"] }
-tower-http = { version = "0.6.0", features = ["decompression-br", "decompression-gzip"] }
+tower-http = { version = "0.6.1", features = ["decompression-br", "decompression-gzip"] }
 tower-lsp = { package = "deno_tower_lsp", version = "0.1.0", features = ["proposed"] }
 tower-service = "0.3.2"
 twox-hash = "=1.6.3"
@@ -398,7 +398,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
-
-[patch.crates-io]
-# Until https://github.com/tower-rs/tower-http/pull/521 is merged and released
-tower-http = { git = "https://github.com/magurotuna/tower-http.git", rev = "d84e6c0b0d1427edb366704b9a3bfd7e48f9d3d4" }


### PR DESCRIPTION
Fixes #25798

This accomplishes the same result as #25800, but not by manually implementing a decompression logic, but by upgrading `tower-http` to incorporate the patch (https://github.com/tower-rs/tower-http/pull/521).

![performance comparison](https://github.com/user-attachments/assets/e008c47c-87f7-4a42-8c27-2eae7e7f659c)
