### PR TITLE
make process.argv a string array instead of getter functions

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -1015,17 +1015,14 @@ function synchronizeListeners() {
   }
 }
 
-// Overwrites the 1st and 2nd items with getters.
-Object.defineProperty(argv, "0", { get: () => argv0 });
-Object.defineProperty(argv, "1", {
-  get: () => {
-    if (Deno.mainModule?.startsWith("file:")) {
-      return pathFromURL(new URL(Deno.mainModule));
-    } else {
-      return join(Deno.cwd(), "$deno$node.mjs");
-    }
-  },
-});
+// Replace getter-based argv definition with real string array (Node.js compatible)
+argv[0] = Deno.execPath();
+
+if (Deno.mainModule?.startsWith("file:")) {
+  argv[1] = pathFromURL(new URL(Deno.mainModule));
+} else {
+  argv[1] = join(Deno.cwd(), "$deno$node.mjs");
+}
 
 internals.dispatchProcessBeforeExitEvent = dispatchProcessBeforeExitEvent;
 internals.dispatchProcessExitEvent = dispatchProcessExitEvent;


### PR DESCRIPTION
This PR fixes an inconsistency between Deno’s Node.js compatibility layer and Node.js itself regarding the behavior of process.argv.

In Node.js, process.argv is a string array that contains the absolute path to the Node executable and the path to the executed script as its first two elements.
In Deno (as of v2.5.4), these elements were exposed as getter functions rather than plain strings, which caused incorrect and confusing output when logged directly:

$ deno run main.ts
[ [Getter], [Getter] ]


This patch updates the initialization of process.argv in ext/node/process.ts to assign real string values instead of getter properties:

argv[0] → the current Deno executable path (Deno.execPath())

argv[1] → the resolved main module path (pathFromURL(new URL(Deno.mainModule)))

This makes process.argv fully consistent with Node.js, improving parity and developer experience.

Before
console.log(process.argv)
# Output:
[ [Getter], [Getter] ]

After
console.log(process.argv)
# Output:
[
  "/usr/local/bin/deno",
  "/Users/username/main.ts"
]
