### PR TITLE
chore: mark worker_large_output as flaky

### DIFF
--- a/tests/specs/test/worker_large_output/__test__.jsonc
+++ b/tests/specs/test/worker_large_output/__test__.jsonc
@@ -1,4 +1,5 @@
 {
   "args": "test main.js",
-  "output": "main.out"
+  "output": "main.out",
+  "flaky": true
 }


### PR DESCRIPTION
Maybe this might be covering up a bug, but it fails too often with "operation failed to complete synchronously".