### PR TITLE
fix(ext/node): node compatibility issue missing fd in createServer callback socket object

### DIFF
--- a/cli/tsc/dts/lib.deno_net.d.ts
+++ b/cli/tsc/dts/lib.deno_net.d.ts
@@ -136,8 +136,8 @@ declare namespace Deno {
     /** Make the connection not block the event loop from finishing. */
     unref(): void;
 
-    readonly readable: ReadableStream<Uint8Array>;
-    readonly writable: WritableStream<Uint8Array>;
+    readonly readable: ReadableStream<Uint8Array<ArrayBuffer>>;
+    readonly writable: WritableStream<Uint8Array<ArrayBufferLike>>;
   }
 
   /** @category Network */

--- a/cli/tsc/dts/lib.deno_net.d.ts
+++ b/cli/tsc/dts/lib.deno_net.d.ts
@@ -138,8 +138,6 @@ declare namespace Deno {
 
     readonly readable: ReadableStream<Uint8Array>;
     readonly writable: WritableStream<Uint8Array>;
-
-    readonly fd: number;
   }
 
   /** @category Network */

--- a/cli/tsc/dts/lib.deno_net.d.ts
+++ b/cli/tsc/dts/lib.deno_net.d.ts
@@ -136,8 +136,10 @@ declare namespace Deno {
     /** Make the connection not block the event loop from finishing. */
     unref(): void;
 
-    readonly readable: ReadableStream<Uint8Array<ArrayBuffer>>;
-    readonly writable: WritableStream<Uint8Array<ArrayBufferLike>>;
+    readonly readable: ReadableStream<Uint8Array>;
+    readonly writable: WritableStream<Uint8Array>;
+
+    readonly fd: number;
   }
 
   /** @category Network */

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -107,7 +107,7 @@ class Conn {
       value: rid,
     });
     ObjectDefineProperty(this, internalFdSymbol, {
-      _proto_: null,
+      __proto__: null,
       enumerable: false,
       value: fd,
     });

--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -5,6 +5,7 @@ const {
   BadResourcePrototype,
   InterruptedPrototype,
   internalRidSymbol,
+  internalFdSymbol,
   createCancelHandle,
 } = core;
 import {
@@ -99,26 +100,24 @@ class Conn {
 
   #readable;
   #writable;
-  #fd = -1;
-
   constructor(rid, remoteAddr, localAddr, fd) {
     ObjectDefineProperty(this, internalRidSymbol, {
       __proto__: null,
       enumerable: false,
       value: rid,
     });
+    ObjectDefineProperty(this, internalFdSymbol, {
+      _proto_: null,
+      enumerable: false,
+      value: fd,
+    });
     this.#rid = rid;
     this.#remoteAddr = remoteAddr;
     this.#localAddr = localAddr;
-    this.#fd = fd;
   }
 
   get remoteAddr() {
     return this.#remoteAddr;
-  }
-
-  get fd() {
-    return this.#fd;
   }
 
   get localAddr() {

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -5,8 +5,6 @@ use std::cell::RefCell;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
-use std::os::fd::AsFd;
-use std::os::fd::AsRawFd;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -187,6 +185,8 @@ pub async fn op_net_accept_tcp(
   let mut _fd_raw: Option<Fd> = None;
   #[cfg(not(windows))]
   {
+    use std::os::fd::AsFd;
+    use std::os::fd::AsRawFd;
     let fd = tcp_stream.as_fd();
     _fd_raw = Some(fd.as_raw_fd() as u32);
   }

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -184,11 +184,11 @@ pub async fn op_net_accept_tcp(
     .try_or_cancel(cancel)
     .await
     .map_err(accept_err)?;
-  let mut fd_raw: Option<Fd> = None;
+  let mut _fd_raw: Option<Fd> = None;
   #[cfg(not(windows))]
   {
     let fd = tcp_stream.as_fd();
-    fd_raw = Some(fd.as_raw_fd() as u32);
+    _fd_raw = Some(fd.as_raw_fd() as u32);
   }
   let local_addr = tcp_stream.local_addr()?;
   let remote_addr = tcp_stream.peer_addr()?;
@@ -201,7 +201,7 @@ pub async fn op_net_accept_tcp(
     rid,
     IpAddr::from(local_addr),
     IpAddr::from(remote_addr),
-    fd_raw,
+    _fd_raw,
   ))
 }
 

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -47,6 +47,8 @@ import {
 } from "ext:deno_node/internal_binding/_listen.ts";
 import { nextTick } from "ext:deno_node/_next_tick.ts";
 
+const fdSymbol: unique symbol = Symbol("fdSymbol");
+
 /** The type of TCP socket. */
 enum socketType {
   SOCKET,
@@ -100,7 +102,8 @@ export class TCP extends ConnectionWrap {
 
   #closed = false;
   #acceptBackoffDelay?: number;
-  fd = -1;
+
+  [fdSymbol]: number = -1;
 
   /**
    * Creates a new TCP class instance.
@@ -129,7 +132,7 @@ export class TCP extends ConnectionWrap {
     super(provider, conn);
 
     if (conn?.fd) {
-      this.fd = conn.fd;
+      this[fdSymbol] = conn.fd;
     }
 
     // TODO(cmorten): the handling of new connections and construction feels
@@ -144,6 +147,10 @@ export class TCP extends ConnectionWrap {
       this.#remotePort = remoteAddr.port;
       this.#remoteFamily = isIP(remoteAddr.hostname);
     }
+  }
+
+  get fd() {
+    return this[fdSymbol];
   }
 
   /**

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -27,6 +27,8 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
+import { core } from "ext:core/mod.js";
+const { internalFdSymbol } = core;
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import { unreachable } from "ext:deno_node/_util/asserts.ts";
 import { ConnectionWrap } from "ext:deno_node/internal_binding/connection_wrap.ts";
@@ -131,8 +133,8 @@ export class TCP extends ConnectionWrap {
 
     super(provider, conn);
 
-    if (conn?.fd) {
-      this[fdSymbol] = conn.fd;
+    if (this[kStreamBaseField]) {
+      this[fdSymbol] = this[kStreamBaseField][internalFdSymbol];
     }
 
     // TODO(cmorten): the handling of new connections and construction feels

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -100,6 +100,7 @@ export class TCP extends ConnectionWrap {
 
   #closed = false;
   #acceptBackoffDelay?: number;
+  fd = -1;
 
   /**
    * Creates a new TCP class instance.
@@ -126,6 +127,10 @@ export class TCP extends ConnectionWrap {
     }
 
     super(provider, conn);
+
+    if (conn?.fd) {
+      this.fd = conn.fd;
+    }
 
     // TODO(cmorten): the handling of new connections and construction feels
     // a little off. Suspect duplicating in some fashion.


### PR DESCRIPTION
This PR will address the node compatibility issue where, the callback socket object in net.createServer is missing a fd in socket._handle

Modified this PR to use internal symbol to expose fd instead of exposing it via lib.deno.d.ts
https://github.com/denoland/deno_core/pull/1061

fixes: https://github.com/denoland/deno/issues/27788

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
