### PR TITLE
ci: Exclude markdown files from triggering the ci workflow on every push

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -324,6 +324,7 @@ const ci = {
     push: {
       branches: ["main"],
       tags: ["*"],
+      "paths-ignore": ["**/*.md"],
     },
     pull_request: {
       types: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       - main
     tags:
       - '*'
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
### Change Summary
Currently, the `ci` workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱.

Fixes #30089.
