### PR TITLE
fix(unstable): lint plugin fix `:has()`, `:is/where/matches` and `:not()` selectors

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -961,7 +961,7 @@ class MatchCtx {
   }
 
   /**
-   * Used for `:has/:is/:where` and `:not`
+   * Used for `:has()` and `:not()`
    * @param {MatcherFn[]} selectors
    * @param {number} idx
    * @returns {boolean}

--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -82,6 +82,7 @@ const PropFlags = {
 /** @typedef {import("./40_lint_types.d.ts").LintState} LintState */
 /** @typedef {import("./40_lint_types.d.ts").TransformFn} TransformFn */
 /** @typedef {import("./40_lint_types.d.ts").MatchContext} MatchContext */
+/** @typedef {import("./40_lint_types.d.ts").MatcherFn} MatcherFn */
 
 /** @type {LintState} */
 const state = {
@@ -770,11 +771,15 @@ function getString(strTable, id) {
 
 /** @implements {MatchContext} */
 class MatchCtx {
+  parentLimitIdx = 0;
+
   /**
    * @param {AstContext} ctx
+   * @param {CancellationToken} cancellationToken
    */
-  constructor(ctx) {
+  constructor(ctx, cancellationToken) {
     this.ctx = ctx;
+    this.cancellationToken = cancellationToken;
   }
 
   /**
@@ -782,6 +787,7 @@ class MatchCtx {
    * @returns {number}
    */
   getParent(idx) {
+    if (idx === this.parentLimitIdx) return AST_IDX_INVALID;
     const parent = readParent(this.ctx.buf, idx);
 
     const parentType = readType(this.ctx.buf, parent);
@@ -953,13 +959,32 @@ class MatchCtx {
 
     return out;
   }
+
+  /**
+   * Used for `:has/:is/:where` and `:not`
+   * TODO: Optimize this
+   * @param {MatcherFn[]} selectors
+   * @param {number} idx
+   * @returns {boolean}
+   */
+  subSelect(selectors, idx) {
+    const prevLimit = this.parentLimitIdx;
+    this.parentLimitIdx = idx;
+
+    try {
+      return subTraverse(this.ctx, selectors, idx, idx, this.cancellationToken);
+    } finally {
+      this.parentLimitIdx = prevLimit;
+    }
+  }
 }
 
 /**
  * @param {Uint8Array} buf
+ * @param {CancellationToken} token
  * @returns {AstContext}
  */
-function createAstContext(buf) {
+function createAstContext(buf, token) {
   /** @type {Map<number, string>} */
   const strTable = new Map();
 
@@ -1039,7 +1064,7 @@ function createAstContext(buf) {
     propByStr,
     matcher: /** @type {*} */ (null),
   };
-  ctx.matcher = new MatchCtx(ctx);
+  ctx.matcher = new MatchCtx(ctx, token);
 
   setNodeGetters(ctx);
 
@@ -1060,7 +1085,8 @@ const NOOP = (_node) => {};
  * @param {Uint8Array} serializedAst
  */
 export function runPluginsForFile(fileName, serializedAst) {
-  const ctx = createAstContext(serializedAst);
+  const token = new CancellationToken();
+  const ctx = createAstContext(serializedAst, token);
 
   /** @type {Map<string, CompiledVisitor["info"]>}>} */
   const bySelector = new Map();
@@ -1169,7 +1195,6 @@ export function runPluginsForFile(fileName, serializedAst) {
     visitors.push({ info, matcher });
   }
 
-  const token = new CancellationToken();
   // Traverse ast with all visitors at the same time to avoid traversing
   // multiple times.
   try {
@@ -1191,11 +1216,12 @@ export function runPluginsForFile(fileName, serializedAst) {
  * @param {CancellationToken} cancellationToken
  */
 function traverse(ctx, visitors, idx, cancellationToken) {
+  const { buf } = ctx;
+
   while (idx !== AST_IDX_INVALID) {
     if (cancellationToken.isCancellationRequested()) return;
 
-    const { buf } = ctx;
-    const nodeType = readType(ctx.buf, idx);
+    const nodeType = readType(buf, idx);
 
     /** @type {VisitorFn[] | null} */
     let exits = null;
@@ -1238,6 +1264,51 @@ function traverse(ctx, visitors, idx, cancellationToken) {
 
     idx = readNext(buf, idx);
   }
+}
+
+/**
+ * Used for subqueries in `:has()` and `:not()`
+ * @param {AstContext} ctx
+ * @param {MatcherFn[]} selectors
+ * @param {number} rootIdx
+ * @param {number} idx
+ * @param {CancellationToken} cancellationToken
+ * @returns {boolean}
+ */
+function subTraverse(ctx, selectors, rootIdx, idx, cancellationToken) {
+  const { buf } = ctx;
+
+  while (idx > AST_IDX_INVALID) {
+    if (cancellationToken.isCancellationRequested()) return false;
+
+    const nodeType = readType(buf, idx);
+
+    if (nodeType !== AST_GROUP_TYPE) {
+      for (let i = 0; i < selectors.length; i++) {
+        const sel = selectors[i];
+
+        if (sel(ctx.matcher, idx)) {
+          return true;
+        }
+      }
+    }
+
+    const childIdx = readChild(buf, idx);
+    if (
+      childIdx > AST_IDX_INVALID &&
+      subTraverse(ctx, selectors, rootIdx, childIdx, cancellationToken)
+    ) {
+      return true;
+    }
+
+    if (idx === rootIdx) {
+      break;
+    }
+
+    idx = readNext(buf, idx);
+  }
+
+  return false;
 }
 
 /**

--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -962,7 +962,6 @@ class MatchCtx {
 
   /**
    * Used for `:has/:is/:where` and `:not`
-   * TODO: Optimize this
    * @param {MatcherFn[]} selectors
    * @param {number} idx
    * @returns {boolean}

--- a/cli/js/40_lint_types.d.ts
+++ b/cli/js/40_lint_types.d.ts
@@ -25,7 +25,7 @@ export interface LintState {
 export type VisitorFn = (node: unknown) => void;
 
 export interface CompiledVisitor {
-  matcher: (ctx: MatchContext, offset: number) => boolean;
+  matcher: MatcherFn;
   info: { enter: VisitorFn; exit: VisitorFn };
 }
 
@@ -103,6 +103,8 @@ export interface SelectorParseCtx {
 }
 
 export interface MatchContext {
+  /** Used for `:has()` and `:not()` */
+  subSelect(selectors: MatcherFn[], idx: number): boolean;
   getFirstChild(id: number): number;
   getLastChild(id: number): number;
   getSiblings(id: number): number[];
@@ -112,7 +114,6 @@ export interface MatchContext {
   getAttrPathValue(id: number, propIds: number[], idx: number): unknown;
 }
 
-export type NextFn = (ctx: MatchContext, id: number) => boolean;
 export type MatcherFn = (ctx: MatchContext, id: number) => boolean;
 export type TransformFn = (value: string) => number;
 

--- a/cli/js/40_lint_types.d.ts
+++ b/cli/js/40_lint_types.d.ts
@@ -68,6 +68,10 @@ export interface PseudoHas {
   type: 6;
   selectors: Selector[];
 }
+export interface PseudoIs {
+  type: 11;
+  selectors: Selector[];
+}
 export interface PseudoNot {
   type: 7;
   selectors: Selector[];
@@ -93,6 +97,7 @@ export type Selector = Array<
   | PseudoNthChild
   | PseudoNot
   | PseudoHas
+  | PseudoIs
   | PseudoFirstChild
   | PseudoLastChild
 >;

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -361,22 +361,10 @@ Deno.test("Plugin - visitor :nth-child", () => {
   assertEquals(result[1].node.name, "foobar");
 });
 
-Deno.test("Plugin - visitor :has/:is/:where", () => {
+Deno.test("Plugin - visitor :has()", () => {
   let result = testVisit(
     "{ foo, bar }",
     "BlockStatement:has(Identifier[name='bar'])",
-  );
-  assertEquals(result[0].node.type, "BlockStatement");
-
-  result = testVisit(
-    "{ foo, bar }",
-    "BlockStatement:is(Identifier[name='bar'])",
-  );
-  assertEquals(result[0].node.type, "BlockStatement");
-
-  result = testVisit(
-    "{ foo, bar }",
-    "BlockStatement:where(Identifier[name='bar'])",
   );
   assertEquals(result[0].node.type, "BlockStatement");
 
@@ -398,6 +386,29 @@ Deno.test("Plugin - visitor :has/:is/:where", () => {
   result = testVisit(
     "{ foo, bar }",
     "Identifier:has([name='bar'])",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "bar");
+});
+
+Deno.test("Plugin - visitor :is()/:where()/:matches()", () => {
+  let result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement :is(Identifier[name='bar'])",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "bar");
+
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement :where(Identifier[name='bar'])",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "bar");
+
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement :matches(Identifier[name='bar'])",
   );
   assertEquals(result[0].node.type, "Identifier");
   assertEquals(result[0].node.name, "bar");

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -361,6 +361,78 @@ Deno.test("Plugin - visitor :nth-child", () => {
   assertEquals(result[1].node.name, "foobar");
 });
 
+Deno.test("Plugin - visitor :has/:is/:where", () => {
+  let result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:has(Identifier[name='bar'])",
+  );
+  assertEquals(result[0].node.type, "BlockStatement");
+
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:is(Identifier[name='bar'])",
+  );
+  assertEquals(result[0].node.type, "BlockStatement");
+
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:where(Identifier[name='bar'])",
+  );
+  assertEquals(result[0].node.type, "BlockStatement");
+
+  // Multiple sub queries
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:has(CallExpression, Identifier[name='bar'])",
+  );
+  assertEquals(result[0].node.type, "BlockStatement");
+
+  // This should not match
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:has(CallExpression, Identifier[name='baz'])",
+  );
+  assertEquals(result, []);
+
+  // Attr match
+  result = testVisit(
+    "{ foo, bar }",
+    "Identifier:has([name='bar'])",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "bar");
+});
+
+Deno.test("Plugin - visitor :not", () => {
+  let result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:not(Identifier[name='baz'])",
+  );
+  assertEquals(result[0].node.type, "BlockStatement");
+
+  // Multiple sub queries
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:not(Identifier[name='baz'], CallExpression)",
+  );
+  assertEquals(result[0].node.type, "BlockStatement");
+
+  // This should not match
+  result = testVisit(
+    "{ foo, bar }",
+    "BlockStatement:not(CallExpression, Identifier)",
+  );
+  assertEquals(result, []);
+
+  // Attr match
+  result = testVisit(
+    "{ foo, bar }",
+    "Identifier:not([name='foo'])",
+  );
+  assertEquals(result[0].node.type, "Identifier");
+  assertEquals(result[0].node.name, "bar");
+});
+
 Deno.test("Plugin - Program", async (t) => {
   await testSnapshot(t, "", "Program");
 });

--- a/tests/unit/lint_selectors_test.ts
+++ b/tests/unit/lint_selectors_test.ts
@@ -11,6 +11,7 @@ import {
   parseSelector,
   PSEUDO_FIRST_CHILD,
   PSEUDO_HAS,
+  PSEUDO_IS,
   PSEUDO_LAST_CHILD,
   PSEUDO_NOT,
   PSEUDO_NTH_CHILD,
@@ -554,7 +555,7 @@ Deno.test("Parser - Pseudo nth-child", () => {
   assertThrows(() => testParse(":nth-child(2n - 1 foo)"));
 });
 
-Deno.test("Parser - Pseudo has/is/where", () => {
+Deno.test("Parser - Pseudo :has()", () => {
   assertEquals(testParse(":has(Foo:has(Foo), Bar)"), [[
     {
       type: PSEUDO_HAS,
@@ -574,14 +575,17 @@ Deno.test("Parser - Pseudo has/is/where", () => {
       ],
     },
   ]]);
-  assertEquals(testParse(":where(Foo:where(Foo), Bar)"), [[
+});
+
+Deno.test("Parser - Pseudo :is()/:where()/:matches()", () => {
+  assertEquals(testParse(":is(Foo:is(Foo), Bar)"), [[
     {
-      type: PSEUDO_HAS,
+      type: PSEUDO_IS,
       selectors: [
         [
           { type: ELEM_NODE, elem: 1, wildcard: false },
           {
-            type: PSEUDO_HAS,
+            type: PSEUDO_IS,
             selectors: [
               [{ type: ELEM_NODE, elem: 1, wildcard: false }],
             ],
@@ -593,19 +597,63 @@ Deno.test("Parser - Pseudo has/is/where", () => {
       ],
     },
   ]]);
-  assertEquals(testParse(":is(Foo:is(Foo), Bar)"), [[
+  assertEquals(testParse(":where(Foo:where(Foo), Bar)"), [[
     {
-      type: PSEUDO_HAS,
+      type: PSEUDO_IS,
       selectors: [
         [
           { type: ELEM_NODE, elem: 1, wildcard: false },
           {
-            type: PSEUDO_HAS,
+            type: PSEUDO_IS,
             selectors: [
               [{ type: ELEM_NODE, elem: 1, wildcard: false }],
             ],
           },
         ],
+        [
+          { type: ELEM_NODE, elem: 2, wildcard: false },
+        ],
+      ],
+    },
+  ]]);
+  assertEquals(testParse(":matches(Foo:matches(Foo), Bar)"), [[
+    {
+      type: PSEUDO_IS,
+      selectors: [
+        [
+          { type: ELEM_NODE, elem: 1, wildcard: false },
+          {
+            type: PSEUDO_IS,
+            selectors: [
+              [{ type: ELEM_NODE, elem: 1, wildcard: false }],
+            ],
+          },
+        ],
+        [
+          { type: ELEM_NODE, elem: 2, wildcard: false },
+        ],
+      ],
+    },
+  ]]);
+
+  assertEquals(testParse("Foo:is(Bar)"), [[
+    { type: ELEM_NODE, elem: 1, wildcard: false },
+    {
+      type: PSEUDO_IS,
+      selectors: [
+        [
+          { type: ELEM_NODE, elem: 2, wildcard: false },
+        ],
+      ],
+    },
+  ]]);
+
+  assertEquals(testParse("Foo :is(Bar)"), [[
+    { type: ELEM_NODE, elem: 1, wildcard: false },
+    { type: RELATION_NODE, op: BinOp.Space },
+    {
+      type: PSEUDO_IS,
+      selectors: [
         [
           { type: ELEM_NODE, elem: 2, wildcard: false },
         ],


### PR DESCRIPTION
This PR adds support for `:has/:is/:where()` and `:not()`. The latter was already present, but found a bunch of issues with it and I'd say that it didn't really work before this PR.


Fixes https://github.com/denoland/deno/issues/28335