### PR TITLE
ci: use windows-2022 image for 'promote_to_release' workflow

### DIFF
--- a/.github/workflows/promote_to_release.yml
+++ b/.github/workflows/promote_to_release.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           cache-dependencies: false
           trace: true
-          append-signature: true
           endpoint: https://eus.codesigning.azure.net/
           trusted-signing-account-name: deno-cli-code-signing
           certificate-profile-name: deno-cli-code-signing-cert


### PR DESCRIPTION
Also changes code-signing step to not cache dependencies, which should fix the 
problem with Azure Codesigning returning error because of missing deps.