### PR TITLE
chore: update nix crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-util",
- "nix 0.26.2",
+ "nix",
  "once_cell",
  "os_pipe",
  "pretty_assertions",
@@ -1223,7 +1223,7 @@ dependencies = [
  "memmem",
  "monch",
  "napi_sym",
- "nix 0.26.2",
+ "nix",
  "node_resolver",
  "notify",
  "once_cell",
@@ -1438,7 +1438,7 @@ dependencies = [
  "deno_unsync",
  "futures",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
  "parking_lot",
  "percent-encoding",
  "pin-project",
@@ -1599,7 +1599,7 @@ dependencies = [
  "filetime",
  "junction",
  "libc",
- "nix 0.26.2",
+ "nix",
  "rand",
  "rayon",
  "serde",
@@ -2035,7 +2035,7 @@ dependencies = [
  "libc",
  "log",
  "netif",
- "nix 0.26.2",
+ "nix",
  "node_resolver",
  "notify",
  "ntapi",
@@ -4399,15 +4399,6 @@ checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4561,20 +4552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -5776,7 +5753,7 @@ checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
 dependencies = [
  "countme",
  "hashbrown",
- "memoffset 0.9.1",
+ "memoffset",
  "rustc-hash 1.1.0",
  "text-size",
 ]
@@ -5984,7 +5961,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.27.1",
+ "nix",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -7187,7 +7164,7 @@ dependencies = [
  "libc",
  "lsp-types",
  "monch",
- "nix 0.26.2",
+ "nix",
  "once_cell",
  "os_pipe",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
 
 # unix
-nix = "=0.26.2"
+nix = "=0.27.1"
 
 # windows deps
 junction = "=0.2.0"

--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -31,7 +31,7 @@ serde.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-nix.workspace = true
+nix = { workspace = true, features = ["user"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["winbase"] }

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -244,7 +244,8 @@ fn op_set_raw(
     let tty_mode_store = state.borrow::<TtyModeStore>().clone();
     let previous_mode = tty_mode_store.get(rid);
 
-    let raw_fd = handle_or_fd;
+    // SAFETY: Nix crate requires value to implement the AsFd trait
+    let raw_fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(handle_or_fd) };
 
     if is_raw {
       let mut raw = match previous_mode {

--- a/tests/util/server/Cargo.toml
+++ b/tests/util/server/Cargo.toml
@@ -35,7 +35,7 @@ lazy-regex.workspace = true
 libc.workspace = true
 lsp-types.workspace = true
 monch.workspace = true
-nix.workspace = true
+nix = { workspace = true, features = ["fs", "term", "signal"] }
 once_cell.workspace = true
 os_pipe.workspace = true
 parking_lot.workspace = true

--- a/tests/util/server/src/pty.rs
+++ b/tests/util/server/src/pty.rs
@@ -297,10 +297,12 @@ fn setup_pty(fd: i32) {
   use nix::sys::termios::tcsetattr;
   use nix::sys::termios::SetArg;
 
-  let mut term = tcgetattr(fd).unwrap();
+  // SAFETY: Nix crate requires value to implement the AsFd trait
+  let as_fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+  let mut term = tcgetattr(as_fd).unwrap();
   // disable cooked mode
   term.local_flags.remove(termios::LocalFlags::ICANON);
-  tcsetattr(fd, SetArg::TCSANOW, &term).unwrap();
+  tcsetattr(as_fd, SetArg::TCSANOW, &term).unwrap();
 
   // turn on non-blocking mode so we get timeouts
   let flags = fcntl(fd, FcntlArg::F_GETFL).unwrap();


### PR DESCRIPTION
Dedupes nix dependency, since `rustyline` depends on a newer version that what we currently use