### PR TITLE
fix(npm): resolve non-version matching peer deps and warn instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
  "deno_lint",
  "deno_lockfile 0.25.0",
  "deno_media_type",
- "deno_npm 0.29.0",
+ "deno_npm 0.30.0",
  "deno_npm_cache",
  "deno_package_json",
  "deno_path_util",
@@ -2151,7 +2151,7 @@ dependencies = [
  "deno_fs",
  "deno_media_type",
  "deno_node",
- "deno_npm 0.29.0",
+ "deno_npm 0.30.0",
  "deno_path_util",
  "deno_resolver",
  "deno_runtime",
@@ -2386,7 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.29.0"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1898f0e811c23246b91b9d424ca0d88c7af2ad87d57949b415be61c1ed2222b7"
 dependencies = [
  "async-trait",
  "capacity_builder 0.5.0",
@@ -2412,7 +2414,7 @@ dependencies = [
  "boxed_error",
  "deno_cache_dir",
  "deno_error",
- "deno_npm 0.29.0",
+ "deno_npm 0.30.0",
  "deno_path_util",
  "deno_semver",
  "deno_unsync",
@@ -2563,7 +2565,7 @@ dependencies = [
  "deno_config",
  "deno_error",
  "deno_media_type",
- "deno_npm 0.29.0",
+ "deno_npm 0.30.0",
  "deno_package_json",
  "deno_path_util",
  "deno_semver",
@@ -2967,7 +2969,7 @@ dependencies = [
  "deno_error",
  "deno_lib",
  "deno_media_type",
- "deno_npm 0.29.0",
+ "deno_npm 0.30.0",
  "deno_package_json",
  "deno_path_util",
  "deno_resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,8 +2387,6 @@ dependencies = [
 [[package]]
 name = "deno_npm"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9391c57ce81d58e83ef4b2e45d001a2674a758a1c914e8562512c147257bc6d"
 dependencies = [
  "async-trait",
  "capacity_builder 0.5.0",
@@ -2396,6 +2394,7 @@ dependencies = [
  "deno_lockfile 0.25.0",
  "deno_semver",
  "futures",
+ "indexmap 2.7.1",
  "log",
  "monch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ deno_graph = "=0.89.2"
 deno_lint = "=0.74.0"
 deno_lockfile = "=0.25.0"
 deno_media_type = { version = "=0.2.8", features = ["module_specifier"] }
-deno_npm = "=0.29.0"
+deno_npm = "=0.30.0"
 deno_path_util = "=0.3.2"
 deno_permissions = { version = "0.55.0", path = "./runtime/permissions" }
 deno_runtime = { version = "0.204.0", path = "./runtime" }
@@ -490,6 +490,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_unsync]
 opt-level = 3
-
-[patch.crates-io]
-deno_npm = { path = "../deno_npm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,3 +490,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_unsync]
 opt-level = 3
+
+[patch.crates-io]
+deno_npm = { path = "../deno_npm" }

--- a/tests/registry/npm/@denotest/peer-dep-specific-constraint/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/peer-dep-specific-constraint/1.0.0/index.js
@@ -1,0 +1,1 @@
+module.exports = require("@denotest/peer-dep-test-grandchild");

--- a/tests/registry/npm/@denotest/peer-dep-specific-constraint/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/peer-dep-specific-constraint/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest/peer-dep-specific-constraint",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@denotest/add": "0.5"
+  }
+}

--- a/tests/specs/install/peer_dep_specific_constraint/__test__.jsonc
+++ b/tests/specs/install/peer_dep_specific_constraint/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "install",
+    "output": "install.out"
+  }, {
+    "args": ["eval", "console.log(Deno.readTextFileSync('deno.lock').trim());"],
+    "output": "lock.out"
+  }]
+}

--- a/tests/specs/install/peer_dep_specific_constraint/install.out
+++ b/tests/specs/install/peer_dep_specific_constraint/install.out
@@ -1,0 +1,12 @@
+Download http://localhost:4260/@denotest%2fadd
+Download http://localhost:4260/@denotest%2fpeer-dep-specific-constraint
+Warning The following peer dependency issues were found:
+└─┬ @denotest/peer-dep-specific-constraint@1.0.0
+  └── peer @denotest/add@0.5: resolved to 1.0.0
+
+[UNORDERED_START]
+Download http://localhost:4260/@denotest/peer-dep-specific-constraint/1.0.0.tgz
+Download http://localhost:4260/@denotest/add/1.0.0.tgz
+Initialize @denotest/peer-dep-specific-constraint@1.0.0
+Initialize @denotest/add@1.0.0
+[UNORDERED_END]

--- a/tests/specs/install/peer_dep_specific_constraint/lock.out
+++ b/tests/specs/install/peer_dep_specific_constraint/lock.out
@@ -1,0 +1,26 @@
+{
+  "version": "4",
+  "specifiers": {
+    "npm:@denotest/add@1": "1.0.0",
+    "npm:@denotest/peer-dep-specific-constraint@*": "1.0.0_@denotest+add@1.0.0"
+  },
+  "npm": {
+    "@denotest/add@1.0.0": {
+      "integrity": "[WILDLINE]"
+    },
+    "@denotest/peer-dep-specific-constraint@1.0.0_@denotest+add@1.0.0": {
+      "integrity": "[WILDLINE]",
+      "dependencies": [
+        "@denotest/add"
+      ]
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/add@1",
+        "npm:@denotest/peer-dep-specific-constraint@*"
+      ]
+    }
+  }
+}

--- a/tests/specs/install/peer_dep_specific_constraint/package.json
+++ b/tests/specs/install/peer_dep_specific_constraint/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@denotest/peer-dep-specific-constraint": "*",
+    "@denotest/add": "1"
+  }
+}


### PR DESCRIPTION
This improves peer dependency resolution to be more relaxed and resolve non-version matching ancestors similar to pnpm rather than introducing duplicate dependencies. Deno will warn when this occurs. In the future, we should look into introducing an option to have Deno error in this scenario.

* https://github.com/denoland/deno_npm/pull/88

Closes https://github.com/denoland/deno/issues/17263
Closes https://github.com/denoland/deno/issues/26841