### PR TITLE
fix(unstable): lint plugin swapped exported and source for ExportAllDeclaration

### DIFF
--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -213,8 +213,12 @@ fn serialize_module_decl(
         ctx.write_export_all_decl(
           &node.span,
           node.type_only,
-          exported,
-          source,
+          // Namespaced export must always have a source, so this
+          // scenario where it's optional can't happen. I think
+          // it's just the way SWC stores things internally, since they
+          // don't have a dedicated node for namespace exports.
+          source.unwrap_or(NodeRef(0)),
+          Some(exported),
           attrs,
         )
       } else {

--- a/tests/unit/__snapshots__/lint_plugin_test.ts.snap
+++ b/tests/unit/__snapshots__/lint_plugin_test.ts.snap
@@ -676,19 +676,6 @@ snapshot[`Plugin - ExportAllDeclaration 2`] = `
   attributes: [],
   exportKind: "value",
   exported: {
-    range: [
-      21,
-      26,
-    ],
-    raw: '"foo"',
-    type: "Literal",
-    value: "foo",
-  },
-  range: [
-    0,
-    27,
-  ],
-  source: {
     name: "foo",
     optional: false,
     range: [
@@ -697,6 +684,19 @@ snapshot[`Plugin - ExportAllDeclaration 2`] = `
     ],
     type: "Identifier",
     typeAnnotation: undefined,
+  },
+  range: [
+    0,
+    27,
+  ],
+  source: {
+    range: [
+      21,
+      26,
+    ],
+    raw: '"foo"',
+    type: "Literal",
+    value: "foo",
   },
   type: "ExportAllDeclaration",
 }


### PR DESCRIPTION
The `source` and `exported` property were swapped for the `ExportAllDeclaration` node.

Fixes one issue reported at https://github.com/denoland/deno/issues/28355