### PR TITLE
fix(fmt): --ext flag requires to pass files

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2274,7 +2274,7 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
             "sass", "less", "html", "svelte", "vue", "astro", "yml", "yaml",
             "ipynb",
           ])
-          .help_heading(FMT_HEADING),
+          .help_heading(FMT_HEADING).requires("files"),
       )
       .arg(
         Arg::new("ignore")
@@ -6799,6 +6799,32 @@ mod tests {
           unstable_component: false,
           watch: Default::default(),
         }),
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec!["deno", "fmt", "--ext", "html"]);
+    assert!(r.is_err());
+    let r = flags_from_vec(svec!["deno", "fmt", "--ext", "html", "./**"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Fmt(FmtFlags {
+          check: false,
+          files: FileFlags {
+            include: vec!["./**".to_string()],
+            ignore: vec![],
+          },
+          use_tabs: None,
+          line_width: None,
+          indent_width: None,
+          single_quote: None,
+          prose_wrap: None,
+          no_semicolons: None,
+          unstable_component: false,
+          watch: Default::default(),
+        }),
+        ext: Some("html".to_string()),
         ..Flags::default()
       }
     );


### PR DESCRIPTION
To avoid situations like described in https://github.com/denoland/deno/issues/26402
using `deno fmt` with `--ext` flag now requires to explicitly specify list of files (or
globs) to format.

Closes https://github.com/denoland/deno/issues/26402