### PR TITLE
fix(compile): display embedded file sizes and total

### DIFF
--- a/cli/standalone/virtual_fs.rs
+++ b/cli/standalone/virtual_fs.rs
@@ -580,10 +580,10 @@ fn vfs_as_display_tree(
           human_size(size.unique as f64)
         } else {
           format!(
-            "{} - {}",
+            "{}{}",
             human_size(size.total as f64),
             deno_terminal::colors::gray(format!(
-              "{} unique",
+              " - {} unique",
               human_size(size.unique as f64)
             ))
           )

--- a/tests/integration/compile_tests.rs
+++ b/tests/integration/compile_tests.rs
@@ -1091,7 +1091,7 @@ Warning Failed resolving symlink. Ignoring.
     Path: [WILDCARD]
     Message: [WILDCARD])
 
-Embedded File System
+Embedded Files
 
 [WILDCARD]
 

--- a/tests/specs/compile/env_vars_support/compile.out
+++ b/tests/specs/compile/env_vars_support/compile.out
@@ -3,8 +3,10 @@ Check [WILDCARD]main.ts
 Compile [WILDCARD]main.ts to out[WILDCARD]
 Warning Environment variables from the file "environment.env" were embedded in the generated executable file
 
-Embedded File System
+Embedded Files
 
 out[WILDLINE]
-└── main.ts
+└── main.ts ([WILDLINE])
+
+Size: [WILDLINE]
 

--- a/tests/specs/compile/global_npm_cache_implicit_read_permission/compile.out
+++ b/tests/specs/compile/global_npm_cache_implicit_read_permission/compile.out
@@ -1,47 +1,49 @@
 [WILDCARD]
 Compile file:///[WILDLINE]/main.ts to [WILDLINE]
 
-Embedded File System
+Embedded Files
 
 main[WILDLINE]
-├─┬ .deno_compile_node_modules
-│ └─┬ localhost
-│   ├─┬ ansi-regex
-│   │ ├── 3.0.1/*
-│   │ └── 5.0.1/*
-│   ├── ansi-styles/4.3.0/*
-│   ├── camelcase/5.3.1/*
-│   ├── cliui/6.0.0/*
-│   ├── color-convert/2.0.1/*
-│   ├── color-name/1.1.4/*
-│   ├── cowsay/1.5.0/*
-│   ├── decamelize/1.2.0/*
-│   ├── emoji-regex/8.0.0/*
-│   ├── find-up/4.1.0/*
-│   ├── get-caller-file/2.0.5/*
-│   ├── get-stdin/8.0.0/*
-│   ├─┬ is-fullwidth-code-point
-│   │ ├── 2.0.0/*
-│   │ └── 3.0.0/*
-│   ├── locate-path/5.0.0/*
-│   ├── p-limit/2.3.0/*
-│   ├── p-locate/4.1.0/*
-│   ├── p-try/2.2.0/*
-│   ├── path-exists/4.0.0/*
-│   ├── require-directory/2.1.1/*
-│   ├── require-main-filename/2.0.0/*
-│   ├── set-blocking/2.0.0/*
-│   ├─┬ string-width
-│   │ ├── 2.1.1/*
-│   │ └── 4.2.3/*
-│   ├─┬ strip-ansi
-│   │ ├── 4.0.0/*
-│   │ └── 6.0.1/*
-│   ├── strip-final-newline/2.0.0/*
-│   ├── which-module/2.0.0/*
-│   ├── wrap-ansi/6.2.0/*
-│   ├── y18n/4.0.3/*
-│   ├── yargs/15.4.1/*
-│   └── yargs-parser/18.1.3/*
-└── main.ts
+├─┬ .deno_compile_node_modules ([WILDLINE])
+│ └─┬ localhost ([WILDLINE])
+│   ├─┬ ansi-regex ([WILDLINE])
+│   │ ├── 3.0.1/* ([WILDLINE])
+│   │ └── 5.0.1/* ([WILDLINE])
+│   ├── ansi-styles/4.3.0/* ([WILDLINE])
+│   ├── camelcase/5.3.1/* ([WILDLINE])
+│   ├── cliui/6.0.0/* ([WILDLINE])
+│   ├── color-convert/2.0.1/* ([WILDLINE])
+│   ├── color-name/1.1.4/* ([WILDLINE])
+│   ├── cowsay/1.5.0/* ([WILDLINE])
+│   ├── decamelize/1.2.0/* ([WILDLINE])
+│   ├── emoji-regex/8.0.0/* ([WILDLINE])
+│   ├── find-up/4.1.0/* ([WILDLINE])
+│   ├── get-caller-file/2.0.5/* ([WILDLINE])
+│   ├── get-stdin/8.0.0/* ([WILDLINE])
+│   ├─┬ is-fullwidth-code-point ([WILDLINE])
+│   │ ├── 2.0.0/* ([WILDLINE])
+│   │ └── 3.0.0/* ([WILDLINE])
+│   ├── locate-path/5.0.0/* ([WILDLINE])
+│   ├── p-limit/2.3.0/* ([WILDLINE])
+│   ├── p-locate/4.1.0/* ([WILDLINE])
+│   ├── p-try/2.2.0/* ([WILDLINE])
+│   ├── path-exists/4.0.0/* ([WILDLINE])
+│   ├── require-directory/2.1.1/* ([WILDLINE])
+│   ├── require-main-filename/2.0.0/* ([WILDLINE])
+│   ├── set-blocking/2.0.0/* ([WILDLINE])
+│   ├─┬ string-width ([WILDLINE])
+│   │ ├── 2.1.1/* ([WILDLINE])
+│   │ └── 4.2.3/* ([WILDLINE])
+│   ├─┬ strip-ansi ([WILDLINE])
+│   │ ├── 4.0.0/* ([WILDLINE])
+│   │ └── 6.0.1/* ([WILDLINE])
+│   ├── strip-final-newline/2.0.0/* ([WILDLINE])
+│   ├── which-module/2.0.0/* ([WILDLINE])
+│   ├── wrap-ansi/6.2.0/* ([WILDLINE])
+│   ├── y18n/4.0.3/* ([WILDLINE])
+│   ├── yargs/15.4.1/* ([WILDLINE])
+│   └── yargs-parser/18.1.3/* ([WILDLINE])
+└── main.ts ([WILDLINE])
+
+Size: [WILDLINE]
 

--- a/tests/specs/compile/include/symlink_twice/compile.out
+++ b/tests/specs/compile/include/symlink_twice/compile.out
@@ -1,9 +1,11 @@
 Compile [WILDLINE]
 
-Embedded File System
+Embedded Files
 
 main[WILDLINE]
-├── index.js
+├── index.js ([WILDLINE])
 ├── link.js --> index.js
-└── setup.js
+└── setup.js ([WILDLINE])
+
+Size: [WILDLINE]
 

--- a/tests/specs/compile/npm_fs/compile.out
+++ b/tests/specs/compile/npm_fs/compile.out
@@ -1,8 +1,10 @@
 [WILDCARD]
 
-Embedded File System
+Embedded Files
 
 main[WILDLINE]
-├── main.ts
-└── node_modules/*
+├── main.ts ([WILDLINE])
+└── node_modules/* ([WILDLINE])
+
+Size: [WILDLINE]
 

--- a/tests/specs/compile/package_json_type/compile.out
+++ b/tests/specs/compile/package_json_type/compile.out
@@ -1,6 +1,6 @@
 Check file:///[WILDLINE]/main.js
 Compile file:///[WILDLINE]
 
-Embedded File System
+Embedded Files
 
 [WILDCARD]

--- a/tests/testdata/compile/node_modules_symlink_outside/main_compile_file.out
+++ b/tests/testdata/compile/node_modules_symlink_outside/main_compile_file.out
@@ -1,5 +1,5 @@
 Compile file:///[WILDCARD]/node_modules_symlink_outside/main.ts to [WILDCARD]
 
-Embedded File System
+Embedded Files
 
 [WILDCARD]

--- a/tests/testdata/compile/node_modules_symlink_outside/main_compile_folder.out
+++ b/tests/testdata/compile/node_modules_symlink_outside/main_compile_folder.out
@@ -4,12 +4,14 @@ Initialize @denotest/esm-basic@1.0.0
 Check file:///[WILDCARD]/node_modules_symlink_outside/main.ts
 Compile file:///[WILDCARD]/node_modules_symlink_outside/main.ts to [WILDLINE]
 
-Embedded File System
+Embedded Files
 
 bin[WILDLINE]
-├─┬ compile
-│ └─┬ node_modules_symlink_outside
-│   ├── main.ts
-│   └── node_modules/*
-└── some_folder/*
+├─┬ compile ([WILDLINE])
+│ └─┬ node_modules_symlink_outside ([WILDLINE])
+│   ├── main.ts ([WILDLINE])
+│   └── node_modules/* ([WILDLINE])
+└── some_folder/* ([WILDLINE])
+
+Size: [WILDLINE]
 


### PR DESCRIPTION
Merging as a fix so that LTS gets this as it's a useful diagnostic tool.

![image](https://github.com/user-attachments/assets/78819eb7-7af7-424b-bd5e-d0e456237df5)

The 1MB unique is because we deduplicate files that we store (ex. some packages have the same file multiple times so we store that once).

Closes #27338