### PR TITLE
refactor(node_resolver): switch to use `bundle_mode`

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -702,6 +702,7 @@ impl DenoPluginHandler {
     graph_permit.commit();
     Ok(())
   }
+
   fn bundle_resolve(
     &self,
     path: &str,
@@ -757,7 +758,7 @@ impl DenoPluginHandler {
       Position::new(0, 0),
       ResolveWithGraphOptions {
         mode: import_kind_to_resolution_mode(kind),
-        kind: NodeResolutionKind::Bundling,
+        kind: NodeResolutionKind::Execution,
         maintain_npm_specifiers: false,
       },
     );

--- a/libs/node_resolver/errors.rs
+++ b/libs/node_resolver/errors.rs
@@ -310,7 +310,7 @@ impl PackageSubpathResolveErrorKind {
     )
   ).unwrap_or_default(),
   match resolution_kind {
-    NodeResolutionKind::Execution | NodeResolutionKind::Bundling => "",
+    NodeResolutionKind::Execution  => "",
     NodeResolutionKind::Types => " for types",
   }
 )]
@@ -937,9 +937,7 @@ impl std::fmt::Display for PackagePathNotExportedError {
     f.write_char(']')?;
 
     let types_msg = match self.resolution_kind {
-      NodeResolutionKind::Execution | NodeResolutionKind::Bundling => {
-        String::new()
-      }
+      NodeResolutionKind::Execution => String::new(),
       NodeResolutionKind::Types => " for types".to_string(),
     };
     if self.subpath == "." {

--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -171,7 +171,6 @@ impl ResolutionMode {
 pub enum NodeResolutionKind {
   Execution,
   Types,
-  Bundling,
 }
 
 impl NodeResolutionKind {
@@ -590,7 +589,7 @@ impl<
       _ => {
         if let Err(e) = maybe_file_type {
           if (resolution_mode == ResolutionMode::Require
-            || resolution_kind == NodeResolutionKind::Bundling)
+            || self.resolution_config.bundle_mode)
             && e.kind() == std::io::ErrorKind::NotFound
           {
             let file_with_ext = with_known_extension(&path, "js");

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -871,7 +871,6 @@ impl From<NodeResolutionKind> for ResolutionKind {
     match value {
       NodeResolutionKind::Execution => Self::Execution,
       NodeResolutionKind::Types => Self::Types,
-      NodeResolutionKind::Bundling => Self::Bundling,
     }
   }
 }


### PR DESCRIPTION
Removes `NodeResolutionKind::Bundling` and prefers checking `bundle_mode` instead.