### PR TITLE
ci: set NODE_SKIP_FLAG_CHECK=1 in node_compat_test workflow

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -222,6 +222,7 @@ async function runSingle(testPath: string, retry = 0): Promise<SingleResult> {
       ],
       env: {
         NODE_TEST_KNOWN_GLOBALS: "0",
+        NODE_SKIP_FLAG_CHECK: "1",
         NO_COLOR: "1",
       },
       stdout: "piped",


### PR DESCRIPTION
`node_compat_test` workflow currently fails on linux because of being killed by OOM killer.

The issue seems happening [here](https://github.com/nodejs/node/blob/186bbf7dfdce4e8b5963fce1ab9567ba0ce04488/test/common/index.js#L88-L116) in `test/common/index.js`, where it checks the flags given to Node.js CLI and respwan the runtime with corrected set of flags if wrong ones are given. This correction of flags doesn't work for Deno because we [map](https://github.com/denoland/deno/blob/2b4de21ea0904148dfa7c28d4e77c7b3838322f8/ext/node/polyfills/internal/child_process.ts#L1064-L1111) node.js flags to Deno's, and this leads to the infinite loop of respawning for some cases.

This PR avoid the above situation by passing `NODE_SKIP_FLAG_CHECK` env var, which skips the above re-spawn behavior.