### PR TITLE
fix(unstable): Missing `PrivateIdentifier` type for `PropertyDefinition` key

### DIFF
--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -1946,7 +1946,12 @@ declare namespace Deno {
       static: boolean;
       accessibility: Accessibility | undefined;
       decorators: Decorator[];
-      key: Expression | Identifier | NumberLiteral | StringLiteral;
+      key:
+        | Expression
+        | Identifier
+        | NumberLiteral
+        | StringLiteral
+        | PrivateIdentifier;
       value: Expression | null;
       typeAnnotation: TSTypeAnnotation | undefined;
     }


### PR DESCRIPTION
The `PropertyDefinition` node also allows `PrivateIdentifier` as a type for the `key`. Example:

```ts
class Foo {
  #foo = 2;
}
```

Fixes one issue reported in https://github.com/denoland/deno/issues/28355