### PR TITLE
fix(lsp): `organizeImports` without resolving specifiers

### DIFF
--- a/cli/lsp/language_server.rs
+++ b/cli/lsp/language_server.rs
@@ -2347,21 +2347,10 @@ impl Inner {
         })?;
 
       if !organize_imports_edit.is_empty() {
-        let mut changes_with_modules = IndexMap::new();
-        changes_with_modules.extend(
-          fix_ts_import_changes(&organize_imports_edit, &module, self, token)
-            .map_err(|err| {
-              if token.is_cancelled() {
-                LspError::request_cancelled()
-              } else {
-                error!("Unable to fix import changes: {:#}", err);
-                LspError::internal_error()
-              }
-            })?
-            .into_iter()
-            .map(|c| (c, module.clone())),
-        );
-
+        let changes_with_modules = organize_imports_edit
+          .into_iter()
+          .map(|c| (c, module.clone()))
+          .collect::<IndexMap<_, _>>();
         all_actions.push(CodeActionOrCommand::CodeAction(CodeAction {
           title: "Organize imports".to_string(),
           kind: Some(CodeActionKind::SOURCE_ORGANIZE_IMPORTS),


### PR DESCRIPTION
Organize imports action should move, group, or delete imports but not rewrite the imported modules.

The current behavior is causing a bug with workspaces, rewriting relative imports to scoped imports if the workspace members are loaded in the server. The two specifiers are not functionally equivalent, at least due to https://github.com/jsr-io/jsr/issues/1220.

This change removes the rewriting and keeps the imports as they are sent from tsc.

Fixes #31141