### PR TITLE
Revert "ci: use self-hosted mac arm runner (#26366)"

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -40,8 +40,7 @@ const Runners = {
   macosArm: {
     os: "macos",
     arch: "aarch64",
-    runner:
-      `\${{ github.repository == 'denoland/deno' && 'self-hosted' || '${macosArmRunner}' }}`,
+    runner: macosArmRunner,
   },
   windowsX86: {
     os: "windows",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,12 @@ jobs:
             skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
           - os: macos
             arch: aarch64
-            runner: '${{ github.repository == ''denoland/deno'' && ''self-hosted'' || ''macos-14'' }}'
+            runner: macos-14
             job: test
             profile: debug
           - os: macos
             arch: aarch64
-            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || github.repository == ''denoland/deno'' && ''self-hosted'' || ''macos-14'' }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-22.04'' || ''macos-14'' }}'
             job: test
             profile: release
             skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'


### PR DESCRIPTION
This reverts commit e22d0e91ef7ce17dca299a44d1ccd292abde34f2.

Reverting because the CI pipeline is actually incorrect.

I intended to only use this self-hosted runner for "release" builds on `main`
branch, but now all PRs are queued waiting for a runner for a "debug" build.