### PR TITLE
fix(bundle): don't force managed npm resolution

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -1227,7 +1227,6 @@ fn new_workspace_factory_options(
         | DenoSubcommand::Init(_)
         | DenoSubcommand::Outdated(_)
         | DenoSubcommand::Clean(_)
-        | DenoSubcommand::Bundle(_)
     ),
     no_lock: flags.no_lock
       || matches!(


### PR DESCRIPTION
Fixes #30187.

If you're using --node-modules-dir=manual we should respect that, since resolution may not work with the managed resolver