### PR TITLE
fix(bundle): do not error on fallible dynamic imports/requires

### DIFF
--- a/tests/registry/npm/@denotest/fallible-imports/1.0.0/infallible.js
+++ b/tests/registry/npm/@denotest/fallible-imports/1.0.0/infallible.js
@@ -1,0 +1,5 @@
+var chalk = require("chalk");
+
+module.exports = {
+  foo: "bar",
+};

--- a/tests/registry/npm/@denotest/fallible-imports/1.0.0/mod.js
+++ b/tests/registry/npm/@denotest/fallible-imports/1.0.0/mod.js
@@ -1,0 +1,9 @@
+let chalk;
+try {
+  chalk = require("chalk");
+} catch (e) {
+}
+
+module.exports = {
+  foo: "bar",
+}

--- a/tests/registry/npm/@denotest/fallible-imports/1.0.0/other.mjs
+++ b/tests/registry/npm/@denotest/fallible-imports/1.0.0/other.mjs
@@ -1,0 +1,6 @@
+try {
+  await import("chalk");
+} catch (e) {
+}
+
+export const thing = "thing";

--- a/tests/registry/npm/@denotest/fallible-imports/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/fallible-imports/1.0.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@denotest/fallible-imports",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./mod.js",
+    "./other": "./other.mjs",
+    "./infallible": "./infallible.js"
+  }
+}

--- a/tests/specs/bundle/fallible_imports/__test__.jsonc
+++ b/tests/specs/bundle/fallible_imports/__test__.jsonc
@@ -1,0 +1,48 @@
+{
+  "tempDir": true,
+
+  "tests": {
+    "npm_ok": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "bundle main.ts",
+          "output": "bundle.out"
+        }
+      ]
+    },
+    "npm_bad": {
+      "steps": [
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "bundle bad.ts",
+          "output": "bad.out",
+          "exitCode": 1
+        }
+      ]
+    },
+    "local_ok": {
+      "steps": [
+        {
+          "args": "bundle local.ts",
+          "output": "local.out"
+        }
+      ]
+    },
+    "local_bad": {
+      "steps": [
+        {
+          "args": "bundle local_bad.ts",
+          "output": "local_bad.out",
+          "exitCode": 1
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/bundle/fallible_imports/bad.out
+++ b/tests/specs/bundle/fallible_imports/bad.out
@@ -1,0 +1,5 @@
+[WILDCARD]
+error: Could not find package 'chalk' from referrer '[WILDLINE]infallible.js'.
+    at [WILDLINE]@denotest/fallible-imports/infallible.js:1:20
+    note: You can mark the path "chalk" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle. You can also surround this "require" call with a try/catch block to handle this failure at run-time instead of bundle-time.
+error: bundling failed

--- a/tests/specs/bundle/fallible_imports/bad.ts
+++ b/tests/specs/bundle/fallible_imports/bad.ts
@@ -1,0 +1,3 @@
+import { foo } from "@denotest/fallible-imports/infallible";
+
+console.log(foo);

--- a/tests/specs/bundle/fallible_imports/bundle.out
+++ b/tests/specs/bundle/fallible_imports/bundle.out
@@ -1,0 +1,28 @@
+[WILDCARD]
+// node_modules/.deno/@denotest+fallible-imports@1.0.0/node_modules/@denotest/fallible-imports/mod.js
+var require_mod = __commonJS({
+  "node_modules/.deno/@denotest+fallible-imports@1.0.0/node_modules/@denotest/fallible-imports/mod.js"(exports, module) {
+    var chalk;
+    try {
+      chalk = __require("chalk");
+    } catch (e) {
+    }
+    module.exports = {
+      foo: "bar"
+    };
+  }
+});
+
+// main.ts
+var import_fallible_imports = __toESM(require_mod());
+
+// node_modules/.deno/@denotest+fallible-imports@1.0.0/node_modules/@denotest/fallible-imports/other.mjs
+try {
+  await import("chalk");
+} catch (e) {
+}
+var thing = "thing";
+
+// main.ts
+console.log(import_fallible_imports.foo);
+console.log(thing);

--- a/tests/specs/bundle/fallible_imports/deno.json
+++ b/tests/specs/bundle/fallible_imports/deno.json
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "manual",
+  "imports": {
+    "@denotest/fallible-imports": "npm:@denotest/fallible-imports"
+  }
+}

--- a/tests/specs/bundle/fallible_imports/local.out
+++ b/tests/specs/bundle/fallible_imports/local.out
@@ -1,0 +1,7 @@
+[WILDCARD]
+// local.ts
+try {
+  await import("bad");
+} catch (e) {
+  console.log(e);
+}

--- a/tests/specs/bundle/fallible_imports/local.ts
+++ b/tests/specs/bundle/fallible_imports/local.ts
@@ -1,0 +1,5 @@
+try {
+  await import("bad");
+} catch (e) {
+  console.log(e);
+}

--- a/tests/specs/bundle/fallible_imports/local_bad.out
+++ b/tests/specs/bundle/fallible_imports/local_bad.out
@@ -1,0 +1,5 @@
+[WILDCARD]
+error: Relative import path "bad" not prefixed with / or ./ or ../ and not in import map from "[WILDLINE]local_bad.ts"
+    at [WILDLINE]/local_bad.ts:1:13
+    note: You can mark the path "bad" as external to exclude it from the bundle, which will remove this error and leave the unresolved path in the bundle. You can also add ".catch()" here to handle this failure at run-time instead of bundle-time.
+error: bundling failed

--- a/tests/specs/bundle/fallible_imports/local_bad.ts
+++ b/tests/specs/bundle/fallible_imports/local_bad.ts
@@ -1,0 +1,1 @@
+await import("bad");

--- a/tests/specs/bundle/fallible_imports/main.ts
+++ b/tests/specs/bundle/fallible_imports/main.ts
@@ -1,0 +1,4 @@
+import { foo } from "@denotest/fallible-imports";
+import { thing } from "@denotest/fallible-imports/other";
+console.log(foo);
+console.log(thing);


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/30510

Basically we save the error for later, return `None` to esbuild. Later when we process esbuild errors, if esbuild failed to resolve the same package then we use our error message instead of esbuild's