### PR TITLE
fix(ext/node): add process._rawDebug

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -6,6 +6,7 @@
 
 import { core, internals, primordials } from "ext:core/mod.js";
 import { initializeDebugEnv } from "ext:deno_node/internal/util/debuglog.ts";
+import { format } from "ext:deno_node/internal/util/inspect.mjs";
 import {
   op_getegid,
   op_geteuid,
@@ -643,6 +644,13 @@ process.exit = exit;
 
 /** https://nodejs.org/api/process.html#processabort */
 process.abort = abort;
+
+// NB(bartlomieju): this is a private API in Node.js, but there are packages like
+// `aws-iot-device-sdk-v2` that depend on it
+// https://github.com/denoland/deno/issues/30115
+process._rawDebug = (...args: unknown[]) => {
+  core.print(`${format(...args)}\n`, true);
+};
 
 // Undocumented Node API that is used by `signal-exit` which in turn
 // is used by `node-tap`. It was marked for removal a couple of years

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -945,6 +945,28 @@ Deno.test({
 });
 
 Deno.test({
+  name: "process._rawDebug",
+  async fn() {
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--quiet",
+        "./testdata/process_raw_debug.ts",
+      ],
+      cwd: testDir,
+    });
+    const { stdout, stderr } = await command.output();
+
+    assertEquals(stdout.length, 0);
+    const decoder = new TextDecoder();
+    assertEquals(
+      stripAnsiCode(decoder.decode(stderr).trim()),
+      "this should go to stderr { a: 1, b: [ 'a', 2 ] }",
+    );
+  },
+});
+
+Deno.test({
   name: "process.stdout isn't closed when source stream ended",
   async fn() {
     const source = Readable.from(["foo", "bar"]);

--- a/tests/unit_node/testdata/process_raw_debug.ts
+++ b/tests/unit_node/testdata/process_raw_debug.ts
@@ -1,0 +1,5 @@
+import process from "node:process";
+
+//deno-lint-ignore no-undef
+// @ts-ignore - this is a private API in Node, but some packages depend on it
+process._rawDebug("this should go to stderr", { a: 1, b: ["a", 2] });


### PR DESCRIPTION
Even though this is a "private" method in Node.js, it's actually
used in the wild, eg. `aws-iot-device-sdk-v2` uses it.

Closes https://github.com/denoland/deno/issues/30115