### PR TITLE
chore: specify python versions in node_compat_test workflow

### DIFF
--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -26,6 +26,10 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: canary
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -55,6 +59,10 @@ jobs:
           submodules: true
       - name: Setup Deno
         uses: denoland/setup-deno@v2
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
`node_compat_test` started failing with the error `gsutil requires Python version 3.8-3.12, but a different version is installed.` recently.

This PR tries to fix it by specifying the version to 3.11. (Chose the version 3.11 because it's the version used in `ci.yml`)