### PR TITLE
fix(lsp): format vscode-userdata schemed documents

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -1549,20 +1549,9 @@ impl Inner {
     _token: &CancellationToken,
   ) -> LspResult<Option<Vec<TextEdit>>> {
     let mark = self.performance.mark_with_args("lsp.formatting", &params);
-    // Untitled files are exempt from enabled-checks because they tend not to
-    // have meaningful paths, and they won't be auto-formatted on save anyway.
-    let is_untitled = params
-      .text_document
-      .uri
-      .scheme()
-      .is_some_and(|s| s.eq_lowercase("untitled"));
     let Some(document) = self.get_document(
       &params.text_document.uri,
-      if is_untitled {
-        Enabled::Ignore
-      } else {
-        Enabled::Filter
-      },
+      Enabled::Ignore,
       Exists::Enforce,
       Diagnosable::Ignore,
     )?
@@ -1574,6 +1563,13 @@ impl Inner {
     };
     let fmt_config =
       self.config.tree.fmt_config_for_specifier(&module.specifier);
+    // Untitled files are exempt from enabled-checks because they tend not to
+    // have meaningful paths, and they won't be auto-formatted on save anyway.
+    let is_untitled = params
+      .text_document
+      .uri
+      .scheme()
+      .is_some_and(|s| s.eq_lowercase("untitled"));
     if !is_untitled && !fmt_config.files.matches_specifier(&module.specifier) {
       return Ok(None);
     }

--- a/cli/lsp/urls.rs
+++ b/cli/lsp/urls.rs
@@ -132,6 +132,7 @@ pub fn uri_to_url(uri: &Uri) -> Url {
     if !scheme.eq_lowercase("untitled")
       && !scheme.eq_lowercase("vscode-notebook-cell")
       && !scheme.eq_lowercase("deno-notebook-cell")
+      && !scheme.eq_lowercase("vscode-userdata")
     {
       return None;
     }
@@ -157,4 +158,5 @@ pub fn uri_is_file_like(uri: &Uri) -> bool {
     || scheme.eq_lowercase("untitled")
     || scheme.eq_lowercase("vscode-notebook-cell")
     || scheme.eq_lowercase("deno-notebook-cell")
+    || scheme.eq_lowercase("vscode-userdata")
 }

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -11800,6 +11800,47 @@ fn lsp_format_json() {
 
 #[test]
 #[timeout(300_000)]
+fn lsp_format_vscode_userdata() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.did_open_raw(json!({
+    "textDocument": {
+      "uri": "vscode-userdata:///a/settings.json",
+      "languageId": "jsonc",
+      "version": 1,
+      "text": "  // foo\n{}\n",
+    }
+  }));
+  let res = client.write_request(
+    "textDocument/formatting",
+    json!({
+      "textDocument": {
+        "uri": "vscode-userdata:///a/settings.json",
+      },
+      "options": {
+        "tabSize": 2,
+        "insertSpaces": true,
+      },
+    }),
+  );
+  assert_eq!(
+    res,
+    json!([
+      {
+        "range": {
+          "start": { "line": 0, "character": 0 },
+          "end": { "line": 0, "character": 2 },
+        },
+        "newText": "",
+      },
+    ]),
+  );
+  client.shutdown();
+}
+
+#[test]
+#[timeout(300_000)]
 fn lsp_format_editor_options() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir();


### PR DESCRIPTION
Server-side change for https://github.com/denoland/vscode_deno/issues/1206. Coupled with https://github.com/denoland/vscode_deno/pull/1278.