### PR TITLE
fix(ext/console): console.group indents two spaces

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -3401,14 +3401,14 @@ class Console {
     if (label.length > 0) {
       this.log(...new SafeArrayIterator(label));
     }
-    this.indentLevel += 2;
+    this.indentLevel++;
   };
 
   groupCollapsed = this.group;
 
   groupEnd = () => {
     if (this.indentLevel > 0) {
-      this.indentLevel -= 2;
+      this.indentLevel--;
     }
   };
 

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -1513,9 +1513,9 @@ Deno.test(function consoleGroup() {
     assertEquals(
       out.toString(),
       `1
-    2
-    3
-        4
+  2
+  3
+    4
 5
 6
 `,
@@ -1542,9 +1542,9 @@ Deno.test(function consoleGroupWarn() {
     assertEquals(
       both.toString(),
       `1
-    2
-        3
-    4
+  2
+    3
+  4
 5
 6
 7


### PR DESCRIPTION
Since `DEFAULT_INDENT` is already two spaces, incrementing `indentLevel` by 2 was causing each group to indent by **four** spaces. Indenting by two spaces matches the behavior Node and Bun.
