### PR TITLE
fix: dont strip n-api symbols in `denort` on mac

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -828,7 +828,7 @@ const ci = {
             "cd target/release",
             "zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno",
             "shasum -a 256 deno-${{ matrix.arch }}-apple-darwin.zip > deno-${{ matrix.arch }}-apple-darwin.zip.sha256sum",
-            "strip ./denort",
+            "strip -x -S ./denort",
             "zip -r denort-${{ matrix.arch }}-apple-darwin.zip denort",
             "shasum -a 256 denort-${{ matrix.arch }}-apple-darwin.zip > denort-${{ matrix.arch }}-apple-darwin.zip.sha256sum",
           ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,7 @@ jobs:
           cd target/release
           zip -r deno-${{ matrix.arch }}-apple-darwin.zip deno
           shasum -a 256 deno-${{ matrix.arch }}-apple-darwin.zip > deno-${{ matrix.arch }}-apple-darwin.zip.sha256sum
-          strip ./denort
+          strip -x -S ./denort
           zip -r denort-${{ matrix.arch }}-apple-darwin.zip denort
           shasum -a 256 denort-${{ matrix.arch }}-apple-darwin.zip > denort-${{ matrix.arch }}-apple-darwin.zip.sha256sum
       - name: Pre-release (windows)


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/24614