### PR TITLE
chore: move tracing build to build job

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -698,14 +698,16 @@ const ci = {
             "deno run --allow-write --allow-read --allow-run=git ./tests/node_compat/runner/setup.ts --check",
         },
         {
+          name: "Check tracing build",
+          if:
+            "matrix.job == 'test' && matrix.profile == 'debug' && matrix.os == 'linux' && matrix.arch == 'x86_64'",
+          run: "cargo check -p deno --features=lsp-tracing ",
+          env: { CARGO_PROFILE_DEV_DEBUG: 0 },
+        },
+        {
           name: "Build debug",
           if: "matrix.job == 'test' && matrix.profile == 'debug'",
-          run: [
-            // output fs space before and after building
-            "df -h",
-            "cargo build --locked --all-targets",
-            "df -h",
-          ].join("\n"),
+          run: "cargo build --locked --all-targets",
           env: { CARGO_PROFILE_DEV_DEBUG: 0 },
         },
         // Uncomment for remote debugging
@@ -1126,33 +1128,6 @@ const ci = {
           name: "Cargo build",
           // we want this crate to be wasm compatible
           run: "cargo build --target wasm32-unknown-unknown -p deno_resolver",
-        },
-      ]),
-    },
-    "check-lsp-tracing": {
-      name: "check lsp tracing",
-      needs: ["pre_build"],
-      if: "${{ needs.pre_build.outputs.skip_build != 'true' }}",
-      "runs-on": ubuntuX86Runner,
-      "timeout-minutes": 30,
-      steps: skipJobsIfPrAndMarkedSkip([
-        ...cloneRepoStep,
-        installRustStep,
-        {
-          // Restore cache from the latest 'main' branch build.
-          name: "Restore cache build output (PR)",
-          uses: "actions/cache/restore@v4",
-          if:
-            "github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/')",
-          with: {
-            path: prCachePath,
-            key: "never_saved",
-            "restore-keys": prCacheKeyPrefix,
-          },
-        },
-        {
-          name: "Check",
-          run: "cargo check -p deno --features=lsp-tracing",
         },
       ]),
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,12 +410,14 @@ jobs:
       - name: node_compat/setup.ts --check
         if: '!(matrix.skip) && (matrix.job == ''lint'' && matrix.os == ''linux'')'
         run: deno run --allow-write --allow-read --allow-run=git ./tests/node_compat/runner/setup.ts --check
+      - name: Check tracing build
+        if: '!(matrix.skip) && (matrix.job == ''test'' && matrix.profile == ''debug'' && matrix.os == ''linux'' && matrix.arch == ''x86_64'')'
+        run: 'cargo check -p deno --features=lsp-tracing '
+        env:
+          CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build debug
         if: '!(matrix.skip) && (matrix.job == ''test'' && matrix.profile == ''debug'')'
-        run: |-
-          df -h
-          cargo build --locked --all-targets
-          df -h
+        run: cargo build --locked --all-targets
         env:
           CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build release
@@ -724,42 +726,6 @@ jobs:
         if: '!(matrix.skip)'
       - name: Cargo build
         run: cargo build --target wasm32-unknown-unknown -p deno_resolver
-        if: '!(matrix.skip)'
-  check-lsp-tracing:
-    name: check lsp tracing
-    needs:
-      - pre_build
-    if: '${{ needs.pre_build.outputs.skip_build != ''true'' }}'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - name: Configure git
-        run: |-
-          git config --global core.symlinks true
-          git config --global fetch.parallel 32
-        if: '!(matrix.skip)'
-      - name: Clone repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 5
-          submodules: false
-        if: '!(matrix.skip)'
-      - uses: dsherret/rust-toolchain-file@v1
-        if: '!(matrix.skip)'
-      - name: Restore cache build output (PR)
-        uses: actions/cache/restore@v4
-        if: '!(matrix.skip) && (github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/''))'
-        with:
-          path: |-
-            ./target
-            !./target/*/gn_out
-            !./target/*/gn_root
-            !./target/*/*.zip
-            !./target/*/*.tar.gz
-          key: never_saved
-          restore-keys: '40-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
-      - name: Check
-        run: cargo check -p deno --features=lsp-tracing
         if: '!(matrix.skip)'
   publish-canary:
     name: publish canary


### PR DESCRIPTION
Testing moving this serially (because my PR had a job fail and then I was waiting for this one to finish... not sure why it wasn't cancelled. I think this can just be serially done because I believe it should be fast to do a non-tracing build immediately after)