### PR TITLE
fix(node): Add missing `inspector/promises`

### DIFF
--- a/ext/node/polyfill.rs
+++ b/ext/node/polyfill.rs
@@ -57,6 +57,7 @@ generate_builtin_node_module_lists! {
   "http2",
   "https",
   "inspector",
+  "inspector/promises",
   "module",
   "net",
   "os",

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8712,6 +8712,7 @@ fn lsp_completions_node_specifier() {
       "node:http2",
       "node:https",
       "node:inspector",
+      "node:inspector/promises",
       "node:module",
       "node:net",
       "node:os",

--- a/tests/unit_node/inspector_test.ts
+++ b/tests/unit_node/inspector_test.ts
@@ -13,10 +13,10 @@ Deno.test("[node/inspector] - Session constructor should not throw", () => {
   new Session();
 });
 
-Deno.test("[node/inspector/promise] - importing inspector works", () => {
+Deno.test("[node/inspector/promises] - importing inspector works", () => {
   assertEquals(typeof inspectorPromises.open, "function");
 });
 
-Deno.test("[node/inspector/promise] - Session constructor should not throw", () => {
+Deno.test("[node/inspector/promises] - Session constructor should not throw", () => {
   new SessionPromise();
 });

--- a/tests/unit_node/inspector_test.ts
+++ b/tests/unit_node/inspector_test.ts
@@ -1,5 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import inspector, { Session } from "node:inspector";
+import inspectorPromises, {
+  Session as SessionPromise,
+} from "node:inspector/promises";
 import { assertEquals } from "@std/assert/equals";
 
 Deno.test("[node/inspector] - importing inspector works", () => {
@@ -8,4 +11,12 @@ Deno.test("[node/inspector] - importing inspector works", () => {
 
 Deno.test("[node/inspector] - Session constructor should not throw", () => {
   new Session();
+});
+
+Deno.test("[node/inspector/promise] - importing inspector works", () => {
+  assertEquals(typeof inspectorPromises.open, "function");
+});
+
+Deno.test("[node/inspector/promise] - Session constructor should not throw", () => {
+  new SessionPromise();
 });


### PR DESCRIPTION
Add missing `inspector/promises` in node builtin module list, that causes types checking error

<img width="713" alt="Screenshot 2024-12-29 at 20 05 30" src="https://github.com/user-attachments/assets/4024ff14-bff6-4369-b6c2-d6bec285ad23" />
