### PR TITLE
chore: downgrade warning to debug log on clonefile failure

### DIFF
--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -179,7 +179,7 @@ pub fn clone_dir_recursive<
         err.kind(),
         std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::Unsupported
       ) {
-        log::warn!(
+        log::debug!(
           "Failed to clone dir {:?} to {:?} via clonefile: {}",
           from,
           to,


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/26928.

This was originally a warning so potential bugs would be visible.  Now that the code has been working for a while without issues, and since the warning can be triggered in a valid case (as in the issue above, where the warnings also hid the real diagnostic), let's downgrade this from a warning to a debug log.