### PR TITLE
fix(node): make Server.setTimeout a no-op to match Node.js

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -2157,9 +2157,9 @@ export class ServerImpl extends EventEmitter {
     this.#server.finished.then(() => this.#serveDeferred!.resolve());
   }
 
-  setTimeout() {
-    // deno-lint-ignore no-console
-    console.error("Not implemented: Server.setTimeout()");
+  setTimeout(_msecs?: number, _callback?: () => void) {
+    // No-op for Node.js compatibility
+    return this;
   }
 
   ref() {


### PR DESCRIPTION
This PR updates the Node.js HTTP polyfill so that `Server.setTimeout()` behaves as a no-op, matching Node.js behavior.  
Currently, Deno prints:

Not implemented: Server.setTimeout()

when frameworks like Fastify call this method internally.  
This warning is unnecessary and creates console noise even though the call is harmless.

### Related Issue

Fixes #31221

### Details

In Node.js, calling `server.setTimeout()` without arguments is a no-op.  
The previous Deno polyfill printed a warning instead of following this behavior.

This PR changes the method in:

deno/ext/node/polyfills/http.ts

from:

```ts
setTimeout() {
  console.error("Not implemented: Server.setTimeout()");
}

to:

ts
setTimeout(_msecs?: number, _callback?: () => void) {
  // No-op for Node.js compatibility
  return this;
}