### PR TITLE
tests: update specs::cache::package_json

### DIFF
--- a/tests/specs/cache/package_json/__test__.jsonc
+++ b/tests/specs/cache/package_json/__test__.jsonc
@@ -1,7 +1,13 @@
 {
   "tempDir": true,
-  // TODO(2.0): decide if this test should be fixed or removed
-  "ignore": true,
-  "args": "cache main.ts",
-  "output": "main.cache.out"
+  "steps": [
+    {
+      "args": "cache main.ts",
+      "output": "main.cache.out"
+    },
+    {
+      "args": "eval console.log(Deno.readTextFileSync('deno.lock').trim())",
+      "output": "deno.lock.out"
+    }
+  ]
 }

--- a/tests/specs/cache/package_json/deno.json
+++ b/tests/specs/cache/package_json/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "none"
+}

--- a/tests/specs/cache/package_json/deno.lock.out
+++ b/tests/specs/cache/package_json/deno.lock.out
@@ -1,0 +1,16 @@
+{
+  "version": "4",
+  "specifiers": {
+    "npm:@denotest/esm-basic@*": "1.0.0"
+  },
+  "npm": {
+    "@denotest/esm-basic@1.0.0": [WILDCARD]
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/esm-basic@*"
+      ]
+    }
+  }
+}

--- a/tests/specs/cache/package_json/main.cache.out
+++ b/tests/specs/cache/package_json/main.cache.out
@@ -1,3 +1,2 @@
 Download http://localhost:4260/@denotest/esm-basic
 Download http://localhost:4260/@denotest/esm-basic/1.0.0.tgz
-Initialize @denotest/esm-basic@1.0.0


### PR DESCRIPTION
Towards https://github.com/denoland/deno/issues/25241

Usage of `deno cache` makes sense when `nodeModulesDir: none` option is used. The test is updated to match the expectation.