### PR TITLE
fix(ext/node): return values in node:domain

### DIFF
--- a/ext/node/polyfills/domain.ts
+++ b/ext/node/polyfills/domain.ts
@@ -50,7 +50,7 @@ export class Domain extends EventEmitter {
     const self = this;
     return function () {
       try {
-        FunctionPrototypeApply(fn, null, ArrayPrototypeSlice(arguments));
+        return FunctionPrototypeApply(fn, null, ArrayPrototypeSlice(arguments));
       } catch (e) {
         FunctionPrototypeCall(emitError, self, e);
       }
@@ -65,7 +65,11 @@ export class Domain extends EventEmitter {
         FunctionPrototypeCall(emitError, self, e);
       } else {
         try {
-          FunctionPrototypeApply(fn, null, ArrayPrototypeSlice(arguments, 1));
+          return FunctionPrototypeApply(
+            fn,
+            null,
+            ArrayPrototypeSlice(arguments, 1),
+          );
         } catch (e) {
           FunctionPrototypeCall(emitError, self, e);
         }
@@ -75,7 +79,7 @@ export class Domain extends EventEmitter {
 
   run(fn) {
     try {
-      fn();
+      return fn();
     } catch (e) {
       FunctionPrototypeCall(emitError, this, e);
     }


### PR DESCRIPTION
When using Domain#bind, Domain#intercept, and Domain#run we were invoking the callback but then not actually returning the value returned from that callback.

This makes Gulp work with async functions as tasks.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
