### PR TITLE
chore: Rust 1.85.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.85.1"
 components = ["rustfmt", "clippy"]

--- a/tests/unit/rename_test.ts
+++ b/tests/unit/rename_test.ts
@@ -252,13 +252,6 @@ Deno.test(
       Error,
       "The directory is not empty",
     );
-    assertThrows(
-      () => {
-        Deno.renameSync(olddir, file);
-      },
-      Error,
-      "The directory name is invalid",
-    );
 
     // should succeed on Windows
     Deno.renameSync(olddir, emptydir);


### PR DESCRIPTION
Rust 1.85.1 releases: https://github.com/rust-lang/rust/releases/tag/1.85.1

Rust 1.85.1 releases log has `std::fs::rename` fix PR

`Deno.renameSync` API error with CI test, Perhaps it is caused by this PR, when I try to upgrade `Rust 1.86.0` or `Rust 1.87.0`

Here use CI to test.