### PR TITLE
fix(npm): handle global cache missing version in pkg info of pkg existing in npm snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,9 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbe8ae992daf5506f430f2df2c5cf1ce95afe0a08d749251a5761488c71426d"
+checksum = "823d70f758afa8ba0f80ee212a79f35dee1b6f19a6d81cebb02c2c5cee3f1f15"
 dependencies = [
  "async-trait",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ deno_lint = "=0.74.0"
 deno_lockfile = "=0.28.0"
 deno_media_type = { version = "=0.2.8", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
-deno_npm = "=0.33.0"
+deno_npm = "=0.33.1"
 deno_package_json = { version = "=0.6.0", default-features = false }
 deno_path_util = "=0.3.2"
 deno_semver = "=0.7.1"


### PR DESCRIPTION
* https://github.com/denoland/deno_npm/pull/102

Closes https://github.com/denoland/deno/issues/29128