### PR TITLE
chore: regression where excluded path stopped being excluded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "deno_path_util"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f0a6c02723e125a14caacfe4a44a4972364a243a6dfed42b4b16128c76bc34"
+checksum = "bfe02936964b2910719bd488841f6e884349360113c7abf6f4c6b28ca9cd7a19"
 dependencies = [
  "deno_error",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ deno_lockfile = "=0.31.0"
 deno_media_type = { version = "=0.2.9", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_npm = "=0.36.0"
-deno_path_util = "=0.6.0"
+deno_path_util = "=0.6.1"
 deno_semver = "=0.9.0"
 deno_task_shell = "=0.26.0"
 deno_terminal = "=0.2.2"


### PR DESCRIPTION
This was a recent regression caused by:

* https://github.com/denoland/deno/pull/30211

Fixed by:

* https://github.com/denoland/deno_path_util/pull/18

PR marked as chore because it's not worth including in the release notes because the bug hasn't hit any releases yet.