### PR TITLE
chore(ext/fetch): re-export FsError to implement FetchPermissions

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -46,7 +46,7 @@ use deno_core::RcRef;
 use deno_core::Resource;
 use deno_core::ResourceId;
 use deno_error::JsErrorBox;
-use deno_fs::FsError;
+pub use deno_fs::FsError;
 use deno_path_util::PathToUrlError;
 use deno_permissions::PermissionCheckError;
 use deno_tls::rustls::RootCertStore;


### PR DESCRIPTION

Currently, there is no way to implement `FetchPermissions` without importing `FsError` from `deno_fs` directly. This PR aims to re-export the `FsError` from `deno_fetch` itself to allow it.