### PR TITLE
refactor: export variables for better consumption from the outside

### DIFF
--- a/tests/node_compat/runner/setup.ts
+++ b/tests/node_compat/runner/setup.ts
@@ -19,7 +19,7 @@ const encoder = new TextEncoder();
 
 const NODE_VERSION = version;
 
-const NODE_IGNORED_TEST_DIRS = [
+export const NODE_IGNORED_TEST_DIRS = [
   "addons",
   "async-hooks",
   "cctest",
@@ -40,13 +40,13 @@ const NODE_IGNORED_TEST_DIRS = [
   "wpt",
 ];
 
-const VENDORED_NODE_TEST = new URL("./suite/test/", import.meta.url);
-const NODE_COMPAT_TEST_DEST_URL = new URL(
+export const VENDORED_NODE_TEST = new URL("./suite/test/", import.meta.url);
+export const NODE_COMPAT_TEST_DEST_URL = new URL(
   "../test/",
   import.meta.url,
 );
 
-async function getNodeTests(): Promise<string[]> {
+export async function getNodeTests(): Promise<string[]> {
   const paths: string[] = [];
   const rootPath = VENDORED_NODE_TEST.href.slice(7);
   for await (
@@ -61,7 +61,7 @@ async function getNodeTests(): Promise<string[]> {
   return paths.sort();
 }
 
-function getDenoTests() {
+export function getDenoTests() {
   return Object.entries(config.tests)
     .filter(([testDir]) => !NODE_IGNORED_TEST_DIRS.includes(testDir))
     .flatMap(([testDir, tests]) => tests.map((test) => testDir + "/" + test));


### PR DESCRIPTION
This will allow others to consume how far Deno is from a compatibility-perspective.

Here's a discussion: https://github.com/denoland/deno/discussions/26745

From that, I made this site: https://ffmathy.github.io/is-deno-compatible-yet/

But it is showing the wrong calculations. Exposing these fields would make it easy for me to "piggyback" on the right numbers.


<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
