### PR TITLE
fix(upgrade): stop running `deno lsp` processes on windows before attempting to replace executable

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -984,15 +984,14 @@ fn kill_running_deno_lsp_processes() {
   let _ = Command::new("powershell.exe")
     .args([
       "-Command",
-      r#"Get-WmiObject Win32_Process |
-          Where-Object {
-              $_.Name -eq 'deno.exe' -and
-              $_.CommandLine -match '^(?:\"[^\"]+\"|\S+)\s+lsp\b'
-          } | ForEach-Object {
-           if ($_.Terminate()) {
-             Write-Host 'Terminated:' $_.ProcessId
-           }
-        }"#,
+      r#"Get-WmiObject Win32_Process | Where-Object {
+    $_.Name -eq 'deno.exe' -and
+    $_.CommandLine -match '^(?:\"[^\"]+\"|\S+)\s+lsp\b'
+} | ForEach-Object {
+  if ($_.Terminate()) {
+    Write-Host 'Terminated:' $_.ProcessId
+  }
+}"#,
     ])
     .stdout(get_pipe())
     .stderr(get_pipe())

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -579,6 +579,10 @@ pub async fn upgrade(
 
   let output_exe_path =
     full_path_output_flag.as_ref().unwrap_or(&current_exe_path);
+
+  #[cfg(windows)]
+  kill_running_deno_lsp_processes();
+
   let output_result = if *output_exe_path == current_exe_path {
     replace_exe(&new_exe_path, output_exe_path)
   } else {
@@ -964,6 +968,16 @@ fn check_windows_access_denied_error(
       output_exe_path.display(),
     )
   })
+}
+
+#[cfg(windows)]
+fn kill_running_deno_lsp_processes() {
+  let _ = Command::new("powershell")
+    .args(&[
+        "-Command",
+        "Get-Process | Where-Object { $_.ProcessName -eq 'deno' -and $_.CommandLine -match 'lsp' } | Stop-Process -Force",
+    ])
+    .output();
 }
 
 fn set_exe_permissions(

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -972,10 +972,11 @@ fn check_windows_access_denied_error(
 
 #[cfg(windows)]
 fn kill_running_deno_lsp_processes() {
+  // limit this to `deno lsp` invocations to avoid killing important programs someone might be running
   let _ = Command::new("powershell")
     .args(&[
         "-Command",
-        "Get-Process | Where-Object { $_.ProcessName -eq 'deno' -and $_.CommandLine -match 'lsp' } | Stop-Process -Force",
+        "Get-Process | Where-Object { $_.ProcessName -eq 'deno' -and ($_.CommandLine -split ' ')[1] -eq 'lsp' } | Stop-Process -Force",
     ])
     .output();
 }

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -974,7 +974,7 @@ fn check_windows_access_denied_error(
 fn kill_running_deno_lsp_processes() {
   // limit this to `deno lsp` invocations to avoid killing important programs someone might be running
   let _ = Command::new("powershell")
-    .args(&[
+    .args([
         "-Command",
         "Get-Process | Where-Object { $_.ProcessName -eq 'deno' -and ($_.CommandLine -split ' ')[1] -eq 'lsp' } | Stop-Process -Force",
     ])


### PR DESCRIPTION
It's such a PITA on Windows to get the error that you need to run `Stop-Process -name deno` to kill running Deno processes. Most of the time this is just running `deno lsp` commands, so we can safely kill those before replacing the executable.