### PR TITLE
chore: run pre-release step for bench CI job

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -788,7 +788,7 @@ const ci = {
           name: "Pre-release (linux)",
           if: [
             "matrix.os == 'linux' &&",
-            "matrix.job == 'test' &&",
+            "(matrix.job == 'test' || matrix.job == 'bench') &&",
             "matrix.profile == 'release' &&",
             "github.repository == 'denoland/deno'",
           ].join("\n"),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,7 +462,7 @@ jobs:
       - name: Pre-release (linux)
         if: |-
           !(matrix.skip) && (matrix.os == 'linux' &&
-          matrix.job == 'test' &&
+          (matrix.job == 'test' || matrix.job == 'bench') &&
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno')
         run: |-


### PR DESCRIPTION
This correctly reports binary size since now we strip binaries in the pre-release step.