### PR TITLE
feat(permissions): allow importing from cdn.jsdelivr.net by default

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -688,10 +688,10 @@ impl PermissionFlags {
       }
 
       let builtin_allowed_import_hosts = [
-        "cdn.jsdelivr.net:443",
+        "jsr.io:443",
         "deno.land:443",
         "esm.sh:443",
-        "jsr.io:443",
+        "cdn.jsdelivr.net:443",
         "raw.githubusercontent.com:443",
         "gist.githubusercontent.com:443",
       ];

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -688,6 +688,7 @@ impl PermissionFlags {
       }
 
       let builtin_allowed_import_hosts = [
+        "cdn.jsdelivr.net:443",
         "deno.land:443",
         "esm.sh:443",
         "jsr.io:443",
@@ -3253,7 +3254,7 @@ fn permission_args(app: Command, requires: Option<&'static str>) -> Command {
   <g>-W, --allow-write[=<<PATH>...]</>            Allow file system write access. Optionally specify allowed paths.
                                              <p(245)>--allow-write  |  --allow-write="/etc,/var/log.txt"</>
   <g>-I, --allow-import[=<<IP_OR_HOSTNAME>...]</> Allow importing from remote hosts. Optionally specify allowed IP addresses and host names, with ports as necessary.
-                                            Default value: <p(245)>deno.land:443,jsr.io:443,esm.sh:443,raw.githubusercontent.com:443,user.githubusercontent.com:443</>
+                                            Default value: <p(245)>deno.land:443,jsr.io:443,esm.sh:443,cdn.jsdelivr.net:443,raw.githubusercontent.com:443,user.githubusercontent.com:443</>
                                              <p(245)>--allow-import  |  --allow-import="example.com,github.com"</>
   <g>-N, --allow-net[=<<IP_OR_HOSTNAME>...]</>    Allow network access. Optionally specify allowed IP addresses and host names, with ports as necessary.
                                              <p(245)>--allow-net  |  --allow-net="localhost:8080,deno.land"</>
@@ -3663,7 +3664,7 @@ fn allow_import_arg() -> Arg {
     .require_equals(true)
     .value_name("IP_OR_HOSTNAME")
     .help(cstr!(
-      "Allow importing from remote hosts. Optionally specify allowed IP addresses and host names, with ports as necessary. Default value: <p(245)>deno.land:443,jsr.io:443,esm.sh:443,raw.githubusercontent.com:443,user.githubusercontent.com:443</>"
+      "Allow importing from remote hosts. Optionally specify allowed IP addresses and host names, with ports as necessary. Default value: <p(245)>deno.land:443,jsr.io:443,esm.sh:443,cdn.jsdelivr.net:443,raw.githubusercontent.com:443,user.githubusercontent.com:443</>"
     ))
     .value_parser(flags_net::validator)
 }


### PR DESCRIPTION
The exploit `--allow-import` is preventing against requires a compromised host. To make things easier and given its popularity, we're going to have the default `--allow-import` value include `cdn.jsdelivr.net:443`, but this can be overridden by replacing the `--allow-import` value with something else.