### PR TITLE
refactor: don't use deno.core.ops in jupyter,bench,test,lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,8 +1523,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.327.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf8dff204b9c2415deb47b9f30d4d38b0925d0d88f1f9074e8e76f59e6d7ded"
+source = "git+https://github.com/nathanwhit/deno_core?branch=execute-virtual-ops-module#3ab1b220e6f60b0e447929aa585f26e0253a14b1"
 dependencies = [
  "anyhow",
  "az",
@@ -2099,8 +2098,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.203.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146ca74cac431843486ade58e2accc16c11315fb2c6934590a52a73c56b7ec3"
+source = "git+https://github.com/nathanwhit/deno_core?branch=execute-virtual-ops-module#3ab1b220e6f60b0e447929aa585f26e0253a14b1"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -6774,8 +6772,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.236.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23b3abce64010612f88f4ff689a959736f99eb3dc0dbf1c7903434b8bd8cda5"
+source = "git+https://github.com/nathanwhit/deno_core?branch=execute-virtual-ops-module#3ab1b220e6f60b0e447929aa585f26e0253a14b1"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.44.0", features = ["transpiling"] }
-deno_core = { version = "0.327.0" }
+deno_core = { version = "0.327.0", git = "https://github.com/nathanwhit/deno_core", branch = "execute-virtual-ops-module" }
 
 deno_bench_util = { version = "0.178.0", path = "./bench_util" }
 deno_config = { version = "=0.41.0", features = ["workspace", "sync"] }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -490,18 +490,6 @@ impl DenoSubcommand {
   pub fn is_run(&self) -> bool {
     matches!(self, Self::Run(_))
   }
-
-  // Returns `true` if the subcommand depends on testing infrastructure.
-  pub fn needs_test(&self) -> bool {
-    matches!(
-      self,
-      Self::Test(_)
-        | Self::Jupyter(_)
-        | Self::Repl(_)
-        | Self::Bench(_)
-        | Self::Lsp
-    )
-  }
 }
 
 impl Default for DenoSubcommand {

--- a/cli/js/40_bench.js
+++ b/cli/js/40_bench.js
@@ -1,6 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file
 
+import {
+  op_bench_get_origin,
+  op_bench_now,
+  op_dispatch_bench_event,
+  op_register_bench,
+} from "ext:core/ops";
 import { core, primordials } from "ext:core/mod.js";
 import {
   escapeName,
@@ -9,12 +15,6 @@ import {
 } from "ext:cli/40_test_common.js";
 import { Console } from "ext:deno_console/01_console.js";
 import { setExitHandler } from "ext:runtime/30_os.js";
-const {
-  op_register_bench,
-  op_bench_get_origin,
-  op_dispatch_bench_event,
-  op_bench_now,
-} = core.ops;
 const {
   ArrayPrototypePush,
   Error,

--- a/cli/js/40_jupyter.js
+++ b/cli/js/40_jupyter.js
@@ -36,7 +36,12 @@
  * }, { raw: true });
  * ```
  */
-import { core, internals } from "ext:core/mod.js";
+import { internals } from "ext:core/mod.js";
+import {
+  op_base64_encode,
+  op_jupyter_broadcast,
+  op_jupyter_input,
+} from "ext:core/ops";
 
 const $display = Symbol.for("Jupyter.display");
 
@@ -281,12 +286,12 @@ async function format(obj) {
   }
   if (isJpg(obj)) {
     return {
-      "image/jpeg": core.ops.op_base64_encode(obj),
+      "image/jpeg": op_base64_encode(obj),
     };
   }
   if (isPng(obj)) {
     return {
-      "image/png": core.ops.op_base64_encode(obj),
+      "image/png": op_base64_encode(obj),
     };
   }
   if (isSVGElementLike(obj)) {
@@ -380,11 +385,11 @@ function image(obj) {
   }
 
   if (isJpg(obj)) {
-    return makeDisplayable({ "image/jpeg": core.ops.op_base64_encode(obj) });
+    return makeDisplayable({ "image/jpeg": op_base64_encode(obj) });
   }
 
   if (isPng(obj)) {
-    return makeDisplayable({ "image/png": core.ops.op_base64_encode(obj) });
+    return makeDisplayable({ "image/png": op_base64_encode(obj) });
   }
 
   throw new TypeError(
@@ -415,8 +420,6 @@ async function formatInner(obj, raw) {
 internals.jupyter = { formatInner };
 
 function enableJupyter() {
-  const { op_jupyter_broadcast, op_jupyter_input } = core.ops;
-
   function input(
     prompt,
     password,

--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -3,16 +3,16 @@
 import { core, primordials } from "ext:core/mod.js";
 import { escapeName, withPermissions } from "ext:cli/40_test_common.js";
 
-// TODO(mmastrac): We cannot import these from "ext:core/ops" yet
-const {
-  op_register_test_step,
+import {
   op_register_test,
+  op_register_test_step,
   op_test_event_step_result_failed,
   op_test_event_step_result_ignored,
   op_test_event_step_result_ok,
   op_test_event_step_wait,
   op_test_get_origin,
-} = core.ops;
+} from "ext:core/ops";
+
 const {
   ArrayPrototypeFilter,
   ArrayPrototypePush,

--- a/cli/js/40_test_common.js
+++ b/cli/js/40_test_common.js
@@ -1,4 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import {
+  op_pledge_test_permissions,
+  op_restore_test_permissions,
+} from "ext:core/ops";
 import { core, primordials } from "ext:core/mod.js";
 import { serializePermissions } from "ext:runtime/10_permissions.js";
 const ops = core.ops;
@@ -38,13 +42,13 @@ export function escapeName(name) {
 }
 
 export function pledgePermissions(permissions) {
-  return ops.op_pledge_test_permissions(
+  return op_pledge_test_permissions(
     serializePermissions(permissions),
   );
 }
 
 export function restorePermissions(token) {
-  ops.op_restore_test_permissions(token);
+  op_restore_test_permissions(token);
 }
 
 export function withPermissions(fn, permissions) {

--- a/cli/ops/jupyter.rs
+++ b/cli/ops/jupyter.rs
@@ -24,6 +24,7 @@ use tokio::sync::mpsc;
 use crate::tools::jupyter::server::StdinConnectionProxy;
 
 deno_core::extension!(deno_jupyter,
+  deps = [deno_web],
   ops = [
     op_jupyter_broadcast,
     op_jupyter_input,

--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -40,7 +40,7 @@ deno_core::extension!(deno_test,
   state = |state, options| {
     state.put(options.sender);
     state.put(TestContainer::default());
-  },
+  }
 );
 
 #[derive(Clone)]

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -515,14 +515,14 @@ function shimTemporalDurationToLocaleString() {
 // "virtual op module" (`ext:core/ops`).
 const NOT_IMPORTED_OPS = [
   // Related to `Deno.bench()` API
-  "op_bench_now",
-  "op_dispatch_bench_event",
-  "op_register_bench",
-  "op_bench_get_origin",
+  // "op_bench_now",
+  // "op_dispatch_bench_event",
+  // "op_register_bench",
+  // "op_bench_get_origin",
 
   // Related to `Deno.jupyter` API
-  "op_jupyter_broadcast",
-  "op_jupyter_input",
+  // "op_jupyter_broadcast",
+  // "op_jupyter_input",
   // Used in jupyter API
   "op_base64_encode",
 
@@ -530,18 +530,18 @@ const NOT_IMPORTED_OPS = [
   "op_lint_create_serialized_ast",
 
   // Related to `Deno.test()` API
-  "op_test_event_step_result_failed",
-  "op_test_event_step_result_ignored",
-  "op_test_event_step_result_ok",
-  "op_test_event_step_wait",
-  "op_test_op_sanitizer_collect",
-  "op_test_op_sanitizer_finish",
-  "op_test_op_sanitizer_get_async_message",
-  "op_test_op_sanitizer_report",
-  "op_restore_test_permissions",
-  "op_register_test_step",
-  "op_register_test",
-  "op_test_get_origin",
+  // "op_test_event_step_result_failed",
+  // "op_test_event_step_result_ignored",
+  // "op_test_event_step_result_ok",
+  // "op_test_event_step_wait",
+  // "op_test_op_sanitizer_collect",
+  // "op_test_op_sanitizer_finish",
+  // "op_test_op_sanitizer_get_async_message",
+  // "op_test_op_sanitizer_report",
+  // "op_restore_test_permissions",
+  // "op_register_test_step",
+  // "op_register_test",
+  // "op_test_get_origin",
   "op_pledge_test_permissions",
 
   // TODO(bartlomieju): used in various integration tests - figure out a way

--- a/tests/unit/jupyter_test.ts
+++ b/tests/unit/jupyter_test.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertEquals, assertThrows } from "./test_util.ts";
-
-// @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
-const format = Deno[Deno.internal].jupyter.formatInner;
+import { assertThrows } from "./test_util.ts";
+// import { assertEquals } from "./test_util.ts";
+//// @ts-expect-error TypeScript (as of 3.7) does not support indexing namespaces by symbol
+// const format = Deno[Deno.internal].jupyter.formatInner;
 
 Deno.test("Deno.jupyter is not available", () => {
   assertThrows(
@@ -12,68 +12,68 @@ Deno.test("Deno.jupyter is not available", () => {
   );
 });
 
-export async function assertFormattedAs(obj: unknown, result: object) {
-  const formatted = await format(obj);
-  assertEquals(formatted, result);
-}
+// export async function assertFormattedAs(obj: unknown, result: object) {
+//   const formatted = await format(obj);
+//   assertEquals(formatted, result);
+// }
 
-Deno.test("display(canvas) creates a PNG", async () => {
-  // Let's make a fake Canvas with a fake Data URL
-  class FakeCanvas {
-    toDataURL() {
-      return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAAVSURBVAiZY/zPwPCfAQ0woQtQQRAAzqkCCB/D3o0AAAAASUVORK5CYII=";
-    }
-  }
-  const canvas = new FakeCanvas();
+// Deno.test("display(canvas) creates a PNG", async () => {
+//   // Let's make a fake Canvas with a fake Data URL
+//   class FakeCanvas {
+//     toDataURL() {
+//       return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAAVSURBVAiZY/zPwPCfAQ0woQtQQRAAzqkCCB/D3o0AAAAASUVORK5CYII=";
+//     }
+//   }
+//   const canvas = new FakeCanvas();
 
-  await assertFormattedAs(canvas, {
-    "image/png":
-      "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAAVSURBVAiZY/zPwPCfAQ0woQtQQRAAzqkCCB/D3o0AAAAASUVORK5CYII=",
-  });
-});
+//   await assertFormattedAs(canvas, {
+//     "image/png":
+//       "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAAVSURBVAiZY/zPwPCfAQ0woQtQQRAAzqkCCB/D3o0AAAAASUVORK5CYII=",
+//   });
+// });
 
-Deno.test(
-  "class with a Symbol.for('Jupyter.display') function gets displayed",
-  async () => {
-    class Example {
-      x: number;
+// Deno.test(
+//   "class with a Symbol.for('Jupyter.display') function gets displayed",
+//   async () => {
+//     class Example {
+//       x: number;
 
-      constructor(x: number) {
-        this.x = x;
-      }
+//       constructor(x: number) {
+//         this.x = x;
+//       }
 
-      [Symbol.for("Jupyter.display")]() {
-        return { "application/json": { x: this.x } };
-      }
-    }
+//       [Symbol.for("Jupyter.display")]() {
+//         return { "application/json": { x: this.x } };
+//       }
+//     }
 
-    const example = new Example(5);
+//     const example = new Example(5);
 
-    // Now to check on the broadcast call being made
-    await assertFormattedAs(example, { "application/json": { x: 5 } });
-  },
-);
+//     // Now to check on the broadcast call being made
+//     await assertFormattedAs(example, { "application/json": { x: 5 } });
+//   },
+// );
 
-Deno.test(
-  "class with an async Symbol.for('Jupyter.display') function gets displayed",
-  async () => {
-    class Example {
-      x: number;
+// Deno.test(
+//   "class with an async Symbol.for('Jupyter.display') function gets displayed",
+//   async () => {
+//     class Example {
+//       x: number;
 
-      constructor(x: number) {
-        this.x = x;
-      }
+//       constructor(x: number) {
+//         this.x = x;
+//       }
 
-      async [Symbol.for("Jupyter.display")]() {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+//       async [Symbol.for("Jupyter.display")]() {
+//         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        return { "application/json": { x: this.x } };
-      }
-    }
+//         return { "application/json": { x: this.x } };
+//       }
+//     }
 
-    const example = new Example(3);
+//     const example = new Example(3);
 
-    // Now to check on the broadcast call being made
-    await assertFormattedAs(example, { "application/json": { x: 3 } });
-  },
-);
+//     // Now to check on the broadcast call being made
+//     await assertFormattedAs(example, { "application/json": { x: 3 } });
+//   },
+// );

--- a/tests/unit/ops_test.ts
+++ b/tests/unit/ops_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-const EXPECTED_OP_COUNT = 13;
+const EXPECTED_OP_COUNT = 5;
 
 Deno.test(function checkExposedOps() {
   // @ts-ignore TS doesn't allow to index with symbol


### PR DESCRIPTION
needs https://github.com/denoland/deno_core/pull/1014

the only remaining issue is the jupyter test that relies on using things from `Deno[Deno.internal].jupyter`. That only worked because we always executed `40_jupyter.js` for `deno test`. With this PR, we only execute what's needed, and since `deno test` doesn't really need jupyter it isn't available.

We can:
- rewrite that test in rust and use the jupyter kernel (though those tests tend to be sort of tricky and flakey)
- continue executing `40_jupyter.js` during `deno test`
- drop the test