### PR TITLE
perf(fs/windows): stat - only open file once

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -896,8 +896,7 @@ fn stat_extra(
     }
     let file_handle = WinHandle(file_handle);
 
-    let result = get_dev(file_handle.0);
-    fsstat.dev = result?;
+    fsstat.dev = get_dev(file_handle.0)?;
 
     if let Ok(file_info) = query_file_information(file_handle.0) {
       fsstat.ctime = Some(windows_time_to_unix_time_msec(


### PR DESCRIPTION
Even debug is way faster:

```
> cat main.cts
for (let i = 0; i < 100_000; i++) {
  Deno.statSync("b.txt");
}
> Measure-Command { deno run -A main.cts } | Select-Object -Property TotalMilliseconds    
          2684.68
> Measure-Command { ../deno/target/debug/deno run -A main.cts } | Select-Object -Property TotalMilliseconds
           988.55
```