### PR TITLE
perf(ext/http): optimize inferrable content-type responses

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -564,6 +564,12 @@ function mapToCallback(context, callback, onError) {
     const headers = inner.headerList;
     if (headers && headers.length > 0) {
       if (headers.length == 1) {
+        if (
+          inner.canInferContentType &&
+          headers[0][0] === "Content-Type"
+        ) {
+          continue;
+        }
         op_http_set_response_header(req, headers[0][0], headers[0][1]);
       } else {
         op_http_set_response_headers(req, headers);

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -565,12 +565,11 @@ function mapToCallback(context, callback, onError) {
     if (headers && headers.length > 0) {
       if (headers.length == 1) {
         if (
-          inner.canInferContentType &&
-          headers[0][0] === "Content-Type"
+          !(inner.canInferContentType &&
+            headers[0][0] === "Content-Type")
         ) {
-          continue;
+          op_http_set_response_header(req, headers[0][0], headers[0][1]);
         }
-        op_http_set_response_header(req, headers[0][0], headers[0][1]);
       } else {
         op_http_set_response_headers(req, headers);
       }

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -739,7 +739,19 @@ pub fn op_http_set_response_body_text(
   let http =
     // SAFETY: external is deleted before calling this op.
     unsafe { take_external!(external, "op_http_set_response_body_text") };
+
   if !text.is_empty() {
+    {
+      let mut response_parts = http.response_parts();
+      if !response_parts.headers.contains_key(CONTENT_TYPE) {
+        response_parts.headers.append(
+          CONTENT_TYPE,
+          HeaderValue::from_static("text/plain; charset=utf-8"),
+        );
+      }
+    }
+
+    // set content-type to text/plain; charset=utf-8 if not set
     set_response(http, Some(text.len()), status, false, |compression| {
       ResponseBytesInner::from_vec(compression, text.into_bytes())
     });

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -746,7 +746,7 @@ pub fn op_http_set_response_body_text(
       if !response_parts.headers.contains_key(CONTENT_TYPE) {
         response_parts.headers.append(
           CONTENT_TYPE,
-          HeaderValue::from_static("text/plain; charset=utf-8"),
+          HeaderValue::from_static("text/plain;charset=UTF-8"),
         );
       }
     }


### PR DESCRIPTION
Skip manually setting header via `op_http_set_response_header` if `Content-Type` can be inferred from body. Optimizes the case for `new Response(<string>)`

--strace-ops in `main`:
```
[     1.726] op_http_wait                                       : Dispatched Async
[     1.726] op_http_set_response_header                        : Dispatched Fast
[     1.726] op_http_set_response_header                        : Completed Fast
[     1.726] op_http_set_response_body_text                     : Dispatched Fast
[     1.726] op_http_set_response_body_text                     : Completed Fast
[     1.726] op_run_microtasks                                  : Completed Fast
```

--strace-ops for this patch:
```
[     1.726] op_http_wait                                       : Dispatched Async
[     1.726] op_http_set_response_body_text                     : Dispatched Fast
[     1.726] op_http_set_response_body_text                     : Completed Fast
[     1.726] op_run_microtasks                                  : Completed Fast
```