### PR TITLE
fix(runtime): handling the error in the child process

### DIFF
--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -299,17 +299,16 @@ class ChildProcess {
     try {
       const onAbort = () => this.kill("SIGTERM");
       signal?.[abortSignal.add](onAbort);
+      const waitPromise = op_spawn_wait(this.#rid);
+      this.#waitPromise = waitPromise;
+      this.#status = PromisePrototypeThen(waitPromise, (res) => {
+        signal?.[abortSignal.remove](onAbort);
+        this.#waitComplete = true;
+        return res;
+      });
     } catch (e) {
       void e;
     }
-
-    const waitPromise = op_spawn_wait(this.#rid);
-    this.#waitPromise = waitPromise;
-    this.#status = PromisePrototypeThen(waitPromise, (res) => {
-      signal?.[abortSignal.remove](onAbort);
-      this.#waitComplete = true;
-      return res;
-    });
   }
 
   #status;

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -296,8 +296,12 @@ class ChildProcess {
       this.#stderr = readableStreamForRidUnrefable(stderrRid);
     }
 
-    const onAbort = () => this.kill("SIGTERM");
-    signal?.[abortSignal.add](onAbort);
+    try {
+      const onAbort = () => this.kill("SIGTERM");
+      signal?.[abortSignal.add](onAbort);
+    } catch (TypeError) {
+      throw new TypeError("Child process has already terminated");
+    }
 
     const waitPromise = op_spawn_wait(this.#rid);
     this.#waitPromise = waitPromise;

--- a/runtime/js/40_process.js
+++ b/runtime/js/40_process.js
@@ -299,8 +299,8 @@ class ChildProcess {
     try {
       const onAbort = () => this.kill("SIGTERM");
       signal?.[abortSignal.add](onAbort);
-    } catch (TypeError) {
-      throw new TypeError("Child process has already terminated");
+    } catch (e) {
+      void e;
     }
 
     const waitPromise = op_spawn_wait(this.#rid);


### PR DESCRIPTION
This PR fixes #27112 
The PR includes error handling using a try-catch block for the SIGTERM signal, as it is the cause of the error.