### PR TITLE
fix(ext/node): only set our end of child process pipe to nonblocking mode

### DIFF
--- a/tests/specs/node/child_process_extra_pipes/main.out
+++ b/tests/specs/node/child_process_extra_pipes/main.out
@@ -1,5 +1,5 @@
-data: hello world
 [UNORDERED_START]
 child closed
+got: hello world
 pipe closed
 [UNORDERED_END]

--- a/tests/specs/node/child_process_extra_pipes/main.ts
+++ b/tests/specs/node/child_process_extra_pipes/main.ts
@@ -1,5 +1,4 @@
 import child_process from "node:child_process";
-import { Buffer } from "node:buffer";
 import console from "node:console";
 
 const child = child_process.spawn("./test-pipe/target/debug/test-pipe", [], {
@@ -8,19 +7,32 @@ const child = child_process.spawn("./test-pipe/target/debug/test-pipe", [], {
 
 const extra = child.stdio[4];
 
-const p = Promise.withResolvers();
+if (!extra) {
+  throw new Error("no extra pipe");
+}
+
+const p = Promise.withResolvers<void>();
+
+let got = "";
 
 child.on("close", () => {
   console.log("child closed");
-  p.resolve();
+  console.log("got:", got);
+  if (got === "hello world") {
+    p.resolve();
+  } else {
+    p.reject(new Error(`wanted "hello world", got "${got}"`));
+  }
 });
 
 extra.on("data", (d) => {
-  console.log("data:", d.toString().trim());
+  got += d.toString();
 });
 
 extra.on("close", () => {
   console.log("pipe closed");
 });
+
+extra.write("start");
 
 await p.promise;

--- a/tests/specs/node/child_process_extra_pipes/test-pipe/src/main.rs
+++ b/tests/specs/node/child_process_extra_pipes/test-pipe/src/main.rs
@@ -1,12 +1,31 @@
+use std::fs::File;
 use std::io::prelude::*;
 use std::os::fd::FromRawFd;
-use std::os::unix::net::UnixStream;
 
 fn main() {
   #[cfg(unix)]
   {
-    let mut stream = unsafe { UnixStream::from_raw_fd(4) };
+    let mut pipe = unsafe { File::from_raw_fd(4) };
 
-    stream.write_all(b"hello world\n").unwrap();
+    let mut read = 0;
+    let mut buf = [0u8; 1024];
+    loop {
+      if read > 4 {
+        assert_eq!(&buf[..5], b"start");
+        break;
+      }
+      match pipe.read(&mut buf) {
+        Ok(n) => {
+          read += n;
+        }
+        Ok(0) => {
+          return;
+        }
+        Err(e) => {
+          eprintln!("GOT ERROR: {e:?}");
+        }
+      }
+    }
+    pipe.write_all(b"hello world").unwrap();
   }
 }


### PR DESCRIPTION
Fixes playwright on linux, as reported in https://github.com/denoland/deno/issues/16899#issuecomment-2378268454.

The issue was that we were opening the socket in nonblocking mode, which meant that subprocesses trying to use it would get a `EWOULDBLOCK` error (unexpectedly). The fix here is to only set nonblocking mode on our end (which we need to use asynchronously)