### PR TITLE
fix(fmt): fix handling of indent inside template language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,8 +3316,7 @@ dependencies = [
 [[package]]
 name = "dprint-plugin-typescript"
 version = "0.95.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1120849c597c9196726c0e9df7032ed20eb0844289f0e81e9b046ed92a5b7f6"
+source = "git+https://github.com/kt3k/dprint-plugin-typescript.git?rev=81060251e411676d5bbf608890078399d5dcd943#81060251e411676d5bbf608890078399d5dcd943"
 dependencies = [
  "anyhow",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -521,3 +521,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.deno_npm_cache]
 opt-level = 3
+
+[patch.crates-io]
+dprint-plugin-typescript = { rev = "81060251e411676d5bbf608890078399d5dcd943", git = "https://github.com/kt3k/dprint-plugin-typescript.git" }

--- a/tests/specs/fmt/external_formatter/badly_formatted.in
+++ b/tests/specs/fmt/external_formatter/badly_formatted.in
@@ -11,6 +11,8 @@ margin: 0.5rem;
         ${OTHER_STYLES};
 		}
 	}
+
+  div { padding: ${condition ? expression1 + expression2 * expression3 : expression3}px; }
 `;
 
 cssString = css`

--- a/tests/specs/fmt/external_formatter/well_formatted.out
+++ b/tests/specs/fmt/external_formatter/well_formatted.out
@@ -11,6 +11,12 @@ const EqualDivider = styled.div`
       ${OTHER_STYLES};
     }
   }
+
+  div {
+    padding: ${condition
+      ? expression1 + expression2 * expression3
+      : expression3}px;
+  }
 `;
 
 cssString = css`

--- a/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
@@ -11,6 +11,12 @@ const EqualDivider = styled.div`
       ${OTHER_STYLES};
     }
   }
+
+  div {
+    padding: ${condition
+      ? expression1 + expression2 * expression3
+      : expression3}px;
+  }
 `;
 
 cssString = css`

--- a/tests/specs/fmt/external_formatter/well_formatted_use_tabs.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_use_tabs.out
@@ -11,6 +11,12 @@ const EqualDivider = styled.div`
 			${OTHER_STYLES};
 		}
 	}
+
+	div {
+		padding: ${condition
+			? expression1 + expression2 * expression3
+			: expression3}px;
+	}
 `;
 
 cssString = css`


### PR DESCRIPTION
This PR fixes the handling of indent inside the template languages.

See https://github.com/dprint/dprint-plugin-typescript/pull/718 for details

fixes #29164