### PR TITLE
fix(node/assert): deepStrictEqual now throws for different Number obj…

### DIFF
--- a/ext/node/polyfills/assert.ts
+++ b/ext/node/polyfills/assert.ts
@@ -16,7 +16,7 @@ import {
   ERR_INVALID_RETURN_VALUE,
   ERR_MISSING_ARGS,
 } from "ext:deno_node/internal/errors.ts";
-import { isDeepEqual } from "ext:deno_node/internal/util/comparisons.ts";
+import { isDeepEqual, isDeepStrictEqual } from "ext:deno_node/internal/util/comparisons.ts";
 import { primordials } from "ext:core/mod.js";
 import { CallTracker } from "ext:deno_node/internal/assert/calltracker.js";
 import { deprecate } from "node:util";
@@ -394,7 +394,7 @@ function deepStrictEqual(
     throw new ERR_MISSING_ARGS("actual", "expected");
   }
 
-  if (!asserts.equal(actual, expected)) {
+  if (!isDeepStrictEqual(actual, expected)) {
     throw new AssertionError({
       message,
       actual,

--- a/tests/specs/node/assert_deepstrictequal_number/__test__.jsonc
+++ b/tests/specs/node/assert_deepstrictequal_number/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "number_objects_different_values": {
+      "args": "run test.mjs",
+      "output": "test.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/node/assert_deepstrictequal_number/test.mjs
+++ b/tests/specs/node/assert_deepstrictequal_number/test.mjs
@@ -1,0 +1,3 @@
+import assert from 'node:assert/strict';
+
+assert.deepStrictEqual(new Number(1), new Number(2));

--- a/tests/specs/node/assert_deepstrictequal_number/test.out
+++ b/tests/specs/node/assert_deepstrictequal_number/test.out
@@ -1,0 +1,8 @@
+error: Uncaught (in promise) AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
++ actual - expected
+
++ [Number: 1]
+- [Number: 2]
+
+    at deepStrictEqual ([WILDCARD])
+    at file://[WILDCARD]/test.mjs:3:8

--- a/tests/unit_node/assert_test.ts
+++ b/tests/unit_node/assert_test.ts
@@ -45,3 +45,72 @@ Deno.test("[node/assert] error message from strictEqual should be the same as As
     { message },
   );
 });
+
+Deno.test("[node/assert] deepStrictEqual with Number objects", () => {
+  // Different Number objects should throw
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new Number(1), new Number(2));
+    },
+    assert.AssertionError,
+  );
+
+  // Same Number objects should not throw
+  assert.doesNotThrow(() => {
+    assert.deepStrictEqual(new Number(1), new Number(1));
+  });
+
+  // Number object vs primitive should throw
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new Number(1), 1);
+    },
+    assert.AssertionError,
+  );
+});
+
+Deno.test("[node/assert] deepStrictEqual with String objects", () => {
+  // Different String objects should throw
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new String("hello"), new String("world"));
+    },
+    assert.AssertionError,
+  );
+
+  // Same String objects should not throw
+  assert.doesNotThrow(() => {
+    assert.deepStrictEqual(new String("hello"), new String("hello"));
+  });
+
+  // String object vs primitive should throw
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new String("hello"), "hello");
+    },
+    assert.AssertionError,
+  );
+});
+
+Deno.test("[node/assert] deepStrictEqual with Boolean objects", () => {
+  // Different Boolean objects should throw
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new Boolean(true), new Boolean(false));
+    },
+    assert.AssertionError,
+  );
+
+  // Same Boolean objects should not throw
+  assert.doesNotThrow(() => {
+    assert.deepStrictEqual(new Boolean(true), new Boolean(true));
+  });
+
+  // Boolean object vs primitive should throw
+  assert.throws(
+    () => {
+      assert.deepStrictEqual(new Boolean(true), true);
+    },
+    assert.AssertionError,
+  );
+});


### PR DESCRIPTION
fix(node/assert): deepStrictEqual now throws for different Number objects

- Replace asserts.equal() with isDeepStrictEqual() in deepStrictEqual function
- Fixes issue where new Number(1) and new Number(2) were incorrectly considered equal
- Add comprehensive tests for Number, String, and Boolean object comparisons
- Add spec test reproducing the exact GitHub issue #31172

Fixes #31172

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
