### PR TITLE
fix(ext/node): incorrect `ERR_INVALID_ARG_VALUE` constructor arguments position

### DIFF
--- a/ext/node/polyfills/internal/fs/utils.mjs
+++ b/ext/node/polyfills/internal/fs/utils.mjs
@@ -154,7 +154,7 @@ export const kMaxUserId = 2 ** 32 - 1;
 export function assertEncoding(encoding) {
   if (encoding && !Buffer.isEncoding(encoding)) {
     const reason = "is invalid encoding";
-    throw new ERR_INVALID_ARG_VALUE(encoding, "encoding", reason);
+    throw new ERR_INVALID_ARG_VALUE("encoding", encoding, reason);
   }
 }
 

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -428,6 +428,7 @@
 "parallel/test-fs-existssync-false.js" = {}
 "parallel/test-fs-fchown.js" = {}
 "parallel/test-fs-fsync.js" = {}
+"parallel/test-fs-internal-assertencoding.js" = {}
 "parallel/test-fs-link.js" = { flaky = true }
 "parallel/test-fs-long-path.js" = {}
 "parallel/test-fs-open-no-close.js" = {}

--- a/tests/unit_node/_fs/_fs_appendFile_test.ts
+++ b/tests/unit_node/_fs/_fs_appendFile_test.ts
@@ -29,7 +29,7 @@ Deno.test({
         appendFile("some/path", "some data", "made-up-encoding", () => {});
       },
       Error,
-      "The argument 'made-up-encoding' is invalid encoding. Received 'encoding'",
+      "The argument 'encoding' is invalid encoding. Received 'made-up-encoding'",
     );
     assertThrows(
       () => {
@@ -42,13 +42,13 @@ Deno.test({
         );
       },
       Error,
-      "The argument 'made-up-encoding' is invalid encoding. Received 'encoding'",
+      "The argument 'encoding' is invalid encoding. Received 'made-up-encoding'",
     );
     assertThrows(
       // @ts-expect-error Type '"made-up-encoding"' is not assignable to type
       () => appendFileSync("some/path", "some data", "made-up-encoding"),
       Error,
-      "The argument 'made-up-encoding' is invalid encoding. Received 'encoding'",
+      "The argument 'encoding' is invalid encoding. Received 'made-up-encoding'",
     );
     assertThrows(
       () =>
@@ -57,7 +57,7 @@ Deno.test({
           encoding: "made-up-encoding",
         }),
       Error,
-      "The argument 'made-up-encoding' is invalid encoding. Received 'encoding'",
+      "The argument 'encoding' is invalid encoding. Received 'made-up-encoding'",
     );
   },
 });


### PR DESCRIPTION
This allows [parallel/test-fs-internal-assertencoding.js](https://github.com/nodejs/node/blob/v23.9.0/test/parallel/test-fs-internal-assertencoding.js) to pass.

Towards #29972

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
