### PR TITLE
fix(bundle): resolve "sloppy imports" in npm packages when bundling

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -730,7 +730,7 @@ impl DenoPluginHandler {
       Position::new(0, 0),
       ResolveWithGraphOptions {
         mode: import_kind_to_resolution_mode(kind),
-        kind: NodeResolutionKind::Execution,
+        kind: NodeResolutionKind::Bundling,
         maintain_npm_specifiers: false,
       },
     );

--- a/libs/node_resolver/errors.rs
+++ b/libs/node_resolver/errors.rs
@@ -310,7 +310,7 @@ impl PackageSubpathResolveErrorKind {
     )
   ).unwrap_or_default(),
   match resolution_kind {
-    NodeResolutionKind::Execution => "",
+    NodeResolutionKind::Execution | NodeResolutionKind::Bundling => "",
     NodeResolutionKind::Types => " for types",
   }
 )]
@@ -922,7 +922,9 @@ impl std::fmt::Display for PackagePathNotExportedError {
     f.write_char(']')?;
 
     let types_msg = match self.resolution_kind {
-      NodeResolutionKind::Execution => String::new(),
+      NodeResolutionKind::Execution | NodeResolutionKind::Bundling => {
+        String::new()
+      }
       NodeResolutionKind::Types => " for types".to_string(),
     };
     if self.subpath == "." {

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -171,6 +171,7 @@ impl ResolutionMode {
 pub enum NodeResolutionKind {
   Execution,
   Types,
+  Bundling,
 }
 
 impl NodeResolutionKind {
@@ -588,7 +589,8 @@ impl<
       }
       _ => {
         if let Err(e) = maybe_file_type {
-          if resolution_mode == ResolutionMode::Require
+          if (resolution_mode == ResolutionMode::Require
+            || resolution_kind == NodeResolutionKind::Bundling)
             && e.kind() == std::io::ErrorKind::NotFound
           {
             let file_with_ext = with_known_extension(&path, "js");

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -856,6 +856,8 @@ pub enum ResolutionKind {
   Execution,
   /// Resolving for code that will be used for type information.
   Types,
+  /// Resolving for code that will be bundled.
+  Bundling,
 }
 
 impl ResolutionKind {
@@ -869,6 +871,7 @@ impl From<NodeResolutionKind> for ResolutionKind {
     match value {
       NodeResolutionKind::Execution => Self::Execution,
       NodeResolutionKind::Types => Self::Types,
+      NodeResolutionKind::Bundling => Self::Bundling,
     }
   }
 }

--- a/tests/registry/npm/@denotest/sloppy-import/1.0.0/foo.js
+++ b/tests/registry/npm/@denotest/sloppy-import/1.0.0/foo.js
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/tests/registry/npm/@denotest/sloppy-import/1.0.0/index.js
+++ b/tests/registry/npm/@denotest/sloppy-import/1.0.0/index.js
@@ -1,0 +1,5 @@
+import { foo } from "./foo";
+
+export function sayHiFoo() {
+  console.log("Hi " + foo);
+}

--- a/tests/registry/npm/@denotest/sloppy-import/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/sloppy-import/1.0.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@denotest/sloppy-import",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/tests/specs/bundle/sloppy_import_in_npm_package/__test__.jsonc
+++ b/tests/specs/bundle/sloppy_import_in_npm_package/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "bundle -o out.js main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "run out.js",
+      "output": "Hi foo\n"
+    }
+  ]
+}

--- a/tests/specs/bundle/sloppy_import_in_npm_package/main.ts
+++ b/tests/specs/bundle/sloppy_import_in_npm_package/main.ts
@@ -1,0 +1,3 @@
+import { sayHiFoo } from "npm:@denotest/sloppy-import";
+
+sayHiFoo();


### PR DESCRIPTION
Fixes a case reported in discord. At runtime node (and us) would fail on this, but all major bundlers permit this. So as a fix, just allow it during bundling only.