### PR TITLE
fix(publish): error on missing name field

### DIFF
--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -97,11 +97,10 @@ pub async fn publish(
     match cli_options.start_dir.maybe_deno_json() {
       Some(deno_json) => {
         debug_assert!(!deno_json.is_package());
+        if deno_json.json.name.is_none() {
+          bail!("Missing 'name' field in '{}'.", deno_json.specifier);
+        }
         error_missing_exports_field(deno_json)?;
-        bail!(
-          "Missing 'name' or 'exports' field in '{}'.",
-          deno_json.specifier
-        );
       }
       None => {
         bail!(

--- a/tests/specs/publish/missing_name/__test__.jsonc
+++ b/tests/specs/publish/missing_name/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "publish --token 'sadfasdf'",
+  "output": "publish.out",
+  "exitCode": 1
+}

--- a/tests/specs/publish/missing_name/deno.json
+++ b/tests/specs/publish/missing_name/deno.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "exports": "./mod.ts"
+}

--- a/tests/specs/publish/missing_name/mod.ts
+++ b/tests/specs/publish/missing_name/mod.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/tests/specs/publish/missing_name/publish.out
+++ b/tests/specs/publish/missing_name/publish.out
@@ -1,0 +1,1 @@
+error: Missing 'name' field in 'file:///[WILDCARD]deno.json'.


### PR DESCRIPTION
This PR improves the error output on publish when the `name` filed is missing:

```json
{
  "exports": "./mod.ts",
  "version": "0.0.1"
}
```

Before:

```sh
deno publish --dry-run
error: You did not specify an entrypoint in file:///Users/marvinh/dev/test/deno-pkg-timers/deno.json. Add `exports` mapping in the configuration file, eg:
{
  "name": "@scope/name",
  "version": "0.0.0",
  "exports": "<path_to_entrypoint>"
}
```

After:

```sh
deno publish --dry-run
error: Missing 'name' field in 'file:///Users/marvinh/dev/test/deno-pkg-timers/deno.json'.
```

Fixes https://github.com/denoland/deno/issues/27116