### PR TITLE
feat(ext/kv): allow specifying default path and path prefix

### DIFF
--- a/ext/kv/dynamic.rs
+++ b/ext/kv/dynamic.rs
@@ -65,7 +65,9 @@ impl DatabaseHandler for MultiBackendDbHandler {
   ) -> Result<Self::DB, JsErrorBox> {
     if path.is_none() {
       if let Ok(x) = std::env::var("DENO_KV_DEFAULT_PATH") {
-        path = Some(x);
+        if !x.is_empty() {
+          path = Some(x);
+        }
       }
     }
 


### PR DESCRIPTION
The `Deno.openKv()` API now checks these env vars:

- `DENO_KV_DEFAULT_PATH` - if set, when no database path is specified, use the provided path.
- `DENO_KV_PATH_PREFIX` - if set, prepend this to the provided database path - e.g. if `DENO_KV_PATH_PREFIX=https://example.com/db/`, `Deno.openKv("default")` will open the database at `https://example.com/db/default`.