### PR TITLE
chore: add lint rule to prevent capital letter short flags

### DIFF
--- a/tools/lint.js
+++ b/tools/lint.js
@@ -13,6 +13,7 @@ import {
   ROOT_PATH,
   walk,
 } from "./util.js";
+import { assertEquals } from "@std/assert";
 import { checkCopyright } from "./copyright_checker.js";
 import * as ciFile from "../.github/workflows/ci.generate.ts";
 
@@ -27,13 +28,14 @@ if (!js && !rs) {
 
 if (rs) {
   promises.push(clippy());
+  promises.push(ensureNoNewITests());
+  promises.push(ensureNoNonPermissionCapitalLetterShortFlags());
 }
 
 if (js) {
   promises.push(dlint());
   promises.push(dlintPreferPrimordials());
   promises.push(ensureCiYmlUpToDate());
-  promises.push(ensureNoNewITests());
   promises.push(ensureNoUnusedOutFiles());
 
   if (rs) {
@@ -264,6 +266,45 @@ async function ensureNoNewITests() {
       );
     }
   }
+}
+
+/**
+ * When short permission flags were being proposed, a concern that was raised was that
+ * it would degrade the permission system by making the flags obscure. To address this
+ * concern, we decided to make uppercase short flags ONLY relate to permissions. That
+ * way if someone specifies something like `-E`, the user can scrutinize the command
+ * a bit more than if it were `-e`. This custom lint rule attempts to try to maintain
+ * this convention.
+ */
+async function ensureNoNonPermissionCapitalLetterShortFlags() {
+  const text = await Deno.readTextFile(join(ROOT_PATH, "cli/args/flags.rs"));
+  const shortFlags = text.matchAll(/\.short\('([A-Z])'\)/g);
+  const values = Array.from(shortFlags.map((flag) => flag[1])).sort();
+  // DO NOT update this list with a non-permission short flag without
+  // discussion--there needs to be precedence to add to this list.
+  const expected = [
+    // --allow-all
+    "A",
+    // --dev flag for `deno install` (precedence: `npm install -D <package>`)
+    "D",
+    // --allow-env
+    "E",
+    // --allow-import
+    "I",
+    // log level (precedence: legacy)
+    "L",
+    // --allow-net
+    "N",
+    // --allow-read
+    "R",
+    // --allow-sys
+    "S",
+    // version flag (precedence: legacy)
+    "V",
+    // --allow-write
+    "W",
+  ];
+  assertEquals(values, expected);
 }
 
 async function ensureNoUnusedOutFiles() {


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/29886 (assuming https://github.com/denoland/deno/pull/30067 is merged)