### PR TITLE
chore: remove error-prone wildcard_match function

### DIFF
--- a/tests/integration/test_tests.rs
+++ b/tests/integration/test_tests.rs
@@ -1,12 +1,12 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-use test_util as util;
+use test_util::TestContext;
+use test_util::TestContextBuilder;
+use test_util::assert_contains;
+use test_util::assert_not_contains;
+use test_util::assertions::assert_wildcard_match;
 use test_util::test;
-use util::TestContext;
-use util::TestContextBuilder;
-use util::assert_contains;
-use util::assert_not_contains;
-use util::wildcard_match;
+use test_util::with_pty;
 
 #[test]
 fn junit_path() {
@@ -29,7 +29,7 @@ fn junit_path() {
 // todo(#18480): re-enable
 #[ignore]
 fn sigint_with_hanging_test() {
-  util::with_pty(
+  with_pty(
     &[
       "test",
       "--quiet",
@@ -40,7 +40,7 @@ fn sigint_with_hanging_test() {
       std::thread::sleep(std::time::Duration::from_secs(1));
       console.write_line("\x03");
       let text = console.read_until("hanging_test.ts:10:15");
-      wildcard_match(
+      assert_wildcard_match(
         include_str!("../testdata/test/sigint_with_hanging_test.out"),
         &text,
       );

--- a/tests/util/server/src/lib.rs
+++ b/tests/util/server/src/lib.rs
@@ -53,7 +53,6 @@ pub use parsers::parse_strace_output;
 pub use parsers::parse_wrk_output;
 pub use test_macro::test;
 pub use wildcard::WildcardMatchResult;
-pub use wildcard::wildcard_match;
 pub use wildcard::wildcard_match_detailed;
 
 pub const PERMISSION_VARIANTS: [&str; 5] =

--- a/tests/util/server/src/wildcard.rs
+++ b/tests/util/server/src/wildcard.rs
@@ -1,21 +1,16 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use crate::colors;
-use crate::eprintln;
-
-pub fn wildcard_match(pattern: &str, text: &str) -> bool {
-  match wildcard_match_detailed(pattern, text) {
-    WildcardMatchResult::Success => true,
-    WildcardMatchResult::Fail(debug_output) => {
-      eprintln!("{}", debug_output);
-      false
-    }
-  }
-}
 
 pub enum WildcardMatchResult {
   Success,
   Fail(String),
+}
+
+impl WildcardMatchResult {
+  pub fn is_success(&self) -> bool {
+    matches!(self, WildcardMatchResult::Success)
+  }
 }
 
 pub fn wildcard_match_detailed(
@@ -215,7 +210,8 @@ pub fn wildcard_match_detailed(
           let maybe_found_index =
             expected_lines.iter().position(|expected_line| {
               actual_line == *expected_line
-                || wildcard_match(expected_line, actual_line)
+                || wildcard_match_detailed(expected_line, actual_line)
+                  .is_success()
             });
           if let Some(found_index) = maybe_found_index {
             let expected = expected_lines.remove(found_index);
@@ -469,7 +465,7 @@ mod test {
 
     // Iterate through the fixture lists, testing each one
     for (pattern, string, expected) in fixtures {
-      let actual = wildcard_match(pattern, string);
+      let actual = wildcard_match_detailed(pattern, string).is_success();
       dbg!(pattern, string, expected);
       assert_eq!(actual, expected);
     }
@@ -477,8 +473,11 @@ mod test {
 
   #[test]
   fn test_wildcard_match2() {
-    // foo, bar, baz, qux, quux, quuz, corge, grault, garply, waldo, fred, plugh, xyzzy
+    let wildcard_match = |pattern: &str, text: &str| {
+      wildcard_match_detailed(pattern, text).is_success()
+    };
 
+    // foo, bar, baz, qux, quux, quuz, corge, grault, garply, waldo, fred, plugh, xyzzy
     assert!(wildcard_match("foo[WILDCARD]baz", "foobarbaz"));
     assert!(!wildcard_match("foo[WILDCARD]baz", "foobazbar"));
 
@@ -548,6 +547,9 @@ grault",
 
   #[test]
   fn test_wildcard_match_unordered_lines() {
+    let wildcard_match = |pattern: &str, text: &str| {
+      wildcard_match_detailed(pattern, text).is_success()
+    };
     // matching
     assert!(wildcard_match(
       concat!("[UNORDERED_START]\n", "B\n", "A\n", "[UNORDERED_END]\n"),


### PR DESCRIPTION
This function was error-prone. In one place it was causing output where it shouldn't and in another place it wasn't asserting the test.