### PR TITLE
fix(ext/node): Fix missing core_import_map node internal file path for http2

### DIFF
--- a/tools/core_import_map.json
+++ b/tools/core_import_map.json
@@ -142,6 +142,7 @@
     "ext:deno_node/internal/fs/utils.mjs": "../ext/node/polyfills/internal/fs/utils.mjs",
     "ext:deno_node/internal/hide_stack_frames.ts": "../ext/node/polyfills/internal/hide_stack_frames.ts",
     "ext:deno_node/internal/http.ts": "../ext/node/polyfills/internal/http.ts",
+    "ext:deno_node/internal/http2/util.ts": "../ext/node/polyfills/internal/http2/util.ts",
     "ext:deno_node/internal/net.ts": "../ext/node/polyfills/internal/net.ts",
     "ext:deno_node/internal/normalize_encoding.mjs": "../ext/node/polyfills/internal/normalize_encoding.mjs",
     "ext:deno_node/internal/options.ts": "../ext/node/polyfills/internal/options.ts",


### PR DESCRIPTION
The path for `/ext/node/polyfills/internal/http2/util.ts` was missing from core_import_map.json. Therefore, VSCode IntelliSense had an error in `ext/node/polyfills/http2.ts`.

| Before(has an error) | After(dependency resolved) |
| --- | --- |
| <img width="1020" alt="スクリーンショット 2025-06-07 18 26 18" src="https://github.com/user-attachments/assets/932bf4a0-6df7-4b98-9e0a-8019ca354a79" /> | <img width="889" alt="スクリーンショット 2025-06-07 18 28 17" src="https://github.com/user-attachments/assets/b89ed722-fe0a-4b20-af94-b0373a1e831b" /> | 

related: #27689

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
