### PR TITLE
fix(check): move module not found errors to typescript diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.86.6"
+version = "0.86.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83af194ca492ea7b624d21055f933676d3f3d27586de93be31c8f1babcc73510"
+checksum = "ace3acf321fac446636ae605b01723f2120b40ab3d32c6836aeb7d603a8e08f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa135b8a9febc9a51c16258e294e268a1276750780d69e46edb31cced2826e4"
+checksum = "a417f8bd3f1074185c4c8ccb6ea6261ae173781596cc358e68ad07aaac11009d"
 dependencies = [
  "data-url",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ deno_core = { version = "0.327.0" }
 deno_bench_util = { version = "0.178.0", path = "./bench_util" }
 deno_config = { version = "=0.42.0", features = ["workspace", "sync"] }
 deno_lockfile = "=0.24.0"
-deno_media_type = { version = "0.2.0", features = ["module_specifier"] }
+deno_media_type = { version = "0.2.3", features = ["module_specifier"] }
 deno_npm = "=0.27.0"
 deno_path_util = "=0.3.0"
 deno_permissions = { version = "0.43.0", path = "./runtime/permissions" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ deno_config.workspace = true
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.161.3", features = ["rust", "comrak"] }
 deno_error.workspace = true
-deno_graph = { version = "=0.86.6" }
+deno_graph = { version = "=0.86.7" }
 deno_lint = { version = "=0.68.2", features = ["docs"] }
 deno_lockfile.workspace = true
 deno_npm.workspace = true

--- a/cli/errors.rs
+++ b/cli/errors.rs
@@ -26,51 +26,55 @@ fn get_diagnostic_class(_: &ParseDiagnostic) -> &'static str {
   "SyntaxError"
 }
 
-fn get_module_graph_error_class(err: &ModuleGraphError) -> &'static str {
-  use deno_graph::JsrLoadError;
-  use deno_graph::NpmLoadError;
-
+pub fn get_module_graph_error_class(err: &ModuleGraphError) -> &'static str {
   match err {
     ModuleGraphError::ResolutionError(err)
     | ModuleGraphError::TypesResolutionError(err) => {
       get_resolution_error_class(err)
     }
-    ModuleGraphError::ModuleError(err) => match err {
-      ModuleError::InvalidTypeAssertion { .. } => "SyntaxError",
-      ModuleError::ParseErr(_, diagnostic) => get_diagnostic_class(diagnostic),
-      ModuleError::WasmParseErr(..) => "SyntaxError",
-      ModuleError::UnsupportedMediaType { .. }
-      | ModuleError::UnsupportedImportAttributeType { .. } => "TypeError",
-      ModuleError::Missing(_, _) | ModuleError::MissingDynamic(_, _) => {
-        "NotFound"
-      }
-      ModuleError::LoadingErr(_, _, err) => match err {
-        ModuleLoadError::Loader(err) => get_error_class_name(err.as_ref()),
-        ModuleLoadError::HttpsChecksumIntegrity(_)
-        | ModuleLoadError::TooManyRedirects => "Error",
-        ModuleLoadError::NodeUnknownBuiltinModule(_) => "NotFound",
-        ModuleLoadError::Decode(_) => "TypeError",
-        ModuleLoadError::Npm(err) => match err {
-          NpmLoadError::NotSupportedEnvironment
-          | NpmLoadError::PackageReqResolution(_)
-          | NpmLoadError::RegistryInfo(_) => "Error",
-          NpmLoadError::PackageReqReferenceParse(_) => "TypeError",
-        },
-        ModuleLoadError::Jsr(err) => match err {
-          JsrLoadError::UnsupportedManifestChecksum
-          | JsrLoadError::PackageFormat(_) => "TypeError",
-          JsrLoadError::ContentLoadExternalSpecifier
-          | JsrLoadError::ContentLoad(_)
-          | JsrLoadError::ContentChecksumIntegrity(_)
-          | JsrLoadError::PackageManifestLoad(_, _)
-          | JsrLoadError::PackageVersionManifestChecksumIntegrity(..)
-          | JsrLoadError::PackageVersionManifestLoad(_, _)
-          | JsrLoadError::RedirectInPackage(_) => "Error",
-          JsrLoadError::PackageNotFound(_)
-          | JsrLoadError::PackageReqNotFound(_)
-          | JsrLoadError::PackageVersionNotFound(_)
-          | JsrLoadError::UnknownExport { .. } => "NotFound",
-        },
+    ModuleGraphError::ModuleError(err) => get_module_error_class(err),
+  }
+}
+
+pub fn get_module_error_class(err: &ModuleError) -> &'static str {
+  use deno_graph::JsrLoadError;
+  use deno_graph::NpmLoadError;
+
+  match err {
+    ModuleError::InvalidTypeAssertion { .. } => "SyntaxError",
+    ModuleError::ParseErr(_, diagnostic) => get_diagnostic_class(diagnostic),
+    ModuleError::WasmParseErr(..) => "SyntaxError",
+    ModuleError::UnsupportedMediaType { .. }
+    | ModuleError::UnsupportedImportAttributeType { .. } => "TypeError",
+    ModuleError::Missing(_, _) | ModuleError::MissingDynamic(_, _) => {
+      "NotFound"
+    }
+    ModuleError::LoadingErr(_, _, err) => match err {
+      ModuleLoadError::Loader(err) => get_error_class_name(err.as_ref()),
+      ModuleLoadError::HttpsChecksumIntegrity(_)
+      | ModuleLoadError::TooManyRedirects => "Error",
+      ModuleLoadError::NodeUnknownBuiltinModule(_) => "NotFound",
+      ModuleLoadError::Decode(_) => "TypeError",
+      ModuleLoadError::Npm(err) => match err {
+        NpmLoadError::NotSupportedEnvironment
+        | NpmLoadError::PackageReqResolution(_)
+        | NpmLoadError::RegistryInfo(_) => "Error",
+        NpmLoadError::PackageReqReferenceParse(_) => "TypeError",
+      },
+      ModuleLoadError::Jsr(err) => match err {
+        JsrLoadError::UnsupportedManifestChecksum
+        | JsrLoadError::PackageFormat(_) => "TypeError",
+        JsrLoadError::ContentLoadExternalSpecifier
+        | JsrLoadError::ContentLoad(_)
+        | JsrLoadError::ContentChecksumIntegrity(_)
+        | JsrLoadError::PackageManifestLoad(_, _)
+        | JsrLoadError::PackageVersionManifestChecksumIntegrity(..)
+        | JsrLoadError::PackageVersionManifestLoad(_, _)
+        | JsrLoadError::RedirectInPackage(_) => "Error",
+        JsrLoadError::PackageNotFound(_)
+        | JsrLoadError::PackageReqNotFound(_)
+        | JsrLoadError::PackageVersionNotFound(_)
+        | JsrLoadError::UnknownExport { .. } => "NotFound",
       },
     },
   }

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -753,6 +753,7 @@ impl CliFactory {
           self.module_graph_builder().await?.clone(),
           self.node_resolver().await?.clone(),
           self.npm_resolver().await?.clone(),
+          self.sys(),
         )))
       })
       .await

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -409,9 +409,20 @@ delete Object.prototype.__proto__;
       messageText = formatMessage(msgText, ri.code);
     }
     if (start !== undefined && length !== undefined && file) {
-      const startPos = file.getLineAndCharacterOfPosition(start);
-      const sourceLine = file.getFullText().split("\n")[startPos.line];
-      const fileName = file.fileName;
+      let startPos = file.getLineAndCharacterOfPosition(start);
+      let sourceLine = file.getFullText().split("\n")[startPos.line];
+      const originalFileName = file.fileName;
+      const fileName = ops.op_remap_specifier
+        ? (ops.op_remap_specifier(file.fileName) ?? file.fileName)
+        : file.fileName;
+      // Bit of a hack to detect when we have a .wasm file and want to hide
+      // the .d.ts text. This is not perfect, but will work in most scenarios
+      if (
+        fileName.endsWith(".wasm") && originalFileName.endsWith(".wasm.d.mts")
+      ) {
+        startPos = { line: 0, character: 0 };
+        sourceLine = undefined;
+      }
       return {
         start: startPos,
         end: file.getLineAndCharacterOfPosition(start + length),
@@ -470,11 +481,6 @@ delete Object.prototype.__proto__;
     // TS2688: Cannot find type definition file for '...'.
     // We ignore because type definition files can end with '.ts'.
     2688,
-    // TS2792: Cannot find module. Did you mean to set the 'moduleResolution'
-    // option to 'node', or to add aliases to the 'paths' option?
-    2792,
-    // TS2307: Cannot find module '{0}' or its corresponding type declarations.
-    2307,
     // TS5009: Cannot find the common subdirectory path for the input files.
     5009,
     // TS5055: Cannot write file
@@ -888,6 +894,8 @@ delete Object.prototype.__proto__;
     const nodeMessage = "Cannot find name '{0}'."; // don't offer any suggestions
     const jqueryMessage =
       "Cannot find name '{0}'. Did you mean to import jQuery? Try adding `import $ from \"npm:jquery\";`.";
+    const cannotFindModuleMessage = "Cannot find module '{0}'.";
+    const cannotFindModuleNoIterpolationMessage = "Cannot find module.";
     return {
       "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashno_2580":
         nodeMessage,
@@ -899,6 +907,14 @@ delete Object.prototype.__proto__;
         jqueryMessage,
       "Module_0_was_resolved_to_1_but_allowArbitraryExtensions_is_not_set_6263":
         "Module '{0}' was resolved to '{1}', but importing these modules is not supported.",
+      "Cannot_find_module_0_Consider_using_resolveJsonModule_to_import_module_with_json_extension_2732":
+        cannotFindModuleMessage,
+      "Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_t_2792":
+        cannotFindModuleMessage,
+      "Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_n_2834":
+        cannotFindModuleNoIterpolationMessage,
+      "Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_n_2835":
+        cannotFindModuleNoIterpolationMessage,
     };
   })());
 
@@ -1037,24 +1053,27 @@ delete Object.prototype.__proto__;
       configFileParsingDiagnostics,
     });
 
-    const checkFiles = localOnly
-      ? rootNames
-        .filter((n) => !n.startsWith("http"))
-        .map((checkName) => {
-          const sourceFile = program.getSourceFile(checkName);
-          if (sourceFile == null) {
-            throw new Error("Could not find source file for: " + checkName);
-          }
-          return sourceFile;
-        })
-      : undefined;
+    let checkFiles = undefined;
 
-    if (checkFiles != null) {
+    if (localOnly) {
+      const checkFileNames = new Set();
+      checkFiles = [];
+
+      for (const checkName of rootNames) {
+        if (checkName.startsWith("http")) {
+          continue;
+        }
+        const sourceFile = program.getSourceFile(checkName);
+        if (sourceFile != null) {
+          checkFiles.push(sourceFile);
+        }
+        checkFileNames.add(checkName);
+      }
+
       // When calling program.getSemanticDiagnostics(...) with a source file, we
       // need to call this code first in order to get it to invalidate cached
       // diagnostics correctly. This is what program.getSemanticDiagnostics()
       // does internally when calling without any arguments.
-      const checkFileNames = new Set(checkFiles.map((f) => f.fileName));
       while (
         program.getSemanticDiagnosticsOfNextAffectedFile(
           undefined,

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -481,6 +481,14 @@ delete Object.prototype.__proto__;
     // TS2688: Cannot find type definition file for '...'.
     // We ignore because type definition files can end with '.ts'.
     2688,
+    // TS2792: Cannot find module. Did you mean to set the 'moduleResolution'
+    // option to 'node', or to add aliases to the 'paths' option?
+    2792,
+    // TS2307: Cannot find module '{0}' or its corresponding type declarations.
+    2307,
+    // Relative import errors to add an extension
+    2834,
+    2835,
     // TS5009: Cannot find the common subdirectory path for the input files.
     5009,
     // TS5055: Cannot write file
@@ -894,8 +902,6 @@ delete Object.prototype.__proto__;
     const nodeMessage = "Cannot find name '{0}'."; // don't offer any suggestions
     const jqueryMessage =
       "Cannot find name '{0}'. Did you mean to import jQuery? Try adding `import $ from \"npm:jquery\";`.";
-    const cannotFindModuleMessage = "Cannot find module '{0}'.";
-    const cannotFindModuleNoIterpolationMessage = "Cannot find module.";
     return {
       "Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashno_2580":
         nodeMessage,
@@ -907,14 +913,6 @@ delete Object.prototype.__proto__;
         jqueryMessage,
       "Module_0_was_resolved_to_1_but_allowArbitraryExtensions_is_not_set_6263":
         "Module '{0}' was resolved to '{1}', but importing these modules is not supported.",
-      "Cannot_find_module_0_Consider_using_resolveJsonModule_to_import_module_with_json_extension_2732":
-        cannotFindModuleMessage,
-      "Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_t_2792":
-        cannotFindModuleMessage,
-      "Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_n_2834":
-        cannotFindModuleNoIterpolationMessage,
-      "Relative_import_paths_need_explicit_file_extensions_in_ECMAScript_imports_when_moduleResolution_is_n_2835":
-        cannotFindModuleNoIterpolationMessage,
     };
   })());
 

--- a/cli/tsc/diagnostics.rs
+++ b/cli/tsc/diagnostics.rs
@@ -173,7 +173,7 @@ impl Diagnostic {
         additional_message.unwrap_or_default()
       )),
       message_chain: None,
-      source: maybe_range.map(|r| r.specifier.to_string()),
+      source: None,
       source_line: None,
       file_name: maybe_range.map(|r| r.specifier.to_string()),
       related_information: None,

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -705,7 +705,7 @@ fn op_remap_specifier(
   state: &mut OpState,
   #[string] specifier: &str,
 ) -> Option<String> {
-  let state = state.borrow_mut::<State>();
+  let state = state.borrow::<State>();
   state
     .maybe_remapped_specifier(specifier)
     .map(|url| url.to_string())

--- a/tests/integration/jsr_tests.rs
+++ b/tests/integration/jsr_tests.rs
@@ -66,12 +66,11 @@ fn fast_check_cache() {
   // ensure cache works
   let output = check_debug_cmd.run();
   assert_contains!(output.combined_output(), "Already type checked.");
-  let building_fast_check_msg = "Building fast check graph";
-  assert_not_contains!(output.combined_output(), building_fast_check_msg);
 
   // now validated
   type_check_cache_path.remove_file();
   let output = check_debug_cmd.run();
+  let building_fast_check_msg = "Building fast check graph";
   assert_contains!(output.combined_output(), building_fast_check_msg);
   assert_contains!(
     output.combined_output(),

--- a/tests/specs/check/css_import/__test__.jsonc
+++ b/tests/specs/check/css_import/__test__.jsonc
@@ -8,6 +8,10 @@
     "exitCode": 1
   }, {
     "args": "check not_exists.ts",
+    "output": "not_exists_check.out",
+    "exitCode": 0 // typescript doesn't raise errors for non-existent side-effect imports
+  }, {
+    "args": "run --check not_exists.ts",
     "output": "not_exists.out",
     "exitCode": 1
   }, {

--- a/tests/specs/check/css_import/__test__.jsonc
+++ b/tests/specs/check/css_import/__test__.jsonc
@@ -8,8 +8,8 @@
     "exitCode": 1
   }, {
     "args": "check not_exists.ts",
-    "output": "not_exists_check.out",
-    "exitCode": 0 // typescript doesn't raise errors for non-existent side-effect imports
+    "output": "not_exists.out",
+    "exitCode": 1
   }, {
     "args": "run --check not_exists.ts",
     "output": "not_exists.out",

--- a/tests/specs/check/css_import/not_exists.out
+++ b/tests/specs/check/css_import/not_exists.out
@@ -1,2 +1,3 @@
-error: Module not found "file:///[WILDLINE]/not_exists.css".
+Check [WILDLINE]exists.ts
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/not_exists.css'.
     at file:///[WILDLINE]/not_exists.ts:1:8

--- a/tests/specs/check/css_import/not_exists_check.out
+++ b/tests/specs/check/css_import/not_exists_check.out
@@ -1,0 +1,1 @@
+Check [WILDLINE]exists.ts

--- a/tests/specs/check/css_import/not_exists_check.out
+++ b/tests/specs/check/css_import/not_exists_check.out
@@ -1,1 +1,0 @@
-Check [WILDLINE]exists.ts

--- a/tests/specs/check/dts_importing_non_existent/check.out
+++ b/tests/specs/check/dts_importing_non_existent/check.out
@@ -1,2 +1,5 @@
-error: Module not found "file:///[WILDLINE]/test".
+Check file:///[WILDLINE]/dts_importing_non_existent/index.js
+error: TS2834 [ERROR]: Cannot find module.
+export { Test } from "./test";
+                     ~~~~~~~~
     at file:///[WILDLINE]/index.d.ts:1:22

--- a/tests/specs/check/dts_importing_non_existent/check.out
+++ b/tests/specs/check/dts_importing_non_existent/check.out
@@ -1,5 +1,3 @@
 Check file:///[WILDLINE]/dts_importing_non_existent/index.js
-error: TS2834 [ERROR]: Cannot find module.
-export { Test } from "./test";
-                     ~~~~~~~~
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/test'.
     at file:///[WILDLINE]/index.d.ts:1:22

--- a/tests/specs/check/import_non_existent_in_remote/__test__.jsonc
+++ b/tests/specs/check/import_non_existent_in_remote/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "not_all": {
+      "args": "check --allow-import import_remote.ts",
+      "output": "[WILDCARD]",
+      "exitCode": 0
+    },
+    "all": {
+      "args": "check --all --allow-import import_remote.ts",
+      "output": "check_all.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/check/import_non_existent_in_remote/check_all.out
+++ b/tests/specs/check/import_non_existent_in_remote/check_all.out
@@ -1,0 +1,5 @@
+Download http://localhost:4545/check/import_non_existent.ts
+Download http://localhost:4545/check/non-existent-module.ts
+Check file:///[WILDLINE]/import_remote.ts
+error: TS2307 [ERROR]: Cannot find module 'http://localhost:4545/check/non-existent-module.ts'.
+    at http://localhost:4545/check/import_non_existent.ts:1:22

--- a/tests/specs/check/import_non_existent_in_remote/import_remote.ts
+++ b/tests/specs/check/import_non_existent_in_remote/import_remote.ts
@@ -1,0 +1,3 @@
+import { Other } from "http://localhost:4545/check/import_non_existent.ts";
+
+console.log(Other);

--- a/tests/specs/check/module_not_found/__test__.jsonc
+++ b/tests/specs/check/module_not_found/__test__.jsonc
@@ -1,0 +1,24 @@
+{
+  "tests": {
+    "check": {
+      "args": "check --allow-import main.ts",
+      "output": "main.out",
+      "exitCode": 1
+    },
+    "run": {
+      "args": "run --check --allow-import main.ts",
+      "output": "main.out",
+      "exitCode": 1
+    },
+    "missing_local_root": {
+      "args": "check --allow-import non_existent.ts",
+      "output": "missing_local_root.out",
+      "exitCode": 1
+    },
+    "missing_remote_root": {
+      "args": "check --allow-import http://localhost:4545/missing_non_existent.ts",
+      "output": "missing_remote_root.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/check/module_not_found/main.out
+++ b/tests/specs/check/module_not_found/main.out
@@ -1,13 +1,9 @@
 Download http://localhost:4545/remote.ts
 Check file:///[WILDLINE]/module_not_found/main.ts
-error: TS2307 [ERROR]: Cannot find module './other.js' or its corresponding type declarations.
-import { Test } from "./other.js";
-                     ~~~~~~~~~~~~
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/other.js'.
     at file:///[WILDLINE]/main.ts:1:22
 
-TS2307 [ERROR]: Cannot find module 'http://localhost:4545/remote.ts' or its corresponding type declarations.
-import { Remote } from "http://localhost:4545/remote.ts";
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TS2307 [ERROR]: Cannot find module 'http://localhost:4545/remote.ts'.
     at file:///[WILDLINE]/main.ts:2:24
 
 Found 2 errors.

--- a/tests/specs/check/module_not_found/main.out
+++ b/tests/specs/check/module_not_found/main.out
@@ -1,0 +1,13 @@
+Download http://localhost:4545/remote.ts
+Check file:///[WILDLINE]/module_not_found/main.ts
+error: TS2307 [ERROR]: Cannot find module './other.js' or its corresponding type declarations.
+import { Test } from "./other.js";
+                     ~~~~~~~~~~~~
+    at file:///[WILDLINE]/main.ts:1:22
+
+TS2307 [ERROR]: Cannot find module 'http://localhost:4545/remote.ts' or its corresponding type declarations.
+import { Remote } from "http://localhost:4545/remote.ts";
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    at file:///[WILDLINE]/main.ts:2:24
+
+Found 2 errors.

--- a/tests/specs/check/module_not_found/main.ts
+++ b/tests/specs/check/module_not_found/main.ts
@@ -1,0 +1,5 @@
+import { Test } from "./other.js";
+import { Remote } from "http://localhost:4545/remote.ts";
+
+console.log(new Test());
+console.log(new Remote());

--- a/tests/specs/check/module_not_found/missing_local_root.out
+++ b/tests/specs/check/module_not_found/missing_local_root.out
@@ -1,0 +1,2 @@
+Check file:///[WILDLINE]/non_existent.ts
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/non_existent.ts'.

--- a/tests/specs/check/module_not_found/missing_remote_root.out
+++ b/tests/specs/check/module_not_found/missing_remote_root.out
@@ -1,0 +1,3 @@
+Download http://localhost:4545/missing_non_existent.ts
+Check http://localhost:4545/missing_non_existent.ts
+error: TS2307 [ERROR]: Cannot find module 'http://localhost:4545/missing_non_existent.ts'.

--- a/tests/specs/check/types_resolved_relative_config/main.out
+++ b/tests/specs/check/types_resolved_relative_config/main.out
@@ -1,3 +1,4 @@
 [# It should be resolving relative the config in sub_dir instead of the cwd]
-error: Module not found "file:///[WILDLINE]/sub_dir/a.d.ts".
+Check file:///[WILDLINE]/main.ts
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/sub_dir/a.d.ts'.
     at file:///[WILDLINE]/sub_dir/deno.json:1:1

--- a/tests/specs/publish/sloppy_imports/sloppy_imports_not_enabled.out
+++ b/tests/specs/publish/sloppy_imports/sloppy_imports_not_enabled.out
@@ -1,2 +1,3 @@
-error: [WILDCARD] Maybe specify path to 'index.ts' file in directory instead or run with --unstable-sloppy-imports
-    at file:///[WILDCARD]/mod.ts:1:20
+Check file:///[WILDLINE]/mod.ts
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/b'. Maybe specify path to 'index.ts' file in directory instead or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/mod.ts:1:20

--- a/tests/specs/run/jsx_import_source/jsx_import_source_error.out
+++ b/tests/specs/run/jsx_import_source/jsx_import_source_error.out
@@ -1,2 +1,3 @@
-error: Module not found "file:///[WILDCARD]/nonexistent/jsx-runtime".
-    at file:///[WILDCARD]/jsx_import_source_no_pragma.tsx:1:1
+Check file:///[WILDLINE]/jsx_import_source_no_pragma.tsx
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDCARD]/nonexistent/jsx-runtime'.
+    at file:///[WILDLINE]/jsx_import_source_no_pragma.tsx:1:1

--- a/tests/specs/run/reference_types_error/reference_types_error.js.out
+++ b/tests/specs/run/reference_types_error/reference_types_error.js.out
@@ -1,2 +1,3 @@
-error: Module not found "file:///[WILDCARD]/nonexistent.d.ts".
-    at file:///[WILDCARD]/reference_types_error.js:1:22
+Check file:///[WILDLINE]/reference_types_error.js
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/nonexistent.d.ts'.
+    at file:///[WILDLINE]/reference_types_error.js:1:22

--- a/tests/specs/run/reference_types_error_vendor_dir/reference_types_error.js.out
+++ b/tests/specs/run/reference_types_error_vendor_dir/reference_types_error.js.out
@@ -1,2 +1,3 @@
-error: Module not found "file:///[WILDCARD]/nonexistent.d.ts".
-    at file:///[WILDCARD]/reference_types_error.js:1:22
+Check file:///[WILDLINE]/reference_types_error.js
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/nonexistent.d.ts'.
+    at file:///[WILDLINE]/reference_types_error.js:1:22

--- a/tests/specs/run/sloppy_imports/no_sloppy.out
+++ b/tests/specs/run/sloppy_imports/no_sloppy.out
@@ -1,2 +1,26 @@
-error: Module not found "file:///[WILDCARD]/a.js". Maybe change the extension to '.ts' or run with --unstable-sloppy-imports
+Check file:///[WILDLINE]/main.ts
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/a.js'. Maybe change the extension to '.ts' or run with --unstable-sloppy-imports
     at file:///[WILDLINE]/main.ts:1:20
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/b'. Maybe add a '.js' extension or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:2:20
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/c'. Maybe add a '.mts' extension or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:3:20
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/d'. Maybe add a '.mjs' extension or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:4:20
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/e'. Maybe add a '.tsx' extension or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:5:20
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/e.js'. Maybe change the extension to '.tsx' or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:6:21
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/f'. Maybe add a '.jsx' extension or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:7:20
+
+TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/dir'. Maybe specify path to 'index.tsx' file in directory instead or run with --unstable-sloppy-imports
+    at file:///[WILDLINE]/main.ts:8:20
+
+Found 8 errors.

--- a/tests/specs/run/wasm_module/import_file_not_found/__test__.jsonc
+++ b/tests/specs/run/wasm_module/import_file_not_found/__test__.jsonc
@@ -1,5 +1,14 @@
 {
-  "args": "--allow-import main.js",
-  "output": "main.out",
-  "exitCode": 1
+  "tests": {
+    "run": {
+      "args": "--allow-import main.js",
+      "output": "main.out",
+      "exitCode": 1
+    },
+    "check": {
+      "args": "check --all --allow-import main.js",
+      "output": "check.out",
+      "exitCode": 1
+    }
+  }
 }

--- a/tests/specs/run/wasm_module/import_file_not_found/check.out
+++ b/tests/specs/run/wasm_module/import_file_not_found/check.out
@@ -1,4 +1,4 @@
 Download http://localhost:4545/wasm/math_with_import.wasm
 Check file:///[WILDLINE]/main.js
-error: TS2307 [ERROR]: Cannot find module './math.ts' or its corresponding type declarations.
-    at http://localhost:4545/wasm/math_with_import.wasm:1:1
+error: TS2307 [ERROR]: Cannot find module 'file:///V:/deno/tests/specs/run/wasm_module/import_file_not_found/local_math.ts'.
+    at http://localhost:4545/wasm/math_with_import.wasm:1:87

--- a/tests/specs/run/wasm_module/import_file_not_found/check.out
+++ b/tests/specs/run/wasm_module/import_file_not_found/check.out
@@ -1,0 +1,4 @@
+Download http://localhost:4545/wasm/math_with_import.wasm
+Check file:///[WILDLINE]/main.js
+error: TS2307 [ERROR]: Cannot find module './math.ts' or its corresponding type declarations.
+    at http://localhost:4545/wasm/math_with_import.wasm:1:1

--- a/tests/specs/run/wasm_module/import_file_not_found/check.out
+++ b/tests/specs/run/wasm_module/import_file_not_found/check.out
@@ -1,4 +1,4 @@
 Download http://localhost:4545/wasm/math_with_import.wasm
 Check file:///[WILDLINE]/main.js
-error: TS2307 [ERROR]: Cannot find module 'file:///V:/deno/tests/specs/run/wasm_module/import_file_not_found/local_math.ts'.
+error: TS2307 [ERROR]: Cannot find module 'file:///[WILDLINE]/local_math.ts'.
     at http://localhost:4545/wasm/math_with_import.wasm:1:87

--- a/tests/specs/run/wasm_module/import_file_not_found/main.js
+++ b/tests/specs/run/wasm_module/import_file_not_found/main.js
@@ -1,3 +1,4 @@
+// @ts-check
 import {
   add,
   subtract,

--- a/tests/specs/run/wasm_module/import_file_not_found/main.out
+++ b/tests/specs/run/wasm_module/import_file_not_found/main.out
@@ -1,3 +1,3 @@
 Download http://localhost:4545/wasm/math_with_import.wasm
 error: Module not found "file:///[WILDLINE]/local_math.ts".
-    at http://localhost:4545/wasm/math_with_import.wasm:1:8
+    at http://localhost:4545/wasm/math_with_import.wasm:1:87

--- a/tests/specs/run/wasm_module/import_named_export_not_found/__test__.jsonc
+++ b/tests/specs/run/wasm_module/import_named_export_not_found/__test__.jsonc
@@ -1,5 +1,14 @@
 {
-  "args": "--allow-import main.js",
-  "output": "main.out",
-  "exitCode": 1
+  "tests": {
+    "run": {
+      "args": "--allow-import main.js",
+      "output": "main.out",
+      "exitCode": 1
+    },
+    "check": {
+      "args": "check --all --allow-import main.js",
+      "output": "check.out",
+      "exitCode": 1
+    }
+  }
 }

--- a/tests/specs/run/wasm_module/import_named_export_not_found/check.out
+++ b/tests/specs/run/wasm_module/import_named_export_not_found/check.out
@@ -1,0 +1,9 @@
+Download http://localhost:4545/wasm/math_with_import.wasm
+Check file:///[WILDLINE]/main.js
+error: TS2305 [ERROR]: Module '"file:///[WILDLINE]/local_math.ts"' has no exported member '"add"'.
+    at http://localhost:4545/wasm/math_with_import.wasm:1:1
+
+TS2305 [ERROR]: Module '"file:///[WILDLINE]/local_math.ts"' has no exported member '"subtract"'.
+    at http://localhost:4545/wasm/math_with_import.wasm:1:1
+
+Found 2 errors.

--- a/tests/specs/run/wasm_module/import_named_export_not_found/main.js
+++ b/tests/specs/run/wasm_module/import_named_export_not_found/main.js
@@ -1,3 +1,4 @@
+// @ts-check
 import {
   add,
   subtract,

--- a/tests/testdata/check/import_non_existent.ts
+++ b/tests/testdata/check/import_non_existent.ts
@@ -1,0 +1,5 @@
+import { Test } from "./non-existent-module.ts";
+
+console.log(Test);
+
+export class Other {}


### PR DESCRIPTION
Instead of hard erroring, we now surface module not found errors as TypeScript diagnostics (we have yet to show the source code of the error, but something we can improve over time).

```
> deno check main.ts
error: Module not found "file:///V:/scratch/other1.js".
    at file:///V:/scratch/main.ts:1:23
V:\scratch
> ../deno/target/debug/deno check main.ts
Check file:///V:/scratch/main.ts
error: TS2307 [ERROR]: Cannot find module 'file:///V:/scratch/other1.js'.
    at file:///V:/scratch/main.ts:1:23

TS2307 [ERROR]: Cannot find module 'file:///V:/scratch/other2.js'.
    at file:///V:/scratch/main.ts:2:23

Found 2 errors.
> npx tsc
main.ts:1:23 - error TS2307: Cannot find module './other1.js' or its corresponding type declarations.

1 import { TestA } from "./other1.js";
                        ~~~~~~~~~~~~~

main.ts:2:23 - error TS2307: Cannot find module './other2.js' or its corresponding type declarations.

2 import { TestB } from "./other2.js";
                        ~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: main.ts:1
```

This doesn't work yet for npm modules, but it's what I'll work on next.

Closes https://github.com/denoland/deno/issues/27188