### PR TITLE
feat(ext/fetch): add support for fetch on vsock sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-socks",
  "tokio-util",
+ "tokio-vsock",
  "tower 0.5.2",
  "tower-http",
  "tower-service",

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -6205,6 +6205,8 @@ declare namespace Deno {
    *    through a different server.
    *  - Unix domain socket: this sends all requests to a local Unix domain
    *    socket rather than a TCP socket. *Not supported on Windows.*
+   *  - Vsock socket: this sends all requests to a local vsock socket.
+   *    *Only supported on Linux and macOS.*
    *
    * @category Fetch
    */
@@ -6226,6 +6228,12 @@ declare namespace Deno {
     transport: "unix";
     /** The path to the unix domain socket to use. */
     path: string;
+  } | {
+    transport: "vsock";
+    /** The CID (Context Identifier) of the vsock to connect to. */
+    cid: number;
+    /** The port of the vsock to connect to. */
+    port: number;
   };
 
   /**

--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -78,6 +78,9 @@ function createHttpClient(options) {
         case "unix": {
           break;
         }
+        case "vsock": {
+          break;
+        }
         default: {
           throw new TypeError(
             `Invalid value for 'proxy.transport' option: ${

--- a/ext/fetch/Cargo.toml
+++ b/ext/fetch/Cargo.toml
@@ -46,5 +46,8 @@ tower.workspace = true
 tower-http.workspace = true
 tower-service.workspace = true
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+tokio-vsock.workspace = true
+
 [dev-dependencies]
 fast-socks5.workspace = true

--- a/ext/fetch/proxy.rs
+++ b/ext/fetch/proxy.rs
@@ -31,6 +31,8 @@ use tokio::net::UnixStream;
 use tokio_rustls::client::TlsStream;
 use tokio_rustls::TlsConnector;
 use tokio_socks::tcp::Socks5Stream;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use tokio_vsock::VsockStream;
 use tower_service::Service;
 
 #[derive(Debug, Clone)]
@@ -74,6 +76,11 @@ pub(crate) enum Target {
   #[cfg(not(windows))]
   Unix {
     path: PathBuf,
+  },
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
+  Vsock {
+    cid: u32,
+    port: u32,
   },
 }
 
@@ -163,6 +170,10 @@ impl Intercept {
       Target::Unix { .. } => {
         // Auth not supported for Unix sockets
       }
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Target::Vsock { .. } => {
+        // Auth not supported for Vsock sockets
+      }
     }
   }
 }
@@ -244,6 +255,11 @@ impl Target {
   #[cfg(not(windows))]
   pub(crate) fn new_unix(path: PathBuf) -> Self {
     Target::Unix { path }
+  }
+
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
+  pub(crate) fn new_vsock(cid: u32, port: u32) -> Self {
+    Target::Vsock { cid, port }
   }
 }
 
@@ -449,6 +465,9 @@ pub enum Proxied<T> {
   /// Forwarded via Unix socket
   #[cfg(not(windows))]
   Unix(TokioIo<UnixStream>),
+  /// Forwarded via Vsock socket
+  #[cfg(any(target_os = "linux", target_os = "macos"))]
+  Vsock(TokioIo<VsockStream>),
 }
 
 impl<C> Service<Uri> for ProxyConnector<C>
@@ -553,6 +572,12 @@ where
             Ok(Proxied::Unix(TokioIo::new(io)))
           })
         }
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        Target::Vsock { cid, port } => Box::pin(async move {
+          let addr = tokio_vsock::VsockAddr::new(cid, port);
+          let io = VsockStream::connect(addr).await?;
+          Ok(Proxied::Vsock(TokioIo::new(io)))
+        }),
       };
     }
 
@@ -664,6 +689,8 @@ where
       Proxied::SocksTls(ref mut p) => Pin::new(p).poll_read(cx, buf),
       #[cfg(not(windows))]
       Proxied::Unix(ref mut p) => Pin::new(p).poll_read(cx, buf),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(ref mut p) => Pin::new(p).poll_read(cx, buf),
     }
   }
 }
@@ -685,6 +712,8 @@ where
       Proxied::SocksTls(ref mut p) => Pin::new(p).poll_write(cx, buf),
       #[cfg(not(windows))]
       Proxied::Unix(ref mut p) => Pin::new(p).poll_write(cx, buf),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(ref mut p) => Pin::new(p).poll_write(cx, buf),
     }
   }
 
@@ -700,6 +729,8 @@ where
       Proxied::SocksTls(ref mut p) => Pin::new(p).poll_flush(cx),
       #[cfg(not(windows))]
       Proxied::Unix(ref mut p) => Pin::new(p).poll_flush(cx),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(ref mut p) => Pin::new(p).poll_flush(cx),
     }
   }
 
@@ -715,6 +746,8 @@ where
       Proxied::SocksTls(ref mut p) => Pin::new(p).poll_shutdown(cx),
       #[cfg(not(windows))]
       Proxied::Unix(ref mut p) => Pin::new(p).poll_shutdown(cx),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(ref mut p) => Pin::new(p).poll_shutdown(cx),
     }
   }
 
@@ -727,6 +760,8 @@ where
       Proxied::SocksTls(ref p) => p.is_write_vectored(),
       #[cfg(not(windows))]
       Proxied::Unix(ref p) => p.is_write_vectored(),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(ref p) => p.is_write_vectored(),
     }
   }
 
@@ -749,6 +784,8 @@ where
       Proxied::SocksTls(ref mut p) => Pin::new(p).poll_write_vectored(cx, bufs),
       #[cfg(not(windows))]
       Proxied::Unix(ref mut p) => Pin::new(p).poll_write_vectored(cx, bufs),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(ref mut p) => Pin::new(p).poll_write_vectored(cx, bufs),
     }
   }
 }
@@ -780,6 +817,8 @@ where
       }
       #[cfg(not(windows))]
       Proxied::Unix(_) => Connected::new(),
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
+      Proxied::Vsock(_) => Connected::new(),
     }
   }
 }

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -169,6 +169,10 @@ pub enum Proxy {
   Unix {
     path: String,
   },
+  Vsock {
+    cid: u32,
+    port: u32,
+  },
 }
 
 #[derive(Deserialize, Default, Debug, Clone)]

--- a/runtime/snapshot_info.rs
+++ b/runtime/snapshot_info.rs
@@ -59,6 +59,15 @@ impl deno_fetch::FetchPermissions for Permissions {
   ) -> Result<deno_fs::CheckedPath<'a>, FsError> {
     unreachable!("snapshotting!")
   }
+
+  fn check_net_vsock(
+    &mut self,
+    _cid: u32,
+    _port: u32,
+    _api_name: &str,
+  ) -> Result<(), PermissionCheckError> {
+    unreachable!("snapshotting!")
+  }
 }
 
 impl deno_ffi::FfiPermissions for Permissions {

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2310,3 +2310,21 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  {
+    permissions: { net: true },
+    ignore: Deno.build.os === "windows",
+  },
+  function createHttpClientWithVsockProxy() {
+    // Test that creating an HttpClient with vsock proxy succeeds
+    using client = Deno.createHttpClient({
+      proxy: {
+        transport: "vsock",
+        cid: 2,
+        port: 80,
+      },
+    });
+    assert(client instanceof Deno.HttpClient);
+  },
+);


### PR DESCRIPTION
This commit adds support for using [vsock](https://man7.org/linux/man-pages/man7/vsock.7.html) transport in fetch API on Linux and macOS.

Similar to #29154, a vsock transport can be specified in the `proxy` field when calling `Deno.createHttpClient`.

```ts
const client = Deno.createHttpClient({
  proxy: {
    transport: "vsock",
    cid: 2,
    port: 80,
  },
});

await fetch("http://localhost/ping", { client });
```