### PR TITLE
fix(lint): `Deno.lint.runPlugin` throws in `deno run`

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1473,7 +1473,9 @@ declare namespace Deno {
     }
 
     /**
-     * This API is a noop in `deno run`...
+     * This API is useful for testing lint plugins.
+     *
+     * It throws an error if it's not used in `deno test` subcommand.
      * @category Linter
      * @experimental
      */

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -585,7 +585,11 @@ const finalDenoNs = {
   test: () => {},
   bench: () => {},
   lint: {
-    runPlugin: () => {},
+    runPlugin: () => {
+      throw new Error(
+        "`Deno.lint.runPlugin` is only available in `deno test` subcommand.",
+      );
+    },
   },
 };
 

--- a/tests/specs/lint/lint_plugin_runtime_api/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_runtime_api/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "steps": [
+    {
+      "args": "run main.ts",
+      "output": "run.out",
+      "exitCode": 1
+    },
+    {
+      "args": "test main.ts",
+      "output": "test.out"
+    }
+  ]
+}

--- a/tests/specs/lint/lint_plugin_runtime_api/main.ts
+++ b/tests/specs/lint/lint_plugin_runtime_api/main.ts
@@ -1,0 +1,12 @@
+const plugin = {
+  name: "test-plugin",
+  rules: {
+    testRule: {
+      create() {
+        return {};
+      },
+    },
+  },
+};
+
+Deno.lint.runPlugin(plugin, "source.ts", "export default {}");

--- a/tests/specs/lint/lint_plugin_runtime_api/run.out
+++ b/tests/specs/lint/lint_plugin_runtime_api/run.out
@@ -1,0 +1,5 @@
+error: Uncaught (in promise) Error: `Deno.lint.runPlugin` is only available in `deno test` subcommand.
+Deno.lint.runPlugin(plugin, "source.ts", "export default {}");
+          ^
+    at Object.runPlugin ([WILDCARD])
+    at [WILDCARD]main.ts:12:11

--- a/tests/specs/lint/lint_plugin_runtime_api/test.out
+++ b/tests/specs/lint/lint_plugin_runtime_api/test.out
@@ -1,0 +1,5 @@
+Check [WILDCARD]main.ts
+running 0 tests from ./main.ts
+
+ok | 0 passed | 0 failed [WILDCARD]
+


### PR DESCRIPTION
This commit changes `Deno.lint.runPlugin` to throw
in non-`deno test` subcommand, instead of returning
`undefined`.