### PR TITLE
fix(check): support `typesVersions` in npm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "deno_package_json"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9809d81d43f1805533e71d88adbe14343ada394abb236a754c8429ddd071ec65"
+checksum = "36ea66a2e2f45fe056b3db3e701e16c139767cb214530f339e9e86217b296cc6"
 dependencies = [
  "boxed_error",
  "deno_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ data-url = "=0.3.1"
 deno_cache_dir = "=0.18.0"
 deno_error = "=0.5.6"
 deno_native_certs = "0.3.0"
-deno_package_json = { version = "=0.5.1", default-features = false }
+deno_package_json = { version = "=0.5.2", default-features = false }
 deno_task_shell = "=0.20.2"
 deno_unsync = "0.4.2"
 deno_whoami = "0.1.0"

--- a/resolvers/node/Cargo.toml
+++ b/resolvers/node/Cargo.toml
@@ -37,3 +37,6 @@ serde_json.workspace = true
 sys_traits.workspace = true
 thiserror.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+sys_traits = { workspace = true, features = ["memory"] }

--- a/resolvers/node/resolution.rs
+++ b/resolvers/node/resolution.rs
@@ -1571,7 +1571,7 @@ impl<
     }
 
     if package_subpath == "." {
-      return self
+      self
         .legacy_main_resolve(
           package_json,
           referrer,
@@ -1581,36 +1581,74 @@ impl<
         )
         .map(|url| (url, ResolvedMethod::PackageSubPath))
         .map_err(|err| {
-          PackageSubpathResolveErrorKind::LegacyResolve(err).into()
-        });
+          PackageSubpathResolveErrorKind::LegacyResolve(err).into_box()
+        })
+    } else {
+      self
+        .resolve_subpath_exact(
+          package_json.path.parent().unwrap(),
+          package_subpath,
+          Some(package_json),
+          referrer,
+          resolution_mode,
+          conditions,
+          resolution_kind,
+        )
+        .map(|url| (url, ResolvedMethod::PackageSubPath))
+        .map_err(|err| {
+          PackageSubpathResolveErrorKind::LegacyResolve(err.into()).into_box()
+        })
     }
+  }
 
-    self
-      .resolve_subpath_exact(
-        package_json.path.parent().unwrap(),
-        package_subpath,
-        referrer,
-        resolution_mode,
-        conditions,
-        resolution_kind,
-      )
-      .map(|url| (url, ResolvedMethod::PackageSubPath))
-      .map_err(|err| {
-        PackageSubpathResolveErrorKind::LegacyResolve(err.into()).into()
+  fn pkg_json_types_versions<'a>(
+    &'a self,
+    pkg_json: &'a PackageJson,
+    resolution_kind: NodeResolutionKind,
+  ) -> Option<TypesVersions<'a, TSys>> {
+    if !resolution_kind.is_types() {
+      return None;
+    }
+    pkg_json
+      .types_versions
+      .as_ref()
+      .and_then(|entries| {
+        let ts_version = self.typescript_version.as_ref()?;
+        entries
+          .iter()
+          .filter_map(|(k, v)| {
+            let version_req = VersionReq::parse_from_npm(k).ok()?;
+            version_req.matches(ts_version).then_some(v)
+          })
+          .next()
+      })
+      .and_then(|value| value.as_object())
+      .map(|value| TypesVersions {
+        value,
+        dir_path: pkg_json.dir_path(),
+        sys: &self.sys,
       })
   }
 
+  #[allow(clippy::too_many_arguments)]
   fn resolve_subpath_exact(
     &self,
     directory: &Path,
     package_subpath: &str,
+    package_json: Option<&PackageJson>,
     referrer: Option<&UrlOrPathRef>,
     resolution_mode: ResolutionMode,
     conditions: &[&str],
     resolution_kind: NodeResolutionKind,
   ) -> Result<MaybeTypesResolvedUrl, TypesNotFoundError> {
     assert_ne!(package_subpath, ".");
-    let file_path = directory.join(package_subpath);
+    let types_versions = package_json.and_then(|pkg_json| {
+      self.pkg_json_types_versions(pkg_json, resolution_kind)
+    });
+    let package_subpath = types_versions
+      .and_then(|v| v.map(package_subpath))
+      .unwrap_or(Cow::Borrowed(package_subpath));
+    let file_path = directory.join(package_subpath.as_ref());
     self.maybe_resolve_types(
       LocalUrlOrPath::Path(LocalPath {
         path: file_path,
@@ -1644,6 +1682,7 @@ impl<
         .resolve_subpath_exact(
           directory,
           package_subpath,
+          None,
           maybe_referrer,
           resolution_mode,
           conditions,
@@ -1665,9 +1704,18 @@ impl<
       ResolutionMode::Require => deno_package_json::NodeModuleKind::Cjs,
       ResolutionMode::Import => deno_package_json::NodeModuleKind::Esm,
     };
+
     let maybe_main = if resolution_kind.is_types() {
       match package_json.types.as_ref() {
-        Some(types) => Some(types.as_str()),
+        Some(types) => {
+          let types_versions =
+            self.pkg_json_types_versions(package_json, resolution_kind);
+          Some(
+            types_versions
+              .and_then(|v| v.map(types.as_ref()))
+              .unwrap_or(Cow::Borrowed(types.as_str())),
+          )
+        }
         None => {
           // fallback to checking the main entrypoint for
           // a corresponding declaration file
@@ -1691,10 +1739,10 @@ impl<
         }
       }
     } else {
-      package_json.main(pkg_json_kind)
+      package_json.main(pkg_json_kind).map(Cow::Borrowed)
     };
 
-    if let Some(main) = maybe_main {
+    if let Some(main) = maybe_main.as_deref() {
       let guess = package_json.path.parent().unwrap().join(main).clean();
       if self.sys.is_file(&guess) {
         return Ok(self.maybe_resolve_types(
@@ -2133,9 +2181,64 @@ fn node_join_url(url: &Url, path: &str) -> Result<Url, url::ParseError> {
   }
 }
 
+struct TypesVersions<'a, TSys: FsMetadata> {
+  dir_path: &'a Path,
+  value: &'a serde_json::Map<std::string::String, serde_json::Value>,
+  sys: &'a NodeResolutionSys<TSys>,
+}
+
+impl<'a, TSys: FsMetadata> TypesVersions<'a, TSys> {
+  pub fn map(&self, search: &str) -> Option<Cow<'a, str>> {
+    let mut search = search
+      .strip_prefix("./")
+      .unwrap_or(search)
+      .trim_matches('/');
+    for (key, value) in self.value {
+      let key = key.strip_suffix("./").unwrap_or(key).trim_matches('/');
+      let is_match = if key == "*" || key == search {
+        true
+      } else if let Some(key_prefix) = key.strip_suffix("/*") {
+        if let Some(new_search) = search.strip_prefix(key_prefix) {
+          search = new_search.trim_matches('/');
+          true
+        } else {
+          false
+        }
+      } else {
+        false
+      };
+      if !is_match {
+        continue;
+      }
+      if let Some(values) = value.as_array() {
+        for value in values.iter().filter_map(|s| s.as_str()) {
+          let value = if let Some(asterisk_index) = value.find('*') {
+            Cow::Owned(format!(
+              "{}{}{}",
+              &value[..asterisk_index],
+              search,
+              &value[asterisk_index + 1..]
+            ))
+          } else {
+            Cow::Borrowed(value)
+          };
+          let path = self.dir_path.join(value.as_ref());
+          if self.sys.is_file(&path) {
+            return Some(value);
+          }
+        }
+      }
+    }
+    None
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use serde_json::json;
+  use sys_traits::impls::InMemorySys;
+  use sys_traits::FsCreateDirAll;
+  use sys_traits::FsWrite;
 
   use super::*;
 
@@ -2322,5 +2425,110 @@ mod tests {
       types_package_name("@scoped/package"),
       "@types/scoped__package"
     );
+  }
+
+  #[test]
+  fn test_types_versions() {
+    let dir_path = PathBuf::from("/dir");
+    let sys = InMemorySys::default();
+    sys.fs_create_dir_all(dir_path.join("ts3.1")).unwrap();
+    sys.fs_write(dir_path.join("file.d.ts"), "").unwrap();
+    sys.fs_write(dir_path.join("ts3.1/file.d.ts"), "").unwrap();
+    sys.fs_write(dir_path.join("ts3.1/file2.d.ts"), "").unwrap();
+    let node_resolution_sys = NodeResolutionSys::new(sys, None);
+
+    // asterisk key
+    {
+      let value = serde_json::json!({
+        "*": ["ts3.1/*"]
+      });
+      let types_versions = TypesVersions {
+        dir_path: &dir_path,
+        value: value.as_object().unwrap(),
+        sys: &node_resolution_sys,
+      };
+      assert_eq!(types_versions.map("file.d.ts").unwrap(), "ts3.1/file.d.ts");
+      assert_eq!(
+        types_versions.map("file2.d.ts").unwrap(),
+        "ts3.1/file2.d.ts"
+      );
+      assert!(types_versions.map("non_existent/file.d.ts").is_none());
+    }
+    // specific file
+    {
+      let value = serde_json::json!({
+        "types.d.ts": ["ts3.1/file.d.ts"]
+      });
+      let types_versions = TypesVersions {
+        dir_path: &dir_path,
+        value: value.as_object().unwrap(),
+        sys: &node_resolution_sys,
+      };
+      assert_eq!(types_versions.map("types.d.ts").unwrap(), "ts3.1/file.d.ts");
+      assert!(types_versions.map("file2.d.ts").is_none());
+    }
+    // multiple specific files
+    {
+      let value = serde_json::json!({
+        "types.d.ts": ["ts3.1/file.d.ts"],
+        "other.d.ts": ["ts3.1/file2.d.ts"],
+      });
+      let types_versions = TypesVersions {
+        dir_path: &dir_path,
+        value: value.as_object().unwrap(),
+        sys: &node_resolution_sys,
+      };
+      assert_eq!(types_versions.map("types.d.ts").unwrap(), "ts3.1/file.d.ts");
+      assert_eq!(
+        types_versions.map("other.d.ts").unwrap(),
+        "ts3.1/file2.d.ts"
+      );
+      assert!(types_versions.map("file2.d.ts").is_none());
+    }
+    // existing fallback
+    {
+      let value = serde_json::json!({
+        "*": ["ts3.1/*", "ts3.1/file2.d.ts"]
+      });
+      let types_versions = TypesVersions {
+        dir_path: &dir_path,
+        value: value.as_object().unwrap(),
+        sys: &node_resolution_sys,
+      };
+      assert_eq!(
+        types_versions.map("testing/types.d.ts").unwrap(),
+        "ts3.1/file2.d.ts"
+      );
+    }
+    // text then asterisk in key
+    {
+      let value = serde_json::json!({
+        "sub/*": ["ts3.1/file.d.ts"]
+      });
+      let types_versions = TypesVersions {
+        dir_path: &dir_path,
+        value: value.as_object().unwrap(),
+        sys: &node_resolution_sys,
+      };
+      assert_eq!(
+        types_versions.map("sub/types.d.ts").unwrap(),
+        "ts3.1/file.d.ts"
+      );
+    }
+    // text then asterisk in key and asterisk in value
+    {
+      let value = serde_json::json!({
+        "sub/*": ["ts3.1/*"]
+      });
+      let types_versions = TypesVersions {
+        dir_path: &dir_path,
+        value: value.as_object().unwrap(),
+        sys: &node_resolution_sys,
+      };
+      assert_eq!(
+        types_versions.map("sub/file.d.ts").unwrap(),
+        "ts3.1/file.d.ts"
+      );
+    }
   }
 }

--- a/tests/specs/node/types_versions/__test__.jsonc
+++ b/tests/specs/node/types_versions/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "check main.ts",
+  "output": "check.out",
+  "exitCode": 1
+}

--- a/tests/specs/node/types_versions/check.out
+++ b/tests/specs/node/types_versions/check.out
@@ -1,0 +1,14 @@
+Check file:///[WILDLINE]/main.ts
+TS2322 [ERROR]: Type '"expected"' is not assignable to type '"not"'.
+  const local: "not" = pkg.value;
+        ~~~~~
+    at file:///[WILDLINE]/main.ts:6:9
+
+TS2322 [ERROR]: Type '"sub-types"' is not assignable to type '"not"'.
+  const local: "not" = sub.value;
+        ~~~~~
+    at file:///[WILDLINE]/main.ts:12:9
+
+Found 2 errors.
+
+error: Type checking failed.

--- a/tests/specs/node/types_versions/main.ts
+++ b/tests/specs/node/types_versions/main.ts
@@ -1,0 +1,14 @@
+import * as pkg from "package";
+import * as sub from "package/sub";
+
+// should cause a type error where the type of value is "expected"
+{
+  const local: "not" = pkg.value;
+  console.log(local);
+}
+
+// should also cause a type error
+{
+  const local: "not" = sub.value;
+  console.log(local);
+}

--- a/tests/specs/node/types_versions/node_modules/package/index.js
+++ b/tests/specs/node/types_versions/node_modules/package/index.js
@@ -1,0 +1,1 @@
+module.exports.value = 5;

--- a/tests/specs/node/types_versions/node_modules/package/package.json
+++ b/tests/specs/node/types_versions/node_modules/package/package.json
@@ -1,0 +1,12 @@
+{
+  "types": "./types-4.8.d.ts",
+  "typesVersions": {
+    "<=5.0": {
+      "types-4.8.d.ts": ["types-4.8.d.ts"]
+    },
+    ">5.0": {
+      "types-4.8.d.ts": ["types-expected.d.ts"],
+      "sub": ["sub-types.d.ts"]
+    }
+  }
+}

--- a/tests/specs/node/types_versions/node_modules/package/sub-types.d.ts
+++ b/tests/specs/node/types_versions/node_modules/package/sub-types.d.ts
@@ -1,0 +1,1 @@
+export const value: "sub-types";

--- a/tests/specs/node/types_versions/node_modules/package/types-4.8.d.ts
+++ b/tests/specs/node/types_versions/node_modules/package/types-4.8.d.ts
@@ -1,0 +1,1 @@
+export const value: "4.8";

--- a/tests/specs/node/types_versions/node_modules/package/types-expected.d.ts
+++ b/tests/specs/node/types_versions/node_modules/package/types-expected.d.ts
@@ -1,0 +1,1 @@
+export const value: "expected";

--- a/tests/specs/node/types_versions/package.json
+++ b/tests/specs/node/types_versions/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "package": "*"
+  }
+}


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/28450

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions

Closes https://github.com/denoland/deno/issues/27861