### PR TITLE
fix(x): correct alias deno command location for Windows

### DIFF
--- a/cli/tools/x.rs
+++ b/cli/tools/x.rs
@@ -251,7 +251,7 @@ exec "$SCRIPT_DIR/deno" x --default-allow-all "$@"
     std::fs::write(
       out_path,
       r##"@echo off
-./deno.exe x %*
+"%~dp0deno.exe" x %*
 exit /b %ERRORLEVEL%
 "##,
     )?;

--- a/tests/specs/x/alias/__test__.jsonc
+++ b/tests/specs/x/alias/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "x --install-alias",
+      "output": ""
+    },
+    {
+      "args": "task --eval \"dx\"",
+      "output": "alias.out"
+    }
+  ]
+}

--- a/tests/specs/x/alias/alias.out
+++ b/tests/specs/x/alias/alias.out
@@ -1,0 +1,2 @@
+Task  dx
+No local commands found


### PR DESCRIPTION
I'm not familiar with Rust or Windows CMD syntax. But I tried both the current option and just plain `deno.exe` locally by changing `dx.cmd`, which solved the issue for me.

Closes #31572 