### PR TITLE
fix(types): add [Symbol.iterator]() to NodeListOf (fixes #31382)

### DIFF
--- a/tests/tsc/dom_nodelistof_iterable.ts
+++ b/tests/tsc/dom_nodelistof_iterable.ts
@@ -1,0 +1,8 @@
+const div = document.createElement("div");
+div.innerHTML = "<p>a</p><p>b</p>";
+
+for (const child of div.childNodes) {
+  void child.nodeName;
+}
+
+


### PR DESCRIPTION
This PR adds the missing `[Symbol.iterator]()` to `NodeListOf<TNode>`, fixing
the type error when iterating over `childNodes`.

Deno already allows this at runtime, so this aligns the DOM types with actual
behavior. A small TSC test is included to make sure `for...of` works as
expected.

Fixes #31382. Thanks @0f-0b for the guidance in the issue!

