### PR TITLE
fix(node compat): shake-128, shake-256 aliases for shake128 and shake256 hash algorithms

### DIFF
--- a/ext/node/ops/crypto/digest.rs
+++ b/ext/node/ops/crypto/digest.rs
@@ -1,4 +1,3 @@
-// Copyright 2018-2025 the Deno authors. MIT license.
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -200,8 +199,8 @@ impl Hash {
     output_length: Option<usize>,
   ) -> Result<Self, HashError> {
     match algorithm_name {
-      "shake128" => return Ok(Shake128(Default::default(), output_length)),
-      "shake256" => return Ok(Shake256(Default::default(), output_length)),
+      "shake128" | "shake-128" => return Ok(Shake128(Default::default(), output_length)),
+      "shake256" | "shake-256" => return Ok(Shake256(Default::default(), output_length)),
       "sha256" => {
         let digest = ring_sha2::RingSha256::new();
         if let Some(length) = output_length {
@@ -337,6 +336,8 @@ impl Hash {
       "sha512WithRSAEncryption",
       "shake128",
       "shake256",
+      "shake-128",
+      "shake-256",
       "sm3",
       "sm3WithRSAEncryption",
       "ssl3-md5",

--- a/tests/unit_node/crypto/crypto_hash_test.ts
+++ b/tests/unit_node/crypto/crypto_hash_test.ts
@@ -2,7 +2,7 @@
 import { createHash, createHmac, getHashes, hash } from "node:crypto";
 import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals } from "jsr:@std/assert";
 
 // https://github.com/denoland/deno/issues/18140
 Deno.test({
@@ -131,4 +131,14 @@ Deno.test("[node/crypto.hash] does not leak", () => {
 Deno.test("[node/crypto.hash] oneshot hash API", () => {
   const d = hash("sha1", "Node.js");
   assertEquals(d, "10b3493287f831e81a438811a1ffba01f8cec4b7");
+});
+
+Deno.test("[node/crypto.hash] shake-128 alias", () => {
+  const d = hash("shake-128", "Node.js", "base64url");
+  assertEquals(d, "Nkx9-EgHpFkeXY5OPsL0rg");
+});
+
+Deno.test("[node/crypto.hash] shake-256 alias", () => {
+  const d = hash("shake-256", "Node.js", "base64url");
+  assertEquals(d, "JdelDxiwp92tkk9jYjEFPMlHD0gC8bMbYtHRCIM6TTQ");
 });


### PR DESCRIPTION
- Fixes #28442
- Node.js seems to manage these aliases here: [deps/openssl/openssl/providers/implementations/include/prov/names.h](https://github.com/nodejs/node/blob/96457b433fb1b9cdcc7d957914ae815aa40a5c78/deps/openssl/openssl/providers/implementations/include/prov/names.h#L222-L223)
- Tested against `crypto_hash_test.ts` locally against a debug build. The debug build passes, the current stable release fails.
