### PR TITLE
Revert "refactor: remove 'managed globals' infra (#31318)"

### DIFF
--- a/ext/node/global.rs
+++ b/ext/node/global.rs
@@ -1,0 +1,488 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+use std::rc::Rc;
+
+use deno_core::v8;
+use deno_core::v8::GetPropertyNamesArgs;
+use deno_core::v8::MapFnTo;
+
+// NOTE(bartlomieju): somehow calling `.map_fn_to()` multiple times on a function
+// returns two different pointers. That shouldn't be the case as `.map_fn_to()`
+// creates a thin wrapper that is a pure function. @piscisaureus suggests it
+// might be a bug in Rust compiler; so for now we just create and store
+// these mapped functions per-thread. We should revisit it in the future and
+// ideally remove altogether.
+thread_local! {
+  pub static GETTER_MAP_FN: v8::NamedPropertyGetterCallback = getter.map_fn_to();
+  pub static SETTER_MAP_FN: v8::NamedPropertySetterCallback = setter.map_fn_to();
+  pub static QUERY_MAP_FN: v8::NamedPropertyQueryCallback = query.map_fn_to();
+  pub static DELETER_MAP_FN: v8::NamedPropertyDeleterCallback = deleter.map_fn_to();
+  pub static ENUMERATOR_MAP_FN: v8::NamedPropertyEnumeratorCallback = enumerator.map_fn_to();
+  pub static DEFINER_MAP_FN: v8::NamedPropertyDefinerCallback = definer.map_fn_to();
+  pub static DESCRIPTOR_MAP_FN: v8::NamedPropertyGetterCallback = descriptor.map_fn_to();
+}
+
+/// Convert an ASCII string to a UTF-16 byte encoding of the string.
+const fn str_to_utf16<const N: usize>(s: &str) -> [u16; N] {
+  let mut out = [0_u16; N];
+  let mut i = 0;
+  let bytes = s.as_bytes();
+  assert!(N == bytes.len());
+  while i < bytes.len() {
+    assert!(bytes[i] < 128, "only works for ASCII strings");
+    out[i] = bytes[i] as u16;
+    i += 1;
+  }
+  out
+}
+
+// ext/node changes the global object to be a proxy object that intercepts all
+// property accesses for globals that are different between Node and Deno and
+// dynamically returns a different value depending on if the accessing code is
+// in node_modules/ or not.
+//
+// To make this performant, a v8 named property handler is used, that only
+// intercepts property accesses for properties that are not already present on
+// the global object (it is non-masking). This means that in the common case,
+// when a user accesses a global that is the same between Node and Deno (like
+// Uint8Array or fetch), the proxy overhead is avoided.
+//
+// The Deno and Node specific globals are stored in a struct in a context slot.
+//
+// These are the globals that are handled:
+// - clearInterval (both, but different implementation)
+// - clearTimeout (both, but different implementation)
+// - process (always available in Node, while the availability in Deno depends
+//   on project creation time in Deno Deploy)
+// - setInterval (both, but different implementation)
+// - setTimeout (both, but different implementation)
+// - window (deno only)
+
+// UTF-16 encodings of the managed globals. THIS LIST MUST BE SORTED.
+#[rustfmt::skip]
+const MANAGED_GLOBALS: [&[u16]; 6] = [
+  &str_to_utf16::<13>("clearInterval"),
+  &str_to_utf16::<12>("clearTimeout"),
+  &str_to_utf16::<7>("process"),
+  &str_to_utf16::<11>("setInterval"),
+  &str_to_utf16::<10>("setTimeout"),
+  &str_to_utf16::<6>("window"),
+];
+
+// Calculates the shortest & longest length of global var names
+const MANAGED_GLOBALS_INFO: (usize, usize) = {
+  let l = MANAGED_GLOBALS[0].len();
+  let (mut longest, mut shortest, mut i) = (l, l, 1);
+  while i < MANAGED_GLOBALS.len() {
+    let l = MANAGED_GLOBALS[i].len();
+    if l > longest {
+      longest = l
+    }
+    if l < shortest {
+      shortest = l
+    }
+    i += 1;
+  }
+  (shortest, longest)
+};
+
+const SHORTEST_MANAGED_GLOBAL: usize = MANAGED_GLOBALS_INFO.0;
+const LONGEST_MANAGED_GLOBAL: usize = MANAGED_GLOBALS_INFO.1;
+
+#[derive(Debug, Clone, Copy)]
+enum Mode {
+  Deno,
+  Node,
+}
+
+pub struct GlobalsStorage {
+  deno_globals: v8::Global<v8::Object>,
+  node_globals: v8::Global<v8::Object>,
+}
+
+impl GlobalsStorage {
+  fn inner_for_mode(&self, mode: Mode) -> v8::Global<v8::Object> {
+    match mode {
+      Mode::Deno => &self.deno_globals,
+      Mode::Node => &self.node_globals,
+    }
+    .clone()
+  }
+}
+
+pub fn global_template_middleware<'s>(
+  _scope: &mut v8::PinScope<'s, '_, ()>,
+  template: v8::Local<'s, v8::ObjectTemplate>,
+) -> v8::Local<'s, v8::ObjectTemplate> {
+  let mut config = v8::NamedPropertyHandlerConfiguration::new().flags(
+    v8::PropertyHandlerFlags::NON_MASKING
+      | v8::PropertyHandlerFlags::HAS_NO_SIDE_EFFECT,
+  );
+
+  config = GETTER_MAP_FN.with(|getter| config.getter_raw(*getter));
+  config = SETTER_MAP_FN.with(|setter| config.setter_raw(*setter));
+  config = QUERY_MAP_FN.with(|query| config.query_raw(*query));
+  config = DELETER_MAP_FN.with(|deleter| config.deleter_raw(*deleter));
+  config =
+    ENUMERATOR_MAP_FN.with(|enumerator| config.enumerator_raw(*enumerator));
+  config = DEFINER_MAP_FN.with(|definer| config.definer_raw(*definer));
+  config =
+    DESCRIPTOR_MAP_FN.with(|descriptor| config.descriptor_raw(*descriptor));
+
+  template.set_named_property_handler(config);
+
+  template
+}
+
+pub fn global_object_middleware<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  global: v8::Local<'s, v8::Object>,
+) {
+  // ensure the global object is not Object.prototype
+  let object_key =
+    v8::String::new_external_onebyte_static(scope, b"Object").unwrap();
+  let object = global
+    .get(scope, object_key.into())
+    .unwrap()
+    .to_object(scope)
+    .unwrap();
+  let prototype_key =
+    v8::String::new_external_onebyte_static(scope, b"prototype").unwrap();
+  let object_prototype = object
+    .get(scope, prototype_key.into())
+    .unwrap()
+    .to_object(scope)
+    .unwrap();
+  assert_ne!(global, object_prototype);
+
+  // globalThis.__bootstrap.ext_node_denoGlobals and
+  // globalThis.__bootstrap.ext_node_nodeGlobals are the objects that contain
+  // the Deno and Node specific globals respectively. If they do not yet exist
+  // on the global object, create them as null prototype objects.
+  let bootstrap_key =
+    v8::String::new_external_onebyte_static(scope, b"__bootstrap").unwrap();
+  let bootstrap = match global.get(scope, bootstrap_key.into()) {
+    Some(value) if value.is_object() => value.to_object(scope).unwrap(),
+    Some(value) if value.is_undefined() => {
+      let null = v8::null(scope);
+      let obj =
+        v8::Object::with_prototype_and_properties(scope, null.into(), &[], &[]);
+      global.set(scope, bootstrap_key.into(), obj.into());
+      obj
+    }
+    _ => panic!("__bootstrap should not be tampered with"),
+  };
+  let deno_globals_key =
+    v8::String::new_external_onebyte_static(scope, b"ext_node_denoGlobals")
+      .unwrap();
+  let deno_globals = match bootstrap.get(scope, deno_globals_key.into()) {
+    Some(value) if value.is_object() => value,
+    Some(value) if value.is_undefined() => {
+      let null = v8::null(scope);
+      let obj =
+        v8::Object::with_prototype_and_properties(scope, null.into(), &[], &[])
+          .into();
+      bootstrap.set(scope, deno_globals_key.into(), obj);
+      obj
+    }
+    _ => panic!("__bootstrap.ext_node_denoGlobals should not be tampered with"),
+  };
+  let deno_globals_obj: v8::Local<v8::Object> =
+    deno_globals.try_into().unwrap();
+  let deno_globals = v8::Global::new(scope, deno_globals_obj);
+  let node_globals_key =
+    v8::String::new_external_onebyte_static(scope, b"ext_node_nodeGlobals")
+      .unwrap();
+  let node_globals = match bootstrap.get(scope, node_globals_key.into()) {
+    Some(value) if value.is_object() => value,
+    Some(value) if value.is_undefined() => {
+      let null = v8::null(scope);
+      let obj =
+        v8::Object::with_prototype_and_properties(scope, null.into(), &[], &[])
+          .into();
+      bootstrap.set(scope, node_globals_key.into(), obj);
+      obj
+    }
+    _ => panic!("__bootstrap.ext_node_nodeGlobals should not be tampered with"),
+  };
+  let node_globals_obj: v8::Local<v8::Object> =
+    node_globals.try_into().unwrap();
+  let node_globals = v8::Global::new(scope, node_globals_obj);
+
+  // Create the storage struct and store it in a context slot.
+  let storage = GlobalsStorage {
+    deno_globals,
+    node_globals,
+  };
+  scope.get_current_context().set_slot(Rc::new(storage));
+}
+
+fn is_managed_key(
+  scope: &mut v8::PinScope<'_, '_>,
+  key: v8::Local<v8::Name>,
+) -> bool {
+  let Ok(str): Result<v8::Local<v8::String>, _> = key.try_into() else {
+    return false;
+  };
+  let len = str.length();
+
+  #[allow(clippy::manual_range_contains)]
+  if len < SHORTEST_MANAGED_GLOBAL || len > LONGEST_MANAGED_GLOBAL {
+    return false;
+  }
+  let buf = &mut [0u16; LONGEST_MANAGED_GLOBAL];
+  str.write_v2(scope, 0, buf.as_mut_slice(), v8::WriteFlags::empty());
+  MANAGED_GLOBALS.binary_search(&&buf[..len]).is_ok()
+}
+
+fn current_mode(scope: &mut v8::PinScope<'_, '_>) -> Mode {
+  let Some(host_defined_options) = scope.get_current_host_defined_options()
+  else {
+    return Mode::Deno;
+  };
+  // SAFETY: host defined options must always be a PrimitiveArray in current V8.
+  let host_defined_options = unsafe {
+    v8::Local::<v8::PrimitiveArray>::cast_unchecked(host_defined_options)
+  };
+  if host_defined_options.length() < 1 {
+    return Mode::Deno;
+  }
+  let is_node = host_defined_options.get(scope, 0).is_true();
+  if is_node { Mode::Node } else { Mode::Deno }
+}
+
+pub fn getter<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  key: v8::Local<'s, v8::Name>,
+  args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue,
+) -> v8::Intercepted {
+  if !is_managed_key(scope, key) {
+    return v8::Intercepted::No;
+  };
+
+  let this = args.this();
+  let mode = current_mode(scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return v8::Intercepted::No;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  if !inner.has_own_property(scope, key).unwrap_or(false) {
+    return v8::Intercepted::No;
+  }
+
+  let Some(value) = inner.get_with_receiver(scope, key.into(), this) else {
+    return v8::Intercepted::No;
+  };
+
+  rv.set(value);
+  v8::Intercepted::Yes
+}
+
+pub fn setter<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  key: v8::Local<'s, v8::Name>,
+  value: v8::Local<'s, v8::Value>,
+  args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<()>,
+) -> v8::Intercepted {
+  if !is_managed_key(scope, key) {
+    return v8::Intercepted::No;
+  };
+
+  let this = args.this();
+  let mode = current_mode(scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return v8::Intercepted::No;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  let Some(success) = inner.set_with_receiver(scope, key.into(), value, this)
+  else {
+    return v8::Intercepted::No;
+  };
+
+  rv.set_bool(success);
+  v8::Intercepted::Yes
+}
+
+pub fn query<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  key: v8::Local<'s, v8::Name>,
+  _args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<v8::Integer>,
+) -> v8::Intercepted {
+  if !is_managed_key(scope, key) {
+    return v8::Intercepted::No;
+  };
+  let mode = current_mode(scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return v8::Intercepted::No;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  let Some(true) = inner.has_own_property(scope, key) else {
+    return v8::Intercepted::No;
+  };
+
+  let Some(attributes) = inner.get_property_attributes(scope, key.into())
+  else {
+    return v8::Intercepted::No;
+  };
+
+  rv.set_uint32(attributes.as_u32());
+  v8::Intercepted::Yes
+}
+
+pub fn deleter<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  key: v8::Local<'s, v8::Name>,
+  args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<v8::Boolean>,
+) -> v8::Intercepted {
+  if !is_managed_key(scope, key) {
+    return v8::Intercepted::No;
+  };
+
+  let mode = current_mode(scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return v8::Intercepted::No;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  let Some(success) = inner.delete(scope, key.into()) else {
+    return v8::Intercepted::No;
+  };
+
+  if args.should_throw_on_error() && !success {
+    let message = v8::String::new(scope, "Cannot delete property").unwrap();
+    let exception = v8::Exception::type_error(scope, message);
+    scope.throw_exception(exception);
+    return v8::Intercepted::Yes;
+  }
+
+  rv.set_bool(success);
+  v8::Intercepted::Yes
+}
+
+pub fn enumerator<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  _args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue<v8::Array>,
+) {
+  let mode = current_mode(scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  let Some(array) = inner.get_property_names(
+    scope,
+    GetPropertyNamesArgs {
+      mode: v8::KeyCollectionMode::OwnOnly,
+      property_filter: v8::PropertyFilter::ALL_PROPERTIES,
+      ..Default::default()
+    },
+  ) else {
+    return;
+  };
+
+  rv.set(array);
+}
+
+pub fn definer<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  key: v8::Local<'s, v8::Name>,
+  descriptor: &v8::PropertyDescriptor,
+  args: v8::PropertyCallbackArguments<'s>,
+  _rv: v8::ReturnValue<()>,
+) -> v8::Intercepted {
+  if !is_managed_key(scope, key) {
+    return v8::Intercepted::No;
+  };
+
+  let mode = current_mode(scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return v8::Intercepted::No;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  let Some(success) = inner.define_property(scope, key, descriptor) else {
+    return v8::Intercepted::No;
+  };
+
+  if args.should_throw_on_error() && !success {
+    let message = v8::String::new(scope, "Cannot define property").unwrap();
+    let exception = v8::Exception::type_error(scope, message);
+    scope.throw_exception(exception);
+  }
+
+  v8::Intercepted::Yes
+}
+
+pub fn descriptor<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  key: v8::Local<'s, v8::Name>,
+  _args: v8::PropertyCallbackArguments<'s>,
+  mut rv: v8::ReturnValue,
+) -> v8::Intercepted {
+  if !is_managed_key(scope, key) {
+    return v8::Intercepted::No;
+  };
+
+  let mode = current_mode(scope);
+
+  v8::tc_scope!(scope, scope);
+
+  let context = scope.get_current_context();
+  let inner = {
+    let Some(storage) = context.get_slot::<GlobalsStorage>() else {
+      return v8::Intercepted::No;
+    };
+    storage.inner_for_mode(mode)
+  };
+  let inner = v8::Local::new(scope, inner);
+
+  let Some(descriptor) = inner.get_own_property_descriptor(scope, key) else {
+    scope.rethrow().expect("to have caught an exception");
+    return v8::Intercepted::Yes;
+  };
+
+  if descriptor.is_undefined() {
+    return v8::Intercepted::No;
+  }
+
+  rv.set(descriptor);
+  v8::Intercepted::Yes
+}

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -25,6 +25,8 @@ use node_resolver::PackageJsonResolverRc;
 use node_resolver::errors::PackageJsonLoadError;
 
 extern crate libz_sys as zlib;
+
+mod global;
 pub mod ops;
 
 pub use deno_package_json::PackageJson;
@@ -38,6 +40,10 @@ pub use ops::vm::ContextInitMode;
 pub use ops::vm::VM_CONTEXT_INDEX;
 pub use ops::vm::create_v8_context;
 pub use ops::vm::init_global_template;
+
+pub use crate::global::GlobalsStorage;
+use crate::global::global_object_middleware;
+use crate::global::global_template_middleware;
 
 pub fn is_builtin_node_module(module_name: &str) -> bool {
   DenoIsBuiltInNodeModuleChecker.is_builtin_node_module(module_name)
@@ -411,6 +417,7 @@ deno_core::extension!(deno_node,
   esm_entry_point = "ext:deno_node/02_init.js",
   esm = [
     dir "polyfills",
+    "00_globals.js",
     "02_init.js",
     "_events.mjs",
     "_fs/_fs_access.ts",
@@ -682,6 +689,8 @@ deno_core::extension!(deno_node,
 
     state.put(AsyncId::default());
   },
+  global_template_middleware = global_template_middleware,
+  global_object_middleware = global_object_middleware,
   customizer = |ext: &mut deno_core::Extension| {
     let external_references = [
       vm::QUERY_MAP_FN.with(|query| {
@@ -753,6 +762,42 @@ deno_core::extension!(deno_node,
       vm::INDEXED_ENUMERATOR_MAP_FN.with(|enumerator| {
         ExternalReference {
           enumerator: *enumerator,
+        }
+      }),
+
+      global::GETTER_MAP_FN.with(|getter| {
+        ExternalReference {
+          named_getter: *getter,
+        }
+      }),
+      global::SETTER_MAP_FN.with(|setter| {
+        ExternalReference {
+          named_setter: *setter,
+        }
+      }),
+      global::QUERY_MAP_FN.with(|query| {
+        ExternalReference {
+          named_query: *query,
+        }
+      }),
+      global::DELETER_MAP_FN.with(|deleter| {
+        ExternalReference {
+          named_deleter: *deleter,
+        }
+      }),
+      global::ENUMERATOR_MAP_FN.with(|enumerator| {
+        ExternalReference {
+          enumerator: *enumerator,
+        }
+      }),
+      global::DEFINER_MAP_FN.with(|definer| {
+        ExternalReference {
+          named_definer: *definer,
+        }
+      }),
+      global::DESCRIPTOR_MAP_FN.with(|descriptor| {
+        ExternalReference {
+          named_getter: *descriptor,
         }
       }),
     ];

--- a/ext/node/polyfills/00_globals.js
+++ b/ext/node/polyfills/00_globals.js
@@ -1,0 +1,6 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+// deno-lint-ignore-file
+
+export const denoGlobals = globalThis.__bootstrap.ext_node_denoGlobals;
+export const nodeGlobals = globalThis.__bootstrap.ext_node_nodeGlobals;

--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -961,8 +961,7 @@ Module.prototype.require = function (id) {
 // wrapper function we run the users code in. The only observable difference is
 // that in Deno `arguments.callee` is not null.
 Module.wrapper = [
-  // TODO(bartlomieju): these should actually be stored somewhere
-  `(function (exports, require, module, __filename, __dirname) { var { Buffer, clearImmediate, clearInterval, clearTimeout, global, process, setImmediate, setInterval, setTimeout } = globalThis; (() => {`,
+  `(function (exports, require, module, __filename, __dirname) { var { Buffer, clearImmediate, clearInterval, clearTimeout, global, process, setImmediate, setInterval, setTimeout } = Deno[Deno.internal].nodeGlobals; (() => {`,
   "\n})(); })",
 ];
 Module.wrap = function (script) {

--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -5,6 +5,7 @@
 import { internals } from "ext:core/mod.js";
 const requireImpl = internals.requireImpl;
 
+import { nodeGlobals } from "ext:deno_node/00_globals.js";
 import "node:module";
 
 let initialized = false;
@@ -73,15 +74,15 @@ internals.node = {
 };
 
 const nativeModuleExports = requireImpl.nativeModuleExports;
-globalThis.Buffer = nativeModuleExports["buffer"].Buffer;
-globalThis.clearImmediate = nativeModuleExports["timers"].clearImmediate;
-globalThis.clearInterval = nativeModuleExports["timers"].clearInterval;
-globalThis.clearTimeout = nativeModuleExports["timers"].clearTimeout;
-globalThis.global = globalThis;
-globalThis.process = nativeModuleExports["process"];
-globalThis.setImmediate = nativeModuleExports["timers"].setImmediate;
-globalThis.setInterval = nativeModuleExports["timers"].setInterval;
-globalThis.setTimeout = nativeModuleExports["timers"].setTimeout;
+nodeGlobals.Buffer = nativeModuleExports["buffer"].Buffer;
+nodeGlobals.clearImmediate = nativeModuleExports["timers"].clearImmediate;
+nodeGlobals.clearInterval = nativeModuleExports["timers"].clearInterval;
+nodeGlobals.clearTimeout = nativeModuleExports["timers"].clearTimeout;
+nodeGlobals.global = globalThis;
+nodeGlobals.process = nativeModuleExports["process"];
+nodeGlobals.setImmediate = nativeModuleExports["timers"].setImmediate;
+nodeGlobals.setInterval = nativeModuleExports["timers"].setInterval;
+nodeGlobals.setTimeout = nativeModuleExports["timers"].setTimeout;
 
 nativeModuleExports["internal/console/constructor"].bindStreamsLazy(
   nativeModuleExports["console"],

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -90,6 +90,7 @@ import {
 } from "ext:runtime/98_global_scope_worker.js";
 import { SymbolMetadata } from "ext:deno_web/00_infra.js";
 import { bootstrap as bootstrapOtel } from "ext:deno_telemetry/telemetry.ts";
+import { nodeGlobals } from "ext:deno_node/00_globals.js";
 
 // deno-lint-ignore prefer-primordials
 if (Symbol.metadata) {
@@ -557,7 +558,7 @@ function removeImportedOps() {
 // FIXME(bartlomieju): temporarily add whole `Deno.core` to
 // `Deno[Deno.internal]` namespace. It should be removed and only necessary
 // methods should be left there.
-ObjectAssign(internals, { core });
+ObjectAssign(internals, { core, nodeGlobals: { ...nodeGlobals } });
 const internalSymbol = Symbol("Deno.internal");
 const finalDenoNs = {
   internal: internalSymbol,

--- a/tests/specs/npm/compare_globals/__test__.jsonc
+++ b/tests/specs/npm/compare_globals/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run --allow-read --check=all main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/npm/compare_globals/main.out
+++ b/tests/specs/npm/compare_globals/main.out
@@ -1,0 +1,31 @@
+[UNORDERED_START]
+Download http://localhost:4260/@types%2fnode
+Download http://localhost:4260/undici-types
+Download http://localhost:4260/@denotest%2fglobals
+[UNORDERED_END]
+[UNORDERED_START]
+Download http://localhost:4260/@denotest/globals/1.0.0.tgz
+Download http://localhost:4260/@types/node/node-[WILDLINE].tgz
+Download http://localhost:4260/undici-types/undici-types-[WILDLINE].tgz
+[UNORDERED_END]
+Check [WILDCARD]main.ts
+true
+true
+[]
+process equals process true
+setTimeout 1 true
+setTimeout 2 function
+setTimeout 3 function
+setTimeout 4 function
+setTimeout 5 undefined
+window 1 false
+window 2 false
+false
+false
+self 1 true
+self 2 true
+true
+true
+bar
+bar
+true

--- a/tests/specs/npm/compare_globals/main.ts
+++ b/tests/specs/npm/compare_globals/main.ts
@@ -1,0 +1,61 @@
+/// <reference types="npm:@types/node" />
+
+import * as globals from "npm:@denotest/globals";
+console.log(globals.global === globals.globalThis);
+// @ts-expect-error even though these are the same object, they have different types
+console.log(globals.globalThis === globalThis);
+console.log(globals.process.execArgv);
+console.log("process equals process", process === globals.process);
+
+type AssertTrue<T extends true> = never;
+type _TestHasProcessGlobal = AssertTrue<
+  typeof globalThis extends { process: any } ? true : false
+>;
+type _TestProcessGlobalVersion = AssertTrue<
+  typeof process.versions.node extends string ? true : false
+>;
+type _TestNoBufferGlogal = AssertTrue<
+  typeof globalThis extends { Buffer: any } ? false : true
+>;
+type _TestHasNodeJsGlobal = NodeJS.Architecture;
+
+const controller = new AbortController();
+controller.abort("reason"); // in the NodeJS declaration it doesn't have a reason
+
+// Some globals are not the same between Node and Deno.
+// @ts-expect-error incompatible types between Node and Deno
+console.log("setTimeout 1", globalThis.setTimeout === globals.getSetTimeout());
+
+// Super edge case where some Node code deletes a global where the
+// Node code has its own global and the Deno code has the same global,
+// but it's different. Basically if some Node code deletes
+// one of these globals then we don't want it to suddenly inherit
+// the Deno global (or touch the Deno global at all).
+console.log("setTimeout 2", typeof globalThis.setTimeout);
+console.log("setTimeout 3", typeof globals.getSetTimeout());
+globals.deleteSetTimeout();
+console.log("setTimeout 4", typeof globalThis.setTimeout);
+console.log("setTimeout 5", typeof globals.getSetTimeout());
+
+// In Deno 2 and Node.js, the window global is not defined.
+console.log("window 1", "window" in globalThis);
+console.log(
+  "window 2",
+  Object.getOwnPropertyDescriptor(globalThis, "window") !== undefined,
+);
+globals.checkWindowGlobal();
+
+// In Deno 2 self global is defined, but in Node it is not.
+console.log("self 1", "self" in globalThis);
+console.log(
+  "self 2",
+  Object.getOwnPropertyDescriptor(globalThis, "self") !== undefined,
+);
+globals.checkSelfGlobal();
+
+// "Non-managed" globals are shared between Node and Deno.
+(globalThis as any).foo = "bar";
+console.log((globalThis as any).foo);
+console.log(globals.getFoo());
+
+console.log(Reflect.ownKeys(globalThis).includes("console")); // non-enumerable keys are included

--- a/tools/core_import_map.json
+++ b/tools/core_import_map.json
@@ -573,6 +573,7 @@
     "ext:deno_node/_util/std_fmt_colors.ts": "../ext/node/polyfills/_util/std_fmt_colors.ts",
     "ext:deno_node/_utils.ts": "../ext/node/polyfills/_utils.ts",
     "ext:deno_node/_zlib_binding.mjs": "../ext/node/polyfills/_zlib_binding.mjs",
+    "ext:deno_node/00_globals.js": "../ext/node/polyfills/00_globals.js",
     "ext:deno_node/inspector.ts": "../ext/node/polyfills/inspector.ts",
     "ext:deno_node/internal_binding/_libuv_winerror.ts": "../ext/node/polyfills/internal_binding/_libuv_winerror.ts",
     "ext:deno_node/internal_binding/_listen.ts": "../ext/node/polyfills/internal_binding/_listen.ts",


### PR DESCRIPTION
This reverts commit 9498b36170ab00490b9143dd42e83a2f3ca50323.

This is a breaking change and is postponed until Deno 3.0.
Related to https://github.com/denoland/deno/pull/31490