### PR TITLE
feat(ext/http): abort event when request is cancelled

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -281,11 +281,11 @@ class Request {
     if (signal === undefined) {
       const signal = newSignal();
       this[_signalCache] = signal;
-      return signal;
-    }
+      this[_request].onCancel?.(() => {
+        signal[signalAbort](signalAbortError);
+      });
 
-    if (!signal.aborted && this[_request].isCancelled) {
-      signal[signalAbort](signalAbortError);
+      return signal;
     }
 
     return signal;

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -15,6 +15,7 @@ import {
   op_http_get_request_headers,
   op_http_get_request_method_and_url,
   op_http_read_request_body,
+  op_http_request_on_cancel,
   op_http_serve,
   op_http_serve_on,
   op_http_set_promise_complete,
@@ -375,11 +376,14 @@ class InnerRequest {
     return this.#external;
   }
 
-  get isCancelled() {
+  onCancel(callback) {
     if (this.#external === null) {
-      return true;
+      callback();
+      return;
     }
-    return op_http_get_request_cancelled(this.#external);
+
+    op_http_request_on_cancel(this.#external)
+      .then(callback);
   }
 }
 

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -381,8 +381,10 @@ class InnerRequest {
       return;
     }
 
-    op_http_request_on_cancel(this.#external)
-      .then(callback);
+    PromisePrototypeThen(
+      op_http_request_on_cancel(this.#external),
+      callback,
+    );
   }
 }
 

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -11,7 +11,6 @@ import {
   op_http_cancel,
   op_http_close,
   op_http_close_after_finish,
-  op_http_get_request_cancelled,
   op_http_get_request_headers,
   op_http_get_request_method_and_url,
   op_http_read_request_body,

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -713,9 +713,9 @@ pub async fn op_http_request_on_cancel(external: *const c_void) {
   let http =
     // SAFETY: op is called with external.
     unsafe { clone_external!(external, "op_http_request_on_cancel") };
-  let (tx, rx) = tokio::sync::oneshot::channel();
 
   http.on_cancel(tx);
+  drop(http);
 
   rx.await.ok();
 }

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -708,6 +708,18 @@ pub fn op_http_get_request_cancelled(external: *const c_void) -> bool {
   http.cancelled()
 }
 
+#[op2(async)]
+pub async fn op_http_request_on_cancel(external: *const c_void) {
+  let http =
+    // SAFETY: op is called with external.
+    unsafe { clone_external!(external, "op_http_request_on_cancel") };
+  let (tx, rx) = tokio::sync::oneshot::channel();
+
+  http.on_cancel(tx);
+
+  rx.await.ok();
+}
+
 /// Returned promise resolves when body streaming finishes.
 /// Call [`op_http_close_after_finish`] when done with the external.
 #[op2(async)]

--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -713,6 +713,7 @@ pub async fn op_http_request_on_cancel(external: *const c_void) {
   let http =
     // SAFETY: op is called with external.
     unsafe { clone_external!(external, "op_http_request_on_cancel") };
+  let (tx, rx) = tokio::sync::oneshot::channel();
 
   http.on_cancel(tx);
   drop(http);

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -112,6 +112,7 @@ deno_core::extension!(
     http_next::op_http_close_after_finish,
     http_next::op_http_get_request_header,
     http_next::op_http_get_request_headers,
+    http_next::op_http_request_on_cancel,
     http_next::op_http_get_request_method_and_url<HTTP>,
     http_next::op_http_get_request_cancelled,
     http_next::op_http_read_request_body,

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -4305,8 +4305,6 @@ Deno.test({
 }, async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
-  let cancelled = false;
-
   const server = Deno.serve({
     hostname: "0.0.0.0",
     port: servePort,

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -4299,3 +4299,33 @@ Deno.test({
 
   assert(cancelled);
 });
+
+Deno.test({
+  name: "AbortSignal event aborted when request is cancelled",
+}, async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  let cancelled = false;
+
+  const server = Deno.serve({
+    hostname: "0.0.0.0",
+    port: servePort,
+    onListen: () => resolve(),
+  }, async (request) => {
+    const { promise: promiseAbort, resolve: resolveAbort } = Promise
+      .withResolvers<void>();
+    request.signal.addEventListener("abort", () => resolveAbort());
+    assert(!request.signal.aborted);
+
+    await promiseAbort;
+
+    return new Response("Ok");
+  });
+
+  await promise;
+  await fetch(`http://localhost:${servePort}/`, {
+    signal: AbortSignal.timeout(100),
+  }).catch(() => {});
+
+  await server.shutdown();
+});


### PR DESCRIPTION
```js
Deno.serve(async (req) => {
  const { promise, resolve } = Promise.withResolvers<void>();

  req.signal.addEventListener("abort", () => {
    resolve();
  });

  await promise;

  return new Response("Ok");
});
```