### PR TITLE
refactor(permissions): remove `all` state in permissions

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1035,7 +1035,6 @@ impl CliOptions {
       }
 
       PermissionsOptions {
-        allow_all: flags.allow_all,
         allow_env: handle_allow(flags.allow_all, flags.allow_env.clone()),
         deny_env: flags.deny_env.clone(),
         allow_net: handle_allow(flags.allow_all, flags.allow_net.clone()),
@@ -1063,7 +1062,7 @@ impl CliOptions {
 
   fn augment_import_permissions(&self, options: &mut PermissionsOptions) {
     // do not add if the user specified --allow-all or --allow-import
-    if !options.allow_all && options.allow_import.is_none() {
+    if options.allow_import.is_none() {
       options.allow_import = Some(self.implicit_allow_import());
     }
     options.deny_import = options.deny_import.clone();

--- a/ext/fs/lib.rs
+++ b/ext/fs/lib.rs
@@ -52,10 +52,6 @@ pub trait FsPermissions {
   ) -> Result<CheckedPath<'a>, PermissionCheckError>;
   fn check_write_all(&self, api_name: &str)
   -> Result<(), PermissionCheckError>;
-
-  fn allows_all(&self) -> bool {
-    false
-  }
 }
 
 impl FsPermissions for deno_permissions::PermissionsContainer {
@@ -108,10 +104,6 @@ impl FsPermissions for deno_permissions::PermissionsContainer {
     api_name: &str,
   ) -> Result<(), PermissionCheckError> {
     deno_permissions::PermissionsContainer::check_write_all(self, api_name)
-  }
-
-  fn allows_all(&self) -> bool {
-    self.allows_all()
   }
 }
 

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -397,6 +397,38 @@ impl PermissionState {
     }
   }
 
+  fn prompt(
+    name: &'static str,
+    api_name: Option<&str>,
+    info: impl Fn() -> Option<String>,
+  ) -> (Result<(), PermissionDeniedError>, bool) {
+    let msg = {
+      let info = info();
+      StringBuilder::<String>::build(|builder| {
+        builder.append(name);
+        builder.append(" access");
+        if let Some(info) = &info {
+          builder.append(" to ");
+          builder.append(info);
+        }
+      })
+      .unwrap()
+    };
+    match permission_prompt(&msg, name, api_name, true) {
+      PromptResponse::Allow => {
+        Self::log_perm_access(name, info);
+        (Ok(()), false)
+      }
+      PromptResponse::AllowAll => {
+        Self::log_perm_access(name, info);
+        (Ok(()), true)
+      }
+      PromptResponse::Deny => {
+        (Err(Self::permission_denied_error(name, info)), false)
+      }
+    }
+  }
+
   #[inline]
   fn check(
     self,
@@ -411,31 +443,8 @@ impl PermissionState {
         (Ok(()), false, false)
       }
       PermissionState::Prompt if prompt => {
-        let msg = {
-          let info = info();
-          StringBuilder::<String>::build(|builder| {
-            builder.append(name);
-            builder.append(" access");
-            if let Some(info) = &info {
-              builder.append(" to ");
-              builder.append(info);
-            }
-          })
-          .unwrap()
-        };
-        match permission_prompt(&msg, name, api_name, true) {
-          PromptResponse::Allow => {
-            Self::log_perm_access(name, info);
-            (Ok(()), true, false)
-          }
-          PromptResponse::AllowAll => {
-            Self::log_perm_access(name, info);
-            (Ok(()), true, true)
-          }
-          PromptResponse::Deny => {
-            (Err(Self::permission_denied_error(name, info)), true, false)
-          }
-        }
+        let (result, is_allow_all) = Self::prompt(name, api_name, info);
+        (result, true, is_allow_all)
       }
       _ => (Err(Self::permission_denied_error(name, info)), false, false),
     }
@@ -505,31 +514,6 @@ impl UnitPermission {
       }
     }
     result
-  }
-
-  fn create_child_permissions(
-    &mut self,
-    flag: ChildUnitPermissionArg,
-  ) -> Result<Self, ChildPermissionError> {
-    let mut perm = self.clone();
-    match flag {
-      ChildUnitPermissionArg::Inherit => {
-        // copy
-      }
-      ChildUnitPermissionArg::Granted => {
-        if self.check(|| None).is_err() {
-          return Err(ChildPermissionError::Escalation);
-        }
-        perm.state = PermissionState::Granted;
-      }
-      ChildUnitPermissionArg::NotGranted => {
-        perm.state = PermissionState::Prompt;
-      }
-    }
-    if self.state == PermissionState::Denied {
-      perm.state = PermissionState::Denied;
-    }
-    Ok(perm)
   }
 }
 
@@ -1237,6 +1221,10 @@ impl PathDescriptor {
 
   pub fn into_write(self) -> WriteDescriptor {
     WriteDescriptor(self)
+  }
+
+  pub fn into_path_buf(self) -> PathBuf {
+    self.path
   }
 }
 
@@ -1998,7 +1986,7 @@ impl<'a> RunQueryDescriptor<'a> {
     requested: &'a str,
     sys: &impl which::WhichSys,
   ) -> Result<Self, PathResolveError> {
-    if is_path(requested) {
+    if AllowRunDescriptor::is_path(requested) {
       let path = Path::new(requested);
       let resolved = PathQueryDescriptor::new(sys, Cow::Borrowed(path))?;
       Ok(RunQueryDescriptor::Path(resolved))
@@ -2105,7 +2093,7 @@ impl QueryDescriptor for RunQueryDescriptor<'_> {
           return true;
         }
         match &path.requested {
-          Some(requested) if is_path(requested) => false,
+          Some(requested) if AllowRunDescriptor::is_path(requested) => false,
           None => false, // is path
           Some(requested) => denies_run_name(requested, &other.0.path),
         }
@@ -2158,7 +2146,7 @@ impl AllowRunDescriptor {
     cwd: &Path,
     sys: &impl WhichSys,
   ) -> Result<AllowRunDescriptorParseResult, which::Error> {
-    let is_path = is_path(text);
+    let is_path = Self::is_path(text);
     let path = if is_path {
       Cow::Borrowed(Path::new(text))
     } else {
@@ -2186,6 +2174,14 @@ impl AllowRunDescriptor {
     Ok(AllowRunDescriptorParseResult::Descriptor(
       AllowRunDescriptor(path),
     ))
+  }
+
+  pub fn is_path(text: &str) -> bool {
+    if cfg!(windows) {
+      text.contains('/') || text.contains('\\') || Path::new(text).is_absolute()
+    } else {
+      text.contains('/')
+    }
   }
 }
 
@@ -2215,14 +2211,6 @@ impl DenyRunDescriptor {
     } else {
       DenyRunDescriptor::Name(text.to_string())
     }
-  }
-}
-
-fn is_path(text: &str) -> bool {
-  if cfg!(windows) {
-    text.contains('/') || text.contains('\\') || Path::new(text).is_absolute()
-  } else {
-    text.contains('/')
   }
 }
 
@@ -2769,6 +2757,7 @@ impl UnaryPermission<FfiDescriptor, FfiDescriptor> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Permissions {
+  // WARNING: update the methods below if ever adding anything here
   pub read: UnaryPermission<ReadDescriptor, ReadDescriptor>,
   pub write: UnaryPermission<WriteDescriptor, WriteDescriptor>,
   pub net: UnaryPermission<NetDescriptor, NetDescriptor>,
@@ -2777,12 +2766,45 @@ pub struct Permissions {
   pub run: UnaryPermission<AllowRunDescriptor, DenyRunDescriptor>,
   pub ffi: UnaryPermission<FfiDescriptor, FfiDescriptor>,
   pub import: UnaryPermission<ImportDescriptor, ImportDescriptor>,
-  pub all: UnitPermission,
+}
+
+impl Permissions {
+  pub fn all_granted(&self) -> bool {
+    self.read.is_allow_all()
+      && self.write.is_allow_all()
+      && self.net.is_allow_all()
+      && self.env.is_allow_all()
+      && self.sys.is_allow_all()
+      && self.run.is_allow_all()
+      && self.ffi.is_allow_all()
+      && self.import.is_allow_all()
+  }
+
+  pub fn any_prompt(&self) -> bool {
+    self.read.prompt
+      && self.write.prompt
+      && self.net.prompt
+      && self.env.prompt
+      && self.sys.prompt
+      && self.run.prompt
+      && self.ffi.prompt
+      && self.import.prompt
+  }
+
+  pub fn grant_all_permissions(&mut self) {
+    self.read = UnaryPermission::allow_all();
+    self.write = UnaryPermission::allow_all();
+    self.net = UnaryPermission::allow_all();
+    self.env = UnaryPermission::allow_all();
+    self.sys = UnaryPermission::allow_all();
+    self.run = UnaryPermission::allow_all();
+    self.ffi = UnaryPermission::allow_all();
+    self.import = UnaryPermission::allow_all();
+  }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct PermissionsOptions {
-  pub allow_all: bool,
   pub allow_env: Option<Vec<String>>,
   pub deny_env: Option<Vec<String>>,
   pub allow_net: Option<Vec<String>>,
@@ -2992,7 +3014,6 @@ impl Permissions {
         })?,
         opts.prompt,
       ),
-      all: Permissions::new_all(opts.allow_all),
     })
   }
 
@@ -3007,7 +3028,6 @@ impl Permissions {
       run: UnaryPermission::allow_all(),
       ffi: UnaryPermission::allow_all(),
       import: UnaryPermission::allow_all(),
-      all: Permissions::new_all(true),
     }
   }
 
@@ -3031,7 +3051,6 @@ impl Permissions {
       run: Permissions::new_unary(None, None, prompt),
       ffi: Permissions::new_unary(None, None, prompt),
       import: Permissions::new_unary(None, None, prompt),
-      all: Permissions::new_all(false),
     }
   }
 }
@@ -3154,40 +3173,9 @@ impl PermissionsContainer {
     &self,
     child_permissions_arg: ChildPermissionsArg,
   ) -> Result<PermissionsContainer, ChildPermissionError> {
-    fn is_granted_unary(arg: &ChildUnaryPermissionArg) -> bool {
-      match arg {
-        ChildUnaryPermissionArg::Inherit | ChildUnaryPermissionArg::Granted => {
-          true
-        }
-        ChildUnaryPermissionArg::NotGranted
-        | ChildUnaryPermissionArg::GrantedList(_) => false,
-      }
-    }
-
     let mut worker_perms = Permissions::none_without_prompt();
 
     let mut inner = self.inner.lock();
-    worker_perms.all = inner
-      .all
-      .create_child_permissions(ChildUnitPermissionArg::Inherit)?;
-
-    // downgrade the `worker_perms.all` based on the other values
-    if worker_perms.all.query() == PermissionState::Granted {
-      let unary_perms = [
-        &child_permissions_arg.read,
-        &child_permissions_arg.write,
-        &child_permissions_arg.net,
-        &child_permissions_arg.import,
-        &child_permissions_arg.env,
-        &child_permissions_arg.sys,
-        &child_permissions_arg.run,
-        &child_permissions_arg.ffi,
-      ];
-      let allow_all = unary_perms.into_iter().all(is_granted_unary);
-      if !allow_all {
-        worker_perms.all.revoke();
-      }
-    }
 
     // WARNING: When adding a permission here, ensure it is handled
     // in the worker_perms.all block above
@@ -3343,7 +3331,7 @@ impl PermissionsContainer {
     // If somehow read or write aren't specified, use read
     let path = {
       let mut inner = self.inner.lock();
-      if matches!(inner.all.state, PermissionState::Granted) {
+      if inner.all_granted() {
         return Ok(CheckedPath {
           path: PathWithRequested {
             path,
@@ -3514,17 +3502,29 @@ impl PermissionsContainer {
     Ok(())
   }
 
-  /// This checks to see if the allow-all flag was passed, not whether all
-  /// permissions are enabled!
   #[inline(always)]
-  fn check_was_allow_all_flag_passed(
+  fn check_has_all_permissions(
     &self,
     context_path: &Path,
   ) -> Result<(), PermissionCheckError> {
-    self.inner.lock().all.check(|| {
-      Some(format_display_name(context_path.to_string_lossy()).into_owned())
-    })?;
-    Ok(())
+    let mut inner = self.inner.lock();
+    let fmt_name =
+      || Some(format_display_name(context_path.to_string_lossy()).into_owned());
+    if inner.all_granted() {
+      Ok(())
+    } else if inner.any_prompt() {
+      let (result, _is_allow_all) =
+        PermissionState::prompt("all", None, fmt_name);
+      match result {
+        Ok(()) => {
+          inner.grant_all_permissions();
+          Ok(())
+        }
+        Err(err) => Err(err.into()),
+      }
+    } else {
+      Err(PermissionState::permission_denied_error("all", fmt_name).into())
+    }
   }
 
   /// Checks special file access, returning the failed permission type if
@@ -3614,12 +3614,12 @@ impl PermissionsContainer {
         if path.ends_with("/environ") {
           self.check_env_all()?;
         } else {
-          self.check_was_allow_all_flag_passed(&path)?;
+          self.check_has_all_permissions(&path)?;
         }
       }
     } else if cfg!(unix) {
       if path.starts_with("/dev") {
-        self.check_was_allow_all_flag_passed(&path)?;
+        self.check_has_all_permissions(&path)?;
       }
     } else if cfg!(target_os = "windows") {
       // \\.\nul is allowed
@@ -3652,7 +3652,7 @@ impl PermissionsContainer {
 
       // If this is a normalized drive path, accept it
       if !is_normalized_windows_drive_path(&path) {
-        self.check_was_allow_all_flag_passed(&path)?;
+        self.check_has_all_permissions(&path)?;
       }
     } else {
       unimplemented!()
@@ -4210,7 +4210,7 @@ impl PermissionsContainer {
   }
 
   pub fn allows_all(&self) -> bool {
-    matches!(self.inner.lock().all.state, PermissionState::Granted)
+    self.inner.lock().all_granted()
   }
 }
 
@@ -5115,7 +5115,6 @@ mod tests {
         allow_env: Some(svec!["HOME"]),
         allow_sys: Some(svec!["hostname"]),
         allow_run: Some(svec!["/deno"]),
-        allow_all: false,
         ..Default::default()
       },
     )

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -4208,10 +4208,6 @@ impl PermissionsContainer {
       ),
     )
   }
-
-  pub fn allows_all(&self) -> bool {
-    self.inner.lock().all_granted()
-  }
 }
 
 const fn unit_permission_from_flag_bools(

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -1240,10 +1240,6 @@ impl PathDescriptor {
   pub fn into_write(self) -> WriteDescriptor {
     WriteDescriptor(self)
   }
-
-  pub fn into_path_buf(self) -> PathBuf {
-    self.path
-  }
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
@@ -2004,7 +2000,7 @@ impl<'a> RunQueryDescriptor<'a> {
     requested: &'a str,
     sys: &impl which::WhichSys,
   ) -> Result<Self, PathResolveError> {
-    if AllowRunDescriptor::is_path(requested) {
+    if is_path(requested) {
       let path = Path::new(requested);
       let resolved = PathQueryDescriptor::new(sys, Cow::Borrowed(path))?;
       Ok(RunQueryDescriptor::Path(resolved))
@@ -2111,7 +2107,7 @@ impl QueryDescriptor for RunQueryDescriptor<'_> {
           return true;
         }
         match &path.requested {
-          Some(requested) if AllowRunDescriptor::is_path(requested) => false,
+          Some(requested) if is_path(requested) => false,
           None => false, // is path
           Some(requested) => denies_run_name(requested, &other.0.path),
         }
@@ -2164,7 +2160,7 @@ impl AllowRunDescriptor {
     cwd: &Path,
     sys: &impl WhichSys,
   ) -> Result<AllowRunDescriptorParseResult, which::Error> {
-    let is_path = Self::is_path(text);
+    let is_path = is_path(text);
     let path = if is_path {
       Cow::Borrowed(Path::new(text))
     } else {
@@ -2192,14 +2188,6 @@ impl AllowRunDescriptor {
     Ok(AllowRunDescriptorParseResult::Descriptor(
       AllowRunDescriptor(path),
     ))
-  }
-
-  pub fn is_path(text: &str) -> bool {
-    if cfg!(windows) {
-      text.contains('/') || text.contains('\\') || Path::new(text).is_absolute()
-    } else {
-      text.contains('/')
-    }
   }
 }
 
@@ -2229,6 +2217,14 @@ impl DenyRunDescriptor {
     } else {
       DenyRunDescriptor::Name(text.to_string())
     }
+  }
+}
+
+fn is_path(text: &str) -> bool {
+  if cfg!(windows) {
+    text.contains('/') || text.contains('\\') || Path::new(text).is_absolute()
+  } else {
+    text.contains('/')
   }
 }
 

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -2808,6 +2808,17 @@ impl Permissions {
       && self.ffi.prompt
       && self.import.prompt
   }
+
+  pub fn grant_all_permissions(&mut self) {
+    self.read = UnaryPermission::allow_all();
+    self.write = UnaryPermission::allow_all();
+    self.net = UnaryPermission::allow_all();
+    self.env = UnaryPermission::allow_all();
+    self.sys = UnaryPermission::allow_all();
+    self.run = UnaryPermission::allow_all();
+    self.ffi = UnaryPermission::allow_all();
+    self.import = UnaryPermission::allow_all();
+  }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
@@ -3513,15 +3524,15 @@ impl PermissionsContainer {
     &self,
     context_path: &Path,
   ) -> Result<(), PermissionCheckError> {
-    let inner = self.inner.lock();
+    let mut inner = self.inner.lock();
     if inner.all_granted() {
       Ok(())
     } else {
       let display_name = format_display_name(context_path.to_string_lossy());
       if inner.any_prompt() {
         let msg = format!(
-          "all access in order to access {} or run again with --allow-all to disable this prompt",
-          display_name
+          "all access in order to access {} -- WARNING: This will open the sandbox and allow all actions",
+          display_name,
         );
         let (result, _is_allow_all) = PermissionState::prompt(PromptOptions {
           name: "all",
@@ -3531,7 +3542,10 @@ impl PermissionsContainer {
           is_unary: false,
         });
         match result {
-          Ok(()) => Ok(()),
+          Ok(()) => {
+            inner.grant_all_permissions();
+            Ok(())
+          }
           Err(err) => Err(err.into()),
         }
       } else {

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -3531,9 +3531,8 @@ impl PermissionsContainer {
       let display_name = format_display_name(context_path.to_string_lossy());
       if inner.any_prompt() {
         let msg = format!(
-          "all access in order to access {} -- {} This will elevate all permissions!",
+          "all access in order to access {} -- WARNING: This will open the sandbox and allow all actions!",
           display_name,
-          colors::yellow("Warning")
         );
         let (result, _is_allow_all) = PermissionState::prompt(PromptOptions {
           name: "all",

--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -3531,7 +3531,7 @@ impl PermissionsContainer {
       let display_name = format_display_name(context_path.to_string_lossy());
       if inner.any_prompt() {
         let msg = format!(
-          "all access in order to access {} -- WARNING: This will open the sandbox and allow all actions!",
+          "all access in order to access {} -- WARNING: This will open the sandbox and allow all actions",
           display_name,
         );
         let (result, _is_allow_all) = PermissionState::prompt(PromptOptions {


### PR DESCRIPTION
Removes the `all` state and instead derives the state from the other permissions.