### PR TITLE
fix(npmrc): discovery in cwd when there is no package.json or deno.json

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -606,7 +606,7 @@ fn discover_npmrc(
   // 3. Try `.npmrc` in cwd if no package.json or deno.json(c) was found
   if let Some(cwd) = cwd {
     if maybe_package_json_path.is_none() && maybe_deno_json_path.is_none() {
-      if let Some((source, path)) = try_to_read_npmrc(&cwd)? {
+      if let Some((source, path)) = try_to_read_npmrc(cwd)? {
         return try_to_parse_npmrc(source, &path).map(|r| (r, Some(path)));
       }
     }

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1342,7 +1342,7 @@ impl ConfigData {
     }
 
     // todo(dsherret): cache this so we don't load this so many times
-    let npmrc = discover_npmrc_from_workspace(&member_dir.workspace)
+    let npmrc = discover_npmrc_from_workspace(&member_dir.workspace, None)
       .inspect(|(_, path)| {
         if let Some(path) = path {
           lsp_log!("  Resolved .npmrc: \"{}\"", path.display());

--- a/tests/registry/npm-private/@denotest/bin/1.0.0/cli.mjs
+++ b/tests/registry/npm-private/@denotest/bin/1.0.0/cli.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S node
+
+import process from "node:process";
+
+for (const arg of process.argv.slice(2)) {
+  console.log(arg);
+}

--- a/tests/registry/npm-private/@denotest/bin/1.0.0/package.json
+++ b/tests/registry/npm-private/@denotest/bin/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/bin",
+  "version": "1.0.0",
+  "bin": "./cli.mjs"
+}

--- a/tests/specs/npm/npmrc_no_package_json/.npmrc
+++ b/tests/specs/npm/npmrc_no_package_json/.npmrc
@@ -1,0 +1,4 @@
+@denotest:registry=http://localhost:4261/
+//localhost:4261/:_authToken=private-reg-token
+@denotest2:registry=http://localhost:4262/
+//localhost:4262/:_authToken=private-reg-token2

--- a/tests/specs/npm/npmrc_no_package_json/__test__.jsonc
+++ b/tests/specs/npm/npmrc_no_package_json/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tempDir": true,
+  "tests": {
+    "run_script_with_npm_with_no_project": {
+      "args": "run -A main.js",
+      "output": "main.out"
+    },
+
+    "run_npm_with_no_project": {
+      "args": "run -A npm:@denotest/bin deno",
+      "output": "direct.out"
+    }
+  }
+}

--- a/tests/specs/npm/npmrc_no_package_json/direct.out
+++ b/tests/specs/npm/npmrc_no_package_json/direct.out
@@ -1,0 +1,3 @@
+Download http://localhost:4261/@denotest%2fbin
+Download http://localhost:4261/@denotest/bin/1.0.0.tgz
+deno

--- a/tests/specs/npm/npmrc_no_package_json/main.js
+++ b/tests/specs/npm/npmrc_no_package_json/main.js
@@ -1,0 +1,8 @@
+import { getValue, setValue } from "npm:@denotest/basic";
+import * as test from "npm:@denotest2/basic";
+
+console.log(getValue());
+setValue(42);
+console.log(getValue());
+
+console.log(test.getValue());

--- a/tests/specs/npm/npmrc_no_package_json/main.out
+++ b/tests/specs/npm/npmrc_no_package_json/main.out
@@ -1,0 +1,7 @@
+Download http://localhost:4261/@denotest%2fbasic
+Download http://localhost:4262/@denotest2%2fbasic
+Download http://localhost:4261/@denotest/basic/1.0.0.tgz
+Download http://localhost:4262/@denotest2/basic/1.0.0.tgz
+0
+42
+0


### PR DESCRIPTION
This enables support for discovering `.npmrc` in the current working directory when no `package.json` or `deno.json(c` were found. This situation can occur when the user is creating a script or calling `deno run npm:<package>` directly.