### PR TITLE
fix(bundle): Deno.bundle work in Worker

### DIFF
--- a/cli/lib/worker.rs
+++ b/cli/lib/worker.rs
@@ -462,6 +462,7 @@ impl<TSys: DenoLibSys> LibWorkerFactorySharedState<TSys> {
           shared.npm_process_state_provider.clone(),
         ),
         permissions: args.permissions,
+        bundle_provider: shared.bundle_provider.clone(),
       };
       let maybe_initial_cwd = shared.options.maybe_initial_cwd.clone();
       let options = WebWorkerOptions {

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -389,6 +389,7 @@ pub struct WebWorkerServiceOptions<
   pub permissions: PermissionsContainer,
   pub root_cert_store_provider: Option<Arc<dyn RootCertStoreProvider>>,
   pub shared_array_buffer_store: Option<SharedArrayBufferStore>,
+  pub bundle_provider: Option<Arc<dyn deno_bundle_runtime::BundleProvider>>,
 }
 
 pub struct WebWorkerOptions {
@@ -596,7 +597,7 @@ impl WebWorker {
       ops::permissions::deno_permissions::init(),
       ops::tty::deno_tty::init(),
       ops::http::deno_http_runtime::init(),
-      deno_bundle_runtime::deno_bundle_runtime::init(None),
+      deno_bundle_runtime::deno_bundle_runtime::init(services.bundle_provider),
       ops::bootstrap::deno_bootstrap::init(
         options.startup_snapshot.and_then(|_| Default::default()),
         false,

--- a/tests/specs/bundle/worker/__test__.jsonc
+++ b/tests/specs/bundle/worker/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "tests": {
+    "bundle_in_worker": {
+      "steps": [
+        {
+          "args": "run --unstable-bundle --quiet --allow-read=./worker.ts main.ts",
+          "output": "main.ts.out"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/bundle/worker/main.ts
+++ b/tests/specs/bundle/worker/main.ts
@@ -1,0 +1,4 @@
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+});
+worker.onmessage = () => Deno.exit(0);

--- a/tests/specs/bundle/worker/main.ts.out
+++ b/tests/specs/bundle/worker/main.ts.out
@@ -1,0 +1,2 @@
+Worker: bundling module
+Worker: bundle result.success: true

--- a/tests/specs/bundle/worker/worker.ts
+++ b/tests/specs/bundle/worker/worker.ts
@@ -1,0 +1,10 @@
+// deno-lint-ignore-file no-console
+console.log("Worker: bundling module");
+const result = await Deno.bundle({
+  entrypoints: ["./main.ts"],
+  write: false,
+  outputDir: "/",
+});
+console.log("Worker: bundle result.success:", result.success);
+
+postMessage("done");


### PR DESCRIPTION
Currently, `Deno.bundle` throws exception in a `Worker`.

```
error: Uncaught (in worker "") (in promise) Error: default BundleProvider does not do anything
```

This PR passes the clone of BundleProvider to workers.

---
minimum reproduction:
```ts
#! /usr/bin/env -S deno run --allow-read=. --unstable-bundle

if (typeof WorkerGlobalScope === "undefined") {
  const worker = new Worker(import.meta.url, { type: "module" });
  worker.onmessage = () => Deno.exit();
} else {
  await Deno.bundle({
    entrypoints: [import.meta.url],
    write: false
  });
  postMessage("done");
}
```

