### PR TITLE
fix: op_run_microtasks crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,9 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.316.0"
+version = "0.318.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f68061c88ced959c6b0417f0f0d0b3dbeaeb18013b55f86c505e9fba705cf8"
+checksum = "10cae2393219ff9278123f7b24799cdfab37c7d6561b69ca06ced115cac92111"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.192.0"
+version = "0.194.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb7096887508456349d7e7e09e326d157d4dba46ef1f5849bc544592ea3042a"
+checksum = "f760b492bd638c1dc3e992d11672c259fbe9a233162099a8347591c9e22d0391"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6169,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.225.0"
+version = "0.227.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4b71200ef49a9e629edaea3d13fc98c25ede07e1496558df7f09354e37976f"
+checksum = "0a8294c2223c53bed343be8b80564ece4dc0d03b643b06fa86c4ccc0e064eda0"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.43.3", features = ["transpiling"] }
-deno_core = { version = "0.316.0" }
+deno_core = { version = "0.318.0" }
 
 deno_bench_util = { version = "0.169.0", path = "./bench_util" }
 deno_lockfile = "=0.23.1"


### PR DESCRIPTION
Upgrade deno_core to 0.318.0

Fixes https://github.com/denoland/deno_core/issues/951
Fixes https://github.com/denoland/deno/issues/26468
