### PR TITLE
docs(test): document DENO_COVERAGE_DIR in help message

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3236,7 +3236,8 @@ or <c>**/__tests__/**</>:
           .conflicts_with("inspect")
           .conflicts_with("inspect-wait")
           .conflicts_with("inspect-brk")
-          .help("Collect coverage profile data into DIR. If DIR is not specified, it uses 'coverage/'")
+          .help("Collect coverage profile data into DIR. If DIR is not specified, it uses 'coverage/'.
+  <p(245)>This option can also be set via the DENO_COVERAGE_DIR environment variable.")
           .help_heading(TEST_HEADING),
       )
       .arg(

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3236,8 +3236,8 @@ or <c>**/__tests__/**</>:
           .conflicts_with("inspect")
           .conflicts_with("inspect-wait")
           .conflicts_with("inspect-brk")
-          .help("Collect coverage profile data into DIR. If DIR is not specified, it uses 'coverage/'.
-  <p(245)>This option can also be set via the DENO_COVERAGE_DIR environment variable.")
+          .help(cstr!("Collect coverage profile data into DIR. If DIR is not specified, it uses 'coverage/'.
+  <p(245)>This option can also be set via the DENO_COVERAGE_DIR environment variable."))
           .help_heading(TEST_HEADING),
       )
       .arg(


### PR DESCRIPTION
This PR documents DENO_COVERAGE_DIR in `deno test --help` message.

related https://github.com/denoland/deno/pull/28291