### PR TITLE
docs: adding a missing full stop to context help text

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4217,7 +4217,7 @@ fn config_arg() -> Arg {
     .short('c')
     .long("config")
     .value_name("FILE")
-    .help(cstr!("Configure different aspects of deno including TypeScript, linting, and code formatting
+    .help(cstr!("Configure different aspects of deno including TypeScript, linting, and code formatting.
   <p(245)>Typically the configuration file will be called `deno.json` or `deno.jsonc` and
   automatically detected; in that case this flag is not necessary.
   Docs: https://docs.deno.com/go/config</>"))


### PR DESCRIPTION
Full top missing from help text of config