### PR TITLE
fix(task): ensure root config always looks up dependencies in root

### DIFF
--- a/tests/specs/task/dependencies_root_not_cycle/__test__.jsonc
+++ b/tests/specs/task/dependencies_root_not_cycle/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "task a",
+  "cwd": "member",
+  "output": "task.out"
+}

--- a/tests/specs/task/dependencies_root_not_cycle/deno.json
+++ b/tests/specs/task/dependencies_root_not_cycle/deno.json
@@ -1,0 +1,10 @@
+{
+  "tasks": {
+    "a": "echo root-a",
+    "b": {
+      "dependencies": ["a"],
+      "command": "echo b"
+    }
+  },
+  "workspace": ["./member"]
+}

--- a/tests/specs/task/dependencies_root_not_cycle/member/deno.json
+++ b/tests/specs/task/dependencies_root_not_cycle/member/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "a": {
+      "dependencies": ["b"],
+      "command": "echo a"
+    }
+  }
+}

--- a/tests/specs/task/dependencies_root_not_cycle/task.out
+++ b/tests/specs/task/dependencies_root_not_cycle/task.out
@@ -1,0 +1,6 @@
+Task a echo root-a
+a
+Task b echo b
+b
+Task a echo a
+a

--- a/tests/specs/task/dependencies_root_not_cycle/task.out
+++ b/tests/specs/task/dependencies_root_not_cycle/task.out
@@ -1,5 +1,5 @@
 Task a echo root-a
-a
+root-a
 Task b echo b
 b
 Task a echo a

--- a/tests/specs/task/dependencies_shadowed_root_name/__test__.jsonc
+++ b/tests/specs/task/dependencies_shadowed_root_name/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "root_dependending_root": {
+      "args": "task root-depending-root",
+      "cwd": "member",
+      "output": "root_dependending_root.out"
+    },
+    "member_depending_root_and_member": {
+      "args": "task member-dependending-root-and-member",
+      "cwd": "member",
+      "output": "member_depending_root_and_member.out"
+    }
+  }
+}

--- a/tests/specs/task/dependencies_shadowed_root_name/deno.jsonc
+++ b/tests/specs/task/dependencies_shadowed_root_name/deno.jsonc
@@ -1,0 +1,12 @@
+{
+  "tasks": {
+    "build": "echo root",
+    "root-depending-root": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "echo test"
+    }
+  },
+  "workspace": ["./member"]
+}

--- a/tests/specs/task/dependencies_shadowed_root_name/member/deno.jsonc
+++ b/tests/specs/task/dependencies_shadowed_root_name/member/deno.jsonc
@@ -1,0 +1,12 @@
+{
+  "tasks": {
+    "build": "echo member",
+    "member-dependending-root-and-member": {
+      "dependencies": [
+        "build",
+        "root-depending-root"
+      ],
+      "command": "echo member-test"
+    }
+  }
+}

--- a/tests/specs/task/dependencies_shadowed_root_name/member_depending_root_and_member.out
+++ b/tests/specs/task/dependencies_shadowed_root_name/member_depending_root_and_member.out
@@ -1,10 +1,10 @@
 [UNORDERED_START]
 Task build echo member
 member
+Task build echo root
+root
 Task root-depending-root echo test
 test
-Task root echo root
-root
 [UNORDERED_END]
-Task member-depending-root-and-member echo member-test
+Task member-dependending-root-and-member echo member-test
 member-test

--- a/tests/specs/task/dependencies_shadowed_root_name/member_depending_root_and_member.out
+++ b/tests/specs/task/dependencies_shadowed_root_name/member_depending_root_and_member.out
@@ -1,0 +1,10 @@
+[UNORDERED_START]
+Task build echo member
+member
+Task root-depending-root echo test
+test
+Task root echo root
+root
+[UNORDERED_END]
+Task member-depending-root-and-member echo member-test
+member-test

--- a/tests/specs/task/dependencies_shadowed_root_name/root_dependending_root.out
+++ b/tests/specs/task/dependencies_shadowed_root_name/root_dependending_root.out
@@ -1,0 +1,4 @@
+Task build echo root
+root
+Task root-depending-root echo test
+test


### PR DESCRIPTION
We were accidentally looking up dependencies in the member.