### PR TITLE
fix(config): schemas for lint rule and tag autocompletion

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -291,7 +291,7 @@
               "type": "array",
               "description": "List of tag names that will be run. Empty list disables all tags and will only use rules from `include`.",
               "items": {
-                "type": "string"
+                "$ref": "https://raw.githubusercontent.com/denoland/deno_lint/main/schemas/tags.v1.json"
               },
               "minItems": 0,
               "uniqueItems": true
@@ -300,7 +300,7 @@
               "type": "array",
               "description": "List of rule names that will be excluded from configured tag sets. If the same rule is in `include` it will be run.",
               "items": {
-                "type": "string"
+                "$ref": "https://raw.githubusercontent.com/denoland/deno_lint/main/schemas/rules.v1.json"
               },
               "minItems": 0,
               "uniqueItems": true
@@ -309,7 +309,7 @@
               "type": "array",
               "description": "List of rule names that will be run. Even if the same rule is in `exclude` it will be run.",
               "items": {
-                "type": "string"
+                "$ref": "https://raw.githubusercontent.com/denoland/deno_lint/main/schemas/rules.v1.json"
               },
               "minItems": 0,
               "uniqueItems": true


### PR DESCRIPTION
Closes #26314. Follow up to https://github.com/denoland/deno_lint/pull/1335. It will work as soon as this lands since the extension links to main: https://github.com/denoland/vscode_deno/blob/3.42.0/package.json#L596.