### PR TITLE
fix(node): handle resolving ".//<something>" in npm packages

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -474,21 +474,6 @@ impl<TGraphContainer: ModuleGraphContainer>
     raw_specifier: &str,
     referrer: &ModuleSpecifier,
   ) -> Result<ModuleSpecifier, AnyError> {
-    if self.shared.in_npm_pkg_checker.in_npm_package(referrer) {
-      return Ok(
-        self
-          .shared
-          .node_resolver
-          .resolve(
-            raw_specifier,
-            referrer,
-            self.shared.cjs_tracker.get_referrer_kind(referrer),
-            NodeResolutionMode::Execution,
-          )?
-          .into_url(),
-      );
-    }
-
     let graph = self.graph_container.graph();
     let resolution = match graph.get(referrer) {
       Some(Module::Js(module)) => module

--- a/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/index.js
@@ -1,0 +1,2 @@
+// node.js will resolve this as ./other.js
+export * from ".//other.js";

--- a/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/other.js
+++ b/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/other.js
@@ -1,0 +1,3 @@
+export function add(a, b) {
+  return a + b;
+}

--- a/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/specifier-two-slashes",
+  "type": "module",
+  "main": "index.js"
+}

--- a/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/specifier-two-slashes/1.0.0/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@denotest/specifier-two-slashes",
+  "version": "1.0.0",
   "type": "module",
   "main": "index.js"
 }

--- a/tests/specs/npm/specifier_two_slashes/__test__.jsonc
+++ b/tests/specs/npm/specifier_two_slashes/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run main.ts",
+  "output": "3\n"
+}

--- a/tests/specs/npm/specifier_two_slashes/__test__.jsonc
+++ b/tests/specs/npm/specifier_two_slashes/__test__.jsonc
@@ -1,4 +1,4 @@
 {
-  "args": "run main.ts",
+  "args": "run --quiet main.ts",
   "output": "3\n"
 }

--- a/tests/specs/npm/specifier_two_slashes/main.ts
+++ b/tests/specs/npm/specifier_two_slashes/main.ts
@@ -1,0 +1,3 @@
+import { add } from "npm:@denotest/specifier-two-slashes";
+
+console.log(add(1, 2));


### PR DESCRIPTION
The issue was this package had an import like: `".//index.js"` and we resolved that as specified, but node normalizes it to `"./index.js"` so we have to copy node.

Closes https://github.com/denoland/deno/issues/26903
Closes https://github.com/denoland/deno/issues/25532