### PR TITLE
perf(npm): deserialize cached npm packuments on blocking task

### DIFF
--- a/resolvers/npm_cache/lib.rs
+++ b/resolvers/npm_cache/lib.rs
@@ -308,7 +308,7 @@ impl<
       })
   }
 
-  pub fn load_package_info(
+  pub async fn load_package_info(
     &self,
     name: &str,
   ) -> Result<Option<SerializedCachedPackageInfo>, serde_json::Error> {
@@ -320,8 +320,9 @@ impl<
       Err(err) => return Err(serde_json::Error::io(err)),
     };
 
-    // todo(dsherret): deserialize in a blocking task
-    serde_json::from_slice(&file_bytes)
+    deno_unsync::spawn_blocking(move || serde_json::from_slice(&file_bytes))
+      .await
+      .unwrap()
   }
 
   pub fn save_package_info(

--- a/resolvers/npm_cache/registry_info.rs
+++ b/resolvers/npm_cache/registry_info.rs
@@ -347,13 +347,13 @@ impl<
         || downloader.previously_loaded_packages.lock().contains(&name)
       {
         // attempt to load from the file cache
-        if let Some(cached_info) = downloader.cache.load_package_info(&name).map_err(JsErrorBox::from_err)? {
+        if let Some(cached_info) = downloader.cache.load_package_info(&name).await.map_err(JsErrorBox::from_err)? {
           return Ok(FutureResult::SavedFsCache(Arc::new(cached_info.info)));
         } else {
           None
         }
       } else {
-        downloader.cache.load_package_info(&name).ok().flatten()
+        downloader.cache.load_package_info(&name).await.ok().flatten()
       };
 
       if *downloader.cache.cache_setting() == NpmCacheSetting::Only {


### PR DESCRIPTION
Noticed we missed doing this when looking through this code.

```sh
> cat package.json
{
  "dependencies": {
    "dax-sh": "^0.43.0",
    "next": "^15.3.1",
    "ts-morph": "^25.0.1"
  }
}
> hyperfine --warmup=1 "V:\deno\target\release\deno_main.exe install --no-lock" "V:\deno\target\release\deno.exe install --no-lock"                                
Benchmark 1: V:\deno\target\release\deno_main.exe install --no-lock
  Time (mean ± σ):     198.5 ms ±   3.2 ms    [User: 166.8 ms, System: 38.6 ms]                                                                                                                                                                                                                             
  Range (min … max):   192.7 ms … 203.3 ms    14 runs

Benchmark 2: V:\deno\target\release\deno.exe install --no-lock
  Time (mean ± σ):     146.4 ms ±   2.4 ms    [User: 178.7 ms, System: 133.0 ms]
  Range (min … max):   142.0 ms … 150.0 ms    19 runs

Summary
  V:\deno\target\release\deno.exe install --no-lock ran
    1.36 ± 0.03 times faster than V:\deno\target\release\deno_main.exe install --no-lock
```