### PR TITLE
fix(ext/node): ignore some Node.js specific flags

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1220,6 +1220,10 @@ function toDenoArgs(args: string[]): string[] {
     if (flagInfo === undefined) {
       if (arg === "--no-warnings") {
         denoArgs.push("--quiet");
+      } else if (arg === "--expose-internals") {
+        // internals are always exposed in Deno.
+      } else if (arg === "--permission") {
+        // ignore --permission flag
       } else {
         // Not a known flag that expects a value. Just copy it to the output.
         denoArgs.push(arg);


### PR DESCRIPTION
Unavailability of these flags cause many errors in node compat test (See https://node-test-viewer.deno.dev/results/2025-05-26/linux.errors.txt ). This unblocks those failures