### PR TITLE
perf(http): make heap allocation for path conditional

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -305,15 +305,25 @@ where
   };
 
   // Only extract the path part - we handle authority elsewhere
-  let path = match &request_parts.uri.path_and_query() {
-    Some(path_and_query) => path_and_query.to_string(),
-    None => "".to_owned(),
+  let path = match request_parts.uri.path_and_query() {
+    Some(path_and_query) => {
+      let path = path_and_query.as_str();
+      if matches!(path.as_bytes().first(), Some(b'/' | b'*')) {
+        Cow::Borrowed(path)
+      } else {
+        Cow::Owned(format!("/{}", path))
+      }
+    }
+    None => Cow::Borrowed(""),
   };
 
-  let path: v8::Local<v8::Value> =
-    v8::String::new_from_utf8(scope, path.as_ref(), v8::NewStringType::Normal)
-      .unwrap()
-      .into();
+  let path: v8::Local<v8::Value> = v8::String::new_from_utf8(
+    scope,
+    path.as_bytes(),
+    v8::NewStringType::Normal,
+  )
+  .unwrap()
+  .into();
 
   let peer_address: v8::Local<v8::Value> = v8::String::new_from_utf8(
     scope,


### PR DESCRIPTION
Code:

```js
Deno.serve({ port: 8085 }, request => {
  return new Response(request.url);
});
```

Before:

```
% wrk -d60s http://localhost:8085/path/testing\?testing=5
Running 1m test @ http://localhost:8085/path/testing?testing=5
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    56.01us   18.34us   3.28ms   93.84%
    Req/Sec    81.80k     3.13k   88.26k    90.77%
  9783713 requests in 1.00m, 1.67GB read
Requests/sec: 162789.89
Transfer/sec:     28.41MB
```

After:

```
% wrk -d60s http://localhost:8085/path/testing\?testing=5
Running 1m test @ http://localhost:8085/path/testing?testing=5
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    55.44us   15.20us   2.42ms   90.41%
    Req/Sec    82.71k     2.92k   88.10k    89.93%
  9892916 requests in 1.00m, 1.69GB read
Requests/sec: 164607.06
Transfer/sec:     28.73MB
```