### PR TITLE
test: Capture output of failing node compat tests

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -277,9 +277,10 @@ async function runSingle(testPath: string, retry = 0): Promise<SingleResult> {
     if (result.code === 0) {
       return [true];
     } else {
+      const output = usesNodeTest ? result.stdout : result.stderr;
       return [false, {
         code: result.code,
-        stderr: truncateTestOutput(new TextDecoder().decode(result.stderr)),
+        stderr: truncateTestOutput(new TextDecoder().decode(output)),
       }];
     }
   } catch (e) {


### PR DESCRIPTION
Will actually show test error instead of "error: Test failed"