### PR TITLE
feat(unstable): refactor js lint plugin AST

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -1072,9 +1072,10 @@ function _dump(ctx) {
  */
 function runLintPlugin(plugin, fileName, sourceText) {
   installPlugin(plugin);
-  const serializedAst = op_lint_create_serialized_ast(fileName, sourceText);
 
   try {
+    const serializedAst = op_lint_create_serialized_ast(fileName, sourceText);
+
     runPluginsForFile(fileName, serializedAst);
   } finally {
     // During testing we don't want to keep plugins around

--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -741,7 +741,7 @@ function createAstContext(buf) {
   setNodeGetters(ctx);
 
   // DEV ONLY: Enable this to inspect the buffer message
-  _dump(ctx);
+  // _dump(ctx);
 
   return ctx;
 }

--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -236,7 +236,7 @@ function setNodeGetters(ctx) {
           this[INTERNAL_CTX],
           this[INTERNAL_IDX],
           i,
-          nodeToFacade,
+          getNode,
         );
       },
     });
@@ -271,14 +271,6 @@ function nodeToJson(ctx, idx) {
   }
 
   return node;
-}
-
-/**
- * @param {AstContext} ctx
- * @param {number} idx
- */
-function nodeToFacade(ctx, idx) {
-  return getNode(ctx, idx);
 }
 
 /**

--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -766,8 +766,7 @@ export function compileSelector(selector) {
  */
 function matchFirstChild(next) {
   return (ctx, id) => {
-    const parent = ctx.getParent(id);
-    const first = ctx.getFirstChild(parent);
+    const first = ctx.getFirstChild(id);
     return first === id && next(ctx, first);
   };
 }
@@ -778,8 +777,7 @@ function matchFirstChild(next) {
  */
 function matchLastChild(next) {
   return (ctx, id) => {
-    const parent = ctx.getParent(id);
-    const last = ctx.getLastChild(parent);
+    const last = ctx.getLastChild(id);
     return last === id && next(ctx, id);
   };
 }
@@ -954,7 +952,9 @@ function matchElem(part, next) {
     else if (part.elem === 0) return false;
 
     const type = ctx.getType(id);
-    if (type > 0 && type === part.elem) return next(ctx, id);
+    if (type > 0 && type === part.elem) {
+      return next(ctx, id);
+    }
 
     return false;
   };

--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -744,8 +744,7 @@ export function compileSelector(selector) {
         fn = matchNthChild(node, fn);
         break;
       case PSEUDO_HAS:
-        // FIXME
-        // fn = matchIs(part, fn);
+        // TODO(@marvinhagemeister)
         throw new Error("TODO: :has");
       case PSEUDO_NOT:
         fn = matchNot(node.selectors, fn);
@@ -968,7 +967,16 @@ function matchElem(part, next) {
  */
 function matchAttrExists(attr, next) {
   return (ctx, id) => {
-    return ctx.hasAttrPath(id, attr.prop, 0) ? next(ctx, id) : false;
+    try {
+      ctx.getAttrPathValue(id, attr.prop, 0);
+      return next(ctx, id);
+    } catch (err) {
+      if (err === -1) {
+        return false;
+      }
+
+      throw err;
+    }
   };
 }
 
@@ -979,9 +987,15 @@ function matchAttrExists(attr, next) {
  */
 function matchAttrBin(attr, next) {
   return (ctx, id) => {
-    if (!ctx.hasAttrPath(id, attr.prop, 0)) return false;
-    const value = ctx.getAttrPathValue(id, attr.prop, 0);
-    if (!matchAttrValue(attr, value)) return false;
+    try {
+      const value = ctx.getAttrPathValue(id, attr.prop, 0);
+      if (!matchAttrValue(attr, value)) return false;
+    } catch (err) {
+      if (err === -1) {
+        return false;
+      }
+      throw err;
+    }
     return next(ctx, id);
   };
 }

--- a/cli/js/40_lint_types.d.ts
+++ b/cli/js/40_lint_types.d.ts
@@ -12,12 +12,20 @@ export interface AstContext {
   strTableOffset: number;
   rootOffset: number;
   nodes: Map<number, NodeFacade>;
+  spansOffset: number;
+  propsOffset: number;
   strByType: number[];
   strByProp: number[];
   typeByStr: Map<string, number>;
   propByStr: Map<string, number>;
   matcher: MatchContext;
 }
+
+export interface Node {
+  range: Range;
+}
+
+export type Range = [number, number];
 
 // TODO(@marvinhagemeister) Remove once we land "official" types
 export interface RuleContext {
@@ -121,7 +129,6 @@ export interface MatchContext {
   getSiblings(id: number): number[];
   getParent(id: number): number;
   getType(id: number): number;
-  hasAttrPath(id: number, propIds: number[], idx: number): boolean;
   getAttrPathValue(id: number, propIds: number[], idx: number): unknown;
 }
 

--- a/cli/tools/lint/ast_buffer/buffer.rs
+++ b/cli/tools/lint/ast_buffer/buffer.rs
@@ -173,13 +173,13 @@ impl SerializeCtx {
     let kind_size = kind_len as usize;
     let prop_size = prop_len as usize;
     let mut ctx = Self {
-      spans: vec![],
+      spans: Vec::with_capacity(512),
       root_idx: 0,
-      nodes: vec![],
+      nodes: Vec::with_capacity(512),
       prop_stack: vec![vec![]],
       prev_sibling_stack: vec![0],
       field_count: vec![0],
-      field_buf: vec![],
+      field_buf: Vec::with_capacity(1024),
       str_table: StringTable::new(),
       kind_name_map: vec![0; kind_size],
       prop_name_map: vec![0; prop_size],

--- a/cli/tools/lint/ast_buffer/buffer.rs
+++ b/cli/tools/lint/ast_buffer/buffer.rs
@@ -487,8 +487,7 @@ impl SerializeCtx {
     let buf = self.prop_stack.last_mut().unwrap();
     append_u32(buf, group_id);
 
-    self.set_child(parent_ref.0, group_id);
-    self.set_parent(group_id, parent_ref.0);
+    self.update_ref_links(parent_ref.0, group_id);
 
     let mut prev_id = 0;
     for (i, item) in value.iter().enumerate() {

--- a/cli/tools/lint/ast_buffer/buffer.rs
+++ b/cli/tools/lint/ast_buffer/buffer.rs
@@ -14,9 +14,14 @@ pub enum PropFlags {
   Ref,
   RefArr,
   String,
+  Number,
   Bool,
   Null,
   Undefined,
+  Object,
+  Regex,
+  BigInt,
+  Array,
 }
 
 impl From<PropFlags> for u8 {
@@ -33,21 +38,29 @@ impl TryFrom<u8> for PropFlags {
       0 => Ok(PropFlags::Ref),
       1 => Ok(PropFlags::RefArr),
       2 => Ok(PropFlags::String),
-      3 => Ok(PropFlags::Bool),
-      4 => Ok(PropFlags::Null),
-      5 => Ok(PropFlags::Undefined),
+      3 => Ok(PropFlags::Number),
+      4 => Ok(PropFlags::Bool),
+      5 => Ok(PropFlags::Null),
+      6 => Ok(PropFlags::Undefined),
+      7 => Ok(PropFlags::Object),
+      8 => Ok(PropFlags::Regex),
+      9 => Ok(PropFlags::BigInt),
+      10 => Ok(PropFlags::Array),
       _ => Err("Unknown Prop flag"),
     }
   }
 }
 
+pub type Index = u32;
+
+const GROUP_KIND: u8 = 1;
 const MASK_U32_1: u32 = 0b11111111_00000000_00000000_00000000;
 const MASK_U32_2: u32 = 0b00000000_11111111_00000000_00000000;
 const MASK_U32_3: u32 = 0b00000000_00000000_11111111_00000000;
 const MASK_U32_4: u32 = 0b00000000_00000000_00000000_11111111;
 
-// TODO: There is probably a native Rust function to do this.
-pub fn append_u32(result: &mut Vec<u8>, value: u32) {
+#[inline]
+fn append_u32(result: &mut Vec<u8>, value: u32) {
   let v1: u8 = ((value & MASK_U32_1) >> 24) as u8;
   let v2: u8 = ((value & MASK_U32_2) >> 16) as u8;
   let v3: u8 = ((value & MASK_U32_3) >> 8) as u8;
@@ -59,23 +72,9 @@ pub fn append_u32(result: &mut Vec<u8>, value: u32) {
   result.push(v4);
 }
 
-pub fn append_usize(result: &mut Vec<u8>, value: usize) {
+fn append_usize(result: &mut Vec<u8>, value: usize) {
   let raw = u32::try_from(value).unwrap();
   append_u32(result, raw);
-}
-
-pub fn write_usize(result: &mut [u8], value: usize, idx: usize) {
-  let raw = u32::try_from(value).unwrap();
-
-  let v1: u8 = ((raw & MASK_U32_1) >> 24) as u8;
-  let v2: u8 = ((raw & MASK_U32_2) >> 16) as u8;
-  let v3: u8 = ((raw & MASK_U32_3) >> 8) as u8;
-  let v4: u8 = (raw & MASK_U32_4) as u8;
-
-  result[idx] = v1;
-  result[idx + 1] = v2;
-  result[idx + 2] = v3;
-  result[idx + 3] = v4;
 }
 
 #[derive(Debug)]
@@ -119,71 +118,48 @@ impl StringTable {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct NodeRef(pub usize);
-
-/// Represents an offset to a node whose schema hasn't been committed yet
+pub struct NodeRef(pub Index);
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PendingNodeRef(pub NodeRef);
+pub struct PendingRef(pub Index);
 
-#[derive(Debug)]
-pub struct BoolPos(pub usize);
-#[derive(Debug)]
-pub struct FieldPos(pub usize);
-#[derive(Debug)]
-pub struct FieldArrPos(pub usize);
-#[derive(Debug)]
-pub struct StrPos(pub usize);
-#[derive(Debug)]
-pub struct UndefPos(pub usize);
-#[derive(Debug)]
-pub struct NullPos(pub usize);
-
-#[derive(Debug)]
-pub enum NodePos {
-  Bool(BoolPos),
-  #[allow(dead_code)]
-  Field(FieldPos),
-  #[allow(dead_code)]
-  FieldArr(FieldArrPos),
-  Str(StrPos),
-  Undef(UndefPos),
-  #[allow(dead_code)]
-  Null(NullPos),
+pub trait AstBufSerializer {
+  fn serialize(&mut self) -> Vec<u8>;
 }
 
-pub trait AstBufSerializer<K, P>
-where
-  K: Into<u8> + Display,
-  P: Into<u8> + Display,
-{
-  fn header(&mut self, kind: K, parent: NodeRef, span: &Span)
-    -> PendingNodeRef;
-  fn ref_field(&mut self, prop: P) -> FieldPos;
-  fn ref_vec_field(&mut self, prop: P, len: usize) -> FieldArrPos;
-  fn str_field(&mut self, prop: P) -> StrPos;
-  fn bool_field(&mut self, prop: P) -> BoolPos;
-  fn undefined_field(&mut self, prop: P) -> UndefPos;
-  #[allow(dead_code)]
-  fn null_field(&mut self, prop: P) -> NullPos;
-  fn commit_schema(&mut self, offset: PendingNodeRef) -> NodeRef;
-
-  fn write_ref(&mut self, pos: FieldPos, value: NodeRef);
-  fn write_maybe_ref(&mut self, pos: FieldPos, value: Option<NodeRef>);
-  fn write_refs(&mut self, pos: FieldArrPos, value: Vec<NodeRef>);
-  fn write_str(&mut self, pos: StrPos, value: &str);
-  fn write_bool(&mut self, pos: BoolPos, value: bool);
-
-  fn serialize(&mut self) -> Vec<u8>;
+/// <type u8>
+/// <prop offset u32>
+/// <child idx u32>
+/// <next idx u32>
+/// <parent idx u32>
+#[derive(Debug)]
+struct Node {
+  kind: u8,
+  prop_offset: u32,
+  child: u32,
+  next: u32,
+  parent: u32,
 }
 
 #[derive(Debug)]
 pub struct SerializeCtx {
-  buf: Vec<u8>,
-  start_buf: NodeRef,
+  root_idx: Index,
+
+  nodes: Vec<Node>,
+  prop_stack: Vec<Vec<u8>>,
+  field_count: Vec<usize>,
+  field_buf: Vec<u8>,
+
+  /// Vec of spans
+  spans: Vec<u32>,
+
+  /// Maps string id to the actual string
   str_table: StringTable,
-  kind_map: Vec<usize>,
-  prop_map: Vec<usize>,
-  field_count: u8,
+  /// Maps kind id to string id
+  kind_name_map: Vec<usize>,
+  /// Maps prop id to string id
+  prop_name_map: Vec<usize>,
+
+  prev_sibling_node: Option<u32>,
 }
 
 /// This is the internal context used to allocate and fill the buffer. The point
@@ -198,20 +174,24 @@ impl SerializeCtx {
     let kind_size = kind_len as usize;
     let prop_size = prop_len as usize;
     let mut ctx = Self {
-      start_buf: NodeRef(0),
-      buf: vec![],
+      spans: vec![],
+      root_idx: 0,
+      nodes: vec![],
+      prop_stack: vec![vec![]],
+      field_count: vec![0],
+      field_buf: vec![],
       str_table: StringTable::new(),
-      kind_map: vec![0; kind_size],
-      prop_map: vec![0; prop_size],
-      field_count: 0,
+      kind_name_map: vec![0; kind_size],
+      prop_name_map: vec![0; prop_size],
+      prev_sibling_node: None,
     };
 
     let empty_str = ctx.str_table.insert("");
 
     // Placeholder node is always 0
-    ctx.append_node(0, NodeRef(0), &DUMMY_SP, 0);
-    ctx.kind_map[0] = empty_str;
-    ctx.start_buf = NodeRef(ctx.buf.len());
+    ctx.append_node(0, &DUMMY_SP);
+    ctx.kind_name_map[0] = empty_str;
+    ctx.kind_name_map[1] = empty_str;
 
     // Insert default props that are always present
     let type_str = ctx.str_table.insert("type");
@@ -220,258 +200,308 @@ impl SerializeCtx {
     let length_str = ctx.str_table.insert("length");
 
     // These values are expected to be in this order on the JS side
-    ctx.prop_map[0] = empty_str;
-    ctx.prop_map[1] = type_str;
-    ctx.prop_map[2] = parent_str;
-    ctx.prop_map[3] = range_str;
-    ctx.prop_map[4] = length_str;
+    ctx.prop_name_map[0] = empty_str;
+    ctx.prop_name_map[1] = type_str;
+    ctx.prop_name_map[2] = parent_str;
+    ctx.prop_name_map[3] = range_str;
+    ctx.prop_name_map[4] = length_str;
 
     ctx
   }
 
+  pub fn set_root_idx(&mut self, idx: Index) {
+    self.root_idx = idx;
+  }
+
   /// Allocate a node's header
-  fn field_header<P>(&mut self, prop: P, prop_flags: PropFlags) -> usize
+  fn field_header<P>(&mut self, prop: P, prop_flags: PropFlags)
   where
     P: Into<u8> + Display + Clone,
   {
-    self.field_count += 1;
-
-    let offset = self.buf.len();
-
+    let flags: u8 = prop_flags.into();
     let n: u8 = prop.clone().into();
-    self.buf.push(n);
 
-    if let Some(v) = self.prop_map.get::<usize>(n.into()) {
+    if let Some(v) = self.prop_name_map.get::<usize>(n.into()) {
       if *v == 0 {
         let id = self.str_table.insert(&format!("{prop}"));
-        self.prop_map[n as usize] = id;
+        self.prop_name_map[n as usize] = id;
       }
     }
 
-    let flags: u8 = prop_flags.into();
-    self.buf.push(flags);
+    // Increment field counter
+    let idx = self.field_count.len() - 1;
+    let count = self.field_count[idx];
+    self.field_count[idx] = count + 1;
 
-    offset
+    let buf = self.prop_stack.last_mut().unwrap();
+    buf.push(n);
+    buf.push(flags);
   }
 
-  /// Allocate a property pointing to another node.
-  fn field<P>(&mut self, prop: P, prop_flags: PropFlags) -> usize
+  fn get_node(&mut self, id: Index) -> &mut Node {
+    self.nodes.get_mut(id as usize).unwrap()
+  }
+
+  fn set_parent(&mut self, child_id: Index, parent_id: Index) {
+    let child = self.get_node(child_id);
+    child.parent = parent_id;
+  }
+
+  fn set_child(&mut self, parent_id: Index, child_id: Index) {
+    let parent = self.get_node(parent_id);
+    parent.child = child_id;
+  }
+
+  fn set_next(&mut self, node_id: Index, next_id: Index) {
+    let node = self.get_node(node_id);
+    node.next = next_id;
+  }
+
+  fn update_ref_links(&mut self, parent_id: Index, child_id: Index) {
+    self.set_parent(child_id, parent_id);
+
+    let parent = self.get_node(parent_id);
+    if parent.child == 0 {
+      parent.child = child_id;
+    }
+
+    // Update next pointer of previous sibling
+    if let Some(prev_id) = self.prev_sibling_node {
+      self.set_next(prev_id, child_id);
+    }
+
+    self.prev_sibling_node = Some(child_id)
+  }
+
+  pub fn append_node<K>(&mut self, kind: K, span: &Span) -> PendingRef
   where
-    P: Into<u8> + Display + Clone,
+    K: Into<u8> + Display + Clone,
   {
-    let offset = self.field_header(prop, prop_flags);
-
-    append_usize(&mut self.buf, 0);
-
-    offset
+    self.append_inner(kind, span.lo.0, span.hi.0)
   }
 
-  fn append_node(
+  pub fn append_inner<K>(
     &mut self,
-    kind: u8,
-    parent: NodeRef,
-    span: &Span,
-    prop_count: usize,
-  ) -> PendingNodeRef {
-    let offset = self.buf.len();
-
-    // Node type fits in a u8
-    self.buf.push(kind);
-
-    // Offset to the parent node. Will be 0 if none exists
-    append_usize(&mut self.buf, parent.0);
-
-    // Span, the start and end location of this node
-    append_u32(&mut self.buf, span.lo.0);
-    append_u32(&mut self.buf, span.hi.0);
-
-    // No node has more than <10 properties
-    debug_assert!(prop_count < 10);
-    self.buf.push(prop_count as u8);
-
-    PendingNodeRef(NodeRef(offset))
-  }
-
-  pub fn commit_schema(&mut self, node_ref: PendingNodeRef) -> NodeRef {
-    let mut offset = node_ref.0 .0;
-
-    // type + parentId + span lo + span hi
-    offset += 1 + 4 + 4 + 4;
-
-    self.buf[offset] = self.field_count;
-    self.field_count = 0;
-
-    node_ref.0
-  }
-
-  /// Allocate the node header. It's always the same for every node.
-  ///   <type u8>
-  ///   <parent offset u32>
-  ///   <span lo u32>
-  ///   <span high u32>
-  ///   <property count u8> (There is no node with more than 10 properties)
-  pub fn header<N>(
-    &mut self,
-    kind: N,
-    parent: NodeRef,
-    span: &Span,
-  ) -> PendingNodeRef
+    kind: K,
+    span_lo: u32,
+    span_hi: u32,
+  ) -> PendingRef
   where
-    N: Into<u8> + Display + Clone,
+    K: Into<u8> + Display + Clone,
   {
-    let n: u8 = kind.clone().into();
+    let kind_u8: u8 = kind.clone().into();
 
-    if let Some(v) = self.kind_map.get::<usize>(n.into()) {
+    let id: Index = self.nodes.len() as u32;
+
+    self.nodes.push(Node {
+      kind: kind_u8,
+      prop_offset: 0,
+      child: 0,
+      next: 0,
+      parent: 0,
+    });
+
+    if let Some(v) = self.kind_name_map.get::<usize>(kind_u8.into()) {
       if *v == 0 {
-        let id = self.str_table.insert(&format!("{kind}"));
-        self.kind_map[n as usize] = id;
+        let s_id = self.str_table.insert(&format!("{kind}"));
+        self.kind_name_map[kind_u8 as usize] = s_id;
       }
     }
 
-    // Prop count will be filled with the actual value when the
-    // schema is committed.
-    self.append_node(n, parent, span, 0)
+    self.field_count.push(0);
+    self.prop_stack.push(vec![]);
+
+    // write spans
+    self.spans.push(span_lo);
+    self.spans.push(span_hi);
+
+    PendingRef(id)
   }
 
-  /// Allocate a reference property that will hold the offset of
-  /// another node.
-  pub fn ref_field<P>(&mut self, prop: P) -> usize
+  pub fn commit_node(&mut self, id: PendingRef) -> NodeRef {
+    let mut buf = self.prop_stack.pop().unwrap();
+    let count = self.field_count.pop().unwrap();
+    let offset = self.field_buf.len();
+
+    // All nodes have <10 fields
+    self.field_buf.push(count as u8);
+    self.field_buf.append(&mut buf);
+
+    let node = self.nodes.get_mut(id.0 as usize).unwrap();
+    node.prop_offset = offset as u32;
+
+    self.prev_sibling_node = None;
+
+    NodeRef(id.0)
+  }
+
+  // Allocate an object field
+  pub fn open_obj(&mut self) {
+    self.field_count.push(0);
+    self.prop_stack.push(vec![]);
+  }
+
+  pub fn commit_obj<P>(&mut self, prop: P)
   where
     P: Into<u8> + Display + Clone,
   {
-    self.field(prop, PropFlags::Ref)
+    let mut buf = self.prop_stack.pop().unwrap();
+    let count = self.field_count.pop().unwrap();
+    let offset = self.field_buf.len();
+    append_usize(&mut self.field_buf, count);
+    self.field_buf.append(&mut buf);
+
+    self.field_header(prop, PropFlags::Object);
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_usize(buf, offset);
   }
 
-  /// Allocate a property that is a vec of node offsets pointing to other
-  /// nodes.
-  pub fn ref_vec_field<P>(&mut self, prop: P, len: usize) -> usize
+  /// Allocate an null field
+  pub fn write_null<P>(&mut self, prop: P)
   where
     P: Into<u8> + Display + Clone,
   {
-    let offset = self.field(prop, PropFlags::RefArr);
+    self.field_header(prop, PropFlags::Null);
 
-    for _ in 0..len {
-      append_u32(&mut self.buf, 0);
-    }
-
-    offset
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_u32(buf, 0);
   }
 
-  // Allocate a property representing a string. Strings are deduplicated
-  // in the message and the property will only contain the string id.
-  pub fn str_field<P>(&mut self, prop: P) -> usize
+  /// Allocate an null field
+  pub fn write_undefined<P>(&mut self, prop: P)
   where
     P: Into<u8> + Display + Clone,
   {
-    self.field(prop, PropFlags::String)
+    self.field_header(prop, PropFlags::Undefined);
+
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_u32(buf, 0);
   }
 
-  /// Allocate a bool field
-  pub fn bool_field<P>(&mut self, prop: P) -> usize
+  /// Allocate a number field
+  pub fn write_num<P>(&mut self, prop: P, value: &str)
   where
     P: Into<u8> + Display + Clone,
   {
-    let offset = self.field_header(prop, PropFlags::Bool);
-    self.buf.push(0);
-    offset
+    self.field_header(prop, PropFlags::Number);
+
+    let id = self.str_table.insert(value);
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_usize(buf, id);
   }
 
-  /// Allocate an undefined field
-  pub fn undefined_field<P>(&mut self, prop: P) -> usize
+  /// Allocate a bigint field
+  pub fn write_bigint<P>(&mut self, prop: P, value: &str)
   where
     P: Into<u8> + Display + Clone,
   {
-    self.field_header(prop, PropFlags::Undefined)
+    self.field_header(prop, PropFlags::BigInt);
+
+    let id = self.str_table.insert(value);
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_usize(buf, id);
   }
 
-  /// Allocate an undefined field
-  #[allow(dead_code)]
-  pub fn null_field<P>(&mut self, prop: P) -> usize
+  /// Allocate a RegExp field
+  pub fn write_regex<P>(&mut self, prop: P, value: &str)
   where
     P: Into<u8> + Display + Clone,
   {
-    self.field_header(prop, PropFlags::Null)
-  }
+    self.field_header(prop, PropFlags::Regex);
 
-  /// Replace the placeholder of a reference field with the actual offset
-  /// to the node we want to point to.
-  pub fn write_ref(&mut self, field_offset: usize, value: NodeRef) {
-    #[cfg(debug_assertions)]
-    {
-      let value_kind = self.buf[field_offset + 1];
-      if PropFlags::try_from(value_kind).unwrap() != PropFlags::Ref {
-        panic!("Trying to write a ref into a non-ref field")
-      }
-    }
-
-    write_usize(&mut self.buf, value.0, field_offset + 2);
-  }
-
-  /// Helper for writing optional node offsets
-  pub fn write_maybe_ref(
-    &mut self,
-    field_offset: usize,
-    value: Option<NodeRef>,
-  ) {
-    #[cfg(debug_assertions)]
-    {
-      let value_kind = self.buf[field_offset + 1];
-      if PropFlags::try_from(value_kind).unwrap() != PropFlags::Ref {
-        panic!("Trying to write a ref into a non-ref field")
-      }
-    }
-
-    let ref_value = if let Some(v) = value { v } else { NodeRef(0) };
-    write_usize(&mut self.buf, ref_value.0, field_offset + 2);
-  }
-
-  /// Write a vec of node offsets into the property. The necessary space
-  /// has been reserved earlier.
-  pub fn write_refs(&mut self, field_offset: usize, value: Vec<NodeRef>) {
-    #[cfg(debug_assertions)]
-    {
-      let value_kind = self.buf[field_offset + 1];
-      if PropFlags::try_from(value_kind).unwrap() != PropFlags::RefArr {
-        panic!("Trying to write a ref into a non-ref array field")
-      }
-    }
-
-    let mut offset = field_offset + 2;
-    write_usize(&mut self.buf, value.len(), offset);
-    offset += 4;
-
-    for item in value {
-      write_usize(&mut self.buf, item.0, offset);
-      offset += 4;
-    }
+    let id = self.str_table.insert(value);
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_usize(buf, id);
   }
 
   /// Store the string in our string table and save the id of the string
   /// in the current field.
-  pub fn write_str(&mut self, field_offset: usize, value: &str) {
-    #[cfg(debug_assertions)]
-    {
-      let value_kind = self.buf[field_offset + 1];
-      if PropFlags::try_from(value_kind).unwrap() != PropFlags::String {
-        panic!("Trying to write a ref into a non-string field")
-      }
-    }
+  pub fn write_str<P>(&mut self, prop: P, value: &str)
+  where
+    P: Into<u8> + Display + Clone,
+  {
+    self.field_header(prop, PropFlags::String);
 
     let id = self.str_table.insert(value);
-    write_usize(&mut self.buf, id, field_offset + 2);
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_usize(buf, id);
   }
 
   /// Write a bool to a field.
-  pub fn write_bool(&mut self, field_offset: usize, value: bool) {
-    #[cfg(debug_assertions)]
-    {
-      let value_kind = self.buf[field_offset + 1];
-      if PropFlags::try_from(value_kind).unwrap() != PropFlags::Bool {
-        panic!("Trying to write a ref into a non-bool field")
-      }
-    }
+  pub fn write_bool<P>(&mut self, prop: P, value: bool)
+  where
+    P: Into<u8> + Display + Clone,
+  {
+    self.field_header(prop, PropFlags::Bool);
 
-    self.buf[field_offset + 2] = if value { 1 } else { 0 };
+    let n = if value { 1 } else { 0 };
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_u32(buf, n);
+  }
+
+  /// Replace the placeholder of a reference field with the actual offset
+  /// to the node we want to point to.
+  pub fn write_ref<P>(&mut self, prop: P, parent: &PendingRef, value: NodeRef)
+  where
+    P: Into<u8> + Display + Clone,
+  {
+    self.field_header(prop, PropFlags::Ref);
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_u32(buf, value.0);
+
+    if parent.0 > 0 {
+      self.update_ref_links(parent.0, value.0);
+    }
+  }
+
+  /// Helper for writing optional node offsets
+  pub fn write_maybe_ref<P>(
+    &mut self,
+    prop: P,
+    parent: &PendingRef,
+    value: Option<NodeRef>,
+  ) where
+    P: Into<u8> + Display + Clone,
+  {
+    if let Some(v) = value {
+      self.write_ref(prop, parent, v);
+    } else {
+      self.write_null(prop);
+    };
+  }
+
+  /// Write a vec of node offsets into the property. The necessary space
+  /// has been reserved earlier.
+  pub fn write_ref_vec<P>(
+    &mut self,
+    prop: P,
+    parent_ref: &PendingRef,
+    value: Vec<NodeRef>,
+  ) where
+    P: Into<u8> + Display + Clone,
+  {
+    self.field_header(prop, PropFlags::RefArr);
+    let group_id = self.append_node(GROUP_KIND, &DUMMY_SP);
+    let group_id = self.commit_node(group_id).0;
+
+    let buf = self.prop_stack.last_mut().unwrap();
+    append_u32(buf, group_id);
+
+    self.set_child(parent_ref.0, group_id);
+    self.set_parent(group_id, parent_ref.0);
+
+    let mut prev_id = 0;
+    for (i, item) in value.iter().enumerate() {
+      self.set_parent(item.0, group_id);
+
+      if i == 0 {
+        self.set_child(group_id, item.0);
+      } else {
+        self.set_next(prev_id, item.0);
+      }
+
+      prev_id = item.0;
+    }
   }
 
   /// Serialize all information we have into a buffer that can be sent to JS.
@@ -481,6 +511,8 @@ impl SerializeCtx {
   ///   <string table>
   ///   <node kind map>  <- node kind id maps to string id
   ///   <node prop map> <- node property id maps to string id
+  ///   <spans> <- List of spans, rarely needed
+  ///   <offset spans>
   ///   <offset kind map>
   ///   <offset prop map>
   ///   <offset str table>
@@ -490,7 +522,13 @@ impl SerializeCtx {
     // The buffer starts with the serialized AST first, because that
     // contains absolute offsets. By butting this at the start of the
     // message we don't have to waste time updating any offsets.
-    buf.append(&mut self.buf);
+    for node in &self.nodes {
+      buf.push(node.kind);
+      append_u32(&mut buf, node.prop_offset);
+      append_u32(&mut buf, node.child);
+      append_u32(&mut buf, node.next);
+      append_u32(&mut buf, node.parent);
+    }
 
     // Next follows the string table. We'll keep track of the offset
     // in the message of where the string table begins
@@ -507,8 +545,8 @@ impl SerializeCtx {
 
     // Write the total number of entries in the kind -> str mapping table
     // TODO: make this a u8
-    append_usize(&mut buf, self.kind_map.len());
-    for v in &self.kind_map {
+    append_usize(&mut buf, self.kind_name_map.len());
+    for v in &self.kind_name_map {
       append_usize(&mut buf, *v);
     }
 
@@ -517,19 +555,35 @@ impl SerializeCtx {
     // as u8.
     let offset_prop_map = buf.len();
     // Write the total number of entries in the kind -> str mapping table
-    append_usize(&mut buf, self.prop_map.len());
-    for v in &self.prop_map {
+    append_usize(&mut buf, self.prop_name_map.len());
+    for v in &self.prop_name_map {
       append_usize(&mut buf, *v);
     }
+
+    // Spans are rarely needed, so they're stored in a separate array.
+    // They're indexed by the node id.
+    let offset_spans = buf.len();
+    for v in &self.spans {
+      append_u32(&mut buf, *v);
+    }
+
+    // The field value table. They're detached from nodes as they're not
+    // as frequently needed as the nodes themselves. The most common
+    // operation is traversal and we can traverse nodes without knowing
+    // about the fields.
+    let offset_props = buf.len();
+    buf.append(&mut self.field_buf);
 
     // Putting offsets of relevant parts of the buffer at the end. This
     // allows us to hop to the relevant part by merely looking at the last
     // for values in the message. Each value represents an offset into the
     // buffer.
+    append_usize(&mut buf, offset_props);
+    append_usize(&mut buf, offset_spans);
     append_usize(&mut buf, offset_kind_map);
     append_usize(&mut buf, offset_prop_map);
     append_usize(&mut buf, offset_str_table);
-    append_usize(&mut buf, self.start_buf.0);
+    append_u32(&mut buf, self.root_idx);
 
     buf
   }

--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -2,10 +2,13 @@
 
 use deno_ast::swc::ast::AssignTarget;
 use deno_ast::swc::ast::AssignTargetPat;
+use deno_ast::swc::ast::BindingIdent;
 use deno_ast::swc::ast::BlockStmtOrExpr;
 use deno_ast::swc::ast::Callee;
 use deno_ast::swc::ast::ClassMember;
 use deno_ast::swc::ast::Decl;
+use deno_ast::swc::ast::Decorator;
+use deno_ast::swc::ast::DefaultDecl;
 use deno_ast::swc::ast::ExportSpecifier;
 use deno_ast::swc::ast::Expr;
 use deno_ast::swc::ast::ExprOrSpread;
@@ -14,13 +17,13 @@ use deno_ast::swc::ast::ForHead;
 use deno_ast::swc::ast::Function;
 use deno_ast::swc::ast::Ident;
 use deno_ast::swc::ast::IdentName;
+use deno_ast::swc::ast::ImportSpecifier;
 use deno_ast::swc::ast::JSXAttrName;
 use deno_ast::swc::ast::JSXAttrOrSpread;
 use deno_ast::swc::ast::JSXAttrValue;
 use deno_ast::swc::ast::JSXElement;
 use deno_ast::swc::ast::JSXElementChild;
 use deno_ast::swc::ast::JSXElementName;
-use deno_ast::swc::ast::JSXEmptyExpr;
 use deno_ast::swc::ast::JSXExpr;
 use deno_ast::swc::ast::JSXExprContainer;
 use deno_ast::swc::ast::JSXFragment;
@@ -28,12 +31,14 @@ use deno_ast::swc::ast::JSXMemberExpr;
 use deno_ast::swc::ast::JSXNamespacedName;
 use deno_ast::swc::ast::JSXObject;
 use deno_ast::swc::ast::JSXOpeningElement;
+use deno_ast::swc::ast::Key;
 use deno_ast::swc::ast::Lit;
 use deno_ast::swc::ast::MemberExpr;
 use deno_ast::swc::ast::MemberProp;
 use deno_ast::swc::ast::ModuleDecl;
 use deno_ast::swc::ast::ModuleExportName;
 use deno_ast::swc::ast::ModuleItem;
+use deno_ast::swc::ast::ObjectLit;
 use deno_ast::swc::ast::ObjectPatProp;
 use deno_ast::swc::ast::OptChainBase;
 use deno_ast::swc::ast::Param;
@@ -50,11 +55,16 @@ use deno_ast::swc::ast::SuperProp;
 use deno_ast::swc::ast::Tpl;
 use deno_ast::swc::ast::TsEntityName;
 use deno_ast::swc::ast::TsEnumMemberId;
+use deno_ast::swc::ast::TsExprWithTypeArgs;
 use deno_ast::swc::ast::TsFnOrConstructorType;
 use deno_ast::swc::ast::TsFnParam;
 use deno_ast::swc::ast::TsIndexSignature;
 use deno_ast::swc::ast::TsLit;
 use deno_ast::swc::ast::TsLitType;
+use deno_ast::swc::ast::TsModuleName;
+use deno_ast::swc::ast::TsModuleRef;
+use deno_ast::swc::ast::TsNamespaceBody;
+use deno_ast::swc::ast::TsParamPropParam;
 use deno_ast::swc::ast::TsThisTypeOrIdent;
 use deno_ast::swc::ast::TsType;
 use deno_ast::swc::ast::TsTypeAnn;
@@ -71,7 +81,7 @@ use deno_ast::swc::common::SyntaxContext;
 use deno_ast::view::Accessibility;
 use deno_ast::view::AssignOp;
 use deno_ast::view::BinaryOp;
-use deno_ast::view::TruePlusMinus;
+use deno_ast::view::MethodKind;
 use deno_ast::view::TsKeywordTypeKind;
 use deno_ast::view::TsTypeOperatorOp;
 use deno_ast::view::UnaryOp;
@@ -80,53 +90,39 @@ use deno_ast::view::VarDeclKind;
 use deno_ast::ParsedSource;
 
 use super::buffer::AstBufSerializer;
-use super::buffer::BoolPos;
-use super::buffer::NodePos;
 use super::buffer::NodeRef;
-use super::buffer::StrPos;
 use super::ts_estree::AstNode;
-use super::ts_estree::AstProp;
 use super::ts_estree::TsEsTreeBuilder;
+use super::ts_estree::TsKeywordKind;
 
 pub fn serialize_swc_to_buffer(parsed_source: &ParsedSource) -> Vec<u8> {
   let mut ctx = TsEsTreeBuilder::new();
 
   let program = &parsed_source.program();
 
-  let raw = ctx.header(AstNode::Program, NodeRef(0), &program.span());
-  let source_type_pos = ctx.str_field(AstProp::SourceType);
-
   match program.as_ref() {
     Program::Module(module) => {
-      let body_pos = ctx.ref_vec_field(AstProp::Body, module.body.len());
-      let pos = ctx.commit_schema(raw);
-
       let children = module
         .body
         .iter()
         .map(|item| match item {
           ModuleItem::ModuleDecl(module_decl) => {
-            serialize_module_decl(&mut ctx, module_decl, pos)
+            serialize_module_decl(&mut ctx, module_decl)
           }
-          ModuleItem::Stmt(stmt) => serialize_stmt(&mut ctx, stmt, pos),
+          ModuleItem::Stmt(stmt) => serialize_stmt(&mut ctx, stmt),
         })
         .collect::<Vec<_>>();
 
-      ctx.write_str(source_type_pos, "module");
-      ctx.write_refs(body_pos, children);
+      ctx.write_program(&module.span, "module", children);
     }
     Program::Script(script) => {
-      let body_pos = ctx.ref_vec_field(AstProp::Body, script.body.len());
-      let pos = ctx.commit_schema(raw);
-
       let children = script
         .body
         .iter()
-        .map(|stmt| serialize_stmt(&mut ctx, stmt, pos))
+        .map(|stmt| serialize_stmt(&mut ctx, stmt))
         .collect::<Vec<_>>();
 
-      ctx.write_str(source_type_pos, "script");
-      ctx.write_refs(body_pos, children);
+      ctx.write_program(&script.span, "script", children);
     }
   }
 
@@ -136,539 +132,508 @@ pub fn serialize_swc_to_buffer(parsed_source: &ParsedSource) -> Vec<u8> {
 fn serialize_module_decl(
   ctx: &mut TsEsTreeBuilder,
   module_decl: &ModuleDecl,
-  parent: NodeRef,
 ) -> NodeRef {
   match module_decl {
     ModuleDecl::Import(node) => {
-      let raw = ctx.header(AstNode::ImportExpression, parent, &node.span);
-      ctx.commit_schema(raw)
-    }
-    ModuleDecl::ExportDecl(node) => {
-      let raw = ctx.header(AstNode::ExportNamedDeclaration, parent, &node.span);
-      let decl_pos = ctx.ref_field(AstProp::Declarations);
-      let pos = ctx.commit_schema(raw);
+      let src = serialize_lit(ctx, &Lit::Str(node.src.as_ref().clone()));
+      let attrs = serialize_import_attrs(ctx, &node.with);
 
-      let decl = serialize_decl(ctx, &node.decl, pos);
-
-      ctx.write_ref(decl_pos, decl);
-
-      pos
-    }
-    ModuleDecl::ExportNamed(node) => {
-      let raw = ctx.header(AstNode::ExportNamedDeclaration, parent, &node.span);
-      let src_pos = ctx.ref_field(AstProp::Source);
-      let spec_pos =
-        ctx.ref_vec_field(AstProp::Specifiers, node.specifiers.len());
-      let id = ctx.commit_schema(raw);
-
-      // FIXME: Flags
-      // let mut flags = FlagValue::new();
-      // flags.set(Flag::ExportType);
-
-      let src_id = node
-        .src
-        .as_ref()
-        .map(|src| serialize_lit(ctx, &Lit::Str(*src.clone()), id));
-
-      let spec_ids = node
+      let specifiers = node
         .specifiers
         .iter()
-        .map(|spec| {
-          match spec {
-            ExportSpecifier::Named(child) => {
-              let raw = ctx.header(AstNode::ExportSpecifier, id, &child.span);
-              let local_pos = ctx.ref_field(AstProp::Local);
-              let exp_pos = ctx.ref_field(AstProp::Exported);
-              let spec_pos = ctx.commit_schema(raw);
-
-              // let mut flags = FlagValue::new();
-              // flags.set(Flag::ExportType);
-
-              let local =
-                serialize_module_exported_name(ctx, &child.orig, spec_pos);
-
-              let exported = child.exported.as_ref().map(|exported| {
-                serialize_module_exported_name(ctx, exported, spec_pos)
+        .map(|spec| match spec {
+          ImportSpecifier::Named(spec) => {
+            let local = serialize_ident(ctx, &spec.local);
+            let imported = spec
+              .imported
+              .as_ref()
+              .map_or(serialize_ident(ctx, &spec.local), |v| {
+                serialize_module_export_name(ctx, &v)
               });
-
-              // ctx.write_flags(&flags);
-              ctx.write_ref(local_pos, local);
-              ctx.write_maybe_ref(exp_pos, exported);
-
-              spec_pos
-            }
-
-            // These two aren't syntactically valid
-            ExportSpecifier::Namespace(_) => todo!(),
-            ExportSpecifier::Default(_) => todo!(),
+            ctx.write_import_spec(
+              &spec.span,
+              spec.is_type_only,
+              local,
+              imported,
+            )
+          }
+          ImportSpecifier::Default(spec) => {
+            let local = serialize_ident(ctx, &spec.local);
+            ctx.write_import_default_spec(&spec.span, local)
+          }
+          ImportSpecifier::Namespace(spec) => {
+            let local = serialize_ident(ctx, &spec.local);
+            ctx.write_import_ns_spec(&spec.span, local)
           }
         })
         .collect::<Vec<_>>();
 
-      // ctx.write_flags(&flags);
-      ctx.write_maybe_ref(src_pos, src_id);
-      ctx.write_refs(spec_pos, spec_ids);
+      ctx.write_import_decl(&node.span, node.type_only, src, specifiers, attrs)
+    }
+    ModuleDecl::ExportDecl(node) => {
+      let decl = serialize_decl(ctx, &node.decl);
+      ctx.write_export_decl(&node.span, decl)
+    }
+    ModuleDecl::ExportNamed(node) => {
+      let attrs = serialize_import_attrs(ctx, &node.with);
+      let source = node
+        .src
+        .as_ref()
+        .map(|src| serialize_lit(ctx, &Lit::Str(*src.clone())));
 
-      id
+      if let Some(ExportSpecifier::Namespace(ns)) = node.specifiers.first() {
+        let exported = serialize_module_export_name(ctx, &ns.name);
+        ctx.write_export_all_decl(
+          &node.span,
+          node.type_only,
+          exported,
+          source,
+          attrs,
+        )
+      } else {
+        let specifiers = node
+          .specifiers
+          .iter()
+          .map(|spec| {
+            match spec {
+              ExportSpecifier::Named(spec) => {
+                let local = serialize_module_export_name(ctx, &spec.orig);
+
+                let exported = spec
+                  .exported
+                  .as_ref()
+                  .map(|exported| serialize_module_export_name(ctx, exported));
+
+                ctx.write_export_spec(
+                  &spec.span,
+                  spec.is_type_only,
+                  local,
+                  exported,
+                )
+              }
+
+              // Already handled earlier
+              ExportSpecifier::Namespace(_) => unreachable!(),
+              // this is not syntactically valid
+              ExportSpecifier::Default(_) => unreachable!(),
+            }
+          })
+          .collect::<Vec<_>>();
+
+        ctx.write_export_named_decl(&node.span, specifiers, source, attrs)
+      }
     }
     ModuleDecl::ExportDefaultDecl(node) => {
-      let raw =
-        ctx.header(AstNode::ExportDefaultDeclaration, parent, &node.span);
-      ctx.commit_schema(raw)
+      let (is_type_only, decl) = match &node.decl {
+        DefaultDecl::Class(node) => {
+          let ident =
+            node.ident.as_ref().map(|ident| serialize_ident(ctx, ident));
+
+          let super_class = node
+            .class
+            .super_class
+            .as_ref()
+            .map(|expr| serialize_expr(ctx, expr.as_ref()));
+
+          let implements = node
+            .class
+            .implements
+            .iter()
+            .map(|item| serialize_ts_expr_with_type_args(ctx, item))
+            .collect::<Vec<_>>();
+
+          let members = node
+            .class
+            .body
+            .iter()
+            .map(|member| serialize_class_member(ctx, member))
+            .flatten()
+            .collect::<Vec<_>>();
+
+          let body = ctx.write_class_body(&node.class.span, members);
+
+          let decl = ctx.write_class_decl(
+            &node.class.span,
+            false,
+            node.class.is_abstract,
+            ident,
+            super_class,
+            implements,
+            body,
+          );
+
+          (false, decl)
+        }
+        DefaultDecl::Fn(node) => {
+          let ident =
+            node.ident.as_ref().map(|ident| serialize_ident(ctx, ident));
+
+          let fn_obj = node.function.as_ref();
+
+          let type_params =
+            maybe_serialize_ts_type_param_decl(ctx, &fn_obj.type_params);
+
+          let params = fn_obj
+            .params
+            .iter()
+            .map(|param| serialize_pat(ctx, &param.pat))
+            .collect::<Vec<_>>();
+
+          let return_type =
+            maybe_serialize_ts_type_ann(ctx, &fn_obj.return_type);
+          let body = fn_obj
+            .body
+            .as_ref()
+            .map(|block| serialize_stmt(ctx, &Stmt::Block(block.clone())));
+
+          let decl = ctx.write_fn_decl(
+            &fn_obj.span,
+            false,
+            fn_obj.is_async,
+            fn_obj.is_generator,
+            ident,
+            type_params,
+            return_type,
+            body,
+            params,
+          );
+
+          (false, decl)
+        }
+        DefaultDecl::TsInterfaceDecl(node) => {
+          let ident_id = serialize_ident(ctx, &node.id);
+          let type_param =
+            maybe_serialize_ts_type_param_decl(ctx, &node.type_params);
+
+          let extend_ids = node
+            .extends
+            .iter()
+            .map(|item| {
+              let expr = serialize_expr(ctx, &item.expr);
+              let type_args = item
+                .type_args
+                .clone()
+                .map(|params| serialize_ts_param_inst(ctx, params.as_ref()));
+
+              ctx.write_ts_interface_heritage(&item.span, expr, type_args)
+            })
+            .collect::<Vec<_>>();
+
+          let body_elem_ids = node
+            .body
+            .body
+            .iter()
+            .map(|item| serialize_ts_type_elem(ctx, item))
+            .collect::<Vec<_>>();
+
+          let body_pos =
+            ctx.write_ts_interface_body(&node.body.span, body_elem_ids);
+
+          let decl = ctx.write_ts_interface_decl(
+            &node.span,
+            node.declare,
+            ident_id,
+            type_param,
+            extend_ids,
+            body_pos,
+          );
+
+          (true, decl)
+        }
+      };
+
+      ctx.write_export_default_decl(&node.span, is_type_only, decl)
     }
     ModuleDecl::ExportDefaultExpr(node) => {
-      let raw =
-        ctx.header(AstNode::ExportDefaultDeclaration, parent, &node.span);
-      ctx.commit_schema(raw)
+      let expr = serialize_expr(ctx, &node.expr);
+      ctx.write_export_default_decl(&node.span, false, expr)
     }
     ModuleDecl::ExportAll(node) => {
-      let raw = ctx.header(AstNode::ExportAllDeclaration, parent, &node.span);
-      ctx.commit_schema(raw)
+      let src = serialize_lit(ctx, &Lit::Str(node.src.as_ref().clone()));
+      let attrs = serialize_import_attrs(ctx, &node.with);
+
+      ctx.write_export_all_decl(&node.span, node.type_only, src, None, attrs)
     }
     ModuleDecl::TsImportEquals(node) => {
-      let raw = ctx.header(AstNode::TsImportEquals, parent, &node.span);
-      ctx.commit_schema(raw)
+      let ident = serialize_ident(ctx, &node.id);
+      let module_ref = match &node.module_ref {
+        TsModuleRef::TsEntityName(entity) => {
+          serialize_ts_entity_name(ctx, &entity)
+        }
+        TsModuleRef::TsExternalModuleRef(external) => {
+          let expr = serialize_lit(ctx, &Lit::Str(external.expr.clone()));
+          ctx.write_ts_external_mod_ref(&external.span, expr)
+        }
+      };
+
+      ctx.write_export_ts_import_equals(
+        &node.span,
+        node.is_type_only,
+        ident,
+        module_ref,
+      )
     }
     ModuleDecl::TsExportAssignment(node) => {
-      let raw = ctx.header(AstNode::TsExportAssignment, parent, &node.span);
-      ctx.commit_schema(raw)
+      let expr = serialize_expr(ctx, &node.expr);
+      ctx.write_export_assign(&node.span, expr)
     }
     ModuleDecl::TsNamespaceExport(node) => {
-      let raw = ctx.header(AstNode::TsNamespaceExport, parent, &node.span);
-      ctx.commit_schema(raw)
+      let decl = serialize_ident(ctx, &node.id);
+      ctx.write_export_ts_namespace(&node.span, decl)
     }
   }
 }
 
-fn serialize_stmt(
+fn serialize_import_attrs(
   ctx: &mut TsEsTreeBuilder,
-  stmt: &Stmt,
-  parent: NodeRef,
-) -> NodeRef {
+  raw_attrs: &Option<Box<ObjectLit>>,
+) -> Vec<NodeRef> {
+  raw_attrs.as_ref().map_or(vec![], |obj| {
+    obj
+      .props
+      .iter()
+      .map(|prop| {
+        let (key, value) = match prop {
+          // Invalid syntax
+          PropOrSpread::Spread(_) => unreachable!(),
+          PropOrSpread::Prop(prop) => {
+            match prop.as_ref() {
+              Prop::Shorthand(ident) => {
+                (serialize_ident(ctx, ident), serialize_ident(ctx, ident))
+              }
+              Prop::KeyValue(kv) => (
+                serialize_prop_name(ctx, &kv.key),
+                serialize_expr(ctx, &kv.value.as_ref()),
+              ),
+              // Invalid syntax
+              Prop::Assign(_)
+              | Prop::Getter(_)
+              | Prop::Setter(_)
+              | Prop::Method(_) => unreachable!(),
+            }
+          }
+        };
+
+        ctx.write_import_attr(&prop.span(), key, value)
+      })
+      .collect::<Vec<_>>()
+  })
+}
+
+fn serialize_stmt(ctx: &mut TsEsTreeBuilder, stmt: &Stmt) -> NodeRef {
   match stmt {
     Stmt::Block(node) => {
-      let raw = ctx.header(AstNode::BlockStatement, parent, &node.span);
-      let body_pos = ctx.ref_vec_field(AstProp::Body, node.stmts.len());
-      let pos = ctx.commit_schema(raw);
-
       let children = node
         .stmts
         .iter()
-        .map(|stmt| serialize_stmt(ctx, stmt, pos))
+        .map(|stmt| serialize_stmt(ctx, stmt))
         .collect::<Vec<_>>();
 
-      ctx.write_refs(body_pos, children);
-
-      pos
+      ctx.write_block_stmt(&node.span, children)
     }
     Stmt::Empty(_) => NodeRef(0),
-    Stmt::Debugger(node) => {
-      let raw = ctx.header(AstNode::DebuggerStatement, parent, &node.span);
-      ctx.commit_schema(raw)
+    Stmt::Debugger(node) => ctx.write_debugger_stmt(&node.span),
+    Stmt::With(node) => {
+      let obj = serialize_expr(ctx, &node.obj);
+      let body = serialize_stmt(ctx, &node.body);
+
+      ctx.write_with_stmt(&node.span, obj, body)
     }
-    Stmt::With(_) => todo!(),
     Stmt::Return(node) => {
-      let raw = ctx.header(AstNode::ReturnStatement, parent, &node.span);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
-
-      let arg = node.arg.as_ref().map(|arg| serialize_expr(ctx, arg, pos));
-      ctx.write_maybe_ref(arg_pos, arg);
-
-      pos
+      let arg = node.arg.as_ref().map(|arg| serialize_expr(ctx, arg));
+      ctx.write_return_stmt(&node.span, arg)
     }
     Stmt::Labeled(node) => {
-      let raw = ctx.header(AstNode::LabeledStatement, parent, &node.span);
-      let label_pos = ctx.ref_field(AstProp::Label);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
+      let ident = serialize_ident(ctx, &node.label);
+      let stmt = serialize_stmt(ctx, &node.body);
 
-      let ident = serialize_ident(ctx, &node.label, pos);
-      let stmt = serialize_stmt(ctx, &node.body, pos);
-
-      ctx.write_ref(label_pos, ident);
-      ctx.write_ref(body_pos, stmt);
-
-      pos
+      ctx.write_labeled_stmt(&node.span, ident, stmt)
     }
     Stmt::Break(node) => {
-      let raw = ctx.header(AstNode::BreakStatement, parent, &node.span);
-      let label_pos = ctx.ref_field(AstProp::Label);
-      let pos = ctx.commit_schema(raw);
-
-      let arg = node
-        .label
-        .as_ref()
-        .map(|label| serialize_ident(ctx, label, pos));
-
-      ctx.write_maybe_ref(label_pos, arg);
-
-      pos
+      let arg = node.label.as_ref().map(|label| serialize_ident(ctx, label));
+      ctx.write_break_stmt(&node.span, arg)
     }
     Stmt::Continue(node) => {
-      let raw = ctx.header(AstNode::ContinueStatement, parent, &node.span);
-      let label_pos = ctx.ref_field(AstProp::Label);
-      let pos = ctx.commit_schema(raw);
+      let arg = node.label.as_ref().map(|label| serialize_ident(ctx, label));
 
-      let arg = node
-        .label
-        .as_ref()
-        .map(|label| serialize_ident(ctx, label, pos));
-
-      ctx.write_maybe_ref(label_pos, arg);
-
-      pos
+      ctx.write_continue_stmt(&node.span, arg)
     }
     Stmt::If(node) => {
-      let raw = ctx.header(AstNode::IfStatement, parent, &node.span);
-      let test_pos = ctx.ref_field(AstProp::Test);
-      let cons_pos = ctx.ref_field(AstProp::Consequent);
-      let alt_pos = ctx.ref_field(AstProp::Alternate);
-      let pos = ctx.commit_schema(raw);
+      let test = serialize_expr(ctx, node.test.as_ref());
+      let cons = serialize_stmt(ctx, node.cons.as_ref());
+      let alt = node.alt.as_ref().map(|alt| serialize_stmt(ctx, alt));
 
-      let test = serialize_expr(ctx, node.test.as_ref(), pos);
-      let cons = serialize_stmt(ctx, node.cons.as_ref(), pos);
-      let alt = node.alt.as_ref().map(|alt| serialize_stmt(ctx, alt, pos));
-
-      ctx.write_ref(test_pos, test);
-      ctx.write_ref(cons_pos, cons);
-      ctx.write_maybe_ref(alt_pos, alt);
-
-      pos
+      ctx.write_if_stmt(&node.span, test, cons, alt)
     }
     Stmt::Switch(node) => {
-      let raw = ctx.header(AstNode::SwitchStatement, parent, &node.span);
-      let disc_pos = ctx.ref_field(AstProp::Discriminant);
-      let cases_pos = ctx.ref_vec_field(AstProp::Cases, node.cases.len());
-      let pos = ctx.commit_schema(raw);
-
-      let disc = serialize_expr(ctx, &node.discriminant, pos);
+      let disc = serialize_expr(ctx, &node.discriminant);
 
       let cases = node
         .cases
         .iter()
         .map(|case| {
-          let raw = ctx.header(AstNode::SwitchCase, pos, &case.span);
-          let test_pos = ctx.ref_field(AstProp::Test);
-          let cons_pos =
-            ctx.ref_vec_field(AstProp::Consequent, case.cons.len());
-          let case_pos = ctx.commit_schema(raw);
-
-          let test = case
-            .test
-            .as_ref()
-            .map(|test| serialize_expr(ctx, test, case_pos));
+          let test = case.test.as_ref().map(|test| serialize_expr(ctx, test));
 
           let cons = case
             .cons
             .iter()
-            .map(|cons| serialize_stmt(ctx, cons, case_pos))
+            .map(|cons| serialize_stmt(ctx, cons))
             .collect::<Vec<_>>();
 
-          ctx.write_maybe_ref(test_pos, test);
-          ctx.write_refs(cons_pos, cons);
-
-          case_pos
+          ctx.write_switch_case(&case.span, test, cons)
         })
         .collect::<Vec<_>>();
 
-      ctx.write_ref(disc_pos, disc);
-      ctx.write_refs(cases_pos, cases);
-
-      pos
+      ctx.write_switch_stmt(&node.span, disc, cases)
     }
     Stmt::Throw(node) => {
-      let raw = ctx.header(AstNode::ThrowStatement, parent, &node.span);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
-
-      let arg = serialize_expr(ctx, &node.arg, pos);
-      ctx.write_ref(arg_pos, arg);
-
-      pos
+      let arg = serialize_expr(ctx, &node.arg);
+      ctx.write_throw_stmt(&node.span, arg)
     }
     Stmt::Try(node) => {
-      let raw = ctx.header(AstNode::TryStatement, parent, &node.span);
-      let block_pos = ctx.ref_field(AstProp::Block);
-      let handler_pos = ctx.ref_field(AstProp::Handler);
-      let finalizer_pos = ctx.ref_field(AstProp::Finalizer);
-      let pos = ctx.commit_schema(raw);
-
-      let block = serialize_stmt(ctx, &Stmt::Block(node.block.clone()), pos);
+      let block = serialize_stmt(ctx, &Stmt::Block(node.block.clone()));
 
       let handler = node.handler.as_ref().map(|catch| {
-        let raw = ctx.header(AstNode::CatchClause, pos, &catch.span);
-        let param_pos = ctx.ref_field(AstProp::Param);
-        let body_pos = ctx.ref_field(AstProp::Body);
-        let clause_pos = ctx.commit_schema(raw);
+        let param = catch.param.as_ref().map(|param| serialize_pat(ctx, param));
 
-        let param = catch
-          .param
-          .as_ref()
-          .map(|param| serialize_pat(ctx, param, clause_pos));
+        let body = serialize_stmt(ctx, &Stmt::Block(catch.body.clone()));
 
-        let body =
-          serialize_stmt(ctx, &Stmt::Block(catch.body.clone()), clause_pos);
-
-        ctx.write_maybe_ref(param_pos, param);
-        ctx.write_ref(body_pos, body);
-
-        clause_pos
+        ctx.write_catch_clause(&catch.span, param, body)
       });
 
-      let finalizer = node.finalizer.as_ref().map(|finalizer| {
-        serialize_stmt(ctx, &Stmt::Block(finalizer.clone()), pos)
-      });
+      let finalizer = node
+        .finalizer
+        .as_ref()
+        .map(|finalizer| serialize_stmt(ctx, &Stmt::Block(finalizer.clone())));
 
-      ctx.write_ref(block_pos, block);
-      ctx.write_maybe_ref(handler_pos, handler);
-      ctx.write_maybe_ref(finalizer_pos, finalizer);
-
-      pos
+      ctx.write_try_stmt(&node.span, block, handler, finalizer)
     }
     Stmt::While(node) => {
-      let raw = ctx.header(AstNode::WhileStatement, parent, &node.span);
-      let test_pos = ctx.ref_field(AstProp::Test);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
+      let test = serialize_expr(ctx, node.test.as_ref());
+      let stmt = serialize_stmt(ctx, node.body.as_ref());
 
-      let test = serialize_expr(ctx, node.test.as_ref(), pos);
-      let stmt = serialize_stmt(ctx, node.body.as_ref(), pos);
-
-      ctx.write_ref(test_pos, test);
-      ctx.write_ref(body_pos, stmt);
-
-      pos
+      ctx.write_while_stmt(&node.span, test, stmt)
     }
     Stmt::DoWhile(node) => {
-      let raw = ctx.header(AstNode::DoWhileStatement, parent, &node.span);
-      let test_pos = ctx.ref_field(AstProp::Test);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
+      let expr = serialize_expr(ctx, node.test.as_ref());
+      let stmt = serialize_stmt(ctx, node.body.as_ref());
 
-      let expr = serialize_expr(ctx, node.test.as_ref(), pos);
-      let stmt = serialize_stmt(ctx, node.body.as_ref(), pos);
-
-      ctx.write_ref(test_pos, expr);
-      ctx.write_ref(body_pos, stmt);
-
-      pos
+      ctx.write_do_while_stmt(&node.span, expr, stmt)
     }
     Stmt::For(node) => {
-      let raw = ctx.header(AstNode::ForStatement, parent, &node.span);
-      let init_pos = ctx.ref_field(AstProp::Init);
-      let test_pos = ctx.ref_field(AstProp::Test);
-      let update_pos = ctx.ref_field(AstProp::Update);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
-
       let init = node.init.as_ref().map(|init| match init {
         VarDeclOrExpr::VarDecl(var_decl) => {
-          serialize_stmt(ctx, &Stmt::Decl(Decl::Var(var_decl.clone())), pos)
+          serialize_stmt(ctx, &Stmt::Decl(Decl::Var(var_decl.clone())))
         }
-        VarDeclOrExpr::Expr(expr) => serialize_expr(ctx, expr, pos),
+        VarDeclOrExpr::Expr(expr) => serialize_expr(ctx, expr),
       });
 
-      let test = node
-        .test
-        .as_ref()
-        .map(|expr| serialize_expr(ctx, expr, pos));
-      let update = node
-        .update
-        .as_ref()
-        .map(|expr| serialize_expr(ctx, expr, pos));
-      let body = serialize_stmt(ctx, node.body.as_ref(), pos);
+      let test = node.test.as_ref().map(|expr| serialize_expr(ctx, expr));
+      let update = node.update.as_ref().map(|expr| serialize_expr(ctx, expr));
+      let body = serialize_stmt(ctx, node.body.as_ref());
 
-      ctx.write_maybe_ref(init_pos, init);
-      ctx.write_maybe_ref(test_pos, test);
-      ctx.write_maybe_ref(update_pos, update);
-      ctx.write_ref(body_pos, body);
-
-      pos
+      ctx.write_for_stmt(&node.span, init, test, update, body)
     }
     Stmt::ForIn(node) => {
-      let raw = ctx.header(AstNode::ForInStatement, parent, &node.span);
-      let left_pos = ctx.ref_field(AstProp::Left);
-      let right_pos = ctx.ref_field(AstProp::Right);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
+      let left = serialize_for_head(ctx, &node.left);
+      let right = serialize_expr(ctx, node.right.as_ref());
+      let body = serialize_stmt(ctx, node.body.as_ref());
 
-      let left = serialize_for_head(ctx, &node.left, pos);
-      let right = serialize_expr(ctx, node.right.as_ref(), pos);
-      let body = serialize_stmt(ctx, node.body.as_ref(), pos);
-
-      ctx.write_ref(left_pos, left);
-      ctx.write_ref(right_pos, right);
-      ctx.write_ref(body_pos, body);
-
-      pos
+      ctx.write_for_in_stmt(&node.span, left, right, body)
     }
     Stmt::ForOf(node) => {
-      let raw = ctx.header(AstNode::ForOfStatement, parent, &node.span);
-      let await_pos = ctx.bool_field(AstProp::Await);
-      let left_pos = ctx.ref_field(AstProp::Left);
-      let right_pos = ctx.ref_field(AstProp::Right);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
+      let left = serialize_for_head(ctx, &node.left);
+      let right = serialize_expr(ctx, node.right.as_ref());
+      let body = serialize_stmt(ctx, node.body.as_ref());
 
-      let left = serialize_for_head(ctx, &node.left, pos);
-      let right = serialize_expr(ctx, node.right.as_ref(), pos);
-      let body = serialize_stmt(ctx, node.body.as_ref(), pos);
-
-      ctx.write_bool(await_pos, node.is_await);
-      ctx.write_ref(left_pos, left);
-      ctx.write_ref(right_pos, right);
-      ctx.write_ref(body_pos, body);
-
-      pos
+      ctx.write_for_of_stmt(&node.span, node.is_await, left, right, body)
     }
-    Stmt::Decl(node) => serialize_decl(ctx, node, parent),
+    Stmt::Decl(node) => serialize_decl(ctx, node),
     Stmt::Expr(node) => {
-      let raw = ctx.header(AstNode::ExpressionStatement, parent, &node.span);
-      let expr_pos = ctx.ref_field(AstProp::Expression);
-      let pos = ctx.commit_schema(raw);
-
-      let expr = serialize_expr(ctx, node.expr.as_ref(), pos);
-      ctx.write_ref(expr_pos, expr);
-
-      pos
+      let expr = serialize_expr(ctx, node.expr.as_ref());
+      ctx.write_expr_stmt(&node.span, expr)
     }
   }
 }
 
-fn serialize_expr(
-  ctx: &mut TsEsTreeBuilder,
-  expr: &Expr,
-  parent: NodeRef,
-) -> NodeRef {
+fn serialize_expr(ctx: &mut TsEsTreeBuilder, expr: &Expr) -> NodeRef {
   match expr {
-    Expr::This(node) => {
-      let raw = ctx.header(AstNode::ThisExpression, parent, &node.span);
-      ctx.commit_schema(raw)
-    }
+    Expr::This(node) => ctx.write_this_expr(&node.span),
     Expr::Array(node) => {
-      let raw = ctx.header(AstNode::ArrayExpression, parent, &node.span);
-      let elems_pos = ctx.ref_vec_field(AstProp::Elements, node.elems.len());
-      let pos = ctx.commit_schema(raw);
-
       let elems = node
         .elems
         .iter()
         .map(|item| {
           item
             .as_ref()
-            .map_or(NodeRef(0), |item| serialize_expr_or_spread(ctx, item, pos))
+            .map_or(NodeRef(0), |item| serialize_expr_or_spread(ctx, item))
         })
         .collect::<Vec<_>>();
 
-      ctx.write_refs(elems_pos, elems);
-
-      pos
+      ctx.write_arr_expr(&node.span, elems)
     }
     Expr::Object(node) => {
-      let raw = ctx.header(AstNode::ObjectExpression, parent, &node.span);
-      let props_pos = ctx.ref_vec_field(AstProp::Properties, node.props.len());
-      let pos = ctx.commit_schema(raw);
-
-      let prop_ids = node
+      let props = node
         .props
         .iter()
-        .map(|prop| serialize_prop_or_spread(ctx, prop, pos))
+        .map(|prop| serialize_prop_or_spread(ctx, prop))
         .collect::<Vec<_>>();
 
-      ctx.write_refs(props_pos, prop_ids);
-
-      pos
+      ctx.write_obj_expr(&node.span, props)
     }
     Expr::Fn(node) => {
       let fn_obj = node.function.as_ref();
 
-      let raw = ctx.header(AstNode::FunctionExpression, parent, &fn_obj.span);
-
-      let async_pos = ctx.bool_field(AstProp::Async);
-      let gen_pos = ctx.bool_field(AstProp::Generator);
-      let id_pos = ctx.ref_field(AstProp::Id);
-      let tparams_pos = ctx.ref_field(AstProp::TypeParameters);
-      let params_pos = ctx.ref_vec_field(AstProp::Params, fn_obj.params.len());
-      let return_pos = ctx.ref_field(AstProp::ReturnType);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
-
-      let ident = node
-        .ident
-        .as_ref()
-        .map(|ident| serialize_ident(ctx, ident, pos));
+      let ident = node.ident.as_ref().map(|ident| serialize_ident(ctx, ident));
 
       let type_params =
-        maybe_serialize_ts_type_param(ctx, &fn_obj.type_params, pos);
+        maybe_serialize_ts_type_param_decl(ctx, &fn_obj.type_params);
 
       let params = fn_obj
         .params
         .iter()
-        .map(|param| serialize_pat(ctx, &param.pat, pos))
+        .map(|param| serialize_pat(ctx, &param.pat))
         .collect::<Vec<_>>();
 
-      let return_id =
-        maybe_serialize_ts_type_ann(ctx, &fn_obj.return_type, pos);
+      let return_id = maybe_serialize_ts_type_ann(ctx, &fn_obj.return_type);
       let body = fn_obj
         .body
         .as_ref()
-        .map(|block| serialize_stmt(ctx, &Stmt::Block(block.clone()), pos));
+        .map(|block| serialize_stmt(ctx, &Stmt::Block(block.clone())));
 
-      ctx.write_bool(async_pos, fn_obj.is_async);
-      ctx.write_bool(gen_pos, fn_obj.is_generator);
-      ctx.write_maybe_ref(id_pos, ident);
-      ctx.write_maybe_ref(tparams_pos, type_params);
-      ctx.write_refs(params_pos, params);
-      ctx.write_maybe_ref(return_pos, return_id);
-      ctx.write_maybe_ref(body_pos, body);
-
-      pos
+      ctx.write_fn_expr(
+        &fn_obj.span,
+        fn_obj.is_async,
+        fn_obj.is_generator,
+        ident,
+        type_params,
+        params,
+        return_id,
+        body,
+      )
     }
     Expr::Unary(node) => {
-      let raw = ctx.header(AstNode::UnaryExpression, parent, &node.span);
-      let flag_pos = ctx.str_field(AstProp::Operator);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
+      let arg = serialize_expr(ctx, &node.arg);
+      let op = match node.op {
+        UnaryOp::Minus => "-",
+        UnaryOp::Plus => "+",
+        UnaryOp::Bang => "!",
+        UnaryOp::Tilde => "~",
+        UnaryOp::TypeOf => "typeof",
+        UnaryOp::Void => "void",
+        UnaryOp::Delete => "delete",
+      };
 
-      let arg = serialize_expr(ctx, &node.arg, pos);
-
-      ctx.write_str(
-        flag_pos,
-        match node.op {
-          UnaryOp::Minus => "-",
-          UnaryOp::Plus => "+",
-          UnaryOp::Bang => "!",
-          UnaryOp::Tilde => "~",
-          UnaryOp::TypeOf => "typeof",
-          UnaryOp::Void => "void",
-          UnaryOp::Delete => "delete",
-        },
-      );
-      ctx.write_ref(arg_pos, arg);
-
-      pos
+      ctx.write_unary_expr(&node.span, op, arg)
     }
     Expr::Update(node) => {
-      let raw = ctx.header(AstNode::UpdateExpression, parent, &node.span);
-      let prefix_pos = ctx.bool_field(AstProp::Prefix);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let op_ops = ctx.str_field(AstProp::Operator);
-      let pos = ctx.commit_schema(raw);
+      let arg = serialize_expr(ctx, node.arg.as_ref());
+      let op = match node.op {
+        UpdateOp::PlusPlus => "++",
+        UpdateOp::MinusMinus => "--",
+      };
 
-      let arg = serialize_expr(ctx, node.arg.as_ref(), pos);
-
-      ctx.write_bool(prefix_pos, node.prefix);
-      ctx.write_ref(arg_pos, arg);
-      ctx.write_str(
-        op_ops,
-        match node.op {
-          UpdateOp::PlusPlus => "++",
-          UpdateOp::MinusMinus => "--",
-        },
-      );
-
-      pos
+      ctx.write_update_expr(&node.span, node.prefix, op, arg)
     }
     Expr::Bin(node) => {
       let (node_type, flag_str) = match node.op {
@@ -699,501 +664,359 @@ fn serialize_expr(
         BinaryOp::Exp => (AstNode::BinaryExpression, "**"),
       };
 
-      let raw = ctx.header(node_type, parent, &node.span);
-      let op_pos = ctx.str_field(AstProp::Operator);
-      let left_pos = ctx.ref_field(AstProp::Left);
-      let right_pos = ctx.ref_field(AstProp::Right);
-      let pos = ctx.commit_schema(raw);
+      let left = serialize_expr(ctx, node.left.as_ref());
+      let right = serialize_expr(ctx, node.right.as_ref());
 
-      let left_id = serialize_expr(ctx, node.left.as_ref(), pos);
-      let right_id = serialize_expr(ctx, node.right.as_ref(), pos);
-
-      ctx.write_str(op_pos, flag_str);
-      ctx.write_ref(left_pos, left_id);
-      ctx.write_ref(right_pos, right_id);
-
-      pos
+      match node_type {
+        AstNode::LogicalExpression => {
+          ctx.write_logical_expr(&node.span, flag_str, left, right)
+        }
+        AstNode::BinaryExpression => {
+          ctx.write_bin_expr(&node.span, flag_str, left, right)
+        }
+        _ => unreachable!(),
+      }
     }
     Expr::Assign(node) => {
-      let raw = ctx.header(AstNode::AssignmentExpression, parent, &node.span);
-      let op_pos = ctx.str_field(AstProp::Operator);
-      let left_pos = ctx.ref_field(AstProp::Left);
-      let right_pos = ctx.ref_field(AstProp::Right);
-      let pos = ctx.commit_schema(raw);
-
       let left = match &node.left {
         AssignTarget::Simple(simple_assign_target) => {
           match simple_assign_target {
             SimpleAssignTarget::Ident(target) => {
-              serialize_ident(ctx, &target.id, pos)
+              serialize_ident(ctx, &target.id)
             }
             SimpleAssignTarget::Member(target) => {
-              serialize_expr(ctx, &Expr::Member(target.clone()), pos)
+              serialize_expr(ctx, &Expr::Member(target.clone()))
             }
             SimpleAssignTarget::SuperProp(target) => {
-              serialize_expr(ctx, &Expr::SuperProp(target.clone()), pos)
+              serialize_expr(ctx, &Expr::SuperProp(target.clone()))
             }
             SimpleAssignTarget::Paren(target) => {
-              serialize_expr(ctx, &target.expr, pos)
+              serialize_expr(ctx, &target.expr)
             }
             SimpleAssignTarget::OptChain(target) => {
-              serialize_expr(ctx, &Expr::OptChain(target.clone()), pos)
+              serialize_expr(ctx, &Expr::OptChain(target.clone()))
             }
             SimpleAssignTarget::TsAs(target) => {
-              serialize_expr(ctx, &Expr::TsAs(target.clone()), pos)
+              serialize_expr(ctx, &Expr::TsAs(target.clone()))
             }
             SimpleAssignTarget::TsSatisfies(target) => {
-              serialize_expr(ctx, &Expr::TsSatisfies(target.clone()), pos)
+              serialize_expr(ctx, &Expr::TsSatisfies(target.clone()))
             }
             SimpleAssignTarget::TsNonNull(target) => {
-              serialize_expr(ctx, &Expr::TsNonNull(target.clone()), pos)
+              serialize_expr(ctx, &Expr::TsNonNull(target.clone()))
             }
             SimpleAssignTarget::TsTypeAssertion(target) => {
-              serialize_expr(ctx, &Expr::TsTypeAssertion(target.clone()), pos)
+              serialize_expr(ctx, &Expr::TsTypeAssertion(target.clone()))
             }
             SimpleAssignTarget::TsInstantiation(target) => {
-              serialize_expr(ctx, &Expr::TsInstantiation(target.clone()), pos)
+              serialize_expr(ctx, &Expr::TsInstantiation(target.clone()))
             }
             SimpleAssignTarget::Invalid(_) => unreachable!(),
           }
         }
         AssignTarget::Pat(target) => match target {
           AssignTargetPat::Array(array_pat) => {
-            serialize_pat(ctx, &Pat::Array(array_pat.clone()), pos)
+            serialize_pat(ctx, &Pat::Array(array_pat.clone()))
           }
           AssignTargetPat::Object(object_pat) => {
-            serialize_pat(ctx, &Pat::Object(object_pat.clone()), pos)
+            serialize_pat(ctx, &Pat::Object(object_pat.clone()))
           }
           AssignTargetPat::Invalid(_) => unreachable!(),
         },
       };
 
-      let right = serialize_expr(ctx, node.right.as_ref(), pos);
+      let right = serialize_expr(ctx, node.right.as_ref());
 
-      ctx.write_str(
-        op_pos,
-        match node.op {
-          AssignOp::Assign => "=",
-          AssignOp::AddAssign => "+=",
-          AssignOp::SubAssign => "-=",
-          AssignOp::MulAssign => "*=",
-          AssignOp::DivAssign => "/=",
-          AssignOp::ModAssign => "%=",
-          AssignOp::LShiftAssign => "<<=",
-          AssignOp::RShiftAssign => ">>=",
-          AssignOp::ZeroFillRShiftAssign => ">>>=",
-          AssignOp::BitOrAssign => "|=",
-          AssignOp::BitXorAssign => "^=",
-          AssignOp::BitAndAssign => "&=",
-          AssignOp::ExpAssign => "**=",
-          AssignOp::AndAssign => "&&=",
-          AssignOp::OrAssign => "||=",
-          AssignOp::NullishAssign => "??=",
-        },
-      );
-      ctx.write_ref(left_pos, left);
-      ctx.write_ref(right_pos, right);
+      let op = match node.op {
+        AssignOp::Assign => "=",
+        AssignOp::AddAssign => "+=",
+        AssignOp::SubAssign => "-=",
+        AssignOp::MulAssign => "*=",
+        AssignOp::DivAssign => "/=",
+        AssignOp::ModAssign => "%=",
+        AssignOp::LShiftAssign => "<<=",
+        AssignOp::RShiftAssign => ">>=",
+        AssignOp::ZeroFillRShiftAssign => ">>>=",
+        AssignOp::BitOrAssign => "|=",
+        AssignOp::BitXorAssign => "^=",
+        AssignOp::BitAndAssign => "&=",
+        AssignOp::ExpAssign => "**=",
+        AssignOp::AndAssign => "&&=",
+        AssignOp::OrAssign => "||=",
+        AssignOp::NullishAssign => "??=",
+      };
 
-      pos
+      ctx.write_assignment_expr(&node.span, op, left, right)
     }
-    Expr::Member(node) => serialize_member_expr(ctx, node, parent, false),
+    Expr::Member(node) => serialize_member_expr(ctx, node, false),
     Expr::SuperProp(node) => {
-      let raw = ctx.header(AstNode::MemberExpression, parent, &node.span);
-      let computed_pos = ctx.bool_field(AstProp::Computed);
-      let obj_pos = ctx.ref_field(AstProp::Object);
-      let prop_pos = ctx.ref_field(AstProp::Property);
-      let pos = ctx.commit_schema(raw);
-
-      let raw = ctx.header(AstNode::Super, pos, &node.obj.span);
-      let obj = ctx.commit_schema(raw);
+      let obj = ctx.write_super(&node.obj.span);
 
       let mut computed = false;
       let prop = match &node.prop {
-        SuperProp::Ident(ident_name) => {
-          serialize_ident_name(ctx, ident_name, pos)
-        }
+        SuperProp::Ident(ident_name) => serialize_ident_name(ctx, ident_name),
         SuperProp::Computed(prop) => {
           computed = true;
-          serialize_expr(ctx, &prop.expr, pos)
+          serialize_expr(ctx, &prop.expr)
         }
       };
 
-      ctx.write_bool(computed_pos, computed);
-      ctx.write_ref(obj_pos, obj);
-      ctx.write_ref(prop_pos, prop);
-
-      pos
+      ctx.write_member_expr(&node.span, false, computed, obj, prop)
     }
     Expr::Cond(node) => {
-      let raw = ctx.header(AstNode::ConditionalExpression, parent, &node.span);
-      let test_pos = ctx.ref_field(AstProp::Test);
-      let cons_pos = ctx.ref_field(AstProp::Consequent);
-      let alt_pos = ctx.ref_field(AstProp::Alternate);
-      let pos = ctx.commit_schema(raw);
+      let test = serialize_expr(ctx, node.test.as_ref());
+      let cons = serialize_expr(ctx, node.cons.as_ref());
+      let alt = serialize_expr(ctx, node.alt.as_ref());
 
-      let test = serialize_expr(ctx, node.test.as_ref(), pos);
-      let cons = serialize_expr(ctx, node.cons.as_ref(), pos);
-      let alt = serialize_expr(ctx, node.alt.as_ref(), pos);
-
-      ctx.write_ref(test_pos, test);
-      ctx.write_ref(cons_pos, cons);
-      ctx.write_ref(alt_pos, alt);
-
-      pos
+      ctx.write_conditional_expr(&node.span, test, cons, alt)
     }
     Expr::Call(node) => {
-      let raw = ctx.header(AstNode::CallExpression, parent, &node.span);
-      let opt_pos = ctx.bool_field(AstProp::Optional);
-      let callee_pos = ctx.ref_field(AstProp::Callee);
-      let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-      let args_pos = ctx.ref_vec_field(AstProp::Arguments, node.args.len());
-      let pos = ctx.commit_schema(raw);
+      if let Callee::Import(_) = node.callee {
+        let source = node
+          .args
+          .first()
+          .map_or(NodeRef(0), |arg| serialize_expr_or_spread(ctx, arg));
 
-      let callee = match &node.callee {
-        Callee::Super(super_node) => {
-          let raw = ctx.header(AstNode::Super, pos, &super_node.span);
-          ctx.commit_schema(raw)
-        }
-        Callee::Import(_) => todo!(),
-        Callee::Expr(expr) => serialize_expr(ctx, expr, pos),
-      };
+        let options = node
+          .args
+          .get(1)
+          .map_or(NodeRef(0), |arg| serialize_expr_or_spread(ctx, arg));
 
-      let type_arg = node.type_args.clone().map(|param_node| {
-        serialize_ts_param_inst(ctx, param_node.as_ref(), pos)
-      });
+        ctx.write_import_expr(&node.span, source, options)
+      } else {
+        let callee = match &node.callee {
+          Callee::Super(super_node) => ctx.write_super(&super_node.span),
+          Callee::Import(_) => unreachable!("Already handled"),
+          Callee::Expr(expr) => serialize_expr(ctx, expr),
+        };
 
-      let args = node
-        .args
-        .iter()
-        .map(|arg| serialize_expr_or_spread(ctx, arg, pos))
-        .collect::<Vec<_>>();
+        let type_arg = node
+          .type_args
+          .clone()
+          .map(|param_node| serialize_ts_param_inst(ctx, param_node.as_ref()));
 
-      ctx.write_bool(opt_pos, false);
-      ctx.write_ref(callee_pos, callee);
-      ctx.write_maybe_ref(type_args_pos, type_arg);
-      ctx.write_refs(args_pos, args);
+        let args = node
+          .args
+          .iter()
+          .map(|arg| serialize_expr_or_spread(ctx, arg))
+          .collect::<Vec<_>>();
 
-      pos
+        ctx.write_call_expr(&node.span, false, callee, type_arg, args)
+      }
     }
     Expr::New(node) => {
-      let raw = ctx.header(AstNode::NewExpression, parent, &node.span);
-      let callee_pos = ctx.ref_field(AstProp::Callee);
-      let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-      let args_pos = ctx.ref_vec_field(
-        AstProp::Arguments,
-        node.args.as_ref().map_or(0, |v| v.len()),
-      );
-      let pos = ctx.commit_schema(raw);
-
-      let callee = serialize_expr(ctx, node.callee.as_ref(), pos);
+      let callee = serialize_expr(ctx, node.callee.as_ref());
 
       let args: Vec<NodeRef> = node.args.as_ref().map_or(vec![], |args| {
         args
           .iter()
-          .map(|arg| serialize_expr_or_spread(ctx, arg, pos))
+          .map(|arg| serialize_expr_or_spread(ctx, arg))
           .collect::<Vec<_>>()
       });
 
-      let type_args = node.type_args.clone().map(|param_node| {
-        serialize_ts_param_inst(ctx, param_node.as_ref(), pos)
-      });
+      let type_args = node
+        .type_args
+        .clone()
+        .map(|param_node| serialize_ts_param_inst(ctx, param_node.as_ref()));
 
-      ctx.write_ref(callee_pos, callee);
-      ctx.write_maybe_ref(type_args_pos, type_args);
-      ctx.write_refs(args_pos, args);
-
-      pos
+      ctx.write_new_expr(&node.span, callee, type_args, args)
     }
     Expr::Seq(node) => {
-      let raw = ctx.header(AstNode::SequenceExpression, parent, &node.span);
-      let exprs_pos = ctx.ref_vec_field(AstProp::Expressions, node.exprs.len());
-      let pos = ctx.commit_schema(raw);
-
       let children = node
         .exprs
         .iter()
-        .map(|expr| serialize_expr(ctx, expr, pos))
+        .map(|expr| serialize_expr(ctx, expr))
         .collect::<Vec<_>>();
 
-      ctx.write_refs(exprs_pos, children);
-
-      pos
+      ctx.write_sequence_expr(&node.span, children)
     }
-    Expr::Ident(node) => serialize_ident(ctx, node, parent),
-    Expr::Lit(node) => serialize_lit(ctx, node, parent),
+    Expr::Ident(node) => serialize_ident(ctx, node),
+    Expr::Lit(node) => serialize_lit(ctx, node),
     Expr::Tpl(node) => {
-      let raw = ctx.header(AstNode::TemplateLiteral, parent, &node.span);
-      let quasis_pos = ctx.ref_vec_field(AstProp::Quasis, node.quasis.len());
-      let exprs_pos = ctx.ref_vec_field(AstProp::Expressions, node.exprs.len());
-      let pos = ctx.commit_schema(raw);
-
       let quasis = node
         .quasis
         .iter()
         .map(|quasi| {
-          let raw = ctx.header(AstNode::TemplateElement, pos, &quasi.span);
-          let tail_pos = ctx.bool_field(AstProp::Tail);
-          let raw_pos = ctx.str_field(AstProp::Raw);
-          let cooked_pos = ctx.str_field(AstProp::Cooked);
-          let tpl_pos = ctx.commit_schema(raw);
-
-          ctx.write_bool(tail_pos, quasi.tail);
-          ctx.write_str(raw_pos, &quasi.raw);
-          ctx.write_str(
-            cooked_pos,
+          ctx.write_template_elem(
+            &quasi.span,
+            quasi.tail,
+            &quasi.raw,
             &quasi
               .cooked
               .as_ref()
               .map_or("".to_string(), |v| v.to_string()),
-          );
-
-          tpl_pos
+          )
         })
         .collect::<Vec<_>>();
 
       let exprs = node
         .exprs
         .iter()
-        .map(|expr| serialize_expr(ctx, expr, pos))
+        .map(|expr| serialize_expr(ctx, expr))
         .collect::<Vec<_>>();
 
-      ctx.write_refs(quasis_pos, quasis);
-      ctx.write_refs(exprs_pos, exprs);
-
-      pos
+      ctx.write_template_lit(&node.span, quasis, exprs)
     }
     Expr::TaggedTpl(node) => {
-      let raw =
-        ctx.header(AstNode::TaggedTemplateExpression, parent, &node.span);
-      let tag_pos = ctx.ref_field(AstProp::Tag);
-      let type_arg_pos = ctx.ref_field(AstProp::TypeArguments);
-      let quasi_pos = ctx.ref_field(AstProp::Quasi);
-      let pos = ctx.commit_schema(raw);
-
-      let tag = serialize_expr(ctx, &node.tag, pos);
-
-      let type_param_id = node
+      let tag = serialize_expr(ctx, &node.tag);
+      let type_param = node
         .type_params
         .clone()
-        .map(|params| serialize_ts_param_inst(ctx, params.as_ref(), pos));
-      let quasi = serialize_expr(ctx, &Expr::Tpl(*node.tpl.clone()), pos);
+        .map(|params| serialize_ts_param_inst(ctx, params.as_ref()));
+      let quasi = serialize_expr(ctx, &Expr::Tpl(*node.tpl.clone()));
 
-      ctx.write_ref(tag_pos, tag);
-      ctx.write_maybe_ref(type_arg_pos, type_param_id);
-      ctx.write_ref(quasi_pos, quasi);
-
-      pos
+      ctx.write_tagged_template_expr(&node.span, tag, type_param, quasi)
     }
     Expr::Arrow(node) => {
-      let raw =
-        ctx.header(AstNode::ArrowFunctionExpression, parent, &node.span);
-      let async_pos = ctx.bool_field(AstProp::Async);
-      let gen_pos = ctx.bool_field(AstProp::Generator);
-      let type_param_pos = ctx.ref_field(AstProp::TypeParameters);
-      let params_pos = ctx.ref_vec_field(AstProp::Params, node.params.len());
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let return_type_pos = ctx.ref_field(AstProp::ReturnType);
-      let pos = ctx.commit_schema(raw);
-
       let type_param =
-        maybe_serialize_ts_type_param(ctx, &node.type_params, pos);
+        maybe_serialize_ts_type_param_decl(ctx, &node.type_params);
 
       let params = node
         .params
         .iter()
-        .map(|param| serialize_pat(ctx, param, pos))
+        .map(|param| serialize_pat(ctx, param))
         .collect::<Vec<_>>();
 
       let body = match node.body.as_ref() {
         BlockStmtOrExpr::BlockStmt(block_stmt) => {
-          serialize_stmt(ctx, &Stmt::Block(block_stmt.clone()), pos)
+          serialize_stmt(ctx, &Stmt::Block(block_stmt.clone()))
         }
-        BlockStmtOrExpr::Expr(expr) => serialize_expr(ctx, expr.as_ref(), pos),
+        BlockStmtOrExpr::Expr(expr) => serialize_expr(ctx, expr.as_ref()),
       };
 
-      let return_type =
-        maybe_serialize_ts_type_ann(ctx, &node.return_type, pos);
+      let return_type = maybe_serialize_ts_type_ann(ctx, &node.return_type);
 
-      ctx.write_bool(async_pos, node.is_async);
-      ctx.write_bool(gen_pos, node.is_generator);
-      ctx.write_maybe_ref(type_param_pos, type_param);
-      ctx.write_refs(params_pos, params);
-      ctx.write_ref(body_pos, body);
-      ctx.write_maybe_ref(return_type_pos, return_type);
-
-      pos
+      ctx.write_arrow_fn_expr(
+        &node.span,
+        node.is_async,
+        node.is_generator,
+        type_param,
+        params,
+        return_type,
+        body,
+      )
     }
     Expr::Class(node) => {
-      // FIXME
-      let raw = ctx.header(AstNode::ClassExpression, parent, &node.class.span);
-      ctx.commit_schema(raw)
+      let ident = node.ident.as_ref().map(|ident| serialize_ident(ctx, ident));
+
+      let super_class = node
+        .class
+        .super_class
+        .as_ref()
+        .map(|expr| serialize_expr(ctx, expr.as_ref()));
+
+      let implements = node
+        .class
+        .implements
+        .iter()
+        .map(|item| serialize_ts_expr_with_type_args(ctx, item))
+        .collect::<Vec<_>>();
+
+      let members = node
+        .class
+        .body
+        .iter()
+        .map(|member| serialize_class_member(ctx, member))
+        .flatten()
+        .collect::<Vec<_>>();
+
+      let body = ctx.write_class_body(&node.class.span, members);
+
+      ctx.write_class_expr(
+        &node.class.span,
+        false,
+        node.class.is_abstract,
+        ident,
+        super_class,
+        implements,
+        body,
+      )
     }
     Expr::Yield(node) => {
-      let raw = ctx.header(AstNode::YieldExpression, parent, &node.span);
-      let delegate_pos = ctx.bool_field(AstProp::Delegate);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
-
       let arg = node
         .arg
         .as_ref()
-        .map(|arg| serialize_expr(ctx, arg.as_ref(), pos));
+        .map(|arg| serialize_expr(ctx, arg.as_ref()));
 
-      ctx.write_bool(delegate_pos, node.delegate);
-      ctx.write_maybe_ref(arg_pos, arg);
-
-      pos
+      ctx.write_yield_expr(&node.span, node.delegate, arg)
     }
     Expr::MetaProp(node) => {
-      let raw = ctx.header(AstNode::MetaProp, parent, &node.span);
-      ctx.commit_schema(raw)
+      let prop = ctx.write_identifier(&node.span, "meta", false, None);
+      ctx.write_meta_prop(&node.span, prop)
     }
     Expr::Await(node) => {
-      let raw = ctx.header(AstNode::AwaitExpression, parent, &node.span);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
-
-      let arg = serialize_expr(ctx, node.arg.as_ref(), pos);
-
-      ctx.write_ref(arg_pos, arg);
-
-      pos
+      let arg = serialize_expr(ctx, node.arg.as_ref());
+      ctx.write_await_expr(&node.span, arg)
     }
     Expr::Paren(node) => {
       // Paren nodes are treated as a syntax only thing in TSEStree
       // and are never materialized to actual AST nodes.
-      serialize_expr(ctx, &node.expr, parent)
+      serialize_expr(ctx, &node.expr)
     }
-    Expr::JSXMember(node) => serialize_jsx_member_expr(ctx, node, parent),
-    Expr::JSXNamespacedName(node) => {
-      serialize_jsx_namespaced_name(ctx, node, parent)
-    }
-    Expr::JSXEmpty(node) => serialize_jsx_empty_expr(ctx, node, parent),
-    Expr::JSXElement(node) => serialize_jsx_element(ctx, node, parent),
-    Expr::JSXFragment(node) => serialize_jsx_fragment(ctx, node, parent),
+    Expr::JSXMember(node) => serialize_jsx_member_expr(ctx, node),
+    Expr::JSXNamespacedName(node) => serialize_jsx_namespaced_name(ctx, node),
+    Expr::JSXEmpty(node) => ctx.write_jsx_empty_expr(&node.span),
+    Expr::JSXElement(node) => serialize_jsx_element(ctx, node),
+    Expr::JSXFragment(node) => serialize_jsx_fragment(ctx, node),
     Expr::TsTypeAssertion(node) => {
-      let raw = ctx.header(AstNode::TSTypeAssertion, parent, &node.span);
-      let expr_pos = ctx.ref_field(AstProp::Expression);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
+      let expr = serialize_expr(ctx, &node.expr);
+      let type_ann = serialize_ts_type(ctx, &node.type_ann);
 
-      let expr = serialize_expr(ctx, &node.expr, parent);
-      let type_ann = serialize_ts_type(ctx, &node.type_ann, pos);
-
-      ctx.write_ref(expr_pos, expr);
-      ctx.write_ref(type_ann_pos, type_ann);
-
-      pos
+      ctx.write_ts_type_assertion(&node.span, expr, type_ann)
     }
     Expr::TsConstAssertion(node) => {
-      let raw = ctx.header(AstNode::TsConstAssertion, parent, &node.span);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
+      let expr = serialize_expr(ctx, node.expr.as_ref());
 
-      let arg = serialize_expr(ctx, node.expr.as_ref(), pos);
+      let type_name = ctx.write_identifier(&node.span, "const", false, None);
+      let type_ann = ctx.write_ts_type_ref(&node.span, type_name, None);
 
-      // FIXME
-      ctx.write_ref(arg_pos, arg);
-
-      pos
+      ctx.write_ts_as_expr(&node.span, expr, type_ann)
     }
     Expr::TsNonNull(node) => {
-      let raw = ctx.header(AstNode::TSNonNullExpression, parent, &node.span);
-      let expr_pos = ctx.ref_field(AstProp::Expression);
-      let pos = ctx.commit_schema(raw);
-
-      let expr_id = serialize_expr(ctx, node.expr.as_ref(), pos);
-
-      ctx.write_ref(expr_pos, expr_id);
-
-      pos
+      let expr = serialize_expr(ctx, node.expr.as_ref());
+      ctx.write_ts_non_null(&node.span, expr)
     }
     Expr::TsAs(node) => {
-      let raw = ctx.header(AstNode::TSAsExpression, parent, &node.span);
-      let expr_pos = ctx.ref_field(AstProp::Expression);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
+      let expr = serialize_expr(ctx, node.expr.as_ref());
+      let type_ann = serialize_ts_type(ctx, node.type_ann.as_ref());
 
-      let expr = serialize_expr(ctx, node.expr.as_ref(), pos);
-      let type_ann = serialize_ts_type(ctx, node.type_ann.as_ref(), pos);
-
-      ctx.write_ref(expr_pos, expr);
-      ctx.write_ref(type_ann_pos, type_ann);
-
-      pos
+      ctx.write_ts_as_expr(&node.span, expr, type_ann)
     }
-    Expr::TsInstantiation(node) => {
-      let raw = ctx.header(AstNode::TsInstantiation, parent, &node.span);
-      let expr_pos = ctx.ref_field(AstProp::Expression);
-      let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-      let pos = ctx.commit_schema(raw);
-
-      let expr = serialize_expr(ctx, node.expr.as_ref(), pos);
-
-      let type_arg = serialize_ts_param_inst(ctx, node.type_args.as_ref(), pos);
-
-      ctx.write_ref(expr_pos, expr);
-      ctx.write_ref(type_args_pos, type_arg);
-
-      pos
+    Expr::TsInstantiation(_) => {
+      // Invalid syntax
+      unreachable!()
     }
     Expr::TsSatisfies(node) => {
-      let raw = ctx.header(AstNode::TSSatisfiesExpression, parent, &node.span);
-      let expr_pos = ctx.ref_field(AstProp::Expression);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
+      let expr = serialize_expr(ctx, node.expr.as_ref());
+      let type_ann = serialize_ts_type(ctx, node.type_ann.as_ref());
 
-      let epxr = serialize_expr(ctx, node.expr.as_ref(), pos);
-      let type_ann = serialize_ts_type(ctx, node.type_ann.as_ref(), pos);
-
-      ctx.write_ref(expr_pos, epxr);
-      ctx.write_ref(type_ann_pos, type_ann);
-
-      pos
+      ctx.write_ts_satisfies_expr(&node.span, expr, type_ann)
     }
-    Expr::PrivateName(node) => serialize_private_name(ctx, node, parent),
+    Expr::PrivateName(node) => serialize_private_name(ctx, node),
     Expr::OptChain(node) => {
-      let raw = ctx.header(AstNode::ChainExpression, parent, &node.span);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
-
-      let arg = match node.base.as_ref() {
+      let expr = match node.base.as_ref() {
         OptChainBase::Member(member_expr) => {
-          serialize_member_expr(ctx, member_expr, pos, true)
+          serialize_member_expr(ctx, member_expr, true)
         }
         OptChainBase::Call(opt_call) => {
-          let raw = ctx.header(AstNode::CallExpression, pos, &opt_call.span);
-          let opt_pos = ctx.bool_field(AstProp::Optional);
-          let callee_pos = ctx.ref_field(AstProp::Callee);
-          let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-          let args_pos =
-            ctx.ref_vec_field(AstProp::Arguments, opt_call.args.len());
-          let call_pos = ctx.commit_schema(raw);
+          let callee = serialize_expr(ctx, &opt_call.callee);
 
-          let callee = serialize_expr(ctx, &opt_call.callee, pos);
-
-          let type_param_id = opt_call.type_args.clone().map(|params| {
-            serialize_ts_param_inst(ctx, params.as_ref(), call_pos)
-          });
+          let type_param_id = opt_call
+            .type_args
+            .clone()
+            .map(|params| serialize_ts_param_inst(ctx, params.as_ref()));
 
           let args = opt_call
             .args
             .iter()
-            .map(|arg| serialize_expr_or_spread(ctx, arg, pos))
+            .map(|arg| serialize_expr_or_spread(ctx, arg))
             .collect::<Vec<_>>();
 
-          ctx.write_bool(opt_pos, true);
-          ctx.write_ref(callee_pos, callee);
-          ctx.write_maybe_ref(type_args_pos, type_param_id);
-          ctx.write_refs(args_pos, args);
-
-          call_pos
+          ctx.write_call_expr(&opt_call.span, true, callee, type_param_id, args)
         }
       };
 
-      ctx.write_ref(arg_pos, arg);
-
-      pos
+      ctx.write_chain_expr(&node.span, expr)
     }
     Expr::Invalid(_) => {
       unreachable!()
@@ -1204,37 +1027,24 @@ fn serialize_expr(
 fn serialize_prop_or_spread(
   ctx: &mut TsEsTreeBuilder,
   prop: &PropOrSpread,
-  parent: NodeRef,
 ) -> NodeRef {
   match prop {
     PropOrSpread::Spread(spread_element) => serialize_spread(
       ctx,
       spread_element.expr.as_ref(),
       &spread_element.dot3_token,
-      parent,
     ),
     PropOrSpread::Prop(prop) => {
-      let raw = ctx.header(AstNode::Property, parent, &prop.span());
-
-      let shorthand_pos = ctx.bool_field(AstProp::Shorthand);
-      let computed_pos = ctx.bool_field(AstProp::Computed);
-      let method_pos = ctx.bool_field(AstProp::Method);
-      let kind_pos = ctx.str_field(AstProp::Kind);
-      let key_pos = ctx.ref_field(AstProp::Key);
-      let value_pos = ctx.ref_field(AstProp::Value);
-      let pos = ctx.commit_schema(raw);
-
       let mut shorthand = false;
       let mut computed = false;
       let mut method = false;
       let mut kind = "init";
 
-      // FIXME: optional
-      let (key_id, value_id) = match prop.as_ref() {
+      let (key, value) = match prop.as_ref() {
         Prop::Shorthand(ident) => {
           shorthand = true;
 
-          let value = serialize_ident(ctx, ident, pos);
+          let value = serialize_ident(ctx, ident);
           (value, value)
         }
         Prop::KeyValue(key_value_prop) => {
@@ -1242,31 +1052,23 @@ fn serialize_prop_or_spread(
             computed = true;
           }
 
-          let key = serialize_prop_name(ctx, &key_value_prop.key, pos);
-          let value = serialize_expr(ctx, key_value_prop.value.as_ref(), pos);
+          let key = serialize_prop_name(ctx, &key_value_prop.key);
+          let value = serialize_expr(ctx, key_value_prop.value.as_ref());
 
           (key, value)
         }
         Prop::Assign(assign_prop) => {
-          let raw =
-            ctx.header(AstNode::AssignmentPattern, pos, &assign_prop.span);
-          let left_pos = ctx.ref_field(AstProp::Left);
-          let right_pos = ctx.ref_field(AstProp::Right);
-          let child_pos = ctx.commit_schema(raw);
+          let left = serialize_ident(ctx, &assign_prop.key);
+          let right = serialize_expr(ctx, assign_prop.value.as_ref());
 
-          let left = serialize_ident(ctx, &assign_prop.key, child_pos);
-          let right =
-            serialize_expr(ctx, assign_prop.value.as_ref(), child_pos);
-
-          ctx.write_ref(left_pos, left);
-          ctx.write_ref(right_pos, right);
+          let child_pos = ctx.write_assign_pat(&assign_prop.span, left, right);
 
           (left, child_pos)
         }
         Prop::Getter(getter_prop) => {
           kind = "get";
 
-          let key = serialize_prop_name(ctx, &getter_prop.key, pos);
+          let key = serialize_prop_name(ctx, &getter_prop.key);
 
           let value = serialize_expr(
             ctx,
@@ -1280,11 +1082,10 @@ fn serialize_prop_or_spread(
                 body: getter_prop.body.clone(),
                 is_generator: false,
                 is_async: false,
-                type_params: None, // FIXME
-                return_type: None,
+                type_params: None,
+                return_type: getter_prop.type_ann.clone(),
               }),
             }),
-            pos,
           );
 
           (key, value)
@@ -1292,7 +1093,7 @@ fn serialize_prop_or_spread(
         Prop::Setter(setter_prop) => {
           kind = "set";
 
-          let key_id = serialize_prop_name(ctx, &setter_prop.key, pos);
+          let key_id = serialize_prop_name(ctx, &setter_prop.key);
 
           let param = Param::from(*setter_prop.param.clone());
 
@@ -1312,7 +1113,6 @@ fn serialize_prop_or_spread(
                 return_type: None,
               }),
             }),
-            pos,
           );
 
           (key_id, value_id)
@@ -1320,7 +1120,7 @@ fn serialize_prop_or_spread(
         Prop::Method(method_prop) => {
           method = true;
 
-          let key_id = serialize_prop_name(ctx, &method_prop.key, pos);
+          let key_id = serialize_prop_name(ctx, &method_prop.key);
 
           let value_id = serialize_expr(
             ctx,
@@ -1328,21 +1128,21 @@ fn serialize_prop_or_spread(
               ident: None,
               function: method_prop.function.clone(),
             }),
-            pos,
           );
 
           (key_id, value_id)
         }
       };
 
-      ctx.write_bool(shorthand_pos, shorthand);
-      ctx.write_bool(computed_pos, computed);
-      ctx.write_bool(method_pos, method);
-      ctx.write_str(kind_pos, kind);
-      ctx.write_ref(key_pos, key_id);
-      ctx.write_ref(value_pos, value_id);
-
-      pos
+      ctx.write_property(
+        &prop.span(),
+        shorthand,
+        computed,
+        method,
+        kind,
+        key,
+        value,
+      )
     }
   }
 }
@@ -1350,396 +1150,182 @@ fn serialize_prop_or_spread(
 fn serialize_member_expr(
   ctx: &mut TsEsTreeBuilder,
   node: &MemberExpr,
-  parent: NodeRef,
   optional: bool,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::MemberExpression, parent, &node.span);
-  let opt_pos = ctx.bool_field(AstProp::Optional);
-  let computed_pos = ctx.bool_field(AstProp::Computed);
-  let obj_pos = ctx.ref_field(AstProp::Object);
-  let prop_pos = ctx.ref_field(AstProp::Property);
-  let pos = ctx.commit_schema(raw);
-
-  let obj = serialize_expr(ctx, node.obj.as_ref(), pos);
-
   let mut computed = false;
+  let obj = serialize_expr(ctx, node.obj.as_ref());
 
   let prop = match &node.prop {
-    MemberProp::Ident(ident_name) => serialize_ident_name(ctx, ident_name, pos),
+    MemberProp::Ident(ident_name) => serialize_ident_name(ctx, ident_name),
     MemberProp::PrivateName(private_name) => {
-      serialize_private_name(ctx, private_name, pos)
+      serialize_private_name(ctx, private_name)
     }
     MemberProp::Computed(computed_prop_name) => {
       computed = true;
-      serialize_expr(ctx, computed_prop_name.expr.as_ref(), pos)
+      serialize_expr(ctx, computed_prop_name.expr.as_ref())
     }
   };
 
-  ctx.write_bool(opt_pos, optional);
-  ctx.write_bool(computed_pos, computed);
-  ctx.write_ref(obj_pos, obj);
-  ctx.write_ref(prop_pos, prop);
-
-  pos
-}
-
-fn serialize_class_member(
-  ctx: &mut TsEsTreeBuilder,
-  member: &ClassMember,
-  parent: NodeRef,
-) -> NodeRef {
-  match member {
-    ClassMember::Constructor(constructor) => {
-      let raw =
-        ctx.header(AstNode::MethodDefinition, parent, &constructor.span);
-      let key_pos = ctx.ref_field(AstProp::Key);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let args_pos =
-        ctx.ref_vec_field(AstProp::Arguments, constructor.params.len());
-      let acc_pos = if constructor.accessibility.is_some() {
-        NodePos::Str(ctx.str_field(AstProp::Accessibility))
-      } else {
-        NodePos::Undef(ctx.undefined_field(AstProp::Accessibility))
-      };
-      let member_id = ctx.commit_schema(raw);
-
-      // FIXME flags
-
-      let key = serialize_prop_name(ctx, &constructor.key, member_id);
-      let body = constructor
-        .body
-        .as_ref()
-        .map(|body| serialize_stmt(ctx, &Stmt::Block(body.clone()), member_id));
-
-      let params = constructor
-        .params
-        .iter()
-        .map(|param| match param {
-          ParamOrTsParamProp::TsParamProp(_) => {
-            todo!()
-          }
-          ParamOrTsParamProp::Param(param) => {
-            serialize_pat(ctx, &param.pat, member_id)
-          }
-        })
-        .collect::<Vec<_>>();
-
-      if let Some(acc) = constructor.accessibility {
-        if let NodePos::Str(str_pos) = acc_pos {
-          ctx.write_str(str_pos, &accessibility_to_str(acc));
-        }
-      }
-
-      ctx.write_ref(key_pos, key);
-      ctx.write_maybe_ref(body_pos, body);
-      // FIXME
-      ctx.write_refs(args_pos, params);
-
-      member_id
-    }
-    ClassMember::Method(method) => {
-      let raw = ctx.header(AstNode::MethodDefinition, parent, &method.span);
-
-      let member_id = ctx.commit_schema(raw);
-
-      // let mut flags = FlagValue::new();
-      // flags.set(Flag::ClassMethod);
-      if method.function.is_async {
-        // FIXME
-      }
-
-      // accessibility_to_flag(&mut flags, method.accessibility);
-
-      let _key_id = serialize_prop_name(ctx, &method.key, member_id);
-
-      let _body_id =
-        method.function.body.as_ref().map(|body| {
-          serialize_stmt(ctx, &Stmt::Block(body.clone()), member_id)
-        });
-
-      let _params = method
-        .function
-        .params
-        .iter()
-        .map(|param| serialize_pat(ctx, &param.pat, member_id))
-        .collect::<Vec<_>>();
-
-      // ctx.write_node(member_id, );
-      // ctx.write_flags(&flags);
-      // ctx.write_id(key_id);
-      // ctx.write_id(body_id);
-      // ctx.write_ids(AstProp::Params, params);
-
-      member_id
-    }
-    ClassMember::PrivateMethod(_) => todo!(),
-    ClassMember::ClassProp(_) => todo!(),
-    ClassMember::PrivateProp(_) => todo!(),
-    ClassMember::TsIndexSignature(member) => {
-      serialize_ts_index_sig(ctx, member, parent)
-    }
-    ClassMember::Empty(_) => unreachable!(),
-    ClassMember::StaticBlock(_) => todo!(),
-    ClassMember::AutoAccessor(_) => todo!(),
-  }
+  ctx.write_member_expr(&node.span, optional, computed, obj, prop)
 }
 
 fn serialize_expr_or_spread(
   ctx: &mut TsEsTreeBuilder,
   arg: &ExprOrSpread,
-  parent: NodeRef,
 ) -> NodeRef {
   if let Some(spread) = &arg.spread {
-    serialize_spread(ctx, &arg.expr, spread, parent)
+    serialize_spread(ctx, &arg.expr, spread)
   } else {
-    serialize_expr(ctx, arg.expr.as_ref(), parent)
+    serialize_expr(ctx, arg.expr.as_ref())
   }
 }
 
-fn serialize_ident(
-  ctx: &mut TsEsTreeBuilder,
-  ident: &Ident,
-  parent: NodeRef,
-) -> NodeRef {
-  let raw = ctx.header(AstNode::Identifier, parent, &ident.span);
-  let name_pos = ctx.str_field(AstProp::Name);
-  let pos = ctx.commit_schema(raw);
-
-  ctx.write_str(name_pos, ident.sym.as_str());
-
-  pos
+fn serialize_ident(ctx: &mut TsEsTreeBuilder, ident: &Ident) -> NodeRef {
+  ctx.write_identifier(&ident.span, ident.sym.as_str(), ident.optional, None)
 }
 
-fn serialize_module_exported_name(
+fn serialize_module_export_name(
   ctx: &mut TsEsTreeBuilder,
   name: &ModuleExportName,
-  parent: NodeRef,
 ) -> NodeRef {
   match &name {
-    ModuleExportName::Ident(ident) => serialize_ident(ctx, ident, parent),
-    ModuleExportName::Str(lit) => {
-      serialize_lit(ctx, &Lit::Str(lit.clone()), parent)
-    }
+    ModuleExportName::Ident(ident) => serialize_ident(ctx, ident),
+    ModuleExportName::Str(lit) => serialize_lit(ctx, &Lit::Str(lit.clone())),
   }
 }
 
-fn serialize_decl(
-  ctx: &mut TsEsTreeBuilder,
-  decl: &Decl,
-  parent: NodeRef,
-) -> NodeRef {
+fn serialize_decl(ctx: &mut TsEsTreeBuilder, decl: &Decl) -> NodeRef {
   match decl {
     Decl::Class(node) => {
-      let raw = ctx.header(AstNode::ClassDeclaration, parent, &node.class.span);
-      let declare_pos = ctx.bool_field(AstProp::Declare);
-      let abstract_pos = ctx.bool_field(AstProp::Abstract);
-      let id_pos = ctx.ref_field(AstProp::Id);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let type_params_pos = ctx.ref_field(AstProp::TypeParameters);
-      let super_pos = ctx.ref_field(AstProp::SuperClass);
-      let super_type_pos = ctx.ref_field(AstProp::SuperTypeArguments);
-      let impl_pos =
-        ctx.ref_vec_field(AstProp::Implements, node.class.implements.len());
-      let id = ctx.commit_schema(raw);
-
-      let body_raw = ctx.header(AstNode::ClassBody, id, &node.class.span);
-      let body_body_pos =
-        ctx.ref_vec_field(AstProp::Body, node.class.body.len());
-      let body_id = ctx.commit_schema(body_raw);
-
-      let ident = serialize_ident(ctx, &node.ident, id);
-      let type_params =
-        maybe_serialize_ts_type_param(ctx, &node.class.type_params, id);
+      let ident = serialize_ident(ctx, &node.ident);
 
       let super_class = node
         .class
         .super_class
         .as_ref()
-        .map(|super_class| serialize_expr(ctx, super_class, id));
+        .map(|expr| serialize_expr(ctx, expr.as_ref()));
 
-      let super_type_params = node
-        .class
-        .super_type_params
-        .as_ref()
-        .map(|super_params| serialize_ts_param_inst(ctx, super_params, id));
-
-      let implement_ids = node
+      let implements = node
         .class
         .implements
         .iter()
-        .map(|implements| {
-          let raw =
-            ctx.header(AstNode::TSClassImplements, id, &implements.span);
-
-          let expr_pos = ctx.ref_field(AstProp::Expression);
-          let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-          let child_pos = ctx.commit_schema(raw);
-
-          let type_args = implements
-            .type_args
-            .clone()
-            .map(|args| serialize_ts_param_inst(ctx, &args, child_pos));
-
-          let expr = serialize_expr(ctx, &implements.expr, child_pos);
-
-          ctx.write_ref(expr_pos, expr);
-          ctx.write_maybe_ref(type_args_pos, type_args);
-
-          child_pos
-        })
+        .map(|item| serialize_ts_expr_with_type_args(ctx, item))
         .collect::<Vec<_>>();
 
-      let member_ids = node
+      let members = node
         .class
         .body
         .iter()
-        .map(|member| serialize_class_member(ctx, member, parent))
+        .map(|member| serialize_class_member(ctx, member))
+        .flatten()
         .collect::<Vec<_>>();
 
-      ctx.write_ref(body_pos, body_id);
+      let body = ctx.write_class_body(&node.class.span, members);
 
-      ctx.write_bool(declare_pos, node.declare);
-      ctx.write_bool(abstract_pos, node.class.is_abstract);
-      ctx.write_ref(id_pos, ident);
-      ctx.write_maybe_ref(type_params_pos, type_params);
-      ctx.write_maybe_ref(super_pos, super_class);
-      ctx.write_maybe_ref(super_type_pos, super_type_params);
-      ctx.write_refs(impl_pos, implement_ids);
-
-      // body
-      ctx.write_refs(body_body_pos, member_ids);
-
-      id
+      ctx.write_class_decl(
+        &node.class.span,
+        false,
+        node.class.is_abstract,
+        Some(ident),
+        super_class,
+        implements,
+        body,
+      )
     }
     Decl::Fn(node) => {
-      let raw =
-        ctx.header(AstNode::FunctionDeclaration, parent, &node.function.span);
-      let declare_pos = ctx.bool_field(AstProp::Declare);
-      let async_pos = ctx.bool_field(AstProp::Async);
-      let gen_pos = ctx.bool_field(AstProp::Generator);
-      let id_pos = ctx.ref_field(AstProp::Id);
-      let type_params_pos = ctx.ref_field(AstProp::TypeParameters);
-      let return_pos = ctx.ref_field(AstProp::ReturnType);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let params_pos =
-        ctx.ref_vec_field(AstProp::Params, node.function.params.len());
-      let pos = ctx.commit_schema(raw);
-
-      let ident_id = serialize_ident(ctx, &node.ident, parent);
+      let ident_id = serialize_ident(ctx, &node.ident);
       let type_param_id =
-        maybe_serialize_ts_type_param(ctx, &node.function.type_params, pos);
+        maybe_serialize_ts_type_param_decl(ctx, &node.function.type_params);
       let return_type =
-        maybe_serialize_ts_type_ann(ctx, &node.function.return_type, pos);
+        maybe_serialize_ts_type_ann(ctx, &node.function.return_type);
 
       let body = node
         .function
         .body
         .as_ref()
-        .map(|body| serialize_stmt(ctx, &Stmt::Block(body.clone()), pos));
+        .map(|body| serialize_stmt(ctx, &Stmt::Block(body.clone())));
 
       let params = node
         .function
         .params
         .iter()
-        .map(|param| serialize_pat(ctx, &param.pat, pos))
+        .map(|param| serialize_pat(ctx, &param.pat))
         .collect::<Vec<_>>();
 
-      ctx.write_bool(declare_pos, node.declare);
-      ctx.write_bool(async_pos, node.function.is_async);
-      ctx.write_bool(gen_pos, node.function.is_generator);
-      ctx.write_ref(id_pos, ident_id);
-      ctx.write_maybe_ref(type_params_pos, type_param_id);
-      ctx.write_maybe_ref(return_pos, return_type);
-      ctx.write_maybe_ref(body_pos, body);
-      ctx.write_refs(params_pos, params);
-
-      pos
+      ctx.write_fn_decl(
+        &node.function.span,
+        node.declare,
+        node.function.is_async,
+        node.function.is_generator,
+        Some(ident_id),
+        type_param_id,
+        return_type,
+        body,
+        params,
+      )
     }
     Decl::Var(node) => {
-      let raw = ctx.header(AstNode::VariableDeclaration, parent, &node.span);
-      let declare_pos = ctx.bool_field(AstProp::Declare);
-      let kind_pos = ctx.str_field(AstProp::Kind);
-      let decls_pos =
-        ctx.ref_vec_field(AstProp::Declarations, node.decls.len());
-      let id = ctx.commit_schema(raw);
+      let children = node
+        .decls
+        .iter()
+        .map(|decl| {
+          let ident = serialize_pat(ctx, &decl.name);
+          let init = decl
+            .init
+            .as_ref()
+            .map(|init| serialize_expr(ctx, init.as_ref()));
+
+          ctx.write_var_declarator(&decl.span, ident, init)
+        })
+        .collect::<Vec<_>>();
+
+      let kind = match node.kind {
+        VarDeclKind::Var => "var",
+        VarDeclKind::Let => "let",
+        VarDeclKind::Const => "const",
+      };
+
+      ctx.write_var_decl(&node.span, node.declare, kind, children)
+    }
+    Decl::Using(node) => {
+      let kind = if node.is_await {
+        "await using"
+      } else {
+        "using"
+      };
 
       let children = node
         .decls
         .iter()
         .map(|decl| {
-          let raw = ctx.header(AstNode::VariableDeclarator, id, &decl.span);
-          let id_pos = ctx.ref_field(AstProp::Id);
-          let init_pos = ctx.ref_field(AstProp::Init);
-          let child_id = ctx.commit_schema(raw);
-
-          // FIXME: Definite?
-
-          let ident = serialize_pat(ctx, &decl.name, child_id);
-
+          let ident = serialize_pat(ctx, &decl.name);
           let init = decl
             .init
             .as_ref()
-            .map(|init| serialize_expr(ctx, init.as_ref(), child_id));
+            .map(|init| serialize_expr(ctx, init.as_ref()));
 
-          ctx.write_ref(id_pos, ident);
-          ctx.write_maybe_ref(init_pos, init);
-
-          child_id
+          ctx.write_var_declarator(&decl.span, ident, init)
         })
         .collect::<Vec<_>>();
 
-      ctx.write_bool(declare_pos, node.declare);
-      ctx.write_str(
-        kind_pos,
-        match node.kind {
-          VarDeclKind::Var => "var",
-          VarDeclKind::Let => "let",
-          VarDeclKind::Const => "const",
-        },
-      );
-      ctx.write_refs(decls_pos, children);
-
-      id
-    }
-    Decl::Using(_) => {
-      todo!();
+      ctx.write_var_decl(&node.span, false, kind, children)
     }
     Decl::TsInterface(node) => {
-      let raw = ctx.header(AstNode::TSInterface, parent, &node.span);
-      let declare_pos = ctx.bool_field(AstProp::Declare);
-      let id_pos = ctx.ref_field(AstProp::Id);
-      let extends_pos = ctx.ref_vec_field(AstProp::Extends, node.extends.len());
-      let type_param_pos = ctx.ref_field(AstProp::TypeParameters);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
-
-      let body_raw = ctx.header(AstNode::TSInterfaceBody, pos, &node.body.span);
-      let body_body_pos =
-        ctx.ref_vec_field(AstProp::Body, node.body.body.len());
-      let body_id = ctx.commit_schema(body_raw);
-
-      let ident_id = serialize_ident(ctx, &node.id, pos);
+      let ident_id = serialize_ident(ctx, &node.id);
       let type_param =
-        maybe_serialize_ts_type_param(ctx, &node.type_params, pos);
+        maybe_serialize_ts_type_param_decl(ctx, &node.type_params);
 
       let extend_ids = node
         .extends
         .iter()
         .map(|item| {
-          let raw = ctx.header(AstNode::TSInterfaceHeritage, pos, &item.span);
-          let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-          let expr_pos = ctx.ref_field(AstProp::Expression);
-          let child_pos = ctx.commit_schema(raw);
+          let expr = serialize_expr(ctx, &item.expr);
+          let type_args = item
+            .type_args
+            .clone()
+            .map(|params| serialize_ts_param_inst(ctx, params.as_ref()));
 
-          let expr = serialize_expr(ctx, &item.expr, child_pos);
-          let type_args = item.type_args.clone().map(|params| {
-            serialize_ts_param_inst(ctx, params.as_ref(), child_pos)
-          });
-
-          ctx.write_ref(expr_pos, expr);
-          ctx.write_maybe_ref(type_args_pos, type_args);
-
-          child_pos
+          ctx.write_ts_interface_heritage(&item.span, expr, type_args)
         })
         .collect::<Vec<_>>();
 
@@ -1747,269 +1333,211 @@ fn serialize_decl(
         .body
         .body
         .iter()
-        .map(|item| match item {
-          TsTypeElement::TsCallSignatureDecl(ts_call) => {
-            let raw = ctx.header(
-              AstNode::TsCallSignatureDeclaration,
-              pos,
-              &ts_call.span,
-            );
-            let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-            let params_pos =
-              ctx.ref_vec_field(AstProp::Params, ts_call.params.len());
-            let return_pos = ctx.ref_field(AstProp::ReturnType);
-            let item_id = ctx.commit_schema(raw);
-
-            let type_param =
-              maybe_serialize_ts_type_param(ctx, &ts_call.type_params, pos);
-            let return_type =
-              maybe_serialize_ts_type_ann(ctx, &ts_call.type_ann, pos);
-            let params = ts_call
-              .params
-              .iter()
-              .map(|param| serialize_ts_fn_param(ctx, param, pos))
-              .collect::<Vec<_>>();
-
-            ctx.write_maybe_ref(type_ann_pos, type_param);
-            ctx.write_refs(params_pos, params);
-            ctx.write_maybe_ref(return_pos, return_type);
-
-            item_id
-          }
-          TsTypeElement::TsConstructSignatureDecl(_) => todo!(),
-          TsTypeElement::TsPropertySignature(sig) => {
-            let raw = ctx.header(AstNode::TSPropertySignature, pos, &sig.span);
-
-            let computed_pos = ctx.bool_field(AstProp::Computed);
-            let optional_pos = ctx.bool_field(AstProp::Optional);
-            let readonly_pos = ctx.bool_field(AstProp::Readonly);
-            // TODO: where is this coming from?
-            let _static_bos = ctx.bool_field(AstProp::Static);
-            let key_pos = ctx.ref_field(AstProp::Key);
-            let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-            let item_pos = ctx.commit_schema(raw);
-
-            let key = serialize_expr(ctx, &sig.key, item_pos);
-            let type_ann =
-              maybe_serialize_ts_type_ann(ctx, &sig.type_ann, item_pos);
-
-            ctx.write_bool(computed_pos, sig.computed);
-            ctx.write_bool(optional_pos, sig.optional);
-            ctx.write_bool(readonly_pos, sig.readonly);
-            ctx.write_ref(key_pos, key);
-            ctx.write_maybe_ref(type_ann_pos, type_ann);
-
-            item_pos
-          }
-          TsTypeElement::TsGetterSignature(sig) => {
-            let raw = ctx.header(AstNode::TSMethodSignature, pos, &sig.span);
-            let computed_pos = ctx.bool_field(AstProp::Computed);
-            let optional_pos = ctx.bool_field(AstProp::Optional);
-            let readonly_pos = ctx.bool_field(AstProp::Readonly);
-            // TODO: where is this coming from?
-            let _static_bos = ctx.bool_field(AstProp::Static);
-            let kind_pos = ctx.str_field(AstProp::Kind);
-            let key_pos = ctx.ref_field(AstProp::Key);
-            let return_type_pos = ctx.ref_field(AstProp::ReturnType);
-            let item_pos = ctx.commit_schema(raw);
-
-            let key = serialize_expr(ctx, sig.key.as_ref(), item_pos);
-            let return_type =
-              maybe_serialize_ts_type_ann(ctx, &sig.type_ann, item_pos);
-
-            ctx.write_bool(computed_pos, false);
-            ctx.write_bool(optional_pos, false);
-            ctx.write_bool(readonly_pos, false);
-            ctx.write_str(kind_pos, "getter");
-            ctx.write_maybe_ref(return_type_pos, return_type);
-            ctx.write_ref(key_pos, key);
-
-            item_pos
-          }
-          TsTypeElement::TsSetterSignature(sig) => {
-            let raw = ctx.header(AstNode::TSMethodSignature, pos, &sig.span);
-            let computed_pos = ctx.bool_field(AstProp::Computed);
-            let optional_pos = ctx.bool_field(AstProp::Optional);
-            let readonly_pos = ctx.bool_field(AstProp::Readonly);
-            // TODO: where is this coming from?
-            let _static_bos = ctx.bool_field(AstProp::Static);
-            let kind_pos = ctx.str_field(AstProp::Kind);
-            let key_pos = ctx.ref_field(AstProp::Key);
-            let params_pos = ctx.ref_vec_field(AstProp::Params, 1);
-            let item_pos = ctx.commit_schema(raw);
-
-            let key = serialize_expr(ctx, sig.key.as_ref(), item_pos);
-            let params = serialize_ts_fn_param(ctx, &sig.param, item_pos);
-
-            ctx.write_bool(computed_pos, false);
-            ctx.write_bool(optional_pos, false);
-            ctx.write_bool(readonly_pos, false);
-            ctx.write_str(kind_pos, "setter");
-            ctx.write_ref(key_pos, key);
-            ctx.write_refs(params_pos, vec![params]);
-
-            item_pos
-          }
-          TsTypeElement::TsMethodSignature(sig) => {
-            let raw = ctx.header(AstNode::TSMethodSignature, pos, &sig.span);
-            let computed_pos = ctx.bool_field(AstProp::Computed);
-            let optional_pos = ctx.bool_field(AstProp::Optional);
-            let readonly_pos = ctx.bool_field(AstProp::Readonly);
-            // TODO: where is this coming from?
-            let _static_bos = ctx.bool_field(AstProp::Static);
-            let kind_pos = ctx.str_field(AstProp::Kind);
-            let key_pos = ctx.ref_field(AstProp::Key);
-            let params_pos =
-              ctx.ref_vec_field(AstProp::Params, sig.params.len());
-            let return_type_pos = ctx.ref_field(AstProp::ReturnType);
-            let item_pos = ctx.commit_schema(raw);
-
-            let key = serialize_expr(ctx, sig.key.as_ref(), item_pos);
-            let params = sig
-              .params
-              .iter()
-              .map(|param| serialize_ts_fn_param(ctx, param, item_pos))
-              .collect::<Vec<_>>();
-            let return_type =
-              maybe_serialize_ts_type_ann(ctx, &sig.type_ann, item_pos);
-
-            ctx.write_bool(computed_pos, false);
-            ctx.write_bool(optional_pos, false);
-            ctx.write_bool(readonly_pos, false);
-            ctx.write_str(kind_pos, "method");
-            ctx.write_ref(key_pos, key);
-            ctx.write_refs(params_pos, params);
-            ctx.write_maybe_ref(return_type_pos, return_type);
-
-            item_pos
-          }
-          TsTypeElement::TsIndexSignature(sig) => {
-            serialize_ts_index_sig(ctx, sig, pos)
-          }
-        })
+        .map(|item| serialize_ts_type_elem(ctx, item))
         .collect::<Vec<_>>();
 
-      ctx.write_bool(declare_pos, node.declare);
-      ctx.write_ref(id_pos, ident_id);
-      ctx.write_maybe_ref(type_param_pos, type_param);
-      ctx.write_refs(extends_pos, extend_ids);
-      ctx.write_ref(body_pos, body_id);
-
-      // Body
-      ctx.write_refs(body_body_pos, body_elem_ids);
-
-      pos
+      let body_pos =
+        ctx.write_ts_interface_body(&node.body.span, body_elem_ids);
+      ctx.write_ts_interface(
+        &node.span,
+        node.declare,
+        ident_id,
+        type_param,
+        extend_ids,
+        body_pos,
+      )
     }
     Decl::TsTypeAlias(node) => {
-      let raw = ctx.header(AstNode::TsTypeAlias, parent, &node.span);
-      let declare_pos = ctx.bool_field(AstProp::Declare);
-      let id_pos = ctx.ref_field(AstProp::Id);
-      let type_params_pos = ctx.ref_field(AstProp::TypeParameters);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
-
-      let ident = serialize_ident(ctx, &node.id, pos);
-      let type_ann = serialize_ts_type(ctx, &node.type_ann, pos);
+      let ident = serialize_ident(ctx, &node.id);
+      let type_ann = serialize_ts_type(ctx, &node.type_ann);
       let type_param =
-        maybe_serialize_ts_type_param(ctx, &node.type_params, pos);
+        maybe_serialize_ts_type_param_decl(ctx, &node.type_params);
 
-      ctx.write_bool(declare_pos, node.declare);
-      ctx.write_ref(id_pos, ident);
-      ctx.write_maybe_ref(type_params_pos, type_param);
-      ctx.write_ref(type_ann_pos, type_ann);
-
-      pos
+      ctx.write_ts_type_alias(
+        &node.span,
+        node.declare,
+        ident,
+        type_param,
+        type_ann,
+      )
     }
     Decl::TsEnum(node) => {
-      let raw = ctx.header(AstNode::TSEnumDeclaration, parent, &node.span);
-      let declare_pos = ctx.bool_field(AstProp::Declare);
-      let const_pos = ctx.bool_field(AstProp::Const);
-      let id_pos = ctx.ref_field(AstProp::Id);
-      let body_pos = ctx.ref_field(AstProp::Body);
-      let pos = ctx.commit_schema(raw);
-
-      let body_raw = ctx.header(AstNode::TSEnumBody, pos, &node.span);
-      let members_pos = ctx.ref_vec_field(AstProp::Members, node.members.len());
-      let body = ctx.commit_schema(body_raw);
-
-      let ident_id = serialize_ident(ctx, &node.id, parent);
+      let id = serialize_ident(ctx, &node.id);
 
       let members = node
         .members
         .iter()
         .map(|member| {
-          let raw = ctx.header(AstNode::TSEnumMember, body, &member.span);
-          let id_pos = ctx.ref_field(AstProp::Id);
-          let init_pos = ctx.ref_field(AstProp::Initializer);
-          let member_id = ctx.commit_schema(raw);
-
           let ident = match &member.id {
-            TsEnumMemberId::Ident(ident) => {
-              serialize_ident(ctx, ident, member_id)
-            }
+            TsEnumMemberId::Ident(ident) => serialize_ident(ctx, ident),
             TsEnumMemberId::Str(lit_str) => {
-              serialize_lit(ctx, &Lit::Str(lit_str.clone()), member_id)
+              serialize_lit(ctx, &Lit::Str(lit_str.clone()))
             }
           };
 
-          let init = member
-            .init
-            .as_ref()
-            .map(|init| serialize_expr(ctx, init, member_id));
+          let init = member.init.as_ref().map(|init| serialize_expr(ctx, init));
 
-          ctx.write_ref(id_pos, ident);
-          ctx.write_maybe_ref(init_pos, init);
-
-          member_id
+          ctx.write_ts_enum_member(&member.span, ident, init)
         })
         .collect::<Vec<_>>();
 
-      ctx.write_refs(members_pos, members);
-
-      ctx.write_bool(declare_pos, node.declare);
-      ctx.write_bool(const_pos, node.is_const);
-      ctx.write_ref(id_pos, ident_id);
-      ctx.write_ref(body_pos, body);
-
-      pos
+      let body = ctx.write_ts_enum_body(&node.span, members);
+      ctx.write_ts_enum(&node.span, node.declare, node.is_const, id, body)
     }
-    Decl::TsModule(ts_module_decl) => {
-      let raw = ctx.header(AstNode::TsModule, parent, &ts_module_decl.span);
-      ctx.commit_schema(raw)
+    Decl::TsModule(node) => {
+      let ident = match &node.id {
+        TsModuleName::Ident(ident) => serialize_ident(ctx, &ident),
+        TsModuleName::Str(str_lit) => {
+          serialize_lit(ctx, &Lit::Str(str_lit.clone()))
+        }
+      };
+
+      let body = node
+        .body
+        .as_ref()
+        .map(|body| serialize_ts_namespace_body(ctx, body));
+
+      ctx.write_ts_module_decl(
+        &node.span,
+        node.declare,
+        node.global,
+        ident,
+        body,
+      )
     }
+  }
+}
+
+fn serialize_ts_namespace_body(
+  ctx: &mut TsEsTreeBuilder,
+  node: &TsNamespaceBody,
+) -> NodeRef {
+  match node {
+    TsNamespaceBody::TsModuleBlock(mod_block) => {
+      let items = mod_block
+        .body
+        .iter()
+        .map(|item| match item {
+          ModuleItem::ModuleDecl(decl) => serialize_module_decl(ctx, decl),
+          ModuleItem::Stmt(stmt) => serialize_stmt(ctx, stmt),
+        })
+        .collect::<Vec<_>>();
+
+      ctx.write_ts_module_block(&mod_block.span, items)
+    }
+    TsNamespaceBody::TsNamespaceDecl(node) => {
+      let ident = serialize_ident(ctx, &node.id);
+      let body = serialize_ts_namespace_body(ctx, &node.body);
+
+      ctx.write_ts_module_decl(
+        &node.span,
+        node.declare,
+        node.global,
+        ident,
+        Some(body),
+      )
+    }
+  }
+}
+
+fn serialize_ts_type_elem(
+  ctx: &mut TsEsTreeBuilder,
+  node: &TsTypeElement,
+) -> NodeRef {
+  match node {
+    TsTypeElement::TsCallSignatureDecl(ts_call) => {
+      let type_ann =
+        maybe_serialize_ts_type_param_decl(ctx, &ts_call.type_params);
+      let return_type = maybe_serialize_ts_type_ann(ctx, &ts_call.type_ann);
+      let params = ts_call
+        .params
+        .iter()
+        .map(|param| serialize_ts_fn_param(ctx, param))
+        .collect::<Vec<_>>();
+
+      ctx.write_ts_call_sig_decl(&ts_call.span, type_ann, params, return_type)
+    }
+    TsTypeElement::TsConstructSignatureDecl(sig) => {
+      let type_params =
+        maybe_serialize_ts_type_param_decl(ctx, &sig.type_params);
+
+      let params = sig
+        .params
+        .iter()
+        .map(|param| serialize_ts_fn_param(ctx, param))
+        .collect::<Vec<_>>();
+
+      // Must be present
+      let return_type =
+        maybe_serialize_ts_type_ann(ctx, &sig.type_ann).unwrap();
+
+      ctx.write_ts_construct_sig(&sig.span, type_params, params, return_type)
+    }
+    TsTypeElement::TsPropertySignature(sig) => {
+      let key = serialize_expr(ctx, &sig.key);
+      let type_ann = maybe_serialize_ts_type_ann(ctx, &sig.type_ann);
+
+      ctx.write_ts_property_sig(
+        &sig.span,
+        sig.computed,
+        sig.optional,
+        sig.readonly,
+        key,
+        type_ann,
+      )
+    }
+    TsTypeElement::TsGetterSignature(sig) => {
+      let key = serialize_expr(ctx, sig.key.as_ref());
+      let return_type = maybe_serialize_ts_type_ann(ctx, &sig.type_ann);
+
+      ctx.write_ts_getter_sig(&sig.span, key, return_type)
+    }
+    TsTypeElement::TsSetterSignature(sig) => {
+      let key = serialize_expr(ctx, sig.key.as_ref());
+      let param = serialize_ts_fn_param(ctx, &sig.param);
+
+      ctx.write_ts_setter_sig(&sig.span, key, param)
+    }
+    TsTypeElement::TsMethodSignature(sig) => {
+      let key = serialize_expr(ctx, &sig.key);
+      let type_parms =
+        maybe_serialize_ts_type_param_decl(ctx, &sig.type_params);
+      let params = sig
+        .params
+        .iter()
+        .map(|param| serialize_ts_fn_param(ctx, param))
+        .collect::<Vec<_>>();
+      let return_type = maybe_serialize_ts_type_ann(ctx, &sig.type_ann);
+
+      ctx.write_ts_method_sig(
+        &sig.span,
+        sig.computed,
+        sig.optional,
+        key,
+        type_parms,
+        params,
+        return_type,
+      )
+    }
+    TsTypeElement::TsIndexSignature(sig) => serialize_ts_index_sig(ctx, sig),
   }
 }
 
 fn serialize_ts_index_sig(
   ctx: &mut TsEsTreeBuilder,
   node: &TsIndexSignature,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::TSMethodSignature, parent, &node.span);
-  let readonly_pos = ctx.bool_field(AstProp::Readonly);
-  // TODO: where is this coming from?
-  let static_pos = ctx.bool_field(AstProp::Static);
-  let params_pos = ctx.ref_vec_field(AstProp::Params, node.params.len());
-  let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-  let pos = ctx.commit_schema(raw);
-
-  let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann, pos);
-
   let params = node
     .params
     .iter()
-    .map(|param| serialize_ts_fn_param(ctx, param, pos))
+    .map(|param| serialize_ts_fn_param(ctx, param))
     .collect::<Vec<_>>();
+  let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann);
 
-  ctx.write_bool(readonly_pos, false);
-  ctx.write_bool(static_pos, node.is_static);
-  ctx.write_refs(params_pos, params);
-  ctx.write_maybe_ref(type_ann_pos, type_ann);
-
-  pos
+  ctx.write_ts_index_sig(&node.span, node.readonly, params, type_ann)
 }
 
-fn accessibility_to_str(accessibility: Accessibility) -> String {
+fn accessibility_to_str(accessibility: &Accessibility) -> String {
   match accessibility {
     Accessibility::Public => "public".to_string(),
     Accessibility::Protected => "protected".to_string(),
@@ -2020,106 +1548,53 @@ fn accessibility_to_str(accessibility: Accessibility) -> String {
 fn serialize_private_name(
   ctx: &mut TsEsTreeBuilder,
   node: &PrivateName,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::PrivateIdentifier, parent, &node.span);
-  let name_pos = ctx.str_field(AstProp::Name);
-  let pos = ctx.commit_schema(raw);
-
-  ctx.write_str(name_pos, node.name.as_str());
-
-  pos
+  ctx.write_private_identifier(&node.span, node.name.as_str())
 }
 
 fn serialize_jsx_element(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXElement,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXElement, parent, &node.span);
-  let open_pos = ctx.ref_field(AstProp::OpeningElement);
-  let close_pos = ctx.ref_field(AstProp::ClosingElement);
-  let children_pos = ctx.ref_vec_field(AstProp::Children, node.children.len());
-  let pos = ctx.commit_schema(raw);
-
-  let open = serialize_jsx_opening_element(ctx, &node.opening, pos);
+  let open = serialize_jsx_opening_element(ctx, &node.opening);
 
   let close = node.closing.as_ref().map(|closing| {
-    let raw = ctx.header(AstNode::JSXClosingElement, pos, &closing.span);
-    let name_pos = ctx.ref_field(AstProp::Name);
-    let closing_pos = ctx.commit_schema(raw);
-
-    let name = serialize_jsx_element_name(ctx, &closing.name, closing_pos);
-    ctx.write_ref(name_pos, name);
-
-    closing_pos
+    let name = serialize_jsx_element_name(ctx, &closing.name);
+    ctx.write_jsx_closing_elem(&closing.span, name)
   });
 
-  let children = serialize_jsx_children(ctx, &node.children, pos);
+  let children = serialize_jsx_children(ctx, &node.children);
 
-  ctx.write_ref(open_pos, open);
-  ctx.write_maybe_ref(close_pos, close);
-  ctx.write_refs(children_pos, children);
-
-  pos
+  ctx.write_jsx_elem(&node.span, open, close, children)
 }
 
 fn serialize_jsx_fragment(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXFragment,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXFragment, parent, &node.span);
+  let opening = ctx.write_jsx_opening_frag(&node.opening.span);
+  let closing = ctx.write_jsx_closing_frag(&node.closing.span);
+  let children = serialize_jsx_children(ctx, &node.children);
 
-  let opening_pos = ctx.ref_field(AstProp::OpeningFragment);
-  let closing_pos = ctx.ref_field(AstProp::ClosingFragment);
-  let children_pos = ctx.ref_vec_field(AstProp::Children, node.children.len());
-  let pos = ctx.commit_schema(raw);
-
-  let raw = ctx.header(AstNode::JSXOpeningFragment, pos, &node.opening.span);
-  let opening_id = ctx.commit_schema(raw);
-
-  let raw = ctx.header(AstNode::JSXClosingFragment, pos, &node.closing.span);
-  let closing_id = ctx.commit_schema(raw);
-
-  let children = serialize_jsx_children(ctx, &node.children, pos);
-
-  ctx.write_ref(opening_pos, opening_id);
-  ctx.write_ref(closing_pos, closing_id);
-  ctx.write_refs(children_pos, children);
-
-  pos
+  ctx.write_jsx_frag(&node.span, opening, closing, children)
 }
 
 fn serialize_jsx_children(
   ctx: &mut TsEsTreeBuilder,
   children: &[JSXElementChild],
-  parent: NodeRef,
 ) -> Vec<NodeRef> {
   children
     .iter()
     .map(|child| {
       match child {
         JSXElementChild::JSXText(text) => {
-          let raw = ctx.header(AstNode::JSXText, parent, &text.span);
-          let raw_pos = ctx.str_field(AstProp::Raw);
-          let value_pos = ctx.str_field(AstProp::Value);
-          let pos = ctx.commit_schema(raw);
-
-          ctx.write_str(raw_pos, &text.raw);
-          ctx.write_str(value_pos, &text.value);
-
-          pos
+          ctx.write_jsx_text(&text.span, &text.raw, &text.value)
         }
         JSXElementChild::JSXExprContainer(container) => {
-          serialize_jsx_container_expr(ctx, container, parent)
+          serialize_jsx_container_expr(ctx, container)
         }
-        JSXElementChild::JSXElement(el) => {
-          serialize_jsx_element(ctx, el, parent)
-        }
-        JSXElementChild::JSXFragment(frag) => {
-          serialize_jsx_fragment(ctx, frag, parent)
-        }
+        JSXElementChild::JSXElement(el) => serialize_jsx_element(ctx, el),
+        JSXElementChild::JSXFragment(frag) => serialize_jsx_fragment(ctx, frag),
         // No parser supports this
         JSXElementChild::JSXSpreadChild(_) => unreachable!(),
       }
@@ -2130,42 +1605,28 @@ fn serialize_jsx_children(
 fn serialize_jsx_member_expr(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXMemberExpr,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXMemberExpression, parent, &node.span);
-  let obj_ref = ctx.ref_field(AstProp::Object);
-  let prop_ref = ctx.ref_field(AstProp::Property);
-  let pos = ctx.commit_schema(raw);
-
   let obj = match &node.obj {
-    JSXObject::JSXMemberExpr(member) => {
-      serialize_jsx_member_expr(ctx, member, pos)
-    }
-    JSXObject::Ident(ident) => serialize_jsx_identifier(ctx, ident, parent),
+    JSXObject::JSXMemberExpr(member) => serialize_jsx_member_expr(ctx, member),
+    JSXObject::Ident(ident) => serialize_jsx_identifier(ctx, ident),
   };
 
-  let prop = serialize_ident_name_as_jsx_identifier(ctx, &node.prop, pos);
+  let prop = serialize_ident_name_as_jsx_identifier(ctx, &node.prop);
 
-  ctx.write_ref(obj_ref, obj);
-  ctx.write_ref(prop_ref, prop);
-
-  pos
+  ctx.write_jsx_member_expr(&node.span, obj, prop)
 }
 
 fn serialize_jsx_element_name(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXElementName,
-  parent: NodeRef,
 ) -> NodeRef {
   match &node {
-    JSXElementName::Ident(ident) => {
-      serialize_jsx_identifier(ctx, ident, parent)
-    }
+    JSXElementName::Ident(ident) => serialize_jsx_identifier(ctx, ident),
     JSXElementName::JSXMemberExpr(member) => {
-      serialize_jsx_member_expr(ctx, member, parent)
+      serialize_jsx_member_expr(ctx, member)
     }
     JSXElementName::JSXNamespacedName(ns) => {
-      serialize_jsx_namespaced_name(ctx, ns, parent)
+      serialize_jsx_namespaced_name(ctx, ns)
     }
   }
 }
@@ -2173,294 +1634,183 @@ fn serialize_jsx_element_name(
 fn serialize_jsx_opening_element(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXOpeningElement,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXOpeningElement, parent, &node.span);
-  let sclose_pos = ctx.bool_field(AstProp::SelfClosing);
-  let name_pos = ctx.ref_field(AstProp::Name);
-  let attrs_pos = ctx.ref_vec_field(AstProp::Attributes, node.attrs.len());
-  let pos = ctx.commit_schema(raw);
+  let name = serialize_jsx_element_name(ctx, &node.name);
 
-  let name = serialize_jsx_element_name(ctx, &node.name, pos);
-
-  // FIXME: type args
+  let type_args = node
+    .type_args
+    .as_ref()
+    .map(|arg| serialize_ts_param_inst(ctx, arg));
 
   let attrs = node
     .attrs
     .iter()
     .map(|attr| match attr {
       JSXAttrOrSpread::JSXAttr(attr) => {
-        let raw = ctx.header(AstNode::JSXAttribute, pos, &attr.span);
-        let name_pos = ctx.ref_field(AstProp::Name);
-        let value_pos = ctx.ref_field(AstProp::Value);
-        let attr_pos = ctx.commit_schema(raw);
-
         let name = match &attr.name {
           JSXAttrName::Ident(name) => {
-            serialize_ident_name_as_jsx_identifier(ctx, name, attr_pos)
+            serialize_ident_name_as_jsx_identifier(ctx, name)
           }
           JSXAttrName::JSXNamespacedName(node) => {
-            serialize_jsx_namespaced_name(ctx, node, attr_pos)
+            serialize_jsx_namespaced_name(ctx, node)
           }
         };
 
         let value = attr.value.as_ref().map(|value| match value {
-          JSXAttrValue::Lit(lit) => serialize_lit(ctx, lit, attr_pos),
+          JSXAttrValue::Lit(lit) => serialize_lit(ctx, lit),
           JSXAttrValue::JSXExprContainer(container) => {
-            serialize_jsx_container_expr(ctx, container, attr_pos)
+            serialize_jsx_container_expr(ctx, container)
           }
-          JSXAttrValue::JSXElement(el) => {
-            serialize_jsx_element(ctx, el, attr_pos)
-          }
-          JSXAttrValue::JSXFragment(frag) => {
-            serialize_jsx_fragment(ctx, frag, attr_pos)
-          }
+          JSXAttrValue::JSXElement(el) => serialize_jsx_element(ctx, el),
+          JSXAttrValue::JSXFragment(frag) => serialize_jsx_fragment(ctx, frag),
         });
 
-        ctx.write_ref(name_pos, name);
-        ctx.write_maybe_ref(value_pos, value);
-
-        attr_pos
+        ctx.write_jsx_attr(&attr.span, name, value)
       }
       JSXAttrOrSpread::SpreadElement(spread) => {
-        let raw = ctx.header(AstNode::JSXAttribute, pos, &spread.dot3_token);
-        let arg_pos = ctx.ref_field(AstProp::Argument);
-        let attr_pos = ctx.commit_schema(raw);
-
-        let arg = serialize_expr(ctx, &spread.expr, attr_pos);
-
-        ctx.write_ref(arg_pos, arg);
-
-        attr_pos
+        let arg = serialize_expr(ctx, &spread.expr);
+        ctx.write_jsx_spread_attr(&spread.dot3_token, arg)
       }
     })
     .collect::<Vec<_>>();
 
-  ctx.write_bool(sclose_pos, node.self_closing);
-  ctx.write_ref(name_pos, name);
-  ctx.write_refs(attrs_pos, attrs);
-
-  pos
+  ctx.write_jsx_opening_elem(
+    &node.span,
+    node.self_closing,
+    name,
+    attrs,
+    type_args,
+  )
 }
 
 fn serialize_jsx_container_expr(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXExprContainer,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXExpressionContainer, parent, &node.span);
-  let expr_pos = ctx.ref_field(AstProp::Expression);
-  let pos = ctx.commit_schema(raw);
-
   let expr = match &node.expr {
-    JSXExpr::JSXEmptyExpr(expr) => serialize_jsx_empty_expr(ctx, expr, pos),
-    JSXExpr::Expr(expr) => serialize_expr(ctx, expr, pos),
+    JSXExpr::JSXEmptyExpr(expr) => ctx.write_jsx_empty_expr(&expr.span),
+    JSXExpr::Expr(expr) => serialize_expr(ctx, expr),
   };
 
-  ctx.write_ref(expr_pos, expr);
-
-  pos
-}
-
-fn serialize_jsx_empty_expr(
-  ctx: &mut TsEsTreeBuilder,
-  node: &JSXEmptyExpr,
-  parent: NodeRef,
-) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXEmptyExpression, parent, &node.span);
-  ctx.commit_schema(raw)
+  ctx.write_jsx_expr_container(&node.span, expr)
 }
 
 fn serialize_jsx_namespaced_name(
   ctx: &mut TsEsTreeBuilder,
   node: &JSXNamespacedName,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXNamespacedName, parent, &node.span);
-  let ns_pos = ctx.ref_field(AstProp::Namespace);
-  let name_pos = ctx.ref_field(AstProp::Name);
-  let pos = ctx.commit_schema(raw);
+  let ns = ctx.write_jsx_identifier(&node.ns.span, &node.ns.sym);
+  let name = ctx.write_jsx_identifier(&node.name.span, &node.name.sym);
 
-  let ns_id = serialize_ident_name_as_jsx_identifier(ctx, &node.ns, pos);
-  let name_id = serialize_ident_name_as_jsx_identifier(ctx, &node.name, pos);
-
-  ctx.write_ref(ns_pos, ns_id);
-  ctx.write_ref(name_pos, name_id);
-
-  pos
+  ctx.write_jsx_namespaced_name(&node.span, ns, name)
 }
 
 fn serialize_ident_name_as_jsx_identifier(
   ctx: &mut TsEsTreeBuilder,
   node: &IdentName,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXIdentifier, parent, &node.span);
-  let name_pos = ctx.str_field(AstProp::Name);
-  let pos = ctx.commit_schema(raw);
-
-  ctx.write_str(name_pos, &node.sym);
-
-  pos
+  ctx.write_jsx_identifier(&node.span, &node.sym)
 }
 
 fn serialize_jsx_identifier(
   ctx: &mut TsEsTreeBuilder,
   node: &Ident,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::JSXIdentifier, parent, &node.span);
-  let name_pos = ctx.str_field(AstProp::Name);
-  let pos = ctx.commit_schema(raw);
-
-  ctx.write_str(name_pos, &node.sym);
-
-  pos
+  ctx.write_jsx_identifier(&node.span, &node.sym)
 }
 
-fn serialize_pat(
-  ctx: &mut TsEsTreeBuilder,
-  pat: &Pat,
-  parent: NodeRef,
-) -> NodeRef {
+fn serialize_pat(ctx: &mut TsEsTreeBuilder, pat: &Pat) -> NodeRef {
   match pat {
-    Pat::Ident(node) => serialize_ident(ctx, &node.id, parent),
+    Pat::Ident(node) => serialize_ident(ctx, &node.id),
     Pat::Array(node) => {
-      let raw = ctx.header(AstNode::ArrayPattern, parent, &node.span);
-      let opt_pos = ctx.bool_field(AstProp::Optional);
-      let type_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let elems_pos = ctx.ref_vec_field(AstProp::Elements, node.elems.len());
-      let pos = ctx.commit_schema(raw);
-
-      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann, pos);
+      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann);
 
       let children = node
         .elems
         .iter()
-        .map(|pat| {
-          pat
-            .as_ref()
-            .map_or(NodeRef(0), |v| serialize_pat(ctx, v, pos))
-        })
+        .map(|pat| pat.as_ref().map_or(NodeRef(0), |v| serialize_pat(ctx, v)))
         .collect::<Vec<_>>();
 
-      ctx.write_bool(opt_pos, node.optional);
-      ctx.write_maybe_ref(type_pos, type_ann);
-      ctx.write_refs(elems_pos, children);
-
-      pos
+      ctx.write_arr_pat(&node.span, node.optional, type_ann, children)
     }
     Pat::Rest(node) => {
-      let raw = ctx.header(AstNode::RestElement, parent, &node.span);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let pos = ctx.commit_schema(raw);
+      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann);
+      let arg = serialize_pat(ctx, &node.arg);
 
-      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann, pos);
-      let arg = serialize_pat(ctx, &node.arg, parent);
-
-      ctx.write_maybe_ref(type_ann_pos, type_ann);
-      ctx.write_ref(arg_pos, arg);
-
-      pos
+      ctx.write_rest_elem(&node.span, type_ann, arg)
     }
     Pat::Object(node) => {
-      let raw = ctx.header(AstNode::ObjectPattern, parent, &node.span);
-      let opt_pos = ctx.bool_field(AstProp::Optional);
-      let props_pos = ctx.ref_vec_field(AstProp::Properties, node.props.len());
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
-
-      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann, pos);
+      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann);
 
       let children = node
         .props
         .iter()
         .map(|prop| match prop {
           ObjectPatProp::KeyValue(key_value_prop) => {
-            let raw =
-              ctx.header(AstNode::Property, pos, &key_value_prop.span());
-            let computed_pos = ctx.bool_field(AstProp::Computed);
-            let key_pos = ctx.ref_field(AstProp::Key);
-            let value_pos = ctx.ref_field(AstProp::Value);
-            let child_pos = ctx.commit_schema(raw);
-
             let computed = matches!(key_value_prop.key, PropName::Computed(_));
 
-            let key = serialize_prop_name(ctx, &key_value_prop.key, child_pos);
-            let value =
-              serialize_pat(ctx, key_value_prop.value.as_ref(), child_pos);
+            let key = serialize_prop_name(ctx, &key_value_prop.key);
+            let value = serialize_pat(ctx, key_value_prop.value.as_ref());
 
-            ctx.write_bool(computed_pos, computed);
-            ctx.write_ref(key_pos, key);
-            ctx.write_ref(value_pos, value);
-
-            child_pos
+            ctx.write_property(
+              &key_value_prop.span(),
+              false,
+              computed,
+              false,
+              "init",
+              key,
+              value,
+            )
           }
           ObjectPatProp::Assign(assign_pat_prop) => {
-            let raw = ctx.header(AstNode::Property, pos, &assign_pat_prop.span);
-            // TOOD: Doesn't seem to be present in SWC ast
-            let _computed_pos = ctx.bool_field(AstProp::Computed);
-            let key_pos = ctx.ref_field(AstProp::Key);
-            let value_pos = ctx.ref_field(AstProp::Value);
-            let child_pos = ctx.commit_schema(raw);
-
-            let ident = serialize_ident(ctx, &assign_pat_prop.key.id, parent);
+            let ident = serialize_ident(ctx, &assign_pat_prop.key.id);
 
             let value = assign_pat_prop
               .value
               .as_ref()
-              .map(|value| serialize_expr(ctx, value, child_pos));
+              .map_or(NodeRef(0), |value| serialize_expr(ctx, value));
 
-            ctx.write_ref(key_pos, ident);
-            ctx.write_maybe_ref(value_pos, value);
-
-            child_pos
+            ctx.write_property(
+              &assign_pat_prop.span,
+              false,
+              false,
+              false,
+              "init",
+              ident,
+              value,
+            )
           }
           ObjectPatProp::Rest(rest_pat) => {
-            serialize_pat(ctx, &Pat::Rest(rest_pat.clone()), parent)
+            serialize_pat(ctx, &Pat::Rest(rest_pat.clone()))
           }
         })
         .collect::<Vec<_>>();
 
-      ctx.write_bool(opt_pos, node.optional);
-      ctx.write_maybe_ref(type_ann_pos, type_ann);
-      ctx.write_refs(props_pos, children);
-
-      pos
+      ctx.write_obj_pat(&node.span, node.optional, type_ann, children)
     }
     Pat::Assign(node) => {
-      let raw = ctx.header(AstNode::AssignmentPattern, parent, &node.span);
-      let left_pos = ctx.ref_field(AstProp::Left);
-      let right_pos = ctx.ref_field(AstProp::Right);
-      let pos = ctx.commit_schema(raw);
+      let left = serialize_pat(ctx, &node.left);
+      let right = serialize_expr(ctx, &node.right);
 
-      let left = serialize_pat(ctx, &node.left, pos);
-      let right = serialize_expr(ctx, &node.right, pos);
-
-      ctx.write_ref(left_pos, left);
-      ctx.write_ref(right_pos, right);
-
-      pos
+      ctx.write_assign_pat(&node.span, left, right)
     }
     Pat::Invalid(_) => unreachable!(),
-    Pat::Expr(node) => serialize_expr(ctx, node, parent),
+    Pat::Expr(node) => serialize_expr(ctx, node),
   }
 }
 
 fn serialize_for_head(
   ctx: &mut TsEsTreeBuilder,
   for_head: &ForHead,
-  parent: NodeRef,
 ) -> NodeRef {
   match for_head {
     ForHead::VarDecl(var_decl) => {
-      serialize_decl(ctx, &Decl::Var(var_decl.clone()), parent)
+      serialize_decl(ctx, &Decl::Var(var_decl.clone()))
     }
     ForHead::UsingDecl(using_decl) => {
-      serialize_decl(ctx, &Decl::Using(using_decl.clone()), parent)
+      serialize_decl(ctx, &Decl::Using(using_decl.clone()))
     }
-    ForHead::Pat(pat) => serialize_pat(ctx, pat, parent),
+    ForHead::Pat(pat) => serialize_pat(ctx, pat),
   }
 }
 
@@ -2468,471 +1818,634 @@ fn serialize_spread(
   ctx: &mut TsEsTreeBuilder,
   expr: &Expr,
   span: &Span,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::SpreadElement, parent, span);
-  let arg_pos = ctx.ref_field(AstProp::Argument);
-  let pos = ctx.commit_schema(raw);
-
-  let expr_pos = serialize_expr(ctx, expr, parent);
-  ctx.write_ref(arg_pos, expr_pos);
-
-  pos
+  let expr = serialize_expr(ctx, expr);
+  ctx.write_spread(span, expr)
 }
 
 fn serialize_ident_name(
   ctx: &mut TsEsTreeBuilder,
   ident_name: &IdentName,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::Identifier, parent, &ident_name.span);
-  let name_pos = ctx.str_field(AstProp::Name);
-  let pos = ctx.commit_schema(raw);
-
-  ctx.write_str(name_pos, ident_name.sym.as_str());
-
-  pos
+  ctx.write_identifier(&ident_name.span, ident_name.sym.as_str(), false, None)
 }
 
 fn serialize_prop_name(
   ctx: &mut TsEsTreeBuilder,
   prop_name: &PropName,
-  parent: NodeRef,
 ) -> NodeRef {
   match prop_name {
-    PropName::Ident(ident_name) => {
-      serialize_ident_name(ctx, ident_name, parent)
-    }
-    PropName::Str(str_prop) => {
-      let raw = ctx.header(AstNode::StringLiteral, parent, &str_prop.span);
-      let value_pos = ctx.str_field(AstProp::Value);
-      ctx.write_str(value_pos, &str_prop.value);
-      ctx.commit_schema(raw)
-    }
-    PropName::Num(number) => {
-      serialize_lit(ctx, &Lit::Num(number.clone()), parent)
-    }
-    PropName::Computed(node) => serialize_expr(ctx, &node.expr, parent),
+    PropName::Ident(ident_name) => serialize_ident_name(ctx, ident_name),
+    PropName::Str(str_prop) => serialize_lit(ctx, &Lit::Str(str_prop.clone())),
+    PropName::Num(number) => serialize_lit(ctx, &Lit::Num(number.clone())),
+    PropName::Computed(node) => serialize_expr(ctx, &node.expr),
     PropName::BigInt(big_int) => {
-      serialize_lit(ctx, &Lit::BigInt(big_int.clone()), parent)
+      serialize_lit(ctx, &Lit::BigInt(big_int.clone()))
     }
   }
 }
 
-fn serialize_lit(
-  ctx: &mut TsEsTreeBuilder,
-  lit: &Lit,
-  parent: NodeRef,
-) -> NodeRef {
+fn serialize_lit(ctx: &mut TsEsTreeBuilder, lit: &Lit) -> NodeRef {
   match lit {
     Lit::Str(node) => {
-      let raw = ctx.header(AstNode::StringLiteral, parent, &node.span);
-      let value_pos = ctx.str_field(AstProp::Value);
-      let pos = ctx.commit_schema(raw);
+      let raw_value = if let Some(v) = &node.raw {
+        v.to_string()
+      } else {
+        format!("{}", node.value).to_string()
+      };
 
-      ctx.write_str(value_pos, &node.value);
-
-      pos
+      ctx.write_str_lit(&node.span, &node.value, &raw_value)
     }
-    Lit::Bool(lit_bool) => {
-      let raw = ctx.header(AstNode::Bool, parent, &lit_bool.span);
-      let value_pos = ctx.bool_field(AstProp::Value);
-      let pos = ctx.commit_schema(raw);
-
-      ctx.write_bool(value_pos, lit_bool.value);
-
-      pos
-    }
-    Lit::Null(node) => {
-      let raw = ctx.header(AstNode::Null, parent, &node.span);
-      ctx.commit_schema(raw)
-    }
+    Lit::Bool(node) => ctx.write_bool_lit(&node.span, node.value),
+    Lit::Null(node) => ctx.write_null_lit(&node.span),
     Lit::Num(node) => {
-      let raw = ctx.header(AstNode::NumericLiteral, parent, &node.span);
-      let value_pos = ctx.str_field(AstProp::Value);
-      let pos = ctx.commit_schema(raw);
+      let raw_value = if let Some(v) = &node.raw {
+        v.to_string()
+      } else {
+        format!("{}", node.value).to_string()
+      };
 
       let value = node.raw.as_ref().unwrap();
-      ctx.write_str(value_pos, value);
-
-      pos
+      ctx.write_num_lit(&node.span, value, &raw_value)
     }
     Lit::BigInt(node) => {
-      let raw = ctx.header(AstNode::BigIntLiteral, parent, &node.span);
-      let value_pos = ctx.str_field(AstProp::Value);
-      let pos = ctx.commit_schema(raw);
+      let raw_bigint_value = if let Some(v) = &node.raw {
+        let mut s = v.to_string();
+        s.pop();
+        s.to_string()
+      } else {
+        format!("{}", node.value).to_string()
+      };
 
-      ctx.write_str(value_pos, &node.value.to_string());
+      let raw_value = if let Some(v) = &node.raw {
+        v.to_string()
+      } else {
+        format!("{}", node.value).to_string()
+      };
 
-      pos
+      ctx.write_bigint_lit(
+        &node.span,
+        &node.value.to_string(),
+        &raw_value,
+        &raw_bigint_value,
+      )
     }
     Lit::Regex(node) => {
-      let raw = ctx.header(AstNode::RegExpLiteral, parent, &node.span);
-      let pattern_pos = ctx.str_field(AstProp::Pattern);
-      let flags_pos = ctx.str_field(AstProp::Flags);
-      let pos = ctx.commit_schema(raw);
+      let raw = format!("/{}/{}", node.exp.as_str(), node.flags.as_str());
 
-      ctx.write_str(pattern_pos, node.exp.as_str());
-      ctx.write_str(flags_pos, node.flags.as_str());
-
-      pos
+      ctx.write_regex_lit(
+        &node.span,
+        node.exp.as_str(),
+        node.flags.as_str(),
+        &raw,
+        &raw,
+      )
     }
-    Lit::JSXText(jsxtext) => {
-      let raw = ctx.header(AstNode::JSXText, parent, &jsxtext.span);
-      ctx.commit_schema(raw)
+    Lit::JSXText(node) => {
+      ctx.write_jsx_text(&node.span, &node.raw, &node.value)
     }
   }
+}
+
+fn serialize_class_member(
+  ctx: &mut TsEsTreeBuilder,
+  member: &ClassMember,
+) -> Option<NodeRef> {
+  match member {
+    ClassMember::Constructor(node) => {
+      let a11y = node.accessibility.as_ref().map(|v| accessibility_to_str(v));
+
+      let key = serialize_prop_name(ctx, &node.key);
+      let params = node
+        .params
+        .iter()
+        .map(|param| match param {
+          ParamOrTsParamProp::TsParamProp(prop) => {
+            let a11y =
+              node.accessibility.as_ref().map(|v| accessibility_to_str(v));
+
+            let decorators = prop
+              .decorators
+              .iter()
+              .map(|deco| serialize_decorator(ctx, deco))
+              .collect::<Vec<_>>();
+
+            let paramter = match &prop.param {
+              TsParamPropParam::Ident(binding_ident) => {
+                serialize_binding_ident(ctx, binding_ident)
+              }
+              TsParamPropParam::Assign(assign_pat) => {
+                serialize_pat(ctx, &Pat::Assign(assign_pat.clone()))
+              }
+            };
+
+            ctx.write_ts_param_prop(
+              &prop.span,
+              prop.is_override,
+              prop.readonly,
+              a11y,
+              decorators,
+              paramter,
+            )
+          }
+          ParamOrTsParamProp::Param(param) => serialize_pat(ctx, &param.pat),
+        })
+        .collect::<Vec<_>>();
+
+      let body = node
+        .body
+        .as_ref()
+        .map(|body| serialize_stmt(ctx, &Stmt::Block(body.clone())));
+
+      let value = ctx.write_fn_expr(
+        &node.span, false, false, None, None, params, None, body,
+      );
+
+      Some(ctx.write_class_method(
+        &node.span,
+        false,
+        false,
+        node.is_optional,
+        false,
+        false,
+        "constructor",
+        a11y,
+        key,
+        value,
+      ))
+    }
+    ClassMember::Method(node) => {
+      let key = serialize_prop_name(ctx, &node.key);
+
+      Some(serialize_class_method(
+        ctx,
+        &node.span,
+        node.is_abstract,
+        node.is_override,
+        node.is_optional,
+        node.is_static,
+        node.accessibility,
+        &node.kind,
+        key,
+        &node.function,
+      ))
+    }
+    ClassMember::PrivateMethod(node) => {
+      let key = serialize_private_name(ctx, &node.key);
+
+      Some(serialize_class_method(
+        ctx,
+        &node.span,
+        node.is_abstract,
+        node.is_override,
+        node.is_optional,
+        node.is_static,
+        node.accessibility,
+        &node.kind,
+        key,
+        &node.function,
+      ))
+    }
+    ClassMember::ClassProp(node) => {
+      let a11y = node.accessibility.as_ref().map(|v| accessibility_to_str(v));
+
+      let key = serialize_prop_name(ctx, &node.key);
+      let value = node.value.as_ref().map(|expr| serialize_expr(ctx, expr));
+
+      let decorators = node
+        .decorators
+        .iter()
+        .map(|deco| serialize_decorator(ctx, deco))
+        .collect::<Vec<_>>();
+
+      Some(ctx.write_class_prop(
+        &node.span,
+        node.declare,
+        false,
+        node.is_optional,
+        node.is_override,
+        node.readonly,
+        node.is_static,
+        a11y,
+        decorators,
+        key,
+        value,
+      ))
+    }
+    ClassMember::PrivateProp(node) => {
+      let a11y = node.accessibility.as_ref().map(|v| accessibility_to_str(v));
+
+      let decorators = node
+        .decorators
+        .iter()
+        .map(|deco| serialize_decorator(ctx, deco))
+        .collect::<Vec<_>>();
+
+      let key = serialize_private_name(ctx, &node.key);
+
+      let value = node.value.as_ref().map(|expr| serialize_expr(ctx, expr));
+
+      Some(ctx.write_class_prop(
+        &node.span,
+        false,
+        false,
+        node.is_optional,
+        node.is_override,
+        node.readonly,
+        node.is_static,
+        a11y,
+        decorators,
+        key,
+        value,
+      ))
+    }
+    ClassMember::TsIndexSignature(node) => {
+      Some(serialize_ts_index_sig(ctx, node))
+    }
+    ClassMember::Empty(_) => None,
+    ClassMember::StaticBlock(node) => {
+      let body = serialize_stmt(ctx, &Stmt::Block(node.body.clone()));
+      Some(ctx.write_static_block(&node.span, body))
+    }
+    ClassMember::AutoAccessor(node) => {
+      let a11y = node.accessibility.as_ref().map(|v| accessibility_to_str(v));
+      let decorators = node
+        .decorators
+        .iter()
+        .map(|deco| serialize_decorator(ctx, deco))
+        .collect::<Vec<_>>();
+
+      let key = match &node.key {
+        Key::Private(private_name) => serialize_private_name(ctx, private_name),
+        Key::Public(prop_name) => serialize_prop_name(ctx, &prop_name),
+      };
+
+      let value = node.value.as_ref().map(|expr| serialize_expr(ctx, expr));
+
+      Some(ctx.write_accessor_property(
+        &node.span,
+        false,
+        false,
+        false,
+        node.is_override,
+        false,
+        node.is_static,
+        a11y,
+        decorators,
+        key,
+        value,
+      ))
+    }
+  }
+}
+
+fn serialize_class_method(
+  ctx: &mut TsEsTreeBuilder,
+  span: &Span,
+  is_abstract: bool,
+  is_override: bool,
+  is_optional: bool,
+  is_static: bool,
+  accessibility: Option<Accessibility>,
+  method_kind: &MethodKind,
+  key: NodeRef,
+  function: &Function,
+) -> NodeRef {
+  let kind = match method_kind {
+    MethodKind::Method => "method",
+    MethodKind::Getter => "getter",
+    MethodKind::Setter => "setter",
+  };
+
+  let type_params =
+    maybe_serialize_ts_type_param_decl(ctx, &function.type_params);
+  let params = function
+    .params
+    .iter()
+    .map(|param| serialize_pat(ctx, &param.pat))
+    .collect::<Vec<_>>();
+
+  let return_type = maybe_serialize_ts_type_ann(ctx, &function.return_type);
+
+  let body = function
+    .body
+    .as_ref()
+    .map(|body| serialize_stmt(ctx, &Stmt::Block(body.clone())));
+
+  let value = if let Some(body) = body {
+    ctx.write_fn_expr(
+      &function.span,
+      function.is_async,
+      function.is_generator,
+      None,
+      type_params,
+      params,
+      return_type,
+      Some(body),
+    )
+  } else {
+    ctx.write_ts_empty_body_fn_expr(
+      &span,
+      false,
+      false,
+      function.is_async,
+      function.is_generator,
+      None,
+      type_params,
+      params,
+      return_type,
+    )
+  };
+
+  let a11y = accessibility.as_ref().map(|v| accessibility_to_str(v));
+
+  if is_abstract {
+    ctx.write_ts_abstract_method_def(
+      &span,
+      false,
+      is_optional,
+      is_override,
+      false,
+      a11y,
+      key,
+      value,
+    )
+  } else {
+    ctx.write_class_method(
+      &span,
+      false,
+      false,
+      is_optional,
+      is_override,
+      is_static,
+      kind,
+      a11y,
+      key,
+      value,
+    )
+  }
+}
+
+fn serialize_ts_expr_with_type_args(
+  ctx: &mut TsEsTreeBuilder,
+  node: &TsExprWithTypeArgs,
+) -> NodeRef {
+  let expr = serialize_expr(ctx, &node.expr);
+  let type_args = node
+    .type_args
+    .as_ref()
+    .map(|arg| serialize_ts_param_inst(ctx, arg));
+
+  ctx.write_ts_class_implements(&node.span, expr, type_args)
+}
+
+fn serialize_decorator(ctx: &mut TsEsTreeBuilder, node: &Decorator) -> NodeRef {
+  let expr = serialize_expr(ctx, &node.expr);
+  ctx.write_decorator(&node.span, expr)
+}
+
+fn serialize_binding_ident(
+  ctx: &mut TsEsTreeBuilder,
+  node: &BindingIdent,
+) -> NodeRef {
+  let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann);
+  ctx.write_identifier(&node.span, &node.sym, node.optional, type_ann)
 }
 
 fn serialize_ts_param_inst(
   ctx: &mut TsEsTreeBuilder,
   node: &TsTypeParamInstantiation,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw =
-    ctx.header(AstNode::TSTypeParameterInstantiation, parent, &node.span);
-  let params_pos = ctx.ref_vec_field(AstProp::Params, node.params.len());
-  let pos = ctx.commit_schema(raw);
-
   let params = node
     .params
     .iter()
-    .map(|param| serialize_ts_type(ctx, param, pos))
+    .map(|param| serialize_ts_type(ctx, param))
     .collect::<Vec<_>>();
 
-  ctx.write_refs(params_pos, params);
-
-  pos
+  ctx.write_ts_type_param_inst(&node.span, params)
 }
 
-fn serialize_ts_type(
-  ctx: &mut TsEsTreeBuilder,
-  node: &TsType,
-  parent: NodeRef,
-) -> NodeRef {
+fn serialize_ts_type(ctx: &mut TsEsTreeBuilder, node: &TsType) -> NodeRef {
   match node {
     TsType::TsKeywordType(node) => {
       let kind = match node.kind {
-        TsKeywordTypeKind::TsAnyKeyword => AstNode::TSAnyKeyword,
-        TsKeywordTypeKind::TsUnknownKeyword => AstNode::TSUnknownKeyword,
-        TsKeywordTypeKind::TsNumberKeyword => AstNode::TSNumberKeyword,
-        TsKeywordTypeKind::TsObjectKeyword => AstNode::TSObjectKeyword,
-        TsKeywordTypeKind::TsBooleanKeyword => AstNode::TSBooleanKeyword,
-        TsKeywordTypeKind::TsBigIntKeyword => AstNode::TSBigIntKeyword,
-        TsKeywordTypeKind::TsStringKeyword => AstNode::TSStringKeyword,
-        TsKeywordTypeKind::TsSymbolKeyword => AstNode::TSSymbolKeyword,
-        TsKeywordTypeKind::TsVoidKeyword => AstNode::TSVoidKeyword,
-        TsKeywordTypeKind::TsUndefinedKeyword => AstNode::TSUndefinedKeyword,
-        TsKeywordTypeKind::TsNullKeyword => AstNode::TSNullKeyword,
-        TsKeywordTypeKind::TsNeverKeyword => AstNode::TSNeverKeyword,
-        TsKeywordTypeKind::TsIntrinsicKeyword => AstNode::TSIntrinsicKeyword,
+        TsKeywordTypeKind::TsAnyKeyword => TsKeywordKind::Any,
+        TsKeywordTypeKind::TsUnknownKeyword => TsKeywordKind::Unknown,
+        TsKeywordTypeKind::TsNumberKeyword => TsKeywordKind::Number,
+        TsKeywordTypeKind::TsObjectKeyword => TsKeywordKind::Object,
+        TsKeywordTypeKind::TsBooleanKeyword => TsKeywordKind::Boolean,
+        TsKeywordTypeKind::TsBigIntKeyword => TsKeywordKind::BigInt,
+        TsKeywordTypeKind::TsStringKeyword => TsKeywordKind::String,
+        TsKeywordTypeKind::TsSymbolKeyword => TsKeywordKind::Symbol,
+        TsKeywordTypeKind::TsVoidKeyword => TsKeywordKind::Void,
+        TsKeywordTypeKind::TsUndefinedKeyword => TsKeywordKind::Undefined,
+        TsKeywordTypeKind::TsNullKeyword => TsKeywordKind::Null,
+        TsKeywordTypeKind::TsNeverKeyword => TsKeywordKind::Never,
+        TsKeywordTypeKind::TsIntrinsicKeyword => TsKeywordKind::Intrinsic,
       };
 
-      let raw = ctx.header(kind, parent, &node.span);
-      ctx.commit_schema(raw)
+      ctx.write_ts_keyword(kind, &node.span)
     }
-    TsType::TsThisType(node) => {
-      let raw = ctx.header(AstNode::TSThisType, parent, &node.span);
-      ctx.commit_schema(raw)
-    }
+    TsType::TsThisType(node) => ctx.write_ts_this_type(&node.span),
     TsType::TsFnOrConstructorType(node) => match node {
       TsFnOrConstructorType::TsFnType(node) => {
-        let raw = ctx.header(AstNode::TSFunctionType, parent, &node.span);
-        let params_pos = ctx.ref_vec_field(AstProp::Params, node.params.len());
-        let pos = ctx.commit_schema(raw);
-
         let param_ids = node
           .params
           .iter()
-          .map(|param| serialize_ts_fn_param(ctx, param, pos))
+          .map(|param| serialize_ts_fn_param(ctx, param))
           .collect::<Vec<_>>();
 
-        ctx.write_refs(params_pos, param_ids);
-
-        pos
+        ctx.write_ts_fn_type(&node.span, param_ids)
       }
-      TsFnOrConstructorType::TsConstructorType(_) => {
-        todo!()
+      TsFnOrConstructorType::TsConstructorType(node) => {
+        // interface Foo { new<T>(arg1: any): any }
+        let type_params = node
+          .type_params
+          .as_ref()
+          .map(|param| serialize_ts_type_param_decl(ctx, param));
+
+        let params = node
+          .params
+          .iter()
+          .map(|param| serialize_ts_fn_param(ctx, param))
+          .collect::<Vec<_>>();
+
+        let return_type = serialize_ts_type_ann(ctx, node.type_ann.as_ref());
+
+        ctx.write_ts_construct_sig(&node.span, type_params, params, return_type)
       }
     },
     TsType::TsTypeRef(node) => {
-      let raw = ctx.header(AstNode::TSTypeReference, parent, &node.span);
-      let name_pos = ctx.ref_field(AstProp::TypeName);
-      let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-      let pos = ctx.commit_schema(raw);
-
-      let name = serialize_ts_entity_name(ctx, &node.type_name, pos);
+      let name = serialize_ts_entity_name(ctx, &node.type_name);
 
       let type_args = node
         .type_params
         .clone()
-        .map(|param| serialize_ts_param_inst(ctx, &param, pos));
+        .map(|param| serialize_ts_param_inst(ctx, &param));
 
-      ctx.write_ref(name_pos, name);
-      ctx.write_maybe_ref(type_args_pos, type_args);
-
-      pos
+      ctx.write_ts_type_ref(&node.span, name, type_args)
     }
     TsType::TsTypeQuery(node) => {
-      let raw = ctx.header(AstNode::TSTypeQuery, parent, &node.span);
-      let name_pos = ctx.ref_field(AstProp::ExprName);
-      let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-      let pos = ctx.commit_schema(raw);
-
       let expr_name = match &node.expr_name {
         TsTypeQueryExpr::TsEntityName(entity) => {
-          serialize_ts_entity_name(ctx, entity, pos)
+          serialize_ts_entity_name(ctx, entity)
         }
         TsTypeQueryExpr::Import(child) => {
-          serialize_ts_type(ctx, &TsType::TsImportType(child.clone()), pos)
+          serialize_ts_type(ctx, &TsType::TsImportType(child.clone()))
         }
       };
 
       let type_args = node
         .type_args
         .clone()
-        .map(|param| serialize_ts_param_inst(ctx, &param, pos));
+        .map(|param| serialize_ts_param_inst(ctx, &param));
 
-      ctx.write_ref(name_pos, expr_name);
-      ctx.write_maybe_ref(type_args_pos, type_args);
-
-      pos
+      ctx.write_ts_type_query(&node.span, expr_name, type_args)
     }
-    TsType::TsTypeLit(_) => {
-      // TODO: Not sure what this is
-      todo!()
+    TsType::TsTypeLit(node) => {
+      let members = node
+        .members
+        .iter()
+        .map(|member| serialize_ts_type_elem(ctx, member))
+        .collect::<Vec<_>>();
+
+      ctx.write_ts_type_lit(&node.span, members)
     }
     TsType::TsArrayType(node) => {
-      let raw = ctx.header(AstNode::TSArrayType, parent, &node.span);
-      let elem_pos = ctx.ref_field(AstProp::ElementType);
-      let pos = ctx.commit_schema(raw);
-
-      let elem = serialize_ts_type(ctx, &node.elem_type, pos);
-
-      ctx.write_ref(elem_pos, elem);
-
-      pos
+      let elem = serialize_ts_type(ctx, &node.elem_type);
+      ctx.write_ts_array_type(&node.span, elem)
     }
     TsType::TsTupleType(node) => {
-      let raw = ctx.header(AstNode::TSTupleType, parent, &node.span);
-      let children_pos =
-        ctx.ref_vec_field(AstProp::ElementTypes, node.elem_types.len());
-      let pos = ctx.commit_schema(raw);
-
       let children = node
         .elem_types
         .iter()
         .map(|elem| {
           if let Some(label) = &elem.label {
-            let raw = ctx.header(AstNode::TSNamedTupleMember, pos, &elem.span);
-            let label_pos = ctx.ref_field(AstProp::Label);
-            let type_pos = ctx.ref_field(AstProp::ElementType);
-            let child_pos = ctx.commit_schema(raw);
+            let label = serialize_pat(ctx, label);
+            let type_id = serialize_ts_type(ctx, elem.ty.as_ref());
 
-            let label_id = serialize_pat(ctx, label, child_pos);
-            let type_id = serialize_ts_type(ctx, elem.ty.as_ref(), child_pos);
-
-            ctx.write_ref(label_pos, label_id);
-            ctx.write_ref(type_pos, type_id);
-
-            child_pos
+            ctx.write_ts_named_tuple_member(&elem.span, label, type_id)
           } else {
-            serialize_ts_type(ctx, elem.ty.as_ref(), pos)
+            serialize_ts_type(ctx, elem.ty.as_ref())
           }
         })
         .collect::<Vec<_>>();
 
-      ctx.write_refs(children_pos, children);
-
-      pos
+      ctx.write_ts_tuple_type(&node.span, children)
     }
-    TsType::TsOptionalType(_) => todo!(),
+    TsType::TsOptionalType(node) => {
+      let type_ann = serialize_ts_type(ctx, &node.type_ann);
+      ctx.write_ts_optional_type(&node.span, type_ann)
+    }
     TsType::TsRestType(node) => {
-      let raw = ctx.header(AstNode::TSRestType, parent, &node.span);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
-
-      let type_ann = serialize_ts_type(ctx, &node.type_ann, pos);
-
-      ctx.write_ref(type_ann_pos, type_ann);
-
-      pos
+      let type_ann = serialize_ts_type(ctx, &node.type_ann);
+      ctx.write_ts_rest_type(&node.span, type_ann)
     }
     TsType::TsUnionOrIntersectionType(node) => match node {
       TsUnionOrIntersectionType::TsUnionType(node) => {
-        let raw = ctx.header(AstNode::TSUnionType, parent, &node.span);
-        let types_pos = ctx.ref_vec_field(AstProp::Types, node.types.len());
-        let pos = ctx.commit_schema(raw);
-
         let children = node
           .types
           .iter()
-          .map(|item| serialize_ts_type(ctx, item, pos))
+          .map(|item| serialize_ts_type(ctx, item))
           .collect::<Vec<_>>();
 
-        ctx.write_refs(types_pos, children);
-
-        pos
+        ctx.write_ts_union_type(&node.span, children)
       }
       TsUnionOrIntersectionType::TsIntersectionType(node) => {
-        let raw = ctx.header(AstNode::TSIntersectionType, parent, &node.span);
-        let types_pos = ctx.ref_vec_field(AstProp::Types, node.types.len());
-        let pos = ctx.commit_schema(raw);
-
         let children = node
           .types
           .iter()
-          .map(|item| serialize_ts_type(ctx, item, pos))
+          .map(|item| serialize_ts_type(ctx, item))
           .collect::<Vec<_>>();
 
-        ctx.write_refs(types_pos, children);
-
-        pos
+        ctx.write_ts_intersection_type(&node.span, children)
       }
     },
     TsType::TsConditionalType(node) => {
-      let raw = ctx.header(AstNode::TSConditionalType, parent, &node.span);
-      let check_pos = ctx.ref_field(AstProp::CheckType);
-      let extends_pos = ctx.ref_field(AstProp::ExtendsType);
-      let true_pos = ctx.ref_field(AstProp::TrueType);
-      let false_pos = ctx.ref_field(AstProp::FalseType);
-      let pos = ctx.commit_schema(raw);
+      let check = serialize_ts_type(ctx, &node.check_type);
+      let extends = serialize_ts_type(ctx, &node.extends_type);
+      let v_true = serialize_ts_type(ctx, &node.true_type);
+      let v_false = serialize_ts_type(ctx, &node.false_type);
 
-      let check = serialize_ts_type(ctx, &node.check_type, pos);
-      let extends = serialize_ts_type(ctx, &node.extends_type, pos);
-      let v_true = serialize_ts_type(ctx, &node.true_type, pos);
-      let v_false = serialize_ts_type(ctx, &node.false_type, pos);
-
-      ctx.write_ref(check_pos, check);
-      ctx.write_ref(extends_pos, extends);
-      ctx.write_ref(true_pos, v_true);
-      ctx.write_ref(false_pos, v_false);
-
-      pos
+      ctx.write_ts_conditional_type(&node.span, check, extends, v_true, v_false)
     }
     TsType::TsInferType(node) => {
-      let raw = ctx.header(AstNode::TSInferType, parent, &node.span);
-      let param_pos = ctx.ref_field(AstProp::TypeParameter);
-      let pos = ctx.commit_schema(raw);
-
-      let param = serialize_ts_type_param(ctx, &node.type_param, parent);
-
-      ctx.write_ref(param_pos, param);
-
-      pos
+      let param = serialize_ts_type_param(ctx, &node.type_param);
+      ctx.write_ts_infer_type(&node.span, param)
     }
-    TsType::TsParenthesizedType(_) => todo!(),
+    TsType::TsParenthesizedType(node) => {
+      // Not materialized in TSEstree
+      serialize_ts_type(ctx, &node.type_ann)
+    }
     TsType::TsTypeOperator(node) => {
-      let raw = ctx.header(AstNode::TSTypeOperator, parent, &node.span);
-      let operator_pos = ctx.str_field(AstProp::Operator);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
+      let type_ann = serialize_ts_type(ctx, &node.type_ann);
 
-      let type_ann = serialize_ts_type(ctx, &node.type_ann, pos);
-
-      ctx.write_str(
-        operator_pos,
-        match node.op {
-          TsTypeOperatorOp::KeyOf => "keyof",
-          TsTypeOperatorOp::Unique => "unique",
-          TsTypeOperatorOp::ReadOnly => "readonly",
-        },
-      );
-      ctx.write_ref(type_ann_pos, type_ann);
-
-      pos
-    }
-    TsType::TsIndexedAccessType(node) => {
-      let raw = ctx.header(AstNode::TSIndexedAccessType, parent, &node.span);
-      let index_type_pos = ctx.ref_field(AstProp::IndexType);
-      let obj_type_pos = ctx.ref_field(AstProp::ObjectType);
-      let pos = ctx.commit_schema(raw);
-
-      let index = serialize_ts_type(ctx, &node.index_type, pos);
-      let obj = serialize_ts_type(ctx, &node.obj_type, pos);
-
-      ctx.write_ref(index_type_pos, index);
-      ctx.write_ref(obj_type_pos, obj);
-
-      pos
-    }
-    TsType::TsMappedType(node) => {
-      let raw = ctx.header(AstNode::TSMappedType, parent, &node.span);
-      let name_pos = ctx.ref_field(AstProp::NameType);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let type_param_pos = ctx.ref_field(AstProp::TypeParameter);
-      let pos = ctx.commit_schema(raw);
-
-      let opt_pos =
-        create_true_plus_minus_field(ctx, AstProp::Optional, node.optional);
-      let readonly_pos =
-        create_true_plus_minus_field(ctx, AstProp::Readonly, node.readonly);
-
-      let name_id = maybe_serialize_ts_type(ctx, &node.name_type, pos);
-      let type_ann = maybe_serialize_ts_type(ctx, &node.type_ann, pos);
-      let type_param = serialize_ts_type_param(ctx, &node.type_param, pos);
-
-      write_true_plus_minus(ctx, opt_pos, node.optional);
-      write_true_plus_minus(ctx, readonly_pos, node.readonly);
-      ctx.write_maybe_ref(name_pos, name_id);
-      ctx.write_maybe_ref(type_ann_pos, type_ann);
-      ctx.write_ref(type_param_pos, type_param);
-
-      pos
-    }
-    TsType::TsLitType(node) => serialize_ts_lit_type(ctx, node, parent),
-    TsType::TsTypePredicate(node) => {
-      let raw = ctx.header(AstNode::TSTypePredicate, parent, &node.span);
-      let asserts_pos = ctx.bool_field(AstProp::Asserts);
-      let param_name_pos = ctx.ref_field(AstProp::ParameterName);
-      let type_ann_pos = ctx.ref_field(AstProp::TypeAnnotation);
-      let pos = ctx.commit_schema(raw);
-
-      let param_name = match &node.param_name {
-        TsThisTypeOrIdent::TsThisType(ts_this_type) => {
-          let raw = ctx.header(AstNode::TSThisType, pos, &ts_this_type.span);
-          ctx.commit_schema(raw)
-        }
-        TsThisTypeOrIdent::Ident(ident) => serialize_ident(ctx, ident, pos),
+      let op = match node.op {
+        TsTypeOperatorOp::KeyOf => "keyof",
+        TsTypeOperatorOp::Unique => "unique",
+        TsTypeOperatorOp::ReadOnly => "readonly",
       };
 
-      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann, pos);
+      ctx.write_ts_type_op(&node.span, op, type_ann)
+    }
+    TsType::TsIndexedAccessType(node) => {
+      let index = serialize_ts_type(ctx, &node.index_type);
+      let obj = serialize_ts_type(ctx, &node.obj_type);
 
-      ctx.write_bool(asserts_pos, node.asserts);
-      ctx.write_ref(param_name_pos, param_name);
-      ctx.write_maybe_ref(type_ann_pos, type_ann);
+      ctx.write_ts_indexed_access_type(&node.span, index, obj)
+    }
+    TsType::TsMappedType(node) => {
+      let name = maybe_serialize_ts_type(ctx, &node.name_type);
+      let type_ann = maybe_serialize_ts_type(ctx, &node.type_ann);
+      let type_param = serialize_ts_type_param(ctx, &node.type_param);
 
-      pos
+      ctx.write_ts_mapped_type(
+        &node.span,
+        node.readonly,
+        node.optional,
+        name,
+        type_ann,
+        type_param,
+      )
+    }
+    TsType::TsLitType(node) => serialize_ts_lit_type(ctx, node),
+    TsType::TsTypePredicate(node) => {
+      let param_name = match &node.param_name {
+        TsThisTypeOrIdent::TsThisType(node) => {
+          ctx.write_ts_this_type(&node.span)
+        }
+        TsThisTypeOrIdent::Ident(ident) => serialize_ident(ctx, ident),
+      };
+
+      let type_ann = maybe_serialize_ts_type_ann(ctx, &node.type_ann);
+
+      ctx.write_ts_type_predicate(
+        &node.span,
+        node.asserts,
+        param_name,
+        type_ann,
+      )
     }
     TsType::TsImportType(node) => {
-      let raw = ctx.header(AstNode::TSTypePredicate, parent, &node.span);
-      let arg_pos = ctx.ref_field(AstProp::Argument);
-      let type_args_pos = ctx.ref_field(AstProp::TypeArguments);
-      let qualifier_pos = ctx.ref_field(AstProp::Qualifier);
-      let pos = ctx.commit_schema(raw);
-
       let arg = serialize_ts_lit_type(
         ctx,
         &TsLitType {
           lit: TsLit::Str(node.arg.clone()),
           span: node.arg.span,
         },
-        pos,
       );
 
-      let type_arg = node.type_args.clone().map(|param_node| {
-        serialize_ts_param_inst(ctx, param_node.as_ref(), pos)
-      });
+      let type_arg = node
+        .type_args
+        .clone()
+        .map(|param_node| serialize_ts_param_inst(ctx, param_node.as_ref()));
 
-      let qualifier = node.qualifier.clone().map_or(NodeRef(0), |quali| {
-        serialize_ts_entity_name(ctx, &quali, pos)
-      });
+      let qualifier = node
+        .qualifier
+        .clone()
+        .map(|quali| serialize_ts_entity_name(ctx, &quali));
 
-      ctx.write_ref(arg_pos, arg);
-      ctx.write_ref(qualifier_pos, qualifier);
-      ctx.write_maybe_ref(type_args_pos, type_arg);
-
-      pos
+      ctx.write_ts_import_type(&node.span, arg, qualifier, type_arg)
     }
   }
 }
@@ -2940,17 +2453,12 @@ fn serialize_ts_type(
 fn serialize_ts_lit_type(
   ctx: &mut TsEsTreeBuilder,
   node: &TsLitType,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::TSLiteralType, parent, &node.span);
-  let lit_pos = ctx.ref_field(AstProp::Literal);
-  let pos = ctx.commit_schema(raw);
-
   let lit = match &node.lit {
-    TsLit::Number(lit) => serialize_lit(ctx, &Lit::Num(lit.clone()), pos),
-    TsLit::Str(lit) => serialize_lit(ctx, &Lit::Str(lit.clone()), pos),
-    TsLit::Bool(lit) => serialize_lit(ctx, &Lit::Bool(*lit), pos),
-    TsLit::BigInt(lit) => serialize_lit(ctx, &Lit::BigInt(lit.clone()), pos),
+    TsLit::Number(lit) => serialize_lit(ctx, &Lit::Num(lit.clone())),
+    TsLit::Str(lit) => serialize_lit(ctx, &Lit::Str(lit.clone())),
+    TsLit::Bool(lit) => serialize_lit(ctx, &Lit::Bool(*lit)),
+    TsLit::BigInt(lit) => serialize_lit(ctx, &Lit::BigInt(lit.clone())),
     TsLit::Tpl(lit) => serialize_expr(
       ctx,
       &Expr::Tpl(Tpl {
@@ -2958,177 +2466,100 @@ fn serialize_ts_lit_type(
         exprs: vec![],
         quasis: lit.quasis.clone(),
       }),
-      pos,
     ),
   };
 
-  ctx.write_ref(lit_pos, lit);
-
-  pos
-}
-
-fn create_true_plus_minus_field(
-  ctx: &mut TsEsTreeBuilder,
-  prop: AstProp,
-  value: Option<TruePlusMinus>,
-) -> NodePos {
-  if let Some(v) = value {
-    match v {
-      TruePlusMinus::True => NodePos::Bool(ctx.bool_field(prop)),
-      TruePlusMinus::Plus | TruePlusMinus::Minus => {
-        NodePos::Str(ctx.str_field(prop))
-      }
-    }
-  } else {
-    NodePos::Undef(ctx.undefined_field(prop))
-  }
-}
-
-fn extract_pos(pos: NodePos) -> usize {
-  match pos {
-    NodePos::Bool(bool_pos) => bool_pos.0,
-    NodePos::Field(field_pos) => field_pos.0,
-    NodePos::FieldArr(field_arr_pos) => field_arr_pos.0,
-    NodePos::Str(str_pos) => str_pos.0,
-    NodePos::Undef(undef_pos) => undef_pos.0,
-    NodePos::Null(null_pos) => null_pos.0,
-  }
-}
-
-fn write_true_plus_minus(
-  ctx: &mut TsEsTreeBuilder,
-  pos: NodePos,
-  value: Option<TruePlusMinus>,
-) {
-  if let Some(v) = value {
-    match v {
-      TruePlusMinus::True => {
-        let bool_pos = BoolPos(extract_pos(pos));
-        ctx.write_bool(bool_pos, true);
-      }
-      TruePlusMinus::Plus => {
-        let str_pos = StrPos(extract_pos(pos));
-        ctx.write_str(str_pos, "+")
-      }
-      TruePlusMinus::Minus => {
-        let str_pos = StrPos(extract_pos(pos));
-        ctx.write_str(str_pos, "-")
-      }
-    }
-  }
+  ctx.write_ts_lit_type(&node.span, lit)
 }
 
 fn serialize_ts_entity_name(
   ctx: &mut TsEsTreeBuilder,
   node: &TsEntityName,
-  parent: NodeRef,
 ) -> NodeRef {
   match &node {
-    TsEntityName::TsQualifiedName(_) => todo!(),
-    TsEntityName::Ident(ident) => serialize_ident(ctx, ident, parent),
+    TsEntityName::TsQualifiedName(node) => {
+      let left = serialize_ts_entity_name(ctx, &node.left);
+      let right = serialize_ident_name(ctx, &node.right);
+
+      ctx.write_ts_qualified_name(&node.span, left, right)
+    }
+    TsEntityName::Ident(ident) => serialize_ident(ctx, ident),
   }
 }
 
 fn maybe_serialize_ts_type_ann(
   ctx: &mut TsEsTreeBuilder,
   node: &Option<Box<TsTypeAnn>>,
-  parent: NodeRef,
 ) -> Option<NodeRef> {
   node
     .as_ref()
-    .map(|type_ann| serialize_ts_type_ann(ctx, type_ann, parent))
+    .map(|type_ann| serialize_ts_type_ann(ctx, type_ann))
 }
 
 fn serialize_ts_type_ann(
   ctx: &mut TsEsTreeBuilder,
   node: &TsTypeAnn,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::TSTypeAnnotation, parent, &node.span);
-  let type_pos = ctx.ref_field(AstProp::TypeAnnotation);
-  let pos = ctx.commit_schema(raw);
-
-  let v_type = serialize_ts_type(ctx, &node.type_ann, pos);
-
-  ctx.write_ref(type_pos, v_type);
-
-  pos
+  let v_type = serialize_ts_type(ctx, &node.type_ann);
+  ctx.write_ts_type_ann(&node.span, v_type)
 }
 
 fn maybe_serialize_ts_type(
   ctx: &mut TsEsTreeBuilder,
   node: &Option<Box<TsType>>,
-  parent: NodeRef,
 ) -> Option<NodeRef> {
-  node
-    .as_ref()
-    .map(|item| serialize_ts_type(ctx, item, parent))
+  node.as_ref().map(|item| serialize_ts_type(ctx, item))
 }
 
 fn serialize_ts_type_param(
   ctx: &mut TsEsTreeBuilder,
   node: &TsTypeParam,
-  parent: NodeRef,
 ) -> NodeRef {
-  let raw = ctx.header(AstNode::TSTypeParameter, parent, &node.span);
-  let name_pos = ctx.ref_field(AstProp::Name);
-  let constraint_pos = ctx.ref_field(AstProp::Constraint);
-  let default_pos = ctx.ref_field(AstProp::Default);
-  let const_pos = ctx.bool_field(AstProp::Const);
-  let in_pos = ctx.bool_field(AstProp::In);
-  let out_pos = ctx.bool_field(AstProp::Out);
-  let pos = ctx.commit_schema(raw);
+  let name = serialize_ident(ctx, &node.name);
+  let constraint = maybe_serialize_ts_type(ctx, &node.constraint);
+  let default = maybe_serialize_ts_type(ctx, &node.default);
 
-  let name = serialize_ident(ctx, &node.name, pos);
-  let constraint = maybe_serialize_ts_type(ctx, &node.constraint, pos);
-  let default = maybe_serialize_ts_type(ctx, &node.default, pos);
-
-  ctx.write_bool(const_pos, node.is_const);
-  ctx.write_bool(in_pos, node.is_in);
-  ctx.write_bool(out_pos, node.is_out);
-  ctx.write_ref(name_pos, name);
-  ctx.write_maybe_ref(constraint_pos, constraint);
-  ctx.write_maybe_ref(default_pos, default);
-
-  pos
+  ctx.write_ts_type_param(
+    &node.span,
+    node.is_in,
+    node.is_out,
+    node.is_const,
+    name,
+    constraint,
+    default,
+  )
 }
 
-fn maybe_serialize_ts_type_param(
+fn maybe_serialize_ts_type_param_decl(
   ctx: &mut TsEsTreeBuilder,
   node: &Option<Box<TsTypeParamDecl>>,
-  parent: NodeRef,
 ) -> Option<NodeRef> {
-  node.as_ref().map(|node| {
-    let raw =
-      ctx.header(AstNode::TSTypeParameterDeclaration, parent, &node.span);
-    let params_pos = ctx.ref_vec_field(AstProp::Params, node.params.len());
-    let pos = ctx.commit_schema(raw);
+  node
+    .as_ref()
+    .map(|node| serialize_ts_type_param_decl(ctx, node))
+}
 
-    let params = node
-      .params
-      .iter()
-      .map(|param| serialize_ts_type_param(ctx, param, pos))
-      .collect::<Vec<_>>();
+fn serialize_ts_type_param_decl(
+  ctx: &mut TsEsTreeBuilder,
+  node: &TsTypeParamDecl,
+) -> NodeRef {
+  let params = node
+    .params
+    .iter()
+    .map(|param| serialize_ts_type_param(ctx, param))
+    .collect::<Vec<_>>();
 
-    ctx.write_refs(params_pos, params);
-
-    pos
-  })
+  ctx.write_ts_type_param_decl(&node.span, params)
 }
 
 fn serialize_ts_fn_param(
   ctx: &mut TsEsTreeBuilder,
   node: &TsFnParam,
-  parent: NodeRef,
 ) -> NodeRef {
   match node {
-    TsFnParam::Ident(ident) => serialize_ident(ctx, ident, parent),
-    TsFnParam::Array(pat) => {
-      serialize_pat(ctx, &Pat::Array(pat.clone()), parent)
-    }
-    TsFnParam::Rest(pat) => serialize_pat(ctx, &Pat::Rest(pat.clone()), parent),
-    TsFnParam::Object(pat) => {
-      serialize_pat(ctx, &Pat::Object(pat.clone()), parent)
-    }
+    TsFnParam::Ident(ident) => serialize_ident(ctx, ident),
+    TsFnParam::Array(pat) => serialize_pat(ctx, &Pat::Array(pat.clone())),
+    TsFnParam::Rest(pat) => serialize_pat(ctx, &Pat::Rest(pat.clone())),
+    TsFnParam::Object(pat) => serialize_pat(ctx, &Pat::Object(pat.clone())),
   }
 }

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -5,22 +5,17 @@ use std::fmt::Debug;
 use std::fmt::Display;
 
 use deno_ast::swc::common::Span;
+use deno_ast::view::TruePlusMinus;
 
 use super::buffer::AstBufSerializer;
-use super::buffer::BoolPos;
-use super::buffer::FieldArrPos;
-use super::buffer::FieldPos;
 use super::buffer::NodeRef;
-use super::buffer::NullPos;
-use super::buffer::PendingNodeRef;
 use super::buffer::SerializeCtx;
-use super::buffer::StrPos;
-use super::buffer::UndefPos;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AstNode {
   // First node must always be the empty/invalid node
   Invalid,
+  RefArray,
   // Typically the
   Program,
 
@@ -29,17 +24,27 @@ pub enum AstNode {
   ExportDefaultDeclaration,
   ExportNamedDeclaration,
   ImportDeclaration,
+  ImportSpecifier,
+  ImportAttribute,
+  ImportDefaultSpecifier,
+  ImportNamespaceSpecifier,
   TsExportAssignment,
   TsImportEquals,
   TsNamespaceExport,
+  TSNamespaceExportDeclaration,
+  TSImportEqualsDeclaration,
+  TSExternalModuleReference,
+  TSModuleDeclaration,
+  TSModuleBlock,
 
   // Decls
   ClassDeclaration,
   FunctionDeclaration,
   TSEnumDeclaration,
   TSInterface,
+  TSInterfaceDeclaration,
   TsModule,
-  TsTypeAlias,
+  TSTypeAliasDeclaration,
   Using,
   VariableDeclaration,
 
@@ -74,12 +79,13 @@ pub enum AstNode {
   ChainExpression,
   ClassExpression,
   ConditionalExpression,
+  EmptyExpr,
   FunctionExpression,
   Identifier,
   ImportExpression,
   LogicalExpression,
   MemberExpression,
-  MetaProp,
+  MetaProperty,
   NewExpression,
   ObjectExpression,
   PrivateIdentifier,
@@ -89,8 +95,6 @@ pub enum AstNode {
   TemplateLiteral,
   ThisExpression,
   TSAsExpression,
-  TsConstAssertion,
-  TsInstantiation,
   TSNonNullExpression,
   TSSatisfiesExpression,
   TSTypeAssertion,
@@ -98,16 +102,8 @@ pub enum AstNode {
   UpdateExpression,
   YieldExpression,
 
-  // TODO: TSEsTree uses a single literal node
-  // Literals
-  StringLiteral,
-  Bool,
-  Null,
-  NumericLiteral,
-  BigIntLiteral,
-  RegExpLiteral,
-
-  EmptyExpr,
+  // Other
+  Literal,
   SpreadElement,
   Property,
   VariableDeclarator,
@@ -117,6 +113,10 @@ pub enum AstNode {
   TemplateElement,
   MethodDefinition,
   ClassBody,
+  PropertyDefinition,
+  Decorator,
+  StaticBlock,
+  AccessorProperty,
 
   // Patterns
   ArrayPattern,
@@ -150,6 +150,7 @@ pub enum AstNode {
   TSTypeReference,
   TSThisType,
   TSLiteralType,
+  TSTypeLiteral,
   TSInferType,
   TSConditionalType,
   TSUnionType,
@@ -167,9 +168,16 @@ pub enum AstNode {
   TSTypeOperator,
   TSTypePredicate,
   TSImportType,
+  TSExportAssignment,
   TSRestType,
   TSArrayType,
   TSClassImplements,
+  TSAbstractMethodDefinition,
+  TSEmptyBodyFunctionExpression,
+  TSParameterProperty,
+  TSConstructSignatureDeclaration,
+  TSQualifiedName,
+  TSOptionalType,
 
   TSAnyKeyword,
   TSBigIntKeyword,
@@ -219,6 +227,7 @@ pub enum AstProp {
   Async,
   Attributes,
   Await,
+  BigInt,
   Block,
   Body,
   Callee,
@@ -235,6 +244,7 @@ pub enum AstProp {
   Declaration,
   Declarations,
   Declare,
+  Decorators,
   Default,
   Definite,
   Delegate,
@@ -246,12 +256,14 @@ pub enum AstProp {
   Expression,
   Expressions,
   Exported,
+  ExportKind,
   Extends,
   ExtendsType,
   FalseType,
   Finalizer,
   Flags,
   Generator,
+  Global,
   Handler,
   Id,
   In,
@@ -259,6 +271,8 @@ pub enum AstProp {
   Init,
   Initializer,
   Implements,
+  Imported,
+  ImportKind,
   Key,
   Kind,
   Label,
@@ -268,6 +282,7 @@ pub enum AstProp {
   Members,
   Meta,
   Method,
+  ModuleReference,
   Name,
   Namespace,
   NameType,
@@ -277,8 +292,12 @@ pub enum AstProp {
   OpeningFragment,
   Operator,
   Optional,
+  Options,
   Out,
+  Override,
   Param,
+  Parameter,
+  Parameters,
   ParameterName,
   Params,
   Pattern,
@@ -290,6 +309,7 @@ pub enum AstProp {
   Quasis,
   Raw,
   Readonly,
+  Regex,
   ReturnType,
   Right,
   SelfClosing,
@@ -314,8 +334,6 @@ pub enum AstProp {
   Value, // Last value is used for max value
 }
 
-// TODO: Feels like there should be an easier way to iterater over an
-// enum in Rust and lowercase the first letter.
 impl Display for AstProp {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     let s = match self {
@@ -333,6 +351,7 @@ impl Display for AstProp {
       AstProp::Async => "async",
       AstProp::Attributes => "attributes",
       AstProp::Await => "await",
+      AstProp::BigInt => "bigint",
       AstProp::Block => "block",
       AstProp::Body => "body",
       AstProp::Callee => "callee",
@@ -349,6 +368,7 @@ impl Display for AstProp {
       AstProp::Declaration => "declaration",
       AstProp::Declarations => "declarations",
       AstProp::Declare => "declare",
+      AstProp::Decorators => "decorators",
       AstProp::Default => "default",
       AstProp::Definite => "definite",
       AstProp::Delegate => "delegate",
@@ -359,6 +379,7 @@ impl Display for AstProp {
       AstProp::ExprName => "exprName",
       AstProp::Expression => "expression",
       AstProp::Expressions => "expressions",
+      AstProp::ExportKind => "exportKind",
       AstProp::Exported => "exported",
       AstProp::Extends => "extends",
       AstProp::ExtendsType => "extendsType",
@@ -366,6 +387,7 @@ impl Display for AstProp {
       AstProp::Finalizer => "finalizer",
       AstProp::Flags => "flags",
       AstProp::Generator => "generator",
+      AstProp::Global => "global",
       AstProp::Handler => "handler",
       AstProp::Id => "id",
       AstProp::In => "in",
@@ -373,6 +395,8 @@ impl Display for AstProp {
       AstProp::Init => "init",
       AstProp::Initializer => "initializer",
       AstProp::Implements => "implements",
+      AstProp::Imported => "imported",
+      AstProp::ImportKind => "importKind",
       AstProp::Key => "key",
       AstProp::Kind => "kind",
       AstProp::Label => "label",
@@ -382,6 +406,7 @@ impl Display for AstProp {
       AstProp::Members => "members",
       AstProp::Meta => "meta",
       AstProp::Method => "method",
+      AstProp::ModuleReference => "moduleReference",
       AstProp::Name => "name",
       AstProp::Namespace => "namespace",
       AstProp::NameType => "nameType",
@@ -391,8 +416,12 @@ impl Display for AstProp {
       AstProp::OpeningFragment => "openingFragment",
       AstProp::Operator => "operator",
       AstProp::Optional => "optional",
+      AstProp::Options => "options",
       AstProp::Out => "out",
+      AstProp::Override => "override",
       AstProp::Param => "param",
+      AstProp::Parameter => "parameter",
+      AstProp::Parameters => "parameters",
       AstProp::ParameterName => "parameterName",
       AstProp::Params => "params",
       AstProp::Pattern => "pattern",
@@ -404,6 +433,7 @@ impl Display for AstProp {
       AstProp::Quasis => "quasis",
       AstProp::Raw => "raw",
       AstProp::Readonly => "readonly",
+      AstProp::Regex => "regex",
       AstProp::ReturnType => "returnType",
       AstProp::Right => "right",
       AstProp::SelfClosing => "selfClosing",
@@ -442,8 +472,12 @@ pub struct TsEsTreeBuilder {
   ctx: SerializeCtx,
 }
 
-// TODO: Add a builder API to make it easier to convert from different source
-// ast formats.
+impl AstBufSerializer for TsEsTreeBuilder {
+  fn serialize(&mut self) -> Vec<u8> {
+    self.ctx.serialize()
+  }
+}
+
 impl TsEsTreeBuilder {
   pub fn new() -> Self {
     // Max values
@@ -454,67 +488,2236 @@ impl TsEsTreeBuilder {
       ctx: SerializeCtx::new(kind_max_count, prop_max_count),
     }
   }
+
+  pub fn write_program(
+    &mut self,
+    span: &Span,
+    source_kind: &str,
+    body: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Program, span);
+
+    self.ctx.write_str(AstProp::SourceType, source_kind);
+    self.ctx.write_ref_vec(AstProp::Body, &id, body);
+
+    self.ctx.set_root_idx(id.0);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_import_decl(
+    &mut self,
+    span: &Span,
+    type_only: bool,
+    source: NodeRef,
+    specifiers: Vec<NodeRef>,
+    attributes: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ImportDeclaration, span);
+
+    let kind = if type_only { "type" } else { "value" };
+    self.ctx.write_str(AstProp::ImportKind, kind);
+    self.ctx.write_ref(AstProp::Source, &id, source);
+    self.ctx.write_ref_vec(AstProp::Specifiers, &id, specifiers);
+    self.ctx.write_ref_vec(AstProp::Attributes, &id, attributes);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_import_spec(
+    &mut self,
+    span: &Span,
+    type_only: bool,
+    local: NodeRef,
+    imported: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ImportSpecifier, span);
+
+    let kind = if type_only { "type" } else { "value" };
+    self.ctx.write_str(AstProp::ImportKind, kind);
+
+    self.ctx.write_ref(AstProp::Imported, &id, imported);
+    self.ctx.write_ref(AstProp::Local, &id, local);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_import_attr(
+    &mut self,
+    span: &Span,
+    key: NodeRef,
+    value: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ImportAttribute, span);
+
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_ref(AstProp::Value, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_import_default_spec(
+    &mut self,
+    span: &Span,
+    local: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ImportDefaultSpecifier, span);
+    self.ctx.write_ref(AstProp::Local, &id, local);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_import_ns_spec(
+    &mut self,
+    span: &Span,
+    local: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::ImportNamespaceSpecifier, span);
+    self.ctx.write_ref(AstProp::Local, &id, local);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_decl(&mut self, span: &Span, decl: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ExportNamedDeclaration, span);
+    self.ctx.write_ref(AstProp::Declaration, &id, decl);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_all_decl(
+    &mut self,
+    span: &Span,
+    is_type_only: bool,
+    source: NodeRef,
+    exported: Option<NodeRef>,
+    attributes: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ExportAllDeclaration, span);
+
+    let value = if is_type_only { "type" } else { "value" };
+    self.ctx.write_str(AstProp::ExportKind, value);
+
+    self.ctx.write_maybe_ref(AstProp::Exported, &id, exported);
+    self.ctx.write_ref(AstProp::Source, &id, source);
+    self.ctx.write_ref_vec(AstProp::Attributes, &id, attributes);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_default_decl(
+    &mut self,
+    span: &Span,
+    is_type_only: bool,
+    decl: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::ExportDefaultDeclaration, span);
+
+    let value = if is_type_only { "type" } else { "value" };
+    self.ctx.write_str(AstProp::ExportKind, value);
+    self.ctx.write_ref(AstProp::Declaration, &id, decl);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_named_decl(
+    &mut self,
+    span: &Span,
+    specifiers: Vec<NodeRef>,
+    source: Option<NodeRef>,
+    attributes: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ExportNamedDeclaration, span);
+
+    self.ctx.write_ref_vec(AstProp::Specifiers, &id, specifiers);
+    self.ctx.write_maybe_ref(AstProp::Source, &id, source);
+    self.ctx.write_ref_vec(AstProp::Attributes, &id, attributes);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_ts_namespace(
+    &mut self,
+    span: &Span,
+    ident: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSNamespaceExportDeclaration, span);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_ts_import_equals(
+    &mut self,
+    span: &Span,
+    is_type_only: bool,
+    ident: NodeRef,
+    reference: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSImportEqualsDeclaration, span);
+
+    let value = if is_type_only { "type" } else { "value" };
+    self.ctx.write_str(AstProp::ImportKind, value);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_ref(AstProp::ModuleReference, &id, reference);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_external_mod_ref(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSExternalModuleReference, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_spec(
+    &mut self,
+    span: &Span,
+    type_only: bool,
+    local: NodeRef,
+    exported: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ExportSpecifier, span);
+
+    let kind = if type_only { "type" } else { "value" };
+    self.ctx.write_str(AstProp::ExportKind, kind);
+
+    let actual = exported.unwrap_or(local.clone());
+    self.ctx.write_ref(AstProp::Exported, &id, actual);
+    self.ctx.write_ref(AstProp::Local, &id, local);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_var_decl(
+    &mut self,
+    span: &Span,
+    declare: bool,
+    kind: &str,
+    decls: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::VariableDeclaration, span);
+
+    self.ctx.write_bool(AstProp::Declare, declare);
+    self.ctx.write_str(AstProp::Kind, kind);
+    self.ctx.write_ref_vec(AstProp::Declarations, &id, decls);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_var_declarator(
+    &mut self,
+    span: &Span,
+    ident: NodeRef,
+    init: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::VariableDeclarator, span);
+
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_maybe_ref(AstProp::Init, &id, init);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_fn_decl(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_async: bool,
+    is_generator: bool,
+    // Ident is required in most cases, but optional as default export
+    // declaration. TsEstree is weird...
+    ident: Option<NodeRef>,
+    type_param: Option<NodeRef>,
+    return_type: Option<NodeRef>,
+    body: Option<NodeRef>,
+    params: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::FunctionDeclaration, span);
+
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Async, is_async);
+    self.ctx.write_bool(AstProp::Generator, is_generator);
+    self.ctx.write_maybe_ref(AstProp::Id, &id, ident);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_param);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+    self.ctx.write_maybe_ref(AstProp::Body, &id, body);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_decorator(&mut self, span: &Span, expr: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Decorator, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_class_decl(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_abstract: bool,
+    // Ident is required in most cases, but optional as default export
+    // declaration. TsEstree is weird...
+    ident: Option<NodeRef>,
+    super_class: Option<NodeRef>,
+    implements: Vec<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ClassDeclaration, span);
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Abstract, is_abstract);
+    self.ctx.write_maybe_ref(AstProp::Id, &id, ident);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::SuperClass, &id, super_class);
+    self.ctx.write_ref_vec(AstProp::Implements, &id, implements);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_class_expr(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_abstract: bool,
+    ident: Option<NodeRef>,
+    super_class: Option<NodeRef>,
+    implements: Vec<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ClassExpression, span);
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Abstract, is_abstract);
+    self.ctx.write_maybe_ref(AstProp::Id, &id, ident);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::SuperClass, &id, super_class);
+    self.ctx.write_ref_vec(AstProp::Implements, &id, implements);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_class_body(
+    &mut self,
+    span: &Span,
+    body: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ClassBody, span);
+    self.ctx.write_ref_vec(AstProp::Body, &id, body);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_static_block(&mut self, span: &Span, body: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::StaticBlock, span);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_accessor_property(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_computed: bool,
+    is_optional: bool,
+    is_override: bool,
+    is_readonly: bool,
+    is_static: bool,
+    accessibility: Option<String>,
+    decorators: Vec<NodeRef>,
+    key: NodeRef,
+    value: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::AccessorProperty, span);
+
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Computed, is_computed);
+    self.ctx.write_bool(AstProp::Optional, is_optional);
+    self.ctx.write_bool(AstProp::Override, is_override);
+    self.ctx.write_bool(AstProp::Readonly, is_readonly);
+    self.ctx.write_bool(AstProp::Static, is_static);
+    self.write_accessibility(accessibility);
+    self.ctx.write_ref_vec(AstProp::Decorators, &id, decorators);
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_maybe_ref(AstProp::Value, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_class_prop(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_computed: bool,
+    is_optional: bool,
+    is_override: bool,
+    is_readonly: bool,
+    is_static: bool,
+    accessibility: Option<String>,
+    decorators: Vec<NodeRef>,
+    key: NodeRef,
+    value: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::PropertyDefinition, span);
+
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Computed, is_computed);
+    self.ctx.write_bool(AstProp::Optional, is_optional);
+    self.ctx.write_bool(AstProp::Override, is_override);
+    self.ctx.write_bool(AstProp::Readonly, is_readonly);
+    self.ctx.write_bool(AstProp::Static, is_static);
+
+    self.write_accessibility(accessibility);
+    self.ctx.write_ref_vec(AstProp::Decorators, &id, decorators);
+
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_maybe_ref(AstProp::Value, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_class_method(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_computed: bool,
+    is_optional: bool,
+    is_override: bool,
+    is_static: bool,
+    kind: &str,
+    accessibility: Option<String>,
+    key: NodeRef,
+    value: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::MethodDefinition, span);
+
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Computed, is_computed);
+    self.ctx.write_bool(AstProp::Optional, is_optional);
+    self.ctx.write_bool(AstProp::Override, is_override);
+    self.ctx.write_bool(AstProp::Static, is_static);
+    self.ctx.write_str(AstProp::Kind, kind);
+    self.write_accessibility(accessibility);
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_ref(AstProp::Value, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_block_stmt(
+    &mut self,
+    span: &Span,
+    body: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::BlockStatement, span);
+    self.ctx.write_ref_vec(AstProp::Body, &id, body);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_debugger_stmt(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::DebuggerStatement, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_with_stmt(
+    &mut self,
+    span: &Span,
+    obj: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::WithStatement, span);
+
+    self.ctx.write_ref(AstProp::Object, &id, obj);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_return_stmt(
+    &mut self,
+    span: &Span,
+    arg: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ReturnStatement, span);
+    self.ctx.write_maybe_ref(AstProp::Argument, &id, arg);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_labeled_stmt(
+    &mut self,
+    span: &Span,
+    label: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::LabeledStatement, span);
+
+    self.ctx.write_ref(AstProp::Label, &id, label);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_break_stmt(
+    &mut self,
+    span: &Span,
+    label: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::LabeledStatement, span);
+    self.ctx.write_maybe_ref(AstProp::Label, &id, label);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_continue_stmt(
+    &mut self,
+    span: &Span,
+    label: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ContinueStatement, span);
+    self.ctx.write_maybe_ref(AstProp::Label, &id, label);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_if_stmt(
+    &mut self,
+    span: &Span,
+    test: NodeRef,
+    consequent: NodeRef,
+    alternate: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::IfStatement, span);
+
+    self.ctx.write_ref(AstProp::Test, &id, test);
+    self.ctx.write_ref(AstProp::Consequent, &id, consequent);
+    self.ctx.write_maybe_ref(AstProp::Alternate, &id, alternate);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_switch_stmt(
+    &mut self,
+    span: &Span,
+    discriminant: NodeRef,
+    cases: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::SwitchStatement, span);
+
+    self.ctx.write_ref(AstProp::Discriminant, &id, discriminant);
+    self.ctx.write_ref_vec(AstProp::Cases, &id, cases);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_switch_case(
+    &mut self,
+    span: &Span,
+    test: Option<NodeRef>,
+    consequent: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::SwitchCase, span);
+
+    self.ctx.write_maybe_ref(AstProp::Test, &id, test);
+    self.ctx.write_ref_vec(AstProp::Consequent, &id, consequent);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_throw_stmt(&mut self, span: &Span, arg: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ThrowStatement, span);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_while_stmt(
+    &mut self,
+    span: &Span,
+    test: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::WhileStatement, span);
+
+    self.ctx.write_ref(AstProp::Test, &id, test);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_do_while_stmt(
+    &mut self,
+    span: &Span,
+    test: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::DoWhileStatement, span);
+
+    self.ctx.write_ref(AstProp::Test, &id, test);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_for_stmt(
+    &mut self,
+    span: &Span,
+    init: Option<NodeRef>,
+    test: Option<NodeRef>,
+    update: Option<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ForStatement, span);
+
+    self.ctx.write_maybe_ref(AstProp::Init, &id, init);
+    self.ctx.write_maybe_ref(AstProp::Test, &id, test);
+    self.ctx.write_maybe_ref(AstProp::Update, &id, update);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_for_in_stmt(
+    &mut self,
+    span: &Span,
+    left: NodeRef,
+    right: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ForInStatement, span);
+
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_for_of_stmt(
+    &mut self,
+    span: &Span,
+    is_await: bool,
+    left: NodeRef,
+    right: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ForOfStatement, span);
+
+    self.ctx.write_bool(AstProp::Await, is_await);
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_expr_stmt(&mut self, span: &Span, expr: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ExpressionStatement, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_try_stmt(
+    &mut self,
+    span: &Span,
+    block: NodeRef,
+    handler: Option<NodeRef>,
+    finalizer: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TryStatement, span);
+
+    self.ctx.write_ref(AstProp::Block, &id, block);
+    self.ctx.write_maybe_ref(AstProp::Handler, &id, handler);
+    self.ctx.write_maybe_ref(AstProp::Finalizer, &id, finalizer);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_catch_clause(
+    &mut self,
+    span: &Span,
+    param: Option<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::CatchClause, span);
+
+    self.ctx.write_maybe_ref(AstProp::Param, &id, param);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_arr_expr(
+    &mut self,
+    span: &Span,
+    elems: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ArrayExpression, span);
+    self.ctx.write_ref_vec(AstProp::Elements, &id, elems);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_obj_expr(
+    &mut self,
+    span: &Span,
+    props: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ObjectExpression, span);
+    self.ctx.write_ref_vec(AstProp::Properties, &id, props);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_bin_expr(
+    &mut self,
+    span: &Span,
+    operator: &str,
+    left: NodeRef,
+    right: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::BinaryExpression, span);
+
+    self.ctx.write_str(AstProp::Operator, operator);
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_logical_expr(
+    &mut self,
+    span: &Span,
+    operator: &str,
+    left: NodeRef,
+    right: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::LogicalExpression, span);
+
+    self.ctx.write_str(AstProp::Operator, operator);
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_fn_expr(
+    &mut self,
+    span: &Span,
+    is_async: bool,
+    is_generator: bool,
+    ident: Option<NodeRef>,
+    type_params: Option<NodeRef>,
+    params: Vec<NodeRef>,
+    return_type: Option<NodeRef>,
+    body: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::FunctionExpression, span);
+
+    self.ctx.write_bool(AstProp::Async, is_async);
+    self.ctx.write_bool(AstProp::Generator, is_generator);
+    self.ctx.write_maybe_ref(AstProp::Id, &id, ident);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_params);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+    self.ctx.write_maybe_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_arrow_fn_expr(
+    &mut self,
+    span: &Span,
+    is_async: bool,
+    is_generator: bool,
+    type_params: Option<NodeRef>,
+    params: Vec<NodeRef>,
+    return_type: Option<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ArrowFunctionExpression, span);
+
+    self.ctx.write_bool(AstProp::Async, is_async);
+    self.ctx.write_bool(AstProp::Generator, is_generator);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_params);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_this_expr(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ThisExpression, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_super(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Super, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_unary_expr(
+    &mut self,
+    span: &Span,
+    operator: &str,
+    arg: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::UnaryExpression, span);
+
+    self.ctx.write_str(AstProp::Operator, operator);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_new_expr(
+    &mut self,
+    span: &Span,
+    callee: NodeRef,
+    type_args: Option<NodeRef>,
+    args: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::NewExpression, span);
+
+    self.ctx.write_ref(AstProp::Callee, &id, callee);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+    self.ctx.write_ref_vec(AstProp::Arguments, &id, args);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_import_expr(
+    &mut self,
+    span: &Span,
+    source: NodeRef,
+    options: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ImportExpression, span);
+
+    self.ctx.write_ref(AstProp::Source, &id, source);
+    self.ctx.write_ref(AstProp::Options, &id, options);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_call_expr(
+    &mut self,
+    span: &Span,
+    optional: bool,
+    callee: NodeRef,
+    type_args: Option<NodeRef>,
+    args: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::CallExpression, span);
+
+    self.ctx.write_bool(AstProp::Optional, optional);
+    self.ctx.write_ref(AstProp::Callee, &id, callee);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+    self.ctx.write_ref_vec(AstProp::Arguments, &id, args);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_update_expr(
+    &mut self,
+    span: &Span,
+    prefix: bool,
+    operator: &str,
+    arg: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::UpdateExpression, span);
+
+    self.ctx.write_bool(AstProp::Prefix, prefix);
+    self.ctx.write_str(AstProp::Operator, operator);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_assignment_expr(
+    &mut self,
+    span: &Span,
+    operator: &str,
+    left: NodeRef,
+    right: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::AssignmentExpression, span);
+
+    self.ctx.write_str(AstProp::Operator, operator);
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_conditional_expr(
+    &mut self,
+    span: &Span,
+    test: NodeRef,
+    consequent: NodeRef,
+    alternate: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ConditionalExpression, span);
+
+    self.ctx.write_ref(AstProp::Test, &id, test);
+    self.ctx.write_ref(AstProp::Consequent, &id, consequent);
+    self.ctx.write_ref(AstProp::Alternate, &id, alternate);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_member_expr(
+    &mut self,
+    span: &Span,
+    optional: bool,
+    computed: bool,
+    obj: NodeRef,
+    prop: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::MemberExpression, span);
+
+    self.ctx.write_bool(AstProp::Optional, optional);
+    self.ctx.write_bool(AstProp::Computed, computed);
+    self.ctx.write_ref(AstProp::Object, &id, obj);
+    self.ctx.write_ref(AstProp::Property, &id, prop);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_chain_expr(&mut self, span: &Span, expr: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ChainExpression, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_sequence_expr(
+    &mut self,
+    span: &Span,
+    exprs: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::SequenceExpression, span);
+    self.ctx.write_ref_vec(AstProp::Expressions, &id, exprs);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_template_lit(
+    &mut self,
+    span: &Span,
+    quasis: Vec<NodeRef>,
+    exprs: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TemplateLiteral, span);
+
+    self.ctx.write_ref_vec(AstProp::Quasis, &id, quasis);
+    self.ctx.write_ref_vec(AstProp::Expressions, &id, exprs);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_template_elem(
+    &mut self,
+    span: &Span,
+    tail: bool,
+    raw: &str,
+    cooked: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TemplateElement, span);
+
+    self.ctx.write_bool(AstProp::Tail, tail);
+    self.ctx.write_str(AstProp::Raw, raw);
+    self.ctx.write_str(AstProp::Cooked, cooked);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_tagged_template_expr(
+    &mut self,
+    span: &Span,
+    tag: NodeRef,
+    type_args: Option<NodeRef>,
+    quasi: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TaggedTemplateExpression, span);
+
+    self.ctx.write_ref(AstProp::Tag, &id, tag);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+    self.ctx.write_ref(AstProp::Quasi, &id, quasi);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_yield_expr(
+    &mut self,
+    span: &Span,
+    delegate: bool,
+    arg: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::YieldExpression, span);
+
+    self.ctx.write_bool(AstProp::Delegate, delegate);
+    self.ctx.write_maybe_ref(AstProp::Argument, &id, arg);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_await_expr(&mut self, span: &Span, arg: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::AwaitExpression, span);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_meta_prop(&mut self, span: &Span, prop: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::MetaProperty, span);
+    self.ctx.write_ref(AstProp::Property, &id, prop);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_identifier(
+    &mut self,
+    span: &Span,
+    name: &str,
+    optional: bool,
+    type_annotation: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Identifier, span);
+
+    self.ctx.write_str(AstProp::Name, name);
+    self.ctx.write_bool(AstProp::Optional, optional);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_annotation);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_private_identifier(
+    &mut self,
+    span: &Span,
+    name: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::PrivateIdentifier, span);
+    self.ctx.write_str(AstProp::Name, name);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_assign_pat(
+    &mut self,
+    span: &Span,
+    left: NodeRef,
+    right: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::AssignmentPattern, span);
+
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_arr_pat(
+    &mut self,
+    span: &Span,
+    optional: bool,
+    type_ann: Option<NodeRef>,
+    elems: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ArrayPattern, span);
+
+    self.ctx.write_bool(AstProp::Optional, optional);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.write_ref_vec(AstProp::Elements, &id, elems);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_obj_pat(
+    &mut self,
+    span: &Span,
+    optional: bool,
+    type_ann: Option<NodeRef>,
+    props: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::ObjectPattern, span);
+
+    self.ctx.write_bool(AstProp::Optional, optional);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.write_ref_vec(AstProp::Properties, &id, props);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_rest_elem(
+    &mut self,
+    span: &Span,
+    type_ann: Option<NodeRef>,
+    arg: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::RestElement, span);
+
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_spread(&mut self, span: &Span, arg: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::SpreadElement, span);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_property(
+    &mut self,
+    span: &Span,
+    shorthand: bool,
+    computed: bool,
+    method: bool,
+    kind: &str,
+    key: NodeRef,
+    value: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Property, span);
+
+    self.ctx.write_bool(AstProp::Shorthand, shorthand);
+    self.ctx.write_bool(AstProp::Computed, computed);
+    self.ctx.write_bool(AstProp::Method, method);
+    self.ctx.write_str(AstProp::Kind, kind);
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_ref(AstProp::Value, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_str_lit(
+    &mut self,
+    span: &Span,
+    value: &str,
+    raw: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Literal, span);
+
+    self.ctx.write_str(AstProp::Value, value);
+    self.ctx.write_str(AstProp::Raw, raw);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_bool_lit(&mut self, span: &Span, value: bool) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Literal, span);
+
+    let raw = &format!("{}", value);
+    self.ctx.write_str(AstProp::Raw, raw);
+    self.ctx.write_bool(AstProp::Value, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_null_lit(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Literal, span);
+
+    self.ctx.write_null(AstProp::Value);
+    self.ctx.write_str(AstProp::Raw, "null");
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_num_lit(
+    &mut self,
+    span: &Span,
+    value: &str,
+    raw: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Literal, span);
+
+    self.ctx.write_num(AstProp::Value, value);
+    self.ctx.write_str(AstProp::Raw, raw);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_bigint_lit(
+    &mut self,
+    span: &Span,
+    value: &str,
+    raw: &str,
+    bigint_value: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Literal, span);
+
+    self.ctx.write_bigint(AstProp::Value, value);
+    self.ctx.write_str(AstProp::Raw, raw);
+    self.ctx.write_str(AstProp::BigInt, bigint_value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_regex_lit(
+    &mut self,
+    span: &Span,
+    pattern: &str,
+    flags: &str,
+    value: &str,
+    raw: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::Literal, span);
+
+    self.ctx.write_regex(AstProp::Value, value);
+    self.ctx.write_str(AstProp::Raw, raw);
+    self.ctx.open_obj();
+    self.ctx.write_str(AstProp::Flags, flags);
+    self.ctx.write_str(AstProp::Pattern, pattern);
+    self.ctx.commit_obj(AstProp::Regex);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_identifier(&mut self, span: &Span, name: &str) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXIdentifier, span);
+    self.ctx.write_str(AstProp::Name, name);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_namespaced_name(
+    &mut self,
+    span: &Span,
+    namespace: NodeRef,
+    name: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXNamespacedName, span);
+
+    self.ctx.write_ref(AstProp::Namespace, &id, namespace);
+    self.ctx.write_ref(AstProp::Name, &id, name);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_empty_expr(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXEmptyExpression, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_elem(
+    &mut self,
+    span: &Span,
+    opening: NodeRef,
+    closing: Option<NodeRef>,
+    children: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXElement, span);
+
+    self.ctx.write_ref(AstProp::OpeningElement, &id, opening);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ClosingElement, &id, closing);
+    self.ctx.write_ref_vec(AstProp::Children, &id, children);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_opening_elem(
+    &mut self,
+    span: &Span,
+    self_closing: bool,
+    name: NodeRef,
+    attrs: Vec<NodeRef>,
+    type_args: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXOpeningElement, span);
+
+    self.ctx.write_bool(AstProp::SelfClosing, self_closing);
+    self.ctx.write_ref(AstProp::Name, &id, name);
+    self.ctx.write_ref_vec(AstProp::Attributes, &id, attrs);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_attr(
+    &mut self,
+    span: &Span,
+    name: NodeRef,
+    value: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXAttribute, span);
+
+    self.ctx.write_ref(AstProp::Name, &id, name);
+    self.ctx.write_maybe_ref(AstProp::Value, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_spread_attr(
+    &mut self,
+    span: &Span,
+    arg: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXSpreadAttribute, span);
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_closing_elem(
+    &mut self,
+    span: &Span,
+    name: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXClosingElement, span);
+    self.ctx.write_ref(AstProp::Name, &id, name);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_frag(
+    &mut self,
+    span: &Span,
+    opening: NodeRef,
+    closing: NodeRef,
+    children: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXFragment, span);
+
+    self.ctx.write_ref(AstProp::OpeningFragment, &id, opening);
+    self.ctx.write_ref(AstProp::ClosingFragment, &id, closing);
+    self.ctx.write_ref_vec(AstProp::Children, &id, children);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_opening_frag(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXOpeningFragment, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_closing_frag(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXClosingFragment, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_expr_container(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXExpressionContainer, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_text(
+    &mut self,
+    span: &Span,
+    raw: &str,
+    value: &str,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXText, span);
+
+    self.ctx.write_str(AstProp::Raw, raw);
+    self.ctx.write_str(AstProp::Value, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_jsx_member_expr(
+    &mut self,
+    span: &Span,
+    obj: NodeRef,
+    prop: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::JSXMemberExpression, span);
+
+    self.ctx.write_ref(AstProp::Object, &id, obj);
+    self.ctx.write_ref(AstProp::Property, &id, prop);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_module_decl(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_global: bool,
+    ident: NodeRef,
+    body: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSModuleDeclaration, span);
+
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Global, is_global);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_maybe_ref(AstProp::Body, &id, body);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_module_block(
+    &mut self,
+    span: &Span,
+    body: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSModuleBlock, span);
+    self.ctx.write_ref_vec(AstProp::Body, &id, body);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_class_implements(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+    type_args: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSClassImplements, span);
+
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_abstract_method_def(
+    &mut self,
+    span: &Span,
+    is_computed: bool,
+    is_optional: bool,
+    is_override: bool,
+    is_static: bool,
+    accessibility: Option<String>,
+    key: NodeRef,
+    value: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSAbstractMethodDefinition, span);
+
+    self.ctx.write_bool(AstProp::Computed, is_computed);
+    self.ctx.write_bool(AstProp::Optional, is_optional);
+    self.ctx.write_bool(AstProp::Override, is_override);
+    self.ctx.write_bool(AstProp::Static, is_static);
+
+    self.write_accessibility(accessibility);
+
+    self.ctx.write_str(AstProp::Kind, "method");
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_ref(AstProp::Key, &id, value);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_empty_body_fn_expr(
+    &mut self,
+    span: &Span,
+    is_declare: bool,
+    is_expression: bool,
+    is_async: bool,
+    is_generator: bool,
+    ident: Option<NodeRef>,
+    type_params: Option<NodeRef>,
+    params: Vec<NodeRef>,
+    return_type: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSEmptyBodyFunctionExpression, span);
+
+    self.ctx.write_bool(AstProp::Declare, is_declare);
+    self.ctx.write_bool(AstProp::Expression, is_expression);
+    self.ctx.write_bool(AstProp::Async, is_async);
+    self.ctx.write_bool(AstProp::Generator, is_generator);
+    self.ctx.write_maybe_ref(AstProp::Id, &id, ident);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_params);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_param_prop(
+    &mut self,
+    span: &Span,
+    is_override: bool,
+    is_readonly: bool,
+    accessibility: Option<String>,
+    decorators: Vec<NodeRef>,
+    param: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSParameterProperty, span);
+
+    self.ctx.write_bool(AstProp::Override, is_override);
+    self.ctx.write_bool(AstProp::Readonly, is_readonly);
+    self.ctx.write_bool(AstProp::Static, false);
+    self.write_accessibility(accessibility);
+    self.ctx.write_ref_vec(AstProp::Decorators, &id, decorators);
+    self.ctx.write_ref(AstProp::Parameter, &id, param);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_call_sig_decl(
+    &mut self,
+    span: &Span,
+    type_ann: Option<NodeRef>,
+    params: Vec<NodeRef>,
+    return_type: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TsCallSignatureDeclaration, span);
+
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_property_sig(
+    &mut self,
+    span: &Span,
+    computed: bool,
+    optional: bool,
+    readonly: bool,
+    key: NodeRef,
+    type_ann: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSPropertySignature, span);
+
+    self.ctx.write_bool(AstProp::Computed, computed);
+    self.ctx.write_bool(AstProp::Optional, optional);
+    self.ctx.write_bool(AstProp::Readonly, readonly);
+    // TODO(@marvinhagemeister) not sure where this is coming from
+    self.ctx.write_bool(AstProp::Static, false);
+
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_enum(
+    &mut self,
+    span: &Span,
+    declare: bool,
+    is_const: bool,
+    ident: NodeRef,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSEnumDeclaration, span);
+
+    self.ctx.write_bool(AstProp::Declare, declare);
+    self.ctx.write_bool(AstProp::Const, is_const);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_enum_body(
+    &mut self,
+    span: &Span,
+    members: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSEnumBody, span);
+    self.ctx.write_ref_vec(AstProp::Members, &id, members);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_enum_member(
+    &mut self,
+    span: &Span,
+    ident: NodeRef,
+    init: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSEnumMember, span);
+
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_maybe_ref(AstProp::Initializer, &id, init);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_assertion(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeAssertion, span);
+
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_param_inst(
+    &mut self,
+    span: &Span,
+    params: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSTypeParameterInstantiation, span);
+
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_alias(
+    &mut self,
+    span: &Span,
+    declare: bool,
+    ident: NodeRef,
+    type_param: Option<NodeRef>,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeAliasDeclaration, span);
+
+    self.ctx.write_bool(AstProp::Declare, declare);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_param);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_satisfies_expr(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSSatisfiesExpression, span);
+
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_as_expr(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSAsExpression, span);
+
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_non_null(&mut self, span: &Span, expr: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSNonNullExpression, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_this_type(&mut self, span: &Span) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSThisType, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_interface(
+    &mut self,
+    span: &Span,
+    declare: bool,
+    ident: NodeRef,
+    type_param: Option<NodeRef>,
+    extends: Vec<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSInterface, span);
+
+    self.ctx.write_bool(AstProp::Declare, declare);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_maybe_ref(AstProp::Extends, &id, type_param);
+    self
+      .ctx
+      .write_ref_vec(AstProp::TypeParameters, &id, extends);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_interface_decl(
+    &mut self,
+    span: &Span,
+    declare: bool,
+    ident: NodeRef,
+    type_param: Option<NodeRef>,
+    extends: Vec<NodeRef>,
+    body: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSInterfaceDeclaration, span);
+
+    self.ctx.write_bool(AstProp::Declare, declare);
+    self.ctx.write_ref(AstProp::Id, &id, ident);
+    self.ctx.write_maybe_ref(AstProp::Extends, &id, type_param);
+    self
+      .ctx
+      .write_ref_vec(AstProp::TypeParameters, &id, extends);
+    self.ctx.write_ref(AstProp::Body, &id, body);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_interface_body(
+    &mut self,
+    span: &Span,
+    body: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSInterfaceBody, span);
+    self.ctx.write_ref_vec(AstProp::Body, &id, body);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_construct_sig(
+    &mut self,
+    span: &Span,
+    type_params: Option<NodeRef>,
+    params: Vec<NodeRef>,
+    return_type: NodeRef,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSConstructSignatureDeclaration, span);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_params);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self.ctx.write_ref(AstProp::ReturnType, &id, return_type);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_getter_sig(
+    &mut self,
+    span: &Span,
+    key: NodeRef,
+    return_type: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSMethodSignature, span);
+
+    self.ctx.write_bool(AstProp::Computed, false);
+    self.ctx.write_bool(AstProp::Optional, false);
+    self.ctx.write_bool(AstProp::Readonly, false);
+    self.ctx.write_bool(AstProp::Static, false);
+    self.ctx.write_str(AstProp::Kind, "getter");
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_setter_sig(
+    &mut self,
+    span: &Span,
+    key: NodeRef,
+    param: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSMethodSignature, span);
+
+    self.ctx.write_bool(AstProp::Computed, false);
+    self.ctx.write_bool(AstProp::Optional, false);
+    self.ctx.write_bool(AstProp::Readonly, false);
+    self.ctx.write_bool(AstProp::Static, false);
+    self.ctx.write_str(AstProp::Kind, "setter");
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self.ctx.write_ref_vec(AstProp::Params, &id, vec![param]);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_method_sig(
+    &mut self,
+    span: &Span,
+    is_computed: bool,
+    is_optional: bool,
+    key: NodeRef,
+    type_params: Option<NodeRef>,
+    params: Vec<NodeRef>,
+    return_type: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSMethodSignature, span);
+
+    self.ctx.write_bool(AstProp::Computed, is_computed);
+    self.ctx.write_bool(AstProp::Optional, is_optional);
+    self.ctx.write_bool(AstProp::Readonly, false);
+    self.ctx.write_bool(AstProp::Static, false);
+    self.ctx.write_str(AstProp::Kind, "method");
+    self.ctx.write_ref(AstProp::Key, &id, key);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeParameters, &id, type_params);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::ReturnType, &id, return_type);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_interface_heritage(
+    &mut self,
+    span: &Span,
+    expr: NodeRef,
+    type_args: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSInterfaceHeritage, span);
+
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_index_sig(
+    &mut self,
+    span: &Span,
+    is_readonly: bool,
+    params: Vec<NodeRef>,
+    type_ann: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSIndexSignature, span);
+
+    self.ctx.write_bool(AstProp::Readonly, is_readonly);
+    self.ctx.write_ref_vec(AstProp::Parameters, &id, params);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_union_type(
+    &mut self,
+    span: &Span,
+    types: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSUnionType, span);
+    self.ctx.write_ref_vec(AstProp::Types, &id, types);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_intersection_type(
+    &mut self,
+    span: &Span,
+    types: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSIntersectionType, span);
+    self.ctx.write_ref_vec(AstProp::Types, &id, types);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_infer_type(
+    &mut self,
+    span: &Span,
+    type_param: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSInferType, span);
+    self.ctx.write_ref(AstProp::TypeParameter, &id, type_param);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_op(
+    &mut self,
+    span: &Span,
+    op: &str,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeOperator, span);
+
+    self.ctx.write_str(AstProp::Operator, op);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_indexed_access_type(
+    &mut self,
+    span: &Span,
+    index: NodeRef,
+    obj: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSIndexedAccessType, span);
+
+    self.ctx.write_ref(AstProp::IndexType, &id, index);
+    self.ctx.write_ref(AstProp::ObjectType, &id, obj);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_keyword(
+    &mut self,
+    kind: TsKeywordKind,
+    span: &Span,
+  ) -> NodeRef {
+    let kind = match kind {
+      TsKeywordKind::Any => AstNode::TSAnyKeyword,
+      TsKeywordKind::Unknown => AstNode::TSUnknownKeyword,
+      TsKeywordKind::Number => AstNode::TSNumberKeyword,
+      TsKeywordKind::Object => AstNode::TSObjectKeyword,
+      TsKeywordKind::Boolean => AstNode::TSBooleanKeyword,
+      TsKeywordKind::BigInt => AstNode::TSBigIntKeyword,
+      TsKeywordKind::String => AstNode::TSStringKeyword,
+      TsKeywordKind::Symbol => AstNode::TSSymbolKeyword,
+      TsKeywordKind::Void => AstNode::TSVoidKeyword,
+      TsKeywordKind::Undefined => AstNode::TSUndefinedKeyword,
+      TsKeywordKind::Null => AstNode::TSNullKeyword,
+      TsKeywordKind::Never => AstNode::TSNeverKeyword,
+      TsKeywordKind::Intrinsic => AstNode::TSIntrinsicKeyword,
+    };
+
+    let id = self.ctx.append_node(kind, span);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_rest_type(
+    &mut self,
+    span: &Span,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSRestType, span);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_conditional_type(
+    &mut self,
+    span: &Span,
+    check: NodeRef,
+    extends: NodeRef,
+    true_type: NodeRef,
+    false_type: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSConditionalType, span);
+
+    self.ctx.write_ref(AstProp::CheckType, &id, check);
+    self.ctx.write_ref(AstProp::ExtendsType, &id, extends);
+    self.ctx.write_ref(AstProp::TrueType, &id, true_type);
+    self.ctx.write_ref(AstProp::FalseType, &id, false_type);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_mapped_type(
+    &mut self,
+    span: &Span,
+    readonly: Option<TruePlusMinus>,
+    optional: Option<TruePlusMinus>,
+    name: Option<NodeRef>,
+    type_ann: Option<NodeRef>,
+    type_param: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSMappedType, span);
+
+    self.write_plus_minus_true(AstProp::Readonly, readonly);
+    self.write_plus_minus_true(AstProp::Optional, optional);
+    self.ctx.write_maybe_ref(AstProp::NameType, &id, name);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.write_ref(AstProp::TypeParameter, &id, type_param);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_lit_type(&mut self, span: &Span, lit: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSLiteralType, span);
+    self.ctx.write_ref(AstProp::Literal, &id, lit);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_lit(
+    &mut self,
+    span: &Span,
+    members: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeLiteral, span);
+    self.ctx.write_ref_vec(AstProp::Members, &id, members);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_optional_type(
+    &mut self,
+    span: &Span,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSOptionalType, span);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_ann(
+    &mut self,
+    span: &Span,
+    type_ann: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeAnnotation, span);
+    self.ctx.write_ref(AstProp::TypeAnnotation, &id, type_ann);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_array_type(
+    &mut self,
+    span: &Span,
+    elem_type: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSArrayType, span);
+    self.ctx.write_ref(AstProp::ElementType, &id, elem_type);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_query(
+    &mut self,
+    span: &Span,
+    expr_name: NodeRef,
+    type_arg: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeQuery, span);
+
+    self.ctx.write_ref(AstProp::ExprName, &id, expr_name);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_arg);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_ref(
+    &mut self,
+    span: &Span,
+    type_name: NodeRef,
+    type_arg: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeReference, span);
+
+    self.ctx.write_ref(AstProp::TypeName, &id, type_name);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_arg);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_predicate(
+    &mut self,
+    span: &Span,
+    asserts: bool,
+    param_name: NodeRef,
+    type_ann: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypePredicate, span);
+
+    self.ctx.write_bool(AstProp::Asserts, asserts);
+    self.ctx.write_ref(AstProp::ParameterName, &id, param_name);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeAnnotation, &id, type_ann);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_tuple_type(
+    &mut self,
+    span: &Span,
+    elem_types: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTupleType, span);
+
+    self
+      .ctx
+      .write_ref_vec(AstProp::ElementTypes, &id, elem_types);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_named_tuple_member(
+    &mut self,
+    span: &Span,
+    label: NodeRef,
+    elem_type: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSNamedTupleMember, span);
+
+    self.ctx.write_ref(AstProp::Label, &id, label);
+    self.ctx.write_ref(AstProp::ElementType, &id, elem_type);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_param_decl(
+    &mut self,
+    span: &Span,
+    params: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self
+      .ctx
+      .append_node(AstNode::TSTypeParameterDeclaration, span);
+
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_type_param(
+    &mut self,
+    span: &Span,
+    is_in: bool,
+    is_out: bool,
+    is_const: bool,
+    name: NodeRef,
+    constraint: Option<NodeRef>,
+    default: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTypeParameter, span);
+
+    self.ctx.write_bool(AstProp::In, is_in);
+    self.ctx.write_bool(AstProp::Out, is_out);
+    self.ctx.write_bool(AstProp::Const, is_const);
+    self.ctx.write_ref(AstProp::Name, &id, name);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::Constraint, &id, constraint);
+    self.ctx.write_maybe_ref(AstProp::Default, &id, default);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_import_type(
+    &mut self,
+    span: &Span,
+    arg: NodeRef,
+    qualifier: Option<NodeRef>,
+    type_args: Option<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSImportType, span);
+
+    self.ctx.write_ref(AstProp::Argument, &id, arg);
+    self.ctx.write_maybe_ref(AstProp::Qualifier, &id, qualifier);
+    self
+      .ctx
+      .write_maybe_ref(AstProp::TypeArguments, &id, type_args);
+
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_export_assign(&mut self, span: &Span, expr: NodeRef) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSExportAssignment, span);
+    self.ctx.write_ref(AstProp::Expression, &id, expr);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_fn_type(
+    &mut self,
+    span: &Span,
+    params: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSFunctionType, span);
+    self.ctx.write_ref_vec(AstProp::Params, &id, params);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_qualified_name(
+    &mut self,
+    span: &Span,
+    left: NodeRef,
+    right: NodeRef,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSQualifiedName, span);
+
+    self.ctx.write_ref(AstProp::Left, &id, left);
+    self.ctx.write_ref(AstProp::Right, &id, right);
+
+    self.ctx.commit_node(id)
+  }
+
+  fn write_accessibility(&mut self, accessibility: Option<String>) {
+    if let Some(value) = accessibility {
+      self.ctx.write_str(AstProp::Accessibility, &value);
+    } else {
+      self.ctx.write_undefined(AstProp::Accessibility);
+    }
+  }
+
+  fn write_plus_minus_true(
+    &mut self,
+    prop: AstProp,
+    value: Option<TruePlusMinus>,
+  ) {
+    match value {
+      Some(TruePlusMinus::Plus) => self.ctx.write_str(prop, "+"),
+      Some(TruePlusMinus::Minus) => self.ctx.write_str(prop, "-"),
+      Some(TruePlusMinus::True) => self.ctx.write_bool(prop, true),
+      _ => self.ctx.write_undefined(prop),
+    }
+  }
 }
 
-impl AstBufSerializer<AstNode, AstProp> for TsEsTreeBuilder {
-  fn header(
-    &mut self,
-    kind: AstNode,
-    parent: NodeRef,
-    span: &Span,
-  ) -> PendingNodeRef {
-    self.ctx.header(kind, parent, span)
-  }
-
-  fn commit_schema(&mut self, offset: PendingNodeRef) -> NodeRef {
-    self.ctx.commit_schema(offset)
-  }
-
-  fn ref_field(&mut self, prop: AstProp) -> FieldPos {
-    FieldPos(self.ctx.ref_field(prop))
-  }
-
-  fn ref_vec_field(&mut self, prop: AstProp, len: usize) -> FieldArrPos {
-    FieldArrPos(self.ctx.ref_vec_field(prop, len))
-  }
-
-  fn str_field(&mut self, prop: AstProp) -> StrPos {
-    StrPos(self.ctx.str_field(prop))
-  }
-
-  fn bool_field(&mut self, prop: AstProp) -> BoolPos {
-    BoolPos(self.ctx.bool_field(prop))
-  }
-
-  fn undefined_field(&mut self, prop: AstProp) -> UndefPos {
-    UndefPos(self.ctx.undefined_field(prop))
-  }
-
-  fn null_field(&mut self, prop: AstProp) -> NullPos {
-    NullPos(self.ctx.null_field(prop))
-  }
-
-  fn write_ref(&mut self, pos: FieldPos, value: NodeRef) {
-    self.ctx.write_ref(pos.0, value);
-  }
-
-  fn write_maybe_ref(&mut self, pos: FieldPos, value: Option<NodeRef>) {
-    self.ctx.write_maybe_ref(pos.0, value);
-  }
-
-  fn write_refs(&mut self, pos: FieldArrPos, value: Vec<NodeRef>) {
-    self.ctx.write_refs(pos.0, value);
-  }
-
-  fn write_str(&mut self, pos: StrPos, value: &str) {
-    self.ctx.write_str(pos.0, value);
-  }
-
-  fn write_bool(&mut self, pos: BoolPos, value: bool) {
-    self.ctx.write_bool(pos.0, value);
-  }
-
-  fn serialize(&mut self) -> Vec<u8> {
-    self.ctx.serialize()
-  }
+#[derive(Debug)]
+pub enum TsKeywordKind {
+  Any,
+  Unknown,
+  Number,
+  Object,
+  Boolean,
+  BigInt,
+  String,
+  Symbol,
+  Void,
+  Undefined,
+  Null,
+  Never,
+  Intrinsic,
 }

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -178,6 +178,7 @@ pub enum AstNode {
   TSConstructSignatureDeclaration,
   TSQualifiedName,
   TSOptionalType,
+  TSTemplateLiteralType,
 
   TSAnyKeyword,
   TSBigIntKeyword,
@@ -683,15 +684,14 @@ impl TsEsTreeBuilder {
     span: &Span,
     type_only: bool,
     local: NodeRef,
-    exported: Option<NodeRef>,
+    exported: NodeRef,
   ) -> NodeRef {
     let id = self.ctx.append_node(AstNode::ExportSpecifier, span);
 
     let kind = if type_only { "type" } else { "value" };
     self.ctx.write_str(AstProp::ExportKind, kind);
 
-    let actual = exported.unwrap_or(local.clone());
-    self.ctx.write_ref(AstProp::Exported, &id, actual);
+    self.ctx.write_ref(AstProp::Exported, &id, exported);
     self.ctx.write_ref(AstProp::Local, &id, local);
 
     self.ctx.commit_node(id)
@@ -977,7 +977,7 @@ impl TsEsTreeBuilder {
     span: &Span,
     label: Option<NodeRef>,
   ) -> NodeRef {
-    let id = self.ctx.append_node(AstNode::LabeledStatement, span);
+    let id = self.ctx.append_node(AstNode::BreakStatement, span);
     self.ctx.write_maybe_ref(AstProp::Label, &id, label);
     self.ctx.commit_node(id)
   }
@@ -2476,6 +2476,20 @@ impl TsEsTreeBuilder {
   pub fn write_ts_lit_type(&mut self, span: &Span, lit: NodeRef) -> NodeRef {
     let id = self.ctx.append_node(AstNode::TSLiteralType, span);
     self.ctx.write_ref(AstProp::Literal, &id, lit);
+    self.ctx.commit_node(id)
+  }
+
+  pub fn write_ts_tpl_lit(
+    &mut self,
+    span: &Span,
+    quasis: Vec<NodeRef>,
+    types: Vec<NodeRef>,
+  ) -> NodeRef {
+    let id = self.ctx.append_node(AstNode::TSTemplateLiteralType, span);
+
+    self.ctx.write_ref_vec(AstProp::Quasis, &id, quasis);
+    self.ctx.write_ref_vec(AstProp::Types, &id, types);
+
     self.ctx.commit_node(id)
   }
 

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -482,7 +482,6 @@ impl AstBufSerializer for TsEsTreeBuilder {
 impl TsEsTreeBuilder {
   pub fn new() -> Self {
     // Max values
-    // TODO: Maybe there is a rust macro to grab the last enum value?
     let kind_max_count: u8 = u8::from(AstNode::TSEnumBody) + 1;
     let prop_max_count: u8 = u8::from(AstProp::Value) + 1;
     Self {

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -727,6 +727,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_fn_decl(
     &mut self,
     span: &Span,
@@ -765,6 +766,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_class_decl(
     &mut self,
     span: &Span,
@@ -790,6 +792,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_class_expr(
     &mut self,
     span: &Span,
@@ -829,6 +832,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_accessor_property(
     &mut self,
     span: &Span,
@@ -859,6 +863,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_class_prop(
     &mut self,
     span: &Span,
@@ -891,6 +896,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_class_method(
     &mut self,
     span: &Span,
@@ -1210,6 +1216,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_fn_expr(
     &mut self,
     span: &Span,
@@ -1238,6 +1245,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_arrow_fn_expr(
     &mut self,
     span: &Span,
@@ -1598,6 +1606,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_property(
     &mut self,
     span: &Span,
@@ -1907,6 +1916,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_ts_abstract_method_def(
     &mut self,
     span: &Span,
@@ -1936,6 +1946,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_ts_empty_body_fn_expr(
     &mut self,
     span: &Span,
@@ -2277,6 +2288,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_ts_method_sig(
     &mut self,
     span: &Span,
@@ -2625,6 +2637,7 @@ impl TsEsTreeBuilder {
     self.ctx.commit_node(id)
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn write_ts_type_param(
     &mut self,
     span: &Span,

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -28,9 +28,9 @@ pub enum AstNode {
   ImportAttribute,
   ImportDefaultSpecifier,
   ImportNamespaceSpecifier,
-  TsExportAssignment,
-  TsImportEquals,
-  TsNamespaceExport,
+  TSExportAssignment,
+  TSImportEqualss,
+  TSNamespaceExport,
   TSNamespaceExportDeclaration,
   TSImportEqualsDeclaration,
   TSExternalModuleReference,
@@ -43,7 +43,7 @@ pub enum AstNode {
   TSEnumDeclaration,
   TSInterface,
   TSInterfaceDeclaration,
-  TsModule,
+  TSModule,
   TSTypeAliasDeclaration,
   Using,
   VariableDeclaration,
@@ -160,7 +160,7 @@ pub enum AstNode {
   TSTupleType,
   TSNamedTupleMember,
   TSFunctionType,
-  TsCallSignatureDeclaration,
+  TSCallSignatureDeclaration,
   TSPropertySignature,
   TSMethodSignature,
   TSIndexSignature,
@@ -168,7 +168,6 @@ pub enum AstNode {
   TSTypeOperator,
   TSTypePredicate,
   TSImportType,
-  TSExportAssignment,
   TSRestType,
   TSArrayType,
   TSClassImplements,
@@ -2008,7 +2007,7 @@ impl TsEsTreeBuilder {
   ) -> NodeRef {
     let id = self
       .ctx
-      .append_node(AstNode::TsCallSignatureDeclaration, span);
+      .append_node(AstNode::TSCallSignatureDeclaration, span);
 
     self
       .ctx

--- a/tests/unit/__snapshots__/lint_plugin_test.ts.snap
+++ b/tests/unit/__snapshots__/lint_plugin_test.ts.snap
@@ -6271,7 +6271,7 @@ snapshot[`Plugin - TSInterface 7`] = `
             },
           },
         },
-        type: "TsCallSignatureDeclaration",
+        type: "TSCallSignatureDeclaration",
         typeAnnotation: {
           params: [
             {

--- a/tests/unit/__snapshots__/lint_plugin_test.ts.snap
+++ b/tests/unit/__snapshots__/lint_plugin_test.ts.snap
@@ -1,0 +1,8608 @@
+export const snapshot = {};
+
+snapshot[`Plugin - Program 1`] = `
+{
+  body: [],
+  range: [
+    1,
+    1,
+  ],
+  sourceType: "script",
+  type: "Program",
+}
+`;
+
+snapshot[`Plugin - ImportDeclaration 1`] = `
+{
+  attributes: [],
+  importKind: "value",
+  range: [
+    1,
+    14,
+  ],
+  source: {
+    range: [
+      8,
+      13,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [],
+  type: "ImportDeclaration",
+}
+`;
+
+snapshot[`Plugin - ImportDeclaration 2`] = `
+{
+  attributes: [],
+  importKind: "value",
+  range: [
+    1,
+    23,
+  ],
+  source: {
+    range: [
+      17,
+      22,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      local: {
+        name: "foo",
+        optional: false,
+        range: [
+          8,
+          11,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        8,
+        11,
+      ],
+      type: "ImportDefaultSpecifier",
+    },
+  ],
+  type: "ImportDeclaration",
+}
+`;
+
+snapshot[`Plugin - ImportDeclaration 3`] = `
+{
+  attributes: [],
+  importKind: "value",
+  range: [
+    1,
+    28,
+  ],
+  source: {
+    range: [
+      22,
+      27,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      local: {
+        name: "foo",
+        optional: false,
+        range: [
+          13,
+          16,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        8,
+        16,
+      ],
+      type: "ImportNamespaceSpecifier",
+    },
+  ],
+  type: "ImportDeclaration",
+}
+`;
+
+snapshot[`Plugin - ImportDeclaration 4`] = `
+{
+  attributes: [],
+  importKind: "value",
+  range: [
+    1,
+    39,
+  ],
+  source: {
+    range: [
+      33,
+      38,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      importKind: "value",
+      imported: {
+        name: "foo",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      local: {
+        name: "foo",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        10,
+        13,
+      ],
+      type: "ImportSpecifier",
+    },
+    {
+      importKind: "value",
+      imported: {
+        name: "bar",
+        optional: false,
+        range: [
+          15,
+          18,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      local: {
+        name: "baz",
+        optional: false,
+        range: [
+          22,
+          25,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        15,
+        25,
+      ],
+      type: "ImportSpecifier",
+    },
+  ],
+  type: "ImportDeclaration",
+}
+`;
+
+snapshot[`Plugin - ImportDeclaration 5`] = `
+{
+  attributes: [
+    {
+      key: {
+        name: "type",
+        optional: false,
+        range: [
+          30,
+          34,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        30,
+        42,
+      ],
+      type: "ImportAttribute",
+      value: {
+        range: [
+          36,
+          42,
+        ],
+        raw: '"json"',
+        type: "Literal",
+        value: "json",
+      },
+    },
+  ],
+  importKind: "value",
+  range: [
+    1,
+    45,
+  ],
+  source: {
+    range: [
+      17,
+      22,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      local: {
+        name: "foo",
+        optional: false,
+        range: [
+          8,
+          11,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        8,
+        11,
+      ],
+      type: "ImportDefaultSpecifier",
+    },
+  ],
+  type: "ImportDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportNamedDeclaration 1`] = `
+{
+  attributes: [],
+  range: [
+    1,
+    27,
+  ],
+  source: {
+    range: [
+      21,
+      26,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      exportKind: "value",
+      exported: {
+        name: "foo",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      local: {
+        name: "foo",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        10,
+        13,
+      ],
+      type: "ExportSpecifier",
+    },
+  ],
+  type: "ExportNamedDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportNamedDeclaration 2`] = `
+{
+  attributes: [],
+  range: [
+    1,
+    34,
+  ],
+  source: {
+    range: [
+      28,
+      33,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      exportKind: "value",
+      exported: {
+        name: "baz",
+        optional: false,
+        range: [
+          17,
+          20,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      local: {
+        name: "bar",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        10,
+        20,
+      ],
+      type: "ExportSpecifier",
+    },
+  ],
+  type: "ExportNamedDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportNamedDeclaration 3`] = `
+{
+  attributes: [
+    {
+      key: {
+        name: "type",
+        optional: false,
+        range: [
+          34,
+          38,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        34,
+        46,
+      ],
+      type: "ImportAttribute",
+      value: {
+        range: [
+          40,
+          46,
+        ],
+        raw: '"json"',
+        type: "Literal",
+        value: "json",
+      },
+    },
+  ],
+  range: [
+    1,
+    49,
+  ],
+  source: {
+    range: [
+      21,
+      26,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  specifiers: [
+    {
+      exportKind: "value",
+      exported: {
+        name: "foo",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      local: {
+        name: "foo",
+        optional: false,
+        range: [
+          10,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        10,
+        13,
+      ],
+      type: "ExportSpecifier",
+    },
+  ],
+  type: "ExportNamedDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportDefaultDeclaration 1`] = `
+{
+  declaration: {
+    async: false,
+    body: {
+      body: [],
+      range: [
+        31,
+        33,
+      ],
+      type: "BlockStatement",
+    },
+    declare: false,
+    generator: false,
+    id: {
+      name: "foo",
+      optional: false,
+      range: [
+        25,
+        28,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    params: [],
+    range: [
+      16,
+      33,
+    ],
+    returnType: null,
+    type: "FunctionDeclaration",
+    typeParameters: null,
+  },
+  exportKind: "value",
+  range: [
+    1,
+    33,
+  ],
+  type: "ExportDefaultDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportDefaultDeclaration 2`] = `
+{
+  declaration: {
+    async: false,
+    body: {
+      body: [],
+      range: [
+        28,
+        30,
+      ],
+      type: "BlockStatement",
+    },
+    declare: false,
+    generator: false,
+    id: null,
+    params: [],
+    range: [
+      16,
+      30,
+    ],
+    returnType: null,
+    type: "FunctionDeclaration",
+    typeParameters: null,
+  },
+  exportKind: "value",
+  range: [
+    1,
+    30,
+  ],
+  type: "ExportDefaultDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportDefaultDeclaration 3`] = `
+{
+  declaration: {
+    abstract: false,
+    body: {
+      body: [],
+      range: [
+        16,
+        28,
+      ],
+      type: "ClassBody",
+    },
+    declare: false,
+    id: {
+      name: "Foo",
+      optional: false,
+      range: [
+        22,
+        25,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    implements: [],
+    range: [
+      16,
+      28,
+    ],
+    superClass: null,
+    type: "ClassDeclaration",
+  },
+  exportKind: "value",
+  range: [
+    1,
+    28,
+  ],
+  type: "ExportDefaultDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportDefaultDeclaration 4`] = `
+{
+  declaration: {
+    abstract: false,
+    body: {
+      body: [],
+      range: [
+        16,
+        24,
+      ],
+      type: "ClassBody",
+    },
+    declare: false,
+    id: null,
+    implements: [],
+    range: [
+      16,
+      24,
+    ],
+    superClass: null,
+    type: "ClassDeclaration",
+  },
+  exportKind: "value",
+  range: [
+    1,
+    24,
+  ],
+  type: "ExportDefaultDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportDefaultDeclaration 5`] = `
+{
+  declaration: {
+    name: "bar",
+    optional: false,
+    range: [
+      16,
+      19,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  exportKind: "value",
+  range: [
+    1,
+    20,
+  ],
+  type: "ExportDefaultDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportDefaultDeclaration 6`] = `
+{
+  declaration: {
+    body: {
+      body: [],
+      range: [
+        30,
+        32,
+      ],
+      type: "TSInterfaceBody",
+    },
+    declare: false,
+    extends: null,
+    id: {
+      name: "Foo",
+      optional: false,
+      range: [
+        26,
+        29,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    range: [
+      16,
+      32,
+    ],
+    type: "TSInterfaceDeclaration",
+    typeParameters: [],
+  },
+  exportKind: "type",
+  range: [
+    1,
+    32,
+  ],
+  type: "ExportDefaultDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportAllDeclaration 1`] = `
+{
+  attributes: [],
+  exportKind: "value",
+  exported: null,
+  range: [
+    1,
+    21,
+  ],
+  source: {
+    range: [
+      15,
+      20,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  type: "ExportAllDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportAllDeclaration 2`] = `
+{
+  attributes: [],
+  exportKind: "value",
+  exported: {
+    range: [
+      22,
+      27,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  range: [
+    1,
+    28,
+  ],
+  source: {
+    name: "foo",
+    optional: false,
+    range: [
+      13,
+      16,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ExportAllDeclaration",
+}
+`;
+
+snapshot[`Plugin - ExportAllDeclaration 3`] = `
+{
+  attributes: [
+    {
+      key: {
+        name: "type",
+        optional: false,
+        range: [
+          28,
+          32,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        28,
+        40,
+      ],
+      type: "ImportAttribute",
+      value: {
+        range: [
+          34,
+          40,
+        ],
+        raw: '"json"',
+        type: "Literal",
+        value: "json",
+      },
+    },
+  ],
+  exportKind: "value",
+  exported: null,
+  range: [
+    1,
+    43,
+  ],
+  source: {
+    range: [
+      15,
+      20,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  type: "ExportAllDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSExportAssignment 1`] = `
+{
+  expression: {
+    name: "foo",
+    optional: false,
+    range: [
+      10,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    14,
+  ],
+  type: "TSExportAssignment",
+}
+`;
+
+snapshot[`Plugin - TSNamespaceExportDeclaration 1`] = `
+{
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      21,
+      22,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    23,
+  ],
+  type: "TSNamespaceExportDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSImportEqualsDeclaration 1`] = `
+{
+  id: {
+    name: "a",
+    optional: false,
+    range: [
+      8,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  importKind: "value",
+  moduleReference: {
+    name: "b",
+    optional: false,
+    range: [
+      12,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    13,
+  ],
+  type: "TSImportEqualsDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSImportEqualsDeclaration 2`] = `
+{
+  id: {
+    name: "a",
+    optional: false,
+    range: [
+      8,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  importKind: "value",
+  moduleReference: {
+    expression: {
+      range: [
+        20,
+        25,
+      ],
+      raw: '"foo"',
+      type: "Literal",
+      value: "foo",
+    },
+    range: [
+      12,
+      26,
+    ],
+    type: "TSExternalModuleReference",
+  },
+  range: [
+    1,
+    26,
+  ],
+  type: "TSImportEqualsDeclaration",
+}
+`;
+
+snapshot[`Plugin - BlockStatement 1`] = `
+{
+  body: [
+    {
+      expression: {
+        name: "foo",
+        optional: false,
+        range: [
+          3,
+          6,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        3,
+        7,
+      ],
+      type: "ExpressionStatement",
+    },
+  ],
+  range: [
+    1,
+    9,
+  ],
+  type: "BlockStatement",
+}
+`;
+
+snapshot[`Plugin - BreakStatement 1`] = `
+{
+  label: null,
+  range: [
+    15,
+    21,
+  ],
+  type: "BreakStatement",
+}
+`;
+
+snapshot[`Plugin - BreakStatement 2`] = `
+{
+  label: {
+    name: "foo",
+    optional: false,
+    range: [
+      26,
+      29,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    20,
+    30,
+  ],
+  type: "BreakStatement",
+}
+`;
+
+snapshot[`Plugin - ContinueStatement 1`] = `
+{
+  label: null,
+  range: [
+    1,
+    10,
+  ],
+  type: "ContinueStatement",
+}
+`;
+
+snapshot[`Plugin - ContinueStatement 2`] = `
+{
+  label: {
+    name: "foo",
+    optional: false,
+    range: [
+      10,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    14,
+  ],
+  type: "ContinueStatement",
+}
+`;
+
+snapshot[`Plugin - DebuggerStatement 1`] = `
+{
+  range: [
+    1,
+    10,
+  ],
+  type: "DebuggerStatement",
+}
+`;
+
+snapshot[`Plugin - DoWhileStatement 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      4,
+      6,
+    ],
+    type: "BlockStatement",
+  },
+  range: [
+    1,
+    19,
+  ],
+  test: {
+    name: "foo",
+    optional: false,
+    range: [
+      14,
+      17,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "DoWhileStatement",
+}
+`;
+
+snapshot[`Plugin - ExpressionStatement 1`] = `
+{
+  expression: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    5,
+  ],
+  type: "ExpressionStatement",
+}
+`;
+
+snapshot[`Plugin - ForInStatement 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      14,
+      16,
+    ],
+    type: "BlockStatement",
+  },
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    16,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ForInStatement",
+}
+`;
+
+snapshot[`Plugin - ForOfStatement 1`] = `
+{
+  await: false,
+  body: {
+    body: [],
+    range: [
+      14,
+      16,
+    ],
+    type: "BlockStatement",
+  },
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    16,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ForOfStatement",
+}
+`;
+
+snapshot[`Plugin - ForOfStatement 2`] = `
+{
+  await: true,
+  body: {
+    body: [],
+    range: [
+      20,
+      22,
+    ],
+    type: "BlockStatement",
+  },
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      12,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    22,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      17,
+      18,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ForOfStatement",
+}
+`;
+
+snapshot[`Plugin - ForStatement 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      10,
+      12,
+    ],
+    type: "BlockStatement",
+  },
+  init: null,
+  range: [
+    1,
+    12,
+  ],
+  test: null,
+  type: "ForStatement",
+  update: null,
+}
+`;
+
+snapshot[`Plugin - ForStatement 2`] = `
+{
+  body: {
+    body: [],
+    range: [
+      15,
+      17,
+    ],
+    type: "BlockStatement",
+  },
+  init: {
+    name: "a",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    17,
+  ],
+  test: {
+    name: "b",
+    optional: false,
+    range: [
+      9,
+      10,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ForStatement",
+  update: {
+    name: "c",
+    optional: false,
+    range: [
+      12,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+}
+`;
+
+snapshot[`Plugin - IfStatement 1`] = `
+{
+  alternate: null,
+  consequent: {
+    body: [],
+    range: [
+      10,
+      12,
+    ],
+    type: "BlockStatement",
+  },
+  range: [
+    1,
+    12,
+  ],
+  test: {
+    name: "foo",
+    optional: false,
+    range: [
+      5,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "IfStatement",
+}
+`;
+
+snapshot[`Plugin - IfStatement 2`] = `
+{
+  alternate: {
+    body: [],
+    range: [
+      18,
+      20,
+    ],
+    type: "BlockStatement",
+  },
+  consequent: {
+    body: [],
+    range: [
+      10,
+      12,
+    ],
+    type: "BlockStatement",
+  },
+  range: [
+    1,
+    20,
+  ],
+  test: {
+    name: "foo",
+    optional: false,
+    range: [
+      5,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "IfStatement",
+}
+`;
+
+snapshot[`Plugin - LabeledStatement 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      6,
+      8,
+    ],
+    type: "BlockStatement",
+  },
+  label: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    8,
+  ],
+  type: "LabeledStatement",
+}
+`;
+
+snapshot[`Plugin - ReturnStatement 1`] = `
+{
+  argument: null,
+  range: [
+    1,
+    7,
+  ],
+  type: "ReturnStatement",
+}
+`;
+
+snapshot[`Plugin - ReturnStatement 2`] = `
+{
+  argument: {
+    name: "foo",
+    optional: false,
+    range: [
+      8,
+      11,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "ReturnStatement",
+}
+`;
+
+snapshot[`Plugin - SwitchStatement 1`] = `
+{
+  cases: [
+    {
+      consequent: [],
+      range: [
+        22,
+        31,
+      ],
+      test: {
+        name: "foo",
+        optional: false,
+        range: [
+          27,
+          30,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      type: "SwitchCase",
+    },
+    {
+      consequent: [
+        {
+          label: null,
+          range: [
+            56,
+            62,
+          ],
+          type: "BreakStatement",
+        },
+      ],
+      range: [
+        38,
+        62,
+      ],
+      test: {
+        name: "bar",
+        optional: false,
+        range: [
+          43,
+          46,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      type: "SwitchCase",
+    },
+    {
+      consequent: [
+        {
+          body: [],
+          range: [
+            86,
+            88,
+          ],
+          type: "BlockStatement",
+        },
+      ],
+      range: [
+        69,
+        88,
+      ],
+      test: null,
+      type: "SwitchCase",
+    },
+  ],
+  discriminant: {
+    name: "foo",
+    optional: false,
+    range: [
+      9,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    94,
+  ],
+  type: "SwitchStatement",
+}
+`;
+
+snapshot[`Plugin - ThrowStatement 1`] = `
+{
+  argument: {
+    name: "foo",
+    optional: false,
+    range: [
+      7,
+      10,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    11,
+  ],
+  type: "ThrowStatement",
+}
+`;
+
+snapshot[`Plugin - TryStatement 1`] = `
+{
+  block: {
+    body: [],
+    range: [
+      5,
+      7,
+    ],
+    type: "BlockStatement",
+  },
+  finalizer: null,
+  handler: {
+    body: {
+      body: [],
+      range: [
+        14,
+        16,
+      ],
+      type: "BlockStatement",
+    },
+    param: null,
+    range: [
+      8,
+      16,
+    ],
+    type: "CatchClause",
+  },
+  range: [
+    1,
+    16,
+  ],
+  type: "TryStatement",
+}
+`;
+
+snapshot[`Plugin - TryStatement 2`] = `
+{
+  block: {
+    body: [],
+    range: [
+      5,
+      7,
+    ],
+    type: "BlockStatement",
+  },
+  finalizer: null,
+  handler: {
+    body: {
+      body: [],
+      range: [
+        18,
+        20,
+      ],
+      type: "BlockStatement",
+    },
+    param: {
+      name: "e",
+      optional: false,
+      range: [
+        15,
+        16,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    range: [
+      8,
+      20,
+    ],
+    type: "CatchClause",
+  },
+  range: [
+    1,
+    20,
+  ],
+  type: "TryStatement",
+}
+`;
+
+snapshot[`Plugin - TryStatement 3`] = `
+{
+  block: {
+    body: [],
+    range: [
+      5,
+      7,
+    ],
+    type: "BlockStatement",
+  },
+  finalizer: {
+    body: [],
+    range: [
+      16,
+      18,
+    ],
+    type: "BlockStatement",
+  },
+  handler: null,
+  range: [
+    1,
+    18,
+  ],
+  type: "TryStatement",
+}
+`;
+
+snapshot[`Plugin - WhileStatement 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      13,
+      15,
+    ],
+    type: "BlockStatement",
+  },
+  range: [
+    1,
+    15,
+  ],
+  test: {
+    name: "foo",
+    optional: false,
+    range: [
+      8,
+      11,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "WhileStatement",
+}
+`;
+
+snapshot[`Plugin - WithStatement 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      11,
+      13,
+    ],
+    type: "BlockStatement",
+  },
+  object: {
+    elements: [],
+    range: [
+      7,
+      9,
+    ],
+    type: "ArrayExpression",
+  },
+  range: [
+    1,
+    13,
+  ],
+  type: "WithStatement",
+}
+`;
+
+snapshot[`Plugin - ArrayExpression 1`] = `
+{
+  elements: [
+    {
+      elements: [],
+      range: [
+        2,
+        4,
+      ],
+      type: "ArrayExpression",
+    },
+  ],
+  range: [
+    1,
+    9,
+  ],
+  type: "ArrayExpression",
+}
+`;
+
+snapshot[`Plugin - ArrowFunctionExpression 1`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      7,
+      9,
+    ],
+    type: "BlockStatement",
+  },
+  generator: false,
+  params: [],
+  range: [
+    1,
+    9,
+  ],
+  returnType: null,
+  type: "ArrowFunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - ArrowFunctionExpression 2`] = `
+{
+  async: true,
+  body: {
+    body: [],
+    range: [
+      13,
+      15,
+    ],
+    type: "BlockStatement",
+  },
+  generator: false,
+  params: [],
+  range: [
+    1,
+    15,
+  ],
+  returnType: null,
+  type: "ArrowFunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - ArrowFunctionExpression 3`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      34,
+      36,
+    ],
+    type: "BlockStatement",
+  },
+  generator: false,
+  params: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        2,
+        11,
+      ],
+      type: "Identifier",
+      typeAnnotation: {
+        range: [
+          3,
+          11,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          range: [
+            5,
+            11,
+          ],
+          type: "TSNumberKeyword",
+        },
+      },
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          16,
+          17,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        13,
+        24,
+      ],
+      type: "RestElement",
+      typeAnnotation: {
+        range: [
+          17,
+          24,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          elementType: {
+            range: [
+              19,
+              22,
+            ],
+            type: "TSAnyKeyword",
+          },
+          range: [
+            19,
+            24,
+          ],
+          type: "TSArrayType",
+        },
+      },
+    },
+  ],
+  range: [
+    1,
+    36,
+  ],
+  returnType: {
+    range: [
+      25,
+      30,
+    ],
+    type: "TSTypeAnnotation",
+    typeAnnotation: {
+      range: [
+        27,
+        30,
+      ],
+      type: "TSAnyKeyword",
+    },
+  },
+  type: "ArrowFunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - AssignmentExpression 1`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "=",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "AssignmentExpression",
+}
+`;
+
+snapshot[`Plugin - AssignmentExpression 2`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "=",
+  range: [
+    1,
+    12,
+  ],
+  right: {
+    left: {
+      name: "a",
+      optional: false,
+      range: [
+        5,
+        6,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    operator: "??=",
+    range: [
+      5,
+      12,
+    ],
+    right: {
+      name: "b",
+      optional: false,
+      range: [
+        11,
+        12,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    type: "AssignmentExpression",
+  },
+  type: "AssignmentExpression",
+}
+`;
+
+snapshot[`Plugin - AwaitExpression 1`] = `
+{
+  argument: {
+    name: "foo",
+    optional: false,
+    range: [
+      7,
+      10,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    10,
+  ],
+  type: "AwaitExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 1`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: ">",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 2`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: ">=",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 3`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "<",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 4`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "<=",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 5`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "==",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 6`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "===",
+  range: [
+    1,
+    8,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      7,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 7`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "!=",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 8`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "!=",
+  range: [
+    1,
+    8,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      7,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 9`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "<<",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 10`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: ">>",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 11`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: ">>>",
+  range: [
+    1,
+    8,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      7,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 12`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "+",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 13`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "-",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 14`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "*",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 15`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "/",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 16`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "%",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 17`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "|",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 18`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "^",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 19`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "&",
+  range: [
+    1,
+    6,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 20`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "in",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - BinaryExpression 21`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "**",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "BinaryExpression",
+}
+`;
+
+snapshot[`Plugin - CallExpression 1`] = `
+{
+  arguments: [],
+  callee: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  optional: false,
+  range: [
+    1,
+    6,
+  ],
+  type: "CallExpression",
+  typeArguments: null,
+}
+`;
+
+snapshot[`Plugin - CallExpression 2`] = `
+{
+  arguments: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        5,
+        6,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          11,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        8,
+        11,
+      ],
+      type: "SpreadElement",
+    },
+  ],
+  callee: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  optional: false,
+  range: [
+    1,
+    13,
+  ],
+  type: "CallExpression",
+  typeArguments: null,
+}
+`;
+
+snapshot[`Plugin - CallExpression 3`] = `
+{
+  arguments: [],
+  callee: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  optional: true,
+  range: [
+    1,
+    8,
+  ],
+  type: "CallExpression",
+  typeArguments: null,
+}
+`;
+
+snapshot[`Plugin - CallExpression 4`] = `
+{
+  arguments: [],
+  callee: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  optional: false,
+  range: [
+    1,
+    9,
+  ],
+  type: "CallExpression",
+  typeArguments: {
+    params: [
+      {
+        range: [
+          5,
+          6,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            5,
+            6,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    ],
+    range: [
+      4,
+      7,
+    ],
+    type: "TSTypeParameterInstantiation",
+  },
+}
+`;
+
+snapshot[`Plugin - ChainExpression 1`] = `
+{
+  expression: {
+    computed: false,
+    object: {
+      name: "a",
+      optional: false,
+      range: [
+        1,
+        2,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    optional: true,
+    property: {
+      name: "b",
+      optional: false,
+      range: [
+        4,
+        5,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    range: [
+      1,
+      5,
+    ],
+    type: "MemberExpression",
+  },
+  range: [
+    1,
+    5,
+  ],
+  type: "ChainExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 1`] = `
+{
+  abstract: false,
+  body: {
+    body: [],
+    range: [
+      5,
+      13,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    13,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 2`] = `
+{
+  abstract: false,
+  body: {
+    body: [],
+    range: [
+      5,
+      17,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      11,
+      14,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  implements: [],
+  range: [
+    5,
+    17,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 3`] = `
+{
+  abstract: false,
+  body: {
+    body: [],
+    range: [
+      5,
+      29,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      11,
+      14,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  implements: [],
+  range: [
+    5,
+    29,
+  ],
+  superClass: {
+    name: "Bar",
+    optional: false,
+    range: [
+      23,
+      26,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 4`] = `
+{
+  abstract: false,
+  body: {
+    body: [],
+    range: [
+      5,
+      50,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      11,
+      14,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  implements: [
+    {
+      expression: {
+        name: "Baz",
+        optional: false,
+        range: [
+          38,
+          41,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        38,
+        41,
+      ],
+      type: "TSClassImplements",
+      typeArguments: null,
+    },
+    {
+      expression: {
+        name: "Baz2",
+        optional: false,
+        range: [
+          43,
+          47,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        43,
+        47,
+      ],
+      type: "TSClassImplements",
+      typeArguments: null,
+    },
+  ],
+  range: [
+    5,
+    50,
+  ],
+  superClass: {
+    name: "Bar",
+    optional: false,
+    range: [
+      23,
+      26,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 5`] = `
+{
+  abstract: false,
+  body: {
+    body: [],
+    range: [
+      5,
+      20,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      11,
+      14,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  implements: [],
+  range: [
+    5,
+    20,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 6`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        key: {
+          name: "foo",
+          optional: false,
+          range: [
+            13,
+            16,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        kind: "method",
+        optional: false,
+        override: false,
+        range: [
+          13,
+          21,
+        ],
+        static: false,
+        type: "MethodDefinition",
+        value: {
+          async: false,
+          body: {
+            body: [],
+            range: [
+              19,
+              21,
+            ],
+            type: "BlockStatement",
+          },
+          generator: false,
+          id: null,
+          params: [],
+          range: [
+            13,
+            21,
+          ],
+          returnType: null,
+          type: "FunctionExpression",
+          typeParameters: null,
+        },
+      },
+    ],
+    range: [
+      5,
+      23,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    23,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 7`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        key: {
+          name: "foo",
+          range: [
+            13,
+            17,
+          ],
+          type: "PrivateIdentifier",
+        },
+        kind: "method",
+        optional: false,
+        override: false,
+        range: [
+          13,
+          22,
+        ],
+        static: false,
+        type: "MethodDefinition",
+        value: {
+          async: false,
+          body: {
+            body: [],
+            range: [
+              20,
+              22,
+            ],
+            type: "BlockStatement",
+          },
+          generator: false,
+          id: null,
+          params: [],
+          range: [
+            13,
+            22,
+          ],
+          returnType: null,
+          type: "FunctionExpression",
+          typeParameters: null,
+        },
+      },
+    ],
+    range: [
+      5,
+      24,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    24,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 8`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        decorators: [],
+        key: {
+          name: "foo",
+          optional: false,
+          range: [
+            13,
+            16,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        override: false,
+        range: [
+          13,
+          24,
+        ],
+        readonly: false,
+        static: false,
+        type: "PropertyDefinition",
+        value: null,
+      },
+    ],
+    range: [
+      5,
+      26,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    26,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 9`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        decorators: [],
+        key: {
+          name: "foo",
+          optional: false,
+          range: [
+            13,
+            16,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        override: false,
+        range: [
+          13,
+          22,
+        ],
+        readonly: false,
+        static: false,
+        type: "PropertyDefinition",
+        value: {
+          name: "bar",
+          optional: false,
+          range: [
+            19,
+            22,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    ],
+    range: [
+      5,
+      24,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    24,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 10`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        key: {
+          name: "constructor",
+          optional: false,
+          range: [
+            13,
+            24,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        kind: "constructor",
+        optional: false,
+        override: false,
+        range: [
+          13,
+          47,
+        ],
+        static: false,
+        type: "MethodDefinition",
+        value: {
+          async: false,
+          body: {
+            body: [],
+            range: [
+              45,
+              47,
+            ],
+            type: "BlockStatement",
+          },
+          generator: false,
+          id: null,
+          params: [
+            {
+              accessibility: undefined,
+              decorators: [],
+              override: false,
+              parameter: {
+                name: "foo",
+                optional: false,
+                range: [
+                  32,
+                  35,
+                ],
+                type: "Identifier",
+                typeAnnotation: {
+                  range: [
+                    35,
+                    43,
+                  ],
+                  type: "TSTypeAnnotation",
+                  typeAnnotation: {
+                    range: [
+                      37,
+                      43,
+                    ],
+                    type: "TSStringKeyword",
+                  },
+                },
+              },
+              range: [
+                25,
+                43,
+              ],
+              readonly: false,
+              static: false,
+              type: "TSParameterProperty",
+            },
+          ],
+          range: [
+            13,
+            47,
+          ],
+          returnType: null,
+          type: "FunctionExpression",
+          typeParameters: null,
+        },
+      },
+    ],
+    range: [
+      5,
+      49,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    49,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 11`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        decorators: [],
+        key: {
+          name: "foo",
+          range: [
+            13,
+            17,
+          ],
+          type: "PrivateIdentifier",
+        },
+        optional: false,
+        override: false,
+        range: [
+          13,
+          31,
+        ],
+        readonly: false,
+        static: false,
+        type: "PropertyDefinition",
+        value: {
+          name: "bar",
+          optional: false,
+          range: [
+            28,
+            31,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    ],
+    range: [
+      5,
+      33,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    33,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 12`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        decorators: [],
+        key: {
+          name: "foo",
+          optional: false,
+          range: [
+            20,
+            23,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        override: false,
+        range: [
+          13,
+          29,
+        ],
+        readonly: false,
+        static: true,
+        type: "PropertyDefinition",
+        value: {
+          name: "bar",
+          optional: false,
+          range: [
+            26,
+            29,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    ],
+    range: [
+      5,
+      31,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    31,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ClassExpression 13`] = `
+{
+  abstract: false,
+  body: {
+    body: [
+      {
+        accessibility: undefined,
+        computed: false,
+        declare: false,
+        decorators: [],
+        key: {
+          name: "foo",
+          optional: false,
+          range: [
+            20,
+            23,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        override: false,
+        range: [
+          13,
+          24,
+        ],
+        readonly: false,
+        static: true,
+        type: "PropertyDefinition",
+        value: null,
+      },
+      {
+        body: {
+          body: [
+            {
+              expression: {
+                left: {
+                  name: "foo",
+                  optional: false,
+                  range: [
+                    34,
+                    37,
+                  ],
+                  type: "Identifier",
+                  typeAnnotation: null,
+                },
+                operator: "=",
+                range: [
+                  34,
+                  43,
+                ],
+                right: {
+                  name: "bar",
+                  optional: false,
+                  range: [
+                    40,
+                    43,
+                  ],
+                  type: "Identifier",
+                  typeAnnotation: null,
+                },
+                type: "AssignmentExpression",
+              },
+              range: [
+                34,
+                43,
+              ],
+              type: "ExpressionStatement",
+            },
+          ],
+          range: [
+            32,
+            45,
+          ],
+          type: "BlockStatement",
+        },
+        range: [
+          25,
+          45,
+        ],
+        type: "StaticBlock",
+      },
+    ],
+    range: [
+      5,
+      47,
+    ],
+    type: "ClassBody",
+  },
+  declare: false,
+  id: null,
+  implements: [],
+  range: [
+    5,
+    47,
+  ],
+  superClass: null,
+  type: "ClassExpression",
+}
+`;
+
+snapshot[`Plugin - ConditionalExpression 1`] = `
+{
+  alternate: {
+    name: "c",
+    optional: false,
+    range: [
+      9,
+      10,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  consequent: {
+    name: "b",
+    optional: false,
+    range: [
+      5,
+      6,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    10,
+  ],
+  test: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "ConditionalExpression",
+}
+`;
+
+snapshot[`Plugin - FunctionExpression 1`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      17,
+      19,
+    ],
+    type: "BlockStatement",
+  },
+  generator: false,
+  id: null,
+  params: [],
+  range: [
+    5,
+    19,
+  ],
+  returnType: null,
+  type: "FunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - FunctionExpression 2`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      20,
+      22,
+    ],
+    type: "BlockStatement",
+  },
+  generator: false,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      14,
+      17,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  params: [],
+  range: [
+    5,
+    22,
+  ],
+  returnType: null,
+  type: "FunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - FunctionExpression 3`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      45,
+      47,
+    ],
+    type: "BlockStatement",
+  },
+  generator: false,
+  id: null,
+  params: [
+    {
+      name: "a",
+      optional: true,
+      range: [
+        15,
+        16,
+      ],
+      type: "Identifier",
+      typeAnnotation: {
+        range: [
+          17,
+          25,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          range: [
+            19,
+            25,
+          ],
+          type: "TSNumberKeyword",
+        },
+      },
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          30,
+          31,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        27,
+        38,
+      ],
+      type: "RestElement",
+      typeAnnotation: {
+        range: [
+          31,
+          38,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          elementType: {
+            range: [
+              33,
+              36,
+            ],
+            type: "TSAnyKeyword",
+          },
+          range: [
+            33,
+            38,
+          ],
+          type: "TSArrayType",
+        },
+      },
+    },
+  ],
+  range: [
+    5,
+    47,
+  ],
+  returnType: {
+    range: [
+      39,
+      44,
+    ],
+    type: "TSTypeAnnotation",
+    typeAnnotation: {
+      range: [
+        41,
+        44,
+      ],
+      type: "TSAnyKeyword",
+    },
+  },
+  type: "FunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - FunctionExpression 4`] = `
+{
+  async: true,
+  body: {
+    body: [],
+    range: [
+      24,
+      26,
+    ],
+    type: "BlockStatement",
+  },
+  generator: true,
+  id: null,
+  params: [],
+  range: [
+    5,
+    26,
+  ],
+  returnType: null,
+  type: "FunctionExpression",
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - Identifier 1`] = `
+{
+  name: "a",
+  optional: false,
+  range: [
+    1,
+    2,
+  ],
+  type: "Identifier",
+  typeAnnotation: null,
+}
+`;
+
+snapshot[`Plugin - ImportExpression 1`] = `
+{
+  options: {
+    properties: [
+      {
+        computed: false,
+        key: {
+          name: "with",
+          optional: false,
+          range: [
+            17,
+            21,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        kind: "init",
+        method: false,
+        range: [
+          17,
+          39,
+        ],
+        shorthand: false,
+        type: "Property",
+        value: {
+          properties: [
+            {
+              computed: false,
+              key: {
+                name: "type",
+                optional: false,
+                range: [
+                  25,
+                  29,
+                ],
+                type: "Identifier",
+                typeAnnotation: null,
+              },
+              kind: "init",
+              method: false,
+              range: [
+                25,
+                37,
+              ],
+              shorthand: false,
+              type: "Property",
+              value: {
+                range: [
+                  31,
+                  37,
+                ],
+                raw: "'json'",
+                type: "Literal",
+                value: "json",
+              },
+            },
+          ],
+          range: [
+            23,
+            39,
+          ],
+          type: "ObjectExpression",
+        },
+      },
+    ],
+    range: [
+      15,
+      41,
+    ],
+    type: "ObjectExpression",
+  },
+  range: [
+    1,
+    42,
+  ],
+  source: {
+    range: [
+      8,
+      13,
+    ],
+    raw: "'foo'",
+    type: "Literal",
+    value: "foo",
+  },
+  type: "ImportExpression",
+}
+`;
+
+snapshot[`Plugin - LogicalExpression 1`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "&&",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "LogicalExpression",
+}
+`;
+
+snapshot[`Plugin - LogicalExpression 2`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "||",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "LogicalExpression",
+}
+`;
+
+snapshot[`Plugin - LogicalExpression 3`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "??",
+  range: [
+    1,
+    7,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "LogicalExpression",
+}
+`;
+
+snapshot[`Plugin - MemberExpression 1`] = `
+{
+  computed: false,
+  object: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  optional: false,
+  property: {
+    name: "b",
+    optional: false,
+    range: [
+      3,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    4,
+  ],
+  type: "MemberExpression",
+}
+`;
+
+snapshot[`Plugin - MemberExpression 2`] = `
+{
+  computed: true,
+  object: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  optional: false,
+  property: {
+    range: [
+      3,
+      6,
+    ],
+    raw: "'b'",
+    type: "Literal",
+    value: "b",
+  },
+  range: [
+    1,
+    7,
+  ],
+  type: "MemberExpression",
+}
+`;
+
+snapshot[`Plugin - MetaProperty 1`] = `
+{
+  property: {
+    name: "meta",
+    optional: false,
+    range: [
+      1,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "MetaProperty",
+}
+`;
+
+snapshot[`Plugin - NewExpression 1`] = `
+{
+  arguments: [],
+  callee: {
+    name: "Foo",
+    optional: false,
+    range: [
+      5,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    10,
+  ],
+  type: "NewExpression",
+  typeArguments: null,
+}
+`;
+
+snapshot[`Plugin - NewExpression 2`] = `
+{
+  arguments: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        12,
+        13,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          18,
+          19,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        15,
+        18,
+      ],
+      type: "SpreadElement",
+    },
+  ],
+  callee: {
+    name: "Foo",
+    optional: false,
+    range: [
+      5,
+      8,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    20,
+  ],
+  type: "NewExpression",
+  typeArguments: {
+    params: [
+      {
+        range: [
+          9,
+          10,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            9,
+            10,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    ],
+    range: [
+      8,
+      11,
+    ],
+    type: "TSTypeParameterInstantiation",
+  },
+}
+`;
+
+snapshot[`Plugin - ObjectExpression 1`] = `
+{
+  properties: [],
+  range: [
+    5,
+    7,
+  ],
+  type: "ObjectExpression",
+}
+`;
+
+snapshot[`Plugin - ObjectExpression 2`] = `
+{
+  properties: [
+    {
+      computed: false,
+      key: {
+        name: "a",
+        optional: false,
+        range: [
+          7,
+          8,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        7,
+        8,
+      ],
+      shorthand: true,
+      type: "Property",
+      value: {
+        name: "a",
+        optional: false,
+        range: [
+          7,
+          8,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+  ],
+  range: [
+    5,
+    10,
+  ],
+  type: "ObjectExpression",
+}
+`;
+
+snapshot[`Plugin - ObjectExpression 3`] = `
+{
+  properties: [
+    {
+      computed: false,
+      key: {
+        name: "b",
+        optional: false,
+        range: [
+          7,
+          8,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        7,
+        11,
+      ],
+      shorthand: false,
+      type: "Property",
+      value: {
+        name: "c",
+        optional: false,
+        range: [
+          10,
+          11,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+    {
+      computed: true,
+      key: {
+        name: "c",
+        optional: false,
+        range: [
+          14,
+          15,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        13,
+        19,
+      ],
+      shorthand: false,
+      type: "Property",
+      value: {
+        name: "d",
+        optional: false,
+        range: [
+          18,
+          19,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+  ],
+  range: [
+    5,
+    21,
+  ],
+  type: "ObjectExpression",
+}
+`;
+
+snapshot[`Plugin - PrivateIdentifier 1`] = `
+{
+  name: "foo",
+  range: [
+    13,
+    17,
+  ],
+  type: "PrivateIdentifier",
+}
+`;
+
+snapshot[`Plugin - SequenceExpression 1`] = `
+{
+  expressions: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        2,
+        3,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    {
+      name: "b",
+      optional: false,
+      range: [
+        5,
+        6,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  ],
+  range: [
+    2,
+    6,
+  ],
+  type: "SequenceExpression",
+}
+`;
+
+snapshot[`Plugin - Super 1`] = `
+{
+  range: [
+    41,
+    46,
+  ],
+  type: "Super",
+}
+`;
+
+snapshot[`Plugin - TaggedTemplateExpression 1`] = `
+{
+  quasi: {
+    expressions: [
+      {
+        name: "bar",
+        optional: false,
+        range: [
+          11,
+          14,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    ],
+    quasis: [
+      {
+        cooked: "foo ",
+        range: [
+          5,
+          9,
+        ],
+        raw: "foo ",
+        tail: false,
+        type: "TemplateElement",
+      },
+      {
+        cooked: " baz",
+        range: [
+          15,
+          19,
+        ],
+        raw: " baz",
+        tail: true,
+        type: "TemplateElement",
+      },
+    ],
+    range: [
+      4,
+      20,
+    ],
+    type: "TemplateLiteral",
+  },
+  range: [
+    1,
+    20,
+  ],
+  tag: {
+    name: "foo",
+    optional: false,
+    range: [
+      1,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "TaggedTemplateExpression",
+  typeArguments: null,
+}
+`;
+
+snapshot[`Plugin - TemplateLiteral 1`] = `
+{
+  expressions: [
+    {
+      name: "bar",
+      optional: false,
+      range: [
+        8,
+        11,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  ],
+  quasis: [
+    {
+      cooked: "foo ",
+      range: [
+        2,
+        6,
+      ],
+      raw: "foo ",
+      tail: false,
+      type: "TemplateElement",
+    },
+    {
+      cooked: " baz",
+      range: [
+        12,
+        16,
+      ],
+      raw: " baz",
+      tail: true,
+      type: "TemplateElement",
+    },
+  ],
+  range: [
+    1,
+    17,
+  ],
+  type: "TemplateLiteral",
+}
+`;
+
+snapshot[`Plugin - ThisExpression 1`] = `
+{
+  range: [
+    1,
+    5,
+  ],
+  type: "ThisExpression",
+}
+`;
+
+snapshot[`Plugin - TSAsExpression 1`] = `
+{
+  expression: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    7,
+  ],
+  type: "TSAsExpression",
+  typeAnnotation: {
+    range: [
+      6,
+      7,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "b",
+      optional: false,
+      range: [
+        6,
+        7,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+}
+`;
+
+snapshot[`Plugin - TSAsExpression 2`] = `
+{
+  expression: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    11,
+  ],
+  type: "TSAsExpression",
+  typeAnnotation: {
+    range: [
+      1,
+      11,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "const",
+      optional: false,
+      range: [
+        1,
+        11,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+}
+`;
+
+snapshot[`Plugin - TSNonNullExpression 1`] = `
+{
+  expression: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    3,
+  ],
+  type: "TSNonNullExpression",
+}
+`;
+
+snapshot[`Plugin - TSSatisfiesExpression 1`] = `
+{
+  expression: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    14,
+  ],
+  type: "TSSatisfiesExpression",
+  typeAnnotation: {
+    range: [
+      13,
+      14,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "b",
+      optional: false,
+      range: [
+        13,
+        14,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+}
+`;
+
+snapshot[`Plugin - UnaryExpression 1`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      8,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "typeof",
+  range: [
+    1,
+    9,
+  ],
+  type: "UnaryExpression",
+}
+`;
+
+snapshot[`Plugin - UnaryExpression 2`] = `
+{
+  argument: {
+    range: [
+      6,
+      7,
+    ],
+    raw: "0",
+    type: "Literal",
+    value: 0,
+  },
+  operator: "void",
+  range: [
+    1,
+    7,
+  ],
+  type: "UnaryExpression",
+}
+`;
+
+snapshot[`Plugin - UnaryExpression 3`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      2,
+      3,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "-",
+  range: [
+    1,
+    3,
+  ],
+  type: "UnaryExpression",
+}
+`;
+
+snapshot[`Plugin - UnaryExpression 4`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      2,
+      3,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "+",
+  range: [
+    1,
+    3,
+  ],
+  type: "UnaryExpression",
+}
+`;
+
+snapshot[`Plugin - UpdateExpression 1`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "++",
+  prefix: false,
+  range: [
+    1,
+    4,
+  ],
+  type: "UpdateExpression",
+}
+`;
+
+snapshot[`Plugin - UpdateExpression 2`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      3,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "++",
+  prefix: true,
+  range: [
+    1,
+    4,
+  ],
+  type: "UpdateExpression",
+}
+`;
+
+snapshot[`Plugin - UpdateExpression 3`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "--",
+  prefix: false,
+  range: [
+    1,
+    4,
+  ],
+  type: "UpdateExpression",
+}
+`;
+
+snapshot[`Plugin - UpdateExpression 4`] = `
+{
+  argument: {
+    name: "a",
+    optional: false,
+    range: [
+      3,
+      4,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  operator: "--",
+  prefix: true,
+  range: [
+    1,
+    4,
+  ],
+  type: "UpdateExpression",
+}
+`;
+
+snapshot[`Plugin - YieldExpression 1`] = `
+{
+  argument: {
+    name: "bar",
+    optional: false,
+    range: [
+      25,
+      28,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  delegate: false,
+  range: [
+    19,
+    28,
+  ],
+  type: "YieldExpression",
+}
+`;
+
+snapshot[`Plugin - Literal 1`] = `
+{
+  range: [
+    1,
+    2,
+  ],
+  raw: "1",
+  type: "Literal",
+  value: 1,
+}
+`;
+
+snapshot[`Plugin - Literal 2`] = `
+{
+  range: [
+    1,
+    6,
+  ],
+  raw: "'foo'",
+  type: "Literal",
+  value: "foo",
+}
+`;
+
+snapshot[`Plugin - Literal 3`] = `
+{
+  range: [
+    1,
+    6,
+  ],
+  raw: '"foo"',
+  type: "Literal",
+  value: "foo",
+}
+`;
+
+snapshot[`Plugin - Literal 4`] = `
+{
+  range: [
+    1,
+    5,
+  ],
+  raw: "true",
+  type: "Literal",
+  value: true,
+}
+`;
+
+snapshot[`Plugin - Literal 5`] = `
+{
+  range: [
+    1,
+    6,
+  ],
+  raw: "false",
+  type: "Literal",
+  value: false,
+}
+`;
+
+snapshot[`Plugin - Literal 6`] = `
+{
+  range: [
+    1,
+    5,
+  ],
+  raw: "null",
+  type: "Literal",
+  value: null,
+}
+`;
+
+snapshot[`Plugin - Literal 7`] = `
+{
+  bigint: "1",
+  range: [
+    1,
+    3,
+  ],
+  raw: "1n",
+  type: "Literal",
+  value: 1n,
+}
+`;
+
+snapshot[`Plugin - Literal 8`] = `
+{
+  range: [
+    1,
+    7,
+  ],
+  raw: "/foo/g",
+  regex: {
+    flags: "g",
+    pattern: "foo",
+  },
+  type: "Literal",
+  value: /foo/g,
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 1`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      8,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    8,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 2`] = `
+{
+  children: [],
+  closingElement: {
+    name: {
+      name: "div",
+      range: [
+        8,
+        11,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      6,
+      12,
+    ],
+    type: "JSXClosingElement",
+  },
+  openingElement: {
+    attributes: [],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      6,
+    ],
+    selfClosing: false,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 3`] = `
+{
+  children: [],
+  closingElement: {
+    name: {
+      name: "div",
+      range: [
+        10,
+        13,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      8,
+      14,
+    ],
+    type: "JSXClosingElement",
+  },
+  openingElement: {
+    attributes: [
+      {
+        name: {
+          name: "a",
+          range: [
+            6,
+            7,
+          ],
+          type: "JSXIdentifier",
+        },
+        range: [
+          6,
+          7,
+        ],
+        type: "JSXAttribute",
+        value: null,
+      },
+    ],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      8,
+    ],
+    selfClosing: false,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    14,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 4`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [
+      {
+        name: {
+          name: "a",
+          range: [
+            6,
+            7,
+          ],
+          type: "JSXIdentifier",
+        },
+        range: [
+          6,
+          11,
+        ],
+        type: "JSXAttribute",
+        value: {
+          range: [
+            8,
+            11,
+          ],
+          raw: '"b"',
+          type: "Literal",
+          value: "b",
+        },
+      },
+    ],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      14,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    14,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 5`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [
+      {
+        name: {
+          name: "a",
+          range: [
+            6,
+            7,
+          ],
+          type: "JSXIdentifier",
+        },
+        range: [
+          6,
+          11,
+        ],
+        type: "JSXAttribute",
+        value: {
+          expression: {
+            range: [
+              9,
+              10,
+            ],
+            raw: "2",
+            type: "Literal",
+            value: 2,
+          },
+          range: [
+            8,
+            11,
+          ],
+          type: "JSXExpressionContainer",
+        },
+      },
+    ],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      14,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    14,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 6`] = `
+{
+  children: [
+    {
+      range: [
+        6,
+        9,
+      ],
+      raw: "foo",
+      type: "JSXText",
+      value: "foo",
+    },
+    {
+      expression: {
+        range: [
+          10,
+          11,
+        ],
+        raw: "2",
+        type: "Literal",
+        value: 2,
+      },
+      range: [
+        9,
+        12,
+      ],
+      type: "JSXExpressionContainer",
+    },
+  ],
+  closingElement: {
+    name: {
+      name: "div",
+      range: [
+        14,
+        17,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      12,
+      18,
+    ],
+    type: "JSXClosingElement",
+  },
+  openingElement: {
+    attributes: [],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      6,
+    ],
+    selfClosing: false,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    18,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 7`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [],
+    name: {
+      object: {
+        name: "a",
+        range: [
+          2,
+          3,
+        ],
+        type: "JSXIdentifier",
+      },
+      property: {
+        name: "b",
+        range: [
+          4,
+          5,
+        ],
+        type: "JSXIdentifier",
+      },
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXMemberExpression",
+    },
+    range: [
+      1,
+      8,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    8,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 8`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [
+      {
+        name: {
+          name: {
+            name: "b",
+            range: [
+              8,
+              9,
+            ],
+            type: "JSXIdentifier",
+          },
+          namespace: {
+            name: "a",
+            range: [
+              6,
+              7,
+            ],
+            type: "JSXIdentifier",
+          },
+          range: [
+            6,
+            9,
+          ],
+          type: "JSXNamespacedName",
+        },
+        range: [
+          6,
+          13,
+        ],
+        type: "JSXAttribute",
+        value: {
+          expression: {
+            range: [
+              11,
+              12,
+            ],
+            raw: "2",
+            type: "Literal",
+            value: 2,
+          },
+          range: [
+            10,
+            13,
+          ],
+          type: "JSXExpressionContainer",
+        },
+      },
+    ],
+    name: {
+      name: "div",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      16,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    16,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 9`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [],
+    name: {
+      name: "Foo",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      8,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: null,
+  },
+  range: [
+    1,
+    8,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr 10`] = `
+{
+  children: [],
+  closingElement: null,
+  openingElement: {
+    attributes: [],
+    name: {
+      name: "Foo",
+      range: [
+        2,
+        5,
+      ],
+      type: "JSXIdentifier",
+    },
+    range: [
+      1,
+      11,
+    ],
+    selfClosing: true,
+    type: "JSXOpeningElement",
+    typeArguments: {
+      params: [
+        {
+          range: [
+            6,
+            7,
+          ],
+          type: "TSTypeReference",
+          typeArguments: null,
+          typeName: {
+            name: "T",
+            optional: false,
+            range: [
+              6,
+              7,
+            ],
+            type: "Identifier",
+            typeAnnotation: null,
+          },
+        },
+      ],
+      range: [
+        5,
+        8,
+      ],
+      type: "TSTypeParameterInstantiation",
+    },
+  },
+  range: [
+    1,
+    11,
+  ],
+  type: "JSXElement",
+}
+`;
+
+snapshot[`Plugin - JSXFragment + JSXOpeningFragment + JSXClosingFragment 1`] = `
+{
+  children: [],
+  closingFragment: {
+    range: [
+      3,
+      6,
+    ],
+    type: "JSXClosingFragment",
+  },
+  openingFragment: {
+    range: [
+      1,
+      3,
+    ],
+    type: "JSXOpeningFragment",
+  },
+  range: [
+    1,
+    6,
+  ],
+  type: "JSXFragment",
+}
+`;
+
+snapshot[`Plugin - JSXFragment + JSXOpeningFragment + JSXClosingFragment 2`] = `
+{
+  children: [
+    {
+      range: [
+        3,
+        6,
+      ],
+      raw: "foo",
+      type: "JSXText",
+      value: "foo",
+    },
+    {
+      expression: {
+        range: [
+          7,
+          8,
+        ],
+        raw: "2",
+        type: "Literal",
+        value: 2,
+      },
+      range: [
+        6,
+        9,
+      ],
+      type: "JSXExpressionContainer",
+    },
+  ],
+  closingFragment: {
+    range: [
+      9,
+      12,
+    ],
+    type: "JSXClosingFragment",
+  },
+  openingFragment: {
+    range: [
+      1,
+      3,
+    ],
+    type: "JSXOpeningFragment",
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "JSXFragment",
+}
+`;
+
+snapshot[`Plugin - TSAsExpression 3`] = `
+{
+  expression: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    9,
+  ],
+  type: "TSAsExpression",
+  typeAnnotation: {
+    range: [
+      6,
+      9,
+    ],
+    type: "TSAnyKeyword",
+  },
+}
+`;
+
+snapshot[`Plugin - TSAsExpression 4`] = `
+{
+  expression: {
+    range: [
+      1,
+      6,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  range: [
+    1,
+    15,
+  ],
+  type: "TSAsExpression",
+  typeAnnotation: {
+    range: [
+      1,
+      15,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "const",
+      optional: false,
+      range: [
+        1,
+        15,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+}
+`;
+
+snapshot[`Plugin - TSEnumDeclaration 1`] = `
+{
+  body: {
+    members: [],
+    range: [
+      1,
+      12,
+    ],
+    type: "TSEnumBody",
+  },
+  const: false,
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      6,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "TSEnumDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSEnumDeclaration 2`] = `
+{
+  body: {
+    members: [],
+    range: [
+      1,
+      18,
+    ],
+    type: "TSEnumBody",
+  },
+  const: true,
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      12,
+      15,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    18,
+  ],
+  type: "TSEnumDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSEnumDeclaration 3`] = `
+{
+  body: {
+    members: [
+      {
+        id: {
+          name: "A",
+          optional: false,
+          range: [
+            12,
+            13,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        initializer: null,
+        range: [
+          12,
+          13,
+        ],
+        type: "TSEnumMember",
+      },
+      {
+        id: {
+          name: "B",
+          optional: false,
+          range: [
+            15,
+            16,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        initializer: null,
+        range: [
+          15,
+          16,
+        ],
+        type: "TSEnumMember",
+      },
+    ],
+    range: [
+      1,
+      18,
+    ],
+    type: "TSEnumBody",
+  },
+  const: false,
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      6,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    18,
+  ],
+  type: "TSEnumDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSEnumDeclaration 4`] = `
+{
+  body: {
+    members: [
+      {
+        id: {
+          range: [
+            12,
+            17,
+          ],
+          raw: '"a-b"',
+          type: "Literal",
+          value: "a-b",
+        },
+        initializer: null,
+        range: [
+          12,
+          17,
+        ],
+        type: "TSEnumMember",
+      },
+    ],
+    range: [
+      1,
+      19,
+    ],
+    type: "TSEnumBody",
+  },
+  const: false,
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      6,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    19,
+  ],
+  type: "TSEnumDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSEnumDeclaration 5`] = `
+{
+  body: {
+    members: [
+      {
+        id: {
+          name: "A",
+          optional: false,
+          range: [
+            12,
+            13,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        initializer: {
+          range: [
+            16,
+            17,
+          ],
+          raw: "1",
+          type: "Literal",
+          value: 1,
+        },
+        range: [
+          12,
+          17,
+        ],
+        type: "TSEnumMember",
+      },
+      {
+        id: {
+          name: "B",
+          optional: false,
+          range: [
+            19,
+            20,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        initializer: {
+          range: [
+            23,
+            24,
+          ],
+          raw: "2",
+          type: "Literal",
+          value: 2,
+        },
+        range: [
+          19,
+          24,
+        ],
+        type: "TSEnumMember",
+      },
+      {
+        id: {
+          name: "C",
+          optional: false,
+          range: [
+            26,
+            27,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        initializer: {
+          left: {
+            name: "A",
+            optional: false,
+            range: [
+              30,
+              31,
+            ],
+            type: "Identifier",
+            typeAnnotation: null,
+          },
+          operator: "|",
+          range: [
+            30,
+            35,
+          ],
+          right: {
+            name: "B",
+            optional: false,
+            range: [
+              34,
+              35,
+            ],
+            type: "Identifier",
+            typeAnnotation: null,
+          },
+          type: "BinaryExpression",
+        },
+        range: [
+          26,
+          35,
+        ],
+        type: "TSEnumMember",
+      },
+    ],
+    range: [
+      1,
+      37,
+    ],
+    type: "TSEnumBody",
+  },
+  const: false,
+  declare: false,
+  id: {
+    name: "Foo",
+    optional: false,
+    range: [
+      6,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    37,
+  ],
+  type: "TSEnumDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSInterface 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      13,
+      15,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    15,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 2`] = `
+{
+  body: {
+    body: [],
+    range: [
+      16,
+      18,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: {
+    params: [
+      {
+        const: false,
+        constraint: null,
+        default: null,
+        in: false,
+        name: {
+          name: "T",
+          optional: false,
+          range: [
+            13,
+            14,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        out: false,
+        range: [
+          13,
+          14,
+        ],
+        type: "TSTypeParameter",
+      },
+    ],
+    range: [
+      12,
+      15,
+    ],
+    type: "TSTypeParameterDeclaration",
+  },
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    18,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 3`] = `
+{
+  body: {
+    body: [],
+    range: [
+      36,
+      38,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    38,
+  ],
+  type: "TSInterface",
+  typeParameters: [
+    {
+      expression: {
+        name: "Foo",
+        optional: false,
+        range: [
+          21,
+          24,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        21,
+        27,
+      ],
+      type: "TSInterfaceHeritage",
+      typeArguments: {
+        params: [
+          {
+            range: [
+              25,
+              26,
+            ],
+            type: "TSTypeReference",
+            typeArguments: null,
+            typeName: {
+              name: "T",
+              optional: false,
+              range: [
+                25,
+                26,
+              ],
+              type: "Identifier",
+              typeAnnotation: null,
+            },
+          },
+        ],
+        range: [
+          24,
+          27,
+        ],
+        type: "TSTypeParameterInstantiation",
+      },
+    },
+    {
+      expression: {
+        name: "Bar",
+        optional: false,
+        range: [
+          29,
+          32,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        29,
+        35,
+      ],
+      type: "TSInterfaceHeritage",
+      typeArguments: {
+        params: [
+          {
+            range: [
+              33,
+              34,
+            ],
+            type: "TSTypeReference",
+            typeArguments: null,
+            typeName: {
+              name: "T",
+              optional: false,
+              range: [
+                33,
+                34,
+              ],
+              type: "Identifier",
+              typeAnnotation: null,
+            },
+          },
+        ],
+        range: [
+          32,
+          35,
+        ],
+        type: "TSTypeParameterInstantiation",
+      },
+    },
+  ],
+}
+`;
+
+snapshot[`Plugin - TSInterface 4`] = `
+{
+  body: {
+    body: [
+      {
+        computed: false,
+        key: {
+          name: "foo",
+          optional: false,
+          range: [
+            15,
+            18,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        range: [
+          15,
+          24,
+        ],
+        readonly: false,
+        static: false,
+        type: "TSPropertySignature",
+        typeAnnotation: {
+          range: [
+            18,
+            23,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              20,
+              23,
+            ],
+            type: "TSAnyKeyword",
+          },
+        },
+      },
+      {
+        computed: false,
+        key: {
+          name: "bar",
+          optional: false,
+          range: [
+            25,
+            28,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: true,
+        range: [
+          25,
+          34,
+        ],
+        readonly: false,
+        static: false,
+        type: "TSPropertySignature",
+        typeAnnotation: {
+          range: [
+            29,
+            34,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              31,
+              34,
+            ],
+            type: "TSAnyKeyword",
+          },
+        },
+      },
+    ],
+    range: [
+      13,
+      36,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    36,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 5`] = `
+{
+  body: {
+    body: [
+      {
+        parameters: [
+          {
+            name: "key",
+            optional: false,
+            range: [
+              25,
+              36,
+            ],
+            type: "Identifier",
+            typeAnnotation: {
+              range: [
+                28,
+                36,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                range: [
+                  30,
+                  36,
+                ],
+                type: "TSStringKeyword",
+              },
+            },
+          },
+        ],
+        range: [
+          15,
+          42,
+        ],
+        readonly: true,
+        type: "TSIndexSignature",
+        typeAnnotation: {
+          range: [
+            37,
+            42,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              39,
+              42,
+            ],
+            type: "TSAnyKeyword",
+          },
+        },
+      },
+    ],
+    range: [
+      13,
+      44,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    44,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 6`] = `
+{
+  body: {
+    body: [
+      {
+        computed: false,
+        key: {
+          name: "a",
+          optional: false,
+          range: [
+            24,
+            25,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        range: [
+          15,
+          30,
+        ],
+        readonly: true,
+        static: false,
+        type: "TSPropertySignature",
+        typeAnnotation: {
+          range: [
+            25,
+            30,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              27,
+              30,
+            ],
+            type: "TSAnyKeyword",
+          },
+        },
+      },
+    ],
+    range: [
+      13,
+      32,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    32,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 7`] = `
+{
+  body: {
+    body: [
+      {
+        params: [
+          {
+            name: "a",
+            optional: false,
+            range: [
+              19,
+              20,
+            ],
+            type: "Identifier",
+            typeAnnotation: {
+              range: [
+                20,
+                23,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                range: [
+                  22,
+                  23,
+                ],
+                type: "TSTypeReference",
+                typeArguments: null,
+                typeName: {
+                  name: "T",
+                  optional: false,
+                  range: [
+                    22,
+                    23,
+                  ],
+                  type: "Identifier",
+                  typeAnnotation: null,
+                },
+              },
+            },
+          },
+        ],
+        range: [
+          15,
+          27,
+        ],
+        returnType: {
+          range: [
+            24,
+            27,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              26,
+              27,
+            ],
+            type: "TSTypeReference",
+            typeArguments: null,
+            typeName: {
+              name: "T",
+              optional: false,
+              range: [
+                26,
+                27,
+              ],
+              type: "Identifier",
+              typeAnnotation: null,
+            },
+          },
+        },
+        type: "TsCallSignatureDeclaration",
+        typeAnnotation: {
+          params: [
+            {
+              const: false,
+              constraint: null,
+              default: null,
+              in: false,
+              name: {
+                name: "T",
+                optional: false,
+                range: [
+                  16,
+                  17,
+                ],
+                type: "Identifier",
+                typeAnnotation: null,
+              },
+              out: false,
+              range: [
+                16,
+                17,
+              ],
+              type: "TSTypeParameter",
+            },
+          ],
+          range: [
+            15,
+            18,
+          ],
+          type: "TSTypeParameterDeclaration",
+        },
+      },
+    ],
+    range: [
+      13,
+      29,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    29,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 8`] = `
+{
+  body: {
+    body: [
+      {
+        params: [
+          {
+            name: "a",
+            optional: false,
+            range: [
+              23,
+              24,
+            ],
+            type: "Identifier",
+            typeAnnotation: {
+              range: [
+                24,
+                27,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                range: [
+                  26,
+                  27,
+                ],
+                type: "TSTypeReference",
+                typeArguments: null,
+                typeName: {
+                  name: "T",
+                  optional: false,
+                  range: [
+                    26,
+                    27,
+                  ],
+                  type: "Identifier",
+                  typeAnnotation: null,
+                },
+              },
+            },
+          },
+        ],
+        range: [
+          15,
+          31,
+        ],
+        returnType: {
+          range: [
+            28,
+            31,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              30,
+              31,
+            ],
+            type: "TSTypeReference",
+            typeArguments: null,
+            typeName: {
+              name: "T",
+              optional: false,
+              range: [
+                30,
+                31,
+              ],
+              type: "Identifier",
+              typeAnnotation: null,
+            },
+          },
+        },
+        type: "TSConstructSignatureDeclaration",
+        typeParameters: {
+          params: [
+            {
+              const: false,
+              constraint: null,
+              default: null,
+              in: false,
+              name: {
+                name: "T",
+                optional: false,
+                range: [
+                  20,
+                  21,
+                ],
+                type: "Identifier",
+                typeAnnotation: null,
+              },
+              out: false,
+              range: [
+                20,
+                21,
+              ],
+              type: "TSTypeParameter",
+            },
+          ],
+          range: [
+            19,
+            22,
+          ],
+          type: "TSTypeParameterDeclaration",
+        },
+      },
+    ],
+    range: [
+      13,
+      33,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    33,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 9`] = `
+{
+  body: {
+    body: [
+      {
+        computed: false,
+        key: {
+          name: "a",
+          optional: false,
+          range: [
+            15,
+            16,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        optional: false,
+        range: [
+          15,
+          36,
+        ],
+        readonly: false,
+        static: false,
+        type: "TSPropertySignature",
+        typeAnnotation: {
+          range: [
+            16,
+            36,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            params: [
+              {
+                name: "a",
+                optional: false,
+                range: [
+                  26,
+                  27,
+                ],
+                type: "Identifier",
+                typeAnnotation: {
+                  range: [
+                    27,
+                    30,
+                  ],
+                  type: "TSTypeAnnotation",
+                  typeAnnotation: {
+                    range: [
+                      29,
+                      30,
+                    ],
+                    type: "TSTypeReference",
+                    typeArguments: null,
+                    typeName: {
+                      name: "T",
+                      optional: false,
+                      range: [
+                        29,
+                        30,
+                      ],
+                      type: "Identifier",
+                      typeAnnotation: null,
+                    },
+                  },
+                },
+              },
+            ],
+            range: [
+              18,
+              36,
+            ],
+            returnType: {
+              range: [
+                32,
+                36,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                range: [
+                  35,
+                  36,
+                ],
+                type: "TSTypeReference",
+                typeArguments: null,
+                typeName: {
+                  name: "T",
+                  optional: false,
+                  range: [
+                    35,
+                    36,
+                  ],
+                  type: "Identifier",
+                  typeAnnotation: null,
+                },
+              },
+            },
+            type: "TSConstructSignatureDeclaration",
+            typeParameters: {
+              params: [
+                {
+                  const: false,
+                  constraint: null,
+                  default: null,
+                  in: false,
+                  name: {
+                    name: "T",
+                    optional: false,
+                    range: [
+                      23,
+                      24,
+                    ],
+                    type: "Identifier",
+                    typeAnnotation: null,
+                  },
+                  out: false,
+                  range: [
+                    23,
+                    24,
+                  ],
+                  type: "TSTypeParameter",
+                },
+              ],
+              range: [
+                22,
+                25,
+              ],
+              type: "TSTypeParameterDeclaration",
+            },
+          },
+        },
+      },
+    ],
+    range: [
+      13,
+      38,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    38,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 10`] = `
+{
+  body: {
+    body: [
+      {
+        computed: false,
+        key: {
+          name: "a",
+          optional: false,
+          range: [
+            19,
+            20,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        kind: "getter",
+        optional: false,
+        range: [
+          15,
+          30,
+        ],
+        readonly: false,
+        returnType: {
+          range: [
+            22,
+            30,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              24,
+              30,
+            ],
+            type: "TSStringKeyword",
+          },
+        },
+        static: false,
+        type: "TSMethodSignature",
+      },
+    ],
+    range: [
+      13,
+      32,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    32,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 11`] = `
+{
+  body: {
+    body: [
+      {
+        computed: false,
+        key: {
+          name: "a",
+          optional: false,
+          range: [
+            19,
+            20,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        kind: "setter",
+        optional: false,
+        params: [
+          {
+            name: "v",
+            optional: false,
+            range: [
+              21,
+              22,
+            ],
+            type: "Identifier",
+            typeAnnotation: {
+              range: [
+                22,
+                30,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                range: [
+                  24,
+                  30,
+                ],
+                type: "TSStringKeyword",
+              },
+            },
+          },
+        ],
+        range: [
+          15,
+          31,
+        ],
+        readonly: false,
+        static: false,
+        type: "TSMethodSignature",
+      },
+    ],
+    range: [
+      13,
+      33,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    33,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSInterface 12`] = `
+{
+  body: {
+    body: [
+      {
+        computed: false,
+        key: {
+          name: "a",
+          optional: false,
+          range: [
+            15,
+            16,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        kind: "method",
+        optional: false,
+        params: [
+          {
+            name: "arg",
+            optional: true,
+            range: [
+              20,
+              23,
+            ],
+            type: "Identifier",
+            typeAnnotation: {
+              range: [
+                24,
+                29,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                range: [
+                  26,
+                  29,
+                ],
+                type: "TSAnyKeyword",
+              },
+            },
+          },
+          {
+            argument: {
+              name: "args",
+              optional: false,
+              range: [
+                34,
+                38,
+              ],
+              type: "Identifier",
+              typeAnnotation: null,
+            },
+            range: [
+              31,
+              45,
+            ],
+            type: "RestElement",
+            typeAnnotation: {
+              range: [
+                38,
+                45,
+              ],
+              type: "TSTypeAnnotation",
+              typeAnnotation: {
+                elementType: {
+                  range: [
+                    40,
+                    43,
+                  ],
+                  type: "TSAnyKeyword",
+                },
+                range: [
+                  40,
+                  45,
+                ],
+                type: "TSArrayType",
+              },
+            },
+          },
+        ],
+        range: [
+          15,
+          51,
+        ],
+        readonly: false,
+        returnType: {
+          range: [
+            46,
+            51,
+          ],
+          type: "TSTypeAnnotation",
+          typeAnnotation: {
+            range: [
+              48,
+              51,
+            ],
+            type: "TSAnyKeyword",
+          },
+        },
+        static: false,
+        type: "TSMethodSignature",
+        typeParameters: {
+          params: [
+            {
+              const: false,
+              constraint: null,
+              default: null,
+              in: false,
+              name: {
+                name: "T",
+                optional: false,
+                range: [
+                  17,
+                  18,
+                ],
+                type: "Identifier",
+                typeAnnotation: null,
+              },
+              out: false,
+              range: [
+                17,
+                18,
+              ],
+              type: "TSTypeParameter",
+            },
+          ],
+          range: [
+            16,
+            19,
+          ],
+          type: "TSTypeParameterDeclaration",
+        },
+      },
+    ],
+    range: [
+      13,
+      53,
+    ],
+    type: "TSInterfaceBody",
+  },
+  declare: false,
+  extends: null,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    53,
+  ],
+  type: "TSInterface",
+  typeParameters: [],
+}
+`;
+
+snapshot[`Plugin - TSSatisfiesExpression 2`] = `
+{
+  expression: {
+    properties: [],
+    range: [
+      11,
+      13,
+    ],
+    type: "ObjectExpression",
+  },
+  range: [
+    11,
+    25,
+  ],
+  type: "TSSatisfiesExpression",
+  typeAnnotation: {
+    range: [
+      24,
+      25,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "A",
+      optional: false,
+      range: [
+        24,
+        25,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+}
+`;
+
+snapshot[`Plugin - TSTypeAliasDeclaration 1`] = `
+{
+  declare: false,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    13,
+  ],
+  type: "TSTypeAliasDeclaration",
+  typeAnnotation: {
+    range: [
+      10,
+      13,
+    ],
+    type: "TSAnyKeyword",
+  },
+  typeParameters: null,
+}
+`;
+
+snapshot[`Plugin - TSTypeAliasDeclaration 2`] = `
+{
+  declare: false,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      6,
+      7,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    16,
+  ],
+  type: "TSTypeAliasDeclaration",
+  typeAnnotation: {
+    range: [
+      13,
+      16,
+    ],
+    type: "TSAnyKeyword",
+  },
+  typeParameters: {
+    params: [
+      {
+        const: false,
+        constraint: null,
+        default: null,
+        in: false,
+        name: {
+          name: "T",
+          optional: false,
+          range: [
+            8,
+            9,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        out: false,
+        range: [
+          8,
+          9,
+        ],
+        type: "TSTypeParameter",
+      },
+    ],
+    range: [
+      7,
+      10,
+    ],
+    type: "TSTypeParameterDeclaration",
+  },
+}
+`;
+
+snapshot[`Plugin - TSTypeAliasDeclaration 3`] = `
+{
+  declare: true,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      14,
+      15,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    24,
+  ],
+  type: "TSTypeAliasDeclaration",
+  typeAnnotation: {
+    range: [
+      21,
+      24,
+    ],
+    type: "TSAnyKeyword",
+  },
+  typeParameters: {
+    params: [
+      {
+        const: false,
+        constraint: null,
+        default: null,
+        in: false,
+        name: {
+          name: "T",
+          optional: false,
+          range: [
+            16,
+            17,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        out: false,
+        range: [
+          16,
+          17,
+        ],
+        type: "TSTypeParameter",
+      },
+    ],
+    range: [
+      15,
+      18,
+    ],
+    type: "TSTypeParameterDeclaration",
+  },
+}
+`;
+
+snapshot[`Plugin - TSNonNullExpression 2`] = `
+{
+  expression: {
+    name: "a",
+    optional: false,
+    range: [
+      1,
+      2,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    3,
+  ],
+  type: "TSNonNullExpression",
+}
+`;
+
+snapshot[`Plugin - TSUnionType 1`] = `
+{
+  range: [
+    10,
+    15,
+  ],
+  type: "TSUnionType",
+  types: [
+    {
+      range: [
+        10,
+        11,
+      ],
+      type: "TSTypeReference",
+      typeArguments: null,
+      typeName: {
+        name: "B",
+        optional: false,
+        range: [
+          10,
+          11,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+    {
+      range: [
+        14,
+        15,
+      ],
+      type: "TSTypeReference",
+      typeArguments: null,
+      typeName: {
+        name: "C",
+        optional: false,
+        range: [
+          14,
+          15,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+  ],
+}
+`;
+
+snapshot[`Plugin - TSIntersectionType 1`] = `
+{
+  range: [
+    10,
+    15,
+  ],
+  type: "TSIntersectionType",
+  types: [
+    {
+      range: [
+        10,
+        11,
+      ],
+      type: "TSTypeReference",
+      typeArguments: null,
+      typeName: {
+        name: "B",
+        optional: false,
+        range: [
+          10,
+          11,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+    {
+      range: [
+        14,
+        15,
+      ],
+      type: "TSTypeReference",
+      typeArguments: null,
+      typeName: {
+        name: "C",
+        optional: false,
+        range: [
+          14,
+          15,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+    },
+  ],
+}
+`;
+
+snapshot[`Plugin - TSModuleDeclaration 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      10,
+      12,
+    ],
+    type: "TSModuleBlock",
+  },
+  declare: false,
+  global: false,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      8,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "TSModuleDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSModuleDeclaration 2`] = `
+{
+  body: {
+    body: [
+      {
+        declaration: {
+          async: false,
+          body: null,
+          declare: false,
+          generator: false,
+          id: {
+            name: "A",
+            optional: false,
+            range: [
+              36,
+              37,
+            ],
+            type: "Identifier",
+            typeAnnotation: null,
+          },
+          params: [],
+          range: [
+            27,
+            45,
+          ],
+          returnType: {
+            range: [
+              39,
+              45,
+            ],
+            type: "TSTypeAnnotation",
+            typeAnnotation: {
+              range: [
+                41,
+                45,
+              ],
+              type: "TSVoidKeyword",
+            },
+          },
+          type: "FunctionDeclaration",
+          typeParameters: null,
+        },
+        range: [
+          20,
+          45,
+        ],
+        type: "ExportNamedDeclaration",
+      },
+    ],
+    range: [
+      18,
+      47,
+    ],
+    type: "TSModuleBlock",
+  },
+  declare: true,
+  global: false,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      16,
+      17,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    47,
+  ],
+  type: "TSModuleDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSModuleDeclaration + TSModuleBlock 1`] = `
+{
+  body: {
+    body: [],
+    range: [
+      10,
+      12,
+    ],
+    type: "TSModuleBlock",
+  },
+  declare: false,
+  global: false,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      8,
+      9,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    12,
+  ],
+  type: "TSModuleDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSModuleDeclaration + TSModuleBlock 2`] = `
+{
+  body: {
+    body: [
+      {
+        body: {
+          body: [],
+          range: [
+            27,
+            29,
+          ],
+          type: "TSModuleBlock",
+        },
+        declare: false,
+        global: false,
+        id: {
+          name: "B",
+          optional: false,
+          range: [
+            25,
+            26,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        range: [
+          15,
+          29,
+        ],
+        type: "TSModuleDeclaration",
+      },
+    ],
+    range: [
+      13,
+      31,
+    ],
+    type: "TSModuleBlock",
+  },
+  declare: false,
+  global: false,
+  id: {
+    name: "A",
+    optional: false,
+    range: [
+      11,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    1,
+    31,
+  ],
+  type: "TSModuleDeclaration",
+}
+`;
+
+snapshot[`Plugin - TSQualifiedName 1`] = `
+{
+  left: {
+    name: "a",
+    optional: false,
+    range: [
+      10,
+      11,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    10,
+    13,
+  ],
+  right: {
+    name: "b",
+    optional: false,
+    range: [
+      12,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  type: "TSQualifiedName",
+}
+`;
+
+snapshot[`Plugin - TSTypeLiteral 1`] = `
+{
+  members: [
+    {
+      computed: false,
+      key: {
+        name: "a",
+        optional: false,
+        range: [
+          12,
+          13,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      optional: false,
+      range: [
+        12,
+        16,
+      ],
+      readonly: false,
+      static: false,
+      type: "TSPropertySignature",
+      typeAnnotation: {
+        range: [
+          13,
+          16,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          literal: {
+            range: [
+              15,
+              16,
+            ],
+            raw: "1",
+            type: "Literal",
+            value: 1,
+          },
+          range: [
+            15,
+            16,
+          ],
+          type: "TSLiteralType",
+        },
+      },
+    },
+  ],
+  range: [
+    10,
+    18,
+  ],
+  type: "TSTypeLiteral",
+}
+`;
+
+snapshot[`Plugin - TSOptionalType 1`] = `
+{
+  range: [
+    11,
+    18,
+  ],
+  type: "TSOptionalType",
+  typeAnnotation: {
+    range: [
+      11,
+      17,
+    ],
+    type: "TSNumberKeyword",
+  },
+}
+`;
+
+snapshot[`Plugin - TSRestType 1`] = `
+{
+  range: [
+    11,
+    22,
+  ],
+  type: "TSRestType",
+  typeAnnotation: {
+    elementType: {
+      range: [
+        14,
+        20,
+      ],
+      type: "TSNumberKeyword",
+    },
+    range: [
+      14,
+      22,
+    ],
+    type: "TSArrayType",
+  },
+}
+`;
+
+snapshot[`Plugin - TSConditionalType 1`] = `
+{
+  checkType: {
+    range: [
+      10,
+      11,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "B",
+      optional: false,
+      range: [
+        10,
+        11,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+  extendsType: {
+    range: [
+      20,
+      21,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "C",
+      optional: false,
+      range: [
+        20,
+        21,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+  falseType: {
+    range: [
+      33,
+      39,
+    ],
+    type: "TSStringKeyword",
+  },
+  range: [
+    10,
+    39,
+  ],
+  trueType: {
+    range: [
+      24,
+      30,
+    ],
+    type: "TSNumberKeyword",
+  },
+  type: "TSConditionalType",
+}
+`;
+
+snapshot[`Plugin - TSInferType 1`] = `
+{
+  range: [
+    29,
+    39,
+  ],
+  type: "TSInferType",
+  typeParameter: {
+    const: false,
+    constraint: null,
+    default: null,
+    in: false,
+    name: {
+      name: "Item",
+      optional: false,
+      range: [
+        35,
+        39,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      35,
+      39,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSTypeOperator 1`] = `
+{
+  operator: "keyof",
+  range: [
+    10,
+    17,
+  ],
+  type: "TSTypeOperator",
+  typeAnnotation: {
+    range: [
+      16,
+      17,
+    ],
+    type: "TSTypeReference",
+    typeArguments: null,
+    typeName: {
+      name: "B",
+      optional: false,
+      range: [
+        16,
+        17,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+  },
+}
+`;
+
+snapshot[`Plugin - TSTypeOperator 2`] = `
+{
+  operator: "unique",
+  range: [
+    21,
+    34,
+  ],
+  type: "TSTypeOperator",
+  typeAnnotation: {
+    range: [
+      28,
+      34,
+    ],
+    type: "TSSymbolKeyword",
+  },
+}
+`;
+
+snapshot[`Plugin - TSTypeOperator 3`] = `
+{
+  operator: "readonly",
+  range: [
+    10,
+    21,
+  ],
+  type: "TSTypeOperator",
+  typeAnnotation: {
+    elementTypes: [],
+    range: [
+      19,
+      21,
+    ],
+    type: "TSTupleType",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 1`] = `
+{
+  nameType: null,
+  optional: undefined,
+  range: [
+    13,
+    41,
+  ],
+  readonly: undefined,
+  type: "TSMappedType",
+  typeAnnotation: {
+    range: [
+      31,
+      38,
+    ],
+    type: "TSBooleanKeyword",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        21,
+        28,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          27,
+          28,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            27,
+            28,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        16,
+        17,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      16,
+      28,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 2`] = `
+{
+  nameType: null,
+  optional: undefined,
+  range: [
+    13,
+    45,
+  ],
+  readonly: true,
+  type: "TSMappedType",
+  typeAnnotation: {
+    elementTypes: [],
+    range: [
+      40,
+      42,
+    ],
+    type: "TSTupleType",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        30,
+        37,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          36,
+          37,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            36,
+            37,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        25,
+        26,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      25,
+      37,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 3`] = `
+{
+  nameType: null,
+  optional: undefined,
+  range: [
+    13,
+    46,
+  ],
+  readonly: "-",
+  type: "TSMappedType",
+  typeAnnotation: {
+    elementTypes: [],
+    range: [
+      41,
+      43,
+    ],
+    type: "TSTupleType",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        31,
+        38,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          37,
+          38,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            37,
+            38,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        26,
+        27,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      26,
+      38,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 4`] = `
+{
+  nameType: null,
+  optional: undefined,
+  range: [
+    13,
+    46,
+  ],
+  readonly: "+",
+  type: "TSMappedType",
+  typeAnnotation: {
+    elementTypes: [],
+    range: [
+      41,
+      43,
+    ],
+    type: "TSTupleType",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        31,
+        38,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          37,
+          38,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            37,
+            38,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        26,
+        27,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      26,
+      38,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 5`] = `
+{
+  nameType: null,
+  optional: true,
+  range: [
+    13,
+    42,
+  ],
+  readonly: undefined,
+  type: "TSMappedType",
+  typeAnnotation: {
+    range: [
+      32,
+      39,
+    ],
+    type: "TSBooleanKeyword",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        21,
+        28,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          27,
+          28,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            27,
+            28,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        16,
+        17,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      16,
+      28,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 6`] = `
+{
+  nameType: null,
+  optional: "-",
+  range: [
+    13,
+    43,
+  ],
+  readonly: undefined,
+  type: "TSMappedType",
+  typeAnnotation: {
+    range: [
+      33,
+      40,
+    ],
+    type: "TSBooleanKeyword",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        21,
+        28,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          27,
+          28,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            27,
+            28,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        16,
+        17,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      16,
+      28,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSMappedType 7`] = `
+{
+  nameType: null,
+  optional: "+",
+  range: [
+    13,
+    43,
+  ],
+  readonly: undefined,
+  type: "TSMappedType",
+  typeAnnotation: {
+    range: [
+      33,
+      40,
+    ],
+    type: "TSBooleanKeyword",
+  },
+  typeParameter: {
+    const: false,
+    constraint: {
+      operator: "keyof",
+      range: [
+        21,
+        28,
+      ],
+      type: "TSTypeOperator",
+      typeAnnotation: {
+        range: [
+          27,
+          28,
+        ],
+        type: "TSTypeReference",
+        typeArguments: null,
+        typeName: {
+          name: "T",
+          optional: false,
+          range: [
+            27,
+            28,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+      },
+    },
+    default: null,
+    in: false,
+    name: {
+      name: "P",
+      optional: false,
+      range: [
+        16,
+        17,
+      ],
+      type: "Identifier",
+      typeAnnotation: null,
+    },
+    out: false,
+    range: [
+      16,
+      28,
+    ],
+    type: "TSTypeParameter",
+  },
+}
+`;
+
+snapshot[`Plugin - TSLiteralType 1`] = `
+{
+  literal: {
+    range: [
+      10,
+      14,
+    ],
+    raw: "true",
+    type: "Literal",
+    value: true,
+  },
+  range: [
+    10,
+    14,
+  ],
+  type: "TSLiteralType",
+}
+`;
+
+snapshot[`Plugin - TSLiteralType 2`] = `
+{
+  literal: {
+    range: [
+      10,
+      15,
+    ],
+    raw: "false",
+    type: "Literal",
+    value: false,
+  },
+  range: [
+    10,
+    15,
+  ],
+  type: "TSLiteralType",
+}
+`;
+
+snapshot[`Plugin - TSLiteralType 3`] = `
+{
+  literal: {
+    range: [
+      10,
+      11,
+    ],
+    raw: "1",
+    type: "Literal",
+    value: 1,
+  },
+  range: [
+    10,
+    11,
+  ],
+  type: "TSLiteralType",
+}
+`;
+
+snapshot[`Plugin - TSLiteralType 4`] = `
+{
+  literal: {
+    range: [
+      10,
+      15,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
+  },
+  range: [
+    10,
+    15,
+  ],
+  type: "TSLiteralType",
+}
+`;
+
+snapshot[`Plugin - TSTemplateLiteralType 1`] = `
+{
+  quasis: [
+    {
+      cooked: "a ",
+      range: [
+        11,
+        13,
+      ],
+      raw: "a ",
+      tail: false,
+      type: "TemplateElement",
+    },
+    {
+      cooked: "",
+      range: [
+        22,
+        22,
+      ],
+      raw: "",
+      tail: true,
+      type: "TemplateElement",
+    },
+  ],
+  range: [
+    10,
+    23,
+  ],
+  type: "TSTemplateLiteralType",
+  types: [
+    {
+      range: [
+        15,
+        21,
+      ],
+      type: "TSStringKeyword",
+    },
+  ],
+}
+`;
+
+snapshot[`Plugin - TSTupleType + TSArrayType 1`] = `
+{
+  elementTypes: [
+    {
+      range: [
+        11,
+        17,
+      ],
+      type: "TSNumberKeyword",
+    },
+  ],
+  range: [
+    10,
+    18,
+  ],
+  type: "TSTupleType",
+}
+`;
+
+snapshot[`Plugin - TSTupleType + TSArrayType 2`] = `
+{
+  elementTypes: [
+    {
+      elementType: {
+        range: [
+          14,
+          20,
+        ],
+        type: "TSNumberKeyword",
+      },
+      label: {
+        name: "x",
+        optional: false,
+        range: [
+          11,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        11,
+        20,
+      ],
+      type: "TSNamedTupleMember",
+    },
+  ],
+  range: [
+    10,
+    21,
+  ],
+  type: "TSTupleType",
+}
+`;
+
+snapshot[`Plugin - TSTupleType + TSArrayType 3`] = `
+{
+  elementTypes: [
+    {
+      elementType: {
+        range: [
+          14,
+          20,
+        ],
+        type: "TSNumberKeyword",
+      },
+      label: {
+        name: "x",
+        optional: false,
+        range: [
+          11,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: null,
+      },
+      range: [
+        11,
+        20,
+      ],
+      type: "TSNamedTupleMember",
+    },
+  ],
+  range: [
+    10,
+    21,
+  ],
+  type: "TSTupleType",
+}
+`;
+
+snapshot[`Plugin - TSTupleType + TSArrayType 4`] = `
+{
+  elementTypes: [
+    {
+      elementType: {
+        elementType: {
+          range: [
+            17,
+            23,
+          ],
+          type: "TSNumberKeyword",
+        },
+        range: [
+          17,
+          25,
+        ],
+        type: "TSArrayType",
+      },
+      label: {
+        argument: {
+          name: "x",
+          optional: false,
+          range: [
+            14,
+            15,
+          ],
+          type: "Identifier",
+          typeAnnotation: null,
+        },
+        range: [
+          11,
+          16,
+        ],
+        type: "RestElement",
+        typeAnnotation: null,
+      },
+      range: [
+        11,
+        25,
+      ],
+      type: "TSNamedTupleMember",
+    },
+  ],
+  range: [
+    10,
+    26,
+  ],
+  type: "TSTupleType",
+}
+`;
+
+snapshot[`Plugin - TSArrayType 1`] = `
+{
+  elementType: {
+    range: [
+      10,
+      16,
+    ],
+    type: "TSNumberKeyword",
+  },
+  range: [
+    10,
+    18,
+  ],
+  type: "TSArrayType",
+}
+`;
+
+snapshot[`Plugin - TSTypeQuery 1`] = `
+{
+  exprName: {
+    name: "B",
+    optional: false,
+    range: [
+      17,
+      18,
+    ],
+    type: "Identifier",
+    typeAnnotation: null,
+  },
+  range: [
+    10,
+    18,
+  ],
+  type: "TSTypeQuery",
+  typeArguments: null,
+}
+`;
+
+snapshot[`Plugin - TS keywords 1`] = `
+{
+  range: [
+    10,
+    13,
+  ],
+  type: "TSAnyKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 2`] = `
+{
+  range: [
+    10,
+    16,
+  ],
+  type: "TSBigIntKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 3`] = `
+{
+  range: [
+    10,
+    17,
+  ],
+  type: "TSBooleanKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 4`] = `
+{
+  range: [
+    10,
+    19,
+  ],
+  type: "TSIntrinsicKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 5`] = `
+{
+  range: [
+    10,
+    15,
+  ],
+  type: "TSNeverKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 6`] = `
+{
+  range: [
+    10,
+    14,
+  ],
+  type: "TSNullKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 7`] = `
+{
+  range: [
+    10,
+    16,
+  ],
+  type: "TSNumberKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 8`] = `
+{
+  range: [
+    10,
+    16,
+  ],
+  type: "TSObjectKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 9`] = `
+{
+  range: [
+    10,
+    16,
+  ],
+  type: "TSStringKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 10`] = `
+{
+  range: [
+    10,
+    16,
+  ],
+  type: "TSSymbolKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 11`] = `
+{
+  range: [
+    10,
+    19,
+  ],
+  type: "TSUndefinedKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 12`] = `
+{
+  range: [
+    10,
+    17,
+  ],
+  type: "TSUnknownKeyword",
+}
+`;
+
+snapshot[`Plugin - TS keywords 13`] = `
+{
+  range: [
+    10,
+    14,
+  ],
+  type: "TSVoidKeyword",
+}
+`;

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 import { assertEquals } from "./test_util.ts";
+import { assertSnapshot } from "@std/testing/snapshot";
 
 // TODO(@marvinhagemeister) Remove once we land "official" types
 export interface LintReportData {
@@ -103,7 +104,18 @@ function testLintNode(source: string, ...selectors: string[]) {
     },
   });
 
+  assertEquals(log.length > 0, true);
+
   return log;
+}
+
+async function testSnapshot(
+  t: Deno.TestContext,
+  source: string,
+  ...selectors: string[]
+) {
+  const res = testLintNode(source, ...selectors);
+  await assertSnapshot(t, res[0]);
 }
 
 Deno.test("Plugin - visitor enter/exit", () => {
@@ -323,293 +335,153 @@ Deno.test("Plugin - Program", () => {
   });
 });
 
-Deno.test("Plugin - BlockStatement", () => {
-  const node = testLintNode("{ foo; }", "BlockStatement");
-  assertEquals(node[0], {
-    type: "BlockStatement",
-    range: [1, 9],
-    body: [{
-      type: "ExpressionStatement",
-      range: [3, 7],
-      expression: {
-        type: "Identifier",
-        name: "foo",
-        range: [3, 6],
-      },
-    }],
-  });
+Deno.test("Plugin - ImportDeclaration", async (t) => {
+  await testSnapshot(t, 'import "foo";', "ImportDeclaration");
+  await testSnapshot(t, 'import foo from "foo";', "ImportDeclaration");
+  await testSnapshot(t, 'import * as foo from "foo";', "ImportDeclaration");
+  await testSnapshot(
+    t,
+    'import { foo, bar as baz } from "foo";',
+    "ImportDeclaration",
+  );
+  await testSnapshot(
+    t,
+    'import foo from "foo" with { type: "json" };',
+    "ImportDeclaration",
+  );
 });
 
-Deno.test("Plugin - BreakStatement", () => {
-  let node = testLintNode("break;", "BreakStatement");
-  assertEquals(node[0], {
-    type: "BreakStatement",
-    range: [1, 7],
-    label: null,
-  });
-
-  node = testLintNode("break foo;", "BreakStatement");
-  assertEquals(node[0], {
-    type: "BreakStatement",
-    range: [1, 11],
-    label: {
-      type: "Identifier",
-      range: [7, 10],
-      name: "foo",
-    },
-  });
+Deno.test("Plugin - ExportNamedDeclaration", async (t) => {
+  await testSnapshot(t, 'export foo from "foo";', "ExportNamedDeclaration");
+  await testSnapshot(
+    t,
+    'export { foo, bar as baz } from "foo";',
+    "ExportNamedDeclaration",
+  );
+  await testSnapshot(
+    t,
+    'export { foo } from "foo" with { type: "json" };',
+    "ExportNamedDeclaration",
+  );
 });
 
-Deno.test("Plugin - ContinueStatement", () => {
-  let node = testLintNode("continue;", "ContinueStatement");
-  assertEquals(node[0], {
-    type: "ContinueStatement",
-    range: [1, 10],
-    label: null,
-  });
-
-  node = testLintNode("continue foo;", "ContinueStatement");
-  assertEquals(node[0], {
-    type: "ContinueStatement",
-    range: [1, 14],
-    label: {
-      type: "Identifier",
-      range: [10, 13],
-      name: "foo",
-    },
-  });
+Deno.test("Plugin - ExportDefaultDeclaration", async (t) => {
+  await testSnapshot(
+    t,
+    "export default function foo() {}",
+    "ExportDefaultDeclaration",
+  );
+  await testSnapshot(
+    t,
+    "export default function () {}",
+    "ExportDefaultDeclaration",
+  );
+  await testSnapshot(
+    t,
+    "export default class Foo {}",
+    "ExportDefaultDeclaration",
+  );
+  await testSnapshot(
+    t,
+    "export default class {}",
+    "ExportDefaultDeclaration",
+  );
+  await testSnapshot(t, "export default bar;", "ExportDefaultDeclaration");
+  await testSnapshot(
+    t,
+    "export default interface Foo {};",
+    "ExportDefaultDeclaration",
+  );
 });
 
-Deno.test("Plugin - DebuggerStatement", () => {
-  const node = testLintNode("debugger;", "DebuggerStatement");
-  assertEquals(node[0], {
-    type: "DebuggerStatement",
-    range: [1, 10],
-  });
+Deno.test("Plugin - ExportAllDeclaration", async (t) => {
+  await testSnapshot(t, 'export * from "foo";', "ExportAllDeclaration");
+  await testSnapshot(t, 'export * as foo from "foo";', "ExportAllDeclaration");
+  await testSnapshot(
+    t,
+    'export * from "foo" with { type: "json" };',
+    "ExportAllDeclaration",
+  );
 });
 
-Deno.test("Plugin - DoWhileStatement", () => {
-  const node = testLintNode("do {} while (foo);", "DoWhileStatement");
-  assertEquals(node[0], {
-    type: "DoWhileStatement",
-    range: [1, 19],
-    test: {
-      type: "Identifier",
-      range: [14, 17],
-      name: "foo",
-    },
-    body: {
-      type: "BlockStatement",
-      range: [4, 6],
-      body: [],
-    },
-  });
+Deno.test("Plugin - TSExportAssignment", async (t) => {
+  await testSnapshot(t, "export = foo;", "TSExportAssignment");
 });
 
-Deno.test("Plugin - ExpressionStatement", () => {
-  const node = testLintNode("foo;", "ExpressionStatement");
-  assertEquals(node[0], {
-    type: "ExpressionStatement",
-    range: [1, 5],
-    expression: {
-      type: "Identifier",
-      range: [1, 4],
-      name: "foo",
-    },
-  });
+Deno.test("Plugin - TSNamespaceExportDeclaration", async (t) => {
+  await testSnapshot(
+    t,
+    "export as namespace A;",
+    "TSNamespaceExportDeclaration",
+  );
 });
 
-Deno.test("Plugin - ForInStatement", () => {
-  const node = testLintNode("for (a in b) {}", "ForInStatement");
-  assertEquals(node[0], {
-    type: "ForInStatement",
-    range: [1, 16],
-    left: {
-      type: "Identifier",
-      range: [6, 7],
-      name: "a",
-    },
-    right: {
-      type: "Identifier",
-      range: [11, 12],
-      name: "b",
-    },
-    body: {
-      type: "BlockStatement",
-      range: [14, 16],
-      body: [],
-    },
-  });
+Deno.test("Plugin - TSImportEqualsDeclaration", async (t) => {
+  await testSnapshot(t, "import a = b", "TSImportEqualsDeclaration");
+  await testSnapshot(
+    t,
+    'import a = require("foo")',
+    "TSImportEqualsDeclaration",
+  );
 });
 
-Deno.test("Plugin - ForOfStatement", () => {
-  let node = testLintNode("for (a of b) {}", "ForOfStatement");
-  assertEquals(node[0], {
-    type: "ForOfStatement",
-    range: [1, 16],
-    await: false,
-    left: {
-      type: "Identifier",
-      range: [6, 7],
-      name: "a",
-    },
-    right: {
-      type: "Identifier",
-      range: [11, 12],
-      name: "b",
-    },
-    body: {
-      type: "BlockStatement",
-      range: [14, 16],
-      body: [],
-    },
-  });
-
-  node = testLintNode("for await (a of b) {}", "ForOfStatement");
-  assertEquals(node[0], {
-    type: "ForOfStatement",
-    range: [1, 22],
-    await: true,
-    left: {
-      type: "Identifier",
-      range: [12, 13],
-      name: "a",
-    },
-    right: {
-      type: "Identifier",
-      range: [17, 18],
-      name: "b",
-    },
-    body: {
-      type: "BlockStatement",
-      range: [20, 22],
-      body: [],
-    },
-  });
+Deno.test("Plugin - BlockStatement", async (t) => {
+  await testSnapshot(t, "{ foo; }", "BlockStatement");
 });
 
-Deno.test("Plugin - ForStatement", () => {
-  let node = testLintNode("for (;;) {}", "ForStatement");
-  assertEquals(node[0], {
-    type: "ForStatement",
-    range: [1, 12],
-    init: null,
-    test: null,
-    update: null,
-    body: {
-      type: "BlockStatement",
-      range: [10, 12],
-      body: [],
-    },
-  });
-
-  node = testLintNode("for (a; b; c) {}", "ForStatement");
-  assertEquals(node[0], {
-    type: "ForStatement",
-    range: [1, 17],
-    init: {
-      type: "Identifier",
-      range: [6, 7],
-      name: "a",
-    },
-    test: {
-      type: "Identifier",
-      range: [9, 10],
-      name: "b",
-    },
-    update: {
-      type: "Identifier",
-      range: [12, 13],
-      name: "c",
-    },
-    body: {
-      type: "BlockStatement",
-      range: [15, 17],
-      body: [],
-    },
-  });
+Deno.test("Plugin - BreakStatement", async (t) => {
+  await testSnapshot(t, "break;", "BreakStatement");
+  await testSnapshot(t, "break foo;", "BreakStatement");
 });
 
-Deno.test("Plugin - IfStatement", () => {
-  let node = testLintNode("if (foo) {}", "IfStatement");
-  assertEquals(node[0], {
-    type: "IfStatement",
-    range: [1, 12],
-    test: {
-      type: "Identifier",
-      name: "foo",
-      range: [5, 8],
-    },
-    consequent: {
-      type: "BlockStatement",
-      range: [10, 12],
-      body: [],
-    },
-    alternate: null,
-  });
-
-  node = testLintNode("if (foo) {} else {}", "IfStatement");
-  assertEquals(node[0], {
-    type: "IfStatement",
-    range: [1, 20],
-    test: {
-      type: "Identifier",
-      name: "foo",
-      range: [5, 8],
-    },
-    consequent: {
-      type: "BlockStatement",
-      range: [10, 12],
-      body: [],
-    },
-    alternate: {
-      type: "BlockStatement",
-      range: [18, 20],
-      body: [],
-    },
-  });
+Deno.test("Plugin - ContinueStatement", async (t) => {
+  await testSnapshot(t, "continue;", "ContinueStatement");
+  await testSnapshot(t, "continue foo;", "ContinueStatement");
 });
 
-Deno.test("Plugin - LabeledStatement", () => {
-  const node = testLintNode("foo: {};", "LabeledStatement");
-  assertEquals(node[0], {
-    type: "LabeledStatement",
-    range: [1, 8],
-    label: {
-      type: "Identifier",
-      name: "foo",
-      range: [1, 4],
-    },
-    body: {
-      type: "BlockStatement",
-      range: [6, 8],
-      body: [],
-    },
-  });
+Deno.test("Plugin - DebuggerStatement", async (t) => {
+  await testSnapshot(t, "debugger;", "DebuggerStatement");
 });
 
-Deno.test("Plugin - ReturnStatement", () => {
-  let node = testLintNode("return", "ReturnStatement");
-  assertEquals(node[0], {
-    type: "ReturnStatement",
-    range: [1, 7],
-    argument: null,
-  });
-
-  node = testLintNode("return foo;", "ReturnStatement");
-  assertEquals(node[0], {
-    type: "ReturnStatement",
-    range: [1, 12],
-    argument: {
-      type: "Identifier",
-      name: "foo",
-      range: [8, 11],
-    },
-  });
+Deno.test("Plugin - DoWhileStatement", async (t) => {
+  await testSnapshot(t, "do {} while (foo);", "DoWhileStatement");
 });
 
-Deno.test("Plugin - SwitchStatement", () => {
-  const node = testLintNode(
+Deno.test("Plugin - ExpressionStatement", async (t) => {
+  await testSnapshot(t, "foo;", "ExpressionStatement");
+});
+
+Deno.test("Plugin - ForInStatement", async (t) => {
+  await testSnapshot(t, "for (a in b) {}", "ForInStatement");
+});
+
+Deno.test("Plugin - ForOfStatement", async (t) => {
+  await testSnapshot(t, "for (a of b) {}", "ForOfStatement");
+  await testSnapshot(t, "for await (a of b) {}", "ForOfStatement");
+});
+
+Deno.test("Plugin - ForStatement", async (t) => {
+  await testSnapshot(t, "for (;;) {}", "ForStatement");
+  await testSnapshot(t, "for (a; b; c) {}", "ForStatement");
+});
+
+Deno.test("Plugin - IfStatement", async (t) => {
+  await testSnapshot(t, "if (foo) {}", "IfStatement");
+  await testSnapshot(t, "if (foo) {} else {}", "IfStatement");
+});
+
+Deno.test("Plugin - LabeledStatement", async (t) => {
+  await testSnapshot(t, "foo: {};", "LabeledStatement");
+});
+
+Deno.test("Plugin - ReturnStatement", async (t) => {
+  await testSnapshot(t, "return", "ReturnStatement");
+  await testSnapshot(t, "return foo;", "ReturnStatement");
+});
+
+Deno.test("Plugin - SwitchStatement", async (t) => {
+  await testSnapshot(
+    t,
     `switch (foo) {
       case foo:
       case bar:
@@ -619,151 +491,439 @@ Deno.test("Plugin - SwitchStatement", () => {
     }`,
     "SwitchStatement",
   );
-  assertEquals(node[0], {
-    type: "SwitchStatement",
-    range: [1, 94],
-    discriminant: {
-      type: "Identifier",
-      range: [9, 12],
-      name: "foo",
-    },
-    cases: [
-      {
-        type: "SwitchCase",
-        range: [22, 31],
-        test: {
-          type: "Identifier",
-          range: [27, 30],
-          name: "foo",
-        },
-        consequent: [],
-      },
-      {
-        type: "SwitchCase",
-        range: [38, 62],
-        test: {
-          type: "Identifier",
-          range: [43, 46],
-          name: "bar",
-        },
-        consequent: [
-          {
-            type: "BreakStatement",
-            label: null,
-            range: [56, 62],
-          },
-        ],
-      },
-      {
-        type: "SwitchCase",
-        range: [69, 88],
-        test: null,
-        consequent: [
-          {
-            type: "BlockStatement",
-            range: [86, 88],
-            body: [],
-          },
-        ],
-      },
-    ],
-  });
 });
 
-Deno.test("Plugin - ThrowStatement", () => {
-  const node = testLintNode("throw foo;", "ThrowStatement");
-  assertEquals(node[0], {
-    type: "ThrowStatement",
-    range: [1, 11],
-    argument: {
-      type: "Identifier",
-      range: [7, 10],
-      name: "foo",
-    },
-  });
+Deno.test("Plugin - ThrowStatement", async (t) => {
+  await testSnapshot(t, "throw foo;", "ThrowStatement");
 });
 
-Deno.test("Plugin - TryStatement", () => {
-  let node = testLintNode("try {} catch {};", "TryStatement");
-  assertEquals(node[0], {
-    type: "TryStatement",
-    range: [1, 16],
-    block: {
-      type: "BlockStatement",
-      range: [5, 7],
-      body: [],
-    },
-    handler: {
-      type: "CatchClause",
-      range: [8, 16],
-      param: null,
-      body: {
-        type: "BlockStatement",
-        range: [14, 16],
-        body: [],
-      },
-    },
-    finalizer: null,
-  });
-
-  node = testLintNode("try {} catch (e) {};", "TryStatement");
-  assertEquals(node[0], {
-    type: "TryStatement",
-    range: [1, 20],
-    block: {
-      type: "BlockStatement",
-      range: [5, 7],
-      body: [],
-    },
-    handler: {
-      type: "CatchClause",
-      range: [8, 20],
-      param: {
-        type: "Identifier",
-        range: [15, 16],
-        name: "e",
-      },
-      body: {
-        type: "BlockStatement",
-        range: [18, 20],
-        body: [],
-      },
-    },
-    finalizer: null,
-  });
-
-  node = testLintNode("try {} finally {};", "TryStatement");
-  assertEquals(node[0], {
-    type: "TryStatement",
-    range: [1, 18],
-    block: {
-      type: "BlockStatement",
-      range: [5, 7],
-      body: [],
-    },
-    handler: null,
-    finalizer: {
-      type: "BlockStatement",
-      range: [16, 18],
-      body: [],
-    },
-  });
+Deno.test("Plugin - TryStatement", async (t) => {
+  await testSnapshot(t, "try {} catch {};", "TryStatement");
+  await testSnapshot(t, "try {} catch (e) {};", "TryStatement");
+  await testSnapshot(t, "try {} finally {};", "TryStatement");
 });
 
-Deno.test("Plugin - WhileStatement", () => {
-  const node = testLintNode("while (foo) {}", "WhileStatement");
-  assertEquals(node[0], {
-    type: "WhileStatement",
-    range: [1, 15],
-    test: {
-      type: "Identifier",
-      range: [8, 11],
-      name: "foo",
-    },
-    body: {
-      type: "BlockStatement",
-      range: [13, 15],
-      body: [],
-    },
-  });
+Deno.test("Plugin - WhileStatement", async (t) => {
+  await testSnapshot(t, "while (foo) {}", "WhileStatement");
+});
+
+Deno.test("Plugin - WithStatement", async (t) => {
+  await testSnapshot(t, "with ([]) {}", "WithStatement");
+});
+
+Deno.test("Plugin - ArrayExpression", async (t) => {
+  await testSnapshot(t, "[[],,[]]", "ArrayExpression");
+});
+
+Deno.test("Plugin - ArrowFunctionExpression", async (t) => {
+  await testSnapshot(t, "() => {}", "ArrowFunctionExpression");
+  await testSnapshot(t, "async () => {}", "ArrowFunctionExpression");
+  await testSnapshot(
+    t,
+    "(a: number, ...b: any[]): any => {}",
+    "ArrowFunctionExpression",
+  );
+});
+
+Deno.test("Plugin - AssignmentExpression", async (t) => {
+  await testSnapshot(t, "a = b", "AssignmentExpression");
+  await testSnapshot(t, "a = a ??= b", "AssignmentExpression");
+});
+
+Deno.test("Plugin - AwaitExpression", async (t) => {
+  await testSnapshot(t, "await foo;", "AwaitExpression");
+});
+
+Deno.test("Plugin - BinaryExpression", async (t) => {
+  await testSnapshot(t, "a > b", "BinaryExpression");
+  await testSnapshot(t, "a >= b", "BinaryExpression");
+  await testSnapshot(t, "a < b", "BinaryExpression");
+  await testSnapshot(t, "a <= b", "BinaryExpression");
+  await testSnapshot(t, "a == b", "BinaryExpression");
+  await testSnapshot(t, "a === b", "BinaryExpression");
+  await testSnapshot(t, "a != b", "BinaryExpression");
+  await testSnapshot(t, "a !== b", "BinaryExpression");
+  await testSnapshot(t, "a << b", "BinaryExpression");
+  await testSnapshot(t, "a >> b", "BinaryExpression");
+  await testSnapshot(t, "a >>> b", "BinaryExpression");
+  await testSnapshot(t, "a + b", "BinaryExpression");
+  await testSnapshot(t, "a - b", "BinaryExpression");
+  await testSnapshot(t, "a * b", "BinaryExpression");
+  await testSnapshot(t, "a / b", "BinaryExpression");
+  await testSnapshot(t, "a % b", "BinaryExpression");
+  await testSnapshot(t, "a | b", "BinaryExpression");
+  await testSnapshot(t, "a ^ b", "BinaryExpression");
+  await testSnapshot(t, "a & b", "BinaryExpression");
+  await testSnapshot(t, "a in b", "BinaryExpression");
+  await testSnapshot(t, "a ** b", "BinaryExpression");
+});
+
+Deno.test("Plugin - CallExpression", async (t) => {
+  await testSnapshot(t, "foo();", "CallExpression");
+  await testSnapshot(t, "foo(a, ...b);", "CallExpression");
+  await testSnapshot(t, "foo?.();", "CallExpression");
+  await testSnapshot(t, "foo<T>();", "CallExpression");
+});
+
+Deno.test("Plugin - ChainExpression", async (t) => {
+  const node = testLintNode("a?.b", "ChainExpression");
+  await assertSnapshot(t, node[0]);
+});
+
+Deno.test("Plugin - ClassExpression", async (t) => {
+  await testSnapshot(t, "a = class {}", "ClassExpression");
+  await testSnapshot(t, "a = class Foo {}", "ClassExpression");
+  await testSnapshot(t, "a = class Foo extends Bar {}", "ClassExpression");
+  await testSnapshot(
+    t,
+    "a = class Foo extends Bar implements Baz, Baz2 {}",
+    "ClassExpression",
+  );
+  await testSnapshot(t, "a = class Foo<T> {}", "ClassExpression");
+  await testSnapshot(t, "a = class { foo() {} }", "ClassExpression");
+  await testSnapshot(t, "a = class { #foo() {} }", "ClassExpression");
+  await testSnapshot(t, "a = class { foo: number }", "ClassExpression");
+  await testSnapshot(t, "a = class { foo = bar }", "ClassExpression");
+  await testSnapshot(
+    t,
+    "a = class { constructor(public foo: string) {} }",
+    "ClassExpression",
+  );
+  await testSnapshot(t, "a = class { #foo: number = bar }", "ClassExpression");
+  await testSnapshot(t, "a = class { static foo = bar }", "ClassExpression");
+  await testSnapshot(
+    t,
+    "a = class { static foo; static { foo = bar } }",
+    "ClassExpression",
+  );
+});
+
+Deno.test("Plugin - ConditionalExpression", async (t) => {
+  await testSnapshot(t, "a ? b : c", "ConditionalExpression");
+});
+
+Deno.test("Plugin - FunctionExpression", async (t) => {
+  await testSnapshot(t, "a = function () {}", "FunctionExpression");
+  await testSnapshot(t, "a = function foo() {}", "FunctionExpression");
+  await testSnapshot(
+    t,
+    "a = function (a?: number, ...b: any[]): any {}",
+    "FunctionExpression",
+  );
+  await testSnapshot(t, "a = async function* () {}", "FunctionExpression");
+});
+
+Deno.test("Plugin - Identifier", async (t) => {
+  await testSnapshot(t, "a", "Identifier");
+});
+
+Deno.test("Plugin - ImportExpression", async (t) => {
+  await testSnapshot(
+    t,
+    "import('foo', { with: { type: 'json' }}",
+    "ImportExpression",
+  );
+});
+
+Deno.test("Plugin - LogicalExpression", async (t) => {
+  await testSnapshot(t, "a && b", "LogicalExpression");
+  await testSnapshot(t, "a || b", "LogicalExpression");
+  await testSnapshot(t, "a ?? b", "LogicalExpression");
+});
+
+Deno.test("Plugin - MemberExpression", async (t) => {
+  await testSnapshot(t, "a.b", "MemberExpression");
+  await testSnapshot(t, "a['b']", "MemberExpression");
+});
+
+Deno.test("Plugin - MetaProp", async (t) => {
+  await testSnapshot(t, "import.meta", "MetaProp");
+});
+
+Deno.test("Plugin - NewExpression", async (t) => {
+  await testSnapshot(t, "new Foo()", "NewExpression");
+  await testSnapshot(t, "new Foo(a?: any, ...b: any[])", "NewExpression");
+});
+
+Deno.test("Plugin - ObjectExpression", async (t) => {
+  await testSnapshot(t, "{}", "ObjectExpression");
+  await testSnapshot(t, "{ a, b: c, [c]: d }", "ObjectExpression");
+});
+
+Deno.test("Plugin - PrivateIdentifier", async (t) => {
+  await testSnapshot(t, "class Foo { #foo = foo }", "PrivateIdentifier");
+});
+
+Deno.test("Plugin - SequenceExpression", async (t) => {
+  await testSnapshot(t, "(a, b)", "SequenceExpression");
+});
+
+Deno.test("Plugin - Super", async (t) => {
+  await testSnapshot(
+    t,
+    "class Foo extends Bar { constructor() { super(); } }",
+    "Super",
+  );
+});
+
+Deno.test("Plugin - TaggedTemplateExpression", async (t) => {
+  await testSnapshot(t, "foo`foo ${bar} baz`", "TaggedTemplateExpression");
+});
+
+Deno.test("Plugin - TemplateLiteral", async (t) => {
+  await testSnapshot(t, "`foo ${bar} baz`", "TemplateLiteral");
+});
+
+Deno.test("Plugin - ThisExpression", async (t) => {
+  await testSnapshot(t, "this", "ThisExpression");
+});
+
+Deno.test("Plugin - TSAsExpression", async (t) => {
+  await testSnapshot(t, "a as b", "TSAsExpression");
+  await testSnapshot(t, "a as const", "TSAsExpression");
+});
+
+Deno.test("Plugin - TSNonNullExpression", async (t) => {
+  const node = testLintNode("a!", "TSNonNullExpression");
+  await assertSnapshot(t, node[0]);
+});
+
+Deno.test("Plugin - TSSatisfiesExpression", async (t) => {
+  await testSnapshot(t, "a satisfies b", "TSSatisfiesExpression");
+});
+
+Deno.test("Plugin - UnaryExpression", async (t) => {
+  await testSnapshot(t, "typeof a", "UnaryExpression");
+  await testSnapshot(t, "void 0", "UnaryExpression");
+  await testSnapshot(t, "-a", "UnaryExpression");
+  await testSnapshot(t, "+a", "UnaryExpression");
+});
+
+Deno.test("Plugin - UpdateExpression", async (t) => {
+  await testSnapshot(t, "a++", "UpdateExpression");
+  await testSnapshot(t, "++a", "UpdateExpression");
+  await testSnapshot(t, "a--", "UpdateExpression");
+  await testSnapshot(t, "--a", "UpdateExpression");
+});
+
+Deno.test("Plugin - YieldExpression", async (t) => {
+  await testSnapshot(t, "function* foo() { yield bar; }", "YieldExpression");
+});
+
+Deno.test("Plugin - Literal", async (t) => {
+  await testSnapshot(t, "1", "Literal");
+  await testSnapshot(t, "'foo'", "Literal");
+  await testSnapshot(t, '"foo"', "Literal");
+  await testSnapshot(t, "true", "Literal");
+  await testSnapshot(t, "false", "Literal");
+  await testSnapshot(t, "null", "Literal");
+  await testSnapshot(t, "1n", "Literal");
+  await testSnapshot(t, "/foo/g", "Literal");
+});
+
+Deno.test("Plugin - JSXElement + JSXOpeningElement + JSXClosingElement + JSXAttr", async (t) => {
+  await testSnapshot(t, "<div />", "JSXElement");
+  await testSnapshot(t, "<div></div>", "JSXElement");
+  await testSnapshot(t, "<div a></div>", "JSXElement");
+  await testSnapshot(t, '<div a="b" />', "JSXElement");
+  await testSnapshot(t, "<div a={2} />", "JSXElement");
+  await testSnapshot(t, "<div>foo{2}</div>", "JSXElement");
+  await testSnapshot(t, "<a.b />", "JSXElement");
+  await testSnapshot(t, "<div a:b={2} />", "JSXElement");
+  await testSnapshot(t, "<Foo />", "JSXElement");
+  await testSnapshot(t, "<Foo<T> />", "JSXElement");
+});
+
+Deno.test("Plugin - JSXFragment + JSXOpeningFragment + JSXClosingFragment", async (t) => {
+  await testSnapshot(t, "<></>", "JSXFragment");
+  await testSnapshot(t, "<>foo{2}</>", "JSXFragment");
+});
+
+Deno.test("Plugin - TSAsExpression", async (t) => {
+  await testSnapshot(t, "a as any", "TSAsExpression");
+  await testSnapshot(t, '"foo" as const', "TSAsExpression");
+});
+
+Deno.test("Plugin - TSEnumDeclaration", async (t) => {
+  await testSnapshot(t, "enum Foo {}", "TSEnumDeclaration");
+  await testSnapshot(t, "const enum Foo {}", "TSEnumDeclaration");
+  await testSnapshot(t, "enum Foo { A, B }", "TSEnumDeclaration");
+  await testSnapshot(t, 'enum Foo { "a-b" }', "TSEnumDeclaration");
+  await testSnapshot(
+    t,
+    "enum Foo { A = 1, B = 2, C = A | B }",
+    "TSEnumDeclaration",
+  );
+});
+
+Deno.test("Plugin - TSInterface", async (t) => {
+  await testSnapshot(t, "interface A {}", "TSInterface");
+  await testSnapshot(t, "interface A<T> {}", "TSInterface");
+  await testSnapshot(t, "interface A extends Foo<T>, Bar<T> {}", "TSInterface");
+  await testSnapshot(t, "interface A { foo: any, bar?: any }", "TSInterface");
+  await testSnapshot(
+    t,
+    "interface A { readonly [key: string]: any }",
+    "TSInterface",
+  );
+
+  await testSnapshot(t, "interface A { readonly a: any }", "TSInterface");
+  await testSnapshot(t, "interface A { <T>(a: T): T }", "TSInterface");
+  await testSnapshot(t, "interface A { new <T>(a: T): T }", "TSInterface");
+  await testSnapshot(t, "interface A { a: new <T>(a: T) => T }", "TSInterface");
+  await testSnapshot(t, "interface A { get a(): string }", "TSInterface");
+  await testSnapshot(t, "interface A { set a(v: string) }", "TSInterface");
+
+  await testSnapshot(
+    t,
+    "interface A { a<T>(arg?: any, ...args: any[]): any",
+    "TSInterface",
+  );
+});
+
+Deno.test("Plugin - TSSatisfiesExpression", async (t) => {
+  await testSnapshot(t, "{} satisfies A", "TSSatisfiesExpression");
+});
+
+Deno.test("Plugin - TSTypeAliasDeclaration", async (t) => {
+  await testSnapshot(t, "type A = any", "TSTypeAliasDeclaration");
+  await testSnapshot(t, "type A<T> = any", "TSTypeAliasDeclaration");
+  await testSnapshot(t, "declare type A<T> = any", "TSTypeAliasDeclaration");
+});
+
+Deno.test("Plugin - TSNonNullExpression", async (t) => {
+  await testSnapshot(t, "a!", "TSNonNullExpression");
+});
+
+Deno.test("Plugin - TSUnionType", async (t) => {
+  await testSnapshot(t, "type A = B | C", "TSUnionType");
+});
+
+Deno.test("Plugin - TSIntersectionType", async (t) => {
+  await testSnapshot(t, "type A = B & C", "TSIntersectionType");
+});
+
+Deno.test("Plugin - TSModuleDeclaration", async (t) => {
+  await testSnapshot(t, "module A;", "TSModuleDeclaration");
+  await testSnapshot(
+    t,
+    "declare module A { export function A(): void }",
+    "TSModuleDeclaration",
+  );
+});
+
+Deno.test("Plugin - TSModuleDeclaration + TSModuleBlock", async (t) => {
+  await testSnapshot(t, "module A {}", "TSModuleDeclaration");
+  await testSnapshot(
+    t,
+    "namespace A { namespace B {} }",
+    "TSModuleDeclaration",
+  );
+});
+
+Deno.test("Plugin - TSQualifiedName", async (t) => {
+  await testSnapshot(t, "type A = a.b;", "TSQualifiedName");
+  await testSnapshot(
+    t,
+    "declare module A { export function A(): void }",
+    "TSQualifiedName",
+  );
+});
+
+Deno.test("Plugin - TSTypeLiteral", async (t) => {
+  await testSnapshot(t, "type A = { a: 1 };", "TSTypeLiteral");
+});
+
+Deno.test("Plugin - TSOptionalType", async (t) => {
+  await testSnapshot(t, "type A = [number?]", "TSOptionalType");
+});
+
+Deno.test("Plugin - TSRestType", async (t) => {
+  await testSnapshot(t, "type A = [...number[]]", "TSRestType");
+});
+
+Deno.test("Plugin - TSConditionalType", async (t) => {
+  await testSnapshot(
+    t,
+    "type A = B extends C ? number : string;",
+    "TSConditionalType",
+  );
+});
+
+Deno.test("Plugin - TSInferType", async (t) => {
+  await testSnapshot(
+    t,
+    "type A<T> = T extends Array<infer Item> ? Item : T;",
+    "TSInferType",
+  );
+});
+
+Deno.test("Plugin - TSTypeOperator", async (t) => {
+  await testSnapshot(t, "type A = keyof B", "TSTypeOperator");
+  await testSnapshot(t, "declare const sym1: unique symbol;", "TSTypeOperator");
+  await testSnapshot(t, "type A = readonly []", "TSTypeOperator");
+});
+
+Deno.test("Plugin - TSMappedType", async (t) => {
+  await testSnapshot(
+    t,
+    "type A<T> = { [P in keyof T]: boolean; };",
+    "TSMappedType",
+  );
+  await testSnapshot(
+    t,
+    "type A<T> = { readonly [P in keyof T]: []; };",
+    "TSMappedType",
+  );
+  await testSnapshot(
+    t,
+    "type A<T> = { -readonly [P in keyof T]: []; };",
+    "TSMappedType",
+  );
+  await testSnapshot(
+    t,
+    "type A<T> = { +readonly [P in keyof T]: []; };",
+    "TSMappedType",
+  );
+  await testSnapshot(
+    t,
+    "type A<T> = { [P in keyof T]?: boolean; };",
+    "TSMappedType",
+  );
+  await testSnapshot(
+    t,
+    "type A<T> = { [P in keyof T]-?: boolean; };",
+    "TSMappedType",
+  );
+  await testSnapshot(
+    t,
+    "type A<T> = { [P in keyof T]+?: boolean; };",
+    "TSMappedType",
+  );
+});
+
+Deno.test("Plugin - TSLiteralType", async (t) => {
+  await testSnapshot(t, "type A = true", "TSLiteralType");
+  await testSnapshot(t, "type A = false", "TSLiteralType");
+  await testSnapshot(t, "type A = 1", "TSLiteralType");
+  await testSnapshot(t, "type A = 'foo''", "TSLiteralType");
+});
+
+Deno.test("Plugin - TSTemplateLiteralType", async (t) => {
+  await testSnapshot(
+    t,
+    "type A<B extends string> = `a ${B}`",
+    "TSTemplateLiteralType",
+  );
+});
+
+Deno.test("Plugin - TSTupleType + TSArrayType", async (t) => {
+  await testSnapshot(t, "type A = [number]", "TSTupleType");
+  await testSnapshot(t, "type A = [x: number]", "TSTupleType");
+  await testSnapshot(t, "type A = [x: number]", "TSTupleType");
+  await testSnapshot(t, "type A = [...x: number[]]", "TSTupleType");
+});
+
+Deno.test("Plugin - TSTypeQuery", async (t) => {
+  await testSnapshot(t, "type A = typeof B", "TSTupleType");
 });


### PR DESCRIPTION
This PR changes the underlying buffer backed AST format we use for JavaScript-based linting plugins. It adds support for various new types, makes traversal code a lot easier and is more polished compared to previous iterations.

Here is a quick summary (in no particular order):

- Node prop data is separate from traversal, which makes traversal code so much easier to reason about. Previously, it was interleaved with node prop data
- spans are in a separate table as well, as they are rarely needed.
- schema is separate from SWC conversion logic, which makes 
- supports recursive plain objects
- supports numbers
- supports bigint
- supports regex
- adds all SWC nodes

Apologies, this is kinda a big PR, but it's worth it imo.

_Marking as draft because I need to update some tests tomorrow._