### PR TITLE
fix(ext/node): support KeyObject in publicEncrypt/privateDecrypt

### DIFF
--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -62,6 +62,19 @@ Deno.test({
 });
 
 Deno.test({
+  name: "encrypt decrypt with KeyObject",
+  fn() {
+    const pair = crypto.generateKeyPairSync("rsa", { modulusLength: 512 });
+    const secret = Buffer.from("secret");
+    const encrypted = crypto.publicEncrypt(pair.publicKey, secret);
+    assert(Buffer.isBuffer(encrypted));
+    const decrypted = crypto.privateDecrypt(pair.privateKey, encrypted);
+    assert(Buffer.isBuffer(decrypted));
+    assertEquals(decrypted, secret);
+  },
+});
+
+Deno.test({
   name: "rsa public decrypt fail",
   fn() {
     const encrypted = crypto.publicEncrypt(rsaPublicKey, input);


### PR DESCRIPTION
This PR adds support of `KeyObject` input for `private(Encrypt|Decrypt)` and `publicEncrypt`.

related #29637 