### PR TITLE
fix(node): update list of builtin node modules, add missing export to _http_common

### DIFF
--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -743,13 +743,16 @@ fn get_node_completions(
   }
   let items = SUPPORTED_BUILTIN_NODE_MODULES
     .iter()
-    .map(|name| {
+    .filter_map(|name| {
+      if name.starts_with('_') {
+        return None;
+      }
       let specifier = format!("node:{}", name);
       let text_edit = Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
         range: *range,
         new_text: specifier.clone(),
       }));
-      lsp::CompletionItem {
+      Some(lsp::CompletionItem {
         label: specifier,
         kind: Some(lsp::CompletionItemKind::FILE),
         detail: Some("(node)".to_string()),
@@ -758,7 +761,7 @@ fn get_node_completions(
           IMPORT_COMMIT_CHARS.iter().map(|&c| c.into()).collect(),
         ),
         ..Default::default()
-      }
+      })
     })
     .collect();
   Some(CompletionList {

--- a/ext/node/polyfill.rs
+++ b/ext/node/polyfill.rs
@@ -25,6 +25,17 @@ macro_rules! generate_builtin_node_module_lists {
 
 // NOTE(bartlomieju): keep this list in sync with `ext/node/polyfills/01_require.js`
 generate_builtin_node_module_lists! {
+  "_http_agent",
+  "_http_common",
+  "_http_outgoing",
+  "_http_server",
+  "_stream_duplex",
+  "_stream_passthrough",
+  "_stream_readable",
+  "_stream_transform",
+  "_stream_writable",
+  "_tls_common",
+  "_tls_wrap",
   "assert",
   "assert/strict",
   "async_hooks",

--- a/ext/node/polyfills/_http_common.ts
+++ b/ext/node/polyfills/_http_common.ts
@@ -7,6 +7,7 @@ const {
   SafeRegExp,
   Symbol,
 } = primordials;
+import { HTTPParser } from "ext:deno_node/internal_binding/http_parser.ts";
 
 export const CRLF = "\r\n";
 export const kIncomingMessage = Symbol("IncomingMessage");
@@ -79,6 +80,8 @@ export {
   checkIsHttpToken as _checkIsHttpToken,
 };
 
+export { HTTPParser };
+
 export default {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   _checkIsHttpToken: checkIsHttpToken,
@@ -87,4 +90,5 @@ export default {
   continueExpression,
   kIncomingMessage,
   methods,
+  HTTPParser,
 };


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/27289

We exported these but forgot to add them to the list of builtins used by the resolver, so we weren't resolving bare imports of some modules (e.g. `"_http_common"`)

Also adds a missing export of `HTTPParser` from `_http_common`