### PR TITLE
fix: update sui to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4174,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e39af24eff8df7c8b9980ef56a1a1f4d2e77b34b2d5c0529f108c53ae96a7a"
+checksum = "205eca4e7beaad637dcd38fe41292065894ee7f498077cf3c135d5f7252b9f27"
 dependencies = [
  "editpe",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -80,7 +80,7 @@ deno_semver.workspace = true
 deno_task_shell = "=0.17.0"
 deno_terminal.workspace = true
 eszip = "=0.78.0"
-libsui = "0.3.1"
+libsui = "0.4.0"
 napi_sym.workspace = true
 node_resolver.workspace = true
 


### PR DESCRIPTION
Properly apply offset fixup to `LC_DYLD_EXPORTS_TRIE` load commands. This should fix Node-API symbols not resolving in RC releases.

Fixes https://github.com/denoland/deno/issues/25879
Fixes https://github.com/denoland/deno/issues/25940

Ref https://github.com/denoland/sui/commit/2b3a33bb6e1afbb04e2e1d345547e5686894e7f0 
