### PR TITLE
fix: panic in `prepare_stack_trace_callback` when global interceptor throws

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8714,3 +8714,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "deno_core"
+version = "0.312.0"
+source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,8 +1423,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.312.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5b20008c84715322782af2f94ff7ebc34eb50294ae098daf36b63a5b9bdd24"
+source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1921,8 +1920,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.188.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1c7a8d9169e23de729000d6903dd0dee39e521e226d1ffbb9c5336665afae6"
+source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6172,8 +6170,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.221.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca142cf34468e22063560302e6cc5e45f48e95a0dd25b3e22d6c32c32251135"
+source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"
 dependencies = [
  "num-bigint",
  "serde",
@@ -8714,8 +8711,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "deno_core"
-version = "0.312.0"
-source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,8 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.312.0"
-source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"
+version = "0.313.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f36be738d78e39b6603a6b07f1cf91e28baf3681f87205f07482999e0d0bc2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1919,8 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.188.0"
-source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"
+version = "0.189.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f998ad1d5b36064109367ffe67b1088385eb3d8025efc95e445bc013a147a2"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6169,8 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.221.0"
-source = "git+https://github.com/lucacasonato/deno_core?branch=boolean_coerce#220079840de3e2374689ff4783064ee8ed4476a6"
+version = "0.222.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27130b5cd87f6f06228940a1f3a7ecc988ea13d1bede1398a48d74cb59dabc9a"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,3 +325,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
+
+[patch.crates-io]
+deno_core = { git = "https://github.com/lucacasonato/deno_core", branch = "boolean_coerce" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.42.2", features = ["transpiling"] }
-deno_core = { version = "0.312.0" }
+deno_core = { version = "0.313.0" }
 
 deno_bench_util = { version = "0.165.0", path = "./bench_util" }
 deno_lockfile = "=0.23.1"
@@ -325,6 +325,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
-
-[patch.crates-io]
-deno_core = { git = "https://github.com/lucacasonato/deno_core", branch = "boolean_coerce" }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26240
Fixes https://github.com/denoland/deno/pull/24985#issuecomment-2365460210

Fix panic when a global interceptor is misconfigured or throws an exception. 

Updates deno_core to 0.313.0