### PR TITLE
feat: fully remove Deno.serveHttp API

### DIFF
--- a/runtime/js/90_deno_ns.js
+++ b/runtime/js/90_deno_ns.js
@@ -138,7 +138,7 @@ const denoNs = {
   permissions: permissions.permissions,
   Permissions: permissions.Permissions,
   PermissionStatus: permissions.PermissionStatus,
-  serveHttp: http.serveHttp,
+  // serveHttp: http.serveHttp,
   serve: serve.serve,
   resolveDns: net.resolveDns,
   upgradeWebSocket: websocket.upgradeWebSocket,

--- a/tests/integration/js_unit_tests.rs
+++ b/tests/integration/js_unit_tests.rs
@@ -44,7 +44,7 @@ util::unit_test_factory!(
     get_random_values_test,
     globals_test,
     headers_test,
-    http_test,
+    // http_test,
     image_bitmap_test,
     image_data_test,
     internals_test,


### PR DESCRIPTION
While technically a breaking change, this API has been soft-deprecated since Deno 1.46 and
hard deprecated in Deno 2 - there are no type declarations nor documentation for this API.

I want to give it a go and remove it for the Deno 3 RC releases and see the impact.