### PR TITLE
build: use 'fs' feature of 'nix' crate in ext/fs

### DIFF
--- a/ext/fs/Cargo.toml
+++ b/ext/fs/Cargo.toml
@@ -31,7 +31,7 @@ serde.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true, features = ["user"] }
+nix = { workspace = true, features = ["fs", "user"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["winbase"] }


### PR DESCRIPTION
Hot-fix to unblock `v2.0.3` release