### PR TITLE
fix(lsp/check): don't resolve unknown media types to a `.js` extension

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4513,7 +4513,7 @@ fn op_resolve(
   state: &mut OpState,
   #[string] base: String,
   #[serde] specifiers: Vec<(bool, String)>,
-) -> Result<Vec<Option<(String, String)>>, deno_core::url::ParseError> {
+) -> Result<Vec<Option<(String, Option<String>)>>, deno_core::url::ParseError> {
   op_resolve_inner(state, ResolveArgs { base, specifiers })
 }
 
@@ -4598,7 +4598,7 @@ async fn op_poll_requests(
 fn op_resolve_inner(
   state: &mut OpState,
   args: ResolveArgs,
-) -> Result<Vec<Option<(String, String)>>, deno_core::url::ParseError> {
+) -> Result<Vec<Option<(String, Option<String>)>>, deno_core::url::ParseError> {
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark_with_args("tsc.op.op_resolve", &args);
   let referrer = state.specifier_map.normalize(&args.base)?;
@@ -4611,7 +4611,11 @@ fn op_resolve_inner(
       o.map(|(s, mt)| {
         (
           state.specifier_map.denormalize(&s),
-          mt.as_ts_extension().to_string(),
+          if matches!(mt, MediaType::Unknown) {
+            None
+          } else {
+            Some(mt.as_ts_extension().to_string())
+          },
         )
       })
     })
@@ -6461,7 +6465,7 @@ mod tests {
       resolved,
       vec![Some((
         temp_dir.url().join("b.ts").unwrap().to_string(),
-        MediaType::TypeScript.as_ts_extension().to_string()
+        Some(MediaType::TypeScript.as_ts_extension().to_string())
       ))]
     );
   }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4509,6 +4509,7 @@ fn op_release(
 
 #[op2]
 #[serde]
+#[allow(clippy::type_complexity)]
 fn op_resolve(
   state: &mut OpState,
   #[string] base: String,
@@ -4595,6 +4596,7 @@ async fn op_poll_requests(
 }
 
 #[inline]
+#[allow(clippy::type_complexity)]
 fn op_resolve_inner(
   state: &mut OpState,
   args: ResolveArgs,

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -723,7 +723,7 @@ delete Object.prototype.__proto__;
           }
           : arg;
         if (fileReference.fileName.startsWith("npm:")) {
-          /** @type {[string, ts.Extension] | undefined} */
+          /** @type {[string, ts.Extension | null] | undefined} */
           const resolved = ops.op_resolve(
             containingFilePath,
             [
@@ -735,7 +735,7 @@ delete Object.prototype.__proto__;
               ],
             ],
           )?.[0];
-          if (resolved) {
+          if (resolved && resolved[1]) {
             return {
               resolvedTypeReferenceDirective: {
                 primary: true,
@@ -785,7 +785,7 @@ delete Object.prototype.__proto__;
         debug(`  base: ${base}`);
         debug(`  specifiers: ${specifiers.map((s) => s[1]).join(", ")}`);
       }
-      /** @type {Array<[string, ts.Extension] | undefined>} */
+      /** @type {Array<[string, ts.Extension | null] | undefined>} */
       const resolved = ops.op_resolve(
         base,
         specifiers,
@@ -793,7 +793,7 @@ delete Object.prototype.__proto__;
       if (resolved) {
         /** @type {Array<ts.ResolvedModuleWithFailedLookupLocations>} */
         const result = resolved.map((item) => {
-          if (item) {
+          if (item && item[1]) {
             const [resolvedFileName, extension] = item;
             return {
               resolvedModule: {

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1442,7 +1442,10 @@ mod tests {
       },
     )
     .expect("should have invoked op");
-    assert_eq!(actual, vec![("https://deno.land/x/b.ts".into(), ".ts")]);
+    assert_eq!(
+      actual,
+      vec![("https://deno.land/x/b.ts".into(), Some(".ts"))]
+    );
   }
 
   #[tokio::test]
@@ -1461,7 +1464,10 @@ mod tests {
       },
     )
     .expect("should have not errored");
-    assert_eq!(actual, vec![(MISSING_DEPENDENCY_SPECIFIER.into(), ".d.ts")]);
+    assert_eq!(
+      actual,
+      vec![(MISSING_DEPENDENCY_SPECIFIER.into(), Some(".d.ts"))]
+    );
   }
 
   #[tokio::test]


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/25762. Note that some of the things in that issue are not resolved (vite/client types not working properly which has other root causes), but the wildcard module augmentation specifically is fixed by this.

We were telling TSC that files with unknown media types had an extension of `.js`, so the ambient module declarations weren't applying. Instead, just don't resolve them, so the ambient declaration applies.