### PR TITLE
test: use longer timeout in netTcpWithAbortSignal test

### DIFF
--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -1290,7 +1290,7 @@ Deno.test(
   { permissions: { net: true } },
   async function netTcpWithAbortSignal() {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(), 100);
+    setTimeout(() => controller.abort(), 1_000);
     const error = await assertRejects(
       async () => {
         await Deno.connect({


### PR DESCRIPTION
This test has been very flaky on Windows CI recently.