### PR TITLE
fix(fmt): stable fmt for JS in .html files

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -418,6 +418,15 @@ pub fn format_html(
           let mut typescript_config =
             get_resolved_typescript_config(fmt_options);
           typescript_config.line_width = hints.print_width as u32;
+          // NOTE(bartlomieju): this is a make-shift fix, to avoid panics for
+          // https://github.com/denoland/deno/issues/26560 and
+          // https://github.com/denoland/deno/issues/26451, but it should
+          // be fixed in dprint directly: https://github.com/dprint/dprint-plugin-typescript/issues/678
+          let text: String = text
+            .lines()
+            .map(|l| l.trim())
+            .collect::<Vec<_>>()
+            .join("\n");
           dprint_plugin_typescript::format_text(
             &path,
             None,

--- a/tests/specs/fmt/html/__test__.jsonc
+++ b/tests/specs/fmt/html/__test__.jsonc
@@ -12,6 +12,20 @@
     "broken": {
       "args": "fmt broken.html",
       "output": "broken.out"
+    },
+    // Regression test for https://github.com/denoland/deno/issues/26560 and
+    // https://github.com/denoland/deno/issues/26451
+    "js_in_html": {
+      "steps": [
+        { "args": "fmt js_in_html.html", "output": "[WILDCARD]js_in_html.html\nChecked 1 file\n" },
+        { 
+          "args": [
+            "eval",
+            "console.log(Deno.readTextFileSync('js_in_html.html').trim())"
+          ], 
+          "output": "js_in_html.out" 
+        }
+      ]
     }
   }
 }

--- a/tests/specs/fmt/html/js_in_html.html
+++ b/tests/specs/fmt/html/js_in_html.html
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        <script>
+            /* some multiline comment
+            with function below it */
+            someFunc();
+        </script>
+    </body>
+</html>

--- a/tests/specs/fmt/html/js_in_html.out
+++ b/tests/specs/fmt/html/js_in_html.out
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <script>
+      /* some multiline comment
+      with function below it */
+      someFunc();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Makeshift fix to avoid panics. The proper fix should be done in dprint,
reported in https://github.com/dprint/dprint-plugin-typescript/issues/678.

Fixes https://github.com/denoland/deno/issues/26560
Fixes https://github.com/denoland/deno/issues/26451
Fixes https://github.com/denoland/deno/issues/26407