### PR TITLE
perf: support negative caching of package.json

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -2038,10 +2038,13 @@ struct PackageJsonMemCache(Mutex<HashMap<PathBuf, Arc<PackageJson>>>);
 
 impl deno_package_json::PackageJsonCache for PackageJsonMemCache {
   fn get(&self, path: &Path) -> PackageJsonCacheResult {
-    self.0.lock().get(path).cloned().map_or_else(
-      || PackageJsonCacheResult::NotCached,
-      |value| PackageJsonCacheResult::Hit(Some(value)),
-    )
+    self
+      .0
+      .lock()
+      .get(path)
+      .cloned()
+      .map(|value| PackageJsonCacheResult::Hit(Some(value)))
+      .unwrap_or_else(|| PackageJsonCacheResult::NotCached)
   }
 
   fn set(&self, path: PathBuf, data: Option<Arc<PackageJson>>) {

--- a/libs/config/workspace/discovery.rs
+++ b/libs/config/workspace/discovery.rs
@@ -278,7 +278,7 @@ fn discover_workspace_config_files_for_single_dir<
             "package.json file found at '{}'",
             pkg_json_path.display()
           );
-          Ok(Some(pkg_json))
+          Ok(pkg_json)
         }
         Err(PackageJsonLoadError::Io { source, .. })
           if is_skippable_io_error(&source) =>

--- a/libs/node_resolver/package_json.rs
+++ b/libs/node_resolver/package_json.rs
@@ -2,11 +2,11 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
 use deno_package_json::PackageJson;
+use deno_package_json::PackageJsonCacheResult;
 use deno_package_json::PackageJsonRc;
 use sys_traits::FsRead;
 
@@ -55,11 +55,18 @@ impl PackageJsonThreadLocalCache {
 }
 
 impl deno_package_json::PackageJsonCache for PackageJsonThreadLocalCache {
-  fn get(&self, path: &Path) -> Option<PackageJsonRc> {
-    CACHE.with_borrow(|cache| cache.get(path).cloned())
+  fn get(&self, path: &Path) -> PackageJsonCacheResult {
+    CACHE.with_borrow(|cache| match cache.get(path).cloned() {
+      Some(value) => PackageJsonCacheResult::Hit(Some(value)),
+      None => PackageJsonCacheResult::NotCached,
+    })
   }
 
-  fn set(&self, path: PathBuf, package_json: PackageJsonRc) {
+  fn set(&self, path: PathBuf, package_json: Option<PackageJsonRc>) {
+    let Some(package_json) = package_json else {
+      // We don't cache misses.
+      return;
+    };
     CACHE.with_borrow_mut(|cache| cache.insert(path, package_json));
   }
 }
@@ -111,12 +118,7 @@ impl<TSys: FsRead> PackageJsonResolver<TSys> {
       path,
     );
     match result {
-      Ok(pkg_json) => Ok(Some(pkg_json)),
-      Err(deno_package_json::PackageJsonLoadError::Io { source, .. })
-        if source.kind() == ErrorKind::NotFound =>
-      {
-        Ok(None)
-      }
+      Ok(pkg_json) => Ok(pkg_json),
       Err(err) => Err(PackageJsonLoadError(err)),
     }
   }

--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -5,6 +5,7 @@
 #![deny(clippy::unused_async)]
 #![deny(clippy::unnecessary_wraps)]
 
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -30,9 +31,14 @@ pub type PackageJsonDepsRc = deno_maybe_sync::MaybeArc<PackageJsonDeps>;
 #[allow(clippy::disallowed_types)]
 type PackageJsonDepsRcCell = deno_maybe_sync::MaybeOnceLock<PackageJsonDepsRc>;
 
+pub enum PackageJsonCacheResult {
+  Hit(Option<PackageJsonRc>),
+  NotCached,
+}
+
 pub trait PackageJsonCache {
-  fn get(&self, path: &Path) -> Option<PackageJsonRc>;
-  fn set(&self, path: PathBuf, package_json: PackageJsonRc);
+  fn get(&self, path: &Path) -> PackageJsonCacheResult;
+  fn set(&self, path: PathBuf, package_json: Option<PackageJsonRc>);
 }
 
 #[derive(Debug, Clone, JsError, PartialEq, Eq, Boxed)]
@@ -240,24 +246,36 @@ impl PackageJson {
     sys: &impl FsRead,
     maybe_cache: Option<&dyn PackageJsonCache>,
     path: &Path,
-  ) -> Result<PackageJsonRc, PackageJsonLoadError> {
-    match maybe_cache.and_then(|c| c.get(path)) {
-      Some(item) => Ok(item),
-      _ => match sys.fs_read_to_string_lossy(path) {
-        Ok(file_text) => {
-          let pkg_json =
-            PackageJson::load_from_string(path.to_path_buf(), &file_text)?;
-          let pkg_json = deno_maybe_sync::new_rc(pkg_json);
-          if let Some(cache) = maybe_cache {
-            cache.set(path.to_path_buf(), pkg_json.clone());
+  ) -> Result<Option<PackageJsonRc>, PackageJsonLoadError> {
+    let cache_entry = maybe_cache
+      .map(|c| c.get(path))
+      .unwrap_or(PackageJsonCacheResult::NotCached);
+
+    match cache_entry {
+      PackageJsonCacheResult::Hit(item) => Ok(item),
+      PackageJsonCacheResult::NotCached => {
+        match sys.fs_read_to_string_lossy(path) {
+          Ok(file_text) => {
+            let pkg_json =
+              PackageJson::load_from_string(path.to_path_buf(), &file_text)?;
+            let pkg_json = deno_maybe_sync::new_rc(pkg_json);
+            if let Some(cache) = maybe_cache {
+              cache.set(path.to_path_buf(), Some(pkg_json.clone()));
+            }
+            Ok(Some(pkg_json))
           }
-          Ok(pkg_json)
+          Err(err) if err.kind() == ErrorKind::NotFound => {
+            if let Some(cache) = maybe_cache {
+              cache.set(path.to_path_buf(), None);
+            }
+            Ok(None)
+          }
+          Err(err) => Err(PackageJsonLoadError::Io {
+            path: path.to_path_buf(),
+            source: err,
+          }),
         }
-        Err(err) => Err(PackageJsonLoadError::Io {
-          path: path.to_path_buf(),
-          source: err,
-        }),
-      },
+      }
     }
   }
 


### PR DESCRIPTION
This is useful for single pass resolvers, like `@deno/loader`. There the probe overhead is so large that package.json probing accounts for up to 90% of readfile calls in a large project.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
