### PR TITLE
Revert "fix(unstable): always require --allow-read permissions for raw imports (#30184)"

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -879,10 +879,7 @@ impl CliFactory {
           &self.cli_options()?.permissions_options(),
         )?;
 
-        Ok(PermissionsContainer::new(
-          desc_parser,
-          permissions,
-        ))
+        Ok(PermissionsContainer::new(desc_parser, permissions))
       })
   }
 

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -881,7 +881,6 @@ impl CliFactory {
 
         Ok(PermissionsContainer::new(
           desc_parser,
-          Some(Arc::new(self.in_npm_pkg_checker()?.clone())),
           permissions,
         ))
       })

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -851,7 +851,7 @@ pub async fn run(
     CjsCodeAnalyzer::new(cjs_tracker.clone(), modules.clone(), sys.clone());
   let cjs_module_export_analyzer = Arc::new(CjsModuleExportAnalyzer::new(
     cjs_esm_code_analyzer,
-    in_npm_pkg_checker.clone(),
+    in_npm_pkg_checker,
     node_resolver.clone(),
     npm_resolver.clone(),
     pkg_json_resolver.clone(),
@@ -971,11 +971,7 @@ pub async fn run(
       Arc::new(RuntimePermissionDescriptorParser::new(sys.clone()));
     let permissions =
       Permissions::from_options(desc_parser.as_ref(), &permissions)?;
-    PermissionsContainer::new(
-      desc_parser,
-      Some(Arc::new(in_npm_pkg_checker)),
-      permissions,
-    )
+    PermissionsContainer::new(desc_parser, permissions)
   };
   let feature_checker = Arc::new({
     let mut checker = FeatureChecker::default();

--- a/cli/worker.rs
+++ b/cli/worker.rs
@@ -530,7 +530,6 @@ mod tests {
         module_loader: Rc::new(FsModuleLoader),
         permissions: PermissionsContainer::new(
           permission_desc_parser,
-          None,
           Permissions::none_without_prompt(),
         ),
         blob_store: Default::default(),

--- a/libs/resolver/npm/mod.rs
+++ b/libs/resolver/npm/mod.rs
@@ -91,15 +91,6 @@ impl InNpmPackageChecker for DenoInNpmPackageChecker {
   }
 }
 
-#[cfg(feature = "graph")]
-impl deno_permissions::PermissionsInNpmPackageChecker
-  for DenoInNpmPackageChecker
-{
-  fn in_npm_package(&self, specifier: &Url) -> bool {
-    InNpmPackageChecker::in_npm_package(self, specifier)
-  }
-}
-
 #[derive(Debug, Error, JsError)]
 #[class(generic)]
 #[error(

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -43,12 +43,6 @@ pub use prompter::set_prompter;
 
 use self::which::WhichSys;
 
-pub trait PermissionsInNpmPackageChecker:
-  std::fmt::Debug + Send + Sync
-{
-  fn in_npm_package(&self, specifier: &Url) -> bool;
-}
-
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 #[error("Requires {access}, {}", format_permission_error(.name))]
 #[class("NotCapable")]
@@ -2907,19 +2901,16 @@ impl PermissionCheckError {
 #[derive(Clone, Debug)]
 pub struct PermissionsContainer {
   descriptor_parser: Arc<dyn PermissionDescriptorParser>,
-  in_npm_package_checker: Option<Arc<dyn PermissionsInNpmPackageChecker>>,
   inner: Arc<Mutex<Permissions>>,
 }
 
 impl PermissionsContainer {
   pub fn new(
     descriptor_parser: Arc<dyn PermissionDescriptorParser>,
-    in_npm_package_checker: Option<Arc<dyn PermissionsInNpmPackageChecker>>,
     perms: Permissions,
   ) -> Self {
     Self {
       descriptor_parser,
-      in_npm_package_checker,
       inner: Arc::new(Mutex::new(perms)),
     }
   }
@@ -2927,7 +2918,6 @@ impl PermissionsContainer {
   pub fn deep_clone(&self) -> PermissionsContainer {
     Self {
       descriptor_parser: self.descriptor_parser.clone(),
-      in_npm_package_checker: self.in_npm_package_checker.clone(),
       inner: Arc::new(Mutex::new(self.inner.lock().clone())),
     }
   }
@@ -2935,7 +2925,7 @@ impl PermissionsContainer {
   pub fn allow_all(
     descriptor_parser: Arc<dyn PermissionDescriptorParser>,
   ) -> Self {
-    Self::new(descriptor_parser, None, Permissions::allow_all())
+    Self::new(descriptor_parser, Permissions::allow_all())
   }
 
   pub fn create_child_permissions(
@@ -3047,7 +3037,6 @@ impl PermissionsContainer {
 
     Ok(PermissionsContainer::new(
       self.descriptor_parser.clone(),
-      self.in_npm_package_checker.clone(),
       worker_perms,
     ))
   }
@@ -3063,13 +3052,6 @@ impl PermissionsContainer {
       "file" => {
         if inner.read.is_allow_all() || kind == CheckSpecifierKind::Static {
           return Ok(());
-        }
-
-        if let Some(in_npm_package_checker) = &self.in_npm_package_checker {
-          // allow importing assets in npm packages
-          if in_npm_package_checker.in_npm_package(specifier) {
-            return Ok(());
-          }
         }
 
         match url_to_file_path(specifier) {
@@ -4526,7 +4508,7 @@ mod tests {
       },
     )
     .unwrap();
-    let mut perms = PermissionsContainer::new(Arc::new(parser), None, perms);
+    let mut perms = PermissionsContainer::new(Arc::new(parser), perms);
 
     let cases = [
       // Inside of /a/specific and /a/specific/dir/name
@@ -4744,7 +4726,7 @@ mod tests {
       },
     )
     .unwrap();
-    let mut perms = PermissionsContainer::new(Arc::new(parser), None, perms);
+    let mut perms = PermissionsContainer::new(Arc::new(parser), perms);
 
     let url_tests = vec![
       // Any protocol + port for localhost should be ok, since we don't specify
@@ -4809,7 +4791,7 @@ mod tests {
       },
     )
     .unwrap();
-    let perms = PermissionsContainer::new(Arc::new(parser), None, perms);
+    let perms = PermissionsContainer::new(Arc::new(parser), perms);
 
     let mut fixtures = vec![
       (
@@ -5582,7 +5564,7 @@ mod tests {
       },
     )
     .unwrap();
-    let mut perms = PermissionsContainer::new(Arc::new(parser), None, perms);
+    let mut perms = PermissionsContainer::new(Arc::new(parser), perms);
     let cases = [
       ("allowed.domain.", true),
       ("1.1.1.1", true),
@@ -5608,7 +5590,7 @@ mod tests {
       },
     )
     .unwrap();
-    let mut perms = PermissionsContainer::new(Arc::new(parser), None, perms);
+    let mut perms = PermissionsContainer::new(Arc::new(parser), perms);
     let cases = [
       ("10.0.0.1", true),
       ("192.168.1.1", false),
@@ -5771,8 +5753,7 @@ mod tests {
       },
     )
     .unwrap();
-    let main_perms =
-      PermissionsContainer::new(Arc::new(parser), None, main_perms);
+    let main_perms = PermissionsContainer::new(Arc::new(parser), main_perms);
     assert_eq!(
       main_perms
         .create_child_permissions(ChildPermissionsArg {
@@ -5837,7 +5818,6 @@ mod tests {
     .unwrap();
     let main_perms = PermissionsContainer::new(
       Arc::new(TestPermissionDescriptorParser),
-      None,
       main_perms,
     );
     prompt_value.set(true);
@@ -5879,7 +5859,7 @@ mod tests {
     )
     .unwrap();
     let main_perms =
-      PermissionsContainer::new(Arc::new(parser.clone()), None, main_perms);
+      PermissionsContainer::new(Arc::new(parser.clone()), main_perms);
     prompt_value.set(false);
     assert!(
       main_perms

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -297,7 +297,7 @@
 "parallel/test-dgram-send-cb-quelches-error.js" = {}
 "parallel/test-dgram-send-default-host.js" = {}
 "parallel/test-dgram-send-empty-array.js" = {}
-"parallel/test-dgram-send-empty-buffer.js" = {}
+"parallel/test-dgram-send-empty-buffer.js" = { flaky = true }
 "parallel/test-dgram-send-empty-packet.js" = {}
 "parallel/test-dgram-send-error.js" = {}
 "parallel/test-dgram-send-invalid-msg-type.js" = {}

--- a/tests/specs/run/bytes_and_text_imports/dynamic/__test__.jsonc
+++ b/tests/specs/run/bytes_and_text_imports/dynamic/__test__.jsonc
@@ -2,10 +2,11 @@
   "tests": {
     "missing_permissions": {
       "args": "run main.ts",
-      "output": "main_missing_permissions.out"
+      "output": "main_missing_permissions.out",
+      "exitCode": 1
     },
     "permissions": {
-      "args": "run --allow-read=non_analyzable.txt,non_analyzable_utf8_bom.txt,hello.txt,utf8_bom.txt main.ts",
+      "args": "run --allow-read=non_analyzable.txt,non_analyzable_utf8_bom.txt main.ts",
       "output": "main.out"
     }
   }

--- a/tests/specs/run/bytes_and_text_imports/dynamic/main.ts
+++ b/tests/specs/run/bytes_and_text_imports/dynamic/main.ts
@@ -6,61 +6,37 @@ function nonAnalyzableUtf8BomPath() {
   return "./non_analyzable_utf8_bom.txt";
 }
 
-async function tryRun(action: () => Promise<void>) {
-  try {
-    await action();
-  } catch (err) {
-    console.log(err.message);
-  }
-}
-
-await tryRun(async () => {
-  const { default: helloText } = await import("./hello.txt", {
-    with: { type: "text" },
-  });
-  console.log(helloText);
+const { default: helloText } = await import("./hello.txt", {
+  with: { type: "text" },
 });
-
-await tryRun(async () => {
-  const { default: helloBytes } = await import("./hello.txt", {
-    with: { type: "bytes" },
-  });
-  console.log(helloBytes);
+const { default: helloBytes } = await import("./hello.txt", {
+  with: { type: "bytes" },
 });
-await tryRun(async () => {
-  const nonAnalyzableTypeText = "text";
-  const { default: nonAnalyzableText } = await import(nonAnalyzablePath(), {
-    with: { type: nonAnalyzableTypeText },
-  });
-  console.log(nonAnalyzableText);
+const nonAnalyzableTypeText = "text";
+const { default: nonAnalyzableText } = await import(nonAnalyzablePath(), {
+  with: { type: nonAnalyzableTypeText },
 });
+const { default: utf8BomText } = await import("./utf8_bom.txt", {
+  with: { type: "text" },
+});
+const { default: utf8BomBytes } = await import("./utf8_bom.txt", {
+  with: { type: "bytes" },
+});
+const { default: nonAnalyzableUtf8BomText } = await import(
+  nonAnalyzableUtf8BomPath(),
+  { with: { type: "text" } }
+);
+const { default: nonAnalyzableUtf8BomBytes } = await import(
+  nonAnalyzableUtf8BomPath(),
+  { with: { type: "bytes" } }
+);
 
+console.log(helloText);
+console.log(helloBytes);
+console.log(nonAnalyzableText);
 console.log("utf8 bom");
-await tryRun(async () => {
-  const { default: utf8BomText } = await import("./utf8_bom.txt", {
-    with: { type: "text" },
-  });
-  console.log(utf8BomText, utf8BomText.length);
-});
-await tryRun(async () => {
-  const { default: utf8BomBytes } = await import("./utf8_bom.txt", {
-    with: { type: "bytes" },
-  });
-  console.log(utf8BomBytes);
-});
-
+console.log(utf8BomText, utf8BomText.length);
+console.log(utf8BomBytes);
 console.log("utf8 bom non-analyzable");
-await tryRun(async () => {
-  const { default: nonAnalyzableUtf8BomText } = await import(
-    nonAnalyzableUtf8BomPath(),
-    { with: { type: "text" } }
-  );
-  console.log(nonAnalyzableUtf8BomText, nonAnalyzableUtf8BomText.length);
-});
-await tryRun(async () => {
-  const { default: nonAnalyzableUtf8BomBytes } = await import(
-    nonAnalyzableUtf8BomPath(),
-    { with: { type: "bytes" } }
-  );
-  console.log(nonAnalyzableUtf8BomBytes);
-});
+console.log(nonAnalyzableUtf8BomText, nonAnalyzableUtf8BomText.length);
+console.log(nonAnalyzableUtf8BomBytes);

--- a/tests/specs/run/bytes_and_text_imports/dynamic/main_missing_permissions.out
+++ b/tests/specs/run/bytes_and_text_imports/dynamic/main_missing_permissions.out
@@ -1,9 +1,4 @@
-Requires read access to "[WILDLINE]hello.txt", run again with the --allow-read flag
-Requires read access to "[WILDLINE]hello.txt", run again with the --allow-read flag
-Requires read access to "[WILDLINE]non_analyzable.txt", run again with the --allow-read flag
-utf8 bom
-Requires read access to "[WILDLINE]utf8_bom.txt", run again with the --allow-read flag
-Requires read access to "[WILDLINE]utf8_bom.txt", run again with the --allow-read flag
-utf8 bom non-analyzable
-Requires read access to "[WILDLINE]non_analyzable_utf8_bom.txt", run again with the --allow-read flag
-Requires read access to "[WILDLINE]non_analyzable_utf8_bom.txt", run again with the --allow-read flag
+error: Uncaught (in promise) TypeError: Requires read access to "[WILDLINE]non_analyzable.txt", run again with the --allow-read flag
+const { default: nonAnalyzableText } = await import(nonAnalyzablePath(), {
+                                       ^
+    at async file:///[WILDLINE]/main.ts:[WILDLINE]

--- a/tests/specs/run/bytes_and_text_imports/static/__test__.jsonc
+++ b/tests/specs/run/bytes_and_text_imports/static/__test__.jsonc
@@ -1,13 +1,4 @@
 {
-  "tests": {
-    "missing_permissions": {
-      "args": "run main.ts",
-      "output": "main_missing_permissions.out",
-      "exitCode": 1
-    },
-    "permissions": {
-      "args": "run --allow-read=. main.ts",
-      "output": "main.out"
-    }
-  }
+  "args": "run main.ts",
+  "output": "main.out"
 }

--- a/tests/specs/run/bytes_and_text_imports/static/main_missing_permissions.out
+++ b/tests/specs/run/bytes_and_text_imports/static/main_missing_permissions.out
@@ -1,1 +1,0 @@
-error: Requires read access to "[WILDLINE]hello.txt", run again with the --allow-read flag


### PR DESCRIPTION
This reverts commit 147bbcf8dd7075dd98e47fd123f5600f65e969c5.

(Partial revert actually because i kept some of the refactoring I liked)

Reason for the revert is this is an established security principle:

> The initial static module graph can import local files without restrictions: All files that are imported in the initial static module graph can be imported without restrictions, so even if an explicit read permission is not granted for that file. This does not apply to any dynamic module imports.

https://docs.deno.com/runtime/fundamentals/security/#key-principles