### PR TITLE
fix(node/util): export `styleText` from `node:util`

### DIFF
--- a/ext/node/polyfills/util.ts
+++ b/ext/node/polyfills/util.ts
@@ -39,6 +39,7 @@ import {
   formatWithOptions,
   inspect,
   stripVTControlCharacters,
+  styleText,
 } from "ext:deno_node/internal/util/inspect.mjs";
 import { codes } from "ext:deno_node/internal/error_codes.ts";
 import types from "node:util/types";
@@ -63,6 +64,7 @@ export {
   parseArgs,
   promisify,
   stripVTControlCharacters,
+  styleText,
   types,
 };
 
@@ -354,4 +356,5 @@ export default {
   debuglog,
   debug: debuglog,
   isDeepStrictEqual,
+  styleText,
 };

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -348,3 +348,8 @@ Deno.test("[util] aborted()", async () => {
   await promise;
   assertEquals(done, true);
 });
+
+Deno.test("[util] styleText()", () => {
+  const redText = util.styleText("red", "error");
+  assertEquals(redText, "\x1B[31merror\x1B[39m");
+});


### PR DESCRIPTION
Fixes #26184.

It was added but not publicly exported.