### PR TITLE
feat(internal): support variants of spec tests

### DIFF
--- a/tests/specs/schema.json
+++ b/tests/specs/schema.json
@@ -59,6 +59,16 @@
         },
         "ignore": {
           "type": "boolean"
+        },
+        "variants": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -107,6 +117,16 @@
           },
           "ignore": {
             "type": "boolean"
+          },
+          "variants": {
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              }
+            },
+            "additionalProperties": false
           }
         }
       }, {
@@ -165,6 +185,16 @@
         },
         "ignore": {
           "type": "boolean"
+        },
+        "variants": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
         }
       }
     }


### PR DESCRIPTION
Adds support for a new key `"variants"` that effectively parameterizes a test, allowing you to substitute different values for each scenario. For instance, I'm planning on using this in the tsgo PR, where I'll have tests like

```
{
  "variants": {
     "tsgo": {
        "maybe_unstable_tsgo": "--unstable-tsgo"
     },
    "tsjs": {
        "maybe_unstable_tsgo": ""
     }
  },
  "steps": [
      {
     "args": "install",
     "output": "[WILDCARD]"
     },
    { "args": "check ${maybe_unstable_tsgo} main.ts", "output": "check.out" } ]
  }
```
This effectively expands into two separate tests: one called `test_name::tsgo` which runs `check --unstable-tsgo main.ts`, and another called `test_name::tsjs` which runs `check main.ts`

The values specified for each variant are substituted whenever you refer to them with `${name}` (I added the curly brackets to make it unambiguous when you have variables that are prefixes of one another)

Implementation is not particularly efficient, but it's good enough for now
  