### PR TITLE
fix(tls): replace unimplemented!() with proper error for TLS resolver

### DIFF
--- a/cli/tsc/go.rs
+++ b/cli/tsc/go.rs
@@ -182,6 +182,11 @@ fn maybe_rewrite_message(message: String, code: u64) -> String {
     format!(
       "Property '{name}' does not exist on type 'typeof Deno'. 'Deno.{name}' is an unstable API. If not, try changing the 'lib' compiler option to include 'deno.unstable' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib=\"deno.unstable\" />",
     )
+  } else if code == 2684 && message.contains("'this' parameter") {
+    format!(
+      "{}\n\nNote: The 'this' parameter is used to type the 'this' context, not the function return type. If you're trying to type a React/Preact component, use:\n  const Component: FC<Props> = (props) => {{ ... }}\nor:\n  function Component(props: Props): JSX.Element {{ ... }}",
+      message
+    )
   } else {
     message
   }

--- a/ext/tls/lib.rs
+++ b/ext/tls/lib.rs
@@ -51,6 +51,9 @@ pub enum TlsError {
   #[class("InvalidData")]
   #[error("Unable to decode key")]
   KeyDecode,
+  #[class("NotSupported")]
+  #[error("TLS key resolver is not supported for client connections")]
+  ResolverNotSupported,
 }
 
 /// Lazily resolves the root cert store.
@@ -310,7 +313,9 @@ pub fn create_client_config(
         .with_client_auth_cert(cert_chain, private_key.clone_key())
         .expect("invalid client key or certificate"),
       TlsKeys::Null => client_config.with_no_client_auth(),
-      TlsKeys::Resolver(_) => unimplemented!(),
+      TlsKeys::Resolver(_) => {
+        return Err(TlsError::ResolverNotSupported);
+      }
     };
 
     add_alpn(&mut client, socket_use);
@@ -343,7 +348,9 @@ pub fn create_client_config(
       .with_client_auth_cert(cert_chain, private_key.clone_key())
       .expect("invalid client key or certificate"),
     TlsKeys::Null => client_config.with_no_client_auth(),
-    TlsKeys::Resolver(_) => unimplemented!(),
+    TlsKeys::Resolver(_) => {
+      return Err(TlsError::ResolverNotSupported);
+    }
   };
 
   add_alpn(&mut client, socket_use);


### PR DESCRIPTION
- Add ResolverNotSupported error variant to TlsError enum
- Replace unimplemented!() panics with proper error returns in create_client_config
- Improves error handling by returning graceful errors instead of panicking

fix(tsc): improve error message for invalid 'this' parameter syntax

- Add helpful error message rewrite for TS2684 (invalid 'this' parameter)
- Provides guidance on correct React/Preact component typing syntax
- Helps users understand the difference between 'this' parameter and function return types

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
