### PR TITLE
fix(node): missing `statfs` export from `node:fs/promises`

### DIFF
--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -16,6 +16,7 @@ export const readlink = fsPromises.readlink;
 export const symlink = fsPromises.symlink;
 export const lstat = fsPromises.lstat;
 export const stat = fsPromises.stat;
+export const statfs = fsPromises.statfs;
 export const fstat = fsPromises.fstat;
 export const link = fsPromises.link;
 export const unlink = fsPromises.unlink;

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -42,6 +42,7 @@ import {
   lutimes,
   open,
   stat,
+  statfs,
   writeFile,
 } from "node:fs/promises";
 import process from "node:process";
@@ -180,6 +181,13 @@ Deno.test(
         }'`,
       );
     }
+  },
+);
+
+Deno.test(
+  "[node/fs/promises statfs] export statfs function",
+  async () => {
+    await statfs(import.meta.filename!);
   },
 );
 


### PR DESCRIPTION
We already had the functionality, we just didn't export it.

Fixes https://github.com/denoland/deno/issues/31526