### PR TITLE
chore(lint): update to the new deno_lint API

### DIFF
--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -463,7 +463,7 @@ pub fn print_rules_list(json: bool, maybe_rules_tags: Option<Vec<String>>) {
         .map(|rule| {
           serde_json::json!({
             "code": rule.code(),
-            "tags": rule.tags(),
+            "tags": rule.tags().iter().map(|t| t.to_string()).collect::<Vec<String>>(),
             "docs": rule.docs(),
           })
         })
@@ -479,7 +479,9 @@ pub fn print_rules_list(json: bool, maybe_rules_tags: Option<Vec<String>>) {
       if rule.tags().is_empty() {
         println!();
       } else {
-        println!(" [{}]", colors::gray(rule.tags().join(", ")))
+        let tags: Vec<String> =
+          rule.tags().iter().map(ToString::to_string).collect();
+        println!(" [{}]", colors::gray(tags.join(", ")));
       }
       println!(
         "{}",

--- a/cli/tools/lint/rules/mod.rs
+++ b/cli/tools/lint/rules/mod.rs
@@ -13,6 +13,7 @@ use deno_core::error::AnyError;
 use deno_graph::ModuleGraph;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::rules::LintRule;
+use deno_lint::tags;
 
 use crate::resolver::CliSloppyImportsResolver;
 
@@ -25,7 +26,7 @@ pub use no_slow_types::collect_no_slow_type_diagnostics;
 pub trait PackageLintRule: std::fmt::Debug + Send + Sync {
   fn code(&self) -> &'static str;
 
-  fn tags(&self) -> &'static [&'static str] {
+  fn tags(&self) -> tags::Tags {
     &[]
   }
 
@@ -74,7 +75,7 @@ impl CliLintRule {
     }
   }
 
-  pub fn tags(&self) -> &'static [&'static str] {
+  pub fn tags(&self) -> tags::Tags {
     use CliLintRuleKind::*;
     match &self.0 {
       DenoLint(rule) => rule.tags(),

--- a/cli/tools/lint/rules/no_sloppy_imports.rs
+++ b/cli/tools/lint/rules/no_sloppy_imports.rs
@@ -16,6 +16,7 @@ use deno_lint::diagnostic::LintDiagnosticRange;
 use deno_lint::diagnostic::LintFix;
 use deno_lint::diagnostic::LintFixChange;
 use deno_lint::rules::LintRule;
+use deno_lint::tags;
 use deno_resolver::sloppy_imports::SloppyImportsResolution;
 use deno_resolver::sloppy_imports::SloppyImportsResolutionKind;
 use text_lines::LineAndColumnIndex;
@@ -166,8 +167,8 @@ impl LintRule for NoSloppyImportsRule {
     include_str!("no_sloppy_imports.md")
   }
 
-  fn tags(&self) -> &'static [&'static str] {
-    &["recommended"]
+  fn tags(&self) -> tags::Tags {
+    &[tags::RECOMMENDED]
   }
 }
 

--- a/cli/tools/lint/rules/no_slow_types.rs
+++ b/cli/tools/lint/rules/no_slow_types.rs
@@ -9,6 +9,7 @@ use deno_graph::ModuleGraph;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::diagnostic::LintDiagnosticDetails;
 use deno_lint::diagnostic::LintDiagnosticRange;
+use deno_lint::tags;
 
 use super::PackageLintRule;
 
@@ -22,8 +23,8 @@ impl PackageLintRule for NoSlowTypesRule {
     CODE
   }
 
-  fn tags(&self) -> &'static [&'static str] {
-    &["jsr"]
+  fn tags(&self) -> tags::Tags {
+    &[tags::JSR]
   }
 
   fn docs(&self) -> &'static str {


### PR DESCRIPTION
Tags were made strongly type in [1], however this broke the CLI as tags were being referenced as `&'static [&'static str]`. This change-set updates the CLI to use the new API.

[1] https://github.com/denoland/deno_lint/commit/3184b4012dfc8bbbc7ac57f846985832e0e779e2

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
