### PR TITLE
fix: cache bust http cache on lockfile integrity mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.87.2"
+version = "0.87.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4766f426e4258c481c3af019fb4bba31e3108e80b8b2a48bbeb68bfadcc8c18"
+checksum = "0f1d2f0aa5832b72abdc67e904649aa80ec707f0a5f8cc7825859221b56abd31"
 dependencies = [
  "async-trait",
  "capacity_builder 0.5.0",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,7 +72,7 @@ deno_config = { workspace = true, features = ["sync", "workspace"] }
 deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_doc = { version = "=0.164.0", features = ["rust", "comrak"] }
 deno_error.workspace = true
-deno_graph = { version = "=0.87.2" }
+deno_graph = { version = "=0.87.3" }
 deno_lib.workspace = true
 deno_lint = { version = "0.72.0" }
 deno_lockfile.workspace = true

--- a/tests/specs/lockfile/auto_discover_lockfile/main.out
+++ b/tests/specs/lockfile/auto_discover_lockfile/main.out
@@ -1,5 +1,6 @@
 Download http://localhost:4545/subdir/mod2.ts
 Download http://localhost:4545/subdir/print_hello.ts
+Download http://localhost:4545/subdir/print_hello.ts
 error: Integrity check failed for remote specifier. The source code is invalid, as it does not match the expected hash in the lock file.
 
   Specifier: http://localhost:4545/subdir/print_hello.ts

--- a/tests/specs/lockfile/cache_bust_integrity_failure/__test__.jsonc
+++ b/tests/specs/lockfile/cache_bust_integrity_failure/__test__.jsonc
@@ -1,0 +1,16 @@
+{
+  "tempDir": true,
+  "envs": {
+    "DENO_DIR": "./deno_dir"
+  },
+  "steps": [{
+    "args": "cache --allow-import main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "run -A update.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "run --allow-import main.ts",
+    "output": "main.out"
+  }]
+}

--- a/tests/specs/lockfile/cache_bust_integrity_failure/deno.json
+++ b/tests/specs/lockfile/cache_bust_integrity_failure/deno.json
@@ -1,0 +1,5 @@
+{
+  "lock": {
+    "frozen": true
+  }
+}

--- a/tests/specs/lockfile/cache_bust_integrity_failure/deno.lock
+++ b/tests/specs/lockfile/cache_bust_integrity_failure/deno.lock
@@ -1,0 +1,6 @@
+{
+  "version": "4",
+  "remote": {
+    "http://localhost:4545/welcome.ts": "7353d5fcbc36c45d26bcbca478cf973092523b07c45999f41319820092b4de31"
+  }
+}

--- a/tests/specs/lockfile/cache_bust_integrity_failure/main.out
+++ b/tests/specs/lockfile/cache_bust_integrity_failure/main.out
@@ -1,0 +1,3 @@
+[# should download because it cache busts]
+Download http://localhost:4545/welcome.ts
+Welcome to Deno!

--- a/tests/specs/lockfile/cache_bust_integrity_failure/main.ts
+++ b/tests/specs/lockfile/cache_bust_integrity_failure/main.ts
@@ -1,0 +1,1 @@
+import "http://localhost:4545/welcome.ts";

--- a/tests/specs/lockfile/cache_bust_integrity_failure/update.ts
+++ b/tests/specs/lockfile/cache_bust_integrity_failure/update.ts
@@ -1,0 +1,6 @@
+// make the path in the deno_dir differ from the remote server
+// and what's stored in the lockfile
+const filePath =
+  "./deno_dir/remote/http/localhost_PORT4545/3011c891e5bd4172aa2e157e4c688ab6f31e91da9719704a9a54aa63faa99c88";
+const text = Deno.readTextFileSync(filePath);
+Deno.writeTextFileSync(filePath, "//\n" + text);

--- a/tests/specs/lockfile/no_lock/fail.out
+++ b/tests/specs/lockfile/no_lock/fail.out
@@ -1,4 +1,5 @@
 Download http://localhost:4545/lockfile/basic/mod.ts
+Download http://localhost:4545/lockfile/basic/mod.ts
 error: Integrity check failed for remote specifier. The source code is invalid, as it does not match the expected hash in the lock file.
 
   Specifier: http://localhost:4545/lockfile/basic/mod.ts

--- a/tests/specs/run/wasm_module/integrity_check_failed/main.out
+++ b/tests/specs/run/wasm_module/integrity_check_failed/main.out
@@ -1,4 +1,5 @@
 Download http://localhost:4545/wasm/math.wasm
+Download http://localhost:4545/wasm/math.wasm
 error: Integrity check failed for remote specifier. The source code is invalid, as it does not match the expected hash in the lock file.
 
   Specifier: http://localhost:4545/wasm/math.wasm

--- a/tests/util/server/src/assertions.rs
+++ b/tests/util/server/src/assertions.rs
@@ -65,7 +65,10 @@ pub fn assert_wildcard_match_with_logger(
   expected: &str,
   logger: &mut dyn Write,
 ) {
-  if !expected.contains("[WILD") && !expected.contains("[UNORDERED_START]") {
+  if !expected.contains("[WILD")
+    && !expected.contains("[UNORDERED_START]")
+    && !expected.contains("[#")
+  {
     pretty_assertions::assert_eq!(actual, expected);
   } else {
     match crate::wildcard_match_detailed(expected, actual) {


### PR DESCRIPTION
Cache busts the http cache when the lockfile integrity doesn't match what's in the cache. This will help when someone's lockfile is in line with the remote server, but their local cache isn't.

* https://github.com/denoland/deno_graph/pull/567