### PR TITLE
fix(cli): remove extraneous comma in task --eval help

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3083,7 +3083,7 @@ Evaluate a task from string
         Arg::new("eval")
           .long("eval")
           .help(
-            "Evaluate the passed value as if, it was a task in a configuration file",
+            "Evaluate the passed value as if it was a task in a configuration file",
           ).action(ArgAction::SetTrue)
       )
       .arg(node_modules_dir_arg())


### PR DESCRIPTION
Remove extraneous comma in `--eval` help text on `deno task` subcommand.