### PR TITLE
Revert "feat: warn when using --allow-run with no allow list"

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -825,8 +825,6 @@ impl CliOptions {
       }
     }
 
-    warn_insecure_allow_run_flags(&flags);
-
     let maybe_lockfile = maybe_lockfile.filter(|_| !force_global_cache);
     let deno_dir_provider =
       Arc::new(DenoDirProvider::new(flags.internal.cache_path.clone()));
@@ -1708,27 +1706,6 @@ impl CliOptions {
           | DenoSubcommand::Add(_)
       ),
     }
-  }
-}
-
-/// Warns for specific uses of `--allow-run`. This function is not
-/// intended to catch every single possible insecure use of `--allow-run`,
-/// but is just an attempt to discourage some common pitfalls.
-fn warn_insecure_allow_run_flags(flags: &Flags) {
-  let permissions = &flags.permissions;
-  if permissions.allow_all {
-    return;
-  }
-  let Some(allow_run_list) = permissions.allow_run.as_ref() else {
-    return;
-  };
-
-  // discourage using --allow-run without an allow list
-  if allow_run_list.is_empty() {
-    log::warn!(
-      "{} --allow-run without an allow list is susceptible to exploits. Prefer specifying an allow list (https://docs.deno.com/runtime/fundamentals/security/#running-subprocesses)",
-      colors::yellow("Warning")
-    );
   }
 }
 

--- a/tests/specs/permission/deny_run_binary_absolute_path/main.out
+++ b/tests/specs/permission/deny_run_binary_absolute_path/main.out
@@ -1,4 +1,3 @@
-Warning --allow-run without an allow list is susceptible to exploits. Prefer specifying an allow list (https://docs.deno.com/runtime/fundamentals/security/#running-subprocesses)
 NotCapable: Requires run access to "deno", run again with the --allow-run flag
     at [WILDCARD] {
   name: "NotCapable"

--- a/tests/specs/run/allow_run_insecure_warnings/__test__.jsonc
+++ b/tests/specs/run/allow_run_insecure_warnings/__test__.jsonc
@@ -1,8 +1,0 @@
-{
-  "tests": {
-    "no_allow_list": {
-      "args": "run --allow-run main.ts",
-      "output": "no_allow_list.out"
-    }
-  }
-}

--- a/tests/specs/run/allow_run_insecure_warnings/no_allow_list.out
+++ b/tests/specs/run/allow_run_insecure_warnings/no_allow_list.out
@@ -1,1 +1,0 @@
-Warning --allow-run without an allow list is susceptible to exploits. Prefer specifying an allow list (https://docs.deno.com/runtime/fundamentals/security/#running-subprocesses)

--- a/tests/testdata/run/deny_some_permission_args.out
+++ b/tests/testdata/run/deny_some_permission_args.out
@@ -1,4 +1,3 @@
-Warning --allow-run without an allow list is susceptible to exploits. Prefer specifying an allow list (https://docs.deno.com/runtime/fundamentals/security/#running-subprocesses)
 PermissionStatus { state: "granted", onchange: null, partial: true }
 PermissionStatus { state: "denied", onchange: null }
 PermissionStatus { state: "granted", onchange: null }


### PR DESCRIPTION
Although using `--allow-run` without an allow list gives basically no security, I think we should remove this warning because it gets in the way and the only way to disable it is via --quiet.