### PR TITLE
fix(precompile): escape string literal jsx children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.46.6"
+version = "0.46.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef7f606485e5e5fdee9946d5822de9242d8143da9beb1c32cbaf2e8dd1ef025"
+checksum = "583a4a511dacae723a15700c774c67dee83821af1feefdbc4ebb3b0f3ace4561"
 dependencies = [
  "base64 0.22.1",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ license = "MIT"
 repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
-deno_ast = { version = "=0.46.6", features = ["transpiling"] }
+deno_ast = { version = "=0.46.7", features = ["transpiling"] }
 deno_core = { version = "0.346.0" }
 
 deno_cache_dir = "=0.20.0"


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_ast/pull/304 .

This only affects actual string literals in the source code inside a JSX expression.