### PR TITLE
feat(unstable): support caching npm dependencies only as they're needed

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -245,7 +245,7 @@ pub struct InstallFlagsGlobal {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum InstallKind {
+pub enum InstallFlags {
   Local(InstallFlagsLocal),
   Global(InstallFlagsGlobal),
 }
@@ -255,11 +255,6 @@ pub enum InstallFlagsLocal {
   Add(AddFlags),
   TopLevel,
   Entrypoints(Vec<String>),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct InstallFlags {
-  pub kind: InstallKind,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -4919,15 +4914,14 @@ fn install_parse(
     let module_url = cmd_values.next().unwrap();
     let args = cmd_values.collect();
 
-    flags.subcommand = DenoSubcommand::Install(InstallFlags {
-      kind: InstallKind::Global(InstallFlagsGlobal {
+    flags.subcommand =
+      DenoSubcommand::Install(InstallFlags::Global(InstallFlagsGlobal {
         name,
         module_url,
         args,
         root,
         force,
-      }),
-    });
+      }));
 
     return Ok(());
   }
@@ -4936,22 +4930,19 @@ fn install_parse(
   allow_scripts_arg_parse(flags, matches)?;
   if matches.get_flag("entrypoint") {
     let entrypoints = matches.remove_many::<String>("cmd").unwrap_or_default();
-    flags.subcommand = DenoSubcommand::Install(InstallFlags {
-      kind: InstallKind::Local(InstallFlagsLocal::Entrypoints(
-        entrypoints.collect(),
-      )),
-    });
+    flags.subcommand = DenoSubcommand::Install(InstallFlags::Local(
+      InstallFlagsLocal::Entrypoints(entrypoints.collect()),
+    ));
   } else if let Some(add_files) = matches
     .remove_many("cmd")
     .map(|packages| add_parse_inner(matches, Some(packages)))
   {
-    flags.subcommand = DenoSubcommand::Install(InstallFlags {
-      kind: InstallKind::Local(InstallFlagsLocal::Add(add_files)),
-    })
+    flags.subcommand = DenoSubcommand::Install(InstallFlags::Local(
+      InstallFlagsLocal::Add(add_files),
+    ))
   } else {
-    flags.subcommand = DenoSubcommand::Install(InstallFlags {
-      kind: InstallKind::Local(InstallFlagsLocal::TopLevel),
-    });
+    flags.subcommand =
+      DenoSubcommand::Install(InstallFlags::Local(InstallFlagsLocal::TopLevel));
   }
   Ok(())
 }
@@ -8599,15 +8590,15 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        subcommand: DenoSubcommand::Install(InstallFlags {
-          kind: InstallKind::Global(InstallFlagsGlobal {
+        subcommand: DenoSubcommand::Install(InstallFlags::Global(
+          InstallFlagsGlobal {
             name: None,
             module_url: "jsr:@std/http/file-server".to_string(),
             args: vec![],
             root: None,
             force: false,
-          }),
-        }),
+          }
+        ),),
         ..Flags::default()
       }
     );
@@ -8621,15 +8612,15 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        subcommand: DenoSubcommand::Install(InstallFlags {
-          kind: InstallKind::Global(InstallFlagsGlobal {
+        subcommand: DenoSubcommand::Install(InstallFlags::Global(
+          InstallFlagsGlobal {
             name: None,
             module_url: "jsr:@std/http/file-server".to_string(),
             args: vec![],
             root: None,
             force: false,
-          }),
-        }),
+          }
+        ),),
         ..Flags::default()
       }
     );
@@ -8642,15 +8633,15 @@ mod tests {
     assert_eq!(
       r.unwrap(),
       Flags {
-        subcommand: DenoSubcommand::Install(InstallFlags {
-          kind: InstallKind::Global(InstallFlagsGlobal {
+        subcommand: DenoSubcommand::Install(InstallFlags::Global(
+          InstallFlagsGlobal {
             name: Some("file_server".to_string()),
             module_url: "jsr:@std/http/file-server".to_string(),
             args: svec!["foo", "bar"],
             root: Some("/foo".to_string()),
             force: true,
-          }),
-        }),
+          }
+        ),),
         import_map_path: Some("import_map.json".to_string()),
         no_remote: true,
         config_flag: ConfigFlag::Path("tsconfig.json".to_owned()),
@@ -11204,9 +11195,9 @@ mod tests {
             ..Flags::default()
           },
           "install" => Flags {
-            subcommand: DenoSubcommand::Install(InstallFlags {
-              kind: InstallKind::Local(InstallFlagsLocal::Add(flags)),
-            }),
+            subcommand: DenoSubcommand::Install(InstallFlags::Local(
+              InstallFlagsLocal::Add(flags),
+            )),
             ..Flags::default()
           },
           _ => unreachable!(),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -595,6 +595,7 @@ pub struct UnstableConfig {
   pub bare_node_builtins: bool,
   pub detect_cjs: bool,
   pub sloppy_imports: bool,
+  pub npm_lazy_caching: bool,
   pub features: Vec<String>, // --unstabe-kv --unstable-cron
 }
 
@@ -4401,6 +4402,15 @@ impl CommandExt for Command {
       })
       .help_heading(UNSTABLE_HEADING)
       .display_order(next_display_order())
+    ).arg(
+      Arg::new("unstable-npm-lazy-caching")
+        .long("unstable-npm-lazy-caching")
+        .help("Enable unstable lazy caching of npm dependencies, downloading them only as needed")
+        .value_parser(FalseyValueParser::new())
+        .action(ArgAction::SetTrue)
+        .hide(true)
+        .help_heading(UNSTABLE_HEADING)
+        .display_order(next_display_order()),
     );
 
     for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS.iter() {
@@ -5987,6 +5997,8 @@ fn unstable_args_parse(
   flags.unstable_config.detect_cjs = matches.get_flag("unstable-detect-cjs");
   flags.unstable_config.sloppy_imports =
     matches.get_flag("unstable-sloppy-imports");
+  flags.unstable_config.npm_lazy_caching =
+    matches.get_flag("unstable-npm-lazy-caching");
 
   if matches!(cfg, UnstableArgsConfig::ResolutionAndRuntime) {
     for granular_flag in crate::UNSTABLE_GRANULAR_FLAGS {

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4406,6 +4406,7 @@ impl CommandExt for Command {
       Arg::new("unstable-npm-lazy-caching")
         .long("unstable-npm-lazy-caching")
         .help("Enable unstable lazy caching of npm dependencies, downloading them only as needed")
+        .env("DENO_UNSTABLE_NPM_LAZY_CACHING")
         .value_parser(FalseyValueParser::new())
         .action(ArgAction::SetTrue)
         .hide(true)

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4405,7 +4405,7 @@ impl CommandExt for Command {
     ).arg(
       Arg::new("unstable-npm-lazy-caching")
         .long("unstable-npm-lazy-caching")
-        .help("Enable unstable lazy caching of npm dependencies, downloading them only as needed")
+        .help("Enable unstable lazy caching of npm dependencies, downloading them only as needed (disabled: all npm packages in package.json are installed on startup; enabled: only npm packages that are actually referenced in an import are installed")
         .env("DENO_UNSTABLE_NPM_LAZY_CACHING")
         .value_parser(FalseyValueParser::new())
         .action(ArgAction::SetTrue)

--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -20,7 +20,6 @@ use crate::Flags;
 
 use crate::args::DenoSubcommand;
 use crate::args::InstallFlags;
-use crate::args::InstallKind;
 
 use deno_lockfile::Lockfile;
 
@@ -136,10 +135,8 @@ impl CliLockfile {
     if flags.no_lock
       || matches!(
         flags.subcommand,
-        DenoSubcommand::Install(InstallFlags {
-          kind: InstallKind::Global(..),
-          ..
-        }) | DenoSubcommand::Uninstall(_)
+        DenoSubcommand::Install(InstallFlags::Global(..))
+          | DenoSubcommand::Uninstall(_)
       )
     {
       return Ok(None);

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1687,6 +1687,7 @@ impl CliOptions {
           "detect-cjs",
           "fmt-component",
           "fmt-sql",
+          "lazy-npm-caching",
         ])
         .collect();
 
@@ -1766,17 +1767,18 @@ impl CliOptions {
     }
   }
 
+  pub fn unstable_npm_lazy_caching(&self) -> bool {
+    self.flags.unstable_config.npm_lazy_caching
+      || self.workspace().has_unstable("npm-lazy-caching")
+  }
+
   pub fn default_npm_caching_strategy(&self) -> NpmCachingStrategy {
     match self.sub_command() {
       DenoSubcommand::Install(InstallFlags::Local(
         InstallFlagsLocal::Entrypoints(_),
       )) => NpmCachingStrategy::Lazy,
       _ => {
-        if self
-          .unstable_features()
-          .iter()
-          .any(|v| v == "lazy-npm-caching")
-        {
+        if self.flags.unstable_config.npm_lazy_caching {
           NpmCachingStrategy::Lazy
         } else {
           NpmCachingStrategy::Eager

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1773,17 +1773,10 @@ impl CliOptions {
   }
 
   pub fn default_npm_caching_strategy(&self) -> NpmCachingStrategy {
-    match self.sub_command() {
-      DenoSubcommand::Install(InstallFlags::Local(
-        InstallFlagsLocal::Entrypoints(_),
-      )) => NpmCachingStrategy::Lazy,
-      _ => {
-        if self.flags.unstable_config.npm_lazy_caching {
-          NpmCachingStrategy::Lazy
-        } else {
-          NpmCachingStrategy::Eager
-        }
-      }
+    if self.flags.unstable_config.npm_lazy_caching {
+      NpmCachingStrategy::Lazy
+    } else {
+      NpmCachingStrategy::Eager
     }
   }
 }

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -970,9 +970,7 @@ impl CliOptions {
     match self.sub_command() {
       DenoSubcommand::Cache(_) => GraphKind::All,
       DenoSubcommand::Check(_) => GraphKind::TypesOnly,
-      DenoSubcommand::Install(InstallFlags {
-        kind: InstallKind::Local(_),
-      }) => GraphKind::All,
+      DenoSubcommand::Install(InstallFlags::Local(_)) => GraphKind::All,
       _ => self.type_check_mode().as_graph_kind(),
     }
   }
@@ -1549,11 +1547,11 @@ impl CliOptions {
         DenoSubcommand::Check(check_flags) => {
           Some(files_to_urls(&check_flags.files))
         }
-        DenoSubcommand::Install(InstallFlags {
-          kind: InstallKind::Global(flags),
-        }) => Url::parse(&flags.module_url)
-          .ok()
-          .map(|url| vec![Cow::Owned(url)]),
+        DenoSubcommand::Install(InstallFlags::Global(flags)) => {
+          Url::parse(&flags.module_url)
+            .ok()
+            .map(|url| vec![Cow::Owned(url)])
+        }
         DenoSubcommand::Doc(DocFlags {
           source_files: DocSourceFileFlag::Paths(paths),
           ..
@@ -1765,6 +1763,25 @@ impl CliOptions {
           | DenoSubcommand::Cache(_)
           | DenoSubcommand::Add(_)
       ),
+    }
+  }
+
+  pub fn default_npm_caching_strategy(&self) -> NpmCachingStrategy {
+    match self.sub_command() {
+      DenoSubcommand::Install(InstallFlags::Local(
+        InstallFlagsLocal::Entrypoints(_),
+      )) => NpmCachingStrategy::Lazy,
+      _ => {
+        if self
+          .unstable_features()
+          .iter()
+          .any(|v| v == "lazy-npm-caching")
+        {
+          NpmCachingStrategy::Lazy
+        } else {
+          NpmCachingStrategy::Eager
+        }
+      }
     }
   }
 }
@@ -1979,6 +1996,13 @@ fn load_env_variables_from_env_file(filename: Option<&Vec<String>>) {
       }
     }
   }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NpmCachingStrategy {
+  Eager,
+  Lazy,
+  Manual,
 }
 
 #[cfg(test)]

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -984,6 +984,7 @@ impl CliFactory {
       cli_options.sub_command().clone(),
       self.create_cli_main_worker_options()?,
       self.cli_options()?.otel_config(),
+      self.cli_options()?.default_npm_caching_strategy(),
     ))
   }
 

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -322,7 +322,7 @@ impl ModuleGraphCreator {
         graph_kind: deno_graph::GraphKind::All,
         roots,
         loader: Some(&mut publish_loader),
-        npm_caching: NpmCachingStrategy::Eager,
+        npm_caching: self.options.default_npm_caching_strategy(),
       })
       .await?;
     self.graph_valid(&graph)?;
@@ -717,8 +717,9 @@ impl ModuleGraphBuilder {
     let parser = self.parsed_source_cache.as_capturing_parser();
     let cli_resolver = &self.resolver;
     let graph_resolver = self.create_graph_resolver()?;
-    let graph_npm_resolver =
-      cli_resolver.create_graph_npm_resolver(NpmCachingStrategy::Eager);
+    let graph_npm_resolver = cli_resolver.create_graph_npm_resolver(
+      self.cli_options.default_npm_caching_strategy(),
+    );
 
     graph.build_fast_check_type_graph(
       deno_graph::BuildFastCheckTypeGraphOptions {

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -4,6 +4,7 @@ use crate::args::config_to_deno_graph_workspace_member;
 use crate::args::jsr_url;
 use crate::args::CliLockfile;
 use crate::args::CliOptions;
+pub use crate::args::NpmCachingStrategy;
 use crate::args::DENO_DISABLE_PEDANTIC_NODE_WARNINGS;
 use crate::cache;
 use crate::cache::FetchCacher;
@@ -218,6 +219,7 @@ pub struct CreateGraphOptions<'a> {
   pub is_dynamic: bool,
   /// Specify `None` to use the default CLI loader.
   pub loader: Option<&'a mut dyn Loader>,
+  pub npm_caching: NpmCachingStrategy,
 }
 
 pub struct ModuleGraphCreator {
@@ -246,10 +248,11 @@ impl ModuleGraphCreator {
     &self,
     graph_kind: GraphKind,
     roots: Vec<ModuleSpecifier>,
+    npm_caching: NpmCachingStrategy,
   ) -> Result<deno_graph::ModuleGraph, AnyError> {
     let mut cache = self.module_graph_builder.create_graph_loader();
     self
-      .create_graph_with_loader(graph_kind, roots, &mut cache)
+      .create_graph_with_loader(graph_kind, roots, &mut cache, npm_caching)
       .await
   }
 
@@ -258,6 +261,7 @@ impl ModuleGraphCreator {
     graph_kind: GraphKind,
     roots: Vec<ModuleSpecifier>,
     loader: &mut dyn Loader,
+    npm_caching: NpmCachingStrategy,
   ) -> Result<ModuleGraph, AnyError> {
     self
       .create_graph_with_options(CreateGraphOptions {
@@ -265,6 +269,7 @@ impl ModuleGraphCreator {
         graph_kind,
         roots,
         loader: Some(loader),
+        npm_caching,
       })
       .await
   }
@@ -317,6 +322,7 @@ impl ModuleGraphCreator {
         graph_kind: deno_graph::GraphKind::All,
         roots,
         loader: Some(&mut publish_loader),
+        npm_caching: NpmCachingStrategy::Eager,
       })
       .await?;
     self.graph_valid(&graph)?;
@@ -376,6 +382,7 @@ impl ModuleGraphCreator {
         graph_kind,
         roots,
         loader: None,
+        npm_caching: self.options.default_npm_caching_strategy(),
       })
       .await?;
 
@@ -565,7 +572,8 @@ impl ModuleGraphBuilder {
     };
     let cli_resolver = &self.resolver;
     let graph_resolver = self.create_graph_resolver()?;
-    let graph_npm_resolver = cli_resolver.create_graph_npm_resolver();
+    let graph_npm_resolver =
+      cli_resolver.create_graph_npm_resolver(options.npm_caching);
     let maybe_file_watcher_reporter = self
       .maybe_file_watcher_reporter
       .as_ref()
@@ -592,6 +600,7 @@ impl ModuleGraphBuilder {
           resolver: Some(&graph_resolver),
           locker: locker.as_mut().map(|l| l as _),
         },
+        options.npm_caching,
       )
       .await
   }
@@ -602,6 +611,7 @@ impl ModuleGraphBuilder {
     roots: Vec<ModuleSpecifier>,
     loader: &'a mut dyn deno_graph::source::Loader,
     options: deno_graph::BuildOptions<'a>,
+    npm_caching: NpmCachingStrategy,
   ) -> Result<(), AnyError> {
     // ensure an "npm install" is done if the user has explicitly
     // opted into using a node_modules directory
@@ -612,7 +622,13 @@ impl ModuleGraphBuilder {
       .unwrap_or(false)
     {
       if let Some(npm_resolver) = self.npm_resolver.as_managed() {
-        npm_resolver.ensure_top_level_package_json_install().await?;
+        let already_done =
+          npm_resolver.ensure_top_level_package_json_install().await?;
+        if !already_done && matches!(npm_caching, NpmCachingStrategy::Eager) {
+          npm_resolver
+            .cache_packages(crate::npm::PackageCaching::All)
+            .await?;
+        }
       }
     }
 
@@ -701,7 +717,8 @@ impl ModuleGraphBuilder {
     let parser = self.parsed_source_cache.as_capturing_parser();
     let cli_resolver = &self.resolver;
     let graph_resolver = self.create_graph_resolver()?;
-    let graph_npm_resolver = cli_resolver.create_graph_npm_resolver();
+    let graph_npm_resolver =
+      cli_resolver.create_graph_npm_resolver(NpmCachingStrategy::Eager);
 
     graph.build_fast_check_type_graph(
       deno_graph::BuildFastCheckTypeGraphOptions {

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -270,7 +270,12 @@ impl LanguageServer {
         open_docs: &open_docs,
       };
       let graph = module_graph_creator
-        .create_graph_with_loader(GraphKind::All, roots.clone(), &mut loader)
+        .create_graph_with_loader(
+          GraphKind::All,
+          roots.clone(),
+          &mut loader,
+          graph_util::NpmCachingStrategy::Eager,
+        )
         .await?;
       graph_util::graph_valid(
         &graph,

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -133,7 +133,8 @@ impl LspScopeResolver {
       cache.for_specifier(config_data.map(|d| d.scope.as_ref())),
       config_data.and_then(|d| d.lockfile.clone()),
     )));
-    let npm_graph_resolver = cli_resolver.create_graph_npm_resolver();
+    let npm_graph_resolver = cli_resolver
+      .create_graph_npm_resolver(crate::graph_util::NpmCachingStrategy::Eager);
     let maybe_jsx_import_source_config =
       config_data.and_then(|d| d.maybe_jsx_import_source_config());
     let graph_imports = config_data
@@ -343,7 +344,9 @@ impl LspResolver {
     file_referrer: Option<&ModuleSpecifier>,
   ) -> WorkerCliNpmGraphResolver {
     let resolver = self.get_scope_resolver(file_referrer);
-    resolver.resolver.create_graph_npm_resolver()
+    resolver
+      .resolver
+      .create_graph_npm_resolver(crate::graph_util::NpmCachingStrategy::Eager)
   }
 
   pub fn as_is_cjs_resolver(

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -156,6 +156,7 @@ impl ModuleLoadPreparer {
           graph_kind: graph.graph_kind(),
           roots: roots.to_vec(),
           loader: Some(&mut cache),
+          npm_caching: self.options.default_npm_caching_strategy(),
         },
       )
       .await?;

--- a/cli/npm/managed/mod.rs
+++ b/cli/npm/managed/mod.rs
@@ -582,8 +582,8 @@ impl ManagedCliNpmResolver {
   /// Ensures that the top level `package.json` dependencies are installed.
   /// This may set up the `node_modules` directory.
   ///
-  /// Returns `true` if any changes (such as caching packages) were made.
-  /// If this returns `false`, `node_modules` has _not_ been set up.
+  /// Returns `true` if the top level packages are already installed. A
+  /// return value of `false` means that new packages were added to the NPM resolution.
   pub async fn ensure_top_level_package_json_install(
     &self,
   ) -> Result<bool, AnyError> {

--- a/cli/npm/managed/mod.rs
+++ b/cli/npm/managed/mod.rs
@@ -614,7 +614,7 @@ impl ManagedCliNpmResolver {
       .iter()
       .map(|pkg| pkg.req.clone())
       .collect::<Vec<_>>();
-    let _ = self.add_package_reqs_no_cache(&pkg_reqs).await?;
+    self.add_package_reqs_no_cache(&pkg_reqs).await?;
 
     Ok(false)
   }

--- a/cli/npm/managed/mod.rs
+++ b/cli/npm/managed/mod.rs
@@ -588,12 +588,12 @@ impl ManagedCliNpmResolver {
     &self,
   ) -> Result<bool, AnyError> {
     if !self.top_level_install_flag.raise() {
-      return Ok(false); // already did this
+      return Ok(true); // already did this
     }
 
     let pkg_json_remote_pkgs = self.npm_install_deps_provider.remote_pkgs();
     if pkg_json_remote_pkgs.is_empty() {
-      return Ok(false);
+      return Ok(true);
     }
 
     // check if something needs resolving before bothering to load all
@@ -607,7 +607,7 @@ impl ManagedCliNpmResolver {
       log::debug!(
         "All package.json deps resolvable. Skipping top level install."
       );
-      return Ok(false); // everything is already resolvable
+      return Ok(true); // everything is already resolvable
     }
 
     let pkg_reqs = pkg_json_remote_pkgs

--- a/cli/npm/managed/mod.rs
+++ b/cli/npm/managed/mod.rs
@@ -296,6 +296,12 @@ pub fn create_managed_in_npm_pkg_checker(
   Arc::new(ManagedInNpmPackageChecker { root_dir })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageCaching<'a> {
+  Only(Cow<'a, [PackageReq]>),
+  All,
+}
+
 /// An npm resolver where the resolution is managed by Deno rather than
 /// the user bringing their own node_modules (BYONM) on the file system.
 pub struct ManagedCliNpmResolver {
@@ -420,19 +426,44 @@ impl ManagedCliNpmResolver {
 
   /// Adds package requirements to the resolver and ensures everything is setup.
   /// This includes setting up the `node_modules` directory, if applicable.
-  pub async fn add_package_reqs(
+  pub async fn add_and_cache_package_reqs(
     &self,
     packages: &[PackageReq],
   ) -> Result<(), AnyError> {
     self
-      .add_package_reqs_raw(packages)
+      .add_package_reqs_raw(
+        packages,
+        Some(PackageCaching::Only(packages.into())),
+      )
       .await
       .dependencies_result
   }
 
-  pub async fn add_package_reqs_raw(
+  pub async fn add_package_reqs_no_cache(
     &self,
     packages: &[PackageReq],
+  ) -> Result<(), AnyError> {
+    self
+      .add_package_reqs_raw(packages, None)
+      .await
+      .dependencies_result
+  }
+
+  pub async fn add_package_reqs(
+    &self,
+    packages: &[PackageReq],
+    caching: PackageCaching<'_>,
+  ) -> Result<(), AnyError> {
+    self
+      .add_package_reqs_raw(packages, Some(caching))
+      .await
+      .dependencies_result
+  }
+
+  pub async fn add_package_reqs_raw<'a>(
+    &self,
+    packages: &[PackageReq],
+    caching: Option<PackageCaching<'a>>,
   ) -> AddPkgReqsResult {
     if packages.is_empty() {
       return AddPkgReqsResult {
@@ -449,7 +480,9 @@ impl ManagedCliNpmResolver {
       }
     }
     if result.dependencies_result.is_ok() {
-      result.dependencies_result = self.cache_packages().await;
+      if let Some(caching) = caching {
+        result.dependencies_result = self.cache_packages(caching).await;
+      }
     }
 
     result
@@ -491,16 +524,20 @@ impl ManagedCliNpmResolver {
   pub async fn inject_synthetic_types_node_package(
     &self,
   ) -> Result<(), AnyError> {
+    let reqs = &[PackageReq::from_str("@types/node").unwrap()];
     // add and ensure this isn't added to the lockfile
     self
-      .add_package_reqs(&[PackageReq::from_str("@types/node").unwrap()])
+      .add_package_reqs(reqs, PackageCaching::Only(reqs.into()))
       .await?;
 
     Ok(())
   }
 
-  pub async fn cache_packages(&self) -> Result<(), AnyError> {
-    self.fs_resolver.cache_packages().await
+  pub async fn cache_packages(
+    &self,
+    caching: PackageCaching<'_>,
+  ) -> Result<(), AnyError> {
+    self.fs_resolver.cache_packages(caching).await
   }
 
   pub fn resolve_pkg_folder_from_deno_module(
@@ -577,7 +614,9 @@ impl ManagedCliNpmResolver {
       .iter()
       .map(|pkg| pkg.req.clone())
       .collect::<Vec<_>>();
-    self.add_package_reqs(&pkg_reqs).await.map(|_| true)
+    let _ = self.add_package_reqs_no_cache(&pkg_reqs).await;
+
+    Ok(false)
   }
 
   pub async fn cache_package_info(

--- a/cli/npm/managed/mod.rs
+++ b/cli/npm/managed/mod.rs
@@ -614,7 +614,7 @@ impl ManagedCliNpmResolver {
       .iter()
       .map(|pkg| pkg.req.clone())
       .collect::<Vec<_>>();
-    let _ = self.add_package_reqs_no_cache(&pkg_reqs).await;
+    let _ = self.add_package_reqs_no_cache(&pkg_reqs).await?;
 
     Ok(false)
   }

--- a/cli/npm/managed/resolution.rs
+++ b/cli/npm/managed/resolution.rs
@@ -255,6 +255,10 @@ impl NpmResolution {
       .read()
       .as_valid_serialized_for_system(system_info)
   }
+
+  pub fn subset(&self, package_reqs: &[PackageReq]) -> NpmResolutionSnapshot {
+    self.snapshot.read().subset(package_reqs)
+  }
 }
 
 async fn add_package_reqs_to_snapshot(

--- a/cli/npm/managed/resolvers/common.rs
+++ b/cli/npm/managed/resolvers/common.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use super::super::PackageCaching;
 use async_trait::async_trait;
 use deno_ast::ModuleSpecifier;
 use deno_core::anyhow::Context;
@@ -57,7 +58,10 @@ pub trait NpmPackageFsResolver: Send + Sync {
     specifier: &ModuleSpecifier,
   ) -> Result<Option<NpmPackageCacheFolderId>, AnyError>;
 
-  async fn cache_packages(&self) -> Result<(), AnyError>;
+  async fn cache_packages<'a>(
+    &self,
+    caching: PackageCaching<'a>,
+  ) -> Result<(), AnyError>;
 
   #[must_use = "the resolved return value to mitigate time-of-check to time-of-use issues"]
   fn ensure_read_permission<'a>(

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -41,6 +41,7 @@ pub use self::managed::CliManagedInNpmPkgCheckerCreateOptions;
 pub use self::managed::CliManagedNpmResolverCreateOptions;
 pub use self::managed::CliNpmResolverManagedSnapshotOption;
 pub use self::managed::ManagedCliNpmResolver;
+pub use self::managed::PackageCaching;
 
 pub type CliNpmTarballCache = deno_npm_cache::TarballCache<CliNpmCacheEnv>;
 pub type CliNpmCache = deno_npm_cache::NpmCache<CliNpmCacheEnv>;

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -373,7 +373,12 @@ impl<'a> deno_graph::source::NpmResolver for WorkerCliNpmGraphResolver<'a> {
           Ok(())
         };
 
-        let result = npm_resolver.add_package_reqs_raw(package_reqs).await;
+        let result = npm_resolver
+          .add_package_reqs_raw(
+            package_reqs,
+            Some(crate::npm::PackageCaching::Only(package_reqs.into())),
+          )
+          .await;
 
         NpmResolvePkgReqsResult {
           results: result

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -32,6 +32,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use thiserror::Error;
 
+use crate::args::NpmCachingStrategy;
 use crate::args::DENO_DISABLE_PEDANTIC_NODE_WARNINGS;
 use crate::node::CliNodeCodeTranslator;
 use crate::npm::CliNpmResolver;
@@ -240,11 +241,15 @@ impl CliResolver {
 
   // todo(dsherret): move this off CliResolver as CliResolver is acting
   // like a factory by doing this (it's beyond its responsibility)
-  pub fn create_graph_npm_resolver(&self) -> WorkerCliNpmGraphResolver {
+  pub fn create_graph_npm_resolver(
+    &self,
+    npm_caching: NpmCachingStrategy,
+  ) -> WorkerCliNpmGraphResolver {
     WorkerCliNpmGraphResolver {
       npm_resolver: self.npm_resolver.as_ref(),
       found_package_json_dep_flag: &self.found_package_json_dep_flag,
       bare_node_builtins_enabled: self.bare_node_builtins_enabled,
+      npm_caching,
     }
   }
 
@@ -304,6 +309,7 @@ pub struct WorkerCliNpmGraphResolver<'a> {
   npm_resolver: Option<&'a Arc<dyn CliNpmResolver>>,
   found_package_json_dep_flag: &'a AtomicFlag,
   bare_node_builtins_enabled: bool,
+  npm_caching: NpmCachingStrategy,
 }
 
 #[async_trait(?Send)]
@@ -376,7 +382,15 @@ impl<'a> deno_graph::source::NpmResolver for WorkerCliNpmGraphResolver<'a> {
         let result = npm_resolver
           .add_package_reqs_raw(
             package_reqs,
-            Some(crate::npm::PackageCaching::Only(package_reqs.into())),
+            match self.npm_caching {
+              NpmCachingStrategy::Eager => {
+                Some(crate::npm::PackageCaching::All)
+              }
+              NpmCachingStrategy::Lazy => {
+                Some(crate::npm::PackageCaching::Only(package_reqs.into()))
+              }
+              NpmCachingStrategy::Manual => None,
+            },
           )
           .await;
 

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -779,6 +779,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
         detect_cjs: self.cli_options.unstable_detect_cjs(),
         sloppy_imports: self.cli_options.unstable_sloppy_imports(),
         features: self.cli_options.unstable_features(),
+        npm_lazy_caching: self.cli_options.unstable_npm_lazy_caching(),
       },
       otel_config: self.cli_options.otel_config(),
     };

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -924,6 +924,7 @@ pub async fn run(data: StandaloneData) -> Result<i32, AnyError> {
       serve_host: None,
     },
     metadata.otel_config,
+    crate::args::NpmCachingStrategy::Lazy,
   );
 
   // Initialize v8 once from the main thread.

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -538,7 +538,11 @@ pub async fn run_benchmarks_with_watch(
         )?;
 
         let graph = module_graph_creator
-          .create_graph(graph_kind, collected_bench_modules.clone())
+          .create_graph(
+            graph_kind,
+            collected_bench_modules.clone(),
+            crate::graph_util::NpmCachingStrategy::Eager,
+          )
           .await?;
         module_graph_creator.graph_valid(&graph)?;
         let bench_modules = &graph.roots;

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -69,7 +69,11 @@ pub async fn compile(
     // create a module graph with types information in it. We don't want to
     // store that in the binary so create a code only module graph from scratch.
     module_graph_creator
-      .create_graph(GraphKind::CodeOnly, module_roots)
+      .create_graph(
+        GraphKind::CodeOnly,
+        module_roots,
+        crate::graph_util::NpmCachingStrategy::Eager,
+      )
       .await?
   } else {
     graph

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -131,7 +131,11 @@ pub async fn doc(
         |_| true,
       )?;
       let graph = module_graph_creator
-        .create_graph(GraphKind::TypesOnly, module_specifiers.clone())
+        .create_graph(
+          GraphKind::TypesOnly,
+          module_specifiers.clone(),
+          crate::graph_util::NpmCachingStrategy::Eager,
+        )
         .await?;
 
       graph_exit_integrity_errors(&graph);

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -123,7 +123,12 @@ pub async fn info(
     let mut loader = module_graph_builder.create_graph_loader();
     loader.enable_loading_cache_info(); // for displaying the cache information
     let graph = module_graph_creator
-      .create_graph_with_loader(GraphKind::All, vec![specifier], &mut loader)
+      .create_graph_with_loader(
+        GraphKind::All,
+        vec![specifier],
+        &mut loader,
+        crate::graph_util::NpmCachingStrategy::Eager,
+      )
       .await?;
 
     // write out the lockfile if there is one

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -9,7 +9,6 @@ use crate::args::Flags;
 use crate::args::InstallFlags;
 use crate::args::InstallFlagsGlobal;
 use crate::args::InstallFlagsLocal;
-use crate::args::InstallKind;
 use crate::args::TypeCheckMode;
 use crate::args::UninstallFlags;
 use crate::args::UninstallKind;
@@ -339,11 +338,11 @@ pub async fn install_command(
   flags: Arc<Flags>,
   install_flags: InstallFlags,
 ) -> Result<(), AnyError> {
-  match install_flags.kind {
-    InstallKind::Global(global_flags) => {
+  match install_flags {
+    InstallFlags::Global(global_flags) => {
       install_global(flags, global_flags).await
     }
-    InstallKind::Local(local_flags) => {
+    InstallFlags::Local(local_flags) => {
       if let InstallFlagsLocal::Add(add_flags) = &local_flags {
         check_if_installs_a_single_package_globally(Some(add_flags))?;
       }

--- a/cli/tools/registry/pm/cache_deps.rs
+++ b/cli/tools/registry/pm/cache_deps.rs
@@ -25,7 +25,9 @@ pub async fn cache_top_level_deps(
         lockfile.error_if_changed()?;
       }
 
-      npm_resolver.cache_packages().await?;
+      npm_resolver
+        .cache_packages(crate::npm::PackageCaching::All)
+        .await?;
     }
   }
   // cache as many entries in the import map as we can

--- a/cli/tools/registry/pm/cache_deps.rs
+++ b/cli/tools/registry/pm/cache_deps.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::factory::CliFactory;
 use crate::graph_container::ModuleGraphContainer;
 use crate::graph_container::ModuleGraphUpdatePermit;
+use crate::graph_util::CreateGraphOptions;
 use deno_core::error::AnyError;
 use deno_core::futures::stream::FuturesUnordered;
 use deno_core::futures::StreamExt;
@@ -18,20 +19,16 @@ pub async fn cache_top_level_deps(
 ) -> Result<(), AnyError> {
   let npm_resolver = factory.npm_resolver().await?;
   let cli_options = factory.cli_options()?;
-  let root_permissions = factory.root_permissions_container()?;
   if let Some(npm_resolver) = npm_resolver.as_managed() {
-    if !npm_resolver.ensure_top_level_package_json_install().await? {
-      if let Some(lockfile) = cli_options.maybe_lockfile() {
-        lockfile.error_if_changed()?;
-      }
-
-      npm_resolver
-        .cache_packages(crate::npm::PackageCaching::All)
-        .await?;
+    npm_resolver.ensure_top_level_package_json_install().await?;
+    if let Some(lockfile) = cli_options.maybe_lockfile() {
+      lockfile.error_if_changed()?;
     }
   }
   // cache as many entries in the import map as we can
   let resolver = factory.workspace_resolver().await?;
+
+  let mut maybe_graph_error = Ok(());
   if let Some(import_map) = resolver.maybe_import_map() {
     let jsr_resolver = if let Some(resolver) = jsr_resolver {
       resolver
@@ -124,19 +121,29 @@ pub async fn cache_top_level_deps(
     }
     drop(info_futures);
 
-    factory
-      .module_load_preparer()
-      .await?
-      .prepare_module_load(
+    let graph_builder = factory.module_graph_builder().await?;
+    graph_builder
+      .build_graph_with_npm_resolution(
         graph,
-        &roots,
-        false,
-        deno_config::deno_json::TsTypeLib::DenoWorker,
-        root_permissions.clone(),
-        None,
+        CreateGraphOptions {
+          loader: None,
+          graph_kind: graph.graph_kind(),
+          is_dynamic: false,
+          roots: roots.clone(),
+          npm_caching: crate::graph_util::NpmCachingStrategy::Manual,
+        },
       )
       .await?;
+    maybe_graph_error = graph_builder.graph_roots_valid(graph, &roots);
   }
+
+  if let Some(npm_resolver) = npm_resolver.as_managed() {
+    npm_resolver
+      .cache_packages(crate::npm::PackageCaching::All)
+      .await?;
+  }
+
+  maybe_graph_error?;
 
   Ok(())
 }

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -727,7 +727,9 @@ impl ReplSession {
     let has_node_specifier =
       resolved_imports.iter().any(|url| url.scheme() == "node");
     if !npm_imports.is_empty() || has_node_specifier {
-      npm_resolver.add_package_reqs(&npm_imports).await?;
+      npm_resolver
+        .add_and_cache_package_reqs(&npm_imports)
+        .await?;
 
       // prevent messages in the repl about @types/node not being cached
       if has_node_specifier {

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1716,7 +1716,11 @@ pub async fn run_tests_with_watch(
           &cli_options.permissions_options(),
         )?;
         let graph = module_graph_creator
-          .create_graph(graph_kind, test_modules)
+          .create_graph(
+            graph_kind,
+            test_modules,
+            crate::graph_util::NpmCachingStrategy::Eager,
+          )
           .await?;
         module_graph_creator.graph_valid(&graph)?;
         let test_modules = &graph.roots;

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -504,7 +504,7 @@ impl CliMainWorkerFactory {
               crate::npm::PackageCaching::All
             },
           )
-          .await?;  
+          .await?;
       }
 
       // use a fake referrer that can be used to discover the package.json if necessary

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -487,8 +487,9 @@ impl CliMainWorkerFactory {
       NpmPackageReqReference::from_specifier(&main_module)
     {
       if let Some(npm_resolver) = shared.npm_resolver.as_managed() {
+        let reqs = &[package_ref.req().clone()];
         npm_resolver
-          .add_package_reqs(&[package_ref.req().clone()])
+          .add_package_reqs(reqs, crate::npm::PackageCaching::Only(reqs.into()))
           .await?;
       }
 

--- a/tests/specs/install/entrypoint_only_used_packages/__test__.jsonc
+++ b/tests/specs/install/entrypoint_only_used_packages/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install --entrypoint main.ts",
+      "output": "install-entrypoint.out"
+    },
+    {
+      "args": "install",
+      "output": "install.out"
+    }
+  ]
+}

--- a/tests/specs/install/entrypoint_only_used_packages/__test__.jsonc
+++ b/tests/specs/install/entrypoint_only_used_packages/__test__.jsonc
@@ -2,7 +2,7 @@
   "tempDir": true,
   "steps": [
     {
-      "args": "install --entrypoint main.ts",
+      "args": "install --unstable-npm-lazy-caching --entrypoint main.ts",
       "output": "install-entrypoint.out"
     },
     {

--- a/tests/specs/install/entrypoint_only_used_packages/install-entrypoint.out
+++ b/tests/specs/install/entrypoint_only_used_packages/install-entrypoint.out
@@ -1,0 +1,6 @@
+[UNORDERED_START]
+Download http://localhost:4260/@denotest%2fadd
+Download http://localhost:4260/@denotest%2fsay-hello
+Download http://localhost:4260/@denotest/add/1.0.0.tgz
+[UNORDERED_END]
+Initialize @denotest/add@1.0.0

--- a/tests/specs/install/entrypoint_only_used_packages/install.out
+++ b/tests/specs/install/entrypoint_only_used_packages/install.out
@@ -1,0 +1,2 @@
+Download http://localhost:4260/@denotest/say-hello/1.0.0.tgz
+Initialize @denotest/say-hello@1.0.0

--- a/tests/specs/install/entrypoint_only_used_packages/main.ts
+++ b/tests/specs/install/entrypoint_only_used_packages/main.ts
@@ -1,0 +1,3 @@
+import { add } from "@denotest/add";
+
+console.log(add(1, 2));

--- a/tests/specs/install/entrypoint_only_used_packages/package.json
+++ b/tests/specs/install/entrypoint_only_used_packages/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@denotest/add": "1.0.0",
+    "@denotest/say-hello": "1.0.0"
+  }
+}

--- a/tests/specs/run/jsx_import_source/__test__.jsonc
+++ b/tests/specs/run/jsx_import_source/__test__.jsonc
@@ -1,4 +1,5 @@
 {
+  "tempDir": true,
   "tests": {
     "jsx_import_source_error": {
       "args": "run --config jsx/deno-jsx-error.jsonc --check jsx_import_source_no_pragma.tsx",

--- a/tests/specs/run/lazy_npm/__test__.jsonc
+++ b/tests/specs/run/lazy_npm/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "run --unstable-npm-lazy-caching -A main.ts",
+      "output": "main.out"
+    }
+  ]
+}

--- a/tests/specs/run/lazy_npm/deno.json
+++ b/tests/specs/run/lazy_npm/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}

--- a/tests/specs/run/lazy_npm/main.out
+++ b/tests/specs/run/lazy_npm/main.out
@@ -1,0 +1,7 @@
+[UNORDERED_START]
+Download http://localhost:4260/@denotest%2fadd
+Download http://localhost:4260/@denotest%2fsay-hello
+Download http://localhost:4260/@denotest/add/1.0.0.tgz
+[UNORDERED_END]
+Initialize @denotest/add@1.0.0
+3

--- a/tests/specs/run/lazy_npm/main.ts
+++ b/tests/specs/run/lazy_npm/main.ts
@@ -1,0 +1,3 @@
+import { add } from "@denotest/add";
+
+console.log(add(1, 2));

--- a/tests/specs/run/lazy_npm/package.json
+++ b/tests/specs/run/lazy_npm/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@denotest/add": "1.0.0",
+    "@denotest/say-hello": "1.0.0"
+  }
+}


### PR DESCRIPTION
Currently deno eagerly caches all npm packages in the workspace's npm resolution. So, for instance, running a file `foo.ts` that imports `npm:chalk` will also install all dependencies listed in `package.json` and all `npm` dependencies listed in the lockfile.

This PR refactors things to give more control over when and what npm packages are automatically cached while building the module graph.

After this PR, by default the current behavior is unchanged _except_ for `deno install --entrypoint`, which will only cache npm packages used by the given entrypoint. For the other subcommands, this behavior can be enabled with `--unstable-npm-lazy-caching`


TODO:
- bikeshed the unstable flag name
- add some more tests?

Fixes #25782.
