### PR TITLE
feat: make 'globalThis.location' a configurable property

### DIFF
--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -654,6 +654,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
     if (location_ == null) {
       mainRuntimeGlobalProperties.location = {
         writable: true,
+        configurable: true,
       };
     } else {
       location.setLocationHref(location_);

--- a/tests/specs/run/location/__test__.json
+++ b/tests/specs/run/location/__test__.json
@@ -1,0 +1,6 @@
+{
+  "location_object_defined_property": {
+    "args": "run location.js",
+    "output": "location.out"
+  }
+}

--- a/tests/specs/run/location/__test__.json
+++ b/tests/specs/run/location/__test__.json
@@ -1,6 +1,0 @@
-{
-  "location_object_defined_property": {
-    "args": "run location.js",
-    "output": "location.out"
-  }
-}

--- a/tests/specs/run/location/__test__.jsonc
+++ b/tests/specs/run/location/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "location_object_define_property": {
+      "args": "run location.js",
+      "output": "location.out"
+    }
+  }
+}

--- a/tests/specs/run/location/location.js
+++ b/tests/specs/run/location/location.js
@@ -1,0 +1,24 @@
+let _location = undefined;
+
+console.log(globalThis.location);
+
+Object.defineProperty(globalThis, "location", {
+  get() {
+    return _location;
+  },
+  set(v) {
+    _location = v;
+  },
+  configurable: true,
+});
+
+console.log(globalThis.location);
+
+globalThis.location = "https://deno.com";
+
+console.log(_location);
+console.log(location);
+
+delete globalThis["location"];
+
+console.log(globalThis.location);

--- a/tests/specs/run/location/location.out
+++ b/tests/specs/run/location/location.out
@@ -1,0 +1,5 @@
+undefined
+undefined
+https://deno.com
+https://deno.com
+undefined


### PR DESCRIPTION
This commit changes `globalThis.location` property to be configurable
so that packages wanting to override it (or delete it) work properly.

Towards https://github.com/denoland/deno/issues/23882

This change makes reproduction from https://github.com/denoland/deno/issues/23882#issuecomment-2340783437
pass properly.