### PR TITLE
docs: making copy a little clearer

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1906,7 +1906,7 @@ Under the hood, it bundles a slimmed down version of the Deno runtime along with
 JavaScript or TypeScript code.
 
 Cross-compiling to different target architectures is supported using the <c>--target</> flag.
-On the first invocation with deno will download the proper binary and cache it in <c>$DENO_DIR</>.
+On the first invocation, Deno will download the appropriate binary and cache it in <c>$DENO_DIR</>.
 
 <y>Read more:</> <c>https://docs.deno.com/go/compile</>
 "),

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1906,7 +1906,7 @@ Under the hood, it bundles a slimmed down version of the Deno runtime along with
 JavaScript or TypeScript code.
 
 Cross-compiling to different target architectures is supported using the <c>--target</> flag.
-On the first invocation, Deno will download the appropriate binary and cache it in <c>$DENO_DIR</>.
+On the first invocation of `deno compile`, Deno will download the appropriate binary and cache it in <c>$DENO_DIR</>.
 
 <y>Read more:</> <c>https://docs.deno.com/go/compile</>
 "),


### PR DESCRIPTION
Updating compile help text copy to make it a little clearer