### PR TITLE
feat: upgrade QuotaExceededError to DOMException subclassfeat: upgrade QuotaExceededError to DOMException subclass

### DIFF
--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -81,7 +81,6 @@ const nameToCodeMapping = ObjectCreate(null, {
   NetworkError: { value: NETWORK_ERR },
   AbortError: { value: ABORT_ERR },
   URLMismatchError: { value: URL_MISMATCH_ERR },
-  QuotaExceededError: { value: QUOTA_EXCEEDED_ERR },
   TimeoutError: { value: TIMEOUT_ERR },
   InvalidNodeTypeError: { value: INVALID_NODE_TYPE_ERR },
   DataCloneError: { value: DATA_CLONE_ERR },
@@ -194,4 +193,42 @@ for (let i = 0; i < entries.length; ++i) {
   ObjectDefineProperty(DOMException.prototype, key, desc);
 }
 
-export { DOMException, DOMExceptionPrototype };
+// Defined in WebIDL 4.3.
+// https://webidl.spec.whatwg.org/#quotaexceedederror
+class QuotaExceededError extends DOMException {
+  #quota = null;
+  #requested = null;
+
+  constructor(message = "", options = { __proto__: null }) {
+    message = webidl.converters.DOMString(
+      message,
+      "Failed to construct 'QuotaExceededError'",
+      "Argument 1",
+    );
+    super(message, "QuotaExceededError");
+
+    if (options !== null && options !== undefined) {
+      if (ObjectHasOwn(options, "quota")) {
+        this.#quota = options.quota ?? null;
+      }
+      if (ObjectHasOwn(options, "requested")) {
+        this.#requested = options.requested ?? null;
+      }
+    }
+  }
+
+  get quota() {
+    webidl.assertBranded(this, QuotaExceededErrorPrototype);
+    return this.#quota;
+  }
+
+  get requested() {
+    webidl.assertBranded(this, QuotaExceededErrorPrototype);
+    return this.#requested;
+  }
+}
+
+webidl.configureInterface(QuotaExceededError);
+const QuotaExceededErrorPrototype = QuotaExceededError.prototype;
+
+export { DOMException, DOMExceptionPrototype, QuotaExceededError };

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -76,7 +76,7 @@ import {
 } from "ext:runtime/90_deno_ns.js";
 import { errors } from "ext:runtime/01_errors.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
-import { DOMException } from "ext:deno_web/01_dom_exception.js";
+import { DOMException, QuotaExceededError } from "ext:deno_web/01_dom_exception.js";
 import {
   unstableForWindowOrWorkerGlobalScope,
   windowOrWorkerGlobalScope,
@@ -309,11 +309,10 @@ function formatException(error) {
   ) {
     return null;
   } else if (typeof error == "string") {
-    return `Uncaught ${
-      inspectArgs([quoteString(error, getDefaultInspectOptions())], {
-        colors: !getStderrNoColor(),
-      })
-    }`;
+    return `Uncaught ${inspectArgs([quoteString(error, getDefaultInspectOptions())], {
+      colors: !getStderrNoColor(),
+    })
+      }`;
   } else {
     return `Uncaught ${inspectArgs([error], { colors: !getStderrNoColor() })}`;
   }
@@ -350,7 +349,7 @@ core.registerErrorBuilder(
 core.registerErrorBuilder(
   "DOMExceptionQuotaExceededError",
   function DOMExceptionQuotaExceededError(msg) {
-    return new DOMException(msg, "QuotaExceededError");
+    return new QuotaExceededError(msg);
   },
 );
 core.registerErrorBuilder(
@@ -566,8 +565,8 @@ const finalDenoNs = {
   // Deno.test, Deno.bench, Deno.lint are noops here, but kept for compatibility; so
   // that they don't cause errors when used outside of `deno test`/`deno bench`/`deno lint`
   // contexts.
-  test: () => {},
-  bench: () => {},
+  test: () => { },
+  bench: () => { },
   lint: {
     runPlugin: () => {
       throw new Error(

--- a/tests/unit/dom_exception_test.ts
+++ b/tests/unit/dom_exception_test.ts
@@ -30,3 +30,39 @@ Deno.test(function hasStackAccessor() {
   assert(typeof desc.get === "function");
   assert(typeof desc.set === "function");
 });
+
+Deno.test(function quotaExceededErrorIsSubclass() {
+  const error = new QuotaExceededError("test message");
+  assert(error instanceof QuotaExceededError);
+  assert(error instanceof DOMException);
+  assert(error instanceof Error);
+});
+
+Deno.test(function quotaExceededErrorCodeIsZero() {
+  // QuotaExceededError is now a subclass, not a DOMException name
+  // So creating a DOMException with name "QuotaExceededError" should have code 0
+  const error = new DOMException("test", "QuotaExceededError");
+  assertEquals(error.code, 0);
+});
+
+Deno.test(function quotaExceededErrorHasCorrectName() {
+  const error = new QuotaExceededError("test message");
+  assertEquals(error.name, "QuotaExceededError");
+});
+
+Deno.test(function quotaExceededErrorHasQuotaAndRequestedProperties() {
+  const error = new QuotaExceededError("test message");
+  assertEquals(error.quota, null);
+  assertEquals(error.requested, null);
+});
+
+Deno.test(function quotaExceededErrorWithOptions() {
+  const error = new QuotaExceededError("test message", {
+    quota: 1000,
+    requested: 1500,
+  });
+  assertEquals(error.quota, 1000);
+  assertEquals(error.requested, 1500);
+  assertEquals(error.message, "test message");
+  assertEquals(error.name, "QuotaExceededError");
+});


### PR DESCRIPTION
Implements Web IDL spec change (whatwg/webidl#1465) to upgrade QuotaExceededError from a DOMException name to a proper subclass.

## Changes
- Remove QuotaExceededError from DOMException names table in `ext/web/01_dom_exception.js`
- Create QuotaExceededError class extending DOMException with `quota` and `requested` properties (default to null)
- Update error registration in `runtime/js/99_main.js` to use new QuotaExceededError class
- Add comprehensive tests for QuotaExceededError subclass in `tests/unit/dom_exception_test.ts`

## Breaking Change
⚠️ `new DOMException("message", "QuotaExceededError").code` now returns `0` instead of `22` to align with the Web IDL spec.

Fixes #30028

cc @domenicImplements Web IDL spec change (whatwg/webidl#1465) to upgrade QuotaExceededError from a DOMException name to a proper subclass.

Changes:
- Remove QuotaExceededError from DOMException names table
- Create QuotaExceededError class extending DOMException
- Add quota and requested properties (default to null)
- Update error registration to use new QuotaExceededError class
- Add comprehensive tests for QuotaExceededError subclass

Fixes #30028

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
