### PR TITLE
fix: skip doing npm resolution in more cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2876,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2625b7107cc3f61a462886d5fa77c23e063c1fd15b90e3d5ee2646e9f6178d55"
+checksum = "92d46d2fd6959170a6e9f6607a6f79683868fa82ceac56ca520ab014e4fa5b21"
 dependencies = [
  "capacity_builder",
  "deno_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ deno_media_type = { version = "=0.2.9", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_npm = "=0.42.0"
 deno_path_util = "=0.6.4"
-deno_semver = "=0.9.0"
+deno_semver = "=0.9.1"
 deno_task_shell = "=0.26.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }


### PR DESCRIPTION
There was a bug that was causing npm resolution to occur due to:

* https://github.com/denoland/deno_semver/pull/49

Also includes:

* https://github.com/denoland/deno_semver/pull/45