### PR TITLE
fix(node): do not look up node_module paths when using global resolver

### DIFF
--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1342,12 +1342,14 @@ impl<TGraphContainer: ModuleGraphContainer> NodeRequireLoader
   }
 
   fn resolve_require_node_module_paths(&self, from: &Path) -> Vec<String> {
-    let is_global_resolver = self
+    let is_global_resolver_and_from_in_global_cache = self
       .npm_resolver
       .as_managed()
       .filter(|r| r.root_node_modules_path().is_none())
+      .map(|r| r.global_cache_root_path())
+      .filter(|global_cache_path| from.starts_with(global_cache_path))
       .is_some();
-    if is_global_resolver {
+    if is_global_resolver_and_from_in_global_cache {
       Vec::new()
     } else {
       deno_runtime::deno_node::default_resolve_require_node_module_paths(from)

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -410,6 +410,7 @@ impl CliModuleLoaderFactory {
     let node_require_loader = Rc::new(CliNodeRequireLoader {
       cjs_tracker: self.shared.cjs_tracker.clone(),
       emitter: self.shared.emitter.clone(),
+      npm_resolver: self.shared.npm_resolver.clone(),
       sys: self.shared.sys.clone(),
       graph_container,
       in_npm_pkg_checker: self.shared.in_npm_pkg_checker.clone(),
@@ -1268,6 +1269,7 @@ impl ModuleGraphUpdatePermit for WorkerModuleGraphUpdatePermit {
 struct CliNodeRequireLoader<TGraphContainer: ModuleGraphContainer> {
   cjs_tracker: Arc<CliCjsTracker>,
   emitter: Arc<Emitter>,
+  npm_resolver: CliNpmResolver,
   sys: CliSys,
   graph_container: TGraphContainer,
   in_npm_pkg_checker: DenoInNpmPackageChecker,
@@ -1337,6 +1339,19 @@ impl<TGraphContainer: ModuleGraphContainer> NodeRequireLoader
   ) -> Result<bool, ClosestPkgJsonError> {
     let media_type = MediaType::from_specifier(specifier);
     self.cjs_tracker.is_maybe_cjs(specifier, media_type)
+  }
+
+  fn resolve_require_node_module_paths(&self, from: &Path) -> Vec<String> {
+    let is_global_resolver = self
+      .npm_resolver
+      .as_managed()
+      .filter(|r| r.root_node_modules_path().is_none())
+      .is_some();
+    if is_global_resolver {
+      Vec::new()
+    } else {
+      deno_runtime::deno_node::default_resolve_require_node_module_paths(from)
+    }
   }
 }
 

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -172,6 +172,25 @@ pub trait NodeRequireLoader {
   /// Get if the module kind is maybe CJS and loading should determine
   /// if its CJS or ESM.
   fn is_maybe_cjs(&self, specifier: &Url) -> Result<bool, ClosestPkgJsonError>;
+
+  fn resolve_require_node_module_paths(&self, from: &Path) -> Vec<String> {
+    default_resolve_require_node_module_paths(from)
+  }
+}
+
+pub fn default_resolve_require_node_module_paths(from: &Path) -> Vec<String> {
+  let mut paths = Vec::with_capacity(from.components().count());
+  let mut current_path = from;
+  let mut maybe_parent = Some(current_path);
+  while let Some(parent) = maybe_parent {
+    if !parent.ends_with("node_modules") {
+      paths.push(parent.join("node_modules").to_string_lossy().into_owned());
+    }
+    current_path = parent;
+    maybe_parent = current_path.parent();
+  }
+
+  paths
 }
 
 pub static NODE_ENV_VAR_ALLOWLIST: Lazy<HashSet<String>> = Lazy::new(|| {

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -214,18 +214,8 @@ pub fn op_require_node_module_paths<
     }
   }
 
-  let mut paths = Vec::with_capacity(from.components().count());
-  let mut current_path = from.as_path();
-  let mut maybe_parent = Some(current_path);
-  while let Some(parent) = maybe_parent {
-    if !parent.ends_with("node_modules") {
-      paths.push(parent.join("node_modules").to_string_lossy().into_owned());
-    }
-    current_path = parent;
-    maybe_parent = current_path.parent();
-  }
-
-  Ok(paths)
+  let loader = state.borrow::<NodeRequireLoaderRc>();
+  Ok(loader.resolve_require_node_module_paths(&from))
 }
 
 #[op2]


### PR DESCRIPTION
It doesn't make sense for the global resolver to search for npm packages because the structure of the folder there doesn't do node_resolution.

Also fixes https://github.com/denoland/deno/issues/20484

Probably doing this in addition to https://github.com/denoland/deno/pull/29397 would be good.