### PR TITLE
fix(test): Remove ANSI Escape Codes for Junit Reports

### DIFF
--- a/cli/tools/test/fmt.rs
+++ b/cli/tools/test/fmt.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::ops::AddAssign;
 
+use console_static_text::ansi::strip_ansi_codes;
 use deno_core::stats::RuntimeActivity;
 use deno_core::stats::RuntimeActivityDiff;
 use deno_core::stats::RuntimeActivityTrace;
@@ -88,10 +89,16 @@ pub fn format_test_error(
     .exception_message
     .trim_start_matches("Uncaught ")
     .to_string();
-  if options.hide_stacktraces {
-    return js_error.exception_message;
+  let message = if options.hide_stacktraces {
+    js_error.exception_message
+  } else {
+    format_js_error(&js_error, options.initial_cwd.as_ref())
+  };
+  if options.strip_ascii_color {
+    strip_ansi_codes(&message).to_string()
+  } else {
+    message
   }
-  format_js_error(&js_error, options.initial_cwd.as_ref())
 }
 
 pub fn format_sanitizer_diff(

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -306,6 +306,7 @@ impl From<&TestDescription> for TestFailureDescription {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct TestFailureFormatOptions {
   pub hide_stacktraces: bool,
+  pub strip_ascii_color: bool,
   pub initial_cwd: Option<Url>,
 }
 
@@ -606,6 +607,7 @@ fn get_test_reporter(options: &TestSpecifiersOptions) -> Box<dyn TestReporter> {
   let parallel = options.concurrent_jobs.get() > 1;
   let failure_format_options = TestFailureFormatOptions {
     hide_stacktraces: options.hide_stacktraces,
+    strip_ascii_color: false,
     initial_cwd: Some(options.cwd.clone()),
   };
   let reporter: Box<dyn TestReporter> = match &options.reporter {
@@ -624,7 +626,10 @@ fn get_test_reporter(options: &TestSpecifiersOptions) -> Box<dyn TestReporter> {
     TestReporterConfig::Junit => Box::new(JunitTestReporter::new(
       options.cwd.clone(),
       "-".to_string(),
-      failure_format_options,
+      TestFailureFormatOptions {
+        strip_ascii_color: true,
+        ..failure_format_options
+      },
     )),
     TestReporterConfig::Tap => Box::new(TapTestReporter::new(
       options.cwd.clone(),
@@ -639,6 +644,7 @@ fn get_test_reporter(options: &TestSpecifiersOptions) -> Box<dyn TestReporter> {
       junit_path.to_string(),
       TestFailureFormatOptions {
         hide_stacktraces: options.hide_stacktraces,
+        strip_ascii_color: true,
         initial_cwd: Some(options.cwd.clone()),
       },
     ));

--- a/tests/specs/test/junit_console_formatting/__test__.jsonc
+++ b/tests/specs/test/junit_console_formatting/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --reporter junit main.ts",
+  "exitCode": 1,
+  "output": "main.out"
+}

--- a/tests/specs/test/junit_console_formatting/main.out
+++ b/tests/specs/test/junit_console_formatting/main.out
@@ -1,0 +1,13 @@
+Check [WILDCARD]main.ts
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="deno test" tests="1" failures="1" errors="0" time="[WILDCARD]">
+    <testsuite name="./main.ts" tests="1" disabled="0" errors="0" failures="1">
+        <testcase name="test" classname="./main.ts" time="[WILDCARD]" line="1" col="6">
+            <failure message="Uncaught Error: Oh No Red Error">Error: Oh No Red Error
+  throw new Error(&quot;Oh No \x1b[31mRed\x1b[0m Error&quot;);
+        ^
+    at [WILDCARD]</failure>
+        </testcase>
+    </testsuite>
+</testsuites>
+error: Test failed

--- a/tests/specs/test/junit_console_formatting/main.ts
+++ b/tests/specs/test/junit_console_formatting/main.ts
@@ -1,0 +1,3 @@
+Deno.test("test", () => {
+  throw new Error("Oh No \x1b[31mRed\x1b[0m Error");
+});


### PR DESCRIPTION
* Add an option to the report printer to not use ansi codes.
* Made this default fore the junit file output.
* Implemented removal of codes in the formatter.

It would be preferable for performance to not include them in the first place but that change is higher risk.

Refs: https://github.com/denoland/deno/issues/23316

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
