### PR TITLE
fix(check): ensure module not found errors are surfaced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "deno_doc"
-version = "0.179.0"
+version = "0.180.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15013f500ab72ef8512a5d86eb62253707daad4206fcb958dfa4e4f952f199e0"
+checksum = "9ea005c349842626affe06bca10f6acd9dbc894e7f4d612198f61add73600a8d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2108,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.96.2"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733ed99295ebeddeb0fb33efa41ccd47ccd9481ab1ebe01f2ea8af80204479e"
+checksum = "b88a268f9359a3e35446bde86e77e4264faaffa33a27cbab39c0279d7579b314"
 dependencies = [
  "async-trait",
  "boxed_error",
@@ -3805,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "eszip"
-version = "0.93.0"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404b07854be8333e4827b3cb3055c36ba385c7dafb4e27b8da1a0d078857723b"
+checksum = "2d5887e6e05eca3d113b6d5a568054c216c522802b3d87167b881e51cead6d9f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,9 @@ deno_ast = { version = "=0.48.2", features = ["transpiling"] }
 deno_core = { version = "0.353.0" }
 
 deno_cache_dir = "=0.23.0"
-deno_doc = "=0.179.0"
+deno_doc = "=0.180.0"
 deno_error = "=0.6.1"
-deno_graph = { version = "=0.96.2", default-features = false }
+deno_graph = { version = "=0.97.0", default-features = false }
 deno_lint = "=0.76.0"
 deno_lockfile = "=0.30.2"
 deno_media_type = { version = "=0.2.9", features = ["module_specifier"] }
@@ -77,7 +77,7 @@ deno_task_shell = "=0.25.2"
 deno_terminal = "=0.2.2"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-eszip = "=0.93.0"
+eszip = "=0.94.0"
 
 denokv_proto = "0.11.0"
 denokv_remote = "0.11.0"

--- a/cli/lib/util/result.rs
+++ b/cli/lib/util/result.rs
@@ -6,6 +6,8 @@ use std::fmt::Display;
 
 use deno_error::JsErrorBox;
 use deno_error::JsErrorClass;
+use deno_resolver::DenoResolveError;
+use deno_resolver::DenoResolveErrorKind;
 use deno_runtime::deno_core::error::AnyError;
 use deno_runtime::deno_core::error::CoreError;
 use deno_runtime::deno_core::error::CoreErrorKind;
@@ -56,4 +58,14 @@ pub fn any_and_jserrorbox_downcast_ref<
           _ => None,
         })
     })
+}
+
+pub fn downcast_ref_deno_resolve_error(
+  err: &JsErrorBox,
+) -> Option<&DenoResolveErrorKind> {
+  err
+    .as_any()
+    .downcast_ref::<DenoResolveError>()
+    .map(|e| e.as_kind())
+    .or_else(|| err.as_any().downcast_ref::<DenoResolveErrorKind>())
 }

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1429,18 +1429,7 @@ impl DenoDiagnostic {
         (lsp::DiagnosticSeverity::ERROR, no_local_message(specifier, sloppy_resolution.as_ref().map(|(resolved, sloppy_reason)| sloppy_reason.suggestion_message_for_specifier(resolved))), data)
       },
       Self::ResolutionError(err) => {
-        let mut message;
-        message = enhanced_resolution_error_message(err);
-        if let deno_graph::ResolutionError::ResolverError {error, ..} = err{
-          if let ResolveError::ImportMap(importmap) = (*error).as_ref() {
-            if let ImportMapErrorKind::UnmappedBareSpecifier(specifier, _) = &**importmap {
-              if specifier.chars().next().unwrap_or('\0') == '@'{
-                let hint = format!("\nHint: Use [deno add {}] to add the dependency.", specifier);
-                message.push_str(hint.as_str());
-              }
-            }
-          }
-        }
+        let message = enhanced_resolution_error_message(err);
         (
         lsp::DiagnosticSeverity::ERROR,
         message,

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::thread;
 
+use console_static_text::ansi::strip_ansi_codes;
 use deno_ast::MediaType;
 use deno_core::ModuleSpecifier;
 use deno_core::anyhow::anyhow;
@@ -1429,7 +1430,7 @@ impl DenoDiagnostic {
         (lsp::DiagnosticSeverity::ERROR, no_local_message(specifier, sloppy_resolution.as_ref().map(|(resolved, sloppy_reason)| sloppy_reason.suggestion_message_for_specifier(resolved))), data)
       },
       Self::ResolutionError(err) => {
-        let message = enhanced_resolution_error_message(err);
+        let message = strip_ansi_codes(&enhanced_resolution_error_message(err)).into_owned();
         (
         lsp::DiagnosticSeverity::ERROR,
         message,

--- a/cli/lsp/diagnostics.rs
+++ b/cli/lsp/diagnostics.rs
@@ -1438,7 +1438,7 @@ impl DenoDiagnostic {
           .map(|specifier| json!({ "specifier": specifier }))
       )},
       Self::UnknownNodeSpecifier(specifier) => (lsp::DiagnosticSeverity::ERROR, format!("No such built-in module: node:{}", specifier.path()), None),
-      Self::BareNodeSpecifier(specifier) => (lsp::DiagnosticSeverity::WARNING, format!("\"{}\" is resolved to \"node:{}\". If you want to use a built-in Node module, add a \"node:\" prefix.", specifier, specifier), Some(json!({ "specifier": specifier }))),
+      Self::BareNodeSpecifier(specifier) => (lsp::DiagnosticSeverity::WARNING, format!("\"{0}\" is resolved to \"node:{0}\". If you want to use a built-in Node module, add a \"node:\" prefix.", specifier), Some(json!({ "specifier": specifier }))),
     };
     lsp::Diagnostic {
       range: *range,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -25,6 +25,7 @@ use deno_core::serde_json::json;
 use deno_core::unsync::spawn;
 use deno_core::url;
 use deno_core::url::Url;
+use deno_graph::CheckJsOption;
 use deno_graph::GraphKind;
 use deno_graph::Resolution;
 use deno_lib::args::CaData;
@@ -101,6 +102,7 @@ use crate::args::UnstableFmtOptions;
 use crate::factory::CliFactory;
 use crate::file_fetcher::CreateCliFileFetcherOptions;
 use crate::file_fetcher::create_cli_file_fetcher;
+use crate::graph_util;
 use crate::http_util::HttpClientProvider;
 use crate::lsp::compiler_options::LspCompilerOptionsResolver;
 use crate::lsp::config::ConfigWatchedFileType;
@@ -350,7 +352,7 @@ impl LanguageServer {
           NpmCachingStrategy::Eager,
         )
         .await?;
-      crate::graph_util::graph_valid(
+      graph_util::graph_valid(
         &graph,
         &CliSys::default(),
         &roots,

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -342,7 +342,7 @@ impl LanguageServer {
         inner_loader: &mut inner_loader,
         open_modules: &open_modules,
       };
-      let _graph = module_graph_creator
+      let graph = module_graph_creator
         .create_graph_with_loader(
           GraphKind::All,
           roots.clone(),
@@ -350,6 +350,18 @@ impl LanguageServer {
           NpmCachingStrategy::Eager,
         )
         .await?;
+      crate::graph_util::graph_valid(
+        &graph,
+        &CliSys::default(),
+        &roots,
+        graph_util::GraphValidOptions {
+          kind: GraphKind::All,
+          check_js: CheckJsOption::False,
+          exit_integrity_errors: false,
+          allow_unknown_media_types: true,
+          allow_unknown_jsr_exports: false,
+        },
+      )?;
 
       // Update the lockfile on the file system with anything new
       // found after caching

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -25,7 +25,6 @@ use deno_core::serde_json::json;
 use deno_core::unsync::spawn;
 use deno_core::url;
 use deno_core::url::Url;
-use deno_graph::CheckJsOption;
 use deno_graph::GraphKind;
 use deno_graph::Resolution;
 use deno_lib::args::CaData;
@@ -102,7 +101,6 @@ use crate::args::UnstableFmtOptions;
 use crate::factory::CliFactory;
 use crate::file_fetcher::CreateCliFileFetcherOptions;
 use crate::file_fetcher::create_cli_file_fetcher;
-use crate::graph_util;
 use crate::http_util::HttpClientProvider;
 use crate::lsp::compiler_options::LspCompilerOptionsResolver;
 use crate::lsp::config::ConfigWatchedFileType;
@@ -344,7 +342,7 @@ impl LanguageServer {
         inner_loader: &mut inner_loader,
         open_modules: &open_modules,
       };
-      let graph = module_graph_creator
+      let _graph = module_graph_creator
         .create_graph_with_loader(
           GraphKind::All,
           roots.clone(),
@@ -352,19 +350,6 @@ impl LanguageServer {
           NpmCachingStrategy::Eager,
         )
         .await?;
-      graph_util::graph_valid(
-        &graph,
-        &CliSys::default(),
-        &roots,
-        graph_util::GraphValidOptions {
-          kind: GraphKind::All,
-          check_js: CheckJsOption::False,
-          exit_integrity_errors: false,
-          allow_unknown_media_types: true,
-          ignore_graph_errors: true,
-          allow_unknown_jsr_exports: false,
-        },
-      )?;
 
       // Update the lockfile on the file system with anything new
       // found after caching

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -157,7 +157,6 @@ pub async fn doc(
           check_js: CheckJsOption::False,
           kind: GraphKind::TypesOnly,
           allow_unknown_media_types: false,
-          ignore_graph_errors: true,
           allow_unknown_jsr_exports: false,
         },
       );

--- a/libs/resolver/graph.rs
+++ b/libs/resolver/graph.rs
@@ -19,6 +19,7 @@ use deno_semver::npm::NpmPackageNvReference;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_semver::package::PackageReq;
 use deno_unsync::sync::AtomicFlag;
+use import_map::ImportMapErrorKind;
 use node_resolver::DenoIsBuiltInNodeModuleChecker;
 use node_resolver::InNpmPackageChecker;
 use node_resolver::IsBuiltInNodeModuleChecker;
@@ -783,7 +784,15 @@ fn get_import_prefix_missing_error(error: &ResolutionError) -> Option<&str> {
             maybe_specifier = Some(specifier);
           }
         }
-        ResolveError::ImportMap(_) => {}
+        ResolveError::ImportMap(import_map_err) => {
+          if let ImportMapErrorKind::UnmappedBareSpecifier(
+            specifier,
+            _referrer,
+          ) = import_map_err.as_kind()
+          {
+            maybe_specifier = Some(specifier);
+          }
+        }
       }
     }
   }

--- a/libs/resolver/lib.rs
+++ b/libs/resolver/lib.rs
@@ -22,6 +22,7 @@ use node_resolver::NodeResolverRc;
 use node_resolver::NpmPackageFolderResolver;
 use node_resolver::ResolutionMode;
 use node_resolver::UrlOrPath;
+use node_resolver::errors::NodeJsErrorCode;
 use node_resolver::errors::NodeResolveError;
 use node_resolver::errors::NodeResolveErrorKind;
 use node_resolver::errors::PackageResolveErrorKind;
@@ -164,6 +165,27 @@ pub enum DenoResolveErrorKind {
   #[class(inherit)]
   #[error(transparent)]
   WorkspaceResolvePkgJsonFolder(#[from] WorkspaceResolvePkgJsonFolderError),
+}
+
+impl DenoResolveErrorKind {
+  pub fn maybe_node_code(&self) -> Option<NodeJsErrorCode> {
+    match self {
+      DenoResolveErrorKind::InvalidVendorFolderImport
+      | DenoResolveErrorKind::UnsupportedPackageJsonFileSpecifier
+      | DenoResolveErrorKind::UnsupportedPackageJsonJsrReq
+      | DenoResolveErrorKind::MappedResolution { .. }
+      | DenoResolveErrorKind::NodeModulesOutOfDate { .. }
+      | DenoResolveErrorKind::PackageJsonDepValueParse { .. }
+      | DenoResolveErrorKind::PackageJsonDepValueUrlParse { .. }
+      | DenoResolveErrorKind::PathToUrl { .. }
+      | DenoResolveErrorKind::ResolvePkgFolderFromDenoReq { .. }
+      | DenoResolveErrorKind::WorkspaceResolvePkgJsonFolder { .. } => None,
+      DenoResolveErrorKind::ResolveNpmReqRef(err) => {
+        err.err.as_kind().maybe_code()
+      }
+      DenoResolveErrorKind::Node(err) => err.as_kind().maybe_code(),
+    }
+  }
 }
 
 #[derive(Debug)]

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -10745,7 +10745,7 @@ fn lsp_completions_node_builtin() {
           "severity": 1,
           "code": "import-node-prefix-missing",
           "source": "deno",
-          "message": "Relative import path \"fs\" not prefixed with / or ./ or ../\n  \u{1b}[0m\u{1b}[36mhint:\u{1b}[0m If you want to use a built-in Node module, add a \"node:\" prefix (ex. \"node:fs\").",
+          "message": "Relative import path \"fs\" not prefixed with / or ./ or ../\n  hint: If you want to use a built-in Node module, add a \"node:\" prefix (ex. \"node:fs\").",
           "data": {
             "specifier": "fs"
           },

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -231,7 +231,7 @@ fn unadded_dependency_message_with_import_map() {
   let mut expected_lsp_messages = Vec::from([
     "`x` is never used\nIf this is intentional, prefix it with an underscore like `_x`",
     "'x' is declared but its value is never read.",
-    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \" Hint: Use [deno add @std/fs] to add the dependency.",
+    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \" hint: If you want to use a JSR package, try running `deno add jsr:@std/fs`",
   ]);
   expected_lsp_messages.sort();
   let all_diagnostics = diagnostics.all();
@@ -294,7 +294,7 @@ fn unadded_dependency_message() {
   let mut expected_lsp_messages = Vec::from([
     "`x` is never used\nIf this is intentional, prefix it with an underscore like `_x`",
     "'x' is declared but its value is never read.",
-    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \" Hint: Use [deno add @std/fs] to add the dependency.",
+    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \" hint: If you want to use a JSR package, try running `deno add jsr:@std/fs`",
   ]);
   expected_lsp_messages.sort();
   let all_diagnostics = diagnostics.all();

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -231,7 +231,7 @@ fn unadded_dependency_message_with_import_map() {
   let mut expected_lsp_messages = Vec::from([
     "`x` is never used\nIf this is intentional, prefix it with an underscore like `_x`",
     "'x' is declared but its value is never read.",
-    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \" hint: If you want to use a JSR package, try running `deno add jsr:@std/fs`",
+    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \"   hint: If you want to use the JSR package, try running `deno add jsr:@std/fs`",
   ]);
   expected_lsp_messages.sort();
   let all_diagnostics = diagnostics.all();
@@ -294,7 +294,7 @@ fn unadded_dependency_message() {
   let mut expected_lsp_messages = Vec::from([
     "`x` is never used\nIf this is intentional, prefix it with an underscore like `_x`",
     "'x' is declared but its value is never read.",
-    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \" hint: If you want to use a JSR package, try running `deno add jsr:@std/fs`",
+    "Relative import path \"@std/fs\" not prefixed with / or ./ or ../ and not in import map from \"   hint: If you want to use the JSR package, try running `deno add jsr:@std/fs`",
   ]);
   expected_lsp_messages.sort();
   let all_diagnostics = diagnostics.all();

--- a/tests/specs/cache/with_bare_import/095_cache_with_bare_import.ts.out
+++ b/tests/specs/cache/with_bare_import/095_cache_with_bare_import.ts.out
@@ -1,3 +1,3 @@
 [WILDCARD]error: Relative import path "foo" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add jsr:foo` or `deno add npm:foo`
+  hint: If you want to use the npm package, try running `deno add npm:foo`
     at file:///[WILDCARD]/095_cache_with_bare_import.ts:[WILDCARD]

--- a/tests/specs/check/ambient_modules/bare_specifier.out
+++ b/tests/specs/check/ambient_modules/bare_specifier.out
@@ -1,3 +1,3 @@
 error: Relative import path "foo" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add jsr:foo` or `deno add npm:foo`
+  hint: If you want to use the npm package, try running `deno add npm:foo`
     at file:///[WILDLINE]bare_specifier.ts:1:8

--- a/tests/specs/check/bare_specifier_not_found/__test__.jsonc
+++ b/tests/specs/check/bare_specifier_not_found/__test__.jsonc
@@ -1,0 +1,15 @@
+// https://github.com/denoland/deno/issues/30116
+{
+  "tests": {
+    "import_map": {
+      "args": "check main.ts",
+      "output": "check_import_map.out",
+      "exitCode": 1
+    },
+    "no_import_map": {
+      "args": "check --no-config main.ts",
+      "output": "check_no_import_map.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/check/bare_specifier_not_found/check_import_map.out
+++ b/tests/specs/check/bare_specifier_not_found/check_import_map.out
@@ -1,0 +1,3 @@
+error: Relative import path "@scope/BAZ" not prefixed with / or ./ or ../ and not in import map from "file:///[WILDLINE]/main.ts"
+  hint: If you want to use a JSR or npm package, try running `deno add jsr:@scope/BAZ` or `deno add npm:@scope/BAZ`
+    at file:///[WILDLINE]

--- a/tests/specs/check/bare_specifier_not_found/check_no_import_map.out
+++ b/tests/specs/check/bare_specifier_not_found/check_no_import_map.out
@@ -1,0 +1,3 @@
+error: Relative import path "@scope/BAZ" not prefixed with / or ./ or ../
+  hint: If you want to use a JSR or npm package, try running `deno add jsr:@scope/BAZ` or `deno add npm:@scope/BAZ`
+    at file:///[WILDLINE]

--- a/tests/specs/check/bare_specifier_not_found/deno.jsonc
+++ b/tests/specs/check/bare_specifier_not_found/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  // this just exists so that the code surfaces import map errors
+  "imports": {
+    "@scope/bar": "./other.ts"
+  }
+}

--- a/tests/specs/check/bare_specifier_not_found/main.ts
+++ b/tests/specs/check/bare_specifier_not_found/main.ts
@@ -1,0 +1,2 @@
+import { bar } from "@scope/BAZ"; // => doesn't exist
+console.log(bar);

--- a/tests/specs/check/with_bare_import/095_cache_with_bare_import.ts.out
+++ b/tests/specs/check/with_bare_import/095_cache_with_bare_import.ts.out
@@ -1,3 +1,3 @@
 [WILDCARD]error: Relative import path "foo" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add jsr:foo` or `deno add npm:foo`
+  hint: If you want to use the npm package, try running `deno add npm:foo`
     at file:///[WILDCARD]/095_cache_with_bare_import.ts:[WILDCARD]

--- a/tests/specs/run/bare_specifier_without_import/main.out
+++ b/tests/specs/run/bare_specifier_without_import/main.out
@@ -1,3 +1,3 @@
 error: Relative import path "@std/dotenv/load" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add jsr:@std/dotenv/load` or `deno add npm:@std/dotenv/load`
+  hint: If you want to use the JSR package, try running `deno add jsr:@std/dotenv/load`
     at [WILDCARD]bare_specifier_without_import/main.ts:1:8

--- a/tests/specs/run/error_type_definitions/error_type_definitions.ts.out
+++ b/tests/specs/run/error_type_definitions/error_type_definitions.ts.out
@@ -1,3 +1,3 @@
 [WILDCARD]error: Failed resolving types. Relative import path "baz" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add jsr:baz` or `deno add npm:baz`
+  hint: If you want to use the npm package, try running `deno add npm:baz`
     at [WILDCARD]/type_definitions/bar.d.ts:[WILDCARD]

--- a/tests/specs/run/package_json_auto_discovered_for_local_script_arg_with_stop/main.out
+++ b/tests/specs/run/package_json_auto_discovered_for_local_script_arg_with_stop/main.out
@@ -1,5 +1,5 @@
 [WILDCARD]Config file found at '[WILDCARD]deno.json'
 [WILDCARD]
 error: Relative import path "chalk" not prefixed with / or ./ or ../
-  hint: If you want to use a JSR or npm package, try running `deno add jsr:chalk` or `deno add npm:chalk`
+  hint: If you want to use the npm package, try running `deno add npm:chalk`
     at file:///[WILDCARD]/main.ts:3:19


### PR DESCRIPTION
We were not surfacing module not found errors by accident in too many cases.

* https://github.com/denoland/deno_graph/pull/599
   * Adds back surfacing https://github.com/denoland/deno/pull/29926 without doing it for side effect imports.

Closes https://github.com/denoland/deno/issues/30116