### PR TITLE
chore: skip updating release-latest.txt when current version not greater than latest version

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -7,9 +7,14 @@ on:
 jobs:
   update-dl-version:
     name: update dl.deno.land version
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.repository == 'denoland/deno'
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v1
         with:
@@ -26,4 +31,4 @@ jobs:
       - name: Upload version file to dl.deno.land
         run: |
           echo ${GITHUB_REF#refs/*/} > release-latest.txt
-          gsutil -h "Cache-Control: no-cache" cp release-latest.txt gs://dl.deno.land/release-latest.txt
+          deno run --allow-net tools/release/version_greater_latest.ts ${GITHUB_REF#refs/*/} && gsutil -h "Cache-Control: no-cache" cp release-latest.txt gs://dl.deno.land/release-latest.txt

--- a/tools/release/version_greater_latest.ts
+++ b/tools/release/version_greater_latest.ts
@@ -19,7 +19,7 @@ if (isGreater) {
   console.error("Updating release-latest.txt");
 } else {
   console.error(
-    "Skipping release-latest.txt update because this version was less than the latest.",
+    "Skipping release-latest.txt update because this version is not greater than the latest.",
   );
 }
 Deno.exit(isGreater ? 0 : 1);

--- a/tools/release/version_greater_latest.ts
+++ b/tools/release/version_greater_latest.ts
@@ -1,0 +1,23 @@
+import { greaterThan, parse } from "jsr:@std/semver@1";
+
+const response = await fetch("https://dl.deno.land/release-latest.txt");
+if (!response.ok) {
+  throw new Error(`Failed to fetch: ${response.statusText}`);
+}
+
+const latestVersionText = await response.text();
+const currentVersionText = Deno.args[0];
+console.error("Latest version:", latestVersionText);
+console.error("Current version:", currentVersionText);
+
+const latestVersion = parse(latestVersionText);
+const currentVersion = parse(currentVersionText);
+const isGreater = greaterThan(currentVersion, latestVersion);
+if (isGreater) {
+  console.error("Updating release-latest.txt");
+} else {
+  console.error(
+    "Skipping release-latest.txt update because this version was less than the latest.",
+  );
+}
+Deno.exit(isGreater ? 0 : 1);

--- a/tools/release/version_greater_latest.ts
+++ b/tools/release/version_greater_latest.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+// deno-lint-ignore-file no-console
 import { greaterThan, parse } from "jsr:@std/semver@1";
 
 const response = await fetch("https://dl.deno.land/release-latest.txt");
@@ -5,7 +7,7 @@ if (!response.ok) {
   throw new Error(`Failed to fetch: ${response.statusText}`);
 }
 
-const latestVersionText = await response.text();
+const latestVersionText = (await response.text()).trim();
 const currentVersionText = Deno.args[0];
 console.error("Latest version:", latestVersionText);
 console.error("Current version:", currentVersionText);


### PR DESCRIPTION
This is for LTS releases. We'll update that txt file manually.