### PR TITLE
test(ext/node): prevent running the same test cases twice

### DIFF
--- a/tests/node_compat/test.ts
+++ b/tests/node_compat/test.ts
@@ -19,6 +19,7 @@ import { magenta } from "@std/fmt/colors";
 import { pooledMap } from "@std/async/pool";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { assertEquals, fail } from "@std/assert";
+import { distinct } from "@std/collections";
 import {
   config,
   getPathsFromTestSuites,
@@ -36,6 +37,9 @@ const testPaths = partitionParallelTestPaths(
     getPathsFromTestSuites(config.ignore),
   ),
 );
+testPaths.sequential = distinct(testPaths.sequential);
+testPaths.parallel = distinct(testPaths.parallel);
+
 const cwd = new URL(".", import.meta.url);
 const windowsIgnorePaths = new Set(
   getPathsFromTestSuites(config.windowsIgnore),


### PR DESCRIPTION
Some node compat test cases (for example `test-dns-any.js`) have entries in both `ignore.*` and `test.*` in `tests/node_compat/config.jsonc`, and those files are currently run twice in CI. This PR prevents it by removing the duplicates in test case list.