### PR TITLE
fix(node:http): `ServerResponse.req` not set

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1392,7 +1392,7 @@ function onError(self, error, cb) {
 }
 
 export type ServerResponse = {
-  req: IncomingMessage;
+  req: IncomingMessageForServer;
   statusCode: number;
   statusMessage?: string;
 

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -85,7 +85,6 @@ import { UpgradedConn } from "ext:deno_net/01_net.js";
 import { STATUS_CODES } from "node:_http_server";
 import { methods as METHODS } from "node:_http_common";
 import { deprecate } from "node:util";
-import { IncomingMessage } from "node:http";
 
 const { internalRidSymbol } = core;
 const { ArrayIsArray, StringPrototypeToLowerCase, SafeArrayIterator } =

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -1457,7 +1457,7 @@ type ServerResponseStatic = {
 
 export const ServerResponse = function (
   this: ServerResponse,
-  req: IncomingMessage,
+  req: IncomingMessageForServer,
   resolve: (value: Response | PromiseLike<Response>) => void,
   socket: FakeSocket,
 ) {

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -85,6 +85,7 @@ import { UpgradedConn } from "ext:deno_net/01_net.js";
 import { STATUS_CODES } from "node:_http_server";
 import { methods as METHODS } from "node:_http_common";
 import { deprecate } from "node:util";
+import { IncomingMessage } from "node:http";
 
 const { internalRidSymbol } = core;
 const { ArrayIsArray, StringPrototypeToLowerCase, SafeArrayIterator } =
@@ -1392,6 +1393,7 @@ function onError(self, error, cb) {
 }
 
 export type ServerResponse = {
+  req: IncomingMessage;
   statusCode: number;
   statusMessage?: string;
 
@@ -1456,9 +1458,11 @@ type ServerResponseStatic = {
 
 export const ServerResponse = function (
   this: ServerResponse,
+  req: IncomingMessage,
   resolve: (value: Response | PromiseLike<Response>) => void,
   socket: FakeSocket,
 ) {
+  this.req = req;
   this.statusCode = 200;
   this.statusMessage = undefined;
   this._headers = { __proto__: null };
@@ -1996,7 +2000,7 @@ export class ServerImpl extends EventEmitter {
         return response;
       } else {
         return new Promise<Response>((resolve): void => {
-          const res = new ServerResponse(resolve, socket);
+          const res = new ServerResponse(req, resolve, socket);
 
           if (request.headers.has("expect")) {
             if (/(?:^|\W)100-continue(?:$|\W)/i.test(req.headers.expect)) {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -1254,6 +1254,25 @@ Deno.test("[node/http] ServerResponse header names case insensitive", async () =
   await promise;
 });
 
+Deno.test("[node/http] ServerResponse .req", async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const server = http.createServer((req, res) => {
+    assertEquals(res.req, req);
+    res.end("foo");
+  });
+
+  server.listen(async () => {
+    const { port } = server.address() as { port: number };
+    const res = await fetch(`http://localhost:${port}`);
+    assertEquals(await res.text(), "foo");
+    server.close(() => {
+      resolve();
+    });
+  });
+
+  await promise;
+});
+
 Deno.test("[node/http] IncomingMessage override", () => {
   const req = new http.IncomingMessage(new net.Socket());
   // https://github.com/dougmoscrop/serverless-http/blob/3aaa6d0fe241109a8752efb011c242d249f32368/lib/request.js#L20-L30


### PR DESCRIPTION
This PR sets `ServerRsposne.req` properly. See https://github.com/nodejs/node/blob/e38ce27f3ca0a65f68a31cedd984cddb927d4002/lib/_http_server.js#L201

Fixes https://github.com/denoland/deno/issues/29209