### PR TITLE
feat(fmt): apply object spacing to import/export lines

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -1398,6 +1398,12 @@ fn get_typescript_config_builder(
     options.space_surrounding_properties
   {
     builder.space_surrounding_properties(space_surrounding_properties);
+    builder.import_declaration_space_surrounding_named_imports(
+      space_surrounding_properties,
+    );
+    builder.export_declaration_space_surrounding_named_exports(
+      space_surrounding_properties,
+    );
   }
 
   builder

--- a/tests/testdata/fmt/with_config/subdir/a.ts
+++ b/tests/testdata/fmt/with_config/subdir/a.ts
@@ -68,8 +68,12 @@ Deno.test(
 			+ 'hello world foo bar baz'
 			+ 'hello world foo bar baz'
 
-		// checks typeLiteral.separatorKind=semiColon
+		// checks typeLiteral.separatorKind=comma
 		// checks spaceSurroundingProperties=false
 		type T = {a: 1, b: 2}
 	}
 )
+
+// checks spaceSurroundingProperties=false
+import {foo} from 'bar'
+export {foo} from 'bar'


### PR DESCRIPTION
Hi Deno folks!

I stumbled over an issue during formatting a project that I'm moving to Deno, where curly braces would be handled inconsistently by `deno fmt`, and thought this would make for a nice first contribution.

This lets spacing in named import/export lines follow the config for objects. Spaces would always be added before, which looked odd in projects that otherwise used no spaces for object syntax.

There is no change for users who leave `spaceSurroundingProperties` at the default value (on).

Config:
```json
{
  "fmt": {"spaceSurroundingProperties": false}
}
```

Old formatting:
```ts
// spaces always added here:
import { foo } from "bar";

const baz = {a: 1};
```

New formatting with this PR applied:
```ts
import {foo} from "bar";

const baz = {a: 1};
```

With this change, the behavior roughly matches [that of stylistic's curly rule](https://eslint.style/rules/object-curly-spacing), which seems reasonable to me. For me this simplified migration to deno a lot, because import braces were 90% of formatting changes caused by `deno fmt` w/o option to change them before.

As alternative to this change I considered adding a new property, but exposing all of dprint's internals does not seem right to me. Stylistic does not have an option to configure import/exports and objects separately either.

The documentation already mentions that the given property applies to "object-like nodes", so no change should be needed there.