### PR TITLE
chore: fix serve_watch_all test

### DIFF
--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -572,7 +572,7 @@ async fn serve_watch_all() {
   let main_file_to_watch = t.path().join("main_file_to_watch.js");
   main_file_to_watch.write(
     "export default {
-      fetch(_request: Request) {
+      fetch(_request) {
         return new Response(\"aaaaaaqqq!\");
       },
     };",
@@ -596,7 +596,7 @@ async fn serve_watch_all() {
   // Change content of the file
   main_file_to_watch.write(
     "export default {
-      fetch(_request: Request) {
+      fetch(_request) {
         return new Response(\"aaaaaaqqq123!\");
       },
     };",
@@ -626,7 +626,7 @@ async fn serve_watch_all() {
 
   main_file_to_watch.write(
     "export default {
-      fetch(_request: Request) {
+      fetch(_request) {
         return new Response(\"aaaaaaqqq!\");
       },
     };",


### PR DESCRIPTION
It's been failing a ton lately, it looks like the test is just incorrectly using TS syntax in a JS file https://github.com/denoland/deno/actions/runs/11672972415/job/32502710624?pr=26724#step:43:2791

It also turned out that the test was missing updates to files often because it wasn't waiting for the watcher to be ready after each restart.