### PR TITLE
feat(ext/node): Add compatibility with {Free,Open}BSD

### DIFF
--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -152,13 +152,21 @@ where
     let mut cpath = path.as_bytes().to_vec();
     cpath.push(0);
     if bigint {
-      #[cfg(not(target_os = "macos"))]
+      #[cfg(not(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd"
+      )))]
       // SAFETY: `cpath` is NUL-terminated and result is pointer to valid statfs memory.
       let (code, result) = unsafe {
         let mut result: libc::statfs64 = std::mem::zeroed();
         (libc::statfs64(cpath.as_ptr() as _, &mut result), result)
       };
-      #[cfg(target_os = "macos")]
+      #[cfg(not(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd"
+      )))]
       // SAFETY: `cpath` is NUL-terminated and result is pointer to valid statfs memory.
       let (code, result) = unsafe {
         let mut result: libc::statfs = std::mem::zeroed();
@@ -168,7 +176,10 @@ where
         return Err(std::io::Error::last_os_error().into());
       }
       Ok(StatFs {
+        #[cfg(not(target_os = "openbsd"))]
         typ: result.f_type as _,
+        #[cfg(target_os = "openbsd")]
+        typ: 0 as _,
         bsize: result.f_bsize as _,
         blocks: result.f_blocks as _,
         bfree: result.f_bfree as _,
@@ -186,7 +197,10 @@ where
         return Err(std::io::Error::last_os_error().into());
       }
       Ok(StatFs {
+        #[cfg(not(target_os = "openbsd"))]
         typ: result.f_type as _,
+        #[cfg(target_os = "openbsd")]
+        typ: 0 as _,
         bsize: result.f_bsize as _,
         blocks: result.f_blocks as _,
         bfree: result.f_bfree as _,

--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -162,11 +162,11 @@ where
         let mut result: libc::statfs64 = std::mem::zeroed();
         (libc::statfs64(cpath.as_ptr() as _, &mut result), result)
       };
-      #[cfg(not(any(
+      #[cfg(any(
         target_os = "macos",
         target_os = "freebsd",
         target_os = "openbsd"
-      )))]
+      ))]
       // SAFETY: `cpath` is NUL-terminated and result is pointer to valid statfs memory.
       let (code, result) = unsafe {
         let mut result: libc::statfs = std::mem::zeroed();


### PR DESCRIPTION
Ports for both BSDs contain patches to the same effect.
See https://github.com/freebsd/freebsd-ports/blob/main/www/deno/files/patch-ext_node_ops_fs.rs and https://github.com/openbsd/ports/blob/8644910cae24458306b6a7c4ef4ef7811bc3d1f5/lang/deno/patches/patch-ext_node_ops_fs_rs