### PR TITLE
feat(cli): expose node `global` everywhere

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -61,13 +61,12 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 
 // UTF-16 encodings of the managed globals. THIS LIST MUST BE SORTED.
 #[rustfmt::skip]
-const MANAGED_GLOBALS: [&[u16]; 12] = [
+const MANAGED_GLOBALS: [&[u16]; 11] = [
   &str_to_utf16::<6>("Buffer"),
   &str_to_utf16::<17>("WorkerGlobalScope"),
   &str_to_utf16::<14>("clearImmediate"),
   &str_to_utf16::<13>("clearInterval"),
   &str_to_utf16::<12>("clearTimeout"),
-  &str_to_utf16::<6>("global"),
   &str_to_utf16::<11>("performance"),
   &str_to_utf16::<4>("self"),
   &str_to_utf16::<12>("setImmediate"),

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -52,7 +52,6 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 // - clearImmediate (node only)
 // - clearInterval (both, but different implementation)
 // - clearTimeout (both, but different implementation)
-// - global (node only)
 // - performance (both, but different implementation)
 // - setImmediate (node only)
 // - setInterval (both, but different implementation)

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -136,6 +136,7 @@ const windowOrWorkerGlobalScope = {
   Crypto: core.propNonEnumerable(crypto.Crypto),
   SubtleCrypto: core.propNonEnumerable(crypto.SubtleCrypto),
   fetch: core.propWritable(fetch.fetch),
+  global: core.propWritable(globalThis),
   EventSource: core.propWritable(eventSource.EventSource),
   performance: core.propWritable(performance.performance),
   process: core.propWritable(process),

--- a/tests/specs/run/globals/__test__.jsonc
+++ b/tests/specs/run/globals/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "has_node_global": {
+      "args": "run has_node_global.js",
+      "exitCode": 0,
+      "output": "has_node_global.out"
+    }
+  }
+}

--- a/tests/specs/run/globals/has_node_global.js
+++ b/tests/specs/run/globals/has_node_global.js
@@ -1,0 +1,1 @@
+globalThis === globalThis.global;


### PR DESCRIPTION
Many npm packages still use `global` instead of `globalThis`. By adding a one-liner to alias it, we can get lots more npm packages to work that are distributed through other means than an npm registry like `cdn.jsdelivr.net`. This exposes the `global` everywhere, similar to `process`.

```js
globalThis.global = globalThis
```

Fixes https://github.com/denoland/deno/issues/25819 