### PR TITLE
fix(install): support uninstalling multiple global packages

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3693,12 +3693,12 @@ packages a project declares as dependencies, similar to <p(245)>npm ls</> / <p(2
 fn uninstall_subcommand() -> Command {
   command(
     "uninstall",
-    cstr!("Uninstalls a dependency or an executable script in the installation root's bin directory.
+    cstr!("Uninstalls dependencies or an executable script in the installation root's bin directory.
   <p(245)>deno uninstall @std/dotenv chalk</>
   <p(245)>deno uninstall --global file_server</>
 
 To change the installation root, use <c>--root</> flag:
-  <p(245)>deno uninstall --global --root /usr/local serve</>
+  <p(245)>deno uninstall --global --root /usr/local cowsay serve</>
 
 The installation root is determined, in order of precedence:
   - <p(245)>--root</> option
@@ -3720,13 +3720,12 @@ The installation root is determined, in order of precedence:
         Arg::new("global")
           .long("global")
           .short('g')
-          .help("Remove globally installed package or module")
+          .help("Remove globally installed packages or modules")
           .action(ArgAction::SetTrue),
       )
       .arg(
         Arg::new("additional-packages")
           .help("List of additional packages to remove")
-          .conflicts_with("global")
           .num_args(1..)
           .action(ArgAction::Append)
       )
@@ -6536,25 +6535,19 @@ fn remove_parse(
   matches: &mut ArgMatches,
 ) -> clap::error::Result<()> {
   lock_args_parse(flags, matches);
-  let mut packages = matches.remove_many::<String>("packages").unwrap();
+  let packages = matches.remove_many::<String>("packages").unwrap();
 
-  // `deno remove --global <name>` is an alias for `deno uninstall --global
-  // <name>`: it removes a globally installed executable rather than a
-  // dependency from the configuration file, so route it through the same
+  // `deno remove --global <name>...` is an alias for `deno uninstall --global
+  // <name>...`: it removes globally installed executables rather than
+  // dependencies from the configuration file, so route it through the same
   // subcommand the uninstaller uses.
   if matches.get_flag("global") {
-    let name = packages.next().unwrap();
-    // A global removal targets a single executable, matching
-    // `deno uninstall --global`, so reject any extra names.
-    if packages.next().is_some() {
-      return Err(clap::Error::raw(
-        clap::error::ErrorKind::ArgumentConflict,
-        "--global only removes a single executable, but multiple packages were provided\n",
-      ));
-    }
     let root = matches.remove_one::<String>("root");
     flags.subcommand = DenoSubcommand::Uninstall(UninstallFlags {
-      kind: UninstallKind::Global(UninstallFlagsGlobal { name, root }),
+      kind: UninstallKind::Global(UninstallFlagsGlobal {
+        packages: packages.collect(),
+        root,
+      }),
     });
     return Ok(());
   }
@@ -7634,19 +7627,19 @@ fn jupyter_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 fn uninstall_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   lock_args_parse(flags, matches);
   let name = matches.remove_one::<String>("name-or-package").unwrap();
+  let packages: Vec<_> = vec![name]
+    .into_iter()
+    .chain(
+      matches
+        .remove_many::<String>("additional-packages")
+        .unwrap_or_default(),
+    )
+    .collect();
 
   let kind = if matches.get_flag("global") {
     let root = matches.remove_one::<String>("root");
-    UninstallKind::Global(UninstallFlagsGlobal { name, root })
+    UninstallKind::Global(UninstallFlagsGlobal { packages, root })
   } else {
-    let packages: Vec<_> = vec![name]
-      .into_iter()
-      .chain(
-        matches
-          .remove_many::<String>("additional-packages")
-          .unwrap_or_default(),
-      )
-      .collect();
     UninstallKind::Local(RemoveFlags {
       packages,
       lockfile_only: matches.get_flag("lockfile-only"),
@@ -12154,7 +12147,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Uninstall(UninstallFlags {
           kind: UninstallKind::Global(UninstallFlagsGlobal {
-            name: "file_server".to_string(),
+            packages: svec!["file_server"],
             root: None,
           }),
         }),
@@ -12175,7 +12168,29 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Uninstall(UninstallFlags {
           kind: UninstallKind::Global(UninstallFlagsGlobal {
-            name: "file_server".to_string(),
+            packages: svec!["file_server"],
+            root: Some("/user/foo/bar".to_string()),
+          }),
+        }),
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec![
+      "deno",
+      "uninstall",
+      "-g",
+      "--root",
+      "/user/foo/bar",
+      "cowsay",
+      "file_server"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Uninstall(UninstallFlags {
+          kind: UninstallKind::Global(UninstallFlagsGlobal {
+            packages: svec!["cowsay", "file_server"],
             root: Some("/user/foo/bar".to_string()),
           }),
         }),
@@ -15856,7 +15871,7 @@ mod tests {
         Flags {
           subcommand: DenoSubcommand::Uninstall(UninstallFlags {
             kind: UninstallKind::Global(UninstallFlagsGlobal {
-              name: "file_server".to_string(),
+              packages: svec!["file_server"],
               root: None,
             }),
           }),
@@ -15879,7 +15894,7 @@ mod tests {
       Flags {
         subcommand: DenoSubcommand::Uninstall(UninstallFlags {
           kind: UninstallKind::Global(UninstallFlagsGlobal {
-            name: "file_server".to_string(),
+            packages: svec!["file_server"],
             root: Some("/user/foo/bar".to_string()),
           }),
         }),
@@ -15887,10 +15902,22 @@ mod tests {
       }
     );
 
-    // A global removal targets a single executable; extra names are rejected.
+    // A global removal accepts multiple executables, like `deno uninstall
+    // --global`.
     let r =
       flags_from_vec(svec!["deno", "remove", "-g", "file_server", "chalk"]);
-    assert!(r.is_err());
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Uninstall(UninstallFlags {
+          kind: UninstallKind::Global(UninstallFlagsGlobal {
+            packages: svec!["file_server", "chalk"],
+            root: None,
+          }),
+        }),
+        ..Flags::default()
+      }
+    );
 
     // `--root` requires `--global`.
     let r =

--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -257,70 +257,70 @@ pub async fn uninstall(
     return Err(anyhow!("Installation path is not a directory"));
   }
 
-  let file_path = installation_dir.join(&uninstall_flags.name);
+  for name in &uninstall_flags.packages {
+    let file_path = installation_dir.join(name);
 
-  let mut removed = remove_file_if_exists(&file_path)?;
+    let mut removed = remove_file_if_exists(&file_path)?;
 
-  if cfg!(windows) {
-    removed |= remove_file_if_exists(&file_path.with_extension("cmd"))?;
-    removed |= remove_file_if_exists(&file_path.with_extension("exe"))?;
-  }
+    if cfg!(windows) {
+      removed |= remove_file_if_exists(&file_path.with_extension("cmd"))?;
+      removed |= remove_file_if_exists(&file_path.with_extension("exe"))?;
+    }
 
-  if !removed {
-    return Err(anyhow!(
-      "No installation found for {}",
-      uninstall_flags.name
-    ));
-  }
+    if !removed {
+      return Err(anyhow!("No installation found for {}", name));
+    }
 
-  // There might be some extra files to delete
-  // Note: tsconfig.json is legacy. We renamed it to deno.json in January 2023.
-  // Note: deno.json and lock.json files were removed Feb 2026 in favor of a sub directory
-  // Use the base file path (without extension) to compute related files
-  let base_file = installation_dir.join(&uninstall_flags.name);
-  for ext in ["tsconfig.json", "deno.json", "lock.json"] {
-    // remove the plain extension files (e.g., name.deno.json, name.lock.json)
-    let file_path_ext = base_file.with_extension(ext);
-    remove_file_if_exists(&file_path_ext)?;
+    // There might be some extra files to delete
+    // Note: tsconfig.json is legacy. We renamed it to deno.json in January 2023.
+    // Note: deno.json and lock.json files were removed Feb 2026 in favor of a sub directory
+    // Use the base file path (without extension) to compute related files
+    let base_file = installation_dir.join(name);
+    for ext in ["tsconfig.json", "deno.json", "lock.json"] {
+      // remove the plain extension files (e.g., name.deno.json, name.lock.json)
+      let file_path_ext = base_file.with_extension(ext);
+      remove_file_if_exists(&file_path_ext)?;
 
-    // also remove the hidden per-command copies created at install time
-    // (e.g., .name.deno.json)
-    let hidden_file = get_hidden_file_with_ext(&base_file, ext);
-    remove_file_if_exists(&hidden_file)?;
+      // also remove the hidden per-command copies created at install time
+      // (e.g., .name.deno.json)
+      let hidden_file = get_hidden_file_with_ext(&base_file, ext);
+      remove_file_if_exists(&hidden_file)?;
 
-    // On Windows, installs use a shim with a .cmd extension, which means the
-    // hidden files might be named like `.name.cmd.deno.json`. Attempt to remove
-    // those as well to be thorough.
-    #[cfg(windows)]
+      // On Windows, installs use a shim with a .cmd extension, which means the
+      // hidden files might be named like `.name.cmd.deno.json`. Attempt to remove
+      // those as well to be thorough.
+      #[cfg(windows)]
+      {
+        let base_with_cmd = base_file.with_extension("cmd");
+        let hidden_cmd_file = get_hidden_file_with_ext(&base_with_cmd, ext);
+        remove_file_if_exists(&hidden_cmd_file)?;
+      }
+    }
+
+    // remove the .<name>/ config directory if it exists
+    let config_dir = installation_dir.join(format!(".{}", name));
+
+    // check for extra bin entries stored during install and remove their shims
+    let extra_bins_file = config_dir.join("extra_bin_entries.json");
+    if extra_bins_file.is_file()
+      && let Ok(content) = fs::read_to_string(&extra_bins_file)
+      && let Ok(extra_names) = serde_json::from_str::<Vec<String>>(&content)
     {
-      let base_with_cmd = base_file.with_extension("cmd");
-      let hidden_cmd_file = get_hidden_file_with_ext(&base_with_cmd, ext);
-      remove_file_if_exists(&hidden_cmd_file)?;
+      for extra_name in &extra_names {
+        remove_shim_files(&installation_dir, extra_name)?;
+      }
     }
-  }
 
-  // remove the .<name>/ config directory if it exists
-  let config_dir = installation_dir.join(format!(".{}", uninstall_flags.name));
-
-  // check for extra bin entries stored during install and remove their shims
-  let extra_bins_file = config_dir.join("extra_bin_entries.json");
-  if extra_bins_file.is_file()
-    && let Ok(content) = fs::read_to_string(&extra_bins_file)
-    && let Ok(extra_names) = serde_json::from_str::<Vec<String>>(&content)
-  {
-    for extra_name in &extra_names {
-      remove_shim_files(&installation_dir, extra_name)?;
+    if config_dir.is_dir() {
+      fs::remove_dir_all(&config_dir).with_context(|| {
+        format!("Failed removing directory: {}", config_dir.display())
+      })?;
+      log::info!("deleted {}", config_dir.display());
     }
+
+    log::info!("✅ Successfully uninstalled {}", name);
   }
 
-  if config_dir.is_dir() {
-    fs::remove_dir_all(&config_dir).with_context(|| {
-      format!("Failed removing directory: {}", config_dir.display())
-    })?;
-    log::info!("deleted {}", config_dir.display());
-  }
-
-  log::info!("✅ Successfully uninstalled {}", uninstall_flags.name);
   Ok(())
 }
 
@@ -2359,46 +2359,60 @@ mod tests {
     let bin_dir = temp_dir.path().join("bin");
     std::fs::create_dir(&bin_dir).unwrap();
 
-    let mut file_path = bin_dir.join("echo_test");
-    File::create(&file_path).unwrap();
-    if cfg!(windows) {
-      file_path = file_path.with_extension("cmd");
+    // create a shim plus its extra and hidden per-command files, mirroring
+    // what install produces
+    let create_shim = |name: &str| {
+      let mut file_path = bin_dir.join(name);
       File::create(&file_path).unwrap();
-    }
-    let shim_path = file_path.clone();
+      if cfg!(windows) {
+        file_path = file_path.with_extension("cmd");
+        File::create(&file_path).unwrap();
+      }
+      let shim_path = file_path.clone();
 
-    // create extra files
-    {
-      let file_path = file_path.with_extension("deno.json");
-      File::create(file_path).unwrap();
-    }
-    {
-      // legacy tsconfig.json, make sure it's cleaned up for now
-      let file_path = file_path.with_extension("tsconfig.json");
-      File::create(file_path).unwrap();
-    }
-    {
-      let file_path = file_path.with_extension("lock.json");
-      File::create(file_path).unwrap();
-    }
+      // create extra files
+      {
+        let file_path = file_path.with_extension("deno.json");
+        File::create(file_path).unwrap();
+      }
+      {
+        // legacy tsconfig.json, make sure it's cleaned up for now
+        let file_path = file_path.with_extension("tsconfig.json");
+        File::create(file_path).unwrap();
+      }
+      {
+        let file_path = file_path.with_extension("lock.json");
+        File::create(file_path).unwrap();
+      }
 
-    // create hidden per-command copies as produced by install
-    {
-      let hidden_file =
-        get_hidden_file_with_ext(shim_path.as_path(), "deno.json");
-      File::create(hidden_file).unwrap();
-    }
-    {
-      let hidden_file =
-        get_hidden_file_with_ext(shim_path.as_path(), "lock.json");
-      File::create(hidden_file).unwrap();
-    }
+      // create hidden per-command copies as produced by install
+      {
+        let hidden_file =
+          get_hidden_file_with_ext(shim_path.as_path(), "deno.json");
+        File::create(hidden_file).unwrap();
+      }
+      {
+        let hidden_file =
+          get_hidden_file_with_ext(shim_path.as_path(), "lock.json");
+        File::create(hidden_file).unwrap();
+      }
 
+      (file_path, shim_path)
+    };
+
+    let (mut file_path, shim_path) = create_shim("echo_test");
+    let (mut second_file_path, second_shim_path) =
+      create_shim("second_echo_test");
+
+    // uninstall removes multiple packages at once
     uninstall(
       Default::default(),
       UninstallFlags {
         kind: UninstallKind::Global(UninstallFlagsGlobal {
-          name: "echo_test".to_string(),
+          packages: vec![
+            "echo_test".to_string(),
+            "second_echo_test".to_string(),
+          ],
           root: Some(temp_dir.path().to_string()),
         }),
       },
@@ -2406,22 +2420,30 @@ mod tests {
     .await
     .unwrap();
 
-    assert!(!file_path.exists());
-    assert!(!file_path.with_extension("tsconfig.json").exists());
-    assert!(!file_path.with_extension("deno.json").exists());
-    assert!(!file_path.with_extension("lock.json").exists());
+    for (file_path, shim_path) in [
+      (&file_path, &shim_path),
+      (&second_file_path, &second_shim_path),
+    ] {
+      assert!(!file_path.exists());
+      assert!(!file_path.with_extension("tsconfig.json").exists());
+      assert!(!file_path.with_extension("deno.json").exists());
+      assert!(!file_path.with_extension("lock.json").exists());
 
-    // hidden per-command files should also be removed
-    assert!(
-      !get_hidden_file_with_ext(shim_path.as_path(), "deno.json").exists()
-    );
-    assert!(
-      !get_hidden_file_with_ext(shim_path.as_path(), "lock.json").exists()
-    );
+      // hidden per-command files should also be removed
+      assert!(
+        !get_hidden_file_with_ext(shim_path.as_path(), "deno.json").exists()
+      );
+      assert!(
+        !get_hidden_file_with_ext(shim_path.as_path(), "lock.json").exists()
+      );
+    }
 
     if cfg!(windows) {
       file_path = file_path.with_extension("cmd");
       assert!(!file_path.exists());
+
+      second_file_path = second_file_path.with_extension("cmd");
+      assert!(!second_file_path.exists());
     }
   }
 

--- a/libs/cli_parser/src/flags.rs
+++ b/libs/cli_parser/src/flags.rs
@@ -461,7 +461,7 @@ pub struct JupyterFlags {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UninstallFlagsGlobal {
-  pub name: String,
+  pub packages: Vec<String>,
   pub root: Option<String>,
 }
 

--- a/tests/specs/install/global/uninstall_multiple/__test__.jsonc
+++ b/tests/specs/install/global/uninstall_multiple/__test__.jsonc
@@ -1,0 +1,21 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install --global --root ./bins --name first ./main.js",
+      "output": "install_first.out"
+    },
+    {
+      "args": "install --global --root ./bins --name second ./main.js",
+      "output": "install_second.out"
+    },
+    {
+      "args": "uninstall --global --root ./bins first second",
+      "output": "uninstall.out"
+    },
+    {
+      "args": "run -A assert_removed.js",
+      "output": ""
+    }
+  ]
+}

--- a/tests/specs/install/global/uninstall_multiple/assert_removed.js
+++ b/tests/specs/install/global/uninstall_multiple/assert_removed.js
@@ -1,0 +1,13 @@
+// `deno uninstall --global first second` should remove both executables from
+// the bin dir in a single invocation.
+const binsDir = "./bins/bin";
+for await (const entry of Deno.readDir(binsDir)) {
+  if (
+    entry.name === "first" || entry.name === "first.cmd" ||
+    entry.name === "second" || entry.name === "second.cmd"
+  ) {
+    throw new Error(
+      `Expected ${entry.name} to be removed by 'deno uninstall --global', but it still exists`,
+    );
+  }
+}

--- a/tests/specs/install/global/uninstall_multiple/install_first.out
+++ b/tests/specs/install/global/uninstall_multiple/install_first.out
@@ -1,0 +1,2 @@
+✅ Successfully installed first
+[WILDCARD]

--- a/tests/specs/install/global/uninstall_multiple/install_second.out
+++ b/tests/specs/install/global/uninstall_multiple/install_second.out
@@ -1,0 +1,2 @@
+✅ Successfully installed second
+[WILDCARD]

--- a/tests/specs/install/global/uninstall_multiple/main.js
+++ b/tests/specs/install/global/uninstall_multiple/main.js
@@ -1,0 +1,1 @@
+console.log("hi from multi-uninstall test bin");

--- a/tests/specs/install/global/uninstall_multiple/uninstall.out
+++ b/tests/specs/install/global/uninstall_multiple/uninstall.out
@@ -1,0 +1,2 @@
+[WILDCARD]✅ Successfully uninstalled first
+[WILDCARD]✅ Successfully uninstalled second


### PR DESCRIPTION
Closes #28809.

`deno uninstall --global <a> <b>` previously errored with "the argument
'--global' cannot be used with '[additional-packages]...'", which
contradicted the documented usage that already lists additional packages.

This removes the `conflicts_with("global")` restriction on the
`additional-packages` argument and updates the global uninstall routine to
loop over every provided name, so multiple executables can be uninstalled in
a single invocation.

The same relaxation is applied to the `deno remove --global` alias, which
previously rejected more than one name, so the two paths stay consistent.

Covered by a new `install/global/uninstall_multiple` spec test and an
expanded unit test that uninstalls two executables at once.
