### PR TITLE
fix: Support virtio vsock only on systems on which it is available (#29268)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -193,6 +193,7 @@ winapi = { workspace = true, features = ["knownfolders", "mswsock", "objbase", "
 [target.'cfg(unix)'.dependencies]
 nix.workspace = true
 shell-escape = "=0.1.5"
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 tokio-vsock.workspace = true
 
 [dev-dependencies]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -626,7 +626,15 @@ fn wait_for_start(
     use tokio::io::BufReader;
     use tokio::net::TcpListener;
     use tokio::net::UnixSocket;
+    #[cfg(any(
+      target_os = "linux",
+      target_os = "macos"
+    ))]
     use tokio_vsock::VsockAddr;
+    #[cfg(any(
+      target_os = "linux",
+      target_os = "macos"
+    ))]
     use tokio_vsock::VsockListener;
 
     init_v8(&Flags::default());
@@ -663,6 +671,10 @@ fn wait_for_start(
         let (rx, tx) = stream.into_split();
         (Box::new(rx), Box::new(tx))
       }
+      #[cfg(any(
+        target_os = "linux",
+        target_os = "macos"
+      ))]
       Some(("vsock", addr)) => {
         let Some((cid, port)) = addr.split_once(':') else {
           deno_core::anyhow::bail!("invalid vsock addr");

--- a/ext/net/Cargo.toml
+++ b/ext/net/Cargo.toml
@@ -32,5 +32,5 @@ tokio.workspace = true
 url.workspace = true
 web-transport-proto.workspace = true
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 tokio-vsock.workspace = true

--- a/ext/net/io.rs
+++ b/ext/net/io.rs
@@ -190,14 +190,14 @@ impl Resource for UnixStreamResource {
   }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub type VsockStreamResource =
   FullDuplexResource<tokio_vsock::OwnedReadHalf, tokio_vsock::OwnedWriteHalf>;
 
-#[cfg(not(unix))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub struct VsockStreamResource;
 
-#[cfg(not(unix))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 impl VsockStreamResource {
   fn read(self: Rc<Self>, _data: &mut [u8]) -> AsyncResult<usize> {
     unreachable!()

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -679,7 +679,7 @@ where
   net_listen_udp::<NP>(state, addr, reuse_address, loopback)
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[op2(async, stack_trace)]
 #[serde]
 pub async fn op_net_connect_vsock<NP>(
@@ -727,7 +727,7 @@ where
   ))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 #[op2]
 #[serde]
 pub fn op_net_connect_vsock<NP>() -> Result<(), NetError>
@@ -737,7 +737,7 @@ where
   Err(NetError::VsockUnsupported)
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[op2(stack_trace)]
 #[serde]
 pub fn op_net_listen_vsock<NP>(
@@ -770,7 +770,7 @@ where
   Ok((rid, local_addr.cid(), local_addr.port()))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 #[op2]
 #[serde]
 pub fn op_net_listen_vsock<NP>() -> Result<(), NetError>
@@ -780,7 +780,7 @@ where
   Err(NetError::VsockUnsupported)
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[op2(async)]
 #[serde]
 pub async fn op_net_accept_vsock(
@@ -819,7 +819,7 @@ pub async fn op_net_accept_vsock(
   ))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 #[op2]
 #[serde]
 pub fn op_net_accept_vsock() -> Result<(), NetError> {

--- a/ext/net/raw.rs
+++ b/ext/net/raw.rs
@@ -281,6 +281,7 @@ network_stream!(
     tokio::net::unix::SocketAddr,
     crate::io::UnixStreamResource
   ],
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
   [
     Vsock,
     vsock,
@@ -315,7 +316,7 @@ pub enum NetworkStreamAddress {
   Ip(std::net::SocketAddr),
   #[cfg(unix)]
   Unix(tokio::net::unix::SocketAddr),
-  #[cfg(unix)]
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
   Vsock(tokio_vsock::VsockAddr),
 }
 
@@ -332,7 +333,7 @@ impl From<tokio::net::unix::SocketAddr> for NetworkStreamAddress {
   }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 impl From<tokio_vsock::VsockAddr> for NetworkStreamAddress {
   fn from(value: tokio_vsock::VsockAddr) -> Self {
     NetworkStreamAddress::Vsock(value)
@@ -351,7 +352,7 @@ pub enum TakeNetworkStreamError {
   #[class("Busy")]
   #[error("Unix socket is currently in use")]
   UnixBusy,
-  #[cfg(unix)]
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
   #[class("Busy")]
   #[error("Vsock socket is currently in use")]
   VsockBusy,
@@ -362,7 +363,7 @@ pub enum TakeNetworkStreamError {
   #[class(generic)]
   #[error(transparent)]
   ReuniteUnix(#[from] tokio::net::unix::ReuniteError),
-  #[cfg(unix)]
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
   #[class(generic)]
   #[error("Cannot reunite halves from different streams")]
   ReuniteVsock,
@@ -413,7 +414,7 @@ pub fn take_network_stream_resource(
     return Ok(NetworkStream::Unix(unix_stream));
   }
 
-  #[cfg(unix)]
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
   if let Ok(resource_rc) =
     resource_table.take::<crate::io::VsockStreamResource>(stream_rid)
   {


### PR DESCRIPTION
See https://github.com/denoland/deno/issues/29268 for the related discussion.