### PR TITLE
docs(readme): update redirected links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <img align="right" src="https://deno.land/logo.svg" height="150px" alt="the deno mascot dinosaur standing in the rain">
 
-[Deno](https://www.deno.com)
-([/ˈdiːnoʊ/](http://ipa-reader.xyz/?text=%CB%88di%CB%90no%CA%8A), pronounced
+[Deno](https://deno.com)
+([/ˈdiːnoʊ/](http://ipa-reader.com/?text=%CB%88di%CB%90no%CA%8A), pronounced
 `dee-no`) is a JavaScript, TypeScript, and WebAssembly runtime with secure
 defaults and a great developer experience. It's built on [V8](https://v8.dev/),
 [Rust](https://www.rust-lang.org/), and [Tokio](https://tokio.rs/).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <img align="right" src="https://deno.land/logo.svg" height="150px" alt="the deno mascot dinosaur standing in the rain">
 
 [Deno](https://deno.com)
-([/ˈdiːnoʊ/](http://ipa-reader.com/?text=%CB%88di%CB%90no%CA%8A), pronounced
+([/ˈdiːnoʊ/](https://ipa-reader.com/?text=%CB%88di%CB%90no%CA%8A), pronounced
 `dee-no`) is a JavaScript, TypeScript, and WebAssembly runtime with secure
 defaults and a great developer experience. It's built on [V8](https://v8.dev/),
 [Rust](https://www.rust-lang.org/), and [Tokio](https://tokio.rs/).

--- a/tools/release/npm/build.ts
+++ b/tools/release/npm/build.ts
@@ -48,8 +48,8 @@ const packages: Package[] = [{
 
 const markdownText = `# Deno
 
-[Deno](https://www.deno.com)
-([/ˈdiːnoʊ/](http://ipa-reader.xyz/?text=%CB%88di%CB%90no%CA%8A), pronounced
+[Deno](https://deno.com)
+([/ˈdiːnoʊ/](http://ipa-reader.com/?text=%CB%88di%CB%90no%CA%8A), pronounced
 \`dee-no\`) is a JavaScript, TypeScript, and WebAssembly runtime with secure
 defaults and a great developer experience. It's built on [V8](https://v8.dev/),
 [Rust](https://www.rust-lang.org/), and [Tokio](https://tokio.rs/).

--- a/tools/release/npm/build.ts
+++ b/tools/release/npm/build.ts
@@ -49,7 +49,7 @@ const packages: Package[] = [{
 const markdownText = `# Deno
 
 [Deno](https://deno.com)
-([/ˈdiːnoʊ/](http://ipa-reader.com/?text=%CB%88di%CB%90no%CA%8A), pronounced
+([/ˈdiːnoʊ/](https://ipa-reader.com/?text=%CB%88di%CB%90no%CA%8A), pronounced
 \`dee-no\`) is a JavaScript, TypeScript, and WebAssembly runtime with secure
 defaults and a great developer experience. It's built on [V8](https://v8.dev/),
 [Rust](https://www.rust-lang.org/), and [Tokio](https://tokio.rs/).


### PR DESCRIPTION
- www.deno.com -> deno.com
- ipa-reader.xyz -> ipa-reader.com

As for ipa-reader, due to the redirect, query parameters are not carried over and the pronunciation cannot be easily checked.
