### PR TITLE
fix(ext/node): `process.argv[0]` is equivalent to execPath

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -958,7 +958,9 @@ function synchronizeListeners() {
 }
 
 // Overwrites the 1st and 2nd items with getters.
-Object.defineProperty(argv, "0", { get: () => argv0 });
+// process.argv[0] should return the executable path (same as process.execPath)
+// to match Node.js behavior, not the custom argument (argv0)
+Object.defineProperty(argv, "0", { get: () => String(execPath) });
 Object.defineProperty(argv, "1", {
   get: () => {
     if (Deno.mainModule?.startsWith("file:")) {


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/28889

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
