### PR TITLE
perf: reduce the number of debug impls in release builds

### DIFF
--- a/cli/args/deno_json.rs
+++ b/cli/args/deno_json.rs
@@ -145,7 +145,7 @@ fn check_warn_tsconfig(
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TranspileAndEmitOptions {
   pub transpile: deno_ast::TranspileOptions,
   pub emit: deno_ast::EmitOptions,
@@ -153,13 +153,15 @@ pub struct TranspileAndEmitOptions {
   pub pre_computed_hash: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct LoggedWarnings {
   experimental_decorators: AtomicFlag,
   folders: dashmap::DashSet<Url>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct MemoizedValues {
   deno_window_check_tsconfig: OnceCell<Arc<TsConfig>>,
   deno_worker_check_tsconfig: OnceCell<Arc<TsConfig>>,
@@ -167,7 +169,7 @@ struct MemoizedValues {
   transpile_options: OnceCell<Arc<TranspileAndEmitOptions>>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TsConfigFolderInfo {
   pub dir: WorkspaceDirectory,
   logged_warnings: Arc<LoggedWarnings>,
@@ -228,9 +230,19 @@ impl TsConfigFolderInfo {
   }
 }
 
-#[derive(Debug)]
 pub struct TsConfigResolver {
   map: FolderScopedMap<TsConfigFolderInfo>,
+}
+
+impl std::fmt::Debug for TsConfigResolver {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut f = f.debug_struct("TsConfigResolver");
+    #[cfg(any(test, debug_assertions))]
+    {
+      f.field("map", &self.map);
+    }
+    f.finish()
+  }
 }
 
 impl TsConfigResolver {

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -48,7 +48,8 @@ use serde::Serialize;
 use super::flags_net;
 use crate::util::fs::canonicalize_path;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ConfigFlag {
   #[default]
   Discover,
@@ -56,7 +57,8 @@ pub enum ConfigFlag {
   Disabled,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FileFlags {
   pub ignore: Vec<String>,
   pub include: Vec<String>,
@@ -85,18 +87,21 @@ impl FileFlags {
   }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct AddFlags {
   pub packages: Vec<String>,
   pub dev: bool,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RemoveFlags {
   pub packages: Vec<String>,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct BenchFlags {
   pub files: FileFlags,
   pub filter: Option<String>,
@@ -106,19 +111,22 @@ pub struct BenchFlags {
   pub watch: Option<WatchFlags>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CacheFlags {
   pub files: Vec<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CheckFlags {
   pub files: Vec<String>,
   pub doc: bool,
   pub doc_only: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CompileFlags {
   pub source_file: String,
   pub output: Option<String>,
@@ -138,12 +146,14 @@ impl CompileFlags {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CompletionsFlags {
   pub buf: Box<[u8]>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CoverageType {
   #[default]
   Summary,
@@ -152,7 +162,8 @@ pub enum CoverageType {
   Html,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CoverageFlags {
   pub files: FileFlags,
   pub output: Option<String>,
@@ -161,7 +172,8 @@ pub struct CoverageFlags {
   pub r#type: CoverageType,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DocSourceFileFlag {
   Builtin,
   Paths(Vec<String>),
@@ -173,7 +185,8 @@ impl Default for DocSourceFileFlag {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DocHtmlFlag {
   pub name: Option<String>,
   pub category_docs_path: Option<String>,
@@ -183,7 +196,8 @@ pub struct DocHtmlFlag {
   pub output: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DocFlags {
   pub private: bool,
   pub json: bool,
@@ -193,13 +207,15 @@ pub struct DocFlags {
   pub filter: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct EvalFlags {
   pub print: bool,
   pub code: String,
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FmtFlags {
   pub check: bool,
   pub files: FileFlags,
@@ -221,7 +237,8 @@ impl FmtFlags {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InitFlags {
   pub package: Option<String>,
   pub package_args: Vec<String>,
@@ -230,13 +247,15 @@ pub struct InitFlags {
   pub serve: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InfoFlags {
   pub json: bool,
   pub file: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InstallFlagsGlobal {
   pub module_url: String,
   pub args: Vec<String>,
@@ -245,49 +264,57 @@ pub struct InstallFlagsGlobal {
   pub force: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum InstallFlags {
   Local(InstallFlagsLocal),
   Global(InstallFlagsGlobal),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum InstallFlagsLocal {
   Add(AddFlags),
   TopLevel,
   Entrypoints(Vec<String>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct JSONReferenceFlags {
   pub json: deno_core::serde_json::Value,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct JupyterFlags {
   pub install: bool,
   pub kernel: bool,
   pub conn_file: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UninstallFlagsGlobal {
   pub name: String,
   pub root: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum UninstallKind {
   Local(RemoveFlags),
   Global(UninstallFlagsGlobal),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UninstallFlags {
   pub kind: UninstallKind,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LintFlags {
   pub files: FileFlags,
   pub rules: bool,
@@ -307,14 +334,16 @@ impl LintFlags {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ReplFlags {
   pub eval_files: Option<Vec<String>>,
   pub eval: Option<String>,
   pub is_default_command: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RunFlags {
   pub script: String,
   pub watch: Option<WatchFlagsWithPaths>,
@@ -336,7 +365,8 @@ impl RunFlags {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ServeFlags {
   pub script: String,
   pub watch: Option<WatchFlagsWithPaths>,
@@ -358,14 +388,16 @@ impl ServeFlags {
   }
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WatchFlags {
   pub hmr: bool,
   pub no_clear_screen: bool,
   pub exclude: Vec<String>,
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WatchFlagsWithPaths {
   pub hmr: bool,
   pub paths: Vec<String>,
@@ -373,7 +405,8 @@ pub struct WatchFlagsWithPaths {
   pub exclude: Vec<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TaskFlags {
   pub cwd: Option<String>,
   pub task: Option<String>,
@@ -383,7 +416,8 @@ pub struct TaskFlags {
   pub eval: bool,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TestReporterConfig {
   #[default]
   Pretty,
@@ -392,7 +426,8 @@ pub enum TestReporterConfig {
   Tap,
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestFlags {
   pub doc: bool,
   pub no_run: bool,
@@ -411,7 +446,8 @@ pub struct TestFlags {
   pub hide_stacktraces: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UpgradeFlags {
   pub dry_run: bool,
   pub force: bool,
@@ -422,7 +458,8 @@ pub struct UpgradeFlags {
   pub version_or_hash_or_channel: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PublishFlags {
   pub token: Option<String>,
   pub dry_run: bool,
@@ -432,12 +469,14 @@ pub struct PublishFlags {
   pub set_version: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct HelpFlags {
   pub help: clap::builder::StyledStr,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DenoSubcommand {
   Add(AddFlags),
   Remove(RemoveFlags),
@@ -473,13 +512,15 @@ pub enum DenoSubcommand {
   Help(HelpFlags),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum OutdatedKind {
   Update { latest: bool, interactive: bool },
   PrintOutdated { compatible: bool },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct OutdatedFlags {
   pub filters: Vec<String>,
   pub recursive: bool,
@@ -561,7 +602,8 @@ impl Default for DenoSubcommand {
   }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TypeCheckMode {
   /// Type-check all modules.
   All,
@@ -599,7 +641,8 @@ impl Default for TypeCheckMode {
 }
 
 // Info needed to run NPM lifecycle scripts
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LifecycleScriptsConfig {
   pub allowed: PackagesAllowedScripts,
   pub initial_cwd: PathBuf,
@@ -608,7 +651,8 @@ pub struct LifecycleScriptsConfig {
   pub explicit_install: bool,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 /// The set of npm packages that are allowed to run lifecycle scripts.
 pub enum PackagesAllowedScripts {
   All,
@@ -625,7 +669,8 @@ fn parse_packages_allowed_scripts(s: &str) -> Result<String, AnyError> {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InternalFlags {
   /// Used when the language server is configured with an
   /// explicit cache option.
@@ -634,7 +679,8 @@ pub struct InternalFlags {
   pub lockfile_skip_write: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Eq, PartialEq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Flags {
   /// Vector of CLI arguments - these are user script arguments, all Deno
   /// specific flags are removed.
@@ -678,7 +724,8 @@ pub struct Flags {
   pub allow_scripts: PackagesAllowedScripts,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PermissionFlags {
   pub allow_all: bool,
   pub allow_env: Option<Vec<String>>,

--- a/cli/args/flags_net.rs
+++ b/cli/args/flags_net.rs
@@ -6,10 +6,12 @@ use std::str::FromStr;
 use deno_core::url::Url;
 use deno_runtime::deno_permissions::NetDescriptor;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ParsePortError(String);
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct BarePort(u16);
 
 impl FromStr for BarePort {

--- a/cli/args/lockfile.rs
+++ b/cli/args/lockfile.rs
@@ -25,7 +25,7 @@ use crate::cache;
 use crate::sys::CliSys;
 use crate::Flags;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliLockfileReadFromPathOptions {
   pub file_path: PathBuf,
   pub frozen: bool,
@@ -33,7 +33,7 @@ pub struct CliLockfileReadFromPathOptions {
   pub skip_write: bool,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliLockfile {
   sys: CliSys,
   lockfile: Mutex<Lockfile>,

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -173,7 +173,8 @@ impl WorkspaceBenchOptions {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct BenchOptions {
   pub files: FilePatterns,
 }
@@ -187,13 +188,15 @@ impl BenchOptions {
   }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UnstableFmtOptions {
   pub component: bool,
   pub sql: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FmtOptions {
   pub options: FmtOptionsConfig,
   pub unstable: UnstableFmtOptions,
@@ -268,7 +271,8 @@ fn resolve_fmt_options(
   options
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WorkspaceTestOptions {
   pub doc: bool,
   pub no_run: bool,
@@ -303,7 +307,8 @@ impl WorkspaceTestOptions {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestOptions {
   pub files: FilePatterns,
 }
@@ -317,7 +322,8 @@ impl TestOptions {
   }
 }
 
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum LintReporterKind {
   #[default]
   Pretty,
@@ -325,7 +331,8 @@ pub enum LintReporterKind {
   Compact,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WorkspaceLintOptions {
   pub reporter_kind: LintReporterKind,
 }
@@ -361,7 +368,8 @@ impl WorkspaceLintOptions {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LintOptions {
   pub rules: LintRulesConfig,
   pub files: FilePatterns,
@@ -447,7 +455,7 @@ fn resolve_lint_rules_options(
 
 /// Holds the resolved options of many sources used by subcommands
 /// and provides some helper function for creating common objects.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliOptions {
   // the source of the options is a detail the rest of the
   // application need not concern itself with, so keep these private
@@ -1355,7 +1363,8 @@ fn allow_import_host_from_url(url: &Url) -> Option<String> {
   }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum NpmCachingStrategy {
   Eager,
   Lazy,

--- a/cli/args/package_json.rs
+++ b/cli/args/package_json.rs
@@ -15,14 +15,14 @@ use deno_semver::StackString;
 use deno_semver::VersionReq;
 use thiserror::Error;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InstallNpmRemotePkg {
   pub alias: Option<StackString>,
   pub base_dir: PathBuf,
   pub req: PackageReq,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InstallNpmWorkspacePkg {
   pub alias: Option<StackString>,
   pub target_dir: PathBuf,
@@ -37,7 +37,8 @@ pub struct PackageJsonDepValueParseWithLocationError {
   pub source: PackageJsonDepValueParseError,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmInstallDepsProvider {
   remote_pkgs: Vec<InstallNpmRemotePkg>,
   workspace_pkgs: Vec<InstallNpmWorkspacePkg>,

--- a/cli/bench/lsp.rs
+++ b/cli/bench/lsp.rs
@@ -20,7 +20,8 @@ static FIXTURE_DB_MESSAGES: &[u8] = include_bytes!("testdata/db_messages.json");
 static FIXTURE_DECO_APPS: &[u8] =
   include_bytes!("testdata/deco_apps_requests.json");
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum FixtureType {
   #[serde(rename = "action")]
   Action,
@@ -34,7 +35,8 @@ enum FixtureType {
   Hover,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct FixtureMessage {
   #[serde(rename = "type")]
   fixture_type: FixtureType,

--- a/cli/cache/cache_db.rs
+++ b/cli/cache/cache_db.rs
@@ -16,7 +16,8 @@ use deno_runtime::deno_webstorage::rusqlite::OptionalExtension;
 use deno_runtime::deno_webstorage::rusqlite::Params;
 use once_cell::sync::OnceCell;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CacheDBHash(u64);
 
 impl CacheDBHash {
@@ -57,7 +58,8 @@ impl rusqlite::types::FromSql for CacheDBHash {
 }
 
 /// What should the cache should do on failure?
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CacheFailure {
   /// Return errors if failure mode otherwise unspecified.
   #[default]
@@ -69,7 +71,7 @@ pub enum CacheFailure {
 }
 
 /// Configuration SQL and other parameters for a [`CacheDB`].
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CacheDBConfiguration {
   /// SQL to run for a new database.
   pub table_initializer: &'static str,
@@ -99,7 +101,7 @@ impl CacheDBConfiguration {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ConnectionState {
   Connected(Connection),
   Blackhole,
@@ -108,7 +110,8 @@ enum ConnectionState {
 
 /// A cache database that eagerly initializes itself off-thread, preventing initialization operations
 /// from blocking the main thread.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CacheDB {
   // TODO(mmastrac): We can probably simplify our thread-safe implementation here
   conn: Arc<Mutex<OnceCell<ConnectionState>>>,

--- a/cli/cache/deno_dir.rs
+++ b/cli/cache/deno_dir.rs
@@ -40,7 +40,8 @@ impl DenoDirProvider {
 
 /// `DenoDir` serves as coordinator for multiple `DiskCache`s containing them
 /// in single directory that can be controlled with `$DENO_DIR` env variable.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DenoDir {
   /// Example: /Users/rld/.deno/
   pub root: PathBuf,

--- a/cli/cache/disk_cache.rs
+++ b/cli/cache/disk_cache.rs
@@ -16,7 +16,8 @@ use sys_traits::FsRead;
 
 use crate::sys::CliSys;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DiskCache {
   sys: CliSys,
   pub location: PathBuf,

--- a/cli/cache/emit.rs
+++ b/cli/cache/emit.rs
@@ -11,7 +11,7 @@ use deno_lib::version::DENO_VERSION_INFO;
 use super::DiskCache;
 
 /// The cache that stores previously emitted files.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct EmitCache {
   disk_cache: DiskCache,
   emit_failed_flag: AtomicFlag,
@@ -93,7 +93,7 @@ impl EmitCache {
 
 const LAST_LINE_PREFIX: &str = "\n// denoCacheMetadata=";
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct EmitFileSerializer {
   cli_version: &'static str,
 }

--- a/cli/cache/module_info.rs
+++ b/cli/cache/module_info.rs
@@ -44,7 +44,7 @@ pub static MODULE_INFO_CACHE_DB: CacheDBConfiguration = CacheDBConfiguration {
 /// A cache of `deno_graph::ModuleInfo` objects. Using this leads to a considerable
 /// performance improvement because when it exists we can skip parsing a module for
 /// deno_graph.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ModuleInfoCache {
   conn: CacheDB,
   parsed_source_cache: Arc<ParsedSourceCache>,

--- a/cli/cache/parsed_source.rs
+++ b/cli/cache/parsed_source.rs
@@ -46,7 +46,8 @@ impl<'a> LazyGraphSourceParser<'a> {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ParsedSourceCache {
   sources: Mutex<HashMap<ModuleSpecifier, ParsedSource>>,
 }

--- a/cli/cdp.rs
+++ b/cli/cdp.rs
@@ -7,7 +7,8 @@ use serde::Deserializer;
 use serde::Serialize;
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-awaitPromise>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct AwaitPromiseArgs {
   pub promise_object_id: RemoteObjectId,
@@ -18,7 +19,8 @@ pub struct AwaitPromiseArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunctionOnArgs {
   pub function_declaration: String,
@@ -45,7 +47,8 @@ pub struct CallFunctionOnArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunctionOnResponse {
   pub result: RemoteObject,
@@ -53,7 +56,8 @@ pub struct CallFunctionOnResponse {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-compileScript>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompileScriptArgs {
   pub expression: String,
@@ -64,7 +68,8 @@ pub struct CompileScriptArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateArgs {
   pub expression: String,
@@ -103,7 +108,8 @@ pub struct EvaluateArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateResponse {
   pub result: RemoteObject,
@@ -111,7 +117,8 @@ pub struct EvaluateResponse {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertiesArgs {
   pub object_id: RemoteObjectId,
@@ -126,14 +133,16 @@ pub struct GetPropertiesArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-getProperties>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct GetPropertiesResponse {
   pub result: Vec<PropertyDescriptor>,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalLexicalScopeNamesArgs {
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -141,14 +150,16 @@ pub struct GlobalLexicalScopeNamesArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-globalLexicalScopeNames>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalLexicalScopeNamesResponse {
   pub names: Vec<String>,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-queryObjects>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct QueryObjectsArgs {
   pub prototype_object_id: RemoteObjectId,
@@ -157,21 +168,24 @@ pub struct QueryObjectsArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObject>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseObjectArgs {
   pub object_id: RemoteObjectId,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-releaseObjectGroup>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ReleaseObjectGroupArgs {
   pub object_group: String,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-runScript>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct RunScriptArgs {
   pub script_id: ScriptId,
@@ -195,7 +209,8 @@ pub struct RunScriptArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-setAsyncCallStackDepth>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SetAsyncCallStackDepthArgs {
   pub max_depth: u64,
@@ -204,7 +219,8 @@ pub struct SetAsyncCallStackDepthArgs {
 // types
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteObject {
   #[serde(rename = "type")]
@@ -227,7 +243,8 @@ where
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExceptionDetails>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionDetails {
   pub text: String,
@@ -246,7 +263,8 @@ impl ExceptionDetails {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-CallArgument>
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CallArgument {
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -268,7 +286,8 @@ impl From<&RemoteObject> for CallArgument {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-PropertyDescriptor>
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyDescriptor {
   pub name: String,
@@ -290,12 +309,14 @@ pub type TimeDelta = u64;
 pub type UnserializableValue = String;
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#method-setScriptSource>
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SetScriptSourceResponse {
   pub status: Status,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum Status {
   Ok,
   CompileError,
@@ -305,7 +326,8 @@ pub enum Status {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#event-scriptParsed>
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ScriptParsed {
   pub script_id: String,
@@ -313,7 +335,8 @@ pub struct ScriptParsed {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#type-CoverageRange>
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CoverageRange {
   /// Start character index.
@@ -326,7 +349,8 @@ pub struct CoverageRange {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#type-FunctionCoverage>
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct FunctionCoverage {
   pub function_name: String,
@@ -335,7 +359,8 @@ pub struct FunctionCoverage {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#type-ScriptCoverage>
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ScriptCoverage {
   pub script_id: String,
@@ -344,7 +369,8 @@ pub struct ScriptCoverage {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#method-startPreciseCoverage>
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct StartPreciseCoverageArgs {
   pub call_count: bool,
@@ -353,41 +379,47 @@ pub struct StartPreciseCoverageArgs {
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#method-startPreciseCoverage>
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct StartPreciseCoverageResponse {
   pub timestamp: f64,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#method-takePreciseCoverage>
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TakePreciseCoverageResponse {
   pub result: Vec<ScriptCoverage>,
   pub timestamp: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Notification {
   pub method: String,
   pub params: Value,
 }
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-exceptionThrown>
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionThrown {
   pub exception_details: ExceptionDetails,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-executionContextCreated>
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionContextCreated {
   pub context: ExecutionContextDescription,
 }
 
 /// <https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-ExecutionContextDescription>
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionContextDescription {
   pub id: ExecutionContextId,

--- a/cli/emit.rs
+++ b/cli/emit.rs
@@ -28,7 +28,7 @@ use crate::cache::EmitCache;
 use crate::cache::ParsedSourceCache;
 use crate::resolver::CliCjsTracker;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Emitter {
   cjs_tracker: Arc<CliCjsTracker>,
   emit_cache: Arc<EmitCache>,

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -148,11 +148,26 @@ impl RootCertStoreProvider for CliRootCertStoreProvider {
   }
 }
 
-#[derive(Debug)]
 struct CliSpecifiedImportMapProvider {
   cli_options: Arc<CliOptions>,
   file_fetcher: Arc<CliFileFetcher>,
   workspace_external_import_map_loader: Arc<WorkspaceExternalImportMapLoader>,
+}
+
+impl std::fmt::Debug for CliSpecifiedImportMapProvider {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut f = f.debug_struct("CliSpecifiedImportMapProvider");
+    #[cfg(any(test, debug_assertions))]
+    {
+      f.field("cli_options", &self.cli_options)
+        .field("file_fetcher", &self.file_fetcher)
+        .field(
+          "workspace_external_import_map_loader",
+          &self.workspace_external_import_map_loader,
+        );
+    }
+    f.finish()
+  }
 }
 
 #[async_trait::async_trait(?Send)]
@@ -304,7 +319,8 @@ struct CliFactoryServices {
     Deferred<Arc<WorkspaceExternalImportMapLoader>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CliFactoryOverrides {
   initial_cwd: Option<PathBuf>,
   workspace_directory: Option<Arc<WorkspaceDirectory>>,

--- a/cli/file_fetcher.rs
+++ b/cli/file_fetcher.rs
@@ -40,7 +40,8 @@ use crate::http_util::HttpClientProvider;
 use crate::sys::CliSys;
 use crate::util::progress_bar::ProgressBar;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TextDecodedFile {
   pub media_type: MediaType,
   /// The _final_ specifier for the file.  The requested specifier and the final
@@ -92,11 +93,19 @@ impl deno_cache_dir::file_fetcher::BlobStore for BlobStoreAdapter {
   }
 }
 
-#[derive(Debug)]
 struct HttpClientAdapter {
   http_client_provider: Arc<HttpClientProvider>,
   download_log_level: log::Level,
   progress_bar: Option<ProgressBar>,
+}
+
+impl std::fmt::Debug for HttpClientAdapter {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("HttpClientAdapter")
+      // .field("http_client_provider", &self.http_client_provider)
+      .field("download_log_level", &self.download_log_level)
+      .finish()
+  }
 }
 
 #[async_trait::async_trait(?Send)]
@@ -212,8 +221,16 @@ impl deno_cache_dir::file_fetcher::HttpClient for HttpClientAdapter {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct MemoryFiles(Mutex<HashMap<ModuleSpecifier, File>>);
+
+impl std::fmt::Debug for MemoryFiles {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("MemoryFiles")
+      // .field(&self.0)
+      .finish()
+  }
+}
 
 impl MemoryFiles {
   pub fn insert(&self, specifier: ModuleSpecifier, file: File) -> Option<File> {
@@ -244,13 +261,15 @@ pub enum CliFetchNoFollowErrorKind {
   PermissionCheck(#[from] PermissionCheckError),
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum FetchPermissionsOptionRef<'a> {
   AllowAll,
   Restricted(&'a PermissionsContainer, CheckSpecifierKind),
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FetchOptions<'a> {
   pub maybe_auth: Option<(header::HeaderName, header::HeaderValue)>,
   pub maybe_accept: Option<&'a str>,
@@ -271,10 +290,18 @@ type DenoCacheDirFileFetcher = deno_cache_dir::file_fetcher::FileFetcher<
 >;
 
 /// A structure for resolving, fetching and caching source files.
-#[derive(Debug)]
 pub struct CliFileFetcher {
   file_fetcher: DenoCacheDirFileFetcher,
   memory_files: Arc<MemoryFiles>,
+}
+
+impl std::fmt::Debug for CliFileFetcher {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("CliFileFetcher")
+      // .field("file_fetcher", &self.file_fetcher)
+      // .field("memory_files", &self.memory_files)
+      .finish()
+  }
 }
 
 impl CliFileFetcher {

--- a/cli/graph_container.rs
+++ b/cli/graph_container.rs
@@ -49,7 +49,8 @@ pub struct MainModuleGraphContainer {
   root_permissions: PermissionsContainer,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CheckSpecifiersOptions<'a> {
   pub ext_overwrite: Option<&'a String>,
   pub allow_unknown_media_types: bool,

--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -303,7 +303,8 @@ pub fn resolution_error_for_tsc_diagnostic(
   }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum EnhanceGraphErrorMode {
   ShowRange,
   HideRange,
@@ -1243,10 +1244,22 @@ pub fn has_graph_root_local_dependent_changed(
   false
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct FileWatcherReporter {
   watcher_communicator: Arc<WatcherCommunicator>,
   file_paths: Arc<Mutex<Vec<PathBuf>>>,
+}
+
+impl std::fmt::Debug for FileWatcherReporter {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut f = f.debug_struct("FileWatcherReporter");
+    #[cfg(any(test, debug_assertions))]
+    {
+      f.field("watcher_communicator", &self.watcher_communicator)
+        .field("file_paths", &self.file_paths);
+    }
+    f.finish()
+  }
 }
 
 impl FileWatcherReporter {
@@ -1296,7 +1309,8 @@ pub fn format_range_with_colors(referrer: &deno_graph::Range) -> String {
   )
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliJsrUrlProvider;
 
 impl deno_graph::source::JsrUrlProvider for CliJsrUrlProvider {
@@ -1348,13 +1362,29 @@ fn format_deno_graph_error(err: &dyn Error) -> String {
   message
 }
 
-#[derive(Debug)]
 struct CliGraphResolver<'a> {
   cjs_tracker: &'a CliCjsTracker,
   resolver: &'a CliResolver,
   jsx_import_source_config_unscoped: Option<JsxImportSourceConfig>,
   jsx_import_source_config_by_scope:
     BTreeMap<Arc<ModuleSpecifier>, Option<JsxImportSourceConfig>>,
+}
+
+impl<'a> std::fmt::Debug for CliGraphResolver<'a> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("CliGraphResolver")
+      // .field("cjs_tracker", &self.cjs_tracker)
+      // .field("resolver", &self.resolver)
+      // .field(
+      //   "jsx_import_source_config_unscoped",
+      //   &self.jsx_import_source_config_unscoped,
+      // )
+      // .field(
+      //   "jsx_import_source_config_by_scope",
+      //   &self.jsx_import_source_config_by_scope,
+      // )
+      .finish()
+  }
 }
 
 impl CliGraphResolver<'_> {

--- a/cli/http_util.rs
+++ b/cli/http_util.rs
@@ -47,6 +47,7 @@ pub struct HttpClientProvider {
   clients_by_thread_id: Mutex<HashMap<ThreadId, deno_fetch::Client>>,
 }
 
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for HttpClientProvider {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("HttpClient")
@@ -141,7 +142,7 @@ pub enum DownloadErrorKind {
   Other(JsErrorBox),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct HttpClient {
   client: deno_fetch::Client,
   // don't allow sending this across threads because then

--- a/cli/jsr.rs
+++ b/cli/jsr.rs
@@ -14,7 +14,7 @@ use crate::file_fetcher::CliFileFetcher;
 
 /// This is similar to a subset of `JsrCacheResolver` which fetches rather than
 /// just reads the cache. Keep in sync!
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct JsrFetchResolver {
   nv_by_req: DashMap<PackageReq, Option<PackageNv>>,
   /// The `module_graph` field of the version infos should be forcibly absent.

--- a/cli/lib/args.rs
+++ b/cli/lib/args.rs
@@ -40,7 +40,8 @@ pub fn has_flag_env_var(name: &str) -> bool {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CaData {
   /// The string is a file path
   File(String),
@@ -152,13 +153,15 @@ pub fn get_root_cert_store(
 }
 
 /// State provided to the process via an environment variable.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmProcessState {
   pub kind: NpmProcessStateKind,
   pub local_node_modules_path: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum NpmProcessStateKind {
   Snapshot(deno_npm::resolution::SerializedNpmResolutionSnapshot),
   Byonm,
@@ -208,7 +211,8 @@ pub fn resolve_npm_resolution_snapshot(
   }
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UnstableConfig {
   // TODO(bartlomieju): remove in Deno 2.5
   pub legacy_flag_enabled: bool, // --unstable

--- a/cli/lib/npm/permission_checker.rs
+++ b/cli/lib/npm/permission_checker.rs
@@ -12,14 +12,14 @@ use parking_lot::Mutex;
 
 use crate::sys::DenoLibSys;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum NpmRegistryReadPermissionCheckerMode {
   Byonm,
   Global(PathBuf),
   Local(PathBuf),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmRegistryReadPermissionChecker<TSys: DenoLibSys> {
   sys: TSys,
   cache: Mutex<HashMap<PathBuf, PathBuf>>,

--- a/cli/lib/shared.rs
+++ b/cli/lib/shared.rs
@@ -7,7 +7,8 @@ use thiserror::Error;
 #[error("Unrecognized release channel: {0}")]
 pub struct UnrecognizedReleaseChannelError(pub String);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ReleaseChannel {
   /// Stable version, eg. 1.45.4, 2.0.0, 2.1.0
   #[allow(unused)]

--- a/cli/lib/standalone/binary.rs
+++ b/cli/lib/standalone/binary.rs
@@ -54,7 +54,8 @@ pub struct SerializedWorkspaceResolverImportMap {
   pub json: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SerializedResolverWorkspaceJsrPackage {
   pub relative_base: String,
   pub name: String,
@@ -93,7 +94,8 @@ pub struct Metadata {
   pub vfs_case_sensitivity: FileSystemCaseSensitivity,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SpecifierId(u32);
 
 impl SpecifierId {

--- a/cli/lib/util/hash.rs
+++ b/cli/lib/util/hash.rs
@@ -3,7 +3,8 @@
 use std::hash::Hasher;
 
 /// A very fast insecure hasher that uses the xxHash algorithm.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FastInsecureHasher(twox_hash::XxHash64);
 
 impl FastInsecureHasher {

--- a/cli/lsp/analysis.rs
+++ b/cli/lsp/analysis.rs
@@ -91,14 +91,16 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
   ".d.mts", ".d.cts",
 ];
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DataQuickFixChange {
   pub range: Range,
   pub new_text: String,
 }
 
 /// A quick fix that's stored in the diagnostic's data field.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DataQuickFix {
   pub description: String,
   pub changes: Vec<DataQuickFixChange>,
@@ -106,7 +108,8 @@ pub struct DataQuickFix {
 
 /// Category of self-generated diagnostic messages (those not coming from)
 /// TypeScript.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum Category {
   /// A lint diagnostic, where the first element is the message.
   Lint {
@@ -118,7 +121,8 @@ pub enum Category {
 }
 
 /// A structure to hold a reference to a diagnostic message.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Reference {
   category: Category,
   range: Range,
@@ -838,26 +842,30 @@ pub fn ts_changes_to_edit(
   }))
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CodeActionData {
   pub specifier: ModuleSpecifier,
   pub fix_id: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum CodeActionKind {
   Deno(lsp::CodeAction),
   DenoLint(lsp::CodeAction),
   Tsc(lsp::CodeAction, tsc::CodeFixAction),
 }
 
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Hash, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum FixAllKind {
   Tsc(String),
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CodeActionCollection {
   actions: Vec<CodeActionKind>,
   fix_all_actions: HashMap<FixAllKind, CodeActionKind>,

--- a/cli/lsp/cache.rs
+++ b/cli/lsp/cache.rs
@@ -68,7 +68,8 @@ fn calculate_fs_version_in_cache(
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LspCache {
   deno_dir: DenoDir,
   global: Arc<GlobalHttpCache>,

--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -18,7 +18,7 @@ use super::lsp_custom;
 use super::testing::lsp_custom as testing_lsp_custom;
 use crate::lsp::repl::get_repl_workspace_settings;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TestingNotification {
   Module(testing_lsp_custom::TestModuleNotificationParams),
   DeleteModule(testing_lsp_custom::TestModuleDeleteNotificationParams),

--- a/cli/lsp/code_lens.rs
+++ b/cli/lsp/code_lens.rs
@@ -36,7 +36,8 @@ static ABSTRACT_MODIFIER: Lazy<Regex> = lazy_regex!(r"\babstract\b");
 
 static EXPORT_MODIFIER: Lazy<Regex> = lazy_regex!(r"\bexport\b");
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CodeLensSource {
   #[serde(rename = "implementations")]
   Implementations,
@@ -44,7 +45,8 @@ pub enum CodeLensSource {
   References,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensData {
   pub source: CodeLensSource,

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -47,7 +47,8 @@ const PARENT_PATH: &str = "..";
 const LOCAL_PATHS: &[&str] = &[CURRENT_PATH, PARENT_PATH];
 pub(crate) const IMPORT_COMMIT_CHARS: &[&str] = &["\"", "'"];
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionItemData {
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -80,7 +80,8 @@ fn is_true() -> bool {
 
 /// Wrapper that defaults if it fails to deserialize. Good for individual
 /// settings.
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Default, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SafeValue<T> {
   inner: T,
 }
@@ -126,7 +127,8 @@ impl<T> SafeValue<T> {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CodeLensSettings {
   /// Flag for providing implementation code lenses.
@@ -156,14 +158,16 @@ impl Default for CodeLensSettings {
   }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DenoCompletionSettings {
   #[serde(default)]
   pub imports: ImportCompletionSettings,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ClassMemberSnippets {
   #[serde(default = "is_true")]
@@ -176,7 +180,8 @@ impl Default for ClassMemberSnippets {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectLiteralMethodSnippets {
   #[serde(default = "is_true")]
@@ -189,7 +194,8 @@ impl Default for ObjectLiteralMethodSnippets {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionSettings {
   #[serde(default)]
@@ -228,7 +234,8 @@ impl Default for CompletionSettings {
   }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsSettings {
   #[serde(default)]
@@ -245,7 +252,8 @@ pub struct InlayHintsSettings {
   pub enum_member_values: InlayHintsEnumMemberValuesOptions,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsParamNamesOptions {
   #[serde(default)]
@@ -263,7 +271,8 @@ impl Default for InlayHintsParamNamesOptions {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum InlayHintsParamNamesEnabled {
   None,
@@ -277,14 +286,16 @@ impl Default for InlayHintsParamNamesEnabled {
   }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsParamTypesOptions {
   #[serde(default)]
   pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsVarTypesOptions {
   #[serde(default)]
@@ -302,28 +313,32 @@ impl Default for InlayHintsVarTypesOptions {
   }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsPropDeclTypesOptions {
   #[serde(default)]
   pub enabled: bool,
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsFuncLikeReturnTypesOptions {
   #[serde(default)]
   pub enabled: bool,
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintsEnumMemberValuesOptions {
   #[serde(default)]
   pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ImportCompletionSettings {
   /// A flag that indicates if non-explicitly set origins should be checked for
@@ -345,7 +360,8 @@ impl Default for ImportCompletionSettings {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestingSettings {
   /// A vector of arguments which should be used when running the tests for
@@ -377,7 +393,8 @@ fn empty_string_none<'de, D: serde::Deserializer<'de>>(
   Ok(o.filter(|s| !s.is_empty()))
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 pub enum ImportModuleSpecifier {
   NonRelative,
@@ -392,7 +409,8 @@ impl Default for ImportModuleSpecifier {
   }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 pub enum JsxAttributeCompletionStyle {
   Auto,
@@ -406,7 +424,8 @@ impl Default for JsxAttributeCompletionStyle {
   }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 pub enum QuoteStyle {
   Auto,
@@ -429,7 +448,8 @@ impl From<&FmtOptionsConfig> for QuoteStyle {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct LanguagePreferences {
   #[serde(default)]
@@ -459,7 +479,8 @@ impl Default for LanguagePreferences {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SuggestionActionsSettings {
   #[serde(default = "is_true")]
@@ -472,14 +493,16 @@ impl Default for SuggestionActionsSettings {
   }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateImportsOnFileMoveOptions {
   #[serde(default)]
   pub enabled: UpdateImportsOnFileMoveEnabled,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateImportsOnFileMoveEnabled {
   Always,
@@ -493,7 +516,8 @@ impl Default for UpdateImportsOnFileMoveEnabled {
   }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct LanguageWorkspaceSettings {
   #[serde(default)]
@@ -508,7 +532,8 @@ pub struct LanguageWorkspaceSettings {
   pub update_imports_on_file_move: UpdateImportsOnFileMoveOptions,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum InspectSetting {
@@ -533,7 +558,8 @@ impl InspectSetting {
 }
 
 /// Deno language server specific settings that are applied to a workspace.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceSettings {
   /// A flag that indicates if Deno is enabled for the workspace.
@@ -818,7 +844,8 @@ impl WorkspaceSettings {
   }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Settings {
   pub unscoped: Arc<WorkspaceSettings>,
   pub by_workspace_folder:
@@ -913,7 +940,8 @@ impl Settings {
   }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Config {
   pub client_capabilities: Arc<ClientCapabilities>,
   pub settings: Arc<Settings>,
@@ -1141,7 +1169,8 @@ impl Config {
   }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LspTsConfig {
   #[serde(flatten)]
   inner: TsConfig,
@@ -1183,7 +1212,8 @@ impl LspTsConfig {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ConfigWatchedFileType {
   DenoJson,
   Lockfile,
@@ -1193,7 +1223,8 @@ pub enum ConfigWatchedFileType {
 }
 
 /// Contains the config file and dependent information.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ConfigData {
   pub scope: Arc<ModuleSpecifier>,
   pub canonicalized_scope: Option<Arc<ModuleSpecifier>>,
@@ -1719,7 +1750,8 @@ impl ConfigData {
   }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ConfigTree {
   scopes: Arc<BTreeMap<ModuleSpecifier, Arc<ConfigData>>>,
 }
@@ -2079,7 +2111,8 @@ impl deno_config::deno_json::DenoJsonCache for DenoJsonMemCache {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct PackageJsonMemCache(Mutex<HashMap<PathBuf, Arc<PackageJson>>>);
 
 impl deno_package_json::PackageJsonCache for PackageJsonMemCache {

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -69,19 +69,20 @@ use crate::tools::lint::LintRuleProvider;
 use crate::tsc::DiagnosticCategory;
 use crate::util::path::to_percent_decoded_str;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DiagnosticServerUpdateMessage {
   pub snapshot: Arc<StateSnapshot>,
   pub url_map: LspUrlMap,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct DiagnosticRecord {
   pub specifier: ModuleSpecifier,
   pub versioned: VersionedDiagnostics,
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct VersionedDiagnostics {
   pub version: Option<i32>,
   pub diagnostics: Vec<lsp::Diagnostic>,
@@ -89,7 +90,8 @@ struct VersionedDiagnostics {
 
 type DiagnosticVec = Vec<DiagnosticRecord>;
 
-#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone)]
+#[derive(Hash, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DiagnosticSource {
   Deno,
   Lint,
@@ -110,7 +112,7 @@ impl DiagnosticSource {
 
 type DiagnosticsBySource = HashMap<DiagnosticSource, VersionedDiagnostics>;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct DiagnosticsPublisher {
   client: Client,
   state: Arc<DiagnosticsState>,
@@ -227,7 +229,8 @@ impl DiagnosticsPublisher {
 
 type DiagnosticMap = HashMap<ModuleSpecifier, VersionedDiagnostics>;
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct TsDiagnosticsStore(Arc<deno_core::parking_lot::Mutex<DiagnosticMap>>);
 
 impl TsDiagnosticsStore {
@@ -272,7 +275,8 @@ pub fn should_send_diagnostic_batch_index_notifications() -> bool {
   )
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct DiagnosticBatchCounter(Option<Arc<AtomicUsize>>);
 
 impl Default for DiagnosticBatchCounter {
@@ -301,25 +305,26 @@ impl DiagnosticBatchCounter {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ChannelMessage {
   Update(ChannelUpdateMessage),
   Clear,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct ChannelUpdateMessage {
   message: DiagnosticServerUpdateMessage,
   batch_index: Option<usize>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct SpecifierState {
   version: Option<i32>,
   no_cache_diagnostics: Vec<lsp::Diagnostic>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DiagnosticsState {
   specifiers: RwLock<HashMap<ModuleSpecifier, SpecifierState>>,
 }
@@ -384,13 +389,15 @@ impl DiagnosticsState {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct AmbientModules {
   regex: Option<regex::Regex>,
   dirty: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct DeferredDiagnostics {
   diagnostics: Option<Vec<DeferredDiagnosticRecord>>,
   ambient_modules_by_scope: HashMap<Option<Url>, AmbientModules>,
@@ -506,6 +513,7 @@ pub struct DiagnosticsServer {
   deferred_diagnostics: Arc<deno_core::parking_lot::Mutex<DeferredDiagnostics>>,
 }
 
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for DiagnosticsServer {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("DiagnosticsServer")
@@ -1145,32 +1153,37 @@ async fn generate_ts_diagnostics(
   Ok((diagnostics_vec, ambient_modules_by_scope))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticDataSpecifier {
   pub specifier: ModuleSpecifier,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct DiagnosticDataStrSpecifier {
   pub specifier: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct DiagnosticDataRedirect {
   pub redirect: ModuleSpecifier,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct DiagnosticDataNoLocal {
   pub to: ModuleSpecifier,
   pub message: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct DiagnosticDataImportMapRemap {
   pub from: String,
@@ -1861,7 +1874,7 @@ fn diagnose_dependency(
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct DeferredDiagnosticRecord {
   document_specifier: Url,
   version: Option<i32>,

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -55,7 +55,8 @@ use crate::graph_util::CliJsrUrlProvider;
 pub const DOCUMENT_SCHEMES: [&str; 5] =
   ["data", "blob", "file", "http", "https"];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum LanguageId {
   JavaScript,
   Jsx,
@@ -166,7 +167,8 @@ impl FromStr for LanguageId {
   }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum IndexValid {
   All,
   UpTo(u32),
@@ -183,7 +185,7 @@ impl IndexValid {
 
 /// An lsp representation of an asset in memory, that has either been retrieved
 /// from static assets built into Rust, or static assets built into tsc.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct AssetDocument {
   specifier: ModuleSpecifier,
   text: &'static str,
@@ -226,7 +228,7 @@ impl AssetDocument {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct AssetDocuments {
   inner: HashMap<ModuleSpecifier, Arc<AssetDocument>>,
 }
@@ -254,7 +256,8 @@ pub static ASSET_DOCUMENTS: Lazy<AssetDocuments> =
       .collect(),
   });
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum AssetOrDocument {
   Document(Arc<Document>),
   Asset(Arc<AssetDocument>),
@@ -418,14 +421,15 @@ fn get_maybe_test_module_fut(
   Some(handle)
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DocumentOpenData {
   lsp_version: i32,
   maybe_parsed_source: Option<ParsedSourceResult>,
   maybe_semantic_tokens: Arc<Mutex<Option<lsp::SemanticTokens>>>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Document {
   /// Contains the last-known-good set of dependencies from parsing the module.
   config: Arc<Config>,
@@ -957,7 +961,8 @@ pub fn to_lsp_range(referrer: &deno_graph::Range) -> lsp::Range {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct FileSystemDocuments {
   docs: DashMap<ModuleSpecifier, Arc<Document>>,
   dirty: AtomicBool,
@@ -1096,7 +1101,8 @@ impl FileSystemDocuments {
 }
 
 /// Specify the documents to include on a `documents.documents(...)` call.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DocumentsFilter {
   /// Includes all the documents (diagnosable & non-diagnosable, open & file system).
   All,
@@ -1106,7 +1112,8 @@ pub enum DocumentsFilter {
   OpenDiagnosable,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Documents {
   /// The DENO_DIR that the documents looks for non-file based modules.
   cache: Arc<LspCache>,

--- a/cli/lsp/jsr.rs
+++ b/cli/lsp/jsr.rs
@@ -29,7 +29,7 @@ use crate::jsr::partial_jsr_package_version_info_from_slice;
 use crate::jsr::JsrFetchResolver;
 
 /// Keep in sync with `JsrFetchResolver`!
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct JsrCacheResolver {
   nv_by_req: DashMap<PackageReq, Option<PackageNv>>,
   /// The `module_graph` fields of the version infos should be forcibly absent.
@@ -274,7 +274,7 @@ fn read_cached_url(
     .map(|f| f.content.into_owned())
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliJsrSearchApi {
   file_fetcher: Arc<CliFileFetcher>,
   resolver: JsrFetchResolver,
@@ -368,14 +368,16 @@ impl PackageSearchApi for CliJsrSearchApi {
 }
 
 fn parse_jsr_search_response(source: &str) -> Result<Vec<String>, AnyError> {
-  #[derive(Debug, Deserialize)]
+  #[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   #[serde(rename_all = "camelCase")]
   struct Item {
     scope: String,
     name: String,
     version_count: usize,
   }
-  #[derive(Debug, Deserialize)]
+  #[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   #[serde(rename_all = "camelCase")]
   struct Response {
     items: Vec<Item>,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -125,7 +125,8 @@ impl RootCertStoreProvider for LspRootCertStoreProvider {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LanguageServer {
   client: Client,
   pub inner: Rc<tokio::sync::RwLock<Inner>>,
@@ -140,7 +141,8 @@ pub struct LanguageServer {
 }
 
 /// Snapshot of the state used by TSC.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct StateSnapshot {
   pub project_version: usize,
   pub config: Arc<Config>,
@@ -153,7 +155,7 @@ type LanguageServerTaskFn = Box<dyn FnOnce(LanguageServer) + Send + Sync>;
 /// Used to queue tasks from inside of the language server lock that must be
 /// commenced from outside of it. For example, queue a request to cache a module
 /// after having loaded a config file which references it.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct LanguageServerTaskQueue {
   task_tx: UnboundedSender<LanguageServerTaskFn>,
   /// This is moved out to its own task after initializing.
@@ -186,7 +188,7 @@ impl LanguageServerTaskQueue {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Inner {
   cache: LspCache,
   /// The LSP client that this LSP server is connected to.
@@ -641,7 +643,7 @@ impl Inner {
       if !conf.enabled() {
         return None;
       }
-      lsp_log!("Initializing tracing subscriber: {:#?}", conf);
+      // lsp_log!("Initializing tracing subscriber: {:#?}", conf);
       let config = conf.into();
       super::trace::init_tracing_subscriber(&config)
         .inspect_err(|e| {

--- a/cli/lsp/lsp_custom.rs
+++ b/cli/lsp/lsp_custom.rs
@@ -10,7 +10,8 @@ pub const VIRTUAL_TEXT_DOCUMENT: &str = "deno/virtualTextDocument";
 pub const LATEST_DIAGNOSTIC_BATCH_INDEX: &str =
   "deno/internalLatestDiagnosticBatchIndex";
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TaskDefinition {
   pub name: String,
@@ -18,7 +19,8 @@ pub struct TaskDefinition {
   pub source_uri: lsp::Uri,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RegistryStateNotificationParams {
   pub origin: String,
   pub suggestions: bool,
@@ -32,19 +34,22 @@ impl lsp::notification::Notification for RegistryStateNotification {
   const METHOD: &'static str = "deno/registryState";
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct VirtualTextDocumentParams {
   pub text_document: lsp::TextDocumentIdentifier,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DiagnosticBatchNotificationParams {
   pub batch_index: usize,
   pub messages_len: usize,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DenoConfigurationData {
   pub scope_uri: lsp::Uri,
@@ -53,7 +58,8 @@ pub struct DenoConfigurationData {
   pub package_json: Option<lsp::TextDocumentIdentifier>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DidRefreshDenoConfigurationTreeNotificationParams {
   pub data: Vec<DenoConfigurationData>,
@@ -68,7 +74,8 @@ impl lsp::notification::Notification
   const METHOD: &'static str = "deno/didRefreshDenoConfigurationTree";
 }
 
-#[derive(Debug, Eq, Hash, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Eq, Hash, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum DenoConfigurationChangeType {
   Added,
@@ -87,14 +94,16 @@ impl DenoConfigurationChangeType {
   }
 }
 
-#[derive(Debug, Eq, Hash, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Eq, Hash, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum DenoConfigurationType {
   DenoJson,
   PackageJson,
 }
 
-#[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DenoConfigurationChangeEvent {
   pub scope_uri: lsp::Uri,
@@ -104,7 +113,8 @@ pub struct DenoConfigurationChangeEvent {
   pub configuration_type: DenoConfigurationType,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DidChangeDenoConfigurationNotificationParams {
   pub changes: Vec<DenoConfigurationChangeEvent>,
@@ -129,14 +139,16 @@ impl lsp::notification::Notification for DidUpgradeCheckNotification {
   const METHOD: &'static str = "deno/didUpgradeCheck";
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct UpgradeAvailable {
   pub latest_version: String,
   pub is_canary: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DidUpgradeCheckNotificationParams {
   pub upgrade_available: Option<UpgradeAvailable>,

--- a/cli/lsp/npm.rs
+++ b/cli/lsp/npm.rs
@@ -19,7 +19,7 @@ use crate::file_fetcher::TextDecodedFile;
 use crate::npm::NpmFetchResolver;
 use crate::sys::CliSys;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliNpmSearchApi {
   file_fetcher: Arc<CliFileFetcher>,
   resolver: NpmFetchResolver,
@@ -97,15 +97,18 @@ impl PackageSearchApi for CliNpmSearchApi {
 }
 
 fn parse_npm_search_response(source: &str) -> Result<Vec<String>, AnyError> {
-  #[derive(Debug, Deserialize)]
+  #[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   struct Package {
     name: String,
   }
-  #[derive(Debug, Deserialize)]
+  #[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   struct Object {
     package: Package,
   }
-  #[derive(Debug, Deserialize)]
+  #[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   struct Response {
     objects: Vec<Object>,
   }

--- a/cli/lsp/path_to_regex.rs
+++ b/cli/lsp/path_to_regex.rs
@@ -52,7 +52,7 @@ enum TokenType {
   End,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct LexToken {
   token_type: TokenType,
   index: usize,
@@ -227,7 +227,8 @@ impl fmt::Display for StringOrNumber {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum StringOrVec {
   String(String),
   Vec(Vec<String>),
@@ -300,7 +301,8 @@ impl From<Vec<String>> for StringOrVec {
 }
 
 /// Meta data about a key.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Key {
   pub name: StringOrNumber,
   pub prefix: Option<String>,
@@ -310,19 +312,21 @@ pub struct Key {
 }
 
 /// A token is a string (nothing special) or key metadata (capture group).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum Token {
   String(String),
   Key(Key),
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ParseOptions {
   delimiter: Option<String>,
   prefixes: Option<String>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TokensToCompilerOptions {
   sensitive: bool,
   validate: bool,
@@ -337,7 +341,7 @@ impl Default for TokensToCompilerOptions {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TokensToRegexOptions {
   sensitive: bool,
   strict: bool,
@@ -360,7 +364,8 @@ impl Default for TokensToRegexOptions {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PathToRegexOptions {
   parse_options: Option<ParseOptions>,
   token_to_regex_options: Option<TokensToRegexOptions>,
@@ -794,7 +799,7 @@ impl Compiler {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct MatchResult {
   pub params: HashMap<StringOrNumber, StringOrVec>,
 }
@@ -805,7 +810,7 @@ impl MatchResult {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Matcher {
   maybe_keys: Option<Vec<Key>>,
   re: FancyRegex,

--- a/cli/lsp/performance.rs
+++ b/cli/lsp/performance.rs
@@ -15,7 +15,8 @@ use deno_core::serde_json::json;
 
 use super::logging::lsp_debug;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct PerformanceAverage {
   pub name: String,
@@ -36,7 +37,7 @@ impl Ord for PerformanceAverage {
 }
 
 /// A structure which serves as a start of a measurement span.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PerformanceMark {
   name: String,
   count: u32,
@@ -44,7 +45,8 @@ pub struct PerformanceMark {
 }
 
 /// A structure which holds the information about the measured span.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PerformanceMeasure {
   pub name: String,
   pub count: u32,
@@ -72,7 +74,7 @@ impl From<PerformanceMark> for PerformanceMeasure {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PerformanceScopeMark {
   performance: Arc<Performance>,
   inner: Option<PerformanceMark>,
@@ -88,7 +90,7 @@ impl Drop for PerformanceScopeMark {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct PerformanceInner {
   counts: HashMap<String, u32>,
   measurements_by_type: HashMap<String, (/* count */ u32, /* duration */ f64)>,
@@ -139,7 +141,8 @@ impl Default for PerformanceInner {
 ///
 /// The structure will limit the size of measurements to the most recent 1000,
 /// and will roll off when that limit is reached.
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Performance(Mutex<PerformanceInner>);
 
 impl Performance {

--- a/cli/lsp/refactor.rs
+++ b/cli/lsp/refactor.rs
@@ -147,7 +147,8 @@ pub static ALL_KNOWN_REFACTOR_ACTION_KINDS: Lazy<
   ]
 });
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct RefactorCodeActionData {
   pub specifier: ModuleSpecifier,

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -76,7 +76,7 @@ fn base_url(url: &Url) -> String {
   url.origin().ascii_serialization()
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum CompletionType {
   Literal(String),
   Key {
@@ -347,7 +347,8 @@ fn validate_config(config: &RegistryConfigurationJson) -> Result<(), AnyError> {
   Ok(())
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RegistryConfigurationVariable {
   /// The name of the variable.
   key: String,
@@ -359,7 +360,8 @@ pub struct RegistryConfigurationVariable {
   url: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RegistryConfiguration {
   /// A Express-like path which describes how URLs are composed for a registry.
   schema: String,
@@ -391,13 +393,15 @@ impl RegistryConfiguration {
 
 /// A structure that represents the configuration of an origin and its module
 /// registries.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct RegistryConfigurationJson {
   version: u32,
   registries: Vec<RegistryConfiguration>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct VariableItemsList {
   pub items: Vec<String>,
@@ -406,7 +410,8 @@ struct VariableItemsList {
   pub preselect: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(untagged)]
 enum VariableItems {
   Simple(Vec<String>),
@@ -416,7 +421,8 @@ enum VariableItems {
 /// A structure which holds the information about currently configured module
 /// registries and can provide completion information for URLs that match
 /// one of the enabled registries.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ModuleRegistry {
   origins: HashMap<String, Vec<RegistryConfiguration>>,
   pub location: PathBuf,

--- a/cli/lsp/repl.rs
+++ b/cli/lsp/repl.rs
@@ -45,7 +45,7 @@ use super::config::WorkspaceSettings;
 use super::urls::uri_parse_unencoded;
 use super::urls::url_to_uri;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ReplCompletionItem {
   pub new_text: String,
   pub range: std::ops::Range<usize>,

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -84,7 +84,8 @@ use crate::tsc::into_specifier_and_media_type;
 use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct LspScopeResolver {
   resolver: Arc<CliResolver>,
   in_npm_pkg_checker: DenoInNpmPackageChecker,
@@ -327,7 +328,8 @@ impl LspScopeResolver {
   }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LspResolver {
   unscoped: Arc<LspScopeResolver>,
   by_scope: BTreeMap<ModuleSpecifier, Arc<LspScopeResolver>>,
@@ -647,7 +649,8 @@ impl LspResolver {
   }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ScopeDepInfo {
   pub deno_types_to_code_resolutions: HashMap<ModuleSpecifier, ModuleSpecifier>,
   pub npm_reqs: BTreeSet<PackageReq>,
@@ -954,7 +957,8 @@ impl<'a> ResolverFactory<'a> {
   }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct RedirectEntry {
   headers: Arc<HashMap<String, String>>,
   target: Url,
@@ -969,6 +973,7 @@ struct RedirectResolver {
   entries: DashMap<Url, Option<Arc<RedirectEntry>>>,
 }
 
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for RedirectResolver {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("RedirectResolver")
@@ -978,12 +983,22 @@ impl std::fmt::Debug for RedirectResolver {
   }
 }
 
-#[derive(Debug)]
 pub struct SingleReferrerGraphResolver<'a> {
   pub valid_referrer: &'a ModuleSpecifier,
   pub module_resolution_mode: ResolutionMode,
   pub cli_resolver: &'a CliResolver,
   pub jsx_import_source_config: Option<&'a JsxImportSourceConfig>,
+}
+
+impl<'a> std::fmt::Debug for SingleReferrerGraphResolver<'a> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("SingleReferrerGraphResolver")
+      // .field("valid_referrer", &self.valid_referrer)
+      // .field("module_resolution_mode", &self.module_resolution_mode)
+      // .field("cli_resolver", &self.cli_resolver)
+      // .field("jsx_import_source_config", &self.jsx_import_source_config)
+      .finish()
+  }
 }
 
 impl deno_graph::source::Resolver for SingleReferrerGraphResolver<'_> {

--- a/cli/lsp/search.rs
+++ b/cli/lsp/search.rs
@@ -22,7 +22,8 @@ pub mod tests {
 
   use super::*;
 
-  #[derive(Debug, Default)]
+  #[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   pub struct TestPackageSearchApi {
     /// [(name -> [(version -> [export])])]
     package_versions: BTreeMap<String, BTreeMap<Version, Vec<String>>>,

--- a/cli/lsp/testing/definitions.rs
+++ b/cli/lsp/testing/definitions.rs
@@ -17,7 +17,8 @@ use crate::lsp::urls::url_to_uri;
 use crate::tools::test::TestDescription;
 use crate::tools::test::TestStepDescription;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestDefinition {
   pub id: String,
   pub name: String,
@@ -27,7 +28,8 @@ pub struct TestDefinition {
   pub step_ids: HashSet<String>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestModule {
   pub specifier: ModuleSpecifier,
   pub defs: HashMap<String, TestDefinition>,

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -122,7 +122,8 @@ fn as_test_messages<S: AsRef<str>>(
   }]
 }
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct LspTestFilter {
   include: Option<HashMap<String, TestDefinition>>,
   exclude: HashMap<String, TestDefinition>,
@@ -147,7 +148,8 @@ impl LspTestFilter {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestRun {
   id: u32,
   kind: lsp_custom::TestRunKind,
@@ -497,7 +499,8 @@ impl TestRun {
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum LspTestDescription {
   /// `(desc, static_id)`
   TestDescription(test::TestDescription, String),

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -7,14 +7,16 @@ use tower_lsp::lsp_types as lsp;
 pub const TEST_RUN_CANCEL_REQUEST: &str = "deno/testRunCancel";
 pub const TEST_RUN_REQUEST: &str = "deno/testRun";
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct EnqueuedTestModule {
   pub text_document: lsp::TextDocumentIdentifier,
   pub ids: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestData {
   /// The unique ID of the test
@@ -29,7 +31,8 @@ pub struct TestData {
   pub range: Option<lsp::Range>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum TestModuleNotificationKind {
   /// The test module notification represents an insertion of tests, not
@@ -40,7 +43,8 @@ pub enum TestModuleNotificationKind {
   Replace,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestModuleNotificationParams {
   /// The text document that the notification relates to.
@@ -61,7 +65,8 @@ impl lsp::notification::Notification for TestModuleNotification {
   const METHOD: &'static str = "deno/testModule";
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestModuleDeleteNotificationParams {
   /// The text document that the notification relates to.
@@ -76,7 +81,8 @@ impl lsp::notification::Notification for TestModuleDeleteNotification {
   const METHOD: &'static str = "deno/testModuleDelete";
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum TestRunKind {
   // The run profile is just to execute the tests
@@ -88,7 +94,8 @@ pub enum TestRunKind {
   Coverage,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestRunRequestParams {
   pub id: u32,
@@ -100,20 +107,23 @@ pub struct TestRunRequestParams {
   pub include: Option<Vec<TestIdentifier>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestRunCancelParams {
   pub id: u32,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestRunProgressParams {
   pub id: u32,
   pub message: TestRunProgressMessage,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestIdentifier {
   /// The module identifier which contains the test.
@@ -128,7 +138,8 @@ pub struct TestIdentifier {
   pub step_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum TestRunProgressMessage {
   Enqueued {
@@ -167,7 +178,8 @@ pub enum TestRunProgressMessage {
   End,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestMessage {
   pub message: lsp::MarkupContent,

--- a/cli/lsp/testing/server.rs
+++ b/cli/lsp/testing/server.rs
@@ -44,7 +44,7 @@ pub type TestServerTests =
 
 /// The main structure which handles requests and sends notifications related
 /// to the Testing API.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestServer {
   client: Client,
   performance: Arc<Performance>,

--- a/cli/lsp/text.rs
+++ b/cli/lsp/text.rs
@@ -11,7 +11,8 @@ use tower_lsp::lsp_types::TextEdit;
 
 use crate::util::text_encoding::Utf16Map;
 
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LineIndex {
   inner: Utf16Map,
 }

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -131,7 +131,8 @@ mod stub_tracing {
 
     fn context(&self) -> Context;
   }
-  #[derive(Debug, Clone)]
+  #[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   pub struct Span {}
 
   impl SpanExt for Span {
@@ -153,10 +154,11 @@ mod stub_tracing {
     }
   }
 
-  #[derive(Debug)]
+  #[cfg_attr(any(test, debug_assertions), derive(Debug))]
   pub struct EnteredSpan {}
 
-  #[derive(Clone, Debug)]
+  #[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   pub struct Context {}
 
   pub(crate) fn init_tracing_subscriber(
@@ -169,9 +171,8 @@ mod stub_tracing {
   }
 }
 
-#[derive(
-  Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Copy, Default,
-)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Copy, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum TracingCollector {
   #[default]
@@ -179,7 +180,8 @@ pub(crate) enum TracingCollector {
   Logging,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(default, rename_all = "camelCase")]
 pub(crate) struct TracingConfig {
   /// Enable tracing.
@@ -196,7 +198,8 @@ pub(crate) struct TracingConfig {
   pub(crate) collector_endpoint: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(untagged)]
 pub(crate) enum TracingConfigOrEnabled {
   Config(TracingConfig),

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -130,7 +130,8 @@ type Request = (
   Option<super::trace::Context>,
 );
 
-#[derive(Debug, Clone, Copy, Serialize_repr)]
+#[derive(Clone, Copy, Serialize_repr)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[repr(u8)]
 pub enum IndentStyle {
   #[allow(dead_code)]
@@ -141,7 +142,8 @@ pub enum IndentStyle {
 }
 
 /// Relevant subset of https://github.com/denoland/deno/blob/v1.37.1/cli/tsc/dts/typescript.d.ts#L6658.
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Default, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatCodeSettings {
   base_indent_size: Option<u8>,
@@ -218,7 +220,8 @@ impl From<&FmtOptionsConfig> for FormatCodeSettings {
   }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum SemicolonPreference {
   Insert,
@@ -250,6 +253,7 @@ pub struct TsServer {
   enable_tracing: Arc<AtomicBool>,
 }
 
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for TsServer {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("TsServer")
@@ -262,7 +266,8 @@ impl std::fmt::Debug for TsServer {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[repr(u8)]
 pub enum ChangeKind {
   Opened = 0,
@@ -289,7 +294,7 @@ impl Serialize for ChangeKind {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[cfg_attr(test, derive(Serialize))]
 pub struct PendingChange {
   pub modified_scripts: Vec<(String, ChangeKind)>,
@@ -1510,7 +1515,8 @@ fn parse_kind_modifier(kind_modifiers: &str) -> HashSet<&str> {
   PART_KIND_MODIFIER_RE.split(kind_modifiers).collect()
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(untagged)]
 pub enum OneOrMany<T> {
   One(T),
@@ -1518,7 +1524,8 @@ pub enum OneOrMany<T> {
 }
 
 /// Aligns with ts.ScriptElementKind
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ScriptElementKind {
   #[serde(rename = "")]
   Unknown,
@@ -1708,7 +1715,8 @@ impl From<ScriptElementKind> for lsp::SymbolKind {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TextSpan {
   pub start: u32,
@@ -1733,7 +1741,8 @@ impl TextSpan {
   }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SymbolDisplayPart {
   text: String,
@@ -1745,7 +1754,8 @@ pub struct SymbolDisplayPart {
   target: Option<DocumentSpan>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct JsDocTagInfo {
   name: String,
@@ -1756,7 +1766,8 @@ pub struct JsDocTagInfo {
 // not currently used.  They are commented out in the structures so it is clear
 // that they exist.
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct QuickInfo {
   // kind: ScriptElementKind,
@@ -1929,7 +1940,8 @@ impl QuickInfo {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentSpan {
   text_span: TextSpan,
@@ -2023,7 +2035,8 @@ impl DocumentSpan {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum MatchKind {
   #[serde(rename = "exact")]
   Exact,
@@ -2035,7 +2048,8 @@ pub enum MatchKind {
   CamelCase,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct NavigateToItem {
   name: String,
@@ -2097,7 +2111,8 @@ impl NavigateToItem {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHintDisplayPart {
   pub text: String,
@@ -2141,7 +2156,8 @@ impl InlayHintDisplayPart {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum InlayHintKind {
   Type,
   Parameter,
@@ -2158,7 +2174,8 @@ impl InlayHintKind {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct InlayHint {
   pub text: String,
@@ -2197,7 +2214,8 @@ impl InlayHint {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct NavigationTree {
   pub text: String,
@@ -2373,7 +2391,8 @@ impl NavigationTree {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ImplementationLocation {
   #[serde(flatten)]
@@ -2419,7 +2438,8 @@ impl ImplementationLocation {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct RenameLocation {
   #[serde(flatten)]
@@ -2516,7 +2536,8 @@ impl RenameLocations {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum HighlightSpanKind {
   #[serde(rename = "none")]
   None,
@@ -2528,7 +2549,8 @@ pub enum HighlightSpanKind {
   WrittenReference,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct HighlightSpan {
   // file_name: Option<String>,
@@ -2538,7 +2560,8 @@ pub struct HighlightSpan {
   kind: HighlightSpanKind,
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DefinitionInfo {
   // kind: ScriptElementKind,
@@ -2559,7 +2582,8 @@ impl DefinitionInfo {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DefinitionInfoAndBoundSpan {
   pub definitions: Option<Vec<DefinitionInfo>>,
@@ -2603,7 +2627,8 @@ impl DefinitionInfoAndBoundSpan {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentHighlights {
   // file_name: String,
@@ -2635,7 +2660,8 @@ impl DocumentHighlights {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TextChange {
   pub span: TextSpan,
@@ -2661,7 +2687,8 @@ impl TextChange {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct FileTextChanges {
   pub file_name: String,
@@ -2746,7 +2773,8 @@ impl FileTextChanges {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Classifications {
   spans: Vec<u32>,
@@ -2813,7 +2841,8 @@ impl Classifications {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct RefactorActionInfo {
   name: String,
@@ -2873,7 +2902,8 @@ impl RefactorActionInfo {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicableRefactorInfo {
   name: String,
@@ -2960,7 +2990,8 @@ pub fn file_text_changes_to_workspace_edit(
   }))
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct RefactorEditInfo {
   pub edits: Vec<FileTextChanges>,
@@ -2988,7 +3019,8 @@ impl RefactorEditInfo {
   }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CodeAction {
   description: String,
@@ -3009,7 +3041,8 @@ impl CodeAction {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CodeFixAction {
   pub description: String,
@@ -3046,7 +3079,8 @@ impl CodeFixAction {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CombinedCodeActions {
   pub changes: Vec<FileTextChanges>,
@@ -3065,7 +3099,8 @@ impl CombinedCodeActions {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ReferencedSymbol {
   pub definition: ReferencedSymbolDefinitionInfo,
@@ -3085,7 +3120,8 @@ impl ReferencedSymbol {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ReferencedSymbolDefinitionInfo {
   #[serde(flatten)]
@@ -3102,7 +3138,8 @@ impl ReferencedSymbolDefinitionInfo {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ReferencedSymbolEntry {
   #[serde(default)]
@@ -3121,7 +3158,8 @@ impl ReferencedSymbolEntry {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ReferenceEntry {
   // is_write_access: bool,
@@ -3160,7 +3198,8 @@ impl ReferenceEntry {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CallHierarchyItem {
   name: String,
@@ -3278,7 +3317,8 @@ impl CallHierarchyItem {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CallHierarchyIncomingCall {
   from: CallHierarchyItem,
@@ -3318,7 +3358,8 @@ impl CallHierarchyIncomingCall {
   }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Eq, PartialEq, Hash, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CallHierarchyOutgoingCall {
   to: CallHierarchyItem,
@@ -3493,7 +3534,8 @@ fn get_parameters_from_parts(parts: &[SymbolDisplayPart]) -> Vec<String> {
   parameters
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionEntryDetails {
   display_parts: Vec<SymbolDisplayPart>,
@@ -3653,7 +3695,8 @@ impl CompletionEntryDetails {
   }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionInfo {
   entries: Vec<CompletionEntry>,
@@ -3732,14 +3775,16 @@ impl CompletionInfo {
   }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CompletionSpecifierRewrite {
   old_specifier: String,
   new_specifier: String,
   new_deno_types_specifier: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionItemData {
   pub specifier: ModuleSpecifier,
@@ -3757,20 +3802,22 @@ pub struct CompletionItemData {
   pub use_code_snippet: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct CompletionEntryDataAutoImport {
   module_specifier: String,
   file_name: Option<String>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CompletionNormalizedAutoImportData {
   raw: CompletionEntryDataAutoImport,
   normalized: ModuleSpecifier,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionEntry {
   name: String,
@@ -4092,7 +4139,8 @@ impl CompletionEntry {
   }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct CompletionEntryLabelDetails {
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -4101,7 +4149,8 @@ struct CompletionEntryLabelDetails {
   description: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum OutliningSpanKind {
   #[serde(rename = "comment")]
   Comment,
@@ -4113,7 +4162,8 @@ pub enum OutliningSpanKind {
   Imports,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct OutliningSpan {
   text_span: TextSpan,
@@ -4187,7 +4237,8 @@ impl OutliningSpan {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpItems {
   items: Vec<SignatureHelpItem>,
@@ -4221,7 +4272,8 @@ impl SignatureHelpItems {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpItem {
   // is_variadic: bool,
@@ -4272,7 +4324,8 @@ impl SignatureHelpItem {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpParameter {
   // name: String,
@@ -4303,7 +4356,8 @@ impl SignatureHelpParameter {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SelectionRange {
   text_span: TextSpan,
@@ -4325,7 +4379,8 @@ impl SelectionRange {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TscSpecifierMap {
   normalized_specifiers: DashMap<String, ModuleSpecifier>,
   denormalized_specifiers: DashMap<ModuleSpecifier, String>,
@@ -4509,7 +4564,8 @@ enum LoadError {
   SerdeV8(#[from] serde_v8::Error),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct LoadResponse {
   data: deno_core::FastString,
@@ -4780,7 +4836,8 @@ fn op_exit_span(op_state: &mut OpState, span: *const c_void, root: bool) {
   }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct ScriptNames {
   unscoped: IndexSet<String>,
@@ -5091,7 +5148,8 @@ deno_core::extension!(deno_tsc,
   }
 );
 
-#[derive(Debug, Clone, Deserialize_repr, Serialize_repr)]
+#[derive(Clone, Deserialize_repr, Serialize_repr)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[repr(u32)]
 pub enum CompletionTriggerKind {
   Invoked = 1,
@@ -5116,7 +5174,8 @@ pub type QuotePreference = config::QuoteStyle;
 
 pub type ImportModuleSpecifierPreference = config::ImportModuleSpecifier;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 #[allow(dead_code)]
 pub enum ImportModuleSpecifierEnding {
@@ -5126,7 +5185,8 @@ pub enum ImportModuleSpecifierEnding {
   Js,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 #[allow(dead_code)]
 pub enum IncludeInlayParameterNameHints {
@@ -5147,7 +5207,8 @@ impl From<&config::InlayHintsParamNamesEnabled>
   }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "kebab-case")]
 #[allow(dead_code)]
 pub enum IncludePackageJsonAutoImports {
@@ -5158,7 +5219,8 @@ pub enum IncludePackageJsonAutoImports {
 
 pub type JsxAttributeCompletionStyle = config::JsxAttributeCompletionStyle;
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Default, Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct GetCompletionsAtPositionOptions {
   #[serde(flatten)]
@@ -5169,7 +5231,8 @@ pub struct GetCompletionsAtPositionOptions {
   pub trigger_kind: Option<CompletionTriggerKind>,
 }
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Default, Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct UserPreferences {
   #[serde(skip_serializing_if = "Option::is_none")]
@@ -5365,14 +5428,16 @@ impl UserPreferences {
   }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpItemsOptions {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub trigger_reason: Option<SignatureHelpTriggerReason>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum SignatureHelpTriggerKind {
   #[serde(rename = "characterTyped")]
   CharacterTyped,
@@ -5395,7 +5460,8 @@ impl From<lsp::SignatureHelpTriggerKind> for SignatureHelpTriggerKind {
   }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct SignatureHelpTriggerReason {
   pub kind: SignatureHelpTriggerKind,
@@ -5403,7 +5469,8 @@ pub struct SignatureHelpTriggerReason {
   pub trigger_character: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct GetCompletionDetailsArgs {
   pub specifier: ModuleSpecifier,
@@ -5433,14 +5500,15 @@ impl From<&CompletionItemData> for GetCompletionDetailsArgs {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct GetNavigateToItemsArgs {
   pub search: String,
   pub max_result_count: Option<u32>,
   pub file: Option<String>,
 }
 
-#[derive(Debug, Serialize, Clone, Copy)]
+#[derive(Serialize, Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TscTextRange {
   pos: u32,
   end: u32,
@@ -5455,7 +5523,8 @@ impl From<Range<u32>> for TscTextRange {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Serialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CombinedCodeFixScope {
   r#type: &'static str,
@@ -5465,7 +5534,8 @@ pub struct CombinedCodeFixScope {
 #[derive(Serialize, Clone, Copy)]
 pub struct JsNull;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TscRequest {
   GetDiagnostics((Vec<String>, usize)),
 

--- a/cli/lsp/urls.rs
+++ b/cli/lsp/urls.rs
@@ -121,7 +121,8 @@ fn from_deno_url(url: &Url) -> Option<Url> {
   Url::parse(&string).ok()
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct LspUrlMapInner {
   specifier_to_uri: HashMap<ModuleSpecifier, Uri>,
   uri_to_specifier: HashMap<Uri, ModuleSpecifier>,
@@ -177,7 +178,8 @@ pub fn uri_to_url(uri: &Uri) -> Url {
   Url::parse(uri.as_str()).unwrap()
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum LspUrlKind {
   File,
   Folder,
@@ -186,7 +188,8 @@ pub enum LspUrlKind {
 /// A bi-directional map of URLs sent to the LSP client and internal module
 /// specifiers. We need to map internal specifiers into `deno:` schema URLs
 /// to allow the Deno language server to manage these as virtual documents.
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LspUrlMap {
   cache: LspCache,
   inner: Arc<Mutex<LspUrlMapInner>>,

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1242,7 +1242,7 @@ impl ModuleGraphUpdatePermit for WorkerModuleGraphUpdatePermit {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CliNodeRequireLoader<TGraphContainer: ModuleGraphContainer> {
   cjs_tracker: Arc<CliCjsTracker>,
   emitter: Arc<Emitter>,

--- a/cli/node.rs
+++ b/cli/node.rs
@@ -38,7 +38,8 @@ pub type CliNodeResolver = deno_runtime::deno_node::NodeResolver<
 >;
 pub type CliPackageJsonResolver = node_resolver::PackageJsonResolver<CliSys>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CliCjsAnalysis {
   /// The module was found to be an ES module.
   Esm,

--- a/cli/npm/installer/global.rs
+++ b/cli/npm/installer/global.rs
@@ -23,13 +23,24 @@ use crate::npm::CliNpmCache;
 use crate::npm::CliNpmTarballCache;
 
 /// Resolves packages from the global npm cache.
-#[derive(Debug)]
 pub struct GlobalNpmPackageInstaller {
   cache: Arc<CliNpmCache>,
   tarball_cache: Arc<CliNpmTarballCache>,
   resolution: Arc<NpmResolutionCell>,
   lifecycle_scripts: LifecycleScriptsConfig,
   system_info: NpmSystemInfo,
+}
+
+impl std::fmt::Debug for GlobalNpmPackageInstaller {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("GlobalNpmPackageInstaller")
+      // .field("cache", &self.cache)
+      // .field("tarball_cache", &self.tarball_cache)
+      // .field("resolution", &self.resolution)
+      // .field("lifecycle_scripts", &self.lifecycle_scripts)
+      // .field("system_info", &self.system_info)
+      .finish()
+  }
 }
 
 impl GlobalNpmPackageInstaller {

--- a/cli/npm/installer/local.rs
+++ b/cli/npm/installer/local.rs
@@ -50,7 +50,6 @@ use crate::util::progress_bar::ProgressMessagePrompt;
 
 /// Resolver that creates a local node_modules directory
 /// and resolves packages from it.
-#[derive(Debug)]
 pub struct LocalNpmPackageInstaller {
   cache: Arc<CliNpmCache>,
   npm_install_deps_provider: Arc<NpmInstallDepsProvider>,
@@ -61,6 +60,22 @@ pub struct LocalNpmPackageInstaller {
   lifecycle_scripts: LifecycleScriptsConfig,
   root_node_modules_path: PathBuf,
   system_info: NpmSystemInfo,
+}
+
+impl std::fmt::Debug for LocalNpmPackageInstaller {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("LocalNpmPackageInstaller")
+      // .field("cache", &self.cache)
+      // .field("npm_install_deps_provider", &self.npm_install_deps_provider)
+      // .field("progress_bar", &self.progress_bar)
+      // .field("resolution", &self.resolution)
+      // .field("sys", &self.sys)
+      // .field("tarball_cache", &self.tarball_cache)
+      // .field("lifecycle_scripts", &self.lifecycle_scripts)
+      // .field("root_node_modules_path", &self.root_node_modules_path)
+      // .field("system_info", &self.system_info)
+      .finish()
+  }
 }
 
 impl LocalNpmPackageInstaller {
@@ -800,7 +815,8 @@ impl SetupCacheDep<'_> {
 // Uses BTreeMap to preserve the ordering of the elements in memory, to ensure
 // the file generated from this datastructure is deterministic.
 // See: https://github.com/denoland/deno/issues/24479
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct SetupCacheData {
   root_symlinks: BTreeMap<String, String>,
   deno_symlinks: BTreeMap<String, String>,

--- a/cli/npm/installer/mod.rs
+++ b/cli/npm/installer/mod.rs
@@ -34,13 +34,14 @@ mod global;
 mod local;
 mod resolution;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PackageCaching<'a> {
   Only(Cow<'a, [PackageReq]>),
   All,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmInstaller {
   fs_installer: Arc<dyn NpmPackageFsInstaller>,
   npm_install_deps_provider: Arc<NpmInstallDepsProvider>,

--- a/cli/npm/installer/resolution.rs
+++ b/cli/npm/installer/resolution.rs
@@ -37,7 +37,7 @@ pub struct AddPkgReqsResult {
 }
 
 /// Updates the npm resolution with the provided package requirements.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmResolutionInstaller {
   registry_info_provider: Arc<CliNpmRegistryInfoProvider>,
   resolution: Arc<NpmResolutionCell>,

--- a/cli/npm/managed.rs
+++ b/cli/npm/managed.rs
@@ -20,20 +20,21 @@ use crate::sys::CliSys;
 pub type CliManagedNpmResolverCreateOptions =
   ManagedNpmResolverCreateOptions<CliSys>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CliNpmResolverManagedSnapshotOption {
   ResolveFromLockfile(Arc<CliLockfile>),
   Specified(Option<ValidSerializedNpmResolutionSnapshot>),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum SyncState {
   Pending(Option<CliNpmResolverManagedSnapshotOption>),
   Err(ResolveSnapshotError),
   Success,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmResolutionInitializer {
   npm_registry_info_provider: Arc<CliNpmRegistryInfoProvider>,
   npm_resolution: Arc<NpmResolutionCell>,

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -39,7 +39,7 @@ pub type CliNpmResolverCreateOptions =
 pub type CliByonmNpmResolverCreateOptions =
   ByonmNpmResolverCreateOptions<CliSys>;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliNpmCacheHttpClient {
   http_client_provider: Arc<HttpClientProvider>,
   progress_bar: ProgressBar,
@@ -98,7 +98,7 @@ impl deno_npm_cache::NpmCacheHttpClient for CliNpmCacheHttpClient {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmFetchResolver {
   nv_by_req: DashMap<PackageReq, Option<PackageNv>>,
   info_by_name: DashMap<String, Option<Arc<NpmPackageInfo>>>,

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -46,12 +46,13 @@ pub type CliNpmReqResolver = deno_resolver::npm::NpmReqResolver<
   CliSys,
 >;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FoundPackageJsonDepFlag(AtomicFlag);
 
 /// A resolver that takes care of resolution, taking into account loaded
 /// import map, JSX settings.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliResolver {
   deno_resolver: Arc<CliDenoResolver>,
   found_package_json_dep_flag: Arc<FoundPackageJsonDepFlag>,
@@ -123,12 +124,31 @@ impl CliResolver {
   }
 }
 
-#[derive(Debug)]
 pub struct CliNpmGraphResolver {
   npm_installer: Option<Arc<NpmInstaller>>,
   found_package_json_dep_flag: Arc<FoundPackageJsonDepFlag>,
   bare_node_builtins_enabled: bool,
   npm_caching: NpmCachingStrategy,
+}
+
+impl std::fmt::Debug for CliNpmGraphResolver {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut f = f.debug_struct("CliNpmGraphResolver");
+    #[cfg(any(test, debug_assertions))]
+    {
+      f.field("npm_installer", &self.npm_installer)
+        .field(
+          "found_package_json_dep_flag",
+          &self.found_package_json_dep_flag,
+        )
+        .field(
+          "bare_node_builtins_enabled",
+          &self.bare_node_builtins_enabled,
+        )
+        .field("npm_caching", &self.npm_caching);
+    }
+    f.finish()
+  }
 }
 
 impl CliNpmGraphResolver {

--- a/cli/rt/code_cache.rs
+++ b/cli/rt/code_cache.rs
@@ -24,7 +24,8 @@ enum CodeCacheStrategy {
   SubsequentRun(SubsequentRunCodeCacheStrategy),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DenoCompileCodeCacheEntry {
   pub source_hash: u64,
   pub data: Vec<u8>,

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -40,8 +40,14 @@ use sys_traits::boxed::FsReadDirBoxed;
 use sys_traits::FsCopy;
 use url::Url;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DenoRtSys(Arc<FileBackedVfs>);
+
+impl std::fmt::Debug for DenoRtSys {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_tuple("DenoRtSys").finish()
+  }
+}
 
 impl DenoRtSys {
   pub fn new(vfs: Arc<FileBackedVfs>) -> Self {
@@ -900,7 +906,7 @@ impl sys_traits::BaseEnvVar for DenoRtSys {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct VfsRoot {
   pub dir: VirtualDirectory,
   pub root_path: PathBuf,
@@ -1276,7 +1282,7 @@ impl FileBackedVfsMetadata {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FileBackedVfs {
   vfs_data: Cow<'static, [u8]>,
   fs_root: VfsRoot,

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -73,7 +73,8 @@ use crate::util::progress_bar::ProgressBarStyle;
 ///
 /// After creation, this URL may be used to get the key for a
 /// module in the binary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum StandaloneRelativeFileBaseUrl<'a> {
   WindowsSystemRoot,
   Path(&'a Url),

--- a/cli/standalone/virtual_fs.rs
+++ b/cli/standalone/virtual_fs.rs
@@ -39,7 +39,8 @@ fn vfs_as_display_tree(
 ) -> DisplayTreeNode {
   /// The VFS only stores duplicate files once, so track that and display
   /// it to the user so that it's not confusing.
-  #[derive(Debug, Default, Copy, Clone)]
+  #[derive(Default, Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   struct Size {
     unique: u64,
     total: u64,

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -58,14 +58,16 @@ use reporters::BenchReporter;
 use reporters::ConsoleReporter;
 use reporters::JsonReporter;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct BenchSpecifierOptions {
   filter: TestFilter,
   json: bool,
   log_level: Option<log::Level>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct BenchPlan {
   pub total: usize,
@@ -74,7 +76,8 @@ pub struct BenchPlan {
   pub names: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum BenchEvent {
   Plan(BenchPlan),
@@ -85,14 +88,16 @@ pub enum BenchEvent {
   UncaughtError(String, Box<JsError>),
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum BenchResult {
   Ok(BenchStats),
   Failed(Box<JsError>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct BenchReport {
   pub total: usize,
   pub failed: usize,
@@ -100,7 +105,8 @@ pub struct BenchReport {
   pub measurements: Vec<(BenchDescription, BenchStats)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Eq, Hash)]
+#[derive(Clone, PartialEq, Deserialize, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct BenchDescription {
   pub id: usize,
   pub name: String,
@@ -112,7 +118,8 @@ pub struct BenchDescription {
   pub warmup: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct BenchStats {
   pub n: u64,

--- a/cli/tools/bench/reporters.rs
+++ b/cli/tools/bench/reporters.rs
@@ -19,7 +19,8 @@ pub trait BenchReporter {
 
 const JSON_SCHEMA_VERSION: u8 = 1;
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct JsonReporterOutput {
   version: u8,
   runtime: String,
@@ -38,7 +39,8 @@ impl Default for JsonReporterOutput {
   }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct JsonReporterBench {
   origin: String,
   group: Option<String>,
@@ -47,7 +49,8 @@ struct JsonReporterBench {
   results: Vec<BenchResult>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct JsonReporter(JsonReporterOutput);
 
 impl JsonReporter {

--- a/cli/tools/coverage/merge.rs
+++ b/cli/tools/coverage/merge.rs
@@ -12,7 +12,8 @@ use super::range_tree::RangeTree;
 use super::range_tree::RangeTreeArena;
 use crate::cdp;
 
-#[derive(Eq, PartialEq, Clone, Debug)]
+#[derive(Eq, PartialEq, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ProcessCoverage {
   pub result: Vec<cdp::ScriptCoverage>,
 }
@@ -86,7 +87,8 @@ pub fn merge_scripts(
   })
 }
 
-#[derive(Eq, PartialEq, Hash, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CharRange {
   start: usize,
   end: usize,

--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -177,7 +177,8 @@ impl CoverageCollector {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct BranchCoverageItem {
   line_index: usize,
   block_number: usize,
@@ -186,14 +187,16 @@ struct BranchCoverageItem {
   is_hit: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct FunctionCoverageItem {
   name: String,
   line_index: usize,
   execution_count: i64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CoverageReport {
   url: ModuleSpecifier,
   named_functions: Vec<FunctionCoverageItem>,

--- a/cli/tools/coverage/range_tree.rs
+++ b/cli/tools/coverage/range_tree.rs
@@ -27,7 +27,8 @@ impl<'a> RangeTreeArena<'a> {
   }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RangeTree<'a> {
   pub start: usize,
   pub end: usize,

--- a/cli/tools/lint/ast_buffer/buffer.rs
+++ b/cli/tools/lint/ast_buffer/buffer.rs
@@ -11,7 +11,8 @@ use crate::util::text_encoding::Utf16Map;
 /// Each property has this flag to mark what kind of value it holds-
 /// Plain objects and arrays are not supported yet, but could be easily
 /// added if needed.
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PropFlags {
   Ref,
   RefArr,
@@ -79,7 +80,7 @@ fn append_usize(result: &mut Vec<u8>, value: usize) {
   append_u32(result, raw);
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct StringTable {
   id: usize,
   table: IndexMap<String, usize>,
@@ -119,9 +120,11 @@ impl StringTable {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NodeRef(pub Index);
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PendingRef(pub Index);
 
 pub trait AstBufSerializer {
@@ -133,7 +136,7 @@ pub trait AstBufSerializer {
 /// <child idx u32>
 /// <next idx u32>
 /// <parent idx u32>
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct Node {
   kind: u8,
   prop_offset: u32,
@@ -142,7 +145,7 @@ struct Node {
   parent: u32,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SerializeCtx {
   root_idx: Index,
 

--- a/cli/tools/lint/ast_buffer/ts_estree.rs
+++ b/cli/tools/lint/ast_buffer/ts_estree.rs
@@ -211,7 +211,8 @@ impl From<AstNode> for u8 {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum AstProp {
   // Base, these must be in sync with JS in the same order.
   Invalid,
@@ -2869,7 +2870,7 @@ impl TsEsTreeBuilder {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TsKeywordKind {
   Any,
   Unknown,
@@ -2886,21 +2887,21 @@ pub enum TsKeywordKind {
   Intrinsic,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TsModuleKind {
   Global,
   Namespace,
   Module,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PropertyKind {
   Get,
   Init,
   Set,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum MethodKind {
   Constructor,
   Get,
@@ -2908,7 +2909,7 @@ pub enum MethodKind {
   Set,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum SourceKind {
   Module,
   Script,

--- a/cli/tools/lint/linter.rs
+++ b/cli/tools/lint/linter.rs
@@ -42,7 +42,7 @@ pub struct CliLinterOptions {
   pub maybe_plugin_runner: Option<Arc<PluginHostProxy>>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliLinter {
   fix: bool,
   package_rules: Vec<Box<dyn PackageLintRule>>,

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -37,7 +37,7 @@ use crate::ops::lint::LintPluginContainer;
 use crate::tools::lint::serialize_ast_to_buffer;
 use crate::util::text_encoding::Utf16Map;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PluginHostRequest {
   LoadPlugins {
     specifiers: Vec<ModuleSpecifier>,
@@ -69,7 +69,8 @@ impl std::fmt::Debug for PluginHostResponse {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PluginLogger {
   print: fn(&str, bool),
 }
@@ -102,7 +103,7 @@ v8_static_strings! {
   RUN_PLUGINS_FOR_FILE = "runPluginsForFile",
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PluginHostProxy {
   tx: mpsc::Sender<PluginHostRequest>,
   pub(crate) plugin_info: Arc<Mutex<Vec<PluginInfo>>>,
@@ -209,7 +210,8 @@ async fn create_plugin_runner_inner(
   })
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(serde::Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct PluginInfo {
   pub name: String,

--- a/cli/tools/lint/reporters.rs
+++ b/cli/tools/lint/reporters.rs
@@ -146,7 +146,8 @@ impl LintReporter for CompactLintReporter {
 }
 
 // WARNING: Ensure doesn't change because it's used in the JSON output
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct JsonDiagnosticLintPosition {
   /// The 1-indexed line number.
@@ -167,7 +168,8 @@ impl JsonDiagnosticLintPosition {
 }
 
 // WARNING: Ensure doesn't change because it's used in the JSON output
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct JsonLintDiagnosticRange {
   pub start: JsonDiagnosticLintPosition,
   pub end: JsonDiagnosticLintPosition,

--- a/cli/tools/lint/rules/mod.rs
+++ b/cli/tools/lint/rules/mod.rs
@@ -53,14 +53,14 @@ pub enum FileOrPackageLintRule {
   Package(Box<dyn PackageLintRule>),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum CliLintRuleKind {
   DenoLint(Box<dyn LintRule>),
   Extended(Box<dyn ExtendedLintRule>),
   Package(Box<dyn PackageLintRule>),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CliLintRule(CliLintRuleKind);
 
 impl PartialEq for CliLintRule {
@@ -119,7 +119,7 @@ impl CliLintRule {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ConfiguredRules {
   pub all_rule_codes: HashSet<Cow<'static, str>>,
   pub rules: Vec<CliLintRule>,

--- a/cli/tools/lint/rules/no_sloppy_imports.rs
+++ b/cli/tools/lint/rules/no_sloppy_imports.rs
@@ -25,10 +25,17 @@ use super::ExtendedLintRule;
 use crate::graph_util::CliJsrUrlProvider;
 use crate::sys::CliSys;
 
-#[derive(Debug)]
 pub struct NoSloppyImportsRule {
   // None for making printing out the lint rules easy
   workspace_resolver: Option<Arc<WorkspaceResolver<CliSys>>>,
+}
+
+impl std::fmt::Debug for NoSloppyImportsRule {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("NoSloppyImportsRule")
+      // .field("workspace_resolver", &self.workspace_resolver)
+      .finish()
+  }
 }
 
 impl NoSloppyImportsRule {
@@ -166,12 +173,20 @@ impl LintRule for NoSloppyImportsRule {
   }
 }
 
-#[derive(Debug)]
 struct SloppyImportCaptureResolver<'a> {
   workspace_resolver: &'a WorkspaceResolver<CliSys>,
   captures: RefCell<
     HashMap<Range, (deno_ast::ModuleSpecifier, SloppyImportsResolutionReason)>,
   >,
+}
+
+impl<'a> std::fmt::Debug for SloppyImportCaptureResolver<'a> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("SloppyImportCaptureResolver")
+      // .field("workspace_resolver", &self.workspace_resolver)
+      // .field("captures", &self.captures)
+      .finish()
+  }
 }
 
 impl deno_graph::source::Resolver for SloppyImportCaptureResolver<'_> {

--- a/cli/tools/pm/deps.rs
+++ b/cli/tools/pm/deps.rs
@@ -47,7 +47,8 @@ use crate::npm::CliNpmResolver;
 use crate::npm::NpmFetchResolver;
 use crate::util::sync::AtomicFlag;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ImportMapKind {
   Inline,
   Outline(PathBuf),
@@ -83,8 +84,10 @@ impl DepLocation {
   }
 }
 
+#[cfg(any(test, debug_assertions))]
 struct DebugAdapter<T>(T);
 
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for DebugAdapter<&ConfigFileRc> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("ConfigFile")
@@ -92,6 +95,7 @@ impl std::fmt::Debug for DebugAdapter<&ConfigFileRc> {
       .finish()
   }
 }
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for DebugAdapter<&PackageJsonRc> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("PackageJson")
@@ -100,6 +104,7 @@ impl std::fmt::Debug for DebugAdapter<&PackageJsonRc> {
   }
 }
 
+#[cfg(any(test, debug_assertions))]
 impl std::fmt::Debug for DepLocation {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
@@ -119,7 +124,8 @@ impl std::fmt::Debug for DepLocation {
   }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DepKind {
   Jsr,
   Npm,
@@ -183,7 +189,8 @@ impl KeyPath {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Dep {
   pub req: PackageReq,
   pub kind: DepKind,
@@ -275,7 +282,8 @@ fn deno_json_import_map(
     .map(|import_map| Some((import_map, kind)))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum PackageJsonDepKind {
   Normal,
   Dev,
@@ -408,10 +416,12 @@ fn deps_from_workspace(
   Ok(deps)
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DepId(usize);
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum Change {
   Update(DepId, VersionReq),
 }
@@ -439,7 +449,8 @@ where
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PackageLatestVersion {
   pub semver_compatible: Option<PackageNv>,
   pub latest: Option<PackageNv>,

--- a/cli/tools/pm/mod.rs
+++ b/cli/tools/pm/mod.rs
@@ -40,7 +40,8 @@ mod outdated;
 pub use cache_deps::cache_top_level_deps;
 pub use outdated::outdated;
 
-#[derive(Debug, Copy, Clone, Hash)]
+#[derive(Copy, Clone, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ConfigKind {
   DenoJson,
   PackageJson,
@@ -699,13 +700,15 @@ async fn find_package_and_select_version_for_req(
   }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum AddRmPackageReqValue {
   Jsr(PackageReq),
   Npm(PackageReq),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct AddRmPackageReq {
   alias: StackString,
   value: AddRmPackageReqValue,

--- a/cli/tools/pm/outdated/interactive.rs
+++ b/cli/tools/pm/outdated/interactive.rs
@@ -23,7 +23,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::tools::pm::deps::DepId;
 use crate::tools::pm::deps::DepKind;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PackageInfo {
   pub id: DepId,
   pub current_version: Option<Version>,
@@ -32,7 +32,7 @@ pub struct PackageInfo {
   pub kind: DepKind,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct FormattedPackageInfo {
   dep_ids: Vec<DepId>,
   current_version_string: Option<String>,
@@ -42,7 +42,7 @@ struct FormattedPackageInfo {
   name: String,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct State {
   packages: Vec<FormattedPackageInfo>,
   currently_selected: usize,

--- a/cli/tools/pm/outdated/mod.rs
+++ b/cli/tools/pm/outdated/mod.rs
@@ -28,7 +28,8 @@ use crate::file_fetcher::CliFileFetcher;
 use crate::jsr::JsrFetchResolver;
 use crate::npm::NpmFetchResolver;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct OutdatedPackage {
   kind: DepKind,
   latest: String,

--- a/cli/tools/publish/provenance.rs
+++ b/cli/tools/publish/provenance.rs
@@ -254,19 +254,22 @@ const GITHUB_BUILDER_ID_PREFIX: &str = "https://github.com/actions/runner";
 const GITHUB_BUILD_TYPE: &str =
   "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1";
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct X509Certificate {
   pub raw_bytes: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct X509CertificateChain {
   pub certificates: [X509Certificate; 1],
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct VerificationMaterialContent {
   #[serde(rename = "$case")]
@@ -274,13 +277,15 @@ pub struct VerificationMaterialContent {
   pub x509_certificate_chain: X509CertificateChain,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TlogEntry {
   pub log_index: u64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct VerificationMaterial {
   pub content: VerificationMaterialContent,
@@ -579,7 +584,8 @@ static DEFAULT_REKOR_URL: Lazy<String> = Lazy::new(|| {
     .unwrap_or_else(|_| "https://rekor.sigstore.dev".to_string())
 });
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct LogEntry {
   #[allow(dead_code)]
@@ -590,7 +596,8 @@ pub struct LogEntry {
 
 type RekorEntry = HashMap<String, LogEntry>;
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct RekorSignature {
   sig: String,
@@ -599,7 +606,8 @@ struct RekorSignature {
   public_key: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct DsseEnvelope {
   payload: String,
@@ -607,7 +615,8 @@ struct DsseEnvelope {
   signatures: [RekorSignature; 1],
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct ProposedIntotoEntry {
   api_version: &'static str,
@@ -615,13 +624,15 @@ struct ProposedIntotoEntry {
   spec: ProposedIntotoEntrySpec,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct ProposedIntotoEntrySpec {
   content: ProposedIntotoEntryContent,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct ProposedIntotoEntryContent {
   envelope: DsseEnvelope,
@@ -629,7 +640,8 @@ struct ProposedIntotoEntryContent {
   payload_hash: ProposedIntotoEntryHash,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct ProposedIntotoEntryHash {
   algorithm: &'static str,

--- a/cli/tools/publish/tar.rs
+++ b/cli/tools/publish/tar.rs
@@ -15,7 +15,8 @@ use super::diagnostics::PublishDiagnosticsCollector;
 use super::module_content::ModuleContentProvider;
 use super::paths::CollectedPublishPath;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PublishableTarballFile {
   pub path_str: String,
   pub specifier: Url,
@@ -23,7 +24,8 @@ pub struct PublishableTarballFile {
   pub size: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PublishableTarball {
   pub files: Vec<PublishableTarballFile>,
   pub hash: String,

--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -35,7 +35,8 @@ use sys_traits::FsRead;
 
 use crate::sys::CliSys;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum SpecifierUnfurlerDiagnostic {
   UnanalyzableDynamicImport {
     specifier: ModuleSpecifier,
@@ -199,6 +200,7 @@ impl<TSys: FsMetadata + FsRead> SpecifierUnfurler<TSys> {
     workspace_resolver: Arc<WorkspaceResolver<TSys>>,
     bare_node_builtins: bool,
   ) -> Self {
+    #[cfg(any(test, debug_assertions))]
     debug_assert_eq!(
       workspace_resolver.pkg_json_dep_resolution(),
       PackageJsonDepResolution::Enabled

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -170,7 +170,7 @@ pub fn result_to_evaluation_output(
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TsEvaluateResponse {
   pub ts_code: String,
   pub value: cdp::EvaluateResponse,
@@ -864,7 +864,8 @@ static JSX_RE: Lazy<Regex> =
 static JSX_FRAG_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"(?i)^[\s*]*@jsxFrag\s+(\S+)").unwrap());
 
-#[derive(Default, Debug)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct AnalyzedJsxPragmas {
   /// Information about `@jsxImportSource` pragma.
   jsx_import_source: Option<SpecifierWithRange>,

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -44,7 +44,7 @@ use crate::task_runner;
 use crate::task_runner::run_future_forwarding_signals;
 use crate::util::fs::canonicalize_path;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct PackageTaskInfo {
   matched_tasks: Vec<String>,
   tasks_config: WorkspaceTasksConfig,
@@ -547,7 +547,7 @@ impl<'a> TaskRunner<'a> {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum TaskError {
   NotFound(String),
   TaskDepCycle { path: Vec<String> },
@@ -957,7 +957,7 @@ fn arg_to_task_name_filter(input: &str) -> Result<TaskNameFilter, AnyError> {
   Ok(TaskNameFilter::Regex(re))
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum TaskNameFilter<'s> {
   Exact(&'s str),
   Regex(regex::Regex),

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -144,7 +144,8 @@ fn get_sanitizer_item_ref(
 }
 
 /// The test mode is used to determine how a specifier is to be tested.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TestMode {
   /// Test as documentation, type-checking fenced code blocks.
   Documentation,
@@ -169,7 +170,8 @@ impl TestMode {
   }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestFilter {
   pub substring: Option<String>,
   pub regex: Option<Regex>,
@@ -220,7 +222,8 @@ impl TestFilter {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Eq, Hash)]
+#[derive(Clone, PartialEq, Deserialize, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestLocation {
   pub file_name: String,
@@ -249,7 +252,8 @@ impl TestContainer {
   }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestDescriptions {
   tests: IndexMap<usize, TestDescription>,
 }
@@ -273,7 +277,8 @@ impl<'a> IntoIterator for &'a TestDescriptions {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Eq, Hash)]
+#[derive(Clone, PartialEq, Deserialize, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestDescription {
   pub id: usize,
@@ -287,7 +292,8 @@ pub struct TestDescription {
 }
 
 /// May represent a failure of a test or test step.
-#[derive(Debug, Clone, PartialEq, Deserialize, Eq, Hash)]
+#[derive(Clone, PartialEq, Deserialize, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestFailureDescription {
   pub id: usize,
@@ -307,13 +313,15 @@ impl From<&TestDescription> for TestFailureDescription {
   }
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Default, Clone, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestFailureFormatOptions {
   pub hide_stacktraces: bool,
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum TestFailure {
   JsError(Box<JsError>),
@@ -425,7 +433,8 @@ impl TestFailure {
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum TestResult {
   Ok,
@@ -434,7 +443,8 @@ pub enum TestResult {
   Cancelled,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestStepDescription {
   pub id: usize,
@@ -448,7 +458,8 @@ pub struct TestStepDescription {
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum TestStepResult {
   Ok,
@@ -456,7 +467,8 @@ pub enum TestStepResult {
   Failed(TestFailure),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TestPlan {
   pub origin: String,
@@ -465,13 +477,14 @@ pub struct TestPlan {
   pub used_only: bool,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TestStdioStream {
   Stdout,
   Stderr,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TestEvent {
   Register(Arc<TestDescriptions>),
   Plan(TestPlan),
@@ -510,7 +523,8 @@ impl TestEvent {
   }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestSummary {
   pub total: usize,
   pub passed: usize,
@@ -525,7 +539,8 @@ pub struct TestSummary {
   pub uncaught_errors: Vec<(String, Box<JsError>)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct TestSpecifiersOptions {
   cwd: Url,
   concurrent_jobs: NonZeroUsize,
@@ -538,7 +553,8 @@ struct TestSpecifiersOptions {
   hide_stacktraces: bool,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TestSpecifierOptions {
   pub shuffle: Option<u64>,
   pub filter: TestFilter,

--- a/cli/tools/test/reporters/junit.rs
+++ b/cli/tools/test/reporters/junit.rs
@@ -251,7 +251,8 @@ impl TestReporter for JunitTestReporter {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct TestNameTree(IndexMap<usize, TestNameTreeNode>);
 
 impl TestNameTree {
@@ -298,7 +299,7 @@ impl TestNameTree {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct TestNameTreeNode {
   id: usize,
   parent_id: Option<usize>,

--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -86,7 +86,8 @@ impl UpdateCheckerEnvironment for RealUpdateCheckerEnvironment {
   }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum UpgradeCheckKind {
   Execution,
   Lsp,
@@ -400,7 +401,8 @@ pub fn check_for_upgrades(
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct LspVersionUpgradeInfo {
   pub latest_version: String,
   pub is_canary: bool,
@@ -614,7 +616,8 @@ pub async fn upgrade(
   Ok(())
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum RequestedVersion {
   Latest(ReleaseChannel),
   SpecificVersion(ReleaseChannel, String),
@@ -806,7 +809,8 @@ async fn find_latest_version_to_upgrade(
   Ok(maybe_newer_latest_version)
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct AvailableVersion {
   version_or_hash: String,
   release_channel: ReleaseChannel,
@@ -1043,7 +1047,7 @@ fn check_exe(exe_path: &Path) -> Result<(), AnyError> {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CheckVersionFile {
   pub last_prompt: chrono::DateTime<chrono::Utc>,
   pub last_checked: chrono::DateTime<chrono::Utc>,

--- a/cli/tsc/diagnostics.rs
+++ b/cli/tsc/diagnostics.rs
@@ -14,7 +14,8 @@ use deno_terminal::colors;
 
 const MAX_SOURCE_LINE_LENGTH: usize = 150;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DiagnosticCategory {
   Warning,
   Error,
@@ -74,7 +75,8 @@ impl From<i64> for DiagnosticCategory {
   }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticMessageChain {
   message_text: String,
@@ -101,7 +103,8 @@ impl DiagnosticMessageChain {
   }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Position {
   /// 0-indexed line number
@@ -119,7 +122,8 @@ impl Position {
   }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
   pub category: DiagnosticCategory,
@@ -320,8 +324,9 @@ impl fmt::Display for Diagnostic {
   }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, deno_error::JsError)]
-#[class(generic)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(deno_error::JsError, Debug))]
+#[cfg_attr(any(test, debug_assertions), class(generic))]
 pub struct Diagnostics(Vec<Diagnostic>);
 
 impl Diagnostics {
@@ -452,6 +457,7 @@ fn display_diagnostics(
   Ok(())
 }
 
+#[cfg(any(test, debug_assertions))]
 impl Error for Diagnostics {}
 
 #[cfg(test)]

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -299,7 +299,8 @@ pub static LAZILY_LOADED_STATIC_ASSETS: Lazy<
 });
 
 /// A structure representing stats from a type check operation for a graph.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Stats(pub Vec<(String, u32)>);
 
 impl<'de> Deserialize<'de> for Stats {
@@ -363,7 +364,8 @@ fn hash_url(specifier: &ModuleSpecifier, media_type: MediaType) -> String {
   )
 }
 
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct EmittedFile {
   pub data: String,
   pub maybe_specifiers: Option<Vec<ModuleSpecifier>>,
@@ -386,7 +388,7 @@ pub fn into_specifier_and_media_type(
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TypeCheckingCjsTracker {
   cjs_tracker: Arc<CliCjsTracker>,
   module_info_cache: Arc<ModuleInfoCache>,
@@ -442,7 +444,7 @@ impl TypeCheckingCjsTracker {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RequestNpmState {
   pub cjs_tracker: Arc<TypeCheckingCjsTracker>,
   pub node_resolver: Arc<CliNodeResolver>,
@@ -450,7 +452,7 @@ pub struct RequestNpmState {
 }
 
 /// A structure representing a request to be sent to the tsc runtime.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Request {
   /// The TypeScript compiler options which will be serialized and sent to
   /// tsc.
@@ -467,7 +469,8 @@ pub struct Request {
   pub check_mode: TypeCheckMode,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Response {
   /// Any diagnostics that have been returned from the checker.
   pub diagnostics: Diagnostics,
@@ -479,7 +482,7 @@ pub struct Response {
 
 // TODO(bartlomieju): we have similar struct in `tsc.rs` - maybe at least change
 // the name of the struct to avoid confusion?
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct State {
   hash_data: u64,
   graph: Arc<ModuleGraph>,
@@ -553,7 +556,8 @@ fn op_create_hash_inner(s: &mut OpState, text: &str) -> String {
   get_hash(text, state.hash_data)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct EmitArgs {
   /// The text data/contents of the file.
@@ -629,7 +633,8 @@ pub enum LoadError {
   ClosestPkgJson(#[from] node_resolver::errors::ClosestPkgJsonError),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct LoadResponse {
   data: FastString,
@@ -816,7 +821,8 @@ pub enum ResolveError {
   ResolveNonGraphSpecifierTypes(#[from] ResolveNonGraphSpecifierTypesError),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveArgs {
   /// The base specifier that the supplied specifier strings should be resolved
@@ -1197,7 +1203,8 @@ fn op_is_node_file(state: &mut OpState, #[string] path: &str) -> bool {
     .unwrap_or(false)
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[derive(Deserialize, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct RespondArgs {
   pub diagnostics: Diagnostics,
   pub stats: Stats,
@@ -1472,7 +1479,8 @@ mod tests {
   use super::*;
   use crate::args::TsConfig;
 
-  #[derive(Debug, Default)]
+  #[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
   pub struct MockLoader {
     pub fixtures: PathRef,
   }

--- a/cli/type_checker.rs
+++ b/cli/type_checker.rs
@@ -353,7 +353,8 @@ fn resolve_graph_imports_for_workspace_dir(
 }
 
 /// Key to use to group roots together by config.
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Hash, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CheckGroupKey<'a> {
   ts_config: &'a Arc<TsConfig>,
   imports: Rc<Vec<Url>>,

--- a/cli/util/draw_thread.rs
+++ b/cli/util/draw_thread.rs
@@ -22,7 +22,7 @@ pub trait DrawThreadRenderer: Send + Sync + std::fmt::Debug {
 /// that you wish the entry to be drawn for. Once it is
 /// dropped, then the entry will be removed from the draw
 /// thread.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DrawThreadGuard(u16);
 
 impl Drop for DrawThreadGuard {
@@ -31,13 +31,14 @@ impl Drop for DrawThreadGuard {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct InternalEntry {
   id: u16,
   renderer: Arc<dyn DrawThreadRenderer>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct InternalState {
   // this ensures only one actual draw thread is running
   drawer_id: usize,
@@ -81,7 +82,8 @@ static IS_TTY_WITH_CONSOLE_SIZE: Lazy<bool> = Lazy::new(|| {
 /// The draw thread is responsible for rendering multiple active
 /// `DrawThreadRenderer`s to stderr. It is global because the
 /// concept of stderr in the process is also a global concept.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DrawThread;
 
 impl DrawThread {

--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -141,7 +141,7 @@ fn create_print_after_restart_fn(clear_screen: bool) -> impl Fn() {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WatcherCommunicatorOptions {
   /// Send a list of paths that should be watched for changes.
   pub paths_to_watch_tx: tokio::sync::mpsc::UnboundedSender<Vec<PathBuf>>,
@@ -155,7 +155,7 @@ pub struct WatcherCommunicatorOptions {
 }
 
 /// An interface to interact with Deno's CLI file watcher.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WatcherCommunicator {
   /// Send a list of paths that should be watched for changes.
   paths_to_watch_tx: tokio::sync::mpsc::UnboundedSender<Vec<PathBuf>>,
@@ -268,7 +268,8 @@ where
   fut.await
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum WatcherRestartMode {
   /// When a file path changes the process is restarted.
   Automatic,

--- a/cli/util/progress_bar/mod.rs
+++ b/cli/util/progress_bar/mod.rs
@@ -21,7 +21,8 @@ mod renderer;
 // Inspired by Indicatif, but this custom implementation allows
 // for more control over what's going on under the hood.
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ProgressMessagePrompt {
   Download,
   Blocking,
@@ -42,7 +43,7 @@ impl ProgressMessagePrompt {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UpdateGuard {
   maybe_entry: Option<Arc<ProgressBarEntry>>,
 }
@@ -69,7 +70,8 @@ impl UpdateGuard {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ProgressBarStyle {
   /// Shows a progress bar with human readable download size
   DownloadBars,
@@ -81,7 +83,7 @@ pub enum ProgressBarStyle {
   TextOnly,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct ProgressBarEntry {
   id: usize,
   prompt: ProgressMessagePrompt,
@@ -125,7 +127,7 @@ impl ProgressBarEntry {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct InternalState {
   /// If this guard exists, then it means the progress
   /// bar is displaying in the draw thread.
@@ -136,10 +138,22 @@ struct InternalState {
   entries: Vec<Arc<ProgressBarEntry>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct ProgressBarInner {
   state: Arc<Mutex<InternalState>>,
   renderer: Arc<dyn ProgressBarRenderer>,
+}
+
+impl std::fmt::Debug for ProgressBarInner {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut f = f.debug_struct("ProgressBarInner");
+
+    #[cfg(any(test, debug_assertions))]
+    {
+      f.field("state", &self.state);
+    }
+    f.field("renderer", &self.renderer).finish()
+  }
 }
 
 impl ProgressBarInner {
@@ -261,7 +275,8 @@ impl DrawThreadRenderer for ProgressBarInner {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ProgressBar {
   inner: ProgressBarInner,
 }

--- a/cli/util/sync/async_flag.rs
+++ b/cli/util/sync/async_flag.rs
@@ -2,7 +2,8 @@
 
 use tokio_util::sync::CancellationToken;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct AsyncFlag(CancellationToken);
 
 impl AsyncFlag {

--- a/cli/util/sync/task_queue.rs
+++ b/cli/util/sync/task_queue.rs
@@ -9,14 +9,16 @@ use deno_core::parking_lot::Mutex;
 
 use super::AtomicFlag;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct TaskQueueTaskItem {
   is_ready: AtomicFlag,
   is_future_dropped: AtomicFlag,
   waker: AtomicWaker,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct TaskQueueTasks {
   is_running: bool,
   items: LinkedList<Arc<TaskQueueTaskItem>>,
@@ -27,7 +29,8 @@ struct TaskQueueTasks {
 ///
 /// Note that this differs from tokio's semaphore in that the order
 /// is acquired synchronously.
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TaskQueue {
   tasks: Mutex<TaskQueueTasks>,
 }

--- a/cli/util/text_encoding.rs
+++ b/cli/util/text_encoding.rs
@@ -90,7 +90,8 @@ fn find_source_map_range(code: &[u8]) -> Option<Range<usize>> {
   }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Utf16Char {
   pub start: TextSize,
   pub end: TextSize,
@@ -110,7 +111,8 @@ impl Utf16Char {
   }
 }
 
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Utf16Map {
   utf8_offsets: Vec<TextSize>,
   utf16_lines: HashMap<u32, Vec<Utf16Char>>,

--- a/cli/util/v8/convert.rs
+++ b/cli/util/v8/convert.rs
@@ -4,7 +4,8 @@ use deno_core::v8;
 use deno_core::FromV8;
 use deno_core::ToV8;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 /// A wrapper type for `Option<T>` that (de)serializes `None` as `null`
 #[repr(transparent)]
 pub struct OptionNull<T>(pub Option<T>);

--- a/ext/cache/lib.rs
+++ b/ext/cache/lib.rs
@@ -118,7 +118,8 @@ deno_core::extension!(deno_cache,
   },
 );
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CachePutRequest {
   pub cache_id: i64,
@@ -130,7 +131,8 @@ pub struct CachePutRequest {
   pub response_rid: Option<ResourceId>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CacheMatchRequest {
   pub cache_id: i64,
@@ -138,11 +140,13 @@ pub struct CacheMatchRequest {
   pub request_headers: Vec<(ByteString, ByteString)>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CacheMatchResponse(CacheMatchResponseMeta, Option<ResourceId>);
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CacheMatchResponseMeta {
   pub response_status: u16,
@@ -151,7 +155,8 @@ pub struct CacheMatchResponseMeta {
   pub response_headers: Vec<(ByteString, ByteString)>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CacheDeleteRequest {
   pub cache_id: i64,

--- a/ext/canvas/op_create_image_bitmap.rs
+++ b/ext/canvas/op_create_image_bitmap.rs
@@ -25,33 +25,38 @@ use crate::image_ops::to_srgb_from_icc_profile;
 use crate::image_ops::unpremultiply_alpha;
 use crate::CanvasError;
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ImageBitmapSource {
   Blob,
   ImageData,
   ImageBitmap,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ImageOrientation {
   FlipY,
   FromImage,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum PremultiplyAlpha {
   Default,
   Premultiply,
   None,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ColorSpaceConversion {
   Default,
   None,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ResizeQuality {
   Pixelated,
   Low,
@@ -59,7 +64,8 @@ enum ResizeQuality {
   High,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum MimeType {
   NoMatch,
   Png,
@@ -266,7 +272,8 @@ fn apply_premultiply_alpha(
   }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct ParsedArgs {
   resize_width: Option<u32>,
   resize_height: Option<u32>,

--- a/ext/crypto/key.rs
+++ b/ext/crypto/key.rs
@@ -98,7 +98,8 @@ impl hkdf::KeyType for HkdfOutput<usize> {
   }
 }
 
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum KeyUsage {
   Encrypt,

--- a/ext/fetch/dns.rs
+++ b/ext/fetch/dns.rs
@@ -13,7 +13,8 @@ use hyper_util::client::legacy::connect::dns::Name;
 use tokio::task::JoinHandle;
 use tower::Service;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum Resolver {
   /// A resolver using blocking `getaddrinfo` calls in a threadpool.
   Gai(GaiResolver),

--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -756,7 +756,7 @@ impl Default for FetchResponseReader {
     Self::BodyReader(stream.peekable())
   }
 }
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FetchResponseResource {
   pub response_reader: AsyncRefCell<FetchResponseReader>,
   pub cancel: CancelHandle,
@@ -868,7 +868,8 @@ impl HttpClientResource {
   }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateHttpClientArgs {
   ca_certs: Vec<String>,
@@ -952,7 +953,8 @@ where
   Ok(rid)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CreateHttpClientOptions {
   pub root_cert_store: Option<RootCertStore>,
   pub ca_certs: Vec<Vec<u8>>,
@@ -1102,7 +1104,8 @@ pub fn op_utf8_to_byte_string(#[string] input: String) -> ByteString {
   input.into()
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Client {
   inner: Decompression<
     retry::Retry<
@@ -1303,11 +1306,13 @@ fn op_fetch_promise_is_settled(promise: v8::Local<v8::Promise>) -> bool {
 }
 
 /// Deno.fetch's retry policy.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct FetchRetry;
 
 /// Marker extension that a request has been retried once.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct Retried;
 
 impl<ResBody, E>

--- a/ext/fetch/proxy.rs
+++ b/ext/fetch/proxy.rs
@@ -29,7 +29,8 @@ use tokio_rustls::TlsConnector;
 use tokio_socks::tcp::Socks5Stream;
 use tower_service::Service;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub(crate) struct ProxyConnector<C> {
   pub(crate) http: C,
   pub(crate) proxies: Arc<Proxies>,
@@ -41,7 +42,7 @@ pub(crate) struct ProxyConnector<C> {
   pub(crate) user_agent: Option<HeaderValue>,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub(crate) struct Proxies {
   no: Option<NoProxy>,
   intercepts: Vec<Intercept>,
@@ -231,14 +232,15 @@ impl Target {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct NoProxy {
   domains: DomainMatcher,
   ips: IpMatcher,
 }
 
 /// Represents a possible matching entry for an IP address
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum Ip {
   Address(IpAddr),
   Network(IpNet),
@@ -246,12 +248,14 @@ enum Ip {
 
 /// A wrapper around a list of IP cidr blocks or addresses with a [IpMatcher::contains] method for
 /// checking if an IP address is contained within the matcher
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct IpMatcher(Vec<Ip>);
 
 /// A wrapper around a list of domains with a [DomainMatcher::contains] method for checking if a
 /// domain is contained within the matcher
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct DomainMatcher(Vec<String>);
 
 impl NoProxy {

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -83,7 +83,8 @@ impl DynamicLibraryResource {
   }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct ForeignFunction {
   name: Option<String>,
@@ -103,7 +104,8 @@ fn default_optional() -> bool {
 // ForeignStatic's name and type fields are read and used by
 // serde_v8 to determine which variant a ForeignSymbol is.
 // They are not used beyond that and are thus marked with underscores.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct ForeignStatic {
   #[serde(rename(deserialize = "name"))]
   _name: Option<String>,
@@ -111,7 +113,7 @@ struct ForeignStatic {
   _type: String,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ForeignSymbol {
   ForeignFunction(ForeignFunction),
   ForeignStatic(#[allow(dead_code)] ForeignStatic),
@@ -136,7 +138,8 @@ impl<'de> Deserialize<'de> for ForeignSymbol {
   }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FfiLoadArgs {
   path: String,
   symbols: HashMap<String, ForeignSymbol>,

--- a/ext/ffi/symbol.rs
+++ b/ext/ffi/symbol.rs
@@ -4,7 +4,8 @@ use deno_error::JsErrorBox;
 
 /// Defines the accepted types that can be used as
 /// parameters and return values in FFI.
-#[derive(Clone, Debug, serde::Deserialize, Eq, PartialEq)]
+#[derive(Clone, serde::Deserialize, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "lowercase")]
 pub enum NativeType {
   Void,

--- a/ext/fs/interface.rs
+++ b/ext/fs/interface.rs
@@ -15,7 +15,8 @@ use serde::Serialize;
 use crate::sync::MaybeSend;
 use crate::sync::MaybeSync;
 
-#[derive(Deserialize, Default, Debug, Clone, Copy)]
+#[derive(Deserialize, Default, Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct OpenOptions {
@@ -70,7 +71,8 @@ pub enum FsFileType {
 }
 
 /// WARNING: This is part of the public JS Deno API.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct FsDirEntry {
   pub name: String,

--- a/ext/http/fly_accept_encoding.rs
+++ b/ext/http/fly_accept_encoding.rs
@@ -24,7 +24,8 @@ pub enum EncodingError {
 }
 
 /// Encodings to use.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum Encoding {
   /// The Gzip encoding.
   Gzip,

--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -114,7 +114,8 @@ struct OtelCollectors {
 
 static OTEL_COLLECTORS: OnceCell<OtelCollectors> = OnceCell::new();
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Options {
   /// By passing a hook function, the caller can customize various configuration
   /// options for the HTTP/2 server.

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -325,7 +325,7 @@ pub struct Stdio {
   pub stderr: StdioPipe,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WriteOnlyResource<S> {
   stream: AsyncRefCell<S>,
 }
@@ -363,7 +363,7 @@ where
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ReadOnlyResource<S> {
   stream: AsyncRefCell<S>,
   cancel_handle: CancelHandle,

--- a/ext/kv/config.rs
+++ b/ext/kv/config.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct KvConfig {
   pub max_write_key_size_bytes: usize,
   pub max_read_key_size_bytes: usize,

--- a/ext/kv/lib.rs
+++ b/ext/kv/lib.rs
@@ -259,7 +259,8 @@ fn key_part_to_v8(value: KeyPart) -> AnyValue {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 enum FromV8Value {
   V8(JsBuffer),
@@ -267,7 +268,8 @@ enum FromV8Value {
   U64(BigInt),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 enum ToV8Value {
   V8(ToJsBuffer),

--- a/ext/napi/function.rs
+++ b/ext/napi/function.rs
@@ -2,7 +2,7 @@
 use crate::*;
 
 #[repr(C)]
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CallbackInfo {
   pub env: *mut Env,
   pub cb: napi_callback,

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -24,7 +24,8 @@ use crate::function::create_function_template;
 use crate::function::CallbackInfo;
 use crate::*;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum ReferenceOwnership {
   Runtime,
   Userland,

--- a/ext/napi/lib.rs
+++ b/ext/napi/lib.rs
@@ -262,7 +262,8 @@ pub const napi_default_jsproperty: napi_property_attributes =
   napi_enumerable | napi_configurable | napi_writable;
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct napi_property_descriptor<'a> {
   pub utf8name: *const c_char,
   pub name: napi_value<'a>,
@@ -275,7 +276,7 @@ pub struct napi_property_descriptor<'a> {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct napi_extended_error_info {
   pub error_message: *const c_char,
   pub engine_reserved: *mut c_void,
@@ -284,7 +285,7 @@ pub struct napi_extended_error_info {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct napi_node_version {
   pub major: u32,
   pub minor: u32,
@@ -335,7 +336,7 @@ impl Drop for NapiState {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct InstanceData {
   pub data: *mut c_void,
   pub finalize_cb: Option<napi_finalize>,
@@ -343,7 +344,7 @@ pub struct InstanceData {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 /// Env that is shared between all contexts in same native module.
 pub struct EnvShared {
   pub instance_data: Option<InstanceData>,

--- a/ext/napi/uv.rs
+++ b/ext/napi/uv.rs
@@ -75,7 +75,8 @@ unsafe extern "C" fn uv_mutex_destroy(_lock: *mut uv_mutex_t) {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[allow(dead_code)]
 enum uv_handle_type {
   UV_UNKNOWN_HANDLE = 0,

--- a/ext/napi/value.rs
+++ b/ext/napi/value.rs
@@ -10,7 +10,8 @@ use deno_core::v8;
 /// An FFI-opaque, nullable wrapper around v8::Local<v8::Value>.
 /// rusty_v8 Local handle cannot be empty but napi_value can be.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NapiValue<'s>(
   Option<NonNull<v8::Value>>,
   std::marker::PhantomData<&'s ()>,

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -23,7 +23,7 @@ use tokio::net::unix;
 
 /// A full duplex resource has a read and write ends that are completely
 /// independent, like TCP/Unix sockets and TLS streams.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FullDuplexResource<R, W> {
   rd: AsyncRefCell<R>,
   wr: AsyncRefCell<W>,

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -48,13 +48,15 @@ use crate::NetPermissions;
 
 pub type Fd = u32;
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct TlsHandshakeInfo {
   pub alpn_protocol: Option<ByteString>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct IpAddr {
   pub hostname: String,
   pub port: u16,
@@ -574,7 +576,8 @@ where
   net_listen_udp::<NP>(state, addr, reuse_address, loopback)
 }
 
-#[derive(Serialize, Eq, PartialEq, Debug)]
+#[derive(Serialize, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(untagged)]
 pub enum DnsReturnRecord {
   A(String),

--- a/ext/net/ops_tls.rs
+++ b/ext/net/ops_tls.rs
@@ -89,7 +89,7 @@ impl TlsListener {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TlsStreamResource {
   rd: AsyncRefCell<TlsStreamRead>,
   wr: AsyncRefCell<TlsStreamWrite>,

--- a/ext/net/quic.rs
+++ b/ext/net/quic.rs
@@ -126,7 +126,8 @@ struct CloseInfo {
   reason: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct Addr {
   hostname: String,
   port: u16,

--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -99,7 +99,8 @@ const MANAGED_GLOBALS_INFO: (usize, usize) = {
 const SHORTEST_MANAGED_GLOBAL: usize = MANAGED_GLOBALS_INFO.0;
 const LONGEST_MANAGED_GLOBAL: usize = MANAGED_GLOBALS_INFO.1;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum Mode {
   Deno,
   Node,

--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -118,7 +118,8 @@ where
   Ok(())
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct StatFs {
   #[serde(rename = "type")]
   pub typ: u64,

--- a/ext/node/ops/http.rs
+++ b/ext/node/ops/http.rs
@@ -71,7 +71,8 @@ pub struct NodeHttpResponse {
 type CancelableResponseResult =
   Result<Result<http::Response<Incoming>, hyper::Error>, Canceled>;
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 struct InformationalResponse {
   status: u16,

--- a/ext/node/ops/http2.rs
+++ b/ext/node/ops/http2.rs
@@ -46,7 +46,7 @@ impl Resource for Http2Client {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Http2ClientConn {
   pub conn: AsyncRefCell<h2::client::Connection<NetworkStream, BufView>>,
   cancel_handle: CancelHandle,
@@ -62,7 +62,7 @@ impl Resource for Http2ClientConn {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Http2ClientStream {
   pub response: AsyncRefCell<h2::client::ResponseFuture>,
   pub stream: AsyncRefCell<h2::SendStream<BufView>>,
@@ -74,7 +74,7 @@ impl Resource for Http2ClientStream {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Http2ClientResponseBody {
   pub body: AsyncRefCell<h2::RecvStream>,
   pub trailers_rx:
@@ -89,7 +89,7 @@ impl Resource for Http2ClientResponseBody {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Http2ServerConnection {
   pub conn: AsyncRefCell<h2::server::Connection<NetworkStream, BufView>>,
 }

--- a/ext/node/ops/os/cpus.rs
+++ b/ext/node/ops/os/cpus.rs
@@ -2,7 +2,8 @@
 
 use deno_core::serde::Serialize;
 
-#[derive(Debug, Default, Serialize, Clone)]
+#[derive(Default, Serialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CpuTimes {
   pub user: u64,
   pub nice: u64,
@@ -11,7 +12,8 @@ pub struct CpuTimes {
   pub irq: u64,
 }
 
-#[derive(Debug, Default, Serialize, Clone)]
+#[derive(Default, Serialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CpuInfo {
   pub model: String,
   /* in MHz */

--- a/ext/node/ops/sqlite/statement.rs
+++ b/ext/node/ops/sqlite/statement.rs
@@ -23,7 +23,7 @@ pub struct RunStatementResult {
   changes: u64,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct StatementSync {
   pub inner: *mut ffi::sqlite3_stmt,
   pub db: Rc<RefCell<Option<rusqlite::Connection>>>,

--- a/ext/node/ops/vm.rs
+++ b/ext/node/ops/vm.rs
@@ -489,7 +489,8 @@ pub fn create_v8_context<'a>(
   scope.escape(context)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct SlotContextifyGlobalTemplate(v8::Global<v8::ObjectTemplate>);
 
 pub fn init_global_template<'a>(

--- a/ext/node/ops/vm_internal.rs
+++ b/ext/node/ops/vm_internal.rs
@@ -10,7 +10,7 @@ pub const PRIVATE_SYMBOL_NAME: v8::OneByteConst =
   v8::String::create_external_onebyte_const(b"node:contextify:context");
 
 /// An unbounded script that can be run in a context.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ContextifyScript {
   script: v8::Global<v8::UnboundScript>,
 }
@@ -249,7 +249,8 @@ pub fn create_v8_context<'a>(
   scope.escape(context)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct SlotContextifyGlobalTemplate(v8::Global<v8::ObjectTemplate>);
 
 pub fn init_global_template<'a>(

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -697,7 +697,7 @@ fn compute_run_cmd_and_check_permissions(
   Ok((cmd, run_env))
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct EnvVarKey {
   inner: OsString,
   // Windows treats env vars as case insensitive, so use

--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -116,13 +116,15 @@ deno_core::extension!(
   esm = ["telemetry.ts", "util.ts"],
 );
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct OtelRuntimeConfig {
   pub runtime_name: Cow<'static, str>,
   pub runtime_version: Cow<'static, str>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct OtelConfig {
   pub tracing_enabled: bool,
   pub metrics_enabled: bool,
@@ -141,7 +143,8 @@ impl OtelConfig {
   }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[repr(u8)]
 pub enum OtelConsoleConfig {
   Ignore = 0,
@@ -589,7 +592,7 @@ mod hyper_client {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct OtelGlobals {
   pub span_processor: BatchSpanProcessor<OtelSharedRuntime>,
   pub log_processor: BatchLogProcessor<OtelSharedRuntime>,
@@ -1310,10 +1313,10 @@ struct OtelSpanCannotBeConstructedError;
 struct InvalidSpanStatusCodeError;
 
 // boxed because of https://github.com/denoland/rusty_v8/issues/1676
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct OtelSpan(RefCell<Box<OtelSpanState>>);
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[allow(clippy::large_enum_variant)]
 enum OtelSpanState {
   Recording(SpanData),

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -158,7 +158,8 @@ impl ServerCertVerifier for NoCertificateVerification {
   }
 }
 
-#[derive(Deserialize, Default, Debug, Clone)]
+#[derive(Deserialize, Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct Proxy {
@@ -166,7 +167,8 @@ pub struct Proxy {
   pub basic_auth: Option<BasicAuth>,
 }
 
-#[derive(Deserialize, Default, Debug, Clone)]
+#[derive(Deserialize, Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[serde(default)]
 pub struct BasicAuth {
   pub username: String,

--- a/ext/url/lib.rs
+++ b/ext/url/lib.rs
@@ -126,7 +126,8 @@ fn parse_url(
   }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[repr(u8)]
 pub enum UrlSetter {
   Hash = 0,

--- a/ext/web/blob.rs
+++ b/ext/web/blob.rs
@@ -37,10 +37,22 @@ use crate::Location;
 
 pub type PartMap = HashMap<Uuid, Arc<dyn BlobPart + Send + Sync>>;
 
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct BlobStore {
   parts: Mutex<PartMap>,
   object_urls: Mutex<HashMap<Url, Arc<Blob>>>,
+}
+
+impl Debug for BlobStore {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut f = f.debug_struct("BlobStore");
+    #[cfg(any(test, debug_assertions))]
+    {
+      f.field("parts", &self.parts)
+        .field("object_urls", &self.object_urls);
+    }
+    f.finish()
+  }
 }
 
 impl BlobStore {
@@ -101,7 +113,7 @@ impl BlobStore {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Blob {
   pub media_type: String,
 

--- a/ext/web/compression.rs
+++ b/ext/web/compression.rs
@@ -28,13 +28,13 @@ pub enum CompressionError {
   Io(std::io::Error),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CompressionResource(RefCell<Option<Inner>>);
 
 impl deno_core::GarbageCollected for CompressionResource {}
 
 /// https://wicg.github.io/compression/#supported-formats
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum Inner {
   DeflateDecoder(ZlibDecoder<Vec<u8>>),
   DeflateEncoder(ZlibEncoder<Vec<u8>>),

--- a/ext/web/stream_resource.rs
+++ b/ext/web/stream_resource.rs
@@ -428,12 +428,14 @@ impl Drop for ReadableStreamResource {
 }
 
 // TODO(mmastrac): Move this to deno_core
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CompletionHandle {
   inner: Rc<RefCell<CompletionHandleInner>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CompletionHandleInner {
   complete: bool,
   success: bool,

--- a/resolvers/deno/cjs.rs
+++ b/resolvers/deno/cjs.rs
@@ -15,7 +15,7 @@ use crate::sync::MaybeDashMap;
 /// Modules that are `.js`, `.ts`, `.jsx`, and `tsx` are only known to
 /// be CJS or ESM after they're loaded based on their contents. So these
 /// files will be "maybe CJS" until they're loaded.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CjsTracker<TInNpmPackageChecker: InNpmPackageChecker, TSys: FsRead> {
   is_cjs_resolver: IsCjsResolver<TInNpmPackageChecker, TSys>,
   known: MaybeDashMap<Url, ResolutionMode>,
@@ -135,7 +135,8 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: FsRead>
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum IsCjsResolutionMode {
   /// Requires an explicit `"type": "commonjs"` in the package.json.
   ExplicitTypeCommonJs,
@@ -146,7 +147,7 @@ pub enum IsCjsResolutionMode {
 }
 
 /// Resolves whether a module is CJS or ESM.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct IsCjsResolver<
   TInNpmPackageChecker: InNpmPackageChecker,
   TSys: FsRead,

--- a/resolvers/deno/factory.rs
+++ b/resolvers/deno/factory.rs
@@ -116,7 +116,8 @@ pub enum NpmRcCreateErrorKind {
   NpmRcDiscover(#[from] NpmRcDiscoverError),
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ConfigDiscoveryOption {
   #[default]
   DiscoverCwd,
@@ -136,7 +137,8 @@ pub trait SpecifiedImportMapProvider:
   ) -> Result<Option<crate::workspace::SpecifiedImportMap>, anyhow::Error>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DenoDirPathProviderOptions {
   pub maybe_custom_root: Option<PathBuf>,
 }
@@ -147,7 +149,7 @@ pub type DenoDirPathProviderRc<TSys> =
 
 /// Lazily creates the deno dir which might be useful in scenarios
 /// where functionality wants to continue if the DENO_DIR can't be created.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DenoDirPathProvider<
   TSys: EnvCacheDir + EnvHomeDir + EnvVar + EnvCurrentDir,
 > {
@@ -177,13 +179,14 @@ impl<TSys: EnvCacheDir + EnvHomeDir + EnvVar + EnvCurrentDir>
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmProcessStateOptions {
   pub node_modules_dir: Option<Cow<'static, str>>,
   pub is_byonm: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WorkspaceFactoryOptions<
   TSys: EnvCacheDir + EnvHomeDir + EnvVar + EnvCurrentDir + FsCanonicalize,
 > {
@@ -557,7 +560,8 @@ impl<TSys: WorkspaceFactorySys> WorkspaceFactory<TSys> {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ResolverFactoryOptions {
   pub conditions_from_resolution_mode: ConditionsFromResolutionMode,
   pub npm_system_info: NpmSystemInfo,

--- a/resolvers/deno/lib.rs
+++ b/resolvers/deno/lib.rs
@@ -53,7 +53,8 @@ pub type WorkspaceResolverRc<TSys> =
 #[allow(clippy::disallowed_types)]
 pub(crate) type NpmCacheDirRc = crate::sync::MaybeArc<NpmCacheDir>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DenoResolution {
   pub url: Url,
   pub maybe_diagnostic: Option<Box<MappedResolutionDiagnostic>>,
@@ -100,7 +101,7 @@ pub enum DenoResolveErrorKind {
   WorkspaceResolvePkgJsonFolder(#[from] WorkspaceResolvePkgJsonFolderError),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NodeAndNpmReqResolver<
   TInNpmPackageChecker: InNpmPackageChecker,
   TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,
@@ -171,7 +172,7 @@ pub type DefaultDenoResolverRc<TSys> = DenoResolverRc<
 
 /// A resolver that takes care of resolution, taking into account loaded
 /// import map, JSX settings.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct DenoResolver<
   TInNpmPackageChecker: InNpmPackageChecker,
   TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,

--- a/resolvers/deno/npm/byonm.rs
+++ b/resolvers/deno/npm/byonm.rs
@@ -431,7 +431,8 @@ impl<TSys: FsCanonicalize + FsMetadata + FsRead + FsReadDir>
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ByonmInNpmPackageChecker;
 
 impl InNpmPackageChecker for ByonmInNpmPackageChecker {

--- a/resolvers/deno/npm/managed/mod.rs
+++ b/resolvers/deno/npm/managed/mod.rs
@@ -258,7 +258,8 @@ impl<TSys: FsCanonicalize + FsMetadata> NpmPackageFolderResolver
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ManagedInNpmPackageChecker {
   root_dir: Url,
 }
@@ -269,7 +270,7 @@ impl InNpmPackageChecker for ManagedInNpmPackageChecker {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ManagedInNpmPkgCheckerCreateOptions<'a> {
   pub root_cache_dir_url: &'a Url,
   pub maybe_node_modules_path: Option<&'a Path>,

--- a/resolvers/deno/npm/mod.rs
+++ b/resolvers/deno/npm/mod.rs
@@ -55,13 +55,14 @@ mod byonm;
 mod local;
 pub mod managed;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CreateInNpmPkgCheckerOptions<'a> {
   Managed(ManagedInNpmPkgCheckerCreateOptions<'a>),
   Byonm,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum DenoInNpmPackageChecker {
   Managed(ManagedInNpmPackageChecker),
   Byonm(ByonmInNpmPackageChecker),
@@ -172,7 +173,8 @@ pub enum NpmResolverCreateOptions<
   Byonm(ByonmNpmResolverCreateOptions<TSys>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum NpmResolver<TSys: FsCanonicalize + FsMetadata + FsRead + FsReadDir> {
   /// The resolver when "bring your own node_modules" is enabled where Deno
   /// does not setup the node_modules directories automatically, but instead
@@ -295,7 +297,7 @@ pub type NpmReqResolverRc<
   >,
 >;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmReqResolver<
   TInNpmPackageChecker: InNpmPackageChecker,
   TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,

--- a/resolvers/deno/sync.rs
+++ b/resolvers/deno/sync.rs
@@ -29,7 +29,7 @@ mod inner {
   impl<T> MaybeSend for T where T: ?Sized {}
 
   // Wrapper struct that exposes a subset of `DashMap` API.
-  #[derive(Debug)]
+  #[cfg_attr(any(test, debug_assertions), derive(Debug))]
   pub struct MaybeDashMap<K, V, S = RandomState>(RefCell<HashMap<K, V, S>>);
 
   impl<K, V, S> Default for MaybeDashMap<K, V, S>

--- a/resolvers/deno/workspace.rs
+++ b/resolvers/deno/workspace.rs
@@ -49,7 +49,7 @@ use crate::sync::MaybeDashMap;
 #[allow(clippy::disallowed_types)]
 type UrlRc = crate::sync::MaybeArc<Url>;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct PkgJsonResolverFolderConfig {
   deps: PackageJsonDepsRc,
   pkg_json: PackageJsonRc,
@@ -76,9 +76,8 @@ pub enum WorkspaceResolverCreateError {
 
 /// Whether to resolve dependencies by reading the dependencies list
 /// from a package.json
-#[derive(
-  Debug, Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq,
-)]
+#[derive(Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PackageJsonDepResolution {
   /// Resolves based on the dep entries in the package.json.
   #[default]
@@ -88,9 +87,8 @@ pub enum PackageJsonDepResolution {
   Disabled,
 }
 
-#[derive(
-  Debug, Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq,
-)]
+#[derive(Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum SloppyImportsOptions {
   Enabled,
   #[default]
@@ -99,16 +97,16 @@ pub enum SloppyImportsOptions {
 
 /// Toggle FS metadata caching when probing files for sloppy imports and
 /// `compilerOptions.rootDirs` resolution.
-#[derive(
-  Debug, Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq,
-)]
+#[derive(Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum FsCacheOptions {
   #[default]
   Enabled,
   Disabled,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CreateResolverOptions {
   pub pkg_json_dep_resolution: PackageJsonDepResolution,
   pub specified_import_map: Option<SpecifiedImportMap>,
@@ -116,13 +114,15 @@ pub struct CreateResolverOptions {
   pub fs_cache_options: FsCacheOptions,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SpecifiedImportMap {
   pub base_url: Url,
   pub value: serde_json::Value,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum MappedResolutionDiagnostic {
   ConstraintNotMatchedLocalVersion {
     /// If it was for a patch (true) or workspace (false) member.
@@ -157,7 +157,8 @@ impl std::fmt::Display for MappedResolutionDiagnostic {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum MappedResolution<'a> {
   Normal {
     specifier: Url,
@@ -266,13 +267,14 @@ pub enum WorkspaceResolvePkgJsonFolderErrorKind {
   VersionNotSatisfied(VersionReq, Version),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum CachedMetadataFsEntry {
   File,
   Dir,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CachedMetadataFs<TSys: FsMetadata> {
   sys: TSys,
   cache: Option<MaybeDashMap<PathBuf, Option<CachedMetadataFsEntry>>>,
@@ -315,7 +317,8 @@ impl<TSys: FsMetadata> CachedMetadataFs<TSys> {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum SloppyImportsResolutionReason {
   /// Ex. `./file.js` to `./file.ts`
   JsToTs,
@@ -362,7 +365,7 @@ impl SloppyImportsResolutionReason {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct SloppyImportsResolver<TSys: FsMetadata> {
   fs: CachedMetadataFs<TSys>,
   enabled: bool,
@@ -635,7 +638,8 @@ pub fn sloppy_imports_resolve<TSys: FsMetadata>(
 type SloppyImportsResolverRc<T> =
   crate::sync::MaybeArc<SloppyImportsResolver<T>>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CompilerOptionsRootDirsDiagnostic {
   InvalidType(Url),
   InvalidEntryType(Url, usize),
@@ -654,7 +658,7 @@ impl fmt::Display for CompilerOptionsRootDirsDiagnostic {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct CompilerOptionsRootDirsResolver<TSys: FsMetadata> {
   root_dirs_from_root: Vec<Url>,
   root_dirs_by_member: BTreeMap<Url, Option<Vec<Url>>>,
@@ -828,7 +832,8 @@ impl<TSys: FsMetadata> CompilerOptionsRootDirsResolver<TSys> {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ResolutionKind {
   /// Resolving for code that will be executed.
   Execution,
@@ -851,7 +856,8 @@ impl From<NodeResolutionKind> for ResolutionKind {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum WorkspaceResolverDiagnostic<'a> {
   ImportMap(&'a ImportMapDiagnostic),
   CompilerOptionsRootDirs(&'a CompilerOptionsRootDirsDiagnostic),
@@ -866,7 +872,7 @@ impl fmt::Display for WorkspaceResolverDiagnostic<'_> {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WorkspaceResolver<TSys: FsMetadata + FsRead> {
   workspace_root: UrlRc,
   jsr_pkgs: Vec<ResolverWorkspaceJsrPackage>,
@@ -1586,7 +1592,8 @@ pub struct SerializedWorkspaceResolverImportMap<'a> {
   pub json: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct SerializedResolverWorkspaceJsrPackage<'a> {
   #[serde(borrow)]
   pub relative_base: Cow<'a, str>,
@@ -1610,7 +1617,8 @@ pub struct SerializableWorkspaceResolver<'a> {
   pub root_dirs_by_member: BTreeMap<Cow<'a, str>, Option<Vec<Cow<'a, str>>>>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct BaseUrl<'a>(&'a Url);
 
 impl BaseUrl<'_> {

--- a/resolvers/node/analyze.rs
+++ b/resolvers/node/analyze.rs
@@ -32,7 +32,8 @@ use crate::ResolutionMode;
 use crate::UrlOrPath;
 use crate::UrlOrPathRef;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CjsAnalysis<'a> {
   /// File was found to be an ES module and the translator should
   /// load the code as ESM.
@@ -40,7 +41,8 @@ pub enum CjsAnalysis<'a> {
   Cjs(CjsAnalysisExports),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct CjsAnalysisExports {
   pub exports: Vec<String>,
   pub reexports: Vec<String>,

--- a/resolvers/node/errors.rs
+++ b/resolvers/node/errors.rs
@@ -14,7 +14,8 @@ use crate::path::UrlOrPath;
 use crate::NodeResolutionKind;
 use crate::ResolutionMode;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[allow(non_camel_case_types)]
 pub enum NodeJsErrorCode {
   ERR_INVALID_MODULE_SPECIFIER,

--- a/resolvers/node/resolution.rs
+++ b/resolvers/node/resolution.rs
@@ -116,7 +116,7 @@ impl NodeResolutionKind {
   }
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum NodeResolution {
   Module(UrlOrPath),
   BuiltIn(String),
@@ -183,7 +183,7 @@ pub type NodeResolverRc<
   >,
 >;
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NodeResolver<
   TInNpmPackageChecker: InNpmPackageChecker,
   TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,

--- a/resolvers/npm_cache/lib.rs
+++ b/resolvers/npm_cache/lib.rs
@@ -75,7 +75,8 @@ pub trait NpmCacheHttpClient: Send + Sync + 'static {
 }
 
 /// Indicates how cached source files should be handled.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum NpmCacheSetting {
   /// Only the cached files should be used. Any files not in the cache will
   /// error. This is the equivalent of `--cached-only` in the CLI.
@@ -125,7 +126,7 @@ impl NpmCacheSetting {
 }
 
 /// Stores a single copy of npm packages in a cache.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct NpmCache<
   TSys: FsCreateDirAll
     + FsHardLink

--- a/resolvers/npm_cache/registry_info.rs
+++ b/resolvers/npm_cache/registry_info.rs
@@ -34,14 +34,16 @@ use crate::NpmCacheSetting;
 type LoadResult = Result<FutureResult, Arc<JsErrorBox>>;
 type LoadFuture = LocalBoxFuture<'static, LoadResult>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum FutureResult {
   PackageNotExists,
   SavedFsCache(Arc<NpmPackageInfo>),
   ErroredFsCache(Arc<NpmPackageInfo>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum MemoryCacheItem {
   /// The cache item hasn't loaded yet.
   Pending(Arc<MultiRuntimeAsyncValueCreator<LoadResult>>),
@@ -54,7 +56,8 @@ enum MemoryCacheItem {
   MemoryCached(Result<Option<Arc<NpmPackageInfo>>, Arc<JsErrorBox>>),
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct MemoryCache {
   clear_id: usize,
   items: HashMap<String, MemoryCacheItem>,
@@ -134,7 +137,7 @@ pub enum LoadPackageInfoInnerError {
 /// Downloads packuments from the npm registry.
 ///
 /// This is shared amongst all the workers.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct RegistryInfoProvider<
   THttpClient: NpmCacheHttpClient,
   TSys: FsCreateDirAll

--- a/resolvers/npm_cache/tarball.rs
+++ b/resolvers/npm_cache/tarball.rs
@@ -33,7 +33,8 @@ use crate::NpmCacheSetting;
 type LoadResult = Result<(), Arc<JsErrorBox>>;
 type LoadFuture = LocalBoxFuture<'static, LoadResult>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum MemoryCacheItem {
   /// The cache item hasn't finished yet.
   Pending(Arc<MultiRuntimeAsyncValueCreator<LoadResult>>),
@@ -47,7 +48,7 @@ enum MemoryCacheItem {
 /// the npm registry.
 ///
 /// This is shared amongst all the workers.
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct TarballCache<
   THttpClient: NpmCacheHttpClient,
   TSys: FsCreateDirAll

--- a/resolvers/npm_cache/tarball_extract.rs
+++ b/resolvers/npm_cache/tarball_extract.rs
@@ -16,7 +16,8 @@ use flate2::read::GzDecoder;
 use tar::Archive;
 use tar::EntryType;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum TarballExtractionMode {
   /// Overwrites the destination directory without deleting any files.
   Overwrite,

--- a/runtime/code_cache.rs
+++ b/runtime/code_cache.rs
@@ -2,7 +2,8 @@
 
 use deno_core::ModuleSpecifier;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CodeCacheType {
   EsModule,
   Script,

--- a/runtime/fmt_errors.rs
+++ b/runtime/fmt_errors.rs
@@ -8,32 +8,34 @@ use deno_core::error::format_frame;
 use deno_core::error::JsError;
 use deno_terminal::colors;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct ErrorReference<'a> {
   from: &'a JsError,
   to: &'a JsError,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct IndexedErrorReference<'a> {
   reference: ErrorReference<'a>,
   index: usize,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum FixSuggestionKind {
   Info,
   Hint,
   Docs,
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 enum FixSuggestionMessage<'a> {
   Single(&'a str),
   Multiline(&'a [&'a str]),
 }
 
-#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct FixSuggestion<'a> {
   kind: FixSuggestionKind,
   message: FixSuggestionMessage<'a>,

--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -58,7 +58,8 @@ impl Resource for FsEventsResource {
 ///
 /// Feel free to expand this struct as long as you can add tests to demonstrate
 /// the complexity.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 struct FsEvent {
   kind: &'static str,
   paths: Vec<PathBuf>,

--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -346,7 +346,8 @@ fn op_console_size(
   last_result
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ConsoleSize {
   pub cols: u32,
   pub rows: u32,

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -77,9 +77,8 @@ static DEBUG_LOG_ENABLED: Lazy<bool> =
   Lazy::new(|| log::log_enabled!(log::Level::Debug));
 
 /// Quadri-state value for storing permission state
-#[derive(
-  Eq, PartialEq, Default, Debug, Clone, Copy, Deserialize, PartialOrd,
-)]
+#[derive(Eq, PartialEq, Default, Clone, Copy, Deserialize, PartialOrd)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PermissionState {
   Granted = 0,
   GrantedPartial = 1,
@@ -95,7 +94,8 @@ pub enum PermissionState {
 /// `TreatAsGranted` is used in place of `TreatAsPartialGranted` when we don't
 /// want to wastefully check for partial denials when, say, checking read
 /// access for a file.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 #[allow(clippy::enum_variant_names)]
 enum AllowPartial {
   TreatAsGranted,
@@ -223,7 +223,8 @@ impl fmt::Display for PermissionState {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UnitPermission {
   pub name: &'static str,
   pub description: &'static str,
@@ -361,7 +362,8 @@ fn format_display_name(display_name: Cow<str>) -> Cow<str> {
   }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct UnaryPermission<TQuery: QueryDescriptor + ?Sized> {
   granted_global: bool,
   granted_list: HashSet<TQuery::AllowDesc>,
@@ -2036,7 +2038,8 @@ impl UnaryPermission<FfiQueryDescriptor> {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct Permissions {
   pub read: UnaryPermission<ReadQueryDescriptor>,
   pub write: UnaryPermission<WriteQueryDescriptor>,
@@ -2049,7 +2052,8 @@ pub struct Permissions {
   pub all: UnitPermission,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PermissionsOptions {
   pub allow_all: bool,
   pub allow_env: Option<Vec<String>>,
@@ -2305,7 +2309,8 @@ impl Permissions {
   }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum CheckSpecifierKind {
   Static,
   Dynamic,
@@ -2364,7 +2369,8 @@ pub enum PermissionCheckError {
 /// passed to a future that will prompt the user for permission (and in such
 /// case might need to be mutated). Also for the Web Worker API we need a way
 /// to send permissions to a new thread.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct PermissionsContainer {
   descriptor_parser: Arc<dyn PermissionDescriptorParser>,
   inner: Arc<Mutex<Permissions>>,
@@ -3375,7 +3381,8 @@ fn global_from_option<T>(flag: Option<&HashSet<T>>) -> bool {
   matches!(flag, Some(v) if v.is_empty())
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ChildUnitPermissionArg {
   Inherit,
   Granted,
@@ -3427,7 +3434,8 @@ impl<'de> Deserialize<'de> for ChildUnitPermissionArg {
   }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum ChildUnaryPermissionArg {
   Inherit,
   Granted,
@@ -3495,7 +3503,8 @@ impl<'de> Deserialize<'de> for ChildUnaryPermissionArg {
 }
 
 /// Directly deserializable from JS worker and test permission options.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct ChildPermissionsArg {
   env: ChildUnaryPermissionArg,
   net: ChildUnaryPermissionArg,
@@ -3729,7 +3738,8 @@ mod tests {
       ($($x:expr),*) => (vec![$($x.to_string()),*]);
   }
 
-  #[derive(Debug, Clone)]
+  #[derive(Clone)]
+  #[cfg_attr(any(test, debug_assertions), derive(Debug))]
   struct TestPermissionDescriptorParser;
 
   impl TestPermissionDescriptorParser {

--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -39,7 +39,8 @@ pub const PERMISSION_EMOJI: &str = "⚠️";
 // 10kB of permission prompting should be enough for anyone
 const MAX_PERMISSION_PROMPT_LENGTH: usize = 10 * 1024;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Eq, PartialEq)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum PromptResponse {
   Allow,
   Deny,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -75,7 +75,8 @@ pub struct WorkerMetadata {
 
 static WORKER_ID_COUNTER: AtomicU32 = AtomicU32::new(1);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub struct WorkerId(u32);
 impl WorkerId {
   pub fn new() -> WorkerId {

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -67,7 +67,8 @@ impl WorkerExecutionMode {
 /// Note: This is disconnected with the log crate's log level and the Rust code
 /// in this crate will respect that value instead. To specify that, use
 /// `log::set_max_level`.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
+#[cfg_attr(any(test, debug_assertions), derive(Debug))]
 pub enum WorkerLogLevel {
   // WARNING: Ensure this is kept in sync with
   // the JS values (search for LogLevel).


### PR DESCRIPTION
Mostly an experiment, not sure it's worth the noise.

```
❯ bloaty --domain file target/release/deno -- ./deno-baseline
    FILE SIZE   
 -------------- 
  +200%      +8    [__LINKEDIT]
  -0.4%    -280    Rebase Info
  -0.0%    -368    __TEXT,__unwind_info
  -1.0%    -688    __TEXT,__literals
  -0.2%    -704    Function Start Addresses
  -0.1% -1.06Ki    Code Signature
  -0.1% -2.31Ki    __TEXT,__eh_frame
  -0.0% -4.00Ki    __TEXT,__const
 -23.0% -4.23Ki    [__TEXT]
  -0.2% -4.43Ki    __TEXT,__gcc_except_tab
 -79.5% -7.92Ki    [__DATA_CONST]
  -0.3% -8.08Ki    __DATA_CONST,__const
  -0.2% -10.1Ki    Symbol Table
  -0.2% -43.7Ki    String Table
  -0.1% -48.0Ki    __TEXT,__text
  -0.1%  -135Ki    TOTAL
```