### PR TITLE
fix(unstable): always require --allow-read permissions for raw imports

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -878,7 +878,12 @@ impl CliFactory {
           desc_parser.as_ref(),
           &self.cli_options()?.permissions_options(),
         )?;
-        Ok(PermissionsContainer::new(desc_parser, permissions))
+
+        Ok(PermissionsContainer::new(
+          desc_parser,
+          Some(Arc::new(self.in_npm_pkg_checker()?.clone())),
+          permissions,
+        ))
       })
   }
 

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -17,8 +17,6 @@ use deno_core::futures::stream;
 use deno_core::parking_lot::RwLock;
 use deno_core::unsync::spawn;
 use deno_core::unsync::spawn_blocking;
-use deno_runtime::deno_permissions::Permissions;
-use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::tokio_util::create_and_run_current_thread;
 use indexmap::IndexMap;
 use tokio_util::sync::CancellationToken;
@@ -234,14 +232,7 @@ impl TestRun {
     )?);
     let factory = CliFactory::from_flags(flags);
     let cli_options = factory.cli_options()?;
-    // Various test files should not share the same permissions in terms of
-    // `PermissionsContainer` - otherwise granting/revoking permissions in one
-    // file would have impact on other files, which is undesirable.
-    let permission_desc_parser = factory.permission_desc_parser()?.clone();
-    let permissions = Permissions::from_options(
-      permission_desc_parser.as_ref(),
-      &cli_options.permissions_options(),
-    )?;
+    let permissions_container = factory.root_permissions_container()?;
     let main_graph_container = factory.main_module_graph_container().await?;
     main_graph_container
       .check_specifiers(
@@ -282,10 +273,10 @@ impl TestRun {
     let join_handles = queue.into_iter().map(move |specifier| {
       let specifier = specifier.clone();
       let worker_factory = worker_factory.clone();
-      let permissions_container = PermissionsContainer::new(
-        permission_desc_parser.clone(),
-        permissions.clone(),
-      );
+      // Various test files should not share the same permissions in terms of
+      // `PermissionsContainer` - otherwise granting/revoking permissions in one
+      // file would have impact on other files, which is undesirable.
+      let permissions_container = permissions_container.deep_clone();
       let worker_sender = test_event_sender_factory.worker();
       let fail_fast_tracker = fail_fast_tracker.clone();
       let lsp_filter = self.filters.get(&specifier);

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -851,7 +851,7 @@ pub async fn run(
     CjsCodeAnalyzer::new(cjs_tracker.clone(), modules.clone(), sys.clone());
   let cjs_module_export_analyzer = Arc::new(CjsModuleExportAnalyzer::new(
     cjs_esm_code_analyzer,
-    in_npm_pkg_checker,
+    in_npm_pkg_checker.clone(),
     node_resolver.clone(),
     npm_resolver.clone(),
     pkg_json_resolver.clone(),
@@ -971,7 +971,11 @@ pub async fn run(
       Arc::new(RuntimePermissionDescriptorParser::new(sys.clone()));
     let permissions =
       Permissions::from_options(desc_parser.as_ref(), &permissions)?;
-    PermissionsContainer::new(desc_parser, permissions)
+    PermissionsContainer::new(
+      desc_parser,
+      Some(Arc::new(in_npm_pkg_checker)),
+      permissions,
+    )
   };
   let feature_checker = Arc::new({
     let mut checker = FeatureChecker::default();

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -20,8 +20,6 @@ use deno_core::v8;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_path_util::url_from_file_path;
 use deno_runtime::WorkerExecutionMode;
-use deno_runtime::deno_permissions::Permissions;
-use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::tokio_util;
 use deno_runtime::worker::MainWorker;
 use tokio::sync::mpsc;
@@ -147,12 +145,7 @@ async fn create_plugin_runner_inner(
   let cli_options = factory.cli_options()?;
   let main_module =
     resolve_url_or_path("./$deno$lint.mts", cli_options.initial_cwd()).unwrap();
-  let perm_parser = factory.permission_desc_parser()?;
-  let permissions = Permissions::from_options(
-    perm_parser.as_ref(),
-    &cli_options.permissions_options(),
-  )?;
-  let permissions = PermissionsContainer::new(perm_parser.clone(), permissions);
+  let permissions = factory.root_permissions_container()?.clone();
   // let npm_resolver = factory.npm_resolver().await?.clone();
   // let resolver = factory.resolver().await?.clone();
   let worker_factory = factory.create_cli_main_worker_factory().await?;

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -530,6 +530,7 @@ mod tests {
         module_loader: Rc::new(FsModuleLoader),
         permissions: PermissionsContainer::new(
           permission_desc_parser,
+          None,
           Permissions::none_without_prompt(),
         ),
         blob_store: Default::default(),

--- a/libs/resolver/npm/mod.rs
+++ b/libs/resolver/npm/mod.rs
@@ -91,6 +91,15 @@ impl InNpmPackageChecker for DenoInNpmPackageChecker {
   }
 }
 
+#[cfg(feature = "graph")]
+impl deno_permissions::PermissionsInNpmPackageChecker
+  for DenoInNpmPackageChecker
+{
+  fn in_npm_package(&self, specifier: &Url) -> bool {
+    InNpmPackageChecker::in_npm_package(self, specifier)
+  }
+}
+
 #[derive(Debug, Error, JsError)]
 #[class(generic)]
 #[error(

--- a/tests/specs/run/bytes_and_text_imports/dynamic/__test__.jsonc
+++ b/tests/specs/run/bytes_and_text_imports/dynamic/__test__.jsonc
@@ -2,11 +2,10 @@
   "tests": {
     "missing_permissions": {
       "args": "run main.ts",
-      "output": "main_missing_permissions.out",
-      "exitCode": 1
+      "output": "main_missing_permissions.out"
     },
     "permissions": {
-      "args": "run --allow-read=non_analyzable.txt,non_analyzable_utf8_bom.txt main.ts",
+      "args": "run --allow-read=non_analyzable.txt,non_analyzable_utf8_bom.txt,hello.txt,utf8_bom.txt main.ts",
       "output": "main.out"
     }
   }

--- a/tests/specs/run/bytes_and_text_imports/dynamic/main.ts
+++ b/tests/specs/run/bytes_and_text_imports/dynamic/main.ts
@@ -6,37 +6,61 @@ function nonAnalyzableUtf8BomPath() {
   return "./non_analyzable_utf8_bom.txt";
 }
 
-const { default: helloText } = await import("./hello.txt", {
-  with: { type: "text" },
-});
-const { default: helloBytes } = await import("./hello.txt", {
-  with: { type: "bytes" },
-});
-const nonAnalyzableTypeText = "text";
-const { default: nonAnalyzableText } = await import(nonAnalyzablePath(), {
-  with: { type: nonAnalyzableTypeText },
-});
-const { default: utf8BomText } = await import("./utf8_bom.txt", {
-  with: { type: "text" },
-});
-const { default: utf8BomBytes } = await import("./utf8_bom.txt", {
-  with: { type: "bytes" },
-});
-const { default: nonAnalyzableUtf8BomText } = await import(
-  nonAnalyzableUtf8BomPath(),
-  { with: { type: "text" } }
-);
-const { default: nonAnalyzableUtf8BomBytes } = await import(
-  nonAnalyzableUtf8BomPath(),
-  { with: { type: "bytes" } }
-);
+async function tryRun(action: () => Promise<void>) {
+  try {
+    await action();
+  } catch (err) {
+    console.log(err.message);
+  }
+}
 
-console.log(helloText);
-console.log(helloBytes);
-console.log(nonAnalyzableText);
+await tryRun(async () => {
+  const { default: helloText } = await import("./hello.txt", {
+    with: { type: "text" },
+  });
+  console.log(helloText);
+});
+
+await tryRun(async () => {
+  const { default: helloBytes } = await import("./hello.txt", {
+    with: { type: "bytes" },
+  });
+  console.log(helloBytes);
+});
+await tryRun(async () => {
+  const nonAnalyzableTypeText = "text";
+  const { default: nonAnalyzableText } = await import(nonAnalyzablePath(), {
+    with: { type: nonAnalyzableTypeText },
+  });
+  console.log(nonAnalyzableText);
+});
+
 console.log("utf8 bom");
-console.log(utf8BomText, utf8BomText.length);
-console.log(utf8BomBytes);
+await tryRun(async () => {
+  const { default: utf8BomText } = await import("./utf8_bom.txt", {
+    with: { type: "text" },
+  });
+  console.log(utf8BomText, utf8BomText.length);
+});
+await tryRun(async () => {
+  const { default: utf8BomBytes } = await import("./utf8_bom.txt", {
+    with: { type: "bytes" },
+  });
+  console.log(utf8BomBytes);
+});
+
 console.log("utf8 bom non-analyzable");
-console.log(nonAnalyzableUtf8BomText, nonAnalyzableUtf8BomText.length);
-console.log(nonAnalyzableUtf8BomBytes);
+await tryRun(async () => {
+  const { default: nonAnalyzableUtf8BomText } = await import(
+    nonAnalyzableUtf8BomPath(),
+    { with: { type: "text" } }
+  );
+  console.log(nonAnalyzableUtf8BomText, nonAnalyzableUtf8BomText.length);
+});
+await tryRun(async () => {
+  const { default: nonAnalyzableUtf8BomBytes } = await import(
+    nonAnalyzableUtf8BomPath(),
+    { with: { type: "bytes" } }
+  );
+  console.log(nonAnalyzableUtf8BomBytes);
+});

--- a/tests/specs/run/bytes_and_text_imports/dynamic/main_missing_permissions.out
+++ b/tests/specs/run/bytes_and_text_imports/dynamic/main_missing_permissions.out
@@ -1,4 +1,9 @@
-error: Uncaught (in promise) TypeError: Requires read access to "[WILDLINE]non_analyzable.txt", run again with the --allow-read flag
-const { default: nonAnalyzableText } = await import(nonAnalyzablePath(), {
-                                       ^
-    at async file:///[WILDLINE]/main.ts:[WILDLINE]
+Requires read access to "[WILDLINE]hello.txt", run again with the --allow-read flag
+Requires read access to "[WILDLINE]hello.txt", run again with the --allow-read flag
+Requires read access to "[WILDLINE]non_analyzable.txt", run again with the --allow-read flag
+utf8 bom
+Requires read access to "[WILDLINE]utf8_bom.txt", run again with the --allow-read flag
+Requires read access to "[WILDLINE]utf8_bom.txt", run again with the --allow-read flag
+utf8 bom non-analyzable
+Requires read access to "[WILDLINE]non_analyzable_utf8_bom.txt", run again with the --allow-read flag
+Requires read access to "[WILDLINE]non_analyzable_utf8_bom.txt", run again with the --allow-read flag

--- a/tests/specs/run/bytes_and_text_imports/static/__test__.jsonc
+++ b/tests/specs/run/bytes_and_text_imports/static/__test__.jsonc
@@ -1,4 +1,13 @@
 {
-  "args": "run main.ts",
-  "output": "main.out"
+  "tests": {
+    "missing_permissions": {
+      "args": "run main.ts",
+      "output": "main_missing_permissions.out",
+      "exitCode": 1
+    },
+    "permissions": {
+      "args": "run --allow-read=. main.ts",
+      "output": "main.out"
+    }
+  }
 }

--- a/tests/specs/run/bytes_and_text_imports/static/main_missing_permissions.out
+++ b/tests/specs/run/bytes_and_text_imports/static/main_missing_permissions.out
@@ -1,0 +1,1 @@
+error: Requires read access to "[WILDLINE]hello.txt", run again with the --allow-read flag


### PR DESCRIPTION
After some discussion, we decided to require `--allow-read` permissions in order to do raw imports even for statically analyzable imports (I'd prefer a more relaxed permission model, but it was argued that inspecting the output of `deno info <entrypoint>` is not sufficient). This does not apply to reading assets in dependencies like before.