### PR TITLE
refactor(ext/web): don't accept generic BroadcastChannel

### DIFF
--- a/ext/web/benches/encoding.rs
+++ b/ext/web/benches/encoding.rs
@@ -27,11 +27,7 @@ fn setup() -> Vec<Extension> {
 
   vec![
     deno_webidl::deno_webidl::init(),
-    deno_web::deno_web::init::<deno_web::InMemoryBroadcastChannel>(
-      Default::default(),
-      None,
-      Default::default(),
-    ),
+    deno_web::deno_web::init(Default::default(), None, Default::default()),
     bench_setup::init(),
   ]
 }

--- a/ext/web/benches/timers_ops.rs
+++ b/ext/web/benches/timers_ops.rs
@@ -26,11 +26,7 @@ fn setup() -> Vec<Extension> {
 
   vec![
     deno_webidl::deno_webidl::init(),
-    deno_web::deno_web::init::<deno_web::InMemoryBroadcastChannel>(
-      Default::default(),
-      None,
-      Default::default(),
-    ),
+    deno_web::deno_web::init(Default::default(), None, Default::default()),
     bench_setup::init(),
   ]
 }

--- a/ext/web/benches/url_ops.rs
+++ b/ext/web/benches/url_ops.rs
@@ -20,11 +20,7 @@ fn setup() -> Vec<Extension> {
 
   vec![
     deno_webidl::deno_webidl::init(),
-    deno_web::deno_web::init::<deno_web::InMemoryBroadcastChannel>(
-      Default::default(),
-      None,
-      Default::default(),
-    ),
+    deno_web::deno_web::init(Default::default(), None, Default::default()),
     bench_setup::init(),
   ]
 }

--- a/ext/web/broadcast_channel.rs
+++ b/ext/web/broadcast_channel.rs
@@ -4,14 +4,11 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use deno_core::JsBuffer;
 use deno_core::OpState;
-use deno_core::Resource;
 use deno_core::ResourceId;
 use deno_core::op2;
 use deno_core::parking_lot::Mutex;
-use deno_error::JsErrorBox;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::SendError as BroadcastSendError;
 use tokio::sync::mpsc;
@@ -35,9 +32,6 @@ pub enum BroadcastChannelError {
   BroadcastSendError(
     BroadcastSendError<Box<dyn std::fmt::Debug + Send + Sync>>,
   ),
-  #[class(inherit)]
-  #[error(transparent)]
-  Other(#[inherit] JsErrorBox),
 }
 
 impl<T: std::fmt::Debug + Send + Sync + 'static> From<MpscSendError<T>>
@@ -57,84 +51,56 @@ impl<T: std::fmt::Debug + Send + Sync + 'static> From<BroadcastSendError<T>>
   }
 }
 
-#[async_trait]
-pub trait BroadcastChannel: Clone {
-  type Resource: Resource;
-
-  fn subscribe(&self) -> Result<Self::Resource, BroadcastChannelError>;
-
-  fn unsubscribe(
-    &self,
-    resource: &Self::Resource,
-  ) -> Result<(), BroadcastChannelError>;
-
-  async fn send(
-    &self,
-    resource: &Self::Resource,
-    name: String,
-    data: Vec<u8>,
-  ) -> Result<(), BroadcastChannelError>;
-
-  async fn recv(
-    &self,
-    resource: &Self::Resource,
-  ) -> Result<Option<Message>, BroadcastChannelError>;
-}
-
-pub type Message = (String, Vec<u8>);
+pub type BroadcastChannelMessage = (String, Vec<u8>);
 
 #[op2(fast)]
 #[smi]
-pub fn op_broadcast_subscribe<BC>(
+pub fn op_broadcast_subscribe(
   state: &mut OpState,
-) -> Result<ResourceId, BroadcastChannelError>
-where
-  BC: BroadcastChannel + 'static,
-{
-  let bc = state.borrow::<BC>();
+) -> Result<ResourceId, BroadcastChannelError> {
+  let bc = state.borrow::<InMemoryBroadcastChannel>();
   let resource = bc.subscribe()?;
   Ok(state.resource_table.add(resource))
 }
 
 #[op2(fast)]
-pub fn op_broadcast_unsubscribe<BC>(
+pub fn op_broadcast_unsubscribe(
   state: &mut OpState,
   #[smi] rid: ResourceId,
-) -> Result<(), BroadcastChannelError>
-where
-  BC: BroadcastChannel + 'static,
-{
-  let resource = state.resource_table.get::<BC::Resource>(rid)?;
-  let bc = state.borrow::<BC>();
+) -> Result<(), BroadcastChannelError> {
+  let resource = state
+    .resource_table
+    .get::<InMemoryBroadcastChannelResource>(rid)?;
+  let bc = state.borrow::<InMemoryBroadcastChannel>();
   bc.unsubscribe(&resource)
 }
 
-#[op2(async)]
-pub async fn op_broadcast_send<BC>(
+#[op2]
+pub fn op_broadcast_send(
   state: Rc<RefCell<OpState>>,
   #[smi] rid: ResourceId,
   #[string] name: String,
   #[buffer] buf: JsBuffer,
-) -> Result<(), BroadcastChannelError>
-where
-  BC: BroadcastChannel + 'static,
-{
-  let resource = state.borrow().resource_table.get::<BC::Resource>(rid)?;
-  let bc = state.borrow().borrow::<BC>().clone();
-  bc.send(&resource, name, buf.to_vec()).await
+) -> Result<(), BroadcastChannelError> {
+  let resource = state
+    .borrow()
+    .resource_table
+    .get::<InMemoryBroadcastChannelResource>(rid)?;
+  let bc = state.borrow().borrow::<InMemoryBroadcastChannel>().clone();
+  bc.send(&resource, name, buf.to_vec())
 }
 
 #[op2(async)]
 #[serde]
-pub async fn op_broadcast_recv<BC>(
+pub async fn op_broadcast_recv(
   state: Rc<RefCell<OpState>>,
   #[smi] rid: ResourceId,
-) -> Result<Option<Message>, BroadcastChannelError>
-where
-  BC: BroadcastChannel + 'static,
-{
-  let resource = state.borrow().resource_table.get::<BC::Resource>(rid)?;
-  let bc = state.borrow().borrow::<BC>().clone();
+) -> Result<Option<BroadcastChannelMessage>, BroadcastChannelError> {
+  let resource = state
+    .borrow()
+    .resource_table
+    .get::<InMemoryBroadcastChannelResource>(rid)?;
+  let bc = state.borrow().borrow::<InMemoryBroadcastChannel>().clone();
   bc.recv(&resource).await
 }
 
@@ -152,6 +118,8 @@ pub struct InMemoryBroadcastChannelResource {
   uuid: Uuid,
 }
 
+impl deno_core::Resource for InMemoryBroadcastChannelResource {}
+
 #[derive(Clone, Debug)]
 struct InMemoryChannelMessage {
   name: Arc<String>,
@@ -166,16 +134,15 @@ impl Default for InMemoryBroadcastChannel {
   }
 }
 
-#[async_trait]
-impl BroadcastChannel for InMemoryBroadcastChannel {
-  type Resource = InMemoryBroadcastChannelResource;
-
-  fn subscribe(&self) -> Result<Self::Resource, BroadcastChannelError> {
+impl InMemoryBroadcastChannel {
+  fn subscribe(
+    &self,
+  ) -> Result<InMemoryBroadcastChannelResource, BroadcastChannelError> {
     let (cancel_tx, cancel_rx) = mpsc::unbounded_channel();
     let broadcast_rx = self.0.lock().subscribe();
     let rx = tokio::sync::Mutex::new((broadcast_rx, cancel_rx));
     let uuid = Uuid::new_v4();
-    Ok(Self::Resource {
+    Ok(InMemoryBroadcastChannelResource {
       rx,
       cancel_tx,
       uuid,
@@ -184,14 +151,14 @@ impl BroadcastChannel for InMemoryBroadcastChannel {
 
   fn unsubscribe(
     &self,
-    resource: &Self::Resource,
+    resource: &InMemoryBroadcastChannelResource,
   ) -> Result<(), BroadcastChannelError> {
     Ok(resource.cancel_tx.send(())?)
   }
 
-  async fn send(
+  fn send(
     &self,
-    resource: &Self::Resource,
+    resource: &InMemoryBroadcastChannelResource,
     name: String,
     data: Vec<u8>,
   ) -> Result<(), BroadcastChannelError> {
@@ -207,8 +174,8 @@ impl BroadcastChannel for InMemoryBroadcastChannel {
 
   async fn recv(
     &self,
-    resource: &Self::Resource,
-  ) -> Result<Option<Message>, BroadcastChannelError> {
+    resource: &InMemoryBroadcastChannelResource,
+  ) -> Result<Option<BroadcastChannelMessage>, BroadcastChannelError> {
     let mut g = resource.rx.lock().await;
     let (broadcast_rx, cancel_rx) = &mut *g;
     loop {
@@ -230,5 +197,3 @@ impl BroadcastChannel for InMemoryBroadcastChannel {
     }
   }
 }
-
-impl deno_core::Resource for InMemoryBroadcastChannelResource {}

--- a/ext/web/lib.rs
+++ b/ext/web/lib.rs
@@ -41,7 +41,6 @@ use crate::blob::op_blob_read_part;
 use crate::blob::op_blob_remove_part;
 use crate::blob::op_blob_revoke_object_url;
 use crate::blob::op_blob_slice_part;
-pub use crate::broadcast_channel::BroadcastChannel;
 pub use crate::broadcast_channel::InMemoryBroadcastChannel;
 pub use crate::message_port::JsMessageData;
 pub use crate::message_port::MessagePort;
@@ -60,7 +59,6 @@ use crate::timers::op_time_origin;
 
 deno_core::extension!(deno_web,
   deps = [ deno_webidl ],
-  parameters = [BC: BroadcastChannel],
   ops = [
     op_base64_decode,
     op_base64_encode,
@@ -106,10 +104,10 @@ deno_core::extension!(deno_web,
     urlpattern::op_urlpattern_parse,
     urlpattern::op_urlpattern_process_match_input,
     console::op_preview_entries,
-    broadcast_channel::op_broadcast_subscribe<BC>,
-    broadcast_channel::op_broadcast_unsubscribe<BC>,
-    broadcast_channel::op_broadcast_send<BC>,
-    broadcast_channel::op_broadcast_recv<BC>,
+    broadcast_channel::op_broadcast_subscribe,
+    broadcast_channel::op_broadcast_unsubscribe,
+    broadcast_channel::op_broadcast_send,
+    broadcast_channel::op_broadcast_recv,
   ],
   esm = [
     "00_infra.js",
@@ -139,7 +137,7 @@ deno_core::extension!(deno_web,
   options = {
     blob_store: Arc<BlobStore>,
     maybe_location: Option<Url>,
-    bc: BC,
+    bc: InMemoryBroadcastChannel,
   },
   state = |state, options| {
     state.put(options.blob_store);

--- a/runtime/snapshot.rs
+++ b/runtime/snapshot.rs
@@ -26,7 +26,7 @@ pub fn create_runtime_snapshot(
   let mut extensions: Vec<Extension> = vec![
     deno_telemetry::deno_telemetry::lazy_init(),
     deno_webidl::deno_webidl::lazy_init(),
-    deno_web::deno_web::lazy_init::<deno_web::InMemoryBroadcastChannel>(),
+    deno_web::deno_web::lazy_init(),
     deno_webgpu::deno_webgpu::lazy_init(),
     deno_canvas::deno_canvas::lazy_init(),
     deno_fetch::deno_fetch::lazy_init(),

--- a/runtime/snapshot_info.rs
+++ b/runtime/snapshot_info.rs
@@ -17,7 +17,7 @@ pub fn get_extensions_in_snapshot() -> Vec<Extension> {
   vec![
     deno_telemetry::deno_telemetry::init(),
     deno_webidl::deno_webidl::init(),
-    deno_web::deno_web::init::<deno_web::InMemoryBroadcastChannel>(
+    deno_web::deno_web::init(
       Default::default(),
       Default::default(),
       deno_web::InMemoryBroadcastChannel::default(),

--- a/runtime/web_worker.rs
+++ b/runtime/web_worker.rs
@@ -523,7 +523,7 @@ impl WebWorker {
       deno_telemetry::deno_telemetry::init(),
       // Web APIs
       deno_webidl::deno_webidl::init(),
-      deno_web::deno_web::init::<InMemoryBroadcastChannel>(
+      deno_web::deno_web::init(
         services.blob_store,
         Some(options.main_module.clone()),
         services.broadcast_channel,

--- a/runtime/worker.rs
+++ b/runtime/worker.rs
@@ -530,7 +530,7 @@ impl MainWorker {
 
     js_runtime
       .lazy_init_extensions(vec![
-        deno_web::deno_web::args::<InMemoryBroadcastChannel>(
+        deno_web::deno_web::args(
           services.blob_store.clone(),
           options.bootstrap.location.clone(),
           services.broadcast_channel.clone(),
@@ -1043,7 +1043,7 @@ fn common_extensions<
     deno_telemetry::deno_telemetry::init(),
     // Web APIs
     deno_webidl::deno_webidl::init(),
-    deno_web::deno_web::lazy_init::<InMemoryBroadcastChannel>(),
+    deno_web::deno_web::lazy_init(),
     deno_webgpu::deno_webgpu::init(),
     deno_canvas::deno_canvas::init(),
     deno_fetch::deno_fetch::lazy_init(),


### PR DESCRIPTION
Removes generic `BC` option from the `deno_web` extension - leaving a single,
concrete implementation of the `InMemoryBroadcastChannel`.