### PR TITLE
fix: `global` global should be writeable

### DIFF
--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -145,11 +145,7 @@ const windowOrWorkerGlobalScope = {
   setImmediate: core.propWritable(setImmediate),
   clearImmediate: core.propWritable(clearImmediate),
   Buffer: core.propWritable(Buffer),
-  global: {
-    enumerable: true,
-    configurable: true,
-    get: () => globalThis,
-  },
+  global: core.propWritable(globalThis),
   reportError: core.propWritable(event.reportError),
   setInterval: core.propWritable(timers.setInterval),
   setTimeout: core.propWritable(timers.setTimeout),

--- a/tests/unit/globals_test.ts
+++ b/tests/unit/globals_test.ts
@@ -200,3 +200,11 @@ Deno.test(function mapGroupBy() {
     quantity: 5,
   }]);
 });
+
+// Regression test for https://github.com/denoland/deno/issues/30012
+Deno.test(function globalGlobalIsWritable() {
+  // @ts-ignore the typings here are wrong
+  globalThis.global = "can write to `global`";
+  // @ts-ignore the typings here are wrong
+  globalThis.global = globalThis;
+});


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/30012

Makes `global` global a writeable property.