### PR TITLE
test(ext/http): reduce flakiness of serve_test

### DIFF
--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -4,6 +4,7 @@
 
 import { assertIsError, assertMatch, assertRejects } from "@std/assert";
 import { Buffer, type Reader } from "@std/io";
+import { delay } from "@std/async/delay";
 import { TextProtoReader } from "../testdata/run/textproto.ts";
 import {
   assert,
@@ -4327,6 +4328,7 @@ Deno.test({
 
     try {
       while (true) {
+        await delay(100);
         const { done } = await reader.read();
         if (done) break;
       }
@@ -4342,13 +4344,15 @@ Deno.test({
 
   async function onListen({ port }: { port: number }) {
     const body = "a".repeat(1000);
-    const request = `POST / HTTP/1.1\r\n` +
+    const header = `POST / HTTP/1.1\r\n` +
       `Host: 127.0.0.1:${port}\r\n` +
       `Content-Length: 1000\r\n` +
-      "\r\n" + body;
+      "\r\n";
 
     const connection = await Deno.connect({ hostname: "127.0.0.1", port });
-    await connection.write(new TextEncoder().encode(request));
+    await connection.write(new TextEncoder().encode(header));
+    await delay(100);
+    await connection.write(new TextEncoder().encode(body));
     connection.close();
   }
   await server.finished;


### PR DESCRIPTION
This PR reduces the flakiness of the case `req.body.getReader().read() throws the error with reasonable error message`.

The case tries to cause BadResource error by premature disconnection from the client, but it sometimes completes the request when the reading of tcp data happens quickly. This PR tries to prevent that scenario by adding some delays when reading & writing http messages.