### PR TITLE
fix(upgrade): skip version comparison when upgrading

### DIFF
--- a/cli/tools/upgrade.rs
+++ b/cli/tools/upgrade.rs
@@ -754,46 +754,22 @@ async fn find_latest_version_to_upgrade(
     }
   };
 
-  let (maybe_newer_latest_version, current_version) = match release_channel {
-    ReleaseChannel::Canary => {
-      let current_version = version::DENO_VERSION_INFO.git_hash;
-      let current_is_most_recent =
-        current_version == latest_version_found.version_or_hash;
-
-      if !force && current_is_most_recent {
-        (None, current_version)
-      } else {
-        (Some(latest_version_found), current_version)
-      }
-    }
+  let current_version = match release_channel {
+    ReleaseChannel::Canary => version::DENO_VERSION_INFO.git_hash,
     ReleaseChannel::Stable | ReleaseChannel::Lts | ReleaseChannel::Rc => {
-      let current_version = version::DENO_VERSION_INFO.deno;
-
-      // If the current binary is not the same channel, we can skip
-      // computation if we're on a newer release - we're not.
-      if version::DENO_VERSION_INFO.release_channel != release_channel {
-        (Some(latest_version_found), current_version)
-      } else {
-        let current = Version::parse_standard(current_version)?;
-        let latest =
-          Version::parse_standard(&latest_version_found.version_or_hash)?;
-        let current_is_most_recent = current >= latest;
-
-        if !force && current_is_most_recent {
-          (None, current_version)
-        } else {
-          (Some(latest_version_found), current_version)
-        }
-      }
+      version::DENO_VERSION_INFO.deno
     }
   };
+  let should_upgrade = force
+    || current_version != latest_version_found.version_or_hash
+    || version::DENO_VERSION_INFO.release_channel != release_channel;
 
   log::info!("");
-  if let Some(newer_latest_version) = maybe_newer_latest_version.as_ref() {
+  if should_upgrade {
     log::info!(
       "Found latest {} version {}",
-      newer_latest_version.release_channel.name(),
-      color_print::cformat!("<g>{}</>", newer_latest_version.display())
+      latest_version_found.release_channel.name(),
+      color_print::cformat!("<g>{}</>", latest_version_found.display())
     );
   } else {
     log::info!(
@@ -803,7 +779,7 @@ async fn find_latest_version_to_upgrade(
   }
   log::info!("");
 
-  Ok(maybe_newer_latest_version)
+  Ok(should_upgrade.then_some(latest_version_found))
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
In Deno 2.3.0, the version was accidentally released as `2.4.0`. This was fixed in 2.3.1. Now anyone who upgraded to 2.3.0 can't run `deno upgrade` to upgrade to 2.3.1 because of this upgrade behaviour. It would be better to just always go to the latest remote specified version when someone runs `deno upgrade`.

This also fixes a bug outlined in https://github.com/denoland/deno/issues/29016

Closes https://github.com/denoland/deno/issues/29016