### PR TITLE
fix(ext/http): display localhost url once on windows

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -933,7 +933,8 @@ function serveInner(options, handler) {
       const host = formatHostName(addr.hostname);
 
       const url = `${scheme}${host}:${addr.port}/`;
-      const helper = addr.hostname === "0.0.0.0" || addr.hostname === "::"
+      const helper = host !== "localhost" &&
+          (addr.hostname === "0.0.0.0" || addr.hostname === "::")
         ? ` (${scheme}localhost:${addr.port}/)`
         : "";
 

--- a/tests/specs/run/serve/__test__.jsonc
+++ b/tests/specs/run/serve/__test__.jsonc
@@ -5,6 +5,11 @@
       "output": "on_listen_default.out",
       "if": "unix"
     },
+    "on_listen_default_windows": {
+      "args": "run -A on_listen_default.ts",
+      "output": "on_listen_default_windows.out",
+      "if": "windows"
+    },
     "ipv6_hostname": {
       "args": "run -A ipv6_hostname.ts",
       "output": "ipv6_hostname.out",

--- a/tests/specs/run/serve/on_listen_default_windows.out
+++ b/tests/specs/run/serve/on_listen_default_windows.out
@@ -1,0 +1,1 @@
+Listening on http://localhost:[WILDCARD]/


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

On Windows, `Deno.serve` listening log looks like this:
```sh
Listening on http://localhost:8000/ (http://localhost:8000/)
```
Displaying `(http://localhost:8000/)` is redundant, so this PR changes it to display the following:
```sh
Listening on http://localhost:8000/
```