### PR TITLE
fix(fmt): indent width should be ignored when formatting with use tabs set to true

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -642,10 +642,21 @@ fn format_embedded_css(
       continue;
     }
     let mut chars = l.chars();
+
+    // indent width option is disregarded when use tabs is true since
+    // only one tab will be inserted when indented once
+    // https://malva.netlify.app/config/indent-width.html
+    let indent_width = if config.use_tabs {
+      1
+    } else {
+      config.indent_width as usize
+    };
+
     // drop the indentation
-    for _ in 0..config.indent_width {
+    for _ in 0..indent_width {
       chars.next();
     }
+
     buf.push(chars.as_str());
   }
   Some(buf.join("\n").to_string())

--- a/tests/specs/fmt/external_formatter/__test__.jsonc
+++ b/tests/specs/fmt/external_formatter/__test__.jsonc
@@ -5,11 +5,15 @@
       "input": "badly_formatted.in",
       "output": "well_formatted.out"
     },
+    "format_with_use_tabs": {
+      "args": "fmt --use-tabs -",
+      "input": "badly_formatted.in",
+      "output": "well_formatted_use_tabs.out"
+    },
     "format_with_unstable_sql": {
       "args": "fmt --unstable-sql -",
       "input": "badly_formatted.in",
       "output": "well_formatted_unstable_sql.out"
     }
-
   }
 }

--- a/tests/specs/fmt/external_formatter/badly_formatted.in
+++ b/tests/specs/fmt/external_formatter/badly_formatted.in
@@ -12,6 +12,21 @@ margin: 0.5rem;
 	}
 `;
 
+cssString = css`
+        border: 1px red solid;
+              background-color: red;
+border-radius: 4px;
+`
+
+nestedCssString = tw`
+  animate-pulse
+  border-red
+  ${css`
+         background-color: blue;
+border-radius: 4px;
+  `}
+`
+
 htmlString =
   html`<body><header>${header}</header><main>${main}</main><footer>${footer}</footer></body>`;
 

--- a/tests/specs/fmt/external_formatter/well_formatted.out
+++ b/tests/specs/fmt/external_formatter/well_formatted.out
@@ -12,6 +12,21 @@ const EqualDivider = styled.div`
   }
 `;
 
+cssString = css`
+  border: 1px red solid;
+  background-color: red;
+  border-radius: 4px;
+`;
+
+nestedCssString = tw`
+  animate-pulse
+  border-red
+  ${css`
+  background-color: blue;
+  border-radius: 4px;
+`}
+`;
+
 htmlString = html`
   <body>
     <header>${header}</header>

--- a/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
@@ -12,6 +12,21 @@ const EqualDivider = styled.div`
   }
 `;
 
+cssString = css`
+  border: 1px red solid;
+  background-color: red;
+  border-radius: 4px;
+`;
+
+nestedCssString = tw`
+  animate-pulse
+  border-red
+  ${css`
+  background-color: blue;
+  border-radius: 4px;
+`}
+`;
+
 htmlString = html`
   <body>
     <header>${header}</header>


### PR DESCRIPTION
fixes #29161 

Issue is only specific when use tabs is enabled, and the fix shouldn't affect when it is disabled in any way.

Also, this fix exposes another issue with external formatter, wherein if the external formatter returns a string that contains a tab, then the process panics. This should be fixed with this PR on `dprint-typescript-plugin` https://github.com/dprint/dprint-plugin-typescript/pull/708.