### PR TITLE
feat(run): resolve main module with workspace resolver

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -353,6 +353,118 @@ fn resolve_lint_rules_options(
   }
 }
 
+pub trait MainModuleResolver {
+  fn resolve_main_module(
+    &self,
+    specifier: &str,
+    cwd: &Url,
+  ) -> Result<Url, AnyError>;
+}
+
+pub struct WorkspaceMainModuleResolver {
+  workspace_resolver: Arc<deno_resolver::workspace::WorkspaceResolver<CliSys>>,
+  node_resolver: Arc<crate::node::CliNodeResolver>,
+}
+
+impl WorkspaceMainModuleResolver {
+  pub fn new(
+    workspace_resolver: Arc<
+      deno_resolver::workspace::WorkspaceResolver<CliSys>,
+    >,
+    node_resolver: Arc<crate::node::CliNodeResolver>,
+  ) -> Self {
+    Self {
+      workspace_resolver,
+      node_resolver,
+    }
+  }
+}
+impl MainModuleResolver for WorkspaceMainModuleResolver {
+  fn resolve_main_module(
+    &self,
+    specifier: &str,
+    cwd: &Url,
+  ) -> Result<Url, AnyError> {
+    let resolution = self.workspace_resolver.resolve(
+      &specifier,
+      &cwd,
+      deno_resolver::workspace::ResolutionKind::Execution,
+    )?;
+    let url = match resolution {
+      deno_resolver::workspace::MappedResolution::Normal {
+        specifier, ..
+      } => specifier,
+      deno_resolver::workspace::MappedResolution::WorkspaceJsrPackage {
+        specifier,
+        ..
+      } => specifier,
+      deno_resolver::workspace::MappedResolution::WorkspaceNpmPackage {
+        target_pkg_json,
+        sub_path,
+        ..
+      } => self
+        .node_resolver
+        .resolve_package_subpath_from_deno_module(
+          target_pkg_json.clone().dir_path(),
+          sub_path.as_deref(),
+          Some(cwd),
+          node_resolver::ResolutionMode::Import,
+          node_resolver::NodeResolutionKind::Execution,
+        )?
+        .into_url()?,
+      deno_resolver::workspace::MappedResolution::PackageJson {
+        sub_path,
+        dep_result,
+        alias,
+        ..
+      } => {
+        let result = dep_result
+          .as_ref()
+          .map_err(|e| deno_core::anyhow::anyhow!("{e}"))?;
+        match result {
+          deno_package_json::PackageJsonDepValue::File(file) => {
+            let cwd_path = deno_path_util::url_to_file_path(cwd)?;
+            deno_path_util::resolve_path(file, &cwd_path)?
+          }
+          deno_package_json::PackageJsonDepValue::Req(package_req) => {
+            ModuleSpecifier::parse(&format!(
+              "npm:{}{}",
+              package_req,
+              sub_path.map(|s| format!("/{}", s)).unwrap_or_default()
+            ))?
+          }
+          deno_package_json::PackageJsonDepValue::Workspace(version_req) => {
+            let pkg_folder = self
+              .workspace_resolver
+              .resolve_workspace_pkg_json_folder_for_pkg_json_dep(
+                alias,
+                version_req,
+              )?;
+            self
+              .node_resolver
+              .resolve_package_subpath_from_deno_module(
+                pkg_folder,
+                sub_path.as_deref(),
+                Some(cwd),
+                node_resolver::ResolutionMode::Import,
+                node_resolver::NodeResolutionKind::Execution,
+              )?
+              .into_url()?
+          }
+          deno_package_json::PackageJsonDepValue::JsrReq(_) => {
+            return Err(
+              deno_resolver::DenoResolveErrorKind::UnsupportedPackageJsonJsrReq
+                .into_box()
+                .into(),
+            )
+          }
+        }
+      }
+    };
+    Ok(url)
+  }
+}
+
 /// Holds the resolved options of many sources used by subcommands
 /// and provides some helper function for creating common objects.
 #[derive(Debug)]
@@ -513,7 +625,27 @@ impl CliOptions {
     self.flags.env_file.as_ref()
   }
 
-  pub fn resolve_main_module(&self) -> Result<&ModuleSpecifier, AnyError> {
+  fn resolve_main_module_with_resolver_if_bare(
+    &self,
+    raw_specifier: &str,
+    resolver: Option<impl MainModuleResolver>,
+    default_resolve: impl Fn() -> Result<ModuleSpecifier, AnyError>,
+  ) -> Result<ModuleSpecifier, AnyError> {
+    match resolver {
+      Some(resolver) if !raw_specifier.starts_with(['/', '.', '\\']) => {
+        let cwd = deno_path_util::url_from_directory_path(self.initial_cwd())?;
+        resolver
+          .resolve_main_module(raw_specifier, &cwd)
+          .or_else(|_| default_resolve())
+      }
+      _ => default_resolve(),
+    }
+  }
+
+  pub fn resolve_main_module_with_resolver(
+    &self,
+    resolver: Option<impl MainModuleResolver>,
+  ) -> Result<&ModuleSpecifier, AnyError> {
     self
       .main_module_cell
       .get_or_init(|| {
@@ -531,25 +663,40 @@ impl CliOptions {
             if run_flags.is_stdin() {
               resolve_url_or_path("./$deno$stdin.mts", self.initial_cwd())?
             } else {
-              let url =
-                resolve_url_or_path(&run_flags.script, self.initial_cwd())?;
-              if self.is_node_main()
-                && url.scheme() == "file"
-                && MediaType::from_specifier(&url) == MediaType::Unknown
-              {
-                try_resolve_node_binary_main_entrypoint(
-                  &run_flags.script,
-                  self.initial_cwd(),
-                )?
-                .unwrap_or(url)
-              } else {
-                url
-              }
+              let default_resolve = || {
+                let url =
+                  resolve_url_or_path(&run_flags.script, self.initial_cwd())?;
+                if self.is_node_main()
+                  && url.scheme() == "file"
+                  && MediaType::from_specifier(&url) == MediaType::Unknown
+                {
+                  Ok::<_, AnyError>(
+                    try_resolve_node_binary_main_entrypoint(
+                      &run_flags.script,
+                      self.initial_cwd(),
+                    )?
+                    .unwrap_or(url),
+                  )
+                } else {
+                  Ok(url)
+                }
+              };
+              self.resolve_main_module_with_resolver_if_bare(
+                &run_flags.script,
+                resolver,
+                default_resolve,
+              )?
             }
           }
-          DenoSubcommand::Serve(run_flags) => {
-            resolve_url_or_path(&run_flags.script, self.initial_cwd())?
-          }
+          DenoSubcommand::Serve(run_flags) => self
+            .resolve_main_module_with_resolver_if_bare(
+              &run_flags.script,
+              resolver,
+              || {
+                resolve_url_or_path(&run_flags.script, self.initial_cwd())
+                  .map_err(|e| e.into())
+              },
+            )?,
           _ => {
             bail!("No main module.")
           }
@@ -557,6 +704,10 @@ impl CliOptions {
       })
       .as_ref()
       .map_err(|err| deno_core::anyhow::anyhow!("{}", err))
+  }
+
+  pub fn resolve_main_module(&self) -> Result<&ModuleSpecifier, AnyError> {
+    self.resolve_main_module_with_resolver(None::<WorkspaceMainModuleResolver>)
   }
 
   pub fn resolve_file_header_overrides(

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -386,8 +386,8 @@ impl MainModuleResolver for WorkspaceMainModuleResolver {
     cwd: &Url,
   ) -> Result<Url, AnyError> {
     let resolution = self.workspace_resolver.resolve(
-      &specifier,
-      &cwd,
+      specifier,
+      cwd,
       deno_resolver::workspace::ResolutionKind::Execution,
     )?;
     let url = match resolution {

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -69,7 +69,8 @@ pub async fn run_script(
   let cli_options = factory.cli_options()?;
   let deno_dir = factory.deno_dir()?;
   let http_client = factory.http_client_provider();
-
+  let workspace_resolver = factory.workspace_resolver().await?;
+  let node_resolver = factory.node_resolver().await?;
   // Run a background task that checks for available upgrades or output
   // if an earlier run of this background task found a new version of Deno.
   #[cfg(feature = "upgrade")]
@@ -78,7 +79,12 @@ pub async fn run_script(
     deno_dir.upgrade_check_file_path(),
   );
 
-  let main_module = cli_options.resolve_main_module()?;
+  let main_module = cli_options.resolve_main_module_with_resolver(Some(
+    crate::args::WorkspaceMainModuleResolver::new(
+      workspace_resolver.clone(),
+      node_resolver.clone(),
+    ),
+  ))?;
 
   if main_module.scheme() == "npm" {
     set_npm_user_agent();

--- a/cli/tools/run/mod.rs
+++ b/cli/tools/run/mod.rs
@@ -80,7 +80,7 @@ pub async fn run_script(
   );
 
   let main_module = cli_options.resolve_main_module_with_resolver(Some(
-    crate::args::WorkspaceMainModuleResolver::new(
+    &crate::args::WorkspaceMainModuleResolver::new(
       workspace_resolver.clone(),
       node_resolver.clone(),
     ),

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -50,7 +50,6 @@
 "es-module/test-vm-compile-function-lineoffset.js" = {}
 "es-module/test-wasm-memory-out-of-bound.js" = {}
 "es-module/test-wasm-simple.js" = {}
-"internet/test-dgram-broadcast-multi-process.js" = {}
 "internet/test-dgram-connect.js" = {}
 "internet/test-dns-lookup.js" = {}
 "internet/test-dns-promises-resolve.js" = {}
@@ -1368,7 +1367,6 @@
 "sequential/test-debugger-invalid-args.js" = {}
 "sequential/test-debugger-launch.mjs" = {}
 "sequential/test-debugger-pid.js" = {}
-"sequential/test-dgram-pingpong.js" = {}
 "sequential/test-diagnostic-dir-cpu-prof.js" = {}
 "sequential/test-diagnostic-dir-heap-prof.js" = {}
 "sequential/test-fs-readdir-recursive.js" = {}

--- a/tests/registry/jsr/@denotest/bin/1.0.0/mod.ts
+++ b/tests/registry/jsr/@denotest/bin/1.0.0/mod.ts
@@ -1,0 +1,3 @@
+for (const arg of Deno.args) {
+  console.log(arg);
+}

--- a/tests/registry/jsr/@denotest/bin/1.0.0_meta.json
+++ b/tests/registry/jsr/@denotest/bin/1.0.0_meta.json
@@ -1,0 +1,8 @@
+{
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "moduleGraph1": {
+    "/mod.ts": {}
+  }
+}

--- a/tests/specs/run/import_map_bare_specifier/__test__.jsonc
+++ b/tests/specs/run/import_map_bare_specifier/__test__.jsonc
@@ -1,0 +1,61 @@
+{
+  "tempDir": true,
+  "tests": {
+    "local_file_mapping": {
+      "steps": [
+        {
+          "args": "run foo",
+          "output": "local_file.out"
+        },
+        {
+          "args": "run ./src/app.ts",
+          "output": "direct_file.out"
+        }
+      ]
+    },
+    "npm_nmd_none": {
+      "args": "run --node-modules-dir=none bar hello test",
+      "output": "npm.out"
+    },
+    "npm_nmd_auto": {
+      "args": "run --node-modules-dir=auto bar hello test",
+      "output": "npm.out"
+    },
+    "npm_nmd_manual": {
+      "steps": [
+        {
+          "args": "i --node-modules-dir=manual",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run --node-modules-dir=manual bar hello test",
+          "output": "npm.out"
+        }
+      ]
+    },
+    "jsr_bin": {
+      "args": "run baz",
+      "output": "jsr_specifier.out",
+      "exitCode": 1
+    },
+    "relative_path_not_mapped": {
+      "args": "run ./thing.ts",
+      "output": "relative_mapping.out"
+    },
+    "absolute_path_not_mapped": {
+      "steps": [
+        {
+          "if": "unix",
+          "args": "run /var/thisshouldnotexist.js",
+          "output": "absolute_unix.out",
+          "exitCode": 1
+        },
+        {
+          "if": "windows",
+          "args": "run C:\\var\\thisshouldnotexist.js",
+          "output": "absolute_windows.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/run/import_map_bare_specifier/__test__.jsonc
+++ b/tests/specs/run/import_map_bare_specifier/__test__.jsonc
@@ -53,12 +53,14 @@
         {
           "if": "windows",
           "args": "run C:\\var\\thisshouldnotexist.js",
-          "output": "absolute_windows.out"
+          "output": "absolute_windows.out",
+          "exitCode": 1
         },
         {
           "if": "windows",
           "args": "run C:/var/thisshouldnotexist.js",
-          "output": "absolute_windows.out"
+          "output": "absolute_windows.out",
+          "exitCode": 1
         }
       ]
     }

--- a/tests/specs/run/import_map_bare_specifier/__test__.jsonc
+++ b/tests/specs/run/import_map_bare_specifier/__test__.jsonc
@@ -54,6 +54,11 @@
           "if": "windows",
           "args": "run C:\\var\\thisshouldnotexist.js",
           "output": "absolute_windows.out"
+        },
+        {
+          "if": "windows",
+          "args": "run C:/var/thisshouldnotexist.js",
+          "output": "absolute_windows.out"
         }
       ]
     }

--- a/tests/specs/run/import_map_bare_specifier/absolute_unix.out
+++ b/tests/specs/run/import_map_bare_specifier/absolute_unix.out
@@ -1,0 +1,1 @@
+error: Module not found "file:///var/thisshouldnotexist.js".

--- a/tests/specs/run/import_map_bare_specifier/absolute_windows.out
+++ b/tests/specs/run/import_map_bare_specifier/absolute_windows.out
@@ -1,2 +1,1 @@
-
 error: Module not found "file:///C:/var/thisshouldnotexist.js".

--- a/tests/specs/run/import_map_bare_specifier/absolute_windows.out
+++ b/tests/specs/run/import_map_bare_specifier/absolute_windows.out
@@ -1,0 +1,2 @@
+
+error: Module not found "file:///C:/var/thisshouldnotexist.js".

--- a/tests/specs/run/import_map_bare_specifier/deno.jsonc
+++ b/tests/specs/run/import_map_bare_specifier/deno.jsonc
@@ -1,0 +1,8 @@
+{
+  "imports": {
+    "foo": "./src/app.ts",
+    "bar": "npm:@denotest/bin@0.5.0",
+    "baz": "jsr:@denotest/bin",
+    "./thing.ts": "./src/app.ts"
+  }
+}

--- a/tests/specs/run/import_map_bare_specifier/direct_file.out
+++ b/tests/specs/run/import_map_bare_specifier/direct_file.out
@@ -1,0 +1,1 @@
+Hello from app!

--- a/tests/specs/run/import_map_bare_specifier/jsr_specifier.out
+++ b/tests/specs/run/import_map_bare_specifier/jsr_specifier.out
@@ -1,0 +1,2 @@
+Download http://127.0.0.1:4250/@denotest/bin/meta.json
+error: JSR package not found: @denotest/bin

--- a/tests/specs/run/import_map_bare_specifier/local_file.out
+++ b/tests/specs/run/import_map_bare_specifier/local_file.out
@@ -1,0 +1,1 @@
+Hello from app!

--- a/tests/specs/run/import_map_bare_specifier/npm.out
+++ b/tests/specs/run/import_map_bare_specifier/npm.out
@@ -1,0 +1,2 @@
+[WILDCARD]hello
+test

--- a/tests/specs/run/import_map_bare_specifier/relative_mapping.out
+++ b/tests/specs/run/import_map_bare_specifier/relative_mapping.out
@@ -1,0 +1,1 @@
+Hello from app!

--- a/tests/specs/run/import_map_bare_specifier/src/app.ts
+++ b/tests/specs/run/import_map_bare_specifier/src/app.ts
@@ -1,0 +1,5 @@
+console.log("Hello from app!");
+
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/29897.
Closes https://github.com/denoland/deno/issues/14066.
Closes https://github.com/denoland/deno/issues/19955.

With this PR we'll attempt to resolve bare specifiers passed to `run` or `serve` with the workspace resolver. This means you can run specifiers that are defined in your import map/package.json.

If the specifier looks like a path (starts with `.`, or is an absolute path) then we won't try to resolve it via the import map.

This does have the potential to break someone, in the case that you have something like

```
{
  "imports": { "foo.ts": "./bar.ts" }
}
```

and you have a file named `foo.ts`, previously `deno run foo.ts` would run `./foo.ts`, now we would run `./bar.ts`. I can't see a way around that without doing an extra stat to see if the file exists, or deferring this to module load time (which seems complex). I don't think many people would hit that, and if someone does there's a simple fix – just add `./` to the front.

From my benchmarking, this change has no effect on startup time
