### PR TITLE
fix(node/timers): error when passing id to clearTimeout/clearInterval

### DIFF
--- a/ext/node/polyfills/timers.ts
+++ b/ext/node/polyfills/timers.ts
@@ -54,7 +54,7 @@ export function clearTimeout(timeout?: Timeout | number) {
   const id = +timeout;
   const timer = MapPrototypeGet(activeTimers, id);
   if (timer) {
-    timeout._destroyed = true;
+    timer._destroyed = true;
     MapPrototypeDelete(activeTimers, id);
   }
   clearTimeout_(id);
@@ -74,7 +74,7 @@ export function clearInterval(timeout?: Timeout | number | string) {
   const id = +timeout;
   const timer = MapPrototypeGet(activeTimers, id);
   if (timer) {
-    timeout._destroyed = true;
+    timer._destroyed = true;
     MapPrototypeDelete(activeTimers, id);
   }
   clearInterval_(id);

--- a/tests/unit_node/timers_test.ts
+++ b/tests/unit_node/timers_test.ts
@@ -100,6 +100,16 @@ Deno.test("[node/timers refresh cancelled timer]", () => {
   p.refresh();
 });
 
+Deno.test("[node/timers] clearTimeout with number", () => {
+  const timer = +timers.setTimeout(() => fail(), 10);
+  timers.clearTimeout(timer);
+});
+
+Deno.test("[node/timers] clearInterval with number", () => {
+  const timer = +timers.setInterval(() => fail(), 10);
+  timers.clearInterval(timer);
+});
+
 Deno.test("[node/timers setImmediate returns Immediate object]", () => {
   const { clearImmediate, setImmediate } = timers;
 


### PR DESCRIPTION
As pointed out in https://github.com/denoland/deno/issues/27126 we used a variable which could potentially be of type `number` instead of the `Timeout` class instance. Ensure that we're always setting `_destroyed` on the class instead instead.

Fixes https://github.com/denoland/deno/issues/27126