### PR TITLE
fix(node): use REQUIRE_CONDITIONS for CJS reexport resolution

### DIFF
--- a/libs/node_resolver/analyze.rs
+++ b/libs/node_resolver/analyze.rs
@@ -24,6 +24,7 @@ use crate::NodeResolverSys;
 use crate::NpmPackageFolderResolver;
 use crate::PackageJsonResolverRc;
 use crate::PathClean;
+use crate::REQUIRE_CONDITIONS;
 use crate::ResolutionMode;
 use crate::UrlOrPath;
 use crate::UrlOrPathRef;
@@ -228,14 +229,7 @@ impl<
             .resolve(
               &reexport,
               &referrer,
-              // FIXME(bartlomieju): check if these conditions are okay, probably
-              // should be `deno-require`, because `deno` is already used in `esm_resolver.rs`
-              &[
-                Cow::Borrowed("deno"),
-                Cow::Borrowed("node"),
-                Cow::Borrowed("require"),
-                Cow::Borrowed("default"),
-              ],
+              REQUIRE_CONDITIONS,
               NodeResolutionKind::Execution,
             )
             .and_then(|value| {


### PR DESCRIPTION
Fixes #31481

This fixes a bug where CJS reexport resolution was using incorrect
export conditions. The code was using a hardcoded array with the 'deno'
condition, but should use REQUIRE_CONDITIONS which contains 'require'
and 'node' conditions, consistent with other require-based resolution.

This addresses the FIXME comment in analyze.rs that noted the
conditions were likely incorrect.This fixes a bug where CJS reexport resolution was using incorrect export conditions. The code was using a hardcoded array with 'deno' condition, but should use REQUIRE_CONDITIONS which contains 'require' and 'node' conditions, consistent with other require-based resolution.

This addresses the FIXME comment in analyze.rs that noted the conditions were likely incorrect.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
