### PR TITLE
fix(ext/node): use isDeepStrictEqual internal util for deepStrictEqual

### DIFF
--- a/ext/node/polyfills/assert.ts
+++ b/ext/node/polyfills/assert.ts
@@ -16,7 +16,10 @@ import {
   ERR_INVALID_RETURN_VALUE,
   ERR_MISSING_ARGS,
 } from "ext:deno_node/internal/errors.ts";
-import { isDeepEqual } from "ext:deno_node/internal/util/comparisons.ts";
+import {
+  isDeepEqual,
+  isDeepStrictEqual,
+} from "ext:deno_node/internal/util/comparisons.ts";
 import { primordials } from "ext:core/mod.js";
 import { CallTracker } from "ext:deno_node/internal/assert/calltracker.js";
 import { deprecate } from "node:util";
@@ -395,7 +398,7 @@ function deepStrictEqual(
     throw new ERR_MISSING_ARGS("actual", "expected");
   }
 
-  if (!asserts.equal(actual, expected)) {
+  if (!isDeepStrictEqual(actual, expected)) {
     throw new AssertionError({
       message,
       actual,

--- a/tests/unit_node/assert_test.ts
+++ b/tests/unit_node/assert_test.ts
@@ -30,3 +30,12 @@ Deno.test("[node/assert] CallTracker correctly exported", () => {
   assert.strictEqual(typeof assert.default.CallTracker, "function");
   assert.strictEqual(assert.CallTracker, assert.default.CallTracker);
 });
+
+Deno.test("[node/assert] deepStrictEqual(ArrayBuffer(2), ArrayBuffer(3)", () => {
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new ArrayBuffer(2), new ArrayBuffer(3));
+    },
+    assert.AssertionError,
+  );
+});


### PR DESCRIPTION
Uses `isDeepStrictEqual` internal util instead of `equal` from vendored `std`. This improves the comparison of `ArrayBuffer`s. (This partially fixes `parallel/test-assert-typedarray-deepequal.js`)

towards #29801 