### PR TITLE
chore: fix lint step due to node compat test changes

### DIFF
--- a/tests/node_compat/runner/TODO.md
+++ b/tests/node_compat/runner/TODO.md
@@ -1,7 +1,7 @@
 <!-- deno-fmt-ignore-file -->
 # Remaining Node Tests
 
-594 tests out of 3681 have been ported from Node 20.11.1 (16.14% ported, 83.97% remaining).
+595 tests out of 3681 have been ported from Node 20.11.1 (16.16% ported, 83.94% remaining).
 
 NOTE: This file should not be manually edited. Please edit `tests/node_compat/config.json` and run `deno task setup` in `tests/node_compat/runner` dir instead.
 


### PR DESCRIPTION
Seems due to merging this: https://github.com/denoland/deno/actions/runs/12052779514/job/33606893423