### PR TITLE
ci: move lsp-tracing feature check to 'build-libs' job

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -703,13 +703,6 @@ const ci = {
             "deno run --allow-read --allow-env --allow-sys ./tools/jsdoc_checker.js",
         },
         {
-          name: "Check tracing build",
-          if:
-            "matrix.job == 'test' && matrix.profile == 'debug' && matrix.os == 'linux' && matrix.arch == 'x86_64'",
-          run: "cargo check -p deno --features=lsp-tracing",
-          env: { CARGO_PROFILE_DEV_DEBUG: 0 },
-        },
-        {
           name: "Build debug",
           if: "matrix.job == 'test' && matrix.profile == 'debug'",
           run: "cargo build --locked --all-targets --features=panic-trace",
@@ -1247,6 +1240,7 @@ const ci = {
             "cargo check --no-default-features --features package_json -p deno_config",
             "cargo check --no-default-features --features workspace --features sync -p deno_config",
             "cargo check --target wasm32-unknown-unknown --all-features -p deno_config",
+            "cargo check -p deno --features=lsp-tracing",
           ].join("\n"),
         },
       ]),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,11 +414,6 @@ jobs:
       - name: jsdoc_checker.js
         if: '!(matrix.skip) && (matrix.job == ''lint'')'
         run: deno run --allow-read --allow-env --allow-sys ./tools/jsdoc_checker.js
-      - name: Check tracing build
-        if: '!(matrix.skip) && (matrix.job == ''test'' && matrix.profile == ''debug'' && matrix.os == ''linux'' && matrix.arch == ''x86_64'')'
-        run: cargo check -p deno --features=lsp-tracing
-        env:
-          CARGO_PROFILE_DEV_DEBUG: 0
       - name: Build debug
         if: '!(matrix.skip) && (matrix.job == ''test'' && matrix.profile == ''debug'')'
         run: cargo build --locked --all-targets --features=panic-trace
@@ -810,6 +805,7 @@ jobs:
           cargo check --no-default-features --features package_json -p deno_config
           cargo check --no-default-features --features workspace --features sync -p deno_config
           cargo check --target wasm32-unknown-unknown --all-features -p deno_config
+          cargo check -p deno --features=lsp-tracing
         if: '!(matrix.skip)'
   publish-canary:
     name: publish canary


### PR DESCRIPTION
This stage was needlessly slowing down the debug Linux build.