### PR TITLE
fix(task): strip ansi codes and control chars when printing tasks

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -725,7 +725,11 @@ fn print_available_tasks(
         writeln!(writer, "    {slash_slash} {}", colors::italic_gray(line))?;
       }
     }
-    writeln!(writer, "    {}", desc.task.command)?;
+    writeln!(
+      writer,
+      "    {}",
+      console_static_text::ansi::strip_ansi_codes(&desc.task.command)
+    )?;
     if !desc.task.dependencies.is_empty() {
       writeln!(
         writer,

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -722,7 +722,13 @@ fn print_available_tasks(
     if let Some(description) = &desc.task.description {
       let slash_slash = colors::italic_gray("//");
       for line in description.lines() {
-        writeln!(writer, "    {slash_slash} {}", colors::italic_gray(line))?;
+        writeln!(
+          writer,
+          "    {slash_slash} {}",
+          colors::italic_gray(console_static_text::ansi::strip_ansi_codes(
+            line
+          ))
+        )?;
       }
     }
     writeln!(
@@ -731,11 +737,18 @@ fn print_available_tasks(
       console_static_text::ansi::strip_ansi_codes(&desc.task.command)
     )?;
     if !desc.task.dependencies.is_empty() {
+      let dependencies = desc
+        .task
+        .dependencies
+        .into_iter()
+        .map(|d| console_static_text::ansi::strip_ansi_codes(&d).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
       writeln!(
         writer,
         "    {} {}",
         colors::gray("depends on:"),
-        colors::cyan(desc.task.dependencies.join(", "))
+        colors::cyan(dependencies)
       )?;
     }
   }

--- a/tests/integration/task_tests.rs
+++ b/tests/integration/task_tests.rs
@@ -52,6 +52,38 @@ fn deno_task_ansi_escape_codes() {
       console.expect("- dev");
       console.expect("    echo 'BOOO!!!'");
       console.expect("- next");
-      console.expect("    - dev    echo 'I am your friend.'")
+      console.expect("    - dev    echo 'I am your friend.'");
+    });
+}
+
+#[test]
+fn deno_task_control_chars() {
+  let context = TestContextBuilder::default().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write(
+    "deno.json",
+    r#"{
+  "tasks": {
+    "dev": "echo 'BOOO!!!' && \r    echo hi there is my command",
+    "serve": {
+      "description": "this is a\tm\rangled description",
+      "command": "echo hello"
+    }
+  }
+}
+"#,
+  );
+
+  context
+    .new_command()
+    .args_vec(["task"])
+    .with_pty(|mut console| {
+      console.expect("Available tasks:");
+      console.expect("- dev");
+      console
+        .expect("    echo 'BOOO!!!' && \\r    echo hi there is my command");
+      console.expect("- serve");
+      console.expect("    // this is a\\tm\\rangled description");
+      console.expect("    echo hello");
     });
 }

--- a/tests/integration/task_tests.rs
+++ b/tests/integration/task_tests.rs
@@ -3,6 +3,9 @@
 // Most of the tests for this are in deno_task_shell.
 // These tests are intended to only test integration.
 
+use test_util as util;
+use util::TestContextBuilder;
+
 // use test_util::env_vars_for_npm_tests;
 // use test_util::itest;
 // use test_util::TestContext;
@@ -28,3 +31,27 @@
 //   exit_code: 1,
 //   http_server: true,
 // });
+
+#[test]
+fn deno_task_ansi_escape_codes() {
+  let context = TestContextBuilder::default().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("deno.json", r#"{
+  "tasks": {
+    "dev": "echo 'BOOO!!!'",
+    "next": "\u001b[3F\u001b[0G- dev\u001b[1E\u001b[2K    echo 'I am your friend.'"
+  }
+}
+"#);
+
+  context
+    .new_command()
+    .args_vec(["task"])
+    .with_pty(|mut console| {
+      console.expect("Available tasks:");
+      console.expect("- dev");
+      console.expect("    echo 'BOOO!!!'");
+      console.expect("- next");
+      console.expect("    - dev    echo 'I am your friend.'")
+    });
+}


### PR DESCRIPTION
Strip out ansi codes and ASCII control characters when
printing the commands, descriptions and dependencies
of tasks.