### PR TITLE
feat: multiple import maps

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,3 +36,6 @@ rustflags = [
   "--cfg",
   "tokio_unstable",
 ]
+
+[patch.crates-io]
+import_map = { path = "./import_map/rs-lib" }

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,6 @@
 	url = https://github.com/denoland/deno_lsp_benchdata.git
 	shallow = true
 [submodule "import_map"]
-	path = import_map
-	url = ./import_map
+  path = import_map
+  url = https://github.com/CertainLach/import_map.git
+  shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 	path = cli/bench/testdata/lsp_benchdata
 	url = https://github.com/denoland/deno_lsp_benchdata.git
 	shallow = true
+[submodule "import_map"]
+	path = import_map
+	url = ./import_map

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,6 +2810,7 @@ dependencies = [
  "http 1.1.0",
  "import_map",
  "indexmap 2.9.0",
+ "itertools 0.14.0",
  "jsonc-parser",
  "log",
  "node_resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5352,8 +5352,6 @@ dependencies = [
 [[package]]
 name = "import_map"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce93e07f4819f0db4d2948fffce3ef4760a9940c4ff4f9369dfaf5e357a0d415"
 dependencies = [
  "boxed_error",
  "deno_error",

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -731,7 +731,7 @@ pub struct Flags {
   /// Flags that aren't exposed in the CLI, but are used internally.
   pub internal: InternalFlags,
   pub ignore: Vec<String>,
-  pub import_map_path: Option<String>,
+  pub import_map_paths: Vec<String>,
   pub env_file: Option<Vec<String>>,
   pub inspect_brk: Option<SocketAddr>,
   pub inspect_wait: Option<SocketAddr>,
@@ -4388,6 +4388,7 @@ fn import_map_arg() -> Arg {
   <p(245)>Docs: https://docs.deno.com/runtime/manual/basics/import_maps</>",
     ))
     .value_hint(ValueHint::FilePath)
+    .action(ArgAction::Append)
     .help_heading(DEPENDENCY_MANAGEMENT_HEADING)
 }
 
@@ -6325,7 +6326,10 @@ fn inspect_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
 }
 
 fn import_map_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
-  flags.import_map_path = matches.remove_one::<String>("import-map");
+  flags.import_map_paths = matches
+    .remove_many::<String>("import-map")
+    .unwrap_or_default()
+    .collect();
 }
 
 fn env_file_arg_parse(flags: &mut Flags, matches: &mut ArgMatches) {
@@ -8375,7 +8379,7 @@ mod tests {
           print: false,
           code: "42".to_string(),
         }),
-        import_map_path: Some("import_map.json".to_string()),
+        import_map_paths: vec!["import_map.json".to_string()],
         no_remote: true,
         config_flag: ConfigFlag::Path("tsconfig.json".to_owned()),
         type_check_mode: TypeCheckMode::None,
@@ -8470,7 +8474,7 @@ mod tests {
           is_default_command: false,
           json: false,
         }),
-        import_map_path: Some("import_map.json".to_string()),
+        import_map_paths: vec!["import_map.json".to_string()],
         no_remote: true,
         config_flag: ConfigFlag::Path("tsconfig.json".to_owned()),
         type_check_mode: TypeCheckMode::None,
@@ -9058,7 +9062,7 @@ mod tests {
         subcommand: DenoSubcommand::Run(RunFlags::new_default(
           "script.ts".to_string(),
         )),
-        import_map_path: Some("import_map.json".to_owned()),
+        import_map_paths: vec!["import_map.json".to_owned()],
         code_cache_enabled: true,
         ..Flags::default()
       }
@@ -9080,7 +9084,7 @@ mod tests {
           file: Some("script.ts".to_string()),
           json: false,
         }),
-        import_map_path: Some("import_map.json".to_owned()),
+        import_map_paths: vec!["import_map.json".to_owned()],
         ..Flags::default()
       }
     );
@@ -9100,7 +9104,7 @@ mod tests {
         subcommand: DenoSubcommand::Cache(CacheFlags {
           files: svec!["script.ts"],
         }),
-        import_map_path: Some("import_map.json".to_owned()),
+        import_map_paths: vec!["import_map.json".to_owned()],
         ..Flags::default()
       }
     );
@@ -9125,7 +9129,7 @@ mod tests {
           lint: false,
           filter: None,
         }),
-        import_map_path: Some("import_map.json".to_owned()),
+        import_map_paths: vec!["import_map.json".to_owned()],
         ..Flags::default()
       }
     );
@@ -9360,7 +9364,7 @@ mod tests {
             force: true,
           }
         ),),
-        import_map_path: Some("import_map.json".to_string()),
+        import_map_paths: vec!["import_map.json".to_string()],
         no_remote: true,
         config_flag: ConfigFlag::Path("tsconfig.json".to_owned()),
         type_check_mode: TypeCheckMode::None,
@@ -11081,7 +11085,7 @@ mod tests {
           exclude: vec!["exclude.txt".to_string()],
           eszip: false
         }),
-        import_map_path: Some("import_map.json".to_string()),
+        import_map_paths: vec!["import_map.json".to_string()],
         no_remote: true,
         code_cache_enabled: false,
         config_flag: ConfigFlag::Path("tsconfig.json".to_owned()),

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1419,12 +1419,13 @@ pub struct ImportMapSpecifierResolveError {
   source: deno_path_util::ResolveUrlOrPathError,
 }
 
-// TODO: Shouldn't it also include deno.json in result?
+/// Note: It doesn't include deno.json
 fn resolve_import_map_specifiers<'i>(
-  maybe_import_map_paths: impl Iterator<Item = &'i str>,
+  maybe_import_map_paths: impl IntoIterator<Item = &'i str>,
   current_dir: &Path,
 ) -> Result<Vec<Url>, ImportMapSpecifierResolveError> {
   maybe_import_map_paths
+    .into_iter()
     .map(|import_map_path| {
       let specifier =
         deno_path_util::resolve_url_or_path(import_map_path, current_dir)
@@ -1711,7 +1712,7 @@ mod test {
   #[test]
   fn resolve_import_map_flags_take_precedence() {
     let cwd = &std::env::current_dir().unwrap();
-    let actual = resolve_import_map_specifiers(&["import-map.json"], cwd);
+    let actual = resolve_import_map_specifiers(["import-map.json"], cwd);
     let import_map_path = cwd.join("import-map.json");
     let expected_specifier =
       deno_path_util::url_from_file_path(&import_map_path).unwrap();
@@ -1722,7 +1723,7 @@ mod test {
 
   #[test]
   fn resolve_import_map_none() {
-    let actual = resolve_import_map_specifiers(&[], Path::new("/"));
+    let actual = resolve_import_map_specifiers([], Path::new("/"));
     assert!(actual.is_ok());
     let actual = actual.unwrap();
     assert_eq!(actual, vec![]);
@@ -1730,10 +1731,10 @@ mod test {
 
   #[test]
   fn resolve_import_map_no_config() {
-    let actual = resolve_import_map_specifiers(&[], Path::new("/"));
+    let actual = resolve_import_map_specifiers([], Path::new("/"));
     assert!(actual.is_ok());
     let actual = actual.unwrap();
-    assert_eq!(actual, None);
+    assert_eq!(actual, vec![]);
   }
 
   #[test]

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -186,7 +186,7 @@ struct CliSpecifiedImportMapProvider {
 impl SpecifiedImportMapProvider for CliSpecifiedImportMapProvider {
   async fn get(
     &self,
-  ) -> Result<Option<deno_resolver::workspace::SpecifiedImportMap>, AnyError>
+  ) -> Result<Vec<deno_resolver::workspace::SpecifiedImportMap>, AnyError>
   {
     async fn resolve_import_map_value_from_specifier(
       specifier: &Url,
@@ -204,40 +204,37 @@ impl SpecifiedImportMapProvider for CliSpecifiedImportMapProvider {
       }
     }
 
-    let maybe_import_map_specifier =
-      self.cli_options.resolve_specified_import_map_specifier()?;
-    match maybe_import_map_specifier {
-      Some(specifier) => {
-        let value = match self.eszip_module_loader_provider.get().await? {
-          Some(eszip) => eszip.load_import_map_value(&specifier)?,
-          None => resolve_import_map_value_from_specifier(
-            &specifier,
-            &self.file_fetcher,
-          )
-          .await
-          .with_context(|| {
-            format!("Unable to load '{}' import map", specifier)
-          })?,
-        };
-        Ok(Some(deno_resolver::workspace::SpecifiedImportMap {
-          base_url: specifier,
-          value,
-        }))
-      }
-      None => {
-        if let Some(import_map) =
-          self.workspace_external_import_map_loader.get_or_load()?
-        {
-          let path_url = deno_path_util::url_from_file_path(&import_map.path)?;
-          Ok(Some(deno_resolver::workspace::SpecifiedImportMap {
-            base_url: path_url,
-            value: import_map.value.clone(),
-          }))
-        } else {
-          Ok(None)
-        }
-      }
+    let mut out = Vec::new();
+
+    let maybe_import_map_specifiers =
+      self.cli_options.resolve_specified_import_map_specifiers()?;
+
+    for specifier in maybe_import_map_specifiers {
+      let value = match self.eszip_module_loader_provider.get().await? {
+        Some(eszip) => eszip.load_import_map_value(&specifier)?,
+        None => resolve_import_map_value_from_specifier(
+          &specifier,
+          &self.file_fetcher,
+        )
+        .await
+        .with_context(|| {
+          format!("Unable to load '{}' import map", specifier)
+        })?,
+      };
+      out.push(deno_resolver::workspace::SpecifiedImportMap {
+        base_url: specifier,
+        value,
+      })
     }
+    for import_map in self.workspace_external_import_map_loader.get_or_load()? {
+      let path_url = deno_path_util::url_from_file_path(&import_map.path)?;
+      out.push(deno_resolver::workspace::SpecifiedImportMap {
+        base_url: path_url,
+        value: import_map.value.clone(),
+      })
+    }
+
+    Ok(out)
   }
 }
 
@@ -1192,7 +1189,7 @@ impl CliFactory {
           },
           node_resolution_cache: Some(Arc::new(NodeResolutionThreadLocalCache)),
           npm_system_info: self.flags.subcommand.npm_system_info(),
-          specified_import_map: Some(Box::new(CliSpecifiedImportMapProvider {
+          specified_import_map: Box::new(CliSpecifiedImportMapProvider {
             cli_options: options.clone(),
             eszip_module_loader_provider: self
               .eszip_module_loader_provider()?
@@ -1201,7 +1198,7 @@ impl CliFactory {
             workspace_external_import_map_loader: self
               .workspace_external_import_map_loader()?
               .clone(),
-          })),
+          }),
           bare_node_builtins: options.unstable_bare_node_builtins(),
           unstable_sloppy_imports: options.unstable_sloppy_imports(),
           on_mapped_resolution_diagnostic: Some(Arc::new(

--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -186,8 +186,7 @@ struct CliSpecifiedImportMapProvider {
 impl SpecifiedImportMapProvider for CliSpecifiedImportMapProvider {
   async fn get(
     &self,
-  ) -> Result<Vec<deno_resolver::workspace::SpecifiedImportMap>, AnyError>
-  {
+  ) -> Result<Vec<deno_resolver::workspace::SpecifiedImportMap>, AnyError> {
     async fn resolve_import_map_value_from_specifier(
       specifier: &Url,
       file_fetcher: &CliFileFetcher,

--- a/cli/lib/standalone/binary.rs
+++ b/cli/lib/standalone/binary.rs
@@ -63,7 +63,7 @@ pub struct SerializedResolverWorkspaceJsrPackage {
 
 #[derive(Deserialize, Serialize)]
 pub struct SerializedWorkspaceResolver {
-  pub import_map: Option<SerializedWorkspaceResolverImportMap>,
+  pub import_maps: Vec<SerializedWorkspaceResolverImportMap>,
   pub jsr_pkgs: Vec<SerializedResolverWorkspaceJsrPackage>,
   pub package_jsons: BTreeMap<String, serde_json::Value>,
   pub pkg_json_resolution: PackageJsonDepResolution,

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -45,6 +45,7 @@ use deno_npm_installer::lifecycle_scripts::NullLifecycleScriptsExecutor;
 use deno_package_json::PackageJsonCache;
 use deno_path_util::url_to_file_path;
 use deno_resolver::factory::ConfigDiscoveryOption;
+use deno_resolver::factory::EmptyImportMapProvider;
 use deno_resolver::factory::ResolverFactory;
 use deno_resolver::factory::ResolverFactoryOptions;
 use deno_resolver::factory::WorkspaceFactory;
@@ -1247,8 +1248,9 @@ pub struct ConfigData {
   pub vendor_dir: Option<PathBuf>,
   pub lockfile: Option<Arc<CliLockfile>>,
   pub npmrc: Option<Arc<ResolvedNpmRc>>,
+  // TODO: Should be Vec
   pub import_map_from_settings: Option<ModuleSpecifier>,
-  pub specified_import_map: Option<SpecifiedImportMap>,
+  pub specified_import_maps: Vec<SpecifiedImportMap>,
   pub unstable: BTreeSet<String>,
   watched_files: HashMap<ModuleSpecifier, ConfigWatchedFileType>,
 }
@@ -1460,7 +1462,7 @@ impl ConfigData {
         node_resolution_cache: None,
         package_json_cache: None,
         package_json_dep_resolution: None,
-        specified_import_map: None,
+        specified_import_map: Box::new(EmptyImportMapProvider),
         bare_node_builtins: false,
         unstable_sloppy_imports: false,
         on_mapped_resolution_diagnostic: None,
@@ -1571,12 +1573,13 @@ impl ConfigData {
       .map(|p| p.to_path_buf());
 
     // Mark the import map as a watched file
-    if let Some(import_map_specifier) = member_dir
+    for import_map_specifier in member_dir
       .workspace
-      .to_import_map_path()
+      .to_import_map_paths()
       .ok()
+      .into_iter()
       .flatten()
-      .and_then(|path| Url::from_file_path(path).ok())
+      .flat_map(|path| Url::from_file_path(path).ok())
     {
       add_watched_file(
         import_map_specifier.clone(),
@@ -1586,12 +1589,12 @@ impl ConfigData {
     let mut import_map_from_settings = {
       let is_config_import_map = member_dir
         .maybe_deno_json()
-        .map(|c| c.is_an_import_map() || c.json.import_map.is_some())
+        .map(|c| c.is_an_import_map() || !c.json.import_map.is_empty())
         .or_else(|| {
           member_dir
             .workspace
             .root_deno_json()
-            .map(|c| c.is_an_import_map() || c.json.import_map.is_some())
+            .map(|c| c.is_an_import_map() || !c.json.import_map.is_empty())
         })
         .unwrap_or(false);
       if is_config_import_map {
@@ -1605,20 +1608,7 @@ impl ConfigData {
       }
     };
 
-    let specified_import_map = {
-      let is_config_import_map = member_dir
-        .maybe_deno_json()
-        .map(|c| c.is_an_import_map() || c.json.import_map.is_some())
-        .or_else(|| {
-          member_dir
-            .workspace
-            .root_deno_json()
-            .map(|c| c.is_an_import_map() || c.json.import_map.is_some())
-        })
-        .unwrap_or(false);
-      if is_config_import_map {
-        import_map_from_settings = None;
-      }
+    let specified_import_maps =
       if let Some(import_map_url) = &import_map_from_settings {
         add_watched_file(
           import_map_url.clone(),
@@ -1634,10 +1624,10 @@ impl ConfigData {
           serde_json::from_slice::<Value>(&f.source).map_err(|e| e.into())
         });
         match value_result {
-          Ok(value) => Some(SpecifiedImportMap {
+          Ok(value) => vec![SpecifiedImportMap {
             base_url: import_map_url.clone(),
             value,
-          }),
+          }],
           Err(err) => {
             lsp_warn!(
               "  Couldn't read import map \"{}\": {}",
@@ -1645,13 +1635,12 @@ impl ConfigData {
               err
             );
             import_map_from_settings = None;
-            None
+            vec![]
           }
         }
       } else {
-        None
-      }
-    };
+        vec![]
+      };
     let unstable = member_dir
       .workspace
       .unstable_features()
@@ -1673,7 +1662,7 @@ impl ConfigData {
       lockfile,
       npmrc,
       import_map_from_settings,
-      specified_import_map,
+      specified_import_maps,
       unstable,
       watched_files,
     }

--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -1587,25 +1587,11 @@ impl ConfigData {
       );
     }
     let mut import_map_from_settings = {
-      let is_config_import_map = member_dir
-        .maybe_deno_json()
-        .map(|c| c.is_an_import_map() || !c.json.import_map.is_empty())
-        .or_else(|| {
-          member_dir
-            .workspace
-            .root_deno_json()
-            .map(|c| c.is_an_import_map() || !c.json.import_map.is_empty())
-        })
-        .unwrap_or(false);
-      if is_config_import_map {
-        None
-      } else {
-        settings.import_map.as_ref().and_then(|import_map_str| {
-          Url::parse(import_map_str)
-            .ok()
-            .or_else(|| workspace_folder?.join(import_map_str).ok())
-        })
-      }
+      settings.import_map.as_ref().and_then(|import_map_str| {
+        Url::parse(import_map_str)
+          .ok()
+          .or_else(|| workspace_folder?.join(import_map_str).ok())
+      })
     };
 
     let specified_import_maps =

--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -4743,11 +4743,14 @@ impl Inner {
       unsafely_ignore_certificate_errors: workspace_settings
         .unsafely_ignore_certificate_errors
         .clone(),
-      import_map_path: config_data.and_then(|d| {
-        d.import_map_from_settings
-          .as_ref()
-          .map(|url| url.to_string())
-      }),
+      import_map_paths: config_data
+        .and_then(|d| {
+          d.import_map_from_settings
+            .as_ref()
+            .map(|url| url.to_string())
+        })
+        .into_iter()
+        .collect(),
       // bit of a hack to force the lsp to cache the @types/node package
       type_check_mode: crate::args::TypeCheckMode::Local,
       permissions: crate::args::PermissionFlags {

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -812,14 +812,18 @@ impl ConfiguredDepResolutions {
       .and_then(|(dep_key, kind)| match kind {
         // Ensure the mapping this entry came from is valid for this referrer.
         ConfiguredDepKind::ImportMap { key, value } => {
-          todo!()
-          // self
-          // .workspace_resolver
-          // .as_ref()?
-          // .maybe_import_maps()?
-          // .resolve(key, referrer)
-          // .is_ok_and(|s| &s == value)
-          // .then(|| dep_key.clone())
+          for import_map in
+            self.workspace_resolver.as_ref()?.maybe_import_maps()
+          {
+            if let Some(v) = import_map
+              .resolve(key, referrer)
+              .is_ok_and(|s| &s == value)
+              .then(|| dep_key.clone())
+            {
+              return Some(v);
+            }
+          }
+          None
         }
         ConfiguredDepKind::PackageJson => Some(dep_key.clone()),
       })

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -685,6 +685,7 @@ impl ConfiguredDepResolutions {
         }
       };
     for import_map in workspace_resolver.maybe_import_maps() {
+      #[allow(deprecated, reason = "import map here is not merged, base_url is only used as original location")]
       let referrer = import_map.base_url();
       for entry in import_map.imports().entries().chain(
         import_map

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -684,7 +684,7 @@ impl ConfiguredDepResolutions {
           }
         }
       };
-    if let Some(import_map) = workspace_resolver.maybe_import_map() {
+    for import_map in workspace_resolver.maybe_import_maps() {
       let referrer = import_map.base_url();
       for entry in import_map.imports().entries().chain(
         import_map
@@ -811,13 +811,16 @@ impl ConfiguredDepResolutions {
       .get(resolution)
       .and_then(|(dep_key, kind)| match kind {
         // Ensure the mapping this entry came from is valid for this referrer.
-        ConfiguredDepKind::ImportMap { key, value } => self
-          .workspace_resolver
-          .as_ref()?
-          .maybe_import_map()?
-          .resolve(key, referrer)
-          .is_ok_and(|s| &s == value)
-          .then(|| dep_key.clone()),
+        ConfiguredDepKind::ImportMap { key, value } => {
+          todo!()
+          // self
+          // .workspace_resolver
+          // .as_ref()?
+          // .maybe_import_maps()?
+          // .resolve(key, referrer)
+          // .is_ok_and(|s| &s == value)
+          // .then(|| dep_key.clone())
+        }
         ConfiguredDepKind::PackageJson => Some(dep_key.clone()),
       })
   }
@@ -1065,7 +1068,7 @@ impl<'a> ResolverFactory<'a> {
             CliSys::default(),
             CreateResolverOptions {
               pkg_json_dep_resolution,
-              specified_import_map: d.specified_import_map.clone(),
+              specified_import_maps: d.specified_import_maps.clone(),
               sloppy_imports_options: if unstable_sloppy_imports {
                 SloppyImportsOptions::Enabled
               } else {
@@ -1084,7 +1087,7 @@ impl<'a> ResolverFactory<'a> {
             // create a dummy resolver
             WorkspaceResolver::new_raw(
               d.scope.clone(),
-              None,
+              vec![],
               d.member_dir.workspace.resolver_jsr_pkgs().collect(),
               d.member_dir.workspace.package_jsons().cloned().collect(),
               pkg_json_dep_resolution,
@@ -1098,7 +1101,7 @@ impl<'a> ResolverFactory<'a> {
           WorkspaceResolver::new_raw(
             // this is fine because this is only used before initialization
             Arc::new(ModuleSpecifier::parse("file:///").unwrap()),
-            None,
+            vec![],
             Vec::new(),
             Vec::new(),
             PackageJsonDepResolution::Disabled,

--- a/cli/lsp/resolver.rs
+++ b/cli/lsp/resolver.rs
@@ -685,7 +685,10 @@ impl ConfiguredDepResolutions {
         }
       };
     for import_map in workspace_resolver.maybe_import_maps() {
-      #[allow(deprecated, reason = "import map here is not merged, base_url is only used as original location")]
+      #[allow(
+        deprecated,
+        reason = "import map here is not merged, base_url is only used as original location"
+      )]
       let referrer = import_map.base_url();
       for entry in import_map.imports().entries().chain(
         import_map
@@ -812,20 +815,13 @@ impl ConfiguredDepResolutions {
       .get(resolution)
       .and_then(|(dep_key, kind)| match kind {
         // Ensure the mapping this entry came from is valid for this referrer.
-        ConfiguredDepKind::ImportMap { key, value } => {
-          for import_map in
-            self.workspace_resolver.as_ref()?.maybe_import_maps()
-          {
-            if let Some(v) = import_map
-              .resolve(key, referrer)
-              .is_ok_and(|s| &s == value)
-              .then(|| dep_key.clone())
-            {
-              return Some(v);
-            }
-          }
-          None
-        }
+        ConfiguredDepKind::ImportMap { key, value } => self
+          .workspace_resolver
+          .as_ref()?
+          .merged_import_map()
+          .resolve(key, referrer)
+          .is_ok_and(|s| &s == value)
+          .then(|| dep_key.clone()),
         ConfiguredDepKind::PackageJson => Some(dep_key.clone()),
       })
   }

--- a/cli/standalone/binary.rs
+++ b/cli/standalone/binary.rs
@@ -589,6 +589,10 @@ impl<'a> DenoCompileBinaryWriter<'a> {
     }
 
     for import_map in self.workspace_resolver.maybe_import_maps() {
+      #[allow(
+        deprecated,
+        reason = "import map here is not merged, base_url is only used as original location"
+      )]
       if let Ok(file_path) = url_to_file_path(import_map.base_url())
         && let Some(import_map_parent_dir) = file_path.parent()
       {
@@ -742,6 +746,7 @@ impl<'a> DenoCompileBinaryWriter<'a> {
           .workspace_resolver
           .maybe_import_maps()
           .map(|i| {
+            #[allow(deprecated, reason = "import maps here is not merged, base_url is only used as original location")]
             SerializedWorkspaceResolverImportMap {
               specifier: if i.base_url().scheme() == "file" {
                 root_dir_url.specifier_key(i.base_url()).into_owned()

--- a/cli/tools/compile.rs
+++ b/cli/tools/compile.rs
@@ -174,8 +174,8 @@ pub async fn compile_eszip(
   .await?;
   output_path.set_extension("eszip");
 
-  let maybe_import_map_specifier =
-    cli_options.resolve_specified_import_map_specifier()?;
+  let maybe_import_map_specifiers =
+    cli_options.resolve_specified_import_map_specifiers()?;
   let (module_roots, _include_paths) = get_module_roots_and_include_paths(
     entrypoint,
     &compile_flags,
@@ -223,7 +223,7 @@ pub async fn compile_eszip(
     module_kind_resolver: Default::default(),
   })?;
 
-  if let Some(import_map_specifier) = maybe_import_map_specifier {
+  for import_map_specifier in maybe_import_map_specifiers {
     let import_map_path = import_map_specifier.to_file_path().unwrap();
     let import_map_content = std::fs::read_to_string(&import_map_path)
       .with_context(|| {

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -1014,7 +1014,7 @@ async fn resolve_shim_data(
     executable_args.push(format!("--inspect-brk={inspect_brk}"));
   }
 
-  if let Some(import_map_path) = &flags.import_map_path {
+  for import_map_path in &flags.import_map_paths {
     let import_map_url = resolve_url_or_path(import_map_path, cwd)?;
     executable_args.push("--import-map".to_string());
     executable_args.push(import_map_url.to_string());
@@ -1028,11 +1028,11 @@ async fn resolve_shim_data(
       .with_context(|| format!("error reading {config_path}"))?;
     // always remove the import map field because when someone specifies `--import-map` we
     // don't want that file to be attempted to be loaded and when they don't specify that
-    // (which is just something we haven't implemented yet)
+    // - loading nested import maps is not implemented yet
     if let Some(new_text) = remove_import_map_field_from_text(&config_text) {
-      if flags.import_map_path.is_none() {
+      if flags.import_map_paths.is_empty() {
         log::warn!(
-          "{} \"importMap\" field in the specified config file we be ignored. Use the --import-map flag instead.",
+          "{} \"importMap\" field in the specified config file we be ignored as unimplemented. Use the --import-map flag instead.",
           crate::colors::yellow("Warning"),
         );
       }
@@ -1738,7 +1738,7 @@ mod tests {
 
     let result = create_install_shim(
       &Flags {
-        import_map_path: Some(import_map_path.to_string()),
+        import_map_paths: vec![import_map_path.to_string()],
         ..Flags::default()
       },
       InstallFlagsGlobal {

--- a/cli/tools/installer/mod.rs
+++ b/cli/tools/installer/mod.rs
@@ -1032,7 +1032,7 @@ async fn resolve_shim_data(
     if let Some(new_text) = remove_import_map_field_from_text(&config_text) {
       if flags.import_map_paths.is_empty() {
         log::warn!(
-          "{} \"importMap\" field in the specified config file we be ignored as unimplemented. Use the --import-map flag instead.",
+          "{} \"importMap\" field in the specified config file will be ignored as unimplemented. Use the --import-map flag instead.",
           crate::colors::yellow("Warning"),
         );
       }

--- a/cli/tools/publish/unfurl.rs
+++ b/cli/tools/publish/unfurl.rs
@@ -1048,7 +1048,7 @@ mod tests {
     .unwrap();
     let workspace_resolver = WorkspaceResolver::new_raw(
       Arc::new(ModuleSpecifier::from_directory_path(&cwd).unwrap()),
-      Some(import_map),
+      vec![import_map],
       vec![ResolverWorkspaceJsrPackage {
         is_link: false,
         base: ModuleSpecifier::from_directory_path(cwd.join("jsr-package"))
@@ -1222,7 +1222,7 @@ export type * from "./c.d.ts";
     let sys = CliSys::default();
     let workspace_resolver = WorkspaceResolver::new_raw(
       Arc::new(ModuleSpecifier::from_directory_path(&cwd).unwrap()),
-      None,
+      vec![],
       vec![ResolverWorkspaceJsrPackage {
         is_link: false,
         base: ModuleSpecifier::from_directory_path(

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -968,7 +968,7 @@ impl ImportMap {
     match self {
       Self::Single(_) => false,
       Self::Multiple(v) => v.is_empty(),
-      Self::None => false,
+      Self::None => true,
     }
   }
   pub fn as_slice(&self) -> &[String] {

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -2799,7 +2799,10 @@ mod tests {
     }"#;
     let config_specifier = root_url().join("deno.json").unwrap();
     let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
-    let result = expect_singleton(config_file.to_import_maps(&MockFs).unwrap(), "single importMap path");
+    let result = expect_singleton(
+      config_file.to_import_maps(&MockFs).unwrap(),
+      "single importMap path",
+    );
 
     assert_eq!(
       result.import_map.base_url(),
@@ -2888,7 +2891,10 @@ mod tests {
     let config_specifier = Url::from_file_path(&file_path).unwrap();
     let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
     assert_eq!(
-      expect_singleton(config_file.to_import_map_paths().unwrap(), "relative importMap"),
+      expect_singleton(
+        config_file.to_import_map_paths().unwrap(),
+        "relative importMap"
+      ),
       file_path
         .parent()
         .unwrap()

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -956,10 +956,34 @@ pub struct DeployConfig {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ImportMap {
+  Single(String),
+  Multiple(Vec<String>),
+  None,
+}
+impl ImportMap {
+  pub fn is_empty(&self) -> bool {
+    match self {
+      Self::Single(_) => false,
+      Self::Multiple(v) => v.is_empty(),
+      Self::None => false,
+    }
+  }
+  pub fn as_slice(&self) -> &[String] {
+    match self {
+      Self::Single(v) => std::slice::from_ref(v),
+      Self::Multiple(v) => v.as_slice(),
+      Self::None => &[],
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigFileJson {
   pub compiler_options: Option<Value>,
-  pub import_map: Option<String>,
+  pub import_map: ImportMap,
   pub imports: Option<Value>,
   pub scopes: Option<Value>,
   pub lint: Option<Value>,
@@ -1319,29 +1343,39 @@ impl ConfigFile {
       .to_path_buf()
   }
 
-  pub fn to_import_map_specifier(
-    &self,
-  ) -> Result<Option<Url>, ConfigFileError> {
-    let Some(value) = self.json.import_map.as_ref() else {
-      return Ok(None);
-    };
-    // try to resolve as a url
-    if let Ok(specifier) = Url::parse(value) {
-      if specifier.scheme() != "file" {
-        return Err(ConfigFileError::OnlyFileSpecifiersSupported);
+  pub fn to_import_map_specifiers(&self) -> Result<Vec<Url>, ConfigFileError> {
+    fn import_single(
+      specifier: &Url,
+      path: &str,
+    ) -> Result<Url, ConfigFileError> {
+      if let Ok(specifier) = Url::parse(path) {
+        if specifier.scheme() != "file" {
+          return Err(ConfigFileError::OnlyFileSpecifiersSupported);
+        }
+        return Ok(specifier);
       }
-      return Ok(Some(specifier));
+      // now as a relative file path
+      Ok(url_parent(&specifier).join(path)?)
     }
-    // now as a relative file path
-    Ok(Some(url_parent(&self.specifier).join(value)?))
+
+    self
+      .json
+      .import_map
+      .as_slice()
+      .iter()
+      .map(|v| import_single(&self.specifier, &v))
+      .collect()
+    // try to resolve as a url
   }
 
-  pub fn to_import_map_path(&self) -> Result<Option<PathBuf>, ConfigFileError> {
-    let maybe_specifier = self.to_import_map_specifier()?;
-    match maybe_specifier {
-      Some(specifier) => Ok(Some(url_to_file_path(&specifier)?)),
-      None => Ok(None),
-    }
+  pub fn to_import_map_paths(&self) -> Result<Vec<PathBuf>, ConfigFileError> {
+    self
+      .to_import_map_specifiers()?
+      .into_iter()
+      .map(|specifier| {
+        url_to_file_path(&specifier).map_err(ConfigFileError::from)
+      })
+      .collect()
   }
 
   pub fn vendor(&self) -> Option<bool> {
@@ -1350,47 +1384,56 @@ impl ConfigFile {
 
   /// Resolves the import map potentially resolving the file specified
   /// at the "importMap" entry.
-  pub fn to_import_map(
+  pub fn to_import_maps(
     &self,
     sys: &impl FsRead,
-  ) -> Result<Option<ImportMapWithDiagnostics>, ConfigFileError> {
-    let maybe_result = self.to_import_map_value(sys)?;
-    match maybe_result {
-      Some((specifier, value)) => {
-        let import_map =
-          import_map::parse_from_value(specifier.into_owned(), value)?;
-        Ok(Some(import_map))
-      }
-      None => Ok(None),
-    }
+  ) -> Result<Vec<ImportMapWithDiagnostics>, ConfigFileError> {
+    self
+      .to_import_map_values(sys)?
+      .into_iter()
+      .map(|(specifier, value)| {
+        Ok(import_map::parse_from_value(specifier.into_owned(), value)?)
+      })
+      .collect()
   }
 
   /// Resolves the import map `serde_json::Value` potentially resolving the
   /// file specified at the "importMap" entry.
-  pub fn to_import_map_value(
+  pub fn to_import_map_values(
     &self,
     sys: &impl FsRead,
-  ) -> Result<Option<(Cow<'_, Url>, serde_json::Value)>, ConfigFileError> {
+  ) -> Result<Vec<(Cow<'_, Url>, serde_json::Value)>, ConfigFileError> {
     // has higher precedence over the path
-    if self.json.imports.is_some() || self.json.scopes.is_some() {
-      Ok(Some((
-        Cow::Borrowed(&self.specifier),
-        self.to_import_map_value_from_imports(),
-      )))
-    } else {
-      let Some(specifier) = self.to_import_map_specifier()? else {
-        return Ok(None);
+    let from_config =
+      if self.json.imports.is_some() || self.json.scopes.is_some() {
+        Some((
+          Cow::Borrowed(&self.specifier),
+          self.to_import_map_value_from_imports(),
+        ))
+      } else {
+        None
       };
-      let Ok(import_map_path) = url_to_file_path(&specifier) else {
-        return Ok(None);
-      };
+
+    let process_single = |specifier: Url| {
+      let import_map_path = url_to_file_path(&specifier)?;
       let text = sys
         .fs_read_to_string_lossy(&import_map_path)
         .map_err(ConfigFileError::Io)?;
       let value = serde_json::from_str(&text)?;
       // does not expand the imports because this one will use the import map standard
-      Ok(Some((Cow::Owned(specifier), value)))
-    }
+      Ok((Cow::Owned(specifier), value))
+    };
+
+    from_config
+      .into_iter()
+      .map(Ok)
+      .chain(
+        self
+          .to_import_map_specifiers()?
+          .into_iter()
+          .map(process_single),
+      )
+      .collect()
   }
 
   /// Creates the import map from the imports entry.
@@ -2072,6 +2115,11 @@ mod tests {
       .unwrap_or_else(|err| panic!("error parsing {name} object but got {err}"))
   }
 
+  fn expect_singleton<T>(vec: Vec<T>, msg: &str) -> T {
+    assert_eq!(vec.len(), 1, "expected exactly one element: {msg}");
+    vec.into_iter().next().unwrap()
+  }
+
   #[test]
   fn read_config_file_absolute() {
     let path = testdata_path().join("module_graph/tsconfig.json");
@@ -2726,61 +2774,6 @@ mod tests {
   }
 
   #[test]
-  fn test_to_import_map_imports_entry() {
-    let config_text = r#"{
-      "imports": { "@std/test": "jsr:@std/test@0.2.0" },
-      // will be ignored because imports and scopes takes precedence
-      "importMap": "import_map.json",
-    }"#;
-    let config_specifier = root_url().join("deno.json").unwrap();
-    let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
-    let result = config_file.to_import_map(&UnreachableSys).unwrap().unwrap();
-
-    assert_eq!(
-      result.import_map.base_url(),
-      &root_url().join("deno.json").unwrap()
-    );
-    assert_eq!(
-      json!(result.import_map.imports()),
-      // imports should be expanded
-      json!({
-        "@std/test/": "jsr:/@std/test@0.2.0/",
-        "@std/test": "jsr:@std/test@0.2.0",
-      })
-    );
-  }
-
-  #[test]
-  fn test_to_import_map_scopes_entry() {
-    let config_text = r#"{
-      "scopes": { "https://deno.land/x/test/mod.ts": { "@std/test": "jsr:@std/test@0.2.0" } },
-      // will be ignored because imports and scopes takes precedence
-      "importMap": "import_map.json",
-    }"#;
-    let config_specifier = root_url().join("deno.json").unwrap();
-    let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
-    let result = config_file.to_import_map(&UnreachableSys).unwrap().unwrap();
-
-    assert_eq!(
-      result.import_map.base_url(),
-      &root_url().join("deno.json").unwrap()
-    );
-    assert_eq!(
-      json!(result.import_map),
-      // imports should be expanded
-      json!({
-        "imports": {},
-        "scopes": {
-          "https://deno.land/x/test/mod.ts": {
-            "@std/test/": "jsr:/@std/test@0.2.0/",
-            "@std/test": "jsr:@std/test@0.2.0",
-          }
-        }
-      })
-    );
-  }
-
-  #[test]
   fn test_to_import_map_import_map_entry() {
     struct MockFs;
 
@@ -2804,7 +2797,7 @@ mod tests {
     }"#;
     let config_specifier = root_url().join("deno.json").unwrap();
     let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
-    let result = config_file.to_import_map(&MockFs).unwrap().unwrap();
+    let result = expect_singleton(config_file.to_import_maps(&MockFs).unwrap(), "single importMap path");
 
     assert_eq!(
       result.import_map.base_url(),
@@ -2826,7 +2819,7 @@ mod tests {
     }"#;
     let config_specifier = root_url().join("deno.json").unwrap();
     let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
-    let err = config_file.to_import_map(&UnreachableSys).unwrap_err();
+    let err = config_file.to_import_maps(&UnreachableSys).unwrap_err();
     assert_eq!(
       err.to_string(),
       concat!(
@@ -2893,7 +2886,7 @@ mod tests {
     let config_specifier = Url::from_file_path(&file_path).unwrap();
     let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
     assert_eq!(
-      config_file.to_import_map_path().unwrap().unwrap(),
+      expect_singleton(config_file.to_import_map_paths().unwrap(), "relative importMap"),
       file_path
         .parent()
         .unwrap()

--- a/libs/config/deno_json/mod.rs
+++ b/libs/config/deno_json/mod.rs
@@ -955,11 +955,12 @@ pub struct DeployConfig {
   pub app: String,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(untagged)]
 pub enum ImportMap {
   Single(String),
   Multiple(Vec<String>),
+  #[default]
   None,
 }
 impl ImportMap {
@@ -983,6 +984,7 @@ impl ImportMap {
 #[serde(rename_all = "camelCase")]
 pub struct ConfigFileJson {
   pub compiler_options: Option<Value>,
+  #[serde(default)]
   pub import_map: ImportMap,
   pub imports: Option<Value>,
   pub scopes: Option<Value>,

--- a/libs/config/workspace/mod.rs
+++ b/libs/config/workspace/mod.rs
@@ -153,14 +153,6 @@ pub enum WorkspaceDiagnosticKind {
   #[error("\"exports\" field should be specified when specifying a \"name\".")]
   MissingExports,
   #[error(
-    "\"importMap\" field is ignored when \"imports\" or \"scopes\" are specified in the config file."
-  )]
-  ImportMapReferencingImportMap,
-  #[error(
-    "\"imports\" and \"scopes\" field is ignored when \"importMap\" is specified in the root config file."
-  )]
-  MemberImportsScopesIgnored,
-  #[error(
     "`\"nodeModulesDir\": {previous}` is deprecated in Deno 2.0. Use `\"nodeModulesDir\": \"{suggestion}\"` instead."
   )]
   DeprecatedNodeModulesDirOption {
@@ -986,26 +978,12 @@ impl Workspace {
   pub fn diagnostics(&self) -> Vec<WorkspaceDiagnostic> {
     fn check_member_diagnostics(
       member_config: &ConfigFile,
-      root_config: Option<&ConfigFile>,
       diagnostics: &mut Vec<WorkspaceDiagnostic>,
     ) {
       if !member_config.json.import_map.is_empty() {
         diagnostics.push(WorkspaceDiagnostic {
           config_url: member_config.specifier.clone(),
           kind: WorkspaceDiagnosticKind::RootOnlyOption("importMap"),
-        });
-      } else if member_config.is_an_import_map()
-        && root_config
-          .map(|c| {
-            !c.json.import_map.is_empty()
-              && c.json.imports.is_none()
-              && c.json.scopes.is_none()
-          })
-          .unwrap_or(false)
-      {
-        diagnostics.push(WorkspaceDiagnostic {
-          config_url: member_config.specifier.clone(),
-          kind: WorkspaceDiagnosticKind::MemberImportsScopesIgnored,
         });
       }
       if member_config.json.lock.is_some() {
@@ -1116,11 +1094,7 @@ impl Workspace {
       if let Some(config) = &folder.deno_json {
         let is_root = url == &self.root_dir_url;
         if !is_root {
-          check_member_diagnostics(
-            config,
-            self.root_deno_json().map(|r| r.as_ref()),
-            &mut diagnostics,
-          );
+          check_member_diagnostics(config, &mut diagnostics);
         }
 
         check_all_configs(config, &mut diagnostics);
@@ -3239,35 +3213,6 @@ pub mod test {
         "only root"
       ),
       root_dir().join("other.json")
-    );
-    assert_eq!(
-      workspace_dir.workspace.diagnostics(),
-      vec![WorkspaceDiagnostic {
-        kind: WorkspaceDiagnosticKind::ImportMapReferencingImportMap,
-        config_url: Url::from_file_path(root_dir().join("deno.json")).unwrap(),
-      }]
-    );
-  }
-
-  #[test]
-  fn test_root_import_map_with_member_imports_and_scopes() {
-    let workspace_dir = workspace_for_root_and_member(
-      json!({
-        "importMap": "./other.json"
-      }),
-      json!({
-        "imports": {
-          "@scope/pkg": "jsr:@scope/pkg@3"
-        }
-      }),
-    );
-    assert_eq!(
-      workspace_dir.workspace.diagnostics(),
-      vec![WorkspaceDiagnostic {
-        kind: WorkspaceDiagnosticKind::MemberImportsScopesIgnored,
-        config_url: Url::from_file_path(root_dir().join("member/deno.json"))
-          .unwrap(),
-      }]
     );
   }
 

--- a/libs/resolver/Cargo.toml
+++ b/libs/resolver/Cargo.toml
@@ -53,6 +53,7 @@ futures.workspace = true
 http = { workspace = true, optional = true }
 import_map.workspace = true
 indexmap.workspace = true
+itertools.workspace = true
 jsonc-parser.workspace = true
 log.workspace = true
 node_resolver.workspace = true

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -888,12 +888,8 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
       );
 
       for (url, value) in
-        config_specified_import_maps
-          .into_iter()
-          .chain(std::iter::once((
-            Cow::Owned(scopes_import_map_url),
-            scopes_import_map,
-          )))
+        std::iter::once((Cow::Owned(scopes_import_map_url), scopes_import_map))
+          .chain(config_specified_import_maps.into_iter())
       {
         out.push(import_map::parse_from_value(url.into_owned(), value)?);
       }

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -1673,6 +1673,7 @@ mod test {
   use deno_path_util::url_from_directory_path;
   use deno_path_util::url_from_file_path;
   use deno_semver::VersionReq;
+  use itertools::Itertools;
   use node_resolver::DenoIsBuiltInNodeModuleChecker;
   use node_resolver::NodeResolver;
   use node_resolver::NodeResolverOptions;
@@ -2113,7 +2114,7 @@ mod test {
       sys.clone(),
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
-        specified_import_map: None,
+        specified_import_maps: vec![],
         sloppy_imports_options: SloppyImportsOptions::Unspecified,
         fs_cache_options: FsCacheOptions::Enabled,
       },
@@ -2121,7 +2122,12 @@ mod test {
     .unwrap();
     assert_eq!(
       serde_json::from_str::<serde_json::Value>(
-        &resolver.maybe_import_map().unwrap().to_json()
+        &resolver
+          .maybe_import_maps()
+          .exactly_one()
+          .map_err(|_| "expected only one import map")
+          .unwrap()
+          .to_json()
       )
       .unwrap(),
       json!({
@@ -2354,7 +2360,7 @@ mod test {
       sys.clone(),
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
-        specified_import_map: None,
+        specified_import_maps: vec![],
         sloppy_imports_options: SloppyImportsOptions::Unspecified,
         fs_cache_options: FsCacheOptions::Enabled,
       },
@@ -2478,7 +2484,7 @@ mod test {
       sys.clone(),
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
-        specified_import_map: None,
+        specified_import_maps: vec![],
         sloppy_imports_options: SloppyImportsOptions::Enabled,
         fs_cache_options: FsCacheOptions::Enabled,
       },
@@ -2531,14 +2537,14 @@ mod test {
       sys,
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
-        specified_import_map: Some(SpecifiedImportMap {
+        specified_import_maps: vec![SpecifiedImportMap {
           base_url: url_from_directory_path(&root_dir()).unwrap(),
           value: json!({
             "imports": {
               "b": "./b/mod.ts",
             },
           }),
-        }),
+        }],
         sloppy_imports_options: SloppyImportsOptions::Unspecified,
         fs_cache_options: FsCacheOptions::Enabled,
       },
@@ -2576,14 +2582,14 @@ mod test {
       UnreachableSys,
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
-        specified_import_map: Some(SpecifiedImportMap {
+        specified_import_maps: vec![SpecifiedImportMap {
           base_url: url_from_directory_path(&root_dir()).unwrap(),
           value: json!({
             "imports": {
               "b": "./b/mod.ts",
             },
           }),
-        }),
+        }],
         sloppy_imports_options: SloppyImportsOptions::Unspecified,
         fs_cache_options: FsCacheOptions::Enabled,
       },
@@ -2917,7 +2923,7 @@ mod test {
       UnreachableSys,
       super::CreateResolverOptions {
         pkg_json_dep_resolution: PackageJsonDepResolution::Enabled,
-        specified_import_map: None,
+        specified_import_maps: vec![],
         sloppy_imports_options: SloppyImportsOptions::Unspecified,
         fs_cache_options: FsCacheOptions::Enabled,
       },

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -39,7 +39,6 @@ use import_map::ImportMapDiagnostic;
 use import_map::ImportMapError;
 use import_map::ImportMapErrorKind;
 use import_map::ImportMapWithDiagnostics;
-use import_map::ResolveOptions;
 use import_map::specifier::SpecifierError;
 use indexmap::IndexMap;
 use node_resolver::NodeResolutionKind;
@@ -1136,6 +1135,10 @@ impl<TSys: FsMetadata + FsRead> WorkspaceResolver<TSys> {
 
   pub fn maybe_import_maps(&self) -> impl Iterator<Item = &ImportMap> {
     self.maybe_import_maps.iter().map(|c| &c.import_map)
+  }
+
+  pub fn merged_import_map(&self) -> &ImportMap {
+    &self.merged_import_map.import_map
   }
 
   pub fn package_jsons(&self) -> impl Iterator<Item = &PackageJsonRc> {

--- a/libs/resolver/workspace.rs
+++ b/libs/resolver/workspace.rs
@@ -2136,12 +2136,7 @@ mod test {
     .unwrap();
     assert_eq!(
       serde_json::from_str::<serde_json::Value>(
-        &resolver
-          .maybe_import_maps()
-          .exactly_one()
-          .map_err(|_| "expected only one import map")
-          .unwrap()
-          .to_json()
+        &resolver.merged_import_map().to_json()
       )
       .unwrap(),
       json!({


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

While in web you can have multiple import maps, Deno only allows one to be specified right now.

importMaps are merged at WorkspaceResolver level, and passed as a list everywhere else, as it is useful to look at all requirements sometimes, e.g on package installer level - resolver might want to take into account all the requirements, including overriden.

The current implementation lacks tests, especially around LSP part, as I haven't figured out some parts about the implementation that Deno team wants, e.g: right now deno disallows specifying both import map and imports in deno.json, yet this check seems to be redundant in case of multiple import maps present.

Fixes: https://github.com/denoland/deno/issues/25450 https://github.com/denoland/deno/issues/30689