### PR TITLE
chore: add metadata to node compat test report

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -8,7 +8,7 @@ import { basename } from "@std/path/basename";
 import { pooledMap } from "@std/async/pool";
 import { partition } from "@std/collections/partition";
 import { stripAnsiCode } from "@std/fmt/colors";
-import { version as nodeVersion } from "./runner/suite/node_version.ts"
+import { version as nodeVersion } from "./runner/suite/node_version.ts";
 
 // The timeout ms for single test execution. If a single test didn't finish in this timeout milliseconds, the test is considered as failure
 const TIMEOUT = 2000;
@@ -331,22 +331,26 @@ async function main() {
   // Summary
   const total = tests.length;
   const pass = tests.filter((test) => results[test][0]).length;
-  console.log(`All tests: ${pass}/${total} (${(pass / total * 100).toFixed(2)}%)`);
+  console.log(
+    `All tests: ${pass}/${total} (${(pass / total * 100).toFixed(2)}%)`,
+  );
   console.log(`Elapsed time: ${((Date.now() - start) / 1000).toFixed(2)}s`);
   // Store the results in a JSON file
   Deno.writeTextFile(
     "tests/node_compat/report.json",
-    JSON.stringify({
-      date: new Date().toISOString().slice(0, 10),
-      denoVersion: Deno.version.deno,
-      os: Deno.build.os,
-      arch: Deno.build.arch,
-      nodeVersion,
-      runId: Deno.env.get("GTIHUB_RUN_ID") ?? null,
-      total,
-      pass,
-      results
-    } satisfies TestReport),
+    JSON.stringify(
+      {
+        date: new Date().toISOString().slice(0, 10),
+        denoVersion: Deno.version.deno,
+        os: Deno.build.os,
+        arch: Deno.build.arch,
+        nodeVersion,
+        runId: Deno.env.get("GTIHUB_RUN_ID") ?? null,
+        total,
+        pass,
+        results,
+      } satisfies TestReport,
+    ),
   );
   Deno.exit(0);
 }

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -8,10 +8,28 @@ import { basename } from "@std/path/basename";
 import { pooledMap } from "@std/async/pool";
 import { partition } from "@std/collections/partition";
 import { stripAnsiCode } from "@std/fmt/colors";
+import { version as nodeVersion } from "./runner/suite/node_version.ts"
 
 // The timeout ms for single test execution. If a single test didn't finish in this timeout milliseconds, the test is considered as failure
 const TIMEOUT = 2000;
 const testDirUrl = new URL("runner/suite/test/", import.meta.url).href;
+
+// The metadata of the test report
+type TestReportMetadata = {
+  date: string;
+  denoVersion: string;
+  os: string;
+  arch: string;
+  nodeVersion: string;
+  runId: string | null;
+  total: number;
+  pass: number;
+};
+
+// The test report format, which is stored in JSON file
+type TestReport = TestReportMetadata & {
+  results: Record<string, SingleResult>;
+};
 
 // from https://github.com/denoland/std/pull/2787#discussion_r1001237016
 const NODE_IGNORED_TEST_DIRS = [
@@ -311,13 +329,24 @@ async function main() {
   }
 
   // Summary
-  const all = tests.length;
-  const s = tests.filter((test) => results[test][0]).length;
-  console.log(`All tests: ${s}/${all} (${(s / all * 100).toFixed(2)}%)`);
+  const total = tests.length;
+  const pass = tests.filter((test) => results[test][0]).length;
+  console.log(`All tests: ${pass}/${total} (${(pass / total * 100).toFixed(2)}%)`);
   console.log(`Elapsed time: ${((Date.now() - start) / 1000).toFixed(2)}s`);
+  // Store the results in a JSON file
   Deno.writeTextFile(
     "tests/node_compat/report.json",
-    JSON.stringify(results),
+    JSON.stringify({
+      date: new Date().toISOString().slice(0, 10),
+      denoVersion: Deno.version.deno,
+      os: Deno.build.os,
+      arch: Deno.build.arch,
+      nodeVersion,
+      runId: Deno.env.get("GTIHUB_RUN_ID") ?? null,
+      total,
+      pass,
+      results
+    } satisfies TestReport),
   );
   Deno.exit(0);
 }


### PR DESCRIPTION
This PR adds some metadata to node compat test result JSON file, which is necessary to show the report page better.

```json
{
  "date": "2025-04-03",
  "denoVersion": "2.2.5+d07b7ea",
  "os": "darwin",
  "arch": "aarch64",
  "nodeVersion": "23.9.0",
  "runId": "123456789",
  "total": 3900,
  "pass": 1500,
  "results": {
    "parallel/test-assert-async.js": [true]
    "parallel/test-assert.js": [false, { "message": "error" }],
    ...
  }
}
```

---
FYI The current prototype of the report page:
<img width="331" alt="Screenshot 2025-04-03 at 11 37 03" src="https://github.com/user-attachments/assets/39f19c71-9193-4924-890b-58ddf3822c72" />
