### PR TITLE
fix: node-api function call should use preamble

### DIFF
--- a/cli/napi/js_native_api.rs
+++ b/cli/napi/js_native_api.rs
@@ -1694,15 +1694,14 @@ fn napi_get_new_target(
 }
 
 #[napi_sym]
-fn napi_call_function(
-  env_ptr: *mut Env,
-  recv: napi_value,
-  func: napi_value,
+fn napi_call_function<'s>(
+  env: &'s mut Env,
+  recv: napi_value<'s>,
+  func: napi_value<'s>,
   argc: usize,
-  argv: *const napi_value,
-  result: *mut napi_value,
+  argv: *const napi_value<'s>,
+  result: *mut napi_value<'s>,
 ) -> napi_status {
-  let env = check_env!(env_ptr);
   check_arg!(env, recv);
   let args = if argc > 0 {
     check_arg!(env, argv);
@@ -1716,11 +1715,11 @@ fn napi_call_function(
   let Some(func) =
     func.and_then(|f| v8::Local::<v8::Function>::try_from(f).ok())
   else {
-    return napi_set_last_error(env, napi_function_expected);
+    return napi_function_expected;
   };
 
   let Some(v) = func.call(&mut env.scope(), recv.unwrap(), args) else {
-    return napi_set_last_error(env_ptr, napi_generic_failure);
+    return napi_generic_failure;
   };
 
   if !result.is_null() {
@@ -1729,7 +1728,7 @@ fn napi_call_function(
     }
   }
 
-  return napi_clear_last_error(env_ptr);
+  napi_ok
 }
 
 #[napi_sym]

--- a/tests/napi/callback_test.js
+++ b/tests/napi/callback_test.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, loadTestLibrary } from "./common.js";
+import { assertEquals, assertThrows, loadTestLibrary } from "./common.js";
 
 const callback = loadTestLibrary();
 
@@ -35,4 +35,13 @@ Deno.test("napi callback run with args & recv", function () {
     69,
   );
   assertEquals(result, 69);
+});
+
+Deno.test("napi callback handles errors correctly", function () {
+  const e = new Error("hi!");
+  assertThrows(() => {
+    callback.test_callback_throws(() => {
+      throw e;
+    });
+  }, e);
 });


### PR DESCRIPTION
`napi_call_function` should use our equiv of NAPI_PREAMBLE (`&mut Env` instead of `*mut Env`) since it needs to set error codes based on whether the body of the function raised a JS exception.

Fixes: https://github.com/denoland/deno/issues/26282