### PR TITLE
fix(ext/node): cpus() should not error when there's no cpu info

### DIFF
--- a/ext/node/ops/os/mod.rs
+++ b/ext/node/ops/os/mod.rs
@@ -24,9 +24,6 @@ pub enum OsError {
     #[inherit]
     PermissionCheckError,
   ),
-  #[class(type)]
-  #[error("Failed to get cpu info")]
-  FailedToGetCpuInfo,
   #[class(inherit)]
   #[error("Failed to get user info")]
   FailedToGetUserInfo(
@@ -276,7 +273,7 @@ where
     permissions.check_sys("cpus", "node:os.cpus()")?;
   }
 
-  cpus::cpu_info().ok_or(OsError::FailedToGetCpuInfo)
+  Ok(cpus::cpu_info().unwrap_or_default())
 }
 
 #[op2(stack_trace)]


### PR DESCRIPTION
os.cpus() in Node returns an empty array if there is no cpu info. This is also specified in [its documentation](https://nodejs.org/api/os.html#oscpus:~:text=The%20array%20will%20be%20empty%20if%20no%20CPU%20information%20is%20available): "The array will be empty if no CPU information is available, such as if the /proc file system is unavailable." Currently, Deno throws an error instead.

Fixes #25929.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

3. Ensure there are tests that cover the changes.
-->
