### PR TITLE
fix(ext/node): validate `fs.close` callback function

### DIFF
--- a/ext/node/polyfills/_fs/_fs_close.ts
+++ b/ext/node/polyfills/_fs/_fs_close.ts
@@ -1,14 +1,21 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-// TODO(petamoriken): enable prefer-primordials for node polyfills
-// deno-lint-ignore-file prefer-primordials
-
-import type { CallbackWithError } from "ext:deno_node/_fs/_fs_common.ts";
+import {
+  type CallbackWithError,
+  makeCallback,
+} from "ext:deno_node/_fs/_fs_common.ts";
 import { getValidatedFd } from "ext:deno_node/internal/fs/utils.mjs";
-import { core } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
+
+const {
+  Error,
+  ErrorPrototype,
+  ObjectPrototypeIsPrototypeOf,
+} = primordials;
 
 export function close(fd: number, callback: CallbackWithError) {
   fd = getValidatedFd(fd);
+  callback = makeCallback(callback);
   setTimeout(() => {
     let error = null;
     try {
@@ -16,7 +23,9 @@ export function close(fd: number, callback: CallbackWithError) {
       // implementation detail and may change.
       core.close(fd);
     } catch (err) {
-      error = err instanceof Error ? err : new Error("[non-error thrown]");
+      error = ObjectPrototypeIsPrototypeOf(ErrorPrototype, err)
+        ? err as Error
+        : new Error("[non-error thrown]");
     }
     callback(error);
   }, 0);


### PR DESCRIPTION
Towards #29972

Allows the [parallel/test-fs-close-errors.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-fs-close-errors.js) test to pass, and also addresses the `prefer-primordials` lint rule #24236