### PR TITLE
fix: fetch fd leak

### DIFF
--- a/runtime/ops/web_worker/sync_fetch.rs
+++ b/runtime/ops/web_worker/sync_fetch.rs
@@ -93,10 +93,7 @@ pub fn op_worker_sync_fetch(
   let handle = state.borrow::<WebWorkerInternalHandle>().clone();
   assert_eq!(handle.worker_type, WorkerThreadType::Classic);
 
-  // it's not safe to share a client across tokio runtimes, so create a fresh one
-  // https://github.com/seanmonstar/reqwest/issues/1148#issuecomment-910868788
-  let options = state.borrow::<deno_fetch::Options>().clone();
-  let client = deno_fetch::create_client_from_options(&options)
+  let client = deno_fetch::get_or_create_client_from_state(state)
     .map_err(FetchError::ClientCreate)?;
 
   // TODO(andreubotella) It's not good to throw an exception related to blob


### PR DESCRIPTION
Solution for: https://github.com/denoland/deno/issues/31080

Modern reqwest (0.12+) can safely share clients across tokio runtimes.
Because it uses the current runtime's executor instead of spawning background threads.
Using a single shared client prevents resource leaks when worker threads terminate.

## Context
It seems that we started to use one client per thread because hyper and reqwest was not safe to share across tokio runtimes (https://github.com/denoland/deno/pull/23699). But seems it's fixed at latest reqwest versions (https://github.com/seanmonstar/reqwest/issues/1148#issuecomment-3120048532).

This PR is using one client again, as we now already use the version of reqwest with this fix.