### PR TITLE
fix(ext/node): Fix handling of sqlite large integers

### DIFF
--- a/ext/node/ops/sqlite/statement.rs
+++ b/ext/node/ops/sqlite/statement.rs
@@ -138,7 +138,7 @@ impl StatementSync {
           if self.use_big_ints.get() {
             v8::BigInt::new_from_i64(scope, value).into()
           } else if value.abs() <= MAX_SAFE_JS_INTEGER {
-            v8::Integer::new(scope, value as _).into()
+            v8::Number::new(scope, value as f64).into()
           } else {
             return Err(SqliteError::NumberTooLarge(index, value));
           }

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -236,3 +236,11 @@ Deno.test("[node/sqlite] StatementSync#iterate", () => {
 
   db.close();
 });
+
+// https://github.com/denoland/deno/issues/28187
+Deno.test("[node/sqlite] StatementSync for large integers", () => {
+  const db = new DatabaseSync(":memory:");
+  const result = db.prepare("SELECT 2147483648").get();
+  assertEquals(result, { "2147483648": 2147483648, __proto__: null });
+  db.close();
+});


### PR DESCRIPTION
Use `v8::Number` instead of `v8::Integer` to handle > i32::MAX.

Fixes https://github.com/denoland/deno/issues/28187
