### PR TITLE
perf(http): avoid clone getting request method and url

### DIFF
--- a/ext/http/fly_accept_encoding.rs
+++ b/ext/http/fly_accept_encoding.rs
@@ -119,7 +119,7 @@ fn encodings_iter_inner<'s>(
       };
       Some(Ok((encoding, qval)))
     })
-    .map(|r| r?) // flatten Result<Result<...
+    .flatten()
 }
 
 #[cfg(test)]

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -296,7 +296,7 @@ where
   let authority: v8::Local<v8::Value> = match request_properties.authority {
     Some(authority) => v8::String::new_from_utf8(
       scope,
-      authority.as_ref(),
+      authority.as_bytes(),
       v8::NewStringType::Normal,
     )
     .unwrap()

--- a/ext/http/request_properties.rs
+++ b/ext/http/request_properties.rs
@@ -34,8 +34,8 @@ pub struct HttpConnectionProperties {
   pub stream_type: NetworkStreamType,
 }
 
-pub struct HttpRequestProperties {
-  pub authority: Option<String>,
+pub struct HttpRequestProperties<'a> {
+  pub authority: Option<Cow<'a, str>>,
 }
 
 /// Pluggable trait to determine listen, connection and request properties
@@ -84,11 +84,11 @@ pub trait HttpPropertyExtractor {
   ) -> NetworkStream;
 
   /// Determines the request properties.
-  fn request_properties(
-    connection_properties: &HttpConnectionProperties,
-    uri: &Uri,
-    headers: &HeaderMap,
-  ) -> HttpRequestProperties;
+  fn request_properties<'a>(
+    connection_properties: &'a HttpConnectionProperties,
+    uri: &'a Uri,
+    headers: &'a HeaderMap,
+  ) -> HttpRequestProperties<'a>;
 }
 
 pub struct DefaultHttpPropertyExtractor {}
@@ -180,18 +180,17 @@ impl HttpPropertyExtractor for DefaultHttpPropertyExtractor {
     }
   }
 
-  fn request_properties(
-    connection_properties: &HttpConnectionProperties,
-    uri: &Uri,
-    headers: &HeaderMap,
-  ) -> HttpRequestProperties {
+  fn request_properties<'a>(
+    connection_properties: &'a HttpConnectionProperties,
+    uri: &'a Uri,
+    headers: &'a HeaderMap,
+  ) -> HttpRequestProperties<'a> {
     let authority = req_host(
       uri,
       headers,
       connection_properties.stream_type,
       connection_properties.local_port.unwrap_or_default(),
-    )
-    .map(|s| s.into_owned());
+    );
 
     HttpRequestProperties { authority }
   }


### PR DESCRIPTION
Code:

```js
Deno.serve({ port: 8085 }, request => {
  return new Response(request.url);
});
```

Before:

```
$ wrk -d60s http://localhost:8085
Running 1m test @ http://localhost:8085
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    65.49us   36.05us   5.46ms   96.33%
    Req/Sec    75.71k     1.90k   79.44k    78.87%
  9053462 requests in 1.00m, 1.36GB read
Requests/sec: 150641.83
Transfer/sec:     23.13MB
```

After:

```
$ wrk -d60s http://localhost:8085
Running 1m test @ http://localhost:8085
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    64.72us   38.14us   3.29ms   95.97%
    Req/Sec    76.66k     1.85k   80.17k    77.45%
  9168694 requests in 1.00m, 1.37GB read
Requests/sec: 152557.21
Transfer/sec:     23.42MB
```