### PR TITLE
feat(cli): support `--single-threaded` v8 flag

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -531,10 +531,21 @@ fn resolve_flags_and_init(
     }
   };
 
-  init_v8_flags(&default_v8_flags, &flags.v8_flags, get_v8_flags_from_env());
+  let env_v8_flags = get_v8_flags_from_env();
+  let is_single_threaded = env_v8_flags
+    .iter()
+    .chain(&flags.v8_flags)
+    .any(|flag| flag == "--single-threaded");
+  init_v8_flags(&default_v8_flags, &flags.v8_flags, env_v8_flags);
+  let v8_platform = if is_single_threaded {
+    Some(::deno_core::v8::Platform::new_single_threaded(true).make_shared())
+  } else {
+    None
+  };
   // TODO(bartlomieju): remove last argument once Deploy no longer needs it
   deno_core::JsRuntime::init_platform(
-    None, /* import assertions enabled */ false,
+    v8_platform,
+    /* import assertions enabled */ false,
   );
 
   Ok(flags)

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -988,8 +988,16 @@ pub async fn run(
 
   // Initialize v8 once from the main thread.
   v8_set_flags(construct_v8_flags(&[], &metadata.v8_flags, vec![]));
+  let is_single_threaded = metadata
+    .v8_flags
+    .contains(&String::from("--single-threaded"));
+  let v8_platform = if is_single_threaded {
+    Some(::deno_core::v8::Platform::new_single_threaded(true).make_shared())
+  } else {
+    None
+  };
   // TODO(bartlomieju): remove last argument once Deploy no longer needs it
-  deno_core::JsRuntime::init_platform(None, true);
+  deno_core::JsRuntime::init_platform(v8_platform, true);
 
   let main_module = match NpmPackageReqReference::from_specifier(&main_module) {
     Ok(package_ref) => {


### PR DESCRIPTION
Issue #20602
Builds on top of #29064

For now it is just looking at the DENO_SINGLE_THREADED env var. When set it adds `--single-threaded` to the default v8 flags and runs `init_platform` with `v8::Platform::new_single_threaded(true)`.

Enabling could rely on just the v8 flags `--single-threaded` but I guess it should probably be a cli flag as there are other deno features that rely on threads and these should likely be either disabled or run from the main thread when in single threaded mode.