### PR TITLE
fix(lsp): ignore 'for await' diagnostics in jupyter cells

### DIFF
--- a/cli/tsc/97_ts_host.js
+++ b/cli/tsc/97_ts_host.js
@@ -814,8 +814,8 @@ export function filterMapDiagnostic(diagnostic) {
   }
   const isClassicScript = !diagnostic.file?.["externalModuleIndicator"];
   if (isClassicScript) {
-    // Top-level-await.
-    if (diagnostic.code == 1375) {
+    // Top-level-await, standard and loops.
+    if (diagnostic.code == 1375 || diagnostic.code == 1431) {
       return false;
     }
   }

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -11406,6 +11406,9 @@ fn lsp_jupyter_import_map_and_diagnostics() {
 
           // Top-level-await should be allowed.
           await new Promise((r) => r(null));
+          for await (const foo of []) {
+            console.log(foo);
+          }
 
           // Local variables conflicting with globals.
           const name = "Hello";

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -11453,8 +11453,8 @@ fn lsp_jupyter_import_map_and_diagnostics() {
           // for notebook cells. Figure out a workaround.
           {
             "range": {
-              "start": { "line": 9, "character": 16 },
-              "end": { "line": 9, "character": 20 },
+              "start": { "line": 12, "character": 16 },
+              "end": { "line": 12, "character": 20 },
             },
             "severity": 1,
             "code": 2451,


### PR DESCRIPTION
Fixes part of https://github.com/denoland/vscode_deno/issues/1288.