### PR TITLE
feat: add `DENO_AUTO_SERVE` env var

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1269,6 +1269,8 @@ static ENV_VARIABLES_HELP: &str = cstr!(
   <g>DENO_NO_UPDATE_CHECK</>   Set to disable checking if a newer Deno version is available
   <g>DENO_SERVE_ADDRESS</>     Override address for Deno.serve
                          Example: "tcp:0.0.0.0:8080", "unix:/tmp/deno.sock", or "vsock:1234:5678"
+  <g>DENO_AUTO_SERVE</>        If the entrypoint contains export default { fetch }, `deno run`
+                               behaves like `deno serve`.
   <g>DENO_TLS_CA_STORE</>      Comma-separated list of order dependent certificate stores.
                          Possible values: "system", "mozilla" <p(245)>(defaults to "mozilla")</>
   <g>DENO_TRACE_PERMISSIONS</> Environmental variable to enable stack traces in permission prompts.

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1132,6 +1132,7 @@ impl CliFactory {
       inspect_wait: cli_options.inspect_wait().is_some(),
       strace_ops: cli_options.strace_ops().clone(),
       is_standalone: false,
+      auto_serve: std::env::var("DENO_AUTO_SERVE").is_ok(),
       is_inspecting: cli_options.is_inspecting(),
       location: cli_options.location_flag().clone(),
       // if the user ran a binary command, we'll need to set process.argv[0]

--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -331,6 +331,8 @@ pub struct LibMainWorkerOptions {
   pub is_inspecting: bool,
   /// If this is a `deno compile`-ed executable.
   pub is_standalone: bool,
+  // If the runtime should try to use `export default { fetch }`
+  pub auto_serve: bool,
   pub location: Option<Url>,
   pub argv0: Option<String>,
   pub node_debug: Option<String>,
@@ -474,6 +476,7 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
           user_agent: crate::version::DENO_VERSION_INFO.user_agent.to_string(),
           inspect: shared.options.is_inspecting,
           is_standalone: shared.options.is_standalone,
+          auto_serve: shared.options.auto_serve,
           has_node_modules_dir: shared.options.has_node_modules_dir,
           argv0: shared.options.argv0.clone(),
           node_debug: shared.options.node_debug.clone(),
@@ -654,6 +657,7 @@ impl<TSys: DenoLibSys> LibMainWorkerFactory<TSys> {
         user_agent: crate::version::DENO_VERSION_INFO.user_agent.to_string(),
         inspect: shared.options.is_inspecting,
         is_standalone: shared.options.is_standalone,
+        auto_serve: shared.options.auto_serve,
         has_node_modules_dir: shared.options.has_node_modules_dir,
         argv0: shared.options.argv0.clone(),
         node_debug: shared.options.node_debug.clone(),

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -966,6 +966,7 @@ pub async fn run(
     strace_ops: None,
     is_inspecting: false,
     is_standalone: true,
+    auto_serve: false,
     skip_op_registration: true,
     location: metadata.location,
     argv0: NpmPackageReqReference::from_specifier(&main_module)

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -809,16 +809,24 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       12: serveWorkerCountOrIndex,
       13: otelConfig,
       15: standalone,
+      16: autoServe,
     } = runtimeOptions;
 
     denoNs.build.standalone = standalone;
 
-    if (mode === executionModes.serve) {
-      const hasMultipleThreads = serveIsMain
-        ? serveWorkerCountOrIndex > 0 // count > 0
+    let serveIsMain_ = serveIsMain;
+    let serveWorkerCountOrIndex_ = serveWorkerCountOrIndex;
+    if (autoServe) {
+      serveIsMain_ = true;
+      serveWorkerCountOrIndex_ = 0;
+    }
+
+    if (mode === executionModes.serve || autoServe) {
+      const hasMultipleThreads = serveIsMain_
+        ? serveWorkerCountOrIndex_ > 0 // count > 0
         : true;
       if (hasMultipleThreads) {
-        const serveLogIndex = serveIsMain ? 0 : (serveWorkerCountOrIndex + 1);
+        const serveLogIndex = serveIsMain_ ? 0 : (serveWorkerCountOrIndex_ + 1);
         const base = `serve-worker-${serveLogIndex}`;
         // 15 = "serve-worker-nn".length, assuming
         // serveWorkerCount < 100
@@ -837,14 +845,14 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
           try {
             serve = registerDeclarativeServer(main.default);
           } catch (e) {
-            if (mode === executionModes.serve) {
+            if (mode === executionModes.serve || autoServe) {
               throw e;
             }
           }
         }
 
         if (mode === executionModes.serve && !serve) {
-          if (serveIsMain) {
+          if (serveIsMain_) {
             // Only error if main worker
             import.meta.log(
               "error",
@@ -859,7 +867,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
         }
 
         if (serve) {
-          if (mode === executionModes.run) {
+          if (mode === executionModes.run && !autoServe) {
             import.meta.log(
               "error",
               `%cwarning: %cDetected %cexport default { fetch }%c, did you mean to run \"deno serve\"?`,
@@ -869,12 +877,12 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
               "font-weight: normal;",
             );
           }
-          if (mode === executionModes.serve) {
+          if (mode === executionModes.serve || autoServe) {
             serve({
               servePort,
               serveHost,
-              workerCountWhenMain: serveIsMain
-                ? serveWorkerCountOrIndex
+              workerCountWhenMain: serveIsMain_
+                ? serveWorkerCountOrIndex_
                 : undefined,
             });
           }

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -103,6 +103,7 @@ pub struct BootstrapOptions {
   pub inspect: bool,
   /// If this is a `deno compile`-ed executable.
   pub is_standalone: bool,
+  pub auto_serve: bool,
   pub has_node_modules_dir: bool,
   pub argv0: Option<String>,
   pub node_debug: Option<String>,
@@ -141,6 +142,7 @@ impl Default for BootstrapOptions {
       inspect: false,
       args: Default::default(),
       is_standalone: false,
+      auto_serve: false,
       has_node_modules_dir: false,
       argv0: None,
       node_debug: None,
@@ -198,6 +200,8 @@ struct BootstrapV8<'a>(
   bool,
   // is_standalone
   bool,
+  // auto serve
+  bool,
 );
 
 impl BootstrapOptions {
@@ -230,6 +234,7 @@ impl BootstrapOptions {
       self.otel_config.as_v8(),
       self.close_on_idle,
       self.is_standalone,
+      self.auto_serve,
     );
 
     bootstrap.serialize(ser).unwrap()

--- a/runtime/worker_bootstrap.rs
+++ b/runtime/worker_bootstrap.rs
@@ -103,7 +103,6 @@ pub struct BootstrapOptions {
   pub inspect: bool,
   /// If this is a `deno compile`-ed executable.
   pub is_standalone: bool,
-  pub auto_serve: bool,
   pub has_node_modules_dir: bool,
   pub argv0: Option<String>,
   pub node_debug: Option<String>,
@@ -113,6 +112,7 @@ pub struct BootstrapOptions {
   // Used by `deno serve`
   pub serve_port: Option<u16>,
   pub serve_host: Option<String>,
+  pub auto_serve: bool,
   pub otel_config: OtelConfig,
   pub close_on_idle: bool,
 }

--- a/tests/specs/serve/auto_serve/__test__.jsonc
+++ b/tests/specs/serve/auto_serve/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tempDir": true,
+  "tests": {
+    "basic_not_win": {
+      "if": "unix",
+      "args": "run --check --allow-net main.ts",
+      "envs": {
+        "DENO_SERVE_ADDRESS": "tcp:0.0.0.0:12345",
+        "DENO_AUTO_SERVE": "1"
+      },
+      "output": "main_not_win.out"
+    }
+  }
+}

--- a/tests/specs/serve/auto_serve/main.ts
+++ b/tests/specs/serve/auto_serve/main.ts
@@ -1,0 +1,18 @@
+(async () => {
+  for (let i = 0; i < 1000; i++) {
+    try {
+      const resp = await fetch("http://localhost:12345/");
+      Deno.exit(0);
+    } catch {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+
+  Deno.exit(2);
+})();
+
+export default {
+  fetch(req) {
+    return new Response("Hello world!");
+  },
+} satisfies Deno.ServeDefaultExport;

--- a/tests/specs/serve/auto_serve/main_not_win.out
+++ b/tests/specs/serve/auto_serve/main_not_win.out
@@ -1,0 +1,2 @@
+Check [WILDCARD]
+deno serve: Listening on http://0.0.0.0:12345/


### PR DESCRIPTION
This commits adds `DENO_AUTO_SERVE` env var, that when specified
makes `deno run` behave like `deno serve` if the entrypoint satisfies the
`Deno.ServeDefaultExport` interface.