### PR TITLE
refactor(resolver): support resolving npm req ref not in graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d807160e754edb1989b4a19cac1ac5299065a7a89ff98682a2366cbaa25795"
+checksum = "5a7123b11b66cf19e023372bfcb137498243ef32dd73c725b938c118ac9943f5"
 dependencies = [
  "capacity_builder",
  "deno_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ deno_native_certs = "0.3.0"
 deno_npm = "=0.35.0"
 deno_package_json = { version = "=0.7.0", default-features = false }
 deno_path_util = "=0.4.0"
-deno_semver = "=0.8.0"
+deno_semver = "=0.8.1"
 deno_task_shell = "=0.24.0"
 deno_terminal = "=0.2.2"
 deno_unsync = { version = "0.4.4", default-features = false }

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -39,8 +39,6 @@ use crate::graph_container::ModuleGraphContainer;
 use crate::graph_container::ModuleGraphUpdatePermit;
 use crate::module_loader::ModuleLoadPreparer;
 use crate::module_loader::PrepareModuleLoadOptions;
-use crate::node::CliNodeResolver;
-use crate::npm::CliNpmResolver;
 use crate::resolver::CliResolver;
 use crate::tools::bundle::externals::ExternalsMatcher;
 
@@ -68,8 +66,8 @@ pub async fn bundle(
   let resolver = factory.resolver().await?.clone();
   let module_load_preparer = factory.module_load_preparer().await?.clone();
   let root_permissions = factory.root_permissions_container()?;
-  let npm_resolver = factory.npm_resolver().await?.clone();
-  let node_resolver = factory.node_resolver().await?.clone();
+  let npm_resolver = factory.npm_resolver().await?;
+  let node_resolver = factory.node_resolver().await?;
   let cli_options = factory.cli_options()?;
   let module_loader = factory
     .create_module_loader_factory()
@@ -88,8 +86,6 @@ pub async fn bundle(
       .await?
       .clone(),
     permissions: root_permissions.clone(),
-    npm_resolver: npm_resolver.clone(),
-    node_resolver: node_resolver.clone(),
     module_loader: module_loader.clone(),
     externals_matcher: if bundle_flags.external.is_empty() {
       None
@@ -340,8 +336,6 @@ struct DenoPluginHandler {
   module_load_preparer: Arc<ModuleLoadPreparer>,
   module_graph_container: Arc<MainModuleGraphContainer>,
   permissions: PermissionsContainer,
-  npm_resolver: CliNpmResolver,
-  node_resolver: Arc<CliNodeResolver>,
   module_loader: Rc<dyn ModuleLoader>,
   externals_matcher: Option<ExternalsMatcher>,
 }
@@ -630,21 +624,12 @@ impl DenoPluginHandler {
       ),
       deno_graph::Module::Wasm(_) => todo!(),
       deno_graph::Module::Npm(module) => {
-        let package_folder = self
-          .npm_resolver
-          .as_managed()
-          .unwrap() // byonm won't create a Module::Npm
-          .resolve_pkg_folder_from_deno_module(module.nv_reference.nv())?;
-        let path = self
-          .node_resolver
-          .resolve_package_subpath_from_deno_module(
-            &package_folder,
-            module.nv_reference.sub_path(),
-            None,
-            ResolutionMode::Import,
-            NodeResolutionKind::Execution,
-          )?;
-        let url = path.clone().into_url()?;
+        let url = self.resolver.resolve_npm_nv_ref(
+          &module.nv_reference,
+          None,
+          ResolutionMode::Import,
+          NodeResolutionKind::Execution,
+        )?;
         let (media_type, _charset) =
           deno_media_type::resolve_media_type_and_charset_from_content_type(
             &url, None,


### PR DESCRIPTION
This allows resolving an npm req when it's not in the graph. This is only useful for `@deno/loader` and won't ever be hit in the CLI.