### PR TITLE
docs: remove quotes around `undefined` in Deno.env.get example

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1510,7 +1510,7 @@ declare namespace Deno {
      *
      * ```ts
      * console.log(Deno.env.get("HOME"));  // e.g. outputs "/home/alice"
-     * console.log(Deno.env.get("MADE_UP_VAR"));  // outputs "undefined"
+     * console.log(Deno.env.get("MADE_UP_VAR"));  // outputs undefined
      * ```
      *
      * Requires `allow-env` permission.


### PR DESCRIPTION
`Deno.env.get` returns undefined when the environment variable is not present. I initially interpreted this doc string to indicate that it would return the string literal `"undefined"`, which isn't right.

Could use backticks here as above, but a little confusing in a JS context where this also indicates a (template) string literal.