### PR TITLE
docs(cli/add): add clarification to add command

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1705,7 +1705,13 @@ fn add_subcommand() -> Command {
   <p(245)>deno add jsr:@std/path</>
 
 You can add multiple dependencies at once:
-  <p(245)>deno add jsr:@std/path jsr:@std/assert</>"
+  <p(245)>deno add jsr:@std/path jsr:@std/assert</>
+  
+You can also add npm packages:
+  <p(245)>deno add npm:react</>
+  
+You can mix both jsr and npm packages:
+  <p(245)>deno add jsr:@std/path npm:node-emoji</>"
     ),
     UnstableArgsConfig::None,
   )

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1704,14 +1704,11 @@ fn add_subcommand() -> Command {
       "Add dependencies to your configuration file.
   <p(245)>deno add jsr:@std/path</>
 
-You can add multiple dependencies at once:
-  <p(245)>deno add jsr:@std/path jsr:@std/assert</>
-  
 You can also add npm packages:
   <p(245)>deno add npm:react</>
-  
-You can mix both jsr and npm packages:
-  <p(245)>deno add jsr:@std/path npm:node-emoji</>"
+
+Or multiple dependencies at once:
+  <p(245)>deno add jsr:@std/path jsr:@std/assert npm:chalk</>"
     ),
     UnstableArgsConfig::None,
   )


### PR DESCRIPTION
This PR enhances the deno cli documentation for the deno add command to provide additional clarity on its usage. Seems that the docs file are generated through `deno json_reference`. So updated the source code.

This PR is in reference to [this PR in the docs repository](https://github.com/denoland/docs/pull/1150)

### Changes
- Enhanced the command reference for the add command with additional details.