### PR TITLE
chore(internal): fix source_map_base override not being applied

### DIFF
--- a/libs/resolver/deno_json.rs
+++ b/libs/resolver/deno_json.rs
@@ -1321,7 +1321,7 @@ fn compiler_options_to_transpile_and_emit_options(
     inline_sources: options.inline_sources,
     remove_comments: false,
     source_map,
-    source_map_base: None,
+    source_map_base: overrides.source_map_base.clone(),
     source_map_file: None,
   };
   let transpile_and_emit_options_hash = {


### PR DESCRIPTION
I went to integrate this into deno-js-loader and it looks like I forgot to include this line in the PR: https://github.com/denoland/deno/pull/29996/files#diff-f69eb36ab36f9eff8acf881762dbebe7480a97e41be5b0884012dd6835e1cb57R98