### PR TITLE
feat(runtime): allow dynamic changes to worker permissions

### DIFF
--- a/cli/tsc/dts/lib.deno.shared_globals.d.ts
+++ b/cli/tsc/dts/lib.deno.shared_globals.d.ts
@@ -666,6 +666,24 @@ interface Worker extends EventTarget {
    * ```
    */
   terminate(): void;
+
+  /**
+   * Updates the permissions for the worker.
+   *
+   * @example
+   * ```ts
+   * const worker = new Worker(new URL("./worker.ts", import.meta.url).href, {
+   *   type: "module",
+   *   deno: { permissions: "none" }
+   * });
+   *
+   * // Later, grant network permissions to the worker
+   * worker.updatePermissions({
+   *   net: ["example.com"],
+   * });
+   * ```
+   */
+  updatePermissions(permissions: Deno.PermissionOptions): void;
 }
 
 /**

--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -7,6 +7,7 @@ import {
   op_host_recv_ctrl,
   op_host_recv_message,
   op_host_terminate_worker,
+  op_update_worker_permissions,
 } from "ext:core/ops";
 const {
   ArrayPrototypeFilter,
@@ -289,6 +290,14 @@ class Worker extends EventTarget {
       this.#status = "TERMINATED";
       hostTerminateWorker(this.#id);
     }
+  }
+
+  updatePermissions(permissions) {
+    const prefix = "Failed to execute 'updatePermissions' on 'Worker'";
+    webidl.requiredArguments(arguments.length, 1, prefix);
+
+    const serializedPermissions = serializePermissions(permissions);
+    op_update_worker_permissions(this.#id, serializedPermissions);
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -92,6 +92,7 @@ deno_core::extension!(
     op_host_post_message,
     op_host_recv_ctrl,
     op_host_recv_message,
+    op_update_worker_permissions,
   ],
   options = {
     create_web_worker_cb: Arc<CreateWebWorkerCb>,
@@ -405,6 +406,30 @@ fn op_host_post_message(
     worker_handle.port.send(state, data)?;
   } else {
     debug!("tried to post message to non-existent worker {}", id);
+  }
+  Ok(())
+}
+
+/// Update permissions for a worker
+#[op2]
+fn op_update_worker_permissions(
+  state: &mut OpState,
+  #[serde] id: WorkerId,
+  #[serde] permissions: Option<ChildPermissionsArg>,
+) -> Result<(), deno_permissions::ChildPermissionError> {
+  if let Some(worker_thread) = state.borrow::<WorkersTable>().get(&id) {
+    debug!("updating permissions for worker {}", id);
+    let worker_handle = worker_thread.worker_handle.clone();
+
+    if let Some(new_permissions) = permissions {
+      let parent_permissions = state.borrow::<PermissionsContainer>();
+      let updated_permissions =
+        parent_permissions.create_child_permissions(new_permissions)?;
+
+      worker_handle.update_permissions(updated_permissions);
+    }
+  } else {
+    debug!("tried to update permissions for non-existent worker {}", id);
   }
   Ok(())
 }

--- a/tests/integration/js_unit_tests.rs
+++ b/tests/integration/js_unit_tests.rs
@@ -145,7 +145,10 @@ fn js_unit_test(test: String) {
     deno = deno.arg("--unstable-kv");
   }
 
-  if test == "worker_permissions_test" || test == "worker_dynamic_permissions_test" || test == "worker_test" {
+  if test == "worker_permissions_test"
+    || test == "worker_dynamic_permissions_test"
+    || test == "worker_test"
+  {
     deno = deno.arg("--unstable-worker-options");
   }
 

--- a/tests/integration/js_unit_tests.rs
+++ b/tests/integration/js_unit_tests.rs
@@ -108,6 +108,7 @@ util::unit_test_factory!(
     webgpu_test,
     websocket_test,
     webstorage_test,
+    worker_dynamic_permissions_test,
     worker_permissions_test,
     worker_test,
     write_file_test,
@@ -144,7 +145,7 @@ fn js_unit_test(test: String) {
     deno = deno.arg("--unstable-kv");
   }
 
-  if test == "worker_permissions_test" || test == "worker_test" {
+  if test == "worker_permissions_test" || test == "worker_dynamic_permissions_test" || test == "worker_test" {
     deno = deno.arg("--unstable-worker-options");
   }
 

--- a/tests/testdata/workers/dynamic_permissions_worker.js
+++ b/tests/testdata/workers/dynamic_permissions_worker.js
@@ -1,0 +1,18 @@
+onmessage = async ({ data }) => {
+  const results = {};
+  for (const [permType, paths] of Object.entries(data.permissions)) {
+    results[permType] = {};
+    for (const path of paths) {
+      try {
+        const { state } = await Deno.permissions.query({
+          name: permType,
+          path: path,
+        });
+        results[permType][path] = state;
+      } catch (error) {
+        results[permType][path] = "error: " + error.message;
+      }
+    }
+  }
+  postMessage({ type: "permissionResults", results });
+};

--- a/tests/unit/worker_dynamic_permissions_test.ts
+++ b/tests/unit/worker_dynamic_permissions_test.ts
@@ -1,0 +1,41 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+import { assertEquals, assertThrows } from "./test_util.ts";
+
+Deno.test(
+  { permissions: { read: true } },
+  async function workerDynamicPermissionsUpdate() {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const testFile = import.meta.resolve(
+      "../testdata/workers/env_read_check_worker.js",
+    );
+
+    const worker = new Worker(
+      import.meta.resolve("../testdata/workers/dynamic_permissions_worker.js"),
+      { type: "module", deno: { permissions: { read: false } } },
+    );
+
+    worker.onmessage = ({ data }) => {
+      resolve(data.results.read[testFile]);
+    };
+
+    assertThrows(() => {
+      worker.updatePermissions({
+        write: [testFile],
+      });
+    });
+
+    worker.updatePermissions({
+      read: [testFile],
+    });
+
+    worker.postMessage({
+      type: "checkPermissions",
+      permissions: { read: [testFile] },
+    });
+
+    const result = await promise;
+    assertEquals(result, "granted");
+
+    worker.terminate();
+  },
+);


### PR DESCRIPTION
Add the `Worker.updatePermissions` method to allow Web Worker permissions to be replaced after startup.

Since this is a PR to add an API, I think further discussion may be necessary.

Fixes #30339. Please refer to this issue for details. 

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
