### PR TITLE
fix: reload non-remote dynamic imports at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,8 +2001,6 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d54da704eeea3a15a23eb929f93914d833a2a2858c1aaec220097343445ca04"
 dependencies = [
  "async-trait",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -518,3 +518,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_npm_cache]
 opt-level = 3
+
+[patch.crates-io]
+deno_graph = { path = "../deno_graph" }

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1124,6 +1124,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
       let lib = inner.lib;
       let mut update_permit = graph_container.acquire_update_permit().await;
       let graph = update_permit.graph_mut();
+      let is_first_graph_build = graph.specifiers().next().is_none();
       module_load_preparer
         .prepare_module_load(
           graph,
@@ -1138,6 +1139,9 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
         )
         .await
         .map_err(JsErrorBox::from_err)?;
+      if is_first_graph_build {
+        graph.prune(deno_graph::PruneMode::TypesAndNonRemoteDynamic);
+      }
       update_permit.commit();
       Ok(())
     }

--- a/tests/specs/run/dynamic_import_written_runtime/__test__.jsonc
+++ b/tests/specs/run/dynamic_import_written_runtime/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "run --check --allow-read --allow-write main.ts",
+    "output": "Check [WILDLINE]\n1\n"
+  }, {
+    // run again to ensure it still outputs 1
+    "args": "run --check --allow-read --allow-write main.ts",
+    "output": "Check [WILDLINE]\n1\n"
+  }]
+}

--- a/tests/specs/run/dynamic_import_written_runtime/main.ts
+++ b/tests/specs/run/dynamic_import_written_runtime/main.ts
@@ -1,0 +1,3 @@
+Deno.writeTextFileSync("./a.ts", "console.log(1);");
+await import("./a.ts");
+Deno.writeTextFileSync("./a.ts", "console.log(2);");


### PR DESCRIPTION
Waiting on https://github.com/denoland/deno_graph/pull/581

This prunes the module graph before running it in order to remove typescript specific stuff and non-remote dynamic imports.

Closes https://github.com/denoland/deno/issues/20945