### PR TITLE
refactor: ability to preserve jsx internally

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -33,6 +33,7 @@ use deno_npm_installer::lifecycle_scripts::NullLifecycleScriptsExecutor;
 use deno_npm_installer::process_state::NpmProcessStateKind;
 use deno_resolver::cache::ParsedSourceCache;
 use deno_resolver::cjs::IsCjsResolutionMode;
+use deno_resolver::deno_json::CompilerOptionsOverrides;
 use deno_resolver::deno_json::CompilerOptionsResolver;
 use deno_resolver::factory::ConfigDiscoveryOption;
 use deno_resolver::factory::NpmProcessStateOptions;
@@ -1206,6 +1207,9 @@ fn new_workspace_factory_options(
       &["jsr.json", "jsr.jsonc"]
     } else {
       &[]
+    },
+    compiler_options_overrides: CompilerOptionsOverrides {
+      preserve_jsx: false,
     },
     config_discovery: match &flags.config_flag {
       ConfigFlag::Discover => {

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1474,6 +1474,7 @@ impl ConfigData {
       member_dir.dir_path(),
       WorkspaceFactoryOptions {
         additional_config_file_names: &[],
+        compiler_options_overrides: Default::default(),
         config_discovery: ConfigDiscoveryOption::DiscoverCwd,
         maybe_custom_deno_dir_root: None,
         is_package_manager_subcommand: false,

--- a/cli/tools/publish/module_content.rs
+++ b/cli/tools/publish/module_content.rs
@@ -284,6 +284,7 @@ mod test {
 
   use deno_config::workspace::WorkspaceDiscoverStart;
   use deno_path_util::url_from_file_path;
+  use deno_resolver::deno_json::CompilerOptionsOverrides;
   use deno_resolver::factory::ConfigDiscoveryOption;
   use deno_resolver::factory::WorkspaceDirectoryProvider;
   use deno_resolver::npm::ByonmNpmResolverCreateOptions;
@@ -445,6 +446,7 @@ mod test {
       &WorkspaceDirectoryProvider::from_initial_dir(&Arc::new(workspace_dir)),
       &node_resolver,
       &ConfigDiscoveryOption::DiscoverCwd,
+      &CompilerOptionsOverrides::default(),
     ));
     ModuleContentProvider::new(
       Arc::new(ParsedSourceCache::default()),

--- a/libs/resolver/factory.rs
+++ b/libs/resolver/factory.rs
@@ -57,6 +57,7 @@ use crate::cjs::analyzer::DenoCjsCodeAnalyzer;
 use crate::cjs::analyzer::NodeAnalysisCacheRc;
 use crate::cjs::analyzer::NullNodeAnalysisCache;
 use crate::collections::FolderScopedMap;
+use crate::deno_json::CompilerOptionsOverrides;
 use crate::deno_json::CompilerOptionsResolver;
 use crate::deno_json::CompilerOptionsResolverRc;
 use crate::import_map::WorkspaceExternalImportMapLoader;
@@ -196,6 +197,7 @@ pub struct NpmProcessStateOptions {
 #[derive(Debug, Default)]
 pub struct WorkspaceFactoryOptions {
   pub additional_config_file_names: &'static [&'static str],
+  pub compiler_options_overrides: CompilerOptionsOverrides,
   pub config_discovery: ConfigDiscoveryOption,
   pub is_package_manager_subcommand: bool,
   pub frozen_lockfile: Option<bool>,
@@ -845,6 +847,7 @@ impl<TSys: WorkspaceFactorySys> ResolverFactory<TSys> {
         self.workspace_factory.workspace_directory_provider()?,
         self.node_resolver()?,
         &self.workspace_factory.options.config_discovery,
+        &self.workspace_factory.options.compiler_options_overrides,
       )))
     })
   }


### PR DESCRIPTION
Was integrating my previous PRs into deno-js-loader and I need the ability to preserve jsx.

In the future, this should be useful for `deno bundle` I think.