### PR TITLE
fix(node/fs): missing uv error context for readFile

### DIFF
--- a/ext/node/polyfills/_fs/_fs_readFile.ts
+++ b/ext/node/polyfills/_fs/_fs_readFile.ts
@@ -88,7 +88,7 @@ export function readFile(
       }
       const buffer = maybeDecode(data, encoding);
       (cb as BinaryCallback)(null, buffer);
-    }, (err) => cb && cb(denoErrorToNodeError(err)));
+    }, (err) => cb && cb(denoErrorToNodeError(err, { path, syscall: "open" })));
   }
 }
 
@@ -122,7 +122,7 @@ export function readFileSync(
   try {
     data = Deno.readFileSync(path);
   } catch (err) {
-    throw denoErrorToNodeError(err);
+    throw denoErrorToNodeError(err, { path, syscall: "open" });
   }
   const encoding = getEncoding(opt);
   if (encoding && encoding !== "binary") {

--- a/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -2,7 +2,7 @@
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { promises, readFile, readFileSync } from "node:fs";
 import * as path from "@std/path";
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertMatch } from "@std/assert";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");
@@ -120,4 +120,27 @@ Deno.test("[std/node/fs] readFile callback isn't called twice if error is thrown
 Deno.test("fs.promises.readFile with no arg call rejects with error correctly", async () => {
   // @ts-ignore no arg call needs to be supported
   await promises.readFile().catch((_e) => {});
+});
+
+Deno.test("fs.readFile error message contains path + syscall", async () => {
+  const path = "/does/not/exist";
+  const err = await new Promise((resolve) => {
+    readFile(path, "utf-8", (err) => resolve(err));
+  });
+  if (err instanceof Error) {
+    assert(err.message.includes(path), "Path not found in error message");
+    assertMatch(err.message, /[,\s]open\s/);
+  }
+});
+
+Deno.test("fs.readFileSync error message contains path + syscall", () => {
+  const path = "/does/not/exist";
+  try {
+    readFileSync(path, "utf-8");
+  } catch (err) {
+    if (err instanceof Error) {
+      assert(err.message.includes(path), "Path not found in error message");
+      assertMatch(err.message, /[,\s]open\s/);
+    }
+  }
 });


### PR DESCRIPTION
Dart's Node wrapper code in `npm:sass` does string slicing on the thrown error message which broke because of our missing uv error context.

Code in question:

```js
_systemErrorToFileSystemException0(callback) {
  var error, t1, exception, t2;
  try {
    t1 = callback.call$0();
    return t1;
  } catch (exception) {
    error = A.unwrapException(exception);
    if (!type$.JsSystemError._is(error))
      throw exception;
    t1 = error;
    t2 = J.getInterceptor$x(t1);
    throw A.wrapException(new A.FileSystemException0(J.substring$2$s(t2.get$message(t1), (A.S(t2.get$code(t1)) + ": ").length, J.get$length$asx(t2.get$message(t1)) - (", " + A.S(t2.get$syscall(t1)) + " '" + A.S(t2.get$path(t1)) + "'").length), J.get$path$x(error)));
  }
}
```

Fixes https://github.com/denoland/deno/issues/26994