### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/internal/hide_stack_frames.ts`

### DIFF
--- a/ext/node/polyfills/internal/hide_stack_frames.ts
+++ b/ext/node/polyfills/internal/hide_stack_frames.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
+import { primordials } from "ext:core/mod.js";
+const { ObjectDefineProperty } = primordials;
 
 // deno-lint-ignore no-explicit-any
 type GenericFunction = (...args: any[]) => any;
@@ -13,7 +13,7 @@ export function hideStackFrames<T extends GenericFunction = GenericFunction>(
   // We rename the functions that will be hidden to cut off the stacktrace
   // at the outermost one.
   const hidden = "__node_internal_" + fn.name;
-  Object.defineProperty(fn, "name", { value: hidden });
+  ObjectDefineProperty(fn, "name", { __proto__: null, value: hidden });
 
   return fn;
 }


### PR DESCRIPTION
Towards #24236. This PR replaces `Object.defineProperty` with its primordial `ObjectDefineProperty`.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
