### PR TITLE
refactor: Use 'await using' in serve_test

### DIFF
--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -387,7 +387,7 @@ Deno.test(async function httpServerCanResolveHostnames() {
   const ac = new AbortController();
   const { promise, resolve } = Promise.withResolvers<void>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: (_req) => new Response("ok"),
     hostname: "localhost",
     port: servePort,
@@ -410,7 +410,7 @@ Deno.test(async function httpServerRejectsOnAddrInUse() {
   const ac = new AbortController();
   const { promise, resolve } = Promise.withResolvers<void>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: (_req) => new Response("ok"),
     hostname: "localhost",
     port: servePort,
@@ -441,7 +441,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerBasic() {
   const deferred = Promise.withResolvers<void>();
   const listeningDeferred = Promise.withResolvers<Deno.NetAddr>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: async (request, { remoteAddr }) => {
       // FIXME(bartlomieju):
       // make sure that request can be inspected
@@ -483,7 +483,7 @@ Deno.test(
     const deferred = Promise.withResolvers<void>();
     const listeningDeferred = Promise.withResolvers();
     const listener = Deno.listen({ port: servePort });
-    const server = serveHttpOnListener(
+    await using server = serveHttpOnListener(
       listener,
       ac.signal,
       async (
@@ -532,7 +532,7 @@ Deno.test(
       headers: { "connection": "close" },
     });
 
-    const server = serveHttpOnConnection(
+    await using server = serveHttpOnConnection(
       await acceptPromise,
       ac.signal,
       async (
@@ -572,7 +572,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerOnError() {
   const { promise, resolve } = Promise.withResolvers<void>();
   let requestStash: Request | null;
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: async (request: Request) => {
       requestStash = request;
       await new Promise((r) => setTimeout(r, 100));
@@ -607,7 +607,7 @@ Deno.test(
     // deno-lint-ignore no-unused-vars
     let requestStash: Request | null;
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request: Request) => {
         requestStash = request;
         await new Promise((r) => setTimeout(r, 100));
@@ -640,7 +640,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<void>();
     const response = new Response("Hello World");
     let hadError = false;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         return response;
       },
@@ -684,7 +684,7 @@ Deno.test(
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
     let hadError = false;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         return Response.error();
       },
@@ -717,7 +717,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerOverload1() {
   const deferred = Promise.withResolvers<void>();
   const listeningDeferred = Promise.withResolvers<void>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     port: servePort,
     signal: ac.signal,
     onListen: onListen(listeningDeferred.resolve),
@@ -752,7 +752,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerOverload2() {
   const deferred = Promise.withResolvers<void>();
   const listeningDeferred = Promise.withResolvers<void>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     port: servePort,
     signal: ac.signal,
     onListen: onListen(listeningDeferred.resolve),
@@ -807,7 +807,7 @@ Deno.test(
 Deno.test({ permissions: { net: true } }, async function httpServerPort0() {
   const ac = new AbortController();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler() {
       return new Response("Hello World");
     },
@@ -841,7 +841,7 @@ Deno.test(
     };
 
     try {
-      const server = Deno.serve({
+      await using server = Deno.serve({
         handler() {
           return new Response("Hello World");
         },
@@ -866,7 +866,7 @@ Deno.test(
     const ac = new AbortController();
 
     let headers: Headers;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         await request.text();
         headers = request.headers;
@@ -896,7 +896,7 @@ Deno.test(
 );
 
 Deno.test({ permissions: { net: true } }, async function validPortString() {
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: (_request) => new Response(),
     port: "4501" as unknown as number,
   });
@@ -921,7 +921,7 @@ Deno.test({ permissions: { net: true } }, async function ipv6Hostname() {
   };
 
   try {
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => new Response(),
       hostname: "::1",
       port: 0,
@@ -1017,7 +1017,7 @@ function createUrlTest(
     const listeningDeferred = Promise.withResolvers<number>();
     const urlDeferred = Promise.withResolvers<string>();
     const ac = new AbortController();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request: Request) => {
         urlDeferred.resolve(request.url);
         return new Response("");
@@ -1117,7 +1117,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         assertEquals(request.body, null);
         deferred.resolve();
@@ -1157,7 +1157,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         await assertRejects(async () => {
           await request.text();
@@ -1221,7 +1221,7 @@ function createStreamTest(count: number, delay: number, action: string) {
   Deno.test(`httpServerStreamCount${count}Delay${delay}${action}`, async () => {
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (_request) => {
         return new Response(makeStream(count, delay));
       },
@@ -1275,7 +1275,7 @@ Deno.test(
     writer.close();
     const { promise, resolve } = Promise.withResolvers<void>();
     const ac = new AbortController();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         const reqBody = await request.text();
         assertEquals("hello world", reqBody);
@@ -1303,7 +1303,7 @@ Deno.test(
 Deno.test({ permissions: { net: true } }, async function httpServerClose() {
   const ac = new AbortController();
   const { promise, resolve } = Promise.withResolvers<void>();
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: () => new Response("ok"),
     port: servePort,
     signal: ac.signal,
@@ -1323,7 +1323,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerCloseGet() {
   const listeningDeferred = Promise.withResolvers<void>();
   const requestDeferred = Promise.withResolvers<void>();
   const responseDeferred = Promise.withResolvers<void>();
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: async () => {
       requestDeferred.resolve();
       await new Promise((r) => setTimeout(r, 500));
@@ -1349,13 +1349,12 @@ Deno.test({ permissions: { net: true } }, async function httpServerCloseGet() {
   await server.finished;
 });
 
-// FIXME:
 Deno.test(
   { permissions: { net: true } },
   async function httpServerEmptyBlobResponse() {
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => new Response(new Blob([])),
       port: servePort,
       signal: ac.signal,
@@ -1380,7 +1379,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
     const errorDeferred = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         const body = new ReadableStream({
           start(controller) {
@@ -1421,7 +1420,7 @@ Deno.test(
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => new Response("韓國".repeat(10)),
       port: servePort,
       signal: ac.signal,
@@ -1456,7 +1455,7 @@ Deno.test({ permissions: { net: true } }, async function httpServerWebSocket() {
   const ac = new AbortController();
   const listeningDeferred = Promise.withResolvers<void>();
   const doneDeferred = Promise.withResolvers<void>();
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: (request) => {
       const {
         response,
@@ -1501,7 +1500,7 @@ Deno.test(
   async function httpServerWebSocketRaw() {
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         const { conn, response } = upgradeHttpRaw(request);
         const buf = new Uint8Array(1024);
@@ -1581,7 +1580,7 @@ Deno.test(
     const ac = new AbortController();
     const done = Promise.withResolvers<void>();
     const listeningDeferred = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         const {
           response,
@@ -1635,7 +1634,7 @@ Deno.test(
     const ac = new AbortController();
     const done = Promise.withResolvers<void>();
     const listeningDeferred = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         const {
           response,
@@ -1673,7 +1672,7 @@ Deno.test(
     const ac = new AbortController();
     const done = Promise.withResolvers<void>();
     const listeningDeferred = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         const {
           response,
@@ -1723,7 +1722,7 @@ Deno.test(
     const ac = new AbortController();
 
     let headers: Headers;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         headers = request.headers;
         deferred.resolve();
@@ -1762,7 +1761,7 @@ Deno.test(
 
     let headers: Headers;
     let text: string;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         headers = request.headers;
         text = await request.text();
@@ -1807,7 +1806,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         deferred.resolve();
         return new Response("");
@@ -1858,7 +1857,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve(
+    await using server = Deno.serve(
       { port: servePort, signal: ac.signal },
       (request: Request) => {
         assert(request.body);
@@ -1889,7 +1888,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve(
+    await using server = Deno.serve(
       { port: servePort, signal: ac.signal },
       (request: Request) => {
         assert(request.body);
@@ -2005,7 +2004,7 @@ Deno.test(
       }).pipeThrough(new TextEncoderStream());
     }
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         deferred.resolve();
         return new Response(periodicStream());
@@ -2037,7 +2036,7 @@ Deno.test(
   { permissions: { net: true } },
   async function httpLargeReadableStreamChunk() {
     const ac = new AbortController();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler() {
         return new Response(
           new ReadableStream({
@@ -2077,7 +2076,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const deferred = Promise.withResolvers<void>();
     const ac = new AbortController();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         assertEquals(request.headers.get("X-Header-Test"), "á");
         deferred.resolve();
@@ -2123,7 +2122,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         // FIXME:
         // assertEquals(new URL(request.url).href, `http://127.0.0.1:${servePort}/`);
@@ -2177,7 +2176,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         assertEquals(await request.text(), "");
         assertEquals(request.headers.get("cookie"), "foo=bar; bar=foo");
@@ -2221,7 +2220,7 @@ Deno.test(
 
     const hostname = "localhost";
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         deferred.resolve();
         return new Response("ok");
@@ -2256,7 +2255,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         assertEquals(request.body, null);
         deferred.resolve();
@@ -2292,7 +2291,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         assertEquals(request.method, "GET");
         assertEquals(request.headers.get("host"), "deno.land");
@@ -2326,7 +2325,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         assertEquals(request.method, "GET");
         assertEquals(request.headers.get("server"), "hello\tworld");
@@ -2360,7 +2359,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         assertEquals(request.method, "GET");
         assertEquals(await request.text(), "");
@@ -2396,7 +2395,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         assertEquals(request.method, "POST");
         assertEquals(await request.text(), "I'm a good request.");
@@ -2443,7 +2442,7 @@ function createServerLengthTest(name: string, testCase: TestCase) {
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         assertEquals(request.method, "GET");
         deferred.resolve();
@@ -2575,7 +2574,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         assertEquals(request.method, "POST");
         assertEquals(request.headers.get("content-length"), "5");
@@ -2611,7 +2610,7 @@ Deno.test(
   async function httpServerPostWithInvalidPrefixContentLength() {
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         throw new Error("unreachable");
       },
@@ -2651,7 +2650,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         assertEquals(request.method, "POST");
         assertEquals(await request.text(), "qwert");
@@ -2688,7 +2687,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (r) => {
         deferred.resolve();
         assertEquals(await r.text(), "12345");
@@ -2724,7 +2723,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         deferred.resolve();
         return new Response("NaN".repeat(100));
@@ -2867,7 +2866,7 @@ for (const testCase of compressionTestCases) {
         const deferred = Promise.withResolvers<void>();
         const listeningDeferred = Promise.withResolvers<void>();
         const ac = new AbortController();
-        const server = Deno.serve({
+        await using server = Deno.serve({
           handler: async (_request) => {
             const f = await makeTempFile(testCase.length);
             deferred.resolve();
@@ -2923,7 +2922,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (request) => {
         assertEquals(
           await request.bytes(),
@@ -2971,7 +2970,7 @@ for (const delay of ["delay", "nodelay"]) {
         const listeningDeferred = Promise.withResolvers<void>();
         const waitForAbort = Promise.withResolvers<void>();
         const waitForRequest = Promise.withResolvers<void>();
-        const server = Deno.serve({
+        await using server = Deno.serve({
           port: servePort,
           signal: ac.signal,
           onListen: onListen(listeningDeferred.resolve),
@@ -3121,7 +3120,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<void>();
     const hostname = "127.0.0.1";
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => new Response("Hello World"),
       hostname,
       port: servePort,
@@ -3151,7 +3150,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<void>();
     const hostname = "127.0.0.1";
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => new Response("Hello World"),
       hostname,
       port: servePort,
@@ -3186,7 +3185,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const deferred = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (req) => {
         assertEquals(await req.text(), "");
         deferred.resolve();
@@ -3221,7 +3220,7 @@ Deno.test(
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         throw new Error("oops");
       },
@@ -3268,7 +3267,7 @@ Deno.test(
   async function httpServer204ResponseDoesntSendContentLength() {
     const { promise, resolve } = Promise.withResolvers<void>();
     const ac = new AbortController();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (_request) => new Response(null, { status: 204 }),
       port: servePort,
       signal: ac.signal,
@@ -3298,7 +3297,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         deferred.resolve();
         return new Response(null, { status: 304 });
@@ -3343,7 +3342,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (req) => {
         deferred.resolve();
         assertEquals(await req.text(), "hello");
@@ -3404,7 +3403,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (req) => {
         deferred.resolve();
         assertEquals(await req.text(), "");
@@ -3458,7 +3457,7 @@ for (const [name, req] of badRequests) {
       const ac = new AbortController();
       const { promise, resolve } = Promise.withResolvers<void>();
 
-      const server = Deno.serve({
+      await using server = Deno.serve({
         handler: () => {
           throw new Error("oops");
         },
@@ -3505,7 +3504,7 @@ Deno.test(
 
     let reqCount = -1;
     let timerId: number | undefined;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (_req) => {
         reqCount++;
         if (reqCount === 0) {
@@ -3600,7 +3599,7 @@ Deno.test(
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
     let count = 0;
-    const server = Deno.serve({
+    await using server = Deno.serve({
       async onListen({ port }: { port: number }) {
         const res1 = await fetch(`http://localhost:${port}/`);
         assertEquals(await res1.text(), "hello world 1");
@@ -3630,7 +3629,7 @@ Deno.test(
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<number>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (req) => {
         const cloned = req.clone();
         assertEquals(req.headers, cloned.headers);
@@ -3684,7 +3683,7 @@ Deno.test(
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<number>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (req) => {
         await req.text();
 
@@ -3733,7 +3732,7 @@ Deno.test({
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<number>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: async (req) => {
         const _reader = req.body?.getReader();
 
@@ -3780,7 +3779,7 @@ Deno.test(
   async function testIssue16567() {
     const ac = new AbortController();
     const { promise, resolve } = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       async onListen({ port }) {
         const res1 = await fetch(`http://localhost:${port}/`);
         assertEquals((await res1.text()).length, 40 * 50_000);
@@ -3947,7 +3946,7 @@ Deno.test(
   },
   async function httpServeCurlH2C() {
     const ac = new AbortController();
-    const server = Deno.serve(
+    await using server = Deno.serve(
       { port: servePort, signal: ac.signal },
       () => new Response("hello world!"),
     );
@@ -3982,7 +3981,7 @@ Deno.test(
     const ac = new AbortController();
     const { resolve } = Promise.withResolvers<void>();
 
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: () => {
         const response = new Response("Hello World", {
           headers: {
@@ -4025,7 +4024,7 @@ Deno.test(
   },
   async function httpsServeCurlH2C() {
     const ac = new AbortController();
-    const server = Deno.serve(
+    await using server = Deno.serve(
       {
         signal: ac.signal,
         port: servePort,
@@ -4082,7 +4081,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<Deno.UnixAddr>();
     const ac = new AbortController();
     const filePath = tmpUnixSocketPath();
-    const server = Deno.serve(
+    await using server = Deno.serve(
       {
         signal: ac.signal,
         path: filePath,
@@ -4115,7 +4114,7 @@ Deno.test(
     const listeningDeferred = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve(
+    await using server = Deno.serve(
       {
         port: servePort,
         onListen: onListen(listeningDeferred.resolve),
@@ -4151,7 +4150,7 @@ Deno.test(
     const { promise, resolve } = Promise.withResolvers<void>();
     const ac = new AbortController();
 
-    const server = Deno.serve(
+    await using server = Deno.serve(
       {
         port: servePort,
         onListen: onListen(resolve),
@@ -4187,7 +4186,7 @@ Deno.test(
     let timer: number | undefined = undefined;
     let _controller;
 
-    const server = Deno.serve(
+    await using server = Deno.serve(
       {
         port: servePort,
         onListen: onListen(resolve),
@@ -4237,7 +4236,7 @@ Deno.test({
   await assertRejects(
     async () => {
       const ac = new AbortController();
-      const server = Deno.serve({
+      await using server = Deno.serve({
         path: "path/to/socket",
         handler: (_req) => new Response("Hello, world"),
         signal: ac.signal,
@@ -4260,7 +4259,7 @@ Deno.test({
 }, async () => {
   const { promise, resolve } = Promise.withResolvers<{ hostname: string }>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     handler: (_) => new Response("ok"),
     hostname: "0.0.0.0",
     port: 0,
@@ -4278,7 +4277,7 @@ Deno.test({
 
   let cancelled = false;
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     hostname: "0.0.0.0",
     port: servePort,
     onListen: () => resolve(),
@@ -4305,7 +4304,7 @@ Deno.test({
 }, async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
-  const server = Deno.serve({
+  await using server = Deno.serve({
     hostname: "0.0.0.0",
     port: servePort,
     onListen: () => resolve(),
@@ -4335,7 +4334,7 @@ Deno.test(
     const ac = new AbortController();
     const listeningDeferred = Promise.withResolvers<void>();
     const doneDeferred = Promise.withResolvers<void>();
-    const server = Deno.serve({
+    await using server = Deno.serve({
       handler: (request) => {
         const {
           response,


### PR DESCRIPTION
To make sure the servers are torn down when they throw an error during test execution.