### PR TITLE
fix(install/cache): better discovery for config file based on entrypoint

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1203,12 +1203,10 @@ impl Flags {
       | Compile(CompileFlags {
         source_file: script,
         ..
-      }) => {
-        resolve_single_folder_path(script, current_dir, |mut p| {
-          if p.pop() { Some(p) } else { None }
-        })
-        .map(|p| vec![p])
-      }
+      }) => resolve_single_folder_path(script, current_dir, |mut p| {
+        if p.pop() { Some(p) } else { None }
+      })
+      .map(|p| vec![p]),
       Task(TaskFlags {
         cwd: Some(path), ..
       }) => {

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1205,7 +1205,6 @@ impl Flags {
         ..
       }) => {
         resolve_single_folder_path(script, current_dir, |mut p| {
-          // doesn't check if this is a path
           if p.pop() { Some(p) } else { None }
         })
         .map(|p| vec![p])


### PR DESCRIPTION
Discovers the config file based on the arguments to `deno cache` and `deno install -e <entrypoint>`