### PR TITLE
fix(repl): panic when user `delete globalThis.globalThis`

### DIFF
--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -63,9 +63,13 @@ impl Repl {
 
           // We check for close and break here instead of making it a loop condition to get
           // consistent behavior in when the user evaluates a call to close().
-          if self.session.closing().await? {
-            break;
-          }
+          match self.session.closing().await {
+            Ok(closing) if closing => break,
+            Ok(_) => {}
+            Err(err) => {
+              println!("Error: {:?}", err)
+            }
+          };
 
           println!("{}", output);
         }

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -313,12 +313,10 @@ impl ReplSession {
 
   pub async fn closing(&mut self) -> Result<bool, AnyError> {
     let expression = format!(r#"{}.closed"#, *REPL_INTERNALS_NAME);
-    let closed = self
-      .evaluate_expression(&expression)
-      .await?
-      .result
+    let result = self.evaluate_expression(&expression).await?.result;
+    let closed = result
       .value
-      .unwrap()
+      .ok_or_else(|| anyhow!(result.description.unwrap()))?
       .as_bool()
       .unwrap();
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
Closes #28959 

### Before the pr
![image](https://github.com/user-attachments/assets/6e52a87d-9454-4531-a28a-540293dc99e2)

### With the pr
![image](https://github.com/user-attachments/assets/a958ac92-3507-4f5e-ab32-b03bc156f03e)
At least it didn't panic