### PR TITLE
fix(dts): update stream type declarations to use `Promise<void>`

### DIFF
--- a/cli/tsc/dts/lib.deno_web.d.ts
+++ b/cli/tsc/dts/lib.deno_web.d.ts
@@ -737,7 +737,7 @@ type ReadableStreamController<T> =
 
 /** @category Streams */
 interface ReadableStreamGenericReader {
-  readonly closed: Promise<undefined>;
+  readonly closed: Promise<void>;
   cancel(reason?: any): Promise<void>;
 }
 
@@ -1079,9 +1079,9 @@ declare var WritableStreamDefaultController: {
  * @category Streams
  */
 interface WritableStreamDefaultWriter<W = any> {
-  readonly closed: Promise<undefined>;
+  readonly closed: Promise<void>;
   readonly desiredSize: number | null;
-  readonly ready: Promise<undefined>;
+  readonly ready: Promise<void>;
   abort(reason?: any): Promise<void>;
   close(): Promise<void>;
   releaseLock(): void;
@@ -1533,7 +1533,7 @@ interface WebTransport {
     WebTransportReceiveStream
   >;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebTransport/ready) */
-  readonly ready: Promise<undefined>;
+  readonly ready: Promise<void>;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebTransport/close) */
   close(closeInfo?: WebTransportCloseInfo): void;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebTransport/createBidirectionalStream) */


### PR DESCRIPTION
This updates the type declarations for stream-related interfaces to use `Promise<void>` instead of `Promise<undefined>`, aligning with TypeScript's official type declarations.

### Background

TypeScript's official DOM type declarations have been updated to use `Promise<void>` instead of `Promise<undefined>` since around version 5.8:

- [lib.dom.d.ts in v5.8.2](https://github.com/microsoft/TypeScript/blob/v5.8.2/src/lib/dom.generated.d.ts#L27392)
- [lib.dom.d.ts in v5.7.3](https://github.com/microsoft/TypeScript/blob/v5.7.3/src/lib/dom.generated.d.ts#L26767)

This change causes type mismatch between Web streams converted from Node's stream and Deno's native ones.

### Changes

- Updated `ReadableStreamGenericReader.closed` from `Promise<undefined>` to `Promise<void>`
- Updated `WritableStreamDefaultWriter.closed` from `Promise<undefined>` to `Promise<void>`
- Updated `WritableStreamDefaultWriter.ready` from `Promise<undefined>` to `Promise<void>`
- Updated `WebTransport.ready` from `Promise<undefined>` to `Promise<void>`

### Testing

Confirmed that Deno v2.5.1 gives the type error for the following code while the deno binary with this patch applied doesn't.

```shell
$ cat main.ts
import type { WritableStream as NodeWebWritableStream } from "node:stream/web";

declare const nodeWebWritableStream: NodeWebWritableStream;

const _writableStream: WritableStream = nodeWebWritableStream;

$ /home/yusuke/Repo/github.com/magurotuna/deno/target/debug/deno check ./main.ts

$ echo $?
0
```

---

Fixes #30819
