### PR TITLE
fix(ext/node): implement `before` and `after` hooks in `node:test`

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -7,7 +7,7 @@ const {
   ArrayPrototypeForEach,
   SafePromiseAll,
   TypeError,
-  SafeIterator,
+  SafeArrayIterator,
   SafePromisePrototypeFinally,
   Symbol,
 } = primordials;
@@ -114,12 +114,12 @@ class NodeTestContext {
     // deno-lint-ignore no-this-alias
     const parentContext = this;
     const after = async () => {
-      for (const hook of new SafeIterator(this.#afterHooks)) {
+      for (const hook of new SafeArrayIterator(this.#afterHooks)) {
         await hook();
       }
     };
     const before = async () => {
-      for (const hook of new SafeIterator(this.#beforeHooks)) {
+      for (const hook of new SafeArrayIterator(this.#beforeHooks)) {
         await hook();
       }
     };


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/29360 and https://github.com/denoland/deno/issues/28837. Needed for `node:sqlite` tests