### PR TITLE
perf(lsp): cache completion item resolution during request

### DIFF
--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3686,8 +3686,7 @@ impl CompletionInfo {
     // A cache for costly resolution computations.
     // On a test project, it was found to speed up completion requests
     // by 10-20x and contained ~300 entries for 8000 completion items.
-    let mut cache = HashMap::with_capacity(4096);
-    let entries_count = self.entries.len();
+    let mut cache = HashMap::with_capacity(512);
     let items = self
       .entries
       .iter()

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3903,6 +3903,7 @@ impl CompletionEntry {
     self.insert_text.clone()
   }
 
+  #[allow(clippy::too_many_arguments)]
   pub fn as_completion_item(
     &self,
     line_index: Arc<LineIndex>,
@@ -3989,7 +3990,7 @@ impl CompletionEntry {
               .then(|| import_data.normalized.to_string())
           })
         {
-          cache.insert(
+          resolution_cache.insert(
             (import_data.normalized.clone(), specifier.clone()),
             new_specifier.clone(),
           );


### PR DESCRIPTION
This commit adds a simple HashMap cache to completion requests.

On a test project the time to compute completions went from 1200ms
to 75ms and the cache contained ~300 entries when 8000 completion
items were produced by the TSC.

This is a short-lived cache and is discarded once the completion
request is finished. In a follow up commits we could make it persist
between requests.