### PR TITLE
feat(unstable): lint plugins support field selectors

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -792,13 +792,44 @@ class MatchCtx {
   }
 
   /**
+   * @param {number} idx
+   * @param {number} propId
+   * @returns {number}
+   */
+  getField(idx, propId) {
+    if (idx === AST_IDX_INVALID) return -1;
+
+    // Bail out on fields that can never point to another node
+    switch (propId) {
+      case AST_PROP_TYPE:
+      case AST_PROP_PARENT:
+      case AST_PROP_RANGE:
+        return -1;
+    }
+
+    const { buf } = this.ctx;
+    let offset = readPropOffset(this.ctx, idx);
+    offset = findPropOffset(buf, offset, propId);
+
+    if (offset === -1) return -1;
+    const _prop = buf[offset++];
+    const kind = buf[offset++];
+
+    if (kind === PropFlags.Ref) {
+      return readU32(buf, offset);
+    }
+
+    return -1;
+  }
+
+  /**
    * @param {number} idx - Node idx
    * @param {number[]} propIds
    * @param {number} propIdx
    * @returns {unknown}
    */
   getAttrPathValue(idx, propIds, propIdx) {
-    if (idx === 0) throw -1;
+    if (idx === AST_IDX_INVALID) throw -1;
 
     const { buf, strTable, strByType } = this.ctx;
 

--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -9,6 +9,7 @@
 /** @typedef {import("./40_lint_types.d.ts").AttrBin} AttrBin */
 /** @typedef {import("./40_lint_types.d.ts").AttrSelector} AttrSelector */
 /** @typedef {import("./40_lint_types.d.ts").ElemSelector} ElemSelector */
+/** @typedef {import("./40_lint_types.d.ts").FieldSelector} FieldSelector */
 /** @typedef {import("./40_lint_types.d.ts").PseudoNthChild} PseudoNthChild */
 /** @typedef {import("./40_lint_types.d.ts").PseudoHas} PseudoHas */
 /** @typedef {import("./40_lint_types.d.ts").PseudoNot} PseudoNot */
@@ -376,6 +377,7 @@ export const PSEUDO_HAS = 6;
 export const PSEUDO_NOT = 7;
 export const PSEUDO_FIRST_CHILD = 8;
 export const PSEUDO_LAST_CHILD = 9;
+export const FIELD_NODE = 10;
 
 /**
  * Parse out all unique selectors of a selector list.
@@ -491,6 +493,26 @@ export function parseSelector(input, toElem, toAttr) {
 
       lex.expect(Token.BracketClose);
       lex.next();
+      continue;
+    } else if (lex.token === Token.Dot) {
+      lex.next();
+      lex.expect(Token.Word);
+
+      const props = [toAttr(lex.value)];
+      lex.next();
+
+      while (lex.token === Token.Dot) {
+        lex.next();
+        lex.expect(Token.Word);
+
+        props.push(toAttr(lex.value));
+        lex.next();
+      }
+
+      current.push({
+        type: FIELD_NODE,
+        props,
+      });
       continue;
     } else if (lex.token === Token.Colon) {
       lex.next();
@@ -709,6 +731,9 @@ export function compileSelector(selector) {
     switch (node.type) {
       case ELEM_NODE:
         fn = matchElem(node, fn);
+        break;
+      case FIELD_NODE:
+        fn = matchField(node, fn);
         break;
       case RELATION_NODE:
         switch (node.op) {
@@ -957,6 +982,37 @@ function matchElem(part, next) {
     }
 
     return false;
+  };
+}
+
+/**
+ * @param {FieldSelector} part
+ * @param {MatcherFn} next
+ * @returns {MatcherFn}
+ */
+function matchField(part, next) {
+  return (ctx, id) => {
+    let child = id;
+    let parent = ctx.getParent(id);
+    if (parent === 0) return false;
+
+    // Fields are stored left-ro-right but we need to match
+    // them right-to-left.
+    for (let i = part.props.length - 1; i >= 0; i--) {
+      const prop = part.props[i];
+      const value = ctx.getField(parent, prop);
+
+      if (value === -1) return false;
+      if (value !== child) return false;
+
+      if (i > 0) {
+        child = parent;
+        parent = ctx.getParent(parent);
+        if (parent === 0) return false;
+      }
+    }
+
+    return next(ctx, parent);
   };
 }
 

--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -997,7 +997,9 @@ function matchField(part, next) {
     if (parent === 0) return false;
 
     // Fields are stored left-ro-right but we need to match
-    // them right-to-left.
+    // them right-to-left because we're matching selectors
+    // in that direction. Matching right to left is done for
+    // performance and reduces the number of potential mismatches.
     for (let i = part.props.length - 1; i >= 0; i--) {
       const prop = part.props[i];
       const value = ctx.getField(parent, prop);

--- a/cli/js/40_lint_types.d.ts
+++ b/cli/js/40_lint_types.d.ts
@@ -50,6 +50,11 @@ export interface ElemSelector {
   elem: number;
 }
 
+export interface FieldSelector {
+  type: 10;
+  props: number[];
+}
+
 export interface PseudoNthChild {
   type: 5;
   op: string | null;
@@ -81,6 +86,7 @@ export interface Relation {
 
 export type Selector = Array<
   | ElemSelector
+  | FieldSelector
   | Relation
   | AttrExists
   | AttrBin
@@ -101,6 +107,7 @@ export interface MatchContext {
   getLastChild(id: number): number;
   getSiblings(id: number): number[];
   getParent(id: number): number;
+  getField(id: number, prop: number): number;
   getType(id: number): number;
   getAttrPathValue(id: number, propIds: number[], idx: number): unknown;
 }

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -177,6 +177,29 @@ Deno.test("Plugin - visitor subsequent sibling", () => {
   assertEquals(result.map((r) => r.node.name), ["bar", "baz"]);
 });
 
+Deno.test("Plugin - visitor field", () => {
+  let result = testVisit(
+    "if (foo()) {}",
+    "IfStatement.test.callee",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "foo");
+
+  result = testVisit(
+    "if (foo()) {}",
+    "IfStatement .test .callee",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "foo");
+
+  result = testVisit(
+    "if (foo(bar())) {}",
+    "IfStatement.test CallExpression.callee",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "bar");
+});
+
 Deno.test("Plugin - visitor attr", () => {
   let result = testVisit(
     "for (const a of b) {}",

--- a/tests/unit/lint_selectors_test.ts
+++ b/tests/unit/lint_selectors_test.ts
@@ -6,6 +6,7 @@ import {
   ATTR_EXISTS_NODE,
   BinOp,
   ELEM_NODE,
+  FIELD_NODE,
   Lexer,
   parseSelector,
   PSEUDO_FIRST_CHILD,
@@ -255,6 +256,19 @@ Deno.test("Lexer - Pseudo", () => {
   ]);
 });
 
+Deno.test("Lexer - field", () => {
+  assertEquals(testLexer(".bar"), [
+    { token: Token.Dot, value: "" },
+    { token: Token.Word, value: "bar" },
+  ]);
+  assertEquals(testLexer(".bar.baz"), [
+    { token: Token.Dot, value: "" },
+    { token: Token.Word, value: "bar" },
+    { token: Token.Dot, value: "" },
+    { token: Token.Word, value: "baz" },
+  ]);
+});
+
 Deno.test("Parser - Elem", () => {
   assertEquals(testParse("Foo"), [[
     {
@@ -334,6 +348,33 @@ Deno.test("Parser - Relation", () => {
       elem: 2,
       wildcard: false,
     },
+  ]]);
+});
+
+Deno.test("Parser - Field", () => {
+  assertEquals(testParse("Foo.bar"), [[
+    {
+      type: ELEM_NODE,
+      elem: 1,
+      wildcard: false,
+    },
+    { type: FIELD_NODE, props: [2] },
+  ]]);
+  assertEquals(testParse("Foo .bar"), [[
+    {
+      type: ELEM_NODE,
+      elem: 1,
+      wildcard: false,
+    },
+    { type: FIELD_NODE, props: [2] },
+  ]]);
+  assertEquals(testParse("Foo .foo.bar"), [[
+    {
+      type: ELEM_NODE,
+      elem: 1,
+      wildcard: false,
+    },
+    { type: FIELD_NODE, props: [1, 2] },
   ]]);
 });
 


### PR DESCRIPTION
This PR adds support for field selectors (`.<field>`) in the lint plugin API. This is supported in ESLint as well, but was missing in our implementation.

```css
/* Only search the test expression of an IfStatement */
IfStatement.test
```

Fixes https://github.com/denoland/deno/issues/28314