### PR TITLE
fix(ext/node): fix hang induced by maxSockets bounds

### DIFF
--- a/ext/node/polyfills/_http_agent.mjs
+++ b/ext/node/polyfills/_http_agent.mjs
@@ -268,7 +268,7 @@ Agent.prototype.addRequest = function addRequest(
     this.sockets[name].push(socket);
   } else if (
     // TODO(littledivy): enable maxSockets again when we use removeSocket properly
-    (sockLen < this.maxSockets && this.maxSockets != 0) &&
+    this.maxSockets != 0 &&
     this.totalSocketCount < this.maxTotalSockets
   ) {
     debug("call onSocket", sockLen, freeLen);


### PR DESCRIPTION
Disables `maxSockets` settings in Agent because the server doesn't properly use removeSocket to reuse it.

