### PR TITLE
Revert "feat: use Node.js timers by default (#31272)"

### DIFF
--- a/ext/node/polyfills/internal/timers.mjs
+++ b/ext/node/polyfills/internal/timers.mjs
@@ -32,18 +32,16 @@ import { ERR_OUT_OF_RANGE } from "ext:deno_node/internal/errors.ts";
 import { emitWarning } from "node:process";
 import {
   clearTimeout as clearTimeout_,
-  kTimerId,
   setInterval as setInterval_,
   setTimeout as setTimeout_,
 } from "ext:deno_web/02_timers.js";
 import { runNextTicks } from "ext:deno_node/_next_tick.ts";
 
-export { kTimerId } from "ext:deno_web/02_timers.js";
-
 // Timeout values > TIMEOUT_MAX are set to 1.
 export const TIMEOUT_MAX = 2 ** 31 - 1;
 
 export const kDestroy = Symbol("destroy");
+export const kTimerId = Symbol("timerId");
 export const kTimeout = Symbol("timeout");
 export const kRefed = Symbol("refed");
 const createTimer = Symbol("createTimer");

--- a/ext/web/02_timers.js
+++ b/ext/web/02_timers.js
@@ -7,7 +7,6 @@ const {
   TypeError,
   indirectEval,
   ReflectApply,
-  Symbol,
 } = primordials;
 const {
   getAsyncContext,
@@ -15,8 +14,6 @@ const {
 } = core;
 
 import * as webidl from "ext:deno_webidl/00_webidl.js";
-
-export const kTimerId = Symbol("timerId");
 
 // ---------------------------------------------------------------------------
 
@@ -103,25 +100,17 @@ function clearInterval(id = 0) {
   core.cancelTimer(id);
 }
 
-// TODO(bartlomieju): this should be deprecated I think
 /**
  * Mark a timer as not blocking event loop exit.
  */
 function unrefTimer(id) {
-  if (typeof id !== "number") {
-    id = id[kTimerId];
-  }
   core.unrefTimer(id);
 }
 
-// TODO(bartlomieju): this should be deprecated I think
 /**
  * Mark a timer as blocking event loop exit.
  */
 function refTimer(id) {
-  if (typeof id !== "number") {
-    id = id[kTimerId];
-  }
   core.refTimer(id);
 }
 

--- a/runtime/js/98_global_scope_shared.js
+++ b/runtime/js/98_global_scope_shared.js
@@ -3,6 +3,7 @@
 import { core } from "ext:core/mod.js";
 
 import * as event from "ext:deno_web/02_event.js";
+import * as timers from "ext:deno_web/02_timers.js";
 import * as base64 from "ext:deno_web/05_base64.js";
 import * as encoding from "ext:deno_web/08_text_encoding.js";
 import * as console from "ext:deno_web/01_console.js";
@@ -130,8 +131,8 @@ const windowOrWorkerGlobalScope = {
     (image) => image.createImageBitmap,
     loadImage,
   ),
-  clearInterval: core.propWritable(nodeClearInterval),
-  clearTimeout: core.propWritable(nodeClearTimeout),
+  clearInterval: core.propWritable(timers.clearInterval),
+  clearTimeout: core.propWritable(timers.clearTimeout),
   caches: {
     enumerable: true,
     configurable: true,
@@ -154,8 +155,8 @@ const windowOrWorkerGlobalScope = {
   Buffer: core.propWritable(Buffer),
   global: core.propWritable(globalThis),
   reportError: core.propWritable(event.reportError),
-  setInterval: core.propWritable(nodeSetInterval),
-  setTimeout: core.propWritable(nodeSetTimeout),
+  setInterval: core.propWritable(timers.setInterval),
+  setTimeout: core.propWritable(timers.setTimeout),
   structuredClone: core.propWritable(messagePort.structuredClone),
   // Branding as a WebIDL object
   [webidl.brand]: core.propNonEnumerable(webidl.brand),
@@ -338,5 +339,12 @@ unstableForWindowOrWorkerGlobalScope[unstableIds.net] = {
 };
 
 unstableForWindowOrWorkerGlobalScope[unstableIds.webgpu] = {};
+
+unstableForWindowOrWorkerGlobalScope[unstableIds.nodeGlobals] = {
+  clearInterval: core.propWritable(nodeClearInterval),
+  clearTimeout: core.propWritable(nodeClearTimeout),
+  setInterval: core.propWritable(nodeSetInterval),
+  setTimeout: core.propWritable(nodeSetTimeout),
+};
 
 export { unstableForWindowOrWorkerGlobalScope, windowOrWorkerGlobalScope };

--- a/tests/integration/npm_tests.rs
+++ b/tests/integration/npm_tests.rs
@@ -1444,7 +1444,7 @@ console.log(getKind());
     r#"import { expect } from "chai";
 
     const timeout = setTimeout(() => {}, 0);
-    expect(timeout).to.be.a("object");
+    expect(timeout).to.be.a("number");
     clearTimeout(timeout);"#,
   );
   test_context.new_command().args("run chai.ts").run();
@@ -1607,7 +1607,7 @@ fn byonm_npm_workspaces() {
 import { expect } from "chai";
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 export function add(a, b) {
@@ -1706,7 +1706,7 @@ fn future_byonm_npm_workspaces() {
 import { expect } from "chai";
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 export function add(a, b) {

--- a/tests/specs/npm/cjs_with_deps/main.js
+++ b/tests/specs/npm/cjs_with_deps/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/specs/npm/compare_globals/main.out
+++ b/tests/specs/npm/compare_globals/main.out
@@ -13,7 +13,7 @@ true
 true
 []
 process equals process true
-setTimeout 1 true
+setTimeout 1 false
 setTimeout 2 function
 setTimeout 3 function
 setTimeout 4 function

--- a/tests/specs/npm/info_chalk_display/main.js
+++ b/tests/specs/npm/info_chalk_display/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/specs/npm/info_chalk_display_node_modules_dir/main.js
+++ b/tests/specs/npm/info_chalk_display_node_modules_dir/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/specs/npm/info_chalk_json/main.js
+++ b/tests/specs/npm/info_chalk_json/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/specs/npm/info_chalk_json_node_modules_dir/main.js
+++ b/tests/specs/npm/info_chalk_json_node_modules_dir/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/specs/npm/node_modules_dir_with_deps/main.js
+++ b/tests/specs/npm/node_modules_dir_with_deps/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/specs/run/set_timeout_error/set_timeout_error.ts.out
+++ b/tests/specs/run/set_timeout_error/set_timeout_error.ts.out
@@ -1,5 +1,5 @@
 error: Uncaught Error: foo
   throw new Error("foo");
         ^
-    at [WILDCARD]/set_timeout_error.ts:2:9)
+    at [WILDCARD]/set_timeout_error.ts:2:9
     at [WILDCARD]

--- a/tests/specs/run/set_timeout_error_handled/set_timeout_error_handled.ts.out
+++ b/tests/specs/run/set_timeout_error_handled/set_timeout_error_handled.ts.out
@@ -5,9 +5,9 @@
   lineno: 18,
   colno: 9,
   error: Error: foo
-    at [WILDCARD]/set_timeout_error_handled.ts:18:9)
+    at [WILDCARD]/set_timeout_error_handled.ts:18:9
     at [WILDCARD]
 }
 onerror() called Error: foo
-    at [WILDCARD]/set_timeout_error_handled.ts:18:9)
+    at [WILDCARD]/set_timeout_error_handled.ts:18:9
     at [WILDCARD]

--- a/tests/specs/run/worker_drop_handle_race/worker_drop_handle_race.js.out
+++ b/tests/specs/run/worker_drop_handle_race/worker_drop_handle_race.js.out
@@ -1,7 +1,7 @@
 error: Uncaught (in worker "") Error
   throw new Error();
         ^
-    at [WILDCARD]/drop_handle_race.js:2:9)
+    at [WILDCARD]/drop_handle_race.js:2:9
     at [WILDCARD]
 error: Uncaught (in promise) Error: Unhandled error in child worker.
     at Worker.#pollControl [WILDCARD]

--- a/tests/specs/test/hooks/async_error.out
+++ b/tests/specs/test/hooks/async_error.out
@@ -30,7 +30,7 @@ second test (beforeEach fails) => ./async_error.ts:46:6
 error: (in promise) Error: Async error in beforeEach
       setTimeout(() => reject(new Error("Async error in beforeEach")), 5);
                               ^
-    at [WILDCARD]async_error.ts:18:31)
+    at [WILDCARD]async_error.ts:18:31
 
 third test (afterEach fails) => ./async_error.ts:50:6
 error: (in promise) Error: Async error in afterEach

--- a/tests/specs/test/ops_sanitizer_closed_inside_started_before/ops_sanitizer_closed_inside_started_before.ts
+++ b/tests/specs/test/ops_sanitizer_closed_inside_started_before/ops_sanitizer_closed_inside_started_before.ts
@@ -1,4 +1,4 @@
-const timer = setTimeout(() => {}, 1000000);
+const timer = setTimeout(() => {}, 10000000000);
 
 Deno.test("test 1", () => {
   clearTimeout(timer);

--- a/tests/testdata/npm/cjs_with_deps/main.js
+++ b/tests/testdata/npm/cjs_with_deps/main.js
@@ -4,9 +4,9 @@ import { expect } from "npm:chai@4.3";
 console.log(chalk.green("chalk cjs loads"));
 
 const timeout = setTimeout(() => {}, 0);
-expect(timeout).to.be.a("object");
+expect(timeout).to.be.a("number");
 clearTimeout(timeout);
 
 const interval = setInterval(() => {}, 100);
-expect(interval).to.be.a("object");
+expect(interval).to.be.a("number");
 clearInterval(interval);

--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -28,8 +28,7 @@ Deno.test(async function functionParameterBindingSuccess() {
   assertEquals(count, 1);
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function stringifyAndEvalNonFunctions() {
+Deno.test(async function stringifyAndEvalNonFunctions() {
   // eval can only access global scope
   const global = globalThis as unknown as {
     globalPromise: ReturnType<typeof Promise.withResolvers<void>>;
@@ -66,8 +65,7 @@ Deno.test(async function timeoutSuccess() {
   assertEquals(count, 1);
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function timeoutEvalNoScopeLeak() {
+Deno.test(async function timeoutEvalNoScopeLeak() {
   // eval can only access global scope
   const global = globalThis as unknown as {
     globalPromise: ReturnType<typeof Promise.withResolvers<Error>>;
@@ -88,8 +86,7 @@ Deno.test.ignore(async function timeoutEvalNoScopeLeak() {
   Reflect.deleteProperty(global, "globalPromise");
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function evalPrimordial() {
+Deno.test(async function evalPrimordial() {
   const global = globalThis as unknown as {
     globalPromise: ReturnType<typeof Promise.withResolvers<void>>;
   };
@@ -303,8 +300,7 @@ Deno.test(async function fireCallbackImmediatelyWhenDelayOverMaxValue() {
   assertEquals(count, 1);
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function timeoutCallbackThis() {
+Deno.test(async function timeoutCallbackThis() {
   const { promise, resolve } = Promise.withResolvers<void>();
   let capturedThis: unknown;
   const obj = {
@@ -318,8 +314,7 @@ Deno.test.ignore(async function timeoutCallbackThis() {
   assertEquals(capturedThis, globalThis);
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function timeoutBindThis() {
+Deno.test(async function timeoutBindThis() {
   const thisCheckPassed = [null, undefined, globalThis];
 
   const thisCheckFailed = [
@@ -414,8 +409,7 @@ Deno.test(function testFunctionName() {
   assertEquals(clearInterval.name, "clearInterval");
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(function testFunctionParamsLength() {
+Deno.test(function testFunctionParamsLength() {
   assertEquals(setTimeout.length, 1);
   assertEquals(setInterval.length, 1);
   assertEquals(clearTimeout.length, 0);
@@ -785,8 +779,7 @@ Deno.test({
   },
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function setTimeoutWithStringCallback() {
+Deno.test(async function setTimeoutWithStringCallback() {
   const global = globalThis as unknown as {
     timeoutStringTest: number;
     timeoutStringPromise: ReturnType<typeof Promise.withResolvers<void>>;
@@ -803,8 +796,7 @@ Deno.test.ignore(async function setTimeoutWithStringCallback() {
   Reflect.deleteProperty(global, "timeoutStringPromise");
 });
 
-// TODO(bartlomieju): no longer valid since we're using Node.js timer APIs
-Deno.test.ignore(async function setIntervalWithStringCallback() {
+Deno.test(async function setIntervalWithStringCallback() {
   const global = globalThis as unknown as {
     intervalStringTest: number;
     intervalStringPromise: ReturnType<typeof Promise.withResolvers<void>>;

--- a/tests/wpt/runner/expectation.json
+++ b/tests/wpt/runner/expectation.json
@@ -6112,18 +6112,16 @@
       ],
       "global-object-implicit-this-value.any.html": [
         "Global object's getter throws when called on incompatible object",
-        "Global object's getter works when called on null / undefined",
-        "Global object's operation throws when called on incompatible object",
-        "Global object's operation works when called on null / undefined",
         "Global object's setter throws when called on incompatible object",
+        "Global object's operation throws when called on incompatible object",
+        "Global object's getter works when called on null / undefined",
         "Global object's setter works when called on null / undefined"
       ],
       "global-object-implicit-this-value.any.worker.html": [
         "Global object's getter throws when called on incompatible object",
-        "Global object's getter works when called on null / undefined",
-        "Global object's operation throws when called on incompatible object",
-        "Global object's operation works when called on null / undefined",
         "Global object's setter throws when called on incompatible object",
+        "Global object's operation throws when called on incompatible object",
+        "Global object's getter works when called on null / undefined",
         "Global object's setter works when called on null / undefined"
       ],
       "legacy-factor-function-subclass.window.html": false,
@@ -12910,8 +12908,8 @@
         "clearinterval-from-callback.any.worker.html": true,
         "cleartimeout-clearinterval.any.html": true,
         "cleartimeout-clearinterval.any.worker.html": true,
-        "evil-spec-example.any.html": false,
-        "evil-spec-example.any.worker.html": false,
+        "evil-spec-example.any.html": true,
+        "evil-spec-example.any.worker.html": true,
         "missing-timeout-setinterval.any.html": true,
         "missing-timeout-setinterval.any.worker.html": true,
         "negative-setinterval.any.html": true,


### PR DESCRIPTION
This reverts commit 7ada8d6589de7e237b7af42dd666105a4386f206.

This is a breaking change and is postponed until Deno 3.0.