### PR TITLE
fix(lsp): scope attribution for lazily loaded assets

### DIFF
--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -801,13 +801,15 @@ delete Object.prototype.__proto__;
       if (logDebug) {
         debug(`host.getScriptSnapshot("${specifier}")`);
       }
-      const sourceFile = sourceFileCache.get(specifier);
-      if (sourceFile) {
-        if (!assetScopes.has(specifier)) {
-          assetScopes.set(specifier, lastRequestScope);
+      if (specifier.startsWith(ASSETS_URL_PREFIX)) {
+        const sourceFile = this.getSourceFile(specifier, ts.ScriptTarget.ESNext);
+        if (sourceFile) {
+          if (!assetScopes.has(specifier)) {
+            assetScopes.set(specifier, lastRequestScope);
+          }
+          // This case only occurs for assets.
+          return ts.ScriptSnapshot.fromString(sourceFile.text);
         }
-        // This case only occurs for assets.
-        return ts.ScriptSnapshot.fromString(sourceFile.text);
       }
       let sourceText = sourceTextCache.get(specifier);
       if (sourceText == undefined) {

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -802,7 +802,10 @@ delete Object.prototype.__proto__;
         debug(`host.getScriptSnapshot("${specifier}")`);
       }
       if (specifier.startsWith(ASSETS_URL_PREFIX)) {
-        const sourceFile = this.getSourceFile(specifier, ts.ScriptTarget.ESNext);
+        const sourceFile = this.getSourceFile(
+          specifier,
+          ts.ScriptTarget.ESNext,
+        );
         if (sourceFile) {
           if (!assetScopes.has(specifier)) {
             assetScopes.set(specifier, lastRequestScope);


### PR DESCRIPTION
Fixes #25999. Asset documents at https://github.com/denoland/deno/blob/2c8a0e791732ab00907ca11c3a4918ad26ead03f/cli/tsc/mod.rs#L162-L164 were not being loaded properly.