### PR TITLE
fix(compile): pass default v8 args during compile

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1325,6 +1325,18 @@ fn load_env_variables_from_env_file(filename: Option<&Vec<String>>) {
   }
 }
 
+pub fn get_default_v8_flags() -> Vec<String> {
+  vec![
+    "--stack-size=1024".to_string(),
+    "--js-explicit-resource-management".to_string(),
+    // TODO(bartlomieju): I think this can be removed as it's handled by `deno_core`
+    // and its settings.
+    // deno_ast removes TypeScript `assert` keywords, so this flag only affects JavaScript
+    // TODO(petamoriken): Need to check TypeScript `assert` keywords in deno_ast
+    "--no-harmony-import-assertions".to_string(),
+  ]
+}
+
 /// Gets the --allow-import host from the provided url
 fn allow_import_host_from_url(url: &Url) -> Option<String> {
   let host = url.host()?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -58,9 +58,9 @@ const MODULE_NOT_FOUND: &str = "Module not found";
 const UNSUPPORTED_SCHEME: &str = "Unsupported scheme";
 
 use self::util::draw_thread::DrawThread;
-use crate::args::flags_from_vec;
 use crate::args::DenoSubcommand;
 use crate::args::Flags;
+use crate::args::{flags_from_vec, get_default_v8_flags};
 use crate::util::display;
 use crate::util::v8::get_v8_flags_from_env;
 use crate::util::v8::init_v8_flags;
@@ -512,17 +512,7 @@ fn resolve_flags_and_init(
       // https://github.com/microsoft/vscode/blob/48d4ba271686e8072fc6674137415bc80d936bc7/extensions/typescript-language-features/src/configuration/configuration.ts#L213-L214
       "--max-old-space-size=3072".to_string(),
     ],
-    _ => {
-      vec![
-        "--stack-size=1024".to_string(),
-        "--js-explicit-resource-management".to_string(),
-        // TODO(bartlomieju): I think this can be removed as it's handled by `deno_core`
-        // and its settings.
-        // deno_ast removes TypeScript `assert` keywords, so this flag only affects JavaScript
-        // TODO(petamoriken): Need to check TypeScript `assert` keywords in deno_ast
-        "--no-harmony-import-assertions".to_string(),
-      ]
-    }
+    _ => get_default_v8_flags(),
   };
 
   init_v8_flags(&default_v8_flags, &flags.v8_flags, get_v8_flags_from_env());

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -58,9 +58,10 @@ const MODULE_NOT_FOUND: &str = "Module not found";
 const UNSUPPORTED_SCHEME: &str = "Unsupported scheme";
 
 use self::util::draw_thread::DrawThread;
+use crate::args::flags_from_vec;
+use crate::args::get_default_v8_flags;
 use crate::args::DenoSubcommand;
 use crate::args::Flags;
-use crate::args::{flags_from_vec, get_default_v8_flags};
 use crate::util::display;
 use crate::util::v8::get_v8_flags_from_env;
 use crate::util::v8::init_v8_flags;

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -56,8 +56,9 @@ use indexmap::IndexMap;
 use node_resolver::analyze::ResolvedCjsAnalysis;
 
 use super::virtual_fs::output_vfs;
+use crate::args::get_default_v8_flags;
+use crate::args::CliOptions;
 use crate::args::CompileFlags;
-use crate::args::{get_default_v8_flags, CliOptions};
 use crate::cache::DenoDir;
 use crate::emit::Emitter;
 use crate::http_util::HttpClientProvider;

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -44,6 +44,7 @@ use deno_lib::standalone::virtual_fs::VirtualDirectoryEntries;
 use deno_lib::standalone::virtual_fs::WindowsSystemRootablePath;
 use deno_lib::standalone::virtual_fs::DENO_COMPILE_GLOBAL_NODE_MODULES_DIR_NAME;
 use deno_lib::util::hash::FastInsecureHasher;
+use deno_lib::util::v8::construct_v8_flags;
 use deno_lib::version::DENO_VERSION_INFO;
 use deno_npm::resolution::SerializedNpmResolutionSnapshot;
 use deno_npm::NpmSystemInfo;
@@ -55,8 +56,8 @@ use indexmap::IndexMap;
 use node_resolver::analyze::ResolvedCjsAnalysis;
 
 use super::virtual_fs::output_vfs;
-use crate::args::CliOptions;
 use crate::args::CompileFlags;
+use crate::args::{get_default_v8_flags, CliOptions};
 use crate::cache::DenoDir;
 use crate::emit::Emitter;
 use crate::http_util::HttpClientProvider;
@@ -657,7 +658,11 @@ impl<'a> DenoCompileBinaryWriter<'a> {
       code_cache_key,
       location: self.cli_options.location_flag().clone(),
       permissions: self.cli_options.permissions_options(),
-      v8_flags: self.cli_options.v8_flags().clone(),
+      v8_flags: construct_v8_flags(
+        &get_default_v8_flags(),
+        self.cli_options.v8_flags(),
+        vec![],
+      ),
       unsafely_ignore_certificate_errors: self
         .cli_options
         .unsafely_ignore_certificate_errors()

--- a/tests/specs/compile/default_v8_flags/__test__.jsonc
+++ b/tests/specs/compile/default_v8_flags/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "compile -A --output out main.ts",
+      "output": "compile.out"
+    },
+    {
+      "commandName": "./out",
+      "args": [],
+      "output": "main.out"
+    }
+  ]
+}

--- a/tests/specs/compile/default_v8_flags/compile.out
+++ b/tests/specs/compile/default_v8_flags/compile.out
@@ -1,0 +1,9 @@
+Check file:///[WILDLINE]/main.ts
+Compile file:///[WILDLINE]/main.ts to [WILDLINE]
+
+Embedded Files
+
+[WILDLINE]
+└── main.ts ([WILDLINE])
+
+[WILDCARD]

--- a/tests/specs/compile/default_v8_flags/main.out
+++ b/tests/specs/compile/default_v8_flags/main.out
@@ -1,0 +1,1 @@
+[Function: SuppressedError]

--- a/tests/specs/compile/default_v8_flags/main.ts
+++ b/tests/specs/compile/default_v8_flags/main.ts
@@ -1,0 +1,1 @@
+console.log(SuppressedError);


### PR DESCRIPTION
Fixes #29029

Changes:
- Passes default v8 flags alongside with other flags when compiling