### PR TITLE
fix: use 'deno_signals' crate for signal handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "deno_resolver",
  "deno_runtime",
  "deno_semver",
+ "deno_signals",
  "deno_snapshots",
  "deno_subprocess_windows",
  "deno_task_shell",
@@ -2849,6 +2850,7 @@ name = "deno_signals"
 version = "0.2.0"
 dependencies = [
  "signal-hook",
+ "tokio",
  "winapi",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -89,6 +89,7 @@ deno_path_util.workspace = true
 deno_resolver = { workspace = true, features = ["deno_ast", "graph", "sync"] }
 deno_runtime = { workspace = true, features = ["include_js_files_for_snapshotting"] }
 deno_semver.workspace = true
+deno_signals.workspace = true
 deno_snapshots.workspace = true
 deno_task_shell.workspace = true
 deno_telemetry.workspace = true

--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -632,7 +632,7 @@ pub async fn run_future_forwarding_signals<TOutput>(
 }
 
 async fn listen_ctrl_c(kill_signal: KillSignal) {
-  while let Ok(()) = tokio::signal::ctrl_c().await {
+  while let Ok(()) = deno_signals::ctrl_c().await {
     // On windows, ctrl+c is sent to the process group, so the signal would
     // have already been sent to the child process. We still want to listen
     // for ctrl+c here to keep the process alive when receiving it, but no

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -66,7 +66,6 @@ use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
 use regex::Regex;
 use serde::Deserialize;
-use tokio::signal;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::args::CliOptions;
@@ -1282,7 +1281,7 @@ async fn test_specifiers(
 
   let mut cancel_sender = test_event_sender_factory.weak_sender();
   let sigint_handler_handle = spawn(async move {
-    signal::ctrl_c().await.unwrap();
+    deno_signals::ctrl_c().await.unwrap();
     cancel_sender.send(TestEvent::Sigint).ok();
   });
   HAS_TEST_RUN_SIGINT_HANDLER.store(true, Ordering::Relaxed);
@@ -1734,7 +1733,7 @@ pub async fn run_tests_with_watch(
   // once a user adds one.
   spawn(async move {
     loop {
-      signal::ctrl_c().await.unwrap();
+      deno_signals::ctrl_c().await.unwrap();
       if !HAS_TEST_RUN_SIGINT_HANDLER.load(Ordering::Relaxed) {
         #[allow(clippy::disallowed_methods)]
         std::process::exit(130);

--- a/ext/signals/Cargo.toml
+++ b/ext/signals/Cargo.toml
@@ -15,4 +15,5 @@ path = "lib.rs"
 
 [dependencies]
 signal-hook.workspace = true
+tokio.workspace = true
 winapi.workspace = true

--- a/ext/signals/lib.rs
+++ b/ext/signals/lib.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
 use signal_hook::consts::*;
+use tokio::sync::mpsc;
 
 #[cfg(windows)]
 static SIGHUP: i32 = 1;
@@ -161,4 +162,19 @@ pub fn run_exit() {
 
 pub fn is_forbidden(signo: i32) -> bool {
   FORBIDDEN.contains(&signo)
+}
+
+pub async fn ctrl_c() -> std::io::Result<()> {
+  let (tx, mut rx) = mpsc::unbounded_channel();
+  let cb = Box::new(move || {
+    let _ = tx.send(());
+  });
+  register(/* Sigint */ 2, /* Prevent exit */ true, cb);
+  match rx.recv().await {
+    Some(_) => Ok(()),
+    None => Err(std::io::Error::new(
+      std::io::ErrorKind::Other,
+      "failed to receive Sigint signal",
+    )),
+  }
 }


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno/pull/30029.

Todo:
- [ ] add clippy lint to prevent using `tokio::signal` and other signal handling crates
- [ ] rework `cli/task_runner.rs` and `runtime/worker.rs` to use `deno_signals`