### PR TITLE
refactor(ext/node): use FastBuffer in internal code

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -9,7 +9,7 @@ const {
   encode,
 } = core;
 const {
-  SymbolSpecies
+  SymbolSpecies,
 } = primordials;
 import {
   op_node_cipheriv_encrypt,

--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -4,10 +4,13 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { core } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
 const {
   encode,
 } = core;
+const {
+  SymbolSpecies
+} = primordials;
 import {
   op_node_cipheriv_encrypt,
   op_node_cipheriv_final,
@@ -41,6 +44,8 @@ import {
   isAnyArrayBuffer,
   isArrayBufferView,
 } from "ext:deno_node/internal/util/types.ts";
+
+const FastBuffer = Buffer[SymbolSpecies];
 
 export function isStringOrBuffer(
   val: unknown,
@@ -195,7 +200,7 @@ export class Cipheriv extends Transform implements Cipher {
   }
 
   final(encoding: string = getDefaultEncoding()): Buffer | string {
-    const buf = new Buffer(16);
+    const buf = new FastBuffer(16);
     if (this.#cache.cache.byteLength == 0) {
       const maybeTag = op_node_cipheriv_take(this.#context);
       if (maybeTag) this.#authTag = Buffer.from(maybeTag);
@@ -355,7 +360,7 @@ export class Decipheriv extends Transform implements Cipher {
   }
 
   final(encoding: string = getDefaultEncoding()): Buffer | string {
-    let buf = new Buffer(16);
+    let buf = new FastBuffer(16);
     op_node_decipheriv_final(
       this.#context,
       this.#autoPadding,
@@ -421,7 +426,7 @@ export class Decipheriv extends Transform implements Cipher {
     if (input === null) {
       output = Buffer.alloc(0);
     } else {
-      output = new Buffer(input.length);
+      output = new FastBuffer(input.length);
       op_node_decipheriv_decrypt(this.#context, input, output);
     }
     return outputEncoding === "buffer"

--- a/ext/node/polyfills/internal/crypto/sig.ts
+++ b/ext/node/polyfills/internal/crypto/sig.ts
@@ -4,6 +4,12 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
+import { primordials } from "ext:core/mod.js";
+
+const {
+  SymbolSpecies,
+} = primordials;
+
 import {
   op_node_create_private_key,
   op_node_create_public_key,
@@ -38,6 +44,8 @@ import {
 } from "ext:deno_node/internal/crypto/keys.ts";
 import { createHash } from "ext:deno_node/internal/crypto/hash.ts";
 import { ERR_CRYPTO_SIGN_KEY_REQUIRED } from "ext:deno_node/internal/errors.ts";
+
+const FastBuffer = Buffer[SymbolSpecies];
 
 export type DSAEncoding = "der" | "ieee-p1363";
 
@@ -261,7 +269,7 @@ export function signOneShot(
     if (algorithm != null && algorithm !== "sha512") {
       throw new TypeError("Only 'sha512' is supported for Ed25519 keys");
     }
-    result = new Buffer(64);
+    result = new FastBuffer(64);
     op_node_sign_ed25519(handle, data, result);
   } else if (algorithm == null) {
     throw new TypeError(


### PR DESCRIPTION
This PR replaces deprecated `new Buffer` call with `new FastBuffer` in internal code.