### PR TITLE
fix(unstable/lint): remove duplicated `Fix` vs `FixData` interface

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -16,7 +16,9 @@ const {
   op_is_cancelled,
 } = core.ops;
 
+/** @type {(id: string, message: string, hint: string | undefined, start: number, end: number, fix: Deno.lint.Fix[]) => void} */
 let doReport = op_lint_report;
+/** @type {() => string} */
 let doGetSource = op_lint_get_source;
 
 // Keep these in sync with Rust
@@ -315,7 +317,7 @@ export class Context {
     const start = range[0];
     const end = range[1];
 
-    /** @type {Deno.lint.FixData[]} */
+    /** @type {Deno.lint.Fix[]} */
     const fixes = [];
 
     if (typeof data.fix === "function") {
@@ -1349,13 +1351,14 @@ internals.runPluginsForFile = runPluginsForFile;
 internals.resetState = resetState;
 
 /**
- * @param {LintPlugin} plugin
+ * @param {Deno.lint.Plugin} plugin
  * @param {string} fileName
  * @param {string} sourceText
  */
 function runLintPlugin(plugin, fileName, sourceText) {
   installPlugin(plugin);
 
+  /** @type {Deno.lint.Diagnostic[]} */
   const diagnostics = [];
   doReport = (id, message, hint, start, end, fix) => {
     diagnostics.push({

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1359,7 +1359,7 @@ declare namespace Deno {
      * @category Linter
      * @experimental
      */
-    export interface FixData {
+    export interface Fix {
       range: Range;
       text?: string;
     }
@@ -1369,14 +1369,14 @@ declare namespace Deno {
      * @experimental
      */
     export interface Fixer {
-      insertTextAfter(node: Node, text: string): FixData;
-      insertTextAfterRange(range: Range, text: string): FixData;
-      insertTextBefore(node: Node, text: string): FixData;
-      insertTextBeforeRange(range: Range, text: string): FixData;
-      remove(node: Node): FixData;
-      removeRange(range: Range): FixData;
-      replaceText(node: Node, text: string): FixData;
-      replaceTextRange(range: Range, text: string): FixData;
+      insertTextAfter(node: Node, text: string): Fix;
+      insertTextAfterRange(range: Range, text: string): Fix;
+      insertTextBefore(node: Node, text: string): Fix;
+      insertTextBeforeRange(range: Range, text: string): Fix;
+      remove(node: Node): Fix;
+      removeRange(range: Range): Fix;
+      replaceText(node: Node, text: string): Fix;
+      replaceTextRange(range: Range, text: string): Fix;
     }
 
     /**
@@ -1388,7 +1388,7 @@ declare namespace Deno {
       range?: Range;
       message: string;
       hint?: string;
-      fix?(fixer: Fixer): FixData | Iterable<FixData>;
+      fix?(fixer: Fixer): Fix | Iterable<Fix>;
     }
 
     /**
@@ -1502,21 +1502,12 @@ declare namespace Deno {
      * @category Linter
      * @experimental
      */
-    export interface Fix {
-      range: Range;
-      text?: string;
-    }
-
-    /**
-     * @category Linter
-     * @experimental
-     */
     export interface Diagnostic {
       id: string;
       message: string;
       hint?: string;
       range: Range;
-      fix?: Fix;
+      fix?: Fix[];
     }
 
     /**


### PR DESCRIPTION
Noticed that we have two interfaces describing the same thing: `Fix` and `FixData`. This PR removes the `FixData` one.