### PR TITLE
feat(unstable): use Node.js `setTimeout` and `setInterval`

### DIFF
--- a/cli/lib/args.rs
+++ b/cli/lib/args.rs
@@ -245,5 +245,8 @@ impl UnstableConfig {
     self.bare_node_builtins = true;
     self.sloppy_imports = true;
     self.detect_cjs = true;
+    if !self.features.contains(&"node-globals".to_string()) {
+      self.features.push("node-globals".to_string());
+    }
   }
 }

--- a/runtime/features/data.rs
+++ b/runtime/features/data.rs
@@ -130,8 +130,8 @@ pub static FEATURE_DESCRIPTIONS: &[UnstableFeatureDescription] = &[
   },
   UnstableFeatureDescription {
     name: "node-globals",
-    help_text: "Expose Node globals everywhere",
-    show_in_help: false,
+    help_text: "Prefer Node.js globals over Deno globals - currently this refers to `setTimeout` and `setInterval` APIs.",
+    show_in_help: true,
     kind: UnstableFeatureKind::Runtime,
     config_option: ConfigFileOption::SameAsFlagName,
     env_var: None,

--- a/runtime/features/gen.rs
+++ b/runtime/features/gen.rs
@@ -127,8 +127,8 @@ pub static UNSTABLE_FEATURES: &[UnstableFeatureDefinition] = &[
   UnstableFeatureDefinition {
     name: "node-globals",
     flag_name: "unstable-node-globals",
-    help_text: "Expose Node globals everywhere",
-    show_in_help: false,
+    help_text: "Prefer Node.js globals over Deno globals - currently this refers to `setTimeout` and `setInterval` APIs.",
+    show_in_help: true,
     id: 13,
     kind: UnstableFeatureKind::Runtime,
     config_file_option: "node-globals",

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -33,7 +33,14 @@ import * as abortSignal from "ext:deno_web/03_abort_signal.js";
 import * as imageData from "ext:deno_web/16_image_data.js";
 import process from "node:process";
 import { Buffer } from "node:buffer";
-import { clearImmediate, setImmediate } from "node:timers";
+import {
+  clearImmediate,
+  clearInterval as nodeClearInterval,
+  clearTimeout as nodeClearTimeout,
+  setImmediate,
+  setInterval as nodeSetInterval,
+  setTimeout as nodeSetTimeout,
+} from "node:timers";
 import { loadWebGPU } from "ext:deno_webgpu/00_init.js";
 import * as webgpuSurface from "ext:deno_webgpu/02_surface.js";
 import { unstableIds } from "ext:runtime/90_deno_ns.js";
@@ -339,6 +346,11 @@ unstableForWindowOrWorkerGlobalScope[unstableIds.net] = {
 
 unstableForWindowOrWorkerGlobalScope[unstableIds.webgpu] = {};
 
-unstableForWindowOrWorkerGlobalScope[unstableIds.nodeGlobals] = {};
+unstableForWindowOrWorkerGlobalScope[unstableIds.nodeGlobals] = {
+  clearInterval: core.propWritable(nodeClearInterval),
+  clearTimeout: core.propWritable(nodeClearTimeout),
+  setInterval: core.propWritable(nodeSetInterval),
+  setTimeout: core.propWritable(nodeSetTimeout),
+};
 
 export { unstableForWindowOrWorkerGlobalScope, windowOrWorkerGlobalScope };

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -912,7 +912,6 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       location.setLocationHref(location_);
     }
 
-    exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures);
     ObjectDefineProperties(globalThis, mainRuntimeGlobalProperties);
     ObjectDefineProperties(globalThis, {
       // TODO(bartlomieju): in the future we might want to change the
@@ -922,6 +921,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       close: core.propWritable(windowClose),
       closed: core.propGetterOnly(() => windowIsClosing),
     });
+    exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures);
     ObjectSetPrototypeOf(globalThis, Window.prototype);
 
     bootstrapOtel(otelConfig);
@@ -1031,7 +1031,6 @@ function bootstrapWorkerRuntime(
     delete globalThis.bootstrap;
     hasBootstrapped = true;
 
-    exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures);
     if (workerType === "node") {
       delete workerRuntimeGlobalProperties["WorkerGlobalScope"];
       delete workerRuntimeGlobalProperties["self"];
@@ -1050,6 +1049,7 @@ function bootstrapWorkerRuntime(
         core.propWritable(importScripts),
       );
     }
+    exposeUnstableFeaturesForWindowOrWorkerGlobalScope(unstableFeatures);
     ObjectSetPrototypeOf(globalThis, DedicatedWorkerGlobalScope.prototype);
 
     bootstrapOtel(otelConfig);


### PR DESCRIPTION
This commit repurposes `--unstable-node-globals` flag that was deprecated
in https://github.com/denoland/deno/pull/29887 to switch out timers implemention
that is used.

Ie. using this flag cause `setTimeout`, `setInterval`, `clearTimeout` and `clearInterval`
globals to use functions from `node:timers` module instead of the Web version.

This is also enabled using `DENO_COMPAT=1` env var. 

TODO:
make typechecking be conditional depending on this, most likely requires
changes in our TS fork.