### PR TITLE
fix: update permission-broker-response.v1.json

### DIFF
--- a/cli/schemas/permission-broker-response.v1.json
+++ b/cli/schemas/permission-broker-response.v1.json
@@ -12,7 +12,7 @@
     "result": {
       "description": "The result of the check, tells Deno if the request should be granted or rejected",
       "enum": [
-        "grant",
+        "allow",
         "deny"
       ]
     },


### PR DESCRIPTION
It specified "grant" instead of "allow" by mistake.