### PR TITLE
fix(unstable): update deno_tunnel for better reconnect errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tunnel"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386488c23cda3d6f44d4fa5593a45346032902bbd5bf058e48077b85fb550f99"
+checksum = "cbe45dacb6e0d2a646b22a12fea81ba2f7128202f9ee91602782b9208da123b9"
 dependencies = [
  "pin-project",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ napi_sym = { version = "0.142.0", path = "./ext/napi/sym" }
 node_resolver = { version = "0.50.0", path = "./libs/node_resolver" }
 test_util = { package = "test_server", path = "./tests/util/server" }
 
-deno_tunnel = "0.7.0"
+deno_tunnel = "0.8.0"
 
 # widely used libraries
 anyhow = "1.0.57"


### PR DESCRIPTION
event handling is now passed as an argument so they can be emitted before the connect call returns. also adds a "reason" to reconnect to show exactly what error caused it.