### PR TITLE
fix(cli): Fixed missing subcommands and typo in deno --help

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1190,7 +1190,6 @@ static DENO_HELP: &str = cstr!(
     <g>clean</>        Remove the cache directory
     <g>compile</>      Compile the script into a self contained executable
                   <p(245)>deno compile main.ts  |  deno compile --target=x86_64-unknown-linux-gnu</>
-    <g>completions</>  Output shell completions
     <g>coverage</>     Print coverage reports
     <g>doc</>          Generate and show documentation for a module or built-ins
                   <p(245)>deno doc  |  deno doc --json  |  deno doc --html mod.ts</>
@@ -1199,11 +1198,9 @@ static DENO_HELP: &str = cstr!(
     <g>info</>         Show info about cache or info related to source file
     <g>jupyter</>      Deno kernel for Jupyter notebooks
     <g>lint</>         Lint source files
-    <g>lsp</>          Start the language server
     <g>init</>         Initialize a new project
     <g>test</>         Run tests
                   <p(245)>deno test  |  deno test test.ts</>
-    <g>types</>        Print runtime TypeScript declarations
     <g>publish</>      Publish the current working directory's package or workspace
     <g>upgrade</>      Upgrade deno executable to given version
                   <p(245)>deno upgrade  |  deno upgrade 1.45.0  |  deno upgrade canary</>

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1190,7 +1190,7 @@ static DENO_HELP: &str = cstr!(
     <g>clean</>        Remove the cache directory
     <g>compile</>      Compile the script into a self contained executable
                   <p(245)>deno compile main.ts  |  deno compile --target=x86_64-unknown-linux-gnu</>
-    <g>completions</>  Generate shell completions
+    <g>completions</>  Output shell completions
     <g>coverage</>     Print coverage reports
     <g>doc</>          Generate and show documentation for a module or built-ins
                   <p(245)>deno doc  |  deno doc --json  |  deno doc --html mod.ts</>

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1190,17 +1190,20 @@ static DENO_HELP: &str = cstr!(
     <g>clean</>        Remove the cache directory
     <g>compile</>      Compile the script into a self contained executable
                   <p(245)>deno compile main.ts  |  deno compile --target=x86_64-unknown-linux-gnu</>
+    <g>completions</>  Generate shell completions
     <g>coverage</>     Print coverage reports
-    <g>doc</>          Genereate and show documentation for a module or built-ins
+    <g>doc</>          Generate and show documentation for a module or built-ins
                   <p(245)>deno doc  |  deno doc --json  |  deno doc --html mod.ts</>
     <g>fmt</>          Format source files
                   <p(245)>deno fmt  |  deno fmt main.ts</>
     <g>info</>         Show info about cache or info related to source file
     <g>jupyter</>      Deno kernel for Jupyter notebooks
     <g>lint</>         Lint source files
+    <g>lsp</>          Start the language server
     <g>init</>         Initialize a new project
     <g>test</>         Run tests
                   <p(245)>deno test  |  deno test test.ts</>
+    <g>types</>        Print runtime TypeScript declarations
     <g>publish</>      Publish the current working directory's package or workspace
     <g>upgrade</>      Upgrade deno executable to given version
                   <p(245)>deno upgrade  |  deno upgrade 1.45.0  |  deno upgrade canary</>

--- a/tests/integration/flags_tests.rs
+++ b/tests/integration/flags_tests.rs
@@ -32,9 +32,6 @@ fn help_output() {
     "Initialize a new project",
     "Run tests",
     "Publish the current working directory's package or workspace",
-    "Output shell completions",
-    "Print runtime TypeScript declarations",
-    "Start the language server",
     #[cfg(feature = "upgrade")]
     "Upgrade deno executable to given version",
   ];

--- a/tests/integration/flags_tests.rs
+++ b/tests/integration/flags_tests.rs
@@ -24,7 +24,7 @@ fn help_output() {
     "Type-check the dependencies",
     "Compile the script into a self contained executable",
     "Print coverage reports",
-    "Genereate and show documentation for a module or built-ins",
+    "Generate and show documentation for a module or built-ins",
     "Format source files",
     "Show info about cache or info related to source file",
     "Deno kernel for Jupyter notebooks",
@@ -32,6 +32,9 @@ fn help_output() {
     "Initialize a new project",
     "Run tests",
     "Publish the current working directory's package or workspace",
+    "Generate shell completions",
+    "Print runtime TypeScript declarations",
+    "Start the language server",
     #[cfg(feature = "upgrade")]
     "Upgrade deno executable to given version",
   ];

--- a/tests/integration/flags_tests.rs
+++ b/tests/integration/flags_tests.rs
@@ -32,7 +32,7 @@ fn help_output() {
     "Initialize a new project",
     "Run tests",
     "Publish the current working directory's package or workspace",
-    "Generate shell completions",
+    "Output shell completions",
     "Print runtime TypeScript declarations",
     "Start the language server",
     #[cfg(feature = "upgrade")]


### PR DESCRIPTION
Added completions, lsp and types to the list of subcommands in the deno --help command. Also fixed small typo.
Issue: https://github.com/denoland/deno/issues/26096

