### PR TITLE
fix(ext/node): fix playwright http client

### DIFF
--- a/ext/node/polyfills/_tls_wrap.ts
+++ b/ext/node/polyfills/_tls_wrap.ts
@@ -154,7 +154,7 @@ export class TLSSocket extends net.Socket {
       const afterConnect = handle.afterConnect;
       handle.afterConnect = async (req: any, status: number) => {
         options.hostname ??= undefined; // coerce to undefined if null, startTls expects hostname to be undefined
-        if (tlssock._isNpmAgent) {
+        if (tlssock._needsSockInitWorkaround) {
           // skips the TLS handshake for @npmcli/agent as it's handled by
           // onSocket handler of ClientRequest object.
           tlssock.emit("secure");


### PR DESCRIPTION
Similarly to #27639, this PR applies the same workaround to `playwright-core` package.

Confirmed `playwright install` command work with this fix:

```
$ debug_deno run -A "npm:playwright@1.49.1" install chromium-headless-shell
Downloading Chromium Headless Shell 131.0.6778.33 (playwright build v1148) from https://playwright.azureedge.net/builds/chromium/1148/chromium-headless-shell-mac-arm64.zip
77.5 MiB [====================] 100% 0.0s
Chromium Headless Shell 131.0.6778.33 (playwright build v1148) downloaded to /Users/kt3k/Library/Caches/ms-playwright/chromium_headless_shell-1148
Downloading FFMPEG playwright build v1010 from https://playwright.azureedge.net/builds/ffmpeg/1010/ffmpeg-mac-arm64.zip
1.1 MiB [====================] 100% 0.0s
FFMPEG playwright build v1010 downloaded to /Users/kt3k/Library/Caches/ms-playwright/ffmpeg-1010
```

closes #27658

This was caused by #25470
