### PR TITLE
fix: use full SHA for canary panic URLs

### DIFF
--- a/cli/lib/version.rs
+++ b/cli/lib/version.rs
@@ -15,7 +15,7 @@ pub fn otel_runtime_config() -> OtelRuntimeConfig {
 
 const GIT_COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
 const TYPESCRIPT: &str = "5.7.3";
-const DENO_VERSION: &str = env!("DENO_VERSION");
+pub const DENO_VERSION: &str = env!("DENO_VERSION");
 // TODO(bartlomieju): ideally we could remove this const.
 const IS_CANARY: bool = option_env!("DENO_CANARY").is_some();
 // TODO(bartlomieju): this is temporary, to allow Homebrew to cut RC releases as well

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -370,11 +370,19 @@ fn setup_panic_hook() {
     eprintln!("Args: {:?}", env::args().collect::<Vec<_>>());
     eprintln!();
 
+    let info = &deno_lib::version::DENO_VERSION_INFO;
+    let version =
+      if info.release_channel == deno_lib::shared::ReleaseChannel::Canary {
+        format!("{}+{}", deno_lib::version::DENO_VERSION, info.git_hash)
+      } else {
+        info.deno.to_string()
+      };
+
     let trace = deno_panic::trace();
     eprintln!("View stack trace at:");
     eprintln!(
       "https://panic.deno.com/v{}/{}/{}",
-      deno_lib::version::DENO_VERSION_INFO.deno,
+      version,
       env!("TARGET"),
       trace
     );


### PR DESCRIPTION
Use full commit sha and one may not be able to resolve commits with the short sha because of duplicates.