### PR TITLE
perf(lsp): register semantic tokens provider upon opening enabled doc

### DIFF
--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -37,6 +37,43 @@ fn code_action_capabilities(
     .unwrap_or(CodeActionProviderCapability::Simple(true))
 }
 
+pub fn semantic_tokens_registration_options(
+) -> SemanticTokensRegistrationOptions {
+  SemanticTokensRegistrationOptions {
+    text_document_registration_options: TextDocumentRegistrationOptions {
+      document_selector: Some(vec![
+        DocumentFilter {
+          language: Some("javascript".to_string()),
+          scheme: None,
+          pattern: None,
+        },
+        DocumentFilter {
+          language: Some("javascriptreact".to_string()),
+          scheme: None,
+          pattern: None,
+        },
+        DocumentFilter {
+          language: Some("typescript".to_string()),
+          scheme: None,
+          pattern: None,
+        },
+        DocumentFilter {
+          language: Some("typescriptreact".to_string()),
+          scheme: None,
+          pattern: None,
+        },
+      ]),
+    },
+    semantic_tokens_options: SemanticTokensOptions {
+      legend: get_legend(),
+      range: Some(true),
+      full: Some(SemanticTokensFullOptions::Bool(true)),
+      ..Default::default()
+    },
+    static_registration_options: Default::default(),
+  }
+}
+
 pub fn server_capabilities(
   client_capabilities: &ClientCapabilities,
 ) -> ServerCapabilities {
@@ -126,43 +163,21 @@ pub fn server_capabilities(
       ..Default::default()
     }),
     call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
-    semantic_tokens_provider: Some(
-      SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(
-        SemanticTokensRegistrationOptions {
-          text_document_registration_options: TextDocumentRegistrationOptions {
-            document_selector: Some(vec![
-              DocumentFilter {
-                language: Some("javascript".to_string()),
-                scheme: None,
-                pattern: None,
-              },
-              DocumentFilter {
-                language: Some("javascriptreact".to_string()),
-                scheme: None,
-                pattern: None,
-              },
-              DocumentFilter {
-                language: Some("typescript".to_string()),
-                scheme: None,
-                pattern: None,
-              },
-              DocumentFilter {
-                language: Some("typescriptreact".to_string()),
-                scheme: None,
-                pattern: None,
-              },
-            ]),
-          },
-          semantic_tokens_options: SemanticTokensOptions {
-            legend: get_legend(),
-            range: Some(true),
-            full: Some(SemanticTokensFullOptions::Bool(true)),
-            ..Default::default()
-          },
-          static_registration_options: Default::default(),
-        },
-      ),
-    ),
+    semantic_tokens_provider: if client_capabilities
+      .text_document
+      .as_ref()
+      .and_then(|t| t.semantic_tokens.as_ref())
+      .and_then(|s| s.dynamic_registration)
+      .unwrap_or_default()
+    {
+      None
+    } else {
+      Some(
+        SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(
+          semantic_tokens_registration_options(),
+        ),
+      )
+    },
     workspace: Some(WorkspaceServerCapabilities {
       workspace_folders: Some(WorkspaceFoldersServerCapabilities {
         supported: Some(true),


### PR DESCRIPTION
We handle semantic tokens for Deno-disabled files because we register the provider per language ID. You can see this by `Deno` being highlighted as a namespace in such files even though it's untyped. No other request is used for Deno-disabled files.

This PR delays that provider registration at least until a Deno-enabled specifier is opened for the first time.

This will allow us to, for example, lazily spin up the TS server upon first use in an Deno-enabled file (whereas previously that wouldn't work because the TS server was immediately used for semantic tokens even in a Deno-disabled file). This will reduce idle memory usage of the LSP in Node projects. I'll handle this in a follow up PR.