### PR TITLE
fix: terminate control sock event with newline

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -686,7 +686,8 @@ fn wait_for_start(
         Serving,
       }
 
-      let buf = deno_core::serde_json::to_vec(&Event::Serving).unwrap();
+      let mut buf = deno_core::serde_json::to_vec(&Event::Serving).unwrap();
+      buf.push(b'\n');
       let _ = tx.write_all(&buf).await;
     });
 

--- a/tests/specs/run/unconfigured/main.out
+++ b/tests/specs/run/unconfigured/main.out
@@ -1,4 +1,5 @@
 true
 hello world
 EVENT: "Serving"
+
 [Object: null prototype] { success: true, code: 0, signal: null }


### PR DESCRIPTION
these should be newline terminated