### PR TITLE
fix: --preload and --require flags only available in runtime subcommands

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -6847,8 +6847,6 @@ fn compile_args_without_check_parse(
   lock_args_parse(flags, matches);
   ca_file_arg_parse(flags, matches);
   unsafely_ignore_certificate_errors_parse(flags, matches);
-  preload_arg_parse(flags, matches);
-  require_arg_parse(flags, matches);
   min_dep_age_arg_parse(flags, matches);
   Ok(())
 }
@@ -7114,6 +7112,8 @@ fn runtime_args_parse(
   env_file_arg_parse(flags, matches);
   trace_ops_parse(flags, matches);
   eszip_arg_parse(flags, matches);
+  preload_arg_parse(flags, matches);
+  require_arg_parse(flags, matches);
   Ok(())
 }
 


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/31609