### PR TITLE
ci: use macos-14-xlarge on 'main' branch

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -14,6 +14,7 @@ const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const macosX86Runner = "macos-13";
 const macosArmRunner = "macos-14";
+const macosArmXlRunner = "macos-14-xlarge";
 
 const Runners = {
   linuxX86: {
@@ -41,6 +42,12 @@ const Runners = {
     os: "macos",
     arch: "aarch64",
     runner: macosArmRunner,
+  },
+  macosArmXl: {
+    os: "macos",
+    arch: "aarch64",
+    runner:
+      `\${{ github.repository == 'denoland/deno' && '${macosArmXlRunner}' || '${macosArmRunner}' }}`,
   },
   windowsX86: {
     os: "windows",
@@ -378,7 +385,7 @@ const ci = {
             job: "test",
             profile: "debug",
           }, {
-            ...Runners.macosArm,
+            ...Runners.macosArmXl,
             job: "test",
             profile: "release",
             skip_pr: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
             profile: debug
           - os: macos
             arch: aarch64
-            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || ''macos-14'' }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''macos-14-xlarge'' || ''macos-14'' }}'
             job: test
             profile: release
             skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'


### PR DESCRIPTION
We only do `release` build for Mac ARM on `main` branch. It now takes more than 2.5h and sometimes
it even times out after 3h.

Gonna try to use `macos-14-xlarge` runner for a day to evaluate the spending.
https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-arm64-powered-larger-runners