### PR TITLE
fix(types): specify `ArrayBuffer` as a backing buffer type for `TextEncoder.encode()`

### DIFF
--- a/cli/tsc/dts/lib.deno_web.d.ts
+++ b/cli/tsc/dts/lib.deno_web.d.ts
@@ -468,10 +468,13 @@ interface TextEncoderEncodeIntoResult {
  */
 interface TextEncoder extends TextEncoderCommon {
   /** Turns a string into binary data (in the form of a Uint8Array) using UTF-8 encoding. */
-  encode(input?: string): Uint8Array;
+  encode(input?: string): Uint8Array<ArrayBuffer>;
 
   /** Encodes a string into the destination Uint8Array and returns the result of the encoding. */
-  encodeInto(input: string, dest: Uint8Array): TextEncoderEncodeIntoResult;
+  encodeInto(
+    input: string,
+    dest: Uint8Array<ArrayBufferLike>,
+  ): TextEncoderEncodeIntoResult;
 }
 
 /** @category Encoding */

--- a/cli/tsc/dts/lib.deno_web.d.ts
+++ b/cli/tsc/dts/lib.deno_web.d.ts
@@ -452,12 +452,6 @@ interface TextEncoderEncodeIntoResult {
   written: number;
 }
 
-/** @category Encoding */
-interface TextEncoder extends TextEncoderCommon {
-  /** Returns the result of running UTF-8's encoder. */
-  encode(input?: string): Uint8Array;
-  encodeInto(input: string, dest: Uint8Array): TextEncoderEncodeIntoResult;
-}
 /**
  * Allows you to convert a string into binary data (in the form of a Uint8Array)
  * given the encoding.


### PR DESCRIPTION
This patch updates the `TextEncoder` interface type declarations to correctly specify `ArrayBuffer` as the backing buffer type for the `encode()` method, aligning with the spec and addressing the change introduced in TypeScript 5.7 about making `ArrayVBufferLike` a default buffer type behind `Uint8Array`.

### Problem

TypeScript 5.7 changed the default backing buffer type for `Uint8Array` from `ArrayBuffer` to `ArrayBufferLike` (which is a union of `ArrayBuffer` and `SharedArrayBuffer`). However, `TextEncoder.encode()` per specification always returns a `Uint8Array` backed by a standard `ArrayBuffer`, never a `SharedArrayBuffer`. This mismatch causes type errors when passing the buffer to functions expecting `ArrayBuffer`:

```typescript
const data = new TextEncoder().encode("hello");

function processData(d: ArrayBuffer) { /* ... */ }

processData(data.buffer);
```

Type check result with Deno v2.4.4:

```console
Check file:///tmp/arraybuffer.ts
TS2345 [ERROR]: Argument of type 'ArrayBufferLike' is not assignable to parameter of type 'ArrayBuffer'.
  Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
processData(data.buffer) // Type error: ArrayBufferLike is not assignable to ArrayBuffer
            ~~~~~~~~~~~
    at file:///tmp/arraybuffer.ts:7:13

error: Type checking failed.
```

### Solution

This issue is resolved in this patch by explicitly specifying `Uint8Array<ArrayBuffer>` as the return type for `encode()`.

Also, the second parameter type of `encodeInto()` is updated to `Uint8Array<ArrayBufferLike>` to make it less confusing and more explicit.

### Refs

- microsoft/TypeScript#60846
- microsoft/TypeScript-DOM-lib-generator#1893
- microsoft/TypeScript-DOM-lib-generator#1944
