### PR TITLE
fix(lint): plugins ignored when no rust rule active

### DIFF
--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -18,6 +18,7 @@ use deno_config::glob::FileCollector;
 use deno_config::glob::FilePatterns;
 use deno_config::workspace::WorkspaceDirectory;
 use deno_core::anyhow::anyhow;
+use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_core::futures::future::LocalBoxFuture;
 use deno_core::futures::FutureExt;
@@ -289,10 +290,14 @@ impl WorkspaceLinter {
     let exclude = lint_options.rules.exclude.clone();
 
     let plugin_specifiers = lint_options.plugins.clone();
-    let lint_rules = self.lint_rule_provider.resolve_lint_rules_err_empty(
+    let lint_rules = self.lint_rule_provider.resolve_lint_rules(
       lint_options.rules,
       member_dir.maybe_deno_json().map(|c| c.as_ref()),
-    )?;
+    );
+    if lint_rules.rules.is_empty() && plugin_specifiers.is_empty() {
+      bail!("No rules have been configured")
+    }
+
     let mut maybe_incremental_cache = None;
 
     // TODO(bartlomieju): for now we don't support incremental caching if plugins are being used.

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -294,9 +294,6 @@ impl WorkspaceLinter {
       lint_options.rules,
       member_dir.maybe_deno_json().map(|c| c.as_ref()),
     );
-    if lint_rules.rules.is_empty() && plugin_specifiers.is_empty() {
-      bail!("No rules have been configured")
-    }
 
     let mut maybe_incremental_cache = None;
 
@@ -337,6 +334,8 @@ impl WorkspaceLinter {
       )
       .await?;
       plugin_runner = Some(Arc::new(runner));
+    } else if lint_rules.rules.is_empty() {
+      bail!("No rules have been configured")
     }
 
     let linter = Arc::new(CliLinter::new(CliLinterOptions {

--- a/tests/specs/lint/lint_plugin_empty_tags/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_empty_tags/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "lint main.ts",
+      "output": "log.out"
+    }
+  ]
+}

--- a/tests/specs/lint/lint_plugin_empty_tags/deno.json
+++ b/tests/specs/lint/lint_plugin_empty_tags/deno.json
@@ -1,0 +1,9 @@
+{
+  "lint": {
+    "rules": {
+      "tags": [],
+      "include": ["test-plugin/my-rule"]
+    },
+    "plugins": ["./plugin.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_empty_tags/log.out
+++ b/tests/specs/lint/lint_plugin_empty_tags/log.out
@@ -1,0 +1,2 @@
+Plugin: Identifier
+Checked 1 file

--- a/tests/specs/lint/lint_plugin_empty_tags/main.ts
+++ b/tests/specs/lint/lint_plugin_empty_tags/main.ts
@@ -1,0 +1,1 @@
+const foo = 42;

--- a/tests/specs/lint/lint_plugin_empty_tags/plugin.ts
+++ b/tests/specs/lint/lint_plugin_empty_tags/plugin.ts
@@ -1,0 +1,14 @@
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(_context) {
+        return {
+          Identifier(node) {
+            console.log("Plugin:", node.type);
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;


### PR DESCRIPTION
When all Rust-based rules where filtered out we were bailing out early instead of checking if there are plugin rules we need to run. This meant we errored out with a "No lint rules to run" message, even though plugin rules were active.

Fixes https://github.com/denoland/deno/issues/28267