### PR TITLE
fix: panic_hook hangs without procfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205eca4e7beaad637dcd38fe41292065894ee7f498077cf3c135d5f7252b9f27"
+checksum = "89795977654ad6250d6c0915411b622bac22f9efb4f852af94b2e00964cab832"
 dependencies = [
  "editpe",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,7 +84,7 @@ deno_runtime = { workspace = true, features = ["include_js_files_for_snapshottin
 deno_semver.workspace = true
 deno_task_shell = "=0.18.1"
 deno_terminal.workspace = true
-libsui = "0.4.0"
+libsui = "0.5.0"
 node_resolver.workspace = true
 
 anstream = "0.6.14"


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26701

Ref https://github.com/denoland/sui/commit/69e491353fb82ce15a861376ee8dc68f183e0486

