### PR TITLE
fix(publish): continue publishing with errors

### DIFF
--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -856,6 +856,7 @@ async fn perform_publish(
   assert_eq!(prepared_package_by_name.len(), authorizations.len());
   let mut futures: FuturesUnordered<LocalBoxFuture<Result<String, AnyError>>> =
     Default::default();
+  let mut has_errors = false;
   loop {
     let next_batch = publish_order_graph.next();
 
@@ -911,10 +912,17 @@ async fn perform_publish(
         publish_order_graph.finish_package(&package_name);
       }
       Err(err) => {
+        has_errors = true;
         #[allow(clippy::print_stderr)]
-        eprintln!("{}: {}", colors::red("Error publishing"), err);
+        {
+          eprintln!("{}: {}", colors::red("Error publishing"), err);
+        }
       }
     }
+  }
+
+  if has_errors {
+    std::process::exit(1);
   }
 
   Ok(())

--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -911,6 +911,7 @@ async fn perform_publish(
         publish_order_graph.finish_package(&package_name);
       }
       Err(err) => {
+        #[allow(clippy::print_stderr)]
         eprintln!("{}: {}", colors::red("Error publishing"), err);
       }
     }

--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -906,8 +906,14 @@ async fn perform_publish(
       break;
     };
 
-    let package_name = result?;
-    publish_order_graph.finish_package(&package_name);
+    match result {
+      Ok(package_name) => {
+        publish_order_graph.finish_package(&package_name);
+      }
+      Err(err) => {
+        eprintln!("{}: {}", colors::red("Error publishing"), err);
+      }
+    }
   }
 
   Ok(())


### PR DESCRIPTION
In a workspace of two packages A and B, failure during publishing of package B can lead to provenance step being skipped of package A. This PR makes it print out the error and continue publishing other packages instead of a fast fail.