### PR TITLE
fix(lsp): respect document_preload_limit config instead of the hard-coded 1000 #28363

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -845,7 +845,7 @@ impl Inner {
       return (Default::default(), false);
     }
     let mut workspace_files = IndexSet::default();
-    let entry_limit = 1000;
+    let entry_limit = config.workspace_settings().document_preload_limit;
     let mut pending = VecDeque::new();
     let mut entry_count = 0;
     let mut roots = config


### PR DESCRIPTION
Despite the addition of the `deno.documentPreloadLimit` config, it seems that the config value never took effect due to `entry_limit` inside the `walk_workspace` function always being set to `1000`.

I've verified this patch locally.

Fixes https://github.com/denoland/deno/issues/28363