### PR TITLE
fix(check): support `types@` export conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,6 +5589,7 @@ dependencies = [
  "deno_media_type",
  "deno_package_json",
  "deno_path_util",
+ "deno_semver",
  "futures",
  "lazy-regex",
  "once_cell",

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -49,6 +49,7 @@ use deno_runtime::inspector_server::InspectorServer;
 use deno_runtime::permissions::RuntimePermissionDescriptorParser;
 use node_resolver::analyze::NodeCodeTranslator;
 use node_resolver::cache::NodeResolutionThreadLocalCache;
+use node_resolver::NodeResolverOptions;
 use once_cell::sync::OnceCell;
 use sys_traits::EnvCurrentDir;
 
@@ -697,7 +698,15 @@ impl CliFactory {
       Ok(Arc::new(CliResolverFactory::new(
         self.workspace_factory()?.clone(),
         ResolverFactoryOptions {
-          conditions_from_resolution_mode: Default::default(),
+          node_resolver_options: NodeResolverOptions {
+            conditions_from_resolution_mode: Default::default(),
+            typescript_version: Some(
+              deno_semver::Version::parse_standard(
+                deno_lib::version::DENO_VERSION_INFO.typescript,
+              )
+              .unwrap(),
+            ),
+          },
           node_resolution_cache: Some(Arc::new(NodeResolutionThreadLocalCache)),
           npm_system_info: self.flags.subcommand.npm_system_info(),
           specified_import_map: Some(Box::new(CliSpecifiedImportMapProvider {

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -81,7 +81,6 @@ use crate::resolver::CliNpmReqResolver;
 use crate::resolver::CliResolver;
 use crate::resolver::FoundPackageJsonDepFlag;
 use crate::sys::CliSys;
-use crate::tsc;
 use crate::tsc::into_specifier_and_media_type;
 use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -42,6 +42,7 @@ use node_resolver::cache::NodeResolutionSys;
 use node_resolver::cache::NodeResolutionThreadLocalCache;
 use node_resolver::DenoIsBuiltInNodeModuleChecker;
 use node_resolver::NodeResolutionKind;
+use node_resolver::NodeResolverOptions;
 use node_resolver::PackageJsonThreadLocalCache;
 use node_resolver::ResolutionMode;
 
@@ -80,6 +81,7 @@ use crate::resolver::CliNpmReqResolver;
 use crate::resolver::CliResolver;
 use crate::resolver::FoundPackageJsonDepFlag;
 use crate::sys::CliSys;
+use crate::tsc;
 use crate::tsc::into_specifier_and_media_type;
 use crate::util::progress_bar::ProgressBar;
 use crate::util::progress_bar::ProgressBarStyle;
@@ -930,7 +932,15 @@ impl<'a> ResolverFactory<'a> {
           npm_resolver.clone(),
           self.pkg_json_resolver.clone(),
           self.node_resolution_sys.clone(),
-          node_resolver::ConditionsFromResolutionMode::default(),
+          NodeResolverOptions {
+            conditions_from_resolution_mode: Default::default(),
+            typescript_version: Some(
+              deno_semver::Version::parse_standard(
+                deno_lib::version::DENO_VERSION_INFO.typescript,
+              )
+              .unwrap(),
+            ),
+          },
         )))
       })
       .as_ref()

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -786,7 +786,7 @@ pub async fn run(
     npm_resolver.clone(),
     pkg_json_resolver.clone(),
     node_resolution_sys,
-    node_resolver::ConditionsFromResolutionMode::default(),
+    node_resolver::NodeResolverOptions::default(),
   ));
   let cjs_tracker = Arc::new(CjsTracker::new(
     in_npm_pkg_checker.clone(),

--- a/resolvers/deno/factory.rs
+++ b/resolvers/deno/factory.rs
@@ -26,6 +26,7 @@ use node_resolver::cache::NodeResolutionSys;
 use node_resolver::ConditionsFromResolutionMode;
 use node_resolver::DenoIsBuiltInNodeModuleChecker;
 use node_resolver::NodeResolver;
+use node_resolver::NodeResolverOptions;
 use node_resolver::NodeResolverRc;
 use node_resolver::PackageJsonResolver;
 use node_resolver::PackageJsonResolverRc;
@@ -559,8 +560,8 @@ impl<TSys: WorkspaceFactorySys> WorkspaceFactory<TSys> {
 
 #[derive(Debug, Default)]
 pub struct ResolverFactoryOptions {
-  pub conditions_from_resolution_mode: ConditionsFromResolutionMode,
   pub npm_system_info: NpmSystemInfo,
+  pub node_resolver_options: NodeResolverOptions,
   pub node_resolution_cache: Option<node_resolver::NodeResolutionCacheRc>,
   pub package_json_cache: Option<node_resolver::PackageJsonCacheRc>,
   pub package_json_dep_resolution: Option<PackageJsonDepResolution>,
@@ -691,7 +692,7 @@ impl<TSys: WorkspaceFactorySys> ResolverFactory<TSys> {
         self.npm_resolver()?.clone(),
         self.pkg_json_resolver().clone(),
         self.sys.clone(),
-        self.options.conditions_from_resolution_mode.clone(),
+        self.options.node_resolver_options.clone(),
       )))
     })
   }

--- a/resolvers/deno/factory.rs
+++ b/resolvers/deno/factory.rs
@@ -23,7 +23,6 @@ use deno_path_util::fs::canonicalize_path_maybe_not_exists;
 use deno_path_util::normalize_path;
 use futures::future::FutureExt;
 use node_resolver::cache::NodeResolutionSys;
-use node_resolver::ConditionsFromResolutionMode;
 use node_resolver::DenoIsBuiltInNodeModuleChecker;
 use node_resolver::NodeResolver;
 use node_resolver::NodeResolverOptions;

--- a/resolvers/node/Cargo.toml
+++ b/resolvers/node/Cargo.toml
@@ -26,6 +26,7 @@ deno_error.workspace = true
 deno_media_type.workspace = true
 deno_package_json.workspace = true
 deno_path_util.workspace = true
+deno_semver.workspace = true
 futures.workspace = true
 lazy-regex.workspace = true
 once_cell.workspace = true

--- a/resolvers/node/lib.rs
+++ b/resolvers/node/lib.rs
@@ -36,6 +36,7 @@ pub use resolution::ConditionsFromResolutionMode;
 pub use resolution::NodeResolution;
 pub use resolution::NodeResolutionKind;
 pub use resolution::NodeResolver;
+pub use resolution::NodeResolverOptions;
 pub use resolution::NodeResolverRc;
 pub use resolution::ResolutionMode;
 pub use resolution::DEFAULT_CONDITIONS;

--- a/resolvers/node/resolution.rs
+++ b/resolvers/node/resolution.rs
@@ -10,6 +10,7 @@ use anyhow::Error as AnyError;
 use deno_media_type::MediaType;
 use deno_package_json::PackageJson;
 use deno_path_util::url_to_file_path;
+use deno_semver::Version;
 use serde_json::Map;
 use serde_json::Value;
 use sys_traits::FileType;
@@ -168,6 +169,13 @@ enum ResolvedMethod {
   PackageSubPath,
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct NodeResolverOptions {
+  pub conditions_from_resolution_mode: ConditionsFromResolutionMode,
+  /// TypeScript version to use for typesVersions resolution.
+  pub typescript_version: Option<Version>,
+}
+
 #[allow(clippy::disallowed_types)]
 pub type NodeResolverRc<
   TInNpmPackageChecker,
@@ -196,6 +204,7 @@ pub struct NodeResolver<
   pkg_json_resolver: PackageJsonResolverRc<TSys>,
   sys: NodeResolutionSys<TSys>,
   conditions_from_resolution_mode: ConditionsFromResolutionMode,
+  typescript_version: Option<Version>,
 }
 
 impl<
@@ -217,7 +226,7 @@ impl<
     npm_pkg_folder_resolver: TNpmPackageFolderResolver,
     pkg_json_resolver: PackageJsonResolverRc<TSys>,
     sys: NodeResolutionSys<TSys>,
-    conditions_from_resolution_mode: ConditionsFromResolutionMode,
+    options: NodeResolverOptions,
   ) -> Self {
     Self {
       in_npm_pkg_checker,
@@ -225,7 +234,8 @@ impl<
       npm_pkg_folder_resolver,
       pkg_json_resolver,
       sys,
-      conditions_from_resolution_mode,
+      conditions_from_resolution_mode: options.conditions_from_resolution_mode,
+      typescript_version: options.typescript_version,
     }
   }
 

--- a/resolvers/node/resolution.rs
+++ b/resolvers/node/resolution.rs
@@ -173,7 +173,8 @@ enum ResolvedMethod {
 #[derive(Debug, Default, Clone)]
 pub struct NodeResolverOptions {
   pub conditions_from_resolution_mode: ConditionsFromResolutionMode,
-  /// TypeScript version to use for typesVersions resolution.
+  /// TypeScript version to use for typesVersions resolution and
+  /// `types@req` exports resolution.
   pub typescript_version: Option<Version>,
 }
 

--- a/tests/specs/node/types_req_export/__test__.jsonc
+++ b/tests/specs/node/types_req_export/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "check main.ts",
+  "output": "check.out",
+  "exitCode": 1
+}

--- a/tests/specs/node/types_req_export/check.out
+++ b/tests/specs/node/types_req_export/check.out
@@ -1,0 +1,7 @@
+Check file:///[WILDLINE]/main.ts
+TS2322 [ERROR]: Type '"expected"' is not assignable to type '"not"'.
+const local: "not" = value;
+      ~~~~~
+    at file:///[WILDLINE]/main.ts:4:7
+
+error: Type checking failed.

--- a/tests/specs/node/types_req_export/main.ts
+++ b/tests/specs/node/types_req_export/main.ts
@@ -1,0 +1,5 @@
+import { value } from "package";
+
+// should cause a type error where the type of value is "expected"
+const local: "not" = value;
+console.log(local);

--- a/tests/specs/node/types_req_export/node_modules/package/index.js
+++ b/tests/specs/node/types_req_export/node_modules/package/index.js
@@ -1,0 +1,1 @@
+module.exports.value = 5;

--- a/tests/specs/node/types_req_export/node_modules/package/package.json
+++ b/tests/specs/node/types_req_export/node_modules/package/package.json
@@ -1,0 +1,10 @@
+{
+  "exports": {
+    ".": {
+      "types@<4.8": "./types-4.8.d.ts",
+      "types@>5.0": "./types-expected.d.ts",
+      "types": "./types-fallback.d.ts",
+      "import": "./index.js"
+    }
+  }
+}

--- a/tests/specs/node/types_req_export/node_modules/package/types-4.8.d.ts
+++ b/tests/specs/node/types_req_export/node_modules/package/types-4.8.d.ts
@@ -1,0 +1,1 @@
+export const value: "4.8";

--- a/tests/specs/node/types_req_export/node_modules/package/types-expected.d.ts
+++ b/tests/specs/node/types_req_export/node_modules/package/types-expected.d.ts
@@ -1,0 +1,1 @@
+export const value: "expected";

--- a/tests/specs/node/types_req_export/node_modules/package/types-fallback.d.ts
+++ b/tests/specs/node/types_req_export/node_modules/package/types-fallback.d.ts
@@ -1,0 +1,1 @@
+export const value: "fallback";

--- a/tests/specs/node/types_req_export/package.json
+++ b/tests/specs/node/types_req_export/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "package": "*"
+  }
+}


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#exports-is-prioritized-over-typesversions

Part of https://github.com/denoland/deno/issues/27861