### PR TITLE
test(unstable/otel): fix flaky specs::cli::otel_basic::node_http_metric

### DIFF
--- a/tests/specs/cli/otel_basic/node_http_metric.out
+++ b/tests/specs/cli/otel_basic/node_http_metric.out
@@ -249,16 +249,16 @@
             "count": 3,
             "sum": 0,
             "bucketCounts": [
-              3,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE],
+              [WILDLINE]
             ],
             "explicitBounds": [
               0,


### PR DESCRIPTION
It seems `bucketCounts` here is sometimes `[2, 1, 0, ...]`