### PR TITLE
fix(node/fs): validate path parameters on link and linkSync

### DIFF
--- a/ext/node/polyfills/_fs/_fs_link.ts
+++ b/ext/node/polyfills/_fs/_fs_link.ts
@@ -1,50 +1,46 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
+import type { Buffer } from "node:buffer";
 import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
-import { pathFromURL } from "ext:deno_web/00_infra.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";
+import { primordials } from "ext:core/mod.js";
+import { getValidatedPathToString } from "ext:deno_node/internal/fs/utils.mjs";
+import * as pathModule from "node:path";
 
-/**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
- * are implemented. See https://github.com/denoland/deno/issues/3403
- */
+const { PromisePrototypeThen } = primordials;
+
 export function link(
-  existingPath: string | URL,
-  newPath: string | URL,
+  existingPath: string | Buffer | URL,
+  newPath: string | Buffer | URL,
   callback: CallbackWithError,
 ) {
-  existingPath = existingPath instanceof URL
-    ? pathFromURL(existingPath)
-    : existingPath;
-  newPath = newPath instanceof URL ? pathFromURL(newPath) : newPath;
+  existingPath = getValidatedPathToString(existingPath);
+  newPath = getValidatedPathToString(newPath);
 
-  Deno.link(existingPath, newPath).then(() => callback(null), callback);
+  PromisePrototypeThen(
+    Deno.link(
+      pathModule.toNamespacedPath(existingPath),
+      pathModule.toNamespacedPath(newPath),
+    ),
+    () => callback(null),
+    callback,
+  );
 }
 
-/**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
- * are implemented. See https://github.com/denoland/deno/issues/3403
- */
 export const linkPromise = promisify(link) as (
-  existingPath: string | URL,
-  newPath: string | URL,
+  existingPath: string | Buffer | URL,
+  newPath: string | Buffer | URL,
 ) => Promise<void>;
 
-/**
- * TODO: Also accept 'path' parameter as a Node polyfill Buffer type once these
- * are implemented. See https://github.com/denoland/deno/issues/3403
- */
 export function linkSync(
-  existingPath: string | URL,
-  newPath: string | URL,
+  existingPath: string | Buffer | URL,
+  newPath: string | Buffer | URL,
 ) {
-  existingPath = existingPath instanceof URL
-    ? pathFromURL(existingPath)
-    : existingPath;
-  newPath = newPath instanceof URL ? pathFromURL(newPath) : newPath;
+  existingPath = getValidatedPathToString(existingPath);
+  newPath = getValidatedPathToString(newPath);
 
-  Deno.linkSync(existingPath, newPath);
+  Deno.linkSync(
+    pathModule.toNamespacedPath(existingPath),
+    pathModule.toNamespacedPath(newPath),
+  );
 }

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -427,6 +427,7 @@
 "parallel/test-fs-exists.js" = {}
 "parallel/test-fs-existssync-false.js" = {}
 "parallel/test-fs-fchown.js" = {}
+"parallel/test-fs-link.js" = {}
 "parallel/test-fs-long-path.js" = {}
 "parallel/test-fs-promises-exists.js" = {}
 "parallel/test-fs-promises-readfile-empty.js" = {}


### PR DESCRIPTION
Changes in this PR:
- Validate the path parameters of `link` and `linkSync`. Implementation is based on [Node.js v23.9](https://github.com/nodejs/node/blob/9d2368f64329bf194c4e82b349e76fdad879d32a/lib/fs.js#L1898-L1933).
- Fix the `prefer-primordials` lint rule.

This changes allows [parallel/test-fs-link.js](https://github.com/denoland/node_test/blob/8846b5392f4ebd3d4e995b9bed61c23c0192d806/test/parallel/test-fs-link.js) to pass.

Towards #29972, #24236