### PR TITLE
test(ext/node): reduce flakiness of _fs_watch_test.ts

### DIFF
--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -44,6 +44,8 @@ Deno.test({
     await wait(100);
     assertEquals(spyFn.calls.length, 1);
     unwatchFile(file);
+    await wait(100);
+    assertEquals(spyFn.calls.length, 1);
   },
 });
 


### PR DESCRIPTION
A test case in `tests/unit_node/_fs/_fs_watch_test.ts` seems flaky after landing #29659 

This PR tries to fix it