### PR TITLE
fix(fmt): don't use self-closing tags in HTML

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1032,7 +1032,7 @@ fn get_resolved_markup_fmt_config(
     max_attrs_per_line: None,
     prefer_attrs_single_line: false,
     html_normal_self_closing: None,
-    html_void_self_closing: Some(true),
+    html_void_self_closing: None,
     component_self_closing: None,
     svg_self_closing: None,
     mathml_self_closing: None,

--- a/tests/specs/fmt/html/well_formatted.html
+++ b/tests/specs/fmt/html/well_formatted.html
@@ -1,4 +1,4 @@
-<div class="container">content</div>
+<div class="container">content<br></div>
 
 <script>
   let counter = 0;


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/26748