### PR TITLE
refactor: rename "web worker" to "worker thread"

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -35,11 +35,11 @@ runtime's properties:
 ## `Worker` Web API
 
 `deno_runtime` comes with support for `Worker` Web API. The `Worker` API is
-implemented using `WebWorker` structure.
+implemented using `WorkerThread` structure.
 
 When creating a new instance of `MainWorker` implementors must provide a
 callback function that is used when creating a new instance of `Worker`.
 
-All `WebWorker` instances are descendents of `MainWorker` which is responsible
-for setting up communication with child worker. Each `WebWorker` spawns a new OS
-thread that is dedicated solely to that worker.
+All `WorkerThread` instances are descendents of `MainWorker` which is
+responsible for setting up communication with child worker. Each `WorkerThread`
+spawns a new OS thread that is dedicated solely to that worker.

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -42,8 +42,8 @@ pub mod snapshot_info;
 pub mod tokio_util;
 #[cfg(feature = "transpile")]
 pub mod transpile;
-pub mod web_worker;
 pub mod worker;
+pub mod worker_thread;
 
 mod worker_bootstrap;
 pub use worker::UnconfiguredRuntime;

--- a/runtime/ops/mod.rs
+++ b/runtime/ops/mod.rs
@@ -6,8 +6,8 @@ pub mod http;
 pub mod permissions;
 pub mod runtime;
 pub mod tty;
-pub mod web_worker;
 pub mod worker_host;
+pub mod worker_thread;
 
 use std::sync::Arc;
 

--- a/runtime/ops/worker_thread.rs
+++ b/runtime/ops/worker_thread.rs
@@ -13,11 +13,11 @@ use deno_web::MessagePortError;
 pub use sync_fetch::SyncFetchError;
 
 use self::sync_fetch::op_worker_sync_fetch;
-use crate::web_worker::WebWorkerInternalHandle;
-use crate::web_worker::WebWorkerType;
+use crate::worker_thread::WorkerThreadInternalHandle;
+use crate::worker_thread::WorkerThreadType;
 
 deno_core::extension!(
-  deno_web_worker,
+  deno_worker_thread,
   ops = [
     op_worker_post_message,
     op_worker_recv_message,
@@ -33,7 +33,7 @@ fn op_worker_post_message(
   state: &mut OpState,
   #[serde] data: JsMessageData,
 ) -> Result<(), MessagePortError> {
-  let handle = state.borrow::<WebWorkerInternalHandle>().clone();
+  let handle = state.borrow::<WorkerThreadInternalHandle>().clone();
   handle.port.send(state, data)
 }
 
@@ -44,7 +44,7 @@ async fn op_worker_recv_message(
 ) -> Result<Option<JsMessageData>, MessagePortError> {
   let handle = {
     let state = state.borrow();
-    state.borrow::<WebWorkerInternalHandle>().clone()
+    state.borrow::<WorkerThreadInternalHandle>().clone()
   };
   handle
     .port
@@ -56,14 +56,14 @@ async fn op_worker_recv_message(
 #[op2(fast)]
 fn op_worker_close(state: &mut OpState) {
   // Notify parent that we're finished
-  let mut handle = state.borrow_mut::<WebWorkerInternalHandle>().clone();
+  let mut handle = state.borrow_mut::<WorkerThreadInternalHandle>().clone();
 
   handle.terminate();
 }
 
 #[op2]
 #[serde]
-fn op_worker_get_type(state: &mut OpState) -> WebWorkerType {
-  let handle = state.borrow::<WebWorkerInternalHandle>().clone();
+fn op_worker_get_type(state: &mut OpState) -> WorkerThreadType {
+  let handle = state.borrow::<WorkerThreadInternalHandle>().clone();
   handle.worker_type
 }

--- a/runtime/ops/worker_thread/sync_fetch.rs
+++ b/runtime/ops/worker_thread/sync_fetch.rs
@@ -14,8 +14,8 @@ use hyper::body::Bytes;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::web_worker::WebWorkerInternalHandle;
-use crate::web_worker::WebWorkerType;
+use crate::worker_thread::WorkerThreadInternalHandle;
+use crate::worker_thread::WorkerThreadType;
 
 // TODO(andreubotella) Properly parse the MIME type
 fn mime_type_essence(mime_type: &str) -> String {
@@ -90,8 +90,8 @@ pub fn op_worker_sync_fetch(
   #[serde] scripts: Vec<String>,
   loose_mime_checks: bool,
 ) -> Result<Vec<SyncFetchScript>, SyncFetchError> {
-  let handle = state.borrow::<WebWorkerInternalHandle>().clone();
-  assert_eq!(handle.worker_type, WebWorkerType::Classic);
+  let handle = state.borrow::<WorkerThreadInternalHandle>().clone();
+  assert_eq!(handle.worker_type, WorkerThreadType::Classic);
 
   // it's not safe to share a client across tokio runtimes, so create a fresh one
   // https://github.com/seanmonstar/reqwest/issues/1148#issuecomment-910868788

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -66,7 +66,7 @@ pub fn create_runtime_snapshot(
     ops::http::deno_http_runtime::lazy_init(),
     ops::bootstrap::deno_bootstrap::init(Some(snapshot_options), false),
     runtime::lazy_init(),
-    ops::web_worker::deno_web_worker::lazy_init(),
+    ops::worker_thread::deno_worker_thread::lazy_init(),
   ];
   extensions.extend(custom_extensions);
 

--- a/runtime/snapshot_info.rs
+++ b/runtime/snapshot_info.rs
@@ -332,6 +332,6 @@ pub fn get_extensions_in_snapshot() -> Vec<Extension> {
     ops::http::deno_http_runtime::init(),
     ops::bootstrap::deno_bootstrap::init(None, false),
     runtime::init(),
-    ops::web_worker::deno_web_worker::init(),
+    ops::worker_thread::deno_worker_thread::init(),
   ]
 }

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -147,7 +147,7 @@ pub fn make_wait_for_inspector_disconnect_callback() -> Box<dyn Fn()> {
 ///
 /// It provides ops available in the `Deno` namespace.
 ///
-/// All `WebWorker`s created during program execution
+/// All `WorkerThread`s created during program execution
 /// are descendants of this worker.
 pub struct MainWorker {
   pub js_runtime: JsRuntime,
@@ -240,8 +240,8 @@ pub struct WorkerOptions {
   pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
   pub seed: Option<u64>,
 
-  // Callbacks invoked when creating new instance of WebWorker
-  pub create_web_worker_cb: Arc<ops::worker_host::CreateWebWorkerCb>,
+  // Callbacks invoked when creating new instance of WorkerThread
+  pub create_web_worker_cb: Arc<ops::worker_host::CreateWorkerThreadCb>,
   pub format_js_error_fn: Option<Arc<FormatJsErrorFn>>,
 
   pub maybe_inspector_server: Option<Arc<InspectorServer>>,
@@ -1087,7 +1087,7 @@ fn common_extensions<
     // are available and importing them in `99_main.js` doesn't cause an
     // error because they're not defined. Trying to use these ops in non-worker
     // context will cause a panic.
-    ops::web_worker::deno_web_worker::init().disable(),
+    ops::worker_thread::deno_worker_thread::init().disable(),
   ]
 }
 

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -84,7 +84,7 @@ impl From<log::Level> for WorkerLogLevel {
   }
 }
 
-/// Common bootstrap options for MainWorker & WebWorker
+/// Common bootstrap options for MainWorker & WorkerThread
 #[derive(Clone)]
 pub struct BootstrapOptions {
   pub deno_version: String,


### PR DESCRIPTION
This is a completely internal change - throughout the codebase we've used notion
of "web worker" to describe a separate thread running JavaScript. While it started
as a "Web Worker" implementation, this infrastructure is now used to implement
both Web workers as well as Node.js "worker_threads" module. It seems more
fitting to rename these modules and structs to "worker thread" as in reality
"Web Worker" API is a subset of Node.js "worker_threads" module.