### PR TITLE
chore(tests): use docs.deno.com in tests to prevent GitHub rate limits

### DIFF
--- a/tests/integration/check_tests.rs
+++ b/tests/integration/check_tests.rs
@@ -126,7 +126,7 @@ fn ts_no_recheck_on_redirect() {
 
   // run again
   let output = check_command.run();
-  output.assert_matches_text("Hello\n");
+  output.assert_matches_text("Hello, World!\n");
 }
 
 #[test]

--- a/tests/specs/run/_017_import_redirect/017_import_redirect.ts
+++ b/tests/specs/run/_017_import_redirect/017_import_redirect.ts
@@ -1,4 +1,2 @@
 // http -> https redirect would happen:
-import { printHello } from "http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts";
-
-printHello();
+import "http://docs.deno.com/examples/scripts/hello_world.ts";

--- a/tests/specs/run/_017_import_redirect/017_import_redirect.ts.out
+++ b/tests/specs/run/_017_import_redirect/017_import_redirect.ts.out
@@ -1,1 +1,1 @@
-Hello
+Hello, World!

--- a/tests/specs/run/_017_import_redirect_check/017_import_redirect.ts
+++ b/tests/specs/run/_017_import_redirect_check/017_import_redirect.ts
@@ -1,4 +1,2 @@
 // http -> https redirect would happen:
-import { printHello } from "http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts";
-
-printHello();
+import "http://docs.deno.com/examples/scripts/hello_world.ts";

--- a/tests/specs/run/_017_import_redirect_check/017_import_redirect.ts.out
+++ b/tests/specs/run/_017_import_redirect_check/017_import_redirect.ts.out
@@ -1,1 +1,1 @@
-Hello
+Hello, World!

--- a/tests/specs/run/_017_import_redirect_info/017_import_redirect.ts
+++ b/tests/specs/run/_017_import_redirect_info/017_import_redirect.ts
@@ -1,4 +1,2 @@
 // http -> https redirect would happen:
-import { printHello } from "http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts";
-
-printHello();
+import "http://docs.deno.com/examples/scripts/hello_world.ts";

--- a/tests/specs/run/_017_import_redirect_info/017_import_redirect_info.out
+++ b/tests/specs/run/_017_import_redirect_info/017_import_redirect_info.out
@@ -1,7 +1,7 @@
 local: [WILDCARD]017_import_redirect.ts
 type: TypeScript
 dependencies: 1 unique
-size: 278B
+size: 660B
 
 file:///[WILDCARD]/017_import_redirect.ts ([WILDCARD])
-└── https://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts ([WILDCARD])
+└── https://docs.deno.com/examples/scripts/hello_world.ts ([WILDCARD])

--- a/tests/specs/run/_017_import_redirect_vendor_dir/017_import_redirect.ts
+++ b/tests/specs/run/_017_import_redirect_vendor_dir/017_import_redirect.ts
@@ -1,4 +1,2 @@
 // http -> https redirect would happen:
-import { printHello } from "http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts";
-
-printHello();
+import "http://docs.deno.com/examples/scripts/hello_world.ts";

--- a/tests/specs/run/_017_import_redirect_vendor_dir/017_import_redirect.ts.out
+++ b/tests/specs/run/_017_import_redirect_vendor_dir/017_import_redirect.ts.out
@@ -1,1 +1,1 @@
-Hello
+Hello, World!

--- a/tests/testdata/run/017_import_redirect.ts
+++ b/tests/testdata/run/017_import_redirect.ts
@@ -1,4 +1,2 @@
 // http -> https redirect would happen:
-import { printHello } from "http://gist.githubusercontent.com/ry/f12b2aa3409e6b52645bc346a9e22929/raw/79318f239f51d764384a8bded8d7c6a833610dde/print_hello.ts";
-
-printHello();
+import "http://docs.deno.com/examples/scripts/hello_world.ts";


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Fix #29396

As a quick workaround, I quit using `gist.githubusercontent.com` and switched to `docs.deno.com`.
cc: @dsherret