### PR TITLE
fix(publish): correct coloring in --help

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3358,8 +3358,8 @@ fn publish_subcommand() -> Command {
         .arg(
           Arg::new("set-version")
             .long("set-version")
-            .help("Set version for a package to be published.
-  <p(245)>This flag can be used while publishing individual packages and cannot be used in a workspace.</>")
+            .help(cstr!("Set version for a package to be published.
+  <p(245)>This flag can be used while publishing individual packages and cannot be used in a workspace.</>"))
             .value_name("VERSION")
             .help_heading(PUBLISH_HEADING)
         )


### PR DESCRIPTION
It didn't apply coloring:
![Screenshot 2025-02-03 at 01 59 17](https://github.com/user-attachments/assets/b275cd56-930c-43e2-b29f-a706f4f79322)
