### PR TITLE
fix(ext/node): validate `fd` is integer on `fsync` and `fdatasync`

### DIFF
--- a/ext/node/polyfills/_fs/_fs_fdatasync.ts
+++ b/ext/node/polyfills/_fs/_fs_fdatasync.ts
@@ -1,24 +1,28 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { FsFile } from "ext:deno_fs/30_fs.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";
+import { validateInt32 } from "ext:deno_node/internal/validators.mjs";
+import { primordials } from "ext:core/mod.js";
+
+const { PromisePrototypeThen, SymbolFor } = primordials;
 
 export function fdatasync(
   fd: number,
   callback: CallbackWithError,
 ) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).syncData().then(
+  validateInt32(fd, "fd", 0);
+  PromisePrototypeThen(
+    new FsFile(fd, SymbolFor("Deno.internal.FsFile")).syncData(),
     () => callback(null),
     callback,
   );
 }
 
 export function fdatasyncSync(fd: number) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).syncDataSync();
+  validateInt32(fd, "fd", 0);
+  new FsFile(fd, SymbolFor("Deno.internal.FsFile")).syncDataSync();
 }
 
 export const fdatasyncPromise = promisify(fdatasync) as (

--- a/ext/node/polyfills/_fs/_fs_fsync.ts
+++ b/ext/node/polyfills/_fs/_fs_fsync.ts
@@ -1,24 +1,28 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
 import { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
 import { FsFile } from "ext:deno_fs/30_fs.js";
 import { promisify } from "ext:deno_node/internal/util.mjs";
+import { validateInt32 } from "ext:deno_node/internal/validators.mjs";
+import { primordials } from "ext:core/mod.js";
+
+const { PromisePrototypeThen, SymbolFor } = primordials;
 
 export function fsync(
   fd: number,
   callback: CallbackWithError,
 ) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).sync().then(
+  validateInt32(fd, "fd", 0);
+  PromisePrototypeThen(
+    new FsFile(fd, SymbolFor("Deno.internal.FsFile")).sync(),
     () => callback(null),
     callback,
   );
 }
 
 export function fsyncSync(fd: number) {
-  new FsFile(fd, Symbol.for("Deno.internal.FsFile")).syncSync();
+  validateInt32(fd, "fd", 0);
+  new FsFile(fd, SymbolFor("Deno.internal.FsFile")).syncSync();
 }
 
 export const fsyncPromise = promisify(fsync) as (fd: number) => Promise<void>;

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -427,6 +427,7 @@
 "parallel/test-fs-exists.js" = {}
 "parallel/test-fs-existssync-false.js" = {}
 "parallel/test-fs-fchown.js" = {}
+"parallel/test-fs-fsync.js" = {}
 "parallel/test-fs-link.js" = { flaky = true }
 "parallel/test-fs-long-path.js" = {}
 "parallel/test-fs-promises-exists.js" = {}


### PR DESCRIPTION
Also addresses `prefer-primordials` lint rule. This allows [parallel/test-fs-fsync.js](https://github.com/denoland/node_test/blob/8846b5392f4ebd3d4e995b9bed61c23c0192d806/test/parallel/test-fs-fsync.js) test to pass.

Towards #29972, #24236.
