### PR TITLE
fix(ext/node): remove unimplemented promiseHook stubs

### DIFF
--- a/ext/node/polyfills/v8.ts
+++ b/ext/node/polyfills/v8.ts
@@ -313,20 +313,6 @@ export class DefaultDeserializer extends Deserializer {
     );
   }
 }
-export const promiseHooks = {
-  onInit() {
-    notImplemented("v8.promiseHooks.onInit");
-  },
-  onSettled() {
-    notImplemented("v8.promiseHooks.onSetttled");
-  },
-  onBefore() {
-    notImplemented("v8.promiseHooks.onBefore");
-  },
-  createHook() {
-    notImplemented("v8.promiseHooks.createHook");
-  },
-};
 export default {
   cachedDataVersionTag,
   getHeapCodeStatistics,
@@ -343,5 +329,4 @@ export default {
   Deserializer,
   DefaultSerializer,
   DefaultDeserializer,
-  promiseHooks,
 };


### PR DESCRIPTION
`temporalio` sdk [will try to use](https://github.com/temporalio/sdk-typescript/blob/faa64225a7f57154931a38c1fe612fc6520943b2/packages/worker/src/workflow/vm-shared.ts#L199-L202) promiseHook if it is found. This patch removes the unimplemented stubs.

```ts
    if (promiseHooks) {
      // Node >=16.14 only
      this.stopPromiseHook = promiseHooks.createHook({
        init: (promise: Promise<unknown>, parent: Promise<unknown>) => {
```

Fixes https://github.com/denoland/deno/issues/25977
