### PR TITLE
feat(fmt): add TOML formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -200,6 +211,12 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayvec"
@@ -486,6 +503,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bencher"
@@ -1366,6 +1389,7 @@ dependencies = [
  "dprint-plugin-json",
  "dprint-plugin-jupyter",
  "dprint-plugin-markdown",
+ "dprint-plugin-toml",
  "dprint-plugin-typescript",
  "fancy-regex",
  "faster-hex",
@@ -3119,6 +3143,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dprint-plugin-toml"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4db205d7c84101d1e4f6f56f51e50ccf81e528bd7f7eb2d38770f5e2f7259a"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "dprint-core-macros",
+ "itertools 0.10.5",
+ "serde",
+ "taplo",
+]
+
+[[package]]
 name = "dprint-plugin-typescript"
 version = "0.93.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,7 +4067,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -5091,6 +5129,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7688,7 +7749,7 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83406221c501860fce9c27444f44125eafe9e598b8b81be7563d7036784cd05c"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "anyhow",
  "dashmap",
  "once_cell",
@@ -8150,6 +8211,26 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "taplo"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d22577122cf37c9aea9a9363f6f01bddaa1977617fe5abc59e221f23d114817"
+dependencies = [
+ "ahash 0.7.8",
+ "arc-swap",
+ "either",
+ "globset",
+ "itertools 0.10.5",
+ "logos",
+ "once_cell",
+ "rowan",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tracing",
+]
 
 [[package]]
 name = "tar"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -114,6 +114,7 @@ dotenvy = "0.15.7"
 dprint-plugin-json = "=0.19.4"
 dprint-plugin-jupyter = "=0.1.5"
 dprint-plugin-markdown = "=0.17.8"
+dprint-plugin-toml = "=0.6.4"
 dprint-plugin-typescript = "=0.93.3"
 fancy-regex = "=0.10.0"
 faster-hex.workspace = true

--- a/tests/specs/fmt/toml/__test__.jsonc
+++ b/tests/specs/fmt/toml/__test__.jsonc
@@ -1,0 +1,37 @@
+{
+  "tempDir": true,
+  "tests": {
+    "badly_formatted": {
+      "args": "fmt badly_formatted.toml",
+      "output": "[WILDLINE]badly_formatted.toml\nChecked 1 file\n"
+    },
+    "well_formatted": {
+      "args": "fmt --check well_formatted.toml",
+      "output": "Checked 1 file\n"
+    },
+    "ignore_line": {
+      "args": "fmt --check ignore_line.toml",
+      "output": "Checked 1 file\n"
+    },
+    "ignore_file": {
+      "args": "fmt ignore_file.toml",
+      "output": "Checked 1 file\n"
+    },
+    "ignore_file2": {
+      "args": "fmt ignore_file2.toml",
+      "output": "Checked 1 file\n"
+    },
+    "ignore_file3": {
+      "args": "fmt ignore_file3.toml",
+      "output": "Checked 1 file\n"
+    },
+    "ignore_file4": {
+      "args": "fmt ignore_file4.toml",
+      "output": "Checked 1 file\n"
+    },
+    "wrong_file_ignore": {
+      "args": "fmt wrong_file_ignore.toml",
+      "output": "wrong_file_ignore.out"
+    }
+  }
+}

--- a/tests/specs/fmt/toml/badly_formatted.toml
+++ b/tests/specs/fmt/toml/badly_formatted.toml
@@ -1,0 +1,15 @@
+[database]
+enabled = true
+ports = [ 8000, 8001, 8002 ]
+data = [ ["delta", "phi"], [3.14] ]
+temp_targets = { cpu = 79.5, case = 72.0 }
+
+[servers]
+
+[servers.alpha]
+ip = "10.0.0.1"
+role = "frontend"
+
+[servers.beta]
+ip = "10.0.0.2"
+role = "backend"

--- a/tests/specs/fmt/toml/ignore_file.toml
+++ b/tests/specs/fmt/toml/ignore_file.toml
@@ -1,0 +1,2 @@
+# deno-fmt-ignore-file
+enabled =    true

--- a/tests/specs/fmt/toml/ignore_file2.toml
+++ b/tests/specs/fmt/toml/ignore_file2.toml
@@ -1,0 +1,2 @@
+#deno-fmt-ignore-file
+enabled =     true

--- a/tests/specs/fmt/toml/ignore_file3.toml
+++ b/tests/specs/fmt/toml/ignore_file3.toml
@@ -1,0 +1,8 @@
+# Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+# incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, 
+# quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+# deno-fmt-ignore-file
+
+
+
+enabled =     true

--- a/tests/specs/fmt/toml/ignore_file4.toml
+++ b/tests/specs/fmt/toml/ignore_file4.toml
@@ -1,0 +1,4 @@
+# deno-fmt-ignore-file Because this is templated yaml file
+
+
+enabled =     true

--- a/tests/specs/fmt/toml/ignore_line.toml
+++ b/tests/specs/fmt/toml/ignore_line.toml
@@ -1,0 +1,2 @@
+# deno-fmt-ignore
+enabled =     true

--- a/tests/specs/fmt/toml/well_formatted.toml
+++ b/tests/specs/fmt/toml/well_formatted.toml
@@ -1,0 +1,15 @@
+[database]
+enabled = true
+ports = [8000, 8001, 8002]
+data = [["delta", "phi"], [3.14]]
+temp_targets = { cpu = 79.5, case = 72.0 }
+
+[servers]
+
+[servers.alpha]
+ip = "10.0.0.1"
+role = "frontend"
+
+[servers.beta]
+ip = "10.0.0.2"
+role = "backend"

--- a/tests/specs/fmt/toml/wrong_file_ignore.out
+++ b/tests/specs/fmt/toml/wrong_file_ignore.out
@@ -1,0 +1,7 @@
+Error formatting: [WILDCARD]wrong_file_ignore.yaml
+   parse error at line 5, column 1
+  |
+5 | {{something crazy
+  | ^
+
+Checked 1 file

--- a/tests/specs/fmt/toml/wrong_file_ignore.out
+++ b/tests/specs/fmt/toml/wrong_file_ignore.out
@@ -1,7 +1,5 @@
-Error formatting: [WILDCARD]wrong_file_ignore.yaml
-   parse error at line 5, column 1
-  |
-5 | {{something crazy
-  | ^
+Error formatting: [WILDCARD]wrong_file_ignore.toml
+   Line 5, column 10: expected value
 
+  enabled =
 Checked 1 file

--- a/tests/specs/fmt/toml/wrong_file_ignore.toml
+++ b/tests/specs/fmt/toml/wrong_file_ignore.toml
@@ -1,0 +1,5 @@
+# File ignore directive only works if it's in the first cluster
+# of comment, ie. there are no empty lines after the first n-leading lines.
+
+# deno-fmt-ignore-file
+enabled =    true

--- a/tests/specs/fmt/toml/wrong_file_ignore.toml
+++ b/tests/specs/fmt/toml/wrong_file_ignore.toml
@@ -2,4 +2,4 @@
 # of comment, ie. there are no empty lines after the first n-leading lines.
 
 # deno-fmt-ignore-file
-enabled =    true
+enabled =


### PR DESCRIPTION
This commits adds support for formatting
`.toml` files with `deno fmt`.