### PR TITLE
test(ext/node): reduce race condition in test case

### DIFF
--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1370,6 +1370,7 @@ Deno.test("[node/http] client closing a streaming request doesn't terminate serv
   let interval: number;
   let uploadedData = "";
   let requestError: Error | null = null;
+  const deferred1 = Promise.withResolvers<void>();
   const server = http.createServer((req, res) => {
     res.writeHead(200, { "Content-Type": "text/plain" });
     interval = setInterval(() => {
@@ -1382,13 +1383,13 @@ Deno.test("[node/http] client closing a streaming request doesn't terminate serv
       clearInterval(interval);
     });
     req.on("error", (err) => {
+      deferred1.resolve();
       requestError = err;
       clearInterval(interval);
       res.end();
     });
   });
 
-  const deferred1 = Promise.withResolvers<void>();
   server.listen(0, () => {
     // deno-lint-ignore no-explicit-any
     const port = (server.address() as any).port;
@@ -1418,9 +1419,6 @@ Deno.test("[node/http] client closing a streaming request doesn't terminate serv
 
         if (sentChunks >= 3) {
           client.destroy();
-          setTimeout(() => {
-            deferred1.resolve();
-          }, 40);
         } else {
           setTimeout(writeChunk, 10);
         }


### PR DESCRIPTION
This partially addresses #27154 (https://github.com/denoland/deno/issues/27154#issuecomment-2513347521 )

This PR reduces the race condition in unit_node test case `[node/http] client closing a streaming request doesn't terminate server`.

This now resolves the deferred when the server received the error, which is the required condition for the next assertion after `await deferred1.promise`. This should be more correct than resolving it using timer.