### PR TITLE
fix(lint): skip module graph validation

### DIFF
--- a/cli/graph_util.rs
+++ b/cli/graph_util.rs
@@ -385,6 +385,12 @@ pub struct CreateGraphOptions<'a> {
   pub npm_caching: NpmCachingStrategy,
 }
 
+pub struct CreatePublishGraphOptions<'a> {
+  pub packages: &'a [JsrPackageConfig],
+  pub build_fast_check_graph: bool,
+  pub validate_graph: bool,
+}
+
 pub struct ModuleGraphCreator {
   options: Arc<CliOptions>,
   module_graph_builder: Arc<ModuleGraphBuilder>,
@@ -436,10 +442,9 @@ impl ModuleGraphCreator {
       .await
   }
 
-  pub async fn create_and_validate_publish_graph(
+  pub async fn create_publish_graph(
     &self,
-    package_configs: &[JsrPackageConfig],
-    build_fast_check_graph: bool,
+    options: CreatePublishGraphOptions<'_>,
   ) -> Result<ModuleGraph, AnyError> {
     struct PublishLoader(CliDenoGraphLoader);
 
@@ -485,7 +490,7 @@ impl ModuleGraphCreator {
     }
 
     let mut roots = Vec::new();
-    for package_config in package_configs {
+    for package_config in options.packages {
       roots.extend(package_config.config_file.resolve_export_value_urls()?);
     }
 
@@ -502,15 +507,18 @@ impl ModuleGraphCreator {
         npm_caching: self.options.default_npm_caching_strategy(),
       })
       .await?;
-    self.graph_valid(&graph)?;
+    if options.validate_graph {
+      self.graph_valid(&graph)?;
+    }
     if self.options.type_check_mode().is_true()
       && !graph_has_external_remote(&graph)
     {
       self.type_check_graph(graph.clone())?;
     }
 
-    if build_fast_check_graph {
-      let fast_check_workspace_members = package_configs
+    if options.build_fast_check_graph {
+      let fast_check_workspace_members = options
+        .packages
         .iter()
         .map(|p| config_to_deno_graph_workspace_member(&p.config_file))
         .collect::<Result<Vec<_>, _>>()?;

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -45,6 +45,7 @@ use crate::cache::Caches;
 use crate::cache::IncrementalCache;
 use crate::colors;
 use crate::factory::CliFactory;
+use crate::graph_util::CreatePublishGraphOptions;
 use crate::graph_util::ModuleGraphCreator;
 use crate::sys::CliSys;
 use crate::tools::fmt::run_parallelized;
@@ -435,7 +436,11 @@ impl WorkspaceLinter {
       self.workspace_module_graph = Some(
         async move {
           module_graph_creator
-            .create_and_validate_publish_graph(&packages, true)
+            .create_publish_graph(CreatePublishGraphOptions {
+              packages: &packages,
+              build_fast_check_graph: true,
+              validate_graph: false,
+            })
             .await
             .map(Rc::new)
             .map_err(Rc::new)

--- a/cli/tools/publish/mod.rs
+++ b/cli/tools/publish/mod.rs
@@ -49,6 +49,7 @@ use crate::args::PublishFlags;
 use crate::args::jsr_api_url;
 use crate::args::jsr_url;
 use crate::factory::CliFactory;
+use crate::graph_util::CreatePublishGraphOptions;
 use crate::graph_util::ModuleGraphCreator;
 use crate::http_util::HttpClient;
 use crate::registry;
@@ -294,10 +295,11 @@ impl PublishPreparer {
     let build_fast_check_graph = !allow_slow_types;
     let graph = self
       .module_graph_creator
-      .create_and_validate_publish_graph(
-        package_configs,
+      .create_publish_graph(CreatePublishGraphOptions {
+        packages: package_configs,
         build_fast_check_graph,
-      )
+        validate_graph: true,
+      })
       .await?;
 
     // todo(dsherret): move to lint rule

--- a/tests/specs/lint/no_slow_types/b.ts
+++ b/tests/specs/lint/no_slow_types/b.ts
@@ -3,3 +3,4 @@ export function addB(a: number, b: number) {
 }
 
 export * from "./d.ts";
+export * from "./non-existent.ts"; // should not cause a linting error


### PR DESCRIPTION
We should just skip module graph validation here. Someone can verify it via other sub commands and this is only used for `no-slow-types`.

Maybe fixes https://github.com/denoland/deno/issues/30798, but not sure