### PR TITLE
fix(ext/node): add back perf_hooks.markResourceTiming

### DIFF
--- a/ext/node/polyfills/perf_hooks.js
+++ b/ext/node/polyfills/perf_hooks.js
@@ -31,7 +31,7 @@ performance.nodeTiming = {};
 performance.timerify = () => notImplemented("timerify from performance");
 
 // TODO(bartlomieju):
-performance.timerify = () => {};
+performance.markResourceTiming = () => {};
 
 function monitorEventLoopDelay(options = {}) {
   const { resolution = 10 } = options;

--- a/tests/unit_node/perf_hooks_test.ts
+++ b/tests/unit_node/perf_hooks_test.ts
@@ -86,3 +86,7 @@ Deno.test("[perf_hooks]: monitorEventLoopDelay", async () => {
 
   e.disable();
 });
+
+Deno.test("[perf_hooks]: markResourceTiming", () => {
+  assert(typeof performance.markResourceTiming === "function");
+});


### PR DESCRIPTION
Adding back a sham for "perf_hooks.markResourceTiming" that was removed
by accident in https://github.com/denoland/deno/pull/29323; a test was added
too, to ensure it doesn't regress in the future.

Closes https://github.com/denoland/deno/issues/29539