### PR TITLE
fix: remove `self` from global middleware

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -64,14 +64,13 @@ const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
 
 // UTF-16 encodings of the managed globals. THIS LIST MUST BE SORTED.
 #[rustfmt::skip]
-const MANAGED_GLOBALS: [&[u16]; 11] = [
+const MANAGED_GLOBALS: [&[u16]; 10] = [
   &str_to_utf16::<6>("Buffer"),
   &str_to_utf16::<14>("clearImmediate"),
   &str_to_utf16::<13>("clearInterval"),
   &str_to_utf16::<12>("clearTimeout"),
   &str_to_utf16::<6>("global"),
   &str_to_utf16::<7>("process"),
-  &str_to_utf16::<4>("self"),
   &str_to_utf16::<12>("setImmediate"),
   &str_to_utf16::<11>("setInterval"),
   &str_to_utf16::<10>("setTimeout"),

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -719,7 +719,7 @@ Module._load = function (request, parent, isMain) {
   }
   // Don't call updateChildren(), Module constructor already does.
   const module = cachedModule || new Module(filename, parent);
-  console.log("create module", filename);
+
   if (isMain) {
     process.mainModule = module;
     mainModule = module;
@@ -914,7 +914,6 @@ Module.prototype.load = function (filename) {
     pathDirname(this.filename),
   );
   const extension = findLongestRegisteredExtension(filename);
-  console.log("Module.load", filename, extension, Module._extensions);
   Module._extensions[extension](this, this.filename);
   this.loaded = true;
 
@@ -983,7 +982,6 @@ function wrapSafe(
   format,
 ) {
   const wrapper = Module.wrap(content);
-  console.log("wrapped");
   const [f, err] = core.evalContext(
     wrapper,
     url.pathToFileURL(filename).toString(),
@@ -999,7 +997,6 @@ function wrapSafe(
 }
 
 Module.prototype._compile = function (content, filename, format) {
-  console.log("_compile", filename, format);
   if (format === "module") {
     return loadESMFromCJS(this, filename, content);
   }
@@ -1042,14 +1039,6 @@ Module.prototype._compile = function (content, filename, format) {
     setTimeout,
   } = nodeGlobals;
 
-  console.log(
-    "calling wrapped",
-    filename,
-    Buffer,
-    clearImmediate,
-    clearTimeout,
-    setImmediate,
-  );
   const result = compiledWrapper.call(
     thisValue,
     exports,
@@ -1161,7 +1150,6 @@ function createRequireFromPath(filename) {
 
 function makeRequireFunction(mod) {
   const require = function require(path) {
-    console.log("require", path);
     return mod.require(path);
   };
 

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -719,7 +719,7 @@ Module._load = function (request, parent, isMain) {
   }
   // Don't call updateChildren(), Module constructor already does.
   const module = cachedModule || new Module(filename, parent);
-
+  console.log("create module", filename);
   if (isMain) {
     process.mainModule = module;
     mainModule = module;
@@ -914,6 +914,7 @@ Module.prototype.load = function (filename) {
     pathDirname(this.filename),
   );
   const extension = findLongestRegisteredExtension(filename);
+  console.log("Module.load", filename, extension, Module._extensions);
   Module._extensions[extension](this, this.filename);
   this.loaded = true;
 
@@ -982,6 +983,7 @@ function wrapSafe(
   format,
 ) {
   const wrapper = Module.wrap(content);
+  console.log("wrapped");
   const [f, err] = core.evalContext(
     wrapper,
     url.pathToFileURL(filename).toString(),
@@ -997,6 +999,7 @@ function wrapSafe(
 }
 
 Module.prototype._compile = function (content, filename, format) {
+  console.log("_compile", filename, format);
   if (format === "module") {
     return loadESMFromCJS(this, filename, content);
   }
@@ -1039,6 +1042,14 @@ Module.prototype._compile = function (content, filename, format) {
     setTimeout,
   } = nodeGlobals;
 
+  console.log(
+    "calling wrapped",
+    filename,
+    Buffer,
+    clearImmediate,
+    clearTimeout,
+    setImmediate,
+  );
   const result = compiledWrapper.call(
     thisValue,
     exports,
@@ -1150,6 +1161,7 @@ function createRequireFromPath(filename) {
 
 function makeRequireFunction(mod) {
   const require = function require(path) {
+    console.log("require", path);
     return mod.require(path);
   };
 

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1025,6 +1025,7 @@ function bootstrapWorkerRuntime(
     exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures);
     if (workerType === "node") {
       delete workerRuntimeGlobalProperties["WorkerGlobalScope"];
+      delete workerRuntimeGlobalProperties["self"];
     }
     ObjectDefineProperties(globalThis, workerRuntimeGlobalProperties);
     ObjectDefineProperties(globalThis, {

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1047,8 +1047,8 @@ function bootstrapWorkerRuntime(
 
     core.wrapConsole(globalThis.console, core.v8Console);
 
-    event.defineEventHandler(self, "message");
-    event.defineEventHandler(self, "error", undefined, true);
+    event.defineEventHandler(globalThis, "message");
+    event.defineEventHandler(globalThis, "error", undefined, true);
 
     // `Deno.exit()` is an alias to `self.close()`. Setting and exit
     // code using an op in worker context is a no-op.

--- a/tests/registry/npm/@denotest/check-worker-globals/1.0.0/inverse.js
+++ b/tests/registry/npm/@denotest/check-worker-globals/1.0.0/inverse.js
@@ -1,0 +1,7 @@
+if (typeof self === "undefined") {
+  throw new Error("self is not defined");
+}
+
+if (typeof WorkerGlobalScope === "undefined") {
+  throw new Error("WorkerGlobalScope is not defined");
+}

--- a/tests/registry/npm/@denotest/check-worker-globals/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/check-worker-globals/1.0.0/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@denotest/check-worker-globals",
   "version": "1.0.0",
-  "main": "index.js"
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./inverse": "./inverse.js"
+  }
 }

--- a/tests/specs/npm/compare_globals/main.out
+++ b/tests/specs/npm/compare_globals/main.out
@@ -24,8 +24,8 @@ false
 false
 self 1 true
 self 2 true
-false
-false
+true
+true
 bar
 bar
 true

--- a/tests/specs/npm/workers/main.out
+++ b/tests/specs/npm/workers/main.out
@@ -3,4 +3,5 @@
 2
 3
 4
+5
 [UNORDERED_END]

--- a/tests/specs/npm/workers/main.ts
+++ b/tests/specs/npm/workers/main.ts
@@ -10,3 +10,6 @@ new Worker(new URL("./worker3.ts", import.meta.url), {
   type: "module",
 });
 new WorkerThread(new URL("./worker4.mjs", import.meta.url));
+new Worker(new URL("./worker5.mjs", import.meta.url), {
+  type: "module",
+});

--- a/tests/specs/npm/workers/worker4.mjs
+++ b/tests/specs/npm/workers/worker4.mjs
@@ -1,4 +1,4 @@
 import "npm:@denotest/check-worker-globals";
 
 console.log(4);
-self.close();
+globalThis.close();

--- a/tests/specs/npm/workers/worker5.mjs
+++ b/tests/specs/npm/workers/worker5.mjs
@@ -1,0 +1,4 @@
+import "npm:@denotest/check-worker-globals/inverse";
+
+console.log(5);
+self.close();


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/29543 that does
the same for `self` global. Unfortunately this omission led to a problem
described in https://github.com/denoland/deno/issues/29726 where
packages started thinking that they are being run in a web worker
context (because they are!) but the expected "self" global is not
there.