### PR TITLE
fix(ext/node): add null check for kStreamBaseField

### DIFF
--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -300,7 +300,7 @@ export class TCP extends ConnectionWrap {
    * @return An error status code.
    */
   setNoDelay(noDelay: boolean): number {
-    if ("setNoDelay" in this[kStreamBaseField]) {
+    if (this[kStreamBaseField] && "setNoDelay" in this[kStreamBaseField]) {
       this[kStreamBaseField].setNoDelay(noDelay);
     }
     return 0;


### PR DESCRIPTION
It's not guaranteed that `kStreamBaseField` is not undefined, so
added a check for it.

Closes https://github.com/denoland/deno/issues/26363