### PR TITLE
fix(task): use current executable for deno even when not named deno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6413ffc1654cad015edb5c4ab574069acdc929a6efafed23bc947901bcff1a"
+checksum = "4f444918f7102c1a5a143e9d57809e499fb4d365070519bf2e8bdb16d586af2a"
 dependencies = [
  "anyhow",
  "futures",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,7 +77,7 @@ deno_path_util.workspace = true
 deno_resolver.workspace = true
 deno_runtime = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_semver.workspace = true
-deno_task_shell = "=0.17.0"
+deno_task_shell = "=0.18.1"
 deno_terminal.workspace = true
 eszip = "=0.79.1"
 libsui = "0.4.0"


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/26005