### PR TITLE
fix(ext/node): `getColorDepth` for writable stdio streams

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -108,6 +108,7 @@ export function createWritableStdioStream(writer, name, warmup = false) {
       __proto__: null,
       enumerable: true,
       configurable: true,
+      writable: true,
       value: () => op_bootstrap_color_depth(),
     },
   });

--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -23,6 +23,7 @@ import {
 import { Duplex, Readable, Writable } from "node:stream";
 import * as io from "ext:deno_io/12_io.js";
 import { guessHandleType } from "ext:deno_node/internal_binding/util.ts";
+import { op_bootstrap_color_depth } from "ext:core/ops";
 
 // https://github.com/nodejs/node/blob/00738314828074243c9a52a228ab4c68b04259ef/lib/internal/bootstrap/switches/is_main_thread.js#L41
 export function createWritableStdioStream(writer, name, warmup = false) {
@@ -102,6 +103,12 @@ export function createWritableStdioStream(writer, name, warmup = false) {
       configurable: true,
       value: () =>
         writer?.isTerminal() ? ObjectValues(Deno.consoleSize?.()) : undefined,
+    },
+    getColorDepth: {
+      __proto__: null,
+      enumerable: true,
+      configurable: true,
+      value: () => op_bootstrap_color_depth(),
     },
   });
 

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -657,6 +657,7 @@ Deno.test({
     const consoleSize = isTTY ? Deno.consoleSize() : undefined;
     assertEquals(process.stdout.columns, consoleSize?.columns);
     assertEquals(process.stdout.rows, consoleSize?.rows);
+    assert([1, 4, 8, 24].includes(process.stdout.getColorDepth()));
     assertEquals(
       `${process.stdout.getWindowSize()}`,
       `${consoleSize && [consoleSize.columns, consoleSize.rows]}`,


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/28605
Fixes https://github.com/denoland/deno/issues/29175

` ../deno/target/debug/deno run -A npm:create-vue@latest DIR` works now