### PR TITLE
fix(cache): cache excluded modules explicitly provided on the command line

### DIFF
--- a/cli/graph_container.rs
+++ b/cli/graph_container.rs
@@ -55,6 +55,11 @@ pub struct CheckSpecifiersOptions<'a> {
   pub allow_unknown_media_types: bool,
 }
 
+pub struct CollectSpecifiersOptions {
+  /// Whether to include paths that are specified even if they're ignored.
+  pub include_ignored_specified: bool,
+}
+
 impl MainModuleGraphContainer {
   pub fn new(
     cli_options: Arc<CliOptions>,
@@ -103,8 +108,9 @@ impl MainModuleGraphContainer {
   pub async fn load_and_type_check_files(
     &self,
     files: &[String],
+    options: CollectSpecifiersOptions,
   ) -> Result<(), AnyError> {
-    let specifiers = self.collect_specifiers(files)?;
+    let specifiers = self.collect_specifiers(files, options)?;
 
     if specifiers.is_empty() {
       log::warn!("{} No matching files found.", colors::yellow("Warning"));
@@ -116,6 +122,7 @@ impl MainModuleGraphContainer {
   pub fn collect_specifiers(
     &self,
     files: &[String],
+    options: CollectSpecifiersOptions,
   ) -> Result<Vec<ModuleSpecifier>, AnyError> {
     let excludes = self.cli_options.workspace().resolve_config_excludes()?;
     let include_patterns =
@@ -129,8 +136,14 @@ impl MainModuleGraphContainer {
       exclude: excludes,
     };
     collect_specifiers(
-      file_patterns,
-      self.cli_options.vendor_dir_path().map(ToOwned::to_owned),
+      crate::util::fs::CollectSpecifiersOptions {
+        file_patterns,
+        vendor_folder: self
+          .cli_options
+          .vendor_dir_path()
+          .map(ToOwned::to_owned),
+        include_ignored_specified: options.include_ignored_specified,
+      },
       |e| is_script_ext(e.path),
     )
   }

--- a/cli/lib/util/logger.rs
+++ b/cli/lib/util/logger.rs
@@ -89,6 +89,7 @@ pub fn init(options: InitLoggingOptions) {
   // https://github.com/swc-project/swc/blob/74d6478be1eb8cdf1df096c360c159db64b64d8a/crates/swc_ecma_codegen/src/macros.rs#L112
   // We suppress them here to avoid flooding our CI logs in integration tests.
   .filter_module("swc_ecma_codegen", log::LevelFilter::Off)
+  .filter_module("swc_common::source_map", log::LevelFilter::Off)
   .filter_module("swc_ecma_transforms_optimization", log::LevelFilter::Off)
   .filter_module("swc_ecma_parser", log::LevelFilter::Error)
   .filter_module("swc_ecma_lexer", log::LevelFilter::Error)

--- a/cli/tools/bench/mod.rs
+++ b/cli/tools/bench/mod.rs
@@ -43,6 +43,7 @@ use crate::ops;
 use crate::tools::test::TestFilter;
 use crate::tools::test::format_test_error;
 use crate::util::file_watcher;
+use crate::util::fs::CollectSpecifiersOptions;
 use crate::util::fs::collect_specifiers;
 use crate::util::path::is_script_ext;
 use crate::util::path::matches_pattern_or_exact_path;
@@ -452,8 +453,11 @@ pub async fn run_benchmarks(
     .iter()
     .map(|(_, bench_options)| {
       collect_specifiers(
-        bench_options.files.clone(),
-        cli_options.vendor_dir_path().map(ToOwned::to_owned),
+        CollectSpecifiersOptions {
+          file_patterns: bench_options.files.clone(),
+          vendor_folder: cli_options.vendor_dir_path().map(ToOwned::to_owned),
+          include_ignored_specified: false,
+        },
         is_supported_bench_path,
       )
     })
@@ -550,8 +554,13 @@ pub async fn run_benchmarks_with_watch(
           .iter()
           .map(|(_, bench_options)| {
             collect_specifiers(
-              bench_options.files.clone(),
-              cli_options.vendor_dir_path().map(ToOwned::to_owned),
+              CollectSpecifiersOptions {
+                file_patterns: bench_options.files.clone(),
+                vendor_folder: cli_options
+                  .vendor_dir_path()
+                  .map(ToOwned::to_owned),
+                include_ignored_specified: false,
+              },
               is_supported_bench_path,
             )
           })

--- a/cli/tools/check.rs
+++ b/cli/tools/check.rs
@@ -8,6 +8,7 @@ use deno_terminal::colors;
 use crate::args::CheckFlags;
 use crate::args::Flags;
 use crate::factory::CliFactory;
+use crate::graph_container::CollectSpecifiersOptions;
 use crate::util::extract;
 
 pub async fn check(
@@ -18,8 +19,12 @@ pub async fn check(
 
   let main_graph_container = factory.main_module_graph_container().await?;
 
-  let specifiers =
-    main_graph_container.collect_specifiers(&check_flags.files)?;
+  let specifiers = main_graph_container.collect_specifiers(
+    &check_flags.files,
+    CollectSpecifiersOptions {
+      include_ignored_specified: false,
+    },
+  )?;
   if specifiers.is_empty() {
     log::warn!("{} No matching files found.", colors::yellow("Warning"));
   }

--- a/cli/tools/clean.rs
+++ b/cli/tools/clean.rs
@@ -25,6 +25,7 @@ use crate::args::Flags;
 use crate::colors;
 use crate::display;
 use crate::factory::CliFactory;
+use crate::graph_container::CollectSpecifiersOptions;
 use crate::graph_container::ModuleGraphContainer;
 use crate::graph_container::ModuleGraphUpdatePermit;
 use crate::graph_util::BuildGraphRequest;
@@ -207,7 +208,12 @@ async fn clean_except(
   let sys = factory.sys();
   let options = factory.cli_options()?;
   let main_graph_container = factory.main_module_graph_container().await?;
-  let roots = main_graph_container.collect_specifiers(entrypoints)?;
+  let roots = main_graph_container.collect_specifiers(
+    entrypoints,
+    CollectSpecifiersOptions {
+      include_ignored_specified: true,
+    },
+  )?;
   let http_cache = factory.global_http_cache()?;
   let local_or_global_http_cache = factory.http_cache()?.clone();
   let deno_dir = factory.deno_dir()?.clone();

--- a/cli/tools/doc.rs
+++ b/cli/tools/doc.rs
@@ -39,6 +39,7 @@ use crate::graph_util::graph_exit_integrity_errors;
 use crate::graph_util::graph_walk_errors;
 use crate::sys::CliSys;
 use crate::tsc::get_types_declaration_file_text;
+use crate::util::fs::CollectSpecifiersOptions;
 use crate::util::fs::collect_specifiers;
 
 const JSON_SCHEMA_VERSION: u8 = 1;
@@ -127,17 +128,20 @@ pub async fn doc(
       let sys = CliSys::default();
 
       let module_specifiers = collect_specifiers(
-        FilePatterns {
-          base: cli_options.initial_cwd().to_path_buf(),
-          include: Some(
-            PathOrPatternSet::from_include_relative_path_or_patterns(
-              cli_options.initial_cwd(),
-              source_files,
-            )?,
-          ),
-          exclude: Default::default(),
+        CollectSpecifiersOptions {
+          file_patterns: FilePatterns {
+            base: cli_options.initial_cwd().to_path_buf(),
+            include: Some(
+              PathOrPatternSet::from_include_relative_path_or_patterns(
+                cli_options.initial_cwd(),
+                source_files,
+              )?,
+            ),
+            exclude: Default::default(),
+          },
+          vendor_folder: cli_options.vendor_dir_path().map(ToOwned::to_owned),
+          include_ignored_specified: false,
         },
-        cli_options.vendor_dir_path().map(ToOwned::to_owned),
         |_| true,
       )?;
       let graph = module_graph_creator

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -39,6 +39,7 @@ use crate::args::resolve_no_prompt;
 use crate::factory::CliFactory;
 use crate::file_fetcher::CreateCliFileFetcherOptions;
 use crate::file_fetcher::create_cli_file_fetcher;
+use crate::graph_container::CollectSpecifiersOptions;
 use crate::graph_container::ModuleGraphContainer;
 use crate::jsr::JsrFetchResolver;
 use crate::npm::NpmFetchResolver;
@@ -231,7 +232,12 @@ pub(crate) async fn install_from_entrypoints(
   let factory = CliFactory::from_flags(flags.clone());
   let emitter = factory.emitter()?;
   let main_graph_container = factory.main_module_graph_container().await?;
-  let specifiers = main_graph_container.collect_specifiers(entrypoints)?;
+  let specifiers = main_graph_container.collect_specifiers(
+    entrypoints,
+    CollectSpecifiersOptions {
+      include_ignored_specified: true,
+    },
+  )?;
   main_graph_container
     .check_specifiers(
       &specifiers,
@@ -371,9 +377,12 @@ async fn install_global(
   factory
     .main_module_graph_container()
     .await?
-    .load_and_type_check_files(std::slice::from_ref(
-      &install_flags_global.module_url,
-    ))
+    .load_and_type_check_files(
+      std::slice::from_ref(&install_flags_global.module_url),
+      CollectSpecifiersOptions {
+        include_ignored_specified: true,
+      },
+    )
     .await?;
 
   if matches!(flags.config_flag, ConfigFlag::Discover)

--- a/cli/util/fs.rs
+++ b/cli/util/fs.rs
@@ -74,18 +74,29 @@ pub fn canonicalize_path_maybe_not_exists(
   )
 }
 
+pub struct CollectSpecifiersOptions {
+  pub file_patterns: FilePatterns,
+  pub vendor_folder: Option<PathBuf>,
+  /// Whether to include paths that are specified even if they're ignored.
+  pub include_ignored_specified: bool,
+}
+
 /// Collects module specifiers that satisfy the given predicate as a file path, by recursively walking `include`.
 /// Specifiers that start with http and https are left intact.
 /// Note: This ignores all .git and node_modules folders.
 pub fn collect_specifiers(
-  mut files: FilePatterns,
-  vendor_folder: Option<PathBuf>,
+  options: CollectSpecifiersOptions,
   predicate: impl Fn(WalkEntry) -> bool,
 ) -> Result<Vec<ModuleSpecifier>, AnyError> {
+  let CollectSpecifiersOptions {
+    mut file_patterns,
+    vendor_folder,
+    include_ignored_specified: always_include_specified,
+  } = options;
   let mut prepared = vec![];
 
-  // break out the remote specifiers
-  if let Some(include_mut) = &mut files.include {
+  // break out the remote specifiers and explicitly specified paths
+  if let Some(include_mut) = &mut file_patterns.include {
     let includes = std::mem::take(include_mut);
     let path_or_patterns = includes.into_path_or_patterns();
     let mut result = Vec::with_capacity(path_or_patterns.len());
@@ -94,7 +105,9 @@ pub fn collect_specifiers(
         PathOrPattern::Path(path) => {
           if path.is_dir() {
             result.push(PathOrPattern::Path(path));
-          } else if !files.exclude.matches_path(&path) {
+          } else if always_include_specified
+            || !file_patterns.exclude.matches_path(&path)
+          {
             let url = specifier_from_file_path(&path)?;
             prepared.push(url);
           }
@@ -119,7 +132,7 @@ pub fn collect_specifiers(
     .ignore_git_folder()
     .ignore_node_modules()
     .set_vendor_folder(vendor_folder)
-    .collect_file_patterns(&CliSys::default(), files);
+    .collect_file_patterns(&CliSys::default(), file_patterns);
   let mut collected_files_as_urls = collected_files
     .iter()
     .map(|f| specifier_from_file_path(f).unwrap())
@@ -217,24 +230,27 @@ mod tests {
     };
 
     let result = collect_specifiers(
-      FilePatterns {
-        base: root_dir_path.to_path_buf(),
-        include: Some(
-          PathOrPatternSet::from_include_relative_path_or_patterns(
-            root_dir_path.as_path(),
-            &[
-              "http://localhost:8080".to_string(),
-              "./".to_string(),
-              "https://localhost:8080".to_string(),
-            ],
-          )
-          .unwrap(),
-        ),
-        exclude: PathOrPatternSet::new(vec![PathOrPattern::Path(
-          ignore_dir_path.to_path_buf(),
-        )]),
+      CollectSpecifiersOptions {
+        file_patterns: FilePatterns {
+          base: root_dir_path.to_path_buf(),
+          include: Some(
+            PathOrPatternSet::from_include_relative_path_or_patterns(
+              root_dir_path.as_path(),
+              &[
+                "http://localhost:8080".to_string(),
+                "./".to_string(),
+                "https://localhost:8080".to_string(),
+              ],
+            )
+            .unwrap(),
+          ),
+          exclude: PathOrPatternSet::new(vec![PathOrPattern::Path(
+            ignore_dir_path.to_path_buf(),
+          )]),
+        },
+        vendor_folder: None,
+        include_ignored_specified: false,
       },
-      None,
       predicate,
     )
     .unwrap();
@@ -268,19 +284,22 @@ mod tests {
       "file://"
     };
     let result = collect_specifiers(
-      FilePatterns {
-        base: root_dir_path.to_path_buf(),
-        include: Some(PathOrPatternSet::new(vec![
-          PathOrPattern::new(&format!(
-            "{}{}",
-            scheme,
-            root_dir_path.join("child").to_string().replace('\\', "/")
-          ))
-          .unwrap(),
-        ])),
-        exclude: Default::default(),
+      CollectSpecifiersOptions {
+        file_patterns: FilePatterns {
+          base: root_dir_path.to_path_buf(),
+          include: Some(PathOrPatternSet::new(vec![
+            PathOrPattern::new(&format!(
+              "{}{}",
+              scheme,
+              root_dir_path.join("child").to_string().replace('\\', "/")
+            ))
+            .unwrap(),
+          ])),
+          exclude: Default::default(),
+        },
+        vendor_folder: None,
+        include_ignored_specified: false,
       },
-      None,
       predicate,
     )
     .unwrap();

--- a/tests/specs/install/entrypoint_ignored/__test__.jsonc
+++ b/tests/specs/install/entrypoint_ignored/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "install --allow-import -e ignore/main.ts",
+  "output": "install.out"
+}

--- a/tests/specs/install/entrypoint_ignored/deno.json
+++ b/tests/specs/install/entrypoint_ignored/deno.json
@@ -1,0 +1,5 @@
+{
+  "exclude": [
+    "ignore"
+  ]
+}

--- a/tests/specs/install/entrypoint_ignored/deno.lock
+++ b/tests/specs/install/entrypoint_ignored/deno.lock
@@ -1,0 +1,6 @@
+{
+  "version": "5",
+  "remote": {
+    "http://localhost:4545/welcome.ts": "7353d5fcbc36c45d26bcbca478cf973092523b07c45999f41319820092b4de31"
+  }
+}

--- a/tests/specs/install/entrypoint_ignored/ignore/main.ts
+++ b/tests/specs/install/entrypoint_ignored/ignore/main.ts
@@ -1,0 +1,1 @@
+import "http://localhost:4545/welcome.ts";

--- a/tests/specs/install/entrypoint_ignored/install.out
+++ b/tests/specs/install/entrypoint_ignored/install.out
@@ -1,0 +1,2 @@
+Download http://localhost:4545/welcome.ts
+[WILDCARD]


### PR DESCRIPTION
Caches modules explicitly provided on the command line.

Example:

```jsonc
// deno.json
{
  "exclude": ["./ignore"]
}
```

```
deno cache ./ignore/main.ts # should cache this file
```