### PR TITLE
perf: Use more efficient structuredClone API

### DIFF
--- a/ext/web/02_structured_clone.js
+++ b/ext/web/02_structured_clone.js
@@ -134,7 +134,7 @@ function structuredClone(value) {
   }
 
   try {
-    return core.deserialize(core.serialize(value));
+    return core.structuredClone(value);
   } catch (e) {
     if (ObjectPrototypeIsPrototypeOf(TypeErrorPrototype, e)) {
       throw new DOMException(e.message, "DataCloneError");


### PR DESCRIPTION
This PR builds on top of https://github.com/denoland/deno_core/pull/1167 that provided 16%
perf improvement for structured clone algorithm by avoid round-trip serialization and
deserialization.

This was applied to the internal `structuredClone` helper, as well as for `MessagePort.postMessage`
which is what Web worker and `node:worker_thread` APIs are using.