### PR TITLE
fix(check/lsp): correctly resolve compilerOptions.types

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4690,7 +4690,7 @@ fn op_script_names(state: &mut OpState) -> ScriptNames {
 
   // inject these next because they're global
   for (scope, script_names) in &mut result.by_scope {
-    for (_, specifiers) in state
+    for (referrer, specifiers) in state
       .state_snapshot
       .resolver
       .graph_imports_by_referrer(scope)
@@ -4699,10 +4699,10 @@ fn op_script_names(state: &mut OpState) -> ScriptNames {
         let Ok(resolved) = state
           .state_snapshot
           .resolver
-          .as_cli_resolver(Some(scope))
+          .as_cli_resolver(Some(referrer))
           .resolve(
             specifier.as_str(),
-            scope,
+            referrer,
             deno_graph::Position::zeroed(),
             ResolutionMode::Import,
             node_resolver::NodeResolutionKind::Types,

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4690,32 +4690,14 @@ fn op_script_names(state: &mut OpState) -> ScriptNames {
 
   // inject these next because they're global
   for (scope, script_names) in &mut result.by_scope {
-    for (referrer, specifiers) in state
+    for (_, specifiers) in state
       .state_snapshot
       .resolver
       .graph_imports_by_referrer(scope)
     {
       for specifier in specifiers {
-        let Ok(resolved) = state
-          .state_snapshot
-          .resolver
-          .as_cli_resolver(Some(referrer))
-          .resolve(
-            specifier.as_str(),
-            referrer,
-            deno_graph::Position::zeroed(),
-            ResolutionMode::Import,
-            node_resolver::NodeResolutionKind::Types,
-          )
-          .inspect_err(|e| {
-            lsp_log!("failed to resolve compilerOptions.types specifier {specifier}: {e}");
-          })
-        else {
-          continue;
-        };
-
         if let Ok(req_ref) =
-          deno_semver::npm::NpmPackageReqReference::from_specifier(&resolved)
+          deno_semver::npm::NpmPackageReqReference::from_specifier(&specifier)
         {
           let Some((resolved, _)) =
             state.state_snapshot.resolver.npm_to_file_url(

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -72,6 +72,7 @@ use super::documents::Document;
 use super::documents::DocumentsFilter;
 use super::language_server;
 use super::language_server::StateSnapshot;
+use super::logging::lsp_log;
 use super::performance::Performance;
 use super::performance::PerformanceMark;
 use super::refactor::RefactorCodeActionData;
@@ -4695,7 +4696,42 @@ fn op_script_names(state: &mut OpState) -> ScriptNames {
       .graph_imports_by_referrer(scope)
     {
       for specifier in specifiers {
-        script_names.insert(specifier.to_string());
+        let Ok(resolved) = state
+          .state_snapshot
+          .resolver
+          .as_cli_resolver(Some(scope))
+          .resolve(
+            specifier.as_str(),
+            scope,
+            deno_graph::Position::zeroed(),
+            ResolutionMode::Import,
+            node_resolver::NodeResolutionKind::Types,
+          )
+          .inspect_err(|e| {
+            lsp_log!("failed to resolve compilerOptions.types specifier {specifier}: {e}");
+          })
+        else {
+          continue;
+        };
+
+        if let Ok(req_ref) =
+          deno_semver::npm::NpmPackageReqReference::from_specifier(&resolved)
+        {
+          let Some((resolved, _)) =
+            state.state_snapshot.resolver.npm_to_file_url(
+              &req_ref,
+              scope,
+              ResolutionMode::Import,
+              Some(scope),
+            )
+          else {
+            lsp_log!("failed to resolve {req_ref} to file URL");
+            continue;
+          };
+          script_names.insert(resolved.to_string());
+        } else {
+          script_names.insert(specifier.to_string());
+        }
       }
     }
   }

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4697,7 +4697,7 @@ fn op_script_names(state: &mut OpState) -> ScriptNames {
     {
       for specifier in specifiers {
         if let Ok(req_ref) =
-          deno_semver::npm::NpmPackageReqReference::from_specifier(&specifier)
+          deno_semver::npm::NpmPackageReqReference::from_specifier(specifier)
         {
           let Some((resolved, _)) =
             state.state_snapshot.resolver.npm_to_file_url(

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -542,9 +542,7 @@ fn get_tsc_roots(
   while let Some((specifier, is_dynamic)) = pending.pop_front() {
     let module = match graph.try_get(specifier) {
       Ok(Some(module)) => module,
-      Ok(None) => {
-        continue;
-      }
+      Ok(None) => continue,
       Err(ModuleError::Missing(specifier, maybe_range)) => {
         if !is_dynamic {
           result

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -375,6 +375,7 @@ struct TscRoots {
 /// redirects resolved. We need to include all the emittable files in
 /// the roots, so they get type checked and optionally emitted,
 /// otherwise they would be ignored if only imported into JavaScript.
+#[allow(clippy::too_many_arguments)]
 fn get_tsc_roots(
   sys: &CliSys,
   graph: &ModuleGraph,

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17296,3 +17296,52 @@ fn wildcard_augment() {
   let diagnostics = client.did_open_file(&source);
   assert_eq!(diagnostics.all().len(), 0);
 }
+
+#[test]
+fn compiler_options_types() {
+  let context = TestContextBuilder::for_npm().use_temp_cwd().build();
+  let mut client = context.new_lsp_command().build();
+  let temp = context.temp_dir();
+  let temp_dir = temp.path();
+  let source = source_file(
+    temp_dir.join("index.ts"),
+    r#"
+      const foo = [1];
+      foo.augmented();
+    "#,
+  );
+
+  let deno_json = json!({
+    "imports": {
+      "@denotest/augments-global": "npm:@denotest/augments-global@1"
+    },
+    "compilerOptions": { "types": ["@denotest/augments-global"] },
+  });
+
+  temp.write("deno.json", deno_json.to_string());
+
+  client.initialize_default();
+
+  for node_modules_dir in ["none", "auto", "manual"] {
+    let mut deno_json = deno_json.clone();
+    deno_json["nodeModulesDir"] = json!(node_modules_dir);
+    temp.write("deno.json", deno_json.to_string());
+    context
+      .new_command()
+      .args("install")
+      .run()
+      .skip_output_check()
+      .assert_exit_code(0);
+    client.did_change_watched_files(json!({
+      "changes": [{
+        "uri": temp.url().join("deno.json").unwrap(),
+        "type": 2,
+      }],
+    }));
+
+    let diagnostics = client.did_open_file(&source);
+    eprintln!("{:#?}", diagnostics.all());
+    assert_eq!(diagnostics.all().len(), 0);
+    client.did_close_file(&source);
+  }
+}

--- a/tests/registry/npm/@denotest/augments-global/1.0.0/index.d.ts
+++ b/tests/registry/npm/@denotest/augments-global/1.0.0/index.d.ts
@@ -1,0 +1,6 @@
+export {}
+declare global {
+  interface Array<T> {
+    augmented(): void
+  }
+}

--- a/tests/registry/npm/@denotest/augments-global/1.0.0/index.d.ts
+++ b/tests/registry/npm/@denotest/augments-global/1.0.0/index.d.ts
@@ -1,6 +1,1 @@
-export {}
-declare global {
-  interface Array<T> {
-    augmented(): void
-  }
-}
+import "./other.d.ts";

--- a/tests/registry/npm/@denotest/augments-global/1.0.0/other.d.ts
+++ b/tests/registry/npm/@denotest/augments-global/1.0.0/other.d.ts
@@ -1,0 +1,6 @@
+export {}
+declare global {
+  interface Array<T> {
+    augmented(): void
+  }
+}

--- a/tests/registry/npm/@denotest/augments-global/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/augments-global/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/augments-global",
+  "version": "1.0.0",
+  "types": "./index.d.ts"
+}

--- a/tests/specs/check/compiler_options_types/__test__.jsonc
+++ b/tests/specs/check/compiler_options_types/__test__.jsonc
@@ -1,0 +1,53 @@
+{
+  "tempDir": true,
+  "tests": {
+    "node_modules_dir_none": {
+      "steps": [
+        {
+          "args": "run -A ./set_node_modules_dir.ts none",
+          "output": ""
+        },
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "check ./main.ts",
+          "output": "Check [WILDCARD]main.ts\n"
+        }
+      ]
+    },
+    "node_modules_dir_auto": {
+      "steps": [
+        {
+          "args": "run -A ./set_node_modules_dir.ts auto",
+          "output": ""
+        },
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "check ./main.ts",
+          "output": "Check [WILDCARD]main.ts\n"
+        }
+      ]
+    },
+    "node_modules_dir_manual": {
+      "steps": [
+        {
+          "args": "run -A ./set_node_modules_dir.ts auto",
+          "output": ""
+        },
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "check ./main.ts",
+          "output": "Check [WILDCARD]main.ts\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/check/compiler_options_types/deno.json
+++ b/tests/specs/check/compiler_options_types/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@denotest/augments-global": "npm:@denotest/augments-global@1"
+  },
+  "compilerOptions": { "types": ["@denotest/augments-global"] }
+}

--- a/tests/specs/check/compiler_options_types/main.ts
+++ b/tests/specs/check/compiler_options_types/main.ts
@@ -1,0 +1,2 @@
+const foo = [1];
+foo.augmented();

--- a/tests/specs/check/compiler_options_types/set_node_modules_dir.ts
+++ b/tests/specs/check/compiler_options_types/set_node_modules_dir.ts
@@ -1,0 +1,8 @@
+if (Deno.args.length !== 1) {
+  console.error("Usage: set_node_modules_dir.ts <setting>");
+  Deno.exit(1);
+}
+const setting = Deno.args[0].trim();
+const denoJson = JSON.parse(Deno.readTextFileSync("./deno.json"));
+denoJson["nodeModulesDir"] = setting;
+Deno.writeTextFileSync("./deno.json", JSON.stringify(denoJson, null, 2));

--- a/tests/util/server/src/lsp.rs
+++ b/tests/util/server/src/lsp.rs
@@ -900,6 +900,20 @@ impl LspClient {
     self.read_diagnostics()
   }
 
+  pub fn did_close_file(&mut self, file: &SourceFile) {
+    self.did_close(json!({
+        "textDocument": file.identifier(),
+    }))
+  }
+
+  pub fn did_close(&mut self, params: Value) {
+    self.did_close_raw(params);
+  }
+
+  pub fn did_close_raw(&mut self, params: Value) {
+    self.write_notification("textDocument/didClose", params);
+  }
+
   pub fn did_open_raw(&mut self, params: Value) {
     self.write_notification("textDocument/didOpen", params);
   }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/27062

In the LSP we were passing `npm` specifiers to TSC as roots, but TSC needs fully resolved specifiers (like the actual file path).

In `deno check` we were often excluding the specifiers entirely from the roots.

In both cases, we need to resolve the specifiers fully and then pass them to tsc