### PR TITLE
fix(bundle): do not error on failing to clean up esbuild dir

### DIFF
--- a/cli/tools/bundle/esbuild.rs
+++ b/cli/tools/bundle/esbuild.rs
@@ -110,9 +110,13 @@ pub async fn ensure_esbuild(
     })?;
 
     if !existed {
-      std::fs::remove_dir_all(&package_folder).with_context(|| {
-        format!("failed to remove directory {}", package_folder.display())
-      })?;
+      let _ = std::fs::remove_dir_all(&package_folder).inspect_err(|e| {
+        log::warn!(
+          "failed to remove directory {}: {}",
+          package_folder.display(),
+          e
+        );
+      });
     }
     Ok(esbuild_path)
   } else {


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/31406

This is just to save some space on the user's device, no need to hard error if it fails.