### PR TITLE
feat(permissions): subdomain wildcards

### DIFF
--- a/cli/args/flags_net.rs
+++ b/cli/args/flags_net.rs
@@ -32,7 +32,7 @@ pub fn validator(host_and_port: &str) -> Result<String, String> {
   if Url::parse(&format!("internal://{host_and_port}")).is_ok()
     || host_and_port.parse::<IpAddr>().is_ok()
     || host_and_port.parse::<BarePort>().is_ok()
-    || NetDescriptor::parse(host_and_port).is_ok()
+    || NetDescriptor::parse_for_list(host_and_port).is_ok()
   {
     Ok(host_and_port.to_string())
   } else {
@@ -52,7 +52,7 @@ pub fn parse(paths: Vec<String>) -> clap::error::Result<Vec<String>> {
         out.push(format!("{}:{}", host, port.0));
       }
     } else {
-      NetDescriptor::parse(&host_and_port).map_err(|e| {
+      NetDescriptor::parse_for_list(&host_and_port).map_err(|e| {
         clap::Error::raw(clap::error::ErrorKind::InvalidValue, e.to_string())
       })?;
       out.push(host_and_port)
@@ -120,6 +120,7 @@ mod tests {
     let entries = svec![
       "deno.land",
       "deno.land:80",
+      "*.deno.land",
       "[::]",
       "[::1]",
       "127.0.0.1",
@@ -141,6 +142,7 @@ mod tests {
     let expected = svec![
       "deno.land",
       "deno.land:80",
+      "*.deno.land",
       "[::]",
       "[::1]",
       "127.0.0.1",

--- a/runtime/permissions.rs
+++ b/runtime/permissions.rs
@@ -77,14 +77,14 @@ impl<TSys: sys_traits::EnvCurrentDir + Send + Sync + std::fmt::Debug>
     &self,
     text: &str,
   ) -> Result<NetDescriptor, deno_permissions::NetDescriptorParseError> {
-    NetDescriptor::parse(text)
+    NetDescriptor::parse_for_list(text)
   }
 
   fn parse_import_descriptor(
     &self,
     text: &str,
   ) -> Result<ImportDescriptor, deno_permissions::NetDescriptorParseError> {
-    ImportDescriptor::parse(text)
+    ImportDescriptor::parse_for_list(text)
   }
 
   fn parse_env_descriptor(
@@ -142,6 +142,13 @@ impl<TSys: sys_traits::EnvCurrentDir + Send + Sync + std::fmt::Debug>
     })
   }
 
+  fn parse_net_query(
+    &self,
+    text: &str,
+  ) -> Result<NetDescriptor, deno_permissions::NetDescriptorParseError> {
+    NetDescriptor::parse_for_query(text)
+  }
+
   fn parse_run_query(
     &self,
     requested: &str,
@@ -170,6 +177,7 @@ mod test {
     assert!(parser.parse_net_descriptor("").is_err());
     assert!(parser.parse_ffi_descriptor("").is_err());
     assert!(parser.parse_path_query("").is_err());
+    assert!(parser.parse_net_query("").is_err());
     assert!(parser.parse_run_query("").is_err());
   }
 }

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -818,6 +818,7 @@ pub struct WriteDescriptor(pub PathBuf);
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Host {
   Fqdn(FQDN),
+  FqdnWithSubdomainWildcard(FQDN),
   Ip(IpAddr),
   Vsock(u32),
 }
@@ -840,7 +841,19 @@ pub enum HostParseError {
 }
 
 impl Host {
-  fn parse(s: &str) -> Result<Self, HostParseError> {
+  fn parse_for_query(s: &str) -> Result<Self, HostParseError> {
+    Self::parse_inner(s, false)
+  }
+
+  #[cfg(test)]
+  fn parse_for_list(s: &str) -> Result<Self, HostParseError> {
+    Self::parse_inner(s, true)
+  }
+
+  fn parse_inner(
+    s: &str,
+    allow_subdomain_wildcard: bool,
+  ) -> Result<Self, HostParseError> {
     if s.starts_with('[') && s.ends_with(']') {
       let ip = s[1..s.len() - 1]
         .parse::<Ipv6Addr>()
@@ -862,9 +875,17 @@ impl Host {
       } else {
         Cow::Owned(s.to_ascii_lowercase())
       };
+      let mut host_or_suffix = lower.as_ref();
+      let mut has_subdomain_wildcard = false;
+      if allow_subdomain_wildcard {
+        if let Some(suffix) = lower.strip_prefix("*.") {
+          host_or_suffix = suffix;
+          has_subdomain_wildcard = true;
+        }
+      }
       let fqdn = {
         use std::str::FromStr;
-        FQDN::from_str(&lower).map_err(|e| HostParseError::Fqdn {
+        FQDN::from_str(host_or_suffix).map_err(|e| HostParseError::Fqdn {
           error: e,
           host: s.to_string(),
         })?
@@ -872,14 +893,18 @@ impl Host {
       if fqdn.is_root() {
         return Err(HostParseError::InvalidEmptyHost(s.to_string()));
       }
-      Ok(Host::Fqdn(fqdn))
+      if has_subdomain_wildcard {
+        Ok(Host::FqdnWithSubdomainWildcard(fqdn))
+      } else {
+        Ok(Host::Fqdn(fqdn))
+      }
     }
   }
 
   #[cfg(test)]
   #[track_caller]
   fn must_parse(s: &str) -> Self {
-    Self::parse(s).unwrap()
+    Self::parse_for_list(s).unwrap()
   }
 }
 
@@ -920,7 +945,22 @@ impl QueryDescriptor for NetDescriptor {
   }
 
   fn matches_allow(&self, other: &Self::AllowDesc) -> bool {
-    self.0 == other.0 && (other.1.is_none() || self.1 == other.1)
+    if other.1.is_some() && self.1 != other.1 {
+      return false;
+    }
+    match (&other.0, &self.0) {
+      (Host::Fqdn(a), Host::Fqdn(b)) => a == b,
+      (Host::FqdnWithSubdomainWildcard(a), Host::Fqdn(b)) => {
+        b.is_subdomain_of(a)
+      }
+      (
+        Host::FqdnWithSubdomainWildcard(a),
+        Host::FqdnWithSubdomainWildcard(b),
+      ) => a == b,
+      (Host::Ip(a), Host::Ip(b)) => a == b,
+      (Host::Vsock(a), Host::Vsock(b)) => a == b,
+      _ => false,
+    }
   }
 
   fn matches_deny(&self, other: &Self::DenyDesc) -> bool {
@@ -971,7 +1011,22 @@ pub enum NetDescriptorFromUrlParseError {
 }
 
 impl NetDescriptor {
-  pub fn parse(hostname: &str) -> Result<Self, NetDescriptorParseError> {
+  pub fn parse_for_query(
+    hostname: &str,
+  ) -> Result<Self, NetDescriptorParseError> {
+    Self::parse_inner(hostname, false)
+  }
+
+  pub fn parse_for_list(
+    hostname: &str,
+  ) -> Result<Self, NetDescriptorParseError> {
+    Self::parse_inner(hostname, true)
+  }
+
+  fn parse_inner(
+    hostname: &str,
+    allow_subdomain_wildcard: bool,
+  ) -> Result<Self, NetDescriptorParseError> {
     #[cfg(unix)]
     if let Some(vsock) = hostname.strip_prefix("vsock:") {
       let mut split = vsock.split(':');
@@ -1035,7 +1090,7 @@ impl NetDescriptor {
       Some((host, port)) => (host, port),
       None => (hostname, ""),
     };
-    let host = Host::parse(host)?;
+    let host = Host::parse_inner(host, allow_subdomain_wildcard)?;
 
     let port = if port.is_empty() {
       None
@@ -1065,7 +1120,7 @@ impl NetDescriptor {
     let host = url.host_str().ok_or_else(|| {
       NetDescriptorFromUrlParseError::MissingHost(url.clone())
     })?;
-    let host = Host::parse(host)?;
+    let host = Host::parse_for_query(host)?;
     let port = url.port_or_known_default();
     Ok(NetDescriptor(host, port.map(Into::into)))
   }
@@ -1082,6 +1137,7 @@ impl fmt::Display for NetDescriptor {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match &self.0 {
       Host::Fqdn(fqdn) => write!(f, "{fqdn}"),
+      Host::FqdnWithSubdomainWildcard(fqdn) => write!(f, "*.{fqdn}"),
       Host::Ip(IpAddr::V4(ip)) => write!(f, "{ip}"),
       Host::Ip(IpAddr::V6(ip)) => write!(f, "[{ip}]"),
       Host::Vsock(cid) => write!(f, "vsock:{cid}"),
@@ -1151,8 +1207,10 @@ impl QueryDescriptor for ImportDescriptor {
 }
 
 impl ImportDescriptor {
-  pub fn parse(specifier: &str) -> Result<Self, NetDescriptorParseError> {
-    Ok(ImportDescriptor(NetDescriptor::parse(specifier)?))
+  pub fn parse_for_list(
+    specifier: &str,
+  ) -> Result<Self, NetDescriptorParseError> {
+    Ok(ImportDescriptor(NetDescriptor::parse_for_list(specifier)?))
   }
 
   pub fn from_url(url: &Url) -> Result<Self, NetDescriptorFromUrlParseError> {
@@ -2966,7 +3024,7 @@ impl PermissionsContainer {
     let mut inner = self.inner.lock();
     let inner = &mut inner.net;
     skip_check_if_is_permission_fully_granted!(inner);
-    let hostname = Host::parse(host.0.as_ref())?;
+    let hostname = Host::parse_for_query(host.0.as_ref())?;
     let descriptor = NetDescriptor(hostname, host.1.map(Into::into));
     inner.check(&descriptor, Some(api_name))?;
     Ok(())
@@ -3098,7 +3156,7 @@ impl PermissionsContainer {
       permission.query(
         match host {
           None => None,
-          Some(h) => Some(self.descriptor_parser.parse_net_descriptor(h)?),
+          Some(h) => Some(self.descriptor_parser.parse_net_query(h)?),
         }
         .as_ref(),
       ),
@@ -3228,7 +3286,7 @@ impl PermissionsContainer {
       self.inner.lock().net.revoke(
         match host {
           None => None,
-          Some(h) => Some(self.descriptor_parser.parse_net_descriptor(h)?),
+          Some(h) => Some(self.descriptor_parser.parse_net_query(h)?),
         }
         .as_ref(),
       ),
@@ -3338,7 +3396,7 @@ impl PermissionsContainer {
       self.inner.lock().net.request(
         match host {
           None => None,
-          Some(h) => Some(self.descriptor_parser.parse_net_descriptor(h)?),
+          Some(h) => Some(self.descriptor_parser.parse_net_query(h)?),
         }
         .as_ref(),
       ),
@@ -3752,6 +3810,11 @@ pub trait PermissionDescriptorParser: Debug + Send + Sync {
     path: &str,
   ) -> Result<PathQueryDescriptor, PathResolveError>;
 
+  fn parse_net_query(
+    &self,
+    text: &str,
+  ) -> Result<NetDescriptor, NetDescriptorParseError>;
+
   fn parse_run_query(
     &self,
     requested: &str,
@@ -3815,14 +3878,14 @@ mod tests {
       &self,
       text: &str,
     ) -> Result<NetDescriptor, NetDescriptorParseError> {
-      NetDescriptor::parse(text)
+      NetDescriptor::parse_for_list(text)
     }
 
     fn parse_import_descriptor(
       &self,
       text: &str,
     ) -> Result<ImportDescriptor, NetDescriptorParseError> {
-      ImportDescriptor::parse(text)
+      ImportDescriptor::parse_for_list(text)
     }
 
     fn parse_env_descriptor(
@@ -3874,6 +3937,13 @@ mod tests {
         resolved: self.join_path_with_root(path),
         requested: path.to_string(),
       })
+    }
+
+    fn parse_net_query(
+      &self,
+      text: &str,
+    ) -> Result<NetDescriptor, NetDescriptorParseError> {
+      NetDescriptor::parse_for_query(text)
     }
 
     fn parse_run_query(
@@ -3945,7 +4015,8 @@ mod tests {
           "172.16.0.2:8000",
           "www.github.com:443",
           "80.example.com:80",
-          "443.example.com:443"
+          "443.example.com:443",
+          "*.discord.gg"
         ]),
         ..Default::default()
       },
@@ -3973,13 +4044,15 @@ mod tests {
       ("443.example.com", 444, false),
       ("80.example.com", 81, false),
       ("80.example.com", 80, true),
+      ("discord.gg", 0, true),
+      ("foo.discord.gg", 0, true),
       // Just some random hosts that should err
       ("somedomain", 0, false),
       ("192.168.0.1", 0, false),
     ];
 
     for (host, port, is_ok) in domain_tests {
-      let host = Host::parse(host).unwrap();
+      let host = Host::parse_for_query(host).unwrap();
       let descriptor = NetDescriptor(host, Some(port));
       assert_eq!(
         is_ok,
@@ -4025,7 +4098,7 @@ mod tests {
     ];
 
     for (host_str, port) in domain_tests {
-      let host = Host::parse(host_str).unwrap();
+      let host = Host::parse_for_query(host_str).unwrap();
       let descriptor = NetDescriptor(host, Some(port));
       assert!(
         perms.net.check(&descriptor, None).is_ok(),
@@ -4070,7 +4143,7 @@ mod tests {
     ];
 
     for (host_str, port) in domain_tests {
-      let host = Host::parse(host_str).unwrap();
+      let host = Host::parse_for_query(host_str).unwrap();
       let descriptor = NetDescriptor(host, Some(port));
       assert!(
         perms.net.check(&descriptor, None).is_err(),
@@ -5042,7 +5115,7 @@ mod tests {
       &parser,
       &PermissionsOptions {
         allow_env: Some(vec![]),
-        allow_net: Some(svec!["foo", "bar"]),
+        allow_net: Some(svec!["*.foo", "bar"]),
         ..Default::default()
       },
     )
@@ -5063,7 +5136,9 @@ mod tests {
       Permissions {
         env: Permissions::new_unary(Some(HashSet::new()), None, false),
         net: Permissions::new_unary(
-          Some(HashSet::from([NetDescriptor::parse("foo").unwrap()])),
+          Some(HashSet::from([
+            NetDescriptor::parse_for_list("foo").unwrap()
+          ])),
           None,
           false
         ),
@@ -5159,9 +5234,57 @@ mod tests {
   }
 
   #[test]
-  fn test_host_parse() {
+  fn test_host_parse_for_query() {
     let hosts = &[
       ("deno.land", Some(Host::Fqdn(fqdn!("deno.land")))),
+      ("DENO.land", Some(Host::Fqdn(fqdn!("deno.land")))),
+      ("deno.land.", Some(Host::Fqdn(fqdn!("deno.land")))),
+      (
+        "1.1.1.1",
+        Some(Host::Ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)))),
+      ),
+      (
+        "::1",
+        Some(Host::Ip(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))),
+      ),
+      (
+        "[::1]",
+        Some(Host::Ip(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))),
+      ),
+      ("[::1", None),
+      ("::1]", None),
+      ("deno. land", None),
+      ("1. 1.1.1", None),
+      ("1.1.1.1.", None),
+      ("1::1.", None),
+      ("deno.land.", Some(Host::Fqdn(fqdn!("deno.land")))),
+      (".deno.land", None),
+      ("*.deno.land", None),
+      (
+        "::ffff:1.1.1.1",
+        Some(Host::Ip(IpAddr::V6(Ipv6Addr::new(
+          0, 0, 0, 0, 0, 0xffff, 0x0101, 0x0101,
+        )))),
+      ),
+    ];
+
+    for (host_str, expected) in hosts {
+      assert_eq!(
+        Host::parse_for_query(host_str).ok(),
+        *expected,
+        "{host_str}"
+      );
+    }
+  }
+
+  #[test]
+  fn test_host_parse_for_list() {
+    let hosts = &[
+      ("deno.land", Some(Host::Fqdn(fqdn!("deno.land")))),
+      (
+        "*.deno.land",
+        Some(Host::FqdnWithSubdomainWildcard(fqdn!("deno.land"))),
+      ),
       ("DENO.land", Some(Host::Fqdn(fqdn!("deno.land")))),
       ("deno.land.", Some(Host::Fqdn(fqdn!("deno.land")))),
       (
@@ -5193,12 +5316,12 @@ mod tests {
     ];
 
     for (host_str, expected) in hosts {
-      assert_eq!(Host::parse(host_str).ok(), *expected, "{host_str}");
+      assert_eq!(Host::parse_for_list(host_str).ok(), *expected, "{host_str}");
     }
   }
 
   #[test]
-  fn test_net_descriptor_parse() {
+  fn test_net_descriptor_parse_for_query() {
     let cases = &[
       (
         "deno.land",
@@ -5211,6 +5334,84 @@ mod tests {
       (
         "deno.land:8000",
         Some(NetDescriptor(Host::Fqdn(fqdn!("deno.land")), Some(8000))),
+      ),
+      ("*.deno.land", None),
+      ("deno.land:", None),
+      ("deno.land:a", None),
+      ("deno. land:a", None),
+      ("deno.land.: a", None),
+      (
+        "1.1.1.1",
+        Some(NetDescriptor(
+          Host::Ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))),
+          None,
+        )),
+      ),
+      ("1.1.1.1.", None),
+      ("1.1.1.1..", None),
+      (
+        "1.1.1.1:8000",
+        Some(NetDescriptor(
+          Host::Ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))),
+          Some(8000),
+        )),
+      ),
+      ("::", None),
+      (":::80", None),
+      ("::80", None),
+      (
+        "[::]",
+        Some(NetDescriptor(
+          Host::Ip(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0))),
+          None,
+        )),
+      ),
+      ("[::1", None),
+      ("::1]", None),
+      ("::1]", None),
+      ("[::1]:", None),
+      ("[::1]:a", None),
+      (
+        "[::1]:443",
+        Some(NetDescriptor(
+          Host::Ip(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+          Some(443),
+        )),
+      ),
+      ("", None),
+      ("deno.land..", None),
+    ];
+
+    for (input, expected) in cases {
+      assert_eq!(
+        NetDescriptor::parse_for_query(input).ok(),
+        *expected,
+        "'{input}'"
+      );
+    }
+  }
+
+  #[test]
+  fn test_net_descriptor_parse_for_list() {
+    let cases = &[
+      (
+        "deno.land",
+        Some(NetDescriptor(Host::Fqdn(fqdn!("deno.land")), None)),
+      ),
+      (
+        "DENO.land",
+        Some(NetDescriptor(Host::Fqdn(fqdn!("deno.land")), None)),
+      ),
+      (
+        "deno.land:8000",
+        Some(NetDescriptor(Host::Fqdn(fqdn!("deno.land")), Some(8000))),
+      ),
+      (
+        "*.deno.land",
+        Some(NetDescriptor(
+          Host::FqdnWithSubdomainWildcard(fqdn!("deno.land")),
+          None,
+        )),
       ),
       ("deno.land:", None),
       ("deno.land:a", None),
@@ -5259,7 +5460,11 @@ mod tests {
     ];
 
     for (input, expected) in cases {
-      assert_eq!(NetDescriptor::parse(input).ok(), *expected, "'{input}'");
+      assert_eq!(
+        NetDescriptor::parse_for_list(input).ok(),
+        *expected,
+        "'{input}'"
+      );
     }
   }
 

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -1445,6 +1445,19 @@ mod permissions {
   }
 
   #[test]
+  fn net_fetch_localhost_subdomain() {
+    let _http_guard = util::http_server();
+    let (_, err) = util::run_and_collect_output(
+      true,
+        "run --allow-net=*.localhost run/complex_permissions_test.ts netFetch http://localhost:4545/ http://localhost:4546/ http://localhost:4547/",
+        None,
+        None,
+        true,
+      );
+    assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
+  }
+
+  #[test]
   fn net_connect_allow_localhost_ip_4555() {
     let _http_guard = util::http_server();
     let (_, err) = util::run_and_collect_output(


### PR DESCRIPTION
Addresses part of #6532.

Supports prefix-only subdomain wildcards: `--allow-net=*.github.com` matches `fetch("https://foo.github.com")`.

Doesn't support wildcards in a middle label like `cloudformation.*.amazonaws.com`. I might implement that in this PR, but handling multiple wildcards for example seems complicated.

> **https only**
> `deno run --allow-net=https://* server.js`

Let's decline this one.