### PR TITLE
fix(ext/node): handle http2 server ending stream

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -331,8 +331,8 @@ export class Http2Session extends EventEmitter {
     if (typeof error === "number") {
       code = error;
       error = code !== constants.NGHTTP2_NO_ERROR
-          ? new ERR_HTTP2_SESSION_ERROR(code)
-          : undefined;
+        ? new ERR_HTTP2_SESSION_ERROR(code)
+        : undefined;
     }
     if (code === undefined && error != null) {
       code = constants.NGHTTP2_INTERNAL_ERROR;
@@ -1173,13 +1173,13 @@ export class ClientHttp2Stream extends Duplex {
       this.#rid,
       trailerList,
     ).then(() => {
-        stream[kMaybeDestroy]();
-        core.tryClose(this.#rid);
+      stream[kMaybeDestroy]();
+      core.tryClose(this.#rid);
     }).catch((e) => {
-        debugHttp2(">>> send trailers error", e);
-        core.tryClose(this.#rid);
-        stream._destroy(e);
-      });
+      debugHttp2(">>> send trailers error", e);
+      core.tryClose(this.#rid);
+      stream._destroy(e);
+    });
   }
 
   get closed(): boolean {
@@ -1387,32 +1387,32 @@ function finishCloseStream(stream, code) {
       stream[kDenoRid],
       code,
     ).then(() => {
-        debugHttp2(
-          ">>> finishCloseStream close2",
-          stream[kDenoRid],
+      debugHttp2(
+        ">>> finishCloseStream close2",
+        stream[kDenoRid],
         stream[kDenoResponse].bodyRid,
-        );
-        core.tryClose(stream[kDenoRid]);
-        if (stream[kDenoResponse]) {
-          core.tryClose(stream[kDenoResponse].bodyRid);
-        }
-        nextTick(() => {
-          stream.emit("close");
-        });
-    }).catch(() => {
-        debugHttp2(
-          ">>> finishCloseStream close2 catch",
-          stream[kDenoRid],
-        stream[kDenoResponse]?.bodyRid,
-        );
-        core.tryClose(stream[kDenoRid]);
-        if (stream[kDenoResponse]) {
-          core.tryClose(stream[kDenoResponse].bodyRid);
-        }
-        nextTick(() => {
-          stream.emit("close");
-        });
+      );
+      core.tryClose(stream[kDenoRid]);
+      if (stream[kDenoResponse]) {
+        core.tryClose(stream[kDenoResponse].bodyRid);
+      }
+      nextTick(() => {
+        stream.emit("close");
       });
+    }).catch(() => {
+      debugHttp2(
+        ">>> finishCloseStream close2 catch",
+        stream[kDenoRid],
+        stream[kDenoResponse]?.bodyRid,
+      );
+      core.tryClose(stream[kDenoRid]);
+      if (stream[kDenoResponse]) {
+        core.tryClose(stream[kDenoResponse].bodyRid);
+      }
+      nextTick(() => {
+        stream.emit("close");
+      });
+    });
   }
 }
 
@@ -1629,54 +1629,54 @@ export class Http2Server extends Server {
     this.on(
       "connection",
       (conn: Deno.Conn) => {
-      try {
-        const session = new ServerHttp2Session();
-        this.emit("session", session);
-        this.#server = serveHttpOnConnection(
-          conn,
-          this.#abortController.signal,
-          async (req: Request) => {
-            try {
+        try {
+          const session = new ServerHttp2Session();
+          this.emit("session", session);
+          this.#server = serveHttpOnConnection(
+            conn,
+            this.#abortController.signal,
+            async (req: Request) => {
+              try {
                 const controllerDeferred = Promise.withResolvers<
                   ReadableStreamDefaultController<Uint8Array>
                 >();
-              const body = new ReadableStream({
-                start(controller) {
-                  controllerDeferred.resolve(controller);
-                },
-              });
-              const headers: Http2Headers = {};
-              for (const [name, value] of req.headers) {
-                headers[name] = value;
-              }
+                const body = new ReadableStream({
+                  start(controller) {
+                    controllerDeferred.resolve(controller);
+                  },
+                });
+                const headers: Http2Headers = {};
+                for (const [name, value] of req.headers) {
+                  headers[name] = value;
+                }
                 headers[constants.HTTP2_HEADER_PATH] =
                   new URL(req.url).pathname;
-              const stream = new ServerHttp2Stream(
-                session,
-                Promise.resolve(headers),
-                controllerDeferred.promise,
-                req.body,
-                body,
+                const stream = new ServerHttp2Stream(
+                  session,
+                  Promise.resolve(headers),
+                  controllerDeferred.promise,
+                  req.body,
+                  body,
                   req,
-              );
-              this.emit("stream", stream, headers);
-              return await stream._deferred.promise;
-            } catch (e) {
+                );
+                this.emit("stream", stream, headers);
+                return await stream._deferred.promise;
+              } catch (e) {
+                // deno-lint-ignore no-console
+                console.log(">>> Error in serveHttpOnConnection", e);
+              }
+              return new Response("");
+            },
+            () => {
               // deno-lint-ignore no-console
-              console.log(">>> Error in serveHttpOnConnection", e);
-            }
-            return new Response("");
-          },
-          () => {
-            // deno-lint-ignore no-console
-            console.log(">>> error");
-          },
+              console.log(">>> error");
+            },
             () => {},
-        );
-      } catch (e) {
-        // deno-lint-ignore no-console
-        console.log(">>> Error in Http2Server", e);
-      }
+          );
+        } catch (e) {
+          // deno-lint-ignore no-console
+          console.log(">>> Error in Http2Server", e);
+        }
       },
     );
     this.#options = options;


### PR DESCRIPTION
Fixes #24845 

Creating standalone tests is difficult since from what I can make out this error is only manifested when talking to C++ grpc servers, but there is a full reproduction described [here](https://github.com/TobyEalden/deno-issue-24845). See also #26234.