### PR TITLE
ci: Update release doc template

### DIFF
--- a/tools/release/release_doc_template.md
+++ b/tools/release/release_doc_template.md
@@ -28,44 +28,6 @@ Deno v$VERSION is now getting released.
 Release checklist: <LINK TO THIS FORKED GIST GOES HERE>
 ```
 
-## Patch release preparation
-
-⛔ **If you are cutting a patch release**: First you need to sync commits to the
-`v$MINOR_VERSION` branch in the `deno` repo.
-
-To do that, you need to cherry-pick commits from the main branch to the
-`v$MINOR_VERSION` branch. If the branch doesn't exist yet, create one from the
-latest minor tag:
-
-```
-# checkout latest minor release
-$ git checkout v$PAST_VERSION
-
-# create a branch
-$ git checkout v$MINOR_VERSION
-
-# push the branch to the `denoland/deno` repository
-$ git push upstream v$MINOR_VERSION
-```
-
-For patch releases we want to cherry-pick all commits that do not add features
-to the CLI. This generally means to filter out `feat` commits.
-
-Check what was the last commit on `v$MINOR_VERSION` branch before the previous
-release and start cherry-picking newer commits from the `main`.
-
-<!--
-      TODO: we should add sample deno program that does that for you,
-      and then provides a complete `git` command to run.
--->
-
-Once all relevant commits are cherry-picked, push the branch to the upstream and
-verify on GitHub that everything looks correct.
-
-- ⛔ DO NOT create a `v$VERSION`-like branch! You are meant to cherry pick to
-  the `v$MINOR_VERSION` branch. If you have accidentally created then
-  `v$VERSION` branch then delete it as tagging the CLI will fail otherwise.
-
 ## Updating `deno`
 
 ### Phase 1: Bumping versions
@@ -140,10 +102,6 @@ verify on GitHub that everything looks correct.
 - [ ] For minor releases: make sure https://github.com/mdn/browser-compat-data
       has been updated to reflect Web API changes in this release. Usually done
       ahead of time by @lucacasonato.
-
-- [ ] **If you are cutting a patch release**: a PR should have been
-      automatically opened that forwards the release commit back to main. If so,
-      merge it. If not and it failed, please manually create one.
 
 ## Updating `deno_docker`
 


### PR DESCRIPTION
We're gonna be cutting patch release from `main` branch from now on.