### PR TITLE
test: disable flaky Node compat tests

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -301,7 +301,7 @@
 "parallel/test-dgram-send-callback-recursive.js" = {}
 "parallel/test-dgram-send-cb-quelches-error.js" = {}
 "parallel/test-dgram-send-default-host.js" = {}
-\# TODO(bartlomieju): disabled for now, because it causes CI failures on main
+# TODO(bartlomieju): disabled for now, because it causes CI failures on main
 # "parallel/test-dgram-send-empty-array.js" = { flaky = true }
 # TODO(bartlomieju): disabled for now, because it causes CI failures on main
 # "parallel/test-dgram-send-empty-buffer.js" = { darwin = false, flaky = true }


### PR DESCRIPTION
These tests are very flaky and even after retries they often cause CI failures.