### PR TITLE
perf(lsp): add built-in tracing support for the LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,16 +5711,15 @@ checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,15 +5711,16 @@ checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,10 @@ dependencies = [
  "notify",
  "once_cell",
  "open",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "p256",
  "pathdiff",
  "percent-encoding",
@@ -1426,7 +1430,10 @@ dependencies = [
  "thiserror 2.0.3",
  "tokio",
  "tokio-util",
+ "tower 0.5.2",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "twox-hash",
  "typed-arena",
  "unicode-width",
@@ -5704,21 +5711,22 @@ checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -8618,9 +8626,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -8630,9 +8638,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8641,9 +8649,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -8661,10 +8669,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
+name = "tracing-opentelemetry"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,7 @@ opentelemetry = "0.27.0"
 opentelemetry-http = "0.27.0"
 opentelemetry-otlp = { version = "0.27.0", features = ["logs", "http-proto", "http-json"] }
 opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
-opentelemetry_sdk = "0.27.0"
+opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio", "trace"] }
 
 # crypto
 hkdf = "0.12.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -141,6 +141,10 @@ monch.workspace = true
 notify.workspace = true
 once_cell.workspace = true
 open = "5.0.1"
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry-semantic-conventions.workspace = true
+opentelemetry_sdk.workspace = true
 p256.workspace = true
 pathdiff = "0.2.1"
 percent-encoding.workspace = true
@@ -166,8 +170,11 @@ text_lines = "=0.6.0"
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tower.workspace = true
 tower-lsp.workspace = true
-tracing = { version = "0.1", features = ["log", "default"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-opentelemetry = "0.28.0"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 twox-hash.workspace = true
 typed-arena = "=2.0.2"
 unicode-width = "0.1.3"

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -95,7 +95,7 @@ fn bench_deco_apps_edits(deno_exe: &Path) -> Duration {
     c.set_workspace_folders(vec![lsp_types::WorkspaceFolder {
       uri: apps.uri_dir(),
       name: "apps".to_string(),
-    }]);
+    }]);  
     c.set_deno_enable(true);
     c.set_unstable(true);
     c.set_preload_limit(1000);

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -95,7 +95,7 @@ fn bench_deco_apps_edits(deno_exe: &Path) -> Duration {
     c.set_workspace_folders(vec![lsp_types::WorkspaceFolder {
       uri: apps.uri_dir(),
       name: "apps".to_string(),
-    }]);  
+    }]);
     c.set_deno_enable(true);
     c.set_unstable(true);
     c.set_preload_limit(1000);

--- a/cli/lib/util/logger.rs
+++ b/cli/lib/util/logger.rs
@@ -92,6 +92,7 @@ pub fn init<
   // Suppress span lifecycle logs since they are too verbose
   .filter_module("tracing::span", log::LevelFilter::Off)
   .filter_module("tower_lsp", log::LevelFilter::Trace)
+  .filter_module("opentelemetry_sdk", log::LevelFilter::Off)
   // for deno_compile, this is too verbose
   .filter_module("editpe", log::LevelFilter::Error)
   .format(|buf, record| {

--- a/cli/lib/util/logger.rs
+++ b/cli/lib/util/logger.rs
@@ -91,6 +91,7 @@ pub fn init<
   .filter_module("swc_ecma_parser", log::LevelFilter::Error)
   // Suppress span lifecycle logs since they are too verbose
   .filter_module("tracing::span", log::LevelFilter::Off)
+  .filter_module("tower_lsp", log::LevelFilter::Trace)
   // for deno_compile, this is too verbose
   .filter_module("editpe", log::LevelFilter::Error)
   .format(|buf, record| {

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -150,6 +150,7 @@ fn to_narrow_lsp_range(
 /// completion response, which will be valid import completions for the specific
 /// context.
 #[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip_all)]
 pub async fn get_import_completions(
   specifier: &ModuleSpecifier,
   position: &lsp::Position,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -619,6 +619,9 @@ pub struct WorkspaceSettings {
 
   #[serde(default)]
   pub typescript: LanguageWorkspaceSettings,
+
+  #[serde(default)]
+  pub tracing: Option<super::trace::TracingConfigOrEnabled>,
 }
 
 impl Default for WorkspaceSettings {
@@ -645,6 +648,7 @@ impl Default for WorkspaceSettings {
       unstable: Default::default(),
       javascript: Default::default(),
       typescript: Default::default(),
+      tracing: Default::default(),
     }
   }
 }
@@ -2309,8 +2313,9 @@ mod tests {
           suggestion_actions: SuggestionActionsSettings { enabled: true },
           update_imports_on_file_move: UpdateImportsOnFileMoveOptions {
             enabled: UpdateImportsOnFileMoveEnabled::Prompt
-          }
+          },
         },
+        tracing: Default::default()
       }
     );
   }

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1297,6 +1297,7 @@ impl Documents {
   /// For a given set of string specifiers, resolve each one from the graph,
   /// for a given referrer. This is used to provide resolution information to
   /// tsc when type checking.
+  #[tracing::instrument(skip_all)]
   pub fn resolve(
     &self,
     // (is_cjs: bool, raw_specifier: String)
@@ -1555,6 +1556,7 @@ impl Documents {
     self.dirty = false;
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn resolve_dependency(
     &self,
     specifier: &ModuleSpecifier,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -3218,7 +3218,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn semantic_tokens_range(
     &self,
     params: SemanticTokensRangeParams,
@@ -3284,7 +3283,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn signature_help(
     &self,
     params: SignatureHelpParams,
@@ -3360,7 +3358,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn will_rename_files(
     &self,
     params: RenameFilesParams,
@@ -3423,7 +3420,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn symbol(
     &self,
     params: WorkspaceSymbolParams,
@@ -4232,7 +4228,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn post_cache(&mut self) {
     self.resolver.did_cache();
     self.refresh_dep_info().await;
@@ -4274,7 +4269,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn post_did_change_workspace_folders(&mut self) {
     self.refresh_workspace_files();
     self.refresh_config_tree().await;
@@ -4354,6 +4348,7 @@ impl Inner {
     Ok(result)
   }
 
+  #[tracing::instrument(skip_all)]
   async fn inlay_hint(
     &self,
     params: InlayHintParams,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1252,7 +1252,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn did_change_configuration(
     &mut self,
     params: DidChangeConfigurationParams,
@@ -1286,7 +1285,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip(self))]
-
   async fn did_change_watched_files(
     &mut self,
     params: DidChangeWatchedFilesParams,
@@ -1373,7 +1371,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn document_symbol(
     &self,
     params: DocumentSymbolParams,
@@ -1427,7 +1424,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn formatting(
     &self,
     params: DocumentFormattingParams,
@@ -1687,7 +1683,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn code_action(
     &self,
     params: CodeActionParams,
@@ -1948,7 +1943,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn code_action_resolve(
     &self,
     params: CodeAction,
@@ -2116,7 +2110,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn code_lens(
     &self,
     params: CodeLensParams,
@@ -2202,7 +2195,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn code_lens_resolve(
     &self,
     code_lens: CodeLens,
@@ -2232,7 +2224,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn document_highlight(
     &self,
     params: DocumentHighlightParams,
@@ -2300,7 +2291,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn references(
     &self,
     params: ReferenceParams,
@@ -2367,7 +2357,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn goto_definition(
     &self,
     params: GotoDefinitionParams,
@@ -2428,7 +2417,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn goto_type_definition(
     &self,
     params: GotoTypeDefinitionParams,
@@ -2492,7 +2480,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn completion(
     &self,
     params: CompletionParams,
@@ -2620,7 +2607,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn completion_resolve(
     &self,
     params: CompletionItem,
@@ -2710,7 +2696,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn goto_implementation(
     &self,
     params: GotoImplementationParams,
@@ -2773,7 +2758,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn folding_range(
     &self,
     params: FoldingRangeParams,
@@ -2835,7 +2819,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn incoming_calls(
     &self,
     params: CallHierarchyIncomingCallsParams,
@@ -2895,7 +2878,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn outgoing_calls(
     &self,
     params: CallHierarchyOutgoingCallsParams,
@@ -2957,7 +2939,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn prepare_call_hierarchy(
     &self,
     params: CallHierarchyPrepareParams,
@@ -3036,7 +3017,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn rename(
     &self,
     params: RenameParams,
@@ -3098,7 +3078,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn selection_range(
     &self,
     params: SelectionRangeParams,
@@ -3154,7 +3133,6 @@ impl Inner {
   }
 
   #[tracing::instrument(skip_all)]
-
   async fn semantic_tokens_full(
     &self,
     params: SemanticTokensParams,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1271,6 +1271,7 @@ impl Inner {
         self.config.set_workspace_settings(settings, vec![]);
       }
     };
+    // TODO(nathanwhit): allow updating after startup, needs work to set thread local collector on tsc thread
     // self.update_tracing();
     self.update_debug_flag();
     self.update_global_cache().await;

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1151,7 +1151,6 @@ impl Inner {
     let specifier = self
       .url_map
       .uri_to_specifier(&params.text_document.uri, LspUrlKind::File);
-    eprintln!("did_change: {specifier}");
     match self.documents.change(
       &specifier,
       params.text_document.version,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -650,6 +650,9 @@ impl Inner {
             .into()
           })
         });
+    self
+      .ts_server
+      .set_tracing_enabled(tracing.as_ref().is_some_and(|t| t.enabled()));
     self._tracing = tracing.and_then(|conf| {
       if !conf.enabled() {
         return None;

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -227,6 +227,8 @@ pub struct Inner {
   /// Set to `self.config.settings.enable_settings_hash()` after
   /// refreshing `self.workspace_files`.
   workspace_files_hash: u64,
+
+  _tracing: Option<super::trace::TracingGuard>,
 }
 
 impl LanguageServer {
@@ -246,6 +248,7 @@ impl LanguageServer {
 
   /// Similar to `deno install --entrypoint` on the command line, where modules will be cached
   /// in the Deno cache, including any of their dependencies.
+  #[tracing::instrument(skip_all)]
   pub async fn cache(
     &self,
     specifiers: Vec<ModuleSpecifier>,
@@ -431,6 +434,7 @@ impl LanguageServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn refresh_configuration(&self) {
     let (folders, capable) = {
       let inner = self.inner.read().await;
@@ -522,11 +526,13 @@ impl Inner {
       url_map: Default::default(),
       workspace_files: Default::default(),
       workspace_files_hash: 0,
+      _tracing: Default::default(),
     }
   }
 
   /// Searches assets and documents for the provided
   /// specifier erroring if it doesn't exist.
+  #[tracing::instrument(skip_all)]
   pub fn get_asset_or_document(
     &self,
     specifier: &ModuleSpecifier,
@@ -553,6 +559,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_navigation_tree(
     &self,
     specifier: &ModuleSpecifier,
@@ -616,6 +623,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn snapshot(&self) -> Arc<StateSnapshot> {
     Arc::new(StateSnapshot {
       project_version: self.project_version,
@@ -626,6 +634,37 @@ impl Inner {
     })
   }
 
+  pub fn update_tracing(&mut self) {
+    let tracing =
+      self
+        .config
+        .workspace_settings()
+        .tracing
+        .clone()
+        .or_else(|| {
+          std::env::var("DENO_LSP_TRACE").ok().map(|_| {
+            super::trace::TracingConfig {
+              enable: true,
+              ..Default::default()
+            }
+            .into()
+          })
+        });
+    self._tracing = tracing.and_then(|conf| {
+      if !conf.enabled() {
+        return None;
+      }
+      lsp_log!("Initializing tracing subscriber: {:#?}", conf);
+      let config = conf.into();
+      super::trace::init_tracing_subscriber(&config)
+        .inspect_err(|e| {
+          lsp_warn!("Error initializing tracing subscriber: {e:#}");
+        })
+        .ok()
+    });
+  }
+
+  #[tracing::instrument(skip_all)]
   pub async fn update_global_cache(&mut self) {
     let mark = self.performance.mark("lsp.update_global_cache");
     let maybe_cache = self.config.workspace_settings().cache.as_ref();
@@ -683,6 +722,7 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   pub fn update_cache(&mut self) {
     let mark = self.performance.mark("lsp.update_cache");
     self.cache.update_config(&self.config);
@@ -792,6 +832,7 @@ impl Inner {
       return Err(tower_lsp::jsonrpc::Error::internal_error());
     };
 
+    self.update_tracing();
     self.update_debug_flag();
 
     if capabilities.code_action_provider.is_some() {
@@ -810,6 +851,7 @@ impl Inner {
     })
   }
 
+  #[tracing::instrument(skip_all)]
   fn walk_workspace(config: &Config) -> (IndexSet<ModuleSpecifier>, bool) {
     if !config.workspace_capable() {
       log::debug!("Skipped workspace walk due to client incapability.");
@@ -969,6 +1011,7 @@ impl Inner {
     self.workspace_files_hash = enable_settings_hash;
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_config_tree(&mut self) {
     let file_fetcher = CliFileFetcher::new(
       self.cache.global().clone(),
@@ -1024,6 +1067,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_resolver(&mut self) {
     self.resolver = Arc::new(
       LspResolver::from_config(
@@ -1035,6 +1079,7 @@ impl Inner {
     );
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_documents_config(&mut self) {
     self.documents.update_config(
       &self.config,
@@ -1050,6 +1095,7 @@ impl Inner {
     self.project_changed([], true);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_open(&mut self, params: DidOpenTextDocumentParams) {
     let mark = self.performance.mark_with_args("lsp.did_open", &params);
     let Some(scheme) = params.text_document.uri.scheme() else {
@@ -1099,11 +1145,13 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_change(&mut self, params: DidChangeTextDocumentParams) {
     let mark = self.performance.mark_with_args("lsp.did_change", &params);
     let specifier = self
       .url_map
       .uri_to_specifier(&params.text_document.uri, LspUrlKind::File);
+    eprintln!("did_change: {specifier}");
     match self.documents.change(
       &specifier,
       params.text_document.version,
@@ -1136,6 +1184,7 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
   fn did_save(&mut self, params: DidSaveTextDocumentParams) {
     let _mark = self.performance.measure_scope("lsp.did_save");
     let specifier = self
@@ -1164,6 +1213,7 @@ impl Inner {
     }));
   }
 
+  #[tracing::instrument(skip_all)]
   async fn refresh_dep_info(&mut self) {
     let dep_info_by_scope = self.documents.dep_info_by_scope();
     self
@@ -1172,6 +1222,7 @@ impl Inner {
       .await;
   }
 
+  #[tracing::instrument(skip_all)]
   async fn did_close(&mut self, params: DidCloseTextDocumentParams) {
     let mark = self.performance.mark_with_args("lsp.did_close", &params);
     let Some(scheme) = params.text_document.uri.scheme() else {
@@ -1198,6 +1249,8 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn did_change_configuration(
     &mut self,
     params: DidChangeConfigurationParams,
@@ -1216,6 +1269,7 @@ impl Inner {
         self.config.set_workspace_settings(settings, vec![]);
       }
     };
+    // self.update_tracing();
     self.update_debug_flag();
     self.update_global_cache().await;
     self.refresh_workspace_files();
@@ -1227,6 +1281,8 @@ impl Inner {
     self.send_diagnostics_update();
     self.send_testing_update();
   }
+
+  #[tracing::instrument(skip(self))]
 
   async fn did_change_watched_files(
     &mut self,
@@ -1313,6 +1369,8 @@ impl Inner {
     self.performance.measure(mark);
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn document_symbol(
     &self,
     params: DocumentSymbolParams,
@@ -1364,6 +1422,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(response)
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn formatting(
     &self,
@@ -1479,6 +1539,7 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   async fn hover(
     &self,
     params: HoverParams,
@@ -1578,6 +1639,8 @@ impl Inner {
     Ok(hover)
   }
 
+  #[tracing::instrument(skip_all)]
+
   fn resolution_to_hover_text(
     &self,
     resolution: &Resolution,
@@ -1619,6 +1682,8 @@ impl Inner {
       Resolution::None => "_[missing]_".to_string(),
     }
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn code_action(
     &self,
@@ -1879,6 +1944,8 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn code_action_resolve(
     &self,
     params: CodeAction,
@@ -2045,6 +2112,8 @@ impl Inner {
     )
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn code_lens(
     &self,
     params: CodeLensParams,
@@ -2129,6 +2198,8 @@ impl Inner {
     Ok(Some(code_lenses))
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn code_lens_resolve(
     &self,
     code_lens: CodeLens,
@@ -2156,6 +2227,8 @@ impl Inner {
     self.performance.measure(mark);
     result
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn document_highlight(
     &self,
@@ -2223,6 +2296,8 @@ impl Inner {
     Ok(document_highlights)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn references(
     &self,
     params: ReferenceParams,
@@ -2288,6 +2363,8 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn goto_definition(
     &self,
     params: GotoDefinitionParams,
@@ -2346,6 +2423,8 @@ impl Inner {
       Ok(None)
     }
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn goto_type_definition(
     &self,
@@ -2408,6 +2487,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(response)
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn completion(
     &self,
@@ -2475,7 +2556,7 @@ impl Inner {
       let scope = asset_or_doc.scope();
       let maybe_completion_info = self
         .ts_server
-        .get_completions(
+        .get_completions_tsc(
           self.snapshot(),
           specifier.clone(),
           position,
@@ -2534,6 +2615,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(response)
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn completion_resolve(
     &self,
@@ -2623,6 +2706,8 @@ impl Inner {
     Ok(completion_item)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn goto_implementation(
     &self,
     params: GotoImplementationParams,
@@ -2684,6 +2769,8 @@ impl Inner {
     Ok(result)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn folding_range(
     &self,
     params: FoldingRangeParams,
@@ -2744,6 +2831,8 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn incoming_calls(
     &self,
     params: CallHierarchyIncomingCallsParams,
@@ -2801,6 +2890,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(Some(resolved_items))
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn outgoing_calls(
     &self,
@@ -2861,6 +2952,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(Some(resolved_items))
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn prepare_call_hierarchy(
     &self,
@@ -2939,6 +3032,8 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn rename(
     &self,
     params: RenameParams,
@@ -2999,6 +3094,8 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn selection_range(
     &self,
     params: SelectionRangeParams,
@@ -3052,6 +3149,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(Some(selection_ranges))
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn semantic_tokens_full(
     &self,
@@ -3119,6 +3218,8 @@ impl Inner {
     Ok(response)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn semantic_tokens_range(
     &self,
     params: SemanticTokensRangeParams,
@@ -3182,6 +3283,8 @@ impl Inner {
     self.performance.measure(mark);
     Ok(response)
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn signature_help(
     &self,
@@ -3257,6 +3360,8 @@ impl Inner {
     }
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn will_rename_files(
     &self,
     params: RenameFilesParams,
@@ -3318,6 +3423,8 @@ impl Inner {
     file_text_changes_to_workspace_edit(&changes, self, token)
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn symbol(
     &self,
     params: WorkspaceSymbolParams,
@@ -3369,6 +3476,8 @@ impl Inner {
     Ok(maybe_symbol_information)
   }
 
+  #[tracing::instrument(skip_all)]
+
   fn project_changed<'a>(
     &mut self,
     modified_scripts: impl IntoIterator<Item = (&'a ModuleSpecifier, ChangeKind)>,
@@ -3390,6 +3499,7 @@ impl Inner {
     );
   }
 
+  #[tracing::instrument(skip_all)]
   fn send_diagnostics_update(&self) {
     let snapshot = DiagnosticServerUpdateMessage {
       snapshot: self.snapshot(),
@@ -4042,6 +4152,8 @@ impl Inner {
     registrations
   }
 
+  #[tracing::instrument(skip_all)]
+
   fn prepare_cache(
     &mut self,
     specifiers: Vec<ModuleSpecifier>,
@@ -4120,6 +4232,8 @@ impl Inner {
     })
   }
 
+  #[tracing::instrument(skip_all)]
+
   async fn post_cache(&mut self) {
     self.resolver.did_cache();
     self.refresh_dep_info().await;
@@ -4129,6 +4243,8 @@ impl Inner {
     self.send_diagnostics_update();
     self.send_testing_update();
   }
+
+  #[tracing::instrument(skip_all)]
 
   fn pre_did_change_workspace_folders(
     &mut self,
@@ -4157,6 +4273,8 @@ impl Inner {
     }
     self.config.set_workspace_folders(workspace_folders);
   }
+
+  #[tracing::instrument(skip_all)]
 
   async fn post_did_change_workspace_folders(&mut self) {
     self.refresh_workspace_files();

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2556,7 +2556,7 @@ impl Inner {
       let scope = asset_or_doc.scope();
       let maybe_completion_info = self
         .ts_server
-        .get_completions_tsc(
+        .get_completions(
           self.snapshot(),
           specifier.clone(),
           position,

--- a/cli/lsp/mod.rs
+++ b/cli/lsp/mod.rs
@@ -36,6 +36,7 @@ mod search;
 mod semantic_tokens;
 mod testing;
 mod text;
+mod trace;
 mod tsc;
 mod urls;
 

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -601,6 +601,7 @@ impl ModuleRegistry {
 
   /// For a string specifier from the client, provide a set of completions, if
   /// any, for the specifier.
+  #[tracing::instrument(skip_all)]
   pub async fn get_completions(
     &self,
     text: &str,

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -357,5 +357,6 @@ pub fn get_repl_workspace_settings() -> WorkspaceSettings {
       },
       ..Default::default()
     },
+    tracing: Default::default(),
   }
 }

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -34,7 +34,8 @@ pub(crate) fn make_tracer(
 }
 
 pub(crate) struct TracingGuard(
-  #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
+  // #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
+  #[allow(dead_code)] (),
 );
 
 impl fmt::Debug for TracingGuard {
@@ -143,12 +144,13 @@ pub(crate) fn init_tracing_subscriber(
     _ => None,
   };
 
-  let guard = tracing::subscriber::set_default(
+  let guard = tracing::subscriber::set_global_default(
     tracing_subscriber::registry()
       .with(filter)
       .with(logging_layer)
       .with(open_telemetry_layer),
-  );
+  )
+  .unwrap();
 
   Ok(TracingGuard(guard))
 }

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::fmt;
 

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -34,6 +34,7 @@ pub(crate) fn make_tracer(
 }
 
 pub(crate) struct TracingGuard(
+  // TODO(nathanwhit): look again if we should be using a guard or if a global default is fine
   // #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
   #[allow(dead_code)] (),
 );
@@ -144,7 +145,7 @@ pub(crate) fn init_tracing_subscriber(
     _ => None,
   };
 
-  let guard = tracing::subscriber::set_global_default(
+  tracing::subscriber::set_global_default(
     tracing_subscriber::registry()
       .with(filter)
       .with(logging_layer)
@@ -152,5 +153,6 @@ pub(crate) fn init_tracing_subscriber(
   )
   .unwrap();
 
+  let guard = ();
   Ok(TracingGuard(guard))
 }

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -34,8 +34,7 @@ pub(crate) fn make_tracer(
 }
 
 pub(crate) struct TracingGuard(
-  // #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
-  (),
+  #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
 );
 
 impl fmt::Debug for TracingGuard {
@@ -144,15 +143,12 @@ pub(crate) fn init_tracing_subscriber(
     _ => None,
   };
 
-  tracing::subscriber::set_global_default(
+  let guard = tracing::subscriber::set_default(
     tracing_subscriber::registry()
       .with(filter)
       .with(logging_layer)
       .with(open_telemetry_layer),
-  )
-  .unwrap();
-  // let guard =
-  //   .set_global_default();
-  let guard = ();
+  );
+
   Ok(TracingGuard(guard))
 }

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -34,7 +34,8 @@ pub(crate) fn make_tracer(
 }
 
 pub(crate) struct TracingGuard(
-  // TODO(nathanwhit): look again if we should be using a guard or if a global default is fine
+  // TODO(nathanwhit): use default guard here so we can change tracing after init
+  // but needs wiring through the subscriber to the TSC thread, as it can't be a global default
   // #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
   #[allow(dead_code)] (),
 );

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -1,0 +1,158 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use std::fmt;
+
+use deno_core::anyhow;
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::level_filters::LevelFilter;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+
+use crate::lsp::logging::lsp_debug;
+
+pub(crate) fn make_tracer(
+  endpoint: Option<&str>,
+) -> Result<opentelemetry_sdk::trace::Tracer, anyhow::Error> {
+  let endpoint = endpoint.unwrap_or("http://localhost:4317");
+  let exporter = opentelemetry_otlp::SpanExporter::builder()
+    .with_tonic()
+    .with_endpoint(endpoint)
+    .build()?;
+  let provider = opentelemetry_sdk::trace::Builder::default()
+    .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+    .with_resource(Resource::new(vec![KeyValue::new(SERVICE_NAME, "deno-lsp")]))
+    .build();
+  opentelemetry::global::set_tracer_provider(provider.clone());
+  Ok(provider.tracer("deno-lsp-tracer"))
+}
+
+pub(crate) struct TracingGuard(
+  // #[allow(dead_code)] tracing::dispatcher::DefaultGuard,
+  (),
+);
+
+impl fmt::Debug for TracingGuard {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_tuple("TracingGuard").finish()
+  }
+}
+
+impl Drop for TracingGuard {
+  fn drop(&mut self) {
+    lsp_debug!("Shutting down tracing");
+    tokio::task::spawn_blocking(|| {
+      opentelemetry::global::shutdown_tracer_provider()
+    });
+  }
+}
+
+#[derive(
+  Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Copy, Default,
+)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum TracingCollector {
+  #[default]
+  OpenTelemetry,
+  Logging,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct TracingConfig {
+  /// Enable tracing.
+  pub(crate) enable: bool,
+
+  /// The collector to use. Defaults to `OpenTelemetry`.
+  /// If `Logging` is used, the collected traces will be written to stderr.
+  pub(crate) collector: TracingCollector,
+
+  /// The filter to use. Defaults to `INFO`.
+  pub(crate) filter: Option<String>,
+
+  /// The endpoint to use for the OpenTelemetry collector.
+  pub(crate) collector_endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub(crate) enum TracingConfigOrEnabled {
+  Config(TracingConfig),
+  Enabled(bool),
+}
+
+impl From<TracingConfig> for TracingConfigOrEnabled {
+  fn from(value: TracingConfig) -> Self {
+    TracingConfigOrEnabled::Config(value)
+  }
+}
+
+impl From<TracingConfigOrEnabled> for TracingConfig {
+  fn from(value: TracingConfigOrEnabled) -> Self {
+    match value {
+      TracingConfigOrEnabled::Config(config) => config,
+      TracingConfigOrEnabled::Enabled(enabled) => TracingConfig {
+        enable: enabled,
+        ..Default::default()
+      },
+    }
+  }
+}
+
+impl TracingConfigOrEnabled {
+  pub(crate) fn enabled(&self) -> bool {
+    match self {
+      TracingConfigOrEnabled::Config(config) => config.enable,
+      TracingConfigOrEnabled::Enabled(enabled) => *enabled,
+    }
+  }
+}
+
+pub(crate) fn init_tracing_subscriber(
+  config: &TracingConfig,
+) -> Result<TracingGuard, anyhow::Error> {
+  if !config.enable {
+    return Err(anyhow::anyhow!("Tracing is not enabled"));
+  }
+  let filter = tracing_subscriber::EnvFilter::builder()
+    .with_default_directive(LevelFilter::INFO.into());
+  let filter = if let Some(directive) = config.filter.as_ref() {
+    filter.parse(directive)?
+  } else {
+    filter.with_env_var("DENO_LSP_TRACE").from_env()?
+  };
+  let open_telemetry_layer = match config.collector {
+    TracingCollector::OpenTelemetry => Some(OpenTelemetryLayer::new(
+      make_tracer(config.collector_endpoint.as_deref())?,
+    )),
+    _ => None,
+  };
+  let logging_layer = match config.collector {
+    TracingCollector::Logging => Some(
+      tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        // Include span events in the log output.
+        // Without this, only events get logged (and at the moment we have none).
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
+    ),
+    _ => None,
+  };
+
+  tracing::subscriber::set_global_default(
+    tracing_subscriber::registry()
+      .with(filter)
+      .with(logging_layer)
+      .with(open_telemetry_layer),
+  )
+  .unwrap();
+  // let guard =
+  //   .set_global_default();
+  let guard = ();
+  Ok(TracingGuard(guard))
+}

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4806,8 +4806,14 @@ fn op_make_span(
 }
 
 #[op2(fast)]
+fn op_log_event(#[string] msg: &str) {
+  tracing::info!(msg = msg);
+}
+
+#[op2(fast)]
 fn op_exit_span(op_state: &mut OpState, span: *const c_void, root: bool) {
   let ptr = deno_core::ExternalPointer::<TracingSpan>::from_raw(span);
+  // SAFETY: trust me
   let _span = unsafe { ptr.unsafely_take().0 };
   if root {
     let state = op_state.borrow_mut::<State>();
@@ -5095,6 +5101,7 @@ deno_core::extension!(deno_tsc,
     op_poll_requests,
     op_make_span,
     op_exit_span,
+    op_log_event,
     op_libs,
   ],
   options = {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -4779,6 +4779,16 @@ struct TracingSpan(#[allow(dead_code)] tracing::span::EnteredSpan);
 
 deno_core::external!(TracingSpan, "tracingspan");
 
+fn span_with_context(
+  state: &State,
+  span: tracing::Span,
+) -> tracing::span::EnteredSpan {
+  if let Some(context) = &state.context {
+    span.set_parent(context.clone());
+  }
+  span.entered()
+}
+
 #[op2(fast)]
 fn op_make_span(
   op_state: &mut OpState,
@@ -4801,7 +4811,7 @@ fn op_exit_span(op_state: &mut OpState, span: *const c_void, root: bool) {
   let _span = unsafe { ptr.unsafely_take().0 };
   if root {
     let state = op_state.borrow_mut::<State>();
-    state.context.pop();
+    state.context = None;
   }
 }
 

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::Infallible;
+use std::ffi::c_void;
 use std::net::SocketAddr;
 use std::ops::Range;
 use std::path::Path;
@@ -65,6 +66,7 @@ use tokio_util::sync::CancellationToken;
 use tower_lsp::jsonrpc::Error as LspError;
 use tower_lsp::jsonrpc::Result as LspResult;
 use tower_lsp::lsp_types as lsp;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use super::analysis::CodeActionData;
 use super::code_lens;
@@ -124,6 +126,7 @@ type Request = (
   oneshot::Sender<Result<String, AnyError>>,
   CancellationToken,
   Option<PendingChange>,
+  Option<opentelemetry::Context>,
 );
 
 #[derive(Debug, Clone, Copy, Serialize_repr)]
@@ -467,6 +470,7 @@ impl TsServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_diagnostics(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -532,6 +536,7 @@ impl TsServer {
     Ok((diagnostics_map, ambient_modules_by_scope))
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn cleanup_semantic_cache(&self, snapshot: Arc<StateSnapshot>) {
     for scope in snapshot
       .config
@@ -558,6 +563,7 @@ impl TsServer {
     }
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn find_references(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -612,6 +618,7 @@ impl TsServer {
     Ok(Some(all_symbols.into_iter().collect()))
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_navigation_tree(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -625,6 +632,7 @@ impl TsServer {
     self.request(snapshot, req, scope, token).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_supported_code_fixes(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -639,6 +647,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_quick_info(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -655,6 +664,7 @@ impl TsServer {
   }
 
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all)]
   pub async fn get_code_fixes(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -686,6 +696,7 @@ impl TsServer {
   }
 
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all)]
   pub async fn get_applicable_refactors(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -718,6 +729,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_combined_code_fix(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -746,6 +758,7 @@ impl TsServer {
   }
 
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all)]
   pub async fn get_edits_for_refactor(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -775,6 +788,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_edits_for_file_rename(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -833,6 +847,7 @@ impl TsServer {
     Ok(all_changes.into_iter().collect())
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_document_highlights(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -853,6 +868,7 @@ impl TsServer {
     self.request(snapshot, req, scope, token).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_definition(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -878,6 +894,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_type_definition(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -905,6 +922,7 @@ impl TsServer {
   }
 
   #[allow(clippy::too_many_arguments)]
+  #[tracing::instrument(skip_all)]
   pub async fn get_completions(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -932,6 +950,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_completion_details(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -959,6 +978,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_implementations(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1013,6 +1033,7 @@ impl TsServer {
     Ok(Some(all_locations.into_iter().collect()))
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_outlining_spans(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1026,6 +1047,7 @@ impl TsServer {
     self.request(snapshot, req, scope, token).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn provide_call_hierarchy_incoming_calls(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1074,6 +1096,7 @@ impl TsServer {
     Ok(all_calls.into_iter().collect())
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn provide_call_hierarchy_outgoing_calls(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1100,6 +1123,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn prepare_call_hierarchy(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1133,6 +1157,7 @@ impl TsServer {
       })
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn find_rename_locations(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1190,6 +1215,7 @@ impl TsServer {
     Ok(Some(all_locations.into_iter().collect()))
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_smart_selection_range(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1205,6 +1231,7 @@ impl TsServer {
     self.request(snapshot, req, scope, token).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_encoded_semantic_classifications(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1224,6 +1251,7 @@ impl TsServer {
     self.request(snapshot, req, scope, token).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_signature_help_items(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1241,6 +1269,7 @@ impl TsServer {
     self.request(snapshot, req, scope, token).await
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn get_navigate_to_items(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1292,6 +1321,7 @@ impl TsServer {
     Ok(all_items.into_iter().collect())
   }
 
+  #[tracing::instrument(skip_all)]
   pub async fn provide_inlay_hints(
     &self,
     snapshot: Arc<StateSnapshot>,
@@ -1319,6 +1349,7 @@ impl TsServer {
   where
     R: de::DeserializeOwned,
   {
+    let context = tracing::Span::current().context();
     let mark = self
       .performance
       .mark(format!("tsc.request.{}", req.method()));
@@ -1327,7 +1358,15 @@ impl TsServer {
 
     if self
       .sender
-      .send((req, scope, snapshot, tx, token.clone(), change))
+      .send((
+        req,
+        scope,
+        snapshot,
+        tx,
+        token.clone(),
+        change,
+        Some(context),
+      ))
       .is_err()
     {
       return Err(anyhow!("failed to send request to tsc thread"));
@@ -3707,6 +3746,7 @@ impl CompletionInfo {
     Ok(())
   }
 
+  #[tracing::instrument(skip_all, fields(entries = %self.entries.len()))]
   pub fn as_completion_response(
     &self,
     line_index: Arc<LineIndex>,
@@ -4427,6 +4467,7 @@ struct State {
   token: CancellationToken,
   pending_requests: Option<UnboundedReceiver<Request>>,
   mark: Option<PerformanceMark>,
+  context: Option<opentelemetry::Context>,
 }
 
 impl State {
@@ -4446,6 +4487,7 @@ impl State {
       token: Default::default(),
       mark: None,
       pending_requests: Some(pending_requests),
+      context: None,
     }
   }
 
@@ -4541,6 +4583,7 @@ fn op_load<'s>(
   state: &mut OpState,
   #[string] specifier: &str,
 ) -> Result<v8::Local<'s, v8::Value>, LoadError> {
+  let _span = tracing::info_span!("op_load").entered();
   let state = state.borrow_mut::<State>();
   let mark = state
     .performance
@@ -4572,6 +4615,7 @@ fn op_release(
   state: &mut OpState,
   #[string] specifier: &str,
 ) -> Result<(), deno_core::url::ParseError> {
+  let _span = tracing::info_span!("op_release").entered();
   let state = state.borrow_mut::<State>();
   let mark = state
     .performance
@@ -4590,6 +4634,7 @@ fn op_resolve(
   #[string] base: String,
   #[serde] specifiers: Vec<(bool, String)>,
 ) -> Result<Vec<Option<(String, Option<String>)>>, deno_core::url::ParseError> {
+  let _span = tracing::info_span!("op_resolve").entered();
   op_resolve_inner(state, ResolveArgs { base, specifiers })
 }
 
@@ -4644,7 +4689,7 @@ async fn op_poll_requests(
   // clear the resolution cache after each request
   NodeResolutionThreadLocalCache::clear();
 
-  let Some((request, scope, snapshot, response_tx, token, change)) =
+  let Some((request, scope, snapshot, response_tx, token, change, context)) =
     pending_requests.recv().await
   else {
     return None.into();
@@ -4663,6 +4708,7 @@ async fn op_poll_requests(
     .performance
     .mark_with_args(format!("tsc.host.{}", request.method()), &request);
   state.mark = Some(mark);
+  state.context = context;
 
   Some(TscRequestArray {
     request,
@@ -4710,6 +4756,7 @@ fn op_respond(
   #[string] response: String,
   #[string] error: String,
 ) {
+  let _span = tracing::info_span!("op_respond").entered();
   let state = state.borrow_mut::<State>();
   state.performance.measure(state.mark.take().unwrap());
   state.last_scope = None;
@@ -4727,6 +4774,37 @@ fn op_respond(
   }
 }
 
+struct TracingSpan(#[allow(dead_code)] tracing::span::EnteredSpan);
+// struct TracingSpan(#[allow(dead_code)] ());
+
+deno_core::external!(TracingSpan, "tracingspan");
+
+#[op2(fast)]
+fn op_make_span(
+  op_state: &mut OpState,
+  #[string] s: &str,
+  needs_context: bool,
+) -> *const c_void {
+  let state = op_state.borrow_mut::<State>();
+  let sp = tracing::info_span!("js", otel.name = format!("js::{s}").as_str());
+  let span = if needs_context {
+    span_with_context(state, sp)
+  } else {
+    sp.entered()
+  };
+  deno_core::ExternalPointer::new(TracingSpan(span)).into_raw()
+}
+
+#[op2(fast)]
+fn op_exit_span(op_state: &mut OpState, span: *const c_void, root: bool) {
+  let ptr = deno_core::ExternalPointer::<TracingSpan>::from_raw(span);
+  let _span = unsafe { ptr.unsafely_take().0 };
+  if root {
+    let state = op_state.borrow_mut::<State>();
+    state.context.pop();
+  }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ScriptNames {
@@ -4737,6 +4815,7 @@ struct ScriptNames {
 #[op2]
 #[serde]
 fn op_script_names(state: &mut OpState) -> ScriptNames {
+  let _span = tracing::info_span!("op_script_names").entered();
   let state = state.borrow_mut::<State>();
   let mark = state.performance.mark("tsc.op.op_script_names");
   let mut result = ScriptNames {
@@ -5004,6 +5083,8 @@ deno_core::extension!(deno_tsc,
     op_script_version,
     op_project_version,
     op_poll_requests,
+    op_make_span,
+    op_exit_span,
     op_libs,
   ],
   options = {

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -1374,6 +1374,7 @@ impl TsServer {
     tokio::select! {
       value = &mut rx => {
         let value = value??;
+        let _span = tracing::info_span!("Tsc response deserialization");
         let r = Ok(serde_json::from_str(&value)?);
         self.performance.measure(mark);
         r
@@ -4775,9 +4776,8 @@ fn op_respond(
 }
 
 struct TracingSpan(#[allow(dead_code)] tracing::span::EnteredSpan);
-// struct TracingSpan(#[allow(dead_code)] ());
 
-deno_core::external!(TracingSpan, "tracingspan");
+deno_core::external!(TracingSpan, "lsp::TracingSpan");
 
 fn span_with_context(
   state: &State,

--- a/cli/tsc/97_ts_host.js
+++ b/cli/tsc/97_ts_host.js
@@ -751,7 +751,11 @@ const excluded = new Set([
   "getSourceFile",
 ]);
 /** @type {typeof hosty} */
-export const host = {};
+export const host = {
+  log(msg) {
+    ops.op_log_event(msg);
+  },
+};
 for (const [key, value] of Object.entries(hosty)) {
   if (typeof value === "function" && !excluded.has(key)) {
     host[key] = (...args) => {

--- a/cli/tsc/97_ts_host.js
+++ b/cli/tsc/97_ts_host.js
@@ -185,8 +185,6 @@ ts.deno.setIsNodeSourceFileCallback((sourceFile) => {
   return isNodeSourceFile;
 });
 
-ts.deno.setSpanned(spanned);
-
 /**
  * @param msg {string}
  * @param code {number}

--- a/cli/tsc/98_lsp.js
+++ b/cli/tsc/98_lsp.js
@@ -447,9 +447,6 @@ function serverRequestInner(id, method, args, scope, maybeChange) {
         ts.getSupportedCodeFixes(),
       );
     }
-    case "$getAssets": {
-      return respond(id, getAssets());
-    }
     case "$getDiagnostics": {
       const projectVersion = args[1];
       // there's a possibility that we receive a change notification
@@ -471,9 +468,9 @@ function serverRequestInner(id, method, args, scope, maybeChange) {
           ].filter(filterMapDiagnostic));
         }
         let ambient =
-          ls.getProgram()?.getTypeChecker().getAmbientModules().map((
-            symbol,
-          ) => symbol.getName()) ?? [];
+          ls.getProgram()?.getTypeChecker().getAmbientModules().map((symbol) =>
+            symbol.getName()
+          ) ?? [];
         const previousAmbient = ambientModulesCacheByScope.get(scope);
         if (
           ambient && previousAmbient && arraysEqual(ambient, previousAmbient)

--- a/cli/tsc/98_lsp.js
+++ b/cli/tsc/98_lsp.js
@@ -286,6 +286,8 @@ let hasStarted = false;
 
 /** @param {boolean} enableDebugLogging */
 export async function serverMainLoop(enableDebugLogging) {
+  ts.deno.setEnterSpan(ops.op_make_span);
+  ts.deno.setExitSpan(ops.op_exit_span);
   if (hasStarted) {
     throw new Error("The language server has already been initialized.");
   }
@@ -382,146 +384,156 @@ function arraysEqual(a, b) {
  * @param {string | null} scope
  * @param {PendingChange | null} maybeChange
  */
-function serverRequest(id, method, args, scope, maybeChange) {
-  const span = ops.op_make_span(`serverRequest(${method})`, true);
-  try {
-    debug(`serverRequest()`, id, method, args, scope, maybeChange);
-    if (maybeChange !== null) {
-      const changedScripts = maybeChange[0];
-      const newProjectVersion = maybeChange[1];
-      const newConfigsByScope = maybeChange[2];
-      if (newConfigsByScope) {
-        IS_NODE_SOURCE_FILE_CACHE.clear();
-        ASSET_SCOPES.clear();
-        /** @type { typeof LANGUAGE_SERVICE_ENTRIES.byScope } */
-        const newByScope = new Map();
-        for (const [scope, config] of newConfigsByScope) {
-          LAST_REQUEST_SCOPE.set(scope);
-          const oldEntry = LANGUAGE_SERVICE_ENTRIES.byScope.get(scope);
-          const ls = oldEntry
-            ? oldEntry.ls
-            : ts.createLanguageService(host, documentRegistry);
-          const compilerOptions = lspTsConfigToCompilerOptions(config);
-          newByScope.set(scope, { ls, compilerOptions });
-          LANGUAGE_SERVICE_ENTRIES.byScope.delete(scope);
-        }
-        for (const oldEntry of LANGUAGE_SERVICE_ENTRIES.byScope.values()) {
-          oldEntry.ls.dispose();
-        }
-        LANGUAGE_SERVICE_ENTRIES.byScope = newByScope;
+function serverRequestInner(id, method, args, scope, maybeChange) {
+  debug(`serverRequest()`, id, method, args, scope, maybeChange);
+  if (maybeChange !== null) {
+    const changedScripts = maybeChange[0];
+    const newProjectVersion = maybeChange[1];
+    const newConfigsByScope = maybeChange[2];
+    if (newConfigsByScope) {
+      IS_NODE_SOURCE_FILE_CACHE.clear();
+      ASSET_SCOPES.clear();
+      /** @type { typeof LANGUAGE_SERVICE_ENTRIES.byScope } */
+      const newByScope = new Map();
+      for (const [scope, config] of newConfigsByScope) {
+        LAST_REQUEST_SCOPE.set(scope);
+        const oldEntry = LANGUAGE_SERVICE_ENTRIES.byScope.get(scope);
+        const ls = oldEntry
+          ? oldEntry.ls
+          : ts.createLanguageService(host, documentRegistry);
+        const compilerOptions = lspTsConfigToCompilerOptions(config);
+        newByScope.set(scope, { ls, compilerOptions });
+        LANGUAGE_SERVICE_ENTRIES.byScope.delete(scope);
       }
-
-      PROJECT_VERSION_CACHE.set(newProjectVersion);
-
-      let opened = false;
-      let closed = false;
-      for (const { 0: script, 1: changeKind } of changedScripts) {
-        if (changeKind === ChangeKind.Opened) {
-          opened = true;
-        } else if (changeKind === ChangeKind.Closed) {
-          closed = true;
-        }
-        SCRIPT_VERSION_CACHE.delete(script);
-        SCRIPT_SNAPSHOT_CACHE.delete(script);
+      for (const oldEntry of LANGUAGE_SERVICE_ENTRIES.byScope.values()) {
+        oldEntry.ls.dispose();
       }
-
-      if (newConfigsByScope || opened || closed) {
-        clearScriptNamesCache();
-      }
+      LANGUAGE_SERVICE_ENTRIES.byScope = newByScope;
     }
 
-    // For requests pertaining to an asset document, we make it so that the
-    // passed scope is just its own specifier. We map it to an actual scope here
-    // based on the first scope that the asset was loaded into.
-    if (scope?.startsWith(ASSETS_URL_PREFIX)) {
-      scope = ASSET_SCOPES.get(scope) ?? null;
+    PROJECT_VERSION_CACHE.set(newProjectVersion);
+
+    let opened = false;
+    let closed = false;
+    for (const { 0: script, 1: changeKind } of changedScripts) {
+      if (changeKind === ChangeKind.Opened) {
+        opened = true;
+      } else if (changeKind === ChangeKind.Closed) {
+        closed = true;
+      }
+      SCRIPT_VERSION_CACHE.delete(script);
+      SCRIPT_SNAPSHOT_CACHE.delete(script);
     }
-    LAST_REQUEST_METHOD.set(method);
-    LAST_REQUEST_SCOPE.set(scope);
-    const ls =
-      (scope ? LANGUAGE_SERVICE_ENTRIES.byScope.get(scope)?.ls : null) ??
-        LANGUAGE_SERVICE_ENTRIES.unscoped.ls;
-    switch (method) {
-      case "$getSupportedCodeFixes": {
-        return respond(
-          id,
-          ts.getSupportedCodeFixes(),
-        );
+
+    if (newConfigsByScope || opened || closed) {
+      clearScriptNamesCache();
+    }
+  }
+
+  // For requests pertaining to an asset document, we make it so that the
+  // passed scope is just its own specifier. We map it to an actual scope here
+  // based on the first scope that the asset was loaded into.
+  if (scope?.startsWith(ASSETS_URL_PREFIX)) {
+    scope = ASSET_SCOPES.get(scope) ?? null;
+  }
+  LAST_REQUEST_METHOD.set(method);
+  LAST_REQUEST_SCOPE.set(scope);
+  const ls = (scope ? LANGUAGE_SERVICE_ENTRIES.byScope.get(scope)?.ls : null) ??
+    LANGUAGE_SERVICE_ENTRIES.unscoped.ls;
+  switch (method) {
+    case "$getSupportedCodeFixes": {
+      return respond(
+        id,
+        ts.getSupportedCodeFixes(),
+      );
+    }
+    case "$getAssets": {
+      return respond(id, getAssets());
+    }
+    case "$getDiagnostics": {
+      const projectVersion = args[1];
+      // there's a possibility that we receive a change notification
+      // but the diagnostic server queues a `$getDiagnostics` request
+      // with a stale project version. in that case, treat it as cancelled
+      // (it's about to be invalidated anyway).
+      const cachedProjectVersion = PROJECT_VERSION_CACHE.get();
+      if (cachedProjectVersion && projectVersion !== cachedProjectVersion) {
+        return respond(id, [{}, null]);
       }
-      case "$getAssets": {
-        return respond(id, getAssets());
+      try {
+        /** @type {Record<string, any[]>} */
+        const diagnosticMap = {};
+        for (const specifier of args[0]) {
+          diagnosticMap[specifier] = fromTypeScriptDiagnostics([
+            ...ls.getSemanticDiagnostics(specifier),
+            ...ls.getSuggestionDiagnostics(specifier),
+            ...ls.getSyntacticDiagnostics(specifier),
+          ].filter(filterMapDiagnostic));
+        }
+        let ambient =
+          ls.getProgram()?.getTypeChecker().getAmbientModules().map((
+            symbol,
+          ) => symbol.getName()) ?? [];
+        const previousAmbient = ambientModulesCacheByScope.get(scope);
+        if (
+          ambient && previousAmbient && arraysEqual(ambient, previousAmbient)
+        ) {
+          ambient = null; // null => use previous value
+        } else {
+          ambientModulesCacheByScope.set(scope, ambient);
+        }
+        return respond(id, [diagnosticMap, ambient]);
+      } catch (e) {
+        if (
+          !isCancellationError(e)
+        ) {
+          return respond(
+            id,
+            [{}, null],
+            formatErrorWithArgs(e, [id, method, args, scope, maybeChange]),
+          );
+        }
+        return respond(id, [{}, null]);
       }
-      case "$getDiagnostics": {
-        const projectVersion = args[1];
-        // there's a possibility that we receive a change notification
-        // but the diagnostic server queues a `$getDiagnostics` request
-        // with a stale project version. in that case, treat it as cancelled
-        // (it's about to be invalidated anyway).
-        const cachedProjectVersion = PROJECT_VERSION_CACHE.get();
-        if (cachedProjectVersion && projectVersion !== cachedProjectVersion) {
-          return respond(id, [{}, null]);
+    }
+    default:
+      if (typeof ls[method] === "function") {
+        // The `getCompletionEntryDetails()` method returns null if the
+        // `source` is `null` for whatever reason. It must be `undefined`.
+        if (method == "getCompletionEntryDetails") {
+          args[4] ??= undefined;
         }
         try {
-          /** @type {Record<string, any[]>} */
-          const diagnosticMap = {};
-          for (const specifier of args[0]) {
-            diagnosticMap[specifier] = fromTypeScriptDiagnostics([
-              ...ls.getSemanticDiagnostics(specifier),
-              ...ls.getSuggestionDiagnostics(specifier),
-              ...ls.getSyntacticDiagnostics(specifier),
-            ].filter(filterMapDiagnostic));
-          }
-          let ambient =
-            ls.getProgram()?.getTypeChecker().getAmbientModules().map((
-              symbol,
-            ) => symbol.getName()) ?? [];
-          const previousAmbient = ambientModulesCacheByScope.get(scope);
-          if (
-            ambient && previousAmbient && arraysEqual(ambient, previousAmbient)
-          ) {
-            ambient = null; // null => use previous value
-          } else {
-            ambientModulesCacheByScope.set(scope, ambient);
-          }
-          return respond(id, [diagnosticMap, ambient]);
+          return respond(id, ls[method](...args));
         } catch (e) {
-          if (
-            !isCancellationError(e)
-          ) {
+          if (!isCancellationError(e)) {
             return respond(
               id,
-              [{}, null],
+              null,
               formatErrorWithArgs(e, [id, method, args, scope, maybeChange]),
             );
           }
-          return respond(id, [{}, null]);
+          return respond(id);
         }
       }
-      default:
-        if (typeof ls[method] === "function") {
-          // The `getCompletionEntryDetails()` method returns null if the
-          // `source` is `null` for whatever reason. It must be `undefined`.
-          if (method == "getCompletionEntryDetails") {
-            args[4] ??= undefined;
-          }
-          try {
-            return respond(id, ls[method](...args));
-          } catch (e) {
-            if (!isCancellationError(e)) {
-              return respond(
-                id,
-                null,
-                formatErrorWithArgs(e, [id, method, args, scope, maybeChange]),
-              );
-            }
-            return respond(id);
-          }
-        }
-        throw new TypeError(
-          // @ts-ignore exhausted case statement sets type to never
-          `Invalid request method for request: "${method}" (${id})`,
-        );
-    }
+      throw new TypeError(
+        // @ts-ignore exhausted case statement sets type to never
+        `Invalid request method for request: "${method}" (${id})`,
+      );
+  }
+}
+
+/**
+ * @param {number} id
+ * @param {string} method
+ * @param {any[]} args
+ * @param {string | null} scope
+ * @param {PendingChange | null} maybeChange
+ */
+function serverRequest(id, method, args, scope, maybeChange) {
+  const span = ops.op_make_span(`serverRequest(${method})`, true);
+  try {
+    serverRequestInner(id, method, args, scope, maybeChange);
   } finally {
     ops.op_exit_span(span, true);
   }

--- a/cli/tsc/dts/typescript.d.ts
+++ b/cli/tsc/dts/typescript.d.ts
@@ -15,6 +15,9 @@ and limitations under the License.
 
 declare namespace ts {
     namespace deno {
+        function setEnterSpan(f: EnterSpan): void;
+        function setExitSpan(f: ExitSpan): void;
+        function spanned<T>(name: string, f: () => T): T;
         function setIsNodeSourceFileCallback(callback: IsNodeSourceFileCallback): void;
         function setNodeOnlyGlobalNames(names: Set<string>): void;
         function setTypesNodeIgnorableNames(names: Set<string>): void;
@@ -26,6 +29,10 @@ declare namespace ts {
         function tryParseNpmPackageReference(text: string): NpmPackageReference | undefined;
         function parseNpmPackageReference(text: string): NpmPackageReference;
         type IsNodeSourceFileCallback = (sourceFile: ts.SourceFile) => boolean;
+        type EnterSpan = (name: string) => object;
+        type ExitSpan = (span: object) => void;
+        let enterSpan: EnterSpan;
+        let exitSpan: ExitSpan;
         interface DenoForkContext {
             hasNodeSourceFile: (node: ts.Node | undefined) => boolean;
             getGlobalsForName: (id: ts.__String) => ts.SymbolTable;

--- a/tests/specs/lint/lint_plugin/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin/__test__.jsonc
@@ -1,4 +1,5 @@
 {
+  "tempDir": true,
   "steps": [
     {
       "args": "lint a.ts",


### PR DESCRIPTION
adds tracing and opentelemetry exporting to the LSP.

enable it in `.vscode/settings.json` (or wherever you configure the LSP), like

```
{
  "deno.tracing": true
}
```

which will by default export opentelemetry traces to `localhost:4317`
or
```
{
  "deno.tracing": {
    // all fields optional
     "collector": "openTelemetry" (default) | "logging" (output in lsp log window)
     "collectorEndpoint": "http://localhost:4318" (for opentelemetry)
     "enable": true | false,
     "filter": "info" // defaults to "info", but can be any span filter
   }
}
```

---

a full working setup would be 

1: Run jaeger (an opentelemetry collector with a nice UI):
```
docker run --rm -p 16686:16686 -p 4317:4317 jaegertracing/jaeger
```
2. Enable in .vscode/settings.json
```
{
  "deno.tracing": true
}
```
3. Restart LSP (right now it only will start the opentelemetry exporter on LSP startup)
3. open `http://localhost:16686` in your browser