### PR TITLE
fix(ext/node): make DatabaseSync `readOnly` optional

### DIFF
--- a/ext/node/ops/sqlite/database.rs
+++ b/ext/node/ops/sqlite/database.rs
@@ -36,6 +36,7 @@ struct DatabaseSyncOptions {
   open: bool,
   #[serde(default = "true_fn")]
   enable_foreign_key_constraints: bool,
+  #[serde(default = "false_fn")]
   read_only: bool,
   #[serde(default = "false_fn")]
   allow_extension: bool,


### PR DESCRIPTION
Extracted from https://github.com/denoland/deno/pull/29404