### PR TITLE
fix: do not panic when fetching invalid file url on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "bytes",
  "data-url",
  "deno_core",
+ "deno_path_util",
  "deno_permissions",
  "deno_tls",
  "dyn-clone",

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -18,6 +18,7 @@ base64.workspace = true
 bytes.workspace = true
 data-url.workspace = true
 deno_core.workspace = true
+deno_path_util.workspace = true
 deno_permissions.workspace = true
 deno_tls.workspace = true
 dyn-clone = "1"

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -41,6 +41,8 @@ use deno_core::OpState;
 use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
+use deno_path_util::url_from_file_path;
+use deno_path_util::PathToUrlError;
 use deno_permissions::PermissionCheckError;
 use deno_tls::rustls::RootCertStore;
 use deno_tls::Proxy;
@@ -172,6 +174,8 @@ pub enum FetchError {
   NetworkError,
   #[error("Fetching files only supports the GET method: received {0}")]
   FsNotGet(Method),
+  #[error(transparent)]
+  PathToUrl(#[from] PathToUrlError),
   #[error("Invalid URL {0}")]
   InvalidUrl(Url),
   #[error(transparent)]
@@ -436,7 +440,7 @@ where
       let permissions = state.borrow_mut::<FP>();
       let path = permissions.check_read(&path, "fetch()")?;
       let url = match path {
-        Cow::Owned(path) => Url::from_file_path(path).unwrap(),
+        Cow::Owned(path) => url_from_file_path(&path)?,
         Cow::Borrowed(_) => url,
       };
 

--- a/runtime/errors.rs
+++ b/runtime/errors.rs
@@ -696,6 +696,7 @@ fn get_fetch_error(error: &FetchError) -> &'static str {
     FetchError::Permission(e) => get_permission_check_error_class(e),
     FetchError::NetworkError => "TypeError",
     FetchError::FsNotGet(_) => "TypeError",
+    FetchError::PathToUrl(_) => "TypeError",
     FetchError::InvalidUrl(_) => "TypeError",
     FetchError::InvalidHeaderName(_) => "TypeError",
     FetchError::InvalidHeaderValue(_) => "TypeError",


### PR DESCRIPTION
I tried adding a test, but it's not possible due to a debug assertion in the url crate (https://github.com/servo/rust-url/issues/505)

Closes https://github.com/denoland/deno/issues/27258