### PR TITLE
fix(ext/console): ignore casing for named colors in css parsing

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -2653,7 +2653,7 @@ const HSL_PATTERN = new SafeRegExp(
 );
 
 function parseCssColor(colorString) {
-  colorString = colorString.toLowerCase();
+  colorString = StringPrototypeToLowerCase(colorString);
   if (colorKeywords.has(colorString)) {
     colorString = colorKeywords.get(colorString);
   }

--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -2653,6 +2653,7 @@ const HSL_PATTERN = new SafeRegExp(
 );
 
 function parseCssColor(colorString) {
+  colorString = colorString.toLowerCase();
   if (colorKeywords.has(colorString)) {
     colorString = colorKeywords.get(colorString);
   }

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -1227,6 +1227,7 @@ Deno.test(function consoleParseCssColor() {
   assertEquals(parseCssColor("inherit"), null);
   assertEquals(parseCssColor("black"), [0, 0, 0]);
   assertEquals(parseCssColor("darkmagenta"), [139, 0, 139]);
+  assertEquals(parseCssColor("darkMaGenta"), [139, 0, 139]);
   assertEquals(parseCssColor("slateblue"), [106, 90, 205]);
   assertEquals(parseCssColor("#ffaa00"), [255, 170, 0]);
   assertEquals(parseCssColor("#ffAA00"), [255, 170, 0]);


### PR DESCRIPTION
Fixes #26459