### PR TITLE
fix(lint): update jsx/react related rules and names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802583d3ca6c7063e14cafa02ddc206fb34e804e095d52032baf375c56a99515"
+checksum = "ac94db8d8597b96c92d30a68b11d4bec6822dcbb3e8675ab1e0136816a301a34"
 dependencies = [
  "anyhow",
  "deno_ast",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,7 +74,7 @@ deno_doc = { version = "=0.164.0", features = ["rust", "comrak"] }
 deno_error.workspace = true
 deno_graph = { version = "=0.87.0" }
 deno_lib.workspace = true
-deno_lint = { version = "0.69.0" }
+deno_lint = { version = "0.70.0" }
 deno_lockfile.workspace = true
 deno_media_type = { workspace = true, features = ["data_url", "decoding", "module_specifier"] }
 deno_npm.workspace = true


### PR DESCRIPTION
This PR updates `deno_lint` which contains a couple of bug fixes for JSX/React related rules. The react rules now have all a `react-*` prefix in the name as well.