### PR TITLE
fix(outdated): retain strict semver specifier when updating

### DIFF
--- a/cli/tools/registry/pm/outdated.rs
+++ b/cli/tools/registry/pm/outdated.rs
@@ -280,9 +280,15 @@ fn choose_new_version_req(
     if preferred.version <= resolved?.version {
       return None;
     }
+    let exact = if let Some(range) = dep.req.version_req.range() {
+      range.0[0].start == range.0[0].end
+    } else {  
+      false
+    };
     Some(
       VersionReq::parse_from_specifier(
-        format!("^{}", preferred.version).as_str(),
+        format!("{}{}", if exact { "" } else { "^" }, preferred.version)
+          .as_str(),
       )
       .unwrap(),
     )

--- a/cli/tools/registry/pm/outdated.rs
+++ b/cli/tools/registry/pm/outdated.rs
@@ -282,7 +282,7 @@ fn choose_new_version_req(
     }
     let exact = if let Some(range) = dep.req.version_req.range() {
       range.0[0].start == range.0[0].end
-    } else {  
+    } else {
       false
     };
     Some(

--- a/tests/specs/update/deno_json/filtered/deno.json.out
+++ b/tests/specs/update/deno_json/filtered/deno.json.out
@@ -5,7 +5,7 @@
     "@denotest/subtract": "jsr:@denotest/subtract@^0.2.0",
     "@denotest/with-subpath": "jsr:@denotest/multiple-exports@0.5.0/data-json",
     "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@1.0.0",
-    "@denotest/bin": "npm:@denotest/bin@^1.0.0",
+    "@denotest/bin": "npm:@denotest/bin@1.0.0",
     "@denotest/has-patch-versions": "npm:@denotest/has-patch-versions@^0.1.0"
   },
   "scopes": {

--- a/tests/specs/update/deno_json/update_latest/deno.json.out
+++ b/tests/specs/update/deno_json/update_latest/deno.json.out
@@ -3,9 +3,9 @@
     "@denotest/add": "jsr:@denotest/add@^1.0.0",
     "@denotest/add/": "jsr:/@denotest/add@^1.0.0/",
     "@denotest/subtract": "jsr:@denotest/subtract@^1.0.0",
-    "@denotest/with-subpath": "jsr:@denotest/multiple-exports@^1.0.0/data-json",
-    "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@^2.0.0",
-    "@denotest/bin": "npm:@denotest/bin@^1.0.0",
+    "@denotest/with-subpath": "jsr:@denotest/multiple-exports@1.0.0/data-json",
+    "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@2.0.0",
+    "@denotest/bin": "npm:@denotest/bin@1.0.0",
     "@denotest/has-patch-versions": "npm:@denotest/has-patch-versions@^0.2.0"
   },
   "scopes": {
@@ -13,7 +13,7 @@
       "@denotest/add": "jsr:@denotest/add@^1.0.0",
       "@denotest/add/": "jsr:/@denotest/add@^1.0.0/",
       "@denotest/subtract": "jsr:@denotest/subtract@^1.0.0",
-      "@denotest/with-subpath": "jsr:@denotest/multiple-exports@^1.0.0/data-json"
+      "@denotest/with-subpath": "jsr:@denotest/multiple-exports@1.0.0/data-json"
     }
   }
 }

--- a/tests/specs/update/deno_json/update_latest/deno.lock.out
+++ b/tests/specs/update/deno_json/update_latest/deno.lock.out
@@ -2,10 +2,10 @@
   "version": "4",
   "specifiers": {
     "jsr:@denotest/add@1": "1.0.0",
-    "jsr:@denotest/multiple-exports@1": "1.0.0",
+    "jsr:@denotest/multiple-exports@1.0.0": "1.0.0",
     "jsr:@denotest/subtract@1": "1.0.0",
-    "npm:@denotest/bin@1": "1.0.0",
-    "npm:@denotest/breaking-change-between-versions@2": "2.0.0",
+    "npm:@denotest/bin@1.0.0": "1.0.0",
+    "npm:@denotest/breaking-change-between-versions@2.0.0": "2.0.0",
     "npm:@denotest/has-patch-versions@0.2": "0.2.0"
   },
   "jsr": {
@@ -33,10 +33,10 @@
   "workspace": {
     "dependencies": [
       "jsr:@denotest/add@1",
-      "jsr:@denotest/multiple-exports@1",
+      "jsr:@denotest/multiple-exports@1.0.0",
       "jsr:@denotest/subtract@1",
-      "npm:@denotest/bin@1",
-      "npm:@denotest/breaking-change-between-versions@2",
+      "npm:@denotest/bin@1.0.0",
+      "npm:@denotest/breaking-change-between-versions@2.0.0",
       "npm:@denotest/has-patch-versions@0.2"
     ]
   }

--- a/tests/specs/update/external_import_map/import_map.json.out
+++ b/tests/specs/update/external_import_map/import_map.json.out
@@ -2,7 +2,7 @@
   "imports": {
     "@denotest/add": "jsr:@denotest/add@^1.0.0",
     "@denotest/subtract": "jsr:@denotest/subtract@^1.0.0",
-    "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@^2.0.0",
+    "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@2.0.0",
     "@denotest/has-patch-versions": "npm:@denotest/has-patch-versions@^0.2.0"
   }
 }

--- a/tests/specs/update/mixed_workspace/filtered/member_b_package.json.out
+++ b/tests/specs/update/mixed_workspace/filtered/member_b_package.json.out
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "@denotest/has-patch-versions": "0.1.0",
-    "aliased": "npm:@denotest/bin@^1.0.0"
+    "aliased": "npm:@denotest/bin@1.0.0"
   }
 }

--- a/tests/specs/update/mixed_workspace/update_latest/subdir/member_a_deno.json.out
+++ b/tests/specs/update/mixed_workspace/update_latest/subdir/member_a_deno.json.out
@@ -4,7 +4,7 @@
   "imports": {
     "@denotest/add": "jsr:@denotest/add@^1.0.0",
     "@denotest/add/": "jsr:/@denotest/add@^1.0.0/",
-    "@denotest/with-subpath": "jsr:@denotest/multiple-exports@^1.0.0/data-json",
-    "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@^2.0.0"
+    "@denotest/with-subpath": "jsr:@denotest/multiple-exports@1.0.0/data-json",
+    "@denotest/breaking-change-between-versions": "npm:@denotest/breaking-change-between-versions@2.0.0"
   }
 }

--- a/tests/specs/update/mixed_workspace/update_latest/subdir/member_b_package.json.out
+++ b/tests/specs/update/mixed_workspace/update_latest/subdir/member_b_package.json.out
@@ -2,7 +2,7 @@
   "name": "@denotest/member-b",
   "version": "0.1.0",
   "dependencies": {
-    "@denotest/has-patch-versions": "^0.2.0",
-    "aliased": "npm:@denotest/bin@^1.0.0"
+    "@denotest/has-patch-versions": "0.2.0",
+    "aliased": "npm:@denotest/bin@1.0.0"
   }
 }

--- a/tests/specs/update/package_json/update_latest/deno.lock.out
+++ b/tests/specs/update/package_json/update_latest/deno.lock.out
@@ -2,7 +2,7 @@
   "version": "4",
   "specifiers": {
     "npm:@denotest/bin@1": "1.0.0",
-    "npm:@denotest/breaking-change-between-versions@2": "2.0.0",
+    "npm:@denotest/breaking-change-between-versions@2.0.0": "2.0.0",
     "npm:@denotest/has-patch-versions@0.2": "0.2.0"
   },
   "npm": {
@@ -20,7 +20,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@denotest/bin@1",
-        "npm:@denotest/breaking-change-between-versions@2",
+        "npm:@denotest/breaking-change-between-versions@2.0.0",
         "npm:@denotest/has-patch-versions@0.2"
       ]
     }

--- a/tests/specs/update/package_json/update_latest/package.json.out
+++ b/tests/specs/update/package_json/update_latest/package.json.out
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@denotest/has-patch-versions": "^0.2.0",
-    "@denotest/breaking-change-between-versions": "^2.0.0"
+    "@denotest/breaking-change-between-versions": "2.0.0"
   },
   "devDependencies": {
     "aliased": "npm:@denotest/bin@^1.0.0"


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/27697

If it's a strict bound (e.g. `1.0.0` as opposed to `^1.0.0` or other), retain the strictness when we update