### PR TITLE
fix(ext/fetch): better error message when body resource is unavailable

### DIFF
--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -27,6 +27,7 @@ const {
   JSONParse,
   ObjectDefineProperties,
   ObjectPrototypeIsPrototypeOf,
+  PromisePrototypeCatch,
   TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
   TypedArrayPrototypeGetByteOffset,
@@ -161,15 +162,18 @@ class InnerBody {
       )
     ) {
       readableStreamThrowIfErrored(this.stream);
-      return readableStreamCollectIntoUint8Array(this.stream).catch((e) => {
-        if (ObjectPrototypeIsPrototypeOf(BadResourcePrototype, e)) {
-          // TODO(kt3k): We probably like to pass e as `cause` if BadResource supports it.
-          throw new e.constructor(
-            "Cannot read body as underlying resource unavailable",
-          );
-        }
-        throw e;
-      });
+      return PromisePrototypeCatch(
+        readableStreamCollectIntoUint8Array(this.stream),
+        (e) => {
+          if (ObjectPrototypeIsPrototypeOf(BadResourcePrototype, e)) {
+            // TODO(kt3k): We probably like to pass e as `cause` if BadResource supports it.
+            throw new e.constructor(
+              "Cannot read body as underlying resource unavailable",
+            );
+          }
+          throw e;
+        },
+      );
     } else {
       this.streamOrStatic.consumed = true;
       return this.streamOrStatic.body;

--- a/ext/fetch/22_body.js
+++ b/ext/fetch/22_body.js
@@ -152,7 +152,7 @@ class InnerBody {
    * https://fetch.spec.whatwg.org/#concept-body-consume-body
    * @returns {Promise<Uint8Array>}
    */
-  async consume() {
+  consume() {
     if (this.unusable()) throw new TypeError("Body already consumed");
     if (
       ObjectPrototypeIsPrototypeOf(
@@ -161,9 +161,7 @@ class InnerBody {
       )
     ) {
       readableStreamThrowIfErrored(this.stream);
-      try {
-        return await readableStreamCollectIntoUint8Array(this.stream);
-      } catch (e) {
+      return readableStreamCollectIntoUint8Array(this.stream).catch((e) => {
         if (ObjectPrototypeIsPrototypeOf(BadResourcePrototype, e)) {
           // TODO(kt3k): We probably like to pass e as `cause` if BadResource supports it.
           throw new e.constructor(
@@ -171,7 +169,7 @@ class InnerBody {
           );
         }
         throw e;
-      }
+      });
     } else {
       this.streamOrStatic.consumed = true;
       return this.streamOrStatic.body;

--- a/tests/unit/body_test.ts
+++ b/tests/unit/body_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals } from "./test_util.ts";
+import { assert, assertEquals, assertRejects } from "./test_util.ts";
 
 // just a hack to get a body object
 // deno-lint-ignore no-explicit-any
@@ -187,3 +187,14 @@ Deno.test(
     assertEquals(file.size, 1);
   },
 );
+
+Deno.test(async function bodyBadResourceError() {
+  const file = await Deno.open("README.md");
+  file.close();
+  const body = buildBody(file.readable);
+  await assertRejects(
+    () => body.arrayBuffer(),
+    Deno.errors.BadResource,
+    "Cannot read body as underlying resource unavailable",
+  );
+});


### PR DESCRIPTION
fixes #27132

When the body resource is unavailable when start reading it, the error message is `Bad Resource ID` and that doesn't tell what's wrong very well.

This PR changes that error message to `Cannot read body as underlying resource unavailable`