### PR TITLE
fix(ext/node): validate readlink arguments

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -470,6 +470,7 @@
 "parallel/test-fs-readfile-unlink.js" = {}
 "parallel/test-fs-readfile-zero-byte-liar.js" = {}
 "parallel/test-fs-readfilesync-enoent.js" = {}
+"parallel/test-fs-readlink-type-check.js" = {}
 "parallel/test-fs-readv-promisify.js" = {}
 "parallel/test-fs-ready-event-stream.js" = {}
 "parallel/test-fs-rename-type-check.js" = {}

--- a/tests/unit_node/_fs/_fs_readlink_test.ts
+++ b/tests/unit_node/_fs/_fs_readlink_test.ts
@@ -3,6 +3,7 @@ import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { readlink, readlinkSync } from "node:fs";
 import { assert, assertEquals } from "@std/assert";
 import * as path from "@std/path";
+import { Buffer } from "node:buffer";
 
 const testDir = Deno.makeTempDirSync();
 const oldname = path.join(testDir, "oldname");
@@ -72,4 +73,21 @@ Deno.test("[std/node/fs] readlink callback isn't called twice if error is thrown
     prelude: `import { readlink } from ${JSON.stringify(importUrl)}`,
     invocation: `readlink(${JSON.stringify(newname)}, `,
   });
+});
+
+Deno.test("[node/fs] readlink accepts Buffer as path", async () => {
+  const data = await new Promise((res, rej) => {
+    readlink(Buffer.from(newname), (err, data) => {
+      if (err) {
+        rej(err);
+      }
+      res(data);
+    });
+  });
+  assertEquals(data, oldname);
+});
+
+Deno.test("[node/fs] readlinkSync accepts Buffer as path", () => {
+  const data = readlinkSync(Buffer.from(newname));
+  assertEquals(data, oldname);
 });


### PR DESCRIPTION
Also accepts `Buffer` typed path. Allows https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-fs-readlink-type-check.js test to pass.

Towards #29972