### PR TITLE
fix: `process.stdin.pause()`

### DIFF
--- a/ext/fetch/lib.rs
+++ b/ext/fetch/lib.rs
@@ -235,6 +235,7 @@ impl From<deno_fs::FsError> for FetchError {
   fn from(value: deno_fs::FsError) -> Self {
     match value {
       deno_fs::FsError::Io(_)
+      | deno_fs::FsError::Paused
       | deno_fs::FsError::FileBusy
       | deno_fs::FsError::NotSupported => FetchError::NetworkError,
       deno_fs::FsError::NotCapable(err) => FetchError::NotCapable(err),

--- a/ext/fs/ops.rs
+++ b/ext/fs/ops.rs
@@ -102,6 +102,7 @@ impl From<FsError> for FsOpsError {
         FsOpsErrorKind::Other(JsErrorBox::not_supported())
       }
       FsError::NotCapable(err) => FsOpsErrorKind::NotCapable(err),
+      FsError::Paused => FsOpsErrorKind::Canceled(deno_core::Canceled),
     }
     .into_box()
   }

--- a/ext/io/fs.rs
+++ b/ext/io/fs.rs
@@ -26,6 +26,8 @@ pub enum FsError {
   NotSupported,
   #[class("NotCapable")]
   NotCapable(&'static str),
+  #[class(generic)]
+  Paused,
 }
 
 impl std::fmt::Display for FsError {
@@ -37,6 +39,7 @@ impl std::fmt::Display for FsError {
       FsError::NotCapable(err) => {
         f.write_str(&format!("requires {err} access"))
       }
+      FsError::Paused => f.write_str("paused"),
     }
   }
 }
@@ -50,6 +53,7 @@ impl FsError {
       Self::FileBusy => io::ErrorKind::Other,
       Self::NotSupported => io::ErrorKind::Other,
       Self::NotCapable(_) => io::ErrorKind::Other,
+      Self::Paused => io::ErrorKind::Other,
     }
   }
 
@@ -61,6 +65,7 @@ impl FsError {
       FsError::NotCapable(err) => {
         io::Error::new(self.kind(), format!("requires {err} access"))
       }
+      FsError::Paused => io::Error::new(self.kind(), "paused"),
     }
   }
 }
@@ -267,6 +272,7 @@ pub trait File {
   fn as_stdio(self: Rc<Self>) -> FsResult<std::process::Stdio>;
   fn backing_fd(self: Rc<Self>) -> Option<ResourceHandleFd>;
   fn try_clone_inner(self: Rc<Self>) -> FsResult<Rc<dyn File>>;
+  fn read_stop(self: Rc<Self>) {}
 }
 
 pub struct FileResource {

--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -217,6 +217,25 @@ export const initStdin = (warmup = false) => {
     }
   }
 
+  if (stdin._handle?.readStop) {
+    stdin._handle.reading = false;
+    stdin._readableState.reading = false;
+    stdin._handle.readStop();
+  }
+
+  function onpause() {
+    if (!stdin._handle) {
+      return;
+    }
+	  console.log(!stdin.readableFlowing, stdin._handle.reading);
+    if (stdin._handle.reading && !stdin.readableFlowing) {
+      stdin._readableState.reading = false;
+	    console.log("readStop");
+      stdin._handle.reading = false;
+      stdin._handle.readStop();
+    }
+  }
+  stdin.on("pause", process.nextTick.bind(null, onpause));
   stdin.on("close", () => io.stdin?.close());
   stdin.fd = io.stdin ? io.STDIN_RID : -1;
   ObjectDefineProperty(stdin, "isTTY", {


### PR DESCRIPTION
Attempt 2 at fixing `process.stdin` pause. 

Currently, there is no way to pause ongoing reads. This PR adds `op_io_read_stop` that races against the blocking read task essentially like a CancelHandle but resets for every read.

I don't think this is the right fix yet, there are still fundamental differences and assumption that read ops are always active and don't pause. This sometimes causes `readStop()` to prematurely exit as the event loop sees there are no tasks left.

Fixes https://github.com/denoland/deno/issues/26403