### PR TITLE
feat(ext/napi): Export dynamic symbols list for {Free,Open}BSD

### DIFF
--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -662,7 +662,11 @@ pub fn print_linker_flags(name: &str) {
     symbols_path,
   );
 
-  #[cfg(target_os = "linux")]
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "openbsd"
+  ))]  
   println!(
     "cargo:rustc-link-arg-bin={name}=-Wl,--export-dynamic-symbol-list={}",
     symbols_path,

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -666,7 +666,7 @@ pub fn print_linker_flags(name: &str) {
     target_os = "linux",
     target_os = "freebsd",
     target_os = "openbsd"
-  ))]  
+  ))]
   println!(
     "cargo:rustc-link-arg-bin={name}=-Wl,--export-dynamic-symbol-list={}",
     symbols_path,


### PR DESCRIPTION
The two BSD ports are reusing the Linux code here.