### PR TITLE
fix(ext/node): mTLS support for `node:tls`

### DIFF
--- a/ext/net/02_tls.js
+++ b/ext/net/02_tls.js
@@ -203,6 +203,7 @@ function startTlsInternal(
     hostname = "127.0.0.1",
     caCerts = [],
     alpnProtocols = undefined,
+    keyPair = null,
     rejectUnauthorized,
   },
 ) {
@@ -212,7 +213,7 @@ function startTlsInternal(
     caCerts,
     alpnProtocols,
     rejectUnauthorized,
-  }, null);
+  }, keyPair);
   return new TlsConn(rid, remoteAddr, localAddr);
 }
 

--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -113,7 +113,6 @@ export class TLSSocket extends net.Socket {
     tlsOptions.alpnProtocols = opts.ALPNProtocols;
     tlsOptions.rejectUnauthorized = opts.rejectUnauthorized !== false;
 
-    console.log(tlsOptions);
     super({
       handle: _wrapHandle(tlsOptions, socket),
       ...opts,
@@ -204,8 +203,7 @@ export class TLSSocket extends net.Socket {
 
           tlssock.emit("secure");
           tlssock.removeListener("end", onConnectEnd);
-        } catch (e) {
-          console.log(e);
+        } catch {
           // TODO(kt3k): Handle this
         }
       };


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/28341

- handle `secureContext.key` and `secureContext.cert` in `new TLSSocket()`
- Fix serialize when `secureContext.ca` is an array

Fixes MQTT connect support:
```
New connection from 127.0.0.1:58119 on port 8883.
1755367370: New client connected from 127.0.0.1:58119 as 637013c2-53c7-4779-9e84-50dcf2f2f81b (p5, c0, k60, u'test-client').
1755367370: No will message specified.
1755367370: Sending CONNACK to 637013c2-53c7-4779-9e84-50dcf2f2f81b (0, 0)
```