### PR TITLE
fix(lsp): exclude unmapped npm cache paths from auto-imports

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -223,7 +223,7 @@ impl LanguageServerTaskQueue {
 }
 
 pub struct Inner {
-  cache: LspCache,
+  pub cache: LspCache,
   /// The LSP client that this LSP server is connected to.
   pub client: Client,
   /// Configuration information.

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3610,6 +3610,13 @@ pub struct CompletionNormalizedAutoImportData {
   normalized: ModuleSpecifier,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum ResolutionLookup {
+  PrettySpecifier(String),
+  Preserve,
+  Invalid,
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionEntry {
@@ -3783,7 +3790,7 @@ impl CompletionEntry {
   }
 
   #[allow(clippy::too_many_arguments)]
-  pub fn as_completion_item(
+  fn as_completion_item(
     &self,
     line_index: Arc<LineIndex>,
     info: &CompletionInfo,
@@ -3791,9 +3798,9 @@ impl CompletionEntry {
     module: &DocumentModule,
     position: u32,
     language_server: &language_server::Inner,
-    resolution_cache: &mut HashMap<
+    resolution_lookup_cache: &mut HashMap<
       (ModuleSpecifier, Arc<ModuleSpecifier>),
-      String,
+      ResolutionLookup,
     >,
   ) -> Option<lsp::CompletionItem> {
     let mut label = self.name.clone();
@@ -3854,30 +3861,46 @@ impl CompletionEntry {
         let mut display_source = source.clone();
         let import_mapper =
           language_server.get_ts_response_import_mapper(module);
-        let maybe_cached = resolution_cache
-          .get(&(import_data.normalized.clone(), module.specifier.clone()))
-          .cloned();
-        if let Some(mut new_specifier) = maybe_cached
-          .or_else(|| {
-            import_mapper
+        let resolution_lookup = resolution_lookup_cache
+          .entry((import_data.normalized.clone(), module.specifier.clone()))
+          .or_insert_with(|| {
+            if let Some(specifier) = import_mapper
               .check_specifier(&import_data.normalized, &module.specifier)
-          })
-          .or_else(|| {
-            relative_specifier(&module.specifier, &import_data.normalized)
-          })
-          .or_else(|| {
-            ModuleSpecifier::parse(&import_data.raw.module_specifier)
-              .is_ok()
-              .then(|| import_data.normalized.to_string())
-          })
+            {
+              return ResolutionLookup::PrettySpecifier(specifier);
+            }
+            if language_server
+              .resolver
+              .in_node_modules(&import_data.normalized)
+              || language_server
+                .cache
+                .in_cache_directory(&import_data.normalized)
+              || import_data
+                .normalized
+                .as_str()
+                .starts_with(jsr_url().as_str())
+            {
+              return ResolutionLookup::Invalid;
+            }
+            if let Some(specifier) =
+              relative_specifier(&module.specifier, &import_data.normalized)
+            {
+              return ResolutionLookup::PrettySpecifier(specifier);
+            }
+            if Url::parse(&import_data.raw.module_specifier).is_ok() {
+              return ResolutionLookup::PrettySpecifier(
+                import_data.normalized.to_string(),
+              );
+            }
+            ResolutionLookup::Preserve
+          });
+        if let ResolutionLookup::Invalid = resolution_lookup {
+          return None;
+        }
+        if let ResolutionLookup::PrettySpecifier(new_specifier) =
+          resolution_lookup
         {
-          resolution_cache.insert(
-            (import_data.normalized.clone(), module.specifier.clone()),
-            new_specifier.clone(),
-          );
-          if new_specifier.contains("/node_modules/") {
-            return None;
-          }
+          let mut new_specifier = new_specifier.clone();
           let mut new_deno_types_specifier = None;
           if let Some(code_specifier) = language_server
             .resolver
@@ -3902,8 +3925,6 @@ impl CompletionEntry {
               new_deno_types_specifier,
             });
           }
-        } else if source.starts_with(jsr_url().as_str()) {
-          return None;
         }
         // We want relative or bare (import-mapped or otherwise) specifiers to
         // appear at the top.

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -8837,6 +8837,61 @@ fn lsp_npm_types_nested_js_dts() {
   );
 }
 
+// Regression test for https://github.com/denoland/deno/issues/28777.
+#[test]
+#[timeout(300_000)]
+fn lsp_npm_reexport_from_non_export() {
+  let context = TestContextBuilder::new()
+    .use_http_server()
+    .use_temp_cwd()
+    .build();
+  let temp_dir = context.temp_dir();
+  let file = source_file(
+    temp_dir.path().join("file.ts"),
+    r#"
+      import {} from "npm:@denotest/reexport-from-non-export";
+      getValue;
+    "#,
+  );
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.write_request(
+    "workspace/executeCommand",
+    json!({
+      "command": "deno.cache",
+      "arguments": [[], file.url()],
+    }),
+  );
+  client.read_diagnostics();
+  let list = client.get_completion_list(
+    file.uri().as_str(),
+    (2, 14),
+    json!({
+      "triggerKind": 2,
+      "triggerCharacter": ".",
+    }),
+  );
+  assert!(!list.is_incomplete);
+  // Get all matching entries, then assert that there's only one and it has the
+  // correct auto-import specifier.
+  let items = list
+    .items
+    .iter()
+    .filter(|i| i.label == "getValue")
+    .collect::<Vec<_>>();
+  assert_eq!(
+    json!(items
+      .iter()
+      .map(|i| i
+        .label_details
+        .as_ref()
+        .and_then(|d| d.description.as_ref()))
+      .collect::<Vec<_>>()),
+    json!(["npm:@denotest/reexport-from-non-export"]),
+  );
+  client.shutdown();
+}
+
 #[test]
 #[timeout(300_000)]
 fn lsp_completions_using_decl() {

--- a/tests/registry/npm/@denotest/reexport-from-non-export/1.0.0/index.d.ts
+++ b/tests/registry/npm/@denotest/reexport-from-non-export/1.0.0/index.d.ts
@@ -1,0 +1,1 @@
+export { getValue } from "@denotest/types-exports-import-types";

--- a/tests/registry/npm/@denotest/reexport-from-non-export/1.0.0/index.mjs
+++ b/tests/registry/npm/@denotest/reexport-from-non-export/1.0.0/index.mjs
@@ -1,0 +1,1 @@
+export { getValue } from "@denotest/types-exports-import-types";

--- a/tests/registry/npm/@denotest/reexport-from-non-export/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/reexport-from-non-export/1.0.0/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@denotest/reexport-from-non-export",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "imports": "./index.mjs"
+    }
+  },
+  "dependencies": {
+    "@denotest/types-exports-import-types": "*"
+  }
+}


### PR DESCRIPTION
Fixes #28777.