### PR TITLE
feat: Upgrade V8 to 13.4

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -102,6 +102,8 @@ ${installPkgsCommand} || echo 'Failed. Trying again.' && sudo apt-get clean && s
 # Fix alternatives
 (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
+clang-${llvmVersion} -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+
 echo "Decompressing sysroot..."
 wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20241030/sysroot-\`uname -m\`.tar.xz -O /tmp/sysroot.tar.xz
 cd /
@@ -139,6 +141,7 @@ RUSTFLAGS<<__1
   -C link-arg=-Wl,--allow-shlib-undefined
   -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
   -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
+  -C link-arg=/tmp/memfd_create_shim.o
   --cfg tokio_unstable
   $RUSTFLAGS
 __1
@@ -150,6 +153,7 @@ RUSTDOCFLAGS<<__1
   -C link-arg=-Wl,--allow-shlib-undefined
   -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
   -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
+  -C link-arg=/tmp/memfd_create_shim.o
   --cfg tokio_unstable
   $RUSTFLAGS
 __1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,8 @@ jobs:
           # Fix alternatives
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
+          clang-19 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20241030/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
           cd /
@@ -316,6 +318,7 @@ jobs:
             -C link-arg=-Wl,--allow-shlib-undefined
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
+            -C link-arg=/tmp/memfd_create_shim.o
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -327,6 +330,7 @@ jobs:
             -C link-arg=-Wl,--allow-shlib-undefined
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
+            -C link-arg=/tmp/memfd_create_shim.o
             --cfg tokio_unstable
             $RUSTFLAGS
           __1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -26,6 +26,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aead"
@@ -188,15 +194,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -425,17 +431,17 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.4",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1060,6 +1066,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71de5e59f616d79d14d2c71aa2799ce898241d7f10f7e64a4997014b4000a28"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-module",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash 2.0.0",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
+
+[[package]]
+name = "cranelift-module"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d55612bebcf16ff7306c8a6f5bdb6d45662b8aa1ee058ecce8807ad87db719b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
 name = "crc"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.336.0"
+version = "0.338.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd50476c4325d5fa52bb906804a1e35b127d2a1dcf674e3447b53dcf25525bf"
+checksum = "113f3f08bd5daf99f1a7876c0f99cd8c3c609439fa0b808311ec856a253e95f0"
 dependencies = [
  "anyhow",
  "az",
@@ -1805,14 +1934,16 @@ dependencies = [
 name = "deno_ffi"
 version = "0.176.0"
 dependencies = [
+ "cranelift",
+ "cranelift-native",
  "deno_core",
  "deno_error",
  "deno_permissions",
  "dlopen2",
- "dynasmrt",
  "libffi",
  "libffi-sys",
  "log",
+ "memmap2",
  "num-bigint",
  "serde",
  "serde-value",
@@ -2249,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.212.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d328067139909aa81522a5d90f119368b541fbddd73ab630e4d9f777865f0d"
+checksum = "6ad885bf882be535f7714c713042129acba6f31a8efb5e6b2298f6e40cab9b16"
 dependencies = [
  "indexmap 2.3.0",
  "proc-macro-rules",
@@ -2859,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3154,32 +3285,6 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap2",
-]
 
 [[package]]
 name = "ecb"
@@ -3536,13 +3641,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide",
+ "miniz_oxide 0.8.4",
 ]
 
 [[package]]
@@ -3796,9 +3901,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "gl_generator"
@@ -3997,6 +4107,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -5166,9 +5282,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -5223,6 +5339,15 @@ checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
  "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -6055,7 +6180,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
 ]
 
 [[package]]
@@ -6145,30 +6270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -6535,6 +6636,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145c1c267e14f20fb0f88aa76a1c5ffec42d592c1d28b3cd9148ae35916158d3"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.2",
+ "log",
+ "rustc-hash 2.0.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -7063,9 +7178,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.205"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -7102,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.205"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7149,9 +7264,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.245.0"
+version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945f93c91e0c7e4799b5fefff076756141aae92e262c4dc4833310dd3d2d845e"
+checksum = "12bbfafb7b707cbed49d1eaf48f4aa41b5ff57f813d1a80f77244e6e2fa4507e"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -8088,6 +8203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8841,16 +8962,16 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "130.0.7"
+version = "134.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a511192602f7b435b0a241c1947aa743eb7717f20a9195f4b5e8ed1952e01db1"
+checksum = "224c6c3d1fd3c0356224b2ad355b61c242cdafa9d14cc31b7f161ea177b3b4e9"
 dependencies = [
  "bindgen 0.70.1",
  "bitflags 2.6.0",
  "fslock",
  "gzip-header",
  "home",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
  "once_cell",
  "paste",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.44.0", features = ["transpiling"] }
-deno_core = { version = "0.336.0" }
+deno_core = { version = "0.338.0" }
 
 deno_bench_util = { version = "0.183.0", path = "./bench_util" }
 deno_config = { version = "=0.48.0", features = ["workspace"] }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -470,15 +470,21 @@ fn resolve_flags_and_init(
   }
 
   let default_v8_flags = match flags.subcommand {
-    // Using same default as VSCode:
-    // https://github.com/microsoft/vscode/blob/48d4ba271686e8072fc6674137415bc80d936bc7/extensions/typescript-language-features/src/configuration/configuration.ts#L213-L214
-    DenoSubcommand::Lsp => vec!["--max-old-space-size=3072".to_string()],
+    DenoSubcommand::Lsp => vec![
+      "--stack-size=1024".to_string(),
+      // Using same default as VSCode:
+      // https://github.com/microsoft/vscode/blob/48d4ba271686e8072fc6674137415bc80d936bc7/extensions/typescript-language-features/src/configuration/configuration.ts#L213-L214
+      "--max-old-space-size=3072".to_string(),
+    ],
     _ => {
-      // TODO(bartlomieju): I think this can be removed as it's handled by `deno_core`
-      // and its settings.
-      // deno_ast removes TypeScript `assert` keywords, so this flag only affects JavaScript
-      // TODO(petamoriken): Need to check TypeScript `assert` keywords in deno_ast
-      vec!["--no-harmony-import-assertions".to_string()]
+      vec![
+        "--stack-size=1024".to_string(),
+        // TODO(bartlomieju): I think this can be removed as it's handled by `deno_core`
+        // and its settings.
+        // deno_ast removes TypeScript `assert` keywords, so this flag only affects JavaScript
+        // TODO(petamoriken): Need to check TypeScript `assert` keywords in deno_ast
+        "--no-harmony-import-assertions".to_string(),
+      ]
     }
   };
 

--- a/ext/ffi/Cargo.toml
+++ b/ext/ffi/Cargo.toml
@@ -14,14 +14,16 @@ description = "Dynamic library ffi for deno"
 path = "lib.rs"
 
 [dependencies]
+cranelift = "0.116"
+cranelift-native = "0.116"
 deno_core.workspace = true
 deno_error.workspace = true
 deno_permissions.workspace = true
 dlopen2.workspace = true
-dynasmrt = "1.2.3"
 libffi = "=3.2.0"
 libffi-sys = "=2.3.0"
 log.workspace = true
+memmap2 = "0.9"
 num-bigint.workspace = true
 serde.workspace = true
 serde-value = "0.7"

--- a/ext/ffi/turbocall.rs
+++ b/ext/ffi/turbocall.rs
@@ -1,43 +1,179 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-use std::cmp::max;
 use std::ffi::c_void;
-use std::iter::once;
 
 use deno_core::v8::fast_api;
-use dynasmrt::dynasm;
-use dynasmrt::DynasmApi;
-use dynasmrt::ExecutableBuffer;
 
 use crate::NativeType;
 use crate::Symbol;
 
 pub(crate) fn is_compatible(sym: &Symbol) -> bool {
-  // TODO: Support structs by value in fast call
-  cfg!(any(
-    all(target_arch = "x86_64", target_family = "unix"),
-    all(target_arch = "x86_64", target_family = "windows"),
-    all(target_arch = "aarch64", target_vendor = "apple")
-  )) && !matches!(sym.result_type, NativeType::Struct(_))
+  !matches!(sym.result_type, NativeType::Struct(_))
     && !sym
       .parameter_types
       .iter()
       .any(|t| matches!(t, NativeType::Struct(_)))
 }
 
-// Unused on linux aarch64
+/// Trampoline for fast-call FFI functions
+///
+/// Calls the FFI function without the first argument (the receiver)
+pub(crate) struct Trampoline(memmap2::Mmap);
+
+impl Trampoline {
+  pub(crate) fn ptr(&self) -> *const c_void {
+    self.0.as_ptr() as *const c_void
+  }
+}
+
 #[allow(unused)]
 pub(crate) fn compile_trampoline(sym: &Symbol) -> Trampoline {
-  #[cfg(all(target_arch = "x86_64", target_family = "unix"))]
-  return SysVAmd64::compile(sym);
-  #[cfg(all(target_arch = "x86_64", target_family = "windows"))]
-  return Win64::compile(sym);
-  #[cfg(all(target_arch = "aarch64", target_vendor = "apple"))]
-  return Aarch64Apple::compile(sym);
-  #[allow(unreachable_code)]
-  {
-    unimplemented!("fast API is not implemented for the current target");
+  use cranelift::prelude::*;
+
+  let mut flag_builder = settings::builder();
+  flag_builder.set("is_pic", "true").unwrap();
+  flag_builder.set("opt_level", "speed_and_size").unwrap();
+  let flags = settings::Flags::new(flag_builder);
+
+  let isa = cranelift_native::builder().unwrap().finish(flags).unwrap();
+
+  let mut wrapper_sig =
+    cranelift::codegen::ir::Signature::new(isa.default_call_conv());
+  let mut target_sig =
+    cranelift::codegen::ir::Signature::new(isa.default_call_conv());
+
+  #[cfg(target_pointer_width = "32")]
+  const ISIZE: Type = types::I32;
+  #[cfg(target_pointer_width = "64")]
+  const ISIZE: Type = types::I64;
+
+  // Local<Value> receiver
+  wrapper_sig.params.push(AbiParam::new(ISIZE));
+
+  fn convert(t: &NativeType) -> AbiParam {
+    match t {
+      NativeType::U8 => AbiParam::new(types::I8).uext(),
+      NativeType::I8 => AbiParam::new(types::I8).sext(),
+      NativeType::U16 => AbiParam::new(types::I16).uext(),
+      NativeType::I16 => AbiParam::new(types::I16).sext(),
+      NativeType::U32 => AbiParam::new(types::I32),
+      NativeType::I32 => AbiParam::new(types::I32),
+      NativeType::U64 => AbiParam::new(types::I64),
+      NativeType::I64 => AbiParam::new(types::I64),
+      NativeType::USize => AbiParam::new(ISIZE),
+      NativeType::ISize => AbiParam::new(ISIZE),
+      NativeType::F32 => AbiParam::new(types::F32),
+      NativeType::F64 => AbiParam::new(types::F64),
+      NativeType::Bool => AbiParam::new(types::I8).uext(),
+      NativeType::Pointer => AbiParam::new(ISIZE),
+      NativeType::Buffer => AbiParam::new(ISIZE),
+      NativeType::Function => AbiParam::new(ISIZE),
+      NativeType::Struct(_) => AbiParam::new(types::INVALID),
+      NativeType::Void => AbiParam::new(types::INVALID),
+    }
   }
+
+  for pty in &sym.parameter_types {
+    let param = convert(pty);
+
+    target_sig.params.push(param);
+
+    if param.value_type == types::I8 || param.value_type == types::I16 {
+      wrapper_sig.params.push(AbiParam::new(types::I32));
+    } else {
+      wrapper_sig.params.push(param);
+    }
+  }
+
+  let param = convert(&sym.result_type);
+  if param.value_type != types::INVALID {
+    target_sig.returns.push(param);
+
+    if param.value_type == types::I8 || param.value_type == types::I16 {
+      wrapper_sig.returns.push(AbiParam::new(types::I32));
+    } else {
+      wrapper_sig.returns.push(param);
+    }
+  }
+
+  let mut ab_sig =
+    cranelift::codegen::ir::Signature::new(isa.default_call_conv());
+  ab_sig.params.push(AbiParam::new(ISIZE));
+  ab_sig.returns.push(AbiParam::new(ISIZE));
+
+  let mut ctx = cranelift::codegen::Context::new();
+  let mut fn_builder_ctx = FunctionBuilderContext::new();
+
+  ctx.func = cranelift::codegen::ir::Function::with_name_signature(
+    cranelift::codegen::ir::UserFuncName::user(0, 0),
+    wrapper_sig,
+  );
+
+  let mut f = FunctionBuilder::new(&mut ctx.func, &mut fn_builder_ctx);
+
+  let target_sig = f.import_signature(target_sig);
+  let ab_sig = f.import_signature(ab_sig);
+
+  {
+    let block = f.create_block();
+    f.append_block_params_for_function_params(block);
+    f.switch_to_block(block);
+
+    let args = f.block_params(block);
+    let mut args = (args[1..]).to_owned();
+
+    for (arg, nty) in args.iter_mut().zip(&sym.parameter_types) {
+      match nty {
+        NativeType::U8 | NativeType::I8 | NativeType::Bool => {
+          *arg = f.ins().ireduce(types::I8, *arg);
+        }
+        NativeType::U16 | NativeType::I16 => {
+          *arg = f.ins().ireduce(types::I16, *arg);
+        }
+        NativeType::Buffer => {
+          let callee = f.ins().iconst(
+            ISIZE,
+            Imm64::new(turbocall_ab_contents as usize as isize as i64),
+          );
+          let call = f.ins().call_indirect(ab_sig, callee, &[*arg]);
+          let results = f.inst_results(call);
+          *arg = results[0];
+        }
+        _ => {}
+      }
+    }
+
+    let callee = f.ins().iconst(ISIZE, Imm64::new(sym.ptr.as_ptr() as i64));
+    let call = f.ins().call_indirect(target_sig, callee, &args);
+    let mut results = f.inst_results(call).to_owned();
+
+    match sym.result_type {
+      NativeType::U8 | NativeType::U16 | NativeType::Bool => {
+        results[0] = f.ins().uextend(types::I32, results[0]);
+      }
+      NativeType::I8 | NativeType::I16 => {
+        results[0] = f.ins().sextend(types::I32, results[0]);
+      }
+      _ => {}
+    }
+
+    f.ins().return_(&results);
+  }
+
+  f.seal_all_blocks();
+  f.finalize();
+
+  cranelift::codegen::verifier::verify_function(&ctx.func, isa.flags())
+    .unwrap();
+
+  let code_info = ctx.compile(&*isa, &mut Default::default()).unwrap();
+
+  let data = code_info.buffer.data();
+  let mut mutable = memmap2::MmapMut::map_anon(data.len()).unwrap();
+  mutable.copy_from_slice(data);
+  let buffer = mutable.make_exec().unwrap();
+
+  Trampoline(buffer)
 }
 
 pub(crate) struct Turbocall {
@@ -51,13 +187,13 @@ pub(crate) struct Turbocall {
 }
 
 pub(crate) fn make_template(sym: &Symbol, trampoline: Trampoline) -> Turbocall {
-  let param_info = once(fast_api::Type::V8Value.scalar()) // Receiver
+  let param_info = std::iter::once(fast_api::Type::V8Value.as_info()) // Receiver
     .chain(sym.parameter_types.iter().map(|t| t.into()))
     .collect::<Box<_>>();
 
   let ret = if sym.result_type == NativeType::Buffer {
     // Buffer can be used as a return type and converts differently than in parameters.
-    fast_api::Type::Pointer.scalar()
+    fast_api::Type::Pointer.as_info()
   } else {
     (&sym.result_type).into()
   };
@@ -75,1738 +211,45 @@ pub(crate) fn make_template(sym: &Symbol, trampoline: Trampoline) -> Turbocall {
   }
 }
 
-/// Trampoline for fast-call FFI functions
-///
-/// Calls the FFI function without the first argument (the receiver)
-pub(crate) struct Trampoline(ExecutableBuffer);
-
-impl Trampoline {
-  pub(crate) fn ptr(&self) -> *const c_void {
-    &self.0[0] as *const u8 as *const c_void
-  }
-}
-
 impl From<&NativeType> for fast_api::CTypeInfo {
   fn from(native_type: &NativeType) -> Self {
     match native_type {
-      NativeType::Bool => fast_api::Type::Bool.scalar(),
+      NativeType::Bool => fast_api::Type::Bool.as_info(),
       NativeType::U8 | NativeType::U16 | NativeType::U32 => {
-        fast_api::Type::Uint32.scalar()
+        fast_api::Type::Uint32.as_info()
       }
       NativeType::I8 | NativeType::I16 | NativeType::I32 => {
-        fast_api::Type::Int32.scalar()
+        fast_api::Type::Int32.as_info()
       }
-      NativeType::F32 => fast_api::Type::Float32.scalar(),
-      NativeType::F64 => fast_api::Type::Float64.scalar(),
-      NativeType::Void => fast_api::Type::Void.scalar(),
-      NativeType::I64 => fast_api::Type::Int64.scalar(),
-      NativeType::U64 => fast_api::Type::Uint64.scalar(),
-      NativeType::ISize => fast_api::Type::Int64.scalar(),
-      NativeType::USize => fast_api::Type::Uint64.scalar(),
+      NativeType::F32 => fast_api::Type::Float32.as_info(),
+      NativeType::F64 => fast_api::Type::Float64.as_info(),
+      NativeType::Void => fast_api::Type::Void.as_info(),
+      NativeType::I64 => fast_api::Type::Int64.as_info(),
+      NativeType::U64 => fast_api::Type::Uint64.as_info(),
+      NativeType::ISize => fast_api::Type::Int64.as_info(),
+      NativeType::USize => fast_api::Type::Uint64.as_info(),
       NativeType::Pointer | NativeType::Function => {
-        fast_api::Type::Pointer.scalar()
+        fast_api::Type::Pointer.as_info()
       }
-      NativeType::Buffer => fast_api::Type::Uint8.typed_array(),
-      NativeType::Struct(_) => fast_api::Type::Uint8.typed_array(),
+      NativeType::Buffer => fast_api::Type::V8Value.as_info(),
+      NativeType::Struct(_) => fast_api::Type::V8Value.as_info(),
     }
   }
 }
 
-macro_rules! x64 {
-  ($assembler:expr; $($tokens:tt)+) => {
-    dynasm!($assembler; .arch x64; $($tokens)+)
-  }
-}
-
-macro_rules! aarch64 {
-  ($assembler:expr; $($tokens:tt)+) => {
-    dynasm!($assembler; .arch aarch64; $($tokens)+)
-  }
-}
-
-struct SysVAmd64 {
-  // Reference: https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf
-  assmblr: dynasmrt::x64::Assembler,
-  // Parameter counters
-  integral_params: u32,
-  float_params: u32,
-  // Stack offset accumulators
-  offset_trampoline: u32,
-  offset_callee: u32,
-  allocated_stack: u32,
-  frame_pointer: u32,
-}
-
-#[cfg_attr(
-  not(all(target_aarch = "x86_64", target_family = "unix")),
-  allow(dead_code)
-)]
-impl SysVAmd64 {
-  // Integral arguments go to the following GPR, in order: rdi, rsi, rdx, rcx, r8, r9
-  const INTEGRAL_REGISTERS: u32 = 6;
-  // SSE arguments go to the first 8 SSE registers: xmm0-xmm7
-  const FLOAT_REGISTERS: u32 = 8;
-
-  fn new() -> Self {
-    Self {
-      assmblr: dynasmrt::x64::Assembler::new().unwrap(),
-      integral_params: 0,
-      float_params: 0,
-      // Start at 8 to account for trampoline caller's return address
-      offset_trampoline: 8,
-      // default to tail-call mode. If a new stack frame is allocated this becomes 0
-      offset_callee: 8,
-      allocated_stack: 0,
-      frame_pointer: 0,
-    }
-  }
-
-  fn compile(sym: &Symbol) -> Trampoline {
-    let mut compiler = Self::new();
-
-    let must_cast_return_value =
-      compiler.must_cast_return_value(&sym.result_type);
-    let cannot_tailcall = must_cast_return_value;
-
-    if cannot_tailcall {
-      compiler.allocate_stack(&sym.parameter_types);
-    }
-
-    for param in sym.parameter_types.iter().cloned() {
-      compiler.move_left(param)
-    }
-    if !compiler.is_recv_arg_overridden() {
-      // the receiver object should never be expected. Avoid its unexpected or deliberate leak
-      compiler.zero_first_arg();
-    }
-
-    if cannot_tailcall {
-      compiler.call(sym.ptr.as_ptr());
-      if must_cast_return_value {
-        compiler.cast_return_value(&sym.result_type);
-      }
-      compiler.deallocate_stack();
-      compiler.ret();
-    } else {
-      compiler.tailcall(sym.ptr.as_ptr());
-    }
-
-    Trampoline(compiler.finalize())
-  }
-
-  fn move_left(&mut self, param: NativeType) {
-    // Section 3.2.3 of the SysV ABI spec, on argument classification:
-    // - INTEGER:
-    //    > Arguments of types (signed and unsigned) _Bool, char, short, int,
-    //    > long, long long, and pointers are in the INTEGER class.
-    // - SSE:
-    //    > Arguments of types float, double, _Decimal32, _Decimal64 and
-    //    > __m64 are in class SSE.
-    match param.into() {
-      Int(integral) => self.move_integral(integral),
-      Float(float) => self.move_float(float),
-    }
-  }
-
-  fn move_float(&mut self, param: Floating) {
-    // Section 3.2.3 of the SysV AMD64 ABI:
-    // > If the class is SSE, the next available vector register is used, the registers
-    // > are taken in the order from %xmm0 to %xmm7.
-    // [...]
-    // > Once registers are assigned, the arguments passed in memory are pushed on
-    // > the stack in reversed (right-to-left) order
-    let param_i = self.float_params;
-
-    let is_in_stack = param_i >= Self::FLOAT_REGISTERS;
-    // floats are only moved to accommodate integer movement in the stack
-    let stack_has_moved = self.allocated_stack > 0
-      || self.integral_params >= Self::INTEGRAL_REGISTERS;
-
-    if is_in_stack && stack_has_moved {
-      let s = &mut self.assmblr;
-      let ot = self.offset_trampoline as i32;
-      let oc = self.offset_callee as i32;
-      match param {
-        Single => x64!(s
-          ; movss xmm8, [rsp + ot]
-          ; movss [rsp + oc], xmm8
-        ),
-        Double => x64!(s
-          ; movsd xmm8, [rsp + ot]
-          ; movsd [rsp + oc], xmm8
-        ),
-      }
-
-      // Section 3.2.3 of the SysV AMD64 ABI:
-      // > The size of each argument gets rounded up to eightbytes. [...] Therefore the stack will always be eightbyte aligned.
-      self.offset_trampoline += 8;
-      self.offset_callee += 8;
-
-      debug_assert!(
-        self.allocated_stack == 0 || self.offset_callee <= self.allocated_stack
-      );
-    }
-    self.float_params += 1;
-  }
-
-  fn move_integral(&mut self, arg: Integral) {
-    // Section 3.2.3 of the SysV AMD64 ABI:
-    // > If the class is INTEGER, the next available register of the sequence %rdi,
-    // > %rsi, %rdx, %rcx, %r8 and %r9 is used
-    // [...]
-    // > Once registers are assigned, the arguments passed in memory are pushed on
-    // > the stack in reversed (right-to-left) order
-    let s = &mut self.assmblr;
-    let param_i = self.integral_params;
-
-    // move each argument one position to the left. The first argument in the stack moves to the last integer register (r9).
-    // If the FFI function is called with a new stack frame, the arguments remaining in the stack are copied to the new stack frame.
-    // Otherwise, they are copied 8 bytes lower in the same frame
-    match (param_i, arg) {
-      // u8 and u16 parameters are defined as u32 parameters in the V8's fast API function. The trampoline takes care of the cast.
-      // Conventionally, many compilers expect 8 and 16 bit arguments to be sign/zero extended by the caller
-      // See https://stackoverflow.com/a/36760539/2623340
-      (0, U(B)) => x64!(s; movzx edi, sil),
-      (0, I(B)) => x64!(s; movsx edi, sil),
-      (0, U(W)) => x64!(s; movzx edi, si),
-      (0, I(W)) => x64!(s; movsx edi, si),
-      (0, U(DW) | I(DW)) => x64!(s; mov edi, esi),
-      (0, U(QW) | I(QW)) => x64!(s; mov rdi, rsi),
-      // The fast API expects buffer arguments passed as a pointer to a FastApiTypedArray<Uint8> struct
-      // Here we blindly follow the layout of https://github.com/denoland/rusty_v8/blob/main/src/fast_api.rs#L190-L200
-      // although that might be problematic: https://discord.com/channels/684898665143206084/956626010248478720/1009450940866252823
-      (0, Buffer) => x64!(s; mov rdi, [rsi + 8]),
-
-      (1, U(B)) => x64!(s; movzx esi, dl),
-      (1, I(B)) => x64!(s; movsx esi, dl),
-      (1, U(W)) => x64!(s; movzx esi, dx),
-      (1, I(W)) => x64!(s; movsx esi, dx),
-      (1, U(DW) | I(DW)) => x64!(s; mov esi, edx),
-      (1, U(QW) | I(QW)) => x64!(s; mov rsi, rdx),
-      (1, Buffer) => x64!(s; mov rsi, [rdx + 8]),
-
-      (2, U(B)) => x64!(s; movzx edx, cl),
-      (2, I(B)) => x64!(s; movsx edx, cl),
-      (2, U(W)) => x64!(s; movzx edx, cx),
-      (2, I(W)) => x64!(s; movsx edx, cx),
-      (2, U(DW) | I(DW)) => x64!(s; mov edx, ecx),
-      (2, U(QW) | I(QW)) => x64!(s; mov rdx, rcx),
-      (2, Buffer) => x64!(s; mov rdx, [rcx + 8]),
-
-      (3, U(B)) => x64!(s; movzx ecx, r8b),
-      (3, I(B)) => x64!(s; movsx ecx, r8b),
-      (3, U(W)) => x64!(s; movzx ecx, r8w),
-      (3, I(W)) => x64!(s; movsx ecx, r8w),
-      (3, U(DW) | I(DW)) => x64!(s; mov ecx, r8d),
-      (3, U(QW) | I(QW)) => x64!(s; mov rcx, r8),
-      (3, Buffer) => x64!(s; mov rcx, [r8 + 8]),
-
-      (4, U(B)) => x64!(s; movzx r8d, r9b),
-      (4, I(B)) => x64!(s; movsx r8d, r9b),
-      (4, U(W)) => x64!(s; movzx r8d, r9w),
-      (4, I(W)) => x64!(s; movsx r8d, r9w),
-      (4, U(DW) | I(DW)) => x64!(s; mov r8d, r9d),
-      (4, U(QW) | I(QW)) => x64!(s; mov r8, r9),
-      (4, Buffer) => x64!(s; mov r8, [r9 + 8]),
-
-      (5, param) => {
-        let ot = self.offset_trampoline as i32;
-        // First argument in stack goes to last register (r9)
-        match param {
-          U(B) => x64!(s; movzx r9d, BYTE [rsp + ot]),
-          I(B) => x64!(s; movsx r9d, BYTE [rsp + ot]),
-          U(W) => x64!(s; movzx r9d, WORD [rsp + ot]),
-          I(W) => x64!(s; movsx r9d, WORD [rsp + ot]),
-          U(DW) | I(DW) => x64!(s; mov r9d, [rsp + ot]),
-          U(QW) | I(QW) => x64!(s; mov r9, [rsp + ot]),
-          Buffer => x64!(s
-            ; mov r9, [rsp + ot]
-            ; mov r9, [r9 + 8]
-          ),
-        }
-        // Section 3.2.3 of the SysV AMD64 ABI:
-        // > The size of each argument gets rounded up to eightbytes. [...] Therefore the stack will always be eightbyte aligned.
-        self.offset_trampoline += 8;
-      }
-
-      (6.., param) => {
-        let ot = self.offset_trampoline as i32;
-        let oc = self.offset_callee as i32;
-        match param {
-          U(B) => x64!(s
-            // TODO: optimize to [rsp] (without immediate) when offset is 0
-            ; movzx eax, BYTE [rsp + ot]
-            ; mov [rsp + oc], eax
-          ),
-          I(B) => x64!(s
-            ; movsx eax, BYTE [rsp + ot]
-            ; mov [rsp + oc], eax
-          ),
-          U(W) => x64!(s
-            ; movzx eax, WORD [rsp + ot]
-            ; mov [rsp + oc], eax
-          ),
-          I(W) => x64!(s
-            ; movsx eax, WORD [rsp + ot]
-            ; mov [rsp + oc], eax
-          ),
-          U(DW) | I(DW) => x64!(s
-            ; mov eax, [rsp + ot]
-            ; mov [rsp + oc], eax
-          ),
-          U(QW) | I(QW) => x64!(s
-            ; mov rax, [rsp + ot]
-            ; mov [rsp + oc], rax
-          ),
-          Buffer => x64!(s
-            ; mov rax, [rsp + ot]
-            ; mov rax, [rax + 8]
-            ; mov [rsp + oc], rax
-          ),
-        }
-        // Section 3.2.3 of the SysV AMD64 ABI:
-        // > The size of each argument gets rounded up to eightbytes. [...] Therefore the stack will always be eightbyte aligned.
-        self.offset_trampoline += 8;
-        self.offset_callee += 8;
-
-        debug_assert!(
-          self.allocated_stack == 0
-            || self.offset_callee <= self.allocated_stack
-        );
-      }
-    }
-    self.integral_params += 1;
-  }
-
-  fn zero_first_arg(&mut self) {
-    debug_assert!(
-      self.integral_params == 0,
-      "the trampoline would zero the first argument after having overridden it with the second one"
-    );
-    dynasm!(self.assmblr
-      ; .arch x64
-      ; xor edi, edi
-    );
-  }
-
-  fn cast_return_value(&mut self, rv: &NativeType) {
-    let s = &mut self.assmblr;
-    // V8 only supports 32bit integers. We support 8 and 16 bit integers casting them to 32bits.
-    // In SysV-AMD64 the convention dictates that the unused bits of the return value contain garbage, so we
-    // need to zero/sign extend the return value explicitly
-    match rv {
-      NativeType::U8 => x64!(s; movzx eax, al),
-      NativeType::I8 => x64!(s; movsx eax, al),
-      NativeType::U16 => x64!(s; movzx eax, ax),
-      NativeType::I16 => x64!(s; movsx eax, ax),
-      _ => (),
-    }
-  }
-
-  fn save_out_array_to_preserved_register(&mut self) {
-    let s = &mut self.assmblr;
-    // functions returning 64 bit integers have the out array appended as their last parameter,
-    // and it is a *FastApiTypedArray<Int32>
-    match self.integral_params {
-      // Trampoline's signature is (receiver, [param0, param1, ...], *FastApiTypedArray)
-      // self.integral_params account only for the original params [param0, param1, ...]
-      // and the out array has not been moved left
-      0 => x64!(s; mov rbx, [rsi + 8]),
-      1 => x64!(s; mov rbx, [rdx + 8]),
-      2 => x64!(s; mov rbx, [rcx + 8]),
-      3 => x64!(s; mov rbx, [r8 + 8]),
-      4 => x64!(s; mov rbx, [r9 + 8]),
-      5.. => {
-        x64!(s
-          ; mov rax, [rsp + self.offset_trampoline as i32]
-          ; mov rbx, [rax + 8]
-        )
-      }
-    }
-  }
-
-  fn wrap_return_value_in_out_array(&mut self) {
-    x64!(self.assmblr; mov [rbx], rax);
-  }
-
-  fn save_preserved_register_to_stack(&mut self) {
-    x64!(self.assmblr; push rbx);
-    self.offset_trampoline += 8;
-    // stack pointer has been modified, and the callee stack parameters are expected at the top of the stack
-    self.offset_callee = 0;
-    self.frame_pointer += 8;
-  }
-
-  fn recover_preserved_register(&mut self) {
-    debug_assert!(
-      self.frame_pointer >= 8,
-      "the trampoline would try to pop from the stack beyond its frame pointer"
-    );
-    x64!(self.assmblr; pop rbx);
-    self.frame_pointer -= 8;
-    // parameter offsets are invalid once this method is called
-  }
-
-  fn allocate_stack(&mut self, params: &[NativeType]) {
-    let mut int_params = 0u32;
-    let mut float_params = 0u32;
-    for param in params {
-      match param {
-        NativeType::F32 | NativeType::F64 => float_params += 1,
-        _ => int_params += 1,
-      }
-    }
-    let mut stack_size = (int_params.saturating_sub(Self::INTEGRAL_REGISTERS)
-      + float_params.saturating_sub(Self::FLOAT_REGISTERS))
-      * 8;
-
-    // Align new stack frame (accounting for the 8 byte of the trampoline caller's return address
-    // and any other potential addition to the stack prior to this allocation)
-    // Section 3.2.2 of the SysV AMD64 ABI:
-    // > The end of the input argument area shall be aligned on a 16 (32 or 64, if
-    // > __m256 or __m512 is passed on stack) byte boundary. In other words, the value
-    // > (%rsp + 8) is always a multiple of 16 (32 or 64) when control is transferred to
-    // > the function entry point. The stack pointer, %rsp, always points to the end of the
-    // > latest allocated stack frame.
-    stack_size += padding_to_align(16, self.frame_pointer + stack_size + 8);
-
-    if stack_size > 0 {
-      x64!(self.assmblr; sub rsp, stack_size as i32);
-      self.offset_trampoline += stack_size;
-      // stack pointer has been modified, and the callee stack parameters are expected at the top of the stack
-      self.offset_callee = 0;
-      self.allocated_stack += stack_size;
-      self.frame_pointer += stack_size;
-    }
-  }
-
-  fn deallocate_stack(&mut self) {
-    debug_assert!(
-      self.frame_pointer >= self.allocated_stack,
-      "the trampoline would try to deallocate stack beyond its frame pointer"
-    );
-    if self.allocated_stack > 0 {
-      x64!(self.assmblr; add rsp, self.allocated_stack as i32);
-
-      self.frame_pointer -= self.allocated_stack;
-      self.allocated_stack = 0;
-    }
-  }
-
-  fn call(&mut self, ptr: *const c_void) {
-    // the stack has been aligned during stack allocation and/or pushing of preserved registers
-    debug_assert!(
-      (8 + self.frame_pointer) % 16 == 0,
-      "the trampoline would call the FFI function with an unaligned stack"
-    );
-    x64!(self.assmblr
-      ; mov rax, QWORD ptr as _
-      ; call rax
-    );
-  }
-
-  fn tailcall(&mut self, ptr: *const c_void) {
-    // stack pointer is never modified and remains aligned
-    // return address remains the one provided by the trampoline's caller (V8)
-    debug_assert!(
-      self.allocated_stack == 0,
-      "the trampoline would tail call the FFI function with an outstanding stack allocation"
-    );
-    debug_assert!(
-      self.frame_pointer == 0,
-      "the trampoline would tail call the FFI function with outstanding locals in the frame"
-    );
-    x64!(self.assmblr
-      ; mov rax, QWORD ptr as _
-      ; jmp rax
-    );
-  }
-
-  fn ret(&mut self) {
-    debug_assert!(
-      self.allocated_stack == 0,
-      "the trampoline would return with an outstanding stack allocation"
-    );
-    debug_assert!(
-      self.frame_pointer == 0,
-      "the trampoline would return with outstanding locals in the frame"
-    );
-    x64!(self.assmblr; ret);
-  }
-
-  fn is_recv_arg_overridden(&self) -> bool {
-    // V8 receiver is the first parameter of the trampoline function and is a pointer
-    self.integral_params > 0
-  }
-
-  fn must_cast_return_value(&self, rv: &NativeType) -> bool {
-    // V8 only supports i32 and u32 return types for integers
-    // We support 8 and 16 bit integers by extending them to 32 bits in the trampoline before returning
-    matches!(
-      rv,
-      NativeType::U8 | NativeType::I8 | NativeType::U16 | NativeType::I16
-    )
-  }
-
-  fn finalize(self) -> ExecutableBuffer {
-    self.assmblr.finalize().unwrap()
-  }
-}
-
-struct Aarch64Apple {
-  // Reference https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst
-  assmblr: dynasmrt::aarch64::Assembler,
-  // Parameter counters
-  integral_params: u32,
-  float_params: u32,
-  // Stack offset accumulators
-  offset_trampoline: u32,
-  offset_callee: u32,
-  allocated_stack: u32,
-}
-
-#[cfg_attr(
-  not(all(target_aarch = "aarch64", target_vendor = "apple")),
-  allow(dead_code)
-)]
-impl Aarch64Apple {
-  // Integral arguments go to the first 8 GPR: x0-x7
-  const INTEGRAL_REGISTERS: u32 = 8;
-  // Floating-point arguments go to the first 8 SIMD & Floating-Point registers: v0-v1
-  const FLOAT_REGISTERS: u32 = 8;
-
-  fn new() -> Self {
-    Self {
-      assmblr: dynasmrt::aarch64::Assembler::new().unwrap(),
-      integral_params: 0,
-      float_params: 0,
-      offset_trampoline: 0,
-      offset_callee: 0,
-      allocated_stack: 0,
-    }
-  }
-
-  fn compile(sym: &Symbol) -> Trampoline {
-    let mut compiler = Self::new();
-
-    for param in sym.parameter_types.iter().cloned() {
-      compiler.move_left(param)
-    }
-    if !compiler.is_recv_arg_overridden() {
-      // the receiver object should never be expected. Avoid its unexpected or deliberate leak
-      compiler.zero_first_arg();
-    }
-
-    compiler.tailcall(sym.ptr.as_ptr());
-
-    Trampoline(compiler.finalize())
-  }
-
-  fn move_left(&mut self, param: NativeType) {
-    // Section 6.4.2 of the Aarch64 Procedure Call Standard (PCS), on argument classification:
-    // - INTEGRAL or POINTER:
-    //    > If the argument is an Integral or Pointer Type, the size of the argument is less than or equal to 8 bytes
-    //    > and the NGRN is less than 8, the argument is copied to the least significant bits in x[NGRN].
-    //
-    // - Floating-Point or Vector:
-    //    > If the argument is a Half-, Single-, Double- or Quad- precision Floating-point or short vector type
-    //    > and the NSRN is less than 8, then the argument is allocated to the least significant bits of register v[NSRN]
-    match param.into() {
-      Int(integral) => self.move_integral(integral),
-      Float(float) => self.move_float(float),
-    }
-  }
-
-  fn move_float(&mut self, param: Floating) {
-    // Section 6.4.2 of the Aarch64 PCS:
-    // > If the argument is a Half-, Single-, Double- or Quad- precision Floating-point or short vector type and the NSRN is less than 8, then the
-    // > argument is allocated to the least significant bits of register v[NSRN]. The NSRN is incremented by one. The argument has now been allocated.
-    // > [if NSRN is equal or more than 8]
-    // > The argument is copied to memory at the adjusted NSAA. The NSAA is incremented by the size of the argument. The argument has now been allocated.
-    let param_i = self.float_params;
-
-    let is_in_stack = param_i >= Self::FLOAT_REGISTERS;
-    if is_in_stack {
-      // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms:
-      // > Function arguments may consume slots on the stack that are not multiples of 8 bytes.
-      // (i.e. natural alignment instead of eightbyte alignment)
-      let padding_trampl =
-        (param.size() - self.offset_trampoline % param.size()) % param.size();
-      let padding_callee =
-        (param.size() - self.offset_callee % param.size()) % param.size();
-
-      // floats are only moved to accommodate integer movement in the stack
-      let stack_has_moved = self.integral_params >= Self::INTEGRAL_REGISTERS;
-      if stack_has_moved {
-        let s = &mut self.assmblr;
-        let ot = self.offset_trampoline;
-        let oc = self.offset_callee;
-        match param {
-          Single => aarch64!(s
-            // 6.1.2 Aarch64 PCS:
-            // > Registers v8-v15 must be preserved by a callee across subroutine calls;
-            // > the remaining registers (v0-v7, v16-v31) do not need to be preserved (or should be preserved by the caller).
-            ; ldr s16, [sp, ot + padding_trampl]
-            ; str s16, [sp, oc + padding_callee]
-          ),
-          Double => aarch64!(s
-            ; ldr d16, [sp, ot + padding_trampl]
-            ; str d16, [sp, oc + padding_callee]
-          ),
-        }
-      }
-      self.offset_trampoline += padding_trampl + param.size();
-      self.offset_callee += padding_callee + param.size();
-
-      debug_assert!(
-        self.allocated_stack == 0 || self.offset_callee <= self.allocated_stack
-      );
-    }
-    self.float_params += 1;
-  }
-
-  fn move_integral(&mut self, param: Integral) {
-    let s = &mut self.assmblr;
-    // Section 6.4.2 of the Aarch64 PCS:
-    // If the argument is an Integral or Pointer Type, the size of the argument is less than or
-    // equal to 8 bytes and the NGRN is less than 8, the argument is copied to the least
-    // significant bits in x[NGRN]. The NGRN is incremented by one. The argument has now been
-    // allocated.
-    // [if NGRN is equal or more than 8]
-    // The argument is copied to memory at the adjusted NSAA. The NSAA is incremented by the size
-    // of the argument. The argument has now been allocated.
-    let param_i = self.integral_params;
-
-    // move each argument one position to the left. The first argument in the stack moves to the last integer register (x7).
-    match (param_i, param) {
-      // From https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms:
-      // > The caller of a function is responsible for signing or zero-extending any argument with fewer than 32 bits.
-      // > The standard ABI expects the callee to sign or zero-extend those arguments.
-      // (this applies to register parameters, as stack parameters are not eightbyte aligned in Apple)
-      (0, I(B)) => aarch64!(s; sxtb w0, w1),
-      (0, U(B)) => aarch64!(s; and w0, w1, 0xFF),
-      (0, I(W)) => aarch64!(s; sxth w0, w1),
-      (0, U(W)) => aarch64!(s; and w0, w1, 0xFFFF),
-      (0, I(DW) | U(DW)) => aarch64!(s; mov w0, w1),
-      (0, I(QW) | U(QW)) => aarch64!(s; mov x0, x1),
-      // The fast API expects buffer arguments passed as a pointer to a FastApiTypedArray<Uint8> struct
-      // Here we blindly follow the layout of https://github.com/denoland/rusty_v8/blob/main/src/fast_api.rs#L190-L200
-      // although that might be problematic: https://discord.com/channels/684898665143206084/956626010248478720/1009450940866252823
-      (0, Buffer) => aarch64!(s; ldr x0, [x1, 8]),
-
-      (1, I(B)) => aarch64!(s; sxtb w1, w2),
-      (1, U(B)) => aarch64!(s; and w1, w2, 0xFF),
-      (1, I(W)) => aarch64!(s; sxth w1, w2),
-      (1, U(W)) => aarch64!(s; and w1, w2, 0xFFFF),
-      (1, I(DW) | U(DW)) => aarch64!(s; mov w1, w2),
-      (1, I(QW) | U(QW)) => aarch64!(s; mov x1, x2),
-      (1, Buffer) => aarch64!(s; ldr x1, [x2, 8]),
-
-      (2, I(B)) => aarch64!(s; sxtb w2, w3),
-      (2, U(B)) => aarch64!(s; and w2, w3, 0xFF),
-      (2, I(W)) => aarch64!(s; sxth w2, w3),
-      (2, U(W)) => aarch64!(s; and w2, w3, 0xFFFF),
-      (2, I(DW) | U(DW)) => aarch64!(s; mov w2, w3),
-      (2, I(QW) | U(QW)) => aarch64!(s; mov x2, x3),
-      (2, Buffer) => aarch64!(s; ldr x2, [x3, 8]),
-
-      (3, I(B)) => aarch64!(s; sxtb w3, w4),
-      (3, U(B)) => aarch64!(s; and w3, w4, 0xFF),
-      (3, I(W)) => aarch64!(s; sxth w3, w4),
-      (3, U(W)) => aarch64!(s; and w3, w4, 0xFFFF),
-      (3, I(DW) | U(DW)) => aarch64!(s; mov w3, w4),
-      (3, I(QW) | U(QW)) => aarch64!(s; mov x3, x4),
-      (3, Buffer) => aarch64!(s; ldr x3, [x4, 8]),
-
-      (4, I(B)) => aarch64!(s; sxtb w4, w5),
-      (4, U(B)) => aarch64!(s; and w4, w5, 0xFF),
-      (4, I(W)) => aarch64!(s; sxth w4, w5),
-      (4, U(W)) => aarch64!(s; and w4, w5, 0xFFFF),
-      (4, I(DW) | U(DW)) => aarch64!(s; mov w4, w5),
-      (4, I(QW) | U(QW)) => aarch64!(s; mov x4, x5),
-      (4, Buffer) => aarch64!(s; ldr x4, [x5, 8]),
-
-      (5, I(B)) => aarch64!(s; sxtb w5, w6),
-      (5, U(B)) => aarch64!(s; and w5, w6, 0xFF),
-      (5, I(W)) => aarch64!(s; sxth w5, w6),
-      (5, U(W)) => aarch64!(s; and w5, w6, 0xFFFF),
-      (5, I(DW) | U(DW)) => aarch64!(s; mov w5, w6),
-      (5, I(QW) | U(QW)) => aarch64!(s; mov x5, x6),
-      (5, Buffer) => aarch64!(s; ldr x5, [x6, 8]),
-
-      (6, I(B)) => aarch64!(s; sxtb w6, w7),
-      (6, U(B)) => aarch64!(s; and w6, w7, 0xFF),
-      (6, I(W)) => aarch64!(s; sxth w6, w7),
-      (6, U(W)) => aarch64!(s; and w6, w7, 0xFFFF),
-      (6, I(DW) | U(DW)) => aarch64!(s; mov w6, w7),
-      (6, I(QW) | U(QW)) => aarch64!(s; mov x6, x7),
-      (6, Buffer) => aarch64!(s; ldr x6, [x7, 8]),
-
-      (7, param) => {
-        let ot = self.offset_trampoline;
-        match param {
-          I(B) => {
-            aarch64!(s; ldrsb w7, [sp, ot])
-          }
-          U(B) => {
-            // ldrb zero-extends the byte to fill the 32bits of the register
-            aarch64!(s; ldrb w7, [sp, ot])
-          }
-          I(W) => {
-            aarch64!(s; ldrsh w7, [sp, ot])
-          }
-          U(W) => {
-            // ldrh zero-extends the half-word to fill the 32bits of the register
-            aarch64!(s; ldrh w7, [sp, ot])
-          }
-          I(DW) | U(DW) => {
-            aarch64!(s; ldr w7, [sp, ot])
-          }
-          I(QW) | U(QW) => {
-            aarch64!(s; ldr x7, [sp, ot])
-          }
-          Buffer => {
-            aarch64!(s
-              ; ldr x7, [sp, ot]
-              ; ldr x7, [x7, 8]
-            )
-          }
-        }
-        // 16 and 8 bit integers are 32 bit integers in v8
-        self.offset_trampoline += max(param.size(), 4);
-      }
-
-      (8.., param) => {
-        // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms:
-        // > Function arguments may consume slots on the stack that are not multiples of 8 bytes.
-        // (i.e. natural alignment instead of eightbyte alignment)
-        //
-        // N.B. V8 does not currently follow this Apple's policy, and instead aligns all arguments to 8 Byte boundaries.
-        // The current implementation follows the V8 incorrect calling convention for the sake of a seamless experience
-        // for the Deno users. Whenever upgrading V8 we should make sure that the bug has not been amended, and revert this
-        // workaround once it has been. The bug is being tracked in https://bugs.chromium.org/p/v8/issues/detail?id=13171
-        let size_original = param.size();
-        // 16 and 8 bit integers are 32 bit integers in v8
-        // let size_trampl = max(size_original, 4);  // <-- Apple alignment
-        let size_trampl = 8; // <-- V8 incorrect alignment
-        let padding_trampl =
-          padding_to_align(size_trampl, self.offset_trampoline);
-        let padding_callee =
-          padding_to_align(size_original, self.offset_callee);
-        let ot = self.offset_trampoline;
-        let oc = self.offset_callee;
-        match param {
-          I(B) | U(B) => aarch64!(s
-            ; ldr w8, [sp, ot + padding_trampl]
-            ; strb w8, [sp, oc + padding_callee]
-          ),
-          I(W) | U(W) => aarch64!(s
-            ; ldr w8, [sp, ot + padding_trampl]
-            ; strh w8, [sp, oc + padding_callee]
-          ),
-          I(DW) | U(DW) => aarch64!(s
-            ;  ldr w8, [sp, ot + padding_trampl]
-            ; str w8, [sp, oc + padding_callee]
-          ),
-          I(QW) | U(QW) => aarch64!(s
-            ; ldr x8, [sp, ot + padding_trampl]
-            ; str x8, [sp, oc + padding_callee]
-          ),
-          Buffer => aarch64!(s
-            ; ldr x8, [sp, ot + padding_trampl]
-            ; ldr x8, [x8, 8]
-            ; str x8, [sp, oc + padding_callee]
-          ),
-        }
-        self.offset_trampoline += padding_trampl + size_trampl;
-        self.offset_callee += padding_callee + size_original;
-
-        debug_assert!(
-          self.allocated_stack == 0
-            || self.offset_callee <= self.allocated_stack
-        );
-      }
-    };
-    self.integral_params += 1;
-  }
-
-  fn zero_first_arg(&mut self) {
-    debug_assert!(
-      self.integral_params == 0,
-      "the trampoline would zero the first argument after having overridden it with the second one"
-    );
-    aarch64!(self.assmblr; mov x0, xzr);
-  }
-
-  fn save_out_array_to_preserved_register(&mut self) {
-    let s = &mut self.assmblr;
-    // functions returning 64 bit integers have the out array appended as their last parameter,
-    // and it is a *FastApiTypedArray<Int32>
-    match self.integral_params {
-      // x0 is always V8's receiver
-      0 => aarch64!(s; ldr x19, [x1, 8]),
-      1 => aarch64!(s; ldr x19, [x2, 8]),
-      2 => aarch64!(s; ldr x19, [x3, 8]),
-      3 => aarch64!(s; ldr x19, [x4, 8]),
-      4 => aarch64!(s; ldr x19, [x5, 8]),
-      5 => aarch64!(s; ldr x19, [x6, 8]),
-      6 => aarch64!(s; ldr x19, [x7, 8]),
-      7.. => {
-        aarch64!(s
-          ; ldr x19, [sp, self.offset_trampoline]
-          ; ldr x19, [x19, 8]
-        )
-      }
-    }
-  }
-
-  fn wrap_return_value_in_out_array(&mut self) {
-    aarch64!(self.assmblr; str x0, [x19]);
-  }
-
-  #[allow(clippy::unnecessary_cast)]
-  fn save_frame_record(&mut self) {
-    debug_assert!(
-      self.allocated_stack >= 16,
-      "the trampoline would try to save the frame record to the stack without having allocated enough space for it"
-    );
-    aarch64!(self.assmblr
-      // Frame record is stored at the bottom of the stack frame
-      ; stp x29, x30, [sp, self.allocated_stack - 16]
-      ; add x29, sp, self.allocated_stack - 16
-    )
-  }
-
-  #[allow(clippy::unnecessary_cast)]
-  fn recover_frame_record(&mut self) {
-    // The stack cannot have been deallocated before the frame record is restored
-    debug_assert!(
-      self.allocated_stack >= 16,
-      "the trampoline would try to load the frame record from the stack, but it couldn't possibly contain it"
-    );
-    // Frame record is stored at the bottom of the stack frame
-    aarch64!(self.assmblr; ldp x29, x30, [sp, self.allocated_stack - 16])
-  }
-
-  fn save_preserved_register_to_stack(&mut self) {
-    // If a preserved register needs to be used, we must have allocated at least 32 bytes in the stack
-    // 16 for the frame record, 8 for the preserved register, and 8 for 16-byte alignment.
-    debug_assert!(
-      self.allocated_stack >= 32,
-      "the trampoline would try to save a register to the stack without having allocated enough space for it"
-    );
-    // preserved register is stored after frame record
-    aarch64!(self.assmblr; str x19, [sp, self.allocated_stack - 24]);
-  }
-
-  fn recover_preserved_register(&mut self) {
-    // The stack cannot have been deallocated before the preserved register is restored
-    // 16 for the frame record, 8 for the preserved register, and 8 for 16-byte alignment.
-    debug_assert!(
-      self.allocated_stack >= 32,
-      "the trampoline would try to recover the value of a register from the stack, but it couldn't possibly contain it"
-    );
-    // preserved register is stored after frame record
-    aarch64!(self.assmblr; ldr x19, [sp, self.allocated_stack - 24]);
-  }
-
-  fn allocate_stack(&mut self, symbol: &Symbol) {
-    // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms:
-    // > Function arguments may consume slots on the stack that are not multiples of 8 bytes.
-    // (i.e. natural alignment instead of eightbyte alignment)
-    let mut int_params = 0u32;
-    let mut float_params = 0u32;
-    let mut stack_size = 0u32;
-    for param in symbol.parameter_types.iter().cloned() {
-      match param.into() {
-        Float(float_param) => {
-          float_params += 1;
-          if float_params > Self::FLOAT_REGISTERS {
-            stack_size += float_param.size();
-          }
-        }
-        Int(integral_param) => {
-          int_params += 1;
-          if int_params > Self::INTEGRAL_REGISTERS {
-            stack_size += integral_param.size();
-          }
-        }
-      }
-    }
-
-    // Section 6.2.3 of the Aarch64 PCS:
-    // > Each frame shall link to the frame of its caller by means of a frame record of two 64-bit values on the stack
-    stack_size += 16;
-
-    // Section 6.2.2 of Aarch64 PCS:
-    // > At any point at which memory is accessed via SP, the hardware requires that
-    // > - SP mod 16 = 0. The stack must be quad-word aligned.
-    // > The stack must also conform to the following constraint at a public interface:
-    // > - SP mod 16 = 0. The stack must be quad-word aligned.
-    stack_size += padding_to_align(16, stack_size);
-
-    if stack_size > 0 {
-      aarch64!(self.assmblr; sub sp, sp, stack_size);
-      self.offset_trampoline += stack_size;
-      // stack pointer has been modified, and the callee stack parameters are expected at the top of the stack
-      self.offset_callee = 0;
-      self.allocated_stack += stack_size;
-    }
-  }
-
-  fn deallocate_stack(&mut self) {
-    if self.allocated_stack > 0 {
-      aarch64!(self.assmblr; add sp, sp, self.allocated_stack);
-      self.allocated_stack = 0;
-    }
-  }
-
-  fn call(&mut self, ptr: *const c_void) {
-    // the stack has been aligned during stack allocation
-    // Frame record has been stored in stack and frame pointer points to it
-    debug_assert!(
-      self.allocated_stack % 16 == 0,
-      "the trampoline would call the FFI function with an unaligned stack"
-    );
-    debug_assert!(
-      self.allocated_stack >= 16,
-      "the trampoline would call the FFI function without allocating enough stack for the frame record"
-    );
-    self.load_callee_address(ptr);
-    aarch64!(self.assmblr; blr x8);
-  }
-
-  fn tailcall(&mut self, ptr: *const c_void) {
-    // stack pointer is never modified and remains aligned
-    // frame pointer and link register remain the one provided by the trampoline's caller (V8)
-    debug_assert!(
-      self.allocated_stack == 0,
-      "the trampoline would tail call the FFI function with an outstanding stack allocation"
-    );
-    self.load_callee_address(ptr);
-    aarch64!(self.assmblr; br x8);
-  }
-
-  fn ret(&mut self) {
-    debug_assert!(
-      self.allocated_stack == 0,
-      "the trampoline would return with an outstanding stack allocation"
-    );
-    aarch64!(self.assmblr; ret);
-  }
-
-  fn load_callee_address(&mut self, ptr: *const c_void) {
-    // Like all ARM instructions, move instructions are 32bit long and can fit at most 16bit immediates.
-    // bigger immediates are loaded in multiple steps applying a left-shift modifier
-    let mut address = ptr as u64;
-    let mut imm16 = address & 0xFFFF;
-    aarch64!(self.assmblr; movz x8, imm16 as u32);
-    address >>= 16;
-    let mut shift = 16;
-    while address > 0 {
-      imm16 = address & 0xFFFF;
-      if imm16 != 0 {
-        aarch64!(self.assmblr; movk x8, imm16 as u32, lsl shift);
-      }
-      address >>= 16;
-      shift += 16;
-    }
-  }
-
-  fn is_recv_arg_overridden(&self) -> bool {
-    // V8 receiver is the first parameter of the trampoline function and is a pointer
-    self.integral_params > 0
-  }
-
-  fn finalize(self) -> ExecutableBuffer {
-    self.assmblr.finalize().unwrap()
-  }
-}
-
-struct Win64 {
-  // Reference: https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-calling-convention.md
-  assmblr: dynasmrt::x64::Assembler,
-  // Params counter (Windows does not distinguish by type with regards to parameter position)
-  params: u32,
-  // Stack offset accumulators
-  offset_trampoline: u32,
-  offset_callee: u32,
-  allocated_stack: u32,
-  frame_pointer: u32,
-}
-
-#[cfg_attr(
-  not(all(target_aarch = "x86_64", target_family = "windows")),
-  allow(dead_code)
-)]
-impl Win64 {
-  // Section "Parameter Passing" of the Windows x64 calling convention:
-  // > By default, the x64 calling convention passes the first four arguments to a function in registers.
-  const REGISTERS: u32 = 4;
-
-  fn new() -> Self {
-    Self {
-      assmblr: dynasmrt::x64::Assembler::new().unwrap(),
-      params: 0,
-      // trampoline caller's return address + trampoline's shadow space
-      offset_trampoline: 8 + 32,
-      offset_callee: 8 + 32,
-      allocated_stack: 0,
-      frame_pointer: 0,
-    }
-  }
-
-  fn compile(sym: &Symbol) -> Trampoline {
-    let mut compiler = Self::new();
-
-    let must_cast_return_value =
-      compiler.must_cast_return_value(&sym.result_type);
-    let cannot_tailcall = must_cast_return_value;
-
-    if cannot_tailcall {
-      compiler.allocate_stack(&sym.parameter_types);
-    }
-
-    for param in sym.parameter_types.iter().cloned() {
-      compiler.move_left(param)
-    }
-    if !compiler.is_recv_arg_overridden() {
-      // the receiver object should never be expected. Avoid its unexpected or deliberate leak
-      compiler.zero_first_arg();
-    }
-
-    if cannot_tailcall {
-      compiler.call(sym.ptr.as_ptr());
-      if must_cast_return_value {
-        compiler.cast_return_value(&sym.result_type);
-      }
-      compiler.deallocate_stack();
-      compiler.ret();
-    } else {
-      compiler.tailcall(sym.ptr.as_ptr());
-    }
-
-    Trampoline(compiler.finalize())
-  }
-
-  fn move_left(&mut self, param: NativeType) {
-    // Section "Parameter Passing" of the Windows x64 calling convention:
-    // > By default, the x64 calling convention passes the first four arguments to a function in registers.
-    // > The registers used for these arguments depend on the position and type of the argument.
-    // > Remaining arguments get pushed on the stack in right-to-left order.
-    // > [...]
-    // > Integer valued arguments in the leftmost four positions are passed in left-to-right order in RCX, RDX, R8, and R9
-    // > [...]
-    // > Any floating-point and double-precision arguments in the first four parameters are passed in XMM0 - XMM3, depending on position
-    let s = &mut self.assmblr;
-    let param_i = self.params;
-
-    // move each argument one position to the left. The first argument in the stack moves to the last register (r9 or xmm3).
-    // If the FFI function is called with a new stack frame, the arguments remaining in the stack are copied to the new stack frame.
-    // Otherwise, they are copied 8 bytes lower in the same frame
-    match (param_i, param.into()) {
-      // Section "Parameter Passing" of the Windows x64 calling convention:
-      // > All integer arguments in registers are right-justified, so the callee can ignore the upper bits of the register
-      // > and access only the portion of the register necessary.
-      // (i.e. unlike in SysV or Aarch64-Apple, 8/16 bit integers are not expected to be zero/sign extended)
-      (0, Int(U(B | W | DW) | I(B | W | DW))) => x64!(s; mov ecx, edx),
-      (0, Int(U(QW) | I(QW))) => x64!(s; mov rcx, rdx),
-      // The fast API expects buffer arguments passed as a pointer to a FastApiTypedArray<Uint8> struct
-      // Here we blindly follow the layout of https://github.com/denoland/rusty_v8/blob/main/src/fast_api.rs#L190-L200
-      // although that might be problematic: https://discord.com/channels/684898665143206084/956626010248478720/1009450940866252823
-      (0, Int(Buffer)) => x64!(s; mov rcx, [rdx + 8]),
-      // Use movaps for singles and doubles, benefits of smaller encoding outweigh those of using the correct instruction for the type,
-      // which for doubles should technically be movapd
-      (0, Float(_)) => {
-        x64!(s; movaps xmm0, xmm1);
-        self.zero_first_arg();
-      }
-
-      (1, Int(U(B | W | DW) | I(B | W | DW))) => x64!(s; mov edx, r8d),
-      (1, Int(U(QW) | I(QW))) => x64!(s; mov rdx, r8),
-      (1, Int(Buffer)) => x64!(s; mov rdx, [r8 + 8]),
-      (1, Float(_)) => x64!(s; movaps xmm1, xmm2),
-
-      (2, Int(U(B | W | DW) | I(B | W | DW))) => x64!(s; mov r8d, r9d),
-      (2, Int(U(QW) | I(QW))) => x64!(s; mov r8, r9),
-      (2, Int(Buffer)) => x64!(s; mov r8, [r9 + 8]),
-      (2, Float(_)) => x64!(s; movaps xmm2, xmm3),
-
-      (3, param) => {
-        let ot = self.offset_trampoline as i32;
-        match param {
-          Int(U(B | W | DW) | I(B | W | DW)) => {
-            x64!(s; mov r9d, [rsp + ot])
-          }
-          Int(U(QW) | I(QW)) => {
-            x64!(s; mov r9, [rsp + ot])
-          }
-          Int(Buffer) => {
-            x64!(s
-              ; mov r9, [rsp + ot]
-              ; mov r9, [r9 + 8])
-          }
-          Float(_) => {
-            // parameter 4 is always 16-byte aligned, so we can use movaps instead of movups
-            x64!(s; movaps xmm3, [rsp + ot])
-          }
-        }
-        // Section "x64 Aggregate and Union layout" of the windows x64 software conventions doc:
-        // > The alignment of the beginning of a structure or a union is the maximum alignment of any individual member
-        // Ref: https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-software-conventions.md#x64-aggregate-and-union-layout
-        self.offset_trampoline += 8;
-      }
-      (4.., param) => {
-        let ot = self.offset_trampoline as i32;
-        let oc = self.offset_callee as i32;
-        match param {
-          Int(U(B | W | DW) | I(B | W | DW)) => {
-            x64!(s
-              ; mov eax, [rsp + ot]
-              ; mov [rsp + oc], eax
-            )
-          }
-          Int(U(QW) | I(QW)) => {
-            x64!(s
-              ; mov rax, [rsp + ot]
-              ; mov [rsp + oc], rax
-            )
-          }
-          Int(Buffer) => {
-            x64!(s
-              ; mov rax, [rsp + ot]
-              ; mov rax, [rax + 8]
-              ; mov [rsp + oc], rax
-            )
-          }
-          Float(_) => {
-            x64!(s
-              ; movups xmm4, [rsp + ot]
-              ; movups [rsp + oc], xmm4
-            )
-          }
-        }
-        // Section "x64 Aggregate and Union layout" of the windows x64 software conventions doc:
-        // > The alignment of the beginning of a structure or a union is the maximum alignment of any individual member
-        // Ref: https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/build/x64-software-conventions.md#x64-aggregate-and-union-layout
-        self.offset_trampoline += 8;
-        self.offset_callee += 8;
-
-        debug_assert!(
-          self.allocated_stack == 0
-            || self.offset_callee <= self.allocated_stack
-        );
-      }
-    }
-    self.params += 1;
-  }
-
-  fn zero_first_arg(&mut self) {
-    debug_assert!(
-      self.params == 0,
-      "the trampoline would zero the first argument after having overridden it with the second one"
-    );
-    x64!(self.assmblr; xor ecx, ecx);
-  }
-
-  fn cast_return_value(&mut self, rv: &NativeType) {
-    let s = &mut self.assmblr;
-    // V8 only supports 32bit integers. We support 8 and 16 bit integers casting them to 32bits.
-    // Section "Return Values" of the Windows x64 Calling Convention doc:
-    // > The state of unused bits in the value returned in RAX or XMM0 is undefined.
-    match rv {
-      NativeType::U8 => x64!(s; movzx eax, al),
-      NativeType::I8 => x64!(s; movsx eax, al),
-      NativeType::U16 => x64!(s; movzx eax, ax),
-      NativeType::I16 => x64!(s; movsx eax, ax),
-      _ => (),
-    }
-  }
-
-  fn save_out_array_to_preserved_register(&mut self) {
-    let s = &mut self.assmblr;
-    // functions returning 64 bit integers have the out array appended as their last parameter,
-    // and it is a *FastApiTypedArray<Int32>
-    match self.params {
-      // rcx is always V8 receiver
-      0 => x64!(s; mov rbx, [rdx + 8]),
-      1 => x64!(s; mov rbx, [r8 + 8]),
-      2 => x64!(s; mov rbx, [r9 + 8]),
-      3.. => {
-        x64!(s
-          ; mov rax, [rsp + self.offset_trampoline as i32]
-          ; mov rbx, [rax + 8]
-        )
-      }
-    }
-  }
-
-  fn wrap_return_value_in_out_array(&mut self) {
-    x64!(self.assmblr; mov [rbx], rax)
-  }
-
-  fn save_preserved_register_to_stack(&mut self) {
-    x64!(self.assmblr; push rbx);
-    self.offset_trampoline += 8;
-    // stack pointer has been modified, and the callee stack parameters are expected at the top of the stack
-    self.offset_callee = 0;
-    self.frame_pointer += 8;
-  }
-
-  fn recover_preserved_register(&mut self) {
-    debug_assert!(
-      self.frame_pointer >= 8,
-      "the trampoline would try to pop from the stack beyond its frame pointer"
-    );
-    x64!(self.assmblr; pop rbx);
-    self.frame_pointer -= 8;
-    // parameter offsets are invalid once this method is called
-  }
-
-  fn allocate_stack(&mut self, params: &[NativeType]) {
-    let mut stack_size = 0;
-    // Section "Calling Convention Defaults" of the x64-calling-convention and Section "Stack Allocation" of the stack-usage docs:
-    // > The x64 Application Binary Interface (ABI) uses a four-register fast-call calling convention by default.
-    // > Space is allocated on the call stack as a shadow store for callees to save those registers.
-    // > [...]
-    // > Any parameters beyond the first four must be stored on the stack after the shadow store before the call
-    // > [...]
-    // > Even if the called function has fewer than 4 parameters, these 4 stack locations are effectively owned by the called function,
-    // > and may be used by the called function for other purposes besides saving parameter register values
-    stack_size += max(params.len() as u32, 4) * 8;
-
-    // Align new stack frame (accounting for the 8 byte of the trampoline caller's return address
-    // and any other potential addition to the stack prior to this allocation)
-    // Section "Stack Allocation" of stack-usage docs:
-    // > The stack will always be maintained 16-byte aligned, except within the prolog (for example, after the return address is pushed)
-    stack_size += padding_to_align(16, self.frame_pointer + stack_size + 8);
-
-    x64!(self.assmblr; sub rsp, stack_size as i32);
-    self.offset_trampoline += stack_size;
-    // stack pointer has been modified, and the callee stack parameters are expected at the top of the stack right after the shadow space
-    self.offset_callee = 32;
-    self.allocated_stack += stack_size;
-    self.frame_pointer += stack_size;
-  }
-
-  fn deallocate_stack(&mut self) {
-    debug_assert!(
-      self.frame_pointer >= self.allocated_stack,
-      "the trampoline would try to deallocate stack beyond its frame pointer"
-    );
-    x64!(self.assmblr; add rsp, self.allocated_stack as i32);
-    self.frame_pointer -= self.allocated_stack;
-    self.allocated_stack = 0;
-  }
-
-  fn call(&mut self, ptr: *const c_void) {
-    // the stack has been aligned during stack allocation and/or pushing of preserved registers
-    debug_assert!(
-      (8 + self.frame_pointer) % 16 == 0,
-      "the trampoline would call the FFI function with an unaligned stack"
-    );
-    x64!(self.assmblr
-      ; mov rax, QWORD ptr as _
-      ; call rax
-    );
-  }
-
-  fn tailcall(&mut self, ptr: *const c_void) {
-    // stack pointer is never modified and remains aligned
-    // return address remains the one provided by the trampoline's caller (V8)
-    debug_assert!(
-      self.allocated_stack == 0,
-      "the trampoline would tail call the FFI function with an outstanding stack allocation"
-    );
-    debug_assert!(
-      self.frame_pointer == 0,
-      "the trampoline would tail call the FFI function with outstanding locals in the frame"
-    );
-    x64!(self.assmblr
-      ; mov rax, QWORD ptr as _
-      ; jmp rax
-    );
-  }
-
-  fn ret(&mut self) {
-    debug_assert!(
-      self.allocated_stack == 0,
-      "the trampoline would return with an outstanding stack allocation"
-    );
-    debug_assert!(
-      self.frame_pointer == 0,
-      "the trampoline would return with outstanding locals in the frame"
-    );
-    x64!(self.assmblr; ret);
-  }
-
-  fn is_recv_arg_overridden(&self) -> bool {
-    self.params > 0
-  }
-
-  fn must_cast_return_value(&self, rv: &NativeType) -> bool {
-    // V8 only supports i32 and u32 return types for integers
-    // We support 8 and 16 bit integers by extending them to 32 bits in the trampoline before returning
-    matches!(
-      rv,
-      NativeType::U8 | NativeType::I8 | NativeType::U16 | NativeType::I16
-    )
-  }
-
-  fn finalize(self) -> ExecutableBuffer {
-    self.assmblr.finalize().unwrap()
-  }
-}
-
-fn padding_to_align(alignment: u32, size: u32) -> u32 {
-  (alignment - size % alignment) % alignment
-}
-
-#[derive(Clone, Copy, Debug)]
-enum Floating {
-  Single = 4,
-  Double = 8,
-}
-
-impl Floating {
-  fn size(self) -> u32 {
-    self as u32
-  }
-}
-
-use Floating::*;
-
-#[derive(Clone, Copy, Debug)]
-enum Integral {
-  I(Size),
-  U(Size),
-  Buffer,
-}
-
-impl Integral {
-  fn size(self) -> u32 {
-    match self {
-      I(size) | U(size) => size as u32,
-      Buffer => 8,
-    }
-  }
-}
-
-use Integral::*;
-
-#[derive(Clone, Copy, Debug)]
-enum Size {
-  B = 1,
-  W = 2,
-  DW = 4,
-  QW = 8,
-}
-use Size::*;
-
-#[allow(clippy::enum_variant_names)]
-#[derive(Clone, Copy, Debug)]
-enum Param {
-  Int(Integral),
-  Float(Floating),
-}
-
-use Param::*;
-
-impl From<NativeType> for Param {
-  fn from(native: NativeType) -> Self {
-    match native {
-      NativeType::F32 => Float(Single),
-      NativeType::F64 => Float(Double),
-      NativeType::Bool | NativeType::U8 => Int(U(B)),
-      NativeType::U16 => Int(U(W)),
-      NativeType::U32 | NativeType::Void => Int(U(DW)),
-      NativeType::U64
-      | NativeType::USize
-      | NativeType::Pointer
-      | NativeType::Function => Int(U(QW)),
-      NativeType::I8 => Int(I(B)),
-      NativeType::I16 => Int(I(W)),
-      NativeType::I32 => Int(I(DW)),
-      NativeType::I64 | NativeType::ISize => Int(I(QW)),
-      NativeType::Buffer => Int(Buffer),
-      NativeType::Struct(_) => unimplemented!(),
-    }
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use std::ptr::null_mut;
-
-  use libffi::middle::Type;
-
-  use crate::NativeType;
-  use crate::Symbol;
-
-  fn symbol(parameters: Vec<NativeType>, ret: NativeType) -> Symbol {
-    Symbol {
-      cif: libffi::middle::Cif::new(vec![], Type::void()),
-      ptr: libffi::middle::CodePtr(null_mut()),
-      parameter_types: parameters,
-      result_type: ret,
-    }
-  }
-
-  mod sysv_amd64 {
-    use std::ops::Deref;
-
-    use dynasmrt::dynasm;
-    use dynasmrt::DynasmApi;
-
-    use super::super::SysVAmd64;
-    use super::symbol;
-    use crate::NativeType::*;
-
-    #[test]
-    fn tailcall() {
-      let trampoline = SysVAmd64::compile(&symbol(
-        vec![
-          U8, U16, I16, I8, U32, U64, Buffer, Function, I64, I32, I16, I8, F32,
-          F32, F32, F32, F64, F64, F64, F64, F32, F64,
-        ],
-        Void,
-      ));
-
-      let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/KE9x1h9xq
-      dynasm!(assembler
-        ; .arch x64
-        ; movzx edi, sil                   // u8
-        ; movzx esi, dx                    // u16
-        ; movsx edx, cx                    // i16
-        ; movsx ecx, r8b                   // i8
-        ; mov r8d, r9d                     // u32
-        ; mov r9, [DWORD rsp + 8]          // u64
-        ; mov rax, [DWORD rsp + 16]        // Buffer
-        ; mov rax, [rax + 8]               // ..
-        ; mov [DWORD rsp + 8], rax         // ..
-        ; mov rax, [DWORD rsp + 24]        // Function
-        ; mov [DWORD rsp + 16], rax        // ..
-        ; mov rax, [DWORD rsp + 32]        // i64
-        ; mov [DWORD rsp + 24], rax        // ..
-        ; mov eax, [DWORD rsp + 40]        // i32
-        ; mov [DWORD rsp + 32], eax        // ..
-        ; movsx eax, WORD [DWORD rsp + 48] // i16
-        ; mov [DWORD rsp + 40], eax        // ..
-        ; movsx eax, BYTE [DWORD rsp + 56] // i8
-        ; mov [DWORD rsp + 48], eax        // ..
-        ; movss xmm8, [DWORD rsp + 64]     // f32
-        ; movss [DWORD rsp + 56], xmm8     // ..
-        ; movsd xmm8, [DWORD rsp + 72]     // f64
-        ; movsd [DWORD rsp + 64], xmm8     // ..
-        ; mov rax, QWORD 0
-        ; jmp rax
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-
-    #[test]
-    fn integer_casting() {
-      let trampoline = SysVAmd64::compile(&symbol(
-        vec![U8, U16, I8, I16, U8, U16, I8, I16, U8, U16, I8, I16],
-        I8,
-      ));
-
-      let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/qo59bPsfv
-      dynasm!(assembler
-        ; .arch x64
-        ; sub rsp, DWORD 56                 // stack allocation
-        ; movzx edi, sil                    // u8
-        ; movzx esi, dx                     // u16
-        ; movsx edx, cl                     // i8
-        ; movsx ecx, r8w                    // i16
-        ; movzx r8d, r9b                    // u8
-        ; movzx r9d, WORD [DWORD rsp + 64]  // u16
-        ; movsx eax, BYTE [DWORD rsp + 72]  // i8
-        ; mov [DWORD rsp + 0], eax          // ..
-        ; movsx eax, WORD [DWORD rsp + 80]  // i16
-        ; mov [DWORD rsp + 8], eax          // ..
-        ; movzx eax, BYTE [DWORD rsp + 88]  // u8
-        ; mov [DWORD rsp + 16], eax         // ..
-        ; movzx eax, WORD [DWORD rsp + 96]  // u16
-        ; mov [DWORD rsp + 24], eax         // ..
-        ; movsx eax, BYTE [DWORD rsp + 104] // i8
-        ; mov [DWORD rsp + 32], eax         // ..
-        ; movsx eax, WORD [DWORD rsp + 112] // i16
-        ; mov [DWORD rsp + 40], eax         // ..
-        ; mov rax, QWORD 0
-        ; call rax
-        ; movsx eax, al      // return value cast
-        ; add rsp, DWORD 56  // stack deallocation
-        ; ret
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-
-    #[test]
-    fn buffer_parameters() {
-      let trampoline = SysVAmd64::compile(&symbol(
-        vec![
-          Buffer, Buffer, Buffer, Buffer, Buffer, Buffer, Buffer, Buffer,
-        ],
-        Void,
-      ));
-
-      let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/hqv63M3Ko
-      dynasm!(assembler
-        ; .arch x64
-        ; mov rdi, [rsi + 8]               // Buffer
-        ; mov rsi, [rdx + 8]               // Buffer
-        ; mov rdx, [rcx + 8]               // Buffer
-        ; mov rcx, [r8 + 8]                // Buffer
-        ; mov r8, [r9 + 8]                 // Buffer
-        ; mov r9, [DWORD rsp + 8]          // Buffer
-        ; mov r9, [r9 + 8]                 // ..
-        ; mov rax, [DWORD rsp + 16]        // Buffer
-        ; mov rax, [rax + 8]               // ..
-        ; mov [DWORD rsp + 8], rax         // ..
-        ; mov rax, [DWORD rsp + 24]        // Buffer
-        ; mov rax, [rax + 8]               // ..
-        ; mov [DWORD rsp + 16], rax        // ..
-        ; mov rax, QWORD 0
-        ; jmp rax
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-  }
-
-  mod aarch64_apple {
-    use std::ops::Deref;
-
-    use dynasmrt::dynasm;
-
-    use super::super::Aarch64Apple;
-    use super::symbol;
-    use crate::NativeType::*;
-
-    #[test]
-    fn tailcall() {
-      let trampoline = Aarch64Apple::compile(&symbol(
-        vec![
-          U8, U16, I16, I8, U32, U64, Buffer, Function, I64, I32, I16, I8, F32,
-          F32, F32, F32, F64, F64, F64, F64, F32, F64,
-        ],
-        Void,
-      ));
-
-      let mut assembler = dynasmrt::aarch64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/oefqYWT13
-      dynasm!(assembler
-        ; .arch aarch64
-        ; and w0, w1, 0xFF   // u8
-        ; and w1, w2, 0xFFFF // u16
-        ; sxth w2, w3        // i16
-        ; sxtb w3, w4        // i8
-        ; mov w4, w5         // u32
-        ; mov x5, x6         // u64
-        ; ldr x6, [x7, 8]    // Buffer
-        ; ldr x7, [sp]       // Function
-        ; ldr x8, [sp, 8]    // i64
-        ; str x8, [sp]       // ..
-        ; ldr w8, [sp, 16]   // i32
-        ; str w8, [sp, 8]    // ..
-        ; ldr w8, [sp, 24]   // i16
-        ; strh w8, [sp, 12]  // ..
-        ; ldr w8, [sp, 32]   // i8
-        ; strb w8, [sp, 14]  // ..
-        ; ldr s16, [sp, 40]  // f32
-        ; str s16, [sp, 16]  // ..
-        ; ldr d16, [sp, 48]  // f64
-        ; str d16, [sp, 24]  // ..
-        ; movz x8, 0
-        ; br x8
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-
-    #[test]
-    fn integer_casting() {
-      let trampoline = Aarch64Apple::compile(&symbol(
-        vec![U8, U16, I8, I16, U8, U16, I8, I16, U8, U16, I8, I16],
-        I8,
-      ));
-
-      let mut assembler = dynasmrt::aarch64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/7qfzbzobM
-      dynasm!(assembler
-        ; .arch aarch64
-        ; and w0, w1, 0xFF   // u8
-        ; and w1, w2, 0xFFFF // u16
-        ; sxtb w2, w3        // i8
-        ; sxth w3, w4        // i16
-        ; and w4, w5, 0xFF   // u8
-        ; and w5, w6, 0xFFFF // u16
-        ; sxtb w6, w7        // i8
-        ; ldrsh w7, [sp]     // i16
-        ; ldr w8, [sp, 8]    // u8
-        ; strb w8, [sp]      // ..
-        ; ldr w8, [sp, 16]    // u16
-        ; strh w8, [sp, 2]   // ..
-        ; ldr w8, [sp, 24]   // i8
-        ; strb w8, [sp, 4]   // ..
-        ; ldr w8, [sp, 32]   // i16
-        ; strh w8, [sp, 6]   // ..
-        ; movz x8, 0
-        ; br x8
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-
-    #[test]
-    fn buffer_parameters() {
-      let trampoline = Aarch64Apple::compile(&symbol(
-        vec![
-          Buffer, Buffer, Buffer, Buffer, Buffer, Buffer, Buffer, Buffer,
-          Buffer, Buffer,
-        ],
-        Void,
-      ));
-
-      let mut assembler = dynasmrt::aarch64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/obd6z6vsf
-      dynasm!(assembler
-        ; .arch aarch64
-        ; ldr x0, [x1, 8]               // Buffer
-        ; ldr x1, [x2, 8]               // Buffer
-        ; ldr x2, [x3, 8]               // Buffer
-        ; ldr x3, [x4, 8]               // Buffer
-        ; ldr x4, [x5, 8]               // Buffer
-        ; ldr x5, [x6, 8]               // Buffer
-        ; ldr x6, [x7, 8]               // Buffer
-        ; ldr x7, [sp]                  // Buffer
-        ; ldr x7, [x7, 8]               // ..
-        ; ldr x8, [sp, 8]               // Buffer
-        ; ldr x8, [x8, 8]               // ..
-        ; str x8, [sp]                  // ..
-        ; ldr x8, [sp, 16]              // Buffer
-        ; ldr x8, [x8, 8]               // ..
-        ; str x8, [sp, 8]               // ..
-        ; movz x8, 0
-        ; br x8
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-  }
-
-  mod x64_windows {
-    use std::ops::Deref;
-
-    use dynasmrt::dynasm;
-    use dynasmrt::DynasmApi;
-
-    use super::super::Win64;
-    use super::symbol;
-    use crate::NativeType::*;
-
-    #[test]
-    fn tailcall() {
-      let trampoline =
-        Win64::compile(&symbol(vec![U8, I16, F64, F32, U32, I8, Buffer], Void));
-
-      let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/TYzqrf9aj
-      dynasm!(assembler
-        ; .arch x64
-        ; mov ecx, edx                  // u8
-        ; mov edx, r8d                  // i16
-        ; movaps xmm2, xmm3             // f64
-        ; movaps xmm3, [DWORD rsp + 40] // f32
-        ; mov eax, [DWORD rsp + 48]     // u32
-        ; mov [DWORD rsp + 40], eax     // ..
-        ; mov eax, [DWORD rsp + 56]     // i8
-        ; mov [DWORD rsp + 48], eax     // ..
-        ; mov rax, [DWORD rsp + 64]     // Buffer
-        ; mov rax, [rax + 8]            // ..
-        ; mov [DWORD rsp + 56], rax     // ..
-        ; mov rax, QWORD 0
-        ; jmp rax
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-
-    #[test]
-    fn integer_casting() {
-      let trampoline = Win64::compile(&symbol(
-        vec![U8, U16, I8, I16, U8, U16, I8, I16, U8, U16, I8, I16],
-        I8,
-      ));
-
-      let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/KMx56KGTq
-      dynasm!(assembler
-        ; .arch x64
-        ; sub rsp, DWORD 104          // stack allocation
-        ; mov ecx, edx                // u8
-        ; mov edx, r8d                // u16
-        ; mov r8d, r9d                // i8
-        ; mov r9d, [DWORD rsp + 144]  // i16
-        ; mov eax, [DWORD rsp + 152]  // u8
-        ; mov [DWORD rsp + 32], eax   // ..
-        ; mov eax, [DWORD rsp + 160]  // u16
-        ; mov [DWORD rsp + 40], eax   // u16
-        ; mov eax, [DWORD rsp + 168]  // i8
-        ; mov [DWORD rsp + 48], eax   // ..
-        ; mov eax, [DWORD rsp + 176]  // i16
-        ; mov [DWORD rsp + 56], eax   // ..
-        ; mov eax, [DWORD rsp + 184]  // u8
-        ; mov [DWORD rsp + 64], eax   // ..
-        ; mov eax, [DWORD rsp + 192]  // u16
-        ; mov [DWORD rsp + 72], eax   // ..
-        ; mov eax, [DWORD rsp + 200]  // i8
-        ; mov [DWORD rsp + 80], eax   // ..
-        ; mov eax, [DWORD rsp + 208]  // i16
-        ; mov [DWORD rsp + 88], eax   // ..
-        ; mov rax, QWORD 0
-        ; call rax
-        ; movsx eax, al       // return value cast
-        ; add rsp, DWORD 104  // stack deallocation
-        ; ret
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-
-    #[test]
-    fn buffer_parameters() {
-      let trampoline = Win64::compile(&symbol(
-        vec![Buffer, Buffer, Buffer, Buffer, Buffer, Buffer],
-        Void,
-      ));
-
-      let mut assembler = dynasmrt::x64::Assembler::new().unwrap();
-      // See https://godbolt.org/z/TYzqrf9aj
-      dynasm!(assembler
-        ; .arch x64
-        ; mov rcx, [rdx + 8]               // Buffer
-        ; mov rdx, [r8 + 8]                // Buffer
-        ; mov r8, [r9 + 8]                 // Buffer
-        ; mov r9, [DWORD rsp + 40]         // Buffer
-        ; mov r9, [r9 + 8]                 // ..
-        ; mov rax, [DWORD rsp + 48]        // Buffer
-        ; mov rax, [rax + 8]               // ..
-        ; mov [DWORD rsp + 40], rax        // ..
-        ; mov rax, [DWORD rsp + 56]        // Buffer
-        ; mov rax, [rax + 8]               // ..
-        ; mov [DWORD rsp + 48], rax        // ..
-        ; mov rax, QWORD 0
-        ; jmp rax
-      );
-      let expected = assembler.finalize().unwrap();
-      assert_eq!(trampoline.0.deref(), expected.deref());
-    }
-  }
+extern "C" fn turbocall_ab_contents(
+  v: deno_core::v8::Local<deno_core::v8::Value>,
+) -> *mut u8 {
+  let v = v.cast::<deno_core::v8::ArrayBufferView>();
+  const {
+    // We don't keep `buffer` around when this function returns,
+    // so assert that it will be unused.
+    assert!(deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP == 0);
+  }
+  let mut buffer = [0; deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+  // SAFETY: `buffer` is unused due to above, returned pointer is not
+  // dereferenced by rust code, and we keep it alive at least as long
+  // as the turbocall.
+  let (data, _) = unsafe { v.get_contents_raw_parts(&mut buffer) };
+  data
 }

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -2073,6 +2073,7 @@ fn napi_get_value_bool(
   return napi_clear_last_error(env_ptr);
 }
 
+#[allow(deprecated)]
 #[napi_sym]
 fn napi_get_value_string_latin1(
   env_ptr: *mut Env,
@@ -2121,6 +2122,7 @@ fn napi_get_value_string_latin1(
   napi_clear_last_error(env_ptr)
 }
 
+#[allow(deprecated)]
 #[napi_sym]
 fn napi_get_value_string_utf8(
   env_ptr: *mut Env,
@@ -2170,6 +2172,7 @@ fn napi_get_value_string_utf8(
   napi_clear_last_error(env_ptr)
 }
 
+#[allow(deprecated)]
 #[napi_sym]
 fn napi_get_value_string_utf16(
   env_ptr: *mut Env,

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -241,13 +241,7 @@ fn is_managed_key(
     return false;
   }
   let buf = &mut [0u16; LONGEST_MANAGED_GLOBAL];
-  let written = str.write(
-    scope,
-    buf.as_mut_slice(),
-    0,
-    v8::WriteOptions::NO_NULL_TERMINATION,
-  );
-  assert_eq!(written, len);
+  str.write_v2(scope, 0, buf.as_mut_slice(), v8::WriteFlags::empty());
   MANAGED_GLOBALS.binary_search(&&buf[..len]).is_ok()
 }
 

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -357,6 +357,7 @@ struct TextDecoderResource {
 impl deno_core::GarbageCollected for TextDecoderResource {}
 
 #[op2(fast(op_encoding_encode_into_fast))]
+#[allow(deprecated)]
 fn op_encoding_encode_into(
   scope: &mut v8::HandleScope,
   input: v8::Local<v8::Value>,

--- a/tests/ffi/tests/test.js
+++ b/tests/ffi/tests/test.js
@@ -379,7 +379,7 @@ const externalZeroBuffer = new Uint8Array(Deno.UnsafePointerView.getArrayBuffer(
 // V8 Fast calls used to get null pointers for all zero-sized buffers no matter their external backing.
 assertEquals(isNullBuffer(externalZeroBuffer), false, "isNullBuffer(externalZeroBuffer) !== false");
 // V8's `Local<ArrayBuffer>->Data()` method also used to similarly return null pointers for all
-// zero-sized buffers which would not match what `Local<ArrayBuffer>->GetBackingStore()->Data()` 
+// zero-sized buffers which would not match what `Local<ArrayBuffer>->GetBackingStore()->Data()`
 // API returned. These issues have been fixed in https://bugs.chromium.org/p/v8/issues/detail?id=13488.
 assertEquals(isNullBufferDeopt(externalZeroBuffer), false, "isNullBufferDeopt(externalZeroBuffer) !== false");
 

--- a/tests/specs/run/v8_jitless/main.out
+++ b/tests/specs/run/v8_jitless/main.out
@@ -1,2 +1,1 @@
-[# Using wildcard here because v8 outputs the message with \r\n on Windows, but \r on Unix]
-Warning: disabling flag --expose_wasm due to conflicting flags[WILDCARD]Hello[WILDCARD]
+Hello

--- a/tests/specs/run/wasm_unreachable/wasm_unreachable.out
+++ b/tests/specs/run/wasm_unreachable/wasm_unreachable.out
@@ -1,3 +1,3 @@
 error: Uncaught[WILDCARD] RuntimeError: unreachable
-    at <anonymous> (wasm://wasm/d1c677ea:1:41)
+    at <anonymous> (wasm://wasm/2fb7b482:1:41)
     at [WILDCARD]/wasm_unreachable.js:[WILDCARD]

--- a/tools/memfd_create_shim.c
+++ b/tools/memfd_create_shim.c
@@ -1,0 +1,26 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+#define _GNU_SOURCE
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#ifndef SYS_memfd_create
+#  if defined(__x86_64__)
+#    define SYS_memfd_create 319
+#  elif defined(__aarch64__)
+#    define SYS_memfd_create 279
+#  elif defined(__arm__)
+#    define SYS_memfd_create 385
+#  elif defined(__i386__)
+#    define SYS_memfd_create 356
+#  elif defined(__powerpc64__)
+#    define SYS_memfd_create 360
+#  else
+#    error "memfd_create syscall number unknown for this architecture"
+#  endif
+#endif
+
+int memfd_create(const char *name, unsigned int flags) {
+  return syscall(SYS_memfd_create, name, flags);
+}


### PR DESCRIPTION
- upgrade v8 to 13.4
- turbocall conversion for arraybuffers is now much more complex, so use cranelift
- misc updates for deprecated fns
- v8 default stack size is too small now, causing stack overflow exceptions in some tests
- add syscall shim to support new syscall in old sysroot