### PR TITLE
fix(install): don't try to re-symlink binaries in node_modules if the symlink is correct

### DIFF
--- a/libs/npm_installer/bin_entries.rs
+++ b/libs/npm_installer/bin_entries.rs
@@ -500,7 +500,7 @@ fn symlink_bin_entry<'a>(
     .unwrap_or_else(|| Cow::Borrowed(&original));
 
   if let Ok(original_link) = sys.fs_read_link(&link)
-    && &*original_link == &*original_relative
+    && *original_link == *original_relative
   {
     return Ok(EntrySetupOutcome::Success);
   }


### PR DESCRIPTION
Fix #30424.

I think this should avoid the errors. It will add some overhead when they aren't set up yet, but binaries are pretty small in number so I doubt it will matter.

In the case where it's already set up (which is probably common), it should avoid some work and prevent using binaries that are already in use