### PR TITLE
fix(lsp): improve renaming a file with bytes or text imports

### DIFF
--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1596,32 +1596,30 @@ impl DocumentModules {
         true => ResolutionMode::Require,
         false => ResolutionMode::Import,
       };
-      if raw_specifier.starts_with("asset:") {
+      let maybe_stripped =
+        crate::tsc::StrippedSpecifierWithRawImportKind::try_strip(
+          raw_specifier,
+        );
+      let raw_specifier = maybe_stripped
+        .as_ref()
+        .map(|s| &s.specifier)
+        .unwrap_or(raw_specifier);
+      let result = if raw_specifier.starts_with("asset:") {
         if let Ok(specifier) = resolve_url(raw_specifier) {
           let media_type = MediaType::from_specifier(&specifier);
-          results.push(Some((specifier, media_type)));
+          Some((specifier, media_type))
         } else {
-          results.push(None);
+          None
         }
       } else if let Some(dep) =
         dependencies.as_ref().and_then(|d| d.get(raw_specifier))
       {
         if let Some(specifier) = dep.maybe_type.maybe_specifier() {
-          results.push(self.resolve_dependency(
-            specifier,
-            referrer,
-            resolution_mode,
-            scope,
-          ));
+          self.resolve_dependency(specifier, referrer, resolution_mode, scope)
         } else if let Some(specifier) = dep.maybe_code.maybe_specifier() {
-          results.push(self.resolve_dependency(
-            specifier,
-            referrer,
-            resolution_mode,
-            scope,
-          ));
+          self.resolve_dependency(specifier, referrer, resolution_mode, scope)
         } else {
-          results.push(None);
+          None
         }
       } else {
         match scoped_resolver.as_cli_resolver().resolve(
@@ -1631,19 +1629,27 @@ impl DocumentModules {
           resolution_mode,
           NodeResolutionKind::Types,
         ) {
-          Ok(specifier) => {
-            results.push(self.resolve_dependency(
-              &specifier,
-              referrer,
-              resolution_mode,
-              scope,
-            ));
-          }
-          _ => {
-            results.push(None);
-          }
+          Ok(specifier) => self.resolve_dependency(
+            &specifier,
+            referrer,
+            resolution_mode,
+            scope,
+          ),
+          _ => None,
         }
-      }
+      };
+      let result = match maybe_stripped {
+        Some(stripped) => result.map(|(mut specifier, _media_type)| {
+          let mut fragment =
+            specifier.fragment().unwrap_or_default().to_string();
+          stripped.append_to_fragment(&mut fragment);
+          specifier.set_fragment(Some(&fragment));
+          (specifier, MediaType::TypeScript)
+        }),
+        None => result,
+      };
+
+      results.push(result);
     }
     results
   }

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1596,14 +1596,6 @@ impl DocumentModules {
         true => ResolutionMode::Require,
         false => ResolutionMode::Import,
       };
-      let maybe_stripped =
-        crate::tsc::StrippedSpecifierWithRawImportKind::try_strip(
-          raw_specifier,
-        );
-      let raw_specifier = maybe_stripped
-        .as_ref()
-        .map(|s| &s.specifier)
-        .unwrap_or(raw_specifier);
       let result = if raw_specifier.starts_with("asset:") {
         if let Ok(specifier) = resolve_url(raw_specifier) {
           let media_type = MediaType::from_specifier(&specifier);
@@ -1638,17 +1630,6 @@ impl DocumentModules {
           _ => None,
         }
       };
-      let result = match maybe_stripped {
-        Some(stripped) => result.map(|(mut specifier, _media_type)| {
-          let mut fragment =
-            specifier.fragment().unwrap_or_default().to_string();
-          stripped.append_to_fragment(&mut fragment);
-          specifier.set_fragment(Some(&fragment));
-          (specifier, MediaType::TypeScript)
-        }),
-        None => result,
-      };
-
       results.push(result);
     }
     results

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2790,7 +2790,8 @@ impl FileTextChanges {
     &mut self,
     specifier_map: &TscSpecifierMap,
   ) -> Result<(), AnyError> {
-    self.file_name = specifier_map.normalize(&self.file_name)?.to_string();
+    let url = specifier_map.normalize(&self.file_name)?;
+    self.file_name = url.to_string();
     Ok(())
   }
 
@@ -4569,7 +4570,7 @@ impl TscSpecifierMap {
     }
     // If the module's media type doesn't correspond to tsc's path-inferred
     // media type, force it to be the same by appending an extension.
-    if MediaType::from_path(Path::new(specifier.as_str())) != media_type {
+    if MediaType::from_path(Path::new(&specifier)) != media_type {
       specifier += media_type.as_ts_extension();
     }
     if specifier != original.as_str() {
@@ -4733,26 +4734,38 @@ fn op_load<'s>(
     .performance
     .mark_with_args("tsc.op.op_load", specifier);
   let specifier = state.specifier_map.normalize(specifier)?;
-  let module = if specifier.as_str() == MISSING_DEPENDENCY_SPECIFIER {
-    None
-  } else {
-    state.get_module(&specifier)
-  };
-  let maybe_load_response = module.as_ref().map(|m| {
-    let data = if m.media_type == MediaType::Json && m.text.len() > 10_000_000 {
-      // VSCode's TS server types large JSON files this way.
-      DocumentText::Static("{}\n")
+  let maybe_load_response =
+    if let Some(source) = crate::tsc::load_raw_import_source(&specifier) {
+      Some(LoadResponse {
+        data: DocumentText::Static(source),
+        script_kind: crate::tsc::as_ts_script_kind(MediaType::TypeScript),
+        version: Some("1".to_string()),
+        is_cjs: false,
+        is_classic_script: false,
+      })
     } else {
-      m.text.clone()
+      let module = if specifier.as_str() == MISSING_DEPENDENCY_SPECIFIER {
+        None
+      } else {
+        state.get_module(&specifier)
+      };
+      module.as_ref().map(|m| {
+        let data =
+          if m.media_type == MediaType::Json && m.text.len() > 10_000_000 {
+            // VSCode's TS server types large JSON files this way.
+            DocumentText::Static("{}\n")
+          } else {
+            m.text.clone()
+          };
+        LoadResponse {
+          data,
+          script_kind: crate::tsc::as_ts_script_kind(m.media_type),
+          version: state.script_version(&specifier),
+          is_cjs: m.resolution_mode == ResolutionMode::Require,
+          is_classic_script: m.notebook_uri.is_some(),
+        }
+      })
     };
-    LoadResponse {
-      data,
-      script_kind: crate::tsc::as_ts_script_kind(m.media_type),
-      version: state.script_version(&specifier),
-      is_cjs: m.resolution_mode == ResolutionMode::Require,
-      is_classic_script: m.notebook_uri.is_some(),
-    }
-  });
   let serialized = serde_v8::to_v8(scope, maybe_load_response)?;
   state.performance.measure(mark);
   Ok(serialized)

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2790,8 +2790,7 @@ impl FileTextChanges {
     &mut self,
     specifier_map: &TscSpecifierMap,
   ) -> Result<(), AnyError> {
-    let url = specifier_map.normalize(&self.file_name)?;
-    self.file_name = url.to_string();
+    self.file_name = specifier_map.normalize(&self.file_name)?.to_string();
     Ok(())
   }
 

--- a/cli/tsc/97_ts_host.js
+++ b/cli/tsc/97_ts_host.js
@@ -603,19 +603,19 @@ const hostImpl = {
       if (rawKind != null) {
         // hack to get the specifier keyed differently until
         // https://github.com/microsoft/TypeScript/issues/61941 is resolved
-        if (!literal.text.includes("?")) {
-          literal.text += `?${rawKind}`;
+        const fragmentIndex = literal.text.indexOf("#");
+        if (fragmentIndex === -1) {
+          literal.text += `#denoRawImport=${rawKind}`;
         } else if (
-          !literal.text.includes(`?${rawKind}`) &&
-          !literal.text.includes(`&${rawKind}`)
+          !literal.text.substring(fragmentIndex).includes(
+            `denoRawImport=${rawKind}`,
+          )
         ) {
-          literal.text += `&${rawKind}`;
+          literal.text += `&denoRawImport=${rawKind}`;
         }
         return [
           false,
-          rawKind === "text"
-            ? "asset:///text_import.d.ts"
-            : "asset:///bytes_import.d.ts",
+          literal.text,
         ];
       }
       return [

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -838,7 +838,7 @@ pub fn load_raw_import_source(specifier: &Url) -> Option<&'static str> {
   Some(source)
 }
 
-pub enum RawImportKind {
+enum RawImportKind {
   Bytes,
   Text,
 }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -828,7 +828,7 @@ fn op_load_inner(
 }
 
 pub fn load_raw_import_source(specifier: &Url) -> Option<&'static str> {
-  let raw_import = get_specifier_raw_import(&specifier)?;
+  let raw_import = get_specifier_raw_import(specifier)?;
   let source = match raw_import {
     RawImportKind::Bytes => {
       "const data: Uint8Array<ArrayBuffer>;\nexport default data;\n"

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -311,24 +311,6 @@ pub static LAZILY_LOADED_STATIC_ASSETS: Lazy<
         ),
       },
     ),
-    (
-      "text_import.d.ts",
-      StaticAsset {
-        is_lib: false,
-        source: StaticAssetSource::Uncompressed(
-          "export const data: string;\nexport default data;\n",
-        ),
-      },
-    ),
-    (
-      "bytes_import.d.ts",
-      StaticAsset {
-        is_lib: false,
-        source: StaticAssetSource::Uncompressed(
-          "const data: Uint8Array<ArrayBuffer>;\nexport default data;\n",
-        ),
-      },
-    ),
   ])
 });
 
@@ -740,6 +722,13 @@ fn op_load_inner(
     hash = get_maybe_hash(maybe_source, state.hash_data);
     media_type = MediaType::from_str(load_specifier);
     maybe_source.map(FastString::from_static)
+  } else if let Some(source) = load_raw_import_source(&specifier) {
+    return Ok(Some(LoadResponse {
+      data: FastString::from_static(source),
+      version: Some("1".to_string()),
+      script_kind: as_ts_script_kind(MediaType::TypeScript),
+      is_cjs: false,
+    }));
   } else {
     let specifier = if let Some(remapped_specifier) =
       state.maybe_remapped_specifier(load_specifier)
@@ -836,6 +825,130 @@ fn op_load_inner(
     script_kind: as_ts_script_kind(media_type),
     is_cjs,
   }))
+}
+
+pub fn load_raw_import_source(specifier: &Url) -> Option<&'static str> {
+  let raw_import = get_specifier_raw_import(&specifier)?;
+  let source = match raw_import {
+    RawImportKind::Bytes => {
+      "const data: Uint8Array<ArrayBuffer>;\nexport default data;\n"
+    }
+    RawImportKind::Text => "export const data: string;\nexport default data;\n",
+  };
+  Some(source)
+}
+
+pub enum RawImportKind {
+  Bytes,
+  Text,
+}
+
+impl RawImportKind {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      RawImportKind::Bytes => "bytes",
+      RawImportKind::Text => "text",
+    }
+  }
+}
+
+pub struct StrippedSpecifierWithRawImportKind {
+  pub kind: RawImportKind,
+  pub specifier: String,
+}
+
+impl StrippedSpecifierWithRawImportKind {
+  pub fn try_strip(text: &str) -> Option<Self> {
+    let hash_idx = text.find('#')?;
+    let fragment = &text[hash_idx + 1..];
+
+    let key = "denoRawImport=";
+    let idx = fragment.find(key)?;
+
+    // must be preceded by '&' or be at start of fragment
+    if idx > 0 {
+      let prev = fragment.as_bytes()[idx - 1];
+      if prev != b'&' {
+        return None;
+      }
+    }
+
+    let value_start = idx + key.len();
+    let value = &fragment[value_start..];
+
+    let (kind, value_len) = if value.starts_with("bytes") {
+      (RawImportKind::Bytes, 5)
+    } else if value.starts_with("text") {
+      (RawImportKind::Text, 4)
+    } else {
+      return None;
+    };
+
+    // must be end of fragment or followed by '&'
+    if value.len() > value_len && !value[value_len..].starts_with('&') {
+      return None;
+    }
+
+    let mut new = String::with_capacity(text.len());
+    let start = if idx > 0 && &fragment[idx - 1..idx] == "&" {
+      idx - 1
+    } else {
+      idx
+    };
+    let end = value_start + value_len;
+
+    new.push_str(&text[..hash_idx]);
+    if fragment.len() > 0 {
+      let before = &fragment[..start];
+      let after =
+        &fragment[end + (fragment[end..].starts_with('&') as usize)..];
+
+      if !before.is_empty() || !after.is_empty() {
+        new.push('#');
+        if !before.is_empty() {
+          new.push_str(before);
+          if !after.is_empty() {
+            new.push('&');
+          }
+        }
+        if !after.is_empty() {
+          new.push_str(after);
+        }
+      }
+    }
+
+    Some(StrippedSpecifierWithRawImportKind {
+      kind,
+      specifier: new,
+    })
+  }
+
+  pub fn append_to_fragment(&self, specifier_str: &mut String) {
+    specifier_str.push_str("denoRawImport=");
+    specifier_str.push_str(self.kind.as_str());
+    specifier_str.push_str(".ts");
+  }
+}
+
+/// We store the raw import kind in the fragment of the Url
+/// like `#denoRawImport=text`. This is necessary because
+/// TypeScript can't handle different modules at the same
+/// specifier.
+fn get_specifier_raw_import(specifier: &Url) -> Option<RawImportKind> {
+  // this is purposefully relaxed about matching in order to keep the
+  // code less complex. If someone is doing something to cause this to
+  // incorrectly match then they most likely deserve the bug they sought.
+  let fragment = specifier.fragment()?;
+  let key_text = "denoRawImport=";
+  let raw_import_index = fragment.find(key_text)?;
+  let remaining = &fragment[raw_import_index + key_text.len()..];
+  if remaining.starts_with("text") {
+    Some(RawImportKind::Text)
+  } else if remaining.starts_with("bytes") {
+    Some(RawImportKind::Bytes)
+  } else {
+    None
+  }
 }
 
 #[derive(Debug, Error, deno_error::JsError)]
@@ -940,12 +1053,18 @@ fn op_resolve_inner(
       resolved.push((specifier, Some(ext)));
       continue;
     }
+    let maybe_stripped =
+      StrippedSpecifierWithRawImportKind::try_strip(&specifier);
+    let specifier = maybe_stripped
+      .as_ref()
+      .map(|s| &s.specifier)
+      .unwrap_or(&specifier);
 
     let resolved_dep = referrer_module
       .and_then(|m| match m {
-        Module::Js(m) => m.dependencies_prefer_fast_check().get(&specifier),
+        Module::Js(m) => m.dependencies_prefer_fast_check().get(specifier),
         Module::Json(_) => None,
-        Module::Wasm(m) => m.dependencies.get(&specifier),
+        Module::Wasm(m) => m.dependencies.get(specifier),
         Module::Npm(_) | Module::Node(_) | Module::External(_) => None,
       })
       .and_then(|d| d.maybe_type.ok().or_else(|| d.maybe_code.ok()));
@@ -993,7 +1112,7 @@ fn op_resolve_inner(
     };
     let result = match maybe_result {
       Some((specifier, media_type)) => {
-        let specifier_str = match specifier.scheme() {
+        let mut specifier_str = match specifier.scheme() {
           "data" | "blob" => {
             let specifier_str = hash_url(&specifier, media_type);
             state
@@ -1014,12 +1133,24 @@ fn op_resolve_inner(
             }
           }
         };
+        if let Some(stripped) = &maybe_stripped {
+          specifier_str.push(if specifier_str.contains('#') {
+            '&'
+          } else {
+            '#'
+          });
+          stripped.append_to_fragment(&mut specifier_str);
+        }
+
         (
           specifier_str,
-          match media_type {
-            MediaType::Css => Some(".js"), // surface these as .js for typescript
-            MediaType::Unknown => None,
-            media_type => Some(media_type.as_ts_extension()),
+          match maybe_stripped.is_some() {
+            true => Some(".ts"),
+            false => match media_type {
+              MediaType::Css => Some(".js"), // surface these as .js for typescript
+              MediaType::Unknown => None,
+              media_type => Some(media_type.as_ts_extension()),
+            },
           },
         )
       }

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -966,6 +966,7 @@ fn op_resolve_inner(
       resolved.push((specifier, Some(ext)));
       continue;
     }
+
     let resolved_dep = referrer_module
       .and_then(|m| match m {
         Module::Js(m) => m.dependencies_prefer_fast_check().get(&specifier),
@@ -1039,7 +1040,6 @@ fn op_resolve_inner(
             }
           }
         };
-
         (
           specifier_str,
           match media_type {


### PR DESCRIPTION
Also actually goes to the file now when doing "go to definition" on the specifier.