### PR TITLE
perf: key gen cache by emit configuration

### DIFF
--- a/libs/resolver/cache/deno_dir.rs
+++ b/libs/resolver/cache/deno_dir.rs
@@ -66,7 +66,7 @@ impl<TSys: DiskCacheSys> DenoDir<TSys> {
     #[cfg(not(target_arch = "wasm32"))]
     assert!(root.is_absolute());
 
-    let gen_path = root.join("gen");
+    let gen_path = root.join("gen_v2");
     Self {
       root,
       gen_cache: DiskCache::new(sys, gen_path),


### PR DESCRIPTION
Deno internally uses a bunch of different emit configurations, particularly regarding source maps.

The gen cache was layed out to support only one emit for a given source at a time. If two systems were trying to transpile the same source file in different ways, for example `deno run` and `@deno/loader`, the gen output for that file would keep thrashing, making everything slower.

This commit fixes this by including the `transpile_and_emit_options_hash` in the gen folder name. Additionally, we move from `$DENO_DIR/gen` to `$DENO_DIR/gen_v2`.
