### PR TITLE
feat(otel): Stabilize OpenTelemetry support

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1011,11 +1011,6 @@ impl Flags {
   }
 
   pub fn otel_config(&self) -> OtelConfig {
-    let has_unstable_flag = self
-      .unstable_config
-      .features
-      .contains(&String::from("otel"));
-
     let otel_var = |name| match std::env::var(name) {
       Ok(s) if s.eq_ignore_ascii_case("true") => Some(true),
       Ok(s) if s.eq_ignore_ascii_case("false") => Some(false),
@@ -1026,8 +1021,7 @@ impl Flags {
       Err(_) => None,
     };
 
-    let disabled =
-      !has_unstable_flag || otel_var("OTEL_SDK_DISABLED").unwrap_or(false);
+    let disabled = otel_var("OTEL_SDK_DISABLED").unwrap_or(false);
     let default = !disabled && otel_var("OTEL_DENO").unwrap_or(false);
 
     let propagators = if default {

--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -166,6 +166,7 @@ const denoNs = {
   umask: fs.umask,
   HttpClient: httpClient.HttpClient,
   createHttpClient: httpClient.createHttpClient,
+  telemetry: telemetry.telemetry,
 };
 
 const denoNsUnstableById = { __proto__: null };
@@ -228,9 +229,5 @@ ObjectDefineProperties(denoNsUnstableById[unstableIds.webgpu], {
 });
 
 // denoNsUnstableById[unstableIds.workerOptions] = { __proto__: null }
-
-denoNsUnstableById[unstableIds.otel] = {
-  telemetry: telemetry.telemetry,
-};
 
 export { denoNs, denoNsUnstableById, unstableIds };

--- a/tests/specs/cli/otel_basic/http_propagators.ts
+++ b/tests/specs/cli/otel_basic/http_propagators.ts
@@ -6,7 +6,7 @@ const command1 = new Deno.Command(Deno.execPath(), {
     "OTEL_SERVICE_NAME": "server_1",
     "DENO_UNSTABLE_OTEL_DETERMINISTIC": "1",
   },
-  args: ["run", "-A", "--unstable-otel", "http_propagators_1.ts"],
+  args: ["run", "-A", "http_propagators_1.ts"],
 });
 
 const p1 = command1.output();
@@ -19,7 +19,7 @@ const command2 = new Deno.Command(Deno.execPath(), {
     "OTEL_SERVICE_NAME": "server_2",
     "DENO_UNSTABLE_OTEL_DETERMINISTIC": "2",
   },
-  args: ["run", "-A", "--unstable-otel", "http_propagators_2.ts"],
+  args: ["run", "-A", "http_propagators_2.ts"],
 });
 
 const p2 = command2.output();

--- a/tests/specs/cli/otel_basic/main.ts
+++ b/tests/specs/cli/otel_basic/main.ts
@@ -18,7 +18,6 @@ const server = Deno.serve(
           "--env-file=env_file",
           "-A",
           "-q",
-          "--unstable-otel",
           Deno.args[0],
         ],
         env: {


### PR DESCRIPTION
This commit stabilizes support for OpenTelemetry in Deno,
effectively removing the need to use `--unstable-otel` flag
or using `{ "unstable": ["otel"] }` option in the config file.

Supersedes https://github.com/denoland/deno/pull/29500
Closes https://github.com/denoland/deno/issues/29477