### PR TITLE
fix(ext/node): propagate 'close' event of IncomingMessage to Socket

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1001,6 +1001,10 @@ export class IncomingMessageForClient extends NodeReadable {
     // Flag for when we decide that this message cannot possibly be
     // read by the user, so there's no point continuing to handle it.
     this._dumped = false;
+
+    this.on("close", () => {
+      this.socket.emit("close");
+    });
   }
 
   get connection() {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1945,3 +1945,18 @@ Deno.test("[node/http] supports proxy http request", async () => {
   await promise;
   await server.finished;
 });
+
+Deno.test("[node/http] 'close' event is emitted when request finished", async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  let socketCloseEmitted = false;
+  const req = http.request("http://localhost:4545/echo.ts", async (res) => {
+    res.on("close", resolve);
+    req.socket?.on("close", () => {
+      socketCloseEmitted = true;
+    });
+    await text(res);
+  });
+  req.end();
+  await promise;
+  assert(socketCloseEmitted);
+});


### PR DESCRIPTION
closes #28530

In the current `http.request` implementation, we don't use underlying `Socket` class in normal way (We pass the rid (TcpConn/TlsConn) of it to hyper, and let hyper directly use it).

Because of that, 'close' event is never emitted on socket. That causes the socket leak in http agent, and that prevents some http agent for creating more sockets than `maxSockets` number (`maxSockets` is `Infinity` by default though).

`@npmcli/agent` (the agent of npm cli) is one of such agent, affected by this bug. It sets 15 to `macSockets` (ref: https://github.com/npm/agent/blob/3c71f9adb0cce1ec228c2de0ce420e4c86f7fe46/lib/options.js#L14 ), and it caused the issue #28530 

This PR fixes the above issue by propagating 'close' event from `IncomingMessage(ForClient)` to underlying `Socket` object.