### PR TITLE
fix: do not panic when using methods on classes and interfaces in deno doc html output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.152.0"
+version = "0.153.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d237256ad99d6064b271324485120028e843329fd0fa0e93175d5e98f17033"
+checksum = "6925db7ad16bee4bdcb7e654d2475e2fbd5e1d7dd4c6ee5f030ee858b4a2a8ee"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -67,7 +67,7 @@ deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "proposa
 deno_cache_dir = { workspace = true }
 deno_config = { version = "=0.37.1", features = ["workspace", "sync"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
-deno_doc = { version = "0.152.0", features = ["html"] }
+deno_doc = { version = "0.153.0", features = ["html"] }
 deno_graph = { version = "=0.83.3" }
 deno_lint = { version = "=0.67.0", features = ["docs"] }
 deno_lockfile.workspace = true


### PR DESCRIPTION
Fixes #26107