### PR TITLE
fix(task): don't panic with filter on missing task argument

### DIFF
--- a/tests/specs/task/filter/__test__.jsonc
+++ b/tests/specs/task/filter/__test__.jsonc
@@ -30,6 +30,11 @@
       "args": "task --filter @foo/* dev",
       "output": "npm_workspace_order.out"
     },
+    "npm_filter_no_match_no_task": {
+      "cwd": "./npm",
+      "args": "task --filter @asdf",
+      "output": "npm_filter_no_match_no_task.out"
+    },
     "deno_all": {
       "cwd": "./deno",
       "args": "task --filter * dev",
@@ -54,6 +59,11 @@
       "cwd": "./deno_workspace_order",
       "args": "task --filter @foo/* dev",
       "output": "deno_workspace_order.out"
+    },
+    "deno_filter_no_match_no_task": {
+      "cwd": "./deno",
+      "args": "task --filter @asdf",
+      "output": "deno_filter_no_match_no_task.out"
     }
   }
 }

--- a/tests/specs/task/filter/deno_filter_no_match_no_task.out
+++ b/tests/specs/task/filter/deno_filter_no_match_no_task.out
@@ -1,0 +1,2 @@
+Missing task argument.
+No package name matched the filter '@asdf' in available 'deno.json' or 'package.json' files.

--- a/tests/specs/task/filter/npm_filter_no_match_no_task.out
+++ b/tests/specs/task/filter/npm_filter_no_match_no_task.out
@@ -1,0 +1,2 @@
+Missing task argument.
+No package name matched the filter '@asdf' in available 'deno.json' or 'package.json' files.


### PR DESCRIPTION
We were panicing when running `deno task --filter foo` without a task argument.

Fixes https://github.com/denoland/deno/issues/27177