### PR TITLE
fix(check): ignore errors on ambient modules

### DIFF
--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -295,6 +295,9 @@ impl TypeChecker {
       check_mode: type_check_mode,
     })?;
 
+    eprintln!("Ambient modules: {:?}", response.ambient_modules);
+    panic!("STOP"); // prevent saving the type checker cache
+
     let response_diagnostics =
       response.diagnostics.filter(filter_remote_diagnostics);
 

--- a/cli/tsc/99_main_compiler.js
+++ b/cli/tsc/99_main_compiler.js
@@ -410,6 +410,7 @@ delete Object.prototype.__proto__;
     }
     if (start !== undefined && length !== undefined && file) {
       let startPos = file.getLineAndCharacterOfPosition(start);
+      /** @type {string | undefined} */
       let sourceLine = file.getFullText().split("\n")[startPos.line];
       const originalFileName = file.fileName;
       const fileName = ops.op_remap_specifier
@@ -1104,8 +1105,10 @@ delete Object.prototype.__proto__;
 
     performanceProgram({ program });
 
+    const checker = program.getProgram().getTypeChecker();
     ops.op_respond({
       diagnostics: fromTypeScriptDiagnostics(diagnostics),
+      ambientModules: checker.getAmbientModules().map((symbol) => symbol.name),
       stats: performanceEnd(),
     });
     debug("<<< exec stop");


### PR DESCRIPTION
This is for `deno check` only and not for the LSP.

Todo:

- [ ] Surface these deno_graph errors as type checking diagnostics when not found in the list of ambient modules
- [ ] Ensure that these errors are still raised at runtime