### PR TITLE
test: use `Deno.execPath()` instead of `deno`

### DIFF
--- a/tests/unit/process_test.ts
+++ b/tests/unit/process_test.ts
@@ -623,7 +623,7 @@ Deno.test(
 
     // @ts-ignore `Deno.run()` was soft-removed in Deno 2.
     const p = Deno.run({
-      cmd: ["deno", "run", "--watch", tempFile],
+      cmd: [Deno.execPath(), "run", "--watch", tempFile],
       stdout: "piped",
       stderr: "null",
     });
@@ -661,7 +661,7 @@ Deno.serve({ signal: ac.signal }, () => new Response("Hello World"));
 
     // @ts-ignore `Deno.run()` was soft-removed in Deno 2.
     const p = Deno.run({
-      cmd: ["deno", "run", "--watch", tempFile],
+      cmd: [Deno.execPath(), "run", "--watch", tempFile],
       stdout: "piped",
       stderr: "null",
     });


### PR DESCRIPTION
Currently most TS tests use `Deno.execPath()` to identify where `deno` lives
In the event deno is not on the `$PATH` these tests will fail.
If deno is on the `$PATH` you can end up testing the wrong instance of `deno`.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
