### PR TITLE
feat(publish): allow publishing to npm

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -451,6 +451,7 @@ pub struct PublishFlags {
   pub allow_dirty: bool,
   pub no_provenance: bool,
   pub set_version: Option<String>,
+  pub npm: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -3720,6 +3721,14 @@ fn publish_subcommand() -> Command {
         .arg(config_arg())
         .arg(no_config_arg())
         .arg(
+          Arg::new("npm")
+            .long("npm")
+            .help("Publish an npm package")
+            .action(ArgAction::SetTrue)
+            .conflicts_with_all(["allow-slow-types", "no-provenance", "set-version"])
+            .help_heading(PUBLISH_HEADING)
+        )
+        .arg(
           Arg::new("dry-run")
             .long("dry-run")
             .help("Prepare the package for publishing performing all checks and validations without uploading")
@@ -5880,6 +5889,7 @@ fn publish_parse(
     allow_dirty: matches.get_flag("allow-dirty"),
     no_provenance: matches.get_flag("no-provenance"),
     set_version: matches.remove_one::<String>("set-version"),
+    npm: matches.get_flag("npm"),
   });
 
   Ok(())
@@ -11791,6 +11801,7 @@ mod tests {
           allow_dirty: true,
           no_provenance: true,
           set_version: Some("1.0.1".to_string()),
+          npm: false,
         }),
         type_check_mode: TypeCheckMode::Local,
         ..Flags::default()

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -351,7 +351,7 @@ async fn run_subcommand(
     ),
     DenoSubcommand::Vendor => exit_with_message("⚠️ `deno vendor` was removed in Deno 2.\n\nSee the Deno 1.x to 2.x Migration Guide for migration instructions: https://docs.deno.com/runtime/manual/advanced/migrate_deprecations", 1),
     DenoSubcommand::Publish(publish_flags) => spawn_subcommand(async {
-      tools::publish::publish(flags, publish_flags).await
+      tools::publish::publish(flags, publish_flags, roots).await
     }),
     DenoSubcommand::Help(help_flags) => spawn_subcommand(async move {
       use std::io::Write;

--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -26,6 +26,7 @@ use deno_core::serde_json;
 use deno_core::serde_json::json;
 use deno_core::serde_json::Value;
 use deno_core::url::Url;
+use deno_lib::worker::LibWorkerFactoryRoots;
 use deno_runtime::deno_fetch;
 use deno_terminal::colors;
 use http_body_util::BodyExt;
@@ -59,6 +60,7 @@ mod auth;
 mod diagnostics;
 mod graph;
 mod module_content;
+mod npm;
 mod paths;
 mod provenance;
 mod publish_order;
@@ -73,7 +75,12 @@ use unfurl::SpecifierUnfurler;
 pub async fn publish(
   flags: Arc<Flags>,
   publish_flags: PublishFlags,
+  roots: LibWorkerFactoryRoots,
 ) -> Result<(), AnyError> {
+  if publish_flags.npm {
+    return npm::publish_to_npm(flags, publish_flags, roots).await;
+  }
+
   let cli_factory = CliFactory::from_flags(flags);
 
   let auth_method =

--- a/cli/tools/publish/npm.rs
+++ b/cli/tools/publish/npm.rs
@@ -1,0 +1,46 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+use std::sync::Arc;
+
+use deno_core::error::AnyError;
+use deno_lib::worker::LibWorkerFactoryRoots;
+use deno_runtime::WorkerExecutionMode;
+
+use crate::args::DenoSubcommand;
+use crate::args::Flags;
+use crate::args::PublishFlags;
+use crate::args::RunFlags;
+use crate::tools;
+
+const NPM_PACKAGE_REQ: &str = "npm:npm@11.4.2";
+
+pub async fn publish_to_npm(
+  flags: Arc<Flags>,
+  publish_flags: PublishFlags,
+  roots: LibWorkerFactoryRoots,
+) -> Result<(), AnyError> {
+  let mut flags = Arc::unwrap_or_clone(flags);
+  flags.subcommand = DenoSubcommand::Run(RunFlags {
+    script: NPM_PACKAGE_REQ.to_string(),
+    watch: None,
+    bare: false,
+  });
+  if publish_flags.dry_run {
+    flags.argv.insert(0, "--dry-run".to_string());
+  }
+
+  let exit_code = tools::run::run_script(
+    WorkerExecutionMode::Run,
+    Arc::new(flags),
+    None,
+    None,
+    roots,
+  )
+  .await?;
+
+  if exit_code != 0 {
+    deno_runtime::exit(exit_code);
+  }
+
+  Ok(())
+}


### PR DESCRIPTION
This commit adds support for `--npm` flag in `deno publish`
subcommand, allowing to publish packages to the npm registry
(including private ones).

Closes https://github.com/denoland/deno/issues/29782