### PR TITLE
fix(node/fs): copyFile with `COPYFILE_EXCL` should not throw if the destination doesn't exist

### DIFF
--- a/ext/node/polyfills/_fs/_fs_copy.ts
+++ b/ext/node/polyfills/_fs/_fs_copy.ts
@@ -53,8 +53,9 @@ export function copyFile(
     }, (e) => {
       if (e instanceof Deno.errors.NotFound) {
         Deno.copyFile(srcStr, destStr).then(() => cb(null), cb);
+      } else {
+        cb(e);
       }
-      cb(e);
     });
   } else {
     Deno.copyFile(srcStr, destStr).then(() => cb(null), cb);
@@ -83,8 +84,9 @@ export function copyFileSync(
     } catch (e) {
       if (e instanceof Deno.errors.NotFound) {
         Deno.copyFileSync(srcStr, destStr);
+      } else {
+        throw e;
       }
-      throw e;
     }
   } else {
     Deno.copyFileSync(srcStr, destStr);

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -1,11 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assert, assertEquals, assertThrows } from "@std/assert";
+/// <reference lib="deno.ns" />
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   closeSync,
   constants,
+  copyFileSync,
   createWriteStream,
   existsSync,
   lstatSync,
@@ -20,6 +22,7 @@ import {
 } from "node:fs";
 import {
   constants as fsPromiseConstants,
+  copyFile,
   cp,
   FileHandle,
   open,
@@ -211,4 +214,20 @@ Deno.test("[node/fs] readSync works", () => {
   const bytesRead = readSync(fd!, buf);
   assertEquals(bytesRead, 12);
   closeSync(fd!);
+});
+
+Deno.test("[node/fs] copyFile COPYFILE_EXCL works", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "foo-"));
+  const src = join(dir, "src.txt");
+  const dest = join(dir, "dest.txt");
+  await writeFile(src, "");
+  await copyFile(src, dest, fsPromiseConstants.COPYFILE_EXCL);
+  assert(existsSync(dest));
+  assertRejects(() => copyFile(src, dest, fsPromiseConstants.COPYFILE_EXCL));
+  const dest2 = join(dir, "dest2.txt");
+  copyFileSync(src, dest2, fsPromiseConstants.COPYFILE_EXCL);
+  assert(existsSync(dest2));
+  assertThrows(() =>
+    copyFileSync(src, dest2, fsPromiseConstants.COPYFILE_EXCL)
+  );
 });


### PR DESCRIPTION
Fixes #26313.

We were checking for the NotFound error, but still calling the callback with the error / throwing.