### PR TITLE
fix: correctly style rust logs with colors

### DIFF
--- a/cli/lib/util/logger.rs
+++ b/cli/lib/util/logger.rs
@@ -97,6 +97,11 @@ pub fn init<
   .filter_module("editpe", log::LevelFilter::Error)
   // too verbose
   .filter_module("cranelift_codegen", log::LevelFilter::Off)
+  .write_style(if deno_terminal::colors::use_color() {
+    env_logger::WriteStyle::Always
+  } else {
+    env_logger::WriteStyle::Never
+  })
   .format(|buf, record| {
     let mut target = record.target().to_string();
     if let Some(line_no) = record.line() {


### PR DESCRIPTION
We upgraded `env_logger`, which uses a new color detection backend that is backwards incompatible with the old backend and does not detect GitHub Actions as a terminal that supports color. We now force env_logger to respect the color decision that `deno_terminal` has already made.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
