### PR TITLE
chore: fix ci by removing remote server dependent test

### DIFF
--- a/tests/specs/info/import_map/__test__.jsonc
+++ b/tests/specs/info/import_map/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "info preact/debug",
+  "args": "info --allow-import myentry/welcome.ts",
   "output": "with_import_map.out",
   "exitCode": 0
 }

--- a/tests/specs/info/import_map/deno.json
+++ b/tests/specs/info/import_map/deno.json
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "preact": "https://esm.sh/preact@10.15.1",
-    "preact/": "https://esm.sh/preact@10.15.1/"
+    "myentry/": "http://localhost:4545/"
   }
 }

--- a/tests/specs/info/import_map/deno.lock
+++ b/tests/specs/info/import_map/deno.lock
@@ -1,10 +1,6 @@
 {
-  "version": "3",
+  "version": "4",
   "remote": {
-    "https://esm.sh/preact@10.15.1": "4bfd0b2c5a2d432e0c8cda295d6b7304152ae08c85f7d0a22f91289c97085b89",
-    "https://esm.sh/preact@10.15.1/debug": "4bfd0b2c5a2d432e0c8cda295d6b7304152ae08c85f7d0a22f91289c97085b89",
-    "https://esm.sh/stable/preact@10.15.1/denonext/debug.js": "e8e5e198bd48c93d484c91c4c78af1900bd81d9bfcfd543e8ac75216f5404c10",
-    "https://esm.sh/stable/preact@10.15.1/denonext/devtools.js": "f61430e179a84483f8ea8dc098d7d0d46b2f0546de4027518bfcef197cd665c9",
-    "https://esm.sh/stable/preact@10.15.1/denonext/preact.mjs": "30710ac1d5ff3711ae0c04eddbeb706f34f82d97489f61aaf09897bc75d2a628"
+    "http://localhost:4545/welcome.ts": "7353d5fcbc36c45d26bcbca478cf973092523b07c45999f41319820092b4de31"
   }
 }

--- a/tests/specs/info/import_map/with_import_map.out
+++ b/tests/specs/info/import_map/with_import_map.out
@@ -1,16 +1,7 @@
-Download https://esm.sh/preact@10.15.1/debug
-Download https://esm.sh/stable/preact@10.15.1/denonext/preact.mjs
-Download https://esm.sh/stable/preact@10.15.1/denonext/devtools.js
-Download https://esm.sh/stable/preact@10.15.1/denonext/debug.js
-local: [WILDCARD]
-type: JavaScript
-dependencies: 3 unique
-size: [WILDCARD]
+Download http://localhost:4545/welcome.ts
+local: [WILDLINE]
+type: TypeScript
+dependencies: 0 unique
+size: [WILDLINE]
 
-https://esm.sh/preact@10.15.1/debug [WILDCARD]
-├── https://esm.sh/stable/preact@10.15.1/denonext/preact.mjs [WILDCARD]
-├─┬ https://esm.sh/stable/preact@10.15.1/denonext/devtools.js [WILDCARD]
-│ └── https://esm.sh/stable/preact@10.15.1/denonext/preact.mjs [WILDCARD]
-└─┬ https://esm.sh/stable/preact@10.15.1/denonext/debug.js [WILDCARD]
-  ├── https://esm.sh/stable/preact@10.15.1/denonext/preact.mjs [WILDCARD]
-  └── https://esm.sh/stable/preact@10.15.1/denonext/devtools.js [WILDCARD]
+http://localhost:4545/welcome.ts ([WILDLINE])


### PR DESCRIPTION
This was using the lockfile and esm.sh changed breaking the lockfile. We could pin to a specific esm.sh version, but ideally we shouldn't have the test suite dependent on remote servers.