### PR TITLE
fix(ext/node): fix function error message in `invalidArgTypeHelper`

### DIFF
--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -735,7 +735,7 @@ function invalidArgTypeHelper(input: any) {
   if (input == null) {
     return ` Received ${input}`;
   }
-  if (typeof input === "function" && input.name) {
+  if (typeof input === "function") {
     return ` Received function ${input.name}`;
   }
   if (typeof input === "object") {

--- a/tests/node_compat/test/common/index.js
+++ b/tests/node_compat/test/common/index.js
@@ -358,7 +358,7 @@ function invalidArgTypeHelper(input) {
   if (input == null) {
     return ` Received ${input}`;
   }
-  if (typeof input === "function" && input.name) {
+  if (typeof input === "function") {
     return ` Received function ${input.name}`;
   }
   if (typeof input === "object") {


### PR DESCRIPTION
Fixes `parallel/test-buffer-from.js` in daily Node compat tests runs. The test was already enabled in CI but that used a different helper than the daily Node compat tests runners - updated now.

```
divy@divy-macbook deno % deno -A ./tools/node_compat_tests.js -f parallel/test-buffer-from
Found 0 sequential tests and 1 parallel tests
Running 1 tests
   1 FAIL parallel/test-buffer-from.js
    FAIL parallel/test-buffer-from.js
    exit code: 1
    error: Uncaught (in promise) AssertionError: Values are not equal:


    [Diff] Actual / Expected


-   The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type function ([Function (anonymous)])
+   The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received function


    at new AssertionError (ext:deno_node/assertion_error.ts:412:11)
    at toNode (node:assert:48:15)
    at deepStrictEqual (node:assert:267:3)
    at validateThrownError (node:assert:622:9)
    at throws (node:assert:104:9)
    at file:///Users/divy/gh/deno/tests/node_compat/runner/suite/test/parallel/test-buffer-from.js:59:3
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (file:///Users/divy/gh/deno/tests/node_compat/runner/suite/test/parallel/test-buffer-from.js:51:3)
    at Object.<anonymous> (file:///Users/divy/gh/deno/tests/node_compat/runner/suite/test/parallel/test-buffer-from.js:146:4)
    at Module._compile (node:module:745:34)

Filtered tests: 0/1 (0.00%)
Elapsed time: 0.20s
divy@divy-macbook deno % target/debug/deno -A ./tools/node_compat_tests.js -f parallel/test-buffer-from
Found 0 sequential tests and 1 parallel tests
Running 1 tests
   1 PASS parallel/test-buffer-from.js
    PASS parallel/test-buffer-from.js
Filtered tests: 1/1 (100.00%)
Elapsed time: 0.40s
```