### PR TITLE
feat: Don't warn about --allow-script when using esbuild

### DIFF
--- a/cli/npm/managed/resolvers/common/lifecycle_scripts.rs
+++ b/cli/npm/managed/resolvers/common/lifecycle_scripts.rs
@@ -113,6 +113,12 @@ impl<'a> LifecycleScripts<'a> {
       } else if !self.strategy.has_run(package)
         && (self.config.explicit_install || !self.strategy.has_warned(package))
       {
+        // Skip adding `esbuild` as it is known that it can work properly without lifecycle script
+        // being run, and it's also very popular - any project using Vite would raise warnings.
+        if package.id.nv.name == "esbuild" {
+          return;
+        }
+
         self
           .packages_with_scripts_not_run
           .push((package, package_path.into_owned()));

--- a/cli/npm/managed/resolvers/common/lifecycle_scripts.rs
+++ b/cli/npm/managed/resolvers/common/lifecycle_scripts.rs
@@ -4,6 +4,7 @@ use super::bin_entries::BinEntries;
 use crate::args::LifecycleScriptsConfig;
 use deno_npm::resolution::NpmResolutionSnapshot;
 use deno_semver::package::PackageNv;
+use deno_semver::Version;
 use std::borrow::Cow;
 use std::rc::Rc;
 
@@ -115,8 +116,13 @@ impl<'a> LifecycleScripts<'a> {
       {
         // Skip adding `esbuild` as it is known that it can work properly without lifecycle script
         // being run, and it's also very popular - any project using Vite would raise warnings.
-        if package.id.nv.name == "esbuild" {
-          return;
+        {
+          let nv = &package.id.nv;
+          if nv.name == "esbuild"
+            && nv.version >= Version::parse_standard("0.18.0").unwrap()
+          {
+            return;
+          }
         }
 
         self


### PR DESCRIPTION
`esbuild` can work fine without needing to run post-install script, so to make it easier
on users (especially people using Vite) we are not prompting to run with `--allow-scripts` again.
We only do that for version >= 0.18.0 to be sure.