### PR TITLE
feat(cli/watch): reload on `.env` changes with `--env-file`

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1294,6 +1294,16 @@ impl CliOptions {
         full_paths.push(pkg_json.path.clone());
       }
     }
+
+    // If the user specified an env file, we should watch it.
+    if let Some(env_file_names) = &self.flags.env_file {
+      full_paths.extend(
+        env_file_names
+          .iter()
+          .map(|name| self.initial_cwd.join(name)),
+      );
+    }
+
     full_paths
   }
 

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -51,7 +51,7 @@ use deno_semver::StackString;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_telemetry::OtelConfig;
 use deno_terminal::colors;
-use dotenvy::from_filename;
+use dotenvy::from_filename_override;
 pub use flags::*;
 use once_cell::sync::Lazy;
 use thiserror::Error;
@@ -1295,13 +1295,13 @@ impl CliOptions {
       }
     }
 
-    // If the user specified an env file, we should watch it.
-    if let Some(env_file_names) = &self.flags.env_file {
-      full_paths.extend(
-        env_file_names
-          .iter()
-          .map(|name| self.initial_cwd.join(name)),
-      );
+    if let Some(env_files) = &self.flags.env_file {
+      for env_file in env_files {
+        let env_file_path = self.initial_cwd.join(env_file);
+        if env_file_path.exists() {
+          full_paths.push(env_file_path);
+        }
+      }
     }
 
     full_paths
@@ -1437,7 +1437,7 @@ pub fn load_env_variables_from_env_file(
   };
 
   for env_file_name in env_file_names.iter().rev() {
-    match from_filename(env_file_name) {
+    match from_filename_override(env_file_name) {
       Ok(_) => (),
       Err(error) => {
         #[allow(clippy::print_stderr)]

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -51,6 +51,7 @@ use deno_semver::StackString;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_telemetry::OtelConfig;
 use deno_terminal::colors;
+use dotenvy::from_filename;
 use dotenvy::from_filename_override;
 pub use flags::*;
 use once_cell::sync::Lazy;
@@ -1429,6 +1430,52 @@ pub fn config_to_deno_graph_workspace_member(
 }
 
 pub fn load_env_variables_from_env_file(
+  filename: Option<&Vec<String>>,
+  flags_log_level: Option<log::Level>,
+) {
+  let Some(env_file_names) = filename else {
+    return;
+  };
+
+  for env_file_name in env_file_names.iter().rev() {
+    match from_filename(env_file_name) {
+      Ok(_) => (),
+      Err(error) => {
+        #[allow(clippy::print_stderr)]
+        if flags_log_level
+          .map(|l| l >= log::Level::Info)
+          .unwrap_or(true)
+        {
+          match error {
+            dotenvy::Error::LineParse(line, index) => eprintln!(
+              "{} Parsing failed within the specified environment file: {} at index: {} of the value: {}",
+              colors::yellow("Warning"),
+              env_file_name,
+              index,
+              line
+            ),
+            dotenvy::Error::Io(_) => eprintln!(
+              "{} The `--env-file` flag was used, but the environment file specified '{}' was not found.",
+              colors::yellow("Warning"),
+              env_file_name
+            ),
+            dotenvy::Error::EnvVar(_) => eprintln!(
+              "{} One or more of the environment variables isn't present or not unicode within the specified environment file: {}",
+              colors::yellow("Warning"),
+              env_file_name
+            ),
+            _ => eprintln!(
+              "{} Unknown failure occurred with the specified environment file: {}",
+              colors::yellow("Warning"),
+              env_file_name
+            ),
+          }
+        }
+      }
+    }
+  }
+}
+pub fn load_env_variables_from_env_file_override(
   filename: Option<&Vec<String>>,
   flags_log_level: Option<log::Level>,
 ) {

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -22,7 +22,7 @@ use crate::args::EvalFlags;
 use crate::args::Flags;
 use crate::args::RunFlags;
 use crate::args::WatchFlagsWithPaths;
-use crate::args::load_env_variables_from_env_file;
+use crate::args::load_env_variables_from_env_file_override;
 use crate::factory::CliFactory;
 use crate::util;
 use crate::util::file_watcher::WatcherRestartMode;
@@ -185,7 +185,10 @@ fn maybe_update_env_vars(
   });
 
   if should_reload_env {
-    load_env_variables_from_env_file(flags.env_file.as_ref(), flags.log_level);
+    load_env_variables_from_env_file_override(
+      flags.env_file.as_ref(),
+      flags.log_level,
+    );
   }
 }
 

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -2055,3 +2055,59 @@ async fn bundle_watch() {
 
   check_alive_then_kill(child);
 }
+
+#[flaky_test(tokio)]
+async fn run_watch_env_file_reload() {
+  let t = TempDir::new();
+
+  let env_file = t.path().join(".env");
+  env_file.write("INITIAL_VAR=hello\nTEST_PORT=3000");
+
+  let main_file = t.path().join("main.js");
+  main_file.write(
+    r#"
+    console.log("INITIAL_VAR:", Deno.env.get("INITIAL_VAR"));
+    console.log("TEST_PORT:", Deno.env.get("TEST_PORT"));
+    console.log("ENV_LOADED");
+    "#,
+  );
+
+  let mut child = util::deno_cmd()
+    .current_dir(t.path())
+    .arg("run")
+    .arg("--watch")
+    .arg("--env-file")
+    .arg(".env")
+    .arg("--allow-env")
+    .arg("-L")
+    .arg("debug")
+    .arg(&main_file)
+    .env("NO_COLOR", "1")
+    .piped_output()
+    .spawn()
+    .unwrap();
+
+  let (mut stdout_lines, mut stderr_lines) = child_lines(&mut child);
+
+  wait_contains("INITIAL_VAR: hello", &mut stdout_lines).await;
+  wait_contains("TEST_PORT: 3000", &mut stdout_lines).await;
+  wait_contains("ENV_LOADED", &mut stdout_lines).await;
+
+  wait_for_watcher("main.js", &mut stderr_lines).await;
+  wait_for_watcher(".env", &mut stderr_lines).await;
+
+  tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+  env_file.write("INITIAL_VAR=world\nTEST_PORT=4000\nNEW_VAR=added");
+
+  tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+  wait_contains("File change detected", &mut stderr_lines).await;
+  wait_contains("Process started", &mut stderr_lines).await;
+
+  wait_contains("INITIAL_VAR: world", &mut stdout_lines).await;
+  wait_contains("TEST_PORT: 4000", &mut stdout_lines).await;
+  wait_contains("ENV_LOADED", &mut stdout_lines).await;
+
+  check_alive_then_kill(child);
+}


### PR DESCRIPTION
Closes #29483 

This PR enables Deno to watch the `env` files when using `--watch` with `--env-file` flags. Now, changes to environment variables in the `.env` (or in any other file provided as env file) will trigger a reload, ensuring scripts always use the latest values without needing a manual restart.