### PR TITLE
fix(ext/node): support input option in spawnSync

### DIFF
--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -41,6 +41,9 @@ import {
   writableStreamForRid,
 } from "ext:deno_web/06_streams.js";
 
+// The key for private `input` option for `Deno.Command`
+const kInputOption = Symbol("kInputOption");
+
 function opKill(pid, signo, apiName) {
   op_kill(pid, signo, apiName);
 }
@@ -404,6 +407,7 @@ function spawnSync(command, {
   stdout = "piped",
   stderr = "piped",
   windowsRawArguments = false,
+  [kInputOption]: input,
 } = { __proto__: null }) {
   if (stdin === "piped") {
     throw new TypeError(
@@ -425,6 +429,7 @@ function spawnSync(command, {
     extraStdio: [],
     detached: false,
     needsNpmProcessState: false,
+    input,
   });
   return {
     success: result.status.success,
@@ -484,4 +489,4 @@ class Command {
   }
 }
 
-export { ChildProcess, Command, kill, Process, run };
+export { ChildProcess, Command, kill, kInputOption, Process, run };

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1128,3 +1128,46 @@ Deno.test(async function noWarningsFlag() {
 
   await timeout.promise;
 });
+
+Deno.test({
+  name: "[node/child_process] spawnSync supports input option",
+  fn() {
+    const text = "  console.log('hello')";
+    const expected = `console.log("hello");\n`;
+    {
+      const { stdout } = spawnSync(Deno.execPath(), ["fmt", "-"], {
+        input: text,
+      });
+      assertEquals(stdout.toString(), expected);
+    }
+    {
+      const { stdout } = spawnSync(Deno.execPath(), ["fmt", "-"], {
+        input: Buffer.from(text),
+      });
+      assertEquals(stdout.toString(), expected);
+    }
+    {
+      const { stdout } = spawnSync(Deno.execPath(), ["fmt", "-"], {
+        input: new TextEncoder().encode(text),
+      });
+      assertEquals(stdout.toString(), expected);
+    }
+    {
+      const { stdout } = spawnSync(Deno.execPath(), ["fmt", "-"], {
+        input: new DataView(Buffer.from(text).buffer),
+      });
+      assertEquals(stdout.toString(), expected);
+    }
+
+    assertThrows(
+      () => {
+        spawnSync(Deno.execPath(), ["fmt", "-"], {
+          // deno-lint-ignore no-explicit-any
+          input: {} as any,
+        });
+      },
+      Error,
+      'The "input" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object',
+    );
+  },
+});


### PR DESCRIPTION
closes #28784 

This PR adds support of `input` option in `spawnSync` API in `node:child_process`, which passes the given input as stdin of the spawned process.