### PR TITLE
fix(fmt): support "--ext vto" and "--ext njk"

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -2281,7 +2281,7 @@ Ignore formatting a file by adding an ignore comment at the top of the file:
           .value_parser([
             "ts", "tsx", "js", "jsx", "md", "json", "jsonc", "css", "scss",
             "sass", "less", "html", "svelte", "vue", "astro", "yml", "yaml",
-            "ipynb", "sql"
+            "ipynb", "sql", "vto", "njk"
           ])
           .help_heading(FMT_HEADING).requires("files"),
       )

--- a/tests/integration/fmt_tests.rs
+++ b/tests/integration/fmt_tests.rs
@@ -288,18 +288,6 @@ itest!(fmt_stdin_ipynb {
   output_str: Some(include_str!("../testdata/fmt/badly_formatted_fixed.ipynb")),
 });
 
-itest!(fmt_stdin_vto {
-  args: "fmt --unstable-component --ext=vto -",
-  input: Some("<h1>  {{ \"Hello, world!\" |> toUpperCase }}\n  </h1>\n"),
-  output_str: Some("<h1>\n  {{ \"Hello, world!\" |> toUpperCase }}\n</h1>\n"),
-});
-
-itest!(fmt_stdin_njk {
-  args: "fmt --unstable-component --ext=njk -",
-  input: Some("<h1>  {{ \"Hello, world!\" |> upper }}\n  </h1>\n"),
-  output_str: Some("<h1>\n  {{ \"Hello, world!\" |> upper }}\n</h1>\n"),
-});
-
 itest!(fmt_stdin_check_formatted {
   args: "fmt --check -",
   input: Some("const a = 1;\n"),

--- a/tests/integration/fmt_tests.rs
+++ b/tests/integration/fmt_tests.rs
@@ -288,6 +288,18 @@ itest!(fmt_stdin_ipynb {
   output_str: Some(include_str!("../testdata/fmt/badly_formatted_fixed.ipynb")),
 });
 
+itest!(fmt_stdin_vto {
+  args: "fmt --unstable-component --ext=vto -",
+  input: Some("<h1>  {{ \"Hello, world!\" |> toUpperCase }}\n  </h1>\n"),
+  output_str: Some("<h1>\n  {{ \"Hello, world!\" |> toUpperCase }}\n</h1>\n"),
+});
+
+itest!(fmt_stdin_njk {
+  args: "fmt --unstable-component --ext=njk -",
+  input: Some("<h1>  {{ \"Hello, world!\" |> upper }}\n  </h1>\n"),
+  output_str: Some("<h1>\n  {{ \"Hello, world!\" |> upper }}\n</h1>\n"),
+});
+
 itest!(fmt_stdin_check_formatted {
   args: "fmt --check -",
   input: Some("const a = 1;\n"),

--- a/tests/specs/fmt/njk/__test__.jsonc
+++ b/tests/specs/fmt/njk/__test__.jsonc
@@ -1,5 +1,14 @@
 {
   "tempDir": true,
-  "args": "fmt --unstable-component",
-  "output": "[WILDLINE]badly_formatted.njk\nChecked 1 file\n"
+  "steps": [
+    {
+      "args": "fmt --unstable-component",
+      "output": "[WILDLINE]badly_formatted.njk\nChecked 1 file\n"
+    },
+    {
+      "args": "fmt --unstable-component --ext=njk -",
+      "input": "<h1>  {{ \"Hello, world!\" |> toUpperCase }}\n  </h1>\n",
+      "output": "<h1>\n  {{ \"Hello, world!\" |> toUpperCase }}\n</h1>\n"
+    }
+  ]
 }

--- a/tests/specs/fmt/vento/__test__.jsonc
+++ b/tests/specs/fmt/vento/__test__.jsonc
@@ -1,5 +1,14 @@
 {
   "tempDir": true,
-  "args": "fmt --unstable-component",
-  "output": "[WILDLINE]badly_formatted.vto\nChecked 1 file\n"
+  "steps": [
+    {
+      "args": "fmt --unstable-component",
+      "output": "[WILDLINE]badly_formatted.vto\nChecked 1 file\n"
+    },
+    {
+      "args": "fmt --unstable-component --ext=vto -",
+      "input": "<h1>  {{ \"Hello, world!\" |> upper }}\n  </h1>\n",
+      "output": "<h1>\n  {{ \"Hello, world!\" |> upper }}\n</h1>\n"
+    }
+  ]
 }


### PR DESCRIPTION
I can use this to rework formatting in the extension so they don't have to go through the LSP.

Towards https://github.com/denoland/vscode_deno/issues/1228.