### PR TITLE
fix(info): error instead of panic for npm specifiers when using byonm

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1144,10 +1144,6 @@ impl CliOptions {
           DenoSubcommand::Run(run_flags) => {
             if run_flags.is_stdin() {
               resolve_url_or_path("./$deno$stdin.ts", self.initial_cwd())?
-            } else if NpmPackageReqReference::from_str(&run_flags.script)
-              .is_ok()
-            {
-              ModuleSpecifier::parse(&run_flags.script)?
             } else {
               resolve_url_or_path(&run_flags.script, self.initial_cwd())?
             }

--- a/tests/specs/info/byonm/__test__.jsonc
+++ b/tests/specs/info/byonm/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "install",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "info npm:@denotest/add",
+    "output": "info.out",
+    "exitCode": 1
+  }]
+}

--- a/tests/specs/info/byonm/deno.json
+++ b/tests/specs/info/byonm/deno.json
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "manual",
+  "imports": {
+    "chalk": "npm:@denotest/add"
+  }
+}

--- a/tests/specs/info/byonm/info.out
+++ b/tests/specs/info/byonm/info.out
@@ -1,0 +1,1 @@
+error: Resolving npm specifier entrypoints this way is currently not supported with "nodeModules": "manual". In the meantime, try with --node-modules-dir=auto instead

--- a/tests/specs/info/byonm/package.json
+++ b/tests/specs/info/byonm/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/add": "*"
+  }
+}


### PR DESCRIPTION
This is for the time being. We need to decide how this should behave.

It was panicking because npm specifier entrypoints aren't resolved anywhere except for `deno run` (it resolves the binary entrypoint).

Closes https://github.com/denoland/deno/issues/25903