### PR TITLE
feat: support XDG_CACHE_HOME for deno dir on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27429da4d0e601baaa41415a43468d49a586645d13497f12e8a9346f9f6b1347"
+checksum = "4cadb05700726eb97cb4914d8016ff81ece094b1c3ed442d6f48f297961a5a96"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ ctr = { version = "0.9.2", features = ["alloc"] }
 dashmap = "5.5.3"
 data-encoding = "2.3.3"
 data-url = "=0.3.1"
-deno_cache_dir = "=0.17.0"
+deno_cache_dir = "=0.18.0"
 deno_error = "=0.5.5"
 deno_package_json = { version = "=0.4.2", default-features = false }
 deno_unsync = "0.4.2"


### PR DESCRIPTION
* https://github.com/denoland/deno_cache_dir/pull/73