### PR TITLE
chore: move unsafe_use_unprotected_platform feature to cli dev dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,6 @@ dependencies = [
  "chrono",
  "deno_bench_util",
  "deno_cache_dir",
- "deno_core",
  "deno_lockfile 0.30.1",
  "deno_semver",
  "deno_terminal 0.2.2",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -199,6 +199,9 @@ tokio-vsock.workspace = true
 
 [dev-dependencies]
 deno_bench_util.workspace = true
+# unsafe_use_unprotected_platform is a workaround for a segfault that may occur
+# when running multiple v8 tests on different threads
+deno_core = { workspace = true, features = ["include_js_files_for_snapshotting", "unsafe_use_unprotected_platform"] }
 pretty_assertions.workspace = true
 sys_traits = { workspace = true, features = ["memory"] }
 test_util.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -35,7 +35,6 @@ bytes.workspace = true
 chrono = { workspace = true, features = ["now"] }
 deno_bench_util.workspace = true
 deno_cache_dir.workspace = true
-deno_core = { workspace = true, features = ["unsafe_use_unprotected_platform"] }
 deno_lockfile.workspace = true
 deno_semver.workspace = true
 deno_terminal.workspace = true


### PR DESCRIPTION
The tests crate doesn't have a dependency on deno_core.

Amendment to https://github.com/denoland/deno/pull/29794