### PR TITLE
perf(npm): don't try to cache npm packages we've already cached

### DIFF
--- a/cli/npm/installer/mod.rs
+++ b/cli/npm/installer/mod.rs
@@ -181,13 +181,7 @@ impl NpmInstaller {
         let uncached = {
           packages
             .iter()
-            .filter_map(|req| {
-              if !cached_reqs.contains(req) {
-                Some(req)
-              } else {
-                None
-              }
-            })
+            .filter(|req| !cached_reqs.contains(req))
             .collect::<Vec<_>>()
         };
 

--- a/cli/npm/installer/mod.rs
+++ b/cli/npm/installer/mod.rs
@@ -182,8 +182,8 @@ impl NpmInstaller {
           packages
             .iter()
             .filter_map(|req| {
-              if cached_reqs.insert(req.clone()) {
-                Some(req.clone())
+              if !cached_reqs.contains(req) {
+                Some(req)
               } else {
                 None
               }
@@ -193,12 +193,9 @@ impl NpmInstaller {
 
         if !uncached.is_empty() {
           result.dependencies_result = self.cache_packages(caching).await;
-          if result.dependencies_result.is_err() {
-            // if we failed to cache, we need to remove the cached reqs.
-            // we don't really know which ones failed, so just be safe and remove all of them
-            let mut cached_reqs = self.cached_reqs.lock().await;
+          if result.dependencies_result.is_ok() {
             for req in uncached {
-              cached_reqs.remove(&req);
+              cached_reqs.insert(req.clone());
             }
           }
         }


### PR DESCRIPTION
With `nodeModulesDir: auto` (and `none`, to a lesser extent), we frequently repeatedly try to cache npm packages during resolution. On a (private) fresh project, I counted that `sync_resolution_with_fs` was called 478 times over the course of a fresh build. This reduces the number of calls to 8, and doing so speeds things up substantially.

```
❯ hyperfine --warmup 2 -N "deno task build" "../deno/target/release-lite/deno task build"
Benchmark 1: deno task build
  Time (mean ± σ):      3.652 s ±  0.042 s    [User: 3.285 s, System: 2.399 s]
  Range (min … max):    3.587 s …  3.712 s    10 runs

Benchmark 2: ../deno/target/release-lite/deno task build
  Time (mean ± σ):      1.356 s ±  0.007 s    [User: 1.961 s, System: 1.108 s]
  Range (min … max):    1.345 s …  1.372 s    10 runs

Summary
  ../deno/target/release-lite/deno task build ran
    2.69 ± 0.03 times faster than deno task build
```