### PR TITLE
fix(types): specify `ArrayBuffer` as a backing buffer type for `Response.body` and `Response.bytes`

### DIFF
--- a/cli/tsc/dts/lib.deno_fetch.d.ts
+++ b/cli/tsc/dts/lib.deno_fetch.d.ts
@@ -45,7 +45,7 @@ declare var FormData: {
 /** @category Fetch */
 interface Body {
   /** A simple getter used to expose a `ReadableStream` of the body contents. */
-  readonly body: ReadableStream<Uint8Array> | null;
+  readonly body: ReadableStream<Uint8Array<ArrayBuffer>> | null;
   /** Stores a `Boolean` that declares whether the body has been used in a
    * response yet.
    */
@@ -61,7 +61,7 @@ interface Body {
   /** Takes a `Response` stream and reads it to completion. It returns a promise
    * that resolves with a `Uint8Array`.
    */
-  bytes(): Promise<Uint8Array>;
+  bytes(): Promise<Uint8Array<ArrayBuffer>>;
   /** Takes a `Response` stream and reads it to completion. It returns a promise
    * that resolves with a `FormData` object.
    */


### PR DESCRIPTION
This patch updates the `Response` interface type declarations to correctly specify `ArrayBuffer` as the backing buffer type for the `encode()` method, aligning with the spec and addressing the change introduced in TypeScript 5.7 about making `ArrayVBufferLike` a default buffer type behind `Uint8Array`.

In fact, [TypeScript's dom.d.ts got a similar change](https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/fad434be5961529bee396efab03cce2a1bc333e2/baselines/dom.generated.d.ts#L4563-L4580), and now it looks like:

```ts
interface Body {
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/body) */
    readonly body: ReadableStream<Uint8Array<ArrayBuffer>> | null;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bodyUsed) */
    readonly bodyUsed: boolean;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/arrayBuffer) */
    arrayBuffer(): Promise<ArrayBuffer>;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/blob) */
    blob(): Promise<Blob>;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/bytes) */
    bytes(): Promise<Uint8Array<ArrayBuffer>>;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
    formData(): Promise<FormData>;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
    json(): Promise<any>;
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
    text(): Promise<string>;
}
```

### Refs

- microsoft/TypeScript-DOM-lib-generator#1944
- #30434