### PR TITLE
fix(node:perf_hooks): implement performance.timerify()

### DIFF
--- a/ext/node/polyfills/perf_hooks.js
+++ b/ext/node/polyfills/perf_hooks.js
@@ -28,7 +28,29 @@ performance.eventLoopUtilization = () => {
 performance.nodeTiming = {};
 
 // TODO(bartlomieju):
-performance.timerify = () => notImplemented("timerify from performance");
+
+performance.timerify = (fn) => {
+  if (typeof fn !== "function") {
+    throw new TypeError("The 'fn' argument must be of type function");
+  }
+
+  const wrapped = (...args) => {
+    let start = performance.now();
+    let result = fn(...args);
+    let end = performance.now();
+
+    performance.measure(`timerify(${fn.name || "anonymous"})`, { start, end });
+
+    return result;
+  };
+
+  Object.defineProperty(wrapped, "name", {
+    value: fn.name || "wrapped",
+    configurable: true,
+  });
+
+  return wrapped;
+};
 
 // TODO(bartlomieju):
 performance.markResourceTiming = () => {};


### PR DESCRIPTION

**fix(node:perf_hooks): implement performance.timerify()**

Adds the missing implementation for `performance.timerify()`, which was previously throwing a "Not implemented" error.

This ensures compatibility for Node.js projects utilizing the `node:perf_hooks` module, allowing functions to be correctly wrapped and timed.

Fixes #31115 
