### PR TITLE
chore: re-enable napi uv test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,9 +4868,9 @@ dependencies = [
 
 [[package]]
 name = "libuv-sys-lite"
-version = "1.48.2"
+version = "1.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8dfd1a173826d193e3b955e07c22765829890f62c677a59c4a410cb4f47c01"
+checksum = "10de9b449ef5865c757dc2a0c1b1dde1578adf466db4bb0074e5d83b530164f1"
 dependencies = [
  "bindgen",
  "libloading 0.8.5",

--- a/ext/napi/Cargo.toml
+++ b/ext/napi/Cargo.toml
@@ -27,4 +27,4 @@ thiserror.workspace = true
 windows-sys.workspace = true
 
 [dev-dependencies]
-libuv-sys-lite = "=1.48.2"
+libuv-sys-lite = { version = "=1.48.3", features = ["dyn-symbols"] }

--- a/tests/napi/Cargo.toml
+++ b/tests/napi/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-libuv-sys-lite = "=1.48.2"
+libuv-sys-lite = "=1.48.3"
 napi-sys = { version = "=2.2.2", default-features = false, features = ["napi7"] }
 
 [dev-dependencies]

--- a/tests/napi/src/uv.rs
+++ b/tests/napi/src/uv.rs
@@ -137,7 +137,7 @@ unsafe extern "C" fn callback(handle: *mut uv_async_t) {
     &mut result,
   ));
   uv_mutex_unlock((*async_).mutex);
-  if value == 5 {
+  if value == 1 {
     uv_close(handle.cast(), Some(close_cb));
   }
 }
@@ -166,7 +166,6 @@ extern "C" fn test_uv_async(
   let uv_async = uv_async.cast::<uv_async_t>();
   let mut js_cb = null_mut();
   assert_napi_ok!(napi_create_reference(env, args[0], 1, &mut js_cb));
-  // let mut tsfn = null_mut();
 
   let data = new_raw(Async {
     env,
@@ -181,14 +180,13 @@ extern "C" fn test_uv_async(
     let uv_async = UvAsyncPtr(uv_async);
     std::thread::spawn({
       move || {
+        std::thread::sleep(Duration::from_millis(50));
         let data = (*uv_async.0).data as *mut Async;
-        for _ in 0..5 {
-          uv_mutex_lock((*data).mutex);
-          (*data).value += 1;
-          uv_mutex_unlock((*data).mutex);
-          std::thread::sleep(Duration::from_millis(10));
-          uv_async_send(uv_async);
-        }
+        uv_mutex_lock((*data).mutex);
+        (*data).value += 1;
+        uv_mutex_unlock((*data).mutex);
+        std::thread::sleep(Duration::from_millis(10));
+        uv_async_send(uv_async);
       }
     });
   }

--- a/tests/napi/uv_test.js
+++ b/tests/napi/uv_test.js
@@ -6,13 +6,12 @@ const uv = loadTestLibrary();
 
 Deno.test({
   name: "napi uv async",
-  ignore: true,
   fn: async () => {
     let called = false;
     await new Promise((resolve) => {
       uv.test_uv_async((value) => {
         called = true;
-        if (value === 5) {
+        if (value === 1) {
           resolve();
         }
       });


### PR DESCRIPTION
Simplifies it to make it not flaky. while i'm there I updated `libuv-sys-lite` (maintained by me), which drops the requirement of having `clang` installed (which can be tough to install on windows).