### PR TITLE
chore(deno_resolver): make sync feature of transitive deps optional

### DIFF
--- a/resolvers/deno/Cargo.toml
+++ b/resolvers/deno/Cargo.toml
@@ -14,7 +14,7 @@ description = "Deno resolution algorithm"
 path = "lib.rs"
 
 [features]
-sync = ["dashmap"]
+sync = ["dashmap", "deno_package_json/sync", "node_resolver/sync"]
 
 [dependencies]
 anyhow.workspace = true
@@ -24,11 +24,9 @@ dashmap = { workspace = true, optional = true }
 deno_config.workspace = true
 deno_media_type.workspace = true
 deno_package_json.workspace = true
-deno_package_json.features = ["sync"]
 deno_path_util.workspace = true
 deno_semver.workspace = true
 node_resolver.workspace = true
-node_resolver.features = ["sync"]
 thiserror.workspace = true
 url.workspace = true
 


### PR DESCRIPTION
This allows the user of `deno_resolver` to choose whether they want to enable sync feature or not transitively