### PR TITLE
fix(install): cache all exports of JSR packages listed in `deno.json`

### DIFF
--- a/cli/tools/registry/pm/cache_deps.rs
+++ b/cli/tools/registry/pm/cache_deps.rs
@@ -89,10 +89,6 @@ pub async fn cache_top_level_deps(
 
     while let Some(info_future) = info_futures.next().await {
       if let Some((specifier, info)) = info_future {
-        if info.export(".").is_some() {
-          roots.push(specifier.clone());
-          continue;
-        }
         let exports = info.exports();
         for (k, _) in exports {
           if let Ok(spec) = specifier.join(k) {

--- a/tests/specs/install/jsr_exports/__test__.jsonc
+++ b/tests/specs/install/jsr_exports/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "tempDir": true,
+  "steps": [
+    { "args": "install", "output": "install.out" }
+  ]
+}

--- a/tests/specs/install/jsr_exports/deno.json
+++ b/tests/specs/install/jsr_exports/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@denotest/different-deps-per-export": "jsr:@denotest/different-deps-per-export@^1.0.0"
+  }
+}

--- a/tests/specs/install/jsr_exports/install.out
+++ b/tests/specs/install/jsr_exports/install.out
@@ -1,0 +1,12 @@
+[UNORDERED_START]
+Download http://127.0.0.1:4250/@denotest/different-deps-per-export/meta.json
+Download http://127.0.0.1:4250/@denotest/different-deps-per-export/1.0.0_meta.json
+Download http://127.0.0.1:4250/@denotest/different-deps-per-export/1.0.0/add.ts
+Download http://127.0.0.1:4250/@denotest/different-deps-per-export/1.0.0/subtract.ts
+Download http://127.0.0.1:4250/@denotest/add/meta.json
+Download http://127.0.0.1:4250/@denotest/subtract/meta.json
+Download http://127.0.0.1:4250/@denotest/add/1.0.0_meta.json
+Download http://127.0.0.1:4250/@denotest/subtract/1.0.0_meta.json
+Download http://127.0.0.1:4250/@denotest/add/1.0.0/mod.ts
+Download http://127.0.0.1:4250/@denotest/subtract/1.0.0/mod.ts
+[UNORDERED_END]


### PR DESCRIPTION
Fixes #26498.

This was a sort of intentional decision originally, as I wanted to avoid caching extra files that may not be needed. It seems like that behavior is unintuitive, so I propose we cache all of the exports of listed jsr packages when you run a bare `deno install`.