### PR TITLE
feat: add `Deno.colorDepth`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -501,6 +501,13 @@ declare namespace Deno {
   export const noColor: boolean;
 
   /**
+   * Get the terminal's color depth.
+   *
+   * @category Runtime
+   */
+  export const colorDepth: 1 | 4 | 8 | 24;
+
+  /**
    * Returns the release version of the Operating System.
    *
    * ```ts

--- a/ext/node/polyfills/tty.js
+++ b/ext/node/polyfills/tty.js
@@ -133,7 +133,7 @@ export class WriteStream extends Socket {
     // TODO(@marvinhagemeister): Ignore env parameter.
     // Haven't seen it used anywhere, seems more done
     // to make testing easier in Node
-    return op_bootstrap_color_depth();
+    return Deno.colorDepth;
   }
 }
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -8,6 +8,7 @@ import { core, internals, primordials } from "ext:core/mod.js";
 const ops = core.ops;
 import {
   op_bootstrap_args,
+  op_bootstrap_color_depth,
   op_bootstrap_is_stderr_tty,
   op_bootstrap_is_stdout_tty,
   op_bootstrap_no_color,
@@ -599,6 +600,7 @@ ObjectDefineProperties(finalDenoNs, {
   // https://github.com/denoland/deno/issues/23004
   ppid: core.propGetterOnly(() => op_ppid()),
   noColor: core.propGetterOnly(() => op_bootstrap_no_color()),
+  colorDepth: core.propGetterOnly(() => op_bootstrap_color_depth()),
   args: core.propGetterOnly(opArgs),
   mainModule: core.propGetterOnly(() => op_main_module()),
   exitCode: {

--- a/tests/unit/tty_color_test.ts
+++ b/tests/unit/tty_color_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
-import { assertEquals } from "./test_util.ts";
+import { assert, assertEquals } from "./test_util.ts";
 
 // Note tests for Deno.stdin.setRaw is in integration tests.
 
@@ -51,5 +51,30 @@ Deno.test(
     }).output();
     const output = new TextDecoder().decode(stdout);
     assertEquals(output, "true\n");
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function denoColorDepth() {
+    const { stdout } = await new Deno.Command(Deno.execPath(), {
+      args: ["eval", "console.log(Deno.colorDepth)"],
+    }).output();
+    const output = new TextDecoder().decode(stdout).trim();
+    assert([1, 4, 8, 24].includes(+output));
+  },
+);
+
+Deno.test(
+  { permissions: { run: true, read: true } },
+  async function denoColorDepthDisabled() {
+    const { stdout } = await new Deno.Command(Deno.execPath(), {
+      args: ["eval", "console.log(Deno.colorDepth)"],
+      env: {
+        NO_COLOR: "1",
+      },
+    }).output();
+    const output = new TextDecoder().decode(stdout).trim();
+    assert([1, 4, 8, 24].includes(+output));
   },
 );


### PR DESCRIPTION
Adds `Deno.colorDepth` to get the color depth of the tty. It detects the following color depths:

- `1bit`: black & white
- `4bit`:  16 colors
- `8bit`: 256 colors
- `24bit`: 16,777,216 colors (often also referred to as "true color")

This mirrors Node's `tty.getColorDepth` values which we already support.

Not sure if we want to add it or not, but I figured having a PR up might be nice. Idea came from https://github.com/denoland/deno/issues/27866 where environment var permissions are mostly from color libraries trying to determine the currently supported color depth.

