### PR TITLE
perf(ext/node): lazily listen to the abort signal of request object

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -130,6 +130,7 @@ function validateHost(host, name) {
 
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const kError = Symbol("kError");
+const kBindToAbortSignal = Symbol("kBindToAbortSignal");
 
 class FakeSocket extends EventEmitter {
   /** Stores the underlying request for lazily binding to abort signal */
@@ -153,7 +154,7 @@ class FakeSocket extends EventEmitter {
     this.#request = opts.request;
   }
 
-  bindToAbortSignal() {
+  [kBindToAbortSignal]() {
     const signal = this.#request?.signal;
     signal?.addEventListener("abort", () => {
       this.emit("error", signal.reason);
@@ -1508,7 +1509,7 @@ export const ServerResponse = function (
   this.socket = socket;
   this.on("newListener", (event) => {
     if (event === "close") {
-      this.socket?.bindToAbortSignal();
+      this.socket?.[kBindToAbortSignal]();
       this.socket?.on("close", () => {
         if (!this.finished) {
           this.emit("close");


### PR DESCRIPTION
Continued from #29069

This PR improves the http server performance of `node:http` by lazily bind to abort signal of `Response` object.

main: 50.32k RPS
this PR: 85.83k PRS

server script used:
```js
import http from "node:http";
const server = http.createServer((req, res) => {
  res.end("hi");
});
server.listen(3000, () => console.log("listening"));
```

wrk command:
```
wrk -t12 -c400 -d10s http://localhost:3000
```

related #28601