### PR TITLE
fix(cli): increase size of blocking task threadpool on windows

### DIFF
--- a/runtime/tokio_util.rs
+++ b/runtime/tokio_util.rs
@@ -43,7 +43,13 @@ pub fn create_basic_runtime() -> tokio::runtime::Runtime {
     // parallel for deno fmt.
     // The default value is 512, which is an unhelpfully large thread pool. We
     // don't ever want to have more than a couple dozen threads.
-    .max_blocking_threads(32)
+    .max_blocking_threads(if cfg!(windows) {
+      4 * std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8)
+    } else {
+      32
+    })
     .build()
     .unwrap()
 }

--- a/runtime/tokio_util.rs
+++ b/runtime/tokio_util.rs
@@ -44,6 +44,8 @@ pub fn create_basic_runtime() -> tokio::runtime::Runtime {
     // The default value is 512, which is an unhelpfully large thread pool. We
     // don't ever want to have more than a couple dozen threads.
     .max_blocking_threads(if cfg!(windows) {
+      // on windows, tokio uses blocking tasks for child process IO, make sure
+      // we have enough available threads for other tasks to run
       4 * std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(8)


### PR DESCRIPTION
Fixes #26179.

The original error reported in that issue is fixed on canary, but in local testing on my windows machine, `next build` would just hang forever. 

After some digging, what happens is that at some point in next build, readFile promises (from `fs/promises` ) just never resolve, and so next hangs.

It turns out the issue is saturating tokio's blocking task thread pool. We previously limited the number of blocking threads to 32, and at some point those threads are all in use and there's no thread available for the file reads.

What's taking up all of those threads? The answer turns out to be `tokio::process`. On windows, child process stdio uses the blocking threadpool: https://github.com/tokio-rs/tokio/pull/4824. When you poll the child's stdio on windows, it spawns a blocking task per poll, and calls `std::io::Read::read` in the blocking context. That call can block until data is available.
Putting it all together, what happens is that Next.js spawns `2 * the number of CPU cores` deno child subprocesses to do work. We implement `child_process` with `tokio::process`. When the child processes' stdio get polled, blocking tasks get spawned, and those blocking tasks might block until data is available. So if you have 16 cores (as I do), there are going to be potentially >32 blocking task threadpool threads taken just by the child processes. That leaves no room for other tasks to make progress

---

To fix this, for now, increase the size of the blocking threadpool on windows. 4 * the number of CPU cores should be enough to leave room for other tasks to make progress.

Longer term, this can be fixed more properly when we handroll our own subprocess code (needed for detached processes and additional pipes on windows).