### PR TITLE
fix: incorrect memory info free/available bytes on mac

### DIFF
--- a/runtime/sys_info.rs
+++ b/runtime/sys_info.rs
@@ -295,11 +295,9 @@ pub fn mem_info() -> Option<MemInfo> {
         // TODO(@littledivy): Put this in a once_cell
         let page_size = libc::sysconf(libc::_SC_PAGESIZE) as u64;
         mem_info.available =
-          (stat.free_count as u64 + stat.inactive_count as u64) * page_size
-            / 1024;
+          (stat.free_count as u64 + stat.inactive_count as u64) * page_size;
         mem_info.free =
-          (stat.free_count as u64 - stat.speculative_count as u64) * page_size
-            / 1024;
+          (stat.free_count as u64 - stat.speculative_count as u64) * page_size;
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/27435

For some reason this was dividing by 1024 (as if the unit was KB, and we wanted bytes) but the page size is already in bytes.