### PR TITLE
fix(fmt): Return `None` if sql fmt result is the same

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -549,7 +549,11 @@ pub fn format_sql(
   // Add single new line to the end of file.
   formatted_str.push('\n');
 
-  Ok(Some(formatted_str))
+  Ok(if formatted_str == file_text {
+    None
+  } else {
+    Some(formatted_str)
+  })
 }
 
 /// Formats a single TS, TSX, JS, JSX, JSONC, JSON, MD, IPYNB or SQL file.

--- a/tests/specs/fmt/sql/__test__.jsonc
+++ b/tests/specs/fmt/sql/__test__.jsonc
@@ -7,7 +7,7 @@
     },
     "flag": {
       "args": "fmt --unstable-sql",
-      "output": "[UNORDERED_START]\n[WILDLINE]badly_formatted.sql\n[WILDLINE]well_formatted.sql\n[WILDLINE]wrong_file_ignore.sql\n[UNORDERED_END]\nChecked 7 files\n"
+      "output": "[UNORDERED_START]\n[WILDLINE]badly_formatted.sql\n[WILDLINE]wrong_file_ignore.sql\n[UNORDERED_END]\nChecked 7 files\n"
     },
     "config_file": {
       "steps": [{
@@ -18,8 +18,12 @@
         "output": "[WILDCARD]"
       }, {
         "args": "fmt",
-        "output": "[UNORDERED_START]\n[WILDLINE]badly_formatted.sql\n[WILDLINE]well_formatted.sql\n[WILDLINE]wrong_file_ignore.sql\n[UNORDERED_END]\nChecked 8 files\n"
+        "output": "[UNORDERED_START]\n[WILDLINE]badly_formatted.sql\n[WILDLINE]wrong_file_ignore.sql\n[UNORDERED_END]\nChecked 8 files\n"
       }]
+    },
+    "well_formatted_check": {
+      "args": "fmt --unstable-sql --check well_formatted.sql",
+      "output": "Checked 1 file\n"
     }
   }
 }


### PR DESCRIPTION
Similar with https://github.com/denoland/deno/pull/25848, we need to make `format_sql` to return `None` so we do not flag well formatted sql files as being wrong.