### PR TITLE
fix(unstable): don't panic on invalid reported lint range

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -391,6 +391,12 @@ export class Context {
     const start = range[0];
     const end = range[1];
 
+    if (start > end) {
+      throw new RangeError(
+        `Invalid range. Start value is bigger than end value: [${start}, ${end}]`,
+      );
+    }
+
     /** @type {Deno.lint.Fix[]} */
     const fixes = [];
 

--- a/tests/unit/lint_plugin_test.ts
+++ b/tests/unit/lint_plugin_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { assert, assertEquals } from "./test_util.ts";
+import { assert, assertEquals, assertStringIncludes } from "./test_util.ts";
 import { assertSnapshot } from "@std/testing/snapshot";
 
 // TODO(@marvinhagemeister) Remove once we land "official" types
@@ -1245,4 +1245,29 @@ Deno.test("Plugin - enumerable properties", () => {
   });
 
   assert(keys.length > 0);
+});
+
+Deno.test("Plugin - error when reported range start > end", () => {
+  // assertThrows doesn't support checking the error message.
+  try {
+    testPlugin(`foo;`, {
+      create(ctx) {
+        return {
+          Identifier(node) {
+            ctx.report({
+              message: "not ok",
+              range: node.range.reverse() as Deno.lint.Range,
+            });
+          },
+        };
+      },
+    });
+    throw new Error("fail");
+  } catch (err) {
+    if (!(err instanceof Error)) {
+      throw err;
+    }
+
+    assertStringIncludes((err.cause as Error).message, "Invalid range");
+  }
 });


### PR DESCRIPTION
When a lint diagnostic contained an invalid range where the `start` value was bigger than the `end` value, we'd panic when passing the range to `dprint`. We should ensure that the range is correct right when we're creating the lint diagnostic instead.

Fixes https://github.com/denoland/deno/issues/31249