### PR TITLE
feat: add `DENO_COMPAT` env var

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1255,7 +1255,7 @@ static ENV_VARIABLES_HELP: &str = cstr!(
   <g>DENO_CACHE_DB_MODE</>     Controls whether Web cache should use disk based or in-memory database.
   <g>DENO_CERT</>              Load certificate authorities from PEM encoded file
   <g>DENO_COMPAT</>            Enable Node.js compatibility mode - extensionless imports, built-in 
-                               Node.jsmodules, CommonJS detection and more.
+                               Node.js modules, CommonJS detection and more.
   <g>DENO_DIR</>               Set the cache directory
   <g>DENO_INSTALL_ROOT</>      Set deno install's output directory
                           <p(245)>(defaults to $HOME/.deno/bin)</>

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1254,6 +1254,8 @@ static ENV_VARIABLES_HELP: &str = cstr!(
                           <p(245)>(e.g. "abcde12345@deno.land;54321edcba@github.com")</>
   <g>DENO_CACHE_DB_MODE</>     Controls whether Web cache should use disk based or in-memory database.
   <g>DENO_CERT</>              Load certificate authorities from PEM encoded file
+  <g>DENO_COMPAT</>            Enable Node.js compatibility mode - extensionless imports, built-in 
+                               Node.jsmodules, CommonJS detection and more.
   <g>DENO_DIR</>               Set the cache directory
   <g>DENO_INSTALL_ROOT</>      Set deno install's output directory
                           <p(245)>(defaults to $HOME/.deno/bin)</>

--- a/cli/lib/args.rs
+++ b/cli/lib/args.rs
@@ -239,4 +239,10 @@ impl UnstableConfig {
       UNSTABLE_ENV_VAR_NAMES.sloppy_imports,
     );
   }
+
+  pub fn enable_node_compat(&mut self) {
+    self.bare_node_builtins = true;
+    self.sloppy_imports = true;
+    self.detect_cjs = true;
+  }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -548,6 +548,9 @@ fn resolve_flags_and_init(
 
   load_env_variables_from_env_file(flags.env_file.as_ref(), flags.log_level);
   flags.unstable_config.fill_with_env();
+  if std::env::var("DENO_COMPAT").is_ok() {
+    flags.unstable_config.enable_node_compat();
+  }
   if flags.node_conditions.is_empty() {
     if let Ok(conditions) = std::env::var("DENO_NODE_CONDITIONS") {
       flags.node_conditions = conditions

--- a/tests/specs/node/unstable_detect_cjs/no_type_field/__test__.jsonc
+++ b/tests/specs/node/unstable_detect_cjs/no_type_field/__test__.jsonc
@@ -1,4 +1,15 @@
 {
-  "args": "run --unstable-detect-cjs --check --quiet --allow-read=. main.ts",
-  "output": "main.out"
+  "steps": [
+    {
+      "args": "run --unstable-detect-cjs --check --quiet --allow-read=. main.ts",
+      "output": "main.out"
+    },
+    {
+      "args": "run --check --quiet --allow-read=. main.ts",
+      "envs": {
+        "DENO_COMPAT": "1"
+      },
+      "output": "main.out"
+    }
+  ]
 }

--- a/tests/specs/run/node_prefix_missing/__test__.jsonc
+++ b/tests/specs/run/node_prefix_missing/__test__.jsonc
@@ -14,6 +14,13 @@
       "args": "run --unstable-bare-node-builtins main.ts",
       "output": "feature_enabled.out"
     },
+    "unstable_bare_node_builtins_enabled2": {
+      "args": "run main.ts",
+      "envs": {
+        "DENO_COMPAT": "1"
+      },
+      "output": "feature_enabled.out"
+    },
     "unstable_bare_node_builtins_enabled_by_env": {
       "args": "run main.ts",
       "envs": {

--- a/tests/specs/run/sloppy_imports/__test__.jsonc
+++ b/tests/specs/run/sloppy_imports/__test__.jsonc
@@ -9,6 +9,13 @@
       "args": "run --unstable-sloppy-imports --check main.ts",
       "output": "sloppy.out"
     },
+    "sloppy2": {
+      "args": "run --check main.ts",
+      "envs": {
+        "DENO_COMPAT": "1"
+      },
+      "output": "sloppy.out"
+    },
     "sloppy_env": {
       "args": "run --env-file=env_file --check main.ts",
       "output": "sloppy.out"


### PR DESCRIPTION
This commit adds the `DENO_COMPAT` env var, that
when specified enables several features:
- --unstable-bare-node-builtins
- --unstable-detect-cjs
- --unstable-sloppy-imports

With Deno v2.3.x, it is a common situation where these 3 flags have to specified
to run an existing Node.js project, causing a friction that many users experience.

The idea is that this env var could be "set and forget" for many people, that should
provide better DX for running Node.js projects.

It is necessary to note that using this env var _impacts performance_ - especially startup
time.