### PR TITLE
fix(lint): fix single char selectors being ignored

### DIFF
--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -406,8 +406,9 @@ export function splitSelectors(input) {
     }
   }
 
-  if (last < input.length - 1) {
-    out.push(input.slice(last).trim());
+  const remaining = input.slice(last).trim();
+  if (remaining.length > 0) {
+    out.push(remaining);
   }
 
   return out;

--- a/tests/unit/lint_selectors_test.ts
+++ b/tests/unit/lint_selectors_test.ts
@@ -20,6 +20,9 @@ import {
 import { assertThrows } from "@std/assert";
 
 Deno.test("splitSelectors", () => {
+  assertEquals(splitSelectors("*"), ["*"]);
+  assertEquals(splitSelectors("*,*"), ["*", "*"]);
+  assertEquals(splitSelectors("*,*     "), ["*", "*"]);
   assertEquals(splitSelectors("foo"), ["foo"]);
   assertEquals(splitSelectors("foo, bar"), ["foo", "bar"]);
   assertEquals(splitSelectors("foo:f(bar, baz)"), ["foo:f(bar, baz)"]);


### PR DESCRIPTION
The selector splitting code that's used for JS linting plugins didn't properly account for selectors being a single character. This can happen in the case of `*`.

Instead of comparing against the length, we'll now check if the remaining string portion is not empty, which is more robust. It also allows us to detect trailing whitespace, which we didn't before.