### PR TITLE
BREAKING: remove support for remote import maps in deno.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187d7dd888a49bfda396632371139e940c5cf47b15bfcaeeb2ba50f82f6940ec"
+checksum = "105864a9e0a7fbc22f1106784b2d263f402f157be1c3e1a9905f53d182700c9f"
 dependencies = [
  "anyhow",
  "deno_package_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,7 +65,7 @@ winres.workspace = true
 [dependencies]
 deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "proposal", "react", "sourcemap", "transforms", "typescript", "view", "visit"] }
 deno_cache_dir = { workspace = true }
-deno_config = { version = "=0.34.3", features = ["workspace", "sync"] }
+deno_config = { version = "=0.35.0", features = ["workspace", "sync"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "0.148.0", features = ["html", "syntect"] }
 deno_graph = { version = "=0.82.1" }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1071,27 +1071,13 @@ impl CliOptions {
         None => None,
       }
     };
-    Ok(
-      self
-        .workspace()
-        .create_resolver(
-          CreateResolverOptions {
-            pkg_json_dep_resolution,
-            specified_import_map: cli_arg_specified_import_map,
-          },
-          |specifier| {
-            let specifier = specifier.clone();
-            async move {
-              let file = file_fetcher
-                .fetch_bypass_permissions(&specifier)
-                .await?
-                .into_text_decoded()?;
-              Ok(file.source.to_string())
-            }
-          },
-        )
-        .await?,
-    )
+    Ok(self.workspace().create_resolver(
+      CreateResolverOptions {
+        pkg_json_dep_resolution,
+        specified_import_map: cli_arg_specified_import_map,
+      },
+      |path| Ok(std::fs::read_to_string(path)?),
+    )?)
   }
 
   pub fn node_ipc_fd(&self) -> Option<i64> {

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -364,13 +364,6 @@ fn lsp_import_map_remote() {
     .build();
   let temp_dir = context.temp_dir();
   temp_dir.write(
-    "deno.json",
-    json!({
-      "importMap": "http://localhost:4545/import_maps/import_map_remote.json",
-    })
-    .to_string(),
-  );
-  temp_dir.write(
     "file.ts",
     r#"
       import { printHello } from "print_hello";


### PR DESCRIPTION
* https://github.com/denoland/deno_config/pull/116

This is for security reasons for the time being for Deno 2. Details to follow post Deno 2.0 release.

Remote import maps seem incredibly rare (only 2 usages on GitHub from what I can tell), so we'll add this back with more permissions if there's enough demand for it: https://github.com/search?type=code&q=%2F%22importMap%22%3A+%22http%2F

In the meantime, use the `--import-map` flag and `"deno.importMap"` config in the LSP for remote import maps.