### PR TITLE
chore: don't shallow clone in publish job

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           token: ${{ secrets.DENOBOT_PAT }}
           submodules: recursive
 


### PR DESCRIPTION
This should make the "forward release commit" CI job actually work. The issue was that actions/checkout by default does a shallow clone (fetch-deptg == 1), so then when we tried to cherry-pick it would fail due to missing the history. That's why the cherry-pick would work fine locally, but fail every time in CI