### PR TITLE
Revert "ci: skip running WPT and node compat unless labels present (#…

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -419,8 +419,7 @@ const ci = {
             use_sysroot: true,
             // TODO(ry): Because CI is so slow on for OSX and Windows, we
             // currently run the Web Platform tests only on Linux.
-            wpt:
-              "${{ !startsWith(github.ref, 'refs/tags/') && (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci-wpt-test')) }}",
+            wpt: "${{ !startsWith(github.ref, 'refs/tags/') }}",
           }, {
             ...Runners.linuxX86Xl,
             job: "bench",
@@ -470,8 +469,6 @@ const ci = {
         RUST_BACKTRACE: "full",
         // disable anyhow's library backtrace
         RUST_LIB_BACKTRACE: 0,
-        CI_SKIP_NODE_TEST:
-          "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'ci-node-test') }}",
       },
       steps: skipJobsIfPrAndMarkedSkip([
         ...cloneRepoStep,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             job: test
             profile: release
             use_sysroot: true
-            wpt: '${{ !startsWith(github.ref, ''refs/tags/'') && (github.ref == ''refs/heads/main'' || contains(github.event.pull_request.labels.*.name, ''ci-wpt-test'')) }}'
+            wpt: '${{ !startsWith(github.ref, ''refs/tags/'') }}'
           - os: linux
             arch: x86_64
             runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-bench''))) && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && ''ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04'' || ''ubuntu-24.04'' }}'
@@ -143,7 +143,6 @@ jobs:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: full
       RUST_LIB_BACKTRACE: 0
-      CI_SKIP_NODE_TEST: '${{ github.event_name == ''pull_request'' && !contains(github.event.pull_request.labels.*.name, ''ci-node-test'') }}'
     steps:
       - name: Configure git
         run: |-

--- a/tests/node_compat/test_runner.rs
+++ b/tests/node_compat/test_runner.rs
@@ -4,16 +4,7 @@ use test_util as util;
 use util::deno_config_path;
 
 #[test]
-#[allow(clippy::print_stderr)]
 fn node_compat_tests() {
-  // Skip Node.js compatibility tests in CI on PRs unless ci-node-test label is present
-  if std::env::var("CI_SKIP_NODE_TEST").unwrap_or_default() == "true" {
-    eprintln!(
-      "Skipping Node.js compatibility tests (CI_SKIP_NODE_TEST is set)"
-    );
-    return;
-  }
-
   let _server = util::http_server();
 
   let mut deno = util::deno_cmd()


### PR DESCRIPTION
…31012)"

This reverts commit f54a5466e260ccb6fb1c4e49246b651ac372cf76.

This doesn't work, immediately after landing this, `main` branch got broken
with a faulty PR.