### PR TITLE
feat(lint): plugin API has env and read access

### DIFF
--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -134,7 +134,10 @@ async fn create_plugin_runner_inner(
 ) -> Result<PluginHost, AnyError> {
   let flags = Flags {
     subcommand: DenoSubcommand::Lint(LintFlags::default()),
+    // Lint plugins have unconditional access to env vars and file reading.
     permissions: PermissionFlags {
+      allow_env: Some(vec![]),
+      allow_read: Some(vec![]),
       no_prompt: true,
       ..Default::default()
     },

--- a/tests/specs/lint/lint_plugin_permissions/README.md
+++ b/tests/specs/lint/lint_plugin_permissions/README.md
@@ -1,0 +1,1 @@
+This is an example readme file for the lint plugin permissions test suite.

--- a/tests/specs/lint/lint_plugin_permissions/__test__.jsonc
+++ b/tests/specs/lint/lint_plugin_permissions/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "envs": {
+    "MY_ENV_VAR": "I'm in a lint plugin"
+  },
+  "args": "lint a.ts",
+  "output": "lint.out",
+  "exitCode": 1
+}

--- a/tests/specs/lint/lint_plugin_permissions/a.ts
+++ b/tests/specs/lint/lint_plugin_permissions/a.ts
@@ -1,0 +1,1 @@
+const _a = "foo";

--- a/tests/specs/lint/lint_plugin_permissions/deno.json
+++ b/tests/specs/lint/lint_plugin_permissions/deno.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "plugins": ["./plugin.ts"]
+  }
+}

--- a/tests/specs/lint/lint_plugin_permissions/lint.out
+++ b/tests/specs/lint/lint_plugin_permissions/lint.out
@@ -1,0 +1,7 @@
+Environment Variable MY_ENV_VAR: I'm in a lint plugin
+Content of README.md: This is an example readme file for the lint plugin permissions test suite.
+
+[WILDCARD]a.ts:1:7[WILDCARD]
+
+Found 1 problem (1 fixable via --fix)
+Checked 1 file

--- a/tests/specs/lint/lint_plugin_permissions/plugin.ts
+++ b/tests/specs/lint/lint_plugin_permissions/plugin.ts
@@ -1,0 +1,28 @@
+const envVar = Deno.env.get("MY_ENV_VAR");
+console.log(`Environment Variable MY_ENV_VAR: ${envVar}`);
+
+export default {
+  name: "test-plugin",
+  rules: {
+    "my-rule": {
+      create(context) {
+        const readmeContent = Deno.readTextFileSync("./README.md");
+        console.log(`Content of README.md: ${readmeContent}`);
+
+        return {
+          Identifier(node) {
+            if (node.name === "_a") {
+              context.report({
+                node,
+                message: "should be _b",
+                fix(fixer) {
+                  return fixer.replaceText(node, "_b");
+                },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+};


### PR DESCRIPTION
This commit changes the lint plugin API by relaxing permissions -
lint plugins now have _an unconditional_ access to env and read
permissions - ie. they act as if they were run with `--allow-env`
and `--allow-read` flags.