### PR TITLE
fix(cli): add prefix hint when installing a package globally

### DIFF
--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -3,6 +3,7 @@
 use crate::args::resolve_no_prompt;
 use crate::args::AddFlags;
 use crate::args::CaData;
+use crate::args::CacheSetting;
 use crate::args::ConfigFlag;
 use crate::args::Flags;
 use crate::args::InstallFlags;
@@ -13,8 +14,11 @@ use crate::args::TypeCheckMode;
 use crate::args::UninstallFlags;
 use crate::args::UninstallKind;
 use crate::factory::CliFactory;
+use crate::file_fetcher::FileFetcher;
 use crate::graph_container::ModuleGraphContainer;
 use crate::http_util::HttpClientProvider;
+use crate::jsr::JsrFetchResolver;
+use crate::npm::NpmFetchResolver;
 use crate::util::fs::canonicalize_path_maybe_not_exists;
 
 use deno_core::anyhow::bail;
@@ -354,12 +358,51 @@ async fn install_global(
 ) -> Result<(), AnyError> {
   // ensure the module is cached
   let factory = CliFactory::from_flags(flags.clone());
+
+  let http_client = factory.http_client_provider();
+  let deps_http_cache = factory.global_http_cache()?;
+  let mut deps_file_fetcher = FileFetcher::new(
+    deps_http_cache.clone(),
+    CacheSetting::ReloadAll,
+    true,
+    http_client.clone(),
+    Default::default(),
+    None,
+  );
+
+  let npmrc = factory.cli_options().unwrap().npmrc();
+
+  deps_file_fetcher.set_download_log_level(log::Level::Trace);
+  let deps_file_fetcher = Arc::new(deps_file_fetcher);
+  let jsr_resolver = Arc::new(JsrFetchResolver::new(deps_file_fetcher.clone()));
+  let npm_resolver = Arc::new(NpmFetchResolver::new(
+    deps_file_fetcher.clone(),
+    npmrc.clone(),
+  ));
+
+  let entry_text = install_flags_global.module_url.as_str();
+  let req = super::registry::AddRmPackageReq::parse(entry_text);
+
+  // found a package requirement but missing the prefix
+  if let Ok(Err(package_req)) = req {
+    if jsr_resolver.req_to_nv(&package_req).await.is_some() {
+      bail!(
+        "{entry_text} is missing a prefix. Did you mean `{}`?",
+        crate::colors::yellow(format!("deno install -g jsr:{package_req}"))
+      );
+    } else if npm_resolver.req_to_nv(&package_req).await.is_some() {
+      bail!(
+        "{entry_text} is missing a prefix. Did you mean `{}`?",
+        crate::colors::yellow(format!("deno install -g npm:{package_req}"))
+      );
+    }
+  }
+
   factory
     .main_module_graph_container()
     .await?
     .load_and_type_check_files(&[install_flags_global.module_url.clone()])
     .await?;
-  let http_client = factory.http_client_provider();
 
   // create the install shim
   create_install_shim(http_client, &flags, install_flags_global).await

--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -69,6 +69,7 @@ pub use pm::add;
 pub use pm::cache_top_level_deps;
 pub use pm::remove;
 pub use pm::AddCommandName;
+pub use pm::AddRmPackageReq;
 use publish_order::PublishOrderGraph;
 use unfurl::SpecifierUnfurler;
 

--- a/cli/tools/registry/pm.rs
+++ b/cli/tools/registry/pm.rs
@@ -679,7 +679,7 @@ enum AddRmPackageReqValue {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct AddRmPackageReq {
+pub struct AddRmPackageReq {
   alias: String,
   value: AddRmPackageReqValue,
 }


### PR DESCRIPTION
closes #26545

Shows a hint when a package is installed globally, otherwise fallbacks to the existing implementation.