### PR TITLE
fix(ffi): check that fast calls are taken

### DIFF
--- a/ext/ffi/00_ffi.js
+++ b/ext/ffi/00_ffi.js
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { core, primordials } from "ext:core/mod.js";
+import { core, internals, primordials } from "ext:core/mod.js";
 const {
   isArrayBuffer,
   isDataView,
@@ -14,6 +14,7 @@ import {
   op_ffi_cstr_read,
   op_ffi_get_buf,
   op_ffi_get_static,
+  op_ffi_get_turbocall_target,
   op_ffi_load,
   op_ffi_ptr_create,
   op_ffi_ptr_equals,
@@ -562,8 +563,15 @@ function dlopen(path, symbols) {
   return new DynamicLibrary(pathFromURL(path), symbols);
 }
 
+function getTurbocallTarget() {
+  return op_ffi_get_turbocall_target();
+}
+
+internals.getTurbocallTarget = getTurbocallTarget;
+
 export {
   dlopen,
+  getTurbocallTarget,
   UnsafeCallback,
   UnsafeFnPointer,
   UnsafePointer,

--- a/ext/ffi/dlfcn.rs
+++ b/ext/ffi/dlfcn.rs
@@ -249,10 +249,10 @@ where
   Ok(out.into())
 }
 
-struct FunctionData {
+pub struct FunctionData {
   // Held in a box to keep memory while function is alive.
   #[allow(unused)]
-  symbol: Box<Symbol>,
+  pub symbol: Box<Symbol>,
   // Held in a box to keep inner data alive while function is alive.
   #[allow(unused)]
   turbocall: Option<Turbocall>,

--- a/ext/ffi/lib.rs
+++ b/ext/ffi/lib.rs
@@ -36,6 +36,7 @@ pub use r#static::StaticError;
 use r#static::op_ffi_get_static;
 use symbol::NativeType;
 use symbol::Symbol;
+use turbocall::op_ffi_get_turbocall_target;
 
 #[cfg(not(target_pointer_width = "64"))]
 compile_error!("platform not supported");
@@ -107,6 +108,7 @@ deno_core::extension!(deno_ffi,
     op_ffi_unsafe_callback_create<P>,
     op_ffi_unsafe_callback_close,
     op_ffi_unsafe_callback_ref,
+    op_ffi_get_turbocall_target,
   ],
   esm = [ "00_ffi.js" ],
   options = {

--- a/ext/ffi/turbocall.rs
+++ b/ext/ffi/turbocall.rs
@@ -1,11 +1,15 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use std::ffi::c_void;
+use std::sync::LazyLock;
 
+use deno_core::OpState;
+use deno_core::op2;
 use deno_core::v8::fast_api;
 
 use crate::NativeType;
 use crate::Symbol;
+use crate::dlfcn::FunctionData;
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
 pub enum TurbocallError {
@@ -218,6 +222,16 @@ pub(crate) fn compile_trampoline(
 
     f.def_var(options_v, args[argx]);
 
+    static TRACE_TURBO: LazyLock<bool> = LazyLock::new(|| {
+      std::env::var("DENO_UNSTABLE_FFI_TRACE_TURBO").as_deref() == Ok("1")
+    });
+
+    if *TRACE_TURBO {
+      let options = f.use_var(options_v);
+      let trace_fn = f.ins().iconst(ISIZE, turbocall_trace as usize as i64);
+      f.ins().call_indirect(ab_sig, trace_fn, &[options]);
+    }
+
     let mut next = f.create_block();
 
     let mut vidx = 0;
@@ -396,13 +410,35 @@ extern "C" fn turbocall_ab_contents(
 unsafe extern "C" fn turbocall_raise(
   options: *const deno_core::v8::fast_api::FastApiCallbackOptions,
 ) {
-  #[allow(clippy::undocumented_unsafe_blocks)]
-  unsafe {
-    let mut scope = deno_core::v8::CallbackScope::new(&*options);
-    let exception = deno_core::error::to_v8_error(
-      &mut scope,
-      &crate::IRError::InvalidBufferType,
-    );
-    scope.throw_exception(exception);
-  }
+  // SAFETY: This is called with valid FastApiCallbackOptions from within fast callback.
+  let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*options) };
+  let exception = deno_core::error::to_v8_error(
+    &mut scope,
+    &crate::IRError::InvalidBufferType,
+  );
+  scope.throw_exception(exception);
+}
+
+pub struct TurbocallTarget(String);
+
+unsafe extern "C" fn turbocall_trace(
+  options: *const deno_core::v8::fast_api::FastApiCallbackOptions,
+) {
+  // SAFETY: This is called with valid FastApiCallbackOptions from within fast callback.
+  let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*options) };
+  let func_data = deno_core::cppgc::try_unwrap_cppgc_object::<FunctionData>(
+    &mut scope,
+    // SAFETY: This is valid if the options are valid.
+    unsafe { (&*options).data },
+  )
+  .unwrap();
+  deno_core::JsRuntime::op_state_from(&scope)
+    .borrow_mut()
+    .put(TurbocallTarget(func_data.symbol.name.clone()));
+}
+
+#[op2]
+#[string]
+pub fn op_ffi_get_turbocall_target(state: &mut OpState) -> Option<String> {
+  state.try_take::<TurbocallTarget>().map(|t| t.0)
 }

--- a/tests/ffi/tests/integration_tests.rs
+++ b/tests/ffi/tests/integration_tests.rs
@@ -44,6 +44,7 @@ fn basic() {
     .arg(r#"--v8-flags=--allow-natives-syntax"#)
     .arg("tests/test.js")
     .env("NO_COLOR", "1")
+    .env("DENO_UNSTABLE_FFI_TRACE_TURBO", "1")
     .output()
     .unwrap();
   let stdout = std::str::from_utf8(&output.stdout).unwrap();

--- a/tests/ffi/tests/test.js
+++ b/tests/ffi/tests/test.js
@@ -21,6 +21,7 @@ const [libPrefix, libSuffix] = {
 const libPath = `${targetDir}/${libPrefix}test_ffi.${libSuffix}`;
 
 const resourcesPre = Deno[Deno.internal].core.resources();
+const { getTurbocallTarget } = Deno[Deno.internal];
 
 // dlopen shouldn't panic
 assertThrows(() => {
@@ -316,8 +317,7 @@ function returnBuffer() { return return_buffer(); };
 returnBuffer();
 %OptimizeFunctionOnNextCall(returnBuffer);
 const ptr0 = returnBuffer();
-// TODO(bartlomieju): the next line started throwing whem updating to v8 14.0
-// assertIsOptimized(returnBuffer);
+assertFastCall("return_buffer");
 
 dylib.symbols.print_pointer(ptr0, 8);
 const ptrView = new Deno.UnsafePointerView(ptr0);
@@ -358,8 +358,7 @@ isNullBuffer(emptyBuffer);
 %NeverOptimizeFunction(isNullBufferDeopt);
 %OptimizeFunctionOnNextCall(isNullBuffer);
 isNullBuffer(emptyBuffer);
-// TODO(bartlomieju): the next line started throwing whem updating to v8 14.0
-// assertIsOptimized(isNullBuffer);
+assertFastCall("is_null_buf");
 
 // ==== ZERO LENGTH BUFFER TESTS ====
 assertEquals(isNullBuffer(emptyBuffer), true, "isNullBuffer(emptyBuffer) !== true");
@@ -410,10 +409,10 @@ const { add_u32, add_usize_fast } = symbols;
 function addU32Fast(a, b) {
   return add_u32(a, b);
 };
-testOptimized(addU32Fast, () => addU32Fast(123, 456));
+testOptimized(addU32Fast, () => addU32Fast(123, 456), "add_u32");
 
 function addU64Fast(a, b) { return add_usize_fast(a, b); };
-testOptimized(addU64Fast, () => addU64Fast(2n, 3n));
+testOptimized(addU64Fast, () => addU64Fast(2n, 3n), "add_usize_fast");
 
 console.log(dylib.symbols.add_i32(123, 456));
 console.log(dylib.symbols.add_u64(0xffffffffn, 0xffffffffn));
@@ -434,12 +433,12 @@ console.log(dylib.symbols.and(true, false));
 function addF32Fast(a, b) {
   return dylib.symbols.add_f32(a, b);
 };
-testOptimized(addF32Fast, () => addF32Fast(123.123, 456.789));
+testOptimized(addF32Fast, () => addF32Fast(123.123, 456.789), "add_f32");
 
 function addF64Fast(a, b) {
   return dylib.symbols.add_f64(a, b);
 };
-testOptimized(addF64Fast, () => addF64Fast(123.123, 456.789));
+testOptimized(addF64Fast, () => addF64Fast(123.123, 456.789), "add_f64");
 
 // Test adders as nonblocking calls
 console.log(await dylib.symbols.add_i32_nonblocking(123, 456));
@@ -568,34 +567,39 @@ dylib.symbols.call_stored_function_2(20);
 function logManyParametersFast(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) {
   return symbols.log_many_parameters(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s);
 };
+
 testOptimized(
   logManyParametersFast,
   () => logManyParametersFast(
     255, 65535, 4294967295, 4294967296n, 123.456, 789.876, -1n, -2, -3, -4, -1000n, 1000n,
     12345.678910, 12345.678910, 12345.678910, 12345.678910, 12345.678910, 12345.678910, 12345.678910
-  )
+  ),
+  // apple silicon can't handle more than 8 args in fast calls: https://issues.chromium.org/issues/42203110
+  process.platform === 'darwin' && process.arch === 'arm64' ? null : "log_many_parameters",
 );
 
 // Some ABIs rely on the convention to zero/sign-extend arguments by the caller to optimize the callee function.
 // If the trampoline did not zero/sign-extend arguments, this would return 256 instead of the expected 0 (in optimized builds)
 function castU8U32Fast(x) { return symbols.cast_u8_u32(x); };
-testOptimized(castU8U32Fast, () => castU8U32Fast(256));
+testOptimized(castU8U32Fast, () => castU8U32Fast(256), "cast_u8_u32");
 
 // Some ABIs rely on the convention to expect garbage in the bits beyond the size of the return value to optimize the callee function.
 // If the trampoline did not zero/sign-extend the return value, this would return 256 instead of the expected 0 (in optimized builds)
 function castU32U8Fast(x) { return symbols.cast_u32_u8(x); };
-testOptimized(castU32U8Fast, () => castU32U8Fast(256));
+testOptimized(castU32U8Fast, () => castU32U8Fast(256), "cast_u32_u8");
 
 // Generally the trampoline tail-calls into the FFI function, but in certain cases (e.g. when returning 8 or 16 bit integers)
 // the tail call is not possible and a new stack frame must be created. We need enough parameters to have some on the stack
 function addManyU16Fast(a, b, c, d, e, f, g, h, i, j, k, l, m) {
   return symbols.add_many_u16(a, b, c, d, e, f, g, h, i, j, k, l, m);
 };
-// N.B. V8 does not currently follow Aarch64 Apple's calling convention.
-// The current implementation of the JIT trampoline follows the V8 incorrect calling convention. This test covers the use-case
-// and is expected to fail once Deno uses a V8 version with the bug fixed.
-// The V8 bug is being tracked in https://bugs.chromium.org/p/v8/issues/detail?id=13171
-testOptimized(addManyU16Fast, () => addManyU16Fast(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+
+testOptimized(
+  addManyU16Fast,
+  () => addManyU16Fast(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+  // apple silicon can't handle more than 8 args in fast calls: https://issues.chromium.org/issues/42203110
+  process.platform === 'darwin' && process.arch === 'arm64' ? null : "add_many_u16",
+);
 
 
 const nestedCallback = new Deno.UnsafeCallback(
@@ -747,7 +751,7 @@ for (const charBuffer of [
 const bytes = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 function hash() { return dylib.symbols.hash(bytes, bytes.byteLength); };
 
-testOptimized(hash, () => hash());
+testOptimized(hash, () => hash(), "hash");
 
 (function cleanup() {
   dylib.close();
@@ -775,22 +779,21 @@ After: ${postStr}`,
   console.log("Correct number of resources");
 })();
 
-function assertIsOptimized(fn) {
-  const status = %GetOptimizationStatus(fn);
-  assert(status & (1 << 4), `expected ${fn.name} to be optimized, but wasn't`);
+function assertFastCall(name) {
+  assertEquals(getTurbocallTarget(), name);
 }
 
-function testOptimized(fn, callback) {
+function testOptimized(fn, callback, symbol) {
   %PrepareFunctionForOptimization(fn);
   const r1 = callback();
   if (r1 !== undefined) {
     console.log(r1);
   }
   %OptimizeFunctionOnNextCall(fn);
+  getTurbocallTarget();
   const r2 = callback();
   if (r2 !== undefined) {
     console.log(r2);
   }
-  // TODO(bartlomieju): the next line started throwing whem updating to v8 14.0
-  // assertIsOptimized(fn);
+  assertFastCall(symbol);
 }


### PR DESCRIPTION
`assertOptimized` only checks that turbofan ran, not that the fast call is actually used.