### PR TITLE
fix: break unstable lockfile v5 to remove "has" from property names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
  "chrono",
  "deno_bench_util",
  "deno_cache_dir",
- "deno_lockfile",
+ "deno_lockfile 0.28.0",
  "deno_semver",
  "deno_terminal 0.2.2",
  "deno_tower_lsp",
@@ -1478,9 +1478,9 @@ dependencies = [
  "deno_graph",
  "deno_lib",
  "deno_lint",
- "deno_lockfile",
+ "deno_lockfile 0.28.0",
  "deno_media_type",
- "deno_npm",
+ "deno_npm 0.33.0",
  "deno_npm_cache",
  "deno_package_json",
  "deno_panic",
@@ -2145,7 +2145,7 @@ dependencies = [
  "deno_fs",
  "deno_media_type",
  "deno_node",
- "deno_npm",
+ "deno_npm 0.33.0",
  "deno_path_util",
  "deno_resolver",
  "deno_runtime",
@@ -2190,6 +2190,19 @@ name = "deno_lockfile"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089709ffe9ae01616a4933ebd385b4a6d244927165306025e03318d6fdb08f8"
+dependencies = [
+ "async-trait",
+ "deno_semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "deno_lockfile"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a03d93aa789e2652a644e3e71638b4e21faafad5f7392dc8f126589d158695"
 dependencies = [
  "async-trait",
  "deno_semver",
@@ -2361,7 +2374,28 @@ dependencies = [
  "async-trait",
  "capacity_builder",
  "deno_error",
- "deno_lockfile",
+ "deno_lockfile 0.27.1",
+ "deno_semver",
+ "futures",
+ "indexmap 2.8.0",
+ "log",
+ "monch",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "url",
+]
+
+[[package]]
+name = "deno_npm"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbe8ae992daf5506f430f2df2c5cf1ce95afe0a08d749251a5761488c71426d"
+dependencies = [
+ "async-trait",
+ "capacity_builder",
+ "deno_error",
+ "deno_lockfile 0.28.0",
  "deno_semver",
  "futures",
  "indexmap 2.8.0",
@@ -2382,7 +2416,7 @@ dependencies = [
  "boxed_error",
  "deno_cache_dir",
  "deno_error",
- "deno_npm",
+ "deno_npm 0.33.0",
  "deno_path_util",
  "deno_semver",
  "deno_unsync",
@@ -2542,7 +2576,7 @@ dependencies = [
  "deno_config",
  "deno_error",
  "deno_media_type",
- "deno_npm",
+ "deno_npm 0.33.0",
  "deno_package_json",
  "deno_path_util",
  "deno_semver",
@@ -2949,7 +2983,7 @@ dependencies = [
  "deno_error",
  "deno_lib",
  "deno_media_type",
- "deno_npm",
+ "deno_npm 0.33.0",
  "deno_package_json",
  "deno_path_util",
  "deno_resolver",
@@ -3538,7 +3572,7 @@ dependencies = [
  "deno_ast",
  "deno_error",
  "deno_graph",
- "deno_npm",
+ "deno_npm 0.32.0",
  "deno_semver",
  "futures",
  "hashlink 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ deno_doc = "=0.172.0"
 deno_error = "=0.5.6"
 deno_graph = "=0.90.0"
 deno_lint = "=0.74.0"
-deno_lockfile = "=0.27.1"
+deno_lockfile = "=0.28.0"
 deno_media_type = { version = "=0.2.8", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
-deno_npm = "=0.32.0"
+deno_npm = "=0.33.0"
 deno_package_json = { version = "=0.6.0", default-features = false }
 deno_path_util = "=0.3.2"
 deno_semver = "=0.7.1"

--- a/cli/npm/installer/resolution.rs
+++ b/cli/npm/installer/resolution.rs
@@ -280,8 +280,8 @@ fn populate_lockfile_from_snapshot(
         }
       }),
       deprecated: pkg.is_deprecated,
-      has_bin: pkg.has_bin,
-      has_scripts: pkg.has_scripts,
+      bin: pkg.has_bin,
+      scripts: pkg.has_scripts,
       optional_peers,
     }
   }

--- a/cli/npm/mod.rs
+++ b/cli/npm/mod.rs
@@ -99,8 +99,8 @@ async fn get_infos(
           cpu: version_info.cpu.iter().map(|s| s.to_string()).collect(),
           os: version_info.os.iter().map(|s| s.to_string()).collect(),
           deprecated: version_info.deprecated.is_some(),
-          has_bin: version_info.bin.is_some(),
-          has_scripts: version_info.scripts.contains_key("preinstall")
+          bin: version_info.bin.is_some(),
+          scripts: version_info.scripts.contains_key("preinstall")
             || version_info.scripts.contains_key("install")
             || version_info.scripts.contains_key("postinstall"),
           optional_peers: version_info

--- a/tests/specs/lockfile/frozen_lockfile/frozen_package_json_changed.out
+++ b/tests/specs/lockfile/frozen_lockfile/frozen_package_json_changed.out
@@ -8,7 +8,7 @@ changes:
 11 | +    },
 12 | +    "@denotest/bin@0.7.0": {
 13 | +      "integrity": "sha512-RAE7sQrdTUuV4KdDAshObhsULXb2QjTjfRg/KbzE9asZV8dUmwbPZy2kfmE2CunPo8+6DvwPklXFJ4PQi0Usuw==",
-14 | +      "hasBin": true,
+14 | +      "bin": true,
 15 | +      "tarball": "http://localhost:4260/@denotest/bin/0.7.0.tgz"
 16 | +    }
 17 | +  },

--- a/tests/specs/lockfile/frozen_lockfile/frozen_package_json_changed_install.out
+++ b/tests/specs/lockfile/frozen_lockfile/frozen_package_json_changed_install.out
@@ -7,7 +7,7 @@ changes:
 11 | +    },
 12 | +    "@denotest/bin@0.7.0": {
 13 | +      "integrity": "sha512-RAE7sQrdTUuV4KdDAshObhsULXb2QjTjfRg/KbzE9asZV8dUmwbPZy2kfmE2CunPo8+6DvwPklXFJ4PQi0Usuw==",
-14 | +      "hasBin": true,
+14 | +      "bin": true,
 15 | +      "tarball": "http://localhost:4260/@denotest/bin/0.7.0.tgz"
 16 | +    }
 17 | +  },

--- a/tests/specs/lockfile/jsx_import_source_and_types/deno.lock.out
+++ b/tests/specs/lockfile/jsx_import_source_and_types/deno.lock.out
@@ -13,7 +13,7 @@
       "dependencies": [
         "js-tokens"
       ],
-      "hasBin": true,
+      "bin": true,
       "tarball": "http://localhost:4260/loose-envify/loose-envify-1.4.0.tgz"
     },
     "react@18.2.0": {

--- a/tests/specs/outdated/deno_json/update_latest/deno.lock.out
+++ b/tests/specs/outdated/deno_json/update_latest/deno.lock.out
@@ -22,7 +22,7 @@
   "npm": {
     "@denotest/bin@1.0.0": {
       "integrity": "sha512-ZtrWnYYPIzw4a9H1uNeZRZRWuLCpHZZU/SllIyFLqcTLH/3zdRI8UH4Z1Kf+8N++bWGO3fg8Ev4vvS1LoLlidg==",
-      "hasBin": true,
+      "bin": true,
       "tarball": "http://localhost:4260/@denotest/bin/1.0.0.tgz"
     },
     "@denotest/breaking-change-between-versions@2.0.0": {

--- a/tests/specs/outdated/package_json/update_latest/deno.lock.out
+++ b/tests/specs/outdated/package_json/update_latest/deno.lock.out
@@ -8,7 +8,7 @@
   "npm": {
     "@denotest/bin@1.0.0": {
       "integrity": "sha512-ZtrWnYYPIzw4a9H1uNeZRZRWuLCpHZZU/SllIyFLqcTLH/3zdRI8UH4Z1Kf+8N++bWGO3fg8Ev4vvS1LoLlidg==",
-      "hasBin": true,
+      "bin": true,
       "tarball": "http://localhost:4260/@denotest/bin/1.0.0.tgz"
     },
     "@denotest/breaking-change-between-versions@2.0.0": {

--- a/tests/specs/run/lazy_dynamic_imports/lock.out
+++ b/tests/specs/run/lazy_dynamic_imports/lock.out
@@ -6,7 +6,7 @@
   "npm": {
     "@denotest/say-hello@1.0.0": {
       "integrity": "sha512-hgZvkHYIZK+rZP7SzHh5ga5HChPhQUzTs56XZT1v23oE1ZZCTgb3kW38BcBQud8SNfbQCIvoUdbcjjl02vzFfw==",
-      "hasBin": true,
+      "bin": true,
       "tarball": "http://localhost:4260/@denotest/say-hello/1.0.0.tgz"
     }
   }


### PR DESCRIPTION
Lockfile v5 hasn't stabilized yet, so going to do this breaking change in order to make the property names shorter.

* https://github.com/denoland/deno_lockfile/pull/49