### PR TITLE
fix(ext/websocket): initialize `error` attribute of WebSocket ErrorEvent

### DIFF
--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -28,6 +28,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
   ArrayPrototypeSome,
+  Error,
   ErrorPrototypeToString,
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,

--- a/ext/websocket/01_websocket.js
+++ b/ext/websocket/01_websocket.js
@@ -488,8 +488,11 @@ class WebSocket extends EventTarget {
           /* error */
           this[_readyState] = CLOSED;
 
+          const message = op_ws_get_error(rid);
+          const error = new Error(message);
           const errorEv = new ErrorEvent("error", {
-            message: op_ws_get_error(rid),
+            error,
+            message,
           });
           this.dispatchEvent(errorEv);
 

--- a/tests/unit/websocket_test.ts
+++ b/tests/unit/websocket_test.ts
@@ -453,7 +453,8 @@ Deno.test("invalid server", async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
   const ws = new WebSocket("ws://localhost:2121");
   let err = false;
-  ws.onerror = () => {
+  ws.onerror = (e) => {
+    assert(e.error);
     err = true;
   };
   ws.onclose = () => {

--- a/tests/unit/websocket_test.ts
+++ b/tests/unit/websocket_test.ts
@@ -454,7 +454,7 @@ Deno.test("invalid server", async () => {
   const ws = new WebSocket("ws://localhost:2121");
   let err = false;
   ws.onerror = (e) => {
-    assert(e.error);
+    assert("error" in e);
     err = true;
   };
   ws.onclose = () => {

--- a/websocket.js
+++ b/websocket.js
@@ -1,5 +1,0 @@
-const ws = new WebSocket("ws://localhost:8080");
-ws.onerror = (e) => {
-  console.log(e.error);
-  console.log(new Error().stack);
-};

--- a/websocket.js
+++ b/websocket.js
@@ -1,0 +1,5 @@
+const ws = new WebSocket("ws://localhost:8080");
+ws.onerror = (e) => {
+  console.log(e.error);
+  console.log(new Error().stack);
+};


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26216

Not required by the spec but Discord.js depends on it, see https://github.com/denoland/deno/issues/26216#issuecomment-2466060306