### PR TITLE
fix(lint): run with --no-prompt

### DIFF
--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -31,6 +31,7 @@ use tokio::sync::oneshot;
 use crate::args::DenoSubcommand;
 use crate::args::Flags;
 use crate::args::LintFlags;
+use crate::args::PermissionFlags;
 use crate::factory::CliFactory;
 use crate::ops::lint::LintPluginContainer;
 use crate::tools::lint::serialize_ast_to_buffer;
@@ -136,6 +137,10 @@ async fn create_plugin_runner_inner(
 ) -> Result<PluginHost, AnyError> {
   let flags = Flags {
     subcommand: DenoSubcommand::Lint(LintFlags::default()),
+    permissions: PermissionFlags {
+      no_prompt: true,
+      ..Default::default()
+    },
     ..Default::default()
   };
   let flags = Arc::new(flags);


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/28258

This commit forces lint plugins to run with `--no-prompt` flag,
bringing parity between running plugins in the LSP and via
`deno lint`.

There's no agreement how to handle permissions in the lint
plugins yet, so it's better to make both subcommands behave
identically for the time being.