### PR TITLE
perf: strip release binaries to minimize size, but download debug info on panic to get useful stack traces

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -744,7 +744,7 @@ const ci = {
           ].join("\n"),
           run: [
             "dsymutil target/release/deno",
-            "strip -s target/release/deno",
+            "strip target/release/deno",
           ],
         },
         {

--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -721,6 +721,33 @@ const ci = {
           ].join("\n"),
         },
         {
+          name: "Strip and separate debug info (linux)",
+          if: [
+            "matrix.os == 'linux' &&",
+            "(matrix.job == 'test' || matrix.job == 'bench') &&",
+            "matrix.profile == 'release' && (matrix.use_sysroot ||",
+            "github.repository == 'denoland/deno')",
+          ].join("\n"),
+          run: [
+            "objcopy --only-keep-debug target/release/deno target/release/deno.debug",
+            "objcopy --add-gnu-debuglink target/release/deno.debug target/release/deno",
+            "strip -s target/release/deno",
+          ],
+        },
+        {
+          name: "Strip and separate debug info (mac)",
+          if: [
+            "matrix.os == 'macos' &&",
+            "(matrix.job == 'test' || matrix.job == 'bench') &&",
+            "matrix.profile == 'release' && (matrix.use_sysroot ||",
+            "github.repository == 'denoland/deno')",
+          ].join("\n"),
+          run: [
+            "dsymutil target/release/deno",
+            "strip -s target/release/deno",
+          ],
+        },
+        {
           // Run a minimal check to ensure that binary is not corrupted, regardless
           // of our build mode
           name: "Check deno binary",
@@ -766,6 +793,8 @@ const ci = {
             "cd target/release",
             "zip -r deno-${{ matrix.arch }}-unknown-linux-gnu.zip deno",
             "shasum -a 256 deno-${{ matrix.arch }}-unknown-linux-gnu.zip > deno-${{ matrix.arch }}-unknown-linux-gnu.zip.sha256sum",
+            "zip -r deno-debuginfo-${{ matrix.arch}}-unknown-linux-gnu.zip deno.debug",
+            "shasum -a 256 deno-debuginfo-${{ matrix.arch }}-unknown-linux-gnu.zip > deno-debuginfo-${{ matrix.arch }}-unknown-linux-gnu.zip.sha256sum",
             "strip denort",
             "zip -r denort-${{ matrix.arch }}-unknown-linux-gnu.zip denort",
             "shasum -a 256 denort-${{ matrix.arch }}-unknown-linux-gnu.zip > denort-${{ matrix.arch }}-unknown-linux-gnu.zip.sha256sum",
@@ -794,6 +823,8 @@ const ci = {
             "cd target/release",
             "zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno",
             "shasum -a 256 deno-${{ matrix.arch }}-apple-darwin.zip > deno-${{ matrix.arch }}-apple-darwin.zip.sha256sum",
+            "zip -r deno-debuginfo-${{ matrix.arch }}-apple-darwin.zip deno.dSYM",
+            "shasum -a 256 deno-debuginfo-${{ matrix.arch }}-apple-darwin.zip > deno-debuginfo-${{ matrix.arch }}-apple-darwin.zip.sha256sum",
             "strip denort",
             "zip -r denort-${{ matrix.arch }}-apple-darwin.zip denort",
             "shasum -a 256 denort-${{ matrix.arch }}-apple-darwin.zip > denort-${{ matrix.arch }}-apple-darwin.zip.sha256sum",
@@ -812,6 +843,8 @@ const ci = {
           run: [
             "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip",
             "Get-FileHash target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
+            "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.pdb -DestinationPath target/release/deno-debuginfo-${{ matrix.arch }}-pc-windows-msvc.zip",
+            "Get-FileHash target/release/deno-debuginfo-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-debuginfo-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
             "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip",
             "Get-FileHash target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
           ].join("\n"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,25 @@ jobs:
           df -h
           cargo build --release --locked --all-targets
           df -h
+      - name: Strip and separate debug info (linux)
+        if: |-
+          !(matrix.skip) && (matrix.os == 'linux' &&
+          (matrix.job == 'test' || matrix.job == 'bench') &&
+          matrix.profile == 'release' && (matrix.use_sysroot ||
+          github.repository == 'denoland/deno'))
+        run:
+          - objcopy --only-keep-debug target/release/deno target/release/deno.debug
+          - objcopy --add-gnu-debuglink target/release/deno.debug target/release/deno
+          - strip -s target/release/deno
+      - name: Strip and separate debug info (mac)
+        if: |-
+          !(matrix.skip) && (matrix.os == 'macos' &&
+          (matrix.job == 'test' || matrix.job == 'bench') &&
+          matrix.profile == 'release' && (matrix.use_sysroot ||
+          github.repository == 'denoland/deno'))
+        run:
+          - dsymutil target/release/deno
+          - strip -s target/release/deno
       - name: Check deno binary
         if: '!(matrix.skip) && (matrix.job == ''test'')'
         run: 'target/${{ matrix.profile }}/deno eval "console.log(1+2)" | grep 3'
@@ -446,6 +465,8 @@ jobs:
           cd target/release
           zip -r deno-${{ matrix.arch }}-unknown-linux-gnu.zip deno
           shasum -a 256 deno-${{ matrix.arch }}-unknown-linux-gnu.zip > deno-${{ matrix.arch }}-unknown-linux-gnu.zip.sha256sum
+          zip -r deno-debuginfo-${{ matrix.arch}}-unknown-linux-gnu.zip deno.debug
+          shasum -a 256 deno-debuginfo-${{ matrix.arch }}-unknown-linux-gnu.zip > deno-debuginfo-${{ matrix.arch }}-unknown-linux-gnu.zip.sha256sum
           strip denort
           zip -r denort-${{ matrix.arch }}-unknown-linux-gnu.zip denort
           shasum -a 256 denort-${{ matrix.arch }}-unknown-linux-gnu.zip > denort-${{ matrix.arch }}-unknown-linux-gnu.zip.sha256sum
@@ -465,6 +486,8 @@ jobs:
           cd target/release
           zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno
           shasum -a 256 deno-${{ matrix.arch }}-apple-darwin.zip > deno-${{ matrix.arch }}-apple-darwin.zip.sha256sum
+          zip -r deno-debuginfo-${{ matrix.arch }}-apple-darwin.zip deno.dSYM
+          shasum -a 256 deno-debuginfo-${{ matrix.arch }}-apple-darwin.zip > deno-debuginfo-${{ matrix.arch }}-apple-darwin.zip.sha256sum
           strip denort
           zip -r denort-${{ matrix.arch }}-apple-darwin.zip denort
           shasum -a 256 denort-${{ matrix.arch }}-apple-darwin.zip > denort-${{ matrix.arch }}-apple-darwin.zip.sha256sum
@@ -478,6 +501,8 @@ jobs:
         run: |-
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.exe -DestinationPath target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip
           Get-FileHash target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
+          Compress-Archive -CompressionLevel Optimal -Force -Path target/release/deno.pdb -DestinationPath target/release/deno-debuginfo-${{ matrix.arch }}-pc-windows-msvc.zip
+          Get-FileHash target/release/deno-debuginfo-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-debuginfo-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip
           Get-FileHash target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
       - name: Upload canary to dl.deno.land

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,7 @@ jobs:
           github.repository == 'denoland/deno'))
         run:
           - dsymutil target/release/deno
-          - strip -s target/release/deno
+          - strip target/release/deno
       - name: Check deno binary
         if: '!(matrix.skip) && (matrix.job == ''test'')'
         run: 'target/${{ matrix.profile }}/deno eval "console.log(1+2)" | grep 3'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -548,9 +548,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -726,13 +726,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -1170,7 +1170,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libloading 0.8.5",
  "winapi",
 ]
@@ -2103,6 +2103,7 @@ dependencies = [
  "sha3",
  "signature",
  "simd-json",
+ "simdutf",
  "sm3",
  "spki",
  "stable_deref_trait",
@@ -3778,7 +3779,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "gpu-alloc-types",
 ]
 
@@ -3788,7 +3789,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3797,7 +3798,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "gpu-descriptor-types",
  "hashbrown 0.14.5",
 ]
@@ -3808,7 +3809,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -4850,7 +4851,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -5075,7 +5076,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -5163,7 +5164,7 @@ checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "codespan-reporting",
  "hexf-parse",
  "indexmap 2.3.0",
@@ -5242,7 +5243,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "libc",
 ]
@@ -5296,7 +5297,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -6143,7 +6144,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4e75767fbc9d92b90e4d0c011f61358cde9513b31ef07ea3631b15ffc3b4fd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "memchr",
  "unicase",
 ]
@@ -6531,7 +6532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "serde",
  "serde_derive",
 ]
@@ -6600,7 +6601,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cdbe9230a57259b37f7257d0aff38b8c9dbda3513edba2105e59b130189d82f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6659,7 +6660,7 @@ version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6748,7 +6749,7 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -7145,6 +7146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b4b772d0e139c8a272c79b6a98af14053c13f05be5ed86d54ee42111f7dc0a"
+dependencies = [
+ "bitflags 2.8.0",
+ "cc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7270,7 +7281,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -7515,7 +7526,7 @@ version = "0.118.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6f866d12e4d519052b92a0a86d1ac7ff17570da1272ca0c89b3d6f802cd79df"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "is-macro",
  "num-bigint",
  "phf",
@@ -7601,7 +7612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f21494e75d0bd8ef42010b47cabab9caaed8f2207570e809f6f4eb51a710d1"
 dependencies = [
  "better_scoped_tls",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "indexmap 2.3.0",
  "once_cell",
  "phf",
@@ -8340,7 +8351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
  "async-compression",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-core",
  "http 1.1.0",
@@ -8677,7 +8688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a511192602f7b435b0a241c1947aa743eb7717f20a9195f4b5e8ed1952e01db1"
 dependencies = [
  "bindgen",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "fslock",
  "gzip-header",
  "home",
@@ -8693,7 +8704,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97599c400fc79925922b58303e98fcb8fa88f573379a08ddb652e72cbd2e70f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "encoding_rs",
  "indexmap 2.3.0",
  "num-bigint",
@@ -8926,7 +8937,7 @@ checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "document-features",
@@ -8957,7 +8968,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
@@ -8995,7 +9006,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "js-sys",
  "serde",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,6 @@ dependencies = [
  "sha3",
  "signature",
  "simd-json",
- "simdutf",
  "sm3",
  "spki",
  "stable_deref_trait",
@@ -7143,16 +7142,6 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "value-trait",
-]
-
-[[package]]
-name = "simdutf"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b4b772d0e139c8a272c79b6a98af14053c13f05be5ed86d54ee42111f7dc0a"
-dependencies = [
- "bitflags 2.8.0",
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "tracing",
  "twox-hash",
  "typed-arena",
+ "ureq",
  "uuid",
  "walkdir",
  "which",
@@ -6667,9 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.11"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
@@ -6705,9 +6706,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -6726,9 +6727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8587,6 +8588,22 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,16 +255,12 @@ winapi = "=0.3.9"
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Media", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_WindowsProgramming", "Wdk", "Wdk_System", "Wdk_System_SystemInformation", "Win32_Security", "Win32_System_Pipes", "Wdk_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Kernel", "Win32_System_Threading", "Win32_UI", "Win32_UI_Shell"] }
 winres = "=0.1.12"
 
-[profile.dev-stripped]
-inherits = "dev"
-split-debuginfo = "packed"
-strip = "symbols"
-
 [profile.release]
 codegen-units = 1
 incremental = true
 lto = true
 opt-level = 'z' # Optimize for size
+debug = "line-tables-only"
 
 # Build release with debug symbols: cargo build --profile=release-with-debug
 [profile.release-with-debug]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,6 +255,11 @@ winapi = "=0.3.9"
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Media", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_WindowsProgramming", "Wdk", "Wdk_System", "Wdk_System_SystemInformation", "Win32_Security", "Win32_System_Pipes", "Wdk_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Kernel", "Win32_System_Threading", "Win32_UI", "Win32_UI_Shell"] }
 winres = "=0.1.12"
 
+[profile.dev-stripped]
+inherits = "dev"
+split-debuginfo = "packed"
+strip = "symbols"
+
 [profile.release]
 codegen-units = 1
 incremental = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -175,6 +175,7 @@ which.workspace = true
 zeromq.workspace = true
 zip = { version = "2.1.6", default-features = false, features = ["deflate-flate2"] }
 zstd.workspace = true
+ureq = "2.12.1"
 
 [target.'cfg(windows)'.dependencies]
 junction.workspace = true

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -356,7 +356,7 @@ fn download_debug_info(url: &str) -> Result<(), AnyError> {
   let mut data = Vec::new();
   reader.read_to_end(&mut data)?;
 
-  crate::util::archive::unpack_dir_into_dir(debug_file_name, dest, &data)?;
+  crate::util::archive::unpack_zip_into_dir(debug_file_name, dest, &data)?;
   Ok(())
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -356,7 +356,11 @@ fn download_debug_info(url: &str) -> Result<(), AnyError> {
   let mut data = Vec::new();
   reader.read_to_end(&mut data)?;
 
-  crate::util::archive::unpack_zip_into_dir(debug_file_name, dest, &data)?;
+  crate::util::archive::unpack_zip_into_dir(
+    &format!("deno-debuginfo-{}.zip", env!("TARGET")),
+    dest,
+    &data,
+  )?;
   Ok(())
 }
 

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -296,13 +296,14 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     };
     let archive_data = read_file(&binary_path)?;
     let temp_dir = tempfile::TempDir::new()?;
-    let base_binary_path = archive::unpack_into_dir(archive::UnpackArgs {
-      exe_name: "denort",
-      archive_name: &binary_name,
-      archive_data: &archive_data,
-      is_windows: target.contains("windows"),
-      dest_path: temp_dir.path(),
-    })?;
+    let base_binary_path =
+      archive::unpack_binary_into_dir(archive::UnpackArgs {
+        exe_name: "denort",
+        archive_name: &binary_name,
+        archive_data: &archive_data,
+        is_windows: target.contains("windows"),
+        dest_path: temp_dir.path(),
+      })?;
     let base_binary = read_file(&base_binary_path)?;
     drop(temp_dir); // delete the temp dir
     Ok(base_binary)

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -555,7 +555,7 @@ pub async fn upgrade(
   );
 
   let temp_dir = tempfile::TempDir::new()?;
-  let new_exe_path = archive::unpack_into_dir(archive::UnpackArgs {
+  let new_exe_path = archive::unpack_binary_into_dir(archive::UnpackArgs {
     exe_name: "deno",
     archive_name: &ARCHIVE_NAME,
     archive_data: &archive_data,

--- a/cli/util/archive.rs
+++ b/cli/util/archive.rs
@@ -118,22 +118,13 @@ pub fn unpack_binary_into_dir(args: UnpackArgs) -> Result<PathBuf, AnyError> {
 }
 
 pub fn unpack_zip_into_dir(
-  out_name: &str,
+  archive_name: &str,
   dest_path: &Path,
   archive_data: &[u8],
 ) -> Result<(), AnyError> {
-  let ext = out_name.rsplit_once('.').map(|(_, ext)| ext);
-  let archive_path = dest_path.join(out_name).with_extension(
-    ext
-      .map(|s| format!("{s}.zip"))
-      .unwrap_or_else(|| "zip".to_string()),
-  );
+  let archive_path = dest_path.join(archive_name);
 
-  if let Err(e) = unzip(
-    archive_path.file_name().unwrap().to_str().unwrap(),
-    archive_data,
-    dest_path,
-  ) {
+  if let Err(e) = unzip(archive_name, archive_data, dest_path) {
     log::warn!("unpacking via zip crate failed: {e}");
     unzip_with_shell(&archive_path, archive_data, dest_path)?;
   }

--- a/cli/util/archive.rs
+++ b/cli/util/archive.rs
@@ -90,6 +90,7 @@ pub fn unpack_into_dir(args: UnpackArgs) -> Result<PathBuf, AnyError> {
   let exe_ext = if is_windows { "exe" } else { "" };
   let archive_path = dest_path.join(exe_name).with_extension("zip");
   let exe_path = dest_path.join(exe_name).with_extension(exe_ext);
+  dbg!(&exe_path);
   assert!(!exe_path.exists());
 
   let archive_ext = Path::new(archive_name)
@@ -115,4 +116,25 @@ pub fn unpack_into_dir(args: UnpackArgs) -> Result<PathBuf, AnyError> {
 
   assert!(exe_path.exists());
   Ok(exe_path)
+}
+
+pub fn unpack_dir_into_dir(
+  out_name: &str,
+  dest_path: &Path,
+  archive_data: &[u8],
+) -> Result<(), AnyError> {
+  let ext = out_name.rsplit_once('.').map(|(_, ext)| ext);
+  let archive_path = dest_path.join(out_name).with_extension(
+    ext
+      .map(|s| format!("{s}.zip"))
+      .unwrap_or_else(|| "zip".to_string()),
+  );
+
+  unzip(
+    archive_path.file_name().unwrap().to_str().unwrap(),
+    archive_data,
+    dest_path,
+  )?;
+
+  Ok(())
 }


### PR DESCRIPTION
This saves about 26 MB on macOS, should be similar on linux (stripping makes no difference on windows because symbols are already in a separate file).

This PR strips symbols from the release binaries, but separates and uploads the debug info for debugging.

To make sure stack traces on panics are still useful, we lazily download the debug info when panicking (but only if running with `RUST_BACKTRACE` set). Since most users should not hit panics, this means that most people will get the benefits of smaller binary size with no drawbacks.

An additional benefit is that now that debug info is separate, stack traces are actually _more_ useful because we can included more detailed debug info without worrying about the binary size.

This also resolves an issue on windows where stack traces on panics are incorrect, as the symbol information is already separate but we don't distribute it.

---

Remaining questions / things to resolve:

- I pulled in `ureq` for a simple synchronous http client, but maybe we could reuse our own client? just seemed tricky to do in a panic hook context
- how to ensure versioning is correct. right now in this PR we remove the debug info on upgrades, and it'll just get lazily downloaded again for the new version. is this enough?
- how to test this. the debug info download only happens on panic, so how do we get deno to panic reliably in a test (maybe a cargo feature that has an explicit panic somewhere reachable? but feels wrong)