### PR TITLE
fix(ext/webgpu): allow GL backend on Windows

### DIFF
--- a/ext/webgpu/lib.rs
+++ b/ext/webgpu/lib.rs
@@ -44,7 +44,7 @@ mod macros {
         #[cfg(all(not(target_arch = "wasm32"), windows))]
         wgpu_types::Backend::Dx12 => $($c)*.$method::<wgpu_core::api::Dx12> $params,
         #[cfg(any(
-            all(unix, not(target_os = "macos"), not(target_os = "ios")),
+            all(not(target_os = "macos"), not(target_os = "ios")),
             feature = "angle",
             target_arch = "wasm32"
         ))]


### PR DESCRIPTION
It should be supported according to [this](https://github.com/gfx-rs/wgpu?tab=readme-ov-file#supported-platforms).

Fixes https://github.com/denoland/deno/issues/26144