### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/internal/options.ts`

### DIFF
--- a/ext/node/polyfills/internal/options.ts
+++ b/ext/node/polyfills/internal/options.ts
@@ -20,10 +20,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { getOptions } from "ext:deno_node/internal_binding/node_options.ts";
+import { primordials } from "ext:core/mod.js";
+const {
+  MapPrototypeGet,
+  StringPrototypeSlice,
+  StringPrototypeStartsWith,
+} = primordials;
 
 let optionsMap: Map<string, { value: string }>;
 
@@ -38,11 +41,14 @@ function getOptionsFromBinding() {
 export function getOptionValue(optionName: string) {
   const options = getOptionsFromBinding();
 
-  if (optionName.startsWith("--no-")) {
-    const option = options.get("--" + optionName.slice(5));
+  if (StringPrototypeStartsWith(optionName, "--no-")) {
+    const option = MapPrototypeGet(
+      options,
+      "--" + StringPrototypeSlice(optionName, 5),
+    );
 
     return option && !option.value;
   }
 
-  return options.get(optionName)?.value;
+  return MapPrototypeGet(options, optionName)?.value;
 }


### PR DESCRIPTION
Towards #24236. This PR replaces `Map` and `String` methods with their primordial versions.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
