### PR TITLE
fix(ext/node): add `findSourceMap` to the default export of `node:module`

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1312,6 +1312,8 @@ export function findSourceMap(_path) {
   return undefined;
 }
 
+Module.findSourceMap = findSourceMap;
+
 /**
  * @param {string | URL} _specifier
  * @param {string | URL} _parentUrl


### PR DESCRIPTION
Next.js 15.0.4 tries to use this and errors out