### PR TITLE
fix(unstable): lint plugin child combinator not working with groups

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -782,7 +782,14 @@ class MatchCtx {
    * @returns {number}
    */
   getParent(idx) {
-    return readParent(this.ctx.buf, idx);
+    const parent = readParent(this.ctx.buf, idx);
+
+    const parentType = readType(this.ctx.buf, parent);
+    if (parentType === AST_GROUP_TYPE) {
+      return readParent(this.ctx.buf, parent);
+    }
+
+    return parent;
   }
 
   /**

--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -919,7 +919,7 @@ function matchDescendant(next) {
 function matchChild(next) {
   return (ctx, id) => {
     const parent = ctx.getParent(id);
-    if (parent < 0) return false;
+    if (parent === 0) return false;
 
     return next(ctx, parent);
   };

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -155,6 +155,12 @@ Deno.test("Plugin - visitor child combinator", () => {
   assertEquals(result[0].node.name, "foo");
 
   result = testVisit(
+    "class Foo { foo = 2 }",
+    "ClassBody > PropertyDefinition",
+  );
+  assertEquals(result[0].node.type, "PropertyDefinition");
+
+  result = testVisit(
     "if (false) foo; foo()",
     "IfStatement IfStatement",
   );


### PR DESCRIPTION
Internally, we use a group node for array-like children, which is hidden from the user. When we're asking for a parent of a node we need to take group nodes into account and walk over them.

Fixes one issue reported in https://github.com/denoland/deno/issues/28355