### PR TITLE
fix(install): compare versions directly to decide whether to create a child node_modules dir for a workspace member

### DIFF
--- a/cli/npm/managed/resolvers/local.rs
+++ b/cli/npm/managed/resolvers/local.rs
@@ -518,9 +518,9 @@ async fn sync_resolution_with_fs(
         // linked into the root
         match found_names.entry(remote_alias) {
           Entry::Occupied(nv) => {
-            alias_clashes
-              || remote.req.name != nv.get().name // alias to a different package (in case of duplicate aliases)
-              || !remote.req.version_req.matches(&nv.get().version) // incompatible version
+            // alias to a different package (in case of duplicate aliases)
+            // or the version doesn't match the version in the root node_modules
+            alias_clashes || &remote_pkg.id.nv != *nv.get()
           }
           Entry::Vacant(entry) => {
             entry.insert(&remote_pkg.id.nv);

--- a/tests/specs/install/workspace_member_with_tag_dep/__test__.jsonc
+++ b/tests/specs/install/workspace_member_with_tag_dep/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "install.out"
+    }
+  ]
+}

--- a/tests/specs/install/workspace_member_with_tag_dep/install.out
+++ b/tests/specs/install/workspace_member_with_tag_dep/install.out
@@ -1,0 +1,3 @@
+Download http://localhost:4260/@denotest/esm-basic
+Download http://localhost:4260/@denotest/esm-basic/1.0.0.tgz
+Initialize @denotest/esm-basic@1.0.0

--- a/tests/specs/install/workspace_member_with_tag_dep/package.json
+++ b/tests/specs/install/workspace_member_with_tag_dep/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@denotest/esm-basic": "latest"
+  },
+  "workspaces": ["package1"]
+}

--- a/tests/specs/install/workspace_member_with_tag_dep/package1/package.json
+++ b/tests/specs/install/workspace_member_with_tag_dep/package1/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/esm-basic": "latest"
+  }
+}


### PR DESCRIPTION
Fixes #25861.

Previously we were attempting to match the version requirement against the version already present in `node_modules` root, and if they didn't match we would create a node_modules dir in the workspace member's directory with the dependency.

Aside from the fact that this caused the panic, on second thought it just doesn't make sense in general. We shouldn't be semver matching, as resolution has already occurred and decided what package versions are required. Instead, we can just compare the versions directly.