### PR TITLE
fix(ext/node): implement `crypto.hash`

### DIFF
--- a/ext/node/polyfills/crypto.ts
+++ b/ext/node/polyfills/crypto.ts
@@ -173,7 +173,7 @@ function hash(
   algorithm: string,
   data: BinaryLike,
   outputEncoding: BinaryToTextEncoding = "hex",
-): string | Buffer {
+) {
   const hash = createHash(algorithm);
   hash.update(data);
   return hash.digest(outputEncoding);

--- a/ext/node/polyfills/crypto.ts
+++ b/ext/node/polyfills/crypto.ts
@@ -169,6 +169,16 @@ function getRandomValues(typedArray) {
   return webcrypto.getRandomValues(typedArray);
 }
 
+function hash(
+  algorithm: string,
+  data: BinaryLike,
+  outputEncoding: BinaryToTextEncoding = "hex",
+): string | Buffer {
+  const hash = createHash(algorithm);
+  hash.update(data);
+  return hash.digest(outputEncoding);
+}
+
 function createCipheriv(
   algorithm: CipherCCMTypes,
   key: CipherKey,
@@ -350,6 +360,7 @@ export default {
   getDiffieHellman,
   getFips,
   getHashes,
+  hash,
   Hash,
   hkdf,
   hkdfSync,
@@ -489,6 +500,7 @@ export {
   getHashes,
   getRandomValues,
   Hash,
+  hash,
   hkdf,
   hkdfSync,
   Hmac,

--- a/tests/unit_node/crypto/crypto_hash_test.ts
+++ b/tests/unit_node/crypto/crypto_hash_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
-import { createHash, createHmac, getHashes } from "node:crypto";
+import { createHash, createHmac, getHashes, hash } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
 import { assert, assertEquals } from "@std/assert";
@@ -126,4 +126,9 @@ Deno.test("[node/crypto.hash] supports buffer args", () => {
 Deno.test("[node/crypto.hash] does not leak", () => {
   const hasher = createHash("sha1");
   hasher.update("abc");
+});
+
+Deno.test("[node/crypto.hash] oneshot hash API", () => {
+  const d = hash("sha1", "Node.js");
+  assertEquals(d, "10b3493287f831e81a438811a1ffba01f8cec4b7");
 });


### PR DESCRIPTION
Implement [`crypto.hash`](https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding) - one-shot version of `createHash`

Fixes #24945 

