### PR TITLE
fix(install): error gracefully if user passes `--no-config` to `deno install <package>`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5072,7 +5072,7 @@ fn install_parse(
     if matches!(flags.config_flag, ConfigFlag::Disabled) {
       return Err(app.override_usage("deno install [OPTIONS] [PACKAGE]...").error(
         clap::error::ErrorKind::ArgumentConflict,
-        format!("deno install with a list of packages can't be used with --no-config.\n{} To cache the packages without adding to a config, use `deno install --entrypoint`", deno_terminal::colors::cyan("hint:")),
+        format!("deno install can't be used to add packages if `--no-config` is passed.\n{} to cache the packages without adding to a config, pass the `--entrypoint` flag", deno_terminal::colors::cyan("hint:")),
       ));
     }
 

--- a/tests/specs/install/no_config_flag/__test__.jsonc
+++ b/tests/specs/install/no_config_flag/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install --no-config npm:chalk",
+      "output": "err.out",
+      "exitCode": 1
+    }
+  ]
+}

--- a/tests/specs/install/no_config_flag/err.out
+++ b/tests/specs/install/no_config_flag/err.out
@@ -1,5 +1,5 @@
-error: deno install with a list of packages can't be used with --no-config.
-hint: To cache the packages without adding to a config, use `deno install --entrypoint`
+error: deno install can't be used to add packages if `--no-config` is passed.
+hint: to cache the packages without adding to a config, pass the `--entrypoint` flag
 
 Usage: deno install [OPTIONS] [PACKAGE]...
 

--- a/tests/specs/install/no_config_flag/err.out
+++ b/tests/specs/install/no_config_flag/err.out
@@ -1,0 +1,5 @@
+error: deno install with a list of packages can't be used with --no-config.
+hint: To cache the packages without adding to a config, use `deno install --entrypoint`
+
+Usage: deno install [OPTIONS] [PACKAGE]...
+


### PR DESCRIPTION
Fixes #28090. Fixes #28961.