### PR TITLE
fix: support virtio vsock only on systems on which it is available (remainder)

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -1054,7 +1054,7 @@ where
     NetworkStream::Unix(conn) => {
       serve_http(conn, connection_properties, lifetime, tx, options)
     }
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     NetworkStream::Vsock(conn) => {
       serve_http(conn, connection_properties, lifetime, tx, options)
     }

--- a/ext/http/request_properties.rs
+++ b/ext/http/request_properties.rs
@@ -165,14 +165,14 @@ impl HttpPropertyExtractor for DefaultHttpPropertyExtractor {
       NetworkStreamAddress::Ip(ip) => Some(ip.port() as _),
       #[cfg(unix)]
       NetworkStreamAddress::Unix(_) => None,
-      #[cfg(unix)]
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
       NetworkStreamAddress::Vsock(vsock) => Some(vsock.port()),
     };
     let peer_address = match peer_address {
       NetworkStreamAddress::Ip(addr) => Rc::from(addr.ip().to_string()),
       #[cfg(unix)]
       NetworkStreamAddress::Unix(_) => Rc::from("unix"),
-      #[cfg(unix)]
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
       NetworkStreamAddress::Vsock(addr) => {
         Rc::from(format!("vsock:{}", addr.cid()))
       }
@@ -214,7 +214,7 @@ fn listener_properties(
     NetworkStreamAddress::Ip(ip) => Some(ip.port() as _),
     #[cfg(unix)]
     NetworkStreamAddress::Unix(_) => None,
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     NetworkStreamAddress::Vsock(vsock) => Some(vsock.port()),
   };
   Ok(HttpListenProperties {
@@ -260,7 +260,7 @@ fn req_host_from_addr(
       percent_encoding::NON_ALPHANUMERIC,
     )
     .to_string(),
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     NetworkStreamAddress::Vsock(vsock) => {
       format!("{}:{}", vsock.cid(), vsock.port())
     }
@@ -273,7 +273,7 @@ fn req_scheme_from_stream_type(stream_type: NetworkStreamType) -> &'static str {
     NetworkStreamType::Tls => "https://",
     #[cfg(unix)]
     NetworkStreamType::Unix => "http+unix://",
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     NetworkStreamType::Vsock => "http+vsock://",
   }
 }
@@ -299,7 +299,7 @@ fn req_host<'a>(
       }
       #[cfg(unix)]
       NetworkStreamType::Unix => {}
-      #[cfg(unix)]
+      #[cfg(any(target_os = "linux", target_os = "macos"))]
       NetworkStreamType::Vsock => {}
     }
     return Some(Cow::Borrowed(auth.as_str()));


### PR DESCRIPTION
See https://github.com/denoland/deno/issues/29268 for the related discussion. @devsnek @marvinhagemeister

These are two patches I missed with the initial PR (https://github.com/denoland/deno/pull/29354)