### PR TITLE
chore: use main script for verify_pr_title.ts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+# WARNING: This workflow runs in the context of the base repository so the
+# GITHUB_TOKEN it has access to has full write permissions to the repository.
 jobs:
   main:
     name: lint title


### PR DESCRIPTION
This security issue was reported to us where `pull_request_target` always runs in the context of the base repository... meaning if the GITHUB_TOKEN were accessed it would have write permissions to the deno repo. We shouldn't use the PR's script for this. That said, we were saved by this script being executed with zero permissions so it could never read the GITHUB_TOKEN env var or do anything with it anyway. This change adds a bit more defence in depth.