### PR TITLE
refactor: allow lazy main module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,6 +1563,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
+ "tokio-vsock",
  "tower 0.5.2",
  "tracing",
  "tracing-opentelemetry",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -192,6 +192,7 @@ winapi = { workspace = true, features = ["knownfolders", "mswsock", "objbase", "
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true
 shell-escape = "=0.1.5"
+tokio-vsock.workspace = true
 
 [dev-dependencies]
 deno_bench_util.workspace = true

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -29,6 +29,7 @@ use deno_lib::npm::NpmRegistryReadPermissionChecker;
 use deno_lib::npm::NpmRegistryReadPermissionCheckerMode;
 use deno_lib::worker::LibMainWorkerFactory;
 use deno_lib::worker::LibMainWorkerOptions;
+use deno_lib::worker::LibWorkerFactoryRoots;
 use deno_npm::npm_rc::ResolvedNpmRc;
 use deno_npm_cache::NpmCacheSetting;
 use deno_resolver::cjs::IsCjsResolutionMode;
@@ -1203,6 +1204,7 @@ impl CliFactory {
 
   pub async fn create_cli_main_worker_factory(
     &self,
+    roots: LibWorkerFactoryRoots,
   ) -> Result<CliMainWorkerFactory, AnyError> {
     let cli_options = self.cli_options()?;
     let fs = self.fs();
@@ -1286,6 +1288,7 @@ impl CliFactory {
       cli_options.resolve_storage_key_resolver(),
       self.sys(),
       self.create_lib_main_worker_options()?,
+      roots,
     );
 
     Ok(CliMainWorkerFactory::new(

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1204,6 +1204,14 @@ impl CliFactory {
 
   pub async fn create_cli_main_worker_factory(
     &self,
+  ) -> Result<CliMainWorkerFactory, AnyError> {
+    self
+      .create_cli_main_worker_factory_with_roots(Default::default())
+      .await
+  }
+
+  pub async fn create_cli_main_worker_factory_with_roots(
+    &self,
     roots: LibWorkerFactoryRoots,
   ) -> Result<CliMainWorkerFactory, AnyError> {
     let cli_options = self.cli_options()?;

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -190,6 +190,12 @@ pub struct LibMainWorkerOptions {
   pub serve_host: Option<String>,
 }
 
+#[derive(Default, Clone)]
+pub struct LibWorkerFactoryRoots {
+  pub compiled_wasm_module_store: CompiledWasmModuleStore,
+  pub shared_array_buffer_store: SharedArrayBufferStore,
+}
+
 struct LibWorkerFactorySharedState<TSys: DenoLibSys> {
   blob_store: Arc<BlobStore>,
   broadcast_channel: InMemoryBroadcastChannel,
@@ -370,13 +376,14 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
     storage_key_resolver: StorageKeyResolver,
     sys: TSys,
     options: LibMainWorkerOptions,
+    roots: LibWorkerFactoryRoots,
   ) -> Self {
     Self {
       shared: Arc::new(LibWorkerFactorySharedState {
         blob_store,
         broadcast_channel: Default::default(),
         code_cache,
-        compiled_wasm_module_store: Default::default(),
+        compiled_wasm_module_store: roots.compiled_wasm_module_store,
         deno_rt_native_addon_loader,
         feature_checker,
         fs,
@@ -386,7 +393,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
         npm_process_state_provider,
         pkg_json_resolver,
         root_cert_store_provider,
-        shared_array_buffer_store: Default::default(),
+        shared_array_buffer_store: roots.shared_array_buffer_store,
         storage_key_resolver,
         sys,
         options,
@@ -399,6 +406,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
     mode: WorkerExecutionMode,
     permissions: PermissionsContainer,
     main_module: Url,
+    unconfigured: Option<deno_runtime::Unconfigured>,
   ) -> Result<LibMainWorker, CoreError> {
     self.create_custom_worker(
       mode,
@@ -406,6 +414,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
       permissions,
       vec![],
       Default::default(),
+      unconfigured,
     )
   }
 
@@ -416,6 +425,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
     permissions: PermissionsContainer,
     custom_extensions: Vec<Extension>,
     stdio: deno_runtime::deno_io::Stdio,
+    unconfigured: Option<deno_runtime::Unconfigured>,
   ) -> Result<LibMainWorker, CoreError> {
     let shared = &self.shared;
     let CreateModuleLoaderResult {
@@ -516,6 +526,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
       stdio,
       skip_op_registration: shared.options.skip_op_registration,
       enable_stack_trace_arg_in_ops: has_trace_permissions_enabled(),
+      unconfigured,
     };
 
     let worker =

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -406,7 +406,6 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
     mode: WorkerExecutionMode,
     permissions: PermissionsContainer,
     main_module: Url,
-    unconfigured: Option<deno_runtime::Unconfigured>,
   ) -> Result<LibMainWorker, CoreError> {
     self.create_custom_worker(
       mode,
@@ -414,7 +413,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
       permissions,
       vec![],
       Default::default(),
-      unconfigured,
+      None,
     )
   }
 

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -424,7 +424,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
     permissions: PermissionsContainer,
     custom_extensions: Vec<Extension>,
     stdio: deno_runtime::deno_io::Stdio,
-    unconfigured: Option<deno_runtime::Unconfigured>,
+    unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   ) -> Result<LibMainWorker, CoreError> {
     let shared = &self.shared;
     let CreateModuleLoaderResult {
@@ -525,7 +525,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
       stdio,
       skip_op_registration: shared.options.skip_op_registration,
       enable_stack_trace_arg_in_ops: has_trace_permissions_enabled(),
-      unconfigured,
+      unconfigured_runtime,
     };
 
     let worker =

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -270,8 +270,11 @@ impl TestRun {
     let tests: Arc<RwLock<IndexMap<usize, test::TestDescription>>> =
       Arc::new(RwLock::new(IndexMap::new()));
     let mut test_steps = IndexMap::new();
-    let worker_factory =
-      Arc::new(factory.create_cli_main_worker_factory().await?);
+    let worker_factory = Arc::new(
+      factory
+        .create_cli_main_worker_factory(Default::default())
+        .await?,
+    );
 
     let join_handles = queue.into_iter().map(move |specifier| {
       let specifier = specifier.clone();

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -270,11 +270,8 @@ impl TestRun {
     let tests: Arc<RwLock<IndexMap<usize, test::TestDescription>>> =
       Arc::new(RwLock::new(IndexMap::new()));
     let mut test_steps = IndexMap::new();
-    let worker_factory = Arc::new(
-      factory
-        .create_cli_main_worker_factory(Default::default())
-        .await?,
-    );
+    let worker_factory =
+      Arc::new(factory.create_cli_main_worker_factory().await?);
 
     let join_handles = queue.into_iter().map(move |specifier| {
       let specifier = specifier.clone();

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -44,10 +44,12 @@ use deno_core::error::CoreError;
 use deno_core::futures::FutureExt;
 use deno_core::unsync::JoinHandle;
 use deno_lib::util::result::any_and_jserrorbox_downcast_ref;
+use deno_lib::worker::LibWorkerFactoryRoots;
 use deno_resolver::npm::ByonmResolvePkgFolderFromDenoReqError;
 use deno_resolver::npm::ResolvePkgFolderFromDenoReqError;
 use deno_runtime::fmt_errors::format_js_error;
 use deno_runtime::tokio_util::create_and_run_current_thread_with_maybe_metrics;
+use deno_runtime::Unconfigured;
 use deno_runtime::WorkerExecutionMode;
 pub use deno_runtime::UNSTABLE_FEATURES;
 use deno_telemetry::OtelConfig;
@@ -106,7 +108,11 @@ fn spawn_subcommand<F: Future<Output = T> + 'static, T: SubcommandOutput>(
   )
 }
 
-async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
+async fn run_subcommand(
+  flags: Arc<Flags>,
+  unconfigured: Option<Unconfigured>,
+  roots: LibWorkerFactoryRoots,
+) -> Result<i32, AnyError> {
   let handle = match flags.subcommand.clone() {
     DenoSubcommand::Add(add_flags) => spawn_subcommand(async {
       tools::pm::add(flags, add_flags, tools::pm::AddCommandName::Add).await
@@ -217,11 +223,11 @@ async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
     DenoSubcommand::Run(run_flags) => spawn_subcommand(async move {
       if run_flags.is_stdin() {
         // these futures are boxed to prevent stack overflows on Windows
-        tools::run::run_from_stdin(flags.clone()).boxed_local().await
+        tools::run::run_from_stdin(flags.clone(), unconfigured, roots).boxed_local().await
       } else if flags.eszip {
-        tools::run::run_eszip(flags, run_flags).boxed_local().await
+        tools::run::run_eszip(flags, run_flags, unconfigured, roots).boxed_local().await
       } else {
-        let result = tools::run::run_script(WorkerExecutionMode::Run, flags.clone(), run_flags.watch).await;
+        let result = tools::run::run_script(WorkerExecutionMode::Run, flags.clone(), run_flags.watch, unconfigured, roots.clone()).await;
         match result {
           Ok(v) => Ok(v),
           Err(script_err) => {
@@ -237,7 +243,7 @@ async fn run_subcommand(flags: Arc<Flags>) -> Result<i32, AnyError> {
                 if flags.frozen_lockfile.is_none() {
                   flags.internal.lockfile_skip_write = true;
                 }
-                return tools::run::run_script(WorkerExecutionMode::Run, Arc::new(flags), watch).boxed_local().await;
+                return tools::run::run_script(WorkerExecutionMode::Run, Arc::new(flags), watch, None, roots).boxed_local().await;
               }
             }
             let script_err_msg = script_err.to_string();
@@ -449,13 +455,39 @@ pub fn main() {
     Box::new(util::draw_thread::DrawThread::show),
   );
 
-  let args: Vec<_> = env::args_os().collect();
   let future = async move {
+    let roots = LibWorkerFactoryRoots::default();
+
+    #[cfg(unix)]
+    let (waited_unconfigured, waited_args) = match wait_for_start(roots.clone())
+    {
+      Some(f) => match f.await {
+        Ok(v) => match v {
+          Some((u, a)) => (Some(u), Some(a)),
+          None => (None, None),
+        },
+        Err(e) => {
+          panic!("{e:?}");
+        }
+      },
+      None => (None, None),
+    };
+
+    #[cfg(not(unix))]
+    let (waited_unconfigured, waited_args) = (None, None);
+
+    let args: Vec<_> = waited_args.unwrap_or_else(|| env::args_os().collect());
+
     // NOTE(lucacasonato): due to new PKU feature introduced in V8 11.6 we need to
     // initialize the V8 platform on a parent thread of all threads that will spawn
     // V8 isolates.
     let flags = resolve_flags_and_init(args)?;
-    run_subcommand(Arc::new(flags)).await
+
+    if waited_unconfigured.is_none() {
+      init_v8(&flags);
+    }
+
+    run_subcommand(Arc::new(flags), waited_unconfigured, roots).await
   };
 
   let result = create_and_run_current_thread_with_maybe_metrics(future);
@@ -505,6 +537,10 @@ fn resolve_flags_and_init(
     );
   }
 
+  Ok(flags)
+}
+
+fn init_v8(flags: &Flags) {
   let default_v8_flags = match flags.subcommand {
     DenoSubcommand::Lsp => vec![
       "--stack-size=1024".to_string(),
@@ -527,13 +563,12 @@ fn resolve_flags_and_init(
   } else {
     None
   };
+
   // TODO(bartlomieju): remove last argument once Deploy no longer needs it
   deno_core::JsRuntime::init_platform(
     v8_platform,
     /* import assertions enabled */ false,
   );
-
-  Ok(flags)
 }
 
 fn init_logging(
@@ -549,5 +584,77 @@ fn init_logging(
     // thread's state
     on_log_start: DrawThread::hide,
     on_log_end: DrawThread::show,
+  })
+}
+
+#[cfg(unix)]
+#[allow(clippy::type_complexity)]
+fn wait_for_start(
+  roots: LibWorkerFactoryRoots,
+) -> Option<
+  impl Future<
+    Output = Result<Option<(Unconfigured, Vec<std::ffi::OsString>)>, AnyError>,
+  >,
+> {
+  let startup_snapshot = deno_snapshots::CLI_SNAPSHOT?;
+  let path = std::env::var("DENO_CONTROL_SOCK").ok()?;
+  std::env::remove_var("DENO_CONTROL_SOCK");
+
+  Some(async move {
+    use std::os::unix::ffi::OsStringExt;
+
+    use tokio::io::AsyncReadExt;
+
+    init_v8(&Flags::default());
+
+    let unconfigured = deno_runtime::Unconfigured::new::<
+      deno_resolver::npm::DenoInNpmPackageChecker,
+      crate::npm::CliNpmResolver,
+      crate::sys::CliSys,
+    >(
+      startup_snapshot,
+      deno_lib::worker::create_isolate_create_params(),
+      Some(roots.shared_array_buffer_store.clone()),
+      Some(roots.compiled_wasm_module_store.clone()),
+      vec![],
+    );
+
+    let _ = tokio::fs::remove_file(&path).await;
+
+    let socket = tokio::net::UnixSocket::new_stream()?;
+    socket.bind(&path)?;
+    let listener = socket.listen(1)?;
+
+    let (mut stream, _) = listener.accept().await?;
+
+    let mut buf = vec![0; 1024];
+    let n = stream.read(&mut buf).await?;
+    buf.truncate(n);
+
+    #[derive(deno_core::serde::Deserialize)]
+    struct Start {
+      cwd: Vec<u8>,
+      args: Vec<Vec<u8>>,
+      env: Vec<(Vec<u8>, Vec<u8>)>,
+    }
+
+    let cmd: Start = deno_core::serde_json::from_slice(&buf)?;
+
+    std::env::set_current_dir(std::ffi::OsString::from_vec(cmd.cwd))?;
+
+    for (k, v) in cmd.env {
+      std::env::set_var(
+        std::ffi::OsString::from_vec(k),
+        std::ffi::OsString::from_vec(v),
+      );
+    }
+
+    let mut args = Vec::with_capacity(cmd.args.len() + 1);
+    args.push(std::ffi::OsString::from("deno"));
+    for arg in cmd.args {
+      args.push(std::ffi::OsString::from_vec(arg));
+    }
+
+    Ok(Some((unconfigured, args)))
   })
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -455,28 +455,29 @@ pub fn main() {
     Box::new(util::draw_thread::DrawThread::show),
   );
 
+  let args: Vec<_> = env::args_os().collect();
   let future = async move {
     let roots = LibWorkerFactoryRoots::default();
 
     #[cfg(unix)]
-    let (waited_unconfigured, waited_args) = match wait_for_start(roots.clone())
-    {
-      Some(f) => match f.await {
-        Ok(v) => match v {
-          Some((u, a)) => (Some(u), Some(a)),
-          None => (None, None),
+    let (waited_unconfigured, waited_args) =
+      match wait_for_start(&args, roots.clone()) {
+        Some(f) => match f.await {
+          Ok(v) => match v {
+            Some((u, a)) => (Some(u), Some(a)),
+            None => (None, None),
+          },
+          Err(e) => {
+            panic!("Failure from control sock: {e}");
+          }
         },
-        Err(e) => {
-          panic!("{e:?}");
-        }
-      },
-      None => (None, None),
-    };
+        None => (None, None),
+      };
 
     #[cfg(not(unix))]
     let (waited_unconfigured, waited_args) = (None, None);
 
-    let args: Vec<_> = waited_args.unwrap_or_else(|| env::args_os().collect());
+    let args = waited_args.unwrap_or(args);
 
     // NOTE(lucacasonato): due to new PKU feature introduced in V8 11.6 we need to
     // initialize the V8 platform on a parent thread of all threads that will spawn
@@ -590,6 +591,7 @@ fn init_logging(
 #[cfg(unix)]
 #[allow(clippy::type_complexity)]
 fn wait_for_start(
+  args: &[std::ffi::OsString],
   roots: LibWorkerFactoryRoots,
 ) -> Option<
   impl Future<
@@ -600,9 +602,9 @@ fn wait_for_start(
   let addr = std::env::var("DENO_UNSTABLE_CONTROL_SOCK").ok()?;
   std::env::remove_var("DENO_UNSTABLE_CONTROL_SOCK");
 
-  Some(async move {
-    use std::os::unix::ffi::OsStringExt;
+  let argv0 = args[0].clone();
 
+  Some(async move {
     use tokio::io::AsyncBufReadExt;
     use tokio::io::AsyncRead;
     use tokio::io::BufReader;
@@ -642,7 +644,7 @@ fn wait_for_start(
         let Some((cid, port)) = addr.split_once(':') else {
           deno_core::anyhow::bail!("invalid vsock addr");
         };
-        let cid = cid.parse()?;
+        let cid = if cid == "-1" { u32::MAX } else { cid.parse()? };
         let port = port.parse()?;
         let addr = VsockAddr::new(cid, port);
         let listener = VsockListener::bind(addr)?;
@@ -661,27 +663,23 @@ fn wait_for_start(
 
     #[derive(deno_core::serde::Deserialize)]
     struct Start {
-      cwd: Vec<u8>,
-      args: Vec<Vec<u8>>,
-      env: Vec<(Vec<u8>, Vec<u8>)>,
+      cwd: String,
+      args: Vec<String>,
+      env: Vec<(String, String)>,
     }
 
     let cmd: Start = deno_core::serde_json::from_slice(&buf)?;
 
-    std::env::set_current_dir(std::ffi::OsString::from_vec(cmd.cwd))?;
+    std::env::set_current_dir(cmd.cwd)?;
 
     for (k, v) in cmd.env {
-      std::env::set_var(
-        std::ffi::OsString::from_vec(k),
-        std::ffi::OsString::from_vec(v),
-      );
+      std::env::set_var(k, v);
     }
 
-    let mut args = Vec::with_capacity(cmd.args.len() + 1);
-    args.push(std::ffi::OsString::from("deno"));
-    for arg in cmd.args {
-      args.push(std::ffi::OsString::from_vec(arg));
-    }
+    let args = [argv0]
+      .into_iter()
+      .chain(cmd.args.into_iter().map(Into::into))
+      .collect();
 
     Ok(Some((unconfigured, args)))
   })

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -984,6 +984,7 @@ pub async fn run(
     StorageKeyResolver::empty(),
     sys.clone(),
     lib_main_worker_options,
+    Default::default(),
   );
 
   // Initialize v8 once from the main thread.
@@ -1015,6 +1016,7 @@ pub async fn run(
     WorkerExecutionMode::Run,
     permissions,
     main_module,
+    None,
   )?;
 
   let exit_code = worker.run().await?;

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -1016,7 +1016,6 @@ pub async fn run(
     WorkerExecutionMode::Run,
     permissions,
     main_module,
-    None,
   )?;
 
   let exit_code = worker.run().await?;

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -192,6 +192,7 @@ async fn bench_specifier_inner(
       permissions_container,
       vec![ops::bench::deno_bench::init(sender.clone())],
       Default::default(),
+      None,
     )
     .await?;
 
@@ -477,8 +478,11 @@ pub async fn run_benchmarks(
   }
 
   let log_level = cli_options.log_level();
-  let worker_factory =
-    Arc::new(factory.create_cli_main_worker_factory().await?);
+  let worker_factory = Arc::new(
+    factory
+      .create_cli_main_worker_factory(Default::default())
+      .await?,
+  );
   bench_specifiers(
     worker_factory,
     &permissions,
@@ -591,8 +595,11 @@ pub async fn run_benchmarks_with_watch(
           bench_modules.clone()
         };
 
-        let worker_factory =
-          Arc::new(factory.create_cli_main_worker_factory().await?);
+        let worker_factory = Arc::new(
+          factory
+            .create_cli_main_worker_factory(Default::default())
+            .await?,
+        );
 
         let specifiers = collected_bench_modules
           .into_iter()

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -478,11 +478,8 @@ pub async fn run_benchmarks(
   }
 
   let log_level = cli_options.log_level();
-  let worker_factory = Arc::new(
-    factory
-      .create_cli_main_worker_factory(Default::default())
-      .await?,
-  );
+  let worker_factory =
+    Arc::new(factory.create_cli_main_worker_factory().await?);
   bench_specifiers(
     worker_factory,
     &permissions,
@@ -595,11 +592,8 @@ pub async fn run_benchmarks_with_watch(
           bench_modules.clone()
         };
 
-        let worker_factory = Arc::new(
-          factory
-            .create_cli_main_worker_factory(Default::default())
-            .await?,
-        );
+        let worker_factory =
+          Arc::new(factory.create_cli_main_worker_factory().await?);
 
         let specifiers = collected_bench_modules
           .into_iter()

--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -344,6 +344,8 @@ async fn init_npm(name: &str, args: Vec<String>) -> Result<i32, AnyError> {
     WorkerExecutionMode::Run,
     new_flags.into(),
     None,
+    None,
+    Default::default(),
   )
   .await
 }

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -73,9 +73,7 @@ pub async fn kernel(
   let npm_installer = factory.npm_installer_if_managed().await?.cloned();
   let tsconfig_resolver = factory.tsconfig_resolver()?;
   let resolver = factory.resolver().await?.clone();
-  let worker_factory = factory
-    .create_cli_main_worker_factory(Default::default())
-    .await?;
+  let worker_factory = factory.create_cli_main_worker_factory().await?;
   let (stdio_tx, stdio_rx) = mpsc::unbounded_channel();
 
   let conn_file =

--- a/cli/tools/jupyter/mod.rs
+++ b/cli/tools/jupyter/mod.rs
@@ -73,7 +73,9 @@ pub async fn kernel(
   let npm_installer = factory.npm_installer_if_managed().await?.cloned();
   let tsconfig_resolver = factory.tsconfig_resolver()?;
   let resolver = factory.resolver().await?.clone();
-  let worker_factory = factory.create_cli_main_worker_factory().await?;
+  let worker_factory = factory
+    .create_cli_main_worker_factory(Default::default())
+    .await?;
   let (stdio_tx, stdio_rx) = mpsc::unbounded_channel();
 
   let conn_file =
@@ -109,6 +111,7 @@ pub async fn kernel(
         stdout: StdioPipe::file(stdout),
         stderr: StdioPipe::file(stderr),
       },
+      None,
     )
     .await?;
   worker.setup_repl().await?;

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -156,7 +156,9 @@ async fn create_plugin_runner_inner(
   let permissions = PermissionsContainer::new(perm_parser.clone(), permissions);
   // let npm_resolver = factory.npm_resolver().await?.clone();
   // let resolver = factory.resolver().await?.clone();
-  let worker_factory = factory.create_cli_main_worker_factory().await?;
+  let worker_factory = factory
+    .create_cli_main_worker_factory(Default::default())
+    .await?;
 
   let worker = worker_factory
     .create_custom_worker(
@@ -166,6 +168,7 @@ async fn create_plugin_runner_inner(
       permissions,
       vec![crate::ops::lint::deno_lint_ext::init(logger.clone())],
       Default::default(),
+      None,
     )
     .await?;
 

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -156,9 +156,7 @@ async fn create_plugin_runner_inner(
   let permissions = PermissionsContainer::new(perm_parser.clone(), permissions);
   // let npm_resolver = factory.npm_resolver().await?.clone();
   // let resolver = factory.resolver().await?.clone();
-  let worker_factory = factory
-    .create_cli_main_worker_factory(Default::default())
-    .await?;
+  let worker_factory = factory.create_cli_main_worker_factory().await?;
 
   let worker = worker_factory
     .create_custom_worker(

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -178,7 +178,9 @@ pub async fn run(
   let resolver = factory.resolver().await?.clone();
   let file_fetcher = factory.file_fetcher()?;
   let tsconfig_resolver = factory.tsconfig_resolver()?;
-  let worker_factory = factory.create_cli_main_worker_factory().await?;
+  let worker_factory = factory
+    .create_cli_main_worker_factory(Default::default())
+    .await?;
   let history_file_path = factory
     .deno_dir()
     .ok()
@@ -192,6 +194,7 @@ pub async fn run(
       permissions.clone(),
       vec![crate::ops::testing::deno_test::init(test_event_sender)],
       Default::default(),
+      None,
     )
     .await?;
   worker.setup_repl().await?;

--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -178,9 +178,7 @@ pub async fn run(
   let resolver = factory.resolver().await?.clone();
   let file_fetcher = factory.file_fetcher()?;
   let tsconfig_resolver = factory.tsconfig_resolver()?;
-  let worker_factory = factory
-    .create_cli_main_worker_factory(Default::default())
-    .await?;
+  let worker_factory = factory.create_cli_main_worker_factory().await?;
   let history_file_path = factory
     .deno_dir()
     .ok()

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -85,9 +85,15 @@ pub async fn run_script(
 
   maybe_npm_install(&factory).await?;
 
-  let worker_factory = factory.create_cli_main_worker_factory(roots).await?;
+  let worker_factory = factory
+    .create_cli_main_worker_factory_with_roots(roots)
+    .await?;
   let mut worker = worker_factory
-    .create_main_worker(mode, main_module.clone(), unconfigured)
+    .create_main_worker_with_unconfigured(
+      mode,
+      main_module.clone(),
+      unconfigured,
+    )
     .await?;
 
   let exit_code = worker.run().await?;
@@ -106,7 +112,9 @@ pub async fn run_from_stdin(
   maybe_npm_install(&factory).await?;
 
   let file_fetcher = factory.file_fetcher()?;
-  let worker_factory = factory.create_cli_main_worker_factory(roots).await?;
+  let worker_factory = factory
+    .create_cli_main_worker_factory_with_roots(roots)
+    .await?;
   let mut source = Vec::new();
   std::io::stdin().read_to_end(&mut source)?;
   // Save a fake file into file fetcher cache
@@ -118,7 +126,7 @@ pub async fn run_from_stdin(
   });
 
   let mut worker = worker_factory
-    .create_main_worker(
+    .create_main_worker_with_unconfigured(
       WorkerExecutionMode::Run,
       main_module.clone(),
       unconfigured,
@@ -162,9 +170,9 @@ async fn run_with_watch(
         let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
 
         let mut worker = factory
-          .create_cli_main_worker_factory(Default::default())
+          .create_cli_main_worker_factory()
           .await?
-          .create_main_worker(mode, main_module.clone(), None)
+          .create_main_worker(mode, main_module.clone())
           .await?;
 
         if watch_flags.hmr {
@@ -209,11 +217,9 @@ pub async fn eval_command(
     source: source_code.into_bytes().into(),
   });
 
-  let worker_factory = factory
-    .create_cli_main_worker_factory(Default::default())
-    .await?;
+  let worker_factory = factory.create_cli_main_worker_factory().await?;
   let mut worker = worker_factory
-    .create_main_worker(WorkerExecutionMode::Eval, main_module.clone(), None)
+    .create_main_worker(WorkerExecutionMode::Eval, main_module.clone())
     .await?;
   let exit_code = worker.run().await?;
   Ok(exit_code)
@@ -261,9 +267,15 @@ pub async fn run_eszip(
 
   let mode = WorkerExecutionMode::Run;
   let main_module = resolve_url_or_path(entrypoint, cli_options.initial_cwd())?;
-  let worker_factory = factory.create_cli_main_worker_factory(roots).await?;
+  let worker_factory = factory
+    .create_cli_main_worker_factory_with_roots(roots)
+    .await?;
   let mut worker = worker_factory
-    .create_main_worker(mode, main_module.clone(), unconfigured)
+    .create_main_worker_with_unconfigured(
+      mode,
+      main_module.clone(),
+      unconfigured,
+    )
     .await?;
 
   let exit_code = worker.run().await?;

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -53,7 +53,7 @@ pub async fn run_script(
   mode: WorkerExecutionMode,
   flags: Arc<Flags>,
   watch: Option<WatchFlagsWithPaths>,
-  unconfigured: Option<deno_runtime::Unconfigured>,
+  unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   roots: LibWorkerFactoryRoots,
 ) -> Result<i32, AnyError> {
   check_permission_before_script(&flags);
@@ -89,10 +89,10 @@ pub async fn run_script(
     .create_cli_main_worker_factory_with_roots(roots)
     .await?;
   let mut worker = worker_factory
-    .create_main_worker_with_unconfigured(
+    .create_main_worker_with_unconfigured_runtime(
       mode,
       main_module.clone(),
-      unconfigured,
+      unconfigured_runtime,
     )
     .await?;
 
@@ -102,7 +102,7 @@ pub async fn run_script(
 
 pub async fn run_from_stdin(
   flags: Arc<Flags>,
-  unconfigured: Option<deno_runtime::Unconfigured>,
+  unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   roots: LibWorkerFactoryRoots,
 ) -> Result<i32, AnyError> {
   let factory = CliFactory::from_flags(flags);
@@ -126,10 +126,10 @@ pub async fn run_from_stdin(
   });
 
   let mut worker = worker_factory
-    .create_main_worker_with_unconfigured(
+    .create_main_worker_with_unconfigured_runtime(
       WorkerExecutionMode::Run,
       main_module.clone(),
-      unconfigured,
+      unconfigured_runtime,
     )
     .await?;
   let exit_code = worker.run().await?;
@@ -251,7 +251,7 @@ pub async fn maybe_npm_install(factory: &CliFactory) -> Result<(), AnyError> {
 pub async fn run_eszip(
   flags: Arc<Flags>,
   run_flags: RunFlags,
-  unconfigured: Option<deno_runtime::Unconfigured>,
+  unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   roots: LibWorkerFactoryRoots,
 ) -> Result<i32, AnyError> {
   // TODO(bartlomieju): actually I think it will also fail if there's an import
@@ -271,10 +271,10 @@ pub async fn run_eszip(
     .create_cli_main_worker_factory_with_roots(roots)
     .await?;
   let mut worker = worker_factory
-    .create_main_worker_with_unconfigured(
+    .create_main_worker_with_unconfigured_runtime(
       mode,
       main_module.clone(),
-      unconfigured,
+      unconfigured_runtime,
     )
     .await?;
 

--- a/cli/tools/serve.rs
+++ b/cli/tools/serve.rs
@@ -45,8 +45,11 @@ pub async fn serve(
 
   maybe_npm_install(&factory).await?;
 
-  let worker_factory =
-    Arc::new(factory.create_cli_main_worker_factory().await?);
+  let worker_factory = Arc::new(
+    factory
+      .create_cli_main_worker_factory(Default::default())
+      .await?,
+  );
 
   if serve_flags.open_site {
     let url = resolve_serve_url(serve_flags.host, serve_flags.port);
@@ -79,6 +82,7 @@ async fn do_serve(
         worker_count,
       },
       main_module.clone(),
+      None,
     )
     .await?;
   let worker_count = match worker_count {
@@ -136,6 +140,7 @@ async fn run_worker(
         worker_count: Some(worker_count),
       },
       main_module,
+      None,
     )
     .await?;
   if hmr {
@@ -173,8 +178,11 @@ async fn serve_with_watch(
         maybe_npm_install(&factory).await?;
 
         let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
-        let worker_factory =
-          Arc::new(factory.create_cli_main_worker_factory().await?);
+        let worker_factory = Arc::new(
+          factory
+            .create_cli_main_worker_factory(Default::default())
+            .await?,
+        );
 
         do_serve(worker_factory, main_module.clone(), worker_count, hmr)
           .await?;

--- a/cli/tools/serve.rs
+++ b/cli/tools/serve.rs
@@ -45,11 +45,8 @@ pub async fn serve(
 
   maybe_npm_install(&factory).await?;
 
-  let worker_factory = Arc::new(
-    factory
-      .create_cli_main_worker_factory(Default::default())
-      .await?,
-  );
+  let worker_factory =
+    Arc::new(factory.create_cli_main_worker_factory().await?);
 
   if serve_flags.open_site {
     let url = resolve_serve_url(serve_flags.host, serve_flags.port);
@@ -82,7 +79,6 @@ async fn do_serve(
         worker_count,
       },
       main_module.clone(),
-      None,
     )
     .await?;
   let worker_count = match worker_count {
@@ -140,7 +136,6 @@ async fn run_worker(
         worker_count: Some(worker_count),
       },
       main_module,
-      None,
     )
     .await?;
   if hmr {
@@ -178,11 +173,8 @@ async fn serve_with_watch(
         maybe_npm_install(&factory).await?;
 
         let _ = watcher_communicator.watch_paths(cli_options.watch_paths());
-        let worker_factory = Arc::new(
-          factory
-            .create_cli_main_worker_factory(Default::default())
-            .await?,
-        );
+        let worker_factory =
+          Arc::new(factory.create_cli_main_worker_factory().await?);
 
         do_serve(worker_factory, main_module.clone(), worker_count, hmr)
           .await?;

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -640,6 +640,7 @@ async fn configure_main_worker(
         stdout: StdioPipe::file(worker_sender.stdout),
         stderr: StdioPipe::file(worker_sender.stderr),
       },
+      None,
     )
     .await?;
   let coverage_collector = worker.maybe_setup_coverage_collector().await?;
@@ -1619,8 +1620,11 @@ pub async fn run_tests(
     return Ok(());
   }
 
-  let worker_factory =
-    Arc::new(factory.create_cli_main_worker_factory().await?);
+  let worker_factory = Arc::new(
+    factory
+      .create_cli_main_worker_factory(Default::default())
+      .await?,
+  );
 
   // Run tests
   test_specifiers(
@@ -1833,8 +1837,11 @@ pub async fn run_tests_with_watch(
           return Ok(());
         }
 
-        let worker_factory =
-          Arc::new(factory.create_cli_main_worker_factory().await?);
+        let worker_factory = Arc::new(
+          factory
+            .create_cli_main_worker_factory(Default::default())
+            .await?,
+        );
 
         test_specifiers(
           worker_factory,

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1620,11 +1620,8 @@ pub async fn run_tests(
     return Ok(());
   }
 
-  let worker_factory = Arc::new(
-    factory
-      .create_cli_main_worker_factory(Default::default())
-      .await?,
-  );
+  let worker_factory =
+    Arc::new(factory.create_cli_main_worker_factory().await?);
 
   // Run tests
   test_specifiers(
@@ -1837,11 +1834,8 @@ pub async fn run_tests_with_watch(
           return Ok(());
         }
 
-        let worker_factory = Arc::new(
-          factory
-            .create_cli_main_worker_factory(Default::default())
-            .await?,
-        );
+        let worker_factory =
+          Arc::new(factory.create_cli_main_worker_factory().await?);
 
         test_specifiers(
           worker_factory,

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -357,6 +357,7 @@ impl CliMainWorkerFactory {
     &self,
     mode: WorkerExecutionMode,
     main_module: ModuleSpecifier,
+    unconfigured: Option<deno_runtime::Unconfigured>,
   ) -> Result<CliMainWorker, CreateCustomWorkerError> {
     self
       .create_custom_worker(
@@ -365,6 +366,7 @@ impl CliMainWorkerFactory {
         self.root_permissions.clone(),
         vec![],
         Default::default(),
+        unconfigured,
       )
       .await
   }
@@ -376,6 +378,7 @@ impl CliMainWorkerFactory {
     permissions: PermissionsContainer,
     custom_extensions: Vec<Extension>,
     stdio: deno_runtime::deno_io::Stdio,
+    unconfigured: Option<deno_runtime::Unconfigured>,
   ) -> Result<CliMainWorker, CreateCustomWorkerError> {
     let main_module = if let Ok(package_ref) =
       NpmPackageReqReference::from_specifier(&main_module)
@@ -432,6 +435,7 @@ impl CliMainWorkerFactory {
       permissions,
       custom_extensions,
       stdio,
+      unconfigured,
     )?;
 
     if self.needs_test_modules {

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -357,6 +357,23 @@ impl CliMainWorkerFactory {
     &self,
     mode: WorkerExecutionMode,
     main_module: ModuleSpecifier,
+  ) -> Result<CliMainWorker, CreateCustomWorkerError> {
+    self
+      .create_custom_worker(
+        mode,
+        main_module,
+        self.root_permissions.clone(),
+        vec![],
+        Default::default(),
+        None,
+      )
+      .await
+  }
+
+  pub async fn create_main_worker_with_unconfigured(
+    &self,
+    mode: WorkerExecutionMode,
+    main_module: ModuleSpecifier,
     unconfigured: Option<deno_runtime::Unconfigured>,
   ) -> Result<CliMainWorker, CreateCustomWorkerError> {
     self

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -370,11 +370,11 @@ impl CliMainWorkerFactory {
       .await
   }
 
-  pub async fn create_main_worker_with_unconfigured(
+  pub async fn create_main_worker_with_unconfigured_runtime(
     &self,
     mode: WorkerExecutionMode,
     main_module: ModuleSpecifier,
-    unconfigured: Option<deno_runtime::Unconfigured>,
+    unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   ) -> Result<CliMainWorker, CreateCustomWorkerError> {
     self
       .create_custom_worker(
@@ -383,7 +383,7 @@ impl CliMainWorkerFactory {
         self.root_permissions.clone(),
         vec![],
         Default::default(),
-        unconfigured,
+        unconfigured_runtime,
       )
       .await
   }
@@ -395,7 +395,7 @@ impl CliMainWorkerFactory {
     permissions: PermissionsContainer,
     custom_extensions: Vec<Extension>,
     stdio: deno_runtime::deno_io::Stdio,
-    unconfigured: Option<deno_runtime::Unconfigured>,
+    unconfigured_runtime: Option<deno_runtime::UnconfiguredRuntime>,
   ) -> Result<CliMainWorker, CreateCustomWorkerError> {
     let main_module = if let Ok(package_ref) =
       NpmPackageReqReference::from_specifier(&main_module)
@@ -452,7 +452,7 @@ impl CliMainWorkerFactory {
       permissions,
       custom_extensions,
       stdio,
-      unconfigured,
+      unconfigured_runtime,
     )?;
 
     if self.needs_test_modules {

--- a/ext/console/README.md
+++ b/ext/console/README.md
@@ -21,8 +21,8 @@ Object.defineProperty(globalThis, "console", {
 });
 ```
 
-Then from rust, provide `deno_console::deno_console::init_ops_and_esm()` in the
-`extensions` field of your `RuntimeOptions`
+Then from rust, provide `deno_console::deno_console::init()` in the `extensions`
+field of your `RuntimeOptions`
 
 ## Provided ops
 

--- a/ext/crypto/README.md
+++ b/ext/crypto/README.md
@@ -41,9 +41,8 @@ Object.defineProperty(globalThis, "SubtleCrypto", {
 });
 ```
 
-Then from rust, provide:
-`deno_crypto::deno_crypto::init_ops_and_esm(Option<u64>)` in the `extensions`
-field of your `RuntimeOptions`
+Then from rust, provide: `deno_crypto::deno_crypto::init(Option<u64>)` in the
+`extensions` field of your `RuntimeOptions`
 
 Where the `Option<u64>` represents an optional seed for initialization.
 

--- a/ext/fetch/README.md
+++ b/ext/fetch/README.md
@@ -57,8 +57,8 @@ Object.defineProperty(globalThis, "FormData", {
 ```
 
 Then from rust, provide
-`deno_fetch::deno_fetch::init_ops_and_esm<Permissions>(Default::default())` in
-the `extensions` field of your `RuntimeOptions`
+`deno_fetch::deno_fetch::init<Permissions>(Default::default())` in the
+`extensions` field of your `RuntimeOptions`
 
 Where:
 

--- a/ext/io/README.md
+++ b/ext/io/README.md
@@ -11,9 +11,8 @@ From javascript, include the extension's source:
 import * as io from "ext:deno_io/12_io.js";
 ```
 
-Then from rust, provide:
-`deno_io::deno_io::init_ops_and_esm(Option<deno_io::Stdio>)` in the `extensions`
-field of your `RuntimeOptions`
+Then from rust, provide: `deno_io::deno_io::init(Option<deno_io::Stdio>)` in the
+`extensions` field of your `RuntimeOptions`
 
 Where `deno_io::Stdio` implements `Default`, and can therefore be provided as
 `Some(deno_io::Stdio::default())`

--- a/ext/net/README.md
+++ b/ext/net/README.md
@@ -13,7 +13,7 @@ import * as tls from "ext:deno_net/02_tls.js";
 ```
 
 Then from rust, provide:
-`deno_net::deno_net::init_ops_and_esm::<Permissions>(root_cert_store_provider, unsafely_ignore_certificate_errors)`
+`deno_net::deno_net::init::<Permissions>(root_cert_store_provider, unsafely_ignore_certificate_errors)`
 
 Where:
 

--- a/ext/url/README.md
+++ b/ext/url/README.md
@@ -36,8 +36,8 @@ Object.defineProperty(globalThis, "URLSearchParams", {
 });
 ```
 
-Then from rust, provide `deno_url::deno_url::init_ops_and_esm()` in the
-`extensions` field of your `RuntimeOptions`
+Then from rust, provide `deno_url::deno_url::init()` in the `extensions` field
+of your `RuntimeOptions`
 
 ## Dependencies
 

--- a/ext/web/README.md
+++ b/ext/web/README.md
@@ -98,8 +98,8 @@ Object.defineProperty(globalThis, "AbortController", {
 | structuredClone                  | messagePort.structuredClone              | true       | true         | true      |
 
 Then from rust, provide:
-`deno_web::deno_web::init_ops_and_esm::<Permissions>(Arc<BlobStore>, Option<Url>)`
-in the `extensions` field of your `RuntimeOptions`
+`deno_web::deno_web::init::<Permissions>(Arc<BlobStore>, Option<Url>)` in the
+`extensions` field of your `RuntimeOptions`
 
 Where:
 

--- a/ext/webidl/README.md
+++ b/ext/webidl/README.md
@@ -20,5 +20,5 @@ Object.defineProperty(globalThis, webidl.brand, {
 });
 ```
 
-Then from rust, provide `init_webidl::init_webidl::init_ops_and_esm()` in the
-`extensions` field of your `RuntimeOptions`
+Then from rust, provide `init_webidl::init_webidl::init()` in the `extensions`
+field of your `RuntimeOptions`

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -8,6 +8,7 @@ import { core, internals, primordials } from "ext:core/mod.js";
 const ops = core.ops;
 import {
   op_bootstrap_args,
+  op_bootstrap_is_unconfigured,
   op_bootstrap_no_color,
   op_bootstrap_pid,
   op_bootstrap_stderr_no_color,
@@ -115,6 +116,8 @@ ObjectDefineProperties(Symbol, {
     configurable: false,
   },
 });
+
+internals.isUnconfigured = op_bootstrap_is_unconfigured;
 
 // https://docs.rs/log/latest/log/enum.Level.html
 const LOG_LEVELS = {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -8,7 +8,7 @@ import { core, internals, primordials } from "ext:core/mod.js";
 const ops = core.ops;
 import {
   op_bootstrap_args,
-  op_bootstrap_is_unconfigured,
+  op_bootstrap_is_from_unconfigured_runtime,
   op_bootstrap_no_color,
   op_bootstrap_pid,
   op_bootstrap_stderr_no_color,
@@ -117,7 +117,7 @@ ObjectDefineProperties(Symbol, {
   },
 });
 
-internals.isUnconfigured = op_bootstrap_is_unconfigured;
+internals.isFromUnconfiguredRuntime = op_bootstrap_is_from_unconfigured_runtime;
 
 // https://docs.rs/log/latest/log/enum.Level.html
 const LOG_LEVELS = {

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -46,6 +46,7 @@ pub mod web_worker;
 pub mod worker;
 
 mod worker_bootstrap;
+pub use worker::Unconfigured;
 pub use worker_bootstrap::BootstrapOptions;
 pub use worker_bootstrap::WorkerExecutionMode;
 pub use worker_bootstrap::WorkerLogLevel;

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -46,7 +46,7 @@ pub mod web_worker;
 pub mod worker;
 
 mod worker_bootstrap;
-pub use worker::Unconfigured;
+pub use worker::UnconfiguredRuntime;
 pub use worker_bootstrap::BootstrapOptions;
 pub use worker_bootstrap::WorkerExecutionMode;
 pub use worker_bootstrap::WorkerLogLevel;

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -21,15 +21,18 @@ deno_core::extension!(
     op_bootstrap_stdout_no_color,
     op_bootstrap_stderr_no_color,
     op_bootstrap_unstable_args,
+    op_bootstrap_is_unconfigured,
     op_snapshot_options,
   ],
   options = {
     snapshot_options: Option<SnapshotOptions>,
+    is_unconfigured: bool,
   },
   state = |state, options| {
     if let Some(snapshot_options) = options.snapshot_options {
       state.put::<SnapshotOptions>(snapshot_options);
     }
+    state.put(IsUnconfigured(options.is_unconfigured));
   },
 );
 
@@ -40,6 +43,8 @@ pub struct SnapshotOptions {
   pub v8_version: &'static str,
   pub target: String,
 }
+
+struct IsUnconfigured(bool);
 
 impl Default for SnapshotOptions {
   fn default() -> Self {
@@ -150,4 +155,9 @@ pub fn op_bootstrap_stderr_no_color(_state: &mut OpState) -> bool {
   }
 
   !deno_terminal::is_stderr_tty() || !deno_terminal::colors::use_color()
+}
+
+#[op2(fast)]
+pub fn op_bootstrap_is_unconfigured(state: &mut OpState) -> bool {
+  state.borrow::<IsUnconfigured>().0
 }

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -21,18 +21,18 @@ deno_core::extension!(
     op_bootstrap_stdout_no_color,
     op_bootstrap_stderr_no_color,
     op_bootstrap_unstable_args,
-    op_bootstrap_is_unconfigured,
+    op_bootstrap_is_from_unconfigured_runtime,
     op_snapshot_options,
   ],
   options = {
     snapshot_options: Option<SnapshotOptions>,
-    is_unconfigured: bool,
+    is_from_unconfigured_runtime: bool,
   },
   state = |state, options| {
     if let Some(snapshot_options) = options.snapshot_options {
       state.put::<SnapshotOptions>(snapshot_options);
     }
-    state.put(IsUnconfigured(options.is_unconfigured));
+    state.put(IsFromUnconfiguredRuntime(options.is_from_unconfigured_runtime));
   },
 );
 
@@ -44,7 +44,7 @@ pub struct SnapshotOptions {
   pub target: String,
 }
 
-struct IsUnconfigured(bool);
+struct IsFromUnconfiguredRuntime(bool);
 
 impl Default for SnapshotOptions {
   fn default() -> Self {
@@ -158,6 +158,6 @@ pub fn op_bootstrap_stderr_no_color(_state: &mut OpState) -> bool {
 }
 
 #[op2(fast)]
-pub fn op_bootstrap_is_unconfigured(state: &mut OpState) -> bool {
-  state.borrow::<IsUnconfigured>().0
+pub fn op_bootstrap_is_from_unconfigured_runtime(state: &mut OpState) -> bool {
+  state.borrow::<IsFromUnconfiguredRuntime>().0
 }

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -3,7 +3,6 @@
 use std::io::Write;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use deno_core::snapshot::*;
 use deno_core::v8;
@@ -25,62 +24,49 @@ pub fn create_runtime_snapshot(
   // NOTE(bartlomieju): ordering is important here, keep it in sync with
   // `runtime/worker.rs`, `runtime/web_worker.rs`, `runtime/snapshot_info.rs`
   // and `runtime/snapshot.rs`!
-  let fs = std::sync::Arc::new(deno_fs::RealFs);
   let mut extensions: Vec<Extension> = vec![
-    deno_telemetry::deno_telemetry::init(),
-    deno_webidl::deno_webidl::init(),
-    deno_console::deno_console::init(),
-    deno_url::deno_url::init(),
-    deno_web::deno_web::init::<Permissions>(
-      Default::default(),
-      Default::default(),
-    ),
-    deno_webgpu::deno_webgpu::init(),
-    deno_canvas::deno_canvas::init(),
-    deno_fetch::deno_fetch::init::<Permissions>(Default::default()),
-    deno_cache::deno_cache::init(None),
-    deno_websocket::deno_websocket::init::<Permissions>(
-      "".to_owned(),
-      None,
-      None,
-    ),
-    deno_webstorage::deno_webstorage::init(None),
-    deno_crypto::deno_crypto::init(None),
-    deno_broadcast_channel::deno_broadcast_channel::init(
-      deno_broadcast_channel::InMemoryBroadcastChannel::default(),
-    ),
-    deno_ffi::deno_ffi::init::<Permissions>(None),
-    deno_net::deno_net::init::<Permissions>(None, None),
-    deno_tls::deno_tls::init(),
-    deno_kv::deno_kv::init(
-      deno_kv::sqlite::SqliteDbHandler::<Permissions>::new(None, None),
-      deno_kv::KvConfig::builder().build(),
+    deno_telemetry::deno_telemetry::lazy_init(),
+    deno_webidl::deno_webidl::lazy_init(),
+    deno_console::deno_console::lazy_init(),
+    deno_url::deno_url::lazy_init(),
+    deno_web::deno_web::lazy_init::<Permissions>(),
+    deno_webgpu::deno_webgpu::lazy_init(),
+    deno_canvas::deno_canvas::lazy_init(),
+    deno_fetch::deno_fetch::lazy_init::<Permissions>(),
+    deno_cache::deno_cache::lazy_init(),
+    deno_websocket::deno_websocket::lazy_init::<Permissions>(),
+    deno_webstorage::deno_webstorage::lazy_init(),
+    deno_crypto::deno_crypto::lazy_init(),
+    deno_broadcast_channel::deno_broadcast_channel::lazy_init::<
+      deno_broadcast_channel::InMemoryBroadcastChannel,
+    >(),
+    deno_ffi::deno_ffi::lazy_init::<Permissions>(),
+    deno_net::deno_net::lazy_init::<Permissions>(),
+    deno_tls::deno_tls::lazy_init(),
+    deno_kv::deno_kv::lazy_init::<deno_kv::sqlite::SqliteDbHandler<Permissions>>(
     ),
     deno_cron::deno_cron::init(deno_cron::local::LocalCronHandler::new()),
-    deno_napi::deno_napi::init::<Permissions>(None),
-    deno_http::deno_http::init(deno_http::Options::default()),
-    deno_io::deno_io::init(Default::default()),
-    deno_fs::deno_fs::init::<Permissions>(fs.clone()),
-    deno_os::deno_os::init(Default::default()),
-    deno_process::deno_process::init(Default::default()),
-    deno_node::deno_node::init::<
+    deno_napi::deno_napi::lazy_init::<Permissions>(),
+    deno_http::deno_http::lazy_init(),
+    deno_io::deno_io::lazy_init(),
+    deno_fs::deno_fs::lazy_init::<Permissions>(),
+    deno_os::deno_os::lazy_init(),
+    deno_process::deno_process::lazy_init(),
+    deno_node::deno_node::lazy_init::<
       Permissions,
       DenoInNpmPackageChecker,
       NpmResolver<sys_traits::impls::RealSys>,
       sys_traits::impls::RealSys,
-    >(None, fs.clone()),
-    ops::runtime::deno_runtime::init("deno:runtime".parse().unwrap()),
-    ops::worker_host::deno_worker_host::init(
-      Arc::new(|_| unreachable!("not used in snapshot.")),
-      None,
-    ),
-    ops::fs_events::deno_fs_events::init(),
-    ops::permissions::deno_permissions::init(),
-    ops::tty::deno_tty::init(),
-    ops::http::deno_http_runtime::init(),
-    ops::bootstrap::deno_bootstrap::init(Some(snapshot_options)),
-    runtime::init(),
-    ops::web_worker::deno_web_worker::init(),
+    >(),
+    ops::runtime::deno_runtime::lazy_init(),
+    ops::worker_host::deno_worker_host::lazy_init(),
+    ops::fs_events::deno_fs_events::lazy_init(),
+    ops::permissions::deno_permissions::lazy_init(),
+    ops::tty::deno_tty::lazy_init(),
+    ops::http::deno_http_runtime::lazy_init(),
+    ops::bootstrap::deno_bootstrap::init(Some(snapshot_options), false),
+    runtime::lazy_init(),
+    ops::web_worker::deno_web_worker::lazy_init(),
   ];
   extensions.extend(custom_extensions);
 

--- a/runtime/snapshot_info.rs
+++ b/runtime/snapshot_info.rs
@@ -321,7 +321,7 @@ pub fn get_extensions_in_snapshot() -> Vec<Extension> {
     ops::permissions::deno_permissions::init(),
     ops::tty::deno_tty::init(),
     ops::http::deno_http_runtime::init(),
-    ops::bootstrap::deno_bootstrap::init(None),
+    ops::bootstrap::deno_bootstrap::init(None, false),
     runtime::init(),
     ops::web_worker::deno_web_worker::init(),
   ]

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -568,11 +568,8 @@ impl WebWorker {
       ops::tty::deno_tty::init(),
       ops::http::deno_http_runtime::init(),
       ops::bootstrap::deno_bootstrap::init(
-        if options.startup_snapshot.is_some() {
-          None
-        } else {
-          Some(Default::default())
-        },
+        options.startup_snapshot.and_then(|_| Default::default()),
+        false,
       ),
       runtime::init(),
       ops::web_worker::deno_web_worker::init(),

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -392,8 +392,7 @@ impl MainWorker {
     // check options that require configuring a new jsruntime
     if options.unconfigured.is_some()
       && (options.enable_stack_trace_arg_in_ops
-        || op_metrics_factory_fn.is_some()
-        || !services.feature_checker.is_empty())
+        || op_metrics_factory_fn.is_some())
     {
       options.unconfigured = None;
     }
@@ -426,7 +425,6 @@ impl MainWorker {
         services.shared_array_buffer_store,
         services.compiled_wasm_module_store,
         extensions,
-        Some(services.feature_checker.clone()),
         op_metrics_factory_fn,
         options.enable_stack_trace_arg_in_ops,
       )
@@ -1008,7 +1006,6 @@ fn common_runtime(
   shared_array_buffer_store: Option<SharedArrayBufferStore>,
   compiled_wasm_module_store: Option<CompiledWasmModuleStore>,
   extensions: Vec<Extension>,
-  feature_checker: Option<Arc<FeatureChecker>>,
   op_metrics_factory_fn: Option<OpMetricsFactoryFn>,
   enable_stack_trace_arg_in_ops: bool,
 ) -> JsRuntime {
@@ -1028,7 +1025,6 @@ fn common_runtime(
     extension_transpiler: None,
     inspector: true,
     is_main: true,
-    feature_checker,
     op_metrics_factory_fn,
     wait_for_inspector_disconnect_callback: Some(
       make_wait_for_inspector_disconnect_callback(),
@@ -1083,7 +1079,6 @@ impl Unconfigured {
       shared_array_buffer_store,
       compiled_wasm_module_store,
       extensions,
-      None,
       None,
       false,
     );

--- a/tests/specs/run/unconfigured/__test__.jsonc
+++ b/tests/specs/run/unconfigured/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "unconfigured": {
+      "args": "run -A main.ts",
+      "output": "main.out",
+      "if": "unix"
+    }
+  }
+}

--- a/tests/specs/run/unconfigured/main.out
+++ b/tests/specs/run/unconfigured/main.out
@@ -1,0 +1,3 @@
+true
+hello world
+[Object: null prototype] { success: true, code: 0, signal: null }

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -41,6 +41,6 @@ const data = JSON.stringify({
   env: [["A", "hello world"]].map(([k, v]) => [[...encode(k)], [...encode(v)]]),
 });
 
-await sock.write(encode(data));
+await sock.write(encode(data + "\n"));
 
 console.log(await child.status);

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -33,14 +33,12 @@ console.log(Deno.env.get('A'));
 `,
 );
 
-const encode = (s: string) => new TextEncoder().encode(s);
-
 const data = JSON.stringify({
-  cwd: [...encode(tempDirPath)],
-  args: ["run", "-A", "test.ts"].map((v) => [...encode(v)]),
-  env: [["A", "hello world"]].map(([k, v]) => [[...encode(k)], [...encode(v)]]),
+  cwd: tempDirPath,
+  args: ["run", "-A", "test.ts"],
+  env: [["A", "hello world"]],
 });
 
-await sock.write(encode(data + "\n"));
+await sock.write(new TextEncoder().encode(data + "\n"));
 
 console.log(await child.status);

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -5,7 +5,7 @@ const testPath = `${tempDirPath}/test.ts`;
 
 const command = new Deno.Command(Deno.execPath(), {
   env: {
-    DENO_CONTROL_SOCK: sockPath,
+    DENO_UNSTABLE_CONTROL_SOCK: `unix:${sockPath}`,
   },
 });
 

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -1,0 +1,46 @@
+const tempDirPath = await Deno.makeTempDir();
+
+const sockPath = `${tempDirPath}/control.sock`;
+const testPath = `${tempDirPath}/test.ts`;
+
+const command = new Deno.Command(Deno.execPath(), {
+  env: {
+    DENO_CONTROL_SOCK: sockPath,
+  },
+});
+
+const child = command.spawn();
+
+while (true) {
+  try {
+    await Deno.lstat(sockPath);
+    break;
+  } catch {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+const sock = await Deno.connect({
+  transport: "unix",
+  path: sockPath,
+});
+
+Deno.writeTextFile(
+  testPath,
+  `
+console.log(Deno[Deno.internal].isUnconfigured());
+console.log(Deno.env.get('A'));
+`,
+);
+
+const encode = (s: string) => new TextEncoder().encode(s);
+
+const data = JSON.stringify({
+  cwd: [...encode(tempDirPath)],
+  args: ["run", "-A", "test.ts"].map((v) => [...encode(v)]),
+  env: [["A", "hello world"]].map(([k, v]) => [[...encode(k)], [...encode(v)]]),
+});
+
+await sock.write(encode(data));
+
+console.log(await child.status);

--- a/tests/specs/run/unconfigured/main.ts
+++ b/tests/specs/run/unconfigured/main.ts
@@ -11,13 +11,19 @@ const command = new Deno.Command(Deno.execPath(), {
 
 const child = command.spawn();
 
+let i = 0;
 while (true) {
   try {
     await Deno.lstat(sockPath);
     break;
-  } catch {
-    await new Promise((r) => setTimeout(r, 10));
+  } catch {}
+
+  i += 1;
+  if (i > 100) {
+    throw new Error(`${sockPath} did not exist`);
   }
+
+  await new Promise((r) => setTimeout(r, 10));
 }
 
 const sock = await Deno.connect({
@@ -28,7 +34,7 @@ const sock = await Deno.connect({
 Deno.writeTextFile(
   testPath,
   `
-console.log(Deno[Deno.internal].isUnconfigured());
+console.log(Deno[Deno.internal].isFromUnconfiguredRuntime());
 console.log(Deno.env.get('A'));
 `,
 );


### PR DESCRIPTION
implement lazy(?) mode. an unconfigured jsruntime is created if DENO_CONTROL_SOCK is present, and later passed into deno_runtime to be configured and used.