### PR TITLE
fix(unstable): lint plugin `:exit` called at wrong time

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -1186,11 +1186,6 @@ function traverse(ctx, visitors, idx, cancellationToken) {
     if (childIdx > AST_IDX_INVALID) {
       traverse(ctx, visitors, childIdx, cancellationToken);
     }
-
-    const nextIdx = readNext(buf, idx);
-    if (nextIdx > AST_IDX_INVALID) {
-      traverse(ctx, visitors, nextIdx, cancellationToken);
-    }
   } finally {
     if (exits !== null) {
       for (let i = 0; i < exits.length; i++) {
@@ -1198,6 +1193,11 @@ function traverse(ctx, visitors, idx, cancellationToken) {
         exits[i](node);
       }
     }
+  }
+
+  const nextIdx = readNext(buf, idx);
+  if (nextIdx > AST_IDX_INVALID) {
+    traverse(ctx, visitors, nextIdx, cancellationToken);
   }
 }
 

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -101,6 +101,31 @@ Deno.test("Plugin - visitor enter/exit", () => {
   assertEquals(both.map((t) => t.selector), ["Identifier", "Identifier:exit"]);
 });
 
+// https://github.com/denoland/deno/issues/28227
+Deno.test("Plugin - visitor enter/exit", () => {
+  const log: string[] = [];
+
+  testPlugin("{}\nfoo;", {
+    create() {
+      return {
+        "*": (node: Deno.lint.Node) => log.push(`-> ${node.type}`),
+        "*:exit": (node: Deno.lint.Node) => log.push(`<- ${node.type}`),
+      };
+    },
+  });
+
+  assertEquals(log, [
+    "-> Program",
+    "-> BlockStatement",
+    "<- BlockStatement",
+    "-> ExpressionStatement",
+    "-> Identifier",
+    "<- Identifier",
+    "<- ExpressionStatement",
+    "<- Program",
+  ]);
+});
+
 Deno.test("Plugin - visitor descendant", () => {
   let result = testVisit(
     "if (false) foo; if (false) bar()",

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -102,7 +102,7 @@ Deno.test("Plugin - visitor enter/exit", () => {
 });
 
 // https://github.com/denoland/deno/issues/28227
-Deno.test("Plugin - visitor enter/exit", () => {
+Deno.test("Plugin - visitor enter/exit #2", () => {
   const log: string[] = [];
 
   testPlugin("{}\nfoo;", {


### PR DESCRIPTION
The `:exit` selectors were called at the wrong time during visiting.

They need to be called when going upwards and a node and all its children have been fully visited. Instead we called it when the node + all its sibling were visited which is wrong.

Fixes https://github.com/denoland/deno/issues/28227