### PR TITLE
feat(unstable): add js lint plugin source code helpers

### DIFF
--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -94,6 +94,7 @@ use super::buffer::NodeRef;
 use super::ts_estree::AstNode;
 use super::ts_estree::MethodKind as TsEstreeMethodKind;
 use super::ts_estree::PropertyKind;
+use super::ts_estree::SourceKind;
 use super::ts_estree::TsEsTreeBuilder;
 use super::ts_estree::TsKeywordKind;
 use super::ts_estree::TsModuleKind;
@@ -120,7 +121,7 @@ pub fn serialize_swc_to_buffer(
         })
         .collect::<Vec<_>>();
 
-      ctx.write_program(&module.span, "module", children);
+      ctx.write_program(&module.span, SourceKind::Module, children);
     }
     Program::Script(script) => {
       let children = script
@@ -129,7 +130,7 @@ pub fn serialize_swc_to_buffer(
         .map(|stmt| serialize_stmt(&mut ctx, stmt))
         .collect::<Vec<_>>();
 
-      ctx.write_program(&script.span, "script", children);
+      ctx.write_program(&script.span, SourceKind::Script, children);
     }
   }
 

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -499,12 +499,16 @@ impl TsEsTreeBuilder {
   pub fn write_program(
     &mut self,
     span: &Span,
-    source_kind: &str,
+    source_kind: SourceKind,
     body: Vec<NodeRef>,
   ) -> NodeRef {
     let id = self.ctx.append_node(AstNode::Program, span);
 
-    self.ctx.write_str(AstProp::SourceType, source_kind);
+    let kind = match source_kind {
+      SourceKind::Module => "module",
+      SourceKind::Script => "source",
+    };
+    self.ctx.write_str(AstProp::SourceType, kind);
     self.ctx.write_ref_vec(AstProp::Body, &id, body);
 
     self.ctx.set_root_idx(id.0);
@@ -2902,4 +2906,10 @@ pub enum MethodKind {
   Get,
   Method,
   Set,
+}
+
+#[derive(Debug)]
+pub enum SourceKind {
+  Module,
+  Script,
 }

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -506,7 +506,7 @@ impl TsEsTreeBuilder {
 
     let kind = match source_kind {
       SourceKind::Module => "module",
-      SourceKind::Script => "source",
+      SourceKind::Script => "script",
     };
     self.ctx.write_str(AstProp::SourceType, kind);
     self.ctx.write_ref_vec(AstProp::Body, &id, body);

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1501,6 +1501,17 @@ declare namespace Deno {
      * @category Linter
      * @experimental
      */
+    export interface Program {
+      type: "Program";
+      range: Range;
+      sourceType: "module" | "script";
+      body: Statement[];
+    }
+
+    /**
+     * @category Linter
+     * @experimental
+     */
     export interface ImportSpecifier {
       type: "ImportSpecifier";
       range: Range;
@@ -3857,6 +3868,7 @@ declare namespace Deno {
      * @experimental
      */
     export type Node =
+      | Program
       | Expression
       | Statement
       | TypeNode

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1395,6 +1395,31 @@ declare namespace Deno {
      * @category Linter
      * @experimental
      */
+    export interface SourceCode {
+      /**
+       * Get the source test of a node. Omit `node` to get the
+       * full source code.
+       */
+      getText(node?: Node): string;
+      /**
+       * Returns array of ancestors of the current node, excluding the
+       * current node.
+       */
+      getAncestors(node: Node): Node[];
+      /**
+       * Get the full source code.
+       */
+      text: string;
+      /**
+       * Get the root node of the file. It's always the `Program` node.
+       */
+      ast: Program;
+    }
+
+    /**
+     * @category Linter
+     * @experimental
+     */
     export interface RuleContext {
       /**
        * The running rule id: `<plugin-name>/<rule-name>`
@@ -1405,9 +1430,9 @@ declare namespace Deno {
        */
       fileName: string;
       /**
-       * Retrieve the source code of the current file.
+       * Helper methods for working with the raw source code.
        */
-      source(): string;
+      sourceCode: SourceCode;
       /**
        * Report a lint error.
        */

--- a/tests/specs/lint/lint_plugin_multiple_fixes/main.ts
+++ b/tests/specs/lint/lint_plugin_multiple_fixes/main.ts
@@ -1,2 +1,2 @@
-const value = "unfixed";
+const value = "unfixed🚧⚡️🚵";
 console.log(value);

--- a/tests/specs/lint/lint_plugin_source_code/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_source_code/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "lint main.ts",
+      "output": "log.out"
+    }
+  ]
+}

--- a/tests/specs/lint/lint_plugin_source_code/deno.json
+++ b/tests/specs/lint/lint_plugin_source_code/deno.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "plugins": ["./plugin.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_source_code/log.out
+++ b/tests/specs/lint/lint_plugin_source_code/log.out
@@ -1,0 +1,13 @@
+Source:
+const value = "unfixed";
+console.log(value);
+
+Source VariableDeclarator:
+value = "unfixed"
+
+Ancestors:
+[ "Program", "VariableDeclaration" ]
+
+Ast:
+Program
+Checked 1 file

--- a/tests/specs/lint/lint_plugin_source_code/main.ts
+++ b/tests/specs/lint/lint_plugin_source_code/main.ts
@@ -1,0 +1,2 @@
+const value = "unfixed";
+console.log(value);

--- a/tests/specs/lint/lint_plugin_source_code/plugin.ts
+++ b/tests/specs/lint/lint_plugin_source_code/plugin.ts
@@ -1,0 +1,28 @@
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(context) {
+        return {
+          VariableDeclarator(node) {
+            console.log(`Source:`);
+            console.log(context.sourceCode.getText());
+
+            console.log(`Source VariableDeclarator:`);
+            console.log(context.sourceCode.getText(node));
+            console.log();
+
+            console.log(`Ancestors:`);
+            console.log(
+              context.sourceCode.getAncestors(node).map((node) => node.type),
+            );
+            console.log();
+
+            console.log(`Ast:`);
+            console.log(context.sourceCode.ast.type);
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;


### PR DESCRIPTION
This PR adds a part of the `SourceCode` API in eslint (see https://eslint.org/docs/latest/extend/custom-rules#applying-fixes) . It's used to get the text of the current node, etc.