### PR TITLE
fix(ext/signals): don't run exit hooks at non-exit times

### DIFF
--- a/ext/net/tunnel.rs
+++ b/ext/net/tunnel.rs
@@ -48,15 +48,15 @@ pub fn disable_before_exit() {
 }
 
 pub fn before_exit() {
-  if let Some(tunnel) = get_tunnel() {
-    log::trace!("deno_net::tunnel::before_exit >");
+  log::trace!("deno_net::tunnel::before_exit >");
 
+  if let Some(tunnel) = get_tunnel() {
     // stay alive long enough to actually send the close frame, since
     // we can't rely on the linux kernel to close this like with tcp.
     deno_core::futures::executor::block_on(tunnel.close(1u32, b""));
-
-    log::trace!("deno_net::tunnel::before_exit <");
   }
+
+  log::trace!("deno_net::tunnel::before_exit <");
 }
 
 pub fn get_tunnel() -> Option<&'static TunnelConnection> {

--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -1002,6 +1002,8 @@ pub fn init(
 }
 
 fn before_exit() {
+  log::trace!("deno_telemetry::before_exit");
+
   let Some(OtelGlobals {
     span_processor: spans,
     log_processor: logs,
@@ -1011,8 +1013,6 @@ fn before_exit() {
   else {
     return;
   };
-
-  log::trace!("deno_telemetry::before_exit");
 
   let r = spans.shutdown();
   log::trace!("spans={:?}", r);


### PR DESCRIPTION
when we changed the otel exit handler to call shutdown instead of flush, it exposed another bug where we are calling exit handlers multiple times for the 3 signals we have defined. this meant that we would shut down otel before the program finished running.

Fixes: https://github.com/denoland/deno/issues/31242