### PR TITLE
fix(node/http): normalize header names in `ServerResponse`

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -71,7 +71,7 @@ import { STATUS_CODES } from "node:_http_server";
 import { methods as METHODS } from "node:_http_common";
 
 const { internalRidSymbol } = core;
-const { ArrayIsArray } = primordials;
+const { ArrayIsArray, StringPrototypeToLowerCase } = primordials;
 
 type Chunk = string | Buffer | Uint8Array;
 
@@ -1269,20 +1269,21 @@ export class ServerResponse extends NodeWritable {
     if (Array.isArray(value)) {
       this.#hasNonStringHeaders = true;
     }
-    this.#headers[name] = value;
+    this.#headers[StringPrototypeToLowerCase(name)] = value;
     return this;
   }
 
   appendHeader(name: string, value: string | string[]) {
-    if (this.#headers[name] === undefined) {
+    const key = StringPrototypeToLowerCase(name);
+    if (this.#headers[key] === undefined) {
       if (Array.isArray(value)) this.#hasNonStringHeaders = true;
-      this.#headers[name] = value;
+      this.#headers[key] = value;
     } else {
       this.#hasNonStringHeaders = true;
-      if (!Array.isArray(this.#headers[name])) {
-        this.#headers[name] = [this.#headers[name]];
+      if (!Array.isArray(this.#headers[key])) {
+        this.#headers[key] = [this.#headers[key]];
       }
-      const header = this.#headers[name];
+      const header = this.#headers[key];
       if (Array.isArray(value)) {
         header.push(...value);
       } else {
@@ -1293,10 +1294,10 @@ export class ServerResponse extends NodeWritable {
   }
 
   getHeader(name: string) {
-    return this.#headers[name];
+    return this.#headers[StringPrototypeToLowerCase(name)];
   }
   removeHeader(name: string) {
-    delete this.#headers[name];
+    delete this.#headers[StringPrototypeToLowerCase(name)];
   }
   getHeaderNames() {
     return Object.keys(this.#headers);


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26115.

We weren't normalizing the headers to lower case, so code that attempted to delete the `Content-Length` header (but used a different case) wasn't actually removing the header.