### PR TITLE
fix(ext/node): map BadResource error to the corresponding node error

### DIFF
--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -65,6 +65,7 @@ import {
   codeMap,
   errorMap,
   mapSysErrnoToUvErrno,
+  UV_EBADF,
 } from "ext:deno_node/internal_binding/uv.ts";
 import { assert } from "ext:deno_node/_util/asserts.ts";
 import { isWindows } from "ext:deno_node/_util/os.ts";
@@ -2669,6 +2670,13 @@ interface UvExceptionContext {
   dest?: string;
 }
 export function denoErrorToNodeError(e: Error, ctx: UvExceptionContext) {
+  if (ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, e)) {
+    return uvException({
+      errno: UV_EBADF,
+      ...ctx,
+    });
+  }
+
   const errno = extractOsErrorNumberFromErrorMessage(e);
   if (typeof errno === "undefined") {
     return e;

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -480,6 +480,7 @@
 "parallel/test-fs-ready-event-stream.js" = {}
 "parallel/test-fs-rename-type-check.js" = {}
 "parallel/test-fs-rmdir-type-check.js" = {}
+"parallel/test-fs-stat-bigint.js" = {}
 "parallel/test-fs-statfs.js" = {}
 "parallel/test-fs-stream-fs-options.js" = {}
 "parallel/test-fs-stream-options.js" = {}


### PR DESCRIPTION
Allows https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-fs-stat-bigint.js test to pass