### PR TITLE
chore: fix node_compat_test workflow summary job

### DIFF
--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Setup Deno
         uses: denoland/setup-deno@v2
       - name: Authenticate with Google Cloud


### PR DESCRIPTION
Currently the job `summary` is failing because the git submodule `tests/util/std` is unavailable. This PR fixes the checkout config in workflow's yaml.

https://github.com/denoland/deno/actions/runs/14324275694/job/40147206838#step:6:27