### PR TITLE
fix(coverage): pass DENO_COVERAGE_DIR env var correctly

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -308,7 +308,7 @@ async fn run_subcommand(
           // this is set in order to ensure spawned processes use the same
           // coverage directory
           env::set_var(
-            "DENO_UNSTABLE_COVERAGE_DIR",
+            "DENO_COVERAGE_DIR",
             PathBuf::from(coverage_dir).canonicalize()?,
           );
         }

--- a/tests/testdata/coverage/complex_test.ts
+++ b/tests/testdata/coverage/complex_test.ts
@@ -34,3 +34,18 @@ Deno.test("sub process with deno eval", () => {
     throw new Error("Failed");
   }
 });
+
+Deno.test("DENO_COVERAGE_DIR is set and passed down to child process", () => {
+  const coverageDir = Deno.env.get("DENO_COVERAGE_DIR");
+  if (coverageDir === undefined) {
+    throw new Error("DENO_COVERAGE_DIR is not set");
+  }
+  const code = "console.log(Deno.env.get('DENO_COVERAGE_DIR'))";
+  const { stdout } = new Deno.Command(Deno.execPath(), {
+    args: ["eval", code],
+  }).outputSync();
+  const output = new TextDecoder().decode(stdout);
+  if (output.trim() !== coverageDir) {
+    throw new Error("Failed");
+  }
+});


### PR DESCRIPTION
This was missed in https://github.com/denoland/deno/pull/28291

This PR fixes the env var set when code coverage is enabled.

This prepares for supporting coverage from child process https://github.com/denoland/deno/issues/16440