### PR TITLE
fix(ext/node): `path.matchesGlob` compatibility

### DIFF
--- a/ext/node/polyfills/_fs/_fs_glob.ts
+++ b/ext/node/polyfills/_fs/_fs_glob.ts
@@ -926,12 +926,15 @@ export class Glob {
 
 /**
  * Check if a path matches a glob pattern
- * @param {string} path the path to check
- * @param {string} pattern the glob pattern to match
- * @param {boolean} windows whether the path is on a Windows system, defaults to `isWindows`
- * @returns {boolean}
+ * @param path the path to check
+ * @param pattern the glob pattern to match
+ * @param windows whether the path is on a Windows system, defaults to `isWindows`
  */
-export function matchGlobPattern(path, pattern, windows = isWindows) {
+export function matchGlobPattern(
+  path: string,
+  pattern: string,
+  windows = isWindows,
+): boolean {
   validateString(path, "path");
   validateString(pattern, "pattern");
   return lazyMinimatch().default.minimatch(path, pattern, {

--- a/ext/node/polyfills/path/_posix.ts
+++ b/ext/node/polyfills/path/_posix.ts
@@ -15,10 +15,15 @@ import {
   isPosixPathSeparator,
   normalizeString,
 } from "ext:deno_node/path/_util.ts";
-import { primordials } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
 import { validateString } from "ext:deno_node/internal/validators.mjs";
 import { isWindows } from "ext:deno_node/_util/os.ts";
 import process from "node:process";
+import type * as fsGlob from "ext:deno_node/_fs/_fs_glob.ts";
+
+const lazyLoadGlob = core.createLazyLoader<typeof fsGlob>(
+  "ext:deno_node/_fs/_fs_glob.ts",
+);
 
 const {
   StringPrototypeReplace,
@@ -502,6 +507,12 @@ export function parse(path: string): ParsedPath {
 
 export const _makeLong = toNamespacedPath;
 
+let lazyMatchGlobPattern: typeof fsGlob.matchGlobPattern;
+export const matchesGlob = (path: string, pattern: string): boolean => {
+  lazyMatchGlobPattern ??= lazyLoadGlob().matchGlobPattern;
+  return lazyMatchGlobPattern(path, pattern, false);
+};
+
 export default {
   basename,
   delimiter,
@@ -517,4 +528,5 @@ export default {
   sep,
   toNamespacedPath,
   _makeLong,
+  matchesGlob,
 };

--- a/ext/node/polyfills/path/_win32.ts
+++ b/ext/node/polyfills/path/_win32.ts
@@ -23,8 +23,13 @@ import {
   normalizeString,
 } from "ext:deno_node/path/_util.ts";
 import { assert } from "ext:deno_node/_util/asserts.ts";
-import { primordials } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
 import process from "node:process";
+import type * as fsGlob from "ext:deno_node/_fs/_fs_glob.ts";
+
+const lazyLoadGlob = core.createLazyLoader<typeof fsGlob>(
+  "ext:deno_node/_fs/_fs_glob.ts",
+);
 
 const {
   ArrayPrototypeIncludes,
@@ -1157,6 +1162,12 @@ export function parse(path: string): ParsedPath {
 
 export const _makeLong = toNamespacedPath;
 
+let lazyMatchGlobPattern: typeof fsGlob.matchGlobPattern;
+export const matchesGlob = (path: string, pattern: string): boolean => {
+  lazyMatchGlobPattern ??= lazyLoadGlob().matchGlobPattern;
+  return lazyMatchGlobPattern(path, pattern, true);
+};
+
 export default {
   basename,
   delimiter,
@@ -1172,4 +1183,5 @@ export default {
   sep,
   toNamespacedPath,
   _makeLong,
+  matchesGlob,
 };

--- a/ext/node/polyfills/path/mod.ts
+++ b/ext/node/polyfills/path/mod.ts
@@ -37,6 +37,7 @@ export const {
   sep,
   toNamespacedPath,
   _makeLong,
+  matchesGlob,
 } = path;
 export default path;
 export * from "ext:deno_node/path/common.ts";

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -844,6 +844,7 @@
 "parallel/test-path-basename.js" = {}
 "parallel/test-path-dirname.js" = {}
 "parallel/test-path-extname.js" = {}
+"parallel/test-path-glob.js" = {}
 "parallel/test-path-isabsolute.js" = {}
 "parallel/test-path-makelong.js" = {}
 "parallel/test-path-normalize.js" = {}

--- a/tools/core_import_map.json
+++ b/tools/core_import_map.json
@@ -536,6 +536,7 @@
     "ext:deno_node/_fs/cp/cp_sync.ts": "../ext/node/polyfills/_fs/cp/cp_sync.ts",
     "ext:deno_node/_fs/_fs_dir.ts": "../ext/node/polyfills/_fs/_fs_dir.ts",
     "ext:deno_node/_fs/_fs_exists.ts": "../ext/node/polyfills/_fs/_fs_exists.ts",
+    "ext:deno_node/_fs/_fs_glob.ts": "../ext/node/polyfills/_fs/_fs_glob.ts",
     "ext:deno_node/_fs/_fs_lstat.ts": "../ext/node/polyfills/_fs/_fs_lstat.ts",
     "ext:deno_node/_fs/_fs_mkdir.ts": "../ext/node/polyfills/_fs/_fs_mkdir.ts",
     "ext:deno_node/_fs/_fs_open.ts": "../ext/node/polyfills/_fs/_fs_open.ts",


### PR DESCRIPTION
Closes #30975

Also allows the https://github.com/nodejs/node/blob/v24.2.0/test/parallel/test-path-glob.js test to pass