### PR TITLE
feat(unstable): add `lint.plugins` to config schema

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -292,6 +292,13 @@
             "type": "string"
           }
         },
+        "plugins": {
+          "type": "array",
+          "description": "UNSTABLE: List of plugins to load.",
+          "items": {
+            "type": "string"
+          }
+        },
         "rules": {
           "type": "object",
           "properties": {

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -294,7 +294,7 @@
         },
         "plugins": {
           "type": "array",
-          "description": "UNSTABLE: List of plugins to load.",
+          "description": "UNSTABLE: List of plugins to load. These can be paths, npm or jsr specifiers",
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
Not sure what our handling of unstable properties in `deno.json` is. This PR adds it to the config schema.