### PR TITLE
fix(ext/node): hold weak reference to sqlite database in instances

### DIFF
--- a/ext/node/ops/sqlite/database.rs
+++ b/ext/node/ops/sqlite/database.rs
@@ -254,6 +254,7 @@ impl DatabaseSync {
     // Finalize all prepared statements
     for stmt in self.statements.borrow_mut().drain(..) {
       if !stmt.is_null() {
+        // SAFETY: `stmt` is a valid statement handle.
         unsafe {
           libsqlite3_sys::sqlite3_finalize(stmt);
         }

--- a/ext/node/ops/sqlite/database.rs
+++ b/ext/node/ops/sqlite/database.rs
@@ -299,7 +299,7 @@ impl DatabaseSync {
 
     Ok(StatementSync {
       inner: raw_stmt,
-      db: self.conn.clone(),
+      db: Rc::downgrade(&self.conn),
       use_big_ints: Cell::new(false),
       allow_bare_named_params: Cell::new(true),
       is_iter_finished: false,
@@ -547,7 +547,7 @@ impl DatabaseSync {
     Ok(Session {
       inner: raw_session,
       freed: Cell::new(false),
-      db: self.conn.clone(),
+      db: Rc::downgrade(&self.conn),
     })
   }
 }

--- a/ext/node/ops/sqlite/session.rs
+++ b/ext/node/ops/sqlite/session.rs
@@ -3,7 +3,6 @@
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::ffi::c_void;
-use std::rc::Rc;
 use std::rc::Weak;
 
 use deno_core::op2;

--- a/ext/node/ops/sqlite/statement.rs
+++ b/ext/node/ops/sqlite/statement.rs
@@ -2,7 +2,6 @@
 
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::rc::Weak;
 
 use deno_core::op2;

--- a/tests/unit_node/sqlite_test.ts
+++ b/tests/unit_node/sqlite_test.ts
@@ -333,3 +333,13 @@ Deno.test("[node/sqlite] StatementSync empty blob", () => {
 
   db.close();
 });
+
+Deno.test("[node/sqlite] Database close locks", () => {
+  const db = new DatabaseSync(`${tempDir}/test4.db`);
+  const statement = db.prepare(
+    "CREATE TABLE test (key INTEGER PRIMARY KEY, value TEXT)",
+  );
+  statement.run();
+  db.close();
+  Deno.removeSync(`${tempDir}/test4.db`);
+});


### PR DESCRIPTION
Deterministic close and releases file lock on Windows.

Fixes https://github.com/denoland/deno/issues/29033