### PR TITLE
fix: global npm packages have no copies (?)

### DIFF
--- a/libs/resolver/npm/managed/global.rs
+++ b/libs/resolver/npm/managed/global.rs
@@ -50,14 +50,11 @@ impl<TSys: FsCanonicalize + FsMetadata> GlobalNpmPackageResolver<TSys> {
   }
 
   pub fn maybe_package_folder(&self, id: &NpmPackageId) -> Option<PathBuf> {
-    let folder_copy_index = self
-      .resolution
-      .resolve_pkg_cache_folder_copy_index_from_pkg_id(id)?;
     let registry_url = self.npm_rc.get_registry_url(&id.nv.name);
     Some(self.cache.package_folder_for_id(
       &id.nv.name,
       &id.nv.version.to_string(),
-      folder_copy_index,
+      0,
       registry_url,
     ))
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

I am not sure about this fix. As far as I understand, copy indexes are only required with local npm resolver, where different copies might have different internal `node_modules` subdirectories, and in the case of global npm resolver - resolution of dependencies is specifier, not path-based, making pkg copy indexes redundant.

This PR is for collecting review for now, I'll try to fix it another way if I got something wrong, thus no test changes now

Fixes: https://github.com/denoland/deno/issues/28366

