### PR TITLE
fix: revert back to prefering highest previously resolved version for a req

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.95.0"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af557eab0d8abf2c6e7c890d510eccaebe52388924ae4a3e15c8a818c1bbbb90"
+checksum = "365b662cfc14021c2994156d5a58b9c91d655879b817715e2d92d8adce5b3c31"
 dependencies = [
  "async-trait",
  "capacity_builder",
@@ -2803,11 +2803,11 @@ dependencies = [
 
 [[package]]
 name = "deno_unsync"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c618b51088b3ac67f15c69b3ed7620ba3a7d495e5a090186df9424b5ab623e"
+checksum = "6742a724e8becb372a74c650a1aefb8924a5b8107f7d75b3848763ea24b27a87"
 dependencies = [
- "futures",
+ "futures-util",
  "parking_lot",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ deno_cache_dir = "=0.22.2"
 deno_config = { version = "=0.55.0", features = ["workspace"] }
 deno_doc = "=0.178.0"
 deno_error = "=0.6.1"
-deno_graph = { version = "=0.95.0", default-features = false }
+deno_graph = { version = "=0.95.1", default-features = false }
 deno_lint = "=0.76.0"
 deno_lockfile = "=0.29.0"
 deno_media_type = { version = "=0.2.8", features = ["module_specifier"] }
@@ -72,7 +72,7 @@ deno_path_util = "=0.4.0"
 deno_semver = "=0.8.0"
 deno_task_shell = "=0.24.0"
 deno_terminal = "=0.2.2"
-deno_unsync = "0.4.3"
+deno_unsync = "0.4.4"
 deno_whoami = "0.1.0"
 eszip = "=0.92.0"
 


### PR DESCRIPTION
This is a revert

* https://github.com/denoland/deno_graph/pull/589