### PR TITLE
refactor: move creation of NodeResolver's internal lookup store to options bag

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1228,6 +1228,7 @@ impl CliFactory {
               )
               .unwrap(),
             ),
+            use_package_resolution_lookup_store: false,
           },
           node_resolution_cache: Some(Arc::new(NodeResolutionThreadLocalCache)),
           npm_system_info: self.flags.subcommand.npm_system_info(),

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -1105,25 +1105,23 @@ impl<'a> ResolverFactory<'a> {
       .node_resolver
       .get_or_init(|| {
         let npm_resolver = self.services.npm_resolver.as_ref()?;
-        Some(Arc::new(
-          CliNodeResolver::new(
-            self.in_npm_pkg_checker().clone(),
-            DenoIsBuiltInNodeModuleChecker,
-            npm_resolver.clone(),
-            self.pkg_json_resolver.clone(),
-            self.node_resolution_sys.clone(),
-            NodeResolverOptions {
-              condition_resolver: Default::default(),
-              typescript_version: Some(
-                deno_semver::Version::parse_standard(
-                  deno_lib::version::DENO_VERSION_INFO.typescript,
-                )
-                .unwrap(),
-              ),
-            },
-          )
-          .with_package_resolution_lookup_cache(),
-        ))
+        Some(Arc::new(CliNodeResolver::new(
+          self.in_npm_pkg_checker().clone(),
+          DenoIsBuiltInNodeModuleChecker,
+          npm_resolver.clone(),
+          self.pkg_json_resolver.clone(),
+          self.node_resolution_sys.clone(),
+          NodeResolverOptions {
+            condition_resolver: Default::default(),
+            typescript_version: Some(
+              deno_semver::Version::parse_standard(
+                deno_lib::version::DENO_VERSION_INFO.typescript,
+              )
+              .unwrap(),
+            ),
+            use_package_resolution_lookup_store: true,
+          },
+        )))
       })
       .as_ref()
   }


### PR DESCRIPTION
This seems slightly more appropriate now that we have an options bag here. I actually initially thought this was a caching thing we weren't taking advantage of, but it's more like a store than a cache.