### PR TITLE
fix(ext/node): scrypt panic when `log_n` > 64

### DIFF
--- a/ext/node/ops/crypto/mod.rs
+++ b/ext/node/ops/crypto/mod.rs
@@ -571,7 +571,7 @@ fn scrypt(
     parallelization,
     keylen as usize,
   )
-  .unwrap();
+  .map_err(|_| JsErrorBox::generic("scrypt params construction failed"))?;
 
   // Call into scrypt
   let res = scrypt::scrypt(&password, &salt, &params, output_buffer);

--- a/ext/node/polyfills/internal/crypto/scrypt.ts
+++ b/ext/node/polyfills/internal/crypto/scrypt.ts
@@ -107,23 +107,19 @@ export function scrypt(
     throw new Error("exceeds max memory");
   }
 
-  try {
-    op_node_scrypt_async(
-      password,
-      salt,
-      keylen,
-      Math.log2(N),
-      r,
-      p,
-      maxmem,
-    ).then(
-      (buf: Uint8Array) => {
-        cb(null, Buffer.from(buf.buffer));
-      },
-    );
-  } catch (err: unknown) {
-    return cb(err);
-  }
+  op_node_scrypt_async(
+    password,
+    salt,
+    keylen,
+    Math.log2(N),
+    r,
+    p,
+    maxmem,
+  ).then(
+    (buf: Uint8Array) => {
+      cb(null, Buffer.from(buf.buffer));
+    },
+  ).catch((err: unknown) => cb(err));
 }
 
 export default {

--- a/tests/unit_node/crypto/crypto_scrypt_test.ts
+++ b/tests/unit_node/crypto/crypto_scrypt_test.ts
@@ -188,3 +188,14 @@ Deno.test("scryptSync with options works correctly", () => {
     ]),
   );
 });
+
+Deno.test("log_n > 64 doesn't panic", async () => {
+  const { promise, resolve } = Promise.withResolvers<boolean>();
+
+  crypto.scrypt("password", "salt", 128, (err, hashed) => {
+    // log_n > 64 is not supported currently https://github.com/denoland/deno/issues/27716
+    err ? resolve() : reject();
+  });
+
+  await promise;
+});

--- a/tests/unit_node/crypto/crypto_scrypt_test.ts
+++ b/tests/unit_node/crypto/crypto_scrypt_test.ts
@@ -192,7 +192,7 @@ Deno.test("scryptSync with options works correctly", () => {
 Deno.test("log_n > 64 doesn't panic", async () => {
   const { promise, resolve } = Promise.withResolvers<boolean>();
 
-  crypto.scrypt("password", "salt", 128, (err, hashed) => {
+  crypto.scrypt("password", "salt", 128, (err) => {
     // log_n > 64 is not supported currently https://github.com/denoland/deno/issues/27716
     err ? resolve() : reject();
   });

--- a/tests/unit_node/crypto/crypto_scrypt_test.ts
+++ b/tests/unit_node/crypto/crypto_scrypt_test.ts
@@ -190,11 +190,11 @@ Deno.test("scryptSync with options works correctly", () => {
 });
 
 Deno.test("log_n > 64 doesn't panic", async () => {
-  const { promise, resolve } = Promise.withResolvers<boolean>();
+  const { promise, resolve, reject } = Promise.withResolvers<boolean>();
 
-  crypto.scrypt("password", "salt", 128, (err) => {
+  scrypt("password", "salt", 128, (err) => {
     // log_n > 64 is not supported currently https://github.com/denoland/deno/issues/27716
-    err ? resolve() : reject();
+    err ? resolve({}) : reject({});
   });
 
   await promise;

--- a/tests/unit_node/crypto/crypto_scrypt_test.ts
+++ b/tests/unit_node/crypto/crypto_scrypt_test.ts
@@ -190,7 +190,7 @@ Deno.test("scryptSync with options works correctly", () => {
 });
 
 Deno.test("log_n > 64 doesn't panic", async () => {
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const { promise, resolve } = Promise.withResolvers<void>();
 
   scrypt("password", "salt", 128, () => {
     resolve();

--- a/tests/unit_node/crypto/crypto_scrypt_test.ts
+++ b/tests/unit_node/crypto/crypto_scrypt_test.ts
@@ -190,11 +190,10 @@ Deno.test("scryptSync with options works correctly", () => {
 });
 
 Deno.test("log_n > 64 doesn't panic", async () => {
-  const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
 
-  scrypt("password", "salt", 128, (err) => {
-    // log_n > 64 is not supported currently https://github.com/denoland/deno/issues/27716
-    err ? resolve(true) : reject({});
+  scrypt("password", "salt", 128, () => {
+    resolve();
   });
 
   await promise;

--- a/tests/unit_node/crypto/crypto_scrypt_test.ts
+++ b/tests/unit_node/crypto/crypto_scrypt_test.ts
@@ -194,7 +194,7 @@ Deno.test("log_n > 64 doesn't panic", async () => {
 
   scrypt("password", "salt", 128, (err) => {
     // log_n > 64 is not supported currently https://github.com/denoland/deno/issues/27716
-    err ? resolve({}) : reject({});
+    err ? resolve(true) : reject({});
   });
 
   await promise;


### PR DESCRIPTION
Throws an error instead of panic. Ref https://github.com/denoland/deno/issues/27716
