### PR TITLE
chore: update "version_bump" action to allow for RC bumps

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -11,6 +11,7 @@ on:
           - patch
           - minor
           - major
+          - rc
         required: true
 
 jobs:

--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -14,7 +14,7 @@ if (Deno.args.some((a) => a === "--rc")) {
   const cliVersion = semver.parse(cliCrate.version)!;
 
   if (cliVersion.prerelease[0] != "rc") {
-    cliVersion.increment("major");
+    cliVersion.increment("minor");
   }
   cliVersion.increment("pre", "rc");
 

--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -10,6 +10,28 @@ const denoRtCrate = workspace.getDenoRtCrate();
 const denoLibCrate = workspace.getDenoLibCrate();
 const originalCliVersion = cliCrate.version;
 
+if (Deno.args.some((a) => a === "--rc")) {
+  const cliVersion = semver.parse(cliCrate.version)!;
+  console.log("current version", cliVersion);
+
+  if (cliVersion.prerelease[0] != "rc") {
+    cliVersion.increment("major");
+  }
+  cliVersion.increment("pre", "rc");
+  console.log("new version", cliVersion);
+
+  const version = cliVersion.toString();
+  console.log("new version2", version);
+
+  cliCrate.setVersion(version);
+  denoRtCrate.setVersion(version);
+  denoLibCrate.setVersion(version);
+  // Force lockfile update
+  // await workspace.getCliCrate().cargoCheck();
+
+  Deno.exit(0);
+}
+
 await bumpCiCacheVersion();
 
 // increment the cli version
@@ -24,7 +46,7 @@ if (Deno.args.some((a) => a === "--patch")) {
 }
 
 denoRtCrate.setVersion(cliCrate.version);
-denoLibCrate.folderPath.join("version.txt").writeTextSync(cliCrate.version);
+denoLibCrate.setVersion(cliCrate.version);
 
 // increment the dependency crate versions
 for (const crate of workspace.getCliDependencyCrates()) {

--- a/tools/release/01_bump_crate_versions.ts
+++ b/tools/release/01_bump_crate_versions.ts
@@ -12,22 +12,19 @@ const originalCliVersion = cliCrate.version;
 
 if (Deno.args.some((a) => a === "--rc")) {
   const cliVersion = semver.parse(cliCrate.version)!;
-  console.log("current version", cliVersion);
 
   if (cliVersion.prerelease[0] != "rc") {
     cliVersion.increment("major");
   }
   cliVersion.increment("pre", "rc");
-  console.log("new version", cliVersion);
 
   const version = cliVersion.toString();
-  console.log("new version2", version);
 
-  cliCrate.setVersion(version);
-  denoRtCrate.setVersion(version);
-  denoLibCrate.setVersion(version);
+  await cliCrate.setVersion(version);
+  await denoRtCrate.setVersion(version);
+  await denoLibCrate.setVersion(version);
   // Force lockfile update
-  // await workspace.getCliCrate().cargoCheck();
+  await workspace.getCliCrate().cargoUpdate("--workspace");
 
   Deno.exit(0);
 }
@@ -45,8 +42,8 @@ if (Deno.args.some((a) => a === "--patch")) {
   await cliCrate.promptAndIncrement();
 }
 
-denoRtCrate.setVersion(cliCrate.version);
-denoLibCrate.setVersion(cliCrate.version);
+await denoRtCrate.setVersion(cliCrate.version);
+await denoLibCrate.setVersion(cliCrate.version);
 
 // increment the dependency crate versions
 for (const crate of workspace.getCliDependencyCrates()) {


### PR DESCRIPTION
Also fixes the script for other version updates that was missed in https://github.com/denoland/deno/pull/29018.