### PR TITLE
chore: use 'deno test' command when 'node:test' is imported in run_node_test script

### DIFF
--- a/tests/node_compat/common.ts
+++ b/tests/node_compat/common.ts
@@ -142,6 +142,7 @@ export const RUN_ARGS = [
 export const TEST_ARGS = [
   "test",
   ...RUN_ARGS,
+  "--no-check",
   "--unstable-detect-cjs",
 ];
 

--- a/tests/node_compat/common.ts
+++ b/tests/node_compat/common.ts
@@ -126,6 +126,25 @@ export async function getDenoTests() {
 let testSerialId = 0;
 const cwd = new URL(".", import.meta.url);
 
+/** Checks if the test file uses `node:test` module */
+export function usesNodeTestModule(testSource: string): boolean {
+  return testSource.includes("'node:test'");
+}
+
+export const RUN_ARGS = [
+  "-A",
+  "--quiet",
+  "--unstable-unsafe-proto",
+  "--unstable-bare-node-builtins",
+  "--unstable-node-globals",
+];
+
+export const TEST_ARGS = [
+  "test",
+  ...RUN_ARGS,
+  "--unstable-detect-cjs",
+];
+
 export async function runNodeCompatTestCase(
   testCase: string,
   signal?: AbortSignal,
@@ -154,19 +173,10 @@ export async function runNodeCompatTestCase(
   if (knownGlobals.length > 0) {
     envVars["NODE_TEST_KNOWN_GLOBALS"] = knownGlobals.join(",");
   }
-  // TODO(nathanwhit): once we match node's behavior on executing
-  // `node:test` tests when we run a file, we can remove this
-  const usesNodeTest = testSource.includes("node:test");
+  const usesNodeTest = usesNodeTestModule(testSource);
   const args = [
-    usesNodeTest ? "test" : "run",
-    "-A",
-    "--quiet",
-    "--unstable-unsafe-proto",
-    "--unstable-bare-node-builtins",
-    "--unstable-fs",
-    "--unstable-node-globals",
+    ...(usesNodeTest ? TEST_ARGS : RUN_ARGS),
     "--v8-flags=" + v8Flags.join(),
-    "--no-check",
     testCase,
   ];
 


### PR DESCRIPTION
This PR checks if the node test script uses `node:test` module, and changes the command from:

```
deno -A --quiet --unstable-bare-node-builtins --unstable-node-globals <test-file>
```

to:

```
deno test -A --quiet --unstable-bare-node-builtins --unstable-node-globals --no-check <test-file>
```

when it's used.

Note: Currently about 130 test files (3.3%) seem using `node:test` module.