### PR TITLE
fix(lsp): preserve notification order after init flag is raised

### DIFF
--- a/cli/util/sync/async_flag.rs
+++ b/cli/util/sync/async_flag.rs
@@ -1,20 +1,27 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-use tokio_util::sync::CancellationToken;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
 
-#[derive(Debug, Default, Clone)]
-pub struct AsyncFlag(CancellationToken);
+#[derive(Debug, Clone)]
+pub struct AsyncFlag(Arc<Semaphore>);
+
+impl Default for AsyncFlag {
+  fn default() -> Self {
+    Self(Arc::new(Semaphore::new(0)))
+  }
+}
 
 impl AsyncFlag {
   pub fn raise(&self) {
-    self.0.cancel();
+    self.0.close();
   }
 
   pub fn is_raised(&self) -> bool {
-    self.0.is_cancelled()
+    self.0.is_closed()
   }
 
-  pub fn wait_raised(&self) -> impl std::future::Future<Output = ()> + '_ {
-    self.0.cancelled()
+  pub async fn wait_raised(&self) {
+    self.0.acquire().await.unwrap_err();
   }
 }

--- a/cli/util/sync/async_flag.rs
+++ b/cli/util/sync/async_flag.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::sync::Arc;
+
 use tokio::sync::Semaphore;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This fixes desyncs/errors/panics that can happen in the LSP if the user makes edits while `initialized` is still being handled, due to the unblocked notifications from `LanguageServer::init_flag: AsyncFlag` being resumed in the wrong order. Hard to test.

Changing the flag implementation from `CancellationToken::cancel()` to `Semaphore::close()` seems to do the job.