### PR TITLE
chore: fix dts file for DefinitelyTyped linting

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -3957,6 +3957,8 @@ declare namespace Deno {
       | TSTypeAnnotation
       | TSTypeParameterDeclaration
       | TSTypeParameter;
+
+    export {}; // only export exports
   }
 
   export {}; // only export exports


### PR DESCRIPTION
Added this so that we only export exports from `Deno.lint`. Required to pass DefinitelyTyped's linting.