### PR TITLE
perf(process): make sure we can take process spawning fast path on unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,6 +451,8 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_web]
 opt-level = 3
+[profile.release.package.deno_process]
+opt-level = 3
 [profile.release.package.deno_websocket]
 opt-level = 3
 [profile.release.package.fastwebsockets]


### PR DESCRIPTION
The rust standard library has a fast path for process spawning, where it will use `posix_spawn` instead of `fork` + `exec`. In order to take that fast path, you can't have a `pre_exec` hook and you have to pass an absolute path for the program path.

We were already resolving the program path, but we were unconditionally doing a `pre_exec` hook. This PR makes the `pre_exec` hook conditional, which lets us take the fast path in most cases.

**Results**
on an m3 max

canary:
```
took 318755.68ms
```

this PR:
```
took 17184.64ms
```

So an improvement from 318.76 seconds to 17.18 seconds, or about 18.5x faster

**Benchmark**:
```js
import { fileURLToPath } from "node:url";
const performance = globalThis.performance;

const __filename = fileURLToPath(import.meta.url);

async function spawn() {
  const child = new Deno.Command("cat", {
    args: [__filename],
    stderr: "null",
    stdin: "null",
    stdout: "null",
  }).spawn();
  await child.status;
}

async function spawn100() {
  const procs = [];
  for (let i = 0; i < 100; i++) {
    procs.push(spawn());
  }
  await Promise.all(procs);
}

const start = performance.now();

for (let i = 0; i < 1000; i++) {
  console.log(`on ${(i + 1) * 100}`);
  await spawn100();
}
const end = performance.now();

console.log(`took ${end - start}ms`);
```