### PR TITLE
fix(install): ignore unknown JSR export errors on top level install

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -355,6 +355,7 @@ impl LanguageServer {
           exit_integrity_errors: false,
           allow_unknown_media_types: true,
           ignore_graph_errors: true,
+          allow_unknown_jsr_exports: false,
         },
       )?;
 

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -227,7 +227,7 @@ impl ModuleLoadPreparer {
       .await?;
 
     if !skip_graph_roots_validation {
-      self.graph_roots_valid(graph, roots, allow_unknown_media_types)?;
+      self.graph_roots_valid(graph, roots, allow_unknown_media_types, false)?;
     }
 
     drop(_pb_clear_guard);
@@ -305,11 +305,13 @@ impl ModuleLoadPreparer {
     graph: &ModuleGraph,
     roots: &[ModuleSpecifier],
     allow_unknown_media_types: bool,
+    allow_unknown_jsr_exports: bool,
   ) -> Result<(), JsErrorBox> {
     self.module_graph_builder.graph_roots_valid(
       graph,
       roots,
       allow_unknown_media_types,
+      allow_unknown_jsr_exports,
     )
   }
 }
@@ -1382,6 +1384,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
               &graph,
               &[specifier],
               false,
+              false,
             )?;
           }
           return Ok(());
@@ -1426,6 +1429,7 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
         module_load_preparer.graph_roots_valid(
           &graph_container.graph(),
           specifiers,
+          false,
           false,
         )?;
       }

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -156,6 +156,7 @@ pub async fn doc(
           kind: GraphKind::TypesOnly,
           allow_unknown_media_types: false,
           ignore_graph_errors: true,
+          allow_unknown_jsr_exports: false,
         },
       );
       for error in errors {

--- a/cli/tools/pm/cache_deps.rs
+++ b/cli/tools/pm/cache_deps.rs
@@ -188,7 +188,8 @@ pub async fn cache_top_level_deps(
         },
       )
       .await?;
-    maybe_graph_error = graph_builder.graph_roots_valid(graph, &roots, true);
+    maybe_graph_error =
+      graph_builder.graph_roots_valid(graph, &roots, true, true);
   }
 
   npm_installer.cache_packages(PackageCaching::All).await?;


### PR DESCRIPTION
Couldn't write a test, but it happens in some edge cases.