### PR TITLE
perf(ext/node): improve node:http createServer performance

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1501,7 +1501,7 @@ export const ServerResponse = function (
   this.socket = socket;
   this.socket?.on("close", () => {
     if (!this.finished) {
-      this.end()
+      this.end();
     }
   });
   this._header = "";

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1499,7 +1499,11 @@ export const ServerResponse = function (
   this._readable = readable;
   this._resolve = resolve;
   this.socket = socket;
-  this.socket?.on("close", () => this.end());
+  this.socket?.on("close", () => {
+    if (!this.finished) {
+      this.end()
+    }
+  });
   this._header = "";
 } as unknown as ServerResponseStatic;
 


### PR DESCRIPTION
This PR reduces unnecessary `.end()` call on `ServerResponse` object, and improves the http server performance of `node:http`.

- main: 13.786 kRPS
- this PR: 50.32 kRPS