### PR TITLE
perf(install): only read initialized file if we care about the tags

### DIFF
--- a/cli/npm/installer/local.rs
+++ b/cli/npm/installer/local.rs
@@ -279,15 +279,23 @@ async fn sync_resolution_with_fs(
       TagsOutdated,
     }
     let initialized_file = folder_path.join(".initialized");
-    let package_state = std::fs::read_to_string(&initialized_file)
-      .map(|s| {
-        if s != tags {
-          PackageFolderState::TagsOutdated
-        } else {
-          PackageFolderState::UpToDate
-        }
-      })
-      .unwrap_or(PackageFolderState::Uninitialized);
+    let package_state = if tags.is_empty() {
+      if initialized_file.exists() {
+        PackageFolderState::UpToDate
+      } else {
+        PackageFolderState::Uninitialized
+      }
+    } else {
+      std::fs::read_to_string(&initialized_file)
+        .map(|s| {
+          if s != tags {
+            PackageFolderState::TagsOutdated
+          } else {
+            PackageFolderState::UpToDate
+          }
+        })
+        .unwrap_or(PackageFolderState::Uninitialized)
+    };
     if !cache
       .cache_setting()
       .should_use_for_npm_package(&package.id.nv.name)


### PR DESCRIPTION
Speeds up the caching part of this arbitrary `"nodeModulesDir": "auto"` project by about 22%

We write the tags associated with a given npm package to the `.initialized` file, so that byonm can correctly resolve tags. When setting up the node modules dir, we read that file to see if we need to update the tags.

If we don't have any tags associated with the package though, we can just check for existence (which is a fair bit faster than trying to `open` + `read` a file).

```
❯ hyperfine --warmup 3 "deno check src/**/*.ts" "../deno/target/release-lite/deno check src/**/*.ts"
Benchmark 1: deno check src/**/*.ts
  Time (mean ± σ):     369.9 ms ±   5.5 ms    [User: 286.9 ms, System: 128.9 ms]
  Range (min … max):   361.7 ms … 377.7 ms    10 runs

Benchmark 2: ../deno/target/release-lite/deno check src/**/*.ts
  Time (mean ± σ):     303.5 ms ±   5.9 ms    [User: 210.9 ms, System: 124.5 ms]
  Range (min … max):   292.7 ms … 315.0 ms    10 runs

Summary
  ../deno/target/release-lite/deno check src/**/*.ts ran
    1.22 ± 0.03 times faster than deno check src/**/*.ts
```