### PR TITLE
fix(node/worker_threads): data url not encoded properly with eval

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -123,7 +123,10 @@ class NodeWorker extends EventEmitter {
       );
     }
     if (options?.eval) {
-      specifier = `data:text/javascript,${specifier}`;
+      const code = typeof specifier === "string"
+        ? encodeURIComponent(specifier)
+        : specifier.toString();
+      specifier = `data:text/javascript,${code}`;
     } else if (
       !(typeof specifier === "object" && specifier.protocol === "data:")
     ) {

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -137,6 +137,25 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[node/worker_threads] Worker eval",
+  async fn() {
+    // Check that newlines are encoded properly
+    const worker = new workerThreads.Worker(
+      `
+      import { parentPort } from "node:worker_threads"
+      console.log("hey, foo") // comment
+      parentPort.postMessage("It works!");
+      `,
+      {
+        eval: true,
+      },
+    );
+    assertEquals((await once(worker, "message"))[0], "It works!");
+    worker.terminate();
+  },
+});
+
+Deno.test({
   name: "[node/worker_threads] worker thread with type module",
   async fn() {
     function p() {


### PR DESCRIPTION
When using the `eval` option on Node's  `worker_threads` the code is passed as a `data:` URL. But we didn't encode the actual code for that, which lead to syntax errors when including characters not allowed in an URL.

Fixes a part of https://github.com/denoland/deno/issues/27167