### PR TITLE
chore: show expectation diff for wpt tests

### DIFF
--- a/tests/wpt/runner/utils.ts
+++ b/tests/wpt/runner/utils.ts
@@ -76,7 +76,10 @@ export function getManifest(): Manifest {
 
 /// WPT TEST EXPECTATIONS
 
-const EXPECTATION_PATH = join(ROOT_PATH, "./tests/wpt/runner/expectation.json");
+export const EXPECTATION_PATH = join(
+  ROOT_PATH,
+  "./tests/wpt/runner/expectation.json",
+);
 
 export interface Expectation {
   [key: string]: Expectation | boolean | string[] | { ignore: boolean };
@@ -87,9 +90,12 @@ export function getExpectation(): Expectation {
   return JSON.parse(expectationText);
 }
 
-export function saveExpectation(expectation: Expectation) {
+export function saveExpectation(
+  expectation: Expectation,
+  path: string = EXPECTATION_PATH,
+) {
   Deno.writeTextFileSync(
-    EXPECTATION_PATH,
+    path,
     JSON.stringify(expectation, undefined, "  ") + "\n",
   );
 }
@@ -132,6 +138,15 @@ export function runPy<T extends Omit<Deno.CommandOptions, "cwd">>(
     ...options,
     cwd: join(ROOT_PATH, "./tests/wpt/suite/"),
   }).spawn();
+}
+
+export async function runGitDiff(args: string[]): string {
+  await new Deno.Command("git", {
+    args: ["diff", ...args],
+    stdout: "inherit",
+    stderr: "inherit",
+    cwd: ROOT_PATH,
+  }).output();
 }
 
 export async function checkPy3Available() {

--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -258,49 +258,9 @@ async function run() {
     await Deno.writeTextFile(wptreport, JSON.stringify(report) + "\n");
   }
 
-  const resultTests: Record<
-    string,
-    { passed: string[]; failed: string[]; testSucceeded: boolean }
-  > = {};
-  for (const { test, result } of results) {
-    if (!resultTests[test.path]) {
-      resultTests[test.path] = {
-        passed: [],
-        failed: [],
-        testSucceeded: result.status === 0 && result.harnessStatus !== null,
-      };
-    }
-    for (const case_ of result.cases) {
-      if (case_.passed) {
-        resultTests[test.path].passed.push(case_.name);
-      } else {
-        resultTests[test.path].failed.push(case_.name);
-      }
-    }
-  }
-
-  const currentExpectation = getExpectation();
-
-  for (const [path, result] of Object.entries(resultTests)) {
-    const { passed, failed, testSucceeded } = result;
-    let finalExpectation: boolean | string[];
-    if (failed.length == 0 && testSucceeded) {
-      finalExpectation = true;
-    } else if (failed.length > 0 && passed.length > 0 && testSucceeded) {
-      finalExpectation = failed;
-    } else {
-      finalExpectation = false;
-    }
-
-    insertExpectation(
-      path.slice(1).split("/"),
-      currentExpectation,
-      finalExpectation,
-    );
-  }
-
+  const newExpectations = newExpectation(results);
   const tmp = Deno.makeTempFileSync();
-  saveExpectation(currentExpectation, tmp);
+  saveExpectation(newExpectations, tmp);
 
   const code = reportFinal(results, endTime - startTime);
 
@@ -441,6 +401,19 @@ async function update() {
     await Deno.writeTextFile(json, JSON.stringify(results) + "\n");
   }
 
+  const newExpectations = newExpectation(results);
+  saveExpectation(newExpectations);
+
+  reportFinal(results, endTime - startTime);
+
+  console.log(blue("Updated expectation.json to match reality."));
+
+  Deno.exit(0);
+}
+
+function newExpectation(
+  results: { test: TestToRun; result: TestResult }[],
+): Expectation {
   const resultTests: Record<
     string,
     { passed: string[]; failed: string[]; testSucceeded: boolean }
@@ -482,13 +455,7 @@ async function update() {
     );
   }
 
-  saveExpectation(currentExpectation);
-
-  reportFinal(results, endTime - startTime);
-
-  console.log(blue("Updated expectation.json to match reality."));
-
-  Deno.exit(0);
+  return currentExpectation;
 }
 
 function insertExpectation(


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/26012

```
========================================

failures:

        "/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.html - Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CTR"

final result: failed. 1 passed; 1 failed; 0 expected failure; total 2 (15646ms)

diff --git a/Users/divy/gh/deno/tests/wpt/runner/expectation.json b/var/folders/ll/ltqsx4nx72v5_r7rlsl36pgm0000gn/T/375d79f1257b05cd
index fb2063935..4449c5d15 100644
--- a/Users/divy/gh/deno/tests/wpt/runner/expectation.json
+++ b/var/folders/ll/ltqsx4nx72v5_r7rlsl36pgm0000gn/T/375d79f1257b05cd
@@ -1531,6 +1531,7 @@
     },
     "wrapKey_unwrapKey": {
       "wrapKey_unwrapKey.https.any.html": [
+        "Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CTR",
         "Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-CBC",
         "Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-GCM",
         "Can wrap and unwrap X25519 private key keys as non-extractable using pkcs8 and AES-KW",
```
