### PR TITLE
fix(install): remove duplicate deprecated messages

### DIFF
--- a/cli/npm/installer/local.rs
+++ b/cli/npm/installer/local.rs
@@ -355,7 +355,7 @@ async fn sync_resolution_with_fs(
             if let Some(deprecated) = &package.deprecated {
               packages_with_deprecation_warnings
                 .lock()
-                .push((package.id.clone(), deprecated.clone()));
+                .push((package.id.nv.clone(), deprecated.clone()));
             }
 
             // finally stop showing the progress bar
@@ -723,18 +723,18 @@ async fn sync_resolution_with_fs(
         colors::yellow("Warning")
       );
       let len = packages_with_deprecation_warnings.len();
-      for (idx, (package_id, msg)) in
+      for (idx, (package_nv, msg)) in
         packages_with_deprecation_warnings.iter().enumerate()
       {
         if idx != len - 1 {
           log::warn!(
             "┠─ {}",
-            colors::gray(format!("npm:{:?} ({})", package_id, msg))
+            colors::gray(format!("npm:{:?} ({})", package_nv, msg))
           );
         } else {
           log::warn!(
             "┖─ {}",
-            colors::gray(format!("npm:{:?} ({})", package_id, msg))
+            colors::gray(format!("npm:{:?} ({})", package_nv, msg))
           );
         }
       }


### PR DESCRIPTION
We were keying on package id instead of nv.

Noticed this while looking into a bug:

```
Warning The following packages are deprecated:
┠─ npm:@aws-cdk/cloud-assembly-schema@1.204.0 (AWS CDK v1 has reached End-of-Support on 2023-06-01.
This package is no longer being updated, and users should migrate to AWS CDK v2.

For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html)
┠─ npm:@aws-cdk/cx-api@1.204.0_@aws-cdk+cloud-assembly-schema@1.204.0 (AWS CDK v1 has reached End-of-Support on 2023-06-01.
This package is no longer being updated, and users should migrate to AWS CDK v2.

For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html)
┠─ npm:@aws-cdk/region-info@1.204.0 (AWS CDK v1 has reached End-of-Support on 2023-06-01.
This package is no longer being updated, and users should migrate to AWS CDK v2.

For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html)
┠─ npm:@aws-cdk/core@1.204.0_@aws-cdk+cloud-assembly-schema@1.204.0_@aws-cdk+cx-api@1.204.0__@aws-cdk+cloud-assembly-schema@1.204.0_@aws-cdk+region-info@1.204.0_constructs@3.4.344 (AWS CDK v1 has reached End-of-Support on 2023-06-01.
This package is no longer being updated, and users should migrate to AWS CDK v2.

For more information on how to migrate, see https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html)
┠─ npm:@aws-cdk/aws-sqs@1.204.0_@aws-cdk+aws-kms@1.204.0__@aws-cdk+aws-iam@1.204.0___@aws-cdk+core@1.204.0____@aws-cdk+cloud-assembly-schema@1.204.0____@aws-cdk+cx-api@1.204.0_____@aws-cdk+cloud-assembly-schema@1.204.0____@aws-cdk+region-info@1.204.0____constructs@3.4.344__@aws-cdk+core@1.204.0___@aws-cdk+cloud-assembly-schema@1.204.0___@aws-cdk+cx-api@1.204.0____@aws-cdk+cloud-assembly-schema@1.204.0___@aws-cdk+region-info@1.204.0___constructs@3.4.344_@aws-cdk+core@1.204.0__@aws-cdk+cloud-assembly-schema@1.204.0__@aws-cdk+cx-api@1.204.0___@aws-cdk+cloud-assembly-schema@1.204.0__@aws-cdk+region-info@1.204.0__constructs@3.4.344 (AWS CDK v1 has reached End-of-Support on 2023-06-01.
This package is no longer being updated, and users should migrate to AWS CDK v2.

etc...
```