### PR TITLE
fix(ext/node): handle multiple calls in inspector.Session.post()

### DIFF
--- a/tests/unit_node/inspector_test.ts
+++ b/tests/unit_node/inspector_test.ts
@@ -23,7 +23,7 @@ Deno.test("[node/inspector/promises] - Session constructor should not throw", ()
 
 // Regression test for: https://github.com/denoland/deno/issues/31020
 Deno.test({
-  name: "[node/inspector] - deeply nested session.post() calls (4 levels)",
+  name: "[node/inspector] - deeply nested session.post() calls",
   fn: async () => {
     const session = new Session();
     session.connect();


### PR DESCRIPTION
Fixes a panic that occurred when using nested session.post() calls in the node:inspector module. The issue manifested when callbacks from inspector commands (like Profiler.enable) called session.post() again, causing a re-entrant invocation of op_inspector_dispatch.

The fix involves:
  1. Marking op_inspector_dispatch as #[op2(fast, reentrant)] to allow re-entrant calls
  2. Implementing a message queue to handle messages that arrive during nested dispatch calls

  This ensures that:
  - No panics occur during re-entrant calls
  - All messages are dispatched in the correct order
  - Nested callbacks execute properly, matching Node.js behavior

  Includes comprehensive tests for deep nesting, and queue ordering behavior.

Fixes https://github.com/denoland/deno/issues/31020
