### PR TITLE
chore: create monthly summary of node test runs

### DIFF
--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -70,4 +70,3 @@ jobs:
       - name: Upload the month summary
         run: |-
           gsutil -h "Cache-Control: public, max-age=3600" cp tests/node_compat/summary.json.gz gs://dl.deno.land/node-compat-test/summary-$(date +%Y-%m).json.gz
-

--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -69,5 +69,5 @@ jobs:
         run: gzip tests/node_compat/summary.json
       - name: Upload the month summary
         run: |-
-          gsutil -h "Cache-Control: public, max-age=3600" cp tests/node_compat/summary.json.gz gs://dl.deno.land/node-compat-test/summary-$(date +%Y-%m).json
+          gsutil -h "Cache-Control: public, max-age=3600" cp tests/node_compat/summary.json.gz gs://dl.deno.land/node-compat-test/summary-$(date +%Y-%m).json.gz
 

--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -47,6 +47,7 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ always() }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -44,3 +44,30 @@ jobs:
       - name: Upload the report to dl.deno.land
         run: |-
           gsutil -h "Cache-Control: public, max-age=3600" cp tests/node_compat/report.json.gz gs://dl.deno.land/node-compat-test/$(date +%F)/report-${{matrix.os}}.json.gz
+  summary:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: denoland
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          export_environment_variables: true
+          create_credentials_file: true
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: denoland
+      - name: Add the day summary to the month summary
+        run: deno -A --config tests/config/deno.json tests/node_compat/add_day_summary_to_month_summary.ts
+      - name: Gzip the month summary
+        run: gzip tests/node_compat/summary.json
+      - name: Upload the month summary
+        run: |-
+          gsutil -h "Cache-Control: public, max-age=3600" cp tests/node_compat/summary.json.gz gs://dl.deno.land/node-compat-test/summary-$(date +%Y-%m).json
+

--- a/tests/node_compat/.gitignore
+++ b/tests/node_compat/.gitignore
@@ -1,3 +1,5 @@
 test/.tmp.*
 report.json
 report.json.gz
+summary.json
+summary.json.gz

--- a/tests/node_compat/add_day_summary_to_month_summary.ts
+++ b/tests/node_compat/add_day_summary_to_month_summary.ts
@@ -1,0 +1,127 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+// This file mostly mirrors the utils in
+// https://github.com/denoland/node_test_viewer/blob/a642f725f2d9595bc8cf217c41967c446814a79e/util/report.ts
+
+import type { TestReportMetadata, SingleResult } from "./run_all_test_unmodified.ts";
+import { toJson } from "@std/streams/to-json";
+
+/** The test report format, which is stored in JSON file */
+export type TestReport = TestReportMetadata & {
+  results: Record<string, SingleResult>;
+};
+
+export type DayReport = {
+  date: string;
+  windows: TestReport | undefined;
+  linux: TestReport | undefined;
+  darwin: TestReport | undefined;
+};
+
+export type DaySummary = {
+  date: string;
+  windows: TestReportMetadata | undefined;
+  linux: TestReportMetadata | undefined;
+  darwin: TestReportMetadata | undefined;
+};
+
+export type MonthSummary = {
+  reports: Record<string, DaySummary>;
+  month: string;
+};
+
+export async function fetchMonthSummary(
+  month: string,
+): Promise<MonthSummary> {
+  console.log("fetching", month);
+  const res = await fetch(
+    `https://dl.deno.land/node-compat-test/summary-${month}.json.gz`,
+  );
+  if (res.status === 404) {
+    return { reports: {}, month };
+  }
+  try {
+    const summary = await toJson(
+      res.body!.pipeThrough(new DecompressionStream("gzip")),
+    );
+    return summary as MonthSummary;
+  } catch (e) {
+    console.error(e);
+    return { reports: {}, month };
+  }
+}
+
+/** Gets the report summary for the given date. */
+export async function fetchDaySummary(date: string): Promise<DaySummary> {
+  const windows = await fetchReport(date, "windows");
+  const linux = await fetchReport(date, "linux");
+  const darwin = await fetchReport(date, "darwin");
+  return {
+    date,
+    windows: extractMetadata(windows),
+    linux: extractMetadata(linux),
+    darwin: extractMetadata(darwin),
+  };
+}
+
+function extractMetadata(
+  report: TestReport | undefined,
+): TestReportMetadata | undefined {
+  if (!report) {
+    return undefined;
+  }
+  const { date, denoVersion, os, arch, nodeVersion, runId, total, pass } =
+    report;
+  return {
+    date,
+    denoVersion,
+    os,
+    arch,
+    nodeVersion,
+    runId,
+    total,
+    pass,
+  };
+}
+
+export async function fetchReport(
+  date: string,
+  os: "linux" | "windows" | "darwin",
+): Promise<TestReport | undefined> {
+  console.log("fetching", date, os);
+  try {
+    const res = await fetch(
+      `https://dl.deno.land/node-compat-test/${date}/report-${os}.json.gz`,
+    );
+    if (res.status === 404) {
+      return undefined;
+    }
+    const report = await toJson(
+      res.body!.pipeThrough(new DecompressionStream("gzip")),
+    );
+    return report as TestReport;
+  } catch (e) {
+    console.error(e);
+    return undefined;
+  }
+}
+
+async function main() {
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const month = date.slice(0, 7); // YYYY-MM
+
+  const monthSummary = await fetchMonthSummary(month);
+  const daySummary = await fetchDaySummary(date);
+  monthSummary.reports[date] = daySummary;
+  // sort the reports by date
+  const reports = Object.entries(monthSummary.reports).sort(
+    ([a], [b]) => new Date(a).getTime() - new Date(b).getTime(),
+  );
+  monthSummary.reports = Object.fromEntries(reports);
+  console.log("Generated month summary:", monthSummary);
+  const summaryPath = "tests/node_compat/summary.json";
+  // Store the results in a JSON file
+  console.log("Writing month summary to file", summaryPath);
+  await Deno.writeTextFile(summaryPath, JSON.stringify(monthSummary));
+}
+
+await main();

--- a/tests/node_compat/add_day_summary_to_month_summary.ts
+++ b/tests/node_compat/add_day_summary_to_month_summary.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 // This file mostly mirrors the utils in
 // https://github.com/denoland/node_test_viewer/blob/a642f725f2d9595bc8cf217c41967c446814a79e/util/report.ts
+
 // deno-lint-ignore-file no-console
 
 import type {

--- a/tests/node_compat/add_day_summary_to_month_summary.ts
+++ b/tests/node_compat/add_day_summary_to_month_summary.ts
@@ -2,7 +2,10 @@
 // This file mostly mirrors the utils in
 // https://github.com/denoland/node_test_viewer/blob/a642f725f2d9595bc8cf217c41967c446814a79e/util/report.ts
 
-import type { TestReportMetadata, SingleResult } from "./run_all_test_unmodified.ts";
+import type {
+  SingleResult,
+  TestReportMetadata,
+} from "./run_all_test_unmodified.ts";
 import { toJson } from "@std/streams/to-json";
 
 /** The test report format, which is stored in JSON file */

--- a/tests/node_compat/add_day_summary_to_month_summary.ts
+++ b/tests/node_compat/add_day_summary_to_month_summary.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 // This file mostly mirrors the utils in
 // https://github.com/denoland/node_test_viewer/blob/a642f725f2d9595bc8cf217c41967c446814a79e/util/report.ts
+// deno-lint-ignore-file no-console
 
 import type {
   SingleResult,

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -15,7 +15,7 @@ const TIMEOUT = 2000;
 const testDirUrl = new URL("runner/suite/test/", import.meta.url).href;
 
 // The metadata of the test report
-type TestReportMetadata = {
+export type TestReportMetadata = {
   date: string;
   denoVersion: string;
   os: string;
@@ -208,7 +208,7 @@ function truncateTestOutput(output: string): string {
   return output;
 }
 
-type SingleResult = [
+export type SingleResult = [
   pass: boolean,
   error?: ErrorExit | ErrorTimeout | ErrorUnexpected,
 ];
@@ -336,7 +336,7 @@ async function main() {
   );
   console.log(`Elapsed time: ${((Date.now() - start) / 1000).toFixed(2)}s`);
   // Store the results in a JSON file
-  Deno.writeTextFile(
+  await Deno.writeTextFile(
     "tests/node_compat/report.json",
     JSON.stringify(
       {
@@ -355,4 +355,6 @@ async function main() {
   Deno.exit(0);
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
This PR adds `summary` job in `node_compat_test` workflow.

The job runs after 'test' jobs completed, downloads the daily reports for all platforms, extracts the metadata from them, and adds those metadata (summary) to monthly summary data.

The summary json data is uploaded to `dl.deno.land/node-compat-test/summary-YYYY-MM.json.gz`, which will be used by Node test result viewer tool.

The script outputed something like the below when tested locally:
```shellsession
$ deno -A --config tests/config/deno.json tests/node_compat/add_day_summary_to_month_summary.ts
fetching 2025-04
fetching 2025-04-07 windows
fetching 2025-04-07 linux
SyntaxError: Unterminated string in JSON at position 319468 (line 1 column 319469)
    at parse (<anonymous>)
    at eventLoopTick (ext:core/01_core.js:178:7)
    at async fetchReport (file:///Users/kt3k/denoland/deno/tests/node_compat/add_day_summary_to_month_summary.ts:98:20)
    at async fetchDaySummary (file:///Users/kt3k/denoland/deno/tests/node_compat/add_day_summary_to_month_summary.ts:56:17)
    at async main (file:///Users/kt3k/denoland/deno/tests/node_compat/add_day_summary_to_month_summary.ts:113:22)
    at async file:///Users/kt3k/denoland/deno/tests/node_compat/add_day_summary_to_month_summary.ts:127:1
fetching 2025-04-07 darwin
Generated month summary: {
  reports: {
    "2025-04-03": {
      date: "2025-04-03",
      windows: {
        date: "2025-04-03",
        denoVersion: "2.2.6+a0d6411",
        os: "windows",
        arch: "x86_64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1357
      },
      darwin: {
        date: "2025-04-03",
        denoVersion: "2.2.6+a0d6411",
        os: "darwin",
        arch: "aarch64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1363
      }
    },
    "2025-04-04": {
      date: "2025-04-04",
      windows: {
        date: "2025-04-04",
        denoVersion: "2.2.6+8beb90c",
        os: "windows",
        arch: "x86_64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1361
      },
      darwin: {
        date: "2025-04-04",
        denoVersion: "2.2.6+8beb90c",
        os: "darwin",
        arch: "aarch64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1363
      }
    },
    "2025-04-05": {
      date: "2025-04-05",
      darwin: {
        date: "2025-04-05",
        denoVersion: "2.2.7+a192301",
        os: "darwin",
        arch: "aarch64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1367
      }
    },
    "2025-04-06": {
      date: "2025-04-06",
      windows: {
        date: "2025-04-06",
        denoVersion: "2.2.7+a192301",
        os: "windows",
        arch: "x86_64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1358
      }
    },
    "2025-04-07": {
      date: "2025-04-07",
      windows: {
        date: "2025-04-07",
        denoVersion: "2.2.7+a192301",
        os: "windows",
        arch: "x86_64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1356
      },
      linux: undefined,
      darwin: {
        date: "2025-04-07",
        denoVersion: "2.2.7+a192301",
        os: "darwin",
        arch: "aarch64",
        nodeVersion: "23.9.0",
        runId: null,
        total: 3936,
        pass: 1359
      }
    }
  },
  month: "2025-04"
}
Writing month summary to file tests/node_compat/summary.json
```