### PR TITLE
fix(node): make `process.stdout.isTTY` writable

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -65,7 +65,7 @@ export function createWritableStdioStream(writer, name, warmup = false) {
   stream.once("close", () => writer?.close());
 
   // We cannot call `writer?.isTerminal()` eagerly here
-  let getIsTTY = () => writer?.isTerminal()
+  let getIsTTY = () => writer?.isTerminal();
 
   ObjectDefineProperties(stream, {
     columns: {
@@ -88,7 +88,7 @@ export function createWritableStdioStream(writer, name, warmup = false) {
       // Allow users to overwrite it
       get: () => getIsTTY(),
       set: (value) => {
-        (getIsTTY = () => value)
+        getIsTTY = () => value;
       },
     },
     getWindowSize: {

--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -63,6 +63,10 @@ export function createWritableStdioStream(writer, name, warmup = false) {
   stream.destroySoon = stream.destroy;
   stream._isStdio = true;
   stream.once("close", () => writer?.close());
+
+  // We cannot call `writer?.isTerminal()` eagerly here
+  let getIsTTY = () => writer?.isTerminal()
+
   ObjectDefineProperties(stream, {
     columns: {
       __proto__: null,
@@ -81,7 +85,11 @@ export function createWritableStdioStream(writer, name, warmup = false) {
       __proto__: null,
       enumerable: true,
       configurable: true,
-      get: () => writer?.isTerminal(),
+      // Allow users to overwrite it
+      get: () => getIsTTY(),
+      set: (value) => {
+        (getIsTTY = () => value)
+      },
     },
     getWindowSize: {
       __proto__: null,

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -691,6 +691,16 @@ Deno.test({
       assertStrictEquals(process.stdout.clearLine, undefined);
       assertStrictEquals(process.stdout.clearScreenDown, undefined);
     }
+
+    // Allows overwriting `process.stdout.isTTY`
+    // https://github.com/denoland/deno/issues/26123
+    const original = process.stdout.isTTY;
+    try {
+      process.stdout.isTTY = !isTTY;
+      assertEquals(process.stdout.isTTY, !isTTY);
+    } finally {
+      process.stdout.isTTY = original;
+    }
   },
 });
 


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26123