### PR TITLE
WIP - feat(lsp): Run tests with file watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,12 +4804,11 @@ dependencies = [
 
 [[package]]
 name = "libuv-sys-lite"
-version = "1.48.2"
+version = "1.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8dfd1a173826d193e3b955e07c22765829890f62c677a59c4a410cb4f47c01"
+checksum = "10de9b449ef5865c757dc2a0c1b1dde1578adf466db4bb0074e5d83b530164f1"
 dependencies = [
  "bindgen",
- "libloading 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4809,6 +4809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10de9b449ef5865c757dc2a0c1b1dde1578adf466db4bb0074e5d83b530164f1"
 dependencies = [
  "bindgen",
+ "libloading 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ ipnet = "2.3"
 jsonc-parser = { version = "=0.26.2", features = ["serde"] }
 lazy-regex = "3"
 libc = "0.2.168"
-libz-sys = { version = "1.1.20", default-features = false }
+libz-sys = { version = "1.1.20", default-features = false, features = ["zlib-ng-no-cmake-experimental-community-maintained"] }
 log = { version = "0.4.20", features = ["kv"] }
 lsp-types = "=0.97.0" # used by tower-lsp and "proposed" feature is unstable in patch releases
 memmem = "0.1.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ harness = false
 path = "./bench/lsp_bench_standalone.rs"
 
 [features]
-default = ["upgrade", "__vendored_zlib_ng"]
+default = ["upgrade"]
 # A feature that enables heap profiling with dhat on Linux.
 # 1. Compile with `cargo build --profile=release-with-debug --features=dhat-heap`
 # 2. Run the executable. It will output a dhat-heap.json file.

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -190,6 +190,7 @@ impl LspTestFilter {
 pub struct TestRun {
   id: u32,
   kind: lsp_custom::TestRunKind,
+  is_continuous: bool,
   filters: HashMap<ModuleSpecifier, LspTestFilter>,
   queue: HashSet<ModuleSpecifier>,
   tests: TestServerTests,
@@ -211,6 +212,7 @@ impl TestRun {
     Self {
       id: params.id,
       kind: params.kind.clone(),
+      is_continuous: params.is_continuous,
       filters,
       queue,
       tests,
@@ -529,6 +531,9 @@ impl TestRun {
     {
       args.push(Cow::Borrowed("--inspect"));
     }
+    if self.is_continuous && !args.contains(&Cow::Borrowed("--watch")) {
+      args.push(Cow::Borrowed("--watch"));
+    }
     args
   }
 }
@@ -845,6 +850,7 @@ mod tests {
     let params = lsp_custom::TestRunRequestParams {
       id: 1,
       kind: lsp_custom::TestRunKind::Run,
+      is_continuous: false,
       include: Some(vec![
         lsp_custom::TestIdentifier {
           text_document: lsp::TextDocumentIdentifier {

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -467,6 +467,14 @@ impl TestRun {
             permission_desc_parser.as_ref(),
             &cli_options.permissions_options(),
           )?;
+
+          let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
+          let test_files = queue
+            .iter()
+            .filter_map(|v| v.to_file_path().ok())
+            .collect::<Vec<_>>();
+          let _ = watcher_communicator.watch_paths(test_files);
+
           let main_graph_container =
             factory.main_module_graph_container().await?;
           main_graph_container

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -93,6 +93,8 @@ pub enum TestRunKind {
 pub struct TestRunRequestParams {
   pub id: u32,
   pub kind: TestRunKind,
+  /// Corresponds to --watch
+  pub is_continuous: bool,
   #[serde(skip_serializing_if = "Vec::is_empty")]
   #[serde(default)]
   pub exclude: Vec<TestIdentifier>,

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -166,6 +166,9 @@ pub enum TestRunProgressMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     location: Option<lsp::Location>,
   },
+  Restart {
+    enqueued: Vec<EnqueuedTestModule>,
+  },
   End,
 }
 

--- a/cli/lsp/testing/server.rs
+++ b/cli/lsp/testing/server.rs
@@ -215,14 +215,15 @@ impl TestServer {
     params: lsp_custom::TestRunRequestParams,
     workspace_settings: config::WorkspaceSettings,
   ) -> LspResult<Option<Value>> {
+    let id = params.id;
     let test_run =
-      { TestRun::init(&params, self.tests.clone(), workspace_settings).await };
+      { TestRun::init(params, self.tests.clone(), workspace_settings).await };
     let enqueued = test_run.as_enqueued().await;
     {
       let mut runs = self.runs.lock();
-      runs.insert(params.id, test_run);
+      runs.insert(id, test_run);
     }
-    self.enqueue_run(params.id).map_err(|err| {
+    self.enqueue_run(id).map_err(|err| {
       log::error!("cannot enqueue run: {}", err);
       LspError::internal_error()
     })?;

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -14,7 +14,6 @@ use crate::args::WatchFlagsWithPaths;
 use crate::factory::CliFactory;
 use crate::npm::installer::PackageCaching;
 use crate::util;
-use crate::util::file_watcher::WatcherRestartMode;
 
 pub mod hmr;
 
@@ -117,14 +116,13 @@ async fn run_with_watch(
   flags: Arc<Flags>,
   watch_flags: WatchFlagsWithPaths,
 ) -> Result<i32, AnyError> {
-  util::file_watcher::watch_recv(
+  util::file_watcher::watch_func(
     flags,
     util::file_watcher::PrintConfig::new_with_banner(
       if watch_flags.hmr { "HMR" } else { "Watcher" },
       "Process",
       !watch_flags.no_clear_screen,
     ),
-    WatcherRestartMode::Automatic,
     move |flags, watcher_communicator, changed_paths| {
       watcher_communicator.show_path_changed(changed_paths.clone());
       Ok(async move {

--- a/cli/tools/serve.rs
+++ b/cli/tools/serve.rs
@@ -12,7 +12,6 @@ use crate::args::Flags;
 use crate::args::ServeFlags;
 use crate::args::WatchFlagsWithPaths;
 use crate::factory::CliFactory;
-use crate::util::file_watcher::WatcherRestartMode;
 use crate::worker::CliMainWorkerFactory;
 
 pub async fn serve(
@@ -144,14 +143,13 @@ async fn serve_with_watch(
   worker_count: Option<usize>,
 ) -> Result<i32, AnyError> {
   let hmr = watch_flags.hmr;
-  crate::util::file_watcher::watch_recv(
+  crate::util::file_watcher::watch_func(
     flags,
     crate::util::file_watcher::PrintConfig::new_with_banner(
       if watch_flags.hmr { "HMR" } else { "Watcher" },
       "Process",
       !watch_flags.no_clear_screen,
     ),
-    WatcherRestartMode::Automatic,
     move |flags, watcher_communicator, changed_paths| {
       watcher_communicator.show_path_changed(changed_paths.clone());
       Ok(async move {

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -27,4 +27,4 @@ thiserror.workspace = true
 windows-sys.workspace = true
 
 [dev-dependencies]
-libuv-sys-lite = "=1.48.3"
+libuv-sys-lite = { version = "=1.48.3", features = ["dyn-symbols"] }

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -1,14 +1,14 @@
 # Copyright 2018-2025 the Deno authors. MIT license.
 
 [package]
-name = "deno_napi"
-version = "0.116.0"
 authors.workspace = true
+description = "NAPI implementation for Deno"
 edition.workspace = true
 license.workspace = true
+name = "deno_napi"
 readme = "README.md"
 repository.workspace = true
-description = "NAPI implementation for Deno"
+version = "0.116.0"
 
 [lib]
 path = "lib.rs"
@@ -27,4 +27,4 @@ thiserror.workspace = true
 windows-sys.workspace = true
 
 [dev-dependencies]
-libuv-sys-lite = "=1.48.2"
+libuv-sys-lite = "=1.48.3"

--- a/resolvers/npm_cache/Cargo.toml
+++ b/resolvers/npm_cache/Cargo.toml
@@ -24,7 +24,7 @@ deno_path_util.workspace = true
 deno_semver.workspace = true
 deno_unsync = { workspace = true, features = ["tokio"] }
 faster-hex.workspace = true
-flate2 = { workspace = true, features = ["zlib-ng-compat"] }
+flate2 = { workspace = true, features = ["default"] }
 futures.workspace = true
 http.workspace = true
 log.workspace = true

--- a/tests/napi/Cargo.toml
+++ b/tests/napi/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-libuv-sys-lite = "=1.48.3"
+libuv-sys-lite = { version = "=1.48.3", features = ["dyn-symbols"] }
 napi-sys = { version = "=2.2.2", default-features = false, features = [
     "napi7",
 ] }

--- a/tests/napi/Cargo.toml
+++ b/tests/napi/Cargo.toml
@@ -1,20 +1,22 @@
 # Copyright 2018-2025 the Deno authors. MIT license.
 
 [package]
-name = "test_napi"
-version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "test_napi"
 publish = false
 repository.workspace = true
+version = "0.1.0"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-libuv-sys-lite = "=1.48.2"
-napi-sys = { version = "=2.2.2", default-features = false, features = ["napi7"] }
+libuv-sys-lite = "=1.48.3"
+napi-sys = { version = "=2.2.2", default-features = false, features = [
+    "napi7",
+] }
 
 [dev-dependencies]
 test_util.workspace = true


### PR DESCRIPTION
This addresses issue https://github.com/denoland/vscode_deno/issues/1132

See linked PR for more context https://github.com/denoland/vscode_deno/pull/1243

This pull request is not ready for merging yet. I opened it so that I can ask questions about my code, and about how to best achieve certain results.

I did my best to implement the following
- Hooking up the existing error line reporting
- Hooking up the existing expected vs actual reporting
- Supporting "watch mode" for tests that are started from the LSP.

I did not yet
- Use the `changed_files` of the file watcher
- Clean out the debug logging
- Rebase all the commits with good messages

My questions are left as comments in the code. 

Also, this is more of a personal struggle: I initially really struggled to locally build Deno, as Deno requires some dependencies that are nontrivial to install on Windows. 
The instructions were incomplete https://github.com/denoland/deno/issues/27535 Upon updating them, [nathanwhit](https://github.com/nathanwhit) figured out how to change [libuv-sys-lite](https://github.com/nathanwhit/libuv-sys-lite/) to no longer require the LLVM dependency, which was very nice. 
The CMake dependency for libz-sys is still there, and it still causes me troubles, so I tweaked it (`zlib-ng-no-cmake-experimental-community-maintained`). My hope is that zlib will eventually get replaced by zlib-rs, which *just works*.

