### PR TITLE
fix(bundle): improve error handling and reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,9 +3626,9 @@ checksum = "31ae425815400e5ed474178a7a22e275a9687086a12ca63ec793ff292d8fdae8"
 
 [[package]]
 name = "esbuild_client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c22607cae83b2429fc3fac40717bd3baa72b74e70a5e97c6b157ca3a73761e1"
+checksum = "ae80742f94e7a902164f07f0f798ab8cbb86a0254a555785546f75797bcb8a4c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,6 +391,10 @@ winapi = "=0.3.9"
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Media", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_WindowsProgramming", "Wdk", "Wdk_System", "Wdk_System_SystemInformation", "Win32_Security", "Win32_System_Pipes", "Wdk_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Kernel", "Win32_System_Threading", "Win32_UI", "Win32_UI_Shell"] }
 winres = "=0.1.12"
 
+[profile.dev]
+incremental = true
+# codegen-units = 512
+
 [profile.release]
 codegen-units = 1
 incremental = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -120,7 +120,7 @@ dprint-plugin-json.workspace = true
 dprint-plugin-jupyter.workspace = true
 dprint-plugin-markdown.workspace = true
 dprint-plugin-typescript.workspace = true
-esbuild_client = { version = "0.2.0" }
+esbuild_client = { version = "0.3.0" }
 fancy-regex.workspace = true
 faster-hex.workspace = true
 # If you disable the default __vendored_zlib_ng feature above, you _must_ be able to link against `-lz`.

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -557,7 +557,7 @@ pub enum LoadPreparedModuleError {
   LoadMaybeCjs(#[from] LoadMaybeCjsError),
   #[class(inherit)]
   #[error(transparent)]
-  Graph(#[from] EnhancedGraphError),
+  Graph(#[from] Box<EnhancedGraphError>),
   #[class(inherit)]
   #[error(transparent)]
   Other(#[from] JsErrorBox),
@@ -998,15 +998,16 @@ impl<TGraphContainer: ModuleGraphContainer>
       unreachable!("Deno bug. {} was misconfigured internally.", specifier);
     }
 
-    let maybe_module =
-      graph.try_get(specifier).map_err(|err| EnhancedGraphError {
+    let maybe_module = graph.try_get(specifier).map_err(|err| {
+      Box::new(EnhancedGraphError {
         message: enhance_graph_error(
           &self.shared.sys,
           &ModuleGraphError::ModuleError(err.clone()),
           EnhanceGraphErrorMode::ShowRange,
         ),
         error: err.clone(),
-      })?;
+      })
+    })?;
 
     match maybe_module {
       Some(deno_graph::Module::Json(JsonModule {

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -38,7 +38,6 @@ use deno_core::ModuleType;
 use deno_core::RequestedModuleType;
 use deno_core::SourceCodeCacheInfo;
 use deno_error::JsErrorBox;
-use deno_error::JsErrorClass;
 use deno_graph::GraphKind;
 use deno_graph::JsModule;
 use deno_graph::JsonModule;
@@ -503,6 +502,26 @@ impl ModuleLoaderFactory for CliModuleLoaderFactory {
   }
 }
 
+impl CliModuleLoaderFactory {
+  pub fn create_cli_module_loader(
+    &self,
+    root_permissions: PermissionsContainer,
+  ) -> CliModuleLoader<MainModuleGraphContainer> {
+    CliModuleLoader(Rc::new(CliModuleLoaderInner {
+      lib: self.shared.lib_window,
+      is_worker: false,
+      parent_permissions: root_permissions.clone(),
+      permissions: root_permissions,
+      graph_container: (*self.shared.main_module_graph_container).clone(),
+      node_code_translator: self.shared.node_code_translator.clone(),
+      emitter: self.shared.emitter.clone(),
+      parsed_source_cache: self.shared.parsed_source_cache.clone(),
+      shared: self.shared.clone(),
+      loaded_files: Default::default(),
+    }))
+  }
+}
+
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum LoadCodeSourceError {
   #[class(inherit)]
@@ -520,6 +539,15 @@ pub enum LoadCodeSourceError {
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
+#[error("{message}")]
+#[class(inherit)]
+pub struct EnhancedGraphError {
+  #[inherit]
+  pub error: deno_graph::ModuleError,
+  pub message: String,
+}
+
+#[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum LoadPreparedModuleError {
   #[class(inherit)]
   #[error(transparent)]
@@ -527,6 +555,9 @@ pub enum LoadPreparedModuleError {
   #[class(inherit)]
   #[error(transparent)]
   LoadMaybeCjs(#[from] LoadMaybeCjsError),
+  #[class(inherit)]
+  #[error(transparent)]
+  Graph(#[from] EnhancedGraphError),
   #[class(inherit)]
   #[error(transparent)]
   Other(#[from] JsErrorBox),
@@ -558,9 +589,70 @@ struct CliModuleLoaderInner<TGraphContainer: ModuleGraphContainer> {
   loaded_files: RefCell<HashSet<ModuleSpecifier>>,
 }
 
+#[derive(Debug, thiserror::Error, deno_error::JsError)]
+pub enum CliModuleLoaderError {
+  #[class(inherit)]
+  #[error(transparent)]
+  LoadCodeSource(#[from] LoadCodeSourceError),
+  #[class(inherit)]
+  #[error(transparent)]
+  LoadPreparedModule(#[from] LoadPreparedModuleError),
+  #[class(generic)]
+  #[error("Attempted to load JSON module without specifying \"type\": \"json\" attribute in the import statement.")]
+  MissingJsonAttribute,
+  #[class(inherit)]
+  #[error(transparent)]
+  Other(#[from] JsErrorBox),
+}
+
+impl<TGraphContainer: ModuleGraphContainer> CliModuleLoader<TGraphContainer> {
+  pub async fn load_module_source(
+    &self,
+    specifier: &ModuleSpecifier,
+    maybe_referrer: Option<&ModuleSpecifier>,
+    requested_module_type: RequestedModuleType,
+  ) -> Result<ModuleSource, CliModuleLoaderError> {
+    self
+      .0
+      .load_module_source(specifier, maybe_referrer, requested_module_type)
+      .await
+  }
+}
+
 impl<TGraphContainer: ModuleGraphContainer>
   CliModuleLoaderInner<TGraphContainer>
 {
+  async fn load_module_source(
+    &self,
+    specifier: &ModuleSpecifier,
+    maybe_referrer: Option<&ModuleSpecifier>,
+    requested_module_type: RequestedModuleType,
+  ) -> Result<ModuleSource, CliModuleLoaderError> {
+    let code_source = self.load_code_source(specifier, maybe_referrer).await?;
+
+    let module_type = match code_source.media_type {
+      MediaType::Json => ModuleType::Json,
+      MediaType::Wasm => ModuleType::Wasm,
+      _ => ModuleType::JavaScript,
+    };
+
+    // If we loaded a JSON file, but the "requested_module_type" (that is computed from
+    // import attributes) is not JSON we need to fail.
+    if module_type == ModuleType::Json
+      && requested_module_type != RequestedModuleType::Json
+    {
+      return Err(CliModuleLoaderError::MissingJsonAttribute);
+    }
+
+    Ok(ModuleSource::new_with_redirect(
+      module_type,
+      code_source.code,
+      specifier,
+      &code_source.found_url,
+      None,
+    ))
+  }
+
   async fn load_inner(
     &self,
     specifier: &ModuleSpecifier,
@@ -571,16 +663,6 @@ impl<TGraphContainer: ModuleGraphContainer>
       .load_code_source(specifier, maybe_referrer)
       .await
       .map_err(JsErrorBox::from_err)?;
-    let code = if self.shared.is_inspecting
-      || code_source.media_type == MediaType::Wasm
-    {
-      // we need the code with the source map in order for
-      // it to work with --inspect or --inspect-brk
-      code_source.code
-    } else {
-      // v8 is slower when source maps are present, so we strip them
-      code_without_source_map(code_source.code)
-    };
     let module_type = match code_source.media_type {
       MediaType::Json => ModuleType::Json,
       MediaType::Wasm => ModuleType::Wasm,
@@ -594,6 +676,16 @@ impl<TGraphContainer: ModuleGraphContainer>
     {
       return Err(JsErrorBox::generic("Attempted to load JSON module without specifying \"type\": \"json\" attribute in the import statement.").into());
     }
+    let code = if self.shared.is_inspecting
+      || code_source.media_type == MediaType::Wasm
+    {
+      // we need the code with the source map in order for
+      // it to work with --inspect or --inspect-brk
+      code_source.code
+    } else {
+      // v8 is slower when source maps are present, so we strip them
+      code_without_source_map(code_source.code)
+    };
 
     let code_cache = if module_type == ModuleType::JavaScript {
       self.shared.code_cache.as_ref().map(|cache| {
@@ -900,22 +992,21 @@ impl<TGraphContainer: ModuleGraphContainer>
     &self,
     graph: &'graph ModuleGraph,
     specifier: &ModuleSpecifier,
-  ) -> Result<Option<CodeOrDeferredEmit<'graph>>, JsErrorBox> {
+  ) -> Result<Option<CodeOrDeferredEmit<'graph>>, LoadPreparedModuleError> {
     if specifier.scheme() == "node" {
       // Node built-in modules should be handled internally.
       unreachable!("Deno bug. {} was misconfigured internally.", specifier);
     }
 
-    let maybe_module = graph.try_get(specifier).map_err(|err| {
-      JsErrorBox::new(
-        err.get_class(),
-        enhance_graph_error(
+    let maybe_module =
+      graph.try_get(specifier).map_err(|err| EnhancedGraphError {
+        message: enhance_graph_error(
           &self.shared.sys,
           &ModuleGraphError::ModuleError(err.clone()),
           EnhanceGraphErrorMode::ShowRange,
         ),
-      )
-    })?;
+        error: err.clone(),
+      })?;
 
     match maybe_module {
       Some(deno_graph::Module::Json(JsonModule {
@@ -1063,8 +1154,9 @@ enum CodeOrDeferredEmit<'a> {
   },
 }
 
+#[derive(Clone)]
 // todo(dsherret): this double Rc boxing is not ideal
-struct CliModuleLoader<TGraphContainer: ModuleGraphContainer>(
+pub struct CliModuleLoader<TGraphContainer: ModuleGraphContainer>(
   Rc<CliModuleLoaderInner<TGraphContainer>>,
 );
 

--- a/cli/tools/bundle/esbuild.rs
+++ b/cli/tools/bundle/esbuild.rs
@@ -44,6 +44,10 @@ pub async fn ensure_esbuild(
   tarball_cache: &Arc<TarballCache<CliNpmCacheHttpClient, CliSys>>,
   npm_cache: &CliNpmCache,
 ) -> Result<PathBuf, AnyError> {
+  if let Ok(esbuild_path) = std::env::var("ESBUILD_PATH") {
+    return Ok(PathBuf::from(esbuild_path));
+  }
+
   let target = esbuild_platform();
   let mut esbuild_path = deno_dir
     .dl_folder_path()

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -13,6 +13,7 @@ use deno_core::resolve_url_or_path;
 use deno_core::url::Url;
 use deno_core::RequestedModuleType;
 use deno_error::JsError;
+use deno_graph::ModuleError;
 use deno_graph::Position;
 use deno_resolver::graph::ResolveWithGraphError;
 use deno_resolver::npm::managed::ResolvePkgFolderFromDenoModuleError;
@@ -38,6 +39,9 @@ use crate::graph_container::ModuleGraphContainer;
 use crate::graph_container::ModuleGraphUpdatePermit;
 use crate::module_loader::CliModuleLoader;
 use crate::module_loader::CliModuleLoaderError;
+use crate::module_loader::EnhancedGraphError;
+use crate::module_loader::LoadCodeSourceError;
+use crate::module_loader::LoadPreparedModuleError;
 use crate::module_loader::ModuleLoadPreparer;
 use crate::module_loader::PrepareModuleLoadOptions;
 use crate::resolver::CliResolver;
@@ -447,6 +451,22 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
     let result = match result {
       Ok(r) => r,
       Err(e) => {
+        if matches!(
+          e,
+          BundleLoadError::CliModuleLoaderError(
+            CliModuleLoaderError::LoadCodeSource(
+              LoadCodeSourceError::LoadPreparedModule(
+                LoadPreparedModuleError::Graph(EnhancedGraphError {
+                  error: ModuleError::UnsupportedMediaType { .. },
+                  ..
+                })
+              )
+            )
+          )
+        ) {
+          log::debug!("unsupported media type: {:?}", e);
+          return Ok(None);
+        }
         return Ok(Some(esbuild_client::OnLoadResult {
           errors: Some(vec![esbuild_client::protocol::PartialMessage {
             id: "myerror".into(),

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -310,7 +310,7 @@ fn format_message(
     if let Some(location) = &message.location {
       if !message.text.contains(" at ") {
         format!(
-          "\n  at {}:{}:{}",
+          "\n    at {}:{}:{}",
           deno_path_util::resolve_url_or_path(
             location.file.as_str(),
             current_dir
@@ -463,16 +463,16 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
       Err(e) => {
         if matches!(
           e,
-          BundleLoadError::CliModuleLoaderError(
+          BundleLoadError::CliModuleLoader(
             CliModuleLoaderError::LoadCodeSource(
               LoadCodeSourceError::LoadPreparedModule(
-                LoadPreparedModuleError::Graph(EnhancedGraphError {
-                  error: ModuleError::UnsupportedMediaType { .. },
-                  ..
-                })
+                LoadPreparedModuleError::Graph(ref e)
               )
             )
-          )
+          ) if matches!(&**e, EnhancedGraphError {
+            error: ModuleError::UnsupportedMediaType { .. },
+            ..
+          })
         ) {
           log::debug!("unsupported media type: {:?}", e);
           return Ok(None);
@@ -542,13 +542,13 @@ fn import_kind_to_resolution_mode(
 pub enum BundleLoadError {
   #[class(inherit)]
   #[error(transparent)]
-  CliModuleLoaderError(#[from] CliModuleLoaderError),
+  CliModuleLoader(#[from] CliModuleLoaderError),
   #[class(inherit)]
   #[error(transparent)]
-  ResolveUrlOrPathError(#[from] deno_path_util::ResolveUrlOrPathError),
+  ResolveUrlOrPath(#[from] deno_path_util::ResolveUrlOrPathError),
   #[class(inherit)]
   #[error(transparent)]
-  ResolveWithGraphError(#[from] ResolveWithGraphError),
+  ResolveWithGraph(#[from] ResolveWithGraphError),
 }
 
 impl DenoPluginHandler {
@@ -619,7 +619,7 @@ impl DenoPluginHandler {
       Ok(specifier) => Ok(Some(file_path_or_url(&specifier)?)),
       Err(e) => {
         log::debug!("{}: {:?}", deno_terminal::colors::red("error"), e);
-        Err(BundleError::Resolver(e).into())
+        Err(BundleError::Resolver(e))
       }
     }
   }

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -235,8 +235,8 @@ pub async fn bundle(
   for error in &response.errors {
     log::error!(
       "{}: {}",
-      deno_terminal::colors::red("bundler error"),
-      format_message(error)
+      deno_terminal::colors::red_bold("error"),
+      format_message(error, &init_cwd)
     );
   }
 
@@ -244,7 +244,7 @@ pub async fn bundle(
     log::warn!(
       "{}: {}",
       deno_terminal::colors::yellow("bundler warning"),
-      format_message(warning)
+      format_message(warning, &init_cwd)
     );
   }
 
@@ -295,7 +295,10 @@ var __require = createRequire(import.meta.url);
   )
 }
 
-fn format_message(message: &esbuild_client::protocol::Message) -> String {
+fn format_message(
+  message: &esbuild_client::protocol::Message,
+  current_dir: &Path,
+) -> String {
   format!(
     "{}{}{}",
     message.text,
@@ -307,8 +310,15 @@ fn format_message(message: &esbuild_client::protocol::Message) -> String {
     if let Some(location) = &message.location {
       if !message.text.contains(" at ") {
         format!(
-          "\n  at {} {}:{}",
-          location.file, location.line, location.column
+          "\n  at {}:{}:{}",
+          deno_path_util::resolve_url_or_path(
+            location.file.as_str(),
+            current_dir
+          )
+          .map(|url| deno_terminal::colors::cyan(url.to_string()))
+          .unwrap_or(deno_terminal::colors::cyan(location.file.clone())),
+          deno_terminal::colors::yellow(location.line),
+          deno_terminal::colors::yellow(location.column)
         )
       } else {
         String::new()
@@ -469,10 +479,7 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
         }
         return Ok(Some(esbuild_client::OnLoadResult {
           errors: Some(vec![esbuild_client::protocol::PartialMessage {
-            id: "myerror".into(),
             plugin_name: "deno".into(),
-            notes: Some(vec![]),
-            detail: Some(protocol::AnyValue::U32(0)),
             text: e.to_string(),
             ..Default::default()
           }]),

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -4,7 +4,6 @@ mod esbuild;
 mod externals;
 
 use std::path::Path;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use deno_ast::ModuleSpecifier;
@@ -12,11 +11,10 @@ use deno_config::deno_json::TsTypeLib;
 use deno_core::error::AnyError;
 use deno_core::resolve_url_or_path;
 use deno_core::url::Url;
-use deno_core::ModuleLoader;
 use deno_core::RequestedModuleType;
 use deno_error::JsError;
 use deno_graph::Position;
-use deno_lib::worker::ModuleLoaderFactory;
+use deno_resolver::graph::ResolveWithGraphError;
 use deno_resolver::npm::managed::ResolvePkgFolderFromDenoModuleError;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_semver::npm::NpmPackageReqReference;
@@ -38,6 +36,8 @@ use crate::factory::CliFactory;
 use crate::graph_container::MainModuleGraphContainer;
 use crate::graph_container::ModuleGraphContainer;
 use crate::graph_container::ModuleGraphUpdatePermit;
+use crate::module_loader::CliModuleLoader;
+use crate::module_loader::CliModuleLoaderError;
 use crate::module_loader::ModuleLoadPreparer;
 use crate::module_loader::PrepareModuleLoadOptions;
 use crate::resolver::CliResolver;
@@ -77,8 +77,7 @@ pub async fn bundle(
   let module_loader = factory
     .create_module_loader_factory()
     .await?
-    .create_for_main(root_permissions.clone())
-    .module_loader;
+    .create_cli_module_loader(root_permissions.clone());
   let sys = factory.sys();
   let init_cwd = cli_options.initial_cwd().to_path_buf();
 
@@ -294,13 +293,22 @@ var __require = createRequire(import.meta.url);
 
 fn format_message(message: &esbuild_client::protocol::Message) -> String {
   format!(
-    "{}{}",
+    "{}{}{}",
     message.text,
+    if message.id.is_empty() {
+      String::new()
+    } else {
+      format!("[{}] ", message.id)
+    },
     if let Some(location) = &message.location {
-      format!(
-        "\n  at {} {}:{}",
-        location.file, location.line, location.column
-      )
+      if !message.text.contains(" at ") {
+        format!(
+          "\n  at {} {}:{}",
+          location.file, location.line, location.column
+        )
+      } else {
+        String::new()
+      }
     } else {
       String::new()
     }
@@ -354,7 +362,7 @@ struct DenoPluginHandler {
   module_load_preparer: Arc<ModuleLoadPreparer>,
   module_graph_container: Arc<MainModuleGraphContainer>,
   permissions: PermissionsContainer,
-  module_loader: Rc<dyn ModuleLoader>,
+  module_loader: CliModuleLoader<MainModuleGraphContainer>,
   externals_matcher: Option<ExternalsMatcher>,
 }
 
@@ -382,7 +390,22 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
       args.resolve_dir.as_deref(),
       args.kind,
       args.with,
-    )?;
+    );
+
+    let result = match result {
+      Ok(r) => r,
+      Err(e) => {
+        return Ok(Some(esbuild_client::OnResolveResult {
+          errors: Some(vec![esbuild_client::protocol::PartialMessage {
+            id: "myerror".into(),
+            plugin_name: "deno".into(),
+            text: e.to_string(),
+            ..Default::default()
+          }]),
+          ..Default::default()
+        }));
+      }
+    };
 
     Ok(result.map(|r| {
       // TODO(nathanwhit): remap the resolved path to be relative
@@ -420,7 +443,24 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
   ) -> Result<Option<esbuild_client::OnLoadResult>, AnyError> {
     let result = self
       .bundle_load(&args.path, requested_type_from_map(&args.with))
-      .await?;
+      .await;
+    let result = match result {
+      Ok(r) => r,
+      Err(e) => {
+        return Ok(Some(esbuild_client::OnLoadResult {
+          errors: Some(vec![esbuild_client::protocol::PartialMessage {
+            id: "myerror".into(),
+            plugin_name: "deno".into(),
+            notes: Some(vec![]),
+            detail: Some(protocol::AnyValue::U32(0)),
+            text: e.to_string(),
+            ..Default::default()
+          }]),
+          plugin_name: Some("deno".to_string()),
+          ..Default::default()
+        }));
+      }
+    };
     log::trace!(
       "{}: {:?}",
       deno_terminal::colors::magenta("on_load"),
@@ -471,6 +511,19 @@ fn import_kind_to_resolution_mode(
   }
 }
 
+#[derive(Debug, thiserror::Error, deno_error::JsError)]
+pub enum BundleLoadError {
+  #[class(inherit)]
+  #[error(transparent)]
+  CliModuleLoaderError(#[from] CliModuleLoaderError),
+  #[class(inherit)]
+  #[error(transparent)]
+  ResolveUrlOrPathError(#[from] deno_path_util::ResolveUrlOrPathError),
+  #[class(inherit)]
+  #[error(transparent)]
+  ResolveWithGraphError(#[from] ResolveWithGraphError),
+}
+
 impl DenoPluginHandler {
   fn bundle_resolve(
     &self,
@@ -479,7 +532,7 @@ impl DenoPluginHandler {
     resolve_dir: Option<&str>,
     kind: esbuild_client::protocol::ImportKind,
     with: IndexMap<String, String>,
-  ) -> Result<Option<String>, AnyError> {
+  ) -> Result<Option<String>, BundleError> {
     log::debug!(
       "bundle_resolve: {:?} {:?} {:?} {:?} {:?}",
       path,
@@ -574,7 +627,8 @@ impl DenoPluginHandler {
     &self,
     specifier: &str,
     requested_type: RequestedModuleType,
-  ) -> Result<Option<(Vec<u8>, esbuild_client::BuiltinLoader)>, AnyError> {
+  ) -> Result<Option<(Vec<u8>, esbuild_client::BuiltinLoader)>, BundleLoadError>
+  {
     log::debug!(
       "{}: {:?} {:?}",
       deno_terminal::colors::magenta("bundle_load"),
@@ -613,27 +667,21 @@ impl DenoPluginHandler {
       }
       (specifier, media_type_to_loader(media_type))
     };
-    let loaded =
-      self
-        .module_loader
-        .load(&specifier, None, false, requested_type);
+    let loaded = self
+      .module_loader
+      .load_module_source(&specifier, None, requested_type)
+      .await?;
 
-    match loaded {
-      deno_core::ModuleLoadResponse::Sync(module_source) => {
-        Ok(Some((module_source?.code.as_bytes().to_vec(), loader)))
-      }
-      deno_core::ModuleLoadResponse::Async(pin) => {
-        let pin = pin.await?;
-        Ok(Some((pin.code.as_bytes().to_vec(), loader)))
-      }
-    }
+    Ok(Some((loaded.code.as_bytes().to_vec(), loader)))
   }
 
   fn specifier_and_type_from_graph(
     &self,
     specifier: &ModuleSpecifier,
-  ) -> Result<Option<(ModuleSpecifier, esbuild_client::BuiltinLoader)>, AnyError>
-  {
+  ) -> Result<
+    Option<(ModuleSpecifier, esbuild_client::BuiltinLoader)>,
+    ResolveWithGraphError,
+  > {
     let graph = self.module_graph_container.graph();
     let Some(module) = graph.get(specifier) else {
       return Ok(None);
@@ -672,7 +720,9 @@ impl DenoPluginHandler {
   }
 }
 
-fn file_path_or_url(url: &Url) -> Result<String, AnyError> {
+fn file_path_or_url(
+  url: &Url,
+) -> Result<String, deno_path_util::UrlToFilePathError> {
   if url.scheme() == "file" {
     Ok(
       deno_path_util::url_to_file_path(url)?

--- a/tests/specs/bundle/error_message/__test__.jsonc
+++ b/tests/specs/bundle/error_message/__test__.jsonc
@@ -3,15 +3,18 @@
   "tests": {
     "allow_imports": {
       "args": "bundle main.ts -o bundle.js",
-      "output": ""
+      "exitCode": 1,
+      "output": "allow_imports.out"
     },
     "imports_css_no_output": {
       "args": "bundle imports-css.tsx",
-      "output": ""
+      "exitCode": 1,
+      "output": "imports_css.out"
     },
     "imports_fake": {
-      "args": "bundle imports-fake.ts -o bundle.js",
-      "output": ""
+      "args": "bundle -I imports-fake.ts -o bundle.js",
+      "exitCode": 1,
+      "output": "imports_fake.out"
     }
   }
 }

--- a/tests/specs/bundle/error_message/__test__.jsonc
+++ b/tests/specs/bundle/error_message/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "tests": {
+    "allow_imports": {
+      "args": "bundle main.ts -o bundle.js",
+      "output": ""
+    }
+  }
+}

--- a/tests/specs/bundle/error_message/__test__.jsonc
+++ b/tests/specs/bundle/error_message/__test__.jsonc
@@ -4,6 +4,14 @@
     "allow_imports": {
       "args": "bundle main.ts -o bundle.js",
       "output": ""
+    },
+    "imports_css_no_output": {
+      "args": "bundle imports-css.tsx",
+      "output": ""
+    },
+    "imports_fake": {
+      "args": "bundle imports-fake.ts -o bundle.js",
+      "output": ""
     }
   }
 }

--- a/tests/specs/bundle/error_message/allow_imports.out
+++ b/tests/specs/bundle/error_message/allow_imports.out
@@ -1,0 +1,4 @@
+[WILDCARD]
+error: Requires import access to "localhost:4545", run again with the --allow-import flag
+    at file://[WILDCARD]main.ts:1:21
+error: bundling failed

--- a/tests/specs/bundle/error_message/foo.css
+++ b/tests/specs/bundle/error_message/foo.css
@@ -1,0 +1,3 @@
+div {
+  text-align: center;
+}

--- a/tests/specs/bundle/error_message/imports-css.tsx
+++ b/tests/specs/bundle/error_message/imports-css.tsx
@@ -1,0 +1,1 @@
+import "./foo.css";

--- a/tests/specs/bundle/error_message/imports-fake.ts
+++ b/tests/specs/bundle/error_message/imports-fake.ts
@@ -1,2 +1,2 @@
-import * as foo from "https://localhost:4545/does-not-exist.ts";
+import * as foo from "./does-not-exist.ts";
 console.log(foo);

--- a/tests/specs/bundle/error_message/imports-fake.ts
+++ b/tests/specs/bundle/error_message/imports-fake.ts
@@ -1,0 +1,2 @@
+import * as foo from "https://localhost:4545/does-not-exist.ts";
+console.log(foo);

--- a/tests/specs/bundle/error_message/imports_css.out
+++ b/tests/specs/bundle/error_message/imports_css.out
@@ -1,0 +1,4 @@
+[WILDCARD]
+error: Cannot import "foo.css" into a JavaScript file without an output path configured
+    at file://[WILDCARD]imports-css.tsx:1:7
+error: bundling failed

--- a/tests/specs/bundle/error_message/imports_fake.out
+++ b/tests/specs/bundle/error_message/imports_fake.out
@@ -1,0 +1,4 @@
+[WILDCARD]
+error: Module not found "[WILDCARD]does-not-exist.ts".
+    at file://[WILDCARD]imports-fake.ts:1:22
+error: bundling failed

--- a/tests/specs/bundle/error_message/main.ts
+++ b/tests/specs/bundle/error_message/main.ts
@@ -1,0 +1,3 @@
+import { add } from "http://localhost:4545/add.ts";
+
+console.log(add(1, 2));

--- a/tests/specs/bundle/main/uses_node_builtin.cjs
+++ b/tests/specs/bundle/main/uses_node_builtin.cjs
@@ -1,4 +1,4 @@
-const { inspect } = require("util");
+const { inspect } = require("node:util");
 
 console.log(inspect({
   a: 1,


### PR DESCRIPTION
We were effectively ignoring our diagnostics, and instead falling back to esbuild (and then displaying the esbuild diagnostics). That was mostly for simplicity and so we would fall back to esbuild handling unsupported things (for instance css imports).

This does a small refactor on the module loader to give us an API that doesn't have to adhere to the deno_core ModuleLoader API. That lets us return and handle errors more concretely, instead of having indirection and downcasting.

Now, we only ignore our errors about being unable to load unsupport file types, and the rest we handle ourselves.

I've also aligned the formatting of esbuild errors with ours, so it should be more uniform. A few examples (dbgdeno is just an alias for the debug build of this PR):


![Screenshot 2025-06-13 at 5 17 53 PM](https://github.com/user-attachments/assets/e9595d4a-295a-4a10-98c7-0cb169477d24)
