### PR TITLE
fix(test): change `deno test --doc` virtual files sigil from `$` to `#`

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -575,9 +575,9 @@ fn filter_coverages(
     exclude.iter().map(|e| Regex::new(e).unwrap()).collect();
 
   // Matches virtual file paths for doc testing
-  // e.g. file:///path/to/mod.ts$23-29.ts
+  // e.g. file:///path/to/mod.ts#23-29.ts
   let doc_test_re =
-    Regex::new(r"\$\d+-\d+\.(js|mjs|cjs|jsx|ts|mts|cts|tsx)$").unwrap();
+    Regex::new(r"#\d+-\d+\.(js|mjs|cjs|jsx|ts|mts|cts|tsx)$").unwrap();
 
   coverages
     .into_iter()

--- a/cli/util/extract.rs
+++ b/cli/util/extract.rs
@@ -231,7 +231,7 @@ fn extract_files_from_regex_blocks(
       }
 
       let file_specifier = ModuleSpecifier::parse(&format!(
-        "{}${}-{}",
+        "{}#{}-{}",
         specifier,
         file_line_index + line_offset + 1,
         file_line_index + line_offset + line_count + 1,
@@ -501,7 +501,7 @@ fn extract_sym_from_pat(pat: &ast::Pat) -> Vec<Atom> {
 /// import { assertEquals } from "@std/assert/equals";
 /// import { increment, SOME_CONST } from "./base.ts";
 ///
-/// Deno.test("./base.ts$1-3.ts", async () => {
+/// Deno.test("./base.ts#1-3.ts", async () => {
 ///   assertEquals(increment(1), 2);
 /// });
 /// ```
@@ -521,7 +521,7 @@ fn extract_sym_from_pat(pat: &ast::Pat) -> Vec<Atom> {
 /// import { assertEquals } from "@std/assert/equals";
 /// import { doSomething } from "./some_external_module.ts";
 ///
-/// Deno.test("./base.ts$1-3.ts", async () => {
+/// Deno.test("./base.ts#1-3.ts", async () => {
 ///   assertEquals(doSomething(1), 2);
 /// });
 /// ```
@@ -545,7 +545,7 @@ fn extract_sym_from_pat(pat: &ast::Pat) -> Vec<Atom> {
 /// file would look like:
 ///
 /// ```ts
-/// Deno.test("./base.ts$1-7.ts", async () => {
+/// Deno.test("./base.ts#1-7.ts", async () => {
 ///   const logger = createLogger("my-awesome-module");
 ///
 ///   export function sum(a: number, b: number): number {
@@ -562,7 +562,7 @@ fn extract_sym_from_pat(pat: &ast::Pat) -> Vec<Atom> {
 /// stay in the `Deno.test` block's scope:
 ///
 /// ```ts
-/// Deno.test("./base.ts$1-7.ts", async () => {
+/// Deno.test("./base.ts#1-7.ts", async () => {
 ///   const logger = createLogger("my-awesome-module");
 ///
 ///   function sum(a: number, b: number): number {
@@ -877,11 +877,11 @@ export function add(a: number, b: number): number {
         expected: vec![Expected {
           source: r#"import { assertEquals } from "@std/assert/equal";
 import { add } from "file:///main.ts";
-Deno.test("file:///main.ts$3-8.ts", async ()=>{
+Deno.test("file:///main.ts#3-8.ts", async ()=>{
     assertEquals(add(1, 2), 3);
 });
 "#,
-          specifier: "file:///main.ts$3-8.ts",
+          specifier: "file:///main.ts#3-8.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -901,11 +901,11 @@ export default class Bar {}
         },
         expected: vec![Expected {
           source: r#"import Bar, { foo } from "file:///main.ts";
-Deno.test("file:///main.ts$3-6.ts", async ()=>{
+Deno.test("file:///main.ts#3-6.ts", async ()=>{
     foo();
 });
 "#,
-          specifier: "file:///main.ts$3-6.ts",
+          specifier: "file:///main.ts#3-6.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -926,14 +926,14 @@ export type Args = { a: number };
         },
         expected: vec![Expected {
           source: r#"import { Args, foo } from "file:///main.ts";
-Deno.test("file:///main.ts$3-7.ts", async ()=>{
+Deno.test("file:///main.ts#3-7.ts", async ()=>{
     const input = {
         a: 42
     } satisfies Args;
     foo(input);
 });
 "#,
-          specifier: "file:///main.ts$3-7.ts",
+          specifier: "file:///main.ts#3-7.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -953,11 +953,11 @@ Deno.test("file:///main.ts$3-7.ts", async ()=>{
           specifier: "file:///main.ts",
         },
         expected: vec![Expected {
-          source: r#"Deno.test("file:///main.ts$5-8.ts", async ()=>{
+          source: r#"Deno.test("file:///main.ts#5-8.ts", async ()=>{
     foo();
 });
 "#,
-          specifier: "file:///main.ts$5-8.ts",
+          specifier: "file:///main.ts#5-8.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -990,20 +990,20 @@ export * from "./other.ts";
         expected: vec![
           Expected {
             source: r#"import MyClass, { foo } from "file:///main.ts";
-Deno.test("file:///main.ts$5-8.js", async ()=>{
+Deno.test("file:///main.ts#5-8.js", async ()=>{
     const cls = new MyClass();
 });
 "#,
-            specifier: "file:///main.ts$5-8.js",
+            specifier: "file:///main.ts#5-8.js",
             media_type: MediaType::JavaScript,
           },
           Expected {
             source: r#"import MyClass, { foo } from "file:///main.ts";
-Deno.test("file:///main.ts$13-16.ts", async ()=>{
+Deno.test("file:///main.ts#13-16.ts", async ()=>{
     foo();
 });
 "#,
-            specifier: "file:///main.ts$13-16.ts",
+            specifier: "file:///main.ts#13-16.ts",
             media_type: MediaType::TypeScript,
           },
         ],
@@ -1026,11 +1026,11 @@ export default TWO;
         },
         expected: vec![Expected {
           source: r#"import TWO, { ONE, foo } from "file:///main.ts";
-Deno.test("file:///main.ts$3-6.ts", async ()=>{
+Deno.test("file:///main.ts#3-6.ts", async ()=>{
     foo();
 });
 "#,
-          specifier: "file:///main.ts$3-6.ts",
+          specifier: "file:///main.ts#3-6.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1062,11 +1062,11 @@ export { DUPLICATE3 };
 import * as DUPLICATE2 from "./other2.js";
 import { foo as DUPLICATE3 } from "./other3.tsx";
 import { foo } from "file:///main.ts";
-Deno.test("file:///main.ts$3-10.ts", async ()=>{
+Deno.test("file:///main.ts#3-10.ts", async ()=>{
     foo();
 });
 "#,
-          specifier: "file:///main.ts$3-10.ts",
+          specifier: "file:///main.ts#3-10.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1090,12 +1090,12 @@ export const foo = () => "foo";
         },
         expected: vec![Expected {
           source: r#"import { createFoo } from "file:///main.ts";
-Deno.test("file:///main.ts$3-7.ts", async ()=>{
+Deno.test("file:///main.ts#3-7.ts", async ()=>{
     const foo = createFoo();
     foo();
 });
 "#,
-          specifier: "file:///main.ts$3-7.ts",
+          specifier: "file:///main.ts#3-7.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1128,14 +1128,14 @@ Deno.test("file:///main.ts$3-7.ts", async ()=>{
         },
         expected: vec![Expected {
           source: r#"import { getLogger } from "@std/log";
-Deno.test("file:///main.ts$3-12.ts", async ()=>{
+Deno.test("file:///main.ts#3-12.ts", async ()=>{
     const logger = getLogger("my-awesome-module");
     function foo() {
         logger.debug("hello");
     }
 });
 "#,
-          specifier: "file:///main.ts$3-12.ts",
+          specifier: "file:///main.ts#3-12.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1158,11 +1158,11 @@ assertEquals(add(1, 2), 3);
         expected: vec![Expected {
           source: r#"import { assertEquals } from "@std/assert/equal";
 import { add } from "jsr:@deno/non-existent";
-Deno.test("file:///README.md$6-12.js", async ()=>{
+Deno.test("file:///README.md#6-12.js", async ()=>{
     assertEquals(add(1, 2), 3);
 });
 "#,
-          specifier: "file:///README.md$6-12.js",
+          specifier: "file:///README.md#6-12.js",
           media_type: MediaType::JavaScript,
         }],
       },
@@ -1182,11 +1182,11 @@ export default Foo
         },
         expected: vec![Expected {
           source: r#"import { Foo } from "file:///main.ts";
-Deno.test("file:///main.ts$3-6.ts", async ()=>{
+Deno.test("file:///main.ts#3-6.ts", async ()=>{
     console.log(Foo);
 });
 "#,
-          specifier: "file:///main.ts$3-6.ts",
+          specifier: "file:///main.ts#3-6.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1208,12 +1208,12 @@ export function add(first: number, second: number) {
         },
         expected: vec![Expected {
           source: r#"import { add } from "file:///main.ts";
-Deno.test("file:///main.ts$3-7.ts", async ()=>{
+Deno.test("file:///main.ts#3-7.ts", async ()=>{
     // @ts-expect-error: can only add numbers
     add('1', '2');
 });
 "#,
-          specifier: "file:///main.ts$3-7.ts",
+          specifier: "file:///main.ts#3-7.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1239,7 +1239,7 @@ Deno.test("add", ()=>{
     assertEquals(1 + 2, 3);
 });
 "#,
-          specifier: "file:///main.md$4-11.ts",
+          specifier: "file:///main.md#4-11.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1268,7 +1268,7 @@ Deno.test("add", ()=>{
     assertEquals(add(1, 2), 3);
 });
 "#,
-          specifier: "file:///main.ts$3-10.ts",
+          specifier: "file:///main.ts#3-10.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1292,12 +1292,12 @@ export function add(a: number, b: number): number {
         expected: vec![Expected {
           source: r#"import { assertEquals } from "@std/assert/equals";
 import { add } from "file:///main.ts";
-Deno.test("file:///main.ts$3-8.ts", async ()=>{
+Deno.test("file:///main.ts#3-8.ts", async ()=>{
     // Deno.test("add", () => {});
     assertEquals(add(1, 2), 3);
 });
 "#,
-          specifier: "file:///main.ts$3-8.ts",
+          specifier: "file:///main.ts#3-8.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1374,7 +1374,7 @@ export function add(a: number, b: number): number {
 import { add } from "file:///main.ts";
 assertEquals(add(1, 2), 3);
 "#,
-          specifier: "file:///main.ts$3-8.ts",
+          specifier: "file:///main.ts#3-8.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1403,7 +1403,7 @@ import { DUPLICATE } from "./other.ts";
 import { add } from "file:///main.ts";
 assertEquals(add(1, 2), 3);
 "#,
-          specifier: "file:///main.ts$3-9.ts",
+          specifier: "file:///main.ts#3-9.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1431,7 +1431,7 @@ export const foo = () => "foo";
 const foo = createFoo();
 foo();
 "#,
-          specifier: "file:///main.ts$3-7.ts",
+          specifier: "file:///main.ts#3-7.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1463,7 +1463,7 @@ export function foo() {
 }
 const logger = getLogger("my-awesome-module");
 "#,
-          specifier: "file:///main.ts$3-12.ts",
+          specifier: "file:///main.ts#3-12.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1488,7 +1488,7 @@ assertEquals(add(1, 2), 3);
 import { add } from "jsr:@deno/non-existent";
 assertEquals(add(1, 2), 3);
 "#,
-          specifier: "file:///README.md$6-12.js",
+          specifier: "file:///README.md#6-12.js",
           media_type: MediaType::JavaScript,
         }],
       },
@@ -1510,7 +1510,7 @@ export default Foo
           source: r#"import { Foo } from "file:///main.ts";
 console.log(Foo);
 "#,
-          specifier: "file:///main.ts$3-6.ts",
+          specifier: "file:///main.ts#3-6.ts",
           media_type: MediaType::TypeScript,
         }],
       },
@@ -1535,7 +1535,7 @@ export function add(first: number, second: number) {
 // @ts-expect-error: can only add numbers
 add('1', '2');
 "#,
-          specifier: "file:///main.ts$3-7.ts",
+          specifier: "file:///main.ts#3-7.ts",
           media_type: MediaType::TypeScript,
         }],
       },

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1145,7 +1145,7 @@ async fn test_watch_doc() {
 
   assert_eq!(
     skip_restarting_line(&mut stderr_lines).await,
-    format!("Check {foo_file_url}$3-6.ts")
+    format!("Check {foo_file_url}#3-6.ts")
   );
   assert_eq!(
     next_line(&mut stderr_lines).await.unwrap(),
@@ -1158,7 +1158,7 @@ async fn test_watch_doc() {
   assert_eq!(next_line(&mut stderr_lines).await.unwrap(), "          ~~~");
   assert_eq!(
     next_line(&mut stderr_lines).await.unwrap(),
-    format!("    at {foo_file_url}$3-6.ts:3:11")
+    format!("    at {foo_file_url}#3-6.ts:3:11")
   );
   wait_contains("Test failed", &mut stderr_lines).await;
 
@@ -1181,7 +1181,7 @@ async fn test_watch_doc() {
   wait_contains("running 1 test from", &mut stdout_lines).await;
   assert_contains!(
     next_line(&mut stdout_lines).await.unwrap(),
-    &format!("{foo_file_url}$3-8.ts ... FAILED")
+    &format!("{foo_file_url}#3-8.ts ... FAILED")
   );
   wait_contains("ERRORS", &mut stdout_lines).await;
   wait_contains(
@@ -1215,7 +1215,7 @@ async fn test_watch_doc() {
   wait_contains("running 1 test from", &mut stdout_lines).await;
   assert_contains!(
     next_line(&mut stdout_lines).await.unwrap(),
-    &format!("{foo_file_url}$3-8.ts ... ok")
+    &format!("{foo_file_url}#3-8.ts ... ok")
   );
   wait_contains("ok | 1 passed | 0 failed", &mut stdout_lines).await;
 

--- a/tests/specs/check/typecheck_doc_duplicate_identifiers/mod.out
+++ b/tests/specs/check/typecheck_doc_duplicate_identifiers/mod.out
@@ -1,2 +1,2 @@
 Check [WILDCARD]/mod.ts
-Check [WILDCARD]/mod.ts$2-8.ts
+Check [WILDCARD]/mod.ts#2-8.ts

--- a/tests/specs/check/typecheck_doc_failure/mod.out
+++ b/tests/specs/check/typecheck_doc_failure/mod.out
@@ -1,8 +1,8 @@
 Check [WILDCARD]/mod.ts
-Check [WILDCARD]/mod.ts$2-5.ts
+Check [WILDCARD]/mod.ts#2-5.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
 const sum: string = add(1, 2);
       ~~~
-    at [WILDCARD]/mod.ts$2-5.ts:2:7
+    at [WILDCARD]/mod.ts#2-5.ts:2:7
 
 error: Type checking failed.

--- a/tests/specs/check/typecheck_doc_in_markdown/markdown.out
+++ b/tests/specs/check/typecheck_doc_in_markdown/markdown.out
@@ -1,9 +1,9 @@
-Check [WILDCARD]/markdown.md$11-14.js
-Check [WILDCARD]/markdown.md$17-20.ts
-Check [WILDCARD]/markdown.md$29-32.ts
+Check [WILDCARD]/markdown.md#11-14.js
+Check [WILDCARD]/markdown.md#17-20.ts
+Check [WILDCARD]/markdown.md#29-32.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
 const a: string = 42;
       ^
-    at [WILDCARD]/markdown.md$29-32.ts:1:7
+    at [WILDCARD]/markdown.md#29-32.ts:1:7
 
 error: Type checking failed.

--- a/tests/specs/check/typecheck_doc_success/mod.out
+++ b/tests/specs/check/typecheck_doc_success/mod.out
@@ -1,2 +1,2 @@
 Check [WILDCARD]/tests/specs/check/typecheck_doc_success/mod.ts
-Check [WILDCARD]/tests/specs/check/typecheck_doc_success/mod.ts$2-5.ts
+Check [WILDCARD]/tests/specs/check/typecheck_doc_success/mod.ts#2-5.ts

--- a/tests/specs/coverage/default_reports/main.out
+++ b/tests/specs/coverage/default_reports/main.out
@@ -1,9 +1,9 @@
 Check [WILDCARD]/test.ts
-Check [WILDCARD]/source.ts$[WILDCARD].ts
+Check [WILDCARD]/source.ts#[WILDCARD].ts
 running 1 test from ./test.ts
 add() ... ok ([WILDCARD])
-running 1 test from ./source.ts$[WILDCARD].ts
-file:///[WILDCARD]/source.ts$[WILDCARD].ts ... ok ([WILDCARD])
+running 1 test from ./source.ts#[WILDCARD].ts
+file:///[WILDCARD]/source.ts#[WILDCARD].ts ... ok ([WILDCARD])
 
 ok | 2 passed | 0 failed ([WILDCARD])
 

--- a/tests/specs/coverage/filter_doc_testing_urls/test_coverage.out
+++ b/tests/specs/coverage/filter_doc_testing_urls/test_coverage.out
@@ -1,9 +1,9 @@
 Check [WILDCARD]/test.ts
-Check [WILDCARD]/source.ts$[WILDCARD].ts
+Check [WILDCARD]/source.ts#[WILDCARD].ts
 running 1 test from ./test.ts
 add() ... ok ([WILDCARD])
-running 1 test from ./source.ts$[WILDCARD].ts
-file:///[WILDCARD]/source.ts$[WILDCARD].ts ... ok ([WILDCARD])
+running 1 test from ./source.ts#[WILDCARD].ts
+file:///[WILDCARD]/source.ts#[WILDCARD].ts ... ok ([WILDCARD])
 
 ok | 2 passed | 0 failed ([WILDCARD])
 

--- a/tests/specs/test/doc/main.out
+++ b/tests/specs/test/doc/main.out
@@ -1,12 +1,12 @@
-Check [WILDCARD]/main.ts$6-9.js
-Check [WILDCARD]/main.ts$10-13.jsx
-Check [WILDCARD]/main.ts$14-17.ts
-Check [WILDCARD]/main.ts$18-21.tsx
-Check [WILDCARD]/main.ts$30-35.ts
+Check [WILDCARD]/main.ts#6-9.js
+Check [WILDCARD]/main.ts#10-13.jsx
+Check [WILDCARD]/main.ts#14-17.ts
+Check [WILDCARD]/main.ts#18-21.tsx
+Check [WILDCARD]/main.ts#30-35.ts
 TS2367 [ERROR]: This comparison appears to be unintentional because the types 'string' and 'number' have no overlap.
     console.assert(check() == 42);
                    ~~~~~~~~~~~~~
-    at [WILDCARD]/main.ts$30-35.ts:3:20
+    at [WILDCARD]/main.ts#30-35.ts:3:20
 
 error: Type checking failed.
 

--- a/tests/specs/test/doc_duplicate_identifier/main.out
+++ b/tests/specs/test/doc_duplicate_identifier/main.out
@@ -1,11 +1,11 @@
 Check [WILDCARD]/main.ts
-Check [WILDCARD]/main.ts$11-19.ts
-Check [WILDCARD]/main.ts$25-30.ts
+Check [WILDCARD]/main.ts#11-19.ts
+Check [WILDCARD]/main.ts#25-30.ts
 running 0 tests from ./main.ts
-running 1 test from ./main.ts$11-19.ts
-[WILDCARD]/main.ts$11-19.ts ... ok ([WILDLINE])
-running 1 test from ./main.ts$25-30.ts
-[WILDCARD]/main.ts$25-30.ts ... ok ([WILDLINE])
+running 1 test from ./main.ts#11-19.ts
+[WILDCARD]/main.ts#11-19.ts ... ok ([WILDLINE])
+running 1 test from ./main.ts#25-30.ts
+[WILDCARD]/main.ts#25-30.ts ... ok ([WILDLINE])
 
 ok | 2 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/doc_failure/main.out
+++ b/tests/specs/test/doc_failure/main.out
@@ -1,18 +1,18 @@
 Check [WILDCARD]/main.ts
-Check [WILDCARD]/main.ts$2-9.ts
-Check [WILDCARD]/main.ts$13-18.ts
-Check [WILDCARD]/main.ts$24-29.ts
+Check [WILDCARD]/main.ts#2-9.ts
+Check [WILDCARD]/main.ts#13-18.ts
+Check [WILDCARD]/main.ts#24-29.ts
 running 0 tests from ./main.ts
-running 1 test from ./main.ts$2-9.ts
-[WILDCARD]/main.ts$2-9.ts ... FAILED ([WILDLINE])
-running 1 test from ./main.ts$13-18.ts
-[WILDCARD]/main.ts$13-18.ts ... FAILED ([WILDLINE])
-running 1 test from ./main.ts$24-29.ts
-[WILDCARD]/main.ts$24-29.ts ... FAILED ([WILDLINE])
+running 1 test from ./main.ts#2-9.ts
+[WILDCARD]/main.ts#2-9.ts ... FAILED ([WILDLINE])
+running 1 test from ./main.ts#13-18.ts
+[WILDCARD]/main.ts#13-18.ts ... FAILED ([WILDLINE])
+running 1 test from ./main.ts#24-29.ts
+[WILDCARD]/main.ts#24-29.ts ... FAILED ([WILDLINE])
 
- ERRORS 
+ ERRORS
 
-[WILDCARD]/main.ts$13-18.ts => ./main.ts$13-18.ts:3:6
+[WILDCARD]/main.ts#13-18.ts => ./main.ts#13-18.ts:3:6
 error: AssertionError: Values are not equal.
 
 
@@ -25,16 +25,16 @@ error: AssertionError: Values are not equal.
   throw new AssertionError(message);
         ^
     at assertEquals ([WILDCARD]/std/assert/equals.ts:[WILDCARD])
-    at [WILDCARD]/main.ts$13-18.ts:4:5
+    at [WILDCARD]/main.ts#13-18.ts:4:5
 
-[WILDCARD]/main.ts$2-9.ts => ./main.ts$2-9.ts:3:6
+[WILDCARD]/main.ts#2-9.ts => ./main.ts#2-9.ts:3:6
 error: AssertionError: Expected actual: "2.5e+0" to be close to "2": delta "5e-1" is greater than "2e-7".
   throw new AssertionError(
         ^
     at assertAlmostEquals ([WILDCARD]/std/assert/almost_equals.ts:[WILDCARD])
-    at [WILDCARD]/main.ts$2-9.ts:6:5
+    at [WILDCARD]/main.ts#2-9.ts:6:5
 
-[WILDCARD]/main.ts$24-29.ts => ./main.ts$24-29.ts:3:6
+[WILDCARD]/main.ts#24-29.ts => ./main.ts#24-29.ts:3:6
 error: AssertionError: Values are not equal.
 
 
@@ -47,13 +47,13 @@ error: AssertionError: Values are not equal.
   throw new AssertionError(message);
         ^
     at assertEquals ([WILDCARD]/std/assert/equals.ts:[WILDCARD])
-    at [WILDCARD]/main.ts$24-29.ts:4:5
+    at [WILDCARD]/main.ts#24-29.ts:4:5
 
- FAILURES 
+ FAILURES
 
-[WILDCARD]/main.ts$13-18.ts => ./main.ts$13-18.ts:3:6
-[WILDCARD]/main.ts$2-9.ts => ./main.ts$2-9.ts:3:6
-[WILDCARD]/main.ts$24-29.ts => ./main.ts$24-29.ts:3:6
+[WILDCARD]/main.ts#13-18.ts => ./main.ts#13-18.ts:3:6
+[WILDCARD]/main.ts#2-9.ts => ./main.ts#2-9.ts:3:6
+[WILDCARD]/main.ts#24-29.ts => ./main.ts#24-29.ts:3:6
 
 FAILED | 0 passed | 3 failed ([WILDLINE])
 

--- a/tests/specs/test/doc_only/main.out
+++ b/tests/specs/test/doc_only/main.out
@@ -1,6 +1,6 @@
-Check [WILDCARD]/doc_only/mod.ts$2-7.ts
-running 1 test from ./doc_only/mod.ts$2-7.ts
-[WILDCARD]/doc_only/mod.ts$2-7.ts ... ok ([WILDLINE])
+Check [WILDCARD]/doc_only/mod.ts#2-7.ts
+running 1 test from ./doc_only/mod.ts#2-7.ts
+[WILDCARD]/doc_only/mod.ts#2-7.ts ... ok ([WILDLINE])
 
 ok | 1 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/doc_permission_respected/main.out
+++ b/tests/specs/test/doc_permission_respected/main.out
@@ -1,24 +1,24 @@
 Check [WILDCARD]/main.ts
-Check [WILDCARD]/main.ts$3-6.ts
-Check [WILDCARD]/main.ts$8-11.ts
+Check [WILDCARD]/main.ts#3-6.ts
+Check [WILDCARD]/main.ts#8-11.ts
 running 0 tests from ./main.ts
-running 1 test from ./main.ts$3-6.ts
-[WILDCARD]/main.ts$3-6.ts ... ok ([WILDLINE])
-running 1 test from ./main.ts$8-11.ts
-[WILDCARD]/main.ts$8-11.ts ... FAILED ([WILDLINE])
+running 1 test from ./main.ts#3-6.ts
+[WILDCARD]/main.ts#3-6.ts ... ok ([WILDLINE])
+running 1 test from ./main.ts#8-11.ts
+[WILDCARD]/main.ts#8-11.ts ... FAILED ([WILDLINE])
 
- ERRORS 
+ ERRORS
 
-[WILDCARD]/main.ts$8-11.ts => ./main.ts$8-11.ts:1:6
+[WILDCARD]/main.ts#8-11.ts => ./main.ts#8-11.ts:1:6
 error: NotCapable: Requires env access to "USER", run again with the --allow-env flag
     const _user = Deno.env.get("USER");
                            ^
     at Object.getEnv [as get] ([WILDCARD])
-    at [WILDCARD]/main.ts$8-11.ts:2:28
+    at [WILDCARD]/main.ts#8-11.ts:2:28
 
- FAILURES 
+ FAILURES
 
-[WILDCARD]/main.ts$8-11.ts => ./main.ts$8-11.ts:1:6
+[WILDCARD]/main.ts#8-11.ts => ./main.ts#8-11.ts:1:6
 
 FAILED | 1 passed | 1 failed ([WILDLINE])
 

--- a/tests/specs/test/doc_success/main.out
+++ b/tests/specs/test/doc_success/main.out
@@ -1,19 +1,19 @@
-Check [WILDCARD]/main.ts$8-13.js
-Check [WILDCARD]/main.ts$14-19.jsx
-Check [WILDCARD]/main.ts$20-25.ts
-Check [WILDCARD]/main.ts$26-31.tsx
-Check [WILDCARD]/main.ts$42-47.ts
+Check [WILDCARD]/main.ts#8-13.js
+Check [WILDCARD]/main.ts#14-19.jsx
+Check [WILDCARD]/main.ts#20-25.ts
+Check [WILDCARD]/main.ts#26-31.tsx
+Check [WILDCARD]/main.ts#42-47.ts
 running 0 tests from ./main.ts
-running 1 test from ./main.ts$8-13.js
-[WILDCARD]/main.ts$8-13.js ... ok ([WILDCARD]s)
-running 1 test from ./main.ts$14-19.jsx
-[WILDCARD]/main.ts$14-19.jsx ... ok ([WILDCARD]s)
-running 1 test from ./main.ts$20-25.ts
-[WILDCARD]/main.ts$20-25.ts ... ok ([WILDCARD]s)
-running 1 test from ./main.ts$26-31.tsx
-[WILDCARD]/main.ts$26-31.tsx ... ok ([WILDCARD]s)
-running 1 test from ./main.ts$42-47.ts
-[WILDCARD]/main.ts$42-47.ts ... ok ([WILDCARD]s)
+running 1 test from ./main.ts#8-13.js
+[WILDCARD]/main.ts#8-13.js ... ok ([WILDCARD]s)
+running 1 test from ./main.ts#14-19.jsx
+[WILDCARD]/main.ts#14-19.jsx ... ok ([WILDCARD]s)
+running 1 test from ./main.ts#20-25.ts
+[WILDCARD]/main.ts#20-25.ts ... ok ([WILDCARD]s)
+running 1 test from ./main.ts#26-31.tsx
+[WILDCARD]/main.ts#26-31.tsx ... ok ([WILDCARD]s)
+running 1 test from ./main.ts#42-47.ts
+[WILDCARD]/main.ts#42-47.ts ... ok ([WILDCARD]s)
 
 ok | 5 passed | 0 failed ([WILDCARD]s)
 

--- a/tests/specs/test/doc_ts_declare_global/lib.d.ts.out
+++ b/tests/specs/test/doc_ts_declare_global/lib.d.ts.out
@@ -1,6 +1,6 @@
-Check [WILDCARD]/lib$d$ts$5-11.ts
-running 1 test from ./lib$d$ts$5-11.ts
-[WILDCARD]/lib$d$ts$5-11.ts ... ok ([WILDLINE])
+Check [WILDCARD]/lib$d$ts#5-11.ts
+running 1 test from ./lib$d$ts#5-11.ts
+[WILDCARD]/lib$d$ts#5-11.ts ... ok ([WILDLINE])
 
 ok | 1 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/doc_ts_expect_error/mod.out
+++ b/tests/specs/test/doc_ts_expect_error/mod.out
@@ -1,8 +1,8 @@
 Check [WILDCARD]/mod.ts
-Check [WILDCARD]/mod.ts$2-10.ts
+Check [WILDCARD]/mod.ts#2-10.ts
 running 0 tests from ./mod.ts
-running 1 test from ./mod.ts$2-10.ts
-[WILDCARD]/mod.ts$2-10.ts ... ok ([WILDLINE])
+running 1 test from ./mod.ts#2-10.ts
+[WILDCARD]/mod.ts#2-10.ts ... ok ([WILDLINE])
 
 ok | 1 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/doc_ts_namespace_decl/lib.d.ts.out
+++ b/tests/specs/test/doc_ts_namespace_decl/lib.d.ts.out
@@ -1,6 +1,6 @@
-Check [WILDCARD]/lib$d$ts$3-9.ts
-running 1 test from ./lib$d$ts$3-9.ts
-[WILDCARD]/lib$d$ts$3-9.ts ... ok ([WILDLINE])
+Check [WILDCARD]/lib$d$ts#3-9.ts
+running 1 test from ./lib$d$ts#3-9.ts
+[WILDCARD]/lib$d$ts#3-9.ts ... ok ([WILDLINE])
 
 ok | 1 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/markdown/main.out
+++ b/tests/specs/test/markdown/main.out
@@ -1,10 +1,10 @@
-Check [WILDCARD]/main.md$11-14.js
-Check [WILDCARD]/main.md$17-20.ts
-Check [WILDCARD]/main.md$29-32.ts
+Check [WILDCARD]/main.md#11-14.js
+Check [WILDCARD]/main.md#17-20.ts
+Check [WILDCARD]/main.md#29-32.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
     const a: string = 42;
           ^
-    at [WILDCARD]/main.md$29-32.ts:2:11
+    at [WILDCARD]/main.md#29-32.ts:2:11
 
 error: Type checking failed.
 

--- a/tests/specs/test/markdown_full_block_names/main.out
+++ b/tests/specs/test/markdown_full_block_names/main.out
@@ -1,9 +1,9 @@
-Check [WILDCARD]/main.md$5-8.js
-Check [WILDCARD]/main.md$17-20.ts
+Check [WILDCARD]/main.md#5-8.js
+Check [WILDCARD]/main.md#17-20.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
     const a: string = 42;
           ^
-    at [WILDCARD]/main.md$17-20.ts:2:11
+    at [WILDCARD]/main.md#17-20.ts:2:11
 
 error: Type checking failed.
 

--- a/tests/specs/test/markdown_ignore_html_comment/main.out
+++ b/tests/specs/test/markdown_ignore_html_comment/main.out
@@ -1,8 +1,8 @@
-Check [WILDCARD]/main.md$34-37.ts
+Check [WILDCARD]/main.md#34-37.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
     const a: string = 42;
           ^
-    at [WILDCARD]/main.md$34-37.ts:2:11
+    at [WILDCARD]/main.md#34-37.ts:2:11
 
 error: Type checking failed.
 

--- a/tests/specs/test/markdown_ts_expect_error/main.out
+++ b/tests/specs/test/markdown_ts_expect_error/main.out
@@ -1,6 +1,6 @@
-Check [WILDCARD]/main.md$5-9.ts
-running 1 test from ./main.md$5-9.ts
-[WILDCARD]/main.md$5-9.ts ... ok ([WILDLINE])
+Check [WILDCARD]/main.md#5-9.ts
+running 1 test from ./main.md#5-9.ts
+[WILDCARD]/main.md#5-9.ts ... ok ([WILDLINE])
 
 ok | 1 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/markdown_windows/main.out
+++ b/tests/specs/test/markdown_windows/main.out
@@ -1,10 +1,10 @@
-Check [WILDCARD]/main.md$11-14.js
-Check [WILDCARD]/main.md$17-20.ts
-Check [WILDCARD]/main.md$29-32.ts
+Check [WILDCARD]/main.md#11-14.js
+Check [WILDCARD]/main.md#17-20.ts
+Check [WILDCARD]/main.md#29-32.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
     const a: string = 42;
           ^
-    at [WILDCARD]/main.md$29-32.ts:2:11
+    at [WILDCARD]/main.md#29-32.ts:2:11
 
 error: Type checking failed.
 

--- a/tests/specs/test/test_with_shebang/main.out
+++ b/tests/specs/test/test_with_shebang/main.out
@@ -1,10 +1,10 @@
 Download [WILDCARD]
 Check [WILDCARD]
 running 0 tests from ./main.ts
-running 1 test from ./main.ts$11-20.ts
-[WILDLINE]/main.ts$11-20.ts ... ok ([WILDLINE])
-running 1 test from ./markdown.md$5-10.ts
-[WILDLINE]/markdown.md$5-10.ts ... ok ([WILDLINE])
+running 1 test from ./main.ts#11-20.ts
+[WILDLINE]/main.ts#11-20.ts ... ok ([WILDLINE])
+running 1 test from ./markdown.md#5-10.ts
+[WILDLINE]/markdown.md#5-10.ts ... ok ([WILDLINE])
 
 ok | 2 passed | 0 failed ([WILDLINE])
 

--- a/tests/specs/test/type_check_with_doc/main.out
+++ b/tests/specs/test/type_check_with_doc/main.out
@@ -1,5 +1,5 @@
 Check [WILDCARD]/main.ts
-Check [WILDCARD]/main.ts$2-5.ts
+Check [WILDCARD]/main.ts#2-5.ts
 TS2322 [ERROR]: Type 'number' is not assignable to type 'string'.
 const a: string = 1;
       ^
@@ -8,7 +8,7 @@ const a: string = 1;
 TS2322 [ERROR]: Type 'string' is not assignable to type 'number'.
     const b: number = "1";
           ^
-    at file://[WILDCARD]/main.ts$2-5.ts:2:11
+    at file://[WILDCARD]/main.ts#2-5.ts:2:11
 
 Found 2 errors.
 


### PR DESCRIPTION
Closes #29684

As described in the mentioned issue, since `#` is used for URL anchors, 
this subtle change makes it easier to work with anything `import.meta`/`URL` related inside documentation examples