### PR TITLE
fix(ext/node): fix events.once

### DIFF
--- a/ext/node/polyfills/_events.mjs
+++ b/ext/node/polyfills/_events.mjs
@@ -28,6 +28,7 @@
 import { primordials } from "ext:core/mod.js";
 const {
   ArrayPrototypeMap,
+  ArrayPrototypeFilter,
   ObjectDefineProperty,
   ObjectEntries,
   SafeMap,
@@ -57,7 +58,10 @@ import {
 } from "ext:deno_node/internal/validators.mjs";
 import { spliceOne } from "ext:deno_node/_utils.ts";
 import { nextTick } from "ext:deno_node/_process/process.ts";
-import { eventTargetData } from "ext:deno_web/02_event.js";
+import {
+  eventTargetData,
+  kResistStopImmediatePropagation,
+} from "ext:deno_web/02_event.js";
 
 export { addAbortListener } from "./internal/events/abort_listener.mjs";
 
@@ -874,12 +878,22 @@ export function getEventListeners(emitterOrTarget, type) {
  * @returns {Promise}
  */
 // deno-lint-ignore require-await
-export async function once(emitter, name, options = {}) {
+export async function once(emitter, name, options = kEmptyObject) {
+  validateObject(options, "options");
   const signal = options?.signal;
   validateAbortSignal(signal, "options.signal");
   if (signal?.aborted) {
     throw new AbortError();
   }
+
+  if (signal) {
+    // Patches [kEvents] field of AbortSignal to simulate Node.js EventTarget
+    // This is necessary to pass `paralle/test-events-once.js` test
+    // TODO(kt3k): This can be removed if events.getEventListeners() is used
+    // instead of `signal[kEvents]` in upstream.
+    ObjectDefineProperty(signal, kEvents, kEventsGetter);
+  }
+
   return new Promise((resolve, reject) => {
     const errorListener = (err) => {
       emitter.removeListener(name, resolver);
@@ -911,7 +925,7 @@ export async function once(emitter, name, options = {}) {
         signal,
         "abort",
         abortListener,
-        { once: true },
+        { once: true, [kResistStopImmediatePropagation]: true },
       );
     }
   });
@@ -958,9 +972,13 @@ const kEventsGetter = {
       return new SafeMap();
     }
     return new SafeMap(
-      ArrayPrototypeMap(ObjectEntries(data.listeners), (
-        [key, listeners],
-      ) => [key, new SafeSet(listeners)]),
+      ArrayPrototypeMap(
+        ArrayPrototypeFilter(
+          ObjectEntries(data.listeners),
+          ([_, listeners]) => listeners.length > 0,
+        ),
+        ([key, listeners]) => [key, new SafeSet(listeners)],
+      ),
     );
   },
 };


### PR DESCRIPTION
This PR aligns the behavior of `events.once` to Node.js and enables `parallel/test-events-once.js`.

Details:
- Added validation of `options` object.
- Added patching of `kEvents` field for passed `signal` (necessary for passing compat test case)
- Added `kResistStopImmediatePropagation` symbol. That works as private option for event listener. If that option is specified, the event listener ignores `e.stopImmediatePropagation()` call from earlier listeners (Node.js also has this internal option https://github.com/nodejs/node/commit/bcd35c334ec75402ee081f1c4da128c339f70c24 and use it for internal abort listeners)

towards #29595 