### PR TITLE
fix(tests): use correct path separator on unix for code_cache cleanup.ts

### DIFF
--- a/tests/specs/compile/code_cache/cleanup.ts
+++ b/tests/specs/compile/code_cache/cleanup.ts
@@ -5,7 +5,7 @@ try {
   if (Deno.build.os === "windows") {
     Deno.removeSync(tmpdir() + "\\deno-compile-using_code_cache.exe.cache");
   } else {
-    Deno.removeSync(tmpdir() + "\\deno-compile-using_code_cache.cache");
+    Deno.removeSync(tmpdir() + "/deno-compile-using_code_cache.cache");
   }
 } catch {
 }


### PR DESCRIPTION
This has been causing failures on multiple PRs.