### PR TITLE
fix(fmt): allow omission of semicolon in certain cases in css template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,7 +6560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -6750,9 +6750,9 @@ dependencies = [
 
 [[package]]
 name = "raffia"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36f58fa7ad2f26bca656054c902becddeac5582df2bb31d4b4d2a148c62cfd5"
+checksum = "fffe6643ba09b12af3816c6d3687d8c16c8a306bdbf60e2804b4bbd2c1f5447e"
 dependencies = [
  "raffia_macro",
  "smallvec",

--- a/tests/specs/fmt/external_formatter/badly_formatted.in
+++ b/tests/specs/fmt/external_formatter/badly_formatted.in
@@ -11,6 +11,10 @@ margin: 0.5rem;
         ${OTHER_STYLES};
 		}
 	}
+
+  span {
+    ${SOME_STYLE}
+  }
 `;
 
 cssString = css`

--- a/tests/specs/fmt/external_formatter/well_formatted.out
+++ b/tests/specs/fmt/external_formatter/well_formatted.out
@@ -11,6 +11,10 @@ const EqualDivider = styled.div`
       ${OTHER_STYLES};
     }
   }
+
+  span {
+    ${SOME_STYLE};
+  }
 `;
 
 cssString = css`

--- a/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_unstable_sql.out
@@ -11,6 +11,10 @@ const EqualDivider = styled.div`
       ${OTHER_STYLES};
     }
   }
+
+  span {
+    ${SOME_STYLE};
+  }
 `;
 
 cssString = css`

--- a/tests/specs/fmt/external_formatter/well_formatted_use_tabs.out
+++ b/tests/specs/fmt/external_formatter/well_formatted_use_tabs.out
@@ -11,6 +11,10 @@ const EqualDivider = styled.div`
 			${OTHER_STYLES};
 		}
 	}
+
+	span {
+		${SOME_STYLE};
+	}
 `;
 
 cssString = css`


### PR DESCRIPTION
closes #29686

If a semicolon is omitted after the last statement expression (`${SOME_STYLE}` in below) in a block in CSS template literal:

```js
css`
  a {
    ${SOME_STYLE}
  }
`;
```

This currently results in parse error of css and can't be formatted.

The root cause of this is fixed in upstream css parser raffia (https://github.com/g-plane/raffia/issues/11). This PR upgrades raffia to the latest and avoids the above issue.

Note: The example above now formats to the below:

```js
css`
  a {
    ${SOME_STYLE};
  }
`;
```
