### PR TITLE
fix(fetch): fix SOCKS5 proxy URL validation logic

### DIFF
--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -64,7 +64,7 @@ function createHttpClient(options) {
         case "socks5": {
           const url = options.proxy.url;
           if (
-            !StringPrototypeStartsWith(url, "socks5:") ||
+            !StringPrototypeStartsWith(url, "socks5:") &&
             !StringPrototypeStartsWith(url, "socks5h:")
           ) {
             throw new TypeError(

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -2314,6 +2314,38 @@ Deno.test(
 Deno.test(
   {
     permissions: { net: true },
+  },
+  function createHttpClientSocks5ProxyAcceptsSocks5Url() {
+    // Test that socks5 transport accepts socks5:// URLs
+    using client = Deno.createHttpClient({
+      proxy: {
+        transport: "socks5",
+        url: "socks5://localhost:1080",
+      },
+    });
+    assert(client instanceof Deno.HttpClient);
+  },
+);
+
+Deno.test(
+  {
+    permissions: { net: true },
+  },
+  function createHttpClientSocks5ProxyAcceptsSocks5hUrl() {
+    // Test that socks5 transport accepts socks5h:// URLs
+    using client = Deno.createHttpClient({
+      proxy: {
+        transport: "socks5",
+        url: "socks5h://localhost:1080",
+      },
+    });
+    assert(client instanceof Deno.HttpClient);
+  },
+);
+
+Deno.test(
+  {
+    permissions: { net: true },
     ignore: Deno.build.os === "windows",
   },
   function createHttpClientWithVsockProxy() {


### PR DESCRIPTION
## Summary

This PR fixes a logical error in the SOCKS5 proxy URL validation in `Deno.createHttpClient()`.

**The bug:** The condition for validating SOCKS5 proxy URLs was using `||` (OR) instead of `&&` (AND):
```javascript
// Before (broken)
if (
  !StringPrototypeStartsWith(url, "socks5:") ||
  !StringPrototypeStartsWith(url, "socks5h:")
) { throw ... }
```

This meant that a valid `socks5://` URL would still throw because it doesn't start with `socks5h:`, and vice versa. The condition would almost always be true, making SOCKS5 proxies unusable.

**The fix:**
```javascript
// After (fixed)
if (
  !StringPrototypeStartsWith(url, "socks5:") &&
  !StringPrototypeStartsWith(url, "socks5h:")
) { throw ... }
```

Now the error is only thrown when the URL starts with NEITHER `socks5:` nor `socks5h:`.

## Changes

- **ext/fetch/22_http_client.js**: Fixed the logical operator from `||` to `&&`
- **tests/unit/fetch_test.ts**: Added tests to verify that SOCKS5 transport accepts both `socks5://` and `socks5h://` URLs

## Test plan

- [x] Added test `createHttpClientSocks5ProxyAcceptsSocks5Url` - verifies socks5 transport accepts socks5:// URLs
- [x] Added test `createHttpClientSocks5ProxyAcceptsSocks5hUrl` - verifies socks5 transport accepts socks5h:// URLs
- [x] Manually verified with dev build that socks5:// and socks5h:// URLs now work correctly

Closes #31356