### PR TITLE
fix(cli): preserve comments in doc tests

### DIFF
--- a/cli/util/extract.rs
+++ b/cli/util/extract.rs
@@ -1165,6 +1165,33 @@ Deno.test("file:///main.ts$3-6.ts", async ()=>{
           media_type: MediaType::TypeScript,
         }],
       },
+      // https://github.com/denoland/deno/issues/26728
+      Test {
+        input: Input {
+          source: r#"
+/**
+ * ```ts
+ * // @ts-expect-error: can only add numbers
+ * add('1', '2');
+ * ```
+ */
+export function add(first: number, second: number) {
+  return first + second;
+}
+"#,
+          specifier: "file:///main.ts",
+        },
+        expected: vec![Expected {
+          source: r#"import { add } from "file:///main.ts";
+Deno.test("file:///main.ts$3-7.ts", async ()=>{
+    // @ts-expect-error: can only add numbers
+    add('1', '2');
+});
+"#,
+          specifier: "file:///main.ts$3-7.ts",
+          media_type: MediaType::TypeScript,
+        }],
+      },
     ];
 
     for test in tests {
@@ -1373,6 +1400,31 @@ export default Foo
 console.log(Foo);
 "#,
           specifier: "file:///main.ts$3-6.ts",
+          media_type: MediaType::TypeScript,
+        }],
+      },
+      // https://github.com/denoland/deno/issues/26728
+      Test {
+        input: Input {
+          source: r#"
+/**
+ * ```ts
+ * // @ts-expect-error: can only add numbers
+ * add('1', '2');
+ * ```
+ */
+export function add(first: number, second: number) {
+  return first + second;
+}
+"#,
+          specifier: "file:///main.ts",
+        },
+        expected: vec![Expected {
+          source: r#"import { add } from "file:///main.ts";
+// @ts-expect-error: can only add numbers
+add('1', '2');
+"#,
+          specifier: "file:///main.ts$3-7.ts",
           media_type: MediaType::TypeScript,
         }],
       },

--- a/cli/util/extract.rs
+++ b/cli/util/extract.rs
@@ -586,7 +586,10 @@ fn generate_pseudo_file(
         wrap_kind,
       }));
 
-  let source = deno_ast::swc::codegen::to_code(&transformed);
+  let source = deno_ast::swc::codegen::to_code_with_comments(
+    Some(&parsed.comments().as_single_threaded()),
+    &transformed,
+  );
 
   log::debug!("{}:\n{}", file.specifier, source);
 

--- a/tests/specs/test/doc_ts_expect_error/__test__.jsonc
+++ b/tests/specs/test/doc_ts_expect_error/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --doc mod.ts",
+  "exitCode": 0,
+  "output": "mod.out"
+}

--- a/tests/specs/test/doc_ts_expect_error/mod.out
+++ b/tests/specs/test/doc_ts_expect_error/mod.out
@@ -1,0 +1,8 @@
+Check [WILDCARD]/mod.ts
+Check [WILDCARD]/mod.ts$2-10.ts
+running 0 tests from ./mod.ts
+running 1 test from ./mod.ts$2-10.ts
+[WILDCARD]/mod.ts$2-10.ts ... ok ([WILDCARD]ms)
+
+ok | 1 passed | 0 failed ([WILDCARD]ms)
+

--- a/tests/specs/test/doc_ts_expect_error/mod.ts
+++ b/tests/specs/test/doc_ts_expect_error/mod.ts
@@ -1,0 +1,13 @@
+/**
+ * ```ts
+ * import { add } from "./mod.ts";
+ *
+ * add(1, 2);
+ *
+ * // @ts-expect-error: can only add numbers
+ * add('1', '2');
+ * ```
+ */
+export function add(first: number, second: number) {
+  return first + second;
+}

--- a/tests/specs/test/markdown_ts_expect_error/__test__.jsonc
+++ b/tests/specs/test/markdown_ts_expect_error/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --doc main.md",
+  "exitCode": 0,
+  "output": "main.out"
+}

--- a/tests/specs/test/markdown_ts_expect_error/main.md
+++ b/tests/specs/test/markdown_ts_expect_error/main.md
@@ -1,0 +1,8 @@
+# Documentation
+
+This test case checks if `@ts-expect-error` comment works as expected.
+
+```ts
+// @ts-expect-error
+const a: string = 42;
+```

--- a/tests/specs/test/markdown_ts_expect_error/main.out
+++ b/tests/specs/test/markdown_ts_expect_error/main.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]/main.md$5-9.ts
+running 1 test from ./main.md$5-9.ts
+[WILDCARD]/main.md$5-9.ts ... ok ([WILDCARD]ms)
+
+ok | 1 passed | 0 failed ([WILDCARD]ms)
+


### PR DESCRIPTION
This commit makes comments in code snippets in JSDoc or markdown preserved when they are executed as tests. In particular, this is needed to get TypeScript special comments such as `@ts-ignore` or `@ts-expect-error` to work correctly.

Fixes #26728