### PR TITLE
fix(ext/node): use primordials in `ext/node/polyfills/internal/util.mjs`

### DIFF
--- a/ext/node/polyfills/internal/util.mjs
+++ b/ext/node/polyfills/internal/util.mjs
@@ -1,8 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { validateFunction } from "ext:deno_node/internal/validators.mjs";
 import {
   normalizeEncoding,
@@ -17,31 +14,42 @@ import { ERR_UNKNOWN_SIGNAL } from "ext:deno_node/internal/errors.ts";
 import { os } from "ext:deno_node/internal_binding/constants.ts";
 import { primordials } from "ext:core/mod.js";
 const {
+  ArrayPrototypePush,
+  ObjectDefineProperties,
+  ObjectDefineProperty,
+  ObjectFreeze,
+  ObjectGetPrototypeOf,
+  ObjectGetOwnPropertyDescriptors,
+  ObjectSetPrototypeOf,
+  Promise,
+  ReflectApply,
   SafeWeakRef,
+  SymbolFor,
+  WeakRefPrototypeDeref,
 } = primordials;
 
-export const customInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
-export const kEnumerableProperty = Object.create(null);
+export const customInspectSymbol = SymbolFor("nodejs.util.inspect.custom");
+export const kEnumerableProperty = ObjectCreate(null);
 kEnumerableProperty.enumerable = true;
 
-export const kEmptyObject = Object.freeze(Object.create(null));
+export const kEmptyObject = ObjectFreeze(ObjectCreate(null));
 
 export function once(callback) {
   let called = false;
   return function (...args) {
     if (called) return;
     called = true;
-    Reflect.apply(callback, this, args);
+    ReflectApply(callback, this, args);
   };
 }
 
 // In addition to being accessible through util.promisify.custom,
 // this symbol is registered globally and can be accessed in any environment as
 // Symbol.for('nodejs.util.promisify.custom').
-const kCustomPromisifiedSymbol = Symbol.for("nodejs.util.promisify.custom");
+const kCustomPromisifiedSymbol = SymbolFor("nodejs.util.promisify.custom");
 // This is an internal Node symbol used by functions returning multiple
 // arguments, e.g. ['bytesRead', 'buffer'] for fs.read().
-const kCustomPromisifyArgsSymbol = Symbol.for(
+const kCustomPromisifyArgsSymbol = SymbolFor(
   "nodejs.util.promisify.customArgs",
 );
 
@@ -56,7 +64,8 @@ export function promisify(
 
     validateFunction(fn, "util.promisify.custom");
 
-    return Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+    return ObjectDefineProperty(fn, kCustomPromisifiedSymbol, {
+      __proto__: null,
       value: fn,
       enumerable: false,
       writable: false,
@@ -69,7 +78,7 @@ export function promisify(
   const argumentNames = original[kCustomPromisifyArgsSymbol];
   function fn(...args) {
     return new Promise((resolve, reject) => {
-      args.push((err, ...values) => {
+      ArrayPrototypePush(args, (err, ...values) => {
         if (err) {
           return reject(err);
         }
@@ -83,21 +92,22 @@ export function promisify(
           resolve(values[0]);
         }
       });
-      Reflect.apply(original, this, args);
+      ReflectApply(original, this, args);
     });
   }
 
-  Object.setPrototypeOf(fn, Object.getPrototypeOf(original));
+  ObjectSetPrototypeOf(fn, ObjectGetPrototypeOf(original));
 
-  Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+  ObjectDefineProperty(fn, kCustomPromisifiedSymbol, {
+    __proto__: null,
     value: fn,
     enumerable: false,
     writable: false,
     configurable: true,
   });
-  return Object.defineProperties(
+  return ObjectDefineProperties(
     fn,
-    Object.getOwnPropertyDescriptors(original),
+    ObjectGetOwnPropertyDescriptors(original),
   );
 }
 
@@ -139,7 +149,7 @@ export class WeakReference {
   incRef() {
     this.#refCount++;
     if (this.#refCount === 1) {
-      const derefed = this.#weak.deref();
+      const derefed = WeakRefPrototypeDeref(this.#weak);
       if (derefed !== undefined) {
         this.#strong = derefed;
       }
@@ -156,7 +166,7 @@ export class WeakReference {
   }
 
   get() {
-    return this.#weak.deref();
+    return WeakRefPrototypeDeref(this.#weak);
   }
 }
 


### PR DESCRIPTION
Towards #24236. Replaces JS builtins with equivalent primordials.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
