### PR TITLE
fix(unstable): lint plugin `ObjectPattern` inconsistencies

### DIFF
--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -1896,14 +1896,18 @@ fn serialize_pat(ctx: &mut TsEsTreeBuilder, pat: &Pat) -> NodeRef {
           ObjectPatProp::Assign(assign_pat_prop) => {
             let ident = serialize_binding_ident(ctx, &assign_pat_prop.key);
 
-            let value = assign_pat_prop
-              .value
-              .as_ref()
-              .map_or(NodeRef(0), |value| serialize_expr(ctx, value));
+            let shorthand = assign_pat_prop.value.is_none();
+            let value = assign_pat_prop.value.as_ref().map_or(
+              // SWC has value as optional with shorthand properties,
+              // but TSESTree expects the value to be a duplicate of
+              // the binding ident.
+              serialize_binding_ident(ctx, &assign_pat_prop.key),
+              |value| serialize_expr(ctx, value),
+            );
 
             ctx.write_property(
               &assign_pat_prop.span,
-              false,
+              shorthand,
               false,
               false,
               PropertyKind::Init,

--- a/tests/unit/__snapshots__/lint_plugin_test.ts.snap
+++ b/tests/unit/__snapshots__/lint_plugin_test.ts.snap
@@ -12,6 +12,561 @@ snapshot[`Plugin - Program 1`] = `
 }
 `;
 
+snapshot[`Plugin - FunctionDeclaration 1`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      15,
+      17,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: false,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      9,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [],
+  range: [
+    0,
+    17,
+  ],
+  returnType: undefined,
+  type: "FunctionDeclaration",
+  typeParameters: undefined,
+}
+`;
+
+snapshot[`Plugin - FunctionDeclaration 2`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      22,
+      24,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: false,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      9,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        13,
+        14,
+      ],
+      type: "Identifier",
+      typeAnnotation: undefined,
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          19,
+          20,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        16,
+        20,
+      ],
+      type: "RestElement",
+      typeAnnotation: undefined,
+    },
+  ],
+  range: [
+    0,
+    24,
+  ],
+  returnType: undefined,
+  type: "FunctionDeclaration",
+  typeParameters: undefined,
+}
+`;
+
+snapshot[`Plugin - FunctionDeclaration 3`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      56,
+      58,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: false,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      9,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [
+    {
+      left: {
+        name: "a",
+        optional: false,
+        range: [
+          13,
+          14,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        13,
+        18,
+      ],
+      right: {
+        range: [
+          17,
+          18,
+        ],
+        raw: "1",
+        type: "Literal",
+        value: 1,
+      },
+      type: "AssignmentPattern",
+    },
+    {
+      optional: false,
+      properties: [
+        {
+          computed: false,
+          key: {
+            name: "a",
+            optional: false,
+            range: [
+              22,
+              23,
+            ],
+            type: "Identifier",
+            typeAnnotation: undefined,
+          },
+          kind: "init",
+          method: false,
+          range: [
+            22,
+            27,
+          ],
+          shorthand: false,
+          type: "Property",
+          value: {
+            range: [
+              26,
+              27,
+            ],
+            raw: "2",
+            type: "Literal",
+            value: 2,
+          },
+        },
+        {
+          computed: false,
+          key: {
+            name: "b",
+            optional: false,
+            range: [
+              29,
+              30,
+            ],
+            type: "Identifier",
+            typeAnnotation: undefined,
+          },
+          kind: "init",
+          method: false,
+          range: [
+            29,
+            30,
+          ],
+          shorthand: true,
+          type: "Property",
+          value: {
+            name: "b",
+            optional: false,
+            range: [
+              29,
+              30,
+            ],
+            type: "Identifier",
+            typeAnnotation: undefined,
+          },
+        },
+        {
+          argument: {
+            name: "c",
+            optional: false,
+            range: [
+              35,
+              36,
+            ],
+            type: "Identifier",
+            typeAnnotation: undefined,
+          },
+          range: [
+            32,
+            36,
+          ],
+          type: "RestElement",
+          typeAnnotation: undefined,
+        },
+      ],
+      range: [
+        20,
+        38,
+      ],
+      type: "ObjectPattern",
+      typeAnnotation: undefined,
+    },
+    {
+      elements: [
+        {
+          name: "d",
+          optional: false,
+          range: [
+            41,
+            42,
+          ],
+          type: "Identifier",
+          typeAnnotation: undefined,
+        },
+        {
+          argument: {
+            name: "e",
+            optional: false,
+            range: [
+              46,
+              47,
+            ],
+            type: "Identifier",
+            typeAnnotation: undefined,
+          },
+          range: [
+            43,
+            47,
+          ],
+          type: "RestElement",
+          typeAnnotation: undefined,
+        },
+      ],
+      optional: false,
+      range: [
+        40,
+        48,
+      ],
+      type: "ArrayPattern",
+      typeAnnotation: undefined,
+    },
+    {
+      argument: {
+        name: "f",
+        optional: false,
+        range: [
+          53,
+          54,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        50,
+        54,
+      ],
+      type: "RestElement",
+      typeAnnotation: undefined,
+    },
+  ],
+  range: [
+    0,
+    58,
+  ],
+  returnType: undefined,
+  type: "FunctionDeclaration",
+  typeParameters: undefined,
+}
+`;
+
+snapshot[`Plugin - FunctionDeclaration 4`] = `
+{
+  async: true,
+  body: {
+    body: [],
+    range: [
+      21,
+      23,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: false,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      15,
+      18,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [],
+  range: [
+    0,
+    23,
+  ],
+  returnType: undefined,
+  type: "FunctionDeclaration",
+  typeParameters: undefined,
+}
+`;
+
+snapshot[`Plugin - FunctionDeclaration 5`] = `
+{
+  async: true,
+  body: {
+    body: [],
+    range: [
+      22,
+      24,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: true,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      16,
+      19,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [],
+  range: [
+    0,
+    24,
+  ],
+  returnType: undefined,
+  type: "FunctionDeclaration",
+  typeParameters: undefined,
+}
+`;
+
+snapshot[`Plugin - FunctionDeclaration 6`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      16,
+      18,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: true,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      10,
+      13,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [],
+  range: [
+    0,
+    18,
+  ],
+  returnType: undefined,
+  type: "FunctionDeclaration",
+  typeParameters: undefined,
+}
+`;
+
+snapshot[`Plugin - FunctionDeclaration 7`] = `
+{
+  async: false,
+  body: {
+    body: [],
+    range: [
+      41,
+      43,
+    ],
+    type: "BlockStatement",
+  },
+  declare: false,
+  generator: false,
+  id: {
+    name: "foo",
+    optional: false,
+    range: [
+      9,
+      12,
+    ],
+    type: "Identifier",
+    typeAnnotation: undefined,
+  },
+  params: [
+    {
+      name: "a",
+      optional: true,
+      range: [
+        16,
+        17,
+      ],
+      type: "Identifier",
+      typeAnnotation: {
+        range: [
+          18,
+          21,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          literal: {
+            range: [
+              20,
+              21,
+            ],
+            raw: "2",
+            type: "Literal",
+            value: 2,
+          },
+          range: [
+            20,
+            21,
+          ],
+          type: "TSLiteralType",
+        },
+      },
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          26,
+          27,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        23,
+        34,
+      ],
+      type: "RestElement",
+      typeAnnotation: {
+        range: [
+          27,
+          34,
+        ],
+        type: "TSTypeAnnotation",
+        typeAnnotation: {
+          elementType: {
+            range: [
+              29,
+              32,
+            ],
+            type: "TSAnyKeyword",
+          },
+          range: [
+            29,
+            34,
+          ],
+          type: "TSArrayType",
+        },
+      },
+    },
+  ],
+  range: [
+    0,
+    43,
+  ],
+  returnType: {
+    range: [
+      35,
+      40,
+    ],
+    type: "TSTypeAnnotation",
+    typeAnnotation: {
+      range: [
+        37,
+        40,
+      ],
+      type: "TSAnyKeyword",
+    },
+  },
+  type: "FunctionDeclaration",
+  typeParameters: {
+    params: [
+      {
+        const: false,
+        constraint: null,
+        default: null,
+        in: false,
+        name: {
+          name: "T",
+          optional: false,
+          range: [
+            13,
+            14,
+          ],
+          type: "Identifier",
+          typeAnnotation: undefined,
+        },
+        out: false,
+        range: [
+          13,
+          14,
+        ],
+        type: "TSTypeParameter",
+      },
+    ],
+    range: [
+      12,
+      15,
+    ],
+    type: "TSTypeParameterDeclaration",
+  },
+}
+`;
+
 snapshot[`Plugin - ImportDeclaration 1`] = `
 {
   attributes: [],
@@ -4874,6 +5429,362 @@ snapshot[`Plugin - YieldExpression 1`] = `
     27,
   ],
   type: "YieldExpression",
+}
+`;
+
+snapshot[`Plugin - ObjectPattern 1`] = `
+{
+  optional: false,
+  properties: [
+    {
+      computed: false,
+      key: {
+        name: "prop",
+        optional: false,
+        range: [
+          8,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        8,
+        12,
+      ],
+      shorthand: true,
+      type: "Property",
+      value: {
+        name: "prop",
+        optional: false,
+        range: [
+          8,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+    },
+  ],
+  range: [
+    6,
+    14,
+  ],
+  type: "ObjectPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ObjectPattern 2`] = `
+{
+  optional: false,
+  properties: [
+    {
+      computed: false,
+      key: {
+        name: "prop",
+        optional: false,
+        range: [
+          8,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        8,
+        15,
+      ],
+      shorthand: false,
+      type: "Property",
+      value: {
+        name: "A",
+        optional: false,
+        range: [
+          14,
+          15,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+    },
+  ],
+  range: [
+    6,
+    17,
+  ],
+  type: "ObjectPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ObjectPattern 3`] = `
+{
+  optional: false,
+  properties: [
+    {
+      computed: false,
+      key: {
+        range: [
+          8,
+          13,
+        ],
+        raw: "'a.b'",
+        type: "Literal",
+        value: "a.b",
+      },
+      kind: "init",
+      method: false,
+      range: [
+        8,
+        16,
+      ],
+      shorthand: false,
+      type: "Property",
+      value: {
+        name: "A",
+        optional: false,
+        range: [
+          15,
+          16,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+    },
+  ],
+  range: [
+    6,
+    18,
+  ],
+  type: "ObjectPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ObjectPattern 4`] = `
+{
+  optional: false,
+  properties: [
+    {
+      computed: false,
+      key: {
+        name: "prop",
+        optional: false,
+        range: [
+          8,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        8,
+        16,
+      ],
+      shorthand: false,
+      type: "Property",
+      value: {
+        range: [
+          15,
+          16,
+        ],
+        raw: "2",
+        type: "Literal",
+        value: 2,
+      },
+    },
+  ],
+  range: [
+    6,
+    18,
+  ],
+  type: "ObjectPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ObjectPattern 5`] = `
+{
+  optional: false,
+  properties: [
+    {
+      computed: false,
+      key: {
+        name: "prop",
+        optional: false,
+        range: [
+          8,
+          12,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      kind: "init",
+      method: false,
+      range: [
+        8,
+        16,
+      ],
+      shorthand: false,
+      type: "Property",
+      value: {
+        range: [
+          15,
+          16,
+        ],
+        raw: "2",
+        type: "Literal",
+        value: 2,
+      },
+    },
+    {
+      argument: {
+        name: "c",
+        optional: false,
+        range: [
+          21,
+          22,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        18,
+        22,
+      ],
+      type: "RestElement",
+      typeAnnotation: undefined,
+    },
+  ],
+  range: [
+    6,
+    24,
+  ],
+  type: "ObjectPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ArrayPattern 1`] = `
+{
+  elements: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        7,
+        8,
+      ],
+      type: "Identifier",
+      typeAnnotation: undefined,
+    },
+    {
+      name: "b",
+      optional: false,
+      range: [
+        10,
+        11,
+      ],
+      type: "Identifier",
+      typeAnnotation: undefined,
+    },
+  ],
+  optional: false,
+  range: [
+    6,
+    12,
+  ],
+  type: "ArrayPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ArrayPattern 2`] = `
+{
+  elements: [
+    {
+      left: {
+        name: "a",
+        optional: false,
+        range: [
+          7,
+          8,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        7,
+        12,
+      ],
+      right: {
+        range: [
+          11,
+          12,
+        ],
+        raw: "2",
+        type: "Literal",
+        value: 2,
+      },
+      type: "AssignmentPattern",
+    },
+  ],
+  optional: false,
+  range: [
+    6,
+    13,
+  ],
+  type: "ArrayPattern",
+  typeAnnotation: undefined,
+}
+`;
+
+snapshot[`Plugin - ArrayPattern 3`] = `
+{
+  elements: [
+    {
+      name: "a",
+      optional: false,
+      range: [
+        7,
+        8,
+      ],
+      type: "Identifier",
+      typeAnnotation: undefined,
+    },
+    {
+      argument: {
+        name: "b",
+        optional: false,
+        range: [
+          13,
+          14,
+        ],
+        type: "Identifier",
+        typeAnnotation: undefined,
+      },
+      range: [
+        10,
+        14,
+      ],
+      type: "RestElement",
+      typeAnnotation: undefined,
+    },
+  ],
+  optional: false,
+  range: [
+    6,
+    15,
+  ],
+  type: "ArrayPattern",
+  typeAnnotation: undefined,
 }
 `;
 

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -359,6 +359,27 @@ Deno.test("Plugin - Program", async (t) => {
   await testSnapshot(t, "", "Program");
 });
 
+Deno.test("Plugin - FunctionDeclaration", async (t) => {
+  await testSnapshot(t, "function foo() {}", "FunctionDeclaration");
+  await testSnapshot(t, "function foo(a, ...b) {}", "FunctionDeclaration");
+  await testSnapshot(
+    t,
+    "function foo(a = 1, { a = 2, b, ...c }, [d,...e], ...f) {}",
+    "FunctionDeclaration",
+  );
+
+  await testSnapshot(t, "async function foo() {}", "FunctionDeclaration");
+  await testSnapshot(t, "async function* foo() {}", "FunctionDeclaration");
+  await testSnapshot(t, "function* foo() {}", "FunctionDeclaration");
+
+  // TypeScript
+  await testSnapshot(
+    t,
+    "function foo<T>(a?: 2, ...b: any[]): any {}",
+    "FunctionDeclaration",
+  );
+});
+
 Deno.test("Plugin - ImportDeclaration", async (t) => {
   await testSnapshot(t, 'import "foo";', "ImportDeclaration");
   await testSnapshot(t, 'import foo from "foo";', "ImportDeclaration");
@@ -737,6 +758,20 @@ Deno.test("Plugin - UpdateExpression", async (t) => {
 
 Deno.test("Plugin - YieldExpression", async (t) => {
   await testSnapshot(t, "function* foo() { yield bar; }", "YieldExpression");
+});
+
+Deno.test("Plugin - ObjectPattern", async (t) => {
+  await testSnapshot(t, "const { prop } = {}", "ObjectPattern");
+  await testSnapshot(t, "const { prop: A } = {}", "ObjectPattern");
+  await testSnapshot(t, "const { 'a.b': A } = {}", "ObjectPattern");
+  await testSnapshot(t, "const { prop = 2 } = {}", "ObjectPattern");
+  await testSnapshot(t, "const { prop = 2, ...c } = {}", "ObjectPattern");
+});
+
+Deno.test("Plugin - ArrayPattern", async (t) => {
+  await testSnapshot(t, "const [a, b] = []", "ArrayPattern");
+  await testSnapshot(t, "const [a = 2] = []", "ArrayPattern");
+  await testSnapshot(t, "const [a, ...b] = []", "ArrayPattern");
 });
 
 Deno.test("Plugin - Literal", async (t) => {


### PR DESCRIPTION
Fixes inconsistencies with `ObjectPattern` node to match TSESTree.

Fixes one issue reported in https://github.com/denoland/deno/issues/28355