### PR TITLE
chore: record whether node test uses node:test to report.json

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -103,10 +103,14 @@ interface NodeTestFileReport {
 
 type TestReports = Record<string, NodeTestFileReport>;
 
+type SingleResultInfo = {
+  usesNodeTest?: 1;
+}
+
 export type SingleResult = [
   pass: boolean | "IGNORE",
   error: ErrorExit | ErrorTimeout | ErrorUnexpected | undefined,
-  info: string[],
+  info: SingleResultInfo,
 ];
 type ErrorExit = {
   code: number;
@@ -227,9 +231,9 @@ function transformReportsIntoResults(
     if (value.result === NodeTestFileResult.SKIP) {
       throw new Error("Can't transform 'SKIP' result into `SingleResult`");
     }
-    const info = [];
+    const info = {} as SingleResultInfo;
     if (value.usesNodeTest) {
-      info.push("usesNodeTest");
+      info.usesNodeTest = 1;
     }
     let result: SingleResult = [true, undefined, info];
     if (value.result === NodeTestFileResult.FAIL) {

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -105,7 +105,7 @@ type TestReports = Record<string, NodeTestFileReport>;
 
 type SingleResultInfo = {
   usesNodeTest?: 1; // Uses this form to minimize the size of the report.json
-}
+};
 
 export type SingleResult = [
   pass: boolean | "IGNORE",
@@ -208,7 +208,11 @@ async function runSingle(
       } catch {
         // ignore
       }
-      return { result: NodeTestFileResult.FAIL, error: { timeout: TIMEOUT }, usesNodeTest };
+      return {
+        result: NodeTestFileResult.FAIL,
+        error: { timeout: TIMEOUT },
+        usesNodeTest,
+      };
     } else if (e instanceof Deno.errors.WouldBlock && retry < 3) {
       // retry 2 times on WouldBlock error (Resource temporarily unavailable)
       return runSingle(testPath, retry + 1);

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -104,7 +104,7 @@ interface NodeTestFileReport {
 type TestReports = Record<string, NodeTestFileReport>;
 
 type SingleResultInfo = {
-  usesNodeTest?: 1;
+  usesNodeTest?: 1; // Uses this form to minimize the size of the report.json
 }
 
 export type SingleResult = [

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -98,13 +98,15 @@ enum NodeTestFileResult {
 interface NodeTestFileReport {
   result: NodeTestFileResult;
   error?: ErrorExit | ErrorTimeout | ErrorUnexpected;
+  usesNodeTest: boolean; // whether the test uses `node:test` module
 }
 
 type TestReports = Record<string, NodeTestFileReport>;
 
 export type SingleResult = [
   pass: boolean | "IGNORE",
-  error?: ErrorExit | ErrorTimeout | ErrorUnexpected,
+  error: ErrorExit | ErrorTimeout | ErrorUnexpected | undefined,
+  info: string[],
 ];
 type ErrorExit = {
   code: number;
@@ -154,14 +156,15 @@ async function runSingle(
   testPath: string,
   retry = 0,
 ): Promise<NodeTestFileReport> {
-  if (NODE_IGNORED_TEST_CASES.has(testPath)) {
-    return { result: NodeTestFileResult.IGNORED };
-  }
   let cmd: Deno.ChildProcess | undefined;
   const testPath_ = "tests/node_compat/runner/suite/test/" + testPath;
+  let usesNodeTest = false;
   try {
     const source = await Deno.readTextFile(testPath_);
-    const usesNodeTest = usesNodeTestModule(source);
+    usesNodeTest = usesNodeTestModule(source);
+    if (NODE_IGNORED_TEST_CASES.has(testPath)) {
+      return { result: NodeTestFileResult.IGNORED, usesNodeTest };
+    }
     const [v8Flags, nodeOptions] = getFlags(source);
     cmd = new Deno.Command(Deno.execPath(), {
       args: [
@@ -180,7 +183,7 @@ async function runSingle(
     }).spawn();
     const result = await deadline(cmd.output(), TIMEOUT);
     if (result.code === 0) {
-      return { result: NodeTestFileResult.PASS };
+      return { result: NodeTestFileResult.PASS, usesNodeTest };
     } else {
       const output = usesNodeTest ? result.stdout : result.stderr;
       const outputText = new TextDecoder().decode(output);
@@ -191,6 +194,7 @@ async function runSingle(
           code: result.code,
           stderr,
         },
+        usesNodeTest,
       };
     }
   } catch (e) {
@@ -200,7 +204,7 @@ async function runSingle(
       } catch {
         // ignore
       }
-      return { result: NodeTestFileResult.FAIL, error: { timeout: TIMEOUT } };
+      return { result: NodeTestFileResult.FAIL, error: { timeout: TIMEOUT }, usesNodeTest };
     } else if (e instanceof Deno.errors.WouldBlock && retry < 3) {
       // retry 2 times on WouldBlock error (Resource temporarily unavailable)
       return runSingle(testPath, retry + 1);
@@ -208,6 +212,7 @@ async function runSingle(
       return {
         result: NodeTestFileResult.FAIL,
         error: { message: (e as Error).message },
+        usesNodeTest,
       };
     }
   }
@@ -222,11 +227,15 @@ function transformReportsIntoResults(
     if (value.result === NodeTestFileResult.SKIP) {
       throw new Error("Can't transform 'SKIP' result into `SingleResult`");
     }
-    let result: SingleResult = [true];
+    const info = [];
+    if (value.usesNodeTest) {
+      info.push("usesNodeTest");
+    }
+    let result: SingleResult = [true, undefined, info];
     if (value.result === NodeTestFileResult.FAIL) {
-      result = [false, value.error];
+      result = [false, value.error, info];
     } else if (value.result === NodeTestFileResult.IGNORED) {
-      result = ["IGNORE"];
+      result = ["IGNORE", undefined, info];
     }
     results[key] = result;
   }


### PR DESCRIPTION
This PR adds the info about whether each test case uses `node:test` or not to daily node compat  test report.

This info is useful for displaying more correct command for executing a single test case in Tooltip UI in test viewer web page.

https://node-test-viewer.deno.dev/results/2025-06-05


<img width="842" alt="Screenshot 2025-06-06 at 14 10 40" src="https://github.com/user-attachments/assets/0c7b6db8-bac9-4e1f-9026-b017c0520abf" />

(The 2nd command in the above tooltip should be `deno test` instead of `deno run`.)