### PR TITLE
fix(ext/node): propagate socket error to client request object

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -455,8 +455,13 @@ class ClientRequest extends OutgoingMessage {
     (async () => {
       try {
         const parsedUrl = new URL(url);
-        let baseConnRid =
-          this.socket._handle[kStreamBaseField][internalRidSymbol];
+        const handle = this.socket._handle;
+        if (!handle) {
+          // Using non-standard socket. There's no way to handle this type of socket.
+          // This should be only happening in artificial test cases
+          return;
+        }
+        let baseConnRid = handle[kStreamBaseField][internalRidSymbol];
         if (this._encrypted) {
           [baseConnRid] = op_tls_start({
             rid: baseConnRid,
@@ -637,7 +642,7 @@ class ClientRequest extends OutgoingMessage {
         };
         this.socket = socket;
         this.emit("socket", socket);
-        socket.on("error", (err) => {
+        socket.once("error", (err) => {
           // This callback loosely follow `socketErrorListener` in Node.js
           // https://github.com/nodejs/node/blob/f16cd10946ca9ad272f42b94f00cf960571c9181/lib/_http_client.js#L509
           emitErrorEvent(this, err);

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -637,6 +637,12 @@ class ClientRequest extends OutgoingMessage {
         };
         this.socket = socket;
         this.emit("socket", socket);
+        socket.on("error", (err) => {
+          // This callback loosely follow `socketErrorListener` in Node.js
+          // https://github.com/nodejs/node/blob/f16cd10946ca9ad272f42b94f00cf960571c9181/lib/_http_client.js#L509
+          emitErrorEvent(this, err);
+          socket.destroy(err);
+        });
         if (socket.readyState === "opening") {
           socket.on("connect", onConnect);
         } else {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1882,7 +1882,7 @@ Deno.test("[node/http] decompress brotli response", {
   ], ["user-agent", "Deno/2.1.1"]]);
 });
 
-Deno.test("[node/http] an error with DNS propagates to reqeust object", async () => {
+Deno.test("[node/http] an error with DNS propagates to request object", async () => {
   const { resolve, promise } = Promise.withResolvers<void>();
   const req = http.request("http://invalid-hostname.test", () => {});
   req.on("error", (err) => {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1881,3 +1881,14 @@ Deno.test("[node/http] decompress brotli response", {
     "localhost:3000",
   ], ["user-agent", "Deno/2.1.1"]]);
 });
+
+Deno.test("[node/http] an error with DNS propagates to reqeust object", async () => {
+  const { resolve, promise } = Promise.withResolvers<void>();
+  const req = http.request("http://invalid-hostname.test", () => {});
+  req.on("error", (err) => {
+    assertEquals(err.name, "Error");
+    assertEquals(err.message, "getaddrinfo ENOTFOUND invalid-hostname.test");
+    resolve();
+  });
+  await promise;
+});


### PR DESCRIPTION
This addresses the 2nd part of #27670

Currently if socket errors with DNS error, then there's no way to handle it and it becomes uncaught error. This PR propagate it to ClientRequest object and the error can be handled with 'error' event listener on it.

- [x] write test cases 