### PR TITLE
fix(ext/node): make getCiphers return supported ciphers

### DIFF
--- a/ext/node/ops/crypto/cipher.rs
+++ b/ext/node/ops/crypto/cipher.rs
@@ -172,7 +172,7 @@ impl Cipher {
   ) -> Result<Self, CipherError> {
     use Cipher::*;
     Ok(match algorithm_name {
-      "aes-128-cbc" => {
+      "aes128" | "aes-128-cbc" => {
         Aes128Cbc(Box::new(cbc::Encryptor::new(key.into(), iv.into())))
       }
       "aes-128-ecb" => Aes128Ecb(Box::new(ecb::Encryptor::new(key.into()))),

--- a/ext/node/polyfills/internal/crypto/util.ts
+++ b/ext/node/polyfills/internal/crypto/util.ts
@@ -67,22 +67,16 @@ export const ellipticCurves: Array<EllipticCurve> = [
   }, // NIST P-224 EC
 ];
 
-// deno-fmt-ignore
 const supportedCiphers = [
-  "aes-128-ecb",  "aes-192-ecb",
-  "aes-256-ecb",  "aes-128-cbc",
-  "aes-192-cbc",  "aes-256-cbc",
-  "aes128",       "aes192",
-  "aes256",       "aes-128-cfb",
-  "aes-192-cfb",  "aes-256-cfb",
-  "aes-128-cfb8", "aes-192-cfb8",
-  "aes-256-cfb8", "aes-128-cfb1",
-  "aes-192-cfb1", "aes-256-cfb1",
-  "aes-128-ofb",  "aes-192-ofb",
-  "aes-256-ofb",  "aes-128-ctr",
-  "aes-192-ctr",  "aes-256-ctr",
-  "aes-128-gcm",  "aes-192-gcm",
-  "aes-256-gcm"
+  "aes-128-ecb",
+  "aes-192-ecb",
+  "aes-256-ecb",
+  "aes-128-cbc",
+  "aes-256-cbc",
+  "aes128",
+  "aes256",
+  "aes-128-gcm",
+  "aes-256-gcm",
 ];
 
 export function getCiphers(): string[] {

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -362,10 +362,16 @@ Deno.test({
   fn() {
     assertEquals(crypto.getCiphers().includes("aes-128-cbc"), true);
 
-    const getBytes = (cipher: string) => +cipher.match(/\d+/)![0] / 8;
+    const getZeroKey = (cipher: string) => zeros(+cipher.match(/\d+/)![0] / 8);
+    const getZeroIv = (cipher: string) => {
+      if (cipher.includes("gcm") || cipher.includes("ecb")) {
+        return zeros(12);
+      }
+      return zeros(16);
+    };
 
     for (const cipher of crypto.getCiphers()) {
-      crypto.createCipheriv(cipher, zeros(getBytes(cipher)), zeros(16));
+      crypto.createCipheriv(cipher, getZeroKey(cipher), getZeroIv(cipher)).final();
     }
   },
 });

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -361,6 +361,12 @@ Deno.test({
   name: "getCiphers",
   fn() {
     assertEquals(crypto.getCiphers().includes("aes-128-cbc"), true);
+
+    const getBytes = (cipher: string) => +cipher.match(/\d+/)![0] / 8;
+
+    for (const cipher of crypto.getCiphers()) {
+      crypto.createCipheriv(cipher, zeros(getBytes(cipher)), zeros(16));
+    }
   },
 });
 

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -371,7 +371,8 @@ Deno.test({
     };
 
     for (const cipher of crypto.getCiphers()) {
-      crypto.createCipheriv(cipher, getZeroKey(cipher), getZeroIv(cipher)).final();
+      crypto.createCipheriv(cipher, getZeroKey(cipher), getZeroIv(cipher))
+        .final();
     }
   },
 });


### PR DESCRIPTION
Currently we only supports 7 ciphers (`aes-(128|192|256)-ecb` and `aes-(128|256)-(cbc|gcm)`) in `node:crypto`, but `crypto.getCiphers` returns other supported cipher names. That confuses `npm:openpgp` package and causes https://github.com/denoland/deno/issues/26875.

This PR makes `getCiphers` return actually supported cipher names.

With this change, the example given in #26875 can create private and public key files.

closes #26875