### PR TITLE
test: disable test-fs-cp.mjs

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -430,7 +430,9 @@
 "parallel/test-fs-chmod.js" = {}
 "parallel/test-fs-chown-type-check.js" = {}
 "parallel/test-fs-close.js" = {}
-"parallel/test-fs-cp.mjs" = {}
+# TODO(bartlomieju): disabled for now, because it causes CI failures on main
+# related to Unix socket path being too long
+# "parallel/test-fs-cp.mjs" = {}
 # TODO(bartlomieju): appears that part of the test that's broke was removed in Node 24.0
 # but it's actually not included in 24.2 https://github.com/nodejs/node/pull/55862
 # "parallel/test-fs-constants.js" = {}


### PR DESCRIPTION
This is failing on main due to too long socket path.