### PR TITLE
fix(caches/in-memory): allow explicit in-memory caches

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -597,6 +597,8 @@ pub struct Flags {
   pub argv: Vec<String>,
   pub subcommand: DenoSubcommand,
 
+  /// Flag
+  pub in_memory_cache: Option<bool>,
   pub frozen_lockfile: Option<bool>,
   pub ca_stores: Option<Vec<String>>,
   pub ca_data: Option<CaData>,
@@ -2821,6 +2823,7 @@ fn run_args(command: Command, top_level: bool) -> Command {
     })
     .arg(env_file_arg())
     .arg(no_code_cache_arg())
+    .arg(in_memory_cache_arg())
 }
 
 fn run_subcommand() -> Command {
@@ -3949,6 +3952,13 @@ fn no_clear_screen_arg() -> Arg {
     .action(ArgAction::SetTrue)
     .help("Do not clear terminal screen when under watch mode")
     .help_heading(FILE_WATCHING_HEADING)
+}
+
+fn in_memory_cache_arg() -> Arg {
+  Arg::new("in_memory_cache")
+    .long("in-memory-cache")
+    .help("Disable all filesystem caches and use in-memory cache only")
+    .action(ArgAction::SetTrue)
 }
 
 fn no_code_cache_arg() -> Arg {

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1685,6 +1685,10 @@ impl CliOptions {
     self.flags.code_cache_enabled
   }
 
+  pub fn in_memory_cache(&self) -> bool {
+    self.flags.in_memory_cache.unwrap_or(false)
+  }
+
   pub fn watch_paths(&self) -> Vec<PathBuf> {
     let mut full_paths = Vec::new();
     if let DenoSubcommand::Run(RunFlags {

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -265,7 +265,10 @@ impl CliFactory {
   pub fn caches(&self) -> Result<&Arc<Caches>, AnyError> {
     self.services.caches.get_or_try_init(|| {
       let cli_options = self.cli_options()?;
-      let caches = Arc::new(Caches::new(self.deno_dir_provider()?.clone()));
+      let caches = Arc::new(Caches::new(
+        self.deno_dir_provider()?.clone(),
+        cli_options.in_memory_cache(),
+      ));
       // Warm up the caches we know we'll likely need based on the CLI mode
       match cli_options.sub_command() {
         DenoSubcommand::Run(_)

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -632,7 +632,7 @@ pub async fn run(data: StandaloneData) -> Result<i32, AnyError> {
       unstable_detect_cjs: metadata.unstable_config.detect_cjs,
     },
   ));
-  let cache_db = Caches::new(deno_dir_provider.clone());
+  let cache_db = Caches::new(deno_dir_provider.clone(), false);
   let node_analysis_cache = NodeAnalysisCache::new(cache_db.node_analysis_db());
   let cli_node_resolver = Arc::new(CliNodeResolver::new(
     cjs_tracker.clone(),


### PR DESCRIPTION
This fixes the verbose warnings of: https://github.com/denoland/deno/issues/26747

Some users (such as me) don't have access to a writeable file system.
In those cases it would be nice to have a global flag to run deno with in-memory caches only.

EDIT: Some insights into my use case:
The concrete scenario is that i am building a package out of a deno project for the `nix` package manager.
The package contains the `DENO_DIR` (I must ship the dependencies for offline usage)
It would be nice to
- Reduce the noise when no writable file system cache exists
- Provide a seperate setting for decoupling the dependency cache from the analysis cache. Since the dependency cache should not be writable during runtime. While the same is not necessarily true for the analysis cache.

The code for falling back to in-memory caches is already there but no way to use it without beeing spammed with concerning error messages.

I could need some help here because i didn't figure out how to properly register the cli flag.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
