### PR TITLE
fix(node:sqlite): Fix out of order node params

### DIFF
--- a/ext/node/ops/sqlite/statement.rs
+++ b/ext/node/ops/sqlite/statement.rs
@@ -331,18 +331,25 @@ impl StatementSync {
   ) -> Result<(), SqliteError> {
     let raw = self.inner;
 
+    // SAFETY: `self.inner` is a valid pointer to a sqlite3_stmt
+    // as it lives as long as the StatementSync instance.
     unsafe {
       ffi::sqlite3_bind_parameter_index(raw, key.as_ptr() as *const _);
     }
 
     if value.is_number() {
       let value = value.number_value(scope).unwrap();
+
+      // SAFETY: `self.inner` is a valid pointer to a sqlite3_stmt
+      // as it lives as long as the StatementSync instance.
       unsafe {
         ffi::sqlite3_bind_double(raw, count + 1, value);
       }
     } else if value.is_string() {
       let value = value.to_rust_string_lossy(scope);
 
+      // SAFETY: `self.inner` is a valid pointer to a sqlite3_stmt
+      // as it lives as long as the StatementSync instance.
       unsafe {
         ffi::sqlite3_bind_text(
           raw,
@@ -353,6 +360,8 @@ impl StatementSync {
         );
       }
     } else if value.is_null() {
+      // SAFETY: `self.inner` is a valid pointer to a sqlite3_stmt
+      // as it lives as long as the StatementSync instance.
       unsafe {
         ffi::sqlite3_bind_null(raw, count + 1);
       }
@@ -360,6 +369,11 @@ impl StatementSync {
       let value: v8::Local<v8::ArrayBufferView> = value.try_into().unwrap();
       let data = value.data();
       let size = value.byte_length();
+
+      // SAFETY: `self.inner` is a valid pointer to a sqlite3_stmt
+      // as it lives as long as the StatementSync instance.
+      //
+      // SQLITE_TRANSIENT is used to indicate that SQLite should make a copy of the data.
       unsafe {
         ffi::sqlite3_bind_blob(
           raw,
@@ -378,6 +392,8 @@ impl StatementSync {
         ));
       }
 
+      // SAFETY: `self.inner` is a valid pointer to a sqlite3_stmt
+      // as it lives as long as the StatementSync instance.
       unsafe {
         ffi::sqlite3_bind_int64(raw, count + 1, as_int);
       }

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -197,3 +197,22 @@ CREATE TABLE two(id int PRIMARY KEY) STRICT;`);
 
   db.close();
 });
+
+Deno.test("[node/sqlite] query should handle mixed positional and named parameters", () => {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`CREATE TABLE one(variable1 TEXT, variable2 INT, variable3 INT)`);
+  db.exec(
+    `INSERT INTO one (variable1, variable2, variable3) VALUES ("test", 1 , 2);`,
+  );
+
+  const query = "SELECT * FROM one WHERE variable3=:test1";
+  const result = db.prepare(query).all({ test1: 2 });
+  assertEquals(result, [{
+    __proto__: null,
+    variable1: "test",
+    variable2: 1,
+    variable3: 2,
+  }]);
+
+  db.close();
+});

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -205,8 +205,8 @@ Deno.test("[node/sqlite] query should handle mixed positional and named paramete
     `INSERT INTO one (variable1, variable2, variable3) VALUES ("test", 1 , 2);`,
   );
 
-  const query = "SELECT * FROM one WHERE variable3=:test1";
-  const result = db.prepare(query).all({ test1: 2 });
+  const query = "SELECT * FROM one WHERE variable1=:var1 AND variable2=:var2 ";
+  const result = db.prepare(query).all({ var1: "test", var2: 1 });
   assertEquals(result, [{
     __proto__: null,
     variable1: "test",


### PR DESCRIPTION
This PR fixes named params not working in SQLite query if it's out of order #28183 
