### PR TITLE
bench: disable type-checking std submodule

### DIFF
--- a/cli/bench/main.rs
+++ b/cli/bench/main.rs
@@ -118,31 +118,33 @@ const EXEC_TIME_BENCHMARKS: &[(&str, &[&str], Option<i32>)] = &[
     &["run", "tests/testdata/benches/response_string_perf.js"],
     None,
   ),
-  (
-    "check",
-    &[
-      "check",
-      "--reload",
-      "--unstable",
-      "--config",
-      "tests/config/deno.json",
-      "tests/util/std/http/file_server_test.ts",
-    ],
-    None,
-  ),
-  (
-    "no_check",
-    &[
-      "cache",
-      "--reload",
-      "--no-check",
-      "--unstable",
-      "--config",
-      "tests/config/deno.json",
-      "tests/util/std/http/file_server_test.ts",
-    ],
-    None,
-  ),
+  // TODO(bartlomieju): temporarily disabled, because we can't upgrade `tests/util/std` submodule
+  // due to needing it to be published.
+  // (
+  //   "check",
+  //   &[
+  //     "check",
+  //     "--reload",
+  //     "--unstable",
+  //     "--config",
+  //     "tests/config/deno.json",
+  //     "tests/util/std/http/file_server_test.ts",
+  //   ],
+  //   None,
+  // ),
+  // (
+  //   "no_check",
+  //   &[
+  //     "cache",
+  //     "--reload",
+  //     "--no-check",
+  //     "--unstable",
+  //     "--config",
+  //     "tests/config/deno.json",
+  //     "tests/util/std/http/file_server_test.ts",
+  //   ],
+  //   None,
+  // ),
 ];
 
 const RESULT_KEYS: &[&str] =


### PR DESCRIPTION
Can't update `tests/util/std/` submodule for now, because `std` these days relies on JSR publishing process (unfurling of specifiers).