### PR TITLE
fix(ext/node): avoid panic when `crypto.randomInt` has no arguments

### DIFF
--- a/ext/node/polyfills/internal/crypto/_randomInt.ts
+++ b/ext/node/polyfills/internal/crypto/_randomInt.ts
@@ -9,6 +9,7 @@ const {
   MathPow,
   NumberIsSafeInteger,
   RangeError,
+  TypeError,
 } = primordials;
 
 export default function randomInt(max: number): number;
@@ -39,11 +40,8 @@ export default function randomInt(
     min = 0;
   }
 
-  if (
-    !NumberIsSafeInteger(min) ||
-    typeof max === "number" && !NumberIsSafeInteger(max)
-  ) {
-    throw new Error("max or min is not a Safe Number");
+  if (!NumberIsSafeInteger(min) || !NumberIsSafeInteger(max)) {
+    throw new TypeError("max or min is not a Safe Number");
   }
 
   if (max - min > MathPow(2, 48)) {

--- a/tests/unit_node/internal/_randomInt_test.ts
+++ b/tests/unit_node/internal/_randomInt_test.ts
@@ -4,6 +4,10 @@ import { assert, assertThrows } from "@std/assert";
 
 const between = (x: number, min: number, max: number) => x >= min && x < max;
 
+Deno.test("[node/crypto.randomInt] No Params", () => {
+  assertThrows(() => randomInt(undefined as unknown as number));
+});
+
 Deno.test("[node/crypto.randomInt] One Param: Max", () => {
   assert(between(randomInt(55), 0, 55));
 });


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

This should help with https://github.com/denoland/deno/issues/30313

Changed:
- Check that both `min` and `max` are safe integers before proceeding with the random integer calculation, to guard against a lack of arguments or an undefined first argument to the `randomInt` call.

I'm not sure why non-`number` values were prevented from being checked with `NumberIsSafeInteger` or why a generic `Error` was used instead of a `TypeError` — I assume there may have been reasons and so may have missed something here. But it did seem the simplest way to avoid the panic.
