### PR TITLE
refactor(emitter): ability to not transpile and specify a source map base

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1108,6 +1108,11 @@ impl CliFactory {
       Ok(Arc::new(CliResolverFactory::new(
         self.workspace_factory()?.clone(),
         ResolverFactoryOptions {
+          compiler_options_overrides: CompilerOptionsOverrides {
+            no_transpile: false,
+            source_map_base: None,
+            preserve_jsx: false,
+          },
           is_cjs_resolution_mode: if options.is_node_main()
             || options.unstable_detect_cjs()
           {
@@ -1207,9 +1212,6 @@ fn new_workspace_factory_options(
       &["jsr.json", "jsr.jsonc"]
     } else {
       &[]
-    },
-    compiler_options_overrides: CompilerOptionsOverrides {
-      preserve_jsx: false,
     },
     config_discovery: match &flags.config_flag {
       ConfigFlag::Discover => {

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1474,7 +1474,6 @@ impl ConfigData {
       member_dir.dir_path(),
       WorkspaceFactoryOptions {
         additional_config_file_names: &[],
-        compiler_options_overrides: Default::default(),
         config_discovery: ConfigDiscoveryOption::DiscoverCwd,
         maybe_custom_deno_dir_root: None,
         is_package_manager_subcommand: false,
@@ -1497,6 +1496,7 @@ impl ConfigData {
       ResolverFactoryOptions {
         // these default options are fine because we don't use this for
         // anything other than resolving the lockfile at the moment
+        compiler_options_overrides: Default::default(),
         is_cjs_resolution_mode: Default::default(),
         npm_system_info: Default::default(),
         node_code_translator_mode: Default::default(),

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1468,7 +1468,6 @@ impl<TGraphContainer: ModuleGraphContainer> NodeRequireLoader
           &text.into(),
         )
         .map_err(JsErrorBox::from_err)?;
-      self.parsed_soure_cache.free(&specifier);
       Ok(text.into())
     } else {
       Ok(match text {

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -473,7 +473,6 @@ impl CliModuleLoaderFactory {
         .shared
         .npm_registry_permission_checker
         .clone(),
-      parsed_soure_cache: self.shared.parsed_source_cache.clone(),
     });
     CreateModuleLoaderResult {
       module_loader,
@@ -1415,7 +1414,6 @@ struct CliNodeRequireLoader<TGraphContainer: ModuleGraphContainer> {
   in_npm_pkg_checker: DenoInNpmPackageChecker,
   npm_registry_permission_checker:
     Arc<NpmRegistryReadPermissionChecker<CliSys>>,
-  parsed_soure_cache: Arc<ParsedSourceCache>,
 }
 
 impl<TGraphContainer: ModuleGraphContainer> NodeRequireLoader

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -464,7 +464,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
               _ => ModuleKind::Esm,
             };
             let (source, source_map) =
-              self.emitter.emit_parsed_source_for_deno_compile(
+              self.emitter.emit_source_for_deno_compile(
                 &m.specifier,
                 m.media_type,
                 module_kind,

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 
+use deno_core::FastString;
 use deno_core::OpState;
 use deno_core::op2;
 use deno_core::url::Url;
@@ -164,10 +165,8 @@ pub trait NodeRequireLoader {
     path: &'a Path,
   ) -> Result<Cow<'a, Path>, JsErrorBox>;
 
-  fn load_text_file_lossy(
-    &self,
-    path: &Path,
-  ) -> Result<Cow<'static, str>, JsErrorBox>;
+  fn load_text_file_lossy(&self, path: &Path)
+  -> Result<FastString, JsErrorBox>;
 
   /// Get if the module kind is maybe CJS and loading should determine
   /// if its CJS or ESM.

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -558,10 +558,6 @@ where
   let loader = state.borrow::<NodeRequireLoaderRc>();
   loader
     .load_text_file_lossy(&file_path)
-    .map(|s| match s {
-      Cow::Borrowed(s) => FastString::from_static(s),
-      Cow::Owned(s) => s.into(),
-    })
     .map_err(|e| RequireErrorKind::ReadModule(e).into_box())
 }
 

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -1156,6 +1156,7 @@ impl ConfigFile {
     sys: &impl FsRead,
     config_path: &Path,
   ) -> Result<Self, ConfigFileReadError> {
+    #[cfg(not(target_arch = "wasm32"))]
     debug_assert!(config_path.is_absolute());
     let specifier = url_from_file_path(config_path).map_err(|_| {
       ConfigFileReadErrorKind::PathToUrl(config_path.to_path_buf()).into_box()

--- a/libs/resolver/cache/parsed_source.rs
+++ b/libs/resolver/cache/parsed_source.rs
@@ -59,12 +59,26 @@ impl ParsedSourceCache {
     &self,
     module: &deno_graph::JsModule,
   ) -> Result<ParsedSource, deno_ast::ParseDiagnostic> {
+    self.get_matching_parsed_source(
+      &module.specifier,
+      module.media_type,
+      module.source.text.clone(),
+    )
+  }
+
+  #[allow(clippy::result_large_err)]
+  pub fn get_matching_parsed_source(
+    &self,
+    specifier: &Url,
+    media_type: MediaType,
+    source: ArcStr,
+  ) -> Result<ParsedSource, deno_ast::ParseDiagnostic> {
     let parser = self.as_capturing_parser();
     // this will conditionally parse because it's using a CapturingEsParser
     parser.parse_program(deno_graph::ast::ParseOptions {
-      specifier: &module.specifier,
-      source: module.source.text.clone(),
-      media_type: module.media_type,
+      specifier,
+      source,
+      media_type,
       scope_analysis: false,
     })
   }
@@ -73,8 +87,8 @@ impl ParsedSourceCache {
   pub fn remove_or_parse_module(
     &self,
     specifier: &Url,
-    source: ArcStr,
     media_type: MediaType,
+    source: ArcStr,
   ) -> Result<ParsedSource, deno_ast::ParseDiagnostic> {
     if let Some(parsed_source) = self.remove_parsed_source(specifier) {
       if parsed_source.media_type() == media_type

--- a/libs/resolver/deno_json.rs
+++ b/libs/resolver/deno_json.rs
@@ -56,6 +56,7 @@ pub type CompilerOptionsTypesRc =
 #[cfg(feature = "deno_ast")]
 #[derive(Debug)]
 pub struct TranspileAndEmitOptions {
+  pub no_transpile: bool,
   pub transpile: deno_ast::TranspileOptions,
   pub emit: deno_ast::EmitOptions,
   // stored ahead of time so we don't have to recompute this a lot
@@ -90,6 +91,11 @@ struct MemoizedValues {
 
 #[derive(Debug, Clone, Default)]
 pub struct CompilerOptionsOverrides {
+  /// Skip transpiling in the loaders.
+  pub no_transpile: bool,
+  /// Base to use for the source map. This is useful when bundling
+  /// and you want to make file urls relative.
+  pub source_map_base: Option<Url>,
   /// Preserve JSX instead of transforming it.
   ///
   /// This may be useful when bundling.
@@ -870,6 +876,7 @@ fn compiler_options_to_transpile_and_emit_options(
     hasher.finish()
   };
   Ok(TranspileAndEmitOptions {
+    no_transpile: overrides.no_transpile,
     transpile,
     emit,
     pre_computed_hash: transpile_and_emit_options_hash,

--- a/libs/resolver/emit.rs
+++ b/libs/resolver/emit.rs
@@ -144,6 +144,7 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
     parsed_source: deno_ast::ParsedSource,
     module_kind: ModuleKind,
   ) -> Result<ArcStr, EmitParsedSourceHelperError> {
+    // note: this method is used in deno-js-loader
     self
       .maybe_emit_parsed_source_provider(parsed_source, module_kind)
       .await

--- a/libs/resolver/emit.rs
+++ b/libs/resolver/emit.rs
@@ -29,6 +29,8 @@ use crate::cache::ParsedSourceCacheRc;
 use crate::cjs::CjsTrackerRc;
 use crate::deno_json::CompilerOptionsResolverRc;
 use crate::deno_json::TranspileAndEmitOptions;
+use crate::sync::MaybeSend;
+use crate::sync::MaybeSync;
 
 #[allow(clippy::disallowed_types)] // ok because we always store source text as Arc<str>
 type ArcStr = std::sync::Arc<str>;
@@ -386,7 +388,7 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
   }
 }
 
-trait ParsedSourceProvider: Send + Sync + Clone + 'static {
+trait ParsedSourceProvider: MaybeSend + MaybeSync + Clone + 'static {
   fn specifier(&self) -> &Url;
   fn media_type(&self) -> MediaType;
   fn source(&self) -> &ArcStr;

--- a/libs/resolver/emit.rs
+++ b/libs/resolver/emit.rs
@@ -6,6 +6,7 @@ use std::hash::Hasher;
 use anyhow::Error as AnyError;
 use deno_ast::EmittedSourceText;
 use deno_ast::ModuleKind;
+use deno_ast::ParsedSource;
 use deno_ast::SourceMapOption;
 use deno_ast::SourceRange;
 use deno_ast::SourceRanged;
@@ -24,7 +25,6 @@ use url::Url;
 
 use crate::cache::EmitCacheRc;
 use crate::cache::EmitCacheSys;
-use crate::cache::ParsedSourceCache;
 use crate::cache::ParsedSourceCacheRc;
 use crate::cjs::CjsTrackerRc;
 use crate::deno_json::CompilerOptionsResolverRc;
@@ -79,7 +79,7 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
       if module.media_type.is_emittable() {
         futures.push(
           self
-            .emit_parsed_source(
+            .maybe_emit_source(
               &module.specifier,
               module.media_type,
               ModuleKind::from_is_cjs(
@@ -119,50 +119,79 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
     Ok(self.emit_cache.get_emit_code(specifier, source_hash))
   }
 
-  pub async fn emit_parsed_source(
+  pub async fn maybe_emit_source(
     &self,
     specifier: &Url,
     media_type: MediaType,
     module_kind: ModuleKind,
     source: &ArcStr,
   ) -> Result<ArcStr, EmitParsedSourceHelperError> {
-    if !media_type.is_emittable() {
-      return Ok(source.clone());
+    self
+      .maybe_emit_parsed_source_provider(
+        ParsedSourceCacheParsedSourceProvider {
+          parsed_source_cache: self.parsed_source_cache.clone(),
+          specifier: specifier.clone(),
+          media_type,
+          source: source.clone(),
+        },
+        module_kind,
+      )
+      .await
+  }
+
+  pub async fn maybe_emit_parsed_source(
+    &self,
+    parsed_source: deno_ast::ParsedSource,
+    module_kind: ModuleKind,
+  ) -> Result<ArcStr, EmitParsedSourceHelperError> {
+    self
+      .maybe_emit_parsed_source_provider(parsed_source, module_kind)
+      .await
+  }
+
+  async fn maybe_emit_parsed_source_provider<
+    TProvider: ParsedSourceProvider,
+  >(
+    &self,
+    provider: TProvider,
+    module_kind: ModuleKind,
+  ) -> Result<ArcStr, EmitParsedSourceHelperError> {
+    // Note: keep this in sync with the sync version below
+    if !provider.media_type().is_emittable() {
+      return Ok(provider.into_source());
     }
     let transpile_and_emit_options = self
       .compiler_options_resolver
-      .for_specifier(specifier)
+      .for_specifier(provider.specifier())
       .transpile_options()?;
+    if transpile_and_emit_options.no_transpile {
+      return Ok(provider.into_source());
+    }
     let transpile_options = &transpile_and_emit_options.transpile;
-    if matches!(media_type, MediaType::Jsx)
+    if matches!(provider.media_type(), MediaType::Jsx)
       && !transpile_options.transform_jsx
       && !transpile_options.precompile_jsx
     {
       // jsx disabled, so skip
-      return Ok(source.clone());
+      return Ok(provider.into_source());
     }
-    // Note: keep this in sync with the sync version below
     let helper = EmitParsedSourceHelper(self);
     match helper.pre_emit_parsed_source(
-      specifier,
+      provider.specifier(),
       module_kind,
       transpile_and_emit_options,
-      source,
+      provider.source(),
     ) {
       PreEmitResult::Cached(emitted_text) => Ok(emitted_text.into()),
       PreEmitResult::NotCached { source_hash } => {
+        let specifier = provider.specifier().clone();
         let emit = {
-          let parsed_source_cache = self.parsed_source_cache.clone();
           let transpile_and_emit_options = transpile_and_emit_options.clone();
-          let specifier = specifier.clone();
-          let source = source.clone();
           move || {
+            let parsed_source = provider.parsed_source()?;
             transpile(
-              &parsed_source_cache,
-              &specifier,
-              media_type,
+              parsed_source,
               module_kind,
-              source.clone(),
               &transpile_and_emit_options.transpile,
               &transpile_and_emit_options.emit,
             )
@@ -175,7 +204,7 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
         #[cfg(not(feature = "sync"))]
         let transpiled_source = emit()?;
         helper.post_emit_parsed_source(
-          specifier,
+          &specifier,
           &transpiled_source,
           source_hash,
         );
@@ -185,18 +214,32 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
   }
 
   #[allow(clippy::result_large_err)]
-  pub fn emit_parsed_source_sync(
+  pub fn maybe_emit_source_sync(
     &self,
     specifier: &Url,
     media_type: MediaType,
     module_kind: deno_ast::ModuleKind,
     source: &ArcStr,
-  ) -> Result<String, EmitParsedSourceHelperError> {
+  ) -> Result<ArcStr, EmitParsedSourceHelperError> {
+    // Note: keep this in sync with the async version above
+    if !media_type.is_emittable() {
+      return Ok(source.clone());
+    }
     let transpile_and_emit_options = self
       .compiler_options_resolver
       .for_specifier(specifier)
       .transpile_options()?;
-    // Note: keep this in sync with the async version above
+    if transpile_and_emit_options.no_transpile {
+      return Ok(source.clone());
+    }
+    let transpile_options = &transpile_and_emit_options.transpile;
+    if matches!(media_type, MediaType::Jsx)
+      && !transpile_options.transform_jsx
+      && !transpile_options.precompile_jsx
+    {
+      // jsx disabled, so skip
+      return Ok(source.clone());
+    }
     let helper = EmitParsedSourceHelper(self);
     match helper.pre_emit_parsed_source(
       specifier,
@@ -204,14 +247,14 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
       transpile_and_emit_options,
       source,
     ) {
-      PreEmitResult::Cached(emitted_text) => Ok(emitted_text),
+      PreEmitResult::Cached(emitted_text) => Ok(emitted_text.into()),
       PreEmitResult::NotCached { source_hash } => {
+        let parsed_source = self
+          .parsed_source_cache
+          .get_matching_parsed_source(specifier, media_type, source.clone())?;
         let transpiled_source = transpile(
-          &self.parsed_source_cache,
-          specifier,
-          media_type,
+          parsed_source,
           module_kind,
-          source.clone(),
           &transpile_and_emit_options.transpile,
           &transpile_and_emit_options.emit,
         )?
@@ -221,12 +264,12 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
           &transpiled_source,
           source_hash,
         );
-        Ok(transpiled_source)
+        Ok(transpiled_source.into())
       }
     }
   }
 
-  pub fn emit_parsed_source_for_deno_compile(
+  pub fn emit_source_for_deno_compile(
     &self,
     specifier: &Url,
     media_type: MediaType,
@@ -243,12 +286,14 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
     // strip off the path to have more deterministic builds as we don't care
     // about the source name because we manually provide the source map to v8
     emit_options.source_map_base = Some(deno_path_util::url_parent(specifier));
-    let source = transpile(
-      &self.parsed_source_cache,
+    let parsed_source = self.parsed_source_cache.get_matching_parsed_source(
       specifier,
       media_type,
-      module_kind,
       source.clone(),
+    )?;
+    let source = transpile(
+      parsed_source,
+      module_kind,
       &transpile_and_emit_options.transpile,
       &emit_options,
     )?;
@@ -271,7 +316,7 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
         let source_arc: ArcStr = source_code.into();
         let parsed_source = self
           .parsed_source_cache
-          .remove_or_parse_module(specifier, source_arc, media_type)
+          .remove_or_parse_module(specifier, media_type, source_arc)
           .map_err(JsErrorBox::from_err)?;
         // HMR doesn't work with embedded source maps for some reason, so set
         // the option to not use them (though you should test this out because
@@ -337,6 +382,62 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
     transpile_and_emit.pre_computed_hash.hash(&mut hasher);
     module_kind.hash(&mut hasher);
     hasher.finish()
+  }
+}
+
+trait ParsedSourceProvider: Send + Sync + Clone + 'static {
+  fn specifier(&self) -> &Url;
+  fn media_type(&self) -> MediaType;
+  fn source(&self) -> &ArcStr;
+  fn into_source(self) -> ArcStr;
+  fn parsed_source(self) -> Result<ParsedSource, deno_ast::ParseDiagnostic>;
+}
+
+#[derive(Clone)]
+struct ParsedSourceCacheParsedSourceProvider {
+  parsed_source_cache: ParsedSourceCacheRc,
+  specifier: Url,
+  media_type: MediaType,
+  source: ArcStr,
+}
+
+impl ParsedSourceProvider for ParsedSourceCacheParsedSourceProvider {
+  fn specifier(&self) -> &Url {
+    &self.specifier
+  }
+  fn media_type(&self) -> MediaType {
+    self.media_type
+  }
+  fn source(&self) -> &ArcStr {
+    &self.source
+  }
+  fn into_source(self) -> ArcStr {
+    self.source
+  }
+  fn parsed_source(self) -> Result<ParsedSource, deno_ast::ParseDiagnostic> {
+    self.parsed_source_cache.get_matching_parsed_source(
+      &self.specifier,
+      self.media_type,
+      self.source.clone(),
+    )
+  }
+}
+
+impl ParsedSourceProvider for ParsedSource {
+  fn specifier(&self) -> &Url {
+    ParsedSource::specifier(self)
+  }
+  fn media_type(&self) -> MediaType {
+    ParsedSource::media_type(self)
+  }
+  fn source(&self) -> &ArcStr {
+    self.text()
+  }
+  fn into_source(self) -> ArcStr {
+    self.text().clone()
+  }
+  fn parsed_source(self) -> Result<ParsedSource, deno_ast::ParseDiagnostic> {
+    Ok(self)
   }
 }
 
@@ -410,18 +511,11 @@ impl<TInNpmPackageChecker: InNpmPackageChecker, TSys: EmitterSys>
 
 #[allow(clippy::result_large_err)]
 fn transpile(
-  parsed_source_cache: &ParsedSourceCache,
-  specifier: &Url,
-  media_type: MediaType,
+  parsed_source: ParsedSource,
   module_kind: deno_ast::ModuleKind,
-  source: ArcStr,
   transpile_options: &deno_ast::TranspileOptions,
   emit_options: &deno_ast::EmitOptions,
 ) -> Result<EmittedSourceText, EmitParsedSourceHelperError> {
-  // nothing else needs the parsed source at this point, so remove from
-  // the cache in order to not transpile owned
-  let parsed_source = parsed_source_cache
-    .remove_or_parse_module(specifier, source, media_type)?;
   ensure_no_import_assertion(&parsed_source)?;
   let transpile_result = parsed_source.transpile(
     transpile_options,

--- a/libs/resolver/factory.rs
+++ b/libs/resolver/factory.rs
@@ -197,7 +197,6 @@ pub struct NpmProcessStateOptions {
 #[derive(Debug, Default)]
 pub struct WorkspaceFactoryOptions {
   pub additional_config_file_names: &'static [&'static str],
-  pub compiler_options_overrides: CompilerOptionsOverrides,
   pub config_discovery: ConfigDiscoveryOption,
   pub is_package_manager_subcommand: bool,
   pub frozen_lockfile: Option<bool>,
@@ -661,6 +660,7 @@ impl<TSys: WorkspaceFactorySys> WorkspaceFactory<TSys> {
 
 #[derive(Default)]
 pub struct ResolverFactoryOptions {
+  pub compiler_options_overrides: CompilerOptionsOverrides,
   pub is_cjs_resolution_mode: IsCjsResolutionMode,
   pub node_analysis_cache: Option<NodeAnalysisCacheRc>,
   pub node_code_translator_mode: node_resolver::analyze::NodeCodeTranslatorMode,
@@ -847,7 +847,7 @@ impl<TSys: WorkspaceFactorySys> ResolverFactory<TSys> {
         self.workspace_factory.workspace_directory_provider()?,
         self.node_resolver()?,
         &self.workspace_factory.options.config_discovery,
-        &self.workspace_factory.options.compiler_options_overrides,
+        &self.options.compiler_options_overrides,
       )))
     })
   }


### PR DESCRIPTION
This is for the internal library code only. It has no affect on the Deno CLI.

I now have the loader working with deno-js-loader after these changes.