### PR TITLE
fix(lsp): support task object notation for tasks request

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -3781,14 +3781,11 @@ impl Inner {
   fn task_definitions(&self) -> LspResult<Vec<TaskDefinition>> {
     let mut result = vec![];
     for config_file in self.config.tree.config_files() {
-      if let Some(tasks) = json!(&config_file.json.tasks).as_object() {
-        for (name, value) in tasks {
-          let Some(command) = value.as_str() else {
-            continue;
-          };
+      if let Some(tasks) = config_file.to_tasks_config().ok().flatten() {
+        for (name, def) in tasks {
           result.push(TaskDefinition {
             name: name.clone(),
-            command: command.to_string(),
+            command: def.command.clone(),
             source_uri: url_to_uri(&config_file.specifier)
               .map_err(|_| LspError::internal_error())?,
           });

--- a/cli/lsp/lsp_custom.rs
+++ b/cli/lsp/lsp_custom.rs
@@ -14,8 +14,6 @@ pub const LATEST_DIAGNOSTIC_BATCH_INDEX: &str =
 #[serde(rename_all = "camelCase")]
 pub struct TaskDefinition {
   pub name: String,
-  // TODO(nayeemrmn): Rename this to `command` in vscode_deno.
-  #[serde(rename = "detail")]
   pub command: String,
   pub source_uri: lsp::Uri,
 }

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -56,9 +56,6 @@ pub async fn start() -> Result<(), AnyError> {
     LanguageServer::performance_request,
   )
   .custom_method(lsp_custom::TASK_REQUEST, LanguageServer::task_definitions)
-  // TODO(nayeemrmn): Rename this to `deno/taskDefinitions` in vscode_deno and
-  // remove this alias.
-  .custom_method("deno/task", LanguageServer::task_definitions)
   .custom_method(testing::TEST_RUN_REQUEST, LanguageServer::test_run_request)
   .custom_method(
     testing::TEST_RUN_CANCEL_REQUEST,

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -1360,26 +1360,31 @@ fn lsp_deno_task() {
   let temp_dir = context.temp_dir();
   temp_dir.write(
     "deno.jsonc",
-    r#"{
-    "tasks": {
-      "build": "deno test"
-    }
-  }"#,
+    json!({
+      "tasks": {
+        "build": "deno test",
+        "serve": {
+          "description": "Start the dev server",
+          "command": "deno run -RN server.ts",
+        },
+      },
+    })
+    .to_string(),
   );
-
   let mut client = context.new_lsp_command().build();
-  client.initialize(|builder| {
-    builder.set_config("./deno.jsonc");
-  });
-
-  let res = client.write_request("deno/task", json!(null));
-
+  client.initialize_default();
+  let res = client.write_request("deno/taskDefinitions", json!(null));
   assert_eq!(
     res,
     json!([
       {
         "name": "build",
-        "detail": "deno test",
+        "command": "deno test",
+        "sourceUri": temp_dir.url().join("deno.jsonc").unwrap(),
+      },
+      {
+        "name": "serve",
+        "command": "deno run -RN server.ts",
         "sourceUri": temp_dir.url().join("deno.jsonc").unwrap(),
       }
     ])


### PR DESCRIPTION
Fixes https://github.com/denoland/vscode_deno/issues/1211. Requires client-side change as well so 'Open task definition' works: https://github.com/denoland/vscode_deno/pull/1214. Also remove some old compat paths.