### PR TITLE
test: disable test-fs-glob.mjs

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -441,7 +441,8 @@
 "parallel/test-fs-existssync-false.js" = {}
 "parallel/test-fs-fchown.js" = {}
 "parallel/test-fs-fsync.js" = {}
-"parallel/test-fs-glob.mjs" = {}
+# TODO(bartlomieju): crashes constantly on CI, disabling for now
+# "parallel/test-fs-glob.mjs" = {}
 "parallel/test-fs-internal-assertencoding.js" = {}
 "parallel/test-fs-link.js" = { flaky = true }
 "parallel/test-fs-long-path.js" = {}


### PR DESCRIPTION
This test is currently crashing on CI all the time. Disabling for the
time being.