### PR TITLE
test(cli): test support --single-threaded v8 flag

### DIFF
--- a/tests/specs/cli/v8_single_threaded/__test__.jsonc
+++ b/tests/specs/cli/v8_single_threaded/__test__.jsonc
@@ -1,0 +1,55 @@
+// Linux only as thread information is read from /proc
+{
+  "tests": {
+    "run_arg": {
+      "if": "linux",
+      "args": "run --allow-all --v8-flags=--single-threaded main.ts",
+      "output": "false\n"
+    },
+    "run_env": {
+      "if": "linux",
+      "args": "run --allow-all --v8-flags=--single-threaded main.ts",
+      "envs": {
+        "DENO_V8_FLAGS": "--single-threaded"
+      },
+      "output": "false\n"
+    },
+    "run_none": {
+      "if": "linux",
+      "args": "run --allow-all main.ts",
+      "output": "true\n"
+    },
+    "compile_arg": {
+      "tempDir": true,
+      "steps": [
+        {
+          "if": "linux",
+          "args": "compile --allow-all --v8-flags=--single-threaded --output main main.ts",
+          "output": "[WILDLINE]"
+        },
+        {
+          "if": "linux",
+          "commandName": "./main",
+          "args": [],
+          "output": "false\n"
+        }
+      ]
+    },
+    "compile_none": {
+      "tempDir": true,
+      "steps": [
+        {
+          "if": "linux",
+          "args": "compile --allow-all --output main main.ts",
+          "output": "[WILDLINE]"
+        },
+        {
+          "if": "linux",
+          "commandName": "./main",
+          "args": [],
+          "output": "true\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/cli/v8_single_threaded/main.ts
+++ b/tests/specs/cli/v8_single_threaded/main.ts
@@ -1,0 +1,10 @@
+const tids = Array.from(
+  Deno.readDirSync("/proc/self/task"),
+  ({ name }) => Number(name),
+);
+const names = tids.map((tid) =>
+  Deno.readTextFileSync(`/proc/self/task/${tid}/status`).match(
+    /Name:\t(.*)/,
+  )![1]
+);
+console.log(names.some((name) => name.startsWith("V8")));


### PR DESCRIPTION
Tests for #29066.

These only run on linux since they get thread names from /proc.