### PR TITLE
fix(runtime/ops): Fix watchfs remove event

### DIFF
--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -152,7 +152,12 @@ fn start_watcher(
             let _ = sender.try_send(Ok(event.clone()));
           } else {
             // If the event is a remove event, we need to check if the path that was deleted
-            if event.kind.eq("remove") && event.paths.iter().any(|event_path| !event_path.exists()) {
+            if event.kind.eq("remove")
+              && event
+                .paths
+                .iter()
+                .any(|event_path| std::fs::exists(event_path).unwrap_or(false))
+            {
               let remove_event = FsEvent {
                 kind: "remove",
                 paths: event.paths.iter().map(PathBuf::from).collect(),

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -109,6 +109,14 @@ fn starts_with_canonicalized(path: &Path, prefix: &str) -> bool {
   }
 }
 
+fn is_file_removed(event_path: &PathBuf) -> bool {
+  let exists_path = std::fs::exists(event_path);
+  match exists_path {
+    Ok(res) => !res,
+    Err(_) => false,
+  }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum FsEventsError {
   #[error(transparent)]
@@ -150,21 +158,13 @@ fn start_watcher(
             })
           }) {
             let _ = sender.try_send(Ok(event.clone()));
-          } else {
-            // If the event is a remove event, we need to check if the path that was deleted
-            if event.kind.eq("remove")
-              && event
-                .paths
-                .iter()
-                .any(|event_path| std::fs::exists(event_path).unwrap_or(false))
-            {
-              let remove_event = FsEvent {
-                kind: "remove",
-                paths: event.paths.iter().map(PathBuf::from).collect(),
-                flag: None,
-              };
-              let _ = sender.try_send(Ok(remove_event));
-            }
+          } else if event.paths.iter().any(is_file_removed) {
+            let remove_event = FsEvent {
+              kind: "remove",
+              paths: event.paths.clone(),
+              flag: None,
+            };
+            let _ = sender.try_send(Ok(remove_event));
           }
         }
       }

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -150,6 +150,16 @@ fn start_watcher(
             })
           }) {
             let _ = sender.try_send(Ok(event.clone()));
+          } else {
+            // If the event is a remove event, we need to check if the path that was deleted
+            if event.kind.eq("remove") && event.paths.iter().any(|event_path| !event_path.exists()) {
+              let remove_event = FsEvent {
+                kind: "remove",
+                paths: event.paths.iter().map(PathBuf::from).collect(),
+                flag: None,
+              };
+              let _ = sender.try_send(Ok(remove_event));
+            }
           }
         }
       }

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -176,12 +176,12 @@ Deno.test(
         }
       }
     }
-    const eventsPromise = waitForRemove();
+    const eventPromise = waitForRemove();
 
     await Deno.remove(testFile);
 
     // Expect zero events.
-    const events = await eventsPromise;
-    assertEquals(events!.kind, "remove");
+    const event = await eventPromise;
+    assertEquals(event!.kind, "remove");
   },
 );


### PR DESCRIPTION
Fix related to #26906 . 
Currently, if a file is removed, no event is emitted because the file path no longer exists. As a result, [this check](https://github.com/denoland/deno/blob/12b377247be2b74155ded3a678ff2996ef3d7c9f/runtime/ops/fs_events.rs#L149) returns false. 

With this PR, an additional check is introduced to verify if the file exists. If the file does not exist, a custom "remove" event is emitted.
This change is necessary because, based on tests conducted on macOS and Linux (Ubuntu 24.04.1 LTS), Linux emits a "rename" event instead of a "remove" event when a file is deleted. Introducing a dedicated "remove" event ensures consistent and clearer behavior across platforms.

