### PR TITLE
refactor: move more code into ResolverFactory

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -38,7 +38,6 @@ use deno_resolver::factory::DenoDirPathProviderOptions;
 use deno_resolver::factory::NpmProcessStateOptions;
 use deno_resolver::factory::ResolverFactoryOptions;
 use deno_resolver::factory::SpecifiedImportMapProvider;
-use deno_resolver::graph::FoundPackageJsonDepFlag;
 use deno_resolver::npm::managed::NpmResolutionCell;
 use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_resolver::workspace::WorkspaceResolver;
@@ -103,7 +102,6 @@ use crate::npm::NpmResolutionInitializer;
 use crate::npm::WorkspaceNpmPatchPackages;
 use crate::resolver::on_resolve_diagnostic;
 use crate::resolver::CliCjsTracker;
-use crate::resolver::CliDenoResolver;
 use crate::resolver::CliNpmGraphResolver;
 use crate::resolver::CliNpmReqResolver;
 use crate::resolver::CliResolver;
@@ -315,7 +313,6 @@ struct CliFactoryServices {
   eszip_module_loader_provider: Deferred<Arc<EszipModuleLoaderProvider>>,
   feature_checker: Deferred<Arc<FeatureChecker>>,
   file_fetcher: Deferred<Arc<CliFileFetcher>>,
-  found_pkg_json_dep_flag: Arc<FoundPackageJsonDepFlag>,
   fs: Deferred<Arc<dyn deno_fs::FileSystem>>,
   http_client_provider: Deferred<Arc<HttpClientProvider>>,
   main_graph_container: Deferred<Arc<MainModuleGraphContainer>>,
@@ -337,7 +334,6 @@ struct CliFactoryServices {
   parsed_source_cache: Deferred<Arc<ParsedSourceCache>>,
   permission_desc_parser:
     Deferred<Arc<RuntimePermissionDescriptorParser<CliSys>>>,
-  resolver: Deferred<Arc<CliResolver>>,
   resolver_factory: Deferred<Arc<CliResolverFactory>>,
   root_cert_store_provider: Deferred<Arc<dyn RootCertStoreProvider>>,
   root_permissions_container: Deferred<PermissionsContainer>,
@@ -615,7 +611,10 @@ impl CliFactory {
           let cli_options = self.cli_options()?;
           Ok(Arc::new(CliNpmGraphResolver::new(
             self.npm_installer_if_managed().await?.cloned(),
-            self.services.found_pkg_json_dep_flag.clone(),
+            self
+              .resolver_factory()?
+              .found_package_json_dep_flag()
+              .clone(),
             cli_options.default_npm_caching_strategy(),
           )))
         }
@@ -811,26 +810,9 @@ impl CliFactory {
     self.resolver_factory()?.workspace_resolver().await
   }
 
-  pub async fn deno_resolver(&self) -> Result<&Arc<CliDenoResolver>, AnyError> {
+  pub async fn resolver(&self) -> Result<&Arc<CliResolver>, AnyError> {
     self.initialize_npm_resolution_if_managed().await?;
     self.resolver_factory()?.deno_resolver().await
-  }
-
-  pub async fn resolver(&self) -> Result<&Arc<CliResolver>, AnyError> {
-    self
-      .services
-      .resolver
-      .get_or_try_init_async(
-        async {
-          Ok(Arc::new(CliResolver::new(
-            self.deno_resolver().await?.clone(),
-            self.services.found_pkg_json_dep_flag.clone(),
-            Box::new(on_resolve_diagnostic),
-          )))
-        }
-        .boxed_local(),
-      )
-      .await
   }
 
   pub fn maybe_file_watcher_reporter(&self) -> &Option<FileWatcherReporter> {
@@ -1418,6 +1400,9 @@ impl CliFactory {
           })),
           bare_node_builtins: self.flags.unstable_config.bare_node_builtins,
           unstable_sloppy_imports: self.flags.unstable_config.sloppy_imports,
+          on_mapped_resolution_diagnostic: Some(Arc::new(
+            on_resolve_diagnostic,
+          )),
           package_json_cache: Some(Arc::new(
             node_resolver::PackageJsonThreadLocalCache,
           )),

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -77,7 +77,6 @@ use crate::npm::CliNpmResolverManagedSnapshotOption;
 use crate::npm::NpmResolutionInitializer;
 use crate::npm::WorkspaceNpmPatchPackages;
 use crate::resolver::on_resolve_diagnostic;
-use crate::resolver::CliDenoResolver;
 use crate::resolver::CliIsCjsResolver;
 use crate::resolver::CliNpmReqResolver;
 use crate::resolver::CliResolver;
@@ -913,45 +912,49 @@ impl<'a> ResolverFactory<'a> {
   pub fn cli_resolver(&self) -> &Arc<CliResolver> {
     self.services.cli_resolver.get_or_init(|| {
       let npm_req_resolver = self.npm_pkg_req_resolver().cloned();
-      let deno_resolver = Arc::new(CliDenoResolver::new(DenoResolverOptions {
-        in_npm_pkg_checker: self.in_npm_pkg_checker().clone(),
-        node_and_req_resolver: match (self.node_resolver(), npm_req_resolver) {
-          (Some(node_resolver), Some(npm_req_resolver)) => {
-            Some(NodeAndNpmReqResolver {
-              node_resolver: node_resolver.clone(),
-              npm_req_resolver,
-            })
-          }
-          _ => None,
-        },
-        workspace_resolver: self
-          .config_data
-          .map(|d| d.resolver.clone())
-          .unwrap_or_else(|| {
-            Arc::new(WorkspaceResolver::new_raw(
-              // this is fine because this is only used before initialization
-              Arc::new(ModuleSpecifier::parse("file:///").unwrap()),
-              None,
-              Vec::new(),
-              Vec::new(),
-              PackageJsonDepResolution::Disabled,
-              Default::default(),
-              Default::default(),
-              Default::default(),
-              Default::default(),
-              self.sys.clone(),
-            ))
-          }),
-        bare_node_builtins: self
-          .config_data
-          .is_some_and(|d| d.unstable.contains("bare-node-builtins")),
-        is_byonm: self.config_data.map(|d| d.byonm).unwrap_or(false),
-        maybe_vendor_dir: self.config_data.and_then(|d| d.vendor_dir.as_ref()),
-      }));
+      let deno_resolver =
+        Arc::new(deno_resolver::RawDenoResolver::new(DenoResolverOptions {
+          in_npm_pkg_checker: self.in_npm_pkg_checker().clone(),
+          node_and_req_resolver: match (self.node_resolver(), npm_req_resolver)
+          {
+            (Some(node_resolver), Some(npm_req_resolver)) => {
+              Some(NodeAndNpmReqResolver {
+                node_resolver: node_resolver.clone(),
+                npm_req_resolver,
+              })
+            }
+            _ => None,
+          },
+          workspace_resolver: self
+            .config_data
+            .map(|d| d.resolver.clone())
+            .unwrap_or_else(|| {
+              Arc::new(WorkspaceResolver::new_raw(
+                // this is fine because this is only used before initialization
+                Arc::new(ModuleSpecifier::parse("file:///").unwrap()),
+                None,
+                Vec::new(),
+                Vec::new(),
+                PackageJsonDepResolution::Disabled,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                self.sys.clone(),
+              ))
+            }),
+          bare_node_builtins: self
+            .config_data
+            .is_some_and(|d| d.unstable.contains("bare-node-builtins")),
+          is_byonm: self.config_data.map(|d| d.byonm).unwrap_or(false),
+          maybe_vendor_dir: self
+            .config_data
+            .and_then(|d| d.vendor_dir.as_ref()),
+        }));
       Arc::new(CliResolver::new(
         deno_resolver,
         self.services.found_pkg_json_dep_flag.clone(),
-        Box::new(on_resolve_diagnostic),
+        Some(Arc::new(on_resolve_diagnostic)),
       ))
     })
   }

--- a/cli/resolver.rs
+++ b/cli/resolver.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use deno_ast::ModuleSpecifier;
 use deno_error::JsErrorBox;
 use deno_graph::NpmLoadError;
 use deno_graph::NpmResolvePkgReqsResult;
@@ -23,19 +22,13 @@ pub type CliCjsTracker =
   deno_resolver::cjs::CjsTracker<DenoInNpmPackageChecker, CliSys>;
 pub type CliIsCjsResolver =
   deno_resolver::cjs::IsCjsResolver<DenoInNpmPackageChecker, CliSys>;
-pub type CliDenoResolver = deno_resolver::DenoResolver<
-  DenoInNpmPackageChecker,
-  DenoIsBuiltInNodeModuleChecker,
-  CliNpmResolver,
-  CliSys,
->;
 pub type CliNpmReqResolver = deno_resolver::npm::NpmReqResolver<
   DenoInNpmPackageChecker,
   DenoIsBuiltInNodeModuleChecker,
   CliNpmResolver,
   CliSys,
 >;
-pub type CliResolver = deno_resolver::graph::DenoGraphResolver<
+pub type CliResolver = deno_resolver::graph::DenoResolver<
   DenoInNpmPackageChecker,
   DenoIsBuiltInNodeModuleChecker,
   CliNpmResolver,
@@ -43,16 +36,14 @@ pub type CliResolver = deno_resolver::graph::DenoGraphResolver<
 >;
 
 pub fn on_resolve_diagnostic(
-  diagnostic: &deno_resolver::workspace::MappedResolutionDiagnostic,
-  referrer: &ModuleSpecifier,
-  position: deno_graph::Position,
+  diagnostic: deno_resolver::graph::MappedResolutionDiagnosticWithPosition,
 ) {
   log::warn!(
     "{} {}\n    at {}:{}",
     deno_runtime::colors::yellow("Warning"),
-    diagnostic,
-    referrer,
-    position,
+    diagnostic.diagnostic,
+    diagnostic.referrer,
+    diagnostic.start
   );
 }
 

--- a/resolvers/deno/factory.rs
+++ b/resolvers/deno/factory.rs
@@ -71,11 +71,11 @@ use crate::workspace::FsCacheOptions;
 use crate::workspace::PackageJsonDepResolution;
 use crate::workspace::SloppyImportsOptions;
 use crate::workspace::WorkspaceResolver;
-use crate::DefaultDenoResolverRc;
-use crate::DenoResolver;
+use crate::DefaultRawDenoResolverRc;
 use crate::DenoResolverOptions;
 use crate::NodeAndNpmReqResolver;
 use crate::NpmCacheDirRc;
+use crate::RawDenoResolver;
 use crate::WorkspaceResolverRc;
 
 // todo(https://github.com/rust-lang/rust/issues/109737): remove once_cell after get_or_try_init is stabilized
@@ -591,7 +591,7 @@ impl<TSys: WorkspaceFactorySys> WorkspaceFactory<TSys> {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ResolverFactoryOptions {
   pub is_cjs_resolution_mode: IsCjsResolutionMode,
   pub npm_system_info: NpmSystemInfo,
@@ -603,13 +603,20 @@ pub struct ResolverFactoryOptions {
   /// Whether to resolve bare node builtins (ex. "path" as "node:path").
   pub bare_node_builtins: bool,
   pub unstable_sloppy_imports: bool,
+  #[cfg(feature = "graph")]
+  pub on_mapped_resolution_diagnostic:
+    Option<crate::graph::OnMappedResolutionDiagnosticFn>,
 }
 
 pub struct ResolverFactory<TSys: WorkspaceFactorySys> {
   options: ResolverFactoryOptions,
   sys: NodeResolutionSys<TSys>,
   cjs_tracker: Deferred<CjsTrackerRc<DenoInNpmPackageChecker, TSys>>,
-  deno_resolver: async_once_cell::OnceCell<DefaultDenoResolverRc<TSys>>,
+  #[cfg(feature = "graph")]
+  deno_resolver:
+    async_once_cell::OnceCell<crate::graph::DefaultDenoResolverRc<TSys>>,
+  #[cfg(feature = "graph")]
+  found_package_json_dep_flag: crate::graph::FoundPackageJsonDepFlagRc,
   in_npm_package_checker: Deferred<DenoInNpmPackageChecker>,
   node_resolver: Deferred<
     NodeResolverRc<
@@ -630,6 +637,7 @@ pub struct ResolverFactory<TSys: WorkspaceFactorySys> {
   npm_resolver: Deferred<NpmResolver<TSys>>,
   npm_resolution: NpmResolutionCellRc,
   pkg_json_resolver: Deferred<PackageJsonResolverRc<TSys>>,
+  raw_deno_resolver: async_once_cell::OnceCell<DefaultRawDenoResolverRc<TSys>>,
   workspace_factory: WorkspaceFactoryRc<TSys>,
   workspace_resolver: async_once_cell::OnceCell<WorkspaceResolverRc<TSys>>,
 }
@@ -645,7 +653,11 @@ impl<TSys: WorkspaceFactorySys> ResolverFactory<TSys> {
         options.node_resolution_cache.clone(),
       ),
       cjs_tracker: Default::default(),
+      raw_deno_resolver: Default::default(),
+      #[cfg(feature = "graph")]
       deno_resolver: Default::default(),
+      #[cfg(feature = "graph")]
+      found_package_json_dep_flag: Default::default(),
       in_npm_package_checker: Default::default(),
       node_resolver: Default::default(),
       npm_req_resolver: Default::default(),
@@ -658,14 +670,14 @@ impl<TSys: WorkspaceFactorySys> ResolverFactory<TSys> {
     }
   }
 
-  pub async fn deno_resolver(
+  pub async fn raw_deno_resolver(
     &self,
-  ) -> Result<&DefaultDenoResolverRc<TSys>, anyhow::Error> {
+  ) -> Result<&DefaultRawDenoResolverRc<TSys>, anyhow::Error> {
     self
-      .deno_resolver
+      .raw_deno_resolver
       .get_or_try_init(
         async {
-          Ok(new_rc(DenoResolver::new(DenoResolverOptions {
+          Ok(new_rc(RawDenoResolver::new(DenoResolverOptions {
             in_npm_pkg_checker: self.in_npm_package_checker()?.clone(),
             node_and_req_resolver: if self.workspace_factory.no_npm() {
               None
@@ -701,6 +713,29 @@ impl<TSys: WorkspaceFactorySys> ResolverFactory<TSys> {
         self.options.is_cjs_resolution_mode,
       )))
     })
+  }
+
+  #[cfg(feature = "graph")]
+  pub fn found_package_json_dep_flag(
+    &self,
+  ) -> &crate::graph::FoundPackageJsonDepFlagRc {
+    &self.found_package_json_dep_flag
+  }
+
+  #[cfg(feature = "graph")]
+  pub async fn deno_resolver(
+    &self,
+  ) -> Result<&crate::graph::DefaultDenoResolverRc<TSys>, anyhow::Error> {
+    self
+      .deno_resolver
+      .get_or_try_init(async {
+        Ok(new_rc(crate::graph::DenoResolver::new(
+          self.raw_deno_resolver().await?.clone(),
+          self.found_package_json_dep_flag.clone(),
+          self.options.on_mapped_resolution_diagnostic.clone(),
+        )))
+      })
+      .await
   }
 
   pub fn in_npm_package_checker(

--- a/resolvers/deno/lib.rs
+++ b/resolvers/deno/lib.rs
@@ -169,13 +169,13 @@ pub struct DenoResolverOptions<
 }
 
 #[allow(clippy::disallowed_types)]
-pub type DenoResolverRc<
+pub type RawDenoResolverRc<
   TInNpmPackageChecker,
   TIsBuiltInNodeModuleChecker,
   TNpmPackageFolderResolver,
   TSys,
 > = crate::sync::MaybeArc<
-  DenoResolver<
+  RawDenoResolver<
     TInNpmPackageChecker,
     TIsBuiltInNodeModuleChecker,
     TNpmPackageFolderResolver,
@@ -183,9 +183,9 @@ pub type DenoResolverRc<
   >,
 >;
 
-/// Helper type for a DenoResolverRc that has the implementations
+/// Helper type for a RawDenoResolverRc that has the implementations
 /// used by the Deno CLI.
-pub type DefaultDenoResolverRc<TSys> = DenoResolverRc<
+pub type DefaultRawDenoResolverRc<TSys> = RawDenoResolverRc<
   npm::DenoInNpmPackageChecker,
   DenoIsBuiltInNodeModuleChecker,
   npm::NpmResolver<TSys>,
@@ -195,7 +195,7 @@ pub type DefaultDenoResolverRc<TSys> = DenoResolverRc<
 /// A resolver that takes care of resolution, taking into account loaded
 /// import map, JSX settings.
 #[derive(Debug)]
-pub struct DenoResolver<
+pub struct RawDenoResolver<
   TInNpmPackageChecker: InNpmPackageChecker,
   TIsBuiltInNodeModuleChecker: IsBuiltInNodeModuleChecker,
   TNpmPackageFolderResolver: NpmPackageFolderResolver,
@@ -222,7 +222,7 @@ impl<
     TNpmPackageFolderResolver: NpmPackageFolderResolver,
     TSys: DenoResolverSys,
   >
-  DenoResolver<
+  RawDenoResolver<
     TInNpmPackageChecker,
     TIsBuiltInNodeModuleChecker,
     TNpmPackageFolderResolver,


### PR DESCRIPTION
1. Renames `DenoResolver` to `RawDenoResolver`
2. Renames `DenoGraphResolver` to `DenoResolver`
3. Shifts down creation of `DenoGraphResolver` and `HasPackageJsonDepFlag` to `ResolverFactory`