### PR TITLE
fix(outdated): allow `--latest` without `--update`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -11686,6 +11686,14 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
           recursive: false,
         },
       ),
+      (
+        svec!["--latest"],
+        OutdatedFlags {
+          filters: svec![],
+          kind: OutdatedKind::PrintOutdated { compatible: false },
+          recursive: false,
+        },
+      ),
     ];
     for (input, expected) in cases {
       let mut args = svec!["deno", "outdated"];

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2664,10 +2664,10 @@ Display outdated dependencies:
   <p(245)>deno outdated</>
   <p(245)>deno outdated --compatible</>
 
-Update dependencies:
+Update dependencies to latest semver compatible versions:
   <p(245)>deno outdated --update</>
+Update dependencies to latest versions, ignoring semver requirements:
   <p(245)>deno outdated --update --latest</>
-  <p(245)>deno outdated --update</>
 
 Filters can be used to select which packages to act on. Filters can include wildcards (*) to match multiple packages.
   <p(245)>deno outdated --update --latest \"@std/*\"</>
@@ -2703,7 +2703,6 @@ Specific version requirements to update to can be specified:
           .help(
             "Update to the latest version, regardless of semver constraints",
           )
-          .requires("update")
           .conflicts_with("compatible"),
       )
       .arg(


### PR DESCRIPTION
Ref #27025.

it does nothing (it's the default behavior) but it doesn't hurt to allow it