### PR TITLE
refactor: use DataUrl from deno_media_type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,7 @@ dependencies = [
  "deno_lib",
  "deno_lint",
  "deno_lockfile",
+ "deno_media_type",
  "deno_npm",
  "deno_npm_cache",
  "deno_package_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577fe2bbe04f3e9b1b7c6fac6a75101a9fbd611c50a6b68789e69f4d63dcb2b4"
+checksum = "600222d059ab31ff31182b3e12615df2134a9e01605836b78ad8df91ba39eab3"
 dependencies = [
  "data-url",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ deno_core = { version = "0.331.0" }
 deno_bench_util = { version = "0.181.0", path = "./bench_util" }
 deno_config = { version = "=0.45.0", features = ["workspace", "sync"] }
 deno_lockfile = "=0.24.0"
-deno_media_type = { version = "0.2.4", features = ["module_specifier"] }
+deno_media_type = { version = "=0.2.5", features = ["module_specifier"] }
 deno_npm = "=0.27.2"
 deno_path_util = "=0.3.0"
 deno_permissions = { version = "0.46.0", path = "./runtime/permissions" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -76,6 +76,7 @@ deno_graph = { version = "=0.87.0" }
 deno_lib.workspace = true
 deno_lint = { version = "=0.68.2", features = ["docs"] }
 deno_lockfile.workspace = true
+deno_media_type = { workspace = true, features = ["data_url", "decoding", "module_specifier"] }
 deno_npm.workspace = true
 deno_npm_cache.workspace = true
 deno_package_json.workspace = true

--- a/cli/args/import_map.rs
+++ b/cli/args/import_map.rs
@@ -13,7 +13,7 @@ pub async fn resolve_import_map_value_from_specifier(
 ) -> Result<serde_json::Value, AnyError> {
   if specifier.scheme() == "data" {
     let data_url_text =
-      deno_graph::source::RawDataUrl::parse(specifier)?.decode()?;
+      deno_media_type::data_url::RawDataUrl::parse(specifier)?.decode()?;
     Ok(serde_json::from_str(&data_url_text)?)
   } else {
     let file = TextDecodedFile::decode(

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -60,11 +60,10 @@ impl TextDecodedFile {
         file.maybe_headers.as_ref(),
       );
     let specifier = file.url;
-    match deno_graph::source::decode_source(
-      &specifier,
-      file.source,
-      maybe_charset,
-    ) {
+    let charset = maybe_charset.unwrap_or_else(|| {
+      deno_media_type::encoding::detect_charset(&specifier, &file.source)
+    });
+    match deno_media_type::encoding::decode_arc_source(charset, file.source) {
       Ok(source) => Ok(TextDecodedFile {
         media_type,
         specifier,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1756,10 +1756,11 @@ fn bytes_to_content(
     // we use the dts representation for Wasm modules
     Ok(deno_graph::source::wasm::wasm_module_to_dts(&bytes)?)
   } else {
-    Ok(deno_graph::source::decode_owned_source(
-      specifier,
-      bytes,
-      maybe_charset,
+    let charset = maybe_charset.unwrap_or_else(|| {
+      deno_media_type::encoding::detect_charset(specifier, &bytes)
+    });
+    Ok(deno_media_type::encoding::decode_owned_source(
+      charset, bytes,
     )?)
   }
 }

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -936,7 +936,7 @@ impl FileSystemDocuments {
         file_referrer.cloned(),
       )
     } else if specifier.scheme() == "data" {
-      let source = deno_graph::source::RawDataUrl::parse(specifier)
+      let source = deno_media_type::data_url::RawDataUrl::parse(specifier)
         .ok()?
         .decode()
         .ok()?;

--- a/cli/lsp/urls.rs
+++ b/cli/lsp/urls.rs
@@ -219,7 +219,8 @@ impl LspUrlMap {
         let uri_str = if specifier.scheme() == "asset" {
           format!("deno:/asset{}", specifier.path())
         } else if specifier.scheme() == "data" {
-          let data_url = deno_graph::source::RawDataUrl::parse(specifier)?;
+          let data_url =
+            deno_media_type::data_url::RawDataUrl::parse(specifier)?;
           let media_type = data_url.media_type();
           let extension = if media_type == MediaType::Unknown {
             ""

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1179,10 +1179,13 @@ fn read_file_contents(file_path: &Path) -> Result<FileContents, AnyError> {
     .with_context(|| format!("Error reading {}", file_path.display()))?;
   let had_bom = file_bytes.starts_with(&[0xEF, 0xBB, 0xBF]);
   // will have the BOM stripped
-  let text = deno_graph::source::decode_owned_file_source(file_bytes)
-    .with_context(|| {
-      anyhow!("{} is not a valid UTF-8 file", file_path.display())
-    })?;
+  let charset =
+    deno_media_type::encoding::detect_charset_local_file(&file_bytes);
+  let text =
+    deno_media_type::encoding::decode_owned_source(charset, file_bytes)
+      .with_context(|| {
+        anyhow!("{} is not a valid UTF-8 file", file_path.display())
+      })?;
 
   Ok(FileContents { text, had_bom })
 }


### PR DESCRIPTION
This was moved from deno_graph to deno_media_type.