### PR TITLE
fix(npm): support version ranges with && or comma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.5.14"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fec7ef309384e23c2a90ac5d2d9d91a776d225306c75f5cdd28cf6cc8a59f"
+checksum = "c957c6a57c38b7dde2315df0da0ec228911e56a74f185b108a488d0401841a67"
 dependencies = [
  "monch",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ deno_npm = "=0.25.4"
 deno_path_util = "=0.2.1"
 deno_permissions = { version = "0.33.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.182.0", path = "./runtime" }
-deno_semver = "=0.5.14"
+deno_semver = "=0.5.16"
 deno_terminal = "0.2.0"
 napi_sym = { version = "0.103.0", path = "./cli/napi/sym" }
 test_util = { package = "test_server", path = "./tests/util/server" }


### PR DESCRIPTION
* https://github.com/denoland/deno_semver/pull/38

This adds support for npm packages that have dependencies with `&&` or `,` in their version constraints.

Closes https://github.com/denoland/deno/issues/26168