### PR TITLE
ci: restore cargo home cache before rust install

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -491,8 +491,12 @@ const ci = {
             // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
             // Note that with the new sparse registry format, we no longer have to cache a `.git` dir
             path: [
+              "~/.cargo/.crates.toml",
+              "~/.cargo/.crates2.json",
+              "~/.cargo/bin",
               "~/.cargo/registry/index",
               "~/.cargo/registry/cache",
+              "~/.cargo/git/db",
             ].join("\n"),
             key:
               `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}-\${{ hashFiles('Cargo.lock') }}`,

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -484,6 +484,23 @@ const ci = {
             "    -czvf target/release/deno_src.tar.gz -C .. deno",
           ].join("\n"),
         },
+        {
+          name: "Cache Cargo home",
+          uses: "actions/cache@v4",
+          with: {
+            // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+            // Note that with the new sparse registry format, we no longer have to cache a `.git` dir
+            path: [
+              "~/.cargo/registry/index",
+              "~/.cargo/registry/cache",
+            ].join("\n"),
+            key:
+              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}-\${{ hashFiles('Cargo.lock') }}`,
+            // We will try to restore from the closest cargo-home we can find
+            "restore-keys":
+              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}-`,
+          },
+        },
         installRustStep,
         {
           if:
@@ -606,23 +623,6 @@ const ci = {
           run: [
             installBenchTools,
           ].join("\n"),
-        },
-        {
-          name: "Cache Cargo home",
-          uses: "actions/cache@v4",
-          with: {
-            // See https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-            // Note that with the new sparse registry format, we no longer have to cache a `.git` dir
-            path: [
-              "~/.cargo/registry/index",
-              "~/.cargo/registry/cache",
-            ].join("\n"),
-            key:
-              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}-\${{ hashFiles('Cargo.lock') }}`,
-            // We will try to restore from the closest cargo-home we can find
-            "restore-keys":
-              `${cacheVersion}-cargo-home-\${{ matrix.os }}-\${{ matrix.arch }}-`,
-          },
         },
         {
           // Restore cache from the latest 'main' branch build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,15 @@ jobs:
           mkdir -p target/release
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
+      - name: Cache Cargo home
+        uses: actions/cache@v4
+        with:
+          path: |-
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+          key: '30-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '30-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
+        if: '!(matrix.skip)'
       - uses: dsherret/rust-toolchain-file@v1
         if: '!(matrix.skip)'
       - if: '!(matrix.skip) && (matrix.job == ''lint'' || matrix.job == ''test'' || matrix.job == ''bench'')'
@@ -355,15 +364,6 @@ jobs:
       - name: Install benchmark tools
         if: '!(matrix.skip) && (matrix.job == ''bench'')'
         run: ./tools/install_prebuilt.js wrk hyperfine
-      - name: Cache Cargo home
-        uses: actions/cache@v4
-        with:
-          path: |-
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-          key: '30-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '30-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
-        if: '!(matrix.skip)'
       - name: Restore cache build output (PR)
         uses: actions/cache/restore@v4
         if: '!(matrix.skip) && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |-
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
+            ~/.cargo/git/db
           key: '30-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
           restore-keys: '30-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
         if: '!(matrix.skip)'


### PR DESCRIPTION
I think this makes more sense. We'll see if it makes it faster. It was taking 1m 22s to install rust.