### PR TITLE
test(ext/node): skip running test-http-agent-maxtotalsockets.js on darwin

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1408,6 +1408,7 @@
   },
   "darwinIgnore": {
     "parallel": [
+      "test-http-agent-maxtotalsockets.js",
       "test-net-allow-half-open.js",
       "test-net-socket-close-after-end.js",
       "test-fs-watchfile.js"


### PR DESCRIPTION
This test case seems flaky on darwin on CI. I suggest we should skip it on darwin for now.

ref https://github.com/denoland/deno/actions/runs/14343397447/job/40207971728