### PR TITLE
fix(runtime): remove `deno_os::deno_os_worker` to make `WebWorker` work without snapshot

### DIFF
--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -77,49 +77,12 @@ deno_core::extension!(
   ],
   esm = ["30_os.js", "40_signals.js"],
   options = {
-    exit_code: ExitCode,
+    exit_code: Option<ExitCode>,
   },
   state = |state, options| {
-    state.put::<ExitCode>(options.exit_code);
-    #[cfg(unix)]
-    {
-      state.put(ops::signal::SignalState::default());
+    if let Some(exit_code) = options.exit_code {
+      state.put::<ExitCode>(exit_code);
     }
-  }
-);
-
-deno_core::extension!(
-  deno_os_worker,
-  ops = [
-    op_env,
-    op_exec_path,
-    op_exit,
-    op_delete_env,
-    op_get_env,
-    op_gid,
-    op_hostname,
-    op_loadavg,
-    op_network_interfaces,
-    op_os_release,
-    op_os_uptime,
-    op_set_env,
-    op_set_exit_code,
-    op_get_exit_code,
-    op_system_memory_info,
-    op_uid,
-    op_runtime_cpu_usage,
-    op_runtime_memory_usage,
-    ops::signal::op_signal_bind,
-    ops::signal::op_signal_unbind,
-    ops::signal::op_signal_poll,
-  ],
-  esm = ["30_os.js", "40_signals.js"],
-  middleware = |op| match op.name {
-    "op_exit" | "op_set_exit_code" | "op_get_exit_code" =>
-      op.with_implementation_from(&deno_core::op_void_sync()),
-    _ => op,
-  },
-  state = |state| {
     #[cfg(unix)]
     {
       state.put(ops::signal::SignalState::default());
@@ -267,19 +230,26 @@ fn op_delete_env(
 
 #[op2(fast)]
 fn op_set_exit_code(state: &mut OpState, #[smi] code: i32) {
-  state.borrow_mut::<ExitCode>().set(code);
+  if let Some(code_mut) = state.try_borrow_mut::<ExitCode>() {
+    code_mut.set(code);
+  }
 }
 
 #[op2(fast)]
 #[smi]
-fn op_get_exit_code(state: &mut OpState) -> i32 {
-  state.borrow_mut::<ExitCode>().get()
+fn op_get_exit_code(state: &OpState) -> i32 {
+  if let Some(code) = state.try_borrow::<ExitCode>() {
+    code.get()
+  } else {
+    0
+  }
 }
 
 #[op2(fast)]
-fn op_exit(state: &mut OpState) {
-  let code = state.borrow::<ExitCode>().get();
-  exit(code)
+fn op_exit(state: &OpState) {
+  if let Some(code) = state.try_borrow::<ExitCode>() {
+    exit(code.get());
+  }
 }
 
 #[op2(stack_trace)]

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -556,7 +556,7 @@ impl WebWorker {
       deno_fs::deno_fs::init_ops_and_esm::<PermissionsContainer>(
         services.fs.clone(),
       ),
-      deno_os::deno_os_worker::init_ops_and_esm(),
+      deno_os::deno_os::init_ops_and_esm(None),
       deno_process::deno_process::init_ops_and_esm(
         services.npm_process_state_provider,
       ),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -456,7 +456,7 @@ impl MainWorker {
       deno_fs::deno_fs::init_ops_and_esm::<PermissionsContainer>(
         services.fs.clone(),
       ),
-      deno_os::deno_os::init_ops_and_esm(exit_code.clone()),
+      deno_os::deno_os::init_ops_and_esm(Some(exit_code.clone())),
       deno_process::deno_process::init_ops_and_esm(
         services.npm_process_state_provider,
       ),


### PR DESCRIPTION
Closes #28680. Sorry for submitting this without awaiting a response.