### PR TITLE
feat(ext/fetch): Make fetch client parameters configurable

### DIFF
--- a/ext/fetch/tests.rs
+++ b/ext/fetch/tests.rs
@@ -126,6 +126,7 @@ async fn rust_test_client_with_resolver(
       dns_resolver: resolver,
       http1: true,
       http2: true,
+      client_builder_hook: None,
     },
   )
   .unwrap();

--- a/ext/kv/remote.rs
+++ b/ext/kv/remote.rs
@@ -210,6 +210,7 @@ impl<P: RemoteDbHandlerPermissions + 'static> DatabaseHandler
         pool_idle_timeout: None,
         http1: false,
         http2: true,
+        client_builder_hook: None,
       },
     )?;
     let fetch_client = FetchClient(client);


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This commit makes HTTP client parameters used in `fetch` API configurable on the extension initialization via a callback `client_builder_hook` that  users can provide.

The main motivation behind this change is to allow `deno_fetch` users to tune the HTTP/2 client to suit their needs, although Deno CLI users will not benefit from it as no JavaScript interface is exposed to set these parameters currently.

It is up to users whether to provide hook functions. If not provided, the default configuration from hyper crate will be used.

Ref #26785
