### PR TITLE
fix: do not panic deserializing config with invalid number value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5345,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "jsonc-parser"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b558af6b49fd918e970471374e7a798b2c9bbcda624a210ffa3901ee5614bc8e"
+checksum = "1d6d80e6d70e7911a29f3cf3f44f452df85d06f73572b494ca99a2cad3fcf8f4"
 dependencies = [
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ indexmap = { version = "2", features = ["serde"] }
 ipnet = "2.3"
 ipnetwork = "0.20.0"
 itertools = "0.14"
-jsonc-parser = { version = "=0.26.2", features = ["serde"] }
+jsonc-parser = { version = "0.26.3", features = ["serde"] }
 jupyter_runtime = "=0.19.0"
 lazy-regex = "3"
 libc = "0.2.168"


### PR DESCRIPTION
* https://github.com/dprint/jsonc-parser/pull/51

Closes https://github.com/denoland/deno/issues/30168