### PR TITLE
fix(ext/node): set process.env as own property

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -780,6 +780,7 @@ const process = new Process();
 
 /* Set owned property */
 process.versions = versions;
+process.env = env;
 
 Object.defineProperty(process, Symbol.toStringTag, {
   enumerable: false,

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -390,7 +390,7 @@ Deno.test({
 Deno.test({
   name: "process.env",
   fn() {
-    assert(Object.prototype.hasOwnProperty(process, "env"));
+    assert(Object.prototype.hasOwnProperty.call(process, "env"));
 
     Deno.env.set("HELLO", "WORLD");
 

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -390,6 +390,8 @@ Deno.test({
 Deno.test({
   name: "process.env",
   fn() {
+    assert(process.hasOwnProperty("env"));
+
     Deno.env.set("HELLO", "WORLD");
 
     assertObjectMatch(process.env, Deno.env.toObject());

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -390,7 +390,7 @@ Deno.test({
 Deno.test({
   name: "process.env",
   fn() {
-    assert(process.hasOwnProperty("env"));
+    assert(Object.prototype.hasOwnProperty(process, "env"));
 
     Deno.env.set("HELLO", "WORLD");
 


### PR DESCRIPTION
Fixes `gcp-metadata@6.1.1`

```
% deno eval "import 'npm:gcp-metadata@6.1.1'" # main
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'GOOGLE_SDK_NODE_LOGGING')
    at Object.log (file:///Users/divy/Library/Caches/deno/npm/registry.npmjs.org/google-logging-utils/0.0.2/build/src/logging-utils.js:356:36)
    at Object.<anonymous> (file:///Users/divy/Library/Caches/deno/npm/registry.npmjs.org/gcp-metadata/6.1.1/build/src/index.js:52:20)
    at Object.<anonymous> (file:///Users/divy/Library/Caches/deno/npm/registry.npmjs.org/gcp-metadata/6.1.1/build/src/index.js:409:4)
    at Module._compile (node:module:745:34)
    at loadMaybeCjs (node:module:770:10)
    at Object.Module._extensions..js (node:module:755:12)
    at Module.load (node:module:662:32)
    at Function.Module._load (node:module:534:12)
    at Module.require (node:module:681:19)
    at require (node:module:812:16)

% target/debug/deno eval "import 'npm:gcp-metadata@6.1.1'" # this PR
```