### PR TITLE
fix(install): read extra package info from node_modules and fallback to registry

### DIFF
--- a/cli/npm/installer/common/lifecycle_scripts.rs
+++ b/cli/npm/installer/common/lifecycle_scripts.rs
@@ -439,6 +439,7 @@ async fn resolve_custom_commands_from_packages<
       let Ok(extra) = provider
         .get_package_extra_info(
           &package.id.nv,
+          &package_path,
           super::ExpectedExtraInfo::from_package(package),
         )
         .await

--- a/cli/npm/installer/local.rs
+++ b/cli/npm/installer/local.rs
@@ -422,6 +422,7 @@ async fn sync_resolution_with_fs(
               extra_info_provider
                 .get_package_extra_info(
                   &package.id.nv,
+                  &package_path,
                   super::common::ExpectedExtraInfo::from_package(package),
                 )
                 .boxed_local()
@@ -471,6 +472,7 @@ async fn sync_resolution_with_fs(
             let extra = extra_info_provider
               .get_package_extra_info(
                 &package.id.nv,
+                &package_path,
                 super::common::ExpectedExtraInfo::from_package(package),
               )
               .await

--- a/tests/registry/npm/@denotest/extra-info/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/extra-info/1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@denotest/extra-info",
+  "version": "1.0.0",
+  "bin": {
+    "denotest-extra-info": "./bin/main.js"
+  },
+  "scripts": {
+    "postinstall": "echo 'postinstall'"
+  }
+}

--- a/tests/specs/install/package_extra_nmd/__test__.jsonc
+++ b/tests/specs/install/package_extra_nmd/__test__.jsonc
@@ -1,0 +1,78 @@
+{
+  "tempDir": true,
+  "tests": {
+    "auto": {
+      "steps": [
+        {
+          "args": "install --node-modules-dir=auto npm:@denotest/extra-info",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "clean",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "install --node-modules-dir=auto --allow-scripts",
+          "output": "[WILDCARD]running 'postinstall' script\n"
+        }
+      ]
+    },
+    "manual": {
+      "steps": [
+        {
+          "args": "install --node-modules-dir=manual npm:@denotest/extra-info",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "clean",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "install --node-modules-dir=manual --allow-scripts",
+          "output": "[WILDCARD]running 'postinstall' script\n"
+        }
+      ]
+    },
+    "none": {
+      "steps": [
+        {
+          "args": "install --node-modules-dir=none npm:@denotest/extra-info",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "clean",
+          "output": "[WILDCARD]"
+        },
+        {
+          // postinstall scripts aren't a thing, so just add another package to trigger
+          // setting up node_modules
+          "args": "install --node-modules-dir=none npm:chalk",
+          "output": "[WILDCARD]"
+        }
+      ]
+    },
+    "fallback": {
+      "steps": [
+        {
+          "args": "install --node-modules-dir=auto npm:@denotest/extra-info",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "clean",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": [
+            "eval",
+            "Deno.removeSync(Deno.cwd() + '/node_modules/.deno/@denotest+extra-info@1.0.0/node_modules/@denotest/extra-info/package.json')"
+          ],
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "install --node-modules-dir=auto --allow-scripts",
+          "output": "[WILDCARD]running 'postinstall' script\n"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #28891

We were checking if the node_modules entry for the package was present, but then reading from the global cache.

Instead, read from the package.json in node_modules. As a fallback(which in theory should only really happen if the node_modules dir is somehow messed up), take the more expensive (but likely to work) path of reading from the registry.json.