### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/internal/net.ts`

### DIFF
--- a/ext/node/polyfills/internal/net.ts
+++ b/ext/node/polyfills/internal/net.ts
@@ -20,21 +20,21 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { Buffer } from "node:buffer";
 import { uvException } from "ext:deno_node/internal/errors.ts";
 import { writeBuffer } from "ext:deno_node/internal_binding/node_file.ts";
+import { primordials } from "ext:core/mod.js";
+
+const { RegExpPrototypeTest, SafeRegExp, Symbol } = primordials;
 
 // IPv4 Segment
 const v4Seg = "(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])";
 const v4Str = `(${v4Seg}[.]){3}${v4Seg}`;
-const IPv4Reg = new RegExp(`^${v4Str}$`);
+const IPv4Reg = new SafeRegExp(`^${v4Str}$`);
 
 // IPv6 Segment
 const v6Seg = "(?:[0-9a-fA-F]{1,4})";
-const IPv6Reg = new RegExp(
+const IPv6Reg = new SafeRegExp(
   "^(" +
     `(?:${v6Seg}:){7}(?:${v6Seg}|:)|` +
     `(?:${v6Seg}:){6}(?:${v4Str}|:${v6Seg}|:)|` +
@@ -48,11 +48,11 @@ const IPv6Reg = new RegExp(
 );
 
 export function isIPv4(ip: string) {
-  return RegExp.prototype.test.call(IPv4Reg, ip);
+  return RegExpPrototypeTest(IPv4Reg, ip);
 }
 
 export function isIPv6(ip: string) {
-  return RegExp.prototype.test.call(IPv6Reg, ip);
+  return RegExpPrototypeTest(IPv6Reg, ip);
 }
 
 export function isIP(ip: string) {


### PR DESCRIPTION
Towards #24236. Replaces `Symbol`, `RegExp` and its instance method, `.test()`, with primordial equivalents.
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
