### PR TITLE
test(init): add retry in init_subcommand_serve to reduce flakiness

### DIFF
--- a/tests/integration/init_tests.rs
+++ b/tests/integration/init_tests.rs
@@ -199,7 +199,14 @@ async fn init_subcommand_serve() {
     .spawn_with_piped_output();
 
   tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-  let resp = reqwest::get("http://127.0.0.1:9500").await.unwrap();
+  let resp = match reqwest::get("http://127.0.0.1:9500").await {
+    Ok(resp) => resp,
+    Err(_) => {
+      // retry once
+      tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+      reqwest::get("http://127.0.0.1:9500").await.unwrap()
+    }
+  };
 
   let body = resp.text().await.unwrap();
   assert_eq!(body, "Home page");


### PR DESCRIPTION
This PR adds retrying of http request to localhost in `init::init_subcommand_serve` test case to reduce [this](https://github.com/denoland/deno/actions/runs/15542323728/job/43755813240) flakiness.