### PR TITLE
Revert "ci: use macos-15-intel image (#31259)"

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -12,7 +12,7 @@ const ubuntuX86XlRunner = "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04";
 const ubuntuARMRunner = "ubicloud-standard-16-arm";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
-const macosX86Runner = "macos-15-intel";
+const macosX86Runner = "macos-13";
 const macosArmRunner = "macos-14";
 const selfHostedMacosArmRunner = "ghcr.io/cirruslabs/macos-runner:sonoma";
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,12 @@ jobs:
         include:
           - os: macos
             arch: x86_64
-            runner: macos-15-intel
+            runner: macos-13
             job: test
             profile: debug
           - os: macos
             arch: x86_64
-            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-24.04'' || ''macos-15-intel'' }}'
+            runner: '${{ (!contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'')) && ''ubuntu-24.04'' || ''macos-13'' }}'
             job: test
             profile: release
             skip: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && (github.event_name == ''pull_request'') }}'
@@ -762,7 +762,7 @@ jobs:
             job: lint
           - os: macos
             arch: x86_64
-            runner: macos-15-intel
+            runner: macos-13
             profile: debug
             job: lint
           - os: windows


### PR DESCRIPTION
This reverts commit 56dd527ae03578224cd9e09aedc9c1b9895003c4.

It appears `libsui` does not support macOS15 on intel correctly.