### PR TITLE
feat: allow base64 ca cert in args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ name = "deno_lib"
 version = "0.25.0"
 dependencies = [
  "aws-lc-rs",
+ "base64 0.22.1",
  "capacity_builder",
  "deno_error",
  "deno_fs",

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -6174,7 +6174,7 @@ fn reload_arg_parse(
 }
 
 fn ca_file_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
-  flags.ca_data = matches.remove_one::<String>("cert").map(CaData::File);
+  flags.ca_data = matches.remove_one::<String>("cert").and_then(CaData::parse);
 }
 
 fn enable_testing_features_arg_parse(
@@ -9803,6 +9803,28 @@ mod tests {
           "script.ts".to_string(),
         )),
         ca_data: Some(CaData::File("example.crt".to_owned())),
+        code_cache_enabled: true,
+        ..Flags::default()
+      }
+    );
+  }
+
+  #[test]
+  fn run_with_base64_cafile() {
+    let r = flags_from_vec(svec![
+      "deno",
+      "run",
+      "--cert",
+      "base64:bWVvdw==",
+      "script.ts"
+    ]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Run(RunFlags::new_default(
+          "script.ts".to_string(),
+        )),
+        ca_data: Some(CaData::Bytes(b"meow".into())),
         code_cache_enabled: true,
         ..Flags::default()
       }

--- a/cli/lib/Cargo.toml
+++ b/cli/lib/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 aws-lc-rs.workspace = true
+base64.workspace = true
 capacity_builder.workspace = true
 deno_error.workspace = true
 deno_fs = { workspace = true, features = ["sync_fs"] }


### PR DESCRIPTION
This allows loading a base64 encoded cert directly from arg/env by prefixing it with `base64:`