### PR TITLE
fix(ext/canvas): `createImageBitmap` must ignore the `Blob.type` value

### DIFF
--- a/ext/canvas/01_image.js
+++ b/ext/canvas/01_image.js
@@ -250,7 +250,7 @@ function createImageBitmap(
     if (isBlob) {
       imageBitmapSource = 0;
       buf = new Uint8Array(await image.arrayBuffer());
-      const mimeTypeString = sniffImage(image.type);
+      const mimeTypeString = sniffImage(image.type, buf);
 
       if (mimeTypeString === "image/png") {
         mimeType = 1;
@@ -277,17 +277,6 @@ function createImageBitmap(
         return PromiseReject(
           new DOMException(
             "The MIME type of source image is not supported currently",
-            "InvalidStateError",
-          ),
-        );
-      } else if (mimeTypeString === "") {
-        return PromiseReject(
-          new DOMException(
-            `The MIME type of source image is not specified\n
-hint: When you want to get a "Blob" from "fetch", make sure to go through a file server that returns the appropriate content-type response header,
-      and specify the URL to the file server like "await(await fetch('http://localhost:8000/sample.png').blob()".
-      Alternatively, if you are reading a local file using 'Deno.readFile' etc.,
-      set the appropriate MIME type like "new Blob([await Deno.readFile('sample.png')], { type: 'image/png' })".\n`,
             "InvalidStateError",
           ),
         );

--- a/ext/web/01_mimesniff.js
+++ b/ext/web/01_mimesniff.js
@@ -422,21 +422,16 @@ function imageTypePatternMatchingAlgorithm(input) {
 /**
  * Ref: https://mimesniff.spec.whatwg.org/#rules-for-sniffing-images-specifically
  * @param {string} mimeTypeString
+ * @param {Uint8Array} byteSequence
  * @returns {string}
  */
-function sniffImage(mimeTypeString) {
+function sniffImage(mimeTypeString, byteSequence) {
   const mimeType = parseMimeType(mimeTypeString);
-  if (mimeType === null) {
-    return mimeTypeString;
-  }
-
   if (isXML(mimeType)) {
     return mimeTypeString;
   }
 
-  const imageTypeMatched = imageTypePatternMatchingAlgorithm(
-    new TextEncoder().encode(mimeTypeString),
-  );
+  const imageTypeMatched = imageTypePatternMatchingAlgorithm(byteSequence);
   if (imageTypeMatched !== undefined) {
     return imageTypeMatched;
   }

--- a/tests/unit/image_bitmap_test.ts
+++ b/tests/unit/image_bitmap_test.ts
@@ -400,3 +400,22 @@ Deno.test("imageBitmapFromBlobColorspaceConversion", async (t) => {
     assertEquals(firstPixel, new Uint8Array([255, 0, 0, 255]));
   });
 });
+
+// reference:
+// https://github.com/web-platform-tests/wpt/blob/ea49709e5880c8133249d919c72d67798afc31ec/html/canvas/element/manual/imagebitmap/createImageBitmap-blob-invalidtype.html
+Deno.test("imageBitmapFromBlobInvalidtype", async () => {
+  const IMAGE = atob(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAA" +
+      "ACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=",
+  );
+
+  const bytes = new Array(IMAGE.length);
+  for (let i = 0; i < IMAGE.length; i++) {
+    bytes[i] = IMAGE.charCodeAt(i);
+  }
+
+  const blob = new Blob([new Uint8Array(bytes)], { type: "text/html" });
+  const imageBitmap = await createImageBitmap(blob);
+  assertEquals(imageBitmap.width, 1);
+  assertEquals(imageBitmap.height, 1);
+});


### PR DESCRIPTION
fixes https://github.com/denoland/deno/issues/28723

I might misunderstood the spec. We should always sniff the MIME type from the byte sequence when the input is `Blob`.
