### PR TITLE
docs(cli): update description of readFile and readFileSync

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2905,7 +2905,7 @@ declare namespace Deno {
 
   /** Reads and resolves to the entire contents of a file as an array of bytes.
    * `TextDecoder` can be used to transform the bytes to string if required.
-   * Reading a directory returns an empty data array.
+   * Rejects with an error when reading a directory.
    *
    * ```ts
    * const decoder = new TextDecoder("utf-8");
@@ -2925,7 +2925,7 @@ declare namespace Deno {
 
   /** Synchronously reads and returns the entire contents of a file as an array
    * of bytes. `TextDecoder` can be used to transform the bytes to string if
-   * required. Reading a directory returns an empty data array.
+   * required. Throws an error when reading a directory.
    *
    * ```ts
    * const decoder = new TextDecoder("utf-8");


### PR DESCRIPTION
`readFile` and `readFileSync` rejects/throws an error when reading directories since v1.1.0. This PR updates jsdocs to reflect that.

(Note: this was pointed in https://github.com/denoland/std/pull/6394 )

---

Side note: This seems changed between 1.0.5 and 1.1.0, but I couldn't find relevant commit/discussion about it:

```
$ deno1.0.5
Deno 1.0.5
exit using ctrl+d or close()
> Deno.readFileSync(".")
Uint8Array(0) []
> 
$ deno1.1.0
Deno 1.1.0
exit using ctrl+d or close()
> Deno.readFileSync(".")
Uncaught Error: Is a directory (os error 21)
    at unwrapResponse ($deno$/ops/dispatch_minimal.ts:63:11)
    at Object.sendSyncMinimal ($deno$/ops/dispatch_minimal.ts:118:10)
```