### PR TITLE
fix(node/util): support array formats in `styleText`

### DIFF
--- a/ext/node/polyfills/internal/util/inspect.mjs
+++ b/ext/node/polyfills/internal/util/inspect.mjs
@@ -568,9 +568,10 @@ export function styleText(format, text) {
 
   if (Array.isArray(format)) {
     for (let i = 0; i < format.length; i++) {
-      const formatCodes = inspect.colors[format[i]];
+      const item = format[i];
+      const formatCodes = inspect.colors[item];
       if (formatCodes == null) {
-        validateOneOf(format, "format", Object.keys(inspect.colors));
+        validateOneOf(item, "format", Object.keys(inspect.colors));
       }
       text = `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
     }

--- a/ext/node/polyfills/internal/util/inspect.mjs
+++ b/ext/node/polyfills/internal/util/inspect.mjs
@@ -565,6 +565,18 @@ export function stripVTControlCharacters(str) {
 
 export function styleText(format, text) {
   validateString(text, "text");
+
+  if (Array.isArray(format)) {
+    for (let i = 0; i < format.length; i++) {
+      const formatCodes = inspect.colors[format[i]];
+      if (formatCodes == null) {
+        validateOneOf(format, "format", Object.keys(inspect.colors));
+      }
+      text = `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
+    }
+    return text;
+  }
+
   const formatCodes = inspect.colors[format];
   if (formatCodes == null) {
     validateOneOf(format, "format", Object.keys(inspect.colors));

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -353,3 +353,9 @@ Deno.test("[util] styleText()", () => {
   const redText = util.styleText("red", "error");
   assertEquals(redText, "\x1B[31merror\x1B[39m");
 });
+
+Deno.test("[util] styleText() with array of formats", () => {
+  const colored = util.styleText(["red", "green"], "error");
+  console.log(JSON.stringify(colored));
+  assertEquals(colored, "\x1b[32m\x1b[31merror\x1b[39m\x1b[39m");
+});

--- a/tests/unit_node/util_test.ts
+++ b/tests/unit_node/util_test.ts
@@ -356,6 +356,5 @@ Deno.test("[util] styleText()", () => {
 
 Deno.test("[util] styleText() with array of formats", () => {
   const colored = util.styleText(["red", "green"], "error");
-  console.log(JSON.stringify(colored));
   assertEquals(colored, "\x1b[32m\x1b[31merror\x1b[39m\x1b[39m");
 });


### PR DESCRIPTION
We missed adding support for an array of formats being passed to `util.styleText`.

Fixes https://github.com/denoland/deno/issues/26496