### PR TITLE
fix(vendor): strip jsr version meta module graph data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502c5f3120fe5b32908e9a4b3af95b7e1a35e8fa758d87155b03a3810655c9f0"
+checksum = "869a62459ded73382e018c7c58a07df170ba5f5befb67e18ee10494e769efe2a"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ repository = "https://github.com/denoland/deno"
 deno_ast = { version = "=0.46.6", features = ["transpiling"] }
 deno_core = { version = "0.344.0" }
 
-deno_cache_dir = "=0.19.2"
+deno_cache_dir = "=0.20.0"
 deno_config = { version = "=0.54.2", features = ["workspace"] }
 deno_doc = "=0.172.0"
 deno_error = "=0.5.6"

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -47,6 +47,7 @@ use deno_lib::args::NPM_PROCESS_STATE;
 use deno_lib::version::DENO_VERSION_INFO;
 use deno_lib::worker::StorageKeyResolver;
 use deno_npm::NpmSystemInfo;
+use deno_resolver::factory::resolve_jsr_url;
 use deno_runtime::deno_permissions::PermissionsOptions;
 use deno_runtime::inspector_server::InspectorServer;
 use deno_semver::npm::NpmPackageReqReference;
@@ -67,27 +68,7 @@ use thiserror::Error;
 use crate::sys::CliSys;
 
 pub fn jsr_url() -> &'static Url {
-  static JSR_URL: Lazy<Url> = Lazy::new(|| {
-    let env_var_name = "JSR_URL";
-    if let Ok(registry_url) = std::env::var(env_var_name) {
-      // ensure there is a trailing slash for the directory
-      let registry_url = format!("{}/", registry_url.trim_end_matches('/'));
-      match Url::parse(&registry_url) {
-        Ok(url) => {
-          return url;
-        }
-        Err(err) => {
-          log::debug!(
-            "Invalid {} environment variable: {:#}",
-            env_var_name,
-            err,
-          );
-        }
-      }
-    }
-
-    Url::parse("https://jsr.io/").unwrap()
-  });
+  static JSR_URL: Lazy<Url> = Lazy::new(|| resolve_jsr_url(&CliSys::default()));
 
   &JSR_URL
 }


### PR DESCRIPTION
Test is in:

* https://github.com/denoland/deno_cache_dir/pull/78

This removes the `moduleGraphX` data from the `<version>_meta.json` files for jsr packages when copying from the global cache to the local one. This property is not really useful to vendor because it's just a performance optimization when downloading the files and someone may be changing the data in the files leading to the `moduleGraph` data to be out of date.

Closes #28427 (I don't believe there's anything else we could or should strip)