### PR TITLE
fix(install): regression - do not panic when config file contains \r\n newlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,9 +4005,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c78ad024523b61a2f20b1cad47413dd24db744a15d3d1b7276e69d1bee106c"
+checksum = "b558af6b49fd918e970471374e7a798b2c9bbcda624a210ffa3901ee5614bc8e"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ hyper-util = { version = "=0.1.7", features = ["tokio", "client", "client-legacy
 hyper_v014 = { package = "hyper", version = "0.14.26", features = ["runtime", "http1"] }
 indexmap = { version = "2", features = ["serde"] }
 ipnet = "2.3"
-jsonc-parser = { version = "=0.26.1", features = ["serde"] }
+jsonc-parser = { version = "=0.26.2", features = ["serde"] }
 lazy-regex = "3"
 libc = "0.2.126"
 libz-sys = { version = "1.1.20", default-features = false }


### PR DESCRIPTION
This is specifically for `deno install`/`deno add` commands.

* https://github.com/dprint/jsonc-parser/pull/49

Closes https://github.com/denoland/deno/issues/26543