### PR TITLE
Revert "fix(ext/node): handle `null` keypair in tls connect (#30516)"

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -92,8 +92,8 @@ export class TLSSocket extends net.Socket {
 
     const cert = tlsOptions?.secureContext?.cert;
     const key = tlsOptions?.secureContext?.key;
-    const hasTlsKey = key != undefined &&
-      cert != undefined;
+    const hasTlsKey = key !== undefined &&
+      cert !== undefined;
     const keyPair = hasTlsKey
       ? op_tls_key_static(cert, key)
       : op_tls_key_null();

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -159,8 +159,6 @@ Deno.test("tls.connect after-read tls upgrade", async () => {
       socket,
       secureContext: {
         ca: rootCaCert,
-        key: null,
-        cert: null,
         // deno-lint-ignore no-explicit-any
       } as any,
     });


### PR DESCRIPTION
This reverts commit 09036f52410420467fa7e8da1021bac29650cde4.

This causes `npm install` to hang in some cases, leaving spinner running forever.