### PR TITLE
fix(coverage): improve responsiveness of HTML reporter on small screens

### DIFF
--- a/cli/tools/coverage/reporter.rs
+++ b/cli/tools/coverage/reporter.rs
@@ -510,7 +510,7 @@ impl HtmlCoverageReporter {
         <body>
           <div class='wrapper'>
             {header}
-            <div class='pad1'>
+            <div class='pad1 overflow-auto'>
               {main_content}
             </div>
             <div class='push'></div>

--- a/cli/tools/coverage/style.css
+++ b/cli/tools/coverage/style.css
@@ -369,3 +369,6 @@ pre.prettyprint {
 .push {
   height: 48px;
 }
+.overflow-auto {
+  overflow: auto;
+}


### PR DESCRIPTION
Excuse the oversized screenshots. They were taken when scrolled to the right on a small screen. @kt3k

### Before (all files view)
![_Users_asher_GitHub_redis_coverage_html_index html(iPhone SE) (1)](https://github.com/user-attachments/assets/10dc45f7-bf88-4386-b734-59d3060022ec)
### After (all files view)
![_Users_asher_GitHub_redis_coverage_html_index html(iPhone SE) (2)](https://github.com/user-attachments/assets/67790353-a9d0-4e98-88a5-55aaea9a0d79)
### Before (file view)
![_Users_asher_GitHub_redis_coverage_html_mod ts html(iPhone SE)](https://github.com/user-attachments/assets/30ad69d2-9a52-46f2-a48d-cadacc8cbe52)
### After (file view)
![_Users_asher_GitHub_redis_coverage_html_mod ts html(iPhone SE) (1)](https://github.com/user-attachments/assets/03378d50-194e-4885-b057-519d31b6e1b7)




