### PR TITLE
fix(lsp): do not warn about unscoped package name

### DIFF
--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -709,8 +709,7 @@
     },
     "name": {
       "type": "string",
-      "description": "The name of this JSR package. Must be scoped",
-      "pattern": "^@[a-z0-9-]+/[a-z0-9-]+$"
+      "description": "The name of this JSR or workspace package."
     },
     "version": {
       "type": "string",


### PR DESCRIPTION
It's useful to just use a bare specifier for the package name in a workspace.