### PR TITLE
fix: restore Windows debug info

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -761,7 +761,7 @@ const ci = {
           name: "Generate symcache",
           if: [
             "(matrix.job == 'test' || matrix.job == 'bench') &&",
-            "matrix.os != 'windows' && matrix.profile == 'release' && (matrix.use_sysroot ||",
+            "matrix.profile == 'release' && (matrix.use_sysroot ||",
             "github.repository == 'denoland/deno')",
           ].join("\n"),
           run: [
@@ -916,37 +916,14 @@ const ci = {
             "Get-FileHash target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
             "Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip",
             "Get-FileHash target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum",
-            // TODO(bartlomieju): fix the regression from V8 upgrade
-            // https://github.com/denoland/deno/pull/30629
-            // "target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${{ matrix.arch }}-pc-windows-msvc.symcache",
+            "target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${{ matrix.arch }}-pc-windows-msvc.symcache",
           ].join("\n"),
         },
         {
-          name: "Upload canary to dl.deno.land (windows)",
+          name: "Upload canary to dl.deno.land",
           if: [
             "matrix.job == 'test' &&",
             "matrix.profile == 'release' &&",
-            "matrix.os == 'windows' &&",
-            "github.repository == 'denoland/deno' &&",
-            "github.ref == 'refs/heads/main'",
-          ].join("\n"),
-          run: [
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.sha256sum gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-            // TODO(bartlomieju): fix the regression from V8 upgrade
-            // https://github.com/denoland/deno/pull/30629
-            // 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.symcache gs://dl.deno.land/canary/$(git rev-parse HEAD)/',
-            "echo ${{ github.sha }} > canary-latest.txt",
-            'gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt',
-            "rm canary-latest.txt gha-creds-*.json",
-          ].join("\n"),
-        },
-        {
-          name: "Upload canary to dl.deno.land (unix)",
-          if: [
-            "matrix.job == 'test' &&",
-            "matrix.profile == 'release' &&",
-            "matrix.os != 'windows' &&",
             "github.repository == 'denoland/deno' &&",
             "github.ref == 'refs/heads/main'",
           ].join("\n"),
@@ -1168,9 +1145,7 @@ const ci = {
           run: [
             'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
             'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.sha256sum gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
-            // TODO(bartlomieju): fix the regression from V8 upgrade
-            // https://github.com/denoland/deno/pull/30629
-            // 'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.symcache gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
+            'gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.symcache gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/',
           ].join("\n"),
         },
         {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
       - name: Generate symcache
         if: |-
           !(matrix.skip) && ((matrix.job == 'test' || matrix.job == 'bench') &&
-          matrix.os != 'windows' && matrix.profile == 'release' && (matrix.use_sysroot ||
+          matrix.profile == 'release' && (matrix.use_sysroot ||
           github.repository == 'denoland/deno'))
         run: |-
           target/release/deno -A tools/release/create_symcache.ts ./deno.symcache
@@ -560,24 +560,11 @@ jobs:
           Get-FileHash target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/deno-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
           Compress-Archive -CompressionLevel Optimal -Force -Path target/release/denort.exe -DestinationPath target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip
           Get-FileHash target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip -Algorithm SHA256 | Format-List > target/release/denort-${{ matrix.arch }}-pc-windows-msvc.zip.sha256sum
-      - name: Upload canary to dl.deno.land (windows)
+          target/release/deno.exe -A tools/release/create_symcache.ts target/release/deno-${{ matrix.arch }}-pc-windows-msvc.symcache
+      - name: Upload canary to dl.deno.land
         if: |-
           !(matrix.skip) && (matrix.job == 'test' &&
           matrix.profile == 'release' &&
-          matrix.os == 'windows' &&
-          github.repository == 'denoland/deno' &&
-          github.ref == 'refs/heads/main')
-        run: |-
-          gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/canary/$(git rev-parse HEAD)/
-          gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.sha256sum gs://dl.deno.land/canary/$(git rev-parse HEAD)/
-          echo ${{ github.sha }} > canary-latest.txt
-          gsutil -h "Cache-Control: no-cache" cp canary-latest.txt gs://dl.deno.land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
-      - name: Upload canary to dl.deno.land (unix)
-        if: |-
-          !(matrix.skip) && (matrix.job == 'test' &&
-          matrix.profile == 'release' &&
-          matrix.os != 'windows' &&
           github.repository == 'denoland/deno' &&
           github.ref == 'refs/heads/main')
         run: |-
@@ -730,6 +717,7 @@ jobs:
         run: |-
           gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.zip gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
           gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.sha256sum gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
+          gsutil -h "Cache-Control: public, max-age=3600" cp ./target/release/*.symcache gs://dl.deno.land/release/${GITHUB_REF#refs/*/}/
       - name: Create release notes
         if: |-
           !(matrix.skip) && (matrix.job == 'test' &&

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.358.0"
+version = "0.359.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b2303b5bd690de06b04fcd1b544d06e6a73a3ed30569da2504890223d435d8"
+checksum = "704237350e1a21c825c303cd09fb7ba6d2e79552ec5f7ab623b60f4117312045"
 dependencies = [
  "anyhow",
  "az",
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.234.0"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0d3a944fa9ee07021e2514aaf2754db6b30c294899730646b9b3bbae4a9583"
+checksum = "70655c93897d43176740ca0ded39a2e473320aaef9bbb3efc7c93740b28f5415"
 dependencies = [
  "indexmap 2.9.0",
  "proc-macro-rules",
@@ -8252,9 +8252,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.267.0"
+version = "0.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc490dcfb7c8ded6aa0946af8c2f5833ca8ea22c414b9392366c9a8d5e1283c4"
+checksum = "72132bf9d12d1502b20296f5fb4bedb76e3308a2915d0f4ffef5b40522efdb6c"
 dependencies = [
  "deno_error",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.50.0", features = ["transpiling"] }
-deno_core = { version = "0.358.0" }
+deno_core = { version = "0.359.0" }
 
 deno_cache_dir = "=0.25.0"
 deno_doc = "=0.183.0"

--- a/tools/release/create_symcache.ts
+++ b/tools/release/create_symcache.ts
@@ -10,10 +10,7 @@ import path from "node:path";
 let debugFile = Deno.execPath();
 
 if (Deno.build.os === "windows") {
-  // TODO(bartlomieju): fix the regression from V8 upgrade
-  // https://github.com/denoland/deno/pull/30629
-  // debugFile = debugFile.replace(/\.exe$/, ".pdb");
-  Deno.exit(0);
+  debugFile = debugFile.replace(/\.exe$/, ".pdb");
 } else if (Deno.build.os === "darwin") {
   const resolvedPath = Deno.realPathSync(`${debugFile}.dSYM`);
   const { name } = path.parse(resolvedPath);


### PR DESCRIPTION
Restores generation of debug info on Windows, that was disabled in 2.5.0 as part of V8 upgrade - https://github.com/denoland/deno/pull/30629