### PR TITLE
fix(install): don't error on unknown media types in install

### DIFF
--- a/cli/graph_container.rs
+++ b/cli/graph_container.rs
@@ -86,6 +86,34 @@ impl MainModuleGraphContainer {
     graph_permit.commit();
     Ok(())
   }
+  pub async fn check_specifiers_allow_unknown_media_types(
+    &self,
+    specifiers: &[ModuleSpecifier],
+    ext_overwrite: Option<&String>,
+    allow_unknown_media_types: bool,
+  ) -> Result<(), AnyError> {
+    let mut graph_permit = self.acquire_update_permit().await;
+    let graph = graph_permit.graph_mut();
+    self
+      .module_load_preparer
+      .prepare_module_load_maybe_validate(
+        graph,
+        specifiers,
+        false,
+        self.cli_options.ts_type_lib_window(),
+        self.root_permissions.clone(),
+        ext_overwrite,
+        false,
+      )
+      .await?;
+    self.module_load_preparer.graph_roots_valid_allow_unknown(
+      graph,
+      specifiers,
+      allow_unknown_media_types,
+    )?;
+    graph_permit.commit();
+    Ok(())
+  }
 
   /// Helper around prepare_module_load that loads and type checks
   /// the provided files.

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -940,18 +940,11 @@ impl ModuleGraphBuilder {
     self.graph_roots_valid(
       graph,
       &graph.roots.iter().cloned().collect::<Vec<_>>(),
+      false,
     )
   }
 
   pub fn graph_roots_valid(
-    &self,
-    graph: &ModuleGraph,
-    roots: &[ModuleSpecifier],
-  ) -> Result<(), JsErrorBox> {
-    self.graph_roots_valid_allow_unknown(graph, roots, false)
-  }
-
-  pub fn graph_roots_valid_allow_unknown(
     &self,
     graph: &ModuleGraph,
     roots: &[ModuleSpecifier],

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -282,6 +282,7 @@ impl LanguageServer {
           kind: GraphKind::All,
           check_js: CheckJsOption::False,
           exit_integrity_errors: false,
+          allow_unknown_media_types: true,
         },
       )?;
 

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -151,6 +151,7 @@ pub async fn doc(
         GraphWalkErrorsOptions {
           check_js: CheckJsOption::False,
           kind: GraphKind::TypesOnly,
+          allow_unknown_media_types: false,
         },
       );
       for error in errors {

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -279,8 +279,9 @@ pub(crate) async fn install_from_entrypoints(
   let factory = CliFactory::from_flags(flags.clone());
   let emitter = factory.emitter()?;
   let main_graph_container = factory.main_module_graph_container().await?;
+  let specifiers = main_graph_container.collect_specifiers(entrypoints)?;
   main_graph_container
-    .load_and_type_check_files(entrypoints)
+    .check_specifiers_allow_unknown_media_types(&specifiers, None, true)
     .await?;
   emitter
     .cache_module_emits(&main_graph_container.graph())

--- a/cli/tools/registry/pm/cache_deps.rs
+++ b/cli/tools/registry/pm/cache_deps.rs
@@ -136,8 +136,7 @@ pub async fn cache_top_level_deps(
         },
       )
       .await?;
-    maybe_graph_error =
-      graph_builder.graph_roots_valid_allow_unknown(graph, &roots, true);
+    maybe_graph_error = graph_builder.graph_roots_valid(graph, &roots, true);
   }
 
   npm_installer.cache_packages(PackageCaching::All).await?;

--- a/cli/tools/registry/pm/cache_deps.rs
+++ b/cli/tools/registry/pm/cache_deps.rs
@@ -136,7 +136,8 @@ pub async fn cache_top_level_deps(
         },
       )
       .await?;
-    maybe_graph_error = graph_builder.graph_roots_valid(graph, &roots);
+    maybe_graph_error =
+      graph_builder.graph_roots_valid_allow_unknown(graph, &roots, true);
   }
 
   npm_installer.cache_packages(PackageCaching::All).await?;

--- a/cli/tools/registry/pm/deps.rs
+++ b/cli/tools/registry/pm/deps.rs
@@ -611,14 +611,15 @@ impl DepManager {
 
     self
       .module_load_preparer
-      .prepare_module_load(
+      .prepare_module_load(crate::module_loader::PrepareModuleLoadOptions {
         graph,
-        &roots,
-        false,
-        deno_config::deno_json::TsTypeLib::DenoWindow,
-        self.permissions_container.clone(),
-        None,
-      )
+        roots: &roots,
+        is_dynamic: false,
+        lib: deno_config::deno_json::TsTypeLib::DenoWindow,
+        permissions: self.permissions_container.clone(),
+        ext_overwrite: None,
+        allow_unknown_media_types: true,
+      })
       .await?;
 
     self.dependencies_resolved.raise();

--- a/tests/specs/install/unknown_media_type/__test__.jsonc
+++ b/tests/specs/install/unknown_media_type/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": ""
+    }
+  ]
+}

--- a/tests/specs/install/unknown_media_type/deno.json
+++ b/tests/specs/install/unknown_media_type/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "foo": "./foo.ts"
+  }
+}

--- a/tests/specs/install/unknown_media_type/foo.ts
+++ b/tests/specs/install/unknown_media_type/foo.ts
@@ -1,0 +1,1 @@
+import styles from "./styles.css";


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/28223

This is kind of an ugly fix, but it works, and I think is the easiest way to handle the fact that when caching the module graph we might encounter imports that won't actually error at runtime (for instance in files that will be bundled).