### PR TITLE
fixed(node:perf_hooks): implement performance.timerify()

### DIFF
--- a/ext/node/polyfills/perf_hooks.js
+++ b/ext/node/polyfills/perf_hooks.js
@@ -3,7 +3,7 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { notImplemented } from "ext:deno_node/_utils.ts";
+
 import { performance, PerformanceEntry } from "ext:deno_web/15_performance.js";
 import { EldHistogram } from "ext:core/ops";
 
@@ -28,7 +28,29 @@ performance.eventLoopUtilization = () => {
 performance.nodeTiming = {};
 
 // TODO(bartlomieju):
-performance.timerify = () => notImplemented("timerify from performance");
+performance.timerify = (fn) => {
+  if (typeof fn !== "function") {
+    throw new TypeError("The 'fn' argument must be of type function");
+  }
+
+  const wrapped = (...args) => {
+    const start = performance.now();
+    const result = fn(...args);
+    const end = performance.now();
+
+    performance.measure(`timerify(${fn.name || "anonymous"})`, { start, end });
+
+    return result;
+  };
+
+  Object.defineProperty(wrapped, "name", {
+    value: fn.name || "wrapped",
+    configurable: true,
+  });
+
+  return wrapped;
+};
+
 
 // TODO(bartlomieju):
 performance.markResourceTiming = () => {};

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,4 @@
+import { performance } from 'node:perf_hooks';
+function someFunction() { console.log('hello world'); }
+const wrapped = performance.timerify(someFunction);
+wrapped();


### PR DESCRIPTION


fixed(node:perf_hooks): Implement performance.timerify()

Adds the missing implementation for `performance.timerify()` in `node:perf_hooks`, which previously resulted in a "Not implemented" error.

This patch ensures compatibility with Node.js environments by allowing functions to be correctly wrapped.

Fixes #31115 
