### PR TITLE
refactor: remove usages of to_string_lossy().to_string()

### DIFF
--- a/cli/lib/npm/mod.rs
+++ b/cli/lib/npm/mod.rs
@@ -60,7 +60,7 @@ impl<TSys: DenoLibSys> NpmProcessStateProvider
       local_node_modules_path: self
         .0
         .root_node_modules_path()
-        .map(|p| p.to_string_lossy().to_string()),
+        .map(|p| p.to_string_lossy().into_owned()),
     }
     .as_serialized()
   }

--- a/cli/lib/standalone/virtual_fs.rs
+++ b/cli/lib/standalone/virtual_fs.rs
@@ -285,7 +285,7 @@ impl VirtualSymlinkParts {
       path
         .components()
         .filter(|c| !matches!(c, std::path::Component::RootDir))
-        .map(|c| c.as_os_str().to_string_lossy().to_string())
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
         .collect(),
     )
   }

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -441,7 +441,7 @@ fn get_local_completions(
     let items = entries
       .filter_map(|de| {
         let de = de.ok()?;
-        let label = de.path().file_name()?.to_string_lossy().to_string();
+        let label = de.path().file_name()?.to_string_lossy().into_owned();
         let entry_specifier = resolve_path(de.path().to_str()?, &cwd).ok()?;
         if entry_specifier == *referrer {
           return None;

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -3377,7 +3377,11 @@ impl CallHierarchyItem {
     let maybe_file_path = url_to_file_path(&target_module.specifier).ok();
     let name = if use_file_name {
       if let Some(file_path) = &maybe_file_path {
-        file_path.file_name().unwrap().to_string_lossy().to_string()
+        file_path
+          .file_name()
+          .unwrap()
+          .to_string_lossy()
+          .into_owned()
       } else {
         target_module.uri.to_string()
       }
@@ -3393,9 +3397,9 @@ impl CallHierarchyItem {
             .strip_prefix(root_path)
             .unwrap_or(parent_dir)
             .to_string_lossy()
-            .to_string()
+            .into_owned()
         } else {
-          parent_dir.to_string_lossy().to_string()
+          parent_dir.to_string_lossy().into_owned()
         }
       } else {
         String::new()

--- a/cli/rt/binary.rs
+++ b/cli/rt/binary.rs
@@ -88,7 +88,11 @@ pub fn extract_standalone(
     let fs_root = VfsRoot {
       dir: VirtualDirectory {
         // align the name of the directory with the root dir
-        name: root_path.file_name().unwrap().to_string_lossy().to_string(),
+        name: root_path
+          .file_name()
+          .unwrap()
+          .to_string_lossy()
+          .into_owned(),
         entries: vfs_root_entries,
       },
       root_path: root_path.clone(),

--- a/cli/rt/run.rs
+++ b/cli/rt/run.rs
@@ -973,11 +973,11 @@ pub async fn run(
         // do nothing, already granted
       }
       Some(vec) => {
-        vec.push(root_path.to_string_lossy().to_string());
+        vec.push(root_path.to_string_lossy().into_owned());
       }
       None => {
         permissions.allow_read =
-          Some(vec![root_path.to_string_lossy().to_string()]);
+          Some(vec![root_path.to_string_lossy().into_owned()]);
       }
     }
 

--- a/cli/task_runner.rs
+++ b/cli/task_runner.rs
@@ -518,7 +518,7 @@ fn resolve_bin_dir_entry_command(
     return None;
   };
   let text = std::fs::read_to_string(&path).ok()?;
-  let command_name = entry.file_name().to_string_lossy().to_string();
+  let command_name = entry.file_name().to_string_lossy().into_owned();
   if let Some(path) = resolve_execution_path_from_npx_shim(path, &text) {
     log::debug!(
       "Resolved npx command '{}' to '{}'.",

--- a/cli/tools/bundle/externals.rs
+++ b/cli/tools/bundle/externals.rs
@@ -63,7 +63,7 @@ fn to_absolute_path(path: &str, cwd: &Path) -> String {
     let path = cwd.join(path);
     deno_path_util::normalize_path(Cow::Owned(path))
       .to_string_lossy()
-      .to_string()
+      .into_owned()
   }
 }
 
@@ -179,7 +179,7 @@ mod tests {
   }
 
   fn path_str(path: impl AsRef<Path>) -> String {
-    path.as_ref().to_string_lossy().to_string()
+    path.as_ref().to_string_lossy().into_owned()
   }
 
   #[test]

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -332,7 +332,7 @@ impl EsbuildBundler {
       write: false,
       stdin_contents: None.into(),
       stdin_resolve_dir: None.into(),
-      abs_working_dir: self.cwd.to_string_lossy().to_string(),
+      abs_working_dir: self.cwd.to_string_lossy().into_owned(),
       context: matches!(self.mode, BundlingMode::Watch),
       mangle_cache: None,
       node_paths: vec![],

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -746,7 +746,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec![],
         name: None,
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -768,7 +768,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec![],
         name: None,
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -796,7 +796,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec![],
         name: None,
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -824,7 +824,7 @@ mod tests {
         module_url: "http://localhost:4545/subdir/main.ts".to_string(),
         args: vec![],
         name: None,
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -848,7 +848,7 @@ mod tests {
           .to_string(),
         args: vec![],
         name: None,
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -874,7 +874,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec![],
         name: Some("echo_test".to_string()),
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -905,7 +905,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec!["--foobar".to_string()],
         name: Some("echo_test".to_string()),
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -941,7 +941,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec![],
         name: Some("echo_test".to_string()),
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -973,7 +973,7 @@ mod tests {
         module_url: "http://localhost:4545/echo_server.ts".to_string(),
         args: vec![],
         name: Some("echo_test".to_string()),
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -1006,7 +1006,7 @@ mod tests {
         module_url: "npm:cowsay".to_string(),
         args: vec![],
         name: None,
-        root: Some(temp_dir.to_string_lossy().to_string()),
+        root: Some(temp_dir.to_string_lossy().into_owned()),
         force: false,
       },
     )
@@ -1043,7 +1043,7 @@ mod tests {
         module_url: "npm:cowsay".to_string(),
         args: vec![],
         name: None,
-        root: Some(env::temp_dir().to_string_lossy().to_string()),
+        root: Some(env::temp_dir().to_string_lossy().into_owned()),
         force: false,
       },
     )

--- a/cli/tools/jupyter/install.rs
+++ b/cli/tools/jupyter/install.rs
@@ -92,7 +92,7 @@ pub fn install(
   let current_exe_path = current_exe()
     .context("Failed to get current executable path")?
     .to_string_lossy()
-    .to_string();
+    .into_owned();
 
   // TODO(bartlomieju): add remaining fields as per
   // https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs

--- a/cli/tools/lint/reporters.rs
+++ b/cli/tools/lint/reporters.rs
@@ -233,7 +233,7 @@ impl LintReporter for JsonLintReporter {
       .to_file_path()
       .unwrap()
       .to_string_lossy()
-      .to_string();
+      .into_owned();
 
     if !self.checked_files.contains(&file_path) {
       self.checked_files.push(file_path);

--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -505,7 +505,7 @@ impl PublishPreparer {
         .file_name()
         .unwrap()
         .to_string_lossy()
-        .to_string(),
+        .into_owned(),
     }))
   }
 }

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -1713,7 +1713,7 @@ pub async fn run_tests(
         PathBuf::from(coverage)
           .join("lcov.info")
           .to_string_lossy()
-          .to_string(),
+          .into_owned(),
       ),
       &reporters,
     ) {

--- a/ext/node/ops/os/mod.rs
+++ b/ext/node/ops/os/mod.rs
@@ -295,6 +295,6 @@ where
   Ok(
     sys_traits::impls::RealSys
       .env_home_dir()
-      .map(|path| path.to_string_lossy().to_string()),
+      .map(|path| path.to_string_lossy().into_owned()),
   )
 }

--- a/ext/node/ops/require.rs
+++ b/ext/node/ops/require.rs
@@ -762,8 +762,8 @@ fn url_or_path_to_string(
   url: UrlOrPath,
 ) -> Result<String, deno_path_util::UrlToFilePathError> {
   if url.is_file() {
-    Ok(url.into_path()?.to_string_lossy().to_string())
+    Ok(url.into_path()?.to_string_lossy().into_owned())
   } else {
-    Ok(url.to_string_lossy().to_string())
+    Ok(url.to_string_lossy().into_owned())
   }
 }

--- a/ext/os/sys_info.rs
+++ b/ext/os/sys_info.rs
@@ -152,7 +152,7 @@ pub fn hostname() -> String {
     buf[len - 1] = 0;
     std::ffi::CStr::from_ptr(buf.as_ptr() as *const libc::c_char)
       .to_string_lossy()
-      .to_string()
+      .into_owned()
   }
   #[cfg(target_family = "windows")]
   {

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -667,7 +667,7 @@ fn spawn_child(
       }
 
       return Err(ProcessError::SpawnFailed {
-        command: command.get_program().to_string_lossy().to_string(),
+        command: command.get_program().to_string_lossy().into_owned(),
         error: Box::new(err.into()),
       });
     }
@@ -1015,7 +1015,7 @@ fn op_spawn_sync(
     create_command(state, args, "Deno.Command().outputSync()")?;
 
   let mut child = command.spawn().map_err(|e| ProcessError::SpawnFailed {
-    command: command.get_program().to_string_lossy().to_string(),
+    command: command.get_program().to_string_lossy().into_owned(),
     error: Box::new(e.into()),
   })?;
   if let Some(input) = input {
@@ -1029,7 +1029,7 @@ fn op_spawn_sync(
     child
       .wait_with_output()
       .map_err(|e| ProcessError::SpawnFailed {
-        command: command.get_program().to_string_lossy().to_string(),
+        command: command.get_program().to_string_lossy().into_owned(),
         error: Box::new(e.into()),
       })?;
   Ok(SpawnOutput {

--- a/libs/config/glob/collector.rs
+++ b/libs/config/glob/collector.rs
@@ -317,7 +317,7 @@ mod test {
     ];
     let mut file_names = result
       .into_iter()
-      .map(|r| r.file_name().unwrap().to_string_lossy().to_string())
+      .map(|r| r.file_name().unwrap().to_string_lossy().into_owned())
       .collect::<Vec<_>>();
     file_names.sort();
     assert_eq!(file_names, expected);
@@ -340,7 +340,7 @@ mod test {
     ];
     let mut file_names = result
       .into_iter()
-      .map(|r| r.file_name().unwrap().to_string_lossy().to_string())
+      .map(|r| r.file_name().unwrap().to_string_lossy().into_owned())
       .collect::<Vec<_>>();
     file_names.sort();
     assert_eq!(file_names, expected);
@@ -371,7 +371,7 @@ mod test {
     ];
     let mut file_names = result
       .into_iter()
-      .map(|r| r.file_name().unwrap().to_string_lossy().to_string())
+      .map(|r| r.file_name().unwrap().to_string_lossy().into_owned())
       .collect::<Vec<_>>();
     file_names.sort();
     assert_eq!(file_names, expected);

--- a/libs/config/workspace/discovery.rs
+++ b/libs/config/workspace/discovery.rs
@@ -819,7 +819,7 @@ fn resolve_workspace_for_config_folder<
             .parent()
             .unwrap()
             .to_string_lossy()
-            .to_string(),
+            .into_owned(),
           member_dir_url,
         ));
       }

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -2976,7 +2976,7 @@ pub mod test {
     let root_path = root_dir().join("../dir");
     let workspace_dir = workspace_for_root_and_member_with_fs(
       json!({
-        "links": [root_path.to_string_lossy().to_string()],
+        "links": [root_path.to_string_lossy().into_owned()],
       }),
       json!({}),
       |fs| {

--- a/libs/npm_installer/process_state.rs
+++ b/libs/npm_installer/process_state.rs
@@ -39,7 +39,7 @@ impl NpmProcessState {
     NpmProcessState {
       kind: NpmProcessStateKind::Snapshot(snapshot.into_serialized()),
       local_node_modules_path: node_modules_path
-        .map(|p| p.to_string_lossy().to_string()),
+        .map(|p| p.to_string_lossy().into_owned()),
     }
   }
 

--- a/tests/integration/install_tests.rs
+++ b/tests/integration/install_tests.rs
@@ -332,7 +332,7 @@ fn check_local_by_default() {
   let temp_dir_str = temp_dir.path().to_string();
   let script_path =
     util::testdata_path().join("./install/check_local_by_default.ts");
-  let script_path_str = script_path.to_string_lossy().to_string();
+  let script_path_str = script_path.to_string_lossy().into_owned();
   context
     .new_command()
     .args_vec(["install", "-g", "--allow-import", script_path_str.as_str()])
@@ -356,7 +356,7 @@ fn check_local_by_default2() {
   let temp_dir_str = temp_dir.path().to_string();
   let script_path =
     util::testdata_path().join("./install/check_local_by_default2.ts");
-  let script_path_str = script_path.to_string_lossy().to_string();
+  let script_path_str = script_path.to_string_lossy().into_owned();
   context
     .new_command()
     .args_vec(["install", "-g", "--allow-import", script_path_str.as_str()])

--- a/tests/util/server/src/builders.rs
+++ b/tests/util/server/src/builders.rs
@@ -453,7 +453,7 @@ impl TestCommandBuilder {
   }
 
   pub fn name(mut self, name: impl AsRef<OsStr>) -> Self {
-    self.command_name = name.as_ref().to_string_lossy().to_string();
+    self.command_name = name.as_ref().to_string_lossy().into_owned();
     self
   }
 
@@ -470,7 +470,7 @@ impl TestCommandBuilder {
     self.args_vec.extend(
       args
         .into_iter()
-        .map(|s| s.as_ref().to_string_lossy().to_string()),
+        .map(|s| s.as_ref().to_string_lossy().into_owned()),
     );
     self
   }
@@ -481,7 +481,7 @@ impl TestCommandBuilder {
   {
     self
       .args_vec
-      .push(arg.as_ref().to_string_lossy().to_string());
+      .push(arg.as_ref().to_string_lossy().into_owned());
     self
   }
 
@@ -509,8 +509,8 @@ impl TestCommandBuilder {
     V: AsRef<std::ffi::OsStr>,
   {
     self.envs.insert(
-      key.as_ref().to_string_lossy().to_string(),
-      val.as_ref().to_string_lossy().to_string(),
+      key.as_ref().to_string_lossy().into_owned(),
+      val.as_ref().to_string_lossy().into_owned(),
     );
     self
   }
@@ -521,7 +521,7 @@ impl TestCommandBuilder {
   {
     self
       .envs_remove
-      .insert(key.as_ref().to_string_lossy().to_string());
+      .insert(key.as_ref().to_string_lossy().into_owned());
     self
   }
 
@@ -551,7 +551,7 @@ impl TestCommandBuilder {
   }
 
   pub fn current_dir<P: AsRef<OsStr>>(mut self, dir: P) -> Self {
-    let dir = dir.as_ref().to_string_lossy().to_string();
+    let dir = dir.as_ref().to_string_lossy().into_owned();
     self.cwd = Some(match self.cwd {
       Some(current) => current.join(dir),
       None => PathRef::new(dir),

--- a/tests/util/server/src/npm.rs
+++ b/tests/util/server/src/npm.rs
@@ -495,7 +495,7 @@ fn get_npm_package(
     if !file_type.is_dir() {
       continue;
     }
-    let version = entry.file_name().to_string_lossy().to_string();
+    let version = entry.file_name().to_string_lossy().into_owned();
     let version_folder = package_folder.join(&version);
 
     let (tarball_bytes, mut version_info) = create_package_version_info(

--- a/tests/util/server/src/servers/jsr_registry.rs
+++ b/tests/util/server/src/servers/jsr_registry.rs
@@ -235,7 +235,7 @@ fn get_manifest_entries_for_dir(
         let checksum = format!("sha256-{}", get_checksum(&file_bytes));
         let relative_path = path
           .to_string_lossy()
-          .strip_prefix(&root_dir.to_string_lossy().to_string())
+          .strip_prefix(&root_dir.to_string_lossy().into_owned())
           .unwrap()
           .replace('\\', "/");
         manifest.insert(
@@ -254,7 +254,7 @@ fn get_manifest_entries_for_dir(
   DIR_MANIFEST_CACHE
     .lock()
     .unwrap()
-    .entry(dir.to_string_lossy().to_string())
+    .entry(dir.to_string_lossy().into_owned())
     .or_insert_with(|| {
       let mut manifest = BTreeMap::new();
       inner_fill(dir, dir, &mut manifest);


### PR DESCRIPTION
Slightly better to not clone again.