### PR TITLE
fix(ext/node): add AES CTR to supported ciphers list

### DIFF
--- a/ext/node/polyfills/internal/crypto/util.ts
+++ b/ext/node/polyfills/internal/crypto/util.ts
@@ -77,6 +77,9 @@ const supportedCiphers = [
   "aes256",
   "aes-128-gcm",
   "aes-256-gcm",
+  "aes-128-ctr",
+  "aes-192-ctr",
+  "aes-256-ctr",
 ];
 
 export function getCiphers(): string[] {

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -384,6 +384,7 @@ Deno.test({
   name: "getCiphers",
   fn() {
     assertEquals(crypto.getCiphers().includes("aes-128-cbc"), true);
+    assertEquals(crypto.getCiphers().includes("aes-256-ctr"), true);
 
     const getZeroKey = (cipher: string) => zeros(+cipher.match(/\d+/)![0] / 8);
     const getZeroIv = (cipher: string) => {


### PR DESCRIPTION
Fix https://github.com/denoland/deno/issues/29047