### PR TITLE
fix(unstable): parsing regex in selector with character class

### DIFF
--- a/cli/js/40_lint_selector.js
+++ b/cli/js/40_lint_selector.js
@@ -159,6 +159,26 @@ export class Lexer {
     this.value = this.getSlice();
   }
 
+  readBinAttrValue() {
+    const s = this.i;
+    let depth = 0;
+    while (this.token !== Token.EOF) {
+      if (this.token === Token.BracketClose) {
+        if (depth-- <= 0) {
+          break;
+        }
+      } else if (this.token === Token.BracketOpen) {
+        depth++;
+      }
+
+      this.next();
+    }
+
+    this.start = s;
+    this.end = this.i - 1;
+    this.value = this.getSlice();
+  }
+
   getSlice() {
     return this.input.slice(this.start, this.end);
   }
@@ -258,6 +278,11 @@ export class Lexer {
           this.token = Token.Minus;
           this.step();
           return;
+        case Char.BackSlash: {
+          this.step();
+          this.step();
+          continue;
+        }
 
         case Char.Plus:
         case Char.Tilde:
@@ -518,7 +543,7 @@ export function parseSelector(input, toElem, toAttr) {
 
       if (lex.token === Token.Op) {
         const op = getAttrOp(lex.value);
-        lex.readAsWordUntil(Token.BracketClose);
+        lex.readBinAttrValue();
 
         const value = getFromRawValue(lex.value);
         current.push({ type: ATTR_BIN_NODE, prop, op, value });

--- a/tests/unit/lint_selectors_test.ts
+++ b/tests/unit/lint_selectors_test.ts
@@ -464,6 +464,37 @@ Deno.test("Parser - Attr", () => {
   ]]);
 });
 
+// See https://github.com/denoland/deno/issues/30460
+Deno.test("Parser - Attr regex", () => {
+  assertEquals(testParse("Foo[bar=/^[a-z]$/]"), [[
+    {
+      elem: ELEM_NODE,
+      type: 1,
+      wildcard: false,
+    },
+    {
+      type: ATTR_BIN_NODE,
+      op: BinOp.Equal,
+      prop: [2],
+      value: /^[a-z]$/,
+    },
+  ]]);
+
+  assertEquals(testParse("Foo[bar=/^[a-z\\]]foo$/]"), [[
+    {
+      elem: ELEM_NODE,
+      type: 1,
+      wildcard: false,
+    },
+    {
+      type: ATTR_BIN_NODE,
+      op: BinOp.Equal,
+      prop: [2],
+      value: /^[a-z\]]foo$/,
+    },
+  ]]);
+});
+
 Deno.test("Parser - Attr nested", () => {
   assertEquals(testParse("[foo.bar]"), [[
     {


### PR DESCRIPTION
Fixes parsing a regex lint selector with a character class like `[foo=/[a-z]/]`.

The parser just looked for the next `]` character and aborted there. It didn't account for the regex grammar having this character too.