### PR TITLE
refactor(ext/node): align error messages

### DIFF
--- a/ext/node/polyfills/_fs/_fs_writeFile.ts
+++ b/ext/node/polyfills/_fs/_fs_writeFile.ts
@@ -42,7 +42,7 @@ export function writeFile(
     optOrCallback instanceof Function ? undefined : optOrCallback;
 
   if (!callbackFn) {
-    throw new TypeError("Callback must be a function.");
+    throw new TypeError("Callback must be a function");
   }
 
   pathOrRid = pathOrRid instanceof URL ? pathFromURL(pathOrRid) : pathOrRid;

--- a/ext/node/polyfills/_util/std_asserts.ts
+++ b/ext/node/polyfills/_util/std_asserts.ts
@@ -120,7 +120,7 @@ export function equal(c: unknown, d: unknown): boolean {
           !(ObjectPrototypeIsPrototypeOf(WeakMapPrototype, a) &&
             ObjectPrototypeIsPrototypeOf(WeakMapPrototype, b))
         ) return false;
-        throw new TypeError("cannot compare WeakMap instances");
+        throw new TypeError("Cannot compare WeakMap instances");
       }
       if (
         ObjectPrototypeIsPrototypeOf(WeakSetPrototype, a) ||
@@ -130,7 +130,7 @@ export function equal(c: unknown, d: unknown): boolean {
           !(ObjectPrototypeIsPrototypeOf(WeakSetPrototype, a) &&
             ObjectPrototypeIsPrototypeOf(WeakSetPrototype, b))
         ) return false;
-        throw new TypeError("cannot compare WeakSet instances");
+        throw new TypeError("Cannot compare WeakSet instances");
       }
       if (seen.get(a) === b) {
         return true;

--- a/ext/node/polyfills/_utils.ts
+++ b/ext/node/polyfills/_utils.ts
@@ -179,7 +179,7 @@ export function validateIntegerRange(
 
   if (value < min || value > max) {
     throw new Error(
-      `${name} must be >= ${min} && <= ${max}. Value was ${value}`,
+      `${name} must be >= ${min} && <= ${max}: received ${value}`,
     );
   }
 }

--- a/ext/node/polyfills/internal/crypto/_randomBytes.ts
+++ b/ext/node/polyfills/internal/crypto/_randomBytes.ts
@@ -11,7 +11,7 @@ export const MAX_SIZE = 4294967295;
 function generateRandomBytes(size: number) {
   if (size > MAX_SIZE) {
     throw new RangeError(
-      `The value of "size" is out of range. It must be >= 0 && <= ${MAX_SIZE}. Received ${size}`,
+      `The value of "size" is out of range, it must be >= 0 && <= ${MAX_SIZE}: received ${size}`,
     );
   }
 

--- a/ext/node/polyfills/internal/crypto/_randomInt.ts
+++ b/ext/node/polyfills/internal/crypto/_randomInt.ts
@@ -35,15 +35,15 @@ export default function randomInt(
     !Number.isSafeInteger(min) ||
     typeof max === "number" && !Number.isSafeInteger(max)
   ) {
-    throw new Error("max or min is not a Safe Number");
+    throw new Error('"max" or "min" is not a Safe Number');
   }
 
   if (max - min > Math.pow(2, 48)) {
-    throw new RangeError("max - min should be less than 2^48!");
+    throw new RangeError("max - min must be less than 2^48");
   }
 
   if (min >= max) {
-    throw new Error("Min is bigger than Max!");
+    throw new Error('"min" is bigger than "max"');
   }
 
   min = Math.ceil(min);

--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -189,7 +189,7 @@ export class Cipheriv extends Transform implements Cipher {
     this.#needsBlockCache =
       !(cipher == "aes-128-gcm" || cipher == "aes-256-gcm");
     if (this.#context == 0) {
-      throw new TypeError("Unknown cipher");
+      throw new TypeError(`Unknown cipher: ${cipher}`);
     }
   }
 
@@ -347,7 +347,7 @@ export class Decipheriv extends Transform implements Cipher {
     this.#needsBlockCache =
       !(cipher == "aes-128-gcm" || cipher == "aes-256-gcm");
     if (this.#context == 0) {
-      throw new TypeError("Unknown cipher");
+      throw new TypeError(`Unknown cipher: ${cipher}`);
     }
   }
 

--- a/ext/node/polyfills/internal/crypto/diffiehellman.ts
+++ b/ext/node/polyfills/internal/crypto/diffiehellman.ts
@@ -1190,7 +1190,7 @@ export class ECDH {
 
     const c = ellipticCurves.find((x) => x.name == curve);
     if (c == undefined) {
-      throw new Error("invalid curve");
+      throw new Error(`Invalid curve: ${curve}`);
     }
 
     this.#curve = c;

--- a/ext/node/polyfills/internal/crypto/scrypt.ts
+++ b/ext/node/polyfills/internal/crypto/scrypt.ts
@@ -69,7 +69,7 @@ export function scryptSync(
   const blen = p * 128 * r;
 
   if (32 * r * (N + 2) * 4 + blen > maxmem) {
-    throw new Error("exceeds max memory");
+    throw new Error('"scryptSync" exceeds max memory');
   }
 
   const buf = Buffer.alloc(keylen);
@@ -104,7 +104,7 @@ export function scrypt(
 
   const blen = p * 128 * r;
   if (32 * r * (N + 2) * 4 + blen > maxmem) {
-    throw new Error("exceeds max memory");
+    throw new Error('"scryptSync" exceeds max memory');
   }
 
   try {

--- a/ext/node/polyfills/internal/crypto/sig.ts
+++ b/ext/node/polyfills/internal/crypto/sig.ts
@@ -259,7 +259,9 @@ export function signOneShot(
   let result: Buffer;
   if (op_node_get_asymmetric_key_type(handle) === "ed25519") {
     if (algorithm != null && algorithm !== "sha512") {
-      throw new TypeError("Only 'sha512' is supported for Ed25519 keys");
+      throw new TypeError(
+        `Only 'sha512' is supported for Ed25519 keys: received '${algorithm}'`,
+      );
     }
     result = new Buffer(64);
     op_node_sign_ed25519(handle, data, result);
@@ -314,7 +316,9 @@ export function verifyOneShot(
   let result: boolean;
   if (op_node_get_asymmetric_key_type(handle) === "ed25519") {
     if (algorithm != null && algorithm !== "sha512") {
-      throw new TypeError("Only 'sha512' is supported for Ed25519 keys");
+      throw new TypeError(
+        `Only 'sha512' is supported for Ed25519 keys: received '${algorithm}'`,
+      );
     }
     result = op_node_verify_ed25519(handle, data, signature);
   } else if (algorithm == null) {

--- a/ext/node/polyfills/path/_posix.ts
+++ b/ext/node/polyfills/path/_posix.ts
@@ -39,7 +39,7 @@ export function resolve(...pathSegments: string[]): string {
       // deno-lint-ignore no-explicit-any
       const { Deno } = globalThis as any;
       if (typeof Deno?.cwd !== "function") {
-        throw new TypeError("Resolved a relative path without a CWD.");
+        throw new TypeError("Resolved a relative path without a CWD");
       }
       path = Deno.cwd();
     }

--- a/ext/node/polyfills/path/_win32.ts
+++ b/ext/node/polyfills/path/_win32.ts
@@ -46,14 +46,14 @@ export function resolve(...pathSegments: string[]): string {
       path = pathSegments[i];
     } else if (!resolvedDevice) {
       if (typeof Deno?.cwd !== "function") {
-        throw new TypeError("Resolved a drive-letter-less path without a CWD.");
+        throw new TypeError("Resolved a drive-letter-less path without a CWD");
       }
       path = Deno.cwd();
     } else {
       if (
         typeof Deno?.env?.get !== "function" || typeof Deno?.cwd !== "function"
       ) {
-        throw new TypeError("Resolved a relative path without a CWD.");
+        throw new TypeError("Resolved a relative path without a CWD");
       }
       path = Deno.cwd();
 

--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -102,7 +102,7 @@ export function serialize(value: any) {
 export function deserialize(buffer: Buffer | ArrayBufferView | DataView) {
   if (!isArrayBufferView(buffer)) {
     throw new TypeError(
-      "buffer must be a TypedArray or a DataView",
+      "Cannot deserialize: 'buffer' must be a 'TypedArray' or a 'DataView'",
     );
   }
   const der = new DefaultDeserializer(buffer);
@@ -141,7 +141,7 @@ export class Serializer {
   writeRawBytes(source: ArrayBufferView): void {
     if (!isArrayBufferView(source)) {
       throw new TypeError(
-        "source must be a TypedArray or a DataView",
+        "Cannot write bytes: 'source' must be a 'TypedArray' or a 'DataView'",
       );
     }
     op_v8_write_raw_bytes(this[kHandle], source);
@@ -169,7 +169,7 @@ export class Deserializer {
   constructor(buffer: ArrayBufferView) {
     if (!isArrayBufferView(buffer)) {
       throw new TypeError(
-        "buffer must be a TypedArray or a DataView",
+        "Cannot construct 'Deserializer': 'buffer' must be a 'TypedArray' or a 'DataView'",
       );
     }
     this.buffer = buffer;

--- a/tests/node_compat/test/parallel/test-v8-serdes.js
+++ b/tests/node_compat/test/parallel/test-v8-serdes.js
@@ -265,15 +265,15 @@ const objects = [
   serializer.writeHeader();
   assert.throws(
     () => serializer.writeRawBytes(INVALID_SOURCE),
-    /^TypeError: source must be a TypedArray or a DataView$/,
+    /^TypeError: Cannot write bytes: 'source' must be a 'TypedArray' or a 'DataView'$/,
   );
   assert.throws(
     () => v8.deserialize(INVALID_SOURCE),
-    /^TypeError: buffer must be a TypedArray or a DataView$/,
+    /^TypeError: Cannot deserialize: 'buffer' must be a 'TypedArray' or a 'DataView'$/,
   );
   assert.throws(
     () => new v8.Deserializer(INVALID_SOURCE),
-    /^TypeError: buffer must be a TypedArray or a DataView$/,
+    /^TypeError: Cannot construct 'Deserializer': 'buffer' must be a 'TypedArray' or a 'DataView'$/,
   );
 }
 

--- a/tests/unit_node/_fs/_fs_writeFile_test.ts
+++ b/tests/unit_node/_fs/_fs_writeFile_test.ts
@@ -31,7 +31,7 @@ Deno.test("Callback must be a function error", function fn() {
       writeFile("some/path", "some data", "utf8");
     },
     TypeError,
-    "Callback must be a function.",
+    "Callback must be a function",
   );
 });
 


### PR DESCRIPTION
Aligns the error messages in the ext/node folder to be in-line with the Deno style guide.

https://github.com/denoland/deno/issues/25269

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
