### PR TITLE
fix(ext/node): allow writing to tty columns

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -66,14 +66,19 @@ export function createWritableStdioStream(writer, name, warmup = false) {
 
   // We cannot call `writer?.isTerminal()` eagerly here
   let getIsTTY = () => writer?.isTerminal();
+  const getColumns = () =>
+    stream._columns ||
+    (writer?.isTerminal() ? Deno.consoleSize?.().columns : undefined);
 
   ObjectDefineProperties(stream, {
     columns: {
       __proto__: null,
       enumerable: true,
       configurable: true,
-      get: () =>
-        writer?.isTerminal() ? Deno.consoleSize?.().columns : undefined,
+      get: () => getColumns(),
+      set: (value) => {
+        stream._columns = value;
+      },
     },
     rows: {
       __proto__: null,

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -1175,3 +1175,8 @@ Deno.test("process.cpuUsage()", () => {
   assert(typeof cpuUsage.user === "number");
   assert(typeof cpuUsage.system === "number");
 });
+
+Deno.test("process.stdout.columns writable", () => {
+  process.stdout.columns = 80;
+  assertEquals(process.stdout.columns, 80);
+});


### PR DESCRIPTION
Behave similar to Node.js where modifying `stdout.columns` doesn't really resize the terminal. Ref https://github.com/nodejs/node/issues/17529

Fixes https://github.com/denoland/deno/issues/26196