### PR TITLE
ci: reduce the concurrency number of parallel runs to navigator.hardwareConcurrency

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -289,7 +289,7 @@ async function main() {
   }
   // Runs parallel tests
   for await (
-    const _ of pooledMap(navigator.hardwareConcurrency * 2, parallel, run)
+    const _ of pooledMap(navigator.hardwareConcurrency, parallel, run)
   ) {
     // pass
   }


### PR DESCRIPTION
Currently `run_all_test_unmodified.ts` script is killed in linux CI for non obvious reason. I guess this could be caused by too much load to the cpu by using the concurrency of `navigator.hardwareConcurrency * 2`. This PR reduces it to `navigator.hardwareConcurrency`


---
CI run: https://github.com/denoland/deno/actions/runs/14097513475/job/39488256550

Error:
```
/home/runner/work/_temp/9373fec9-14cb-4227-875e-007fc328ab71.sh: line 1:  2301 Killed                  deno -A --config tests/config/deno.json tests/node_compat/run_all_test_unmodified.ts
```