### PR TITLE
fix(bundle): support android

### DIFF
--- a/cli/tools/bundle/esbuild.rs
+++ b/cli/tools/bundle/esbuild.rs
@@ -28,6 +28,8 @@ fn esbuild_platform() -> &'static str {
     ("aarch64", "macos" | "apple") => "darwin-arm64",
     ("x86_64", "windows") => "win32-x64",
     ("aarch64", "windows") => "win32-arm64",
+    ("x86_64", "android") => "android-x64",
+    ("aarch64", "android") => "android-arm64",
     _ => panic!(
       "Unsupported platform: {} {}",
       std::env::consts::ARCH,


### PR DESCRIPTION
support android os in esbuild

linked with https://github.com/denoland/esbuild_client/pull/16