### PR TITLE
feat(check): support erasableSyntaxOnly for type checking

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -42,6 +42,12 @@
           "deprecated": true,
           "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig/#emitDecoratorMetadata"
         },
+        "erasableSyntaxOnly": {
+          "description": "Do not allow runtime constructs that are not part of ECMAScript.",
+          "type": ["boolean", "null"],
+          "default": false,
+          "markdownDescription": "Do not allow runtime constructs that are not part of ECMAScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#erasableSyntaxOnly"
+        },
         "exactOptionalPropertyTypes": {
           "description": "Interpret optional property types as written, rather than adding 'undefined'.",
           "type": "boolean",

--- a/tests/specs/check/erasable_syntax_only/__test__.jsonc
+++ b/tests/specs/check/erasable_syntax_only/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "check main.ts",
+  "output": "error.out",
+  "exitCode": 1
+}

--- a/tests/specs/check/erasable_syntax_only/deno.json
+++ b/tests/specs/check/erasable_syntax_only/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "erasableSyntaxOnly": true
+  }
+}

--- a/tests/specs/check/erasable_syntax_only/error.out
+++ b/tests/specs/check/erasable_syntax_only/error.out
@@ -1,0 +1,7 @@
+Check file:///[WILDLINE]/main.ts
+TS1294 [ERROR]: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.
+namespace Test {
+          ~~~~
+    at file:///[WILDLINE]/main.ts:1:11
+
+error: Type checking failed.

--- a/tests/specs/check/erasable_syntax_only/main.ts
+++ b/tests/specs/check/erasable_syntax_only/main.ts
@@ -1,0 +1,7 @@
+namespace Test {
+  export function sayHi() {
+    console.log("hi");
+  }
+}
+
+Test.sayHi();


### PR DESCRIPTION
Only when using `--check` or `deno check`. Doesn't have this hooked up as part of the swc emit.

* https://github.com/denoland/deno_config/pull/166 (deno_config upgrade happened in a separate PR)

Finishes adding it to the json schema and adds a test to ensure it continues to work.

Closes https://github.com/denoland/deno/issues/28936