### PR TITLE
ci: bump cache version

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -5,7 +5,7 @@ import { stringify } from "jsr:@std/yaml@^0.221/stringify";
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 60;
+const cacheVersion = 61;
 
 const ubuntuX86Runner = "ubuntu-24.04";
 const ubuntuX86XlRunner = "ubuntu-24.04-xl";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '60-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '60-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
+          key: '61-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '61-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
         if: '!(matrix.skip)'
       - uses: dsherret/rust-toolchain-file@v1
         if: '!(matrix.skip)'
@@ -391,7 +391,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '60-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '61-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(matrix.skip) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
@@ -780,7 +780,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '60-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '61-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   libs:
     name: build libs
     needs:


### PR DESCRIPTION
I got a few panics like this in various PRs:
```
error: failed to run custom build command for `deno_snapshots v0.22.0 (D:\a\deno\deno\cli\snapshot)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `D:\a\deno\deno\target\debug\build\deno_snapshots-f65d1827fc7491c3\build-script-build` (exit code: 101)
  --- stdout
  Creating a snapshot...

  --- stderr

  thread 'main' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\deno_core-0.351.0\runtime\jsruntime.rs:2184:9:
  Failed to initialize JsRuntime for snapshotting: Io(Os { code: 3, kind: NotFound, message: "The system cannot find the path specified." })
  stack backtrace:
     0:     0x7ff742714391 - std::backtrace_rs::backtrace::win64::trace
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\..\..\backtrace\src\backtrace\win64.rs:85
     1:     0x7ff742714391 - std::backtrace_rs::backtrace::trace_unsynchronized
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
     2:     0x7ff742714391 - std::sys::backtrace::_print_fmt
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\sys\backtrace.rs:66
     3:     0x7ff742714391 - std::sys::backtrace::impl$0::print::impl$0::fmt
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c[815](https://github.com/denoland/deno/actions/runs/15776776625/job/44472947586?pr=29823#step:35:816)cfecb/library\std\src\sys\backtrace.rs:39
     4:     0x7ff74273412a - core::fmt::rt::Argument::fmt
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\core\src\fmt\rt.rs:177
     5:     0x7ff74273412a - core::fmt::write
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\core\src\fmt\mod.rs:1449
     6:     0x7ff74270e027 - std::io::Write::write_fmt<std::sys::pal::windows::stdio::Stderr>
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\io\mod.rs:1890
     7:     0x7ff7427141d5 - std::sys::backtrace::BacktraceLock::print
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\sys\backtrace.rs:42
     8:     0x7ff742715cc2 - std::panicking::default_hook::closure$0
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\panicking.rs:298
     9:     0x7ff742715ab3 - std::panicking::default_hook
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\panicking.rs:325
    10:     0x7ff74271689f - std::panicking::rust_panic_with_hook
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\panicking.rs:831
    11:     0x7ff742716639 - std::panicking::begin_panic_handler::closure$0
                                 at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library\std\src\panicking.rs:704
```

I can't reproduce them locally and they make no sense that would fail unless the cache got broken.