### PR TITLE
feat(process): add detached option to `Deno.Command`

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -3809,6 +3809,20 @@ declare namespace Deno {
      *
      * @default {false} */
     windowsRawArguments?: boolean;
+
+    /** Whether to detach the spawned process from the current process.
+     * This allows the spawned process to continue running after the current
+     * process exits.
+     *
+     * Note: In order to allow the current process to exit, you need to ensure
+     * you call `unref()` on the child process.
+     *
+     * In addition, the stdio streams – if inherited or piped – may keep the
+     * current process from exiting until the streams are closed.
+     *
+     * @default {false}
+     */
+    detached?: boolean;
   }
 
   /**

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -57,7 +57,6 @@ import { StreamBase } from "ext:deno_node/internal_binding/stream_wrap.ts";
 import { Pipe, socketType } from "ext:deno_node/internal_binding/pipe_wrap.ts";
 import { Socket } from "node:net";
 import {
-  kDetached,
   kExtraStdio,
   kInputOption,
   kIpc,
@@ -286,9 +285,9 @@ export class ChildProcess extends EventEmitter {
         stdout: toDenoStdio(stdout),
         stderr: toDenoStdio(stderr),
         windowsRawArguments: windowsVerbatimArguments,
+        detached,
         [kIpc]: ipc, // internal
         [kExtraStdio]: extraStdioNormalized,
-        [kDetached]: detached,
         // deno-lint-ignore no-explicit-any
         [kNeedsNpmProcessState]: (options ?? {} as any)[kNeedsNpmProcessState],
       }).spawn();

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -162,7 +162,6 @@ function run({
 
 export const kExtraStdio = Symbol("extraStdio");
 export const kIpc = Symbol("ipc");
-export const kDetached = Symbol("detached");
 export const kNeedsNpmProcessState = Symbol("needsNpmProcessState");
 
 const illegalConstructorKey = Symbol("illegalConstructorKey");
@@ -179,7 +178,7 @@ function spawnChildInner(command, apiName, {
   stdout = "piped",
   stderr = "piped",
   windowsRawArguments = false,
-  [kDetached]: detached = false,
+  detached = false,
   [kExtraStdio]: extraStdio = [],
   [kIpc]: ipc = -1,
   [kNeedsNpmProcessState]: needsNpmProcessState = false,


### PR DESCRIPTION
Closes #5501.

Now that we support detached processes on all platforms, we can support this!

TODO: add a test