### PR TITLE
fix(ext/console): incorrect color output for rgb values

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -2847,9 +2847,24 @@ function colorEquals(color1, color2) {
     color1?.[2] == color2?.[2];
 }
 
+function isRgbString(str) {
+  if (!str || typeof str !== "string") return false;
+  return StringPrototypeStartsWith(StringPrototypeTrim(str), "rgb");
+}
+
 function cssToAnsi(css, prevCss = null) {
   prevCss = prevCss ?? getDefaultCss();
   let ansi = "";
+  if (isRgbString(css.color) && isRgbString(prevCss.color)) {
+    css = {
+      ...css,
+      color: parseCssColor(css.color),
+    };
+    prevCss = {
+      ...prevCss,
+      color: parseCssColor(prevCss.color),
+    };
+  }
   if (!colorEquals(css.backgroundColor, prevCss.backgroundColor)) {
     if (css.backgroundColor == null) {
       ansi += "\x1b[49m";


### PR DESCRIPTION
Closes #28039

Parse RGB values before comparison. String comparison is unreliable for RGB formats. This change checks if a parameter is an RGB value; if so, it parses the value and updates the parameter accordingly before proceeding.