### PR TITLE
fix(ext/node): omit `smi` from `zlib.crc32` op function

### DIFF
--- a/ext/node/ops/zlib/mod.rs
+++ b/ext/node/ops/zlib/mod.rs
@@ -923,7 +923,7 @@ impl BrotliDecoder {
 }
 
 #[op2(fast)]
-pub fn op_zlib_crc32_string(#[string] data: &str, #[smi] value: u32) -> u32 {
+pub fn op_zlib_crc32_string(#[string] data: &str, value: u32) -> u32 {
   // SAFETY: `data` is a valid buffer.
   unsafe {
     zlib::crc32(value as c_ulong, data.as_ptr(), data.len() as u32) as u32
@@ -931,7 +931,7 @@ pub fn op_zlib_crc32_string(#[string] data: &str, #[smi] value: u32) -> u32 {
 }
 
 #[op2(fast)]
-pub fn op_zlib_crc32(#[buffer] data: &[u8], #[smi] value: u32) -> u32 {
+pub fn op_zlib_crc32(#[buffer] data: &[u8], value: u32) -> u32 {
   // SAFETY: `data` is a valid buffer.
   unsafe {
     zlib::crc32(value as c_ulong, data.as_ptr(), data.len() as u32) as u32

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -251,6 +251,14 @@ Deno.test("crc32 doesn't overflow", () => {
   assertEquals(checksum, 1466848669);
 });
 
+Deno.test("crc32 large input", () => {
+  let checkSum = 0xffffffff; 
+  for (let i = 0; i < 2**16; i++) {
+    checkSum = crc32("", checkSum);
+  }
+  assertEquals(checkSum, 0xffffffff);
+})
+
 Deno.test("BrotliCompress", async () => {
   const deffered = Promise.withResolvers<void>();
   // @ts-ignore: BrotliCompress is not typed

--- a/tests/unit_node/zlib_test.ts
+++ b/tests/unit_node/zlib_test.ts
@@ -252,12 +252,12 @@ Deno.test("crc32 doesn't overflow", () => {
 });
 
 Deno.test("crc32 large input", () => {
-  let checkSum = 0xffffffff; 
-  for (let i = 0; i < 2**16; i++) {
+  let checkSum = 0xffffffff;
+  for (let i = 0; i < 2 ** 16; i++) {
     checkSum = crc32("", checkSum);
   }
   assertEquals(checkSum, 0xffffffff);
-})
+});
 
 Deno.test("BrotliCompress", async () => {
   const deffered = Promise.withResolvers<void>();


### PR DESCRIPTION
Closes #30636