### PR TITLE
fix(flags): --allow-all should conflict with lower permissions

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3603,6 +3603,14 @@ fn allow_all_arg() -> Arg {
   Arg::new("allow-all")
     .short('A')
     .long("allow-all")
+    .conflicts_with("allow-read")
+    .conflicts_with("allow-write")
+    .conflicts_with("allow-net")
+    .conflicts_with("allow-env")
+    .conflicts_with("allow-run")
+    .conflicts_with("allow-sys")
+    .conflicts_with("allow-ffi")
+    .conflicts_with("allow-import")
     .action(ArgAction::SetTrue)
     .help("Allow all permissions")
 }
@@ -11006,5 +11014,24 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
       Some("example.com:80".to_string())
     );
     assert_eq!(parse("file:///example.com"), None);
+  }
+
+  #[test]
+  fn allow_all_conflicts_allow_perms() {
+    let flags = [
+      "--allow-read",
+      "--allow-write",
+      "--allow-net",
+      "--allow-env",
+      "--allow-run",
+      "--allow-sys",
+      "--allow-ffi",
+      "--allow-import",
+    ];
+    for flag in flags {
+      let r =
+        flags_from_vec(svec!["deno", "run", "--allow-all", flag, "foo.ts"]);
+      assert!(r.is_err());
+    }
   }
 }

--- a/tests/specs/permission/allow_import/__test__.jsonc
+++ b/tests/specs/permission/allow_import/__test__.jsonc
@@ -34,6 +34,11 @@
       "output": "run.out",
       "exitCode": 1
     },
+    "run_allow_all": {
+      "args": "run --quiet --allow-all success.ts",
+      "output": "3\n",
+      "exitCode": 0
+    },
     "serve": {
       "args": "serve main.ts",
       "output": "serve.out",

--- a/tests/specs/permission/allow_import/success.ts
+++ b/tests/specs/permission/allow_import/success.ts
@@ -1,0 +1,3 @@
+import { add } from "http://localhost:4545/add.ts";
+
+console.log(add(1, 2));


### PR DESCRIPTION
Using `--allow-all` with other `--allow-x` permission flags should cause an error since `--allow-all` is a superset of `--allow-x`.

Closes #25901