### PR TITLE
feat(fmt): support vto and njk extensions

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -265,6 +265,8 @@ fn format_markdown(
           | "svelte"
           | "vue"
           | "astro"
+          | "vto"
+          | "njk"
           | "yml"
           | "yaml"
       ) {
@@ -288,7 +290,7 @@ fn format_markdown(
             format_css(&fake_filename, text, fmt_options)
           }
           "html" => format_html(&fake_filename, text, fmt_options),
-          "svelte" | "vue" | "astro" => {
+          "svelte" | "vue" | "astro" | "vto" | "njk" => {
             if unstable_options.component {
               format_html(&fake_filename, text, fmt_options)
             } else {
@@ -460,7 +462,7 @@ pub fn format_file(
       format_css(file_path, file_text, fmt_options)
     }
     "html" => format_html(file_path, file_text, fmt_options),
-    "svelte" | "vue" | "astro" => {
+    "svelte" | "vue" | "astro" | "vto" | "njk" => {
       if unstable_options.component {
         format_html(file_path, file_text, fmt_options)
       } else {
@@ -1139,6 +1141,8 @@ fn is_supported_ext_fmt(path: &Path) -> bool {
         | "svelte"
         | "vue"
         | "astro"
+        | "vto"
+        | "njk"
         | "md"
         | "mkd"
         | "mkdn"
@@ -1197,6 +1201,10 @@ mod test {
     assert!(is_supported_ext_fmt(Path::new("foo.VUE")));
     assert!(is_supported_ext_fmt(Path::new("foo.astro")));
     assert!(is_supported_ext_fmt(Path::new("foo.AsTrO")));
+    assert!(is_supported_ext_fmt(Path::new("foo.vto")));
+    assert!(is_supported_ext_fmt(Path::new("foo.Vto")));
+    assert!(is_supported_ext_fmt(Path::new("foo.njk")));
+    assert!(is_supported_ext_fmt(Path::new("foo.NJk")));
     assert!(is_supported_ext_fmt(Path::new("foo.yml")));
     assert!(is_supported_ext_fmt(Path::new("foo.Yml")));
     assert!(is_supported_ext_fmt(Path::new("foo.yaml")));

--- a/tests/specs/fmt/njk/__test__.jsonc
+++ b/tests/specs/fmt/njk/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "fmt --unstable-component",
+  "output": "[WILDLINE]badly_formatted.njk\nChecked 1 file\n"
+}

--- a/tests/specs/fmt/njk/badly_formatted.njk
+++ b/tests/specs/fmt/njk/badly_formatted.njk
@@ -1,0 +1,3 @@
+<h1>  {{ "Hello, world!" | upper }}
+  </h1>
+

--- a/tests/specs/fmt/vento/__test__.jsonc
+++ b/tests/specs/fmt/vento/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "tempDir": true,
+  "args": "fmt --unstable-component",
+  "output": "[WILDLINE]badly_formatted.vto\nChecked 1 file\n"
+}

--- a/tests/specs/fmt/vento/badly_formatted.vto
+++ b/tests/specs/fmt/vento/badly_formatted.vto
@@ -1,0 +1,3 @@
+<h1>  {{ "Hello, world!" |> toUpperCase }}
+  </h1>
+


### PR DESCRIPTION
Fixes #25802

markup_fmt plugin supports some HTML-like formats like Angular, Jinja, Twig, Nunjucks or Vento, that are not supported by `deno fmt`. This PR adds support for the extensions `njk` (Nunjucks) and `vto` (Vento). Angular doesn't have a custom extension (it uses `html` afaik) and Jinja and Twig are template engines written in Python and PHP respectively so it doesn't make sense to be supported by Deno.
