### PR TITLE
fix(ext/os): pass SignalState to web worker

### DIFF
--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -116,6 +116,12 @@ deno_core::extension!(
     "op_exit" | "op_set_exit_code" | "op_get_exit_code" =>
       op.with_implementation_from(&deno_core::op_void_sync()),
     _ => op,
+  },
+  state = |state| {
+    #[cfg(unix)]
+    {
+      state.put(ops::signal::SignalState::default());
+    }
   }
 );
 


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/27717

Made a mistake in https://github.com/denoland/deno/pull/27655 and
didn't add the `SignalStore` for web worker.