### PR TITLE
fix(lint): clear plugin diagnostics on each lint file run

### DIFF
--- a/cli/ops/lint.rs
+++ b/cli/ops/lint.rs
@@ -60,23 +60,18 @@ pub struct LintPluginContainer {
 }
 
 impl LintPluginContainer {
-  pub fn set_cancellation_token(
-    &mut self,
-    maybe_token: Option<CancellationToken>,
-  ) {
-    let token = maybe_token.unwrap_or_default();
-    self.token = token;
-  }
-
   pub fn set_info_for_file(
     &mut self,
     specifier: ModuleSpecifier,
     source_text_info: SourceTextInfo,
     utf16_map: Utf16Map,
+    maybe_token: Option<CancellationToken>,
   ) {
     self.specifier = Some(specifier);
     self.utf_16_map = Some(utf16_map);
     self.source_text_info = Some(source_text_info);
+    self.diagnostics.clear();
+    self.token = maybe_token.unwrap_or_default();
   }
 
   fn report(

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -325,8 +325,8 @@ impl PluginHost {
         ModuleSpecifier::from_file_path(file_path).unwrap(),
         source_text_info,
         utf16_map,
+        maybe_token,
       );
-      container.set_cancellation_token(maybe_token);
     }
 
     let scope = &mut self.worker.js_runtime.handle_scope();

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -19,6 +19,7 @@ use deno_core::resolve_url_or_path;
 use deno_core::v8;
 use deno_core::PollEventLoopOptions;
 use deno_lint::diagnostic::LintDiagnostic;
+use deno_path_util::url_from_file_path;
 use deno_runtime::deno_permissions::Permissions;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::tokio_util;
@@ -322,7 +323,7 @@ impl PluginHost {
       let mut state = state.borrow_mut();
       let container = state.borrow_mut::<LintPluginContainer>();
       container.set_info_for_file(
-        ModuleSpecifier::from_file_path(file_path).unwrap(),
+        url_from_file_path(file_path)?,
         source_text_info,
         utf16_map,
         maybe_token,


### PR DESCRIPTION
This clears the diagnostics whenever a file is about to run. For example, what could previously occur is an error and the diagnostics would be leftover from the previous run.