### PR TITLE
chore(ext/node): exclude more flaky tests

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -50,19 +50,6 @@
 "es-module/test-vm-compile-function-lineoffset.js" = {}
 "es-module/test-wasm-memory-out-of-bound.js" = {}
 "es-module/test-wasm-simple.js" = {}
-"internet/test-dgram-broadcast-multi-process.js" = {}
-"internet/test-dgram-connect.js" = {}
-"internet/test-dns-lookup.js" = {}
-"internet/test-dns-promises-resolve.js" = {}
-"internet/test-dns-regress-6244.js" = {}
-"internet/test-dns-setserver-in-callback-of-resolve4.js" = {}
-"internet/test-http-dns-fail.js" = {}
-"internet/test-http-https-default-ports.js" = {}
-"internet/test-https-autoselectfamily-slow-timeout.js" = {}
-"internet/test-inspector-help-page.js" = {}
-"internet/test-net-autoselectfamily-events-timeout.js" = {}
-"internet/test-net-connect-unref.js" = {}
-"internet/test-tls-autoselectfamily-servername.js" = {}
 "parallel/test-arm-math-illegal-instruction.js" = {}
 "parallel/test-assert-async.js" = {}
 "parallel/test-assert-calltracker-calls.js" = {}
@@ -286,7 +273,6 @@
 "parallel/test-dgram-connect-send-default-host.js" = {}
 "parallel/test-dgram-connect-send-empty-array.js" = {}
 "parallel/test-dgram-connect-send-empty-buffer.js" = {}
-"parallel/test-dgram-connect-send-empty-packet.js" = {}
 "parallel/test-dgram-connect-send-multi-buffer-copy.js" = {}
 "parallel/test-dgram-connect-send-multi-string-array.js" = {}
 "parallel/test-dgram-connect.js" = {}
@@ -488,7 +474,6 @@
 "parallel/test-http-addrequest-localaddress.js" = {}
 "parallel/test-http-agent-close.js" = {}
 "parallel/test-http-agent-getname.js" = {}
-"parallel/test-http-agent-maxtotalsockets.js" = {}
 "parallel/test-http-agent-no-protocol.js" = {}
 "parallel/test-http-agent-null.js" = {}
 "parallel/test-http-allow-req-after-204-res.js" = {}

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -430,7 +430,6 @@
 "parallel/test-fs-promises-readfile-empty.js" = {}
 "parallel/test-fs-read-file-sync-hostname.js" = {}
 "parallel/test-fs-read-stream-autoClose.js" = {}
-"parallel/test-fs-read-stream-concurrent-reads.js" = {}
 "parallel/test-fs-read-stream-double-close.js" = {}
 "parallel/test-fs-read-stream-encoding.js" = {}
 "parallel/test-fs-read-stream-fd-leak.js" = {}


### PR DESCRIPTION
This PR excludes some node compat test that seem flaky on main:
- `parallel/test-dgram-connect-send-empty-packet.js`
- `parallel/test-http-agent-maxtotalsockets.js`

This change also excludes internet-dependent test cases (`internet/*`) which seem also randomly flaky (example failure: https://github.com/denoland/deno/actions/runs/15925861850/job/44922867049 )
