### PR TITLE
perf: avoid multiple calls to runMicrotask

### DIFF
--- a/ext/node/polyfills/_next_tick.ts
+++ b/ext/node/polyfills/_next_tick.ts
@@ -87,8 +87,7 @@ export function runNextTicks() {
   //   runMicrotasks();
   // if (!hasTickScheduled() && !hasRejectionToWarn())
   //   return;
-  if (!core.hasTickScheduled()) {
-    core.runMicrotasks();
+  if (queue.isEmpty() || !core.hasTickScheduled()) {
     return true;
   }
 


### PR DESCRIPTION
Improves HTTP throughput by 8-9k rps on Linux:

this patch
```
Requests/sec: 145001.69
Transfer/sec:     20.74MB
```

main
```
Requests/sec: 137866.61
Transfer/sec:     19.72MB
```

The improvements comes from the reduced number of calls to `op_run_microtask` per request. Returning `true` from a macrotask callback already calls `op_run_microtask` so the extra call was redundant.

Here's `--strace-ops` output for a single request:

main
```
[     4.667] op_http_wait                                       : CompletedAsync Async
[     4.667] op_run_microtasks                                  : Dispatched Slow
[     4.668] op_http_try_wait                                   : Dispatched Slow
[     4.668] op_http_try_wait                                   : Completed Slow
[     4.668] op_http_wait                                       : Dispatched Async
[     4.668] op_http_set_response_header                        : Dispatched Slow
[     4.668] op_http_set_response_header                        : Completed Slow
[     4.669] op_http_set_response_body_text                     : Dispatched Slow
[     4.669] op_http_set_response_body_text                     : Completed Slow
[     4.669] op_run_microtasks                                  : Completed Slow
[     4.669] op_has_tick_scheduled                              : Dispatched Slow
[     4.669] op_has_tick_scheduled                              : Completed Slow
[     4.669] op_run_microtasks                                  : Dispatched Slow
[     4.669] op_run_microtasks                                  : Completed Slow
[     4.669] op_run_microtasks                                  : Dispatched Slow
[     4.669] op_run_microtasks                                  : Completed Slow
```

this pr
```
[     3.726] op_http_wait                                       : CompletedAsync Async
[     3.727] op_run_microtasks                                  : Dispatched Slow
[     3.727] op_http_try_wait                                   : Dispatched Slow
[     3.727] op_http_try_wait                                   : Completed Slow
[     3.727] op_http_wait                                       : Dispatched Async
[     3.727] op_http_set_response_header                        : Dispatched Slow
[     3.728] op_http_set_response_header                        : Completed Slow
[     3.728] op_http_set_response_body_text                     : Dispatched Slow
[     3.728] op_http_set_response_body_text                     : Completed Slow
[     3.728] op_run_microtasks                                  : Completed Slow
[     3.728] op_run_microtasks                                  : Dispatched Slow
[     3.728] op_run_microtasks                                  : Completed Slow
```