### PR TITLE
fix(lint): don't mark plugin diagnostic as fixable, if it's not

### DIFF
--- a/cli/ops/lint.rs
+++ b/cli/ops/lint.rs
@@ -146,10 +146,14 @@ impl LintPluginContainer {
       })
       .collect::<Result<Vec<LintFixChange>, LintReportError>>()?;
 
-    let fixes = vec![LintFix {
-      changes,
-      description: format!("Fix this {} problem", id).into(),
-    }];
+    let mut fixes = vec![];
+
+    if !changes.is_empty() {
+      fixes.push(LintFix {
+        changes,
+        description: format!("Fix this {} problem", id).into(),
+      });
+    }
 
     let lint_diagnostic = LintDiagnostic {
       specifier,

--- a/tests/specs/lint/lint_plugin_no_fixer/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_no_fixer/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "tempDir": true,
+  "args": "lint a.ts",
+  "output": "lint.out",
+  "exitCode": 1
+}

--- a/tests/specs/lint/lint_plugin_no_fixer/a.ts
+++ b/tests/specs/lint/lint_plugin_no_fixer/a.ts
@@ -1,0 +1,1 @@
+const _a = "foo";

--- a/tests/specs/lint/lint_plugin_no_fixer/deno.json
+++ b/tests/specs/lint/lint_plugin_no_fixer/deno.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "plugins": ["./plugin.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_no_fixer/lint.out
+++ b/tests/specs/lint/lint_plugin_no_fixer/lint.out
@@ -1,0 +1,2 @@
+[WILDCARD]Found 1 problem
+Checked 1 file

--- a/tests/specs/lint/lint_plugin_no_fixer/lint.out
+++ b/tests/specs/lint/lint_plugin_no_fixer/lint.out
@@ -1,2 +1,9 @@
-[WILDCARD]Found 1 problem
+error[test-plugin/my-rule]: should be _b
+ --> [WILDCARD]a.ts:1:7
+  | 
+1 | const _a = "foo";
+  |       ^^
+
+
+Found 1 problem
 Checked 1 file

--- a/tests/specs/lint/lint_plugin_no_fixer/plugin.ts
+++ b/tests/specs/lint/lint_plugin_no_fixer/plugin.ts
@@ -1,0 +1,19 @@
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(context) {
+        return {
+          Identifier(node) {
+            if (node.name === "_a") {
+              context.report({
+                node,
+                message: "should be _b",
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+};


### PR DESCRIPTION
A vector with fixes was always created, even if there were no
applicable fixes.