### PR TITLE
chore: fix cjs_with_deps test to use a temp dir

### DIFF
--- a/tests/specs/npm/cjs_with_deps/__test__.jsonc
+++ b/tests/specs/npm/cjs_with_deps/__test__.jsonc
@@ -1,4 +1,5 @@
 {
+  "tempDir": true,
   "tests": {
     "cjs_with_deps": {
       "args": "run --allow-read --allow-env main.js",

--- a/tests/specs/npm/cjs_with_deps/main_info.out
+++ b/tests/specs/npm/cjs_with_deps/main_info.out
@@ -3,7 +3,7 @@ type: JavaScript
 dependencies: 14 unique
 size: [WILDCARD]
 
-file:///[WILDCARD]/cjs_with_deps/main.js ([WILDCARD])
+file:///[WILDCARD]/main.js ([WILDCARD])
 ├─┬ npm:/chalk@4.1.2 ([WILDCARD])
 │ ├─┬ npm:/ansi-styles@4.3.0 ([WILDCARD])
 │ │ └─┬ npm:/color-convert@2.0.1 ([WILDCARD])


### PR DESCRIPTION
It was creating a node_modules directory.