### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/internal/querystring.ts`

### DIFF
--- a/ext/node/polyfills/internal/querystring.ts
+++ b/ext/node/polyfills/internal/querystring.ts
@@ -1,13 +1,22 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { ERR_INVALID_URI } from "ext:deno_node/internal/errors.ts";
+import { primordials } from "ext:core/mod.js";
+const {
+  Array,
+  Int8Array,
+  NumberPrototypeToString,
+  StringPrototypeCharCodeAt,
+  StringPrototypeSlice,
+  StringPrototypeToUpperCase,
+} = primordials;
 
 export const hexTable = new Array(256);
 for (let i = 0; i < 256; ++i) {
-  hexTable[i] = "%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase();
+  hexTable[i] = "%" +
+    StringPrototypeToUpperCase(
+      (i < 16 ? "0" : "") + NumberPrototypeToString(i, 16),
+    );
 }
 
 // deno-fmt-ignore
@@ -42,17 +51,17 @@ export function encodeStr(
   let lastPos = 0;
 
   for (let i = 0; i < len; i++) {
-    let c = str.charCodeAt(i);
+    let c = StringPrototypeCharCodeAt(str, i);
     // ASCII
     if (c < 0x80) {
       if (noEscapeTable[c] === 1) continue;
-      if (lastPos < i) out += str.slice(lastPos, i);
+      if (lastPos < i) out += StringPrototypeSlice(str, lastPos, i);
       lastPos = i + 1;
       out += hexTable[c];
       continue;
     }
 
-    if (lastPos < i) out += str.slice(lastPos, i);
+    if (lastPos < i) out += StringPrototypeSlice(str, lastPos, i);
 
     // Multi-byte characters ...
     if (c < 0x800) {
@@ -75,7 +84,7 @@ export function encodeStr(
     // completion's sake anyway.
     if (i >= len) throw new ERR_INVALID_URI();
 
-    const c2 = str.charCodeAt(i) & 0x3ff;
+    const c2 = StringPrototypeCharCodeAt(str, i) & 0x3ff;
 
     lastPos = i + 1;
     c = 0x10000 + (((c & 0x3ff) << 10) | c2);
@@ -85,7 +94,7 @@ export function encodeStr(
       hexTable[0x80 | (c & 0x3f)];
   }
   if (lastPos === 0) return str;
-  if (lastPos < len) return out + str.slice(lastPos);
+  if (lastPos < len) return out + StringPrototypeSlice(str, lastPos);
   return out;
 }
 


### PR DESCRIPTION
Towards #24236. Replaces JS intrinsics with equivalent primordial versions.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
