### PR TITLE
test: fix flakiness of specs::coverage::data_url

### DIFF
--- a/tests/specs/coverage/data_url/main_test.ts
+++ b/tests/specs/coverage/data_url/main_test.ts
@@ -1,5 +1,5 @@
 import { foo } from "./main.ts";
 
-Deno.test("test", () => {
-  foo();
+Deno.test("test", async () => {
+  await foo();
 });


### PR DESCRIPTION
This PR tries to fix flakiness of `specs::coverage::data_url`.

`foo` is async function, but is not awaited

closes #29759 