### PR TITLE
fix: upgrade deno_doc to 0.161.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.161.2"
+version = "0.161.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af787319136f3e7f73ef551c618aeec70794522e36cd75ae35132a3bad983ef"
+checksum = "353a39c70d248af04600928cefc8066a9e4535fb6e7d7c518411e5efc822819f"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,7 +72,7 @@ deno_ast = { workspace = true, features = ["bundler", "cjs", "codegen", "proposa
 deno_cache_dir.workspace = true
 deno_config.workspace = true
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
-deno_doc = { version = "=0.161.2", features = ["rust", "comrak"] }
+deno_doc = { version = "=0.161.3", features = ["rust", "comrak"] }
 deno_graph = { version = "=0.86.3" }
 deno_lint = { version = "=0.68.2", features = ["docs"] }
 deno_lockfile.workspace = true


### PR DESCRIPTION
upgrades itoa requirement to `1.0.14`. needed for #27308 