### PR TITLE
refactor(publish): create ModuleContentProvider

### DIFF
--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -53,12 +53,12 @@ mod auth;
 
 mod diagnostics;
 mod graph;
+mod module_content;
 mod paths;
 mod pm;
 mod provenance;
 mod publish_order;
 mod tar;
-mod text_content;
 mod unfurl;
 
 use auth::get_auth_method;
@@ -73,9 +73,9 @@ use publish_order::PublishOrderGraph;
 use unfurl::SpecifierUnfurler;
 
 use self::graph::GraphDiagnosticsCollector;
+use self::module_content::ModuleContentProvider;
 use self::paths::CollectedPublishPath;
 use self::tar::PublishableTarball;
-use self::text_content::ModuleContentProvider;
 use super::check::TypeChecker;
 
 pub async fn publish(

--- a/cli/tools/registry/mod.rs
+++ b/cli/tools/registry/mod.rs
@@ -39,8 +39,6 @@ use crate::args::jsr_url;
 use crate::args::CliOptions;
 use crate::args::Flags;
 use crate::args::PublishFlags;
-use crate::cache::LazyGraphSourceParser;
-use crate::cache::ParsedSourceCache;
 use crate::factory::CliFactory;
 use crate::graph_util::ModuleGraphCreator;
 use crate::http_util::HttpClient;
@@ -60,6 +58,7 @@ mod pm;
 mod provenance;
 mod publish_order;
 mod tar;
+mod text_content;
 mod unfurl;
 
 use auth::get_auth_method;
@@ -76,6 +75,7 @@ use unfurl::SpecifierUnfurler;
 use self::graph::GraphDiagnosticsCollector;
 use self::paths::CollectedPublishPath;
 use self::tar::PublishableTarball;
+use self::text_content::ModuleContentProvider;
 use super::check::TypeChecker;
 
 pub async fn publish(
@@ -119,19 +119,22 @@ pub async fn publish(
     }
   }
 
-  let specifier_unfurler = Arc::new(SpecifierUnfurler::new(
+  let specifier_unfurler = SpecifierUnfurler::new(
     cli_factory.workspace_resolver().await?.clone(),
     cli_options.unstable_bare_node_builtins(),
-  ));
+  );
 
   let diagnostics_collector = PublishDiagnosticsCollector::default();
+  let module_content_provider = Arc::new(ModuleContentProvider::new(
+    specifier_unfurler,
+    cli_factory.parsed_source_cache().clone(),
+  ));
   let publish_preparer = PublishPreparer::new(
     GraphDiagnosticsCollector::new(cli_factory.parsed_source_cache().clone()),
     cli_factory.module_graph_creator().await?.clone(),
-    cli_factory.parsed_source_cache().clone(),
     cli_factory.type_checker().await?.clone(),
     cli_options.clone(),
-    specifier_unfurler,
+    module_content_provider,
   );
 
   let prepared_data = publish_preparer
@@ -211,28 +214,25 @@ struct PreparePackagesData {
 struct PublishPreparer {
   graph_diagnostics_collector: GraphDiagnosticsCollector,
   module_graph_creator: Arc<ModuleGraphCreator>,
-  source_cache: Arc<ParsedSourceCache>,
   type_checker: Arc<TypeChecker>,
   cli_options: Arc<CliOptions>,
-  specifier_unfurler: Arc<SpecifierUnfurler>,
+  module_content_provider: Arc<ModuleContentProvider>,
 }
 
 impl PublishPreparer {
   pub fn new(
     graph_diagnostics_collector: GraphDiagnosticsCollector,
     module_graph_creator: Arc<ModuleGraphCreator>,
-    source_cache: Arc<ParsedSourceCache>,
     type_checker: Arc<TypeChecker>,
     cli_options: Arc<CliOptions>,
-    specifier_unfurler: Arc<SpecifierUnfurler>,
+    module_content_provider: Arc<ModuleContentProvider>,
   ) -> Self {
     Self {
       graph_diagnostics_collector,
       module_graph_creator,
-      source_cache,
       type_checker,
       cli_options,
-      specifier_unfurler,
+      module_content_provider,
     }
   }
 
@@ -424,9 +424,8 @@ impl PublishPreparer {
 
     let tarball = deno_core::unsync::spawn_blocking({
       let diagnostics_collector = diagnostics_collector.clone();
-      let unfurler = self.specifier_unfurler.clone();
+      let module_content_provider = self.module_content_provider.clone();
       let cli_options = self.cli_options.clone();
-      let source_cache = self.source_cache.clone();
       let config_path = config_path.clone();
       let config_url = deno_json.specifier.clone();
       let has_license_field = package.license.is_some();
@@ -472,10 +471,10 @@ impl PublishPreparer {
         }
 
         tar::create_gzipped_tarball(
-          publish_paths,
-          LazyGraphSourceParser::new(&source_cache, &graph),
+          &module_content_provider,
+          &graph,
           &diagnostics_collector,
-          &unfurler,
+          publish_paths,
         )
         .context("Failed to create a tarball")
       }

--- a/cli/tools/registry/module_content.rs
+++ b/cli/tools/registry/module_content.rs
@@ -1,0 +1,105 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use deno_ast::MediaType;
+use deno_core::anyhow::Context;
+use deno_core::error::AnyError;
+use deno_core::url::Url;
+use deno_graph::ModuleGraph;
+
+use super::diagnostics::PublishDiagnosticsCollector;
+use super::unfurl::SpecifierUnfurler;
+use crate::cache::LazyGraphSourceParser;
+use crate::cache::ParsedSourceCache;
+use crate::tools::registry::diagnostics::PublishDiagnostic;
+
+pub struct ModuleContentProvider {
+  unfurler: SpecifierUnfurler,
+  parsed_source_cache: Arc<ParsedSourceCache>,
+}
+
+impl ModuleContentProvider {
+  pub fn new(
+    unfurler: SpecifierUnfurler,
+    parsed_source_cache: Arc<ParsedSourceCache>,
+  ) -> Self {
+    Self {
+      unfurler,
+      parsed_source_cache,
+    }
+  }
+
+  pub fn resolve_content_maybe_unfurling(
+    &self,
+    graph: &ModuleGraph,
+    diagnostics_collector: &PublishDiagnosticsCollector,
+    path: &Path,
+    specifier: &Url,
+  ) -> Result<Vec<u8>, AnyError> {
+    let source_parser =
+      LazyGraphSourceParser::new(&self.parsed_source_cache, graph);
+    let parsed_source = match source_parser.get_or_parse_source(specifier)? {
+      Some(parsed_source) => parsed_source,
+      None => {
+        let data = std::fs::read(path).with_context(|| {
+          format!("Unable to read file '{}'", path.display())
+        })?;
+        let media_type = MediaType::from_specifier(specifier);
+
+        match media_type {
+          MediaType::JavaScript
+          | MediaType::Jsx
+          | MediaType::Mjs
+          | MediaType::Cjs
+          | MediaType::TypeScript
+          | MediaType::Mts
+          | MediaType::Cts
+          | MediaType::Dts
+          | MediaType::Dmts
+          | MediaType::Dcts
+          | MediaType::Tsx => {
+            // continue
+          }
+          MediaType::SourceMap
+          | MediaType::Unknown
+          | MediaType::Json
+          | MediaType::Wasm
+          | MediaType::Css => {
+            // not unfurlable data
+            return Ok(data);
+          }
+        }
+
+        let text = String::from_utf8(data)?;
+        deno_ast::parse_module(deno_ast::ParseParams {
+          specifier: specifier.clone(),
+          text: text.into(),
+          media_type,
+          capture_tokens: false,
+          maybe_syntax: None,
+          scope_analysis: false,
+        })?
+      }
+    };
+
+    log::debug!("Unfurling {}", specifier);
+    let mut reporter = |diagnostic| {
+      diagnostics_collector
+        .push(PublishDiagnostic::SpecifierUnfurl(diagnostic));
+    };
+    let text_info = parsed_source.text_info_lazy();
+    let mut text_changes = Vec::new();
+    self.unfurler.unfurl_to_changes(
+      specifier,
+      &parsed_source,
+      &mut text_changes,
+      &mut reporter,
+    );
+    let rewritten_text =
+      deno_ast::apply_text_changes(text_info.text_str(), text_changes);
+
+    Ok(rewritten_text.into_bytes())
+  }
+}

--- a/cli/tools/registry/tar.rs
+++ b/cli/tools/registry/tar.rs
@@ -12,8 +12,8 @@ use sha2::Digest;
 use tar::Header;
 
 use super::diagnostics::PublishDiagnosticsCollector;
+use super::module_content::ModuleContentProvider;
 use super::paths::CollectedPublishPath;
-use super::text_content::ModuleContentProvider;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PublishableTarballFile {


### PR DESCRIPTION
Adds a `ModuleContentProvider`. Will use this in a future PR to do more than specifier unfurling (JSX support).