### PR TITLE
fix(ext/webgpu): Create GPUQuerySet converter before usage 

### DIFF
--- a/ext/webgpu/01_webgpu.js
+++ b/ext/webgpu/01_webgpu.js
@@ -6982,6 +6982,12 @@ webidl.converters.GPUComputePassEncoder = webidl.createInterfaceConverter(
   GPUComputePassEncoder.prototype,
 );
 
+// INTERFACE: GPUQuerySet
+webidl.converters.GPUQuerySet = webidl.createInterfaceConverter(
+  "GPUQuerySet",
+  GPUQuerySet.prototype,
+);
+
 // DICTIONARY: GPUComputePassTimestampWrites
 webidl.converters["GPUComputePassTimestampWrites"] = webidl
   .createDictionaryConverter(
@@ -7153,12 +7159,6 @@ webidl.converters["GPURenderPassDepthStencilAttachment"] = webidl
     "GPURenderPassDepthStencilAttachment",
     dictMembersGPURenderPassDepthStencilAttachment,
   );
-
-// INTERFACE: GPUQuerySet
-webidl.converters.GPUQuerySet = webidl.createInterfaceConverter(
-  "GPUQuerySet",
-  GPUQuerySet.prototype,
-);
 
 // DICTIONARY: GPURenderPassTimestampWrites
 webidl.converters["GPURenderPassTimestampWrites"] = webidl


### PR DESCRIPTION
Hi, while trying to do performance tests for TypeGPU we encountered a problem when using Timestamp Queries.

Converter for `GPUComputePassTimestampWrites` uses converter for `GPUQuerySet` before it is defined making it impossible to use. This PR simply reorders converter creation to resolve this issue. Logging the `GPUQuerySet` still fails (as mentioned in #26769) but it is now usable inside pass descriptors and works when used.
