### PR TITLE
fix(init): correct dev task for --lib

### DIFF
--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -158,7 +158,7 @@ Deno.test(function addTest() {
         "version": "0.1.0",
         "exports": "./mod.ts",
         "tasks": {
-          "dev": "deno test --watch mod.ts"
+          "dev": "deno test --watch"
         },
         "license": "MIT",
         "imports": {


### PR DESCRIPTION
Was wrong:

```
Task dev deno test --watch mod.ts
Watcher Test started.
running 0 tests from ./mod.ts

ok | 0 passed | 0 failed (2ms)

Watcher Test finished. Restarting on file change...
```