### PR TITLE
refactor(ext/fetch): do not share error instance

### DIFF
--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -273,7 +273,9 @@ class Request {
     if (signal === false) {
       const signal = newSignal();
       this[_signalCache] = signal;
-      signal[signalAbort](signalAbortError);
+      signal[signalAbort](
+        new DOMException(MESSAGE_REQUEST_CANCELLED, "AbortError"),
+      );
       return signal;
     }
 
@@ -282,7 +284,9 @@ class Request {
       const signal = newSignal();
       this[_signalCache] = signal;
       this[_request].onCancel?.(() => {
-        signal[signalAbort](signalAbortError);
+        signal[signalAbort](
+          new DOMException(MESSAGE_REQUEST_CANCELLED, "AbortError"),
+        );
       });
 
       return signal;
@@ -602,15 +606,13 @@ function fromInnerRequest(inner, guard) {
   return request;
 }
 
-const signalAbortError = new DOMException(
-  "The request has been cancelled.",
-  "AbortError",
-);
-ObjectFreeze(signalAbortError);
+const MESSAGE_REQUEST_CANCELLED = "The request has been cancelled.";
 
 function abortRequest(request) {
   if (request[_signalCache] !== undefined) {
-    request[_signal][signalAbort](signalAbortError);
+    request[_signal][signalAbort](
+      new DOMException(MESSAGE_REQUEST_CANCELLED, "AbortError"),
+    );
   } else {
     request[_signalCache] = false;
   }

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -14,7 +14,6 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypeSlice,
   ArrayPrototypeSplice,
-  ObjectFreeze,
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
   RegExpPrototypeExec,


### PR DESCRIPTION
The issue like #27715 is harder to debug because of the shared error instance which is created at the top-level of the file (and therefore it doesn't show any stacktrace when thrown).

This change it to create each instance of AbortError in each code path.

(Question: Is this in this way because of the perf concern?)

Maybe related to #23559