### PR TITLE
fix: don't warn on ignored signals on windows

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -522,7 +522,6 @@ Process.prototype.on = function (
     ) {
       // Ignores all signals except SIGBREAK and SIGINT on windows.
       // deno-lint-ignore no-console
-      console.warn(`Ignoring signal "${event}" on Windows`);
     } else {
       EventEmitter.prototype.on.call(this, event, listener);
       Deno.addSignalListener(event as Deno.Signal, listener);

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -520,7 +520,7 @@ Process.prototype.on = function (
     } else if (
       event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows"
     ) {
-      // TODO: Ignores all signals except SIGBREAK and SIGINT on windows.
+      // TODO(#26331): Ignores all signals except SIGBREAK and SIGINT on windows.
     } else {
       EventEmitter.prototype.on.call(this, event, listener);
       Deno.addSignalListener(event as Deno.Signal, listener);

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -520,8 +520,7 @@ Process.prototype.on = function (
     } else if (
       event !== "SIGBREAK" && event !== "SIGINT" && Deno.build.os === "windows"
     ) {
-      // Ignores all signals except SIGBREAK and SIGINT on windows.
-      // deno-lint-ignore no-console
+      // TODO: Ignores all signals except SIGBREAK and SIGINT on windows.
     } else {
       EventEmitter.prototype.on.call(this, event, listener);
       Deno.addSignalListener(event as Deno.Signal, listener);

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -239,33 +239,6 @@ Deno.test({
   },
 });
 
-Deno.test({
-  name: "process.on - ignored signals on windows",
-  ignore: Deno.build.os !== "windows",
-  fn() {
-    const ignoredSignals = ["SIGHUP", "SIGUSR1", "SIGUSR2"];
-
-    for (const signal of ignoredSignals) {
-      using consoleSpy = spy(console, "warn");
-      const handler = () => {};
-      process.on(signal, handler);
-      process.off(signal, handler);
-      assertSpyCall(consoleSpy, 0, {
-        args: [`Ignoring signal "${signal}" on Windows`],
-      });
-    }
-
-    {
-      using consoleSpy = spy(console, "warn");
-      const handler = () => {};
-      process.on("SIGTERM", handler);
-      process.off("SIGTERM", handler);
-      // No warning is made for SIGTERM
-      assertSpyCalls(consoleSpy, 0);
-    }
-  },
-});
-
 Deno.test(
   { permissions: { run: true, read: true } },
   async function processKill() {

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -25,7 +25,6 @@ import {
   assertThrows,
   fail,
 } from "@std/assert";
-import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
 import { stripAnsiCode } from "@std/fmt/colors";
 import * as path from "@std/path";
 import { delay } from "@std/async/delay";


### PR DESCRIPTION
Closes #26183.

The warnings are super noisy and not actionable for the user