### PR TITLE
Revert "fix(ext/napi): ensure the finalizer callback will be called (…

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -111,11 +111,12 @@ impl Reference {
   fn set_weak(&mut self) {
     let reference = self as *mut Reference;
     if let ReferenceState::Strong(g) = &self.state {
-      let cb = Box::new(move || Reference::weak_callback(reference));
+      let cb = Box::new(move |_: &mut v8::Isolate| {
+        Reference::weak_callback(reference)
+      });
       let isolate = unsafe { (*self.env).isolate() };
-      self.state = ReferenceState::Weak(v8::Weak::with_guaranteed_finalizer(
-        isolate, g, cb,
-      ));
+      self.state =
+        ReferenceState::Weak(v8::Weak::with_finalizer(isolate, g, cb));
     }
   }
 


### PR DESCRIPTION
…#29710)"

This reverts commit 3c3af1011a582398e4e9cadf705f06b4e9cfa69b.

Going to revert this one, because there are multiple issues reported
that cause panics. We are working on a proper fix, but for the time
being it's better to revert.

Closes https://github.com/denoland/deno/issues/29832
Closes https://github.com/denoland/deno/issues/29874
Closes https://github.com/denoland/deno/issues/29911
Closes https://github.com/denoland/deno/issues/29866
Closes https://github.com/denoland/deno/issues/29973
Closes https://github.com/denoland/deno/issues/29978