### PR TITLE
ci: increase node compat test timeout on Mac Intel

### DIFF
--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -994,8 +994,7 @@
 "parallel/test-stdin-pipe-resume.js" = {}
 "parallel/test-stdin-resume-pause.js" = {}
 "parallel/test-stdin-script-child-option.js" = {}
-# TODO(bartlomieju): this test currently times out on macOS intel runners after 10s, consider increasing timeout.
-"parallel/test-stdio-pipe-access.js" = { darwin = false }
+"parallel/test-stdio-pipe-access.js" = {}
 "parallel/test-stdio-pipe-redirect.js" = {}
 "parallel/test-stdio-pipe-stderr.js" = { flaky = true }
 "parallel/test-stdio-undestroy.js" = { flaky = true }

--- a/tests/node_compat/run_all_test_unmodified.ts
+++ b/tests/node_compat/run_all_test_unmodified.ts
@@ -28,7 +28,9 @@ const testSuitePath = new URL(import.meta.resolve("./runner/suite/"));
 const testDirUrl = new URL("runner/suite/test/", import.meta.url).href;
 const IS_CI = !!Deno.env.get("CI");
 // The timeout ms for single test execution. If a single test didn't finish in this timeout milliseconds, the test is considered as failure
-const TIMEOUT = IS_CI ? 10_000 : 5000;
+const TIMEOUT = IS_CI
+  ? Deno.build.os === "darwin" && Deno.build.arch === "x86_64" ? 20_000 : 10_000
+  : 5000;
 
 // The metadata of the test report
 export type TestReportMetadata = {


### PR DESCRIPTION
It appears that Mac Intel runners are slower than before and multiple tests fail to
complete in 10s. This PR increases timeout on Mac Intel to 20s.