### PR TITLE
fix(ext/node): accept ArrayBuffer on crypto.timingSafeEqual

### DIFF
--- a/ext/node/polyfills/internal_binding/_timingSafeEqual.ts
+++ b/ext/node/polyfills/internal_binding/_timingSafeEqual.ts
@@ -4,8 +4,29 @@
 // deno-lint-ignore-file prefer-primordials
 
 import { Buffer } from "node:buffer";
-import { ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH } from "ext:deno_node/internal/errors.ts";
-import { validateBuffer } from "ext:deno_node/internal/validators.mjs";
+import {
+  ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH,
+  ERR_INVALID_ARG_TYPE,
+} from "ext:deno_node/internal/errors.ts";
+import { core } from "ext:core/mod.js";
+
+const {
+  isAnyArrayBuffer,
+  isArrayBufferView,
+} = core;
+
+function validateBuffer(
+  buf: unknown,
+  name: string,
+): asserts buf is ArrayBufferLike | ArrayBufferView {
+  if (!isAnyArrayBuffer(buf) && !isArrayBufferView(buf)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      name,
+      ["Buffer", "ArrayBuffer", "TypedArray", "DataView"],
+      buf,
+    );
+  }
+}
 
 function toDataView(ab: ArrayBufferLike | ArrayBufferView): DataView {
   if (ArrayBuffer.isView(ab)) {

--- a/tests/integration/node_unit_tests.rs
+++ b/tests/integration/node_unit_tests.rs
@@ -68,6 +68,7 @@ util::unit_test_factory!(
     crypto_pbkdf2_test = crypto / crypto_pbkdf2_test,
     crypto_scrypt_test = crypto / crypto_scrypt_test,
     crypto_sign_test = crypto / crypto_sign_test,
+    crypto_timing_safe_equal_test = crypto / crypto_timing_safe_equal_test,
     events_test,
     dgram_test,
     domain_test,

--- a/tests/unit_node/crypto/crypto_timing_safe_equal_test.ts
+++ b/tests/unit_node/crypto/crypto_timing_safe_equal_test.ts
@@ -1,0 +1,38 @@
+import * as crypto from "node:crypto";
+import { assertEquals, assertThrows } from "@std/assert";
+import { Buffer } from "node:buffer";
+
+Deno.test("timingSafeEqual ArrayBuffer and TypedArray", async () => {
+  const data = new TextEncoder().encode("foo"); // Uint8Array
+
+  const hash = await crypto.subtle.digest("SHA-256", data); // ArrayBuffer
+  const ui8a = new Uint8Array(hash); // Uint8Array
+
+  // @ts-ignore crypto.timingSafeEqual accepts ArrayBuffer
+  const eq = crypto.timingSafeEqual(hash, ui8a);
+  assertEquals(eq, true);
+});
+
+Deno.test("timingSafeEqual rejects non ArrayBuffer/TypedArray", () => {
+  const str = "foo";
+  const buf = Buffer.from(str);
+  const i = 123;
+
+  assertThrows(
+    () => {
+      // @ts-expect-error testing invalid input
+      crypto.timingSafeEqual(str, buf);
+    },
+    'TypeError: The "buf1" argument must be an instance of Buffer, ArrayBuffer, TypedArray, or DataView.' +
+      "Received type string ('foo')",
+  );
+
+  assertThrows(
+    () => {
+      // @ts-expect-error testing invalid input
+      crypto.timingSafeEqual(buf, i);
+    },
+    'TypeError: The "buf2" argument must be an instance of Buffer, ArrayBuffer, TypedArray, or DataView.' +
+      "Received type number (123)",
+  );
+});

--- a/tests/unit_node/crypto/crypto_timing_safe_equal_test.ts
+++ b/tests/unit_node/crypto/crypto_timing_safe_equal_test.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
 import * as crypto from "node:crypto";
 import { assertEquals, assertThrows } from "@std/assert";
 import { Buffer } from "node:buffer";


### PR DESCRIPTION
Fixes #30759

The buffer validation is based on Node.js implementation: https://github.com/nodejs/node/blob/591ba692bfe30408e6a67397e7d18bfa1b9c3561/src/crypto/crypto_util.h#L467-L472