### PR TITLE
feat(permissions): expose PermissionPrompter and set_prompter function

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -39,6 +39,8 @@ use prompter::PromptResponse;
 use prompter::PERMISSION_EMOJI;
 
 pub use prompter::set_prompt_callbacks;
+pub use prompter::set_prompter;
+pub use prompter::PermissionPrompter;
 pub use prompter::PromptCallback;
 
 /// Fast exit from permission check routines if this permission

--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -80,6 +80,10 @@ pub fn set_prompt_callbacks(
   *MAYBE_AFTER_PROMPT_CALLBACK.lock() = Some(after_callback);
 }
 
+pub fn set_prompter(prompter: Box<dyn PermissionPrompter>) {
+  *PERMISSION_PROMPTER.lock() = prompter;
+}
+
 pub type PromptCallback = Box<dyn FnMut() + Send + Sync>;
 
 pub trait PermissionPrompter: Send + Sync {
@@ -475,9 +479,5 @@ pub mod tests {
     pub fn set(&self, value: bool) {
       STUB_PROMPT_VALUE.store(value, Ordering::SeqCst);
     }
-  }
-
-  pub fn set_prompter(prompter: Box<dyn PermissionPrompter>) {
-    *PERMISSION_PROMPTER.lock() = prompter;
   }
 }


### PR DESCRIPTION
when defining a custom runtime, it might be useful to define a custom prompter - for instance when you are not relying on the terminal and want a GUI prompter instead

