### PR TITLE
fix(coverage): deno test --coverage fails when importing modules from blob: urls

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -441,6 +441,7 @@ fn filter_coverages(
     .filter(|e| {
       let is_internal = e.url.starts_with("ext:")
         || e.url.starts_with("data:")
+        || e.url.starts_with("blob:")
         || e.url.ends_with("__anonymous__")
         || e.url.ends_with("$deno$test.mjs")
         || e.url.contains("/$deno$stdin.")

--- a/tests/specs/coverage/blob_url/__test__.jsonc
+++ b/tests/specs/coverage/blob_url/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "tempDir": true,
+  "args": "test --coverage main_test.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/coverage/blob_url/main.out
+++ b/tests/specs/coverage/blob_url/main.out
@@ -1,0 +1,12 @@
+Check [WILDLINE]/main_test.ts
+running 1 test from ./main_test.ts
+test ... ok ([WILDLINE])
+
+ok | 1 passed | 0 failed ([WILDLINE])
+
+| File      | Branch % | Line % |
+| --------- | -------- | ------ |
+| main.ts   |    100.0 |  100.0 |
+| All files |    100.0 |  100.0 |
+Lcov coverage report has been generated at [WILDLINE]
+HTML coverage report has been generated at [WILDLINE]

--- a/tests/specs/coverage/blob_url/main.ts
+++ b/tests/specs/coverage/blob_url/main.ts
@@ -1,0 +1,8 @@
+export async function foo() {
+  const { default: bar } = await import(
+    URL.createObjectURL(
+      new Blob(["export default 'bar'"], { type: "application/typescript" }),
+    )
+  );
+  return bar;
+}

--- a/tests/specs/coverage/blob_url/main_test.ts
+++ b/tests/specs/coverage/blob_url/main_test.ts
@@ -1,0 +1,5 @@
+import { foo } from "./main.ts";
+
+Deno.test("test", async () => {
+  await foo();
+});


### PR DESCRIPTION
Fixes #31030. I did try to run the full test suite but some of the tests were failing for seemingly unrelated reasons such as npm 404s. The new test did pass though.