### PR TITLE
fix(install): retry downloads of registry info / tarballs

### DIFF
--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -476,13 +476,16 @@ impl HttpClient {
     maybe_header: Option<(HeaderName, HeaderValue)>,
     progress_guard: &UpdateGuard,
   ) -> Result<Option<Vec<u8>>, DownloadError> {
-    crate::util::retry::retry(|| {
-      self.download_inner(
-        url.clone(),
-        maybe_header.clone(),
-        Some(progress_guard),
-      )
-    })
+    crate::util::retry::retry(
+      || {
+        self.download_inner(
+          url.clone(),
+          maybe_header.clone(),
+          Some(progress_guard),
+        )
+      },
+      |e| matches!(e, DownloadError::BadResponse(_) | DownloadError::Fetch(_)),
+    )
     .await
   }
 

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -470,15 +470,20 @@ impl HttpClient {
     }
   }
 
-  pub async fn download_with_progress(
+  pub async fn download_with_progress_and_retries(
     &self,
     url: Url,
     maybe_header: Option<(HeaderName, HeaderValue)>,
     progress_guard: &UpdateGuard,
   ) -> Result<Option<Vec<u8>>, DownloadError> {
-    self
-      .download_inner(url, maybe_header, Some(progress_guard))
-      .await
+    crate::util::retry::retry(|| {
+      self.download_inner(
+        url.clone(),
+        maybe_header.clone(),
+        Some(progress_guard),
+      )
+    })
+    .await
   }
 
   pub async fn get_redirected_url(

--- a/cli/npm/managed/cache/registry_info.rs
+++ b/cli/npm/managed/cache/registry_info.rs
@@ -202,10 +202,13 @@ impl RegistryInfoDownloader {
     let guard = self.progress_bar.update(package_url.as_str());
     let name = name.to_string();
     async move {
-      let maybe_bytes = downloader
-        .http_client_provider
-        .get_or_create()?
-        .download_with_progress(package_url, maybe_auth_header, &guard)
+      let client = downloader.http_client_provider.get_or_create()?;
+      let maybe_bytes = client
+        .download_with_progress_and_retries(
+          package_url,
+          maybe_auth_header,
+          &guard,
+        )
         .await?;
       match maybe_bytes {
         Some(bytes) => {

--- a/cli/npm/managed/cache/tarball.rs
+++ b/cli/npm/managed/cache/tarball.rs
@@ -172,7 +172,7 @@ impl TarballCache {
       let guard = tarball_cache.progress_bar.update(&dist.tarball);
       let result = tarball_cache.http_client_provider
         .get_or_create()?
-        .download_with_progress(tarball_uri, maybe_auth_header, &guard)
+        .download_with_progress_and_retries(tarball_uri, maybe_auth_header, &guard)
         .await;
       let maybe_bytes = match result {
         Ok(maybe_bytes) => maybe_bytes,

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -468,7 +468,11 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       self
         .http_client_provider
         .get_or_create()?
-        .download_with_progress(download_url.parse()?, None, &progress)
+        .download_with_progress_and_retries(
+          download_url.parse()?,
+          None,
+          &progress,
+        )
         .await?
     };
     let bytes = match maybe_bytes {

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -913,7 +913,7 @@ async fn download_package(
   // text above which will stay alive after the progress bars are complete
   let progress = progress_bar.update("");
   let maybe_bytes = client
-    .download_with_progress(download_url.clone(), None, &progress)
+    .download_with_progress_and_retries(download_url.clone(), None, &progress)
     .await
     .with_context(|| format!("Failed downloading {download_url}. The version you requested may not have been built for the current architecture."))?;
   Ok(maybe_bytes)

--- a/cli/util/mod.rs
+++ b/cli/util/mod.rs
@@ -14,6 +14,7 @@ pub mod logger;
 pub mod path;
 pub mod progress_bar;
 pub mod result;
+pub mod retry;
 pub mod sync;
 pub mod text_encoding;
 pub mod unix;

--- a/cli/util/retry.rs
+++ b/cli/util/retry.rs
@@ -1,0 +1,24 @@
+use std::future::Future;
+use std::time::Duration;
+
+pub fn retry<F: FnMut() -> Fut, Fut: Future<Output = Result<T, E>>, T, E>(
+  mut f: F,
+) -> impl Future<Output = Result<T, E>> {
+  const ATTEMPTS: usize = 4;
+  async move {
+    let mut wait = Duration::from_millis(1);
+    let mut attempt = 1;
+    loop {
+      let result = f().await;
+      if result.is_ok() {
+        return result;
+      }
+      if attempt >= ATTEMPTS {
+        return result;
+      }
+      tokio::time::sleep(wait).await;
+      attempt += 1;
+      wait *= 10;
+    }
+  }
+}

--- a/cli/util/retry.rs
+++ b/cli/util/retry.rs
@@ -3,27 +3,39 @@
 use std::future::Future;
 use std::time::Duration;
 
-pub fn retry<F: FnMut() -> Fut, Fut: Future<Output = Result<T, E>>, T, E>(
+pub fn retry<
+  F: FnMut() -> Fut,
+  T,
+  E,
+  Fut: Future<Output = Result<T, E>>,
+  ShouldRetry: FnMut(&E) -> bool,
+>(
   mut f: F,
+  mut should_retry: ShouldRetry,
 ) -> impl Future<Output = Result<T, E>> {
-  const ATTEMPTS: usize = 5;
-  const MAX_WAIT: Duration = Duration::from_secs(1);
-  const MIN_WAIT: Duration = Duration::from_micros(1);
+  const WAITS: [Duration; 3] = [
+    Duration::from_millis(100),
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+  ];
+
+  let mut waits = WAITS.into_iter();
   async move {
-    let mut wait = Duration::from_millis(1);
-    let mut attempt = 1;
+    let mut first_result = None;
     loop {
       let result = f().await;
-      if result.is_ok() {
-        return result;
+      match result {
+        Ok(r) => return Ok(r),
+        Err(e) if !should_retry(&e) => return Err(e),
+        _ => {}
       }
-      if attempt >= ATTEMPTS {
-        return result;
+      if first_result.is_none() {
+        first_result = Some(result);
       }
+      let Some(wait) = waits.next() else {
+        return first_result.unwrap();
+      };
       tokio::time::sleep(wait).await;
-      attempt += 1;
-      wait *= 10;
-      wait = wait.clamp(MIN_WAIT, MAX_WAIT);
     }
   }
 }

--- a/cli/util/retry.rs
+++ b/cli/util/retry.rs
@@ -1,3 +1,5 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
 use std::future::Future;
 use std::time::Duration;
 

--- a/cli/util/retry.rs
+++ b/cli/util/retry.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 pub fn retry<F: FnMut() -> Fut, Fut: Future<Output = Result<T, E>>, T, E>(
   mut f: F,
 ) -> impl Future<Output = Result<T, E>> {
-  const ATTEMPTS: usize = 4;
+  const ATTEMPTS: usize = 5;
+  const MAX_WAIT: Duration = Duration::from_secs(1);
+  const MIN_WAIT: Duration = Duration::from_micros(1);
   async move {
     let mut wait = Duration::from_millis(1);
     let mut attempt = 1;
@@ -19,6 +21,7 @@ pub fn retry<F: FnMut() -> Fut, Fut: Future<Output = Result<T, E>>, T, E>(
       tokio::time::sleep(wait).await;
       attempt += 1;
       wait *= 10;
+      wait = wait.clamp(MIN_WAIT, MAX_WAIT);
     }
   }
 }


### PR DESCRIPTION
Fixes #26085.

Adds a basic retry utility with some defaults, starts off with a 1ms wait, then 10x for each successive attempt, up to a max of 1 second and 5 attempts.

I've applied the retry in the http client, reusing an existing function, so this also applies to retrying downloads of deno binaries in `upgrade` and `compile`. I can make a separate function that doesn't retry so this doesn't affect `upgrade` and `compile`, but it seemed desirable to have retries there too, so I left it in.