### PR TITLE
fix: performance.timeOrigin

### DIFF
--- a/cli/ops/bench.rs
+++ b/cli/ops/bench.rs
@@ -2,7 +2,6 @@
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::time;
 
 use deno_core::error::generic_error;
 use deno_core::error::type_error;
@@ -13,6 +12,7 @@ use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_runtime::deno_permissions::ChildPermissionsArg;
 use deno_runtime::deno_permissions::PermissionsContainer;
+use deno_runtime::deno_web::StartTime;
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
@@ -148,7 +148,7 @@ fn op_dispatch_bench_event(state: &mut OpState, #[serde] event: BenchEvent) {
 #[op2(fast)]
 #[number]
 fn op_bench_now(state: &mut OpState) -> Result<u64, std::num::TryFromIntError> {
-  let ns = state.borrow::<time::Instant>().elapsed().as_nanos();
+  let ns = state.borrow::<StartTime>().elapsed().as_nanos();
   let ns_u64 = u64::try_from(ns)?;
   Ok(ns_u64)
 }

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -1,12 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { core, primordials } from "ext:core/mod.js";
-import { op_defer, op_now } from "ext:core/ops";
+import { op_defer } from "ext:core/ops";
 const {
-  Uint8Array,
-  Uint32Array,
   PromisePrototypeThen,
-  TypedArrayPrototypeGetBuffer,
   TypeError,
   indirectEval,
   ReflectApply,
@@ -17,13 +14,6 @@ const {
 } = core;
 
 import * as webidl from "ext:deno_webidl/00_webidl.js";
-
-const hrU8 = new Uint8Array(8);
-const hr = new Uint32Array(TypedArrayPrototypeGetBuffer(hrU8));
-function opNow() {
-  op_now(hrU8);
-  return (hr[0] * 1000 + hr[1] / 1e6);
-}
 
 // ---------------------------------------------------------------------------
 
@@ -151,7 +141,6 @@ export {
   clearInterval,
   clearTimeout,
   defer,
-  opNow,
   refTimer,
   setImmediate,
   setInterval,

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -52,7 +52,8 @@ pub use crate::message_port::Transferable;
 
 use crate::timers::op_defer;
 use crate::timers::op_now;
-use crate::timers::StartTime;
+use crate::timers::op_time_origin;
+pub use crate::timers::StartTime;
 pub use crate::timers::TimersPermission;
 
 deno_core::extension!(deno_web,
@@ -84,6 +85,7 @@ deno_core::extension!(deno_web,
     compression::op_compression_write,
     compression::op_compression_finish,
     op_now<P>,
+    op_time_origin<P>,
     op_defer,
     stream_resource::op_readable_stream_resource_allocate,
     stream_resource::op_readable_stream_resource_allocate_sized,
@@ -123,7 +125,7 @@ deno_core::extension!(deno_web,
     if let Some(location) = options.maybe_location {
       state.put(Location(location));
     }
-    state.put(StartTime::now());
+    state.put(StartTime::default());
   }
 );
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -27,7 +27,6 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypeIncludes,
   ArrayPrototypeMap,
-  DateNow,
   Error,
   ErrorPrototype,
   FunctionPrototypeBind,
@@ -642,7 +641,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
 
     removeImportedOps();
 
-    performance.setTimeOrigin(DateNow());
+    performance.setTimeOrigin();
     globalThis_ = globalThis;
 
     // Remove bootstrapping data from the global scope
@@ -858,7 +857,7 @@ function bootstrapWorkerRuntime(
       7: nodeDebug,
     } = runtimeOptions;
 
-    performance.setTimeOrigin(DateNow());
+    performance.setTimeOrigin();
     globalThis_ = globalThis;
 
     // Remove bootstrapping data from the global scope


### PR DESCRIPTION
`performance.timeOrigin` was being set from when JS started executing, but `op_now` measures from an `std::time::Instant` stored in `OpState`, which is created at a completely different time. This caused `performance.timeOrigin` to be very incorrect. This PR corrects the origin and also cleans up some of the timer code.

Compared to `Date.now()`, `performance`'s time origin is now consistently within 5us (0.005ms) of system time.

![image](https://github.com/user-attachments/assets/0a7be04a-4f6d-4816-bd25-38a2e6136926)

