### PR TITLE
fix(installl): make bin entries executable even if not put in `node_modules/.bin`

### DIFF
--- a/cli/npm/managed/resolvers/common/bin_entries.rs
+++ b/cli/npm/managed/resolvers/common/bin_entries.rs
@@ -281,7 +281,7 @@ fn set_up_bin_shim(
 fn make_executable_if_exists(path: &Path) -> Result<bool, AnyError> {
   use std::io;
   use std::os::unix::fs::PermissionsExt;
-  let mut perms = match std::fs::metadata(&path) {
+  let mut perms = match std::fs::metadata(path) {
     Ok(metadata) => metadata.permissions(),
     Err(err) => {
       if err.kind() == io::ErrorKind::NotFound {
@@ -293,7 +293,7 @@ fn make_executable_if_exists(path: &Path) -> Result<bool, AnyError> {
   if perms.mode() & 0o111 == 0 {
     // if the original file is not executable, make it executable
     perms.set_mode(perms.mode() | 0o111);
-    std::fs::set_permissions(&path, perms).with_context(|| {
+    std::fs::set_permissions(path, perms).with_context(|| {
       format!("Setting permissions on '{}'", path.display())
     })?;
   }

--- a/tests/registry/npm/@denotest/bin/1.0.0/cli-cjs.js
+++ b/tests/registry/npm/@denotest/bin/1.0.0/cli-cjs.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env -S node
+
 const process = require("process");
 
 for (const arg of process.argv.slice(2)) {

--- a/tests/specs/npm/bin_entries_prefer_closer/__test__.jsonc
+++ b/tests/specs/npm/bin_entries_prefer_closer/__test__.jsonc
@@ -18,6 +18,13 @@
     {
       "args": "task run-no-ext",
       "output": "Task run-no-ext cli-no-ext hello world\n@denotest/bin 0.7.0\n"
+    },
+    {
+      // even though we didn't put it in .bin, make sure the bin entry is marked executable
+      "if": "unix",
+      "commandName": "node_modules/.deno/@denotest+bin@1.0.0/node_modules/@denotest/bin/cli-cjs.js",
+      "args": "hello",
+      "output": "hello\n"
     }
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/25862.

npm only makes bin entries executable if they get linked into `.bin`, as we did before this PR. So this PR actually deviates from npm, because it's the only reasonable way to fix this that I can think of.

---

The reason this was broken in moment is the following:

Moment has dependencies on two typescript versions: 1.8 and 3.1

If you have two packages with conflicting bin entries (i.e. two typescript versions which both have a bin entry `tsc`), in npm it is non-deterministic and undefined which one will end up in `.bin`.

npm, due to implementation differences, chooses to put typescript 1.8 into the `.bin` directory, and so `node_modules/typescript/bin/tsc` ends up getting marked executable. We, however, choose typescript 3.2, and so we end up making `node_modules/typescript3/bin/tsc` executable.

As part of its tests, moment executes `node_modules/typescript/bin/tsc`. Because we didn't make it executable, this fails.

Since the conflict resolution is undefined in npm, instead of trying to match it, I think it makes more sense to just make bin entries executable even if they aren't chosen in the case of a conflict.