### PR TITLE
fix(npm): do not error on failure to write warned script file

### DIFF
--- a/libs/npm_installer/global.rs
+++ b/libs/npm_installer/global.rs
@@ -222,10 +222,9 @@ impl<TSys: NpmCacheSys> LifecycleScriptsStrategy
     log::warn!("┖─ {}", colors::bold("\"nodeModulesDir\": \"auto\""));
 
     for (package, _) in packages {
-      self.sys.fs_open(
-        self.warned_scripts_file(package),
-        &OpenOptions::new_write(),
-      )?;
+      let _ignore_err = self
+        .sys
+        .fs_open(self.warned_scripts_file(package), &OpenOptions::new_write());
     }
     Ok(())
   }

--- a/tests/specs/npm/peer_deps_with_copied_folders_and_lockfile/__test__.jsonc
+++ b/tests/specs/npm/peer_deps_with_copied_folders_and_lockfile/__test__.jsonc
@@ -1,5 +1,6 @@
 {
   "tempDir": true,
+  "flaky": true,
   "steps": [
     {
       "args": "run -A main.ts",

--- a/tests/specs/schema.json
+++ b/tests/specs/schema.json
@@ -72,6 +72,9 @@
           "canonicalizedTempDir": {
             "type": "boolean"
           },
+          "flaky": {
+            "type": "boolean"
+          },
           "symlinkedTempDir": {
             "type": "boolean"
           },


### PR DESCRIPTION
Looked and we already do this for the local npm install.

Kind of annoying to test this one, so not going to bother to.

Closes https://github.com/denoland/deno/issues/30457