### PR TITLE
fix(lsp): use referrer compiler options for node_modules files

### DIFF
--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -864,6 +864,7 @@ mod tests {
   use std::collections::HashMap;
 
   use deno_core::resolve_url;
+  use deno_resolver::deno_json::CompilerOptionsKey;
   use pretty_assertions::assert_eq;
   use test_util::TempDir;
 
@@ -907,8 +908,11 @@ mod tests {
         .global()
         .set(&specifier, HashMap::default(), source.as_bytes())
         .expect("could not cache file");
-      let module =
-        document_modules.module_for_specifier(&specifier, None, None);
+      let module = document_modules.module_for_specifier(
+        &specifier,
+        None,
+        Some(&CompilerOptionsKey::WorkspaceConfig(None)),
+      );
       assert!(module.is_some(), "source could not be setup");
     }
     document_modules

--- a/cli/lsp/completions.rs
+++ b/cli/lsp/completions.rs
@@ -907,7 +907,8 @@ mod tests {
         .global()
         .set(&specifier, HashMap::default(), source.as_bytes())
         .expect("could not cache file");
-      let module = document_modules.module_for_specifier(&specifier, None);
+      let module =
+        document_modules.module_for_specifier(&specifier, None, None);
       assert!(module.is_some(), "source could not be setup");
     }
     document_modules
@@ -992,7 +993,7 @@ mod tests {
       &[("https://deno.land/x/a/b/c.ts", "console.log(1);\n")],
     );
     let module = document_modules
-      .module_for_specifier(&specifier, None)
+      .module_for_specifier(&specifier, None, None)
       .unwrap();
     let actual =
       get_remote_completions(&module, "h", &range, &document_modules);

--- a/cli/lsp/documents.rs
+++ b/cli/lsp/documents.rs
@@ -1167,8 +1167,15 @@ impl DocumentModules {
     self.documents.close_notebook(uri)
   }
 
-  pub fn release(&self, specifier: &Url, scope: Option<&Url>) {
-    let Some(module) = self.module_for_specifier(specifier, scope) else {
+  pub fn release(
+    &self,
+    specifier: &Url,
+    scope: Option<&Url>,
+    compiler_options_key: Option<&CompilerOptionsKey>,
+  ) {
+    let Some(module) =
+      self.module_for_specifier(specifier, scope, compiler_options_key)
+    else {
       return;
     };
     self.documents.remove_server_doc(&module.uri);
@@ -1201,6 +1208,7 @@ impl DocumentModules {
     document: &Document,
     specifier: Option<&Arc<Url>>,
     scope: Option<&Url>,
+    compiler_options_key: Option<&CompilerOptionsKey>,
   ) -> Option<Arc<DocumentModule>> {
     let modules = self.modules_for_scope(scope)?;
     if let Some(module) = modules.get(document) {
@@ -1209,15 +1217,27 @@ impl DocumentModules {
     let specifier = specifier
       .cloned()
       .or_else(|| self.infer_specifier(document))?;
-    let (compiler_options_key, compiler_options_data) =
+    let scheme = specifier.scheme();
+    let (compiler_options_key, compiler_options_data) = if scheme != "file"
+      || self.resolver.in_node_modules(&specifier)
+      || self.cache.in_global_cache_directory(&specifier)
+    {
+      let key = compiler_options_key?;
+      let value = self
+        .compiler_options_resolver
+        .for_key(key)
+        .expect("Key should be in sync with resolver.");
+      (key, value)
+    } else {
       self.compiler_options_resolver.entry_for_specifier(
-        if specifier.scheme() != "file" && scope.is_some() {
+        if scheme != "file" && scope.is_some() {
           #[allow(clippy::unnecessary_unwrap)]
           scope.unwrap()
         } else {
           &specifier
         },
-      );
+      )
+    };
     let module = Arc::new(DocumentModule::new(
       document,
       specifier,
@@ -1238,13 +1258,14 @@ impl DocumentModules {
     document: &Document,
     scope: Option<&Url>,
   ) -> Option<Arc<DocumentModule>> {
-    self.module_inner(document, None, scope)
+    self.module_inner(document, None, scope, None)
   }
 
   pub fn module_for_specifier(
     &self,
     specifier: &Url,
     scope: Option<&Url>,
+    compiler_options_key: Option<&CompilerOptionsKey>,
   ) -> Option<Arc<DocumentModule>> {
     let scoped_resolver = self.resolver.get_scoped_resolver(scope);
     let specifier = match JsrPackageReqReference::from_specifier(specifier) {
@@ -1258,7 +1279,12 @@ impl DocumentModules {
       self
         .documents
         .get_for_specifier(&specifier, scope, &self.cache)?;
-    self.module_inner(&document, Some(&Arc::new(specifier)), scope)
+    self.module_inner(
+      &document,
+      Some(&Arc::new(specifier)),
+      scope,
+      compiler_options_key,
+    )
   }
 
   pub fn primary_module(
@@ -1586,8 +1612,10 @@ impl DocumentModules {
     raw_specifiers: &[(bool, String)],
     referrer: &Url,
     scope: Option<&Url>,
+    compiler_options_key: Option<&CompilerOptionsKey>,
   ) -> Vec<Option<(Url, MediaType)>> {
-    let referrer_module = self.module_for_specifier(referrer, scope);
+    let referrer_module =
+      self.module_for_specifier(referrer, scope, compiler_options_key);
     let dependencies = referrer_module.as_ref().map(|d| &d.dependencies);
     let mut results = Vec::new();
     let scoped_resolver = self.resolver.get_scoped_resolver(scope);
@@ -1607,9 +1635,21 @@ impl DocumentModules {
         dependencies.as_ref().and_then(|d| d.get(raw_specifier))
       {
         if let Some(specifier) = dep.maybe_type.maybe_specifier() {
-          self.resolve_dependency(specifier, referrer, resolution_mode, scope)
+          self.resolve_dependency(
+            specifier,
+            referrer,
+            resolution_mode,
+            scope,
+            compiler_options_key,
+          )
         } else if let Some(specifier) = dep.maybe_code.maybe_specifier() {
-          self.resolve_dependency(specifier, referrer, resolution_mode, scope)
+          self.resolve_dependency(
+            specifier,
+            referrer,
+            resolution_mode,
+            scope,
+            compiler_options_key,
+          )
         } else {
           None
         }
@@ -1626,6 +1666,7 @@ impl DocumentModules {
             referrer,
             resolution_mode,
             scope,
+            compiler_options_key,
           ),
           _ => None,
         }
@@ -1642,6 +1683,7 @@ impl DocumentModules {
     referrer: &Url,
     resolution_mode: ResolutionMode,
     scope: Option<&Url>,
+    compiler_options_key: Option<&CompilerOptionsKey>,
   ) -> Option<(Url, MediaType)> {
     if let Some(module_name) = specifier.as_str().strip_prefix("node:") {
       if deno_node::is_builtin_node_module(module_name) {
@@ -1664,7 +1706,9 @@ impl DocumentModules {
       specifier = s;
       media_type = Some(mt);
     }
-    let Some(module) = self.module_for_specifier(&specifier, scope) else {
+    let Some(module) =
+      self.module_for_specifier(&specifier, scope, compiler_options_key)
+    else {
       let media_type =
         media_type.unwrap_or_else(|| MediaType::from_specifier(&specifier));
       return Some((specifier, media_type));
@@ -1674,7 +1718,13 @@ impl DocumentModules {
       .as_ref()
       .and_then(|d| d.dependency.maybe_specifier())
     {
-      self.resolve_dependency(types, &specifier, module.resolution_mode, scope)
+      self.resolve_dependency(
+        types,
+        &specifier,
+        module.resolution_mode,
+        scope,
+        compiler_options_key,
+      )
     } else {
       Some((module.specifier.as_ref().clone(), module.media_type))
     }

--- a/cli/schemas/config-file.v1.json
+++ b/cli/schemas/config-file.v1.json
@@ -217,6 +217,12 @@
           },
           "markdownDescription": "Declare many “virtual” directories acting as a single root.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
         },
+        "skipLibCheck": {
+          "description": "Skip type checking all .d.ts files.",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
+        },
         "strict": {
           "description": "Enable all strict type checking options.",
           "type": "boolean",

--- a/libs/resolver/deno_json.rs
+++ b/libs/resolver/deno_json.rs
@@ -130,6 +130,7 @@ static ALLOWED_COMPILER_OPTIONS: phf::Set<&'static str> = phf::phf_set! {
   "noUnusedLocals",
   "noUnusedParameters",
   "rootDirs",
+  "skipLibCheck",
   "strict",
   "strictBindCallApply",
   "strictBuiltinIteratorReturn",
@@ -295,6 +296,7 @@ pub fn get_base_compiler_options_for_emit(
       },
       "resolveJsonModule": true,
       "sourceMap": false,
+      "skipLibCheck": false,
       "strict": match source_kind {
         CompilerOptionsSourceKind::DenoJson => true,
         CompilerOptionsSourceKind::TsConfig => false,

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17335,8 +17335,12 @@ fn lsp_tsconfig_node_modules_dts_diagnostics() {
     .to_string(),
   );
   let file1 = temp_dir.source_file("main.ts", "import type {} from \"foo\";\n");
-  let file2 = temp_dir.source_file(
-    "node_modules/foo/index.d.ts",
+  let file2 = source_file(
+    // Canonicalize for mac.
+    temp_dir
+      .path()
+      .canonicalize()
+      .join("node_modules/foo/index.d.ts"),
     r#"
       export type foo = typeof Deno;
       export type bar = typeof document;

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17311,6 +17311,61 @@ fn lsp_tsconfig_references_extends_include() {
 
 #[test]
 #[timeout(300_000)]
+fn lsp_tsconfig_node_modules_dts_diagnostics() {
+  let context = TestContextBuilder::new()
+    .use_http_server()
+    .use_temp_cwd()
+    .build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write(
+    "deno.json",
+    json!({
+      "nodeModulesDir": "manual",
+    })
+    .to_string(),
+  );
+  temp_dir.write(
+    "tsconfig.json",
+    json!({
+      "include": ["main.ts"],
+      "compilerOptions": {
+        "lib": ["esnext", "dom"],
+      },
+    })
+    .to_string(),
+  );
+  let file1 = temp_dir.source_file("main.ts", "import type {} from \"foo\";\n");
+  let file2 = temp_dir.source_file(
+    "node_modules/foo/index.d.ts",
+    r#"
+      export type foo = typeof Deno;
+      export type bar = typeof document;
+    "#,
+  );
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.did_open_file(&file1);
+  let diagnostics = client.did_open_file(&file2);
+  assert_eq!(
+    json!(diagnostics.all()),
+    json!([
+      {
+        "range": {
+          "start": { "line": 1, "character": 31 },
+          "end": { "line": 1, "character": 35 },
+        },
+        "severity": 1,
+        "code": 2304,
+        "source": "deno-ts",
+        "message": "Cannot find name 'Deno'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'deno.ns' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib=\"deno.ns\" />",
+      },
+    ]),
+  );
+  client.shutdown();
+}
+
+#[test]
+#[timeout(300_000)]
 fn lsp_npm_workspace() {
   let context = TestContextBuilder::new()
     .use_http_server()

--- a/tests/specs/check/skip_lib_check/__test__.jsonc
+++ b/tests/specs/check/skip_lib_check/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "check --quiet types.d.ts",
+  "output": ""
+}

--- a/tests/specs/check/skip_lib_check/deno.json
+++ b/tests/specs/check/skip_lib_check/deno.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/tests/specs/check/skip_lib_check/types.d.ts
+++ b/tests/specs/check/skip_lib_check/types.d.ts
@@ -1,0 +1,3 @@
+// TS2840 [ERROR]: An interface cannot extend a primitive type like 'string'.
+// It can only extend other named object types.
+export interface Foo extends string {}


### PR DESCRIPTION
Follow up to #30242 as proposed there.