### PR TITLE
refactor: remove usage of full_range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,7 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.83.1"
+version = "0.83.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77163c46755676d8f793fc19e365537ba660a8db173cd1e02d21eb010c0b3cef"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,8 +1613,6 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.83.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62ce152f24a4c0580e7a91431f75de48281157cf645459de8e9d7268dd95b2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,6 +325,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
-
-[patch.crates-io]
-deno_graph = { path = "../deno_graph" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,3 +325,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
+
+[patch.crates-io]
+deno_graph = { path = "../deno_graph" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -68,7 +68,7 @@ deno_cache_dir = { workspace = true }
 deno_config = { version = "=0.37.1", features = ["workspace", "sync"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "0.150.1", features = ["html", "syntect"] }
-deno_graph = { version = "=0.83.1" }
+deno_graph = { version = "=0.83.3" }
 deno_lint = { version = "=0.67.0", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm.workspace = true

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -44,6 +44,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
+use text_lines::LineAndColumnIndex;
 use tower_lsp::lsp_types as lsp;
 use tower_lsp::lsp_types::Position;
 use tower_lsp::lsp_types::Range;
@@ -1207,14 +1208,36 @@ impl CodeActionCollection {
         range.end.line as usize,
         range.end.character as usize,
       );
-      let import_range = dependency.imports.iter().find_map(|i| {
+      let import_start = dependency.imports.iter().find_map(|i| {
         if json!(i.kind) != json!("es") && json!(i.kind) != json!("tsType") {
           return None;
         }
         if !i.specifier_range.includes(&position) {
           return None;
         }
-        i.full_range.as_ref()
+
+        // find the top level statement that contains the specifier
+        let parsed_source = document.maybe_parsed_source()?.as_ref().ok()?;
+        let text_info = parsed_source.text_info_lazy();
+        let specifier_range = SourceRange::new(
+          text_info.loc_to_source_pos(LineAndColumnIndex {
+            line_index: i.specifier_range.start.line,
+            column_index: i.specifier_range.start.character,
+          }),
+          text_info.loc_to_source_pos(LineAndColumnIndex {
+            line_index: i.specifier_range.end.line,
+            column_index: i.specifier_range.end.character,
+          }),
+        );
+
+        match parsed_source.program_ref() {
+          deno_ast::swc::ast::Program::Module(module) => module
+            .body
+            .iter()
+            .find(|i| i.range().contains(&specifier_range))
+            .map(|i| text_info.line_and_column_index(i.range().start)),
+          deno_ast::swc::ast::Program::Script(_) => return None,
+        }
       })?;
       let referrer = document.specifier();
       let file_referrer = document.file_referrer();
@@ -1301,8 +1324,8 @@ impl CodeActionCollection {
         .specifier_to_uri(referrer, file_referrer)
         .ok()?;
       let position = lsp::Position {
-        line: import_range.start.line as u32,
-        character: import_range.start.character as u32,
+        line: import_start.line_index as u32,
+        character: import_start.column_index as u32,
       };
       let new_text = format!(
         "{}// @deno-types=\"{}\"\n",


### PR DESCRIPTION
For https://github.com/denoland/deno_graph/pull/538/files

This was removed because the deserialization was not backwards compatible.