### PR TITLE
ci: disable symcache generation on Windows

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -916,7 +916,9 @@ const ci = {
             "Get-FileHash target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
             "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip",
             "Get-FileHash target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
-            "target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${{ matrix.arch }}-pc-windows-msvc.symcache",
+            // TODO(bartlomieju): fix the regression from V8 upgrade
+            // https://github.com/denoland/deno/pull/30629
+            // "target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${{ matrix.arch }}-pc-windows-msvc.symcache",
           ].join("\n"),
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,6 @@ jobs:
           Get-FileHash target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip
           Get-FileHash target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
-          target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${{ matrix.arch }}-pc-windows-msvc.symcache
       - name: Upload canary to dl.deno.land
         if: |-
           !(matrix.skip) && (matrix.job == 'test' &&

--- a/tools/deno.lock.json
+++ b/tools/deno.lock.json
@@ -32,6 +32,7 @@
     "jsr:@std/semver@1.0.3": "1.0.3",
     "jsr:@std/streams@0.221": "0.221.0",
     "jsr:@std/streams@0.221.0": "0.221.0",
+    "jsr:@std/yaml@0.221": "0.221.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "jsr:@ts-morph/ts-morph@23.0.0": "23.0.0",
     "npm:@types/decompress@4.2.7": "4.2.7",
@@ -156,6 +157,9 @@
       "dependencies": [
         "jsr:@std/io@0.221"
       ]
+    },
+    "@std/yaml@0.221.0": {
+      "integrity": "bac8913ee4f6fc600d4b92cc020f755070e22687ad242341f31d123ff690ae98"
     },
     "@ts-morph/common@0.24.0": {
       "integrity": "12b625b8e562446ba658cdbe9ad77774b4bd96b992ae8bd34c60dbf24d06c1f3",

--- a/tools/release/create_symcache.ts
+++ b/tools/release/create_symcache.ts
@@ -10,7 +10,10 @@ import path from "node:path";
 let debugFile = Deno.execPath();
 
 if (Deno.build.os === "windows") {
-  debugFile = debugFile.replace(/\.exe$/, ".pdb");
+  // TODO(bartlomieju): fix the regression from V8 upgrade
+  // https://github.com/denoland/deno/pull/30629
+  // debugFile = debugFile.replace(/\.exe$/, ".pdb");
+  Deno.exit(0);
 } else if (Deno.build.os === "darwin") {
   const resolvedPath = Deno.realPathSync(`${debugFile}.dSYM`);
   const { name } = path.parse(resolvedPath);


### PR DESCRIPTION
Due to V8 upgrade in https://github.com/denoland/deno/pull/30629, we are
not generating debug symbols on Windows and because of that
symcache generation is not available.