### PR TITLE
fix(ext/node): fix fs.watchFile trigger

### DIFF
--- a/ext/node/polyfills/_fs/_fs_watch.ts
+++ b/ext/node/polyfills/_fs/_fs_watch.ts
@@ -298,7 +298,7 @@ class StatWatcher extends EventEmitter {
         while (true) {
           await delay(interval, { signal: this.#abortController.signal });
           const curr = await statAsync(filename);
-          if (curr?.mtime !== prev?.mtime) {
+          if (curr?.mtime.getTime() !== prev?.mtime.getTime()) {
             this.emit("change", curr, prev);
             prev = curr;
           }

--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -2,6 +2,7 @@
 import { unwatchFile, watch, watchFile } from "node:fs";
 import { watch as watchPromise } from "node:fs/promises";
 import { assert, assertEquals } from "@std/assert";
+import { spy } from "@std/testing/mock";
 
 function wait(time: number) {
   return new Promise((resolve) => {
@@ -31,11 +32,17 @@ Deno.test({
   name: "watching a file with options",
   async fn() {
     const file = Deno.makeTempFileSync();
+    const spyFn = spy();
     watchFile(
       file,
-      () => {},
+      { interval: 10 },
+      spyFn,
     );
     await wait(100);
+    assertEquals(spyFn.calls.length, 0);
+    await Deno.writeTextFile(file, "something");
+    await wait(100);
+    assertEquals(spyFn.calls.length, 1);
     unwatchFile(file);
   },
 });


### PR DESCRIPTION
The condition was not working correctly because it compared two Date objects directly, which always results in false even if they represent the same timestamp. The fix uses .getTime() to compare numeric values instead.

Ref: #29421 