### PR TITLE
fix(task): only pass args to root task

### DIFF
--- a/tests/specs/task/dependencies/__test__.jsonc
+++ b/tests/specs/task/dependencies/__test__.jsonc
@@ -56,6 +56,11 @@
       "args": "task a",
       "output": "./cycle_2.out",
       "exitCode": 1
+    },
+    "arg_task_with_deps": {
+      "cwd": "arg_task_with_deps",
+      "args": "task a a",
+      "output": "./arg_task_with_deps.out"
     }
   }
 }

--- a/tests/specs/task/dependencies/arg_task_with_deps.out
+++ b/tests/specs/task/dependencies/arg_task_with_deps.out
@@ -1,0 +1,4 @@
+Task b echo 'b'
+b
+Task a echo "a"
+a

--- a/tests/specs/task/dependencies/arg_task_with_deps/deno.json
+++ b/tests/specs/task/dependencies/arg_task_with_deps/deno.json
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "a": {
+      "command": "echo",
+      "dependencies": ["b"]
+    },
+    "b": "echo 'b'"
+  }
+}


### PR DESCRIPTION
When we run `deno task` with args like `deno task foo arg` the argument should only be passed to the root task, not to its dependencies.

Fixes https://github.com/denoland/deno/issues/27206