### PR TITLE
chore: fix otel test flakiness

### DIFF
--- a/tests/specs/cli/otel_basic/http_metric.out
+++ b/tests/specs/cli/otel_basic/http_metric.out
@@ -20,7 +20,7 @@
         {
           "key": "url.full",
           "value": {
-            "stringValue": "http://localhost:8080/"
+            "stringValue": "http://localhost:[WILDLINE]/"
           }
         },
         {
@@ -78,7 +78,7 @@
         {
           "key": "url.full",
           "value": {
-            "stringValue": "http://localhost:8080/"
+            "stringValue": "http://localhost:[WILDLINE]/"
           }
         },
         {
@@ -136,7 +136,7 @@
         {
           "key": "url.full",
           "value": {
-            "stringValue": "http://localhost:8080/"
+            "stringValue": "http://localhost:[WILDLINE]/"
           }
         },
         {
@@ -194,7 +194,7 @@
         {
           "key": "url.full",
           "value": {
-            "stringValue": "http://localhost:8080/"
+            "stringValue": "http://localhost:[WILDLINE]/"
           }
         },
         {
@@ -252,7 +252,7 @@
         {
           "key": "url.full",
           "value": {
-            "stringValue": "http://localhost:8080/"
+            "stringValue": "http://localhost:[WILDLINE]/"
           }
         },
         {
@@ -310,7 +310,7 @@
         {
           "key": "url.full",
           "value": {
-            "stringValue": "http://localhost:8080/"
+            "stringValue": "http://localhost:[WILDLINE]/"
           }
         },
         {
@@ -493,21 +493,21 @@
             "count": 3,
             "sum": [WILDCARD],
             "bucketCounts": [
-              3,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE]
             ],
             "explicitBounds": [
               0.005,
@@ -573,16 +573,16 @@
             "count": 3,
             "sum": 0,
             "bucketCounts": [
-              3,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE]
             ],
             "explicitBounds": [
               0,

--- a/tests/specs/cli/otel_basic/http_metric.ts
+++ b/tests/specs/cli/otel_basic/http_metric.ts
@@ -1,10 +1,16 @@
+let port;
 const server = Deno.serve(
-  { port: 8080, onListen: () => {} },
+  {
+    port: 0,
+    onListen: (addr) => {
+      port = addr.port;
+    },
+  },
   () => new Response("foo"),
 );
 
 for (let i = 0; i < 3; i++) {
-  await fetch(`http://localhost:8080`);
+  await fetch(`http://localhost:${port}`);
 }
 
 await server.shutdown();


### PR DESCRIPTION
The bucket counts can vary run to run. Also don't hardcode the port