### PR TITLE
fixes:Deno.permissions.query({name:"imports"}) is not supported 

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4042,6 +4042,18 @@ declare namespace Deno {
     variable?: string;
   }
 
+  /** Specifies if the import permission should be requested or revoked.
+   * If set to "inherit" the current import permission will be inherited.
+   * If set to true, the global import permission will be requested.
+   * If set to false, the global import permission will be revoked.
+   * If set to Array<string>, the import permissions will be requested with the specified domains.
+   *
+   * @category Permissions */
+  export interface ImportPermissionDescriptor {
+    name: "import";
+    variable?: string;
+  }
+
   /** The permission descriptor for the `allow-sys` and `deny-sys` permissions, which controls
    * access to sensitive host system information, which malicious code might
    * attempt to exploit. The option `kind` allows scoping the permission to a
@@ -4096,7 +4108,8 @@ declare namespace Deno {
     | NetPermissionDescriptor
     | EnvPermissionDescriptor
     | SysPermissionDescriptor
-    | FfiPermissionDescriptor;
+    | FfiPermissionDescriptor
+    | ImportPermissionDescriptor;
 
   /** The interface which defines what event types are supported by
    * {@linkcode PermissionStatus} instances.

--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -32,5 +32,6 @@ export const appendFile = fsPromises.appendFile;
 export const readFile = fsPromises.readFile;
 export const watch = fsPromises.watch;
 export const cp = fsPromises.cp;
+export const sync = fsPromises.sync;
 
 export default fsPromises;

--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -32,6 +32,5 @@ export const appendFile = fsPromises.appendFile;
 export const readFile = fsPromises.readFile;
 export const watch = fsPromises.watch;
 export const cp = fsPromises.cp;
-export const sync = fsPromises.sync;
 
 export default fsPromises;

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -149,9 +149,8 @@ export class FileHandle extends EventEmitter {
   stat(options?: { bigint: boolean }): Promise<Stats | BigIntStats> {
     return fsCall(promises.fstat, this, options);
   }
-  // readLines(options?):Promise<InterfaceConstructor>
   sync(): Promise<void> {
-    return Promise.resolve(promises.sync());
+    return promises.fsync(this.fd);
   }
 }
 

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -148,6 +148,10 @@ export class FileHandle extends EventEmitter {
   stat(options: { bigint: true }): Promise<BigIntStats>;
   stat(options?: { bigint: boolean }): Promise<Stats | BigIntStats> {
     return fsCall(promises.fstat, this, options);
+  };
+  // readLines(options?):Promise<InterfaceConstructor>
+  sync():Promise<void>{
+    return Promise.resolve(promises.sync());
   }
 }
 

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -150,7 +150,7 @@ export class FileHandle extends EventEmitter {
     return fsCall(promises.fstat, this, options);
   }
   // readLines(options?):Promise<InterfaceConstructor>
-  sync():Promise<void>{
+  sync(): Promise<void> {
     return Promise.resolve(promises.sync());
   }
 }

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -148,7 +148,7 @@ export class FileHandle extends EventEmitter {
   stat(options: { bigint: true }): Promise<BigIntStats>;
   stat(options?: { bigint: boolean }): Promise<Stats | BigIntStats> {
     return fsCall(promises.fstat, this, options);
-  };
+  }
   // readLines(options?):Promise<InterfaceConstructor>
   sync():Promise<void>{
     return Promise.resolve(promises.sync());

--- a/runtime/js/10_permissions.js
+++ b/runtime/js/10_permissions.js
@@ -37,7 +37,7 @@ const illegalConstructorKey = Symbol("illegalConstructorKey");
  * @property {boolean} partial
  */
 
-/** @type {ReadonlyArray<"read" | "write" | "net" | "env" | "sys" | "run" | "ffi">} */
+/** @type {ReadonlyArray<"read" | "write" | "net" | "env" | "sys" | "run" | "ffi" | "import">} */
 const permissionNames = [
   "read",
   "write",
@@ -46,6 +46,7 @@ const permissionNames = [
   "sys",
   "run",
   "ffi",
+  "import",
 ];
 
 /**

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -70,7 +70,6 @@ Deno.test("[node/fs filehandle.write] Write from Buffer", async function () {
 
   const buffer = Buffer.from("hello world");
   const res = await fileHandle.write(buffer, 0, 5, 0);
-  await fileHandle.sync();
 
   const data = Deno.readFileSync(tempFile);
   await Deno.remove(tempFile);
@@ -111,6 +110,7 @@ Deno.test("[node/fs filehandle.writeFile] Write to file", async function () {
 
   const str = "hello world";
   await fileHandle.writeFile(str);
+  await fileHandle.sync();
 
   const data = Deno.readFileSync(tempFile);
   await Deno.remove(tempFile);

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -70,6 +70,7 @@ Deno.test("[node/fs filehandle.write] Write from Buffer", async function () {
 
   const buffer = Buffer.from("hello world");
   const res = await fileHandle.write(buffer, 0, 5, 0);
+  await fileHandle.sync();
 
   const data = Deno.readFileSync(tempFile);
   await Deno.remove(tempFile);


### PR DESCRIPTION
fixes #27050  Deno.permissions.query({name:"imports"}) is not supported 
