### PR TITLE
feat(unstable): add test for lint plugin destroy hook

### DIFF
--- a/tests/specs/lint/lint_plugin_lifecycle/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_lifecycle/__test__.jsonc
@@ -1,0 +1,17 @@
+{
+  "steps": [
+    {
+      "args": "lint a.ts",
+      "output": "lint.out",
+      "exitCode": 1
+    },
+    {
+      "args": "lint -c deno_exclude.json a.ts",
+      "output": "lint_exclude.out"
+    },
+    {
+      "args": "lint --fix a.ts",
+      "output": "lint_fixed.out"
+    }
+  ]
+}

--- a/tests/specs/lint/lint_plugin_lifecycle/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_lifecycle/__test__.jsonc
@@ -2,16 +2,7 @@
   "steps": [
     {
       "args": "lint a.ts",
-      "output": "lint.out",
-      "exitCode": 1
-    },
-    {
-      "args": "lint -c deno_exclude.json a.ts",
-      "output": "lint_exclude.out"
-    },
-    {
-      "args": "lint --fix a.ts",
-      "output": "lint_fixed.out"
+      "output": "lint.out"
     }
   ]
 }

--- a/tests/specs/lint/lint_plugin_lifecycle/a.ts
+++ b/tests/specs/lint/lint_plugin_lifecycle/a.ts
@@ -1,0 +1,1 @@
+const _a = "foo";

--- a/tests/specs/lint/lint_plugin_lifecycle/deno.json
+++ b/tests/specs/lint/lint_plugin_lifecycle/deno.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "plugins": ["./plugin.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_lifecycle/lint.out
+++ b/tests/specs/lint/lint_plugin_lifecycle/lint.out
@@ -1,0 +1,5 @@
+create: test-plugin/my-rule
+create: test-plugin/my-rule-2
+destroy: test-plugin/my-rule
+destroy: test-plugin/my-rule-2
+Checked 1 file

--- a/tests/specs/lint/lint_plugin_lifecycle/plugin.ts
+++ b/tests/specs/lint/lint_plugin_lifecycle/plugin.ts
@@ -1,0 +1,23 @@
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(ctx) {
+        console.log(`create: ${ctx.id}`);
+        return {};
+      },
+      destroy(ctx) {
+        console.log(`destroy: ${ctx.id}`);
+      },
+    },
+    "my-rule-2": {
+      create(ctx) {
+        console.log(`create: ${ctx.id}`);
+        return {};
+      },
+      destroy(ctx) {
+        console.log(`destroy: ${ctx.id}`);
+      },
+    },
+  },
+};


### PR DESCRIPTION
Noticed that we didn't test the `destroy()` hook of lint plugins. This PR adds a test for that.