### PR TITLE
feat(unstable): support multiple fixes from lint plugins

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -234,11 +234,20 @@ export class Context {
     const start = range[0];
     const end = range[1];
 
-    let fix;
+    /** @type {Deno.lint.FixData[]} */
+    const fixes = [];
 
     if (typeof data.fix === "function") {
       const fixer = new Fixer();
-      fix = data.fix(fixer);
+      const result = data.fix(fixer);
+
+      if (Symbol.iterator in result) {
+        for (const fix of result) {
+          fixes.push(fix);
+        }
+      } else {
+        fixes.push(result);
+      }
     }
 
     doReport(
@@ -247,7 +256,7 @@ export class Context {
       data.hint,
       start,
       end,
-      fix,
+      fixes,
     );
   }
 }

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1388,7 +1388,7 @@ declare namespace Deno {
       range?: Range;
       message: string;
       hint?: string;
-      fix?(fixer: Fixer): FixData;
+      fix?(fixer: Fixer): FixData | Iterable<FixData>;
     }
 
     /**

--- a/tests/specs/lint/lint_plugin_multiple_fixes/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "lint --config=deno_gen.json --fix",
+      "output": "fix.out"
+    },
+    {
+      "args": "lint --config=deno_arr.json --fix",
+      "output": "fix.out"
+    }
+  ]
+}

--- a/tests/specs/lint/lint_plugin_multiple_fixes/deno_arr.json
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/deno_arr.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "plugins": ["./plugin_arr.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_multiple_fixes/deno_gen.json
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/deno_gen.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "plugins": ["./plugin_gen.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_multiple_fixes/fix.out
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/fix.out
@@ -1,0 +1,1 @@
+Checked 3 files

--- a/tests/specs/lint/lint_plugin_multiple_fixes/main.ts
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/main.ts
@@ -1,0 +1,2 @@
+const value = "unfixed";
+console.log(value);

--- a/tests/specs/lint/lint_plugin_multiple_fixes/plugin_arr.ts
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/plugin_arr.ts
@@ -1,0 +1,27 @@
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(context) {
+        return {
+          VariableDeclarator(node) {
+            if (
+              node.init?.type === "Literal" && node.init.value === "unfixed"
+            ) {
+              context.report({
+                node: node.init!,
+                message: 'should be "bar" + have string type',
+                fix(fixer) {
+                  return [
+                    fixer.insertTextAfter(node.id, ": string"),
+                    fixer.replaceText(node.init!, '"bar"'),
+                  ];
+                },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;

--- a/tests/specs/lint/lint_plugin_multiple_fixes/plugin_gen.ts
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/plugin_gen.ts
@@ -1,0 +1,25 @@
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(context) {
+        return {
+          VariableDeclarator(node) {
+            if (
+              node.init?.type === "Literal" && node.init.value === "unfixed"
+            ) {
+              context.report({
+                node: node.init!,
+                message: 'should be "bar" + have string type',
+                *fix(fixer) {
+                  yield fixer.insertTextAfter(node.id, ": string");
+                  yield fixer.replaceText(node.init!, '"bar"');
+                },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;


### PR DESCRIPTION
This PR supports returning multiple changes from a lint fix. It works the same way as eslint, see https://eslint.org/docs/latest/extend/custom-rules#applying-fixes .

- Return a single fix
- Return an array of fixes
- Return a generator function with fixes