### PR TITLE
fix(lockfile): purged package reqs should be removed from the jsr deps when changing workspace config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64deefbf7192aab1428bf68d2d221cf3161c47481d03a50f4ffc43c7ee10450f"
+checksum = "3d71c0df1464034be21a9472e7ec8f9a21958418d203fa2c40507fb5cafe799d"
 dependencies = [
  "async-trait",
  "deno_semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ deno_doc = "=0.185.0"
 deno_error = "=0.7.0"
 deno_graph = { version = "=0.102.1", default-features = false }
 deno_lint = "=0.80.0"
-deno_lockfile = "=0.32.1"
+deno_lockfile = "=0.32.2"
 deno_media_type = { version = "=0.2.9", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_npm = "=0.41.0"


### PR DESCRIPTION
* https://github.com/denoland/deno_lockfile/pull/62

Reduces the chance of:

```
> deno i
error: Failed reading lockfile at '.../deno.lock'

Caused by:
    0: Failed deserializing. Lockfile may be corrupt
    1: Invalid jsr dependency 'npm:preact@^10.22.1' for '@preact-icons/common@1.1.0'
```