### PR TITLE
fix(ext/node): `fs.exists` and `fs.existsSync` compatibility

### DIFF
--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -208,14 +208,18 @@ impl FileSystem for DenoRtSys {
   }
 
   fn exists_sync(&self, path: &CheckedPath) -> bool {
-    if self.error_if_in_vfs(path).is_err() {
-      return false;
+    if self.0.is_path_within(path) {
+      self.0.exists(path)
+    } else {
+      RealFs.exists_sync(path)
     }
-    RealFs.exists_sync(path)
   }
   async fn exists_async(&self, path: CheckedPathBuf) -> FsResult<bool> {
-    self.error_if_in_vfs(&path)?;
-    RealFs.exists_async(path).await
+    if self.0.is_path_within(&path) {
+      Ok(self.0.exists(&path))
+    } else {
+      RealFs.exists_async(path).await
+    }
   }
 
   fn lchmod_sync(&self, path: &CheckedPath, mode: u32) -> FsResult<()> {
@@ -1487,6 +1491,10 @@ impl FileBackedVfs {
 
   pub fn is_path_within(&self, path: &Path) -> bool {
     path.starts_with(&self.fs_root.root_path)
+  }
+
+  pub fn exists(&self, path: &Path) -> bool {
+    self.fs_root.find_entry(path, self.case_sensitivity).is_ok()
   }
 
   pub fn open_file(

--- a/cli/rt/file_system.rs
+++ b/cli/rt/file_system.rs
@@ -207,6 +207,17 @@ impl FileSystem for DenoRtSys {
     RealFs.chown_async(path, uid, gid).await
   }
 
+  fn exists_sync(&self, path: &CheckedPath) -> bool {
+    if self.error_if_in_vfs(path).is_err() {
+      return false;
+    }
+    RealFs.exists_sync(path)
+  }
+  async fn exists_async(&self, path: CheckedPathBuf) -> FsResult<bool> {
+    self.error_if_in_vfs(&path)?;
+    RealFs.exists_async(path).await
+  }
+
   fn lchmod_sync(&self, path: &CheckedPath, mode: u32) -> FsResult<()> {
     self.error_if_in_vfs(path)?;
     RealFs.lchmod_sync(path, mode)

--- a/ext/fs/interface.rs
+++ b/ext/fs/interface.rs
@@ -330,12 +330,8 @@ pub trait FileSystem: std::fmt::Debug + MaybeSend + MaybeSync {
       .unwrap_or(false)
   }
 
-  fn exists_sync(&self, path: &CheckedPath) -> bool {
-    self.stat_sync(path).is_ok()
-  }
-  async fn exists_async(&self, path: CheckedPathBuf) -> FsResult<bool> {
-    Ok(self.stat_async(path).await.is_ok())
-  }
+  fn exists_sync(&self, path: &CheckedPath) -> bool;
+  async fn exists_async(&self, path: CheckedPathBuf) -> FsResult<bool>;
 
   fn read_text_file_lossy_sync(
     &self,

--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -1021,20 +1021,7 @@ fn exists(path: &Path) -> bool {
 
   #[cfg(windows)]
   {
-    use std::os::windows::ffi::OsStrExt;
-
-    use winapi::um::fileapi::GetFileAttributesW;
-    use winapi::um::fileapi::INVALID_FILE_ATTRIBUTES;
-
-    let path = path
-      .as_os_str()
-      .encode_wide()
-      .chain(std::iter::once(0))
-      .collect::<Vec<_>>();
-    // Safety: `path` is a null-terminated string
-    let attrs = unsafe { GetFileAttributesW(path.as_ptr()) };
-
-    attrs != INVALID_FILE_ATTRIBUTES
+    fs::exists(path).unwrap_or(false)
   }
 }
 

--- a/ext/node/polyfills/_fs/_fs_exists.ts
+++ b/ext/node/polyfills/_fs/_fs_exists.ts
@@ -7,6 +7,7 @@ import { makeCallback } from "ext:deno_node/_fs/_fs_common.ts";
 import type { Buffer } from "node:buffer";
 import * as pathModule from "node:path";
 import { kCustomPromisifiedSymbol } from "ext:deno_node/internal/util.mjs";
+import * as process from "node:process";
 
 const { ObjectDefineProperty, Promise, PromisePrototypeThen } = primordials;
 
@@ -46,10 +47,20 @@ ObjectDefineProperty(exists, kCustomPromisifiedSymbol, {
   configurable: true,
 });
 
+let showExistsDeprecation = true;
 export function existsSync(path: string | Buffer | URL): boolean {
   try {
     path = getValidatedPathToString(path);
-  } catch {
+  } catch (err) {
+    // @ts-expect-error `code` is safe to check with optional chaining
+    if (showExistsDeprecation && err?.code === "ERR_INVALID_ARG_TYPE") {
+      process.emitWarning(
+        "Passing invalid argument types to fs.existsSync is deprecated",
+        "DeprecationWarning",
+        "DEP0187",
+      );
+      showExistsDeprecation = false;
+    }
     return false;
   }
   return op_node_fs_exists_sync(pathModule.toNamespacedPath(path));

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -428,8 +428,7 @@
 # but it's actually not included in 24.2 https://github.com/nodejs/node/pull/55862
 # "parallel/test-fs-constants.js" = {}
 "parallel/test-fs-empty-readStream.js" = {}
-# TODO(bartlomieju): this is failing on missing warning
-# "parallel/test-fs-exists.js" = {}
+"parallel/test-fs-exists.js" = {}
 "parallel/test-fs-existssync-false.js" = {}
 "parallel/test-fs-fchown.js" = {}
 "parallel/test-fs-fsync.js" = {}
@@ -468,6 +467,7 @@
 "parallel/test-fs-rmdir-type-check.js" = {}
 "parallel/test-fs-stream-fs-options.js" = {}
 "parallel/test-fs-stream-options.js" = {}
+"parallel/test-fs-symlink-dir-junction.js" = {}
 "parallel/test-fs-unlink-type-check.js" = {}
 "parallel/test-fs-util-validateoffsetlength.js" = {}
 "parallel/test-fs-write-negativeoffset.js" = {}


### PR DESCRIPTION
Closes #30506

Other changes:
- Emit deprecation warning.
- Allows [parallel/test-fs-exists.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-fs-exists.js) to pass.
- Allows [test-fs-symlink-dir-junction.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-fs-symlink-dir-junction.js) to pass. Previously it always fail due to invalid assertion using `existsSync`.