### PR TITLE
fix(test): set cwd when running node compatibility tests

### DIFF
--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -22,9 +22,8 @@ import {
   usesNodeTestModule,
 } from "./common.ts";
 import { generateTestSerialId } from "./test.ts";
-import { join } from "@std/path/join";
 
-const testSuitePath = "tests/node_compat/runner/suite";
+const testSuitePath = new URL(import.meta.resolve("./runner/suite/"));
 const testDirUrl = new URL("runner/suite/test/", import.meta.url).href;
 const IS_CI = !!Deno.env.get("CI");
 // The timeout ms for single test execution. If a single test didn't finish in this timeout milliseconds, the test is considered as failure
@@ -176,7 +175,8 @@ export async function runSingle(
   const testPath_ = "test/" + testPath;
   let usesNodeTest = false;
   try {
-    const source = await Deno.readTextFile(join(testSuitePath, testPath_));
+    const testFileUrl = new URL(testPath_, testSuitePath);
+    const source = await Deno.readTextFile(testFileUrl);
     usesNodeTest = usesNodeTestModule(source);
     if (NODE_IGNORED_TEST_CASES.has(testPath)) {
       return { result: NodeTestFileResult.IGNORED, usesNodeTest };

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -22,7 +22,9 @@ import {
   usesNodeTestModule,
 } from "./common.ts";
 import { generateTestSerialId } from "./test.ts";
+import { join } from "@std/path/join";
 
+const testSuitePath = "tests/node_compat/runner/suite";
 const testDirUrl = new URL("runner/suite/test/", import.meta.url).href;
 const IS_CI = !!Deno.env.get("CI");
 // The timeout ms for single test execution. If a single test didn't finish in this timeout milliseconds, the test is considered as failure
@@ -171,10 +173,10 @@ export async function runSingle(
 ): Promise<NodeTestFileReport> {
   const testSerialId = generateTestSerialId();
   let cmd: Deno.ChildProcess | undefined;
-  const testPath_ = "tests/node_compat/runner/suite/test/" + testPath;
+  const testPath_ = "test/" + testPath;
   let usesNodeTest = false;
   try {
-    const source = await Deno.readTextFile(testPath_);
+    const source = await Deno.readTextFile(join(testSuitePath, testPath_));
     usesNodeTest = usesNodeTestModule(source);
     if (NODE_IGNORED_TEST_CASES.has(testPath)) {
       return { result: NodeTestFileResult.IGNORED, usesNodeTest };
@@ -195,6 +197,7 @@ export async function runSingle(
       },
       stdout: "piped",
       stderr: "piped",
+      cwd: testSuitePath,
     }).spawn();
     const result = await deadline(cmd.output(), TIMEOUT);
     if (result.code === 0) {


### PR DESCRIPTION
Allows tests to resolve path correctly, such as this one https://github.com/nodejs/node/blob/591ba692bfe30408e6a67397e7d18bfa1b9c3561/test/parallel/test-fs-cp.mjs#L35