### PR TITLE
fix(compile): multi icon ordering on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5236,11 +5236,12 @@ dependencies = [
 
 [[package]]
 name = "libsui"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89795977654ad6250d6c0915411b622bac22f9efb4f852af94b2e00964cab832"
+checksum = "7550a110415b4780bf6064d280f2dc5b761fb80d9af92258a72e5dc82ca6f05a"
 dependencies = [
  "editpe",
+ "image",
  "libc",
  "sha2",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ libffi = "=3.2.0"
 libffi-sys = "=2.3.0"
 libloading = "0.7"
 libsqlite3-sys = "0.30.1"
-libsui = "0.5.0"
+libsui = "0.7.0"
 libuv-sys-lite = "=1.48.2"
 libz-sys = { version = "1.1.20", default-features = false }
 log = { version = "0.4.20", features = ["kv"] }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/26400. Correctly handle multi-icon icos in `deno compile --icon`.

Ref https://github.com/denoland/sui/commit/bf318ea9c847810b79d6a34a4e744b7b09630ddb

## Explanation

Icons in PE are very sensitive to resource table ordering. Here's what works:

<img width=320 src=https://github.com/user-attachments/assets/8f3e5a18-5f00-42d6-a366-16b6194c711c></img>

We can't use `editpe`'s builtin `set_icon` because it lays out `Icon` and `Icon Group` together before/after the `RCData`. Instead, we need a custom implementation that places RCData between the icon entries. 

This means we defer `Icon Group` to always happen during `PortableExecutable::build`. After the fix:

<img width=440 src=https://github.com/user-attachments/assets/73a9b347-64c2-41e1-a314-918231ba7276></img>

