### PR TITLE
fix(outdated): Use `latest` tag even when it's the same as the current version

### DIFF
--- a/cli/tools/registry/pm/deps.rs
+++ b/cli/tools/registry/pm/deps.rs
@@ -683,7 +683,7 @@ impl DepManager {
               .and_then(|info| {
                 let latest_tag = info.dist_tags.get("latest")?;
                 let lower_bound = &semver_compatible.as_ref()?.version;
-                if latest_tag > lower_bound {
+                if latest_tag >= lower_bound {
                   Some(latest_tag.clone())
                 } else {
                   latest_version(Some(latest_tag), info.versions.keys())

--- a/cli/tools/registry/pm/deps.rs
+++ b/cli/tools/registry/pm/deps.rs
@@ -686,7 +686,18 @@ impl DepManager {
                 if latest_tag >= lower_bound {
                   Some(latest_tag.clone())
                 } else {
-                  latest_version(Some(latest_tag), info.versions.keys())
+                  latest_version(
+                    Some(latest_tag),
+                    info.versions.iter().filter_map(
+                      |(version, version_info)| {
+                        if version_info.deprecated.is_none() {
+                          Some(version)
+                        } else {
+                          None
+                        }
+                      },
+                    ),
+                  )
                 }
               })
               .map(|version| PackageNv {

--- a/tests/specs/update/latest_not_pre_release/__test__.jsonc
+++ b/tests/specs/update/latest_not_pre_release/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "outdated",
+      "output": ""
+    }
+  ]
+}

--- a/tests/specs/update/latest_not_pre_release/package.json
+++ b/tests/specs/update/latest_not_pre_release/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/has-pre-release": "1.0.0"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/27696.

Just a `>` that should've been a `>=`. Also made sure to filter out deprecated versions.