### PR TITLE
fix: Update deno_npm to fix `deno install` with crossws

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61b112e9bb332e8e6b0d82fcea7664423933de476e1726dd23a924a2d94f4ef"
+checksum = "1809e2d77d8a06bc2800dc10c1d4acb664197e518e289a86e336411c1feba785"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,7 +71,7 @@ deno_doc = { version = "0.148.0", features = ["html", "syntect"] }
 deno_graph = { version = "=0.82.1" }
 deno_lint = { version = "=0.67.0", features = ["docs"] }
 deno_lockfile.workspace = true
-deno_npm = "=0.25.1"
+deno_npm = "=0.25.2"
 deno_package_json.workspace = true
 deno_runtime = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_semver.workspace = true

--- a/tests/registry/npm/@denotest/non-existent-optional-peer/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/non-existent-optional-peer/1.0.0/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@denotest/non-existent-optional-peer",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "uWebSockets.js": "*"
+  },
+  "peerDependenciesMeta": {
+    "uWebSockets.js": {
+      "optional": true
+    }
+  }
+}

--- a/tests/specs/install/non_existent_optional_peer/__test__.jsonc
+++ b/tests/specs/install/non_existent_optional_peer/__test__.jsonc
@@ -1,0 +1,11 @@
+// test imitates what crossws 0.2.4 has https://www.npmjs.com/package/crossws/v/0.2.4
+// where uWebSockets.js is an optional peer dep, but doesn't exist on npm
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "install.out"
+    }
+  ]
+}

--- a/tests/specs/install/non_existent_optional_peer/install.out
+++ b/tests/specs/install/non_existent_optional_peer/install.out
@@ -1,0 +1,6 @@
+[UNORDERED_START]
+Download http://localhost:4260/@denotest/non-existent-optional-peer
+Download http://localhost:4260/uWebSockets.js
+Download http://localhost:4260/@denotest/non-existent-optional-peer/1.0.0.tgz
+[UNORDERED_END]
+Initialize @denotest/non-existent-optional-peer@1.0.0

--- a/tests/specs/install/non_existent_optional_peer/package.json
+++ b/tests/specs/install/non_existent_optional_peer/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/non-existent-optional-peer": "1.0.0"
+  }
+}


### PR DESCRIPTION
Partially addresses https://github.com/denoland/deno/issues/25648.

This allows packages that use `crossws` to be installed with `deno install`. `crossws` specifies an optional peer dependency on `uWebSockets`, but `uWebSockets` is not on npm (it is used with `git:` or `github:` specifiers). Previously we would error on this, now we don't error on non-existent optional peer dependencies.
