### PR TITLE
fix(napi): Fix misused `napi_callback_info` in `CallbackInfo`

### DIFF
--- a/ext/napi/function.rs
+++ b/ext/napi/function.rs
@@ -6,7 +6,7 @@ use crate::*;
 pub struct CallbackInfo {
   pub env: *mut Env,
   pub cb: napi_callback,
-  pub cb_info: napi_callback_info,
+  pub data: *mut c_void,
   pub args: *const c_void,
 }
 
@@ -15,12 +15,12 @@ impl CallbackInfo {
   pub fn new_raw(
     env: *mut Env,
     cb: napi_callback,
-    cb_info: napi_callback_info,
+    data: *mut c_void,
   ) -> *mut Self {
     Box::into_raw(Box::new(Self {
       env,
       cb,
-      cb_info,
+      data,
       args: std::ptr::null(),
     }))
   }
@@ -58,10 +58,10 @@ pub fn create_function<'s>(
   env: *mut Env,
   name: Option<v8::Local<v8::String>>,
   cb: napi_callback,
-  cb_info: napi_callback_info,
+  data: *mut c_void,
 ) -> v8::Local<'s, v8::Function> {
   let external =
-    v8::External::new(scope, CallbackInfo::new_raw(env, cb, cb_info) as *mut _);
+    v8::External::new(scope, CallbackInfo::new_raw(env, cb, data) as *mut _);
   let function = v8::Function::builder_raw(call_fn)
     .data(external.into())
     .build(scope)

--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -188,7 +188,7 @@ fn napi_create_function<'s>(
   name: *const c_char,
   length: usize,
   cb: Option<napi_callback>,
-  cb_info: napi_callback_info,
+  data: *mut c_void,
   result: *mut napi_value<'s>,
 ) -> napi_status {
   let env_ptr = env as *mut Env;
@@ -206,8 +206,7 @@ fn napi_create_function<'s>(
 
   unsafe {
     v8::callback_scope!(unsafe scope, env.context());
-    *result =
-      create_function(scope, env_ptr, name, cb.unwrap(), cb_info).into();
+    *result = create_function(scope, env_ptr, name, cb.unwrap(), data).into();
   }
 
   napi_ok
@@ -1674,7 +1673,7 @@ fn napi_get_cb_info(
 
   if !data.is_null() {
     unsafe {
-      *data = cbinfo.cb_info;
+      *data = cbinfo.data;
     }
   }
 


### PR DESCRIPTION
According to https://nodejs.org/api/n-api.html#napi_create_function, the `data` parameter is user-provided data context, which will be passed back into the function when invoked later. But here deno types it as `napi_callback_info`, which seems like a pointer to `CallbackInfo`. This misuse confuses me a lot when I'm reading the code.

References:
- https://github.com/nodejs/node/blob/59b70e5fe397db2457e10469985cb47fd7af0687/src/js_native_api_v8.cc#L939