### PR TITLE
fix(task): properly handle task name wildcards with --recursive

### DIFF
--- a/tests/specs/task/workspace_regex_match/__test__.jsonc
+++ b/tests/specs/task/workspace_regex_match/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  "tests": {
+    // Regression test for https://github.com/denoland/deno/issues/27370
+    "root": {
+      "args": "task test-all",
+      "output": "root.out",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/task/workspace_regex_match/deno.json
+++ b/tests/specs/task/workspace_regex_match/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": ["./subdir"],
+  "tasks": {
+    "test-all": "deno task --recursive test"
+  }
+}

--- a/tests/specs/task/workspace_regex_match/root.out
+++ b/tests/specs/task/workspace_regex_match/root.out
@@ -1,0 +1,3 @@
+Task test-all deno task --recursive test
+Task test echo 'ok'
+ok

--- a/tests/specs/task/workspace_regex_match/subdir/deno.json
+++ b/tests/specs/task/workspace_regex_match/subdir/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "echo 'ok'"
+  }
+}


### PR DESCRIPTION
This commit fixes `deno task` by checking if the provided
task name actually has a wildcard char ("*").

Previously, if the "--recursive" flag was passed, the task name
was treated as a regex, which lead to a situation where exact task
name resulted in a regex that matched all tasks with the specific prefix.

This commit fixes it, by checking if the provided task name, is an exact
name, or is it a wildcard match.

Closes https://github.com/denoland/deno/issues/27370
Closes https://github.com/denoland/deno/issues/27401
Closes https://github.com/denoland/deno/issues/27408