### PR TITLE
fix(net): don't try to set nodelay on upgrade streams

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -193,6 +193,7 @@ class InnerRequest {
         upgradeRid,
         underlyingConn?.remoteAddr,
         underlyingConn?.localAddr,
+        false,
       );
 
       return { response: UPGRADE_RESPONSE_SENTINEL, conn };

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -76,7 +76,12 @@ import {
   ReadableStreamPrototype,
   resourceForReadableStream,
 } from "ext:deno_web/06_streams.js";
-import { listen, listenOptionApiName, TcpConn } from "ext:deno_net/01_net.js";
+import {
+  listen,
+  listenOptionApiName,
+  TcpConn,
+  UpgradedConn,
+} from "ext:deno_net/01_net.js";
 import { hasTlsKeyPairOptions, listenTls } from "ext:deno_net/02_tls.js";
 import { SymbolAsyncDispose } from "ext:deno_web/00_infra.js";
 
@@ -189,11 +194,10 @@ class InnerRequest {
 
       const upgradeRid = op_http_upgrade_raw(external);
 
-      const conn = new TcpConn(
+      const conn = new UpgradedConn(
         upgradeRid,
         underlyingConn?.remoteAddr,
         underlyingConn?.localAddr,
-        false,
       );
 
       return { response: UPGRADE_RESPONSE_SENTINEL, conn };

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -79,7 +79,6 @@ import {
 import {
   listen,
   listenOptionApiName,
-  TcpConn,
   UpgradedConn,
 } from "ext:deno_net/01_net.js";
 import { hasTlsKeyPairOptions, listenTls } from "ext:deno_net/02_tls.js";

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -219,13 +219,10 @@ class TcpConn extends Conn {
       value: rid,
     });
     this.#rid = rid;
-    this.#isTcpStream = isTcpStream;
   }
 
   setNoDelay(noDelay = true) {
-    if (this.#isTcpStream) {
-      return op_set_nodelay(this.#rid, noDelay);
-    }
+    return op_set_nodelay(this.#rid, noDelay);
   }
 
   setKeepAlive(keepAlive = true) {

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -615,5 +615,6 @@ export {
   resolveDns,
   TcpConn,
   UnixConn,
+  UpgradedConn,
   validatePort,
 };

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -196,8 +196,11 @@ class Conn {
 
 class TcpConn extends Conn {
   #rid = 0;
+  // whether the connectino is backed by a
+  // full TCP stream (as opposed to an UpgradeStream)
+  #isTcpStream = true;
 
-  constructor(rid, remoteAddr, localAddr) {
+  constructor(rid, remoteAddr, localAddr, isTcpStream) {
     super(rid, remoteAddr, localAddr);
     ObjectDefineProperty(this, internalRidSymbol, {
       __proto__: null,
@@ -205,10 +208,13 @@ class TcpConn extends Conn {
       value: rid,
     });
     this.#rid = rid;
+    this.#isTcpStream = isTcpStream;
   }
 
   setNoDelay(noDelay = true) {
-    return op_set_nodelay(this.#rid, noDelay);
+    if (this.#isTcpStream) {
+      return op_set_nodelay(this.#rid, noDelay);
+    }
   }
 
   setKeepAlive(keepAlive = true) {

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -194,13 +194,24 @@ class Conn {
   }
 }
 
+class UpgradedConn extends Conn {
+  #rid = 0;
+
+  constructor(rid, remoteAddr, localAddr) {
+    super(rid, remoteAddr, localAddr);
+    ObjectDefineProperty(this, internalRidSymbol, {
+      __proto__: null,
+      enumerable: false,
+      value: rid,
+    });
+    this.#rid = rid;
+  }
+}
+
 class TcpConn extends Conn {
   #rid = 0;
-  // whether the connectino is backed by a
-  // full TCP stream (as opposed to an UpgradeStream)
-  #isTcpStream = true;
 
-  constructor(rid, remoteAddr, localAddr, isTcpStream) {
+  constructor(rid, remoteAddr, localAddr) {
     super(rid, remoteAddr, localAddr);
     ObjectDefineProperty(this, internalRidSymbol, {
       __proto__: null,

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -517,7 +517,7 @@ class ClientRequest extends OutgoingMessage {
           );
           assert(typeof res.remoteAddrIp !== "undefined");
           assert(typeof res.remoteAddrIp !== "undefined");
-          const conn = new TcpConn(
+          const conn = new UpgradedConn(
             upgradeRid,
             {
               transport: "tcp",

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -530,6 +530,7 @@ class ClientRequest extends OutgoingMessage {
               hostname: "127.0.0.1",
               port: 80,
             },
+            false,
           );
           const socket = new Socket({
             handle: new TCP(constants.SERVER, conn),

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -67,7 +67,7 @@ import { headersEntries } from "ext:deno_fetch/20_headers.js";
 import { timerId } from "ext:deno_web/03_abort_signal.js";
 import { clearTimeout as webClearTimeout } from "ext:deno_web/02_timers.js";
 import { resourceForReadableStream } from "ext:deno_web/06_streams.js";
-import { TcpConn } from "ext:deno_net/01_net.js";
+import { UpgradedConn } from "ext:deno_net/01_net.js";
 import { STATUS_CODES } from "node:_http_server";
 import { methods as METHODS } from "node:_http_common";
 
@@ -530,7 +530,6 @@ class ClientRequest extends OutgoingMessage {
               hostname: "127.0.0.1",
               port: 80,
             },
-            false,
           );
           const socket = new Socket({
             handle: new TCP(constants.SERVER, conn),

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -300,7 +300,9 @@ export class TCP extends ConnectionWrap {
    * @return An error status code.
    */
   setNoDelay(noDelay: boolean): number {
-    this[kStreamBaseField].setNoDelay(noDelay);
+    if ("setNoDelay" in this[kStreamBaseField]) {
+      this[kStreamBaseField].setNoDelay(noDelay);
+    }
     return 0;
   }
 


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26341.

We try to call `op_set_nodelay` on an `UpgradeStream`, which doesn't support that operation. When contructing a `TcpConn`,  just store whether or not it's backed by a proper tcp stream.