### PR TITLE
fix: eagerly error for specifier with empty version constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6657fecb9ac6a7a71f552c95e8cc492466a75f5660224577e2226bcf30db9768"
+checksum = "670fec7ef309384e23c2a90ac5d2d9d91a776d225306c75f5cdd28cf6cc8a59f"
 dependencies = [
  "monch",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ deno_npm = "=0.25.2"
 deno_path_util = "=0.1.1"
 deno_permissions = { version = "0.28.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.177.0", path = "./runtime" }
-deno_semver = "=0.5.13"
+deno_semver = "=0.5.14"
 deno_terminal = "0.2.0"
 napi_sym = { version = "0.98.0", path = "./cli/napi/sym" }
 test_util = { package = "test_server", path = "./tests/util/server" }


### PR DESCRIPTION
Eagerly errors for something like `export * from "jsr:@type/is@";` (previously it would just fail elsewhere because it would consider this as having an empty tag)

* https://github.com/denoland/deno_semver/pull/36