### PR TITLE
refactor(resolver/node): use `deno_path_util::is_relative_specifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "deno_path_util"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87b8996966ae1b13ee9c20219b1d10fc53905b9570faae6adfa34614fd15224"
+checksum = "c238a664a0a6f1ce0ff2b73c6854811526d00f442a12f878cb8555b23fe13aa3"
 dependencies = [
  "deno_error",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ deno_config = { version = "=0.49.1", features = ["workspace"] }
 deno_lockfile = "=0.24.0"
 deno_media_type = { version = "=0.2.6", features = ["module_specifier"] }
 deno_npm = "=0.27.2"
-deno_path_util = "=0.3.1"
+deno_path_util = "=0.3.2"
 deno_permissions = { version = "0.51.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.200.0", path = "./runtime" }
 deno_semver = "=0.7.1"

--- a/resolvers/node/resolution.rs
+++ b/resolvers/node/resolution.rs
@@ -1891,25 +1891,7 @@ fn should_be_treated_as_relative_or_absolute_path(specifier: &str) -> bool {
     return true;
   }
 
-  is_relative_specifier(specifier)
-}
-
-// TODO(ry) We very likely have this utility function elsewhere in Deno.
-fn is_relative_specifier(specifier: &str) -> bool {
-  let specifier_len = specifier.len();
-  let specifier_chars: Vec<_> = specifier.chars().take(3).collect();
-
-  if !specifier_chars.is_empty() && specifier_chars[0] == '.' {
-    if specifier_len == 1 || specifier_chars[1] == '/' {
-      return true;
-    }
-    if specifier_chars[1] == '.'
-      && (specifier_len == 2 || specifier_chars[2] == '/')
-    {
-      return true;
-    }
-  }
-  false
+  deno_path_util::is_relative_specifier(specifier)
 }
 
 /// Alternate `PathBuf::with_extension` that will handle known extensions


### PR DESCRIPTION
Should be slightly faster too because it no longer heap allocates.