### PR TITLE
fix(node/http): casing ignored in ServerResponse.hasHeader()

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1409,7 +1409,7 @@ ServerResponse.prototype.hasHeader = function (
   this: ServerResponse,
   name: string,
 ) {
-  return Object.hasOwn(this._headers, name);
+  return Object.hasOwn(this._headers, StringPrototypeToLowerCase(name));
 };
 
 ServerResponse.prototype.writeHead = function (

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1151,6 +1151,7 @@ Deno.test("[node/http] ServerResponse header names case insensitive", async () =
   const { promise, resolve } = Promise.withResolvers<void>();
   const server = http.createServer((_req, res) => {
     res.setHeader("Content-Length", "12345");
+    assert(res.hasHeader("Content-Length"));
     res.removeHeader("content-length");
     assertEquals(res.getHeader("Content-Length"), undefined);
     assert(!res.hasHeader("Content-Length"));


### PR DESCRIPTION
We didn't respect casing when checking if a HTTP header is present in Node's `ServerResponse.hasHeader()`. This lead to us returning incorrect results when the header was present. Koa assumed that the `Content-Type` header wasn't present when it actually was and defaulted to a different `Content-Type` value.

Fixes https://github.com/denoland/deno/issues/27101