### PR TITLE
fix(fmt): allow expressions used as key-value pair in css template literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,8 +3310,7 @@ dependencies = [
 [[package]]
 name = "dprint-plugin-typescript"
 version = "0.95.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b6b18951ebbfe42a284c62dc307a0ae836f8cb1c1aa34aff6aabc21e840d9f"
+source = "git+https://github.com/kt3k/dprint-plugin-typescript.git?branch=fix-embedded-css-allow-key-value-pair-placeholder#f6a076b1f983ce2dc198e5432885a54d008b9608"
 dependencies = [
  "anyhow",
  "capacity_builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,8 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-typescript"
-version = "0.95.3"
-source = "git+https://github.com/kt3k/dprint-plugin-typescript.git?branch=fix-embedded-css-allow-key-value-pair-placeholder#f6a076b1f983ce2dc198e5432885a54d008b9608"
+version = "0.95.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de69002a89b59589b7372206dc8aa3a7b055b4b069c76c889e84e3f53165a93"
 dependencies = [
  "anyhow",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,7 +293,7 @@ dprint-core = "=0.67.4"
 dprint-plugin-json = "=0.20.0"
 dprint-plugin-jupyter = "=0.2.0"
 dprint-plugin-markdown = "=0.18.0"
-dprint-plugin-typescript = "=0.95.3"
+dprint-plugin-typescript = "=0.95.4"
 env_logger = "=0.11.6"
 eszip = "=0.88.0"
 fancy-regex = "=0.14.0"
@@ -518,6 +518,3 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_npm_cache]
 opt-level = 3
-
-[patch.crates-io]
-dprint-plugin-typescript = { git = "https://github.com/kt3k/dprint-plugin-typescript.git", branch = "fix-embedded-css-allow-key-value-pair-placeholder" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,3 +518,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_npm_cache]
 opt-level = 3
+
+[patch.crates-io]
+dprint-plugin-typescript = { git = "https://github.com/kt3k/dprint-plugin-typescript.git", branch = "fix-embedded-css-allow-key-value-pair-placeholder" }

--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -619,11 +619,14 @@ fn format_embedded_css(
       ignore_file_comment_directive: "malva-ignore-file".into(),
     },
   };
-  // Wraps the text in a css block of `a { ... }`
-  // to make it valid css (scss)
+  // Wraps the text in a css block of `a { ... ;}`
+  // to make it valid css
+  // Note: We choose LESS for the syntax because it allows us to use
+  // @variable for both property values and mixins, which is convenient
+  // for handling placeholders used as both properties and mixins.
   let text = malva::format_text(
-    &format!("a{{\n{}\n}}", text),
-    malva::Syntax::Scss,
+    &format!("a{{\n{}\n;}}", text),
+    malva::Syntax::Less,
     &options,
   )?;
   let mut buf = vec![];

--- a/tests/specs/fmt/external_formatter/badly_formatted.in
+++ b/tests/specs/fmt/external_formatter/badly_formatted.in
@@ -8,6 +8,7 @@ margin: 0.5rem;
 
 	&:not(:first-child) {
 			${(props) => props.vertical ? "margin-top" : "margin-left"}: 1rem;
+        ${OTHER_STYLES};
 		}
 	}
 `;
@@ -16,7 +17,7 @@ cssString = css`
         border: 1px red solid;
               background-color: red;
 border-radius: 4px;
-`
+        ${OTHER_STYLES}`
 
 nestedCssString = tw`
   animate-pulse

--- a/tests/specs/fmt/external_formatter/syntax_error_in_css.out
+++ b/tests/specs/fmt/external_formatter/syntax_error_in_css.out
@@ -1,3 +1,3 @@
 Error formatting: [WILDLINE]syntax_error_in_css.js
-   Error formatting tagged template literal at line 0: syntax error at line 3, col 10: component value is expected
+   Error formatting tagged template literal at line 0: syntax error at line 1, col 1: expect token `(`, but found `{`
 error: Failed to format 1 of 1 checked file

--- a/tests/specs/fmt/external_formatter/well_formatted.out
+++ b/tests/specs/fmt/external_formatter/well_formatted.out
@@ -8,6 +8,7 @@ const EqualDivider = styled.div`
 
     &:not(:first-child) {
       ${(props) => props.vertical ? "margin-top" : "margin-left"}: 1rem;
+      ${OTHER_STYLES};
     }
   }
 `;
@@ -16,6 +17,7 @@ cssString = css`
   border: 1px red solid;
   background-color: red;
   border-radius: 4px;
+  ${OTHER_STYLES};
 `;
 
 nestedCssString = tw`

--- a/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
@@ -8,6 +8,7 @@ const EqualDivider = styled.div`
 
     &:not(:first-child) {
       ${(props) => props.vertical ? "margin-top" : "margin-left"}: 1rem;
+      ${OTHER_STYLES};
     }
   }
 `;
@@ -16,6 +17,7 @@ cssString = css`
   border: 1px red solid;
   background-color: red;
   border-radius: 4px;
+  ${OTHER_STYLES};
 `;
 
 nestedCssString = tw`

--- a/tests/specs/fmt/external_formatter/well_formatted_use_tabs.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_use_tabs.out
@@ -8,6 +8,7 @@ const EqualDivider = styled.div`
 
 		&:not(:first-child) {
 			${(props) => props.vertical ? "margin-top" : "margin-left"}: 1rem;
+			${OTHER_STYLES};
 		}
 	}
 `;
@@ -16,6 +17,7 @@ cssString = css`
 	border: 1px red solid;
 	background-color: red;
 	border-radius: 4px;
+	${OTHER_STYLES};
 `;
 
 nestedCssString = tw`


### PR DESCRIPTION
fixes https://github.com/denoland/deno/issues/29337

This PR allows expressions in css template literals to be used as key-value pair replacement.

~~depends on https://github.com/dprint/dprint-plugin-typescript/pull/712~~ published