### PR TITLE
test: disable _fs_watch_test.ts test case

### DIFF
--- a/tests/unit_node/_fs/_fs_watch_test.ts
+++ b/tests/unit_node/_fs/_fs_watch_test.ts
@@ -30,6 +30,8 @@ Deno.test({
 
 Deno.test({
   name: "watching a file with options",
+  // TODO(bartlomieju): this test is flaky on CI
+  ignore: true,
   async fn() {
     const file = Deno.makeTempFileSync();
     const spyFn = spy();


### PR DESCRIPTION
This test was added in https://github.com/denoland/deno/pull/29659 and
an attempt to make it more stable was done in https://github.com/denoland/deno/pull/29699.

Unfortunately it's still very flaky. Ignoring for now.

CC @kt3k 