### PR TITLE
fix(node/fs): add utimes method to the FileHandle class

### DIFF
--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -152,6 +152,14 @@ export class FileHandle extends EventEmitter {
     assertNotClosed(this, promises.chmod.name);
     return promises.chmod(this.#path, mode);
   }
+
+  utimes(
+    atime: number | string | Date,
+    mtime: number | string | Date,
+  ): Promise<void> {
+    assertNotClosed(this, promises.utimes.name);
+    return promises.utimes(this.#path, atime, mtime);
+  }
 }
 
 function assertNotClosed(handle: FileHandle, syscall: string) {

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -157,7 +157,8 @@ export class FileHandle extends EventEmitter {
     atime: number | string | Date,
     mtime: number | string | Date,
   ): Promise<void> {
-    return fsCall(promises.utimes, this, atime, mtime);
+    assertNotClosed(this, promises.utimes.name);
+    return promises.utimes(this.#path, atime, mtime);
   }
 }
 

--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -157,8 +157,7 @@ export class FileHandle extends EventEmitter {
     atime: number | string | Date,
     mtime: number | string | Date,
   ): Promise<void> {
-    assertNotClosed(this, promises.utimes.name);
-    return promises.utimes(this.#path, atime, mtime);
+    return fsCall(promises.utimes, this, atime, mtime);
   }
 }
 

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -217,3 +217,21 @@ Deno.test({
     await fileHandle.close();
   },
 });
+
+Deno.test({
+  name:
+    "[node/fs filehandle.utimes] Change the file system timestamps of the file",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const fileHandle = await fs.open(testData);
+
+    const atime = new Date();
+    const mtime = new Date(0);
+
+    await fileHandle.utimes(atime, mtime);
+    assertEquals(Deno.statSync(testData).atime!, atime);
+    assertEquals(Deno.statSync(testData).mtime!, mtime);
+
+    await fileHandle.close();
+  },
+});

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -221,7 +221,6 @@ Deno.test({
 Deno.test({
   name:
     "[node/fs filehandle.utimes] Change the file system timestamps of the file",
-  ignore: Deno.build.os === "windows",
   async fn() {
     const fileHandle = await fs.open(testData);
 


### PR DESCRIPTION
Added utimes method to the FileHandle class, part of #25554 

✔ cargo test
✔ tools/format
✔ tools/lint