### PR TITLE
fix(cli/init): remove tmp 'node_modules'  dir on init npm project

### DIFF
--- a/cli/tools/init/mod.rs
+++ b/cli/tools/init/mod.rs
@@ -340,14 +340,27 @@ async fn init_npm(name: &str, args: Vec<String>) -> Result<i32, AnyError> {
     reload: true,
     ..Default::default()
   };
-  crate::tools::run::run_script(
+  let result = crate::tools::run::run_script(
     WorkerExecutionMode::Run,
     new_flags.into(),
     None,
     None,
     Default::default(),
   )
-  .await
+  .await;
+
+  try_remove_tmp_node_modules_dir();
+
+  result
+}
+
+// Removes the `node_modules` directory if it exists in the current working directory.
+// Useful for cleaning up after npm init scripts that may create a temporary `node_modules` directory.
+fn try_remove_tmp_node_modules_dir() {
+  if let Ok(cwd) = std::env::current_dir() {
+    let node_modules_dir = cwd.join("node_modules");
+    std::fs::remove_dir_all(&node_modules_dir).ok();
+  };
 }
 
 fn create_json_file(


### PR DESCRIPTION
Closes #29513 

When creating a new project using `deno init --npm <package>`  a  temporary `node_modules` directory is created to store the `package` initializers scripts.

example:
```shell
deno init --npm solid
```
A temporary `node_modules` directory will be created to store the `solid` initializers scripts under `node_modules/create-solid`

This PR aims to delete that  `node_modules` directory after initialization since it is not longer needed.


