### PR TITLE
Revert "chore: Rust 1.91.1 (#31165)"

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -5,7 +5,7 @@ import { stringify } from "jsr:@std/yaml@^0.221/stringify";
 // Bump this number when you want to purge the cache.
 // Note: the tools/release/01_bump_crate_versions.ts script will update this version
 // automatically via regex, so ensure that this line maintains this format.
-const cacheVersion = 81;
+const cacheVersion = 80;
 
 const ubuntuX86Runner = "ubuntu-24.04";
 const ubuntuX86XlRunner = "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04";
@@ -76,7 +76,7 @@ const prCachePath = [
 ].join("\n");
 
 // Note that you may need to add more version to the `apt-get remove` line below if you change this
-const llvmVersion = 21;
+const llvmVersion = 20;
 const installPkgsCommand =
   `sudo apt-get install -y --no-install-recommends clang-${llvmVersion} lld-${llvmVersion} clang-tools-${llvmVersion} clang-format-${llvmVersion} clang-tidy-${llvmVersion}`;
 const sysRootStep = {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,8 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '81-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '81-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
+          key: '80-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '80-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
         if: '!(matrix.skip)'
       - uses: dsherret/rust-toolchain-file@v1
         if: '!(matrix.skip)'
@@ -260,18 +260,18 @@ jobs:
           sudo apt-get -qq remove   'clang-12*' 'clang-13*' 'clang-14*' 'clang-15*' 'clang-16*' 'clang-17*' 'clang-18*' 'clang-19*' 'llvm-12*' 'llvm-13*' 'llvm-14*' 'llvm-15*' 'llvm-16*' 'llvm-17*' 'llvm-18*' 'llvm-19*' 'lld-12*' 'lld-13*' 'lld-14*' 'lld-15*' 'lld-16*' 'lld-17*' 'lld-18*' 'lld-19*' > /dev/null 2> /dev/null
 
           # Install clang-XXX, lld-XXX, and debootstrap.
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" |
-            sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-21.list
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" |
+            sudo dd of=/etc/apt/sources.list.d/llvm-toolchain-jammy-20.list
           curl https://apt.llvm.org/llvm-snapshot.gpg.key |
             gpg --dearmor                                 |
           sudo dd of=/etc/apt/trusted.gpg.d/llvm-snapshot.gpg
           sudo apt-get update
           # this was unreliable sometimes, so try again if it fails
-          sudo apt-get install -y --no-install-recommends clang-21 lld-21 clang-tools-21 clang-format-21 clang-tidy-21 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-21 lld-21 clang-tools-21 clang-format-21 clang-tidy-21
+          sudo apt-get install -y --no-install-recommends clang-20 lld-20 clang-tools-20 clang-format-20 clang-tidy-20 || echo 'Failed. Trying again.' && sudo apt-get clean && sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-20 lld-20 clang-tools-20 clang-format-20 clang-tidy-20
           # Fix alternatives
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
-          clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-20 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -304,8 +304,8 @@ jobs:
           CARGO_PROFILE_RELEASE_INCREMENTAL=false
           RUSTFLAGS<<__1
             -C linker-plugin-lto=true
-            -C linker=clang-21
-            -C link-arg=-fuse-ld=lld-21
+            -C linker=clang-20
+            -C link-arg=-fuse-ld=lld-20
             -C link-arg=-ldl
             -C link-arg=-Wl,--allow-shlib-undefined
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
@@ -316,8 +316,8 @@ jobs:
           __1
           RUSTDOCFLAGS<<__1
             -C linker-plugin-lto=true
-            -C linker=clang-21
-            -C link-arg=-fuse-ld=lld-21
+            -C linker=clang-20
+            -C link-arg=-fuse-ld=lld-20
             -C link-arg=-ldl
             -C link-arg=-Wl,--allow-shlib-undefined
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
@@ -326,7 +326,7 @@ jobs:
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
-          CC=/usr/bin/clang-21
+          CC=/usr/bin/clang-20
           CFLAGS=$CFLAGS
           " > $GITHUB_ENV
       - name: Remove macOS cURL --ipv4 flag
@@ -379,7 +379,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '81-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '80-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: Apply and update mtime cache
         if: '!(matrix.skip) && (!startsWith(github.ref, ''refs/tags/''))'
         uses: ./.github/mtime_cache
@@ -744,7 +744,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '81-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '80-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   lint:
     name: 'lint ${{ matrix.profile }} ${{ matrix.os }}-${{ matrix.arch }}'
     needs:
@@ -795,8 +795,8 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: '81-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
-          restore-keys: '81-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
+          key: '80-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles(''Cargo.lock'') }}'
+          restore-keys: '80-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-'
       - uses: dsherret/rust-toolchain-file@v1
       - name: Install Deno
         uses: denoland/setup-deno@v2
@@ -813,7 +813,7 @@ jobs:
             !./target/*/*.zip
             !./target/*/*.tar.gz
           key: never_saved
-          restore-keys: '81-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
+          restore-keys: '80-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-'
       - name: test_format.js
         if: matrix.os == 'linux'
         run: deno run --allow-write --allow-read --allow-run --allow-net ./tools/format.js --check
@@ -833,7 +833,7 @@ jobs:
             !./target/*/gn_root
             !./target/*/*.zip
             !./target/*/*.tar.gz
-          key: '81-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
+          key: '80-cargo-target-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.profile }}-${{ matrix.job }}-${{ github.sha }}'
   libs:
     name: build libs
     needs:

--- a/cli/tools/coverage/util.rs
+++ b/cli/tools/coverage/util.rs
@@ -54,7 +54,7 @@ mod tests {
 
   #[test]
   fn test_find_root() {
-    let urls = [
+    let urls = vec![
       Url::parse("file:///a/b/c/d/e.ts").unwrap(),
       Url::parse("file:///a/b/c/d/f.ts").unwrap(),
       Url::parse("file:///a/b/c/d/g.ts").unwrap(),
@@ -71,7 +71,7 @@ mod tests {
 
   #[test]
   fn test_find_root_with_similar_filenames() {
-    let urls = [
+    let urls = vec![
       Url::parse("file:///a/b/c/d/foo0.ts").unwrap(),
       Url::parse("file:///a/b/c/d/foo1.ts").unwrap(),
       Url::parse("file:///a/b/c/d/foo2.ts").unwrap(),
@@ -82,7 +82,7 @@ mod tests {
 
   #[test]
   fn test_find_root_with_similar_dirnames() {
-    let urls = [
+    let urls = vec![
       Url::parse("file:///a/b/c/foo0/mod.ts").unwrap(),
       Url::parse("file:///a/b/c/foo1/mod.ts").unwrap(),
       Url::parse("file:///a/b/c/foo2/mod.ts").unwrap(),

--- a/cli/tools/pm/audit.rs
+++ b/cli/tools/pm/audit.rs
@@ -499,16 +499,15 @@ mod npm {
           .iter()
           .any(|action_resolve| action_resolve.id == self.id)
         {
-          let target = if let Some(target) = &action.target {
-            format!("@{}", target)
-          } else {
-            String::new()
-          };
           acts.push(format!(
             "{} {}{}{}",
             action.action,
             action.module,
-            target,
+            if let Some(target) = &action.target {
+              &format!("@{}", target)
+            } else {
+              ""
+            },
             if action.is_major {
               " (major upgrade)"
             } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.90.0"
 components = ["rustfmt", "clippy"]

--- a/tests/specs/test/recursive_permissions_pledge/err.out
+++ b/tests/specs/test/recursive_permissions_pledge/err.out
@@ -10,6 +10,6 @@ Platform: [WILDLINE]
 Version: [WILDLINE]
 Args: [[WILDLINE], "test", "main.js"]
 [WILDCARD]
-thread 'tokio-runtime-worker' ([WILDCARD]) panicked at [WILDCARD]:
+thread 'tokio-runtime-worker' panicked at [WILDLINE]
 pledge test permissions called before restoring previous pledge
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This reverts commit e5f9b441ef9e2ba75306679068ad292a29f690ef.

Trying to revert this because we started getting a lot of seemingly random
failures after this upgrade.