### PR TITLE
refactor(ext/node): remove setProcess workaround

### DIFF
--- a/ext/node/polyfills/_events.mjs
+++ b/ext/node/polyfills/_events.mjs
@@ -72,11 +72,6 @@ const kMaxEventTargetListenersWarned = Symbol(
   "events.maxEventTargetListenersWarned",
 );
 
-let process;
-export function setProcess(p) {
-  process = p;
-}
-
 /**
  * Creates a new `EventEmitter` instance.
  * @param {{ captureRejections?: boolean; }} [opts]

--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -84,7 +84,6 @@ import * as constants from "ext:deno_node/internal_binding/constants.ts";
 import * as uv from "ext:deno_node/internal_binding/uv.ts";
 import type { BindingName } from "ext:deno_node/internal_binding/mod.ts";
 import { buildAllowedFlags } from "ext:deno_node/internal/process/per_thread.mjs";
-import { setProcess } from "ext:deno_node/_events.mjs";
 
 const { NumberMAX_SAFE_INTEGER } = primordials;
 
@@ -1051,7 +1050,5 @@ internals.__bootstrapNodeProcess = function (
     );
   }
 };
-
-setProcess(process);
 
 export default process;


### PR DESCRIPTION
This util seems unnecessary and makes module graph complex. This PR removes it.

(It was introduced in https://github.com/denoland/deno/commit/b333dccee82f4328a65d0c3c45c7aa5c19255220 )