### PR TITLE
test(ext/node): run .mjs test files

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -384,7 +384,7 @@ async function main() {
   const tests = [] as string[];
   const categories = {} as Record<string, string[]>;
   for await (
-    const test of expandGlob("tests/node_compat/runner/suite/**/test-*.js")
+    const test of expandGlob("tests/node_compat/runner/suite/**/test-*{.mjs,.cjs.,.js,.ts}")
   ) {
     if (!test.isFile) continue;
     const relUrl = toFileUrl(test.path).href.replace(testDirUrl, "");

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -384,7 +384,9 @@ async function main() {
   const tests = [] as string[];
   const categories = {} as Record<string, string[]>;
   for await (
-    const test of expandGlob("tests/node_compat/runner/suite/**/test-*{.mjs,.cjs.,.js,.ts}")
+    const test of expandGlob(
+      "tests/node_compat/runner/suite/**/test-*{.mjs,.cjs.,.js,.ts}",
+    )
   ) {
     if (!test.isFile) continue;
     const relUrl = toFileUrl(test.path).href.replace(testDirUrl, "");


### PR DESCRIPTION
`run_all_test_unmodified.ts` missed running `.mjs` test scripts in Node test cases. This PR fixes it.

Note: There are 196 .mjs test cases in vendored node test cases. This seems affecting node compat result in a negative way (I got the number `1482/4125 (35.93%)` from the local run)

Note: There seems no `.ts` or `.cjs` test cases (They only appear in fixtures), but I also added them just in case.