### PR TITLE
Revert "fix: source map file names to non-existent paths"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.373.0"
+version = "0.372.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559b437009e516b78cb30927182ec0b7563bf68a03cbda43fd57573a33196cf8"
+checksum = "e24cc349b258a9825f0dc29e986b33093fabb33f2e332991d35b0641c680b2fb"
 dependencies = [
  "anyhow",
  "az",
@@ -2612,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.249.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e89c54aee7eb075b55a069e65f647c2213e45a4d472e769164e15f587737ab7"
+checksum = "9b1fd01b849fc60fb1206255877d7a183f2e7ee5329e75c389c8470a63437eab"
 dependencies = [
  "indexmap 2.9.0",
  "proc-macro2",
@@ -8173,9 +8173,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.282.0"
+version = "0.281.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7f62a825e28a7e8d77a2afcc6bdb6facb2aade9862baa1f3c6e7c53f1f1270"
+checksum = "55b7d3cf62efe5c68ec52873f3c737dfd76ded33474cf8b928e6a1fb2cd33158"
 dependencies = [
  "deno_error",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ repository = "https://github.com/denoland/deno"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.52.0", features = ["transpiling"] }
-deno_core = { version = "0.373.0" }
+deno_core = { version = "0.372.0" }
 
 deno_cache_dir = "=0.26.3"
 deno_doc = "=0.188.0"

--- a/cli/module_loader.rs
+++ b/cli/module_loader.rs
@@ -1256,19 +1256,6 @@ impl<TGraphContainer: ModuleGraphContainer> ModuleLoader
     None
   }
 
-  fn source_map_source_exists(&self, source_url: &str) -> Option<bool> {
-    let specifier = resolve_url(source_url).ok()?;
-
-    // For npm packages, we can check the file system directly
-    if self.0.shared.in_npm_pkg_checker.in_npm_package(&specifier)
-      && let Ok(path) = deno_path_util::url_to_file_path(&specifier)
-    {
-      return Some(path.is_file());
-    }
-
-    None
-  }
-
   fn get_source_mapped_source_line(
     &self,
     file_name: &str,

--- a/tests/specs/run/sourcemap_nonexistent_source/__test__.jsonc
+++ b/tests/specs/run/sourcemap_nonexistent_source/__test__.jsonc
@@ -1,5 +1,0 @@
-{
-  "args": "run bundle.js",
-  "output": "bundle.js.out",
-  "exitCode": 1
-}

--- a/tests/specs/run/sourcemap_nonexistent_source/bundle.js
+++ b/tests/specs/run/sourcemap_nonexistent_source/bundle.js
@@ -1,8 +1,0 @@
-// Simulates an npm package bundle where source files don't exist
-function throwError() {
-  throw new Error("Test error from bundle with missing source");
-}
-
-throwError();
-
-//# sourceMappingURL=bundle.js.map

--- a/tests/specs/run/sourcemap_nonexistent_source/bundle.js.map
+++ b/tests/specs/run/sourcemap_nonexistent_source/bundle.js.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"bundle.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,2BAA2B;AAC3B,SAAS,UAAU;IACjB,MAAM,IAAI,KAAK,CAAC,oCAAoC,CAAC,CAAC;AACxD,CAAC;AAED,UAAU,EAAE,CAAC"}

--- a/tests/specs/run/sourcemap_nonexistent_source/bundle.js.out
+++ b/tests/specs/run/sourcemap_nonexistent_source/bundle.js.out
@@ -1,5 +1,0 @@
-error: Uncaught (in promise) Error: Test error from bundle with missing source
-  throw new Error("Test error from bundle with missing source");
-  ^
-    at throwError ([WILDCARD]bundle.js:3:3)
-    at [WILDCARD]bundle.js:6:14


### PR DESCRIPTION
Reverts denoland/deno#31564

Unfortunately I think we have to revert this one due to #31594 and I can't get the tests passing atm.

Let's reland on Monday.