### PR TITLE
chore: update wpt message when previously failing test starts passing

### DIFF
--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -689,7 +689,8 @@ function createReportTestCase(expectation: boolean | string[]) {
     switch (status) {
       case 0:
         if (expectFail) {
-          simpleMessage += red("ok (expected fail)");
+          simpleMessage += green("ok") + " ";
+          red("(previously non-conforming—update expectations.json)");
         } else {
           simpleMessage += green("ok");
           if (quiet) {


### PR DESCRIPTION
The message was confusing.