### PR TITLE
fix(ext/node): add a createReadStream & createWriteStream methods to the FileHandle class

### DIFF
--- a/ext/node/polyfills/internal/fs/handle.ts
+++ b/ext/node/polyfills/internal/fs/handle.ts
@@ -5,8 +5,9 @@
 
 import { EventEmitter } from "node:events";
 import { Buffer } from "node:buffer";
-import { Mode, promises, read, write } from "node:fs";
+import { Mode, promises, read, ReadStream, write, WriteStream } from "node:fs";
 import { core } from "ext:core/mod.js";
+export type { BigIntStats, Stats } from "ext:deno_node/_fs/_fs_stat.ts";
 import {
   BinaryOptionsArgument,
   FileOptionsArgument,
@@ -18,6 +19,10 @@ export type { BigIntStats, Stats } from "ext:deno_node/_fs/_fs_stat.ts";
 import { writevPromise, WriteVResult } from "ext:deno_node/_fs/_fs_writev.ts";
 import { fdatasyncPromise } from "ext:deno_node/_fs/_fs_fdatasync.ts";
 import { fsyncPromise } from "ext:deno_node/_fs/_fs_fsync.ts";
+import {
+  CreateReadStreamOptions,
+  CreateWriteStreamOptions,
+} from "node:fs/promises";
 
 interface WriteResult {
   bytesWritten: number;
@@ -179,6 +184,14 @@ export class FileHandle extends EventEmitter {
   chown(uid: number, gid: number): Promise<void> {
     assertNotClosed(this, promises.chown.name);
     return promises.chown(this.#path, uid, gid);
+  }
+
+  createReadStream(options?: CreateReadStreamOptions): ReadStream {
+    return new ReadStream(undefined, { ...options, fd: this.fd });
+  }
+
+  createWriteStream(options?: CreateWriteStreamOptions): WriteStream {
+    return new WriteStream(undefined, { ...options, fd: this.fd });
   }
 }
 


### PR DESCRIPTION
This PR implements the missing support for `createReadStream` and `createWriteStream` on the `FileHandler` class (as outlined in #25554)

Notably, it does so by building on top of #27591 which was presumably abandoned