### PR TITLE
fix(audit): remove unwrap in favor of log, don't print empty reports

### DIFF
--- a/tests/specs/audit/no_vulns/__test__.jsonc
+++ b/tests/specs/audit/no_vulns/__test__.jsonc
@@ -8,10 +8,6 @@
     {
       "args": "audit",
       "output": "audit.out"
-    },
-    {
-      "args": "audit --socket",
-      "output": "audit.out"
     }
   ]
 }


### PR DESCRIPTION
Changes to print reports from socket.dev, only if something is found.