### PR TITLE
fix(ext/node): make some `os` exported properties read only

### DIFF
--- a/ext/node/polyfills/os.ts
+++ b/ext/node/polyfills/os.ts
@@ -38,7 +38,12 @@ import { os } from "ext:deno_node/internal_binding/constants.ts";
 import { osUptime } from "ext:deno_os/30_os.js";
 import { Buffer } from "ext:deno_node/internal/buffer.mjs";
 import { primordials } from "ext:core/mod.js";
-const { StringPrototypeEndsWith, StringPrototypeSlice } = primordials;
+
+const {
+  ObjectDefineProperties,
+  StringPrototypeEndsWith,
+  StringPrototypeSlice,
+} = primordials;
 
 export const constants = os;
 
@@ -359,7 +364,7 @@ export function availableParallelism(): number {
 export const EOL = isWindows ? "\r\n" : "\n";
 export const devNull = isWindows ? "\\\\.\\nul" : "/dev/null";
 
-export default {
+const mod = {
   availableParallelism,
   arch,
   cpus,
@@ -380,7 +385,31 @@ export default {
   uptime,
   userInfo,
   version,
-  constants,
-  EOL,
-  devNull,
 };
+
+ObjectDefineProperties(mod, {
+  constants: {
+    __proto__: null,
+    configurable: false,
+    enumerable: true,
+    value: constants,
+  },
+  EOL: {
+    __proto__: null,
+    configurable: true,
+    enumerable: true,
+    writable: false,
+    value: EOL,
+  },
+  devNull: {
+    __proto__: null,
+    configurable: true,
+    enumerable: true,
+    writable: false,
+    value: devNull,
+  },
+});
+
+// NB(Tango992): we want to have a default exports from this module for ES imports,
+// as well as make it work with `require` in such a way that the object properties are set correctly.
+export { mod as "module.exports", mod as default };

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -806,6 +806,7 @@
 "parallel/test-next-tick.js" = {}
 "parallel/test-no-node-snapshot.js" = {}
 "parallel/test-nodeeventtarget.js" = {}
+"parallel/test-os-eol.js" = {}
 "parallel/test-os-homedir-no-envvar.js" = {}
 "parallel/test-os-userinfo-handles-getter-errors.js" = {}
 "parallel/test-os.js" = {}


### PR DESCRIPTION
These only occurs when importing using `require('os')`, since ES module imports already make it non-writeable. Changes are based on Node.js original implementation [here](https://github.com/nodejs/node/blob/591ba692bfe30408e6a67397e7d18bfa1b9c3561/lib/os.js#L333-L356). This allows [test-os-eol.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-os-eol.js) to pass.