### PR TITLE
chore: build dev profile with unpacked debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,7 +389,7 @@ split-debuginfo = "packed"
 debug = "line-tables-only"
 
 [profile.dev]
-split-debuginfo = "packed"
+split-debuginfo = "unpacked"
 
 # Build release with debug symbols: cargo build --profile=release-with-debug
 [profile.release-with-debug]


### PR DESCRIPTION
When you build with "packed", on macOS rustc does an extra invocation of `dsymutil` which slows down dev builds by a fair bit. This restores cargo's default setting, which speeds up dev builds. Since we aren't doing anything with the debug info in dev builds we don't need the .dSYM.