### PR TITLE
perf: remove now needless canonicalization getting closest package.json

### DIFF
--- a/resolvers/node/errors.rs
+++ b/resolvers/node/errors.rs
@@ -320,7 +320,6 @@ impl NodeJsErrorCoded for PackageJsonLoadError {
 impl NodeJsErrorCoded for ClosestPkgJsonError {
   fn code(&self) -> NodeJsErrorCode {
     match self.as_kind() {
-      ClosestPkgJsonErrorKind::CanonicalizingDir(e) => e.code(),
       ClosestPkgJsonErrorKind::Load(e) => e.code(),
     }
   }
@@ -332,23 +331,7 @@ pub struct ClosestPkgJsonError(pub Box<ClosestPkgJsonErrorKind>);
 #[derive(Debug, Error)]
 pub enum ClosestPkgJsonErrorKind {
   #[error(transparent)]
-  CanonicalizingDir(#[from] CanonicalizingPkgJsonDirError),
-  #[error(transparent)]
   Load(#[from] PackageJsonLoadError),
-}
-
-#[derive(Debug, Error)]
-#[error("[{}] Failed canonicalizing package.json directory '{}'.", self.code(), dir_path.display())]
-pub struct CanonicalizingPkgJsonDirError {
-  pub dir_path: PathBuf,
-  #[source]
-  pub source: std::io::Error,
-}
-
-impl NodeJsErrorCoded for CanonicalizingPkgJsonDirError {
-  fn code(&self) -> NodeJsErrorCode {
-    NodeJsErrorCode::ERR_MODULE_NOT_FOUND
-  }
 }
 
 // todo(https://github.com/denoland/deno_core/issues/810): make this a TypeError


### PR DESCRIPTION
This is no longer required because we now store everything in the file system for deno compile instead of in an eszip.

Before:

```
Timer precision: 41 ns
bench          fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ resolution  217.7 µs      │ 715.5 µs      │ 227.2 µs      │ 233.4 µs      │ 1000    │ 1000
```

After:

```
Timer precision: 41 ns
bench          fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ resolution  191.1 µs      │ 768.7 µs      │ 198.2 µs      │ 205.4 µs      │ 1000    │ 1000
```

(My system is noisy, not doing a proper bench, but it removes some fs operations so going to be faster)