### PR TITLE
chore(test): fix `node:fs.close` test flakiness

### DIFF
--- a/tests/unit_node/_fs/_fs_close_test.ts
+++ b/tests/unit_node/_fs/_fs_close_test.ts
@@ -109,7 +109,7 @@ Deno.test({
   const tempFile = await Deno.makeTempFile();
   const rid = openSync(tempFile, "r");
   close(rid);
-  await setTimeout(1);
+  await setTimeout(1000);
   assertThrows(() => {
     closeSync(rid), Deno.errors.BadResource;
   });

--- a/tests/unit_node/_fs/_fs_close_test.ts
+++ b/tests/unit_node/_fs/_fs_close_test.ts
@@ -2,6 +2,7 @@
 import { assert, assertThrows, fail } from "@std/assert";
 import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { close, closeSync, openSync } from "node:fs";
+import { setTimeout } from "node:timers/promises";
 
 Deno.test({
   name: "ASYNC: File is closed",
@@ -108,5 +109,9 @@ Deno.test({
   const tempFile = await Deno.makeTempFile();
   const rid = openSync(tempFile, "r");
   close(rid);
+  await setTimeout(1);
+  assertThrows(() => {
+    closeSync(rid), Deno.errors.BadResource;
+  });
   await Deno.remove(tempFile);
 });


### PR DESCRIPTION
Test from #30720 is flaky because sometimes the resource ID is not fully closed and caused some CI failures.