### PR TITLE
chore: disallow usage of `clap::Arg::env` method

### DIFF
--- a/cli/clippy.toml
+++ b/cli/clippy.toml
@@ -1,6 +1,7 @@
 disallowed-methods = [
   { path = "reqwest::Client::new", reason = "create an HttpClient via an HttpClientProvider instead" },
   { path = "std::process::exit", reason = "use deno_runtime::exit instead" },
+  { path = "clap::Arg::env", reason = "ensure environment variables are resolved after loading the .env file instead" },
 ]
 disallowed-types = [
   { path = "reqwest::Client", reason = "use crate::http_util::HttpClient instead" },


### PR DESCRIPTION
<img width="859" height="221" alt="image" src="https://github.com/user-attachments/assets/3ad5905d-e200-4013-8c49-2d22b1401968" />

Part of https://github.com/denoland/deno/issues/29886