### PR TITLE
fix: support watch flag to enable watching other files than the main module on serve subcommand

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1672,6 +1672,10 @@ impl CliOptions {
     if let DenoSubcommand::Run(RunFlags {
       watch: Some(WatchFlagsWithPaths { paths, .. }),
       ..
+    })
+    | DenoSubcommand::Serve(ServeFlags {
+      watch: Some(WatchFlagsWithPaths { paths, .. }),
+      ..
     }) = &self.flags.subcommand
     {
       full_paths.extend(paths.iter().map(|path| self.initial_cwd.join(path)));


### PR DESCRIPTION
closes #26618 

**Changes**
- Supported watch flag in order to take files and dirs specified when pairing it with serve subcommand.
- Added a test to practice the change.

