### PR TITLE
chore: update deno_tunnel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tunnel"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d54bc70cc874c19c3703d3b3b7d5fe709cbf98ff0aa7e9298825bf0e7c6f74"
+checksum = "ebd372577d6c2f4f5906c495ef6fee4119a0891c3848b13ef4db6af07505c8c3"
 dependencies = [
  "pin-project",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ napi_sym = { version = "0.141.0", path = "./ext/napi/sym" }
 node_resolver = { version = "0.49.0", path = "./libs/node_resolver" }
 test_util = { package = "test_server", path = "./tests/util/server" }
 
-deno_tunnel = "0.2.0"
+deno_tunnel = "0.4.0"
 
 # widely used libraries
 anyhow = "1.0.57"

--- a/ext/net/tunnel.rs
+++ b/ext/net/tunnel.rs
@@ -36,9 +36,13 @@ pub fn set_tunnel(tunnel: TunnelConnection) {
 
 fn before_exit() {
   if let Some(tunnel) = get_tunnel() {
+    log::trace!("deno_net::tunnel::before_exit >");
+
     // stay alive long enough to actually send the close frame, since
     // we can't rely on the linux kernel to close this like with tcp.
     deno_core::futures::executor::block_on(tunnel.close(1u32, b""));
+
+    log::trace!("deno_net::tunnel::before_exit <");
   }
 }
 

--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -927,26 +927,32 @@ pub fn init(
     })
     .map_err(|_| deno_core::anyhow::anyhow!("failed to set otel globals"))?;
 
-  deno_signals::before_exit(flush);
+  deno_signals::before_exit(before_exit);
 
   Ok(())
 }
 
-/// This function is called by the runtime whenever it is about to call
-/// `process::exit()`, to ensure that all OpenTelemetry logs are properly
-/// flushed before the process terminates.
-pub fn flush() {
-  if let Some(OtelGlobals {
+fn before_exit() {
+  let Some(OtelGlobals {
     span_processor: spans,
     log_processor: logs,
     meter_provider,
     ..
   }) = OTEL_GLOBALS.get()
-  {
-    let _ = spans.force_flush();
-    let _ = logs.force_flush();
-    let _ = meter_provider.force_flush();
-  }
+  else {
+    return;
+  };
+
+  log::trace!("deno_telemetry::before_exit");
+
+  let r = spans.shutdown();
+  log::trace!("spans={:?}", r);
+
+  let r = logs.shutdown();
+  log::trace!("logs={:?}", r);
+
+  let r = meter_provider.shutdown();
+  log::trace!("meters={:?}", r);
 }
 
 pub fn handle_log(record: &log::Record) {


### PR DESCRIPTION
tunnels now automatically reconnect and migrate. also use `shutdown` in telemetry instead of `flush` because it times out after 5s, which is important if the tunnel connection is hanged for some reason.