### PR TITLE
test: add ability to mark Node compat tests as flaky

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -132,7 +132,7 @@
 "parallel/test-buffer-zero-fill-cli.js" = {}
 "parallel/test-buffer-zero-fill-reset.js" = {}
 "parallel/test-buffer-zero-fill.js" = {}
-"parallel/test-child-process-can-write-to-stdout.js" = {}
+"parallel/test-child-process-can-write-to-stdout.js" = { flaky = true }
 "parallel/test-child-process-default-options.js" = {}
 "parallel/test-child-process-detached.js" = {}
 "parallel/test-child-process-disconnect.js" = {}

--- a/tests/node_compat/test.ts
+++ b/tests/node_compat/test.ts
@@ -6,9 +6,10 @@ import { assert } from "@std/assert";
 import { partition } from "@std/collections/partition";
 import { pooledMap } from "@std/async/pool";
 
-// This is a placeholder for the future extension of the config file.
-// deno-lint-ignore ban-types
-type SingleFileConfig = {};
+interface SingleFileConfig {
+  flaky?: boolean;
+}
+
 type Config = {
   tests: Record<string, SingleFileConfig>;
 };
@@ -22,8 +23,8 @@ const [sequentialTests, parallelTests] = partition(
   ([testName]) => testName.startsWith("sequential/"),
 );
 
-async function run(name: string) {
-  const result = await runSingle(name);
+async function run(name: string, testConfig: SingleFileConfig) {
+  const result = await runSingle(name, testConfig);
   let msg = "";
   const error = result.error;
   if (error && "message" in error) {
@@ -36,9 +37,9 @@ async function run(name: string) {
   assert(result.result === "pass", `Test "${name}" failed: ${msg}`);
 }
 
-for (const [name, _testConfig] of sequentialTests) {
+for (const [name, testConfig] of sequentialTests) {
   Deno.test("Node compat: " + name, async () => {
-    await run(name);
+    await run(name, testConfig);
   });
 }
 
@@ -46,10 +47,10 @@ Deno.test("Node compat: parallel tests", async (t) => {
   const iter = pooledMap(
     navigator.hardwareConcurrency,
     parallelTests,
-    ([name, _testConfig]) =>
+    ([name, testConfig]) =>
       t.step({
         name,
-        fn: () => run(name),
+        fn: () => run(name, testConfig),
         sanitizeExit: false,
         sanitizeOps: false,
         sanitizeResources: false,


### PR DESCRIPTION
This commit updates test harness for Node.js compat tests to
allow marking certain tests as flaky. 

This is done by adding `flaky = true` to dict entries in
the `tests/node_compat/config.toml` file.
