### PR TITLE
test: add regression test for --preload with same module as main

### DIFF
--- a/tests/specs/run/preload_same_module/__test__.jsonc
+++ b/tests/specs/run/preload_same_module/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run --preload main.ts main.ts",
+  "exitCode": 0,
+  "output": "main.out"
+}

--- a/tests/specs/run/preload_same_module/main.out
+++ b/tests/specs/run/preload_same_module/main.out
@@ -1,0 +1,1 @@
+executed

--- a/tests/specs/run/preload_same_module/main.ts
+++ b/tests/specs/run/preload_same_module/main.ts
@@ -1,0 +1,1 @@
+console.log("executed");


### PR DESCRIPTION
With the new version of deno-core, we're ignoring if the same modules are requested twice. 
This PR is adding regression test for it.

Closes https://github.com/denoland/deno/issues/30688

Related: https://github.com/denoland/deno_core/pull/1221