### PR TITLE
fix(rt): atime/birthtime/mtime/ctime is none in executable file

### DIFF
--- a/cli/lib/standalone/binary.rs
+++ b/cli/lib/standalone/binary.rs
@@ -95,7 +95,7 @@ pub struct Metadata {
   pub unstable_config: UnstableConfig,
   pub otel_config: OtelConfig,
   pub vfs_case_sensitivity: FileSystemCaseSensitivity,
-  pub build_time: Option<u64>,
+  pub build_time: Option<u128>, // unit: mill
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/cli/lib/standalone/binary.rs
+++ b/cli/lib/standalone/binary.rs
@@ -95,7 +95,6 @@ pub struct Metadata {
   pub unstable_config: UnstableConfig,
   pub otel_config: OtelConfig,
   pub vfs_case_sensitivity: FileSystemCaseSensitivity,
-  pub build_time: Option<u128>, // unit: mill
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/cli/lib/standalone/binary.rs
+++ b/cli/lib/standalone/binary.rs
@@ -95,7 +95,7 @@ pub struct Metadata {
   pub unstable_config: UnstableConfig,
   pub otel_config: OtelConfig,
   pub vfs_case_sensitivity: FileSystemCaseSensitivity,
-  pub build_time: Option<u64>
+  pub build_time: Option<u64>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/cli/lib/standalone/virtual_fs.rs
+++ b/cli/lib/standalone/virtual_fs.rs
@@ -261,7 +261,7 @@ pub struct VirtualFile {
   #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
   pub source_map_offset: Option<OffsetWithLength>,
   #[serde(rename = "t", skip_serializing_if = "Option::is_none")]
-  pub mtime: Option<u128>,   // mtime in milliseconds
+  pub mtime: Option<u128>, // mtime in milliseconds
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -721,7 +721,12 @@ impl VfsBuilder {
       .map(|data| self.files.add_data(data));
     let dir = self.add_dir_raw(path.parent().unwrap());
     let name = path.file_name().unwrap().to_string_lossy();
-    let file_mtime = path.metadata()?.modified()?.duration_since(std::time::UNIX_EPOCH)?.as_millis();
+    #[allow(clippy::disallowed_methods)]
+    let file_mtime = path
+      .metadata()?
+      .modified()?
+      .duration_since(std::time::UNIX_EPOCH)?
+      .as_millis();
 
     dir.entries.insert_or_modify(
       &name,

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -16,6 +16,7 @@ use std::time::SystemTime;
 use deno_core::BufMutView;
 use deno_core::BufView;
 use deno_core::ResourceHandleFd;
+use deno_lib::standalone::binary::METADATA;
 use deno_lib::standalone::virtual_fs::FileSystemCaseSensitivity;
 use deno_lib::standalone::virtual_fs::OffsetWithLength;
 use deno_lib::standalone::virtual_fs::VfsEntry;
@@ -1254,10 +1255,10 @@ impl FileBackedVfsMetadata {
       is_directory: self.file_type == sys_traits::FileType::Dir,
       is_file: self.file_type == sys_traits::FileType::File,
       is_symlink: self.file_type == sys_traits::FileType::Symlink,
-      atime: None,
-      birthtime: None,
-      mtime: None,
-      ctime: None,
+      atime: Some(self.get_build_time()),
+      birthtime: Some(self.get_build_time()),
+      mtime: Some(self.get_build_time()),
+      ctime: Some(self.get_build_time()),
       blksize: 0,
       size: self.len,
       dev: 0,
@@ -1272,6 +1273,13 @@ impl FileBackedVfsMetadata {
       is_char_device: false,
       is_fifo: false,
       is_socket: false,
+    }
+  }
+
+  fn get_build_time(&self) -> u64 {
+    match METADATA.get() {
+      Some(metadata) => metadata.build_time.unwrap_or(0),
+      None => 0
     }
   }
 }

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -1231,7 +1231,7 @@ pub struct FileBackedVfsMetadata {
   pub name: String,
   pub file_type: sys_traits::FileType,
   pub len: u64,
-  pub mtime: Option<u128>
+  pub mtime: Option<u128>,
 }
 
 impl FileBackedVfsMetadata {
@@ -1283,7 +1283,7 @@ impl FileBackedVfsMetadata {
   }
 
   /// if `mtime` is `None`, return `0`.
-  /// 
+  ///
   /// if `mtime` is greater than `u64::MAX`, return `u64::MAX`.
   fn get_mtime(&self) -> u64 {
     self.mtime.unwrap_or(0).try_into().unwrap_or(u64::MAX)

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -1279,7 +1279,7 @@ impl FileBackedVfsMetadata {
   fn get_build_time(&self) -> u64 {
     match METADATA.get() {
       Some(metadata) => metadata.build_time.unwrap_or(0),
-      None => 0
+      None => 0,
     }
   }
 }

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -1277,10 +1277,12 @@ impl FileBackedVfsMetadata {
   }
 
   fn get_build_time(&self) -> u64 {
-    match METADATA.get() {
+    let time = match METADATA.get() {
       Some(metadata) => metadata.build_time.unwrap_or(0),
       None => 0,
-    }
+    };
+
+    time.try_into().unwrap_or_default()
   }
 }
 

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -32,6 +32,7 @@ use deno_lib::npm::create_npm_process_state_provider;
 use deno_lib::npm::NpmRegistryReadPermissionChecker;
 use deno_lib::npm::NpmRegistryReadPermissionCheckerMode;
 use deno_lib::standalone::binary::NodeModules;
+use deno_lib::standalone::binary::METADATA;
 use deno_lib::util::hash::FastInsecureHasher;
 use deno_lib::util::text_encoding::from_utf8_lossy_cow;
 use deno_lib::util::text_encoding::from_utf8_lossy_owned;
@@ -660,6 +661,16 @@ pub async fn run(
     root_path,
     vfs,
   } = data;
+
+  // Leak metadata as a global variable.
+  let metadata_static_ref = Box::leak(Box::new(metadata.clone()));
+  match METADATA.set(metadata_static_ref) {
+    Ok(_) => {},
+    Err(_) => {
+      log::error!("Failed to set metadata globally, already exists.");
+    },
+  }
+
   let root_cert_store_provider = Arc::new(StandaloneRootCertStoreProvider {
     ca_stores: metadata.ca_stores,
     ca_data: metadata.ca_data.map(CaData::Bytes),

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -665,10 +665,10 @@ pub async fn run(
   // Leak metadata as a global variable.
   let metadata_static_ref = Box::leak(Box::new(metadata.clone()));
   match METADATA.set(metadata_static_ref) {
-    Ok(_) => {},
+    Ok(_) => {}
     Err(_) => {
       log::error!("Failed to set metadata globally, already exists.");
-    },
+    }
   }
 
   let root_cert_store_provider = Arc::new(StandaloneRootCertStoreProvider {

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -703,6 +703,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       },
       otel_config: self.cli_options.otel_config(),
       vfs_case_sensitivity: vfs.case_sensitivity,
+      build_time: std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).ok().map(|x| x.as_secs())
     };
 
     let (data_section_bytes, section_sizes) = serialize_binary_data_section(

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -706,7 +706,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       build_time: std::time::SystemTime::now()
         .duration_since(std::time::SystemTime::UNIX_EPOCH)
         .ok()
-        .map(|x| x.as_secs()),
+        .map(|x| x.as_millis()),
     };
 
     let (data_section_bytes, section_sizes) = serialize_binary_data_section(

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -702,11 +702,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
         npm_lazy_caching: self.cli_options.unstable_npm_lazy_caching(),
       },
       otel_config: self.cli_options.otel_config(),
-      vfs_case_sensitivity: vfs.case_sensitivity,
-      build_time: std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .ok()
-        .map(|x| x.as_millis()),
+      vfs_case_sensitivity: vfs.case_sensitivity
     };
 
     let (data_section_bytes, section_sizes) = serialize_binary_data_section(

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -703,7 +703,10 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       },
       otel_config: self.cli_options.otel_config(),
       vfs_case_sensitivity: vfs.case_sensitivity,
-      build_time: std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).ok().map(|x| x.as_secs())
+      build_time: std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|x| x.as_secs()),
     };
 
     let (data_section_bytes, section_sizes) = serialize_binary_data_section(

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -702,7 +702,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
         npm_lazy_caching: self.cli_options.unstable_npm_lazy_caching(),
       },
       otel_config: self.cli_options.otel_config(),
-      vfs_case_sensitivity: vfs.case_sensitivity
+      vfs_case_sensitivity: vfs.case_sensitivity,
     };
 
     let (data_section_bytes, section_sizes) = serialize_binary_data_section(


### PR DESCRIPTION
Fixed issue #28563.

# How to fix

As a quick fix, we implemented a simple low-overhead solution:

1. Introduced a global static variable `METADATA` for standalone mode.
2. All time variable of `FsStats` on VfsFile now return `METADATA.build_time`. If `METADATA` is `None` or `METADATA.build_time` is `None`, return `0`.

# Changed

## Old Behavior

see #28563.

## Now Behavior

Successfully get times.

And no unexpected exception be happened.

![image](https://github.com/user-attachments/assets/8624b4b9-f6b5-41d1-943b-e2de49d033a9)
