### PR TITLE
chore: fix internal hmr feature

### DIFF
--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -69,7 +69,14 @@ impl Default for SnapshotOptions {
 #[op2]
 #[serde]
 pub fn op_snapshot_options(state: &mut OpState) -> SnapshotOptions {
-  state.take::<SnapshotOptions>()
+  #[cfg(feature = "hmr")]
+  {
+    state.try_take::<SnapshotOptions>().unwrap_or_default()
+  }
+  #[cfg(not(feature = "hmr"))]
+  {
+    state.take::<SnapshotOptions>()
+  }
 }
 
 #[op2]


### PR DESCRIPTION
Currently broken on main due to `SnapshotOptions` not being in op state