### PR TITLE
fix(bundle): allow importing json with import attributes inside npm packages

### DIFF
--- a/libs/resolver/loader/module_loader.rs
+++ b/libs/resolver/loader/module_loader.rs
@@ -221,6 +221,7 @@ impl<TSys: ModuleLoaderSys> ModuleLoader<TSys> {
         // If we loaded a JSON file, but the "requested_module_type" (that is computed from
         // import attributes) is not JSON we need to fail.
         if loaded_module.media_type == MediaType::Json
+          && !self.in_npm_pkg_checker.in_npm_package(specifier)
           && !matches!(requested_module_type, RequestedModuleType::Json)
         {
           Err(LoadCodeSourceErrorKind::MissingJsonAttribute.into_box())

--- a/tests/registry/npm/@denotest/require-package-json/1.0.0/main.js
+++ b/tests/registry/npm/@denotest/require-package-json/1.0.0/main.js
@@ -1,0 +1,1 @@
+module.exports = require("./package.json");

--- a/tests/registry/npm/@denotest/require-package-json/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/require-package-json/1.0.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@denotest/require-package-json",
+  "type": "commonjs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "license": "ISC",
+  "author": ""
+}

--- a/tests/specs/bundle/json_require_npm/__test__.jsonc
+++ b/tests/specs/bundle/json_require_npm/__test__.jsonc
@@ -1,0 +1,10 @@
+{
+  "tempDir": true,
+  "steps": [{
+    "args": "bundle -o=./out.js main.ts",
+    "output": "[WILDCARD]"
+  }, {
+    "args": "run ./out.js",
+    "output": "json.out"
+  }]
+}

--- a/tests/specs/bundle/json_require_npm/json.out
+++ b/tests/specs/bundle/json_require_npm/json.out
@@ -1,0 +1,1 @@
+@denotest/require-package-json

--- a/tests/specs/bundle/json_require_npm/main.ts
+++ b/tests/specs/bundle/json_require_npm/main.ts
@@ -1,0 +1,3 @@
+import json from "npm:@denotest/require-package-json";
+
+console.log(json.name);


### PR DESCRIPTION
Running `deno bundle` on an npm module that imports or requires `.json` files should work and not error. This PR updates our "check if import attribute is present" logic to exclude files coming from inside npm packages.

Fixes https://github.com/denoland/deno/issues/30263