### PR TITLE
fix(ext/node): `fs.path`' `makelong` and `resolve` compatibility

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -819,8 +819,10 @@
 "parallel/test-path-dirname.js" = {}
 "parallel/test-path-extname.js" = {}
 "parallel/test-path-isabsolute.js" = {}
+"parallel/test-path-makelong.js" = {}
 "parallel/test-path-parse-format.js" = {}
 "parallel/test-path-posix-exists.js" = {}
+"parallel/test-path-resolve.js" = {}
 "parallel/test-path-win32-exists.js" = {}
 "parallel/test-path-zero-length-strings.js" = {}
 "parallel/test-path.js" = {}


### PR DESCRIPTION
Changes are based on Node.js' implementation https://github.com/nodejs/node/tree/v24.2.0/lib/path.js.

It allows this tests to pass:
- [parallel/test-path-makelong.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-path-makelong.js)
- [parallel/test-path-resolve.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-path-resolve.js)