### PR TITLE
fix(unstable): lint `.parent` property not traversing over groups

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -729,7 +729,12 @@ function readValue(ctx, idx, search, parseNode) {
   } else if (search === AST_PROP_RANGE) {
     return readSpan(ctx, idx);
   } else if (search === AST_PROP_PARENT) {
-    const parent = readParent(buf, idx);
+    let parent = readParent(buf, idx);
+
+    const parentType = readType(buf, parent);
+    if (parentType === AST_GROUP_TYPE) {
+      parent = readParent(buf, parent);
+    }
     return getNode(ctx, parent);
   }
 

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -444,6 +444,22 @@ Deno.test("Plugin - visitor :not", () => {
   assertEquals(result[0].node.name, "bar");
 });
 
+Deno.test("Plugin - parent", () => {
+  let parent: Deno.lint.Node | undefined;
+
+  testPlugin("const foo = 1;", {
+    create() {
+      return {
+        VariableDeclaration(node) {
+          parent = node.parent;
+        },
+      };
+    },
+  });
+
+  assertEquals(parent?.type, "Program");
+});
+
 Deno.test("Plugin - Program", async (t) => {
   await testSnapshot(t, "", "Program");
 });


### PR DESCRIPTION
In our JS lint plugin API each node has a `.parent` property to access its parent. But I forgot to skip group nodes, which lead to an invalid node being returned.

Fixes: https://github.com/denoland/deno/issues/28799