### PR TITLE
refactor(unstable): otel configuration

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -37,6 +37,7 @@ use deno_path_util::url_to_file_path;
 use deno_runtime::deno_permissions::PermissionsOptions;
 use deno_runtime::deno_permissions::SysDescriptor;
 use deno_telemetry::OtelConfig;
+use deno_telemetry::OtelConsoleConfig;
 use log::debug;
 use log::Level;
 use serde::Deserialize;
@@ -986,21 +987,41 @@ impl Flags {
     args
   }
 
-  pub fn otel_config(&self) -> Option<OtelConfig> {
-    if self
+  pub fn otel_config(&self) -> OtelConfig {
+    let has_unstable_flag = self
       .unstable_config
       .features
-      .contains(&String::from("otel"))
-    {
-      Some(OtelConfig {
-        runtime_name: Cow::Borrowed("deno"),
-        runtime_version: Cow::Borrowed(crate::version::DENO_VERSION_INFO.deno),
-        deterministic: std::env::var("DENO_UNSTABLE_OTEL_DETERMINISTIC")
-          .is_ok(),
-        ..Default::default()
-      })
-    } else {
-      None
+      .contains(&String::from("otel"));
+
+    let otel_var = |name| match std::env::var(name) {
+      Ok(s) if s.to_lowercase() == "true" => Some(true),
+      Ok(s) if s.to_lowercase() == "false" => Some(false),
+      _ => None,
+    };
+
+    let disabled =
+      !has_unstable_flag || otel_var("OTEL_SDK_DISABLED").unwrap_or(false);
+    let default = !disabled && otel_var("OTEL_DENO").unwrap_or(false);
+
+    OtelConfig {
+      tracing_enabled: !disabled
+        && otel_var("OTEL_DENO_TRACING").unwrap_or(default),
+      console: match std::env::var("OTEL_DENO_CONSOLE").as_deref() {
+        Ok(_) if disabled => OtelConsoleConfig::Ignore,
+        Ok("ignore") => OtelConsoleConfig::Ignore,
+        Ok("capture") => OtelConsoleConfig::Capture,
+        Ok("replace") => OtelConsoleConfig::Replace,
+        _ => {
+          if default {
+            OtelConsoleConfig::Capture
+          } else {
+            OtelConsoleConfig::Ignore
+          }
+        }
+      },
+      deterministic: std::env::var("DENO_UNSTABLE_OTEL_DETERMINISTIC")
+        .as_deref()
+        == Ok("1"),
     }
   }
 

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -31,6 +31,7 @@ use deno_npm_cache::NpmCacheSetting;
 use deno_path_util::normalize_path;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_telemetry::OtelConfig;
+use deno_telemetry::OtelRuntimeConfig;
 use import_map::resolve_import_map_value_from_specifier;
 
 pub use deno_config::deno_json::BenchConfig;
@@ -1130,7 +1131,7 @@ impl CliOptions {
     }
   }
 
-  pub fn otel_config(&self) -> Option<OtelConfig> {
+  pub fn otel_config(&self) -> OtelConfig {
     self.flags.otel_config()
   }
 
@@ -1998,6 +1999,13 @@ pub enum NpmCachingStrategy {
   Eager,
   Lazy,
   Manual,
+}
+
+pub(crate) fn otel_runtime_config() -> OtelRuntimeConfig {
+  OtelRuntimeConfig {
+    runtime_name: Cow::Borrowed("deno"),
+    runtime_version: Cow::Borrowed(crate::version::DENO_VERSION_INFO.deno),
+  }
 }
 
 #[cfg(test)]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -437,18 +437,18 @@ fn resolve_flags_and_init(
       if err.kind() == clap::error::ErrorKind::DisplayVersion =>
     {
       // Ignore results to avoid BrokenPipe errors.
-      util::logger::init(None);
+      util::logger::init(None, None);
       let _ = err.print();
       deno_runtime::exit(0);
     }
     Err(err) => {
-      util::logger::init(None);
+      util::logger::init(None, None);
       exit_for_error(AnyError::from(err))
     }
   };
 
   deno_telemetry::init(crate::args::otel_runtime_config())?;
-  util::logger::init(flags.log_level);
+  util::logger::init(flags.log_level, Some(flags.otel_config()));
 
   // TODO(bartlomieju): remove in Deno v2.5 and hard error then.
   if flags.unstable_config.legacy_flag_enabled {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -447,9 +447,7 @@ fn resolve_flags_and_init(
     }
   };
 
-  if let Some(otel_config) = flags.otel_config() {
-    deno_telemetry::init(otel_config)?;
-  }
+  deno_telemetry::init(crate::args::otel_runtime_config())?;
   util::logger::init(flags.log_level);
 
   // TODO(bartlomieju): remove in Deno v2.5 and hard error then.

--- a/cli/mainrt.rs
+++ b/cli/mainrt.rs
@@ -88,14 +88,17 @@ fn main() {
     match standalone {
       Ok(Some(data)) => {
         deno_telemetry::init(crate::args::otel_runtime_config())?;
-        util::logger::init(data.metadata.log_level);
+        util::logger::init(
+          data.metadata.log_level,
+          Some(data.metadata.otel_config.clone()),
+        );
         load_env_vars(&data.metadata.env_vars_from_env_file);
         let exit_code = standalone::run(data).await?;
         deno_runtime::exit(exit_code);
       }
       Ok(None) => Ok(()),
       Err(err) => {
-        util::logger::init(None);
+        util::logger::init(None, None);
         Err(err)
       }
     }

--- a/cli/mainrt.rs
+++ b/cli/mainrt.rs
@@ -87,9 +87,7 @@ fn main() {
   let future = async move {
     match standalone {
       Ok(Some(data)) => {
-        if let Some(otel_config) = data.metadata.otel_config.clone() {
-          deno_telemetry::init(otel_config)?;
-        }
+        deno_telemetry::init(crate::args::otel_runtime_config())?;
         util::logger::init(data.metadata.log_level);
         load_env_vars(&data.metadata.env_vars_from_env_file);
         let exit_code = standalone::run(data).await?;

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -191,7 +191,7 @@ pub struct Metadata {
   pub entrypoint_key: String,
   pub node_modules: Option<NodeModules>,
   pub unstable_config: UnstableConfig,
-  pub otel_config: Option<OtelConfig>, // None means disabled.
+  pub otel_config: OtelConfig,
 }
 
 fn write_binary_bytes(

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -154,7 +154,7 @@ struct SharedWorkerState {
   storage_key_resolver: StorageKeyResolver,
   options: CliMainWorkerOptions,
   subcommand: DenoSubcommand,
-  otel_config: Option<OtelConfig>, // `None` means OpenTelemetry is disabled.
+  otel_config: OtelConfig,
   default_npm_caching_strategy: NpmCachingStrategy,
 }
 
@@ -426,7 +426,7 @@ impl CliMainWorkerFactory {
     storage_key_resolver: StorageKeyResolver,
     subcommand: DenoSubcommand,
     options: CliMainWorkerOptions,
-    otel_config: Option<OtelConfig>,
+    otel_config: OtelConfig,
     default_npm_caching_strategy: NpmCachingStrategy,
   ) -> Self {
     Self {

--- a/ext/telemetry/telemetry.ts
+++ b/ext/telemetry/telemetry.ts
@@ -950,15 +950,15 @@ const otelConsoleConfig = {
 };
 
 export function bootstrap(
-  config: [] | [
+  config: [
+    0 | 1,
     typeof otelConsoleConfig[keyof typeof otelConsoleConfig],
-    number,
+    0 | 1,
   ],
 ): void {
-  if (config.length === 0) return;
-  const { 0: consoleConfig, 1: deterministic } = config;
+  const { 0: tracingEnabled, 1: consoleConfig, 2: deterministic } = config;
 
-  TRACING_ENABLED = true;
+  TRACING_ENABLED = tracingEnabled === 1;
   DETERMINISTIC = deterministic === 1;
 
   switch (consoleConfig) {

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -119,8 +119,7 @@ pub struct BootstrapOptions {
   // Used by `deno serve`
   pub serve_port: Option<u16>,
   pub serve_host: Option<String>,
-  // OpenTelemetry output options. If `None`, OpenTelemetry is disabled.
-  pub otel_config: Option<OtelConfig>,
+  pub otel_config: OtelConfig,
 }
 
 impl Default for BootstrapOptions {
@@ -155,7 +154,7 @@ impl Default for BootstrapOptions {
       mode: WorkerExecutionMode::None,
       serve_port: Default::default(),
       serve_host: Default::default(),
-      otel_config: None,
+      otel_config: Default::default(),
     }
   }
 }
@@ -225,11 +224,7 @@ impl BootstrapOptions {
       self.serve_host.as_deref(),
       serve_is_main,
       serve_worker_count,
-      if let Some(otel_config) = self.otel_config.as_ref() {
-        Box::new([otel_config.console as u8, otel_config.deterministic as u8])
-      } else {
-        Box::new([])
-      },
+      self.otel_config.as_v8(),
     );
 
     bootstrap.serialize(ser).unwrap()

--- a/tests/specs/cli/otel_basic/main.ts
+++ b/tests/specs/cli/otel_basic/main.ts
@@ -13,6 +13,7 @@ const server = Deno.serve(
       const command = new Deno.Command(Deno.execPath(), {
         args: ["run", "-A", "-q", "--unstable-otel", Deno.args[0]],
         env: {
+          OTEL_DENO: "true",
           DENO_UNSTABLE_OTEL_DETERMINISTIC: "1",
           OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
           OTEL_EXPORTER_OTLP_ENDPOINT: `http://localhost:${port}`,


### PR DESCRIPTION
split up otel config into user configurable and runtime configurable parts. user configurable part is now set via env vars parsed according to the otel spec. otel is now enabled via `OTEL_DENO=true`, and `--unstable-otel` only acts as a guard.

Fixes: https://github.com/denoland/deno/issues/27273