### PR TITLE
fix(jupyter): copy kernels icons to the kernel directory

### DIFF
--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -58,9 +58,9 @@ pub fn install() -> Result<(), AnyError> {
 
   let f = std::fs::File::create(kernel_json_path)?;
   serde_json::to_writer_pretty(f, &json_data)?;
-  install_icon(&user_data_dir, "logo-32x32.png", DENO_ICON_32)?;
-  install_icon(&user_data_dir, "logo-64x64.png", DENO_ICON_64)?;
-  install_icon(&user_data_dir, "logo-svg.svg", DENO_ICON_SVG)?;
+  install_icon(&kernel_dir, "logo-32x32.png", DENO_ICON_32)?;
+  install_icon(&kernel_dir, "logo-64x64.png", DENO_ICON_64)?;
+  install_icon(&kernel_dir, "logo-svg.svg", DENO_ICON_SVG)?;
 
   log::info!("✅ Deno kernelspec installed successfully.");
   Ok(())


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This should likely fix https://github.com/denoland/deno/issues/26083.

Moving the kernel icons manually to the `kernels/deno` folder seems to be fixing it when testing locally:

![image](https://github.com/user-attachments/assets/7e39bcb5-481d-4583-b1b5-9d5638fa8974)

