### PR TITLE
ci: increase timeout to 240 minutes

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -360,7 +360,7 @@ const ci = {
       needs: ["pre_build"],
       if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
       "runs-on": "${{ matrix.runner }}",
-      "timeout-minutes": 180,
+      "timeout-minutes": 240,
       defaults: {
         run: {
           // GH actions does not fail fast by default on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - pre_build
     if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
     runs-on: '${{ matrix.runner }}'
-    timeout-minutes: 180
+    timeout-minutes: 240
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
With https://github.com/denoland/deno/pull/27507 landed we need to do two
builds that don't really share much codegen units.

This should be reverted once we move to self-hosted runner on `main`
(https://github.com/denoland/deno/pull/27568)