### PR TITLE
chore: speed up macos compile tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -427,7 +427,6 @@ opt-level = 3
 [profile.dev.package.v8]
 opt-level = 1
 
-
 # speeds up deno compile tests a lot
 [profile.dev.package.libsui]
 opt-level = 3


### PR DESCRIPTION
Most of the tests for deno compile take >= 20 seconds (each) on macos. This is mostly due to sha2 and libsui taking a long time to process the debug binary. This speeds them up to <1 sec each, which saves multiple minutes when running all the tests