### PR TITLE
fix(ext/node): fix formatting of debug logs

### DIFF
--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -49,10 +49,10 @@ function debuglogImpl(
   if (debugImpls[set] === undefined) {
     if (enabled) {
       emitWarningIfNeeded(set);
-      debugImpls[set] = function debug(...args: unknown[]) {
-        const msg = args.map((arg) => inspect(arg)).join(" ");
+      debugImpls[set] = function debug(msg, ...args: unknown[]) {
+        args = args.map((arg) => inspect(arg, { colors: true }));
         // deno-lint-ignore no-console
-        console.error("%s %s: %s", set, String(Deno.pid), msg);
+        console.error("%s %s: " + msg, set, String(Deno.pid), ...args);
       };
     } else {
       debugImpls[set] = noop;

--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -4,8 +4,6 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { inspect } from "ext:deno_node/internal/util/inspect.mjs";
-
 // `debugImpls` and `testEnabled` are deliberately not initialized so any call
 // to `debuglog()` before `initializeDebugEnv()` is called will throw.
 let debugImpls: Record<string, (...args: unknown[]) => void>;

--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -50,7 +50,6 @@ function debuglogImpl(
     if (enabled) {
       emitWarningIfNeeded(set);
       debugImpls[set] = function debug(msg, ...args: unknown[]) {
-        args = args.map((arg) => inspect(arg, { colors: true }));
         // deno-lint-ignore no-console
         console.error("%s %s: " + msg, set, String(Deno.pid), ...args);
       };

--- a/tests/specs/node/node_debug/main.out
+++ b/tests/specs/node/node_debug/main.out
@@ -1,36 +1,36 @@
-STREAM [WILDCARD] 'resume'
-STREAM [WILDCARD] 'resume' false
-STREAM [WILDCARD] 'read' 0
-STREAM [WILDCARD] 'need readable' false
-STREAM [WILDCARD] 'length less than watermark' true
-STREAM [WILDCARD] 'reading, ended or constructing' false
-STREAM [WILDCARD] 'flow' true
-STREAM [WILDCARD] 'read' undefined
-STREAM [WILDCARD] 'need readable' true
-STREAM [WILDCARD] 'length less than watermark' true
-STREAM [WILDCARD] 'reading, ended or constructing' false
-STREAM [WILDCARD] 'read' 0
-STREAM [WILDCARD] 'need readable' true
-STREAM [WILDCARD] 'length less than watermark' true
-STREAM [WILDCARD] 'reading, ended or constructing' false
-STREAM [WILDCARD] 'maybeReadMore read 0'
-STREAM [WILDCARD] 'read' 0
-STREAM [WILDCARD] 'need readable' true
-STREAM [WILDCARD] 'length less than watermark' true
-STREAM [WILDCARD] 'do read'
-STREAM [WILDCARD] 'readableAddChunk' <Buffer 68 65 6c 6c 6f 20 77 6f 72 6c 64 0a>
+STREAM [WILDCARD]: resume
+STREAM [WILDCARD]: resume false
+STREAM [WILDCARD]: read 0
+STREAM [WILDCARD]: need readable false
+STREAM [WILDCARD]: length less than watermark true
+STREAM [WILDCARD]: reading, ended or constructing false
+STREAM [WILDCARD]: flow true
+STREAM [WILDCARD]: read undefined
+STREAM [WILDCARD]: need readable true
+STREAM [WILDCARD]: length less than watermark true
+STREAM [WILDCARD]: reading, ended or constructing false
+STREAM [WILDCARD]: read 0
+STREAM [WILDCARD]: need readable true
+STREAM [WILDCARD]: length less than watermark true
+STREAM [WILDCARD]: reading, ended or constructing false
+STREAM [WILDCARD]: maybeReadMore read 0
+STREAM [WILDCARD]: read 0
+STREAM [WILDCARD]: need readable true
+STREAM [WILDCARD]: length less than watermark true
+STREAM [WILDCARD]: do read
+STREAM [WILDCARD]: readableAddChunk <Buffer 68 65 6c 6c 6f 20 77 6f 72 6c 64 0a>
 hello world
 
-STREAM [WILDCARD] 'maybeReadMore read 0'
-STREAM [WILDCARD] 'read' 0
-STREAM [WILDCARD] 'need readable' true
-STREAM [WILDCARD] 'length less than watermark' true
-STREAM [WILDCARD] 'do read'
-STREAM [WILDCARD] 'readableAddChunk' null
-STREAM [WILDCARD] 'onEofChunk'
-STREAM [WILDCARD] 'emitReadable_' false 0 true
-STREAM [WILDCARD] 'flow' true
-STREAM [WILDCARD] 'read' undefined
-STREAM [WILDCARD] 'endReadable' false
-STREAM [WILDCARD] 'endReadableNT' false 0
+STREAM [WILDCARD]: maybeReadMore read 0
+STREAM [WILDCARD]: read 0
+STREAM [WILDCARD]: need readable true
+STREAM [WILDCARD]: length less than watermark true
+STREAM [WILDCARD]: do read
+STREAM [WILDCARD]: readableAddChunk null
+STREAM [WILDCARD]: onEofChunk
+STREAM [WILDCARD]: emitReadable_ false 0 true
+STREAM [WILDCARD]: flow true
+STREAM [WILDCARD]: read undefined
+STREAM [WILDCARD]: endReadable false
+STREAM [WILDCARD]: endReadableNT false 0
 Finished reading the file


### PR DESCRIPTION
Currently `%s` placeholders in debug logs in node compat js code are not handled correctly. This PR fixes it.

BEFORE
<img width="1371" alt="Screenshot 2025-01-22 at 16 18 33" src="https://github.com/user-attachments/assets/00a4c070-9385-4af2-8148-e12cc23da69d" />

AFTER
<img width="1290" alt="Screenshot 2025-01-22 at 16 24 58" src="https://github.com/user-attachments/assets/041ae5ac-5816-4a88-881a-cbebbf5b10e7" />
