### PR TITLE
fix(ext/node): export test as property of default export

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -222,4 +222,6 @@ export const mock = {
   },
 };
 
+test.test = test;
+
 export default test;

--- a/tests/specs/node/node_test_module/test.js
+++ b/tests/specs/node/node_test_module/test.js
@@ -13,7 +13,7 @@ test("sync pass todo", (t) => {
   t.todo();
 });
 
-test("sync pass todo with message", (t) => {
+test.test("sync pass todo with message", (t) => {
   t.todo("this is a passing todo");
 });
 


### PR DESCRIPTION
Currently the pattern below is not supported. This PR fixes it.

```js
const { test } = require('node:test');
```

towards #28837 