### PR TITLE
fix(ext/node): correct `STATUS_CODES` strings

### DIFF
--- a/ext/node/polyfills/_http_server.ts
+++ b/ext/node/polyfills/_http_server.ts
@@ -1,135 +1,135 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-export enum STATUS_CODES {
+export const STATUS_CODES = {
   /** RFC 7231, 6.2.1 */
-  Continue = 100,
+  100: "Continue",
   /** RFC 7231, 6.2.2 */
-  SwitchingProtocols = 101,
+  101: "Switching Protocols",
   /** RFC 2518, 10.1 */
-  Processing = 102,
+  102: "Processing",
   /** RFC 8297 **/
-  EarlyHints = 103,
+  103: "Early Hints",
 
   /** RFC 7231, 6.3.1 */
-  OK = 200,
+  200: "OK",
   /** RFC 7231, 6.3.2 */
-  Created = 201,
+  201: "Created",
   /** RFC 7231, 6.3.3 */
-  Accepted = 202,
+  202: "Accepted",
   /** RFC 7231, 6.3.4 */
-  NonAuthoritativeInfo = 203,
+  203: "Non-Authoritative Information",
   /** RFC 7231, 6.3.5 */
-  NoContent = 204,
+  204: "No Content",
   /** RFC 7231, 6.3.6 */
-  ResetContent = 205,
+  205: "Reset Content",
   /** RFC 7233, 4.1 */
-  PartialContent = 206,
+  206: "Partial Content",
   /** RFC 4918, 11.1 */
-  MultiStatus = 207,
+  207: "Multi-Status",
   /** RFC 5842, 7.1 */
-  AlreadyReported = 208,
+  208: "Already Reported",
   /** RFC 3229, 10.4.1 */
-  IMUsed = 226,
+  226: "IM Used",
 
   /** RFC 7231, 6.4.1 */
-  MultipleChoices = 300,
+  300: "Multiple Choices",
   /** RFC 7231, 6.4.2 */
-  MovedPermanently = 301,
+  301: "Moved Permanently",
   /** RFC 7231, 6.4.3 */
-  Found = 302,
+  302: "Found",
   /** RFC 7231, 6.4.4 */
-  SeeOther = 303,
+  303: "See Other",
   /** RFC 7232, 4.1 */
-  NotModified = 304,
+  304: "Not Modified",
   /** RFC 7231, 6.4.5 */
-  UseProxy = 305,
+  305: "Use Proxy",
   /** RFC 7231, 6.4.7 */
-  TemporaryRedirect = 307,
+  307: "Temporary Redirect",
   /** RFC 7538, 3 */
-  PermanentRedirect = 308,
+  308: "Permanent Redirect",
 
   /** RFC 7231, 6.5.1 */
-  BadRequest = 400,
+  400: "Bad Request",
   /** RFC 7235, 3.1 */
-  Unauthorized = 401,
+  401: "Unauthorized",
   /** RFC 7231, 6.5.2 */
-  PaymentRequired = 402,
+  402: "Payment Required",
   /** RFC 7231, 6.5.3 */
-  Forbidden = 403,
+  403: "Forbidden",
   /** RFC 7231, 6.5.4 */
-  NotFound = 404,
+  404: "Not Found",
   /** RFC 7231, 6.5.5 */
-  MethodNotAllowed = 405,
+  405: "Method Not Allowed",
   /** RFC 7231, 6.5.6 */
-  NotAcceptable = 406,
+  406: "Not Acceptable",
   /** RFC 7235, 3.2 */
-  ProxyAuthRequired = 407,
+  407: "Proxy Authentication Required",
   /** RFC 7231, 6.5.7 */
-  RequestTimeout = 408,
+  408: "Request Timeout",
   /** RFC 7231, 6.5.8 */
-  Conflict = 409,
+  409: "Conflict",
   /** RFC 7231, 6.5.9 */
-  Gone = 410,
+  410: "Gone",
   /** RFC 7231, 6.5.10 */
-  LengthRequired = 411,
+  411: "Length Required",
   /** RFC 7232, 4.2 */
-  PreconditionFailed = 412,
+  412: "Precondition Failed",
   /** RFC 7231, 6.5.11 */
-  RequestEntityTooLarge = 413,
+  413: "Payload Too Large",
   /** RFC 7231, 6.5.12 */
-  RequestURITooLong = 414,
+  414: "URI Too Long",
   /** RFC 7231, 6.5.13 */
-  UnsupportedMediaType = 415,
+  415: "Unsupported Media Type",
   /** RFC 7233, 4.4 */
-  RequestedRangeNotSatisfiable = 416,
+  416: "Range Not Satisfiable",
   /** RFC 7231, 6.5.14 */
-  ExpectationFailed = 417,
+  417: "Expectation Failed",
   /** RFC 7168, 2.3.3 */
-  Teapot = 418,
+  418: "I'm a Teapot",
   /** RFC 7540, 9.1.2 */
-  MisdirectedRequest = 421,
+  421: "Misdirected Request",
   /** RFC 4918, 11.2 */
-  UnprocessableEntity = 422,
+  422: "Unprocessable Entity",
   /** RFC 4918, 11.3 */
-  Locked = 423,
+  423: "Locked",
   /** RFC 4918, 11.4 */
-  FailedDependency = 424,
+  424: "Failed Dependency",
   /** RFC 8470, 5.2 */
-  TooEarly = 425,
+  425: "Too Early",
   /** RFC 7231, 6.5.15 */
-  UpgradeRequired = 426,
+  426: "Upgrade Required",
   /** RFC 6585, 3 */
-  PreconditionRequired = 428,
+  428: "Precondition Required",
   /** RFC 6585, 4 */
-  TooManyRequests = 429,
+  429: "Too Many Requests",
   /** RFC 6585, 5 */
-  RequestHeaderFieldsTooLarge = 431,
+  431: "Request Header Fields Too Large",
   /** RFC 7725, 3 */
-  UnavailableForLegalReasons = 451,
+  451: "Unavailable For Legal Reasons",
 
   /** RFC 7231, 6.6.1 */
-  InternalServerError = 500,
+  500: "Internal Server Error",
   /** RFC 7231, 6.6.2 */
-  NotImplemented = 501,
+  501: "Not Implemented",
   /** RFC 7231, 6.6.3 */
-  BadGateway = 502,
+  502: "Bad Gateway",
   /** RFC 7231, 6.6.4 */
-  ServiceUnavailable = 503,
+  503: "Service Unavailable",
   /** RFC 7231, 6.6.5 */
-  GatewayTimeout = 504,
+  504: "Gateway Timeout",
   /** RFC 7231, 6.6.6 */
-  HTTPVersionNotSupported = 505,
+  505: "HTTP Version Not Supported",
   /** RFC 2295, 8.1 */
-  VariantAlsoNegotiates = 506,
+  506: "Variant Also Negotiates",
   /** RFC 4918, 11.5 */
-  InsufficientStorage = 507,
+  507: "Insufficient Storage",
   /** RFC 5842, 7.2 */
-  LoopDetected = 508,
+  508: "Loop Detected",
   /** RFC 2774, 7 */
-  NotExtended = 510,
+  510: "Not Extended",
   /** RFC 6585, 6 */
-  NetworkAuthenticationRequired = 511,
-}
+  511: "Network Authentication Required",
+};
 
 export default {
   STATUS_CODES,


### PR DESCRIPTION
Matches Node.js `http.STATUS_CODES` values now. Deno is currently exporting an enum directly, which 1) adds keys like `BadRequest` and 2) ships the status-text strings as non-space-delimited values (eg, `'BadRequest`` instead of `'Bad Request'`)

Current `deno repl -A` snapshot:

<img width="565" alt="Screenshot 2025-03-13 at 12 45 42 PM" src="https://github.com/user-attachments/assets/14b78e11-953e-427d-ae04-76aaedcfa2c2" />


<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
