### PR TITLE
fix(node): add reset method to event loop delay histogram

### DIFF
--- a/ext/node/ops/perf_hooks.rs
+++ b/ext/node/ops/perf_hooks.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::cell::Cell;
+use std::cell::RefCell;
 
 use deno_core::op2;
 use deno_core::GarbageCollected;
@@ -13,7 +14,7 @@ pub enum PerfHooksError {
 }
 
 pub struct EldHistogram {
-  eld: tokio_eld::EldHistogram<u64>,
+  eld: RefCell<tokio_eld::EldHistogram<u64>>,
   started: Cell<bool>,
 }
 
@@ -29,7 +30,7 @@ impl EldHistogram {
   #[cppgc]
   pub fn new(#[smi] resolution: u32) -> Result<EldHistogram, PerfHooksError> {
     Ok(EldHistogram {
-      eld: tokio_eld::EldHistogram::new(resolution as usize)?,
+      eld: RefCell::new(tokio_eld::EldHistogram::new(resolution as usize)?),
       started: Cell::new(false),
     })
   }
@@ -43,7 +44,7 @@ impl EldHistogram {
       return false;
     }
 
-    self.eld.start();
+    self.eld.borrow().start();
     self.started.set(true);
 
     true
@@ -58,10 +59,15 @@ impl EldHistogram {
       return false;
     }
 
-    self.eld.stop();
+    self.eld.borrow().stop();
     self.started.set(false);
 
     true
+  }
+
+  #[fast]
+  fn reset(&self) {
+    self.eld.borrow_mut().reset();
   }
 
   // Returns the value at the given percentile.
@@ -70,67 +76,67 @@ impl EldHistogram {
   #[fast]
   #[number]
   fn percentile(&self, percentile: f64) -> u64 {
-    self.eld.value_at_percentile(percentile)
+    self.eld.borrow().value_at_percentile(percentile)
   }
 
   // Returns the value at the given percentile as a bigint.
   #[fast]
   #[bigint]
   fn percentile_big_int(&self, percentile: f64) -> u64 {
-    self.eld.value_at_percentile(percentile)
+    self.eld.borrow().value_at_percentile(percentile)
   }
 
   // The number of samples recorded by the histogram.
   #[getter]
   #[number]
   fn count(&self) -> u64 {
-    self.eld.len()
+    self.eld.borrow().len()
   }
 
   // The number of samples recorded by the histogram as a bigint.
   #[getter]
   #[bigint]
   fn count_big_int(&self) -> u64 {
-    self.eld.len()
+    self.eld.borrow().len()
   }
 
   // The maximum recorded event loop delay.
   #[getter]
   #[number]
   fn max(&self) -> u64 {
-    self.eld.max()
+    self.eld.borrow().max()
   }
 
   // The maximum recorded event loop delay as a bigint.
   #[getter]
   #[bigint]
   fn max_big_int(&self) -> u64 {
-    self.eld.max()
+    self.eld.borrow().max()
   }
 
   // The mean of the recorded event loop delays.
   #[getter]
   fn mean(&self) -> f64 {
-    self.eld.mean()
+    self.eld.borrow().mean()
   }
 
   // The minimum recorded event loop delay.
   #[getter]
   #[number]
   fn min(&self) -> u64 {
-    self.eld.min()
+    self.eld.borrow().min()
   }
 
   // The minimum recorded event loop delay as a bigint.
   #[getter]
   #[bigint]
   fn min_big_int(&self) -> u64 {
-    self.eld.min()
+    self.eld.borrow().min()
   }
 
   // The standard deviation of the recorded event loop delays.
   #[getter]
   fn stddev(&self) -> f64 {
-    self.eld.stdev()
+    self.eld.borrow().stdev()
   }
 }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/28767

Don't love the `RefCell`, but don't really see a (safe) way around it.