### PR TITLE
feat(otel): add events for boot failure and uncaught error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ zip = { version = "2.4.1", default-features = false, features = ["flate2"] }
 
 opentelemetry = "0.27.0"
 opentelemetry-http = "0.27.0"
-opentelemetry-otlp = { version = "0.27.0", features = ["logs", "http-proto", "http-json"] }
+opentelemetry-otlp = { version = "0.27.0", features = ["logs", "http-proto", "http-json", "populate-logs-event-name"] }
 opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio", "trace"] }
 

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -94,9 +94,13 @@ pub async fn run_script(
       main_module.clone(),
       unconfigured_runtime,
     )
-    .await?;
+    .await
+    .inspect_err(|e| deno_telemetry::report_event("boot_failure", e))?;
 
-  let exit_code = worker.run().await?;
+  let exit_code = worker
+    .run()
+    .await
+    .inspect_err(|e| deno_telemetry::report_event("uncaught_exception", e))?;
   Ok(exit_code)
 }
 

--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -1125,6 +1125,27 @@ fn op_otel_log_foreign(
   log_processor.emit(&mut log_record, builtin_instrumentation_scope);
 }
 
+pub fn report_event(name: &'static str, data: impl std::fmt::Display) {
+  let Some(OtelGlobals {
+    log_processor,
+    builtin_instrumentation_scope,
+    ..
+  }) = OTEL_GLOBALS.get()
+  else {
+    return;
+  };
+
+  let mut log_record = LogRecord::default();
+
+  log_record.set_observed_timestamp(SystemTime::now());
+  log_record.set_event_name(name);
+  log_record.set_severity_number(Severity::Trace);
+  log_record.set_severity_text(Severity::Trace.name());
+  log_record.set_body(format!("{data}").into());
+
+  log_processor.emit(&mut log_record, builtin_instrumentation_scope);
+}
+
 fn owned_string<'s>(
   scope: &mut v8::HandleScope<'s>,
   string: v8::Local<'s, v8::String>,


### PR DESCRIPTION
This commit adds "boot_failure" and "uncaught_exception"
events that are sent when a worker crashes during `deno run`.