### PR TITLE
fix(npm): support registries that have no shasums or integrity

### DIFF
--- a/tests/registry/npm/@denotest/no-shasums/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/no-shasums/1.0.0/main.js
@@ -1,0 +1,1 @@
+module.exports.add = (a, b) => a + b;

--- a/tests/registry/npm/@denotest/no-shasums/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/no-shasums/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/no-shasums",
+  "version": "1.0.0",
+  "main": "./main.js"
+}

--- a/tests/specs/npm/no_shasums/__test__.jsonc
+++ b/tests/specs/npm/no_shasums/__test__.jsonc
@@ -4,6 +4,9 @@
     "args": "install",
     "output": "[WILDCARD]"
   }, {
+    "args": "run --node-modules-dir=auto main.js",
+    "output": "3\n"
+  }, {
     "args": ["eval", "console.log(Deno.readTextFileSync('deno.lock').trim());"],
     "output": "deno.lock.out"
   }]

--- a/tests/specs/npm/no_shasums/__test__.jsonc
+++ b/tests/specs/npm/no_shasums/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "install",
+    "output": "[WILDCARD]"
+  }, {
+    "args": ["eval", "console.log(Deno.readTextFileSync('deno.lock').trim());"],
+    "output": "deno.lock.out"
+  }]
+}

--- a/tests/specs/npm/no_shasums/deno.lock.out
+++ b/tests/specs/npm/no_shasums/deno.lock.out
@@ -1,0 +1,18 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@denotest/no-shasums@*": "1.0.0"
+  },
+  "npm": {
+    "@denotest/no-shasums@1.0.0": {
+      "tarball": "http://localhost:4260/@denotest/no-shasums/1.0.0.tgz"
+    }
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@denotest/no-shasums@*"
+      ]
+    }
+  }
+}

--- a/tests/specs/npm/no_shasums/main.js
+++ b/tests/specs/npm/no_shasums/main.js
@@ -1,0 +1,4 @@
+// this is a special package that the registry serves without shasums
+import { add } from "@denotest/no-shasums";
+
+console.log(add(1, 2));

--- a/tests/specs/npm/no_shasums/package.json
+++ b/tests/specs/npm/no_shasums/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/no-shasums": "*"
+  }
+}

--- a/tests/util/server/src/npm.rs
+++ b/tests/util/server/src/npm.rs
@@ -308,16 +308,16 @@ fn get_npm_package(
       encoder.finish()?;
     }
 
-    // get tarball hash
-    let tarball_checksum = get_tarball_checksum(&tarball_bytes);
-
     // create the registry file JSON for this version
     let mut dist = serde_json::Map::new();
-    dist.insert(
-      "integrity".to_string(),
-      format!("sha512-{tarball_checksum}").into(),
-    );
-    dist.insert("shasum".to_string(), "dummy-value".into());
+    if package_name != "@denotest/no-shasums" {
+      let tarball_checksum = get_tarball_checksum(&tarball_bytes);
+      dist.insert(
+        "integrity".to_string(),
+        format!("sha512-{tarball_checksum}").into(),
+      );
+      dist.insert("shasum".to_string(), "dummy-value".into());
+    }
     dist.insert(
       "tarball".to_string(),
       format!("{registry_hostname}/{package_name}/{version}.tgz").into(),


### PR DESCRIPTION
This was actually fixed via the deno_npm and lockfile updates, but it would be good to have an explicit entry for this in the release notes so labeling this as a "fix"

Closes https://github.com/denoland/deno/issues/27758