### PR TITLE
docs: fixed a typo in update_typescript.md

### DIFF
--- a/tools/update_typescript.md
+++ b/tools/update_typescript.md
@@ -107,7 +107,7 @@ contextual awareness, it is the author's opinion that it is best to spend the
    maps `esnext.*` values to the ratified version of them to ensure they are
    less "breaking" so you will want to make sure, like for `esnext.array` that
    it points at `lib.esnext.array.d.ts`. You will also want to revert the
-   deletion of `dom.asynciterables` and `dom.extras`.
+   deletion of `dom.asynciterable` and `dom.extras`.
 
 8. For any new lib files that were added, but not included in the snapshot (e.g.
    `lib.es####.full.d.ts`) add them to `STATIC_ASSETS` in `deno/cli/tsc.rs`.


### PR DESCRIPTION
Asynciterable as singular means it adds the concept of AsyncIterable to DOM instead of providing multiple AsyncIterable instances.