### PR TITLE
fix(lsp): filter scheme in semantic tokens registration options

### DIFF
--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -39,30 +39,33 @@ fn code_action_capabilities(
 
 pub fn semantic_tokens_registration_options(
 ) -> SemanticTokensRegistrationOptions {
+  const LANGUAGES: [&'static str; 4] = [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+  ];
+  const SCHEMES: [&'static str; 5] = [
+    "file",
+    "untitled",
+    "deno",
+    "vscode-notebook-cell",
+    "deno-notebook-cell",
+  ];
+  let mut document_filters =
+    Vec::with_capacity(LANGUAGES.len() * SCHEMES.len());
+  for language in &LANGUAGES {
+    for scheme in &SCHEMES {
+      document_filters.push(DocumentFilter {
+        language: Some(language.to_string()),
+        scheme: Some(scheme.to_string()),
+        pattern: None,
+      });
+    }
+  }
   SemanticTokensRegistrationOptions {
     text_document_registration_options: TextDocumentRegistrationOptions {
-      document_selector: Some(vec![
-        DocumentFilter {
-          language: Some("javascript".to_string()),
-          scheme: None,
-          pattern: None,
-        },
-        DocumentFilter {
-          language: Some("javascriptreact".to_string()),
-          scheme: None,
-          pattern: None,
-        },
-        DocumentFilter {
-          language: Some("typescript".to_string()),
-          scheme: None,
-          pattern: None,
-        },
-        DocumentFilter {
-          language: Some("typescriptreact".to_string()),
-          scheme: None,
-          pattern: None,
-        },
-      ]),
+      document_selector: Some(document_filters),
     },
     semantic_tokens_options: SemanticTokensOptions {
       legend: get_legend(),

--- a/cli/lsp/capabilities.rs
+++ b/cli/lsp/capabilities.rs
@@ -39,13 +39,13 @@ fn code_action_capabilities(
 
 pub fn semantic_tokens_registration_options(
 ) -> SemanticTokensRegistrationOptions {
-  const LANGUAGES: [&'static str; 4] = [
+  const LANGUAGES: [&str; 4] = [
     "javascript",
     "javascriptreact",
     "typescript",
     "typescriptreact",
   ];
-  const SCHEMES: [&'static str; 5] = [
+  const SCHEMES: [&str; 5] = [
     "file",
     "untitled",
     "deno",


### PR DESCRIPTION
Fixes https://github.com/denoland/vscode_deno/issues/1280.

It seems if you explicitly list a document filter in some capability configuration, it will override (not intersect) the document filter specified by the client.