### PR TITLE
refactor(npm): move `InNpmPackageChecker` code to deno_resolver

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -12,6 +12,8 @@ use deno_core::futures::FutureExt;
 use deno_core::FeatureChecker;
 use deno_error::JsErrorBox;
 use deno_resolver::cjs::IsCjsResolutionMode;
+use deno_resolver::npm::managed::ManagedInNpmPkgCheckerCreateOptions;
+use deno_resolver::npm::CreateInNpmPkgCheckerOptions;
 use deno_resolver::npm::NpmReqResolverOptions;
 use deno_resolver::DenoResolverOptions;
 use deno_resolver::NodeAndNpmReqResolver;
@@ -64,14 +66,11 @@ use crate::node::CliNodeCodeTranslator;
 use crate::node::CliNodeResolver;
 use crate::node::CliPackageJsonResolver;
 use crate::npm::create_cli_npm_resolver;
-use crate::npm::create_in_npm_pkg_checker;
 use crate::npm::CliByonmNpmResolverCreateOptions;
-use crate::npm::CliManagedInNpmPkgCheckerCreateOptions;
 use crate::npm::CliManagedNpmResolverCreateOptions;
 use crate::npm::CliNpmResolver;
 use crate::npm::CliNpmResolverCreateOptions;
 use crate::npm::CliNpmResolverManagedSnapshotOption;
-use crate::npm::CreateInNpmPkgCheckerOptions;
 use crate::npm::NpmRegistryReadPermissionChecker;
 use crate::npm::NpmRegistryReadPermissionCheckerMode;
 use crate::resolver::CjsTracker;
@@ -387,7 +386,7 @@ impl CliFactory {
         CreateInNpmPkgCheckerOptions::Byonm
       } else {
         CreateInNpmPkgCheckerOptions::Managed(
-          CliManagedInNpmPkgCheckerCreateOptions {
+          ManagedInNpmPkgCheckerCreateOptions {
             root_cache_dir_url: self.npm_cache_dir()?.root_dir_url(),
             maybe_node_modules_path: cli_options
               .node_modules_dir_path()
@@ -395,7 +394,7 @@ impl CliFactory {
           },
         )
       };
-      Ok(create_in_npm_pkg_checker(options))
+      Ok(deno_resolver::npm::create_in_npm_pkg_checker(options))
     })
   }
 

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -23,6 +23,8 @@ use deno_graph::Range;
 use deno_npm::NpmSystemInfo;
 use deno_path_util::url_to_file_path;
 use deno_resolver::cjs::IsCjsResolutionMode;
+use deno_resolver::npm::managed::ManagedInNpmPkgCheckerCreateOptions;
+use deno_resolver::npm::CreateInNpmPkgCheckerOptions;
 use deno_resolver::npm::NpmReqResolverOptions;
 use deno_resolver::DenoResolverOptions;
 use deno_resolver::NodeAndNpmReqResolver;
@@ -53,12 +55,10 @@ use crate::node::CliNodeResolver;
 use crate::node::CliPackageJsonResolver;
 use crate::npm::create_cli_npm_resolver_for_lsp;
 use crate::npm::CliByonmNpmResolverCreateOptions;
-use crate::npm::CliManagedInNpmPkgCheckerCreateOptions;
 use crate::npm::CliManagedNpmResolverCreateOptions;
 use crate::npm::CliNpmResolver;
 use crate::npm::CliNpmResolverCreateOptions;
 use crate::npm::CliNpmResolverManagedSnapshotOption;
-use crate::npm::CreateInNpmPkgCheckerOptions;
 use crate::npm::ManagedCliNpmResolver;
 use crate::resolver::CliDenoResolver;
 use crate::resolver::CliNpmReqResolver;
@@ -736,14 +736,14 @@ impl<'a> ResolverFactory<'a> {
 
   pub fn in_npm_pkg_checker(&self) -> &Arc<dyn InNpmPackageChecker> {
     self.services.in_npm_pkg_checker.get_or_init(|| {
-      crate::npm::create_in_npm_pkg_checker(
+      deno_resolver::npm::create_in_npm_pkg_checker(
         match self.services.npm_resolver.as_ref().map(|r| r.as_inner()) {
           Some(crate::npm::InnerCliNpmResolverRef::Byonm(_)) | None => {
             CreateInNpmPkgCheckerOptions::Byonm
           }
           Some(crate::npm::InnerCliNpmResolverRef::Managed(m)) => {
             CreateInNpmPkgCheckerOptions::Managed(
-              CliManagedInNpmPkgCheckerCreateOptions {
+              ManagedInNpmPkgCheckerCreateOptions {
                 root_cache_dir_url: m.global_cache_root_url(),
                 maybe_node_modules_path: m.maybe_node_modules_path(),
               },

--- a/cli/npm/managed/mod.rs
+++ b/cli/npm/managed/mod.rs
@@ -38,7 +38,6 @@ use installers::create_npm_fs_installer;
 use installers::NpmPackageFsInstaller;
 use node_resolver::errors::PackageFolderResolveError;
 use node_resolver::errors::PackageFolderResolveIoError;
-use node_resolver::InNpmPackageChecker;
 use node_resolver::NpmPackageFolderResolver;
 
 use super::CliNpmCache;
@@ -274,35 +273,6 @@ async fn snapshot_from_lockfile(
   )
   .await?;
   Ok(snapshot)
-}
-
-#[derive(Debug)]
-struct ManagedInNpmPackageChecker {
-  root_dir: Url,
-}
-
-impl InNpmPackageChecker for ManagedInNpmPackageChecker {
-  fn in_npm_package(&self, specifier: &Url) -> bool {
-    specifier.as_ref().starts_with(self.root_dir.as_str())
-  }
-}
-
-pub struct CliManagedInNpmPkgCheckerCreateOptions<'a> {
-  pub root_cache_dir_url: &'a Url,
-  pub maybe_node_modules_path: Option<&'a Path>,
-}
-
-pub fn create_managed_in_npm_pkg_checker(
-  options: CliManagedInNpmPkgCheckerCreateOptions,
-) -> Arc<dyn InNpmPackageChecker> {
-  let root_dir = match options.maybe_node_modules_path {
-    Some(node_modules_folder) => {
-      deno_path_util::url_from_directory_path(node_modules_folder).unwrap()
-    }
-    None => options.root_cache_dir_url.clone(),
-  };
-  debug_assert!(root_dir.as_str().ends_with('/'));
-  Arc::new(ManagedInNpmPackageChecker { root_dir })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -14,7 +14,6 @@ use deno_core::url::Url;
 use deno_error::JsErrorBox;
 use deno_npm::npm_rc::ResolvedNpmRc;
 use deno_npm::registry::NpmPackageInfo;
-use deno_resolver::npm::ByonmInNpmPackageChecker;
 use deno_resolver::npm::ByonmNpmResolver;
 use deno_resolver::npm::CliNpmReqResolver;
 use deno_resolver::npm::ResolvePkgFolderFromDenoReqError;
@@ -23,13 +22,10 @@ use deno_semver::package::PackageNv;
 use deno_semver::package::PackageReq;
 use http::HeaderName;
 use http::HeaderValue;
-use managed::create_managed_in_npm_pkg_checker;
-use node_resolver::InNpmPackageChecker;
 use node_resolver::NpmPackageFolderResolver;
 
 pub use self::byonm::CliByonmNpmResolver;
 pub use self::byonm::CliByonmNpmResolverCreateOptions;
-pub use self::managed::CliManagedInNpmPkgCheckerCreateOptions;
 pub use self::managed::CliManagedNpmResolverCreateOptions;
 pub use self::managed::CliNpmResolverManagedSnapshotOption;
 pub use self::managed::ManagedCliNpmResolver;
@@ -131,22 +127,6 @@ pub async fn create_cli_npm_resolver(
   match options {
     Managed(options) => managed::create_managed_npm_resolver(options).await,
     Byonm(options) => Ok(Arc::new(ByonmNpmResolver::new(options))),
-  }
-}
-
-pub enum CreateInNpmPkgCheckerOptions<'a> {
-  Managed(CliManagedInNpmPkgCheckerCreateOptions<'a>),
-  Byonm,
-}
-
-pub fn create_in_npm_pkg_checker(
-  options: CreateInNpmPkgCheckerOptions,
-) -> Arc<dyn InNpmPackageChecker> {
-  match options {
-    CreateInNpmPkgCheckerOptions::Managed(options) => {
-      create_managed_in_npm_pkg_checker(options)
-    }
-    CreateInNpmPkgCheckerOptions::Byonm => Arc::new(ByonmInNpmPackageChecker),
   }
 }
 

--- a/cli/standalone/mod.rs
+++ b/cli/standalone/mod.rs
@@ -39,6 +39,9 @@ use deno_error::JsErrorBox;
 use deno_npm::npm_rc::ResolvedNpmRc;
 use deno_package_json::PackageJsonDepValue;
 use deno_resolver::cjs::IsCjsResolutionMode;
+use deno_resolver::npm::create_in_npm_pkg_checker;
+use deno_resolver::npm::managed::ManagedInNpmPkgCheckerCreateOptions;
+use deno_resolver::npm::CreateInNpmPkgCheckerOptions;
 use deno_resolver::npm::NpmReqResolverOptions;
 use deno_runtime::deno_fs;
 use deno_runtime::deno_fs::FileSystem;
@@ -81,14 +84,11 @@ use crate::node::CliNodeCodeTranslator;
 use crate::node::CliNodeResolver;
 use crate::node::CliPackageJsonResolver;
 use crate::npm::create_cli_npm_resolver;
-use crate::npm::create_in_npm_pkg_checker;
 use crate::npm::CliByonmNpmResolverCreateOptions;
-use crate::npm::CliManagedInNpmPkgCheckerCreateOptions;
 use crate::npm::CliManagedNpmResolverCreateOptions;
 use crate::npm::CliNpmResolver;
 use crate::npm::CliNpmResolverCreateOptions;
 use crate::npm::CliNpmResolverManagedSnapshotOption;
-use crate::npm::CreateInNpmPkgCheckerOptions;
 use crate::npm::NpmRegistryReadPermissionChecker;
 use crate::npm::NpmRegistryReadPermissionCheckerMode;
 use crate::resolver::CjsTracker;
@@ -738,7 +738,7 @@ pub async fn run(
         .map(|node_modules_dir| root_path.join(node_modules_dir));
       let in_npm_pkg_checker =
         create_in_npm_pkg_checker(CreateInNpmPkgCheckerOptions::Managed(
-          CliManagedInNpmPkgCheckerCreateOptions {
+          ManagedInNpmPkgCheckerCreateOptions {
             root_cache_dir_url: npm_cache_dir.root_dir_url(),
             maybe_node_modules_path: maybe_node_modules_path.as_deref(),
           },
@@ -796,7 +796,7 @@ pub async fn run(
       ));
       let in_npm_pkg_checker =
         create_in_npm_pkg_checker(CreateInNpmPkgCheckerOptions::Managed(
-          CliManagedInNpmPkgCheckerCreateOptions {
+          ManagedInNpmPkgCheckerCreateOptions {
             root_cache_dir_url: npm_cache_dir.root_dir_url(),
             maybe_node_modules_path: None,
           },

--- a/resolvers/deno/Cargo.toml
+++ b/resolvers/deno/Cargo.toml
@@ -14,7 +14,7 @@ description = "Deno resolution algorithm"
 path = "lib.rs"
 
 [features]
-sync = ["dashmap"]
+sync = ["dashmap", "deno_package_json/sync", "node_resolver/sync"]
 
 [dependencies]
 anyhow.workspace = true
@@ -27,10 +27,10 @@ deno_config.workspace = true
 deno_error.workspace = true
 deno_media_type.workspace = true
 deno_npm.workspace = true
-deno_package_json = { workspace = true, features = ["sync"] }
+deno_package_json.workspace = true
 deno_path_util.workspace = true
 deno_semver.workspace = true
-node_resolver = { workspace = true, features = ["sync"] }
+node_resolver.workspace = true
 parking_lot.workspace = true
 sys_traits.workspace = true
 thiserror.workspace = true

--- a/resolvers/deno/npm/managed/common.rs
+++ b/resolvers/deno/npm/managed/common.rs
@@ -9,6 +9,9 @@ use deno_npm::NpmPackageId;
 use node_resolver::errors::PackageFolderResolveError;
 use url::Url;
 
+use crate::sync::MaybeSend;
+use crate::sync::MaybeSync;
+
 #[allow(clippy::disallowed_types)]
 pub(super) type NpmPackageFsResolverRc =
   crate::sync::MaybeArc<dyn NpmPackageFsResolver>;
@@ -20,7 +23,7 @@ pub struct NpmPackageFsResolverPackageFolderError(deno_semver::StackString);
 
 /// Part of the resolution that interacts with the file system.
 #[async_trait(?Send)]
-pub trait NpmPackageFsResolver: Send + Sync {
+pub trait NpmPackageFsResolver: MaybeSend + MaybeSync {
   /// The local node_modules folder if it is applicable to the implementation.
   fn node_modules_path(&self) -> Option<&Path>;
 

--- a/resolvers/deno/sync.rs
+++ b/resolvers/deno/sync.rs
@@ -6,6 +6,8 @@ pub use inner::*;
 mod inner {
   #![allow(clippy::disallowed_types)]
 
+  pub use core::marker::Send as MaybeSend;
+  pub use core::marker::Sync as MaybeSync;
   pub use std::sync::Arc as MaybeArc;
 
   pub use dashmap::DashMap as MaybeDashMap;
@@ -20,6 +22,11 @@ mod inner {
   use std::hash::Hash;
   use std::hash::RandomState;
   pub use std::rc::Rc as MaybeArc;
+
+  pub trait MaybeSync {}
+  impl<T> MaybeSync for T where T: ?Sized {}
+  pub trait MaybeSend {}
+  impl<T> MaybeSend for T where T: ?Sized {}
 
   // Wrapper struct that exposes a subset of `DashMap` API.
   #[derive(Debug)]


### PR DESCRIPTION
As title. Will allow consumers to create this struct and use our behaviour.

Closes #27409