### PR TITLE
ci: mark all pty tests as flaky

### DIFF
--- a/tests/integration/fmt_tests.rs
+++ b/tests/integration/fmt_tests.rs
@@ -422,7 +422,7 @@ fn opt_out_top_level_exclude_via_fmt_unexclude() {
   assert_not_contains!(output, "actually_excluded.ts");
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn test_tty_non_workspace_directory() {
   let context = TestContextBuilder::new().use_temp_cwd().build();
   let temp_dir = context.temp_dir().path();

--- a/tests/integration/init_tests.rs
+++ b/tests/integration/init_tests.rs
@@ -225,7 +225,7 @@ async fn init_subcommand_serve() {
   output.skip_output_check();
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn init_npm() {
   let context = TestContextBuilder::for_npm().use_temp_cwd().build();
   let cwd = context.temp_dir().path();

--- a/tests/integration/repl_tests.rs
+++ b/tests/integration/repl_tests.rs
@@ -8,7 +8,7 @@ use util::TempDir;
 use util::TestContext;
 use util::TestContextBuilder;
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_multiline() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("(\n1 + 2\n)");
@@ -42,7 +42,7 @@ fn pty_multiline() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_null() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("null");
@@ -50,7 +50,7 @@ fn pty_null() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_unpaired_braces() {
   for right_brace in &[")", "]", "}"] {
     util::with_pty(&["repl"], |mut console| {
@@ -60,7 +60,7 @@ fn pty_unpaired_braces() {
   }
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_bad_input() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("'\\u{1f3b5}'[0]");
@@ -68,7 +68,7 @@ fn pty_bad_input() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_syntax_error_input() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("('\\u')");
@@ -82,7 +82,7 @@ fn pty_syntax_error_input() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_complete_symbol() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line_raw("Symbol.it\t");
@@ -90,7 +90,7 @@ fn pty_complete_symbol() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_complete_declarations() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("class MyClass {}");
@@ -104,7 +104,7 @@ fn pty_complete_declarations() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_complete_primitives() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("let func = function test(){}");
@@ -126,7 +126,7 @@ fn pty_complete_primitives() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_complete_expression() {
   util::with_pty(&["repl"], |mut console| {
     console.write_raw("Deno.\t\t");
@@ -136,7 +136,7 @@ fn pty_complete_expression() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_complete_imports() {
   let context = TestContextBuilder::default().use_temp_cwd().build();
   let temp_dir = context.temp_dir();
@@ -191,7 +191,7 @@ fn pty_complete_imports_no_panic_empty_specifier() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_ignore_symbols() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line_raw("Array.Symbol\t");
@@ -199,7 +199,7 @@ fn pty_ignore_symbols() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_assign_global_this() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("globalThis = 40 + 2;");
@@ -207,7 +207,7 @@ fn pty_assign_global_this() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_assign_deno_keys_and_deno() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line(
@@ -222,7 +222,7 @@ fn pty_assign_deno_keys_and_deno() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_internal_repl() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("'Length: ' + Object.keys(globalThis).filter(k => k.startsWith('__DENO_')).length;");
@@ -238,7 +238,7 @@ fn pty_internal_repl() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_emoji() {
   // windows was having issues displaying this
   util::with_pty(&["repl"], |mut console| {
@@ -247,7 +247,7 @@ fn pty_emoji() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn console_log() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("console.log('hello');");
@@ -271,7 +271,7 @@ fn console_log() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn object_literal() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("{}");
@@ -281,7 +281,7 @@ fn object_literal() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn block_expression() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("{};");
@@ -291,7 +291,7 @@ fn block_expression() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn await_resolve() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("await Promise.resolve('done')");
@@ -299,7 +299,7 @@ fn await_resolve() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn await_timeout() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("await new Promise((r) => setTimeout(r, 0, 'done'))");
@@ -307,7 +307,7 @@ fn await_timeout() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn let_redeclaration() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("let foo = 0;");
@@ -321,7 +321,7 @@ fn let_redeclaration() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn repl_cwd() {
   let context = TestContextBuilder::default().use_temp_cwd().build();
   let temp_dir = context.temp_dir();
@@ -342,7 +342,7 @@ fn repl_cwd() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn typescript() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("function add(a: number, b: number) { return a + b }");
@@ -354,7 +354,7 @@ fn typescript() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn typescript_declarations() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("namespace Test { export enum Values { A, B, C } }");
@@ -370,7 +370,7 @@ fn typescript_declarations() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn typescript_decorators() {
   let context = TestContextBuilder::default().use_temp_cwd().build();
   let temp_dir = context.temp_dir();
@@ -394,7 +394,7 @@ fn typescript_decorators() {
   );
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eof() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("1 + 2");
@@ -402,7 +402,7 @@ fn eof() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn strict() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("let a = {};");
@@ -416,7 +416,7 @@ fn strict() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn close_command() {
   let (out, err) = util::run_and_collect_output(
     true,
@@ -430,7 +430,7 @@ fn close_command() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn function() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("Deno.writeFileSync");
@@ -438,7 +438,7 @@ fn function() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn multiline() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("(\n1 + 2\n)");
@@ -446,7 +446,7 @@ fn multiline() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn import() {
   let context = TestContextBuilder::default()
     .use_copy_temp_dir("./subdir")
@@ -460,7 +460,7 @@ fn import() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn import_declarations() {
   let context = TestContextBuilder::default()
     .use_copy_temp_dir("./subdir")
@@ -474,7 +474,7 @@ fn import_declarations() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn exports_stripped() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("const test = 5 + 1; export default test;");
@@ -484,7 +484,7 @@ fn exports_stripped() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn call_eval_unterminated() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("eval('{')");
@@ -492,7 +492,7 @@ fn call_eval_unterminated() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn unpaired_braces() {
   util::with_pty(&["repl"], |mut console| {
     for right_brace in &[")", "]", "}"] {
@@ -502,7 +502,7 @@ fn unpaired_braces() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn reference_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("not_a_variable");
@@ -510,7 +510,7 @@ fn reference_error() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn syntax_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("syntax error");
@@ -521,7 +521,7 @@ fn syntax_error() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn jsx_errors_without_pragma() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("const element = <div />;");
@@ -529,7 +529,7 @@ fn jsx_errors_without_pragma() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn jsx_import_source() {
   let context = TestContextBuilder::default()
     .use_temp_cwd()
@@ -546,7 +546,7 @@ fn jsx_import_source() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn type_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("console()");
@@ -554,7 +554,7 @@ fn type_error() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn variable() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("var a = 123 + 456;");
@@ -564,7 +564,7 @@ fn variable() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn lexical_scoped_variable() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("let a = 123 + 456;");
@@ -574,7 +574,7 @@ fn lexical_scoped_variable() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn missing_deno_dir() {
   use std::fs::read_dir;
   let temp_dir = TempDir::new();
@@ -594,7 +594,7 @@ fn missing_deno_dir() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn custom_history_path() {
   use std::fs::read;
   let temp_dir = TempDir::new();
@@ -614,7 +614,7 @@ fn custom_history_path() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn disable_history_file() {
   let deno_dir = util::new_deno_dir();
   let default_history_path = deno_dir.path().join("deno_history.txt");
@@ -634,7 +634,7 @@ fn disable_history_file() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn save_last_eval() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("1 + 2");
@@ -644,7 +644,7 @@ fn save_last_eval() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn save_last_thrown() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("throw 1 + 2");
@@ -654,7 +654,7 @@ fn save_last_thrown() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn assign_underscore() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("_ = 1");
@@ -666,7 +666,7 @@ fn assign_underscore() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn assign_underscore_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("_error = 1");
@@ -678,7 +678,7 @@ fn assign_underscore_error() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn custom_inspect() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line(
@@ -694,7 +694,7 @@ fn custom_inspect() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_flag_valid_input() {
   util::with_pty(&["repl", "--eval", "const t = 10;"], |mut console| {
     console.write_line("t * 500");
@@ -702,7 +702,7 @@ fn eval_flag_valid_input() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_flag_parse_error() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -719,7 +719,7 @@ fn eval_flag_parse_error() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_flag_runtime_error() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -733,7 +733,7 @@ fn eval_flag_runtime_error() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_file_flag_valid_input() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -746,7 +746,7 @@ fn eval_file_flag_valid_input() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_file_flag_call_defined_function() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -759,7 +759,7 @@ fn eval_file_flag_call_defined_function() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_file_flag_http_input() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -772,7 +772,7 @@ fn eval_file_flag_http_input() {
   assert!(err.contains("Download"));
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_file_flag_multiple_files() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -812,7 +812,7 @@ fn pty_clear_function() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_tab_handler() {
   // If the last character is **not** whitespace, we show the completions
   util::with_pty(&["repl"], |mut console| {
@@ -833,7 +833,7 @@ fn pty_tab_handler() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn repl_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("console.log(1);");
@@ -893,7 +893,7 @@ fn repl_error_undefined() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_aggregate_error() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("await Promise.any([])");
@@ -901,7 +901,7 @@ fn pty_aggregate_error() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn repl_with_quiet_flag() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -916,7 +916,7 @@ fn repl_with_quiet_flag() {
   assert!(err.is_empty(), "Error: {}", err);
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn repl_deno_test() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line_raw(
@@ -957,7 +957,7 @@ fn repl_deno_test() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn npm_packages() {
   let mut env_vars = util::env_vars_for_npm_tests();
   env_vars.push(("NO_COLOR".to_owned(), "1".to_owned()));
@@ -1043,7 +1043,7 @@ fn npm_packages() {
   }
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn pty_tab_indexable_props() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line("const arr = [1, 2, 3]");
@@ -1058,9 +1058,7 @@ fn pty_tab_indexable_props() {
   });
 }
 
-// TODO(2.0): this should first run `deno install`
 #[flaky_test::flaky_test]
-#[ignore]
 fn package_json_uncached_no_error() {
   let test_context = TestContextBuilder::for_npm()
     .use_temp_cwd()
@@ -1068,6 +1066,7 @@ fn package_json_uncached_no_error() {
     .env("RUST_BACKTRACE", "1")
     .build();
   let temp_dir = test_context.temp_dir();
+  temp_dir.write("deno.json", "{ \"nodeModulesDir\": \"auto\" }");
   temp_dir.write(
     "package.json",
     r#"{
@@ -1098,7 +1097,7 @@ fn package_json_uncached_no_error() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn closed_file_pre_load_does_not_occur() {
   TestContext::default()
     .new_command()
@@ -1111,7 +1110,7 @@ fn closed_file_pre_load_does_not_occur() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn env_file() {
   TestContext::default()
     .new_command()
@@ -1128,7 +1127,7 @@ fn env_file() {
 }
 
 // Regression test for https://github.com/denoland/deno/issues/20528
-#[test]
+#[flaky_test::flaky_test]
 fn pty_promise_was_collected_regression_test() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -1142,7 +1141,7 @@ fn pty_promise_was_collected_regression_test() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn eval_file_promise_error() {
   let (out, err) = util::run_and_collect_output_with_args(
     true,
@@ -1155,7 +1154,7 @@ fn eval_file_promise_error() {
   assert!(err.is_empty());
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn repl_json_imports() {
   let context = TestContextBuilder::default().use_temp_cwd().build();
   let temp_dir = context.temp_dir();
@@ -1174,7 +1173,7 @@ fn repl_json_imports() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn repl_no_globalthis() {
   let context = TestContextBuilder::default().use_temp_cwd().build();
   context

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -167,7 +167,7 @@ itest!(_089_run_allow_list {
   output: "run/089_run_allow_list.ts.out",
 });
 
-#[test]
+#[flaky_test::flaky_test]
 fn _090_run_permissions_request() {
   TestContext::default()
     .new_command()
@@ -200,7 +200,7 @@ fn _090_run_permissions_request() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn _090_run_permissions_request_sync() {
   TestContext::default()
     .new_command()
@@ -233,7 +233,7 @@ fn _090_run_permissions_request_sync() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permissions_prompt_allow_all() {
   TestContext::default()
     .new_command()
@@ -375,7 +375,7 @@ fn permissions_prompt_allow_all_2() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permissions_prompt_allow_all_lowercase_a() {
   TestContext::default()
     .new_command()
@@ -396,7 +396,7 @@ fn permissions_prompt_allow_all_lowercase_a() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permission_request_long() {
   TestContext::default()
     .new_command()
@@ -410,7 +410,7 @@ fn permission_request_long() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permissions_cache() {
   TestContext::default()
     .new_command()
@@ -433,7 +433,7 @@ fn permissions_cache() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permissions_trace() {
   TestContext::default()
     .new_command()
@@ -1626,7 +1626,7 @@ mod permissions {
     assert!(!err.contains(util::PERMISSION_DENIED_PATTERN));
   }
 
-  #[test]
+  #[flaky_test::flaky_test]
   fn _061_permissions_request() {
     TestContext::default()
       .new_command()
@@ -1658,7 +1658,7 @@ mod permissions {
       });
   }
 
-  #[test]
+  #[flaky_test::flaky_test]
   fn _061_permissions_request_sync() {
     TestContext::default()
       .new_command()
@@ -1690,7 +1690,7 @@ mod permissions {
       });
   }
 
-  #[test]
+  #[flaky_test::flaky_test]
   fn _062_permissions_request_global() {
     TestContext::default()
       .new_command()
@@ -1715,7 +1715,7 @@ mod permissions {
       });
   }
 
-  #[test]
+  #[flaky_test::flaky_test]
   fn _062_permissions_request_global_sync() {
     TestContext::default()
       .new_command()
@@ -1791,7 +1791,7 @@ fn process_stdin_read_unblock() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn issue9750() {
   TestContext::default()
     .new_command()
@@ -2019,7 +2019,7 @@ fn check_local_then_remote() {
   assert_contains!(stderr, "Type 'string' is not assignable to type 'number'.");
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permission_request_with_no_prompt() {
   TestContext::default()
     .new_command()
@@ -2803,7 +2803,7 @@ async fn websocket_server_idletimeout() {
 }
 
 // Regression test for https://github.com/denoland/deno/issues/16772
-#[test]
+#[flaky_test::flaky_test]
 fn file_fetcher_preserves_permissions() {
   let context = TestContext::with_http_server();
   context
@@ -2820,7 +2820,7 @@ fn file_fetcher_preserves_permissions() {
     });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn stdio_streams_are_locked_in_permission_prompt() {
   if !util::pty::Pty::is_supported() {
     // Don't deal with the logic below if the with_pty
@@ -2881,7 +2881,7 @@ fn stdio_streams_are_locked_in_permission_prompt() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn permission_prompt_escapes_ansi_codes_and_control_chars() {
   util::with_pty(&["repl"], |mut console| {
     console.write_line(
@@ -3322,7 +3322,7 @@ fn node_process_stdin_pause() {
     .unwrap();
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn node_process_stdin_unref_with_pty() {
   TestContext::default()
     .new_command()

--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -24,7 +24,7 @@ fn junit_path() {
     .assert_matches_text("<?xml [WILDCARD]");
 }
 
-#[test]
+#[flaky_test::flaky_test]
 // todo(#18480): re-enable
 #[ignore]
 fn sigint_with_hanging_test() {

--- a/tests/integration/upgrade_tests.rs
+++ b/tests/integration/upgrade_tests.rs
@@ -72,7 +72,7 @@ fn upgrade_prompt() {
   });
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn upgrade_lsp_repl_sleeps() {
   let context = TestContextBuilder::new()
     .use_http_server()


### PR DESCRIPTION
We spend too much time restarting CI for pty tests. Let's just mark them all as flaky.