### PR TITLE
fix(ext/node): fix handling of abort signal in readFile

### DIFF
--- a/ext/node/polyfills/_fs/_fs_common.ts
+++ b/ext/node/polyfills/_fs/_fs_common.ts
@@ -86,6 +86,18 @@ export function getEncoding(
   return encoding;
 }
 
+export function getSignal(optOrCallback?: FileOptions): AbortSignal | null {
+  if (!optOrCallback || typeof optOrCallback === "function") {
+    return null;
+  }
+
+  const signal = typeof optOrCallback === "object" && optOrCallback.signal
+    ? optOrCallback.signal
+    : null;
+
+  return signal;
+}
+
 export function checkEncoding(encoding: Encodings | null): Encodings | null {
   if (!encoding) return null;
 

--- a/ext/node/polyfills/_fs/_fs_readFile.ts
+++ b/ext/node/polyfills/_fs/_fs_readFile.ts
@@ -7,6 +7,7 @@ import {
   BinaryOptionsArgument,
   FileOptionsArgument,
   getEncoding,
+  getSignal,
   TextOptionsArgument,
 } from "ext:deno_node/_fs/_fs_common.ts";
 import { Buffer } from "node:buffer";
@@ -71,6 +72,7 @@ export function readFile(
   }
 
   const encoding = getEncoding(optOrCallback);
+  const signal = getSignal(optOrCallback);
 
   let p: Promise<Uint8Array>;
   if (path instanceof FileHandle) {
@@ -80,7 +82,7 @@ export function readFile(
     const fsFile = new FsFile(path, Symbol.for("Deno.internal.FsFile"));
     p = readAll(fsFile);
   } else {
-    p = Deno.readFile(path);
+    p = Deno.readFile(path, { signal: signal });
   }
 
   if (cb) {

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -21,6 +21,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import { readFile } from "node:fs/promises";
 import {
   constants as fsPromiseConstants,
   copyFile,
@@ -289,4 +290,21 @@ Deno.test("[node/fs] statSync throws ENOENT for invalid path containing colon in
     statSync("jsr:@std/assert");
   });
   assertEquals(err.code, "ENOENT");
+});
+
+Deno.test("[node/fs] readFile aborted with signal", async () => {
+  const src = mkdtempSync(join(tmpdir(), "foo-")) + "/test.txt";
+  await writeFile(src, "Hello");
+  const controller = new AbortController();
+  const signal = controller.signal;
+  await assertRejects(
+    async () => {
+      await Promise.all([
+        readFile(src, { signal }),
+        controller.abort(),
+      ]);
+    },
+    DOMException,
+    "The signal has been aborted",
+  );
 });

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -295,15 +295,9 @@ Deno.test("[node/fs] statSync throws ENOENT for invalid path containing colon in
 Deno.test("[node/fs] readFile aborted with signal", async () => {
   const src = mkdtempSync(join(tmpdir(), "foo-")) + "/test.txt";
   await writeFile(src, "Hello");
-  const controller = new AbortController();
-  const signal = controller.signal;
+  const signal = AbortSignal.abort();
   await assertRejects(
-    async () => {
-      await Promise.all([
-        readFile(src, { signal }),
-        controller.abort(),
-      ]);
-    },
+    () => readFile(src, { signal }),
     DOMException,
     "The signal has been aborted",
   );


### PR DESCRIPTION
This fix allow abort signal to be correctly supported by node readFile.

Related to #28887 
