### PR TITLE
fix(lsp): improve auto-imports to take into account only package exports

### DIFF
--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -83,7 +83,7 @@ use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;
 
 #[derive(Debug, Clone)]
-struct LspScopeResolver {
+pub struct LspScopeResolver {
   resolver: Arc<CliResolver>,
   in_npm_pkg_checker: DenoInNpmPackageChecker,
   is_cjs_resolver: Arc<CliIsCjsResolver>,
@@ -316,6 +316,30 @@ impl LspScopeResolver {
         .clone(),
       config_data: self.config_data.clone(),
     })
+  }
+
+  pub fn as_config_data(&self) -> Option<&Arc<ConfigData>> {
+    self.config_data.as_ref()
+  }
+
+  pub fn as_jsr_cache_resolver(&self) -> Option<&Arc<JsrCacheResolver>> {
+    self.jsr_resolver.as_ref()
+  }
+
+  pub fn as_in_npm_pkg_checker(&self) -> &DenoInNpmPackageChecker {
+    &self.in_npm_pkg_checker
+  }
+
+  pub fn as_node_resolver(&self) -> Option<&Arc<CliNodeResolver>> {
+    self.node_resolver.as_ref()
+  }
+
+  pub fn as_npm_resolver(&self) -> Option<&CliNpmResolver> {
+    self.npm_resolver.as_ref()
+  }
+
+  pub fn dep_info(&self) -> Arc<ScopeDepInfo> {
+    self.dep_info.lock().clone()
   }
 }
 
@@ -630,7 +654,7 @@ impl LspResolver {
       .collect()
   }
 
-  fn get_scope_resolver(
+  pub fn get_scope_resolver(
     &self,
     file_referrer: Option<&ModuleSpecifier>,
   ) -> &LspScopeResolver {

--- a/cli/tsc/97_ts_host.js
+++ b/cli/tsc/97_ts_host.js
@@ -91,6 +91,7 @@ export function setLogDebug(debug, source) {
 function printStderr(msg) {
   core.print(msg, true);
 }
+globalThis.printStderr = (text) => printStderr(text + "\n");
 
 /** @param args {any[]} */
 export function debug(...args) {
@@ -430,13 +431,6 @@ const hostImpl = {
     return projectVersion;
   },
   // @ts-ignore Undocumented method.
-  getCachedExportInfoMap() {
-    return exportMapCache;
-  },
-  getGlobalTypingsCacheLocation() {
-    return undefined;
-  },
-  // @ts-ignore Undocumented method.
   toPath(fileName) {
     // @ts-ignore Undocumented function.
     return ts.toPath(
@@ -732,6 +726,9 @@ const hostImpl = {
     }
     return scriptSnapshot;
   },
+  getExportImportablePathsFromModule(referrerPath) {
+    return ops.op_export_modules_for_module(referrerPath);
+  },
 };
 
 // these host methods are super noisy (often thousands of calls per TSC request)
@@ -761,9 +758,6 @@ for (const [key, value] of Object.entries(hostImpl)) {
     host[key] = value;
   }
 }
-
-// @ts-ignore Undocumented function.
-const exportMapCache = ts.createCacheableExportInfoMap(host);
 
 // override the npm install @types package diagnostics to be deno specific
 ts.setLocalizedDiagnosticMessages((() => {

--- a/cli/tsc/98_lsp.js
+++ b/cli/tsc/98_lsp.js
@@ -284,6 +284,34 @@ async function pollRequests() {
 
 let hasStarted = false;
 
+function createLs() {
+  let exportInfoMap = undefined;
+  const newHost = {
+    ...host,
+    getCachedExportInfoMap: () => {
+      // this export info map is specific to
+      // the language service instance
+      return exportInfoMap;
+    },
+  };
+  const ls = ts.createLanguageService(
+    newHost,
+    documentRegistry,
+  );
+  exportInfoMap = ts.createCacheableExportInfoMap({
+    getCurrentProgram() {
+      return ls.getCurrentProgram();
+    },
+    getGlobalTypingsCacheLocation() {
+      return undefined;
+    },
+    getPackageJsonAutoImportProvider() {
+      return undefined;
+    },
+  });
+  return ls;
+}
+
 /** @param {boolean} enableDebugLogging */
 export async function serverMainLoop(enableDebugLogging) {
   ts.deno.setEnterSpan(ops.op_make_span);
@@ -293,10 +321,7 @@ export async function serverMainLoop(enableDebugLogging) {
   }
   hasStarted = true;
   LANGUAGE_SERVICE_ENTRIES.unscoped = {
-    ls: ts.createLanguageService(
-      host,
-      documentRegistry,
-    ),
+    ls: createLs(),
     compilerOptions: lspTsConfigToCompilerOptions({
       "allowJs": true,
       "esModuleInterop": true,
@@ -398,9 +423,7 @@ function serverRequestInner(id, method, args, scope, maybeChange) {
       for (const [scope, config] of newConfigsByScope) {
         LAST_REQUEST_SCOPE.set(scope);
         const oldEntry = LANGUAGE_SERVICE_ENTRIES.byScope.get(scope);
-        const ls = oldEntry
-          ? oldEntry.ls
-          : ts.createLanguageService(host, documentRegistry);
+        const ls = oldEntry ? oldEntry.ls : createLs();
         const compilerOptions = lspTsConfigToCompilerOptions(config);
         newByScope.set(scope, { ls, compilerOptions });
         LANGUAGE_SERVICE_ENTRIES.byScope.delete(scope);

--- a/cli/tsc/dts/typescript.d.ts
+++ b/cli/tsc/dts/typescript.d.ts
@@ -6557,6 +6557,8 @@ declare namespace ts {
         isKnownTypesPackageName?(name: string): boolean;
         installPackage?(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;
         writeFile?(fileName: string, content: string): void;
+        getExportImportablePathsFromModule(filePath: string): string[];
+        getCachedExportInfoMap?(): ExportInfoMap;
         getParsedCommandLine?(fileName: string): ParsedCommandLine | undefined;
         jsDocParsingMode?: JSDocParsingMode | undefined;
     }
@@ -7752,6 +7754,12 @@ declare namespace ts {
         host: LanguageServiceHost;
         span: TextSpan;
         preferences: UserPreferences;
+    }
+    function createCacheableExportInfoMap(host: CacheableExportInfoMapHost): ExportInfoMap;
+    interface CacheableExportInfoMapHost {
+        getCurrentProgram(): Program | undefined;
+        getPackageJsonAutoImportProvider(): Program | undefined;
+        getGlobalTypingsCacheLocation(): string | undefined;
     }
     type ExportMapInfoKey = string & {
         __exportInfoKey: void;

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -697,6 +697,15 @@ fn op_emit_inner(state: &mut OpState, args: EmitArgs) -> bool {
   true
 }
 
+#[op2]
+#[serde]
+fn op_export_modules_for_module(
+  _state: &mut OpState,
+  #[string] _module: String,
+) -> Vec<String> {
+  Vec::new()
+}
+
 pub fn as_ts_script_kind(media_type: MediaType) -> i32 {
   match media_type {
     MediaType::JavaScript => 1,
@@ -1342,6 +1351,7 @@ deno_core::extension!(deno_cli_tsc,
   ops = [
     op_create_hash,
     op_emit,
+    op_export_modules_for_module,
     op_is_node_file,
     op_load,
     op_remap_specifier,

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -825,6 +825,7 @@ pub trait ExtNodeSys:
   + sys_traits::BaseFsMetadata
   + sys_traits::BaseFsRead
   + sys_traits::EnvCurrentDir
+  + node_resolver::NodeResolverSys
   + Clone
 {
 }

--- a/resolvers/node/analyze.rs
+++ b/resolvers/node/analyze.rs
@@ -15,12 +15,11 @@ use futures::StreamExt;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde::Serialize;
-use sys_traits::FsCanonicalize;
 use sys_traits::FsMetadata;
-use sys_traits::FsRead;
 use url::Url;
 
 use crate::resolution::NodeResolverRc;
+use crate::resolution::NodeResolverSys;
 use crate::InNpmPackageChecker;
 use crate::IsBuiltInNodeModuleChecker;
 use crate::NodeResolutionKind;
@@ -88,7 +87,7 @@ pub struct NodeCodeTranslator<
   TInNpmPackageChecker: InNpmPackageChecker,
   TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,
   TNpmPackageFolderResolver: NpmPackageFolderResolver,
-  TSys: FsCanonicalize + FsMetadata + FsRead,
+  TSys: NodeResolverSys,
 > {
   cjs_code_analyzer: TCjsCodeAnalyzer,
   in_npm_pkg_checker: TInNpmPackageChecker,
@@ -108,7 +107,7 @@ impl<
     TInNpmPackageChecker: InNpmPackageChecker,
     TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,
     TNpmPackageFolderResolver: NpmPackageFolderResolver,
-    TSys: FsCanonicalize + FsMetadata + FsRead,
+    TSys: NodeResolverSys,
   >
   NodeCodeTranslator<
     TCjsCodeAnalyzer,

--- a/resolvers/node/lib.rs
+++ b/resolvers/node/lib.rs
@@ -36,6 +36,7 @@ pub use resolution::NodeResolution;
 pub use resolution::NodeResolutionKind;
 pub use resolution::NodeResolver;
 pub use resolution::NodeResolverRc;
+pub use resolution::NodeResolverSys;
 pub use resolution::ResolutionMode;
 pub use resolution::DEFAULT_CONDITIONS;
 pub use resolution::REQUIRE_CONDITIONS;


### PR DESCRIPTION
TypeScript's auto-import implementation is implemented specifically for node_modules. Additionally, it seems to traverse through all the source files in a program then filter out any results that aren't importable. This changes things so that we instead provide TypeScript with a limited list of modules to resolve exports from (the entrypoints of every package from JSR or npm in a project).