### PR TITLE
fix(ext/os): explicitly enable `sysinfoapi` feature on `winapi` dependency

### DIFF
--- a/ext/os/Cargo.toml
+++ b/ext/os/Cargo.toml
@@ -27,7 +27,7 @@ thiserror.workspace = true
 tokio.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "tlhelp32", "winbase", "winerror", "winuser", "winsock2"] }
+winapi = { workspace = true, features = ["commapi", "knownfolders", "mswsock", "objbase", "psapi", "shlobj", "sysinfoapi", "tlhelp32", "winbase", "winerror", "winuser", "winsock2"] }
 ntapi = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This pr explicitly enables the `sysinfoapi` feature flag on `winapi` in `deno_os`, so that `deno_os` and other deno crates that rely on it can be built independently outside of the workspace on Windows. (Closes #28557)