### PR TITLE
fix(unstable): lint plugin regex attribute selector not working

### DIFF
--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -1008,9 +1008,13 @@ function matchAttrBin(attr, next) {
 function matchAttrValue(attr, value) {
   switch (attr.op) {
     case BinOp.Equal:
-      return value === attr.value;
+      return attr.value instanceof RegExp
+        ? attr.value.test(value)
+        : value === attr.value;
     case BinOp.NotEqual:
-      return value !== attr.value;
+      return attr.value instanceof RegExp
+        ? !attr.value.test(value)
+        : value !== attr.value;
     case BinOp.Greater:
       return typeof value === "number" && typeof attr.value === "number" &&
         value > attr.value;

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -271,6 +271,22 @@ Deno.test("Plugin - visitor attr length special case", () => {
   assertEquals(result[1].node.arguments.length, 2);
 });
 
+Deno.test("Plugin - visitor attr regex", () => {
+  let result = testVisit(
+    "class Foo { get foo() { return 1 } bar() {} }",
+    "MethodDefinition[kind=/(g|s)et/]",
+  );
+  assertEquals(result[0].node.type, "MethodDefinition");
+  assertEquals(result[0].node.kind, "get");
+
+  result = testVisit(
+    "class Foo { get foo() { return 1 } bar() {} }",
+    "MethodDefinition[kind!=/(g|s)et/]",
+  );
+  assertEquals(result[0].node.type, "MethodDefinition");
+  assertEquals(result[0].node.kind, "method");
+});
+
 Deno.test("Plugin - visitor :first-child", () => {
   const result = testVisit(
     "{ foo; bar }",


### PR DESCRIPTION
The code to support regex matching on attribute values was already there. I just forgot to wire it up properly in the selector matching code.

Fixes https://github.com/denoland/deno/issues/28336