### PR TITLE
fix: don't invoke `Proxy` getter trap on `console.log`

### DIFF
--- a/ext/console/01_console.js
+++ b/ext/console/01_console.js
@@ -634,7 +634,10 @@ function formatRaw(ctx, value, recurseTimes, typedArray, proxyDetails) {
     protoProps = undefined;
   }
 
-  let tag = value[SymbolToStringTag];
+  let tag;
+  if (!proxyDetails) {
+    tag = value[SymbolToStringTag];
+  }
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -2177,7 +2177,7 @@ Deno.test(function inspectProxy() {
         },
       }),
     )),
-    `Object [MyProxy] { prop1: 5, prop2: 5 }`,
+    `{ prop1: 5, prop2: 5 }`,
   );
   assertEquals(
     stripAnsiCode(Deno.inspect(
@@ -2216,6 +2216,18 @@ Deno.test(function inspectProxy() {
       { showProxy: true },
     )),
     "Proxy [ [Function: fn], { get: [Function: get] } ]",
+  );
+
+  // Issue: https://github.com/denoland/deno/issues/30229
+  assertEquals(
+    stripAnsiCode(Deno.inspect(
+      new Proxy({}, {
+        get() {
+          throw new Error("fail");
+        },
+      }),
+    )),
+    "{}",
   );
 });
 


### PR DESCRIPTION
Proxy traps should never be invoked on `console.log()`. This PR aligns Deno's behaviour with other runtimes like Chrome, Firefox and Node. This fixes the linked issue where it wasn't possible to call `console.log()` on vite's module graph without an error being thrown.

Fixes https://github.com/denoland/deno/issues/30229
