### PR TITLE
fix(ext/node): handle non-ws upgrade headers

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -548,8 +548,11 @@ class ClientRequest extends OutgoingMessage {
         incoming.statusMessage = res.statusText;
         incoming.upgrade = null;
 
-        for (const [key, _value] of res.headers) {
-          if (key.toLowerCase() === "upgrade") {
+        for (const [key, value] of res.headers) {
+          if (
+            key.toLowerCase() === "upgrade" &&
+            value.toLowerCase() === "websocket"
+          ) {
             incoming.upgrade = true;
             break;
           }

--- a/test.mjs
+++ b/test.mjs
@@ -1,5 +1,0 @@
-import { got } from "npm:got";
-
-await got.get(
-  "https://saltire.lti.app/platform/jwks/30d3313d7c655cdc2e722bafeb7374b9",
-);

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,5 @@
+import { got } from "npm:got";
+
+await got.get(
+  "https://saltire.lti.app/platform/jwks/30d3313d7c655cdc2e722bafeb7374b9",
+);

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -372,6 +372,35 @@ Deno.test("[node/http] request default protocol", async () => {
   assertEquals(clientRes!.complete, true);
 });
 
+Deno.test("[node/http] request non-ws upgrade header", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { "upgrade": "h2,h2c" });
+    res.end("ok");
+  });
+  server.listen(() => {
+    const req = http.request(
+      {
+        host: "localhost",
+        // deno-lint-ignore no-explicit-any
+        port: (server.address() as any).port,
+      },
+      (res) => {
+        res.on("data", () => {});
+        res.on("end", () => {
+          server.close();
+        });
+        assertEquals(res.statusCode, 200);
+      },
+    );
+    req.end();
+  });
+  server.on("close", () => {
+    resolve();
+  });
+  await promise;
+});
+
 Deno.test("[node/http] request with headers", async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
   const server = http.createServer((req, res) => {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -373,8 +373,8 @@ Deno.test("[node/http] request default protocol", async () => {
 });
 
 Deno.test("[node/http] request non-ws upgrade header", async () => {
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
-  const server = http.createServer((req, res) => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const server = http.createServer((_req, res) => {
     res.writeHead(200, { "upgrade": "h2,h2c" });
     res.end("ok");
   });


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/27091

Don't perform a WS upgrade on non-ws upgrades by checking the value.
