### PR TITLE
feat: Rename --unstable-node-conditions to --unstable-conditions

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -4593,9 +4593,10 @@ fn lock_args() -> [Arg; 3] {
 }
 
 fn node_conditions_arg() -> Arg {
-  Arg::new("unstable-node-conditions")
-    .long("unstable-node-conditions")
-    .help("Use this argument to specify custom conditions for npm package exports. You can also use DENO_NODE_CONDITIONS env var.")
+  Arg::new("unstable-conditions")
+    .long("unstable-conditions")
+    .short('C')
+    .help("Use this argument to specify custom conditions for npm package exports. You can also use DENO_CONDITIONS env var.")
     .use_value_delimiter(true)
     .action(ArgAction::Append)
 }
@@ -6286,8 +6287,7 @@ fn lock_args_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 }
 
 fn node_conditions_args_parse(flags: &mut Flags, matches: &mut ArgMatches) {
-  if let Some(conditions) =
-    matches.remove_many::<String>("unstable-node-conditions")
+  if let Some(conditions) = matches.remove_many::<String>("unstable-conditions")
   {
     flags.node_conditions = conditions.collect();
   }
@@ -12501,7 +12501,7 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
     let flags = flags_from_vec(svec![
       "deno",
       "run",
-      "--unstable-node-conditions",
+      "--unstable-conditions",
       "development",
       "main.ts"
     ])
@@ -12522,7 +12522,7 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
     let flags = flags_from_vec(svec![
       "deno",
       "run",
-      "--unstable-node-conditions",
+      "--unstable-conditions",
       "development,production",
       "main.ts"
     ])
@@ -12543,9 +12543,9 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
     let flags = flags_from_vec(svec![
       "deno",
       "run",
-      "--unstable-node-conditions",
+      "--unstable-conditions",
       "development",
-      "--unstable-node-conditions",
+      "-C",
       "production",
       "main.ts"
     ])

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -549,7 +549,7 @@ fn resolve_flags_and_init(
   load_env_variables_from_env_file(flags.env_file.as_ref(), flags.log_level);
   flags.unstable_config.fill_with_env();
   if flags.node_conditions.is_empty() {
-    if let Ok(conditions) = std::env::var("DENO_NODE_CONDITIONS") {
+    if let Ok(conditions) = std::env::var("DENO_CONDITIONS") {
       flags.node_conditions = conditions
         .split(",")
         .map(|c| c.trim().to_string())

--- a/tests/specs/run/conditional_exports/__test__.jsonc
+++ b/tests/specs/run/conditional_exports/__test__.jsonc
@@ -10,14 +10,14 @@
       "output": "no_condition.out"
     },
     {
-      "args": "run --unstable-node-conditions react-server -A main.js",
+      "args": "run --unstable-conditions react-server -A main.js",
       "output": "condition.out",
       "exitCode": 1
     },
     {
       "args": "run -A main.js",
       "envs": {
-        "DENO_NODE_CONDITIONS": "react-server"
+        "DENO_CONDITIONS": "react-server"
       },
       "output": "condition.out",
       "exitCode": 1

--- a/tests/specs/run/conditional_exports_from_require/__test__.jsonc
+++ b/tests/specs/run/conditional_exports_from_require/__test__.jsonc
@@ -1,4 +1,4 @@
 {
-  "args": "run --unstable-node-conditions some-condition main.cjs",
+  "args": "run --unstable-conditions some-condition main.cjs",
   "output": "good\n"
 }


### PR DESCRIPTION
The `DENO_NODE_CONDITIONS` env var was renamed to `DENO_CONDITIONS`.

Also adds `-C` shorthand alias for the flag.

Ref https://github.com/denoland/deno/pull/29628
Ref https://github.com/denoland/deno/issues/23757