### PR TITLE
fix(unstable): lint node properties should be enumerable

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -607,6 +607,9 @@ function setNodeGetters(ctx) {
     const name = getString(ctx.strTable, id);
 
     Object.defineProperty(FacadeNode.prototype, name, {
+      // The `parent` key is expected to be non-enumerable.
+      // See the npm `zimmerframe` library.
+      enumerable: name !== "parent",
       get() {
         return readValue(
           this[INTERNAL_CTX],

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { assertEquals } from "./test_util.ts";
+import { assert, assertEquals } from "./test_util.ts";
 import { assertSnapshot } from "@std/testing/snapshot";
 
 // TODO(@marvinhagemeister) Remove once we land "official" types
@@ -1227,4 +1227,21 @@ Deno.test("Plugin - TS keywords", async (t) => {
   await testSnapshot(t, "type A = undefined", "TSUndefinedKeyword");
   await testSnapshot(t, "type A = unknown", "TSUnknownKeyword");
   await testSnapshot(t, "type A = void", "TSVoidKeyword");
+});
+
+Deno.test("Plugin - enumerable properties", () => {
+  const keys: string[] = [];
+  testPlugin(`const a = 42`, {
+    create() {
+      return {
+        Program(node) {
+          for (const k in node) {
+            keys.push(k);
+          }
+        },
+      };
+    },
+  });
+
+  assert(keys.length > 0);
 });

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -1235,6 +1235,7 @@ Deno.test("Plugin - enumerable properties", () => {
     create() {
       return {
         Program(node) {
+          // deno-lint-ignore guard-for-in
           for (const k in node) {
             keys.push(k);
           }


### PR DESCRIPTION
This makes npm libraries that traverse the ESTree format like `zimmerframe` or `periscopic` work with our lint ast.