### PR TITLE
fix(node): do not require permission checks for require's node_modules stats

### DIFF
--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -374,7 +374,13 @@ pub fn op_require_stat<
   #[string] path: String,
 ) -> Result<i32, JsErrorBox> {
   let path = PathBuf::from(path);
-  let path = ensure_read_permission::<P>(state, &path)?;
+  let path = if path.ends_with("node_modules") {
+    // skip stat permission checks for node_modules directories
+    // because they're noisy and it's fine
+    Cow::Owned(path)
+  } else {
+    ensure_read_permission::<P>(state, &path)?
+  };
   let sys = state.borrow::<TSys>();
   if let Ok(metadata) = sys.fs_metadata(&path) {
     if metadata.file_type().is_file() {

--- a/tests/registry/npm/@denotest/require-non-existent/1.0.0/index.cjs
+++ b/tests/registry/npm/@denotest/require-non-existent/1.0.0/index.cjs
@@ -1,0 +1,3 @@
+module.exports = () => {
+  require("non-existent")
+};

--- a/tests/registry/npm/@denotest/require-non-existent/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/require-non-existent/1.0.0/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@denotest/require-non-existent",
+    "version": "1.0.0",
+    "main": "index.cjs"
+  }

--- a/tests/specs/node/global_cache_node_modules_perm_checks/__test__.jsonc
+++ b/tests/specs/node/global_cache_node_modules_perm_checks/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  // this will throw that it can't find it rather than asking for permissions
+  "args": "run main.js",
+  "output": "main.out",
+  "exitCode": 1
+}

--- a/tests/specs/node/global_cache_node_modules_perm_checks/main.js
+++ b/tests/specs/node/global_cache_node_modules_perm_checks/main.js
@@ -1,0 +1,3 @@
+import func from "npm:@denotest/require-non-existent";
+
+func();

--- a/tests/specs/node/global_cache_node_modules_perm_checks/main.out
+++ b/tests/specs/node/global_cache_node_modules_perm_checks/main.out
@@ -1,0 +1,5 @@
+Download http://localhost:4260/@denotest%2frequire-non-existent
+Download http://localhost:4260/@denotest/require-non-existent/1.0.0.tgz
+error: Uncaught (in promise) Error: Cannot find module 'non-existent'
+Require stack:
+[WILDCARD]


### PR DESCRIPTION
This change specifically allows op_require_stat to stat node_module directories without having to go through the permission system.

Closes https://github.com/denoland/deno/issues/20484