### PR TITLE
fix: add stackTraceLimit to ErrorConstructor interface and removed ErrorWithStackTraceLimit interface

### DIFF
--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -754,6 +754,7 @@ declare var CustomEvent: {
 interface ErrorConstructor {
   /** See https://v8.dev/docs/stack-trace-api#stack-trace-collection-for-custom-exceptions. */
   captureStackTrace(error: Object, constructor?: Function): void;
+  stackTraceLimit: number;
   // TODO(nayeemrmn): Support `Error.prepareStackTrace()`. We currently use this
   // internally in a way that makes it unavailable for users.
 }

--- a/ext/node/polyfills/assertion_error.ts
+++ b/ext/node/polyfills/assertion_error.ts
@@ -373,10 +373,6 @@ export interface AssertionErrorConstructorOptions {
   stackStartFunction?: Function;
 }
 
-interface ErrorWithStackTraceLimit extends ErrorConstructor {
-  stackTraceLimit: number;
-}
-
 export class AssertionError extends Error {
   [key: string]: unknown;
 
@@ -398,10 +394,8 @@ export class AssertionError extends Error {
       expected,
     } = options;
 
-    // TODO(schwarzkopfb): `stackTraceLimit` should be added to `ErrorConstructor` in
-    // cli/dts/lib.deno.shared_globals.d.ts
-    const limit = (Error as ErrorWithStackTraceLimit).stackTraceLimit;
-    (Error as ErrorWithStackTraceLimit).stackTraceLimit = 0;
+    const limit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 0;
 
     if (message != null) {
       super(String(message));
@@ -501,7 +495,7 @@ export class AssertionError extends Error {
       }
     }
 
-    (Error as ErrorWithStackTraceLimit).stackTraceLimit = limit;
+    Error.stackTraceLimit = limit;
 
     this.generatedMessage = !message;
     ObjectDefineProperty(this, "name", {


### PR DESCRIPTION
When upgrading to Deno 2.x from 1.x I noticed that my project began to get the below error from deno-ts:
>Property 'stackTraceLimit' does not exist on type 'ErrorConstructor'.deno-ts(2339)

Looking through the deno codebase I saw that there wasa todo item to add this field, which is why I have opened this pull-request