### PR TITLE
fix(ext/node): `fs.readFile`, `fs.readFileSync` assert encoding

### DIFF
--- a/ext/node/polyfills/_fs/_fs_common.ts
+++ b/ext/node/polyfills/_fs/_fs_common.ts
@@ -16,6 +16,7 @@ import {
   TextEncodings,
 } from "ext:deno_node/_utils.ts";
 import { type Buffer } from "node:buffer";
+import { assertEncoding } from "ext:deno_node/internal/fs/utils.mjs";
 
 export type CallbackWithError = (err: ErrnoException | null) => void;
 
@@ -74,6 +75,7 @@ export function getEncoding(
     ? optOrCallback
     : optOrCallback.encoding;
   if (!encoding) return null;
+  assertEncoding(encoding);
   return encoding;
 }
 

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -454,6 +454,7 @@
 "parallel/test-fs-promises-readfile-empty.js" = {}
 "parallel/test-fs-promisified.js" = {}
 "parallel/test-fs-read-empty-buffer.js" = {}
+"parallel/test-fs-read-file-assert-encoding.js" = {}
 "parallel/test-fs-read-file-sync-hostname.js" = {}
 "parallel/test-fs-read-stream-autoClose.js" = {}
 "parallel/test-fs-read-stream-double-close.js" = {}

--- a/tests/unit_node/_fs/_fs_readFile_test.ts
+++ b/tests/unit_node/_fs/_fs_readFile_test.ts
@@ -3,6 +3,7 @@ import { assertCallbackErrorUncaught } from "../_test_utils.ts";
 import { promises, readFile, readFileSync } from "node:fs";
 import * as path from "@std/path";
 import { assert, assertEquals, assertMatch } from "@std/assert";
+import { Buffer } from "node:buffer";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testData = path.resolve(moduleDir, "testdata", "hello.txt");
@@ -143,4 +144,46 @@ Deno.test("fs.readFileSync error message contains path + syscall", () => {
       assertMatch(err.message, /[,\s]open\s/);
     }
   }
+});
+
+Deno.test("fs.readFile returns Buffer when encoding is not provided", async () => {
+  const data = await new Promise<Uint8Array>((res, rej) => {
+    readFile(testData, (err, data) => {
+      if (err) {
+        rej(err);
+      }
+      res(data as Uint8Array);
+    });
+  });
+
+  assert(data instanceof Uint8Array);
+  assertEquals(Buffer.isBuffer(data), true);
+  assertEquals(data.toString(), "hello world");
+});
+
+Deno.test("fs.readFile binary encoding returns string", async () => {
+  const data = await new Promise<string>((res, rej) => {
+    readFile(testData, { encoding: "binary" }, (err, data) => {
+      if (err) {
+        rej(err);
+      }
+      res(data as string);
+    });
+  });
+
+  assertEquals(typeof data, "string");
+  assertEquals(data, "hello world");
+});
+
+Deno.test("fs.readFileSync returns Buffer when encoding is not provided", () => {
+  const data = readFileSync(testData);
+  assert(data instanceof Uint8Array);
+  assertEquals(Buffer.isBuffer(data), true);
+  assertEquals(data.toString(), "hello world");
+});
+
+Deno.test("fs.readFileSync binary encoding returns string", () => {
+  const data = readFileSync(testData, { encoding: "binary" });
+  assertEquals(typeof data, "string");
+  assertEquals(data, "hello world");
 });


### PR DESCRIPTION
Towards #29972

- Validates the encoding of `readFile`.
- Fixes the handling of `binary` encoding where previously it returns Buffer. On Node.js, Buffer is only returned when the encoding is not specified.
- Allows [parallel/test-fs-read-file-assert-encoding.js](https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-fs-read-file-assert-encoding.js) test to pass.