### PR TITLE
feat(lint): no-unversioned-import rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,12 +2275,13 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09df3a4046f6711f1fa1610865fd38d420cf20f9889539de0febfcd6a890e8ea"
+checksum = "816be0fe885ac88b200d73d99f8c9557278ff416acf8abc1661b46837f09a303"
 dependencies = [
  "anyhow",
  "deno_ast",
+ "deno_semver",
  "derive_more",
  "if_chain",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ deno_cache_dir = "=0.25.0"
 deno_doc = "=0.183.0"
 deno_error = "=0.7.0"
 deno_graph = { version = "=0.100.0", default-features = false }
-deno_lint = "=0.79.0"
+deno_lint = "=0.80.0"
 deno_lockfile = "=0.31.2"
 deno_media_type = { version = "=0.2.9", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"

--- a/cli/schemas/lint-rules.v1.json
+++ b/cli/schemas/lint-rules.v1.json
@@ -111,6 +111,7 @@
         "no-unsafe-negation",
         "no-unused-labels",
         "no-unused-vars",
+        "no-unversioned-import",
         "no-useless-rename",
         "no-var",
         "no-window",

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -5651,11 +5651,7 @@ fn lsp_jsr_lockfile() {
     json!({
       "lint": {
         "rules": {
-<<<<<<< Updated upstream
-          "tags": ["recommended"]
-=======
           "tags": []
->>>>>>> Stashed changes
         }
       }
     })
@@ -8947,7 +8943,7 @@ fn lsp_npm_types_nested_js_dts() {
   let file = source_file(
     temp_dir.path().join("file.ts"),
     r#"
-      import { someString } from "npm:@denotest/types-nested-js-dts";
+      import { someString } from "npm:@denotest/types-nested-js-dts@1";
       const someNumber: number = someString;
       console.log(someNumber);
     "#,

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -5651,7 +5651,11 @@ fn lsp_jsr_lockfile() {
     json!({
       "lint": {
         "rules": {
+<<<<<<< Updated upstream
           "tags": ["recommended"]
+=======
+          "tags": []
+>>>>>>> Stashed changes
         }
       }
     })
@@ -6268,7 +6272,7 @@ fn lsp_code_actions_deno_cache_npm() {
       "uri": "file:///a/file.ts",
       "languageId": "typescript",
       "version": 1,
-      "text": "import chalk from \"npm:chalk\";\n\nconsole.log(chalk.green);\n"
+      "text": "import chalk from \"npm:chalk@5\";\n\nconsole.log(chalk.green);\n"
     }
   }));
   assert_eq!(
@@ -6278,13 +6282,13 @@ fn lsp_code_actions_deno_cache_npm() {
       "diagnostics": [{
         "range": {
           "start": { "line": 0, "character": 18 },
-          "end": { "line": 0, "character": 29 }
+          "end": { "line": 0, "character": 31 }
         },
         "severity": 1,
         "code": "not-installed-npm",
         "source": "deno",
-        "message": "npm package \"chalk\" is not installed or doesn't exist.",
-        "data": { "specifier": "npm:chalk" }
+        "message": "npm package \"chalk@5\" is not installed or doesn't exist.",
+        "data": { "specifier": "npm:chalk@5" }
       }],
       "version": 1
     }))
@@ -6299,19 +6303,19 @@ fn lsp_code_actions_deno_cache_npm() {
       },
       "range": {
         "start": { "line": 0, "character": 18 },
-        "end": { "line": 0, "character": 29 }
+        "end": { "line": 0, "character": 31 }
       },
       "context": {
         "diagnostics": [{
           "range": {
             "start": { "line": 0, "character": 18 },
-            "end": { "line": 0, "character": 29 }
+            "end": { "line": 0, "character": 31 }
           },
           "severity": 1,
           "code": "not-installed-npm",
           "source": "deno",
-          "message": "npm package \"chalk\" is not installed or doesn't exist.",
-          "data": { "specifier": "npm:chalk" }
+          "message": "npm package \"chalk@5\" is not installed or doesn't exist.",
+          "data": { "specifier": "npm:chalk@5" }
         }],
         "only": ["quickfix"]
       }
@@ -6320,23 +6324,23 @@ fn lsp_code_actions_deno_cache_npm() {
   assert_eq!(
     res,
     json!([{
-      "title": "Install \"npm:chalk\" and its dependencies.",
+      "title": "Install \"npm:chalk@5\" and its dependencies.",
       "kind": "quickfix",
       "diagnostics": [{
         "range": {
           "start": { "line": 0, "character": 18 },
-          "end": { "line": 0, "character": 29 }
+          "end": { "line": 0, "character": 31 }
         },
         "severity": 1,
         "code": "not-installed-npm",
         "source": "deno",
-        "message": "npm package \"chalk\" is not installed or doesn't exist.",
-        "data": { "specifier": "npm:chalk" }
+        "message": "npm package \"chalk@5\" is not installed or doesn't exist.",
+        "data": { "specifier": "npm:chalk@5" }
       }],
       "command": {
         "title": "",
         "command": "deno.cache",
-        "arguments": [["npm:chalk"], "file:///a/file.ts"]
+        "arguments": [["npm:chalk@5"], "file:///a/file.ts"]
       }
     }])
   );
@@ -6356,7 +6360,7 @@ fn lsp_code_actions_deno_cache_all() {
       "version": 1,
       "text": r#"
         import * as a from "https://deno.land/x/a/mod.ts";
-        import chalk from "npm:chalk";
+        import chalk from "npm:chalk@5";
         console.log(a);
         console.log(chalk);
       "#,
@@ -6385,13 +6389,13 @@ fn lsp_code_actions_deno_cache_all() {
         {
           "range": {
             "start": { "line": 2, "character": 26 },
-            "end": { "line": 2, "character": 37 },
+            "end": { "line": 2, "character": 39 },
           },
           "severity": 1,
           "code": "not-installed-npm",
           "source": "deno",
-          "message": "npm package \"chalk\" is not installed or doesn't exist.",
-          "data": { "specifier": "npm:chalk" },
+          "message": "npm package \"chalk@5\" is not installed or doesn't exist.",
+          "data": { "specifier": "npm:chalk@5" },
         },
       ],
       "version": 1,
@@ -6478,13 +6482,13 @@ fn lsp_code_actions_deno_cache_all() {
           {
             "range": {
               "start": { "line": 2, "character": 26 },
-              "end": { "line": 2, "character": 37 },
+              "end": { "line": 2, "character": 39 },
             },
             "severity": 1,
             "code": "not-installed-npm",
             "source": "deno",
-            "message": "npm package \"chalk\" is not installed or doesn't exist.",
-            "data": { "specifier": "npm:chalk" },
+            "message": "npm package \"chalk@5\" is not installed or doesn't exist.",
+            "data": { "specifier": "npm:chalk@5" },
           },
         ],
         "command": {
@@ -6512,7 +6516,7 @@ fn lsp_npm_managed_no_export_diagnostic() {
       "uri": "file:///a/file.ts",
       "languageId": "typescript",
       "version": 1,
-      "text": "import \"npm:chalk/non-existent\";\n",
+      "text": "import \"npm:chalk@5/non-existent\";\n",
     },
   }));
   client.cache_specifier("file:///a/file.ts");
@@ -6523,12 +6527,12 @@ fn lsp_npm_managed_no_export_diagnostic() {
       {
         "range": {
           "start": { "line": 0, "character": 7 },
-          "end": { "line": 0, "character": 31 },
+          "end": { "line": 0, "character": 33 },
         },
         "severity": 1,
         "code": "no-export-npm",
         "source": "deno",
-        "message": "NPM package \"chalk\" does not define an export \"non-existent\".",
+        "message": "NPM package \"chalk@5\" does not define an export \"non-existent\".",
       },
     ]),
   );
@@ -6550,7 +6554,7 @@ fn lsp_npm_managed_type_only_export_no_diagnostic() {
       "uri": "file:///a/file.ts",
       "languageId": "typescript",
       "version": 1,
-      "text": "import \"npm:@minecraft/common\";\n",
+      "text": "import \"npm:@minecraft/common@1\";\n",
     },
   }));
   client.cache_specifier("file:///a/file.ts");
@@ -17396,7 +17400,7 @@ fn lsp_byonm() {
       "languageId": "typescript",
       "version": 1,
       "text": r#"
-        import "npm:chalk";
+        import "npm:chalk@5";
         import "@denotest/esm-basic";
       "#,
     },
@@ -17412,13 +17416,13 @@ fn lsp_byonm() {
           },
           "end": {
             "line": 1,
-            "character": 26,
+            "character": 28,
           },
         },
         "severity": 1,
         "code": "resolver-error",
         "source": "deno",
-        "message": "Could not find a matching package for 'npm:chalk' in the node_modules directory. Ensure you have all your JSR and npm dependencies listed in your deno.json or package.json, then run `deno install`. Alternatively, turn on auto-install by specifying `\"nodeModulesDir\": \"auto\"` in your deno.json file.",
+        "message": "Could not find a matching package for 'npm:chalk@5' in the node_modules directory. Ensure you have all your JSR and npm dependencies listed in your deno.json or package.json, then run `deno install`. Alternatively, turn on auto-install by specifying `\"nodeModulesDir\": \"auto\"` in your deno.json file.",
       },
       {
         "range": {
@@ -17457,13 +17461,13 @@ fn lsp_byonm() {
           },
           "end": {
             "line": 1,
-            "character": 26,
+            "character": 28,
           },
         },
         "severity": 1,
         "code": "resolver-error",
         "source": "deno",
-        "message": "Could not find a matching package for 'npm:chalk' in the node_modules directory. Ensure you have all your JSR and npm dependencies listed in your deno.json or package.json, then run `deno install`. Alternatively, turn on auto-install by specifying `\"nodeModulesDir\": \"auto\"` in your deno.json file.",
+        "message": "Could not find a matching package for 'npm:chalk@5' in the node_modules directory. Ensure you have all your JSR and npm dependencies listed in your deno.json or package.json, then run `deno install`. Alternatively, turn on auto-install by specifying `\"nodeModulesDir\": \"auto\"` in your deno.json file.",
       },
     ])
   );

--- a/tests/specs/lint/no_import_prefix/non_workspace/main.ts
+++ b/tests/specs/lint/no_import_prefix/non_workspace/main.ts
@@ -1,3 +1,3 @@
-import { add } from "jsr:@denotest/add";
+import { add } from "jsr:@denotest/add@1";
 
 console.log(add);

--- a/tests/specs/lint/no_import_prefix/workspace/lint.out
+++ b/tests/specs/lint/no_import_prefix/workspace/lint.out
@@ -1,8 +1,8 @@
 error[no-import-prefix]: Inline 'npm:', 'jsr:' or 'https:' dependency not allowed
  --> [WILDLINE]
   | 
-1 | import { add } from "jsr:@denotest/add";
-  |                     ^^^^^^^^^^^^^^^^^^^
+1 | import { add } from "jsr:@denotest/add@1";
+  |                     ^^^^^^^^^^^^^^^^^^^^^
   = hint: Add it as a dependency in a deno.json or package.json instead and reference it here via its bare specifier
 
   docs: https://docs.deno.com/lint/rules/no-import-prefix

--- a/tests/specs/lint/no_import_prefix/workspace/main.ts
+++ b/tests/specs/lint/no_import_prefix/workspace/main.ts
@@ -1,3 +1,3 @@
-import { add } from "jsr:@denotest/add";
+import { add } from "jsr:@denotest/add@1";
 
 console.log(add);


### PR DESCRIPTION
Bans using npm/jsr imports without specifying a version requirement.

It's bad to not specify a version requirement because without a lockfile Deno will always pull in the latest version of a package, which could cause your code to stop working if the package ever publishes a breaking change.

* https://github.com/denoland/deno_lint/pull/1362