### PR TITLE
fix(ext/node): handle large buffer correctly

### DIFF
--- a/ext/node/ops/buffer.rs
+++ b/ext/node/ops/buffer.rs
@@ -156,7 +156,10 @@ pub fn op_node_decode_utf8<'a>(
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 enum BufferError {
-  #[error("String too long")]
+  #[error(
+    "Cannot create a string longer than 0x{:x} characters",
+    v8::String::MAX_LENGTH
+  )]
   #[class(generic)]
   #[property("code" = "ERR_STRING_TOO_LONG")]
   StringTooLong,

--- a/ext/node/polyfills/string_decoder.ts
+++ b/ext/node/polyfills/string_decoder.ts
@@ -41,6 +41,7 @@ const {
   DataViewPrototypeGetBuffer,
   DataViewPrototypeGetByteLength,
   DataViewPrototypeGetByteOffset,
+  NumberPrototypeToString,
   ObjectPrototypeIsPrototypeOf,
   String,
   TypedArrayPrototypeGetBuffer,
@@ -106,6 +107,7 @@ function normalizeBuffer(buf: Buffer) {
   }
 }
 
+const maxStringLengthHex = NumberPrototypeToString(MAX_STRING_LENGTH, 16);
 function bufferToString(
   buf: Buffer,
   encoding?: string,
@@ -114,7 +116,10 @@ function bufferToString(
 ): string {
   const len = (end ?? buf.length) - (start ?? 0);
   if (len > MAX_STRING_LENGTH) {
-    throw new NodeError("ERR_STRING_TOO_LONG", "string exceeds maximum length");
+    throw new NodeError(
+      "ERR_STRING_TOO_LONG",
+      `Cannot create a string longer than 0x${maxStringLengthHex} characters`,
+    );
   }
   // deno-lint-ignore prefer-primordials
   return buf.toString(encoding as Any, start, end);

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -1345,9 +1345,12 @@
 "pseudo-tty/test-tty-stdin-call-end.js" = {}
 "pseudo-tty/test-tty-stdin-end.js" = {}
 "pseudo-tty/test-tty-stdout-end.js" = {}
+"pummel/test-buffer-large-size-buffer-alloc-unsafe-slow.js" = {}
+"pummel/test-buffer-large-size-buffer-alloc-unsafe.js" = {}
 "pummel/test-dh-regr.js" = {}
 "pummel/test-fs-watch-system-limit.js" = {}
 "pummel/test-heapdump-inspector.js" = {}
+"pummel/test-string-decoder-large-buffer.js" = {}
 "sequential/test-buffer-creation-regression.js" = {}
 "sequential/test-child-process-exit.js" = {}
 "sequential/test-cli-syntax-bad.js" = {}

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -1,7 +1,9 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
-import { Buffer } from "node:buffer";
+import { Buffer, constants } from "node:buffer";
 import { assertEquals, assertThrows } from "@std/assert";
 import { strictEqual } from "node:assert";
+
+const { MAX_STRING_LENGTH } = constants;
 
 Deno.test({
   name: "[node/buffer] alloc fails if size is not a number",
@@ -668,6 +670,21 @@ Deno.test({
     assertEquals(
       Buffer.from([239, 187, 191, 97, 98]).toString("utf8"),
       "\uFEFFab",
+    );
+  },
+});
+
+Deno.test({
+  name: "[node/buffer] throws ERR_STRING_TOO_LONG with the correct message",
+  fn() {
+    assertThrows(
+      () => {
+        Buffer.allocUnsafe(2 ** 31).toString();
+      },
+      Error,
+      `Cannot create a string longer than 0x${
+        MAX_STRING_LENGTH.toString(16)
+      } characters`,
     );
   },
 });


### PR DESCRIPTION
Previously, Deno throws error when creating `Buffer.allocUnsafe` or `Buffer.allocUnsafeSlow` with size of `2**31` where that's not the case with Node.js. 

The changes allow these tests to pass:
- [test-buffer-large-size-buffer-alloc-unsafe-slow.js](https://github.com/nodejs/node/blob/v24.2.0/test/pummel/test-buffer-large-size-buffer-alloc-unsafe-slow.js)
- [test-buffer-large-size-buffer-alloc-unsafe.js](https://github.com/nodejs/node/blob/v24.2.0/test/pummel/test-buffer-large-size-buffer-alloc-unsafe.js)
- [test-string-decoder-large-buffer.js](https://github.com/nodejs/node/blob/v24.2.0/test/pummel/test-string-decoder-large-buffer.js)

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
