### PR TITLE
fix(ext/node): support read-only database in `node:sqlite`

### DIFF
--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -2,6 +2,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { assert, assertEquals, assertThrows } from "@std/assert";
 
+const tempDir = Deno.makeTempDirSync();
+
 Deno.test("[node/sqlite] in-memory databases", () => {
   const db1 = new DatabaseSync(":memory:");
   const db2 = new DatabaseSync(":memory:");
@@ -40,7 +42,6 @@ Deno.test(
     name: "[node/sqlite] PRAGMAs are supported",
   },
   () => {
-    const tempDir = Deno.makeTempDirSync();
     const db = new DatabaseSync(`${tempDir}/test.db`);
 
     assertEquals(db.prepare("PRAGMA journal_mode = WAL").get(), {
@@ -99,5 +100,31 @@ Deno.test({
     assertThrows(() => {
       new DatabaseSync("test.db");
     }, Deno.errors.NotCapable);
+    assertThrows(() => {
+      new DatabaseSync("test.db", { readOnly: true });
+    }, Deno.errors.NotCapable);
+  },
+});
+
+Deno.test({
+  name: "[node/sqlite] readOnly database",
+  permissions: { read: true, write: true },
+  fn() {
+    {
+      const db = new DatabaseSync(`${tempDir}/test3.db`);
+      db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY)");
+      db.close();
+    }
+    {
+      const db = new DatabaseSync(`${tempDir}/test3.db`, { readOnly: true });
+      assertThrows(
+        () => {
+          db.exec("CREATE TABLE test(key INTEGER PRIMARY KEY)");
+        },
+        Error,
+        "attempt to write a readonly database",
+      );
+      db.close();
+    }
   },
 });


### PR DESCRIPTION
Implements the `readOnly` option for `DatabaseSync`.

Permissions:
`--allow-read=test.db --allow-write=test.db` => all works
`--allow-read=test.db` => only `readOnly` dbs work, cannot create new db
