### PR TITLE
feat: Add suggestion for packages using Node-API addons

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -392,6 +392,31 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
           "Run again with `--unstable-webgpu` flag to enable this API.",
         ),
       ];
+    // Try to capture errors like:
+    // ```
+    // Uncaught Error: Cannot find module '../build/Release/canvas.node'
+    // Require stack:
+    // - /.../deno/npm/registry.npmjs.org/canvas/2.11.2/lib/bindings.js
+    // - /.../.cache/deno/npm/registry.npmjs.org/canvas/2.11.2/lib/canvas.js
+    // ```
+    } else if msg.contains("Cannot find module")
+      && msg.contains("Require stack")
+      && msg.contains(".node'")
+    {
+      return vec![
+        FixSuggestion::info_multiline(
+          &[
+            "Trying to execute an npm package using Node-API addons,",
+            "these packages require local `node_modules` directory to be present"
+          ]
+        ),
+        FixSuggestion::hint_multiline(
+          &[
+            "Add `\"nodeModulesDir\": \"auto\" option to `deno.json`,",
+            "and then run `deno install --allow-scripts=npm:<package>` to setup `node_modules` directory."
+          ]
+        )
+      ];
     }
   }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -407,7 +407,7 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
         FixSuggestion::info_multiline(
           &[
             "Trying to execute an npm package using Node-API addons,",
-            "these packages require local `node_modules` directory to be present"
+            "these packages require local `node_modules` directory to be present."
           ]
         ),
         FixSuggestion::hint_multiline(

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -412,8 +412,8 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion> {
         ),
         FixSuggestion::hint_multiline(
           &[
-            "Add `\"nodeModulesDir\": \"auto\" option to `deno.json`,",
-            "and then run `deno install --allow-scripts=npm:<package>` to setup `node_modules` directory."
+            "Add `\"nodeModulesDir\": \"auto\" option to `deno.json`, and then run",
+            "`deno install --allow-scripts=npm:<package> --entrypoint <script>` to setup `node_modules` directory."
           ]
         )
       ];


### PR DESCRIPTION
This commit adds a suggestion with information and hint how
to resolve situation when user tries to run an npm package
with Node-API addons using global cache (which is currently not supported).

![Screenshot 2024-10-01 at 22 29 40](https://github.com/user-attachments/assets/b1b022df-afeb-47eb-9f78-eb9e476c655a)


Closes https://github.com/denoland/deno/issues/25974