### PR TITLE
chore: skip explicit_start_and_end_low_precision test on ci

### DIFF
--- a/tests/specs/bench/explicit_start_and_end_low_precision/__test__.jsonc
+++ b/tests/specs/bench/explicit_start_and_end_low_precision/__test__.jsonc
@@ -1,5 +1,6 @@
 {
   "args": "bench --quiet -A main.bench.ts",
+  "if": "notCI",
   "output": "main.bench.out",
   "flaky": true
 }

--- a/tests/specs/mod.rs
+++ b/tests/specs/mod.rs
@@ -386,6 +386,7 @@ fn should_run_step(step: &StepMetaData) -> bool {
       "unix" => cfg!(unix),
       "mac" => cfg!(target_os = "macos"),
       "linux" => cfg!(target_os = "linux"),
+      "notCI" => std::env::var_os("CI").is_none(),
       value => panic!("Unknown if condition: {}", value),
     }
   } else {


### PR DESCRIPTION
It's gotten too flaky.