### PR TITLE
fix(ext/node): handle `--allow-sys=inspector`

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1461,7 +1461,7 @@ pub struct SysDescriptor(String);
 impl SysDescriptor {
   pub fn parse(kind: String) -> Result<Self, SysDescriptorParseError> {
     match kind.as_str() {
-      "hostname" | "osRelease" | "osUptime" | "loadavg"
+      "hostname" | "inspector" | "osRelease" | "osUptime" | "loadavg"
       | "networkInterfaces" | "systemMemoryInfo" | "uid" | "gid" | "cpus"
       | "homedir" | "getegid" | "statfs" | "getPriority" | "setPriority"
       | "userInfo" => Ok(Self(kind)),


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26809. 

`op_inspector_open` checks for "inspector" as one of the allowed sys value.
