### PR TITLE
refactor(coverage): simplify CoverageReporter trait

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -575,6 +575,8 @@ pub fn cover_files(
     )
   };
 
+  let mut file_reports: Vec<(CoverageReport, String)> = vec![];
+
   for script_coverage in script_coverages {
     let module_specifier = deno_core::resolve_url_or_path(
       &script_coverage.url,
@@ -638,11 +640,11 @@ pub fn cover_files(
     );
 
     if !coverage_report.found_lines.is_empty() {
-      reporter.report(&coverage_report, &original_source)?;
+      file_reports.push((coverage_report, original_source.to_string()));
     }
   }
 
-  reporter.done(&coverage_root);
+  reporter.done(&coverage_root, &file_reports);
 
   Ok(())
 }

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -575,7 +575,7 @@ pub fn cover_files(
     )
   };
 
-  let mut file_reports: Vec<(CoverageReport, String)> = vec![];
+  let mut file_reports = Vec::with_capacity(script_coverages.len());
 
   for script_coverage in script_coverages {
     let module_specifier = deno_core::resolve_url_or_path(

--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -44,13 +44,13 @@ pub trait CoverageReporter {
   fn done(
     &mut self,
     coverage_root: &Path,
-    file_reports: &Vec<(CoverageReport, String)>,
+    file_reports: &[(CoverageReport, String)],
   );
 
   /// Collects the coverage summary of each file or directory.
   fn collect_summary<'a>(
     &'a self,
-    file_reports: &'a Vec<(CoverageReport, String)>,
+    file_reports: &'a [(CoverageReport, String)],
   ) -> CoverageSummary {
     let urls = file_reports.iter().map(|rep| &rep.0.url).collect();
     let root = match util::find_root(urls)
@@ -174,7 +174,7 @@ impl CoverageReporter for SummaryCoverageReporter {
   fn done(
     &mut self,
     _coverage_root: &Path,
-    file_reports: &Vec<(CoverageReport, String)>,
+    file_reports: &[(CoverageReport, String)],
   ) {
     let summary = self.collect_summary(file_reports);
     let root_stats = summary.get("").unwrap();
@@ -212,7 +212,7 @@ impl CoverageReporter for LcovCoverageReporter {
   fn done(
     &mut self,
     _coverage_root: &Path,
-    file_reports: &Vec<(CoverageReport, String)>,
+    file_reports: &[(CoverageReport, String)],
   ) {
     file_reports.iter().for_each(|(report, file_text)| {
       self.report(report, file_text).unwrap();
@@ -322,7 +322,7 @@ impl CoverageReporter for DetailedCoverageReporter {
   fn done(
     &mut self,
     _coverage_root: &Path,
-    file_reports: &Vec<(CoverageReport, String)>,
+    file_reports: &[(CoverageReport, String)],
   ) {
     file_reports.iter().for_each(|(report, file_text)| {
       self.report(report, file_text).unwrap();
@@ -404,7 +404,7 @@ impl CoverageReporter for HtmlCoverageReporter {
   fn done(
     &mut self,
     coverage_root: &Path,
-    file_reports: &Vec<(CoverageReport, String)>,
+    file_reports: &[(CoverageReport, String)],
   ) {
     let summary = self.collect_summary(file_reports);
     let now = chrono::Utc::now().to_rfc2822();


### PR DESCRIPTION
Prerequisite for #28218 

This PR simplifies the CoverageReporter trait. Now `file_reports: Vec<(CoverageReport, String)>` are created outside the reporter class. This enables multiple reporters using the same reports, and reduces the memory usage when implementing #28218