### PR TITLE
fix(ext/node): worker_threads handles basic `require` calls

### DIFF
--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -19,6 +19,7 @@ function initialize(args) {
     maybeWorkerMetadata,
     nodeDebug,
     warmup = false,
+    moduleSpecifier = null,
   } = args;
   if (!warmup) {
     if (initialized) {
@@ -41,6 +42,7 @@ function initialize(args) {
       runningOnMainThread,
       workerId,
       maybeWorkerMetadata,
+      moduleSpecifier,
     );
     internals.__setupChildProcessIpcChannel();
     // `Deno[Deno.internal].requireImpl` will be unreachable after this line.

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1089,6 +1089,7 @@ function bootstrapWorkerRuntime(
     }
 
     // Not available in workers
+    const moduleSpecifier = finalDenoNs.mainModule;
     delete finalDenoNs.mainModule;
 
     if (!ArrayPrototypeIncludes(unstableFeatures, unstableIds.unsafeProto)) {
@@ -1121,6 +1122,7 @@ function bootstrapWorkerRuntime(
         workerId,
         maybeWorkerMetadata: workerMetadata,
         nodeDebug,
+        moduleSpecifier,
       });
     }
   } else {


### PR DESCRIPTION
This is not a full-fledged and fully correct `require`/CJS support
for `node:worker_threads`, but unlocks certain scenarios that
were not working at all previously.