### PR TITLE
feat(test): Add Deno.test.disableSanitizers API

### DIFF
--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -224,8 +224,9 @@ function testInner(
   const defaults = {
     ignore: false,
     only: false,
-    sanitizeOps: true,
-    sanitizeResources: true,
+    sanitizeOps: !sanitizersDisabled,
+    sanitizeResources: !sanitizersDisabled,
+    // Exit sanitizer is never disabled
     sanitizeExit: true,
     permissions: null,
   };
@@ -353,6 +354,12 @@ test.only = function (
   maybeFn,
 ) {
   return testInner(nameOrFnOrOptions, optionsOrFn, maybeFn, { only: true });
+};
+
+let sanitizersDisabled = false;
+
+test.disableSanitizers = function () {
+  sanitizersDisabled = true;
 };
 
 function getFullName(desc) {

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1166,6 +1166,14 @@ declare namespace Deno {
       options: Omit<TestDefinition, "fn" | "only">,
       fn: (t: TestContext) => void | Promise<void>,
     ): void;
+
+    /** Disable op and resource sanitizers for the whole test file.
+     *
+     * Individual tests can still use sanitizers, by specifying relevant
+     * `sanitizeOps` and `sanitizeResources` options.
+     * @category Testing
+     */
+    disableSanitizers(): void;
   }
 
   /**

--- a/tests/specs/test/ops_sanitizer_disabled/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_disabled/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test main.ts",
+  "exitCode": 0,
+  "output": "main.out"
+}

--- a/tests/specs/test/ops_sanitizer_disabled/main.out
+++ b/tests/specs/test/ops_sanitizer_disabled/main.out
@@ -1,0 +1,7 @@
+Check [WILDCARD]/main.ts
+running 2 tests from [WILDCARD]/main.ts
+no-op ... ok ([WILDCARD])
+leak interval ... ok ([WILDCARD])
+
+ok | 2 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/ops_sanitizer_disabled/main.ts
+++ b/tests/specs/test/ops_sanitizer_disabled/main.ts
@@ -1,0 +1,9 @@
+Deno.test.disableSanitizers();
+
+Deno.test("no-op", function () {});
+Deno.test({
+  name: "leak interval",
+  fn() {
+    setInterval(function () {}, 100000);
+  },
+});

--- a/tests/specs/test/ops_sanitizer_disabled_override/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_disabled_override/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --trace-leaks main.ts",
+  "exitCode": 1,
+  "output": "main.out"
+}

--- a/tests/specs/test/ops_sanitizer_disabled_override/main.out
+++ b/tests/specs/test/ops_sanitizer_disabled_override/main.out
@@ -1,0 +1,22 @@
+Check [WILDCARD]/main.ts
+running 2 tests from [WILDCARD]/main.ts
+no-op ... ok ([WILDCARD])
+leak interval ... FAILED ([WILDCARD])
+
+ ERRORS 
+
+leak interval => [WILDCARD]/main.ts:[WILDCARD]
+error: Leaks detected:
+  - An interval was started in this test, but never completed. This is often caused by not calling `clearInterval`. The operation was started here:
+    at [WILDCARD]
+    at setInterval ([WILDCARD])
+    at fn ([WILDCARD]/main.ts:[WILDCARD])
+    at [WILDCARD]
+
+ FAILURES 
+
+leak interval => [WILDCARD]/main.ts:[WILDCARD]
+
+FAILED | 1 passed | 1 failed ([WILDCARD])
+
+error: Test failed

--- a/tests/specs/test/ops_sanitizer_disabled_override/main.ts
+++ b/tests/specs/test/ops_sanitizer_disabled_override/main.ts
@@ -1,0 +1,10 @@
+Deno.test.disableSanitizers();
+
+Deno.test("no-op", function () {});
+Deno.test({
+  name: "leak interval",
+  sanitizeOps: true,
+  fn() {
+    setInterval(function () {}, 100000);
+  },
+});

--- a/tests/specs/test/resource_sanitizer_disabled/__test__.jsonc
+++ b/tests/specs/test/resource_sanitizer_disabled/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --allow-read main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/test/resource_sanitizer_disabled/main.out
+++ b/tests/specs/test/resource_sanitizer_disabled/main.out
@@ -1,0 +1,6 @@
+Check [WILDCARD]main.ts
+running 1 test from [WILDCARD]main.ts
+leak ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/resource_sanitizer_disabled/main.ts
+++ b/tests/specs/test/resource_sanitizer_disabled/main.ts
@@ -1,0 +1,6 @@
+Deno.test.disableSanitizers();
+
+Deno.test("leak", function () {
+  Deno.openSync("../../../testdata/run/001_hello.js");
+  Deno.stdin.close();
+});

--- a/tests/specs/test/resource_sanitizer_disabled_override/__test__.jsonc
+++ b/tests/specs/test/resource_sanitizer_disabled_override/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --allow-read main.ts",
+  "output": "main.out",
+  "exitCode": 1
+}

--- a/tests/specs/test/resource_sanitizer_disabled_override/main.out
+++ b/tests/specs/test/resource_sanitizer_disabled_override/main.out
@@ -1,0 +1,18 @@
+Check [WILDCARD]main.ts
+running 1 test from [WILDCARD]main.ts
+leak ... FAILED (1ms)
+
+ ERRORS 
+
+leak => [WILDCARD]main.ts:3:6
+error: Leaks detected:
+  - A file was opened during the test, but not closed during the test. Close the file handle by calling `file.close()`.
+  - The stdin pipe was opened before the test started, but was closed during the test. Do not close resources in a test that were not created during that test.
+
+ FAILURES 
+
+leak => [WILDCARD]main.ts:3:6
+
+FAILED | 0 passed | 1 failed ([WILDCARD])
+
+error: Test failed

--- a/tests/specs/test/resource_sanitizer_disabled_override/main.ts
+++ b/tests/specs/test/resource_sanitizer_disabled_override/main.ts
@@ -1,0 +1,6 @@
+Deno.test.disableSanitizers();
+
+Deno.test("leak", { sanitizeResources: true }, function () {
+  Deno.openSync("../../../testdata/run/001_hello.js");
+  Deno.stdin.close();
+});


### PR DESCRIPTION
This commit adds `Deno.test.disableSanitizers()` API that can be used
to disable op and resource sanitizers for the whole test file (as opposed
to disabling them per test).

This API would help in situation like https://github.com/denoland/deno/issues/27775
where a 3 party library causes leaks and there's not much end user can do. Instead
of changing potentially tens of tests, the sanitizers can be disabled
by a single line in a file.

Once `Deno.test.disableSanitizers()` is called, individual tests can still
override this and enable relevant sanitizers using `sanitizeOps` and `sanitizeResources`
options.