### PR TITLE
refactor: remove usages of `deno_core::resolve_import` for resolving redirects

### DIFF
--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -59,8 +59,7 @@ impl FileOrRedirect {
     cache_entry: deno_cache_dir::CacheEntry,
   ) -> Result<Self, AnyError> {
     if let Some(redirect_to) = cache_entry.metadata.headers.get("location") {
-      let redirect =
-        deno_core::resolve_import(redirect_to, specifier.as_str())?;
+      let redirect = specifier.join(redirect_to)?;
       Ok(FileOrRedirect::Redirect(redirect))
     } else {
       Ok(FileOrRedirect::File(File {

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -941,9 +941,7 @@ impl RedirectResolver {
         if chain.len() > 10 {
           break None;
         }
-        let Ok(target) =
-          deno_core::resolve_import(location, specifier.as_str())
-        else {
+        let Ok(target) = specifier.join(location) else {
           break None;
         };
         chain.push((


### PR DESCRIPTION
This was doing an allocation for reparsing the specifier. Might as well do `.join` here and it means I can extract out this file fetcher code to deno_cache_dir more easily.