### PR TITLE
v2.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "deno"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anstream",
  "async-trait",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "denort"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "deno_lib"
-version = "2.4.0"
+version = "2.3.1"
 dependencies = [
  "capacity_builder",
  "deno_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ denort_helper = { version = "0.2.0", path = "./ext/rt_helper" }
 # workspace libraries
 deno_bench_util = { version = "0.198.0", path = "./bench_util" }
 deno_features = { version = "0.1.0", path = "./runtime/features" }
-deno_lib = { version = "2.4.0", path = "./cli/lib" }
+deno_lib = { version = "2.3.1", path = "./cli/lib" }
 deno_npm_cache = { version = "0.23.0", path = "./resolvers/npm_cache" }
 deno_permissions = { version = "0.63.0", path = "./runtime/permissions" }
 deno_resolver = { version = "0.35.0", path = "./resolvers/deno" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno"
-version = "2.3.0"
+version = "2.3.1"
 authors.workspace = true
 default-run = "deno"
 edition.workspace = true

--- a/cli/lib/Cargo.toml
+++ b/cli/lib/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_lib"
-version = "2.4.0"
+version = "2.3.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cli/rt/Cargo.toml
+++ b/cli/rt/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "denort"
-version = "2.3.0"
+version = "2.3.1"
 authors.workspace = true
 default-run = "denort"
 edition.workspace = true


### PR DESCRIPTION
Fixes wrong version printed with `deno --version`.

Closes https://github.com/denoland/deno/issues/29108