### PR TITLE
feat(otel): Add support for arrays in OTEL attributes

### DIFF
--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -54,6 +54,7 @@ use opentelemetry::trace::Status as SpanStatus;
 use opentelemetry::trace::TraceFlags;
 use opentelemetry::trace::TraceId;
 use opentelemetry::trace::TraceState;
+use opentelemetry::Array;
 use opentelemetry::InstrumentationScope;
 pub use opentelemetry::Key;
 pub use opentelemetry::KeyValue;
@@ -980,9 +981,111 @@ macro_rules! attr_raw {
     } else if let Ok(bigint) = $value.try_cast::<v8::BigInt>() {
       let (i64_value, _lossless) = bigint.i64_value();
       Some(Value::I64(i64_value))
-    } else if let Ok(_array) = $value.try_cast::<v8::Array>() {
-      // TODO: implement array attributes
-      None
+    } else if let Ok(array) = $value.try_cast::<v8::Array>() {
+      // Build up a homogeneous array of primitive attribute values.
+      let len = array.length();
+      enum Builder {
+        String(Vec<StringValue>),
+        F64(Vec<f64>),
+        Bool(Vec<bool>),
+        I64(Vec<i64>),
+      }
+      let mut builder: Option<Builder> = None;
+      for i in 0..len {
+        let Some(el) = array.get_index($scope, i) else {
+          continue;
+        };
+        if el.is_null_or_undefined() {
+          // Skip null/undefined elements.
+          continue;
+        }
+        if let Some(b) = &mut builder {
+          match b {
+            Builder::String(vec) => {
+              if let Ok(s) = el.try_cast::<v8::String>() {
+                let view = v8::ValueView::new($scope, s);
+                match view.data() {
+                  v8::ValueViewData::OneByte(bytes) => {
+                    vec.push(StringValue::from(
+                      String::from_utf8_lossy(bytes).into_owned(),
+                    ))
+                  }
+                  v8::ValueViewData::TwoByte(bytes) => {
+                    vec.push(StringValue::from(String::from_utf16_lossy(bytes)))
+                  }
+                }
+              } else {
+                builder = None;
+                break;
+              }
+            }
+            Builder::F64(vec) => {
+              if let Ok(n) = el.try_cast::<v8::Number>() {
+                vec.push(n.value());
+              } else {
+                builder = None;
+                break;
+              }
+            }
+            Builder::Bool(vec) => {
+              if let Ok(b) = el.try_cast::<v8::Boolean>() {
+                vec.push(b.is_true());
+              } else {
+                builder = None;
+                break;
+              }
+            }
+            Builder::I64(vec) => {
+              if let Ok(bi) = el.try_cast::<v8::BigInt>() {
+                let (i64_value, _lossless) = bi.i64_value();
+                vec.push(i64_value);
+              } else {
+                builder = None;
+                break;
+              }
+            }
+          }
+        } else {
+          // Determine the array element type.
+          if let Ok(s) = el.try_cast::<v8::String>() {
+            let view = v8::ValueView::new($scope, s);
+            let mut vec = Vec::with_capacity(len as usize);
+            match view.data() {
+              v8::ValueViewData::OneByte(bytes) => vec.push(StringValue::from(
+                String::from_utf8_lossy(bytes).into_owned(),
+              )),
+              v8::ValueViewData::TwoByte(bytes) => {
+                vec.push(StringValue::from(String::from_utf16_lossy(bytes)))
+              }
+            }
+            builder = Some(Builder::String(vec));
+          } else if let Ok(n) = el.try_cast::<v8::Number>() {
+            let mut vec = Vec::with_capacity(len as usize);
+            vec.push(n.value());
+            builder = Some(Builder::F64(vec));
+          } else if let Ok(b) = el.try_cast::<v8::Boolean>() {
+            let mut vec = Vec::with_capacity(len as usize);
+            vec.push(b.is_true());
+            builder = Some(Builder::Bool(vec));
+          } else if let Ok(bi) = el.try_cast::<v8::BigInt>() {
+            let mut vec = Vec::with_capacity(len as usize);
+            let (i64_value, _lossless) = bi.i64_value();
+            vec.push(i64_value);
+            builder = Some(Builder::I64(vec));
+          } else {
+            // unsupported element type
+            builder = None;
+            break;
+          }
+        }
+      }
+      match builder {
+        Some(Builder::String(vec)) => Some(Value::Array(Array::String(vec))),
+        Some(Builder::F64(vec)) => Some(Value::Array(Array::F64(vec))),
+        Some(Builder::Bool(vec)) => Some(Value::Array(Array::Bool(vec))),
+        Some(Builder::I64(vec)) => Some(Value::Array(Array::I64(vec))),
+        None => None,
+      }
     } else {
       None
     };

--- a/ext/telemetry/telemetry.ts
+++ b/ext/telemetry/telemetry.ts
@@ -112,13 +112,19 @@ interface SpanStatus {
   message?: string;
 }
 
+/**
+ * OpenTelemetry attribute values may be primitive types or homogeneous arrays of primitive types.
+ * Bigints are supported and transmitted as signed 64-bit integers.
+ */
 type AttributeValue =
   | string
   | number
   | boolean
+  | bigint
   | Array<null | undefined | string>
   | Array<null | undefined | number>
-  | Array<null | undefined | boolean>;
+  | Array<null | undefined | boolean>
+  | Array<null | undefined | bigint>;
 
 interface Attributes {
   [attributeKey: string]: AttributeValue | undefined;

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -60,6 +60,10 @@
     "events": {
       "args": "run -A main.ts events.ts",
       "output": "events.out"
+    },
+    "arrays": {
+      "args": "run -A main.ts arrays.ts",
+      "output": "arrays.out"
     }
   }
 }

--- a/tests/specs/cli/otel_basic/arrays.out
+++ b/tests/specs/cli/otel_basic/arrays.out
@@ -1,0 +1,88 @@
+{
+  "spans": [
+    {
+      "traceId": "00000000000000000000000000000001",
+      "spanId": "0000000000000001",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "array span",
+      "kind": 1,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "arr.string",
+          "value": {
+            "arrayValue": {
+              "values": [
+                {
+                  "stringValue": "foo"
+                },
+                {
+                  "stringValue": "bar"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "key": "arr.number",
+          "value": {
+            "arrayValue": {
+              "values": [
+                {
+                  "doubleValue": 1
+                },
+                {
+                  "doubleValue": 2
+                }
+              ]
+            }
+          }
+        },
+        {
+          "key": "arr.bigint",
+          "value": {
+            "arrayValue": {
+              "values": [
+                {
+                  "intValue": "3"
+                },
+                {
+                  "intValue": "4"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "key": "arr.bool",
+          "value": {
+            "arrayValue": {
+              "values": [
+                {
+                  "boolValue": true
+                },
+                {
+                  "boolValue": false
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    }
+  ],
+  "logs": [],
+  "metrics": []
+}

--- a/tests/specs/cli/otel_basic/arrays.ts
+++ b/tests/specs/cli/otel_basic/arrays.ts
@@ -1,0 +1,13 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+// This test exercises support for homogeneous array-valued attributes.
+import { trace } from "npm:@opentelemetry/api@1.9.0";
+
+const tracer = trace.getTracer("example-tracer");
+await tracer.startActiveSpan("array span", (span) => {
+  span.setAttribute("arr.string", ["foo", "bar"]);
+  span.setAttribute("arr.number", [1, 2]);
+  span.setAttribute("arr.bigint", [3n, 4n]);
+  span.setAttribute("arr.bool", [true, false]);
+  span.end();
+});


### PR DESCRIPTION
Fixes denoland/deno#27552

This change adds support for homogeneous array-valued attributes to the
OpenTelemetry extension. Previously we only handled primitive attribute
types (`string`, `number`, `boolean`, `bigint`); now `attr_raw` can
recognise and marshal arrays of those primitives through to
`opentelemetry::Value::Array`.

* `ext/telemetry/lib.rs`:
  * import `opentelemetry::Array`
  * extend `attr_raw!` to walk a `v8::Array`, detect an element type
    and build a concrete `Array::String/F64/Bool/I64`
  * fix formatting to satisfy `cargo fmt`
* `ext/telemetry/telemetry.ts`:
  * update `AttributeValue` to include `bigint` and array unions
* add `tests/specs/cli/otel_basic/arrays.ts` and `arrays.out`
  to exercise the new attribute shapes under the Tracer harness
* update `__test__.jsonc` to wire in the new `arrays` test

Running `target/debug/deno run -A main.ts arrays.ts` now yields exported
spans with `arrayValue` payloads; timestamps are wildcarded in the
expected JSON as with existing tests.

All changes have been linted and formatted; `cargo test -p deno_telemetry`
builds cleanly.

Please let me know if you’d like any additional coverage around metrics.

---

This PR was generated by an AI system in collaboration with maintainers: @dsherret 