### PR TITLE
fix(unstable): lint plugin `!==` wrongly parsed as `!=`

### DIFF
--- a/cli/tools/lint/ast_buffer/swc.rs
+++ b/cli/tools/lint/ast_buffer/swc.rs
@@ -716,7 +716,7 @@ fn serialize_expr(ctx: &mut TsEsTreeBuilder, expr: &Expr) -> NodeRef {
         BinaryOp::EqEq => (AstNode::BinaryExpression, "=="),
         BinaryOp::NotEq => (AstNode::BinaryExpression, "!="),
         BinaryOp::EqEqEq => (AstNode::BinaryExpression, "==="),
-        BinaryOp::NotEqEq => (AstNode::BinaryExpression, "!="),
+        BinaryOp::NotEqEq => (AstNode::BinaryExpression, "!=="),
         BinaryOp::Lt => (AstNode::BinaryExpression, "<"),
         BinaryOp::LtEq => (AstNode::BinaryExpression, "<="),
         BinaryOp::Gt => (AstNode::BinaryExpression, ">"),

--- a/tests/unit/__snapshots__/lint_plugin_test.ts.snap
+++ b/tests/unit/__snapshots__/lint_plugin_test.ts.snap
@@ -2630,7 +2630,7 @@ snapshot[`Plugin - BinaryExpression 8`] = `
     type: "Identifier",
     typeAnnotation: undefined,
   },
-  operator: "!=",
+  operator: "!==",
   range: [
     0,
     7,


### PR DESCRIPTION
That's an emberassing typo. The `!==` operator was wrongly converted to `!=`.

Fixes https://github.com/denoland/deno/issues/28397