### PR TITLE
feat(clean): `deno clean --except <paths>`, remove all cache data except what's needed to run `paths`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.18.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cadb05700726eb97cb4914d8016ff81ece094b1c3ed442d6f48f297961a5a96"
+checksum = "502c5f3120fe5b32908e9a4b3af95b7e1a35e8fa758d87155b03a3810655c9f0"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ repository = "https://github.com/denoland/deno"
 deno_ast = { version = "=0.46.6", features = ["transpiling"] }
 deno_core = { version = "0.344.0" }
 
-deno_cache_dir = "=0.18.0"
+deno_cache_dir = "=0.19.2"
 deno_config = { version = "=0.54.2", features = ["workspace"] }
 deno_doc = "=0.172.0"
 deno_error = "=0.5.6"

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -454,6 +454,12 @@ pub struct HelpFlags {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CleanFlags {
+  pub except_paths: Vec<String>,
+  pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DenoSubcommand {
   Add(AddFlags),
   Remove(RemoveFlags),
@@ -461,7 +467,7 @@ pub enum DenoSubcommand {
   Bundle,
   Cache(CacheFlags),
   Check(CheckFlags),
-  Clean,
+  Clean(CleanFlags),
   Compile(CompileFlags),
   Completions(CompletionsFlags),
   Coverage(CoverageFlags),
@@ -1900,6 +1906,31 @@ fn clean_subcommand() -> Command {
     cstr!("Remove the cache directory (<c>$DENO_DIR</>)"),
     UnstableArgsConfig::None,
   )
+  .defer(|cmd| {
+    cmd
+      .arg(
+        Arg::new("except-paths")
+          .required_if_eq("except", "true")
+          .num_args(1..)
+          .value_hint(ValueHint::FilePath),
+      )
+      .arg(
+        Arg::new("except")
+          .long("except")
+          .short('e')
+          .help("Retain cache data needed by the given files")
+          .action(ArgAction::SetTrue),
+      )
+      .arg(
+        Arg::new("dry-run")
+          .long("dry-run")
+          .action(ArgAction::SetTrue)
+          .help("Show what would be removed without performing any actions")
+          .requires("except"),
+      )
+      .arg(node_modules_dir_arg().requires("except"))
+      .arg(vendor_arg().requires("except"))
+  })
 }
 
 fn check_subcommand() -> Command {
@@ -4658,8 +4689,21 @@ fn check_parse(
   Ok(())
 }
 
-fn clean_parse(flags: &mut Flags, _matches: &mut ArgMatches) {
-  flags.subcommand = DenoSubcommand::Clean;
+fn clean_parse(flags: &mut Flags, matches: &mut ArgMatches) {
+  let mut clean_flags = CleanFlags {
+    except_paths: Vec::new(),
+    dry_run: false,
+  };
+  if matches.get_flag("except") {
+    clean_flags.except_paths = matches
+      .remove_many::<String>("except-paths")
+      .unwrap()
+      .collect::<Vec<_>>();
+    flags.cached_only = true;
+    clean_flags.dry_run = matches.get_flag("dry-run");
+    node_modules_and_vendor_dir_arg_parse(flags, matches);
+  }
+  flags.subcommand = DenoSubcommand::Clean(clean_flags);
 }
 
 fn compile_parse(
@@ -11915,6 +11959,63 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
       assert_eq!(
         r.subcommand,
         DenoSubcommand::Outdated(expected),
+        "incorrect result for args: {:?}",
+        args
+      );
+    }
+  }
+
+  #[test]
+  fn clean_subcommand() {
+    let cases = [
+      (
+        svec![],
+        CleanFlags {
+          except_paths: vec![],
+          dry_run: false,
+        },
+      ),
+      (
+        svec!["--except", "path1"],
+        CleanFlags {
+          except_paths: vec!["path1".to_string()],
+          dry_run: false,
+        },
+      ),
+      (
+        svec!["--except", "path1", "path2"],
+        CleanFlags {
+          except_paths: vec!["path1".to_string(), "path2".to_string()],
+          dry_run: false,
+        },
+      ),
+      (
+        svec!["--except", "path1", "--dry-run"],
+        CleanFlags {
+          except_paths: vec!["path1".to_string()],
+          dry_run: true,
+        },
+      ),
+    ];
+    for (input, expected) in cases {
+      let cached_only = !input.is_empty();
+      let mut args = svec!["deno", "clean"];
+      args.extend(input);
+      let r = flags_from_vec(args.clone())
+        .inspect_err(|e| {
+          #[allow(clippy::print_stderr)]
+          {
+            eprintln!("error: {:?} on input: {:?}", e, args);
+          }
+        })
+        .unwrap();
+      assert_eq!(
+        r,
+        Flags {
+          subcommand: DenoSubcommand::Clean(expected),
+          cached_only,
+          ..Flags::default()
+        },
         "incorrect result for args: {:?}",
         args
       );

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use deno_cache_dir::npm::NpmCacheDir;
+use deno_cache_dir::GlobalOrLocalHttpCache;
 use deno_config::deno_json::NodeModulesDirMode;
 use deno_config::workspace::Workspace;
 use deno_config::workspace::WorkspaceDirectory;
@@ -69,7 +70,6 @@ use crate::cache::DenoDir;
 use crate::cache::DenoDirProvider;
 use crate::cache::EmitCache;
 use crate::cache::GlobalHttpCache;
-use crate::cache::HttpCache;
 use crate::cache::ModuleInfoCache;
 use crate::cache::NodeAnalysisCache;
 use crate::cache::ParsedSourceCache;
@@ -511,7 +511,9 @@ impl CliFactory {
     Ok(self.workspace_factory()?.global_http_cache()?)
   }
 
-  pub fn http_cache(&self) -> Result<&Arc<dyn HttpCache>, AnyError> {
+  pub fn http_cache(
+    &self,
+  ) -> Result<&GlobalOrLocalHttpCache<CliSys>, AnyError> {
     Ok(self.workspace_factory()?.http_cache()?)
   }
 
@@ -1461,6 +1463,7 @@ fn new_workspace_factory_options(
         | DenoSubcommand::Remove(_)
         | DenoSubcommand::Init(_)
         | DenoSubcommand::Outdated(_)
+        | DenoSubcommand::Clean(_)
     ),
     no_npm: flags.no_npm,
     node_modules_dir: flags.node_modules_dir,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use deno_ast::MediaType;
 use deno_cache_dir::file_fetcher::CacheSetting;
+use deno_cache_dir::GlobalOrLocalHttpCache;
 use deno_core::anyhow::anyhow;
 use deno_core::error::AnyError;
 use deno_core::serde_json;
@@ -1136,7 +1137,7 @@ impl Inner {
   #[cfg_attr(feature = "lsp-tracing", tracing::instrument(skip_all))]
   async fn refresh_config_tree(&mut self) {
     let file_fetcher = CliFileFetcher::new(
-      self.cache.global().clone(),
+      GlobalOrLocalHttpCache::Global(self.cache.global().clone()),
       self.http_client_provider.clone(),
       CliSys::default(),
       Default::default(),

--- a/cli/lsp/registries.rs
+++ b/cli/lsp/registries.rs
@@ -433,7 +433,7 @@ impl ModuleRegistry {
     let http_cache =
       Arc::new(GlobalHttpCache::new(CliSys::default(), location.clone()));
     let file_fetcher = CliFileFetcher::new(
-      http_cache.clone(),
+      http_cache.clone().into(),
       http_client_provider,
       CliSys::default(),
       Default::default(),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -134,8 +134,8 @@ async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
     DenoSubcommand::Check(check_flags) => spawn_subcommand(async move {
       tools::check::check(flags, check_flags).await
     }),
-    DenoSubcommand::Clean => spawn_subcommand(async move {
-      tools::clean::clean(flags)
+    DenoSubcommand::Clean(clean_flags) => spawn_subcommand(async move {
+      tools::clean::clean(flags, clean_flags).await
     }),
     DenoSubcommand::Compile(compile_flags) => spawn_subcommand(async {
       if compile_flags.eszip {

--- a/cli/npm/installer/local.rs
+++ b/cli/npm/installer/local.rs
@@ -1050,7 +1050,7 @@ struct SetupCacheData {
 /// cache what we've setup on the last run and only update what is necessary.
 /// Obviously this could lead to issues if the cache gets out of date with the
 /// file system, such as if the user manually deletes a symlink.
-struct SetupCache {
+pub struct SetupCache {
   file_path: PathBuf,
   previous: Option<SetupCacheData>,
   current: SetupCacheData,
@@ -1085,6 +1085,14 @@ impl SetupCache {
       .ok()
     });
     true
+  }
+
+  pub fn remove_root_symlink(&mut self, name: &str) {
+    self.current.root_symlinks.remove(name);
+  }
+
+  pub fn remove_deno_symlink(&mut self, name: &str) {
+    self.current.deno_symlinks.remove(name);
   }
 
   /// Inserts and checks for the existence of a root symlink
@@ -1139,7 +1147,7 @@ impl SetupCache {
     }
   }
 
-  pub fn with_dep(&mut self, parent_name: &str) -> SetupCacheDep<'_> {
+  fn with_dep(&mut self, parent_name: &str) -> SetupCacheDep<'_> {
     SetupCacheDep {
       previous: self
         .previous

--- a/cli/npm/installer/mod.rs
+++ b/cli/npm/installer/mod.rs
@@ -12,6 +12,7 @@ use deno_npm::NpmSystemInfo;
 use deno_resolver::npm::managed::NpmResolutionCell;
 use deno_runtime::colors;
 use deno_semver::package::PackageReq;
+pub use local::SetupCache;
 use rustc_hash::FxHashSet;
 
 pub use self::common::NpmPackageFsInstaller;

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -1,36 +1,62 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+use std::ffi::OsString;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use deno_cache_dir::GlobalOrLocalHttpCache;
+use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
+use deno_core::url::Url;
+use deno_graph::packages::PackageSpecifiers;
+use deno_graph::ModuleGraph;
+use sys_traits::FsCanonicalize;
+use sys_traits::FsCreateDirAll;
+use walkdir::WalkDir;
 
+use crate::args::CleanFlags;
 use crate::args::Flags;
 use crate::colors;
 use crate::display;
 use crate::factory::CliFactory;
+use crate::graph_container::ModuleGraphContainer;
+use crate::graph_container::ModuleGraphUpdatePermit;
+use crate::graph_util::CreateGraphOptions;
 use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;
 use crate::util::progress_bar::ProgressMessagePrompt;
 use crate::util::progress_bar::UpdateGuard;
 
+#[derive(Default)]
 struct CleanState {
   files_removed: u64,
   dirs_removed: u64,
   bytes_removed: u64,
-  progress_guard: UpdateGuard,
+  progress_guard: Option<UpdateGuard>,
 }
 
 impl CleanState {
   fn update_progress(&self) {
-    self
-      .progress_guard
-      .set_position(self.files_removed + self.dirs_removed);
+    if let Some(pg) = &self.progress_guard {
+      pg.set_position(self.files_removed + self.dirs_removed);
+    }
   }
 }
 
-pub fn clean(flags: Arc<Flags>) -> Result<(), AnyError> {
+pub async fn clean(
+  flags: Arc<Flags>,
+  clean_flags: CleanFlags,
+) -> Result<(), AnyError> {
+  if !clean_flags.except_paths.is_empty() {
+    return clean_except(flags, &clean_flags.except_paths, clean_flags.dry_run)
+      .await;
+  }
+
   let factory = CliFactory::from_flags(flags);
   let deno_dir = factory.deno_dir()?;
   if deno_dir.root.exists() {
@@ -38,16 +64,13 @@ pub fn clean(flags: Arc<Flags>) -> Result<(), AnyError> {
     let progress_bar = ProgressBar::new(ProgressBarStyle::ProgressBars);
     let progress_guard =
       progress_bar.update_with_prompt(ProgressMessagePrompt::Cleaning, "");
-
+    progress_guard.set_total_size(no_of_files.try_into().unwrap());
     let mut state = CleanState {
       files_removed: 0,
       dirs_removed: 0,
       bytes_removed: 0,
-      progress_guard,
+      progress_guard: Some(progress_guard),
     };
-    state
-      .progress_guard
-      .set_total_size(no_of_files.try_into().unwrap());
 
     rm_rf(&mut state, &deno_dir.root)?;
 
@@ -66,6 +89,530 @@ pub fn clean(flags: Arc<Flags>) -> Result<(), AnyError> {
     );
   }
 
+  Ok(())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Found {
+  Match,
+  Prefix,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PathNode {
+  exact: bool,
+  children: BTreeMap<OsString, usize>,
+}
+
+#[derive(Debug)]
+struct PathTrie {
+  root: usize,
+  nodes: Vec<PathNode>,
+  rewrites: Vec<(PathBuf, PathBuf)>,
+}
+
+impl PathTrie {
+  fn new() -> Self {
+    Self {
+      root: 0,
+      nodes: vec![PathNode {
+        exact: false,
+        children: Default::default(),
+      }],
+      rewrites: vec![],
+    }
+  }
+
+  fn add_rewrite(&mut self, from: PathBuf, to: PathBuf) {
+    self.rewrites.push((from, to));
+  }
+
+  fn rewrite(&self, s: &Path) -> PathBuf {
+    let normalized = deno_path_util::normalize_path(s);
+    for (from, to) in &self.rewrites {
+      if normalized.starts_with(from) {
+        return to.join(normalized.strip_prefix(from).unwrap());
+      }
+    }
+    normalized
+  }
+
+  fn insert(&mut self, s: &Path) {
+    let normalized = self.rewrite(s);
+    let components = normalized.components().map(|c| c.as_os_str());
+    let mut node = self.root;
+
+    for component in components {
+      if let Some(nd) = self.nodes[node].children.get(component).copied() {
+        node = nd;
+      } else {
+        let id = self.nodes.len();
+        self.nodes.push(PathNode::default());
+        self.nodes[node]
+          .children
+          .insert(component.to_os_string(), id);
+        node = id;
+      }
+    }
+
+    self.nodes[node].exact = true;
+  }
+
+  fn find(&self, s: &Path) -> Option<Found> {
+    let normalized = self.rewrite(s);
+    let components = normalized.components().map(|c| c.as_os_str());
+    let mut node = self.root;
+
+    for component in components {
+      if let Some(nd) = self.nodes[node].children.get(component).copied() {
+        node = nd;
+      } else {
+        return None;
+      }
+    }
+
+    Some(if self.nodes[node].exact {
+      Found::Match
+    } else {
+      Found::Prefix
+    })
+  }
+}
+
+fn try_get_canonicalized_root_dir<Sys: FsCanonicalize + FsCreateDirAll>(
+  sys: &Sys,
+  root_dir: &Path,
+) -> Result<PathBuf, std::io::Error> {
+  match sys.fs_canonicalize(root_dir) {
+    Ok(path) => Ok(path),
+    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+      sys.fs_create_dir_all(root_dir)?;
+      sys.fs_canonicalize(root_dir)
+    }
+    Err(err) => Err(err),
+  }
+}
+
+async fn clean_except(
+  flags: Arc<Flags>,
+  entrypoints: &[String],
+  dry_run: bool,
+) -> Result<(), AnyError> {
+  let mut state = CleanState::default();
+
+  let factory = CliFactory::from_flags(flags.clone());
+  let sys = factory.sys();
+  let options = factory.cli_options()?;
+  let main_graph_container = factory.main_module_graph_container().await?;
+  let roots = main_graph_container.collect_specifiers(entrypoints)?;
+  let http_cache = factory.global_http_cache()?;
+  let local_or_global_http_cache = factory.http_cache()?.clone();
+  let deno_dir = factory.deno_dir()?.clone();
+  let deno_dir_root_canonical =
+    try_get_canonicalized_root_dir(&sys, &deno_dir.root)
+      .unwrap_or(deno_dir.root.clone());
+
+  let mut permit = main_graph_container.acquire_update_permit().await;
+  let graph = permit.graph_mut();
+  graph.packages = PackageSpecifiers::default();
+  let graph_builder = factory.module_graph_builder().await?;
+  graph_builder
+    .build_graph_with_npm_resolution(
+      graph,
+      CreateGraphOptions {
+        loader: None,
+        graph_kind: graph.graph_kind(),
+        is_dynamic: false,
+        roots: roots.clone(),
+        npm_caching: crate::graph_util::NpmCachingStrategy::Manual,
+      },
+    )
+    .await?;
+
+  let npm_resolver = factory.npm_resolver().await?;
+
+  let mut keep = HashSet::new();
+  let mut npm_reqs = Vec::new();
+
+  let mut keep_paths_trie = PathTrie::new();
+  if deno_dir_root_canonical != deno_dir.root {
+    keep_paths_trie
+      .add_rewrite(deno_dir.root.clone(), deno_dir_root_canonical.clone());
+  }
+  for (_, entry) in graph.walk(
+    roots.iter(),
+    deno_graph::WalkOptions {
+      check_js: deno_graph::CheckJsOption::False,
+      follow_dynamic: true,
+      kind: graph.graph_kind(),
+      prefer_fast_check_graph: false,
+    },
+  ) {
+    match entry {
+      deno_graph::ModuleEntryRef::Module(module) => match module {
+        deno_graph::Module::Js(js_module) => {
+          keep.insert(&js_module.specifier);
+        }
+        deno_graph::Module::Json(json_module) => {
+          keep.insert(&json_module.specifier);
+        }
+        deno_graph::Module::Wasm(wasm_module) => {
+          keep.insert(&wasm_module.specifier);
+        }
+        deno_graph::Module::Npm(npm_module) => {
+          if let Some(managed) = npm_resolver.as_managed() {
+            let id = managed
+              .resolution()
+              .resolve_pkg_id_from_deno_module(npm_module.nv_reference.nv())
+              .unwrap();
+            npm_reqs
+              .extend(managed.resolution().resolve_pkg_reqs_from_pkg_id(&id));
+          }
+        }
+        deno_graph::Module::Node(_) => {}
+        deno_graph::Module::External(_) => {}
+      },
+      deno_graph::ModuleEntryRef::Err(_) => {}
+      deno_graph::ModuleEntryRef::Redirect(_) => {}
+    }
+  }
+
+  for url in &keep {
+    if url.scheme() == "http" || url.scheme() == "https" {
+      if let Ok(path) = http_cache.local_path_for_url(url) {
+        keep_paths_trie.insert(&path);
+      }
+    }
+    if let Some(path) = deno_dir
+      .gen_cache
+      .get_cache_filename_with_extension(url, "js")
+    {
+      let path = deno_dir.gen_cache.location.join(path);
+      keep_paths_trie.insert(&path);
+    }
+  }
+
+  let npm_cache = factory.npm_cache()?;
+  let snap = npm_resolver.as_managed().unwrap().resolution().snapshot();
+  // TODO(nathanwhit): remove once we don't need packuments for creating the snapshot from lockfile
+  for package in snap.all_system_packages(&options.npm_system_info()) {
+    keep_paths_trie.insert(
+      &npm_cache
+        .package_name_folder(&package.id.nv.name)
+        .join("registry.json"),
+    );
+  }
+  let snap = snap.subset(&npm_reqs);
+  let node_modules_path = npm_resolver.root_node_modules_path();
+  let mut node_modules_keep = HashSet::new();
+  for package in snap.all_system_packages(&options.npm_system_info()) {
+    if node_modules_path.is_some() {
+      node_modules_keep.insert(package.get_package_cache_folder_id());
+    }
+    keep_paths_trie.insert(&npm_cache.package_folder_for_id(
+      &deno_npm::NpmPackageCacheFolderId {
+        nv: package.id.nv.clone(),
+        copy_index: package.copy_index,
+      },
+    ));
+  }
+
+  if dry_run {
+    #[allow(clippy::print_stderr)]
+    {
+      eprintln!("would remove:");
+    }
+  }
+
+  let jsr_url = crate::args::jsr_url();
+  add_jsr_meta_paths(graph, &mut keep_paths_trie, jsr_url, &|url| {
+    http_cache.local_path_for_url(url).map_err(Into::into)
+  })?;
+  walk_removing(
+    &mut state,
+    walkdir::WalkDir::new(&deno_dir.root)
+      .contents_first(false)
+      .min_depth(2),
+    &keep_paths_trie,
+    &deno_dir.root,
+    dry_run,
+  )?;
+  let mut node_modules_cleaned = CleanState::default();
+
+  if let Some(dir) = node_modules_path {
+    // let npm_installer = factory.npm_installer_if_managed().await?.unwrap();
+    // npm_installer.
+    // let npm_installer = npm_installer.as_local().unwrap();
+    clean_node_modules(
+      &mut node_modules_cleaned,
+      &node_modules_keep,
+      dir,
+      dry_run,
+    )?;
+  }
+
+  let mut vendor_cleaned = CleanState::default();
+  if let Some(vendor_dir) = options.vendor_dir_path() {
+    if let GlobalOrLocalHttpCache::Local(cache) = local_or_global_http_cache {
+      let mut trie = PathTrie::new();
+      if deno_dir_root_canonical != deno_dir.root {
+        trie.add_rewrite(deno_dir.root.clone(), deno_dir_root_canonical);
+      }
+      let cache = cache.clone();
+      add_jsr_meta_paths(graph, &mut trie, jsr_url, &|_url| {
+        if let Ok(Some(path)) = cache.local_path_for_url(_url) {
+          Ok(path)
+        } else {
+          panic!("should not happen")
+        }
+      })?;
+      for url in keep {
+        if url.scheme() == "http" || url.scheme() == "https" {
+          if let Ok(Some(path)) = cache.local_path_for_url(url) {
+            trie.insert(&path);
+          } else {
+            panic!("should not happen")
+          }
+        }
+      }
+
+      walk_removing(
+        &mut vendor_cleaned,
+        WalkDir::new(vendor_dir).contents_first(false),
+        &trie,
+        vendor_dir,
+        dry_run,
+      )?;
+    }
+  }
+
+  if !dry_run {
+    log_stats(&state, &deno_dir.root);
+
+    if let Some(dir) = node_modules_path {
+      log_stats(&node_modules_cleaned, dir);
+    }
+    if let Some(dir) = options.vendor_dir_path() {
+      log_stats(&vendor_cleaned, dir);
+    }
+  }
+
+  Ok(())
+}
+
+fn log_stats(state: &CleanState, dir: &Path) {
+  if state.bytes_removed == 0
+    && state.dirs_removed == 0
+    && state.files_removed == 0
+  {
+    return;
+  }
+  log::info!(
+    "{} {}",
+    colors::green("Removed"),
+    colors::gray(&format!(
+      "{} files, {} from {}",
+      state.files_removed + state.dirs_removed,
+      display::human_size(state.bytes_removed as f64),
+      dir.display()
+    ))
+  );
+}
+
+fn add_jsr_meta_paths(
+  graph: &ModuleGraph,
+  path_trie: &mut PathTrie,
+  jsr_url: &Url,
+  url_to_path: &dyn Fn(&Url) -> Result<PathBuf, AnyError>,
+) -> Result<(), AnyError> {
+  for package in graph.packages.mappings().values() {
+    let Ok(base_url) = jsr_url.join(&format!("{}/", &package.name)) else {
+      continue;
+    };
+    let keep = url_to_path(&base_url.join("meta.json").unwrap())?;
+    path_trie.insert(&keep);
+    let keep = url_to_path(
+      &base_url
+        .join(&format!("{}_meta.json", package.version))
+        .unwrap(),
+    )?;
+    path_trie.insert(&keep);
+  }
+  Ok(())
+}
+
+// TODO(nathanwhit): use strategy pattern instead of branching on dry_run
+fn walk_removing(
+  state: &mut CleanState,
+  walker: WalkDir,
+  trie: &PathTrie,
+  base: &Path,
+  dry_run: bool,
+) -> Result<(), AnyError> {
+  let mut walker = walker.into_iter();
+  while let Some(entry) = walker.next() {
+    let entry = entry?;
+    if let Some(found) = trie.find(entry.path()) {
+      if entry.file_type().is_dir() && matches!(found, Found::Match) {
+        walker.skip_current_dir();
+        continue;
+      }
+      continue;
+    }
+    if !entry.path().starts_with(base) {
+      panic!(
+        "would have removed a file outside of the base directory: base: {}, path: {}",
+        base.display(),
+        entry.path().display()
+      );
+    }
+    if entry.file_type().is_dir() {
+      if dry_run {
+        #[allow(clippy::print_stderr)]
+        {
+          eprintln!(" {}", entry.path().display());
+        }
+      } else {
+        rm_rf(state, entry.path())?;
+      }
+      walker.skip_current_dir();
+    } else if dry_run {
+      #[allow(clippy::print_stderr)]
+      {
+        eprintln!(" {}", entry.path().display());
+      }
+    } else {
+      remove_file(state, entry.path(), Some(entry.metadata()?))?;
+    }
+  }
+
+  Ok(())
+}
+
+fn clean_node_modules(
+  state: &mut CleanState,
+  keep_pkgs: &HashSet<deno_npm::NpmPackageCacheFolderId>,
+  dir: &Path,
+  dry_run: bool,
+) -> Result<(), AnyError> {
+  if !dir.ends_with("node_modules") || !dir.is_dir() {
+    bail!("expected a node_modules directory, got: {}", dir.display());
+  }
+  let base = dir.join(".deno");
+  if !base.exists() {
+    return Ok(());
+  }
+
+  let keep_names = keep_pkgs
+    .iter()
+    .map(deno_resolver::npm::get_package_folder_id_folder_name)
+    .collect::<HashSet<_>>();
+
+  // remove the actual packages from node_modules/.deno
+  let entries = match std::fs::read_dir(&base) {
+    Ok(entries) => entries,
+    Err(err)
+      if matches!(
+        err.kind(),
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+      ) =>
+    {
+      return Ok(());
+    }
+    Err(err) => {
+      return Err(err).with_context(|| {
+        format!(
+          "failed to clean node_modules directory at {}",
+          dir.display()
+        )
+      })
+    }
+  };
+
+  // TODO(nathanwhit): this probably shouldn't reach directly into this code
+  let mut setup_cache =
+    crate::npm::installer::SetupCache::load(base.join(".setup-cache.bin"));
+
+  for entry in entries {
+    let entry = entry?;
+    if !entry.file_type()?.is_dir() {
+      continue;
+    }
+    let file_name = entry.file_name();
+    let file_name = file_name.to_string_lossy();
+    if keep_names.contains(file_name.as_ref()) || file_name == "node_modules" {
+      continue;
+    } else if dry_run {
+      #[allow(clippy::print_stderr)]
+      {
+        eprintln!(" {}", entry.path().display());
+      }
+    } else {
+      rm_rf(state, &entry.path())?;
+    }
+  }
+
+  // remove top level symlinks from node_modules/<package> to node_modules/.deno/<package>
+  // where the target doesn't exist (because it was removed above)
+  clean_node_modules_symlinks(state, &keep_names, dir, dry_run, &mut |name| {
+    setup_cache.remove_root_symlink(name);
+  })?;
+
+  // remove symlinks from node_modules/.deno/node_modules/<package> to node_modules/.deno/<package>
+  // where the target doesn't exist (because it was removed above)
+  clean_node_modules_symlinks(
+    state,
+    &keep_names,
+    &base.join("node_modules"),
+    dry_run,
+    &mut |name| {
+      setup_cache.remove_deno_symlink(name);
+    },
+  )?;
+  if !dry_run {
+    setup_cache.save();
+  }
+
+  Ok(())
+}
+
+// node_modules/.deno/chalk@5.0.1/node_modules/chalk -> chalk@5.0.1
+fn node_modules_package_actual_dir_to_name(path: &Path) -> Option<Cow<str>> {
+  path
+    .parent()?
+    .parent()?
+    .file_name()
+    .map(|name| name.to_string_lossy())
+}
+
+fn clean_node_modules_symlinks(
+  state: &mut CleanState,
+  keep_names: &HashSet<String>,
+  dir: &Path,
+  dry_run: bool,
+  on_remove: &mut dyn FnMut(&str),
+) -> Result<(), AnyError> {
+  for entry in std::fs::read_dir(dir)? {
+    let entry = entry?;
+    let ty = entry.file_type()?;
+    if ty.is_symlink() {
+      let target = std::fs::read_link(entry.path())?;
+      let name = node_modules_package_actual_dir_to_name(&target);
+      if let Some(name) = name {
+        if !keep_names.contains(&*name) {
+          if dry_run {
+            #[allow(clippy::print_stderr)]
+            {
+              eprintln!(" {}", entry.path().display());
+            }
+          } else {
+            on_remove(&name);
+            remove_file(state, &entry.path(), None)?;
+          }
+        }
+      }
+    }
+  }
   Ok(())
 }
 
@@ -95,7 +642,123 @@ fn remove_file(
   }
   state.files_removed += 1;
   state.update_progress();
-  std::fs::remove_file(path)
-    .with_context(|| format!("Failed to remove file: {}", path.display()))?;
-  Ok(())
+  if let Err(e) = std::fs::remove_file(path)
+    .with_context(|| format!("Failed to remove file: {}", path.display()))
+  {
+    if cfg!(windows) {
+      if let Ok(meta) = path.symlink_metadata() {
+        if meta.is_symlink() {
+          std::fs::remove_dir(path).with_context(|| {
+            format!("Failed to remove symlink: {}", path.display())
+          })?;
+          return Ok(());
+        }
+      }
+    }
+    Err(e)
+  } else {
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::Found::*;
+
+  #[test]
+  fn path_trie() {
+    use std::path::Path;
+
+    let mut trie = super::PathTrie::new();
+
+    #[cfg(unix)]
+    {
+      trie.add_rewrite(
+        Path::new("/RewriteMe").into(),
+        Path::new("/Actual").into(),
+      );
+    }
+    #[cfg(windows)]
+    {
+      trie.add_rewrite(
+        Path::new("C:/RewriteMe").into(),
+        Path::new("C:/Actual").into(),
+      );
+    }
+
+    let paths = {
+      #[cfg(unix)]
+      {
+        [
+          "/foo/bar/deno",
+          "/foo/bar/deno/1",
+          "/foo/bar/deno/2",
+          "/foo/baz",
+          "/Actual/thing/quux",
+        ]
+      }
+      #[cfg(windows)]
+      {
+        [
+          r"C:\foo\bar\deno",
+          r"C:\foo\bar\deno\1",
+          r"C:\foo\bar\deno\2",
+          r"C:\foo\baz",
+          r"D:\thing",
+          r"C:\Actual\thing\quux",
+        ]
+      }
+    };
+
+    let cases = {
+      #[cfg(unix)]
+      {
+        [
+          ("/", Some(Prefix)),
+          ("/foo", Some(Prefix)),
+          ("/foo/", Some(Prefix)),
+          ("/foo/bar", Some(Prefix)),
+          ("/foo/bar/deno", Some(Match)),
+          ("/foo/bar/deno/1", Some(Match)),
+          ("/foo/bar/deno/2", Some(Match)),
+          ("/foo/baz", Some(Match)),
+          ("/fo", None),
+          ("/foo/baz/deno", None),
+          ("/Actual/thing/quux", Some(Match)),
+          ("/RewriteMe/thing/quux", Some(Match)),
+          ("/RewriteMe/thing", Some(Prefix)),
+        ]
+      }
+      #[cfg(windows)]
+      {
+        [
+          (r"C:\", Some(Prefix)),
+          (r"C:\foo", Some(Prefix)),
+          (r"C:\foo\", Some(Prefix)),
+          (r"C:\foo\", Some(Prefix)),
+          (r"C:\foo\bar", Some(Prefix)),
+          (r"C:\foo\bar\deno\1", Some(Match)),
+          (r"C:\foo\bar\deno\2", Some(Match)),
+          (r"C:\foo\baz", Some(Match)),
+          (r"C:\fo", None),
+          (r"C:\foo\baz\deno", None),
+          (r"D:\", Some(Prefix)),
+          (r"E:\", None),
+          (r"C:\Actual\thing\quux", Some(Match)),
+          (r"C:\RewriteMe\thing\quux", Some(Match)),
+          (r"C:\RewriteMe\thing", Some(Prefix)),
+        ]
+      }
+    };
+
+    for pth in paths {
+      let path = Path::new(pth);
+      trie.insert(path);
+    }
+
+    for (input, expect) in cases {
+      let path = Path::new(input);
+      assert_eq!(trie.find(path), expect, "on input: {input}");
+    }
+  }
 }

--- a/cli/tools/installer.rs
+++ b/cli/tools/installer.rs
@@ -380,7 +380,7 @@ async fn install_global(
   let http_client = factory.http_client_provider();
   let deps_http_cache = factory.global_http_cache()?;
   let deps_file_fetcher = CliFileFetcher::new(
-    deps_http_cache.clone(),
+    deno_cache_dir::GlobalOrLocalHttpCache::Global(deps_http_cache.clone()),
     http_client.clone(),
     factory.sys(),
     Default::default(),

--- a/cli/tools/pm/mod.rs
+++ b/cli/tools/pm/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use deno_cache_dir::file_fetcher::CacheSetting;
+use deno_cache_dir::GlobalOrLocalHttpCache;
 use deno_core::anyhow::bail;
 use deno_core::anyhow::Context;
 use deno_core::error::AnyError;
@@ -413,7 +414,7 @@ pub async fn add(
   let http_client = cli_factory.http_client_provider();
   let deps_http_cache = cli_factory.global_http_cache()?;
   let deps_file_fetcher = CliFileFetcher::new(
-    deps_http_cache.clone(),
+    GlobalOrLocalHttpCache::Global(deps_http_cache.clone()),
     http_client.clone(),
     cli_factory.sys(),
     Default::default(),

--- a/cli/tools/pm/outdated/mod.rs
+++ b/cli/tools/pm/outdated/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use deno_cache_dir::file_fetcher::CacheSetting;
+use deno_cache_dir::GlobalOrLocalHttpCache;
 use deno_core::anyhow::bail;
 use deno_core::error::AnyError;
 use deno_semver::package::PackageNv;
@@ -184,7 +185,7 @@ pub async fn outdated(
   let http_client = factory.http_client_provider();
   let deps_http_cache = factory.global_http_cache()?;
   let file_fetcher = CliFileFetcher::new(
-    deps_http_cache.clone(),
+    GlobalOrLocalHttpCache::Global(deps_http_cache.clone()),
     http_client.clone(),
     factory.sys(),
     Default::default(),

--- a/tests/specs/clean/entrypoint/__test__.jsonc
+++ b/tests/specs/clean/entrypoint/__test__.jsonc
@@ -1,0 +1,100 @@
+{
+  "tempDir": true,
+
+  "tests": {
+    "npm": {
+      "steps": [
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "install --node-modules-dir npm:chalk npm:@denotest/add",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A ./print-dir.ts --max-level=5 ./denodir --max-level=5 ./node_modules",
+          "output": "npm_init.out"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "clean -e --node-modules-dir npm:@denotest/add",
+          "output": "Removed [WILDCARD] files, [WILDCARD] from [WILDCARD]\n"
+        },
+        {
+          "args": "run -A ./print-dir.ts --max-level=5 ./denodir --max-level=5 ./node_modules",
+          "output": "npm_cleaned.out"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "install --node-modules-dir npm:chalk npm:@denotest/add",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A ./print-dir.ts --max-level=5 ./denodir --max-level=5 ./node_modules",
+          "output": "npm_init.out"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "clean -e --node-modules-dir --dry-run npm:@denotest/add",
+          "output": "npm_clean_dry_run.out"
+        }
+      ]
+    },
+    "jsr_http": {
+      "steps": [
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "run -A jsr_http1.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A ./print-dir.ts ./denodir",
+          "output": "jsr_http_init.out"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "run -A jsr_http2.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "clean -e jsr_http2.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A ./print-dir.ts ./denodir",
+          "output": "jsr_http_cleaned.out"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "run -A jsr_http2.ts",
+          "output": "" // nothing downloaded
+        },
+        {
+          "args": "run -A ./print-dir.ts ./denodir",
+          "output": "jsr_http_cleaned.out" // no new cache files
+        }
+      ]
+    },
+    "vendor": {
+      "steps": [
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "run -A --node-modules-dir --vendor vendor1.ts",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run -A ./print-dir.ts ./denodir --max-level=5 ./node_modules ./vendor",
+          "output": "vendor_init.out"
+        },
+        {
+          "envs": { "DENO_DIR": "./denodir" },
+          "args": "clean -e --node-modules-dir --vendor vendor2.ts",
+          "output": "vendor_clean_output.out"
+        },
+        {
+          "args": "run -A ./print-dir.ts ./denodir --max-level=5 ./node_modules ./vendor",
+          "output": "vendor_cleaned.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/clean/entrypoint/jsr_http1.ts
+++ b/tests/specs/clean/entrypoint/jsr_http1.ts
@@ -1,0 +1,4 @@
+import {} from "jsr:@std/http";
+import {} from "jsr:@std/assert";
+
+import {} from "./jsr_http2.ts";

--- a/tests/specs/clean/entrypoint/jsr_http2.ts
+++ b/tests/specs/clean/entrypoint/jsr_http2.ts
@@ -1,0 +1,1 @@
+import {} from "jsr:@std/assert/assert-equals";

--- a/tests/specs/clean/entrypoint/jsr_http_cleaned.out
+++ b/tests/specs/clean/entrypoint/jsr_http_cleaned.out
@@ -1,0 +1,14 @@
+./denodir
+[WILDCARD]- gen
+-- file
+---[WILDCARD]jsr_http2.ts.js
+-- http
+--- 127.0.0.1_PORT4250
+---- http://127.0.0.1:4250/@std/assert/1.0.0/assert_equals.ts ([WILDLINE])
+[WILDCARD]- remote
+-- http
+--- 127.0.0.1_PORT4250
+---- http://127.0.0.1:4250/@std/assert/1.0.0/assert_equals.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/meta.json ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0_meta.json ([WILDLINE])
+- v8_code_cache_v2[WILDCARD]

--- a/tests/specs/clean/entrypoint/jsr_http_init.out
+++ b/tests/specs/clean/entrypoint/jsr_http_init.out
@@ -1,0 +1,25 @@
+./denodir
+[WILDCARD]- gen
+-- file
+[WILDCARD]--- jsr_http1.ts.js
+[WILDCARD]--- jsr_http2.ts.js
+-- http
+--- 127.0.0.1_PORT4250
+---- http://127.0.0.1:4250/@std/assert/1.0.0/mod.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0/assert.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0/assert_equals.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/http/1.0.0/mod.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0/fail.ts ([WILDLINE])
+[WILDCARD]- remote
+-- http
+--- 127.0.0.1_PORT4250
+---- http://127.0.0.1:4250/@std/assert/1.0.0/mod.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0/assert.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0/assert_equals.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/http/meta.json ([WILDLINE])
+---- http://127.0.0.1:4250/@std/http/1.0.0/mod.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0/fail.ts ([WILDLINE])
+---- http://127.0.0.1:4250/@std/http/1.0.0_meta.json ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/meta.json ([WILDLINE])
+---- http://127.0.0.1:4250/@std/assert/1.0.0_meta.json ([WILDLINE])
+- v8_code_cache_v2[WILDCARD]

--- a/tests/specs/clean/entrypoint/npm_clean_dry_run.out
+++ b/tests/specs/clean/entrypoint/npm_clean_dry_run.out
@@ -1,0 +1,7 @@
+would remove:
+[UNORDERED_START]
+ [WILDLINE]denodir[WILDCHAR]npm[WILDCHAR]localhost_4260[WILDCHAR]chalk[WILDCHAR]5.0.1
+ [WILDLINE]denodir[WILDCHAR]remote[WILDCHAR]http
+ [WILDLINE]node_modules[WILDCHAR].deno[WILDCHAR]chalk@5.0.1
+ [WILDLINE]node_modules[WILDCHAR]chalk
+[UNORDERED_END]

--- a/tests/specs/clean/entrypoint/npm_cleaned.out
+++ b/tests/specs/clean/entrypoint/npm_cleaned.out
@@ -1,0 +1,24 @@
+./denodir
+- dep_analysis_cache[WILDCARD]
+- npm
+-- localhost_4260
+--- @denotest
+---- add
+----- 1.0.0
+----- registry.json
+--- chalk
+---- registry.json
+- remote
+
+./node_modules
+- .bin
+- .deno
+-- [WILDCARD]
+-- @denotest+add@1.0.0
+--- .initialized
+--- node_modules
+---- @denotest
+----- add
+-- node_modules
+- @denotest
+-- add (symlink)

--- a/tests/specs/clean/entrypoint/npm_init.out
+++ b/tests/specs/clean/entrypoint/npm_init.out
@@ -1,0 +1,35 @@
+./denodir
+[WILDCARD]- npm
+-- localhost_4260
+--- @denotest
+---- add
+----- 1.0.0
+----- registry.json
+--- chalk
+---- 5.0.1
+-----[WILDCARD]
+---- registry.json
+- remote
+-- http
+--- localhost_PORT4260
+---- http://localhost:4260/chalk ([WILDLINE])
+---- http://localhost:4260/@denotest%2fadd ([WILDLINE])
+
+./node_modules
+- .bin
+- .deno
+-- [WILDCARD]
+-- @denotest+add@1.0.0
+--- .initialized
+--- node_modules
+---- @denotest
+----- add
+-- chalk@5.0.1
+--- .initialized
+--- node_modules
+---- chalk
+----- [WILDCARD]
+-- node_modules
+- @denotest
+-- add (symlink)
+- chalk (symlink)

--- a/tests/specs/clean/entrypoint/print-dir.ts
+++ b/tests/specs/clean/entrypoint/print-dir.ts
@@ -1,0 +1,93 @@
+function realPrintName(name: string, level = 0) {
+  console.log("-".repeat(level + 1) + " " + name);
+}
+
+const httpCacheNames: Map<string, string> = new Map();
+
+function printName(name: string, level = 0) {
+  const nameNoExt = name.replace(/\.js$/, "");
+  const urlName = httpCacheNames.get(nameNoExt);
+  if (urlName) {
+    realPrintName(urlName + " (" + name + ")", level);
+  } else {
+    realPrintName(name, level);
+  }
+}
+
+function walk(
+  dir: string,
+  fn: (
+    { name, dir, level, kind }: {
+      name: string;
+      dir: string;
+      level: number;
+      kind: "file" | "dir" | "symlink";
+    },
+  ) => void,
+  { maxLevel }: { maxLevel: number },
+) {
+  const walkRecursive = (dir: string, level: number) => {
+    if (maxLevel > 0 && level > maxLevel) {
+      return;
+    }
+    const files = Deno.readDirSync(dir).toArray();
+    files.sort((a, b) => a.name.localeCompare(b.name));
+    for (const file of files) {
+      if (file.isDirectory) {
+        fn({ name: file.name, dir, level, kind: "dir" });
+        walkRecursive(dir + "/" + file.name, level + 1);
+      } else if (file.isFile) {
+        fn({ name: file.name, dir, level, kind: "file" });
+      } else {
+        fn({ name: file.name, dir, level, kind: "symlink" });
+      }
+    }
+  };
+  walkRecursive(dir, 0);
+}
+
+function printDir(dir: string, maxLevel = 0) {
+  walk(dir, ({ name, level, kind }) => {
+    printName(name + (kind === "symlink" ? " (symlink)" : ""), level);
+  }, { maxLevel });
+}
+
+function collectHttpCacheNames(
+  { name, dir, kind }: {
+    name: string;
+    dir: string;
+    kind: "file" | "dir" | "symlink";
+  },
+) {
+  if (
+    kind === "file" &&
+    name.length === 64 && name.match(/^[0-9a-f]{64}$/) && dir.includes("http")
+  ) {
+    const fullPath = dir + "/" + name;
+    const contents = Deno.readTextFileSync(fullPath);
+    const lastLine = contents.split("\n").pop();
+    const cacheLine = "// denoCacheMetadata=";
+    if (!lastLine?.startsWith(cacheLine)) {
+      return;
+    }
+    const meta = JSON.parse(lastLine.slice(cacheLine.length));
+    httpCacheNames.set(name, meta.url);
+  }
+}
+
+let maxLevel = 0;
+for (let i = 0; i < Deno.args.length; i++) {
+  const arg = Deno.args[i];
+  if (arg.startsWith("--max-level=")) {
+    maxLevel = parseInt(arg.split("=")[1]) - 1;
+    maxLevel = Math.max(0, maxLevel);
+  } else {
+    walk(arg, collectHttpCacheNames, { maxLevel });
+    console.log(arg);
+    printDir(arg, maxLevel);
+    if (i < Deno.args.length - 1) {
+      console.log("");
+      maxLevel = 0;
+    }
+  }
+}

--- a/tests/specs/clean/entrypoint/rewrite.ts
+++ b/tests/specs/clean/entrypoint/rewrite.ts
@@ -1,0 +1,8 @@
+const path = Deno.args[0];
+const contents = Deno.readTextFileSync(path);
+
+const denoDir = Deno.env.getEnv("DENO_DIR");
+const cwd = Deno.cwd();
+
+const newContents = contents.replace(cwd, "$CWD").replace(denoDir, "$DENO_DIR");
+Deno.writeTextFileSync(path, newContents);

--- a/tests/specs/clean/entrypoint/vendor1.ts
+++ b/tests/specs/clean/entrypoint/vendor1.ts
@@ -1,0 +1,4 @@
+import {} from "npm:chalk";
+import {} from "jsr:@std/assert";
+import {} from "jsr:@std/http";
+import {} from "./vendor2.ts";

--- a/tests/specs/clean/entrypoint/vendor2.ts
+++ b/tests/specs/clean/entrypoint/vendor2.ts
@@ -1,0 +1,2 @@
+import {} from "npm:@denotest/add";
+import {} from "jsr:@std/assert/assert-equals";

--- a/tests/specs/clean/entrypoint/vendor_clean_output.out
+++ b/tests/specs/clean/entrypoint/vendor_clean_output.out
@@ -1,0 +1,3 @@
+Removed 24 files, [WILDLINE] from [WILDLINE]denodir
+Removed 21 files, [WILDLINE] from [WILDLINE]node_modules
+Removed 8 files, [WILDLINE] from [WILDLINE]vendor

--- a/tests/specs/clean/entrypoint/vendor_cleaned.out
+++ b/tests/specs/clean/entrypoint/vendor_cleaned.out
@@ -1,0 +1,44 @@
+./denodir
+- dep_analysis_cache_v2[WILDCARD]
+- gen
+-- file
+[WILDCARD]--- vendor2.ts.js
+-- http
+--- 127.0.0.1_PORT4250
+[# assert_equals.ts]
+---- 5552028e702144b8ef1fc0b0c45082c0feb18f16783148d34065125a2a0781c1.js
+- node_analysis_cache_v2[WILDCARD]
+- npm
+-- localhost_4260
+--- @denotest
+---- add
+----- 1.0.0
+------ index.d.ts
+------ index.js
+------ package.json
+----- registry.json
+- v8_code_cache_v2[WILDCARD]
+
+./node_modules
+- .bin
+- .deno
+-- .deno.lock
+-- .deno.lock.poll
+-- .setup-cache.bin
+-- @denotest+add@1.0.0
+--- .initialized
+--- node_modules
+---- @denotest
+----- add
+-- node_modules
+- @denotest
+-- add (symlink)
+
+./vendor
+- http_127.0.0.1_4250
+-- @std
+--- assert
+---- 1.0.0
+----- assert_equals.ts
+---- 1.0.0_meta.json
+---- meta.json

--- a/tests/specs/clean/entrypoint/vendor_init.out
+++ b/tests/specs/clean/entrypoint/vendor_init.out
@@ -1,0 +1,83 @@
+./denodir
+[WILDCARD]- gen
+-- file
+[WILDCARD]--- vendor1.ts.js
+[WILDLINE]--- vendor2.ts.js
+-- http
+--- 127.0.0.1_PORT4250
+---- 1815d4c0b4f0117f3324c77cd7450c2a10ec60a1cce0c69b4b2c107569340388.js
+---- 5357bcc117136a3ad75cabf9ce53eeee946ebd0348e2f31ba41acbdfdc25b112.js
+---- 5552028e702144b8ef1fc0b0c45082c0feb18f16783148d34065125a2a0781c1.js
+---- 8a0715852e7a15af94225fad9f5d82c2c1e8671a11c5eda17958d5f0b150fffd.js
+---- 91a2012425b2db2e55f27a6c5ba916f923f86f7288685c03865fce38186aea4a.js
+- node_analysis_cache_v2[WILDCARD]
+- npm
+-- localhost_4260
+--- @denotest
+---- add
+----- 1.0.0
+------ index.d.ts
+------ index.js
+------ package.json
+----- registry.json
+--- chalk
+---- 5.0.1
+----- license
+----- package.json
+----- readme.md
+----- source
+------ index.d.ts
+------ index.js
+------ utilities.js
+------ vendor
+------- ansi-styles
+-------- index.d.ts
+-------- index.js
+------- supports-color
+-------- browser.d.ts
+-------- browser.js
+-------- index.d.ts
+-------- index.js
+---- registry.json
+- v8_code_cache_v2[WILDCARD]
+
+./node_modules
+- .bin
+- .deno
+-- .deno.lock
+-- .deno.lock.poll
+-- .setup-cache.bin
+-- @denotest+add@1.0.0
+--- .initialized
+--- node_modules
+---- @denotest
+----- add
+-- chalk@5.0.1
+--- .initialized
+--- node_modules
+---- chalk
+----- license
+----- package.json
+----- readme.md
+----- source
+-- node_modules
+- @denotest
+-- add (symlink)
+- chalk (symlink)
+
+./vendor
+- http_127.0.0.1_4250
+-- @std
+--- assert
+---- 1.0.0
+----- assert_equals.ts
+----- assert.ts
+----- fail.ts
+----- mod.ts
+---- 1.0.0_meta.json
+---- meta.json
+--- http
+---- 1.0.0
+----- mod.ts
+---- 1.0.0_meta.json
+---- meta.json


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/27229.


TODO:
- [x] Tests
- [x] Make some changes to `deno_cache_dir` so we can get the paths for the local http cache
- [x] Right now this leaves the node modules setup cache in an incorrect state (removes the symlinks, but doesn't update the setup cache)
- [ ] ~~Handle code cache and other sqlite caches?~~