### PR TITLE
chore(ext/node): exclude known_issues dir from test targets

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -57,6 +57,7 @@ const NODE_IGNORED_TEST_DIRS = [
   "fixtures",
   "fuzzers",
   "js-native-api",
+  "known_issues",
   "node-api",
   "overlapped-checker",
   "report",


### PR DESCRIPTION
There are 19 tests in `test/known_issues` dir in node compat test. They are not expected to pass even in Node.js. See https://github.com/nodejs/node/commit/32e1f9d0b54fa7c90077b41d763ffd8d0532a0a1

This change excludes them from the test target.