### PR TITLE
fix: Add info/hint for unstable Deno.bundle API

### DIFF
--- a/runtime/fmt_errors.rs
+++ b/runtime/fmt_errors.rs
@@ -358,6 +358,13 @@ fn get_suggestions_for_terminal_errors(e: &JsError) -> Vec<FixSuggestion<'_>> {
           "Run again with `--unstable-kv` flag to enable this API.",
         ),
       ];
+    } else if msg.contains("bundle is not a function") {
+      return vec![
+        FixSuggestion::info("Deno.bundle() is an unstable API."),
+        FixSuggestion::hint(
+          "Run again with `--unstable-bundle` flag to enable this API.",
+        ),
+      ];
     } else if msg.contains("cron is not a function") {
       return vec![
         FixSuggestion::info("Deno.cron() is an unstable API."),

--- a/tests/specs/run/unstable/__test__.jsonc
+++ b/tests/specs/run/unstable/__test__.jsonc
@@ -5,6 +5,11 @@
       "exitCode": 1,
       "output": "broadcast_channel.out"
     },
+    "bundle": {
+      "args": "run bundle.ts",
+      "exitCode": 1,
+      "output": "bundle.out"
+    },
     "cron": {
       "args": "run cron.ts",
       "exitCode": 1,

--- a/tests/specs/run/unstable/bundle.out
+++ b/tests/specs/run/unstable/bundle.out
@@ -1,0 +1,7 @@
+error: Uncaught (in promise) TypeError: Deno.bundle is not a function
+Deno.bundle();
+     ^
+    at [WILDCARD]bundle.ts:1:6
+
+    info: Deno.bundle() is an unstable API.
+    hint: Run again with `--unstable-bundle` flag to enable this API.

--- a/tests/specs/run/unstable/bundle.ts
+++ b/tests/specs/run/unstable/bundle.ts
@@ -1,0 +1,1 @@
+Deno.bundle();


### PR DESCRIPTION
This was missed in https://github.com/denoland/deno/pull/29949