### PR TITLE
feat(runtime): add SIGUSR2 handler for low memory notifications

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1226,7 +1226,8 @@ static ENV_VARIABLES_HELP: &str = cstr!(
   <g>NO_PROXY</>               Comma-separated list of hosts which do not use a proxy
                           <p(245)>(module downloads, fetch)</>
   <g>NPM_CONFIG_REGISTRY</>    URL to use for the npm registry.
-  <g>DENO_TRUST_PROXY_HEADERS</>  If specified, removes X-deno-client-address header when serving HTTP."#
+  <g>DENO_TRUST_PROXY_HEADERS</>  If specified, removes X-deno-client-address header when serving HTTP.
+  <g>DENO_USR2_MEMORY_TRIM</>  If specified, listen for SIGUSR2 signal to try and free memory (Linux only)."#
 );
 
 static DENO_HELP: &str = cstr!(

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -684,8 +684,9 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
       unconfigured_runtime,
     };
 
-    let worker =
+    let mut worker =
       MainWorker::bootstrap_from_options(&main_module, services, options);
+    worker.setup_memory_trim_handler();
 
     Ok(LibMainWorker {
       main_module,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -799,7 +799,7 @@ impl WebWorker {
       return;
     }
 
-    if !MEMORY_TRIM_HANDLER_ENABLED {
+    if !*MEMORY_TRIM_HANDLER_ENABLED {
       return;
     }
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -69,6 +69,8 @@ use crate::worker::FormatJsErrorFn;
 use crate::worker::SIGUSR2_RX;
 use crate::BootstrapOptions;
 use crate::FeatureChecker;
+#[cfg(target_os = "linux")]
+use crate::MEMORY_TRIM_HANDLER_ENABLED;
 
 pub struct WorkerMetadata {
   pub buffer: DetachedBuffer,
@@ -794,6 +796,10 @@ impl WebWorker {
   #[cfg(target_os = "linux")]
   pub fn setup_memory_trim_handler(&mut self) {
     if self.memory_trim_handle.is_some() {
+      return;
+    }
+
+    if !MEMORY_TRIM_HANDLER_ENABLED {
       return;
     }
 

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -66,11 +66,11 @@ use crate::worker::import_meta_resolve_callback;
 use crate::worker::validate_import_attributes_callback;
 use crate::worker::FormatJsErrorFn;
 #[cfg(target_os = "linux")]
+use crate::worker::MEMORY_TRIM_HANDLER_ENABLED;
+#[cfg(target_os = "linux")]
 use crate::worker::SIGUSR2_RX;
 use crate::BootstrapOptions;
 use crate::FeatureChecker;
-#[cfg(target_os = "linux")]
-use crate::MEMORY_TRIM_HANDLER_ENABLED;
 
 pub struct WorkerMetadata {
   pub buffer: DetachedBuffer,

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -65,6 +65,8 @@ use crate::worker::create_op_metrics;
 use crate::worker::import_meta_resolve_callback;
 use crate::worker::validate_import_attributes_callback;
 use crate::worker::FormatJsErrorFn;
+#[cfg(target_os = "linux")]
+use crate::worker::SIGUSR2_RX;
 use crate::BootstrapOptions;
 use crate::FeatureChecker;
 
@@ -400,12 +402,17 @@ pub struct WebWorker {
   bootstrap_fn_global: Option<v8::Global<v8::Function>>,
   // Consumed when `bootstrap_fn` is called
   maybe_worker_metadata: Option<WorkerMetadata>,
+  memory_trim_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Drop for WebWorker {
   fn drop(&mut self) {
     // clean up the package.json thread local cache
     node_resolver::PackageJsonThreadLocalCache::clear();
+
+    if let Some(memory_trim_handle) = self.memory_trim_handle.take() {
+      memory_trim_handle.abort();
+    }
   }
 }
 
@@ -701,6 +708,7 @@ impl WebWorker {
         bootstrap_fn_global: Some(bootstrap_fn_global),
         close_on_idle: options.close_on_idle,
         maybe_worker_metadata: options.maybe_worker_metadata,
+        memory_trim_handle: None,
       },
       external_handle,
       options.bootstrap,
@@ -772,6 +780,45 @@ impl WebWorker {
       self.has_message_event_listener_fn =
         Some(v8::Global::new(scope, has_message_event_listener_fn));
     }
+  }
+
+  #[cfg(not(target_os = "linux"))]
+  pub fn setup_memory_trim_handler(&mut self) {
+    // Noop
+  }
+
+  /// Sets up a handler that responds to SIGUSR2 signals by trimming unused
+  /// memory and notifying V8 of low memory conditions.
+  /// Note that this must be called within a tokio runtime.
+  /// Calling this method multiple times will be a no-op.
+  #[cfg(target_os = "linux")]
+  pub fn setup_memory_trim_handler(&mut self) {
+    if self.memory_trim_handle.is_some() {
+      return;
+    }
+
+    let mut sigusr2_rx = SIGUSR2_RX.clone();
+
+    let spawner = self
+      .js_runtime
+      .op_state()
+      .borrow()
+      .borrow::<deno_core::V8CrossThreadTaskSpawner>()
+      .clone();
+
+    let memory_trim_handle = tokio::spawn(async move {
+      loop {
+        if sigusr2_rx.changed().await.is_err() {
+          break;
+        }
+
+        spawner.spawn(move |isolate| {
+          isolate.low_memory_notification();
+        });
+      }
+    });
+
+    self.memory_trim_handle = Some(memory_trim_handle);
   }
 
   /// See [JsRuntime::execute_script](deno_core::JsRuntime::execute_script)
@@ -964,6 +1011,8 @@ pub async fn run_web_worker(
   mut maybe_source_code: Option<String>,
   format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
 ) -> Result<(), CoreError> {
+  worker.setup_memory_trim_handler();
+
   let name = worker.name.to_string();
   let internal_handle = worker.internal_handle.clone();
 

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use std::sync::LazyLock;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -57,6 +59,34 @@ use crate::BootstrapOptions;
 use crate::FeatureChecker;
 
 pub type FormatJsErrorFn = dyn Fn(&JsError) -> String + Sync + Send;
+
+#[cfg(target_os = "linux")]
+pub(crate) static SIGUSR2_RX: LazyLock<tokio::sync::watch::Receiver<()>> =
+  LazyLock::new(|| {
+    let (tx, rx) = tokio::sync::watch::channel(());
+
+    tokio::spawn(async move {
+      let mut sigusr2 = tokio::signal::unix::signal(
+        tokio::signal::unix::SignalKind::user_defined2(),
+      )
+      .unwrap();
+
+      loop {
+        sigusr2.recv().await;
+
+        // SAFETY: calling into libc, nothing relevant on the Rust side.
+        unsafe {
+          libc::malloc_trim(0);
+        }
+
+        if tx.send(()).is_err() {
+          break;
+        }
+      }
+    });
+
+    rx
+  });
 
 pub fn import_meta_resolve_callback(
   loader: &dyn ModuleLoader,
@@ -125,6 +155,15 @@ pub struct MainWorker {
   dispatch_unload_event_fn_global: v8::Global<v8::Function>,
   dispatch_process_beforeexit_event_fn_global: v8::Global<v8::Function>,
   dispatch_process_exit_event_fn_global: v8::Global<v8::Function>,
+  memory_trim_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for MainWorker {
+  fn drop(&mut self) {
+    if let Some(memory_trim_handle) = self.memory_trim_handle.take() {
+      memory_trim_handle.abort();
+    }
+  }
 }
 
 pub struct WorkerServiceOptions<
@@ -682,6 +721,7 @@ impl MainWorker {
       dispatch_unload_event_fn_global,
       dispatch_process_beforeexit_event_fn_global,
       dispatch_process_exit_event_fn_global,
+      memory_trim_handle: None,
     };
     (worker, options.bootstrap)
   }
@@ -708,6 +748,45 @@ impl MainWorker {
       let error = JsError::from_v8_exception(scope, exception);
       panic!("Bootstrap exception: {error}");
     }
+  }
+
+  #[cfg(not(target_os = "linux"))]
+  pub fn setup_memory_trim_handler(&mut self) {
+    // Noop
+  }
+
+  /// Sets up a handler that responds to SIGUSR2 signals by trimming unused
+  /// memory and notifying V8 of low memory conditions.
+  /// Note that this must be called within a tokio runtime.
+  /// Calling this method multiple times will be a no-op.
+  #[cfg(target_os = "linux")]
+  pub fn setup_memory_trim_handler(&mut self) {
+    if self.memory_trim_handle.is_some() {
+      return;
+    }
+
+    let mut sigusr2_rx = SIGUSR2_RX.clone();
+
+    let spawner = self
+      .js_runtime
+      .op_state()
+      .borrow()
+      .borrow::<deno_core::V8CrossThreadTaskSpawner>()
+      .clone();
+
+    let memory_trim_handle = tokio::spawn(async move {
+      loop {
+        if sigusr2_rx.changed().await.is_err() {
+          break;
+        }
+
+        spawner.spawn(move |isolate| {
+          isolate.low_memory_notification();
+        });
+      }
+    });
+
+    self.memory_trim_handle = Some(memory_trim_handle);
   }
 
   /// See [JsRuntime::execute_script](deno_core::JsRuntime::execute_script)

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -769,7 +769,7 @@ impl MainWorker {
       return;
     }
 
-    if !MEMORY_TRIM_HANDLER_ENABLED {
+    if !*MEMORY_TRIM_HANDLER_ENABLED {
       return;
     }
 


### PR DESCRIPTION
This commit adds a signal handler for SIGUSR2 that helps reduce the memory usage of both main worker and web worker by:

1. Triggering `malloc_trim(0)` to release memory back to the system
2. Invoking V8 isolate's `low_memory_notification` function

This is only available on Linux and enabled when `DENO_USR2_MEMORY_TRIM` env var is specified.