### PR TITLE
Revert "fix(lsp): silence debug error for 'move to a new file' action (#27780)"

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1880,7 +1880,7 @@ impl Inner {
         })?;
       let asset_or_doc = self.get_asset_or_document(&action_data.specifier)?;
       let line_index = asset_or_doc.line_index();
-      let refactor_edit_info = self
+      let mut refactor_edit_info = self
         .ts_server
         .get_edits_for_refactor(
           self.snapshot(),
@@ -1901,34 +1901,19 @@ impl Inner {
           )),
           asset_or_doc.scope().cloned(),
         )
-        .await;
-
-      match refactor_edit_info {
-        Ok(mut refactor_edit_info) => {
-          if kind_suffix == ".rewrite.function.returnType"
-            || kind_suffix == ".move.newFile"
-          {
-            refactor_edit_info.edits =
-              fix_ts_import_changes(&refactor_edit_info.edits, self).map_err(
-                |err| {
-                  error!("Unable to remap changes: {:#}", err);
-                  LspError::internal_error()
-                },
-              )?
-          }
-          code_action.edit = refactor_edit_info.to_workspace_edit(self)?;
-        }
-        Err(err) => {
-          // TODO(nayeemrmn): Investigate cause for
-          // https://github.com/denoland/deno/issues/27778. Prevent popups for
-          // this error for now.
-          if kind_suffix == ".move.newFile" {
-            lsp_warn!("{:#}", err);
-          } else {
-            return Err(err);
-          }
-        }
+        .await?;
+      if kind_suffix == ".rewrite.function.returnType"
+        || kind_suffix == ".move.newFile"
+      {
+        refactor_edit_info.edits =
+          fix_ts_import_changes(&refactor_edit_info.edits, self).map_err(
+            |err| {
+              error!("Unable to remap changes: {:#}", err);
+              LspError::internal_error()
+            },
+          )?
       }
+      code_action.edit = refactor_edit_info.to_workspace_edit(self)?;
       code_action
     } else {
       // The code action doesn't need to be resolved


### PR DESCRIPTION
This reverts commit 7b11670e13810187463169a09c3f7618020189fc (#27780).

This workaround is no longer necessary. Ref https://github.com/denoland/deno/issues/27778#issuecomment-2628581697.