### PR TITLE
fix(ext/node): emit `resize` event on SIGWINCH

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -964,6 +964,11 @@ internals.__bootstrapNodeProcess = function (
         "stdout",
       );
     }
+    if (stdout.isTTY) {
+      Deno.addSignalListener("SIGWINCH", () => {
+        stdout.emit("resize");
+      });
+    }
 
     if (!io.stderr.isTerminal()) {
       /** https://nodejs.org/api/process.html#process_process_stderr */
@@ -971,6 +976,11 @@ internals.__bootstrapNodeProcess = function (
         io.stderr,
         "stderr",
       );
+    }
+    if (stderr.isTTY) {
+      Deno.addSignalListener("SIGWINCH", () => {
+        stderr.emit("resize");
+      });
     }
 
     arch = arch_();


### PR DESCRIPTION
```js
process.stdout.on("resize", () => {
  console.log(`resize ${process.stdout.columns}x${process.stdout.rows}`);
});
```

