### PR TITLE
chore: document why some packages have bin entry only in packument

### DIFF
--- a/libs/npm_installer/extra_info.rs
+++ b/libs/npm_installer/extra_info.rs
@@ -107,7 +107,7 @@ impl NpmPackageExtraInfoProvider {
     } else {
       match self.fetch_from_package_json(package_path).await {
         Ok(extra_info) => {
-          // some packages that use "directories.bin" have "bin" entry in
+          // some packages that use "directories.bin" have a "bin" entry in
           // the packument, but not in package.json (e.g. esbuild-wasm)
           if (expected.bin && extra_info.bin.is_none())
             || (expected.scripts && extra_info.scripts.is_empty())


### PR DESCRIPTION
https://github.com/evanw/esbuild/blob/8f506d5ca6882f2fa96a4a7233ab9784af0a5298/npm/esbuild-wasm/package.json#L16-L18