### PR TITLE
fix(node/fs): add a createReadStream method to the FileHandle class

### DIFF
--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -14,6 +14,7 @@ import {
   ReadStream,
 } from "node:fs";
 import { core } from "ext:core/mod.js";
+export type { BigIntStats, Stats } from "ext:deno_node/_fs/_fs_stat.ts";
 import {
   BinaryOptionsArgument,
   FileOptionsArgument,

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -300,7 +300,7 @@ Deno.test(
     });
 
     await new Promise((resolve) => {
-      stream.close(resolve);
+      stream.on("close", resolve);
     });
     await fileHandle.close();
   }

--- a/tests/unit_node/_fs/_fs_handle_test.ts
+++ b/tests/unit_node/_fs/_fs_handle_test.ts
@@ -45,7 +45,7 @@ Deno.test("read specify opt", async function () {
   assertEquals(res.bytesRead, 5);
   assertEquals(
     new TextDecoder().decode(res.buffer.subarray(6) as Uint8Array),
-    "world",
+    "world"
   );
 
   const opt2 = {
@@ -58,7 +58,7 @@ Deno.test("read specify opt", async function () {
   assertEquals(res.bytesRead, 5);
   assertEquals(
     decoder.decode(res.buffer.subarray(0, 5) as Uint8Array),
-    "hello",
+    "hello"
   );
 
   await fileHandle.close();
@@ -134,7 +134,7 @@ Deno.test(
 
     assertEquals(res.bytesWritten, 11);
     assertEquals(decoder.decode(data), "hello world");
-  },
+  }
 );
 
 Deno.test(
@@ -154,7 +154,7 @@ Deno.test(
     await fileHandle.close();
 
     assertEquals(decoder.decode(data), "hello lorem ipsum");
-  },
+  }
 );
 
 Deno.test(
@@ -172,7 +172,7 @@ Deno.test(
     await fileHandle.close();
 
     assertEquals(decoder.decode(data), "hello");
-  },
+  }
 );
 
 Deno.test(
@@ -190,7 +190,7 @@ Deno.test(
     await fileHandle.close();
 
     assertEquals(decoder.decode(data), "");
-  },
+  }
 );
 
 Deno.test(
@@ -217,7 +217,7 @@ Deno.test(
     assertEquals(data[2], 0);
     assertEquals(data[3], 0);
     assertEquals(data[4], 0);
-  },
+  }
 );
 
 Deno.test(
@@ -236,7 +236,7 @@ Deno.test(
 
     assertEquals(decoder.decode(data), "");
     assertEquals(data.length, 0);
-  },
+  }
 );
 
 Deno.test({
@@ -258,8 +258,7 @@ Deno.test({
 });
 
 Deno.test({
-  name:
-    "[node/fs filehandle.utimes] Change the file system timestamps of the file",
+  name: "[node/fs filehandle.utimes] Change the file system timestamps of the file",
   async fn() {
     const fileHandle = await fs.open(testData);
 
@@ -273,3 +272,36 @@ Deno.test({
     await fileHandle.close();
   },
 });
+
+Deno.test(
+  "[node/fs filehandle.createReadStream] Create a read stream",
+  async function () {
+    const fileHandle = await fs.open(testData);
+    const stream = fileHandle.createReadStream();
+    const fileSize = (await fileHandle.stat()).size;
+
+    assertEquals(stream.bytesRead, 0);
+    assertEquals(stream.readable, true);
+
+    let bytesRead = 0;
+
+    stream.on("open", () => assertEquals(stream.bytesRead, 0));
+
+    stream.on("data", (data) => {
+      assertEquals(data instanceof Buffer, true);
+      assertEquals((data as Buffer).byteOffset % 8, 0);
+      bytesRead += data.length;
+      assertEquals(stream.bytesRead, bytesRead);
+    });
+
+    stream.on("end", () => {
+      assertEquals(stream.bytesRead, fileSize);
+      assertEquals(bytesRead, fileSize);
+    });
+
+    await new Promise((resolve) => {
+      stream.close(resolve);
+    });
+    await fileHandle.close();
+  }
+);


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Add the createReadStream method to the FileHandle class in node compat as part of #25554 