### PR TITLE
fix(ext/node): export CallTracker as named export

### DIFF
--- a/ext/node/polyfills/assert.ts
+++ b/ext/node/polyfills/assert.ts
@@ -938,6 +938,7 @@ export default Object.assign(assert, {
 
 export {
   AssertionError,
+  CallTracker_ as CallTracker,
   deepEqual,
   deepStrictEqual,
   doesNotMatch,

--- a/tests/unit_node/assert_test.ts
+++ b/tests/unit_node/assert_test.ts
@@ -24,3 +24,9 @@ Deno.test("[node/assert] deepStrictEqual(0, -0)", () => {
     },
   );
 });
+
+Deno.test("[node/assert] CallTracker correctly exported", () => {
+  assert.strictEqual(typeof assert.CallTracker, "function");
+  assert.strictEqual(typeof assert.default.CallTracker, "function");
+  assert.strictEqual(assert.CallTracker, assert.default.CallTracker);
+});


### PR DESCRIPTION
#29226 added CallTracker via default export of `node:assert`. This PR adds it as named export of `node:assert` as well.