### PR TITLE
fix(compile): do not include managed npm deps when graph does not have any npm pkgs

### DIFF
--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -392,14 +392,18 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     }
     let npm_snapshot = match &self.npm_resolver {
       CliNpmResolver::Managed(managed) => {
-        let snapshot = managed
-          .resolution()
-          .serialized_valid_snapshot_for_system(&self.npm_system_info);
-        if !snapshot.as_serialized().packages.is_empty() {
-          self.fill_npm_vfs(&mut vfs).context("Building npm vfs.")?;
-          Some(snapshot)
-        } else {
+        if graph.npm_packages.is_empty() {
           None
+        } else {
+          let snapshot = managed
+            .resolution()
+            .serialized_valid_snapshot_for_system(&self.npm_system_info);
+          if !snapshot.as_serialized().packages.is_empty() {
+            self.fill_npm_vfs(&mut vfs).context("Building npm vfs.")?;
+            Some(snapshot)
+          } else {
+            None
+          }
         }
       }
       CliNpmResolver::Byonm(_) => {

--- a/tests/specs/compile/npm_pkgs_lockfile_unused/__test__.jsonc
+++ b/tests/specs/compile/npm_pkgs_lockfile_unused/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "install",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "compile main.ts",
+    "output": "compile.out"
+  }]
+}

--- a/tests/specs/compile/npm_pkgs_lockfile_unused/compile.out
+++ b/tests/specs/compile/npm_pkgs_lockfile_unused/compile.out
@@ -1,0 +1,9 @@
+[WILDCARD]
+
+Embedded Files
+
+[# this should not contain the npm packages found in the lockfile]
+[WILDLINE]
+└── main.ts ([WILDLINE])
+
+[WILDCARD]

--- a/tests/specs/compile/npm_pkgs_lockfile_unused/deno.json
+++ b/tests/specs/compile/npm_pkgs_lockfile_unused/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "add": "npm:@denotest/add"
+  }
+}

--- a/tests/specs/compile/npm_pkgs_lockfile_unused/main.ts
+++ b/tests/specs/compile/npm_pkgs_lockfile_unused/main.ts
@@ -1,0 +1,1 @@
+console.log(1);


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/30177 (along with https://github.com/denoland/deno/pull/30188)