### PR TITLE
docs(cli): add DENO_KV_DEFAULT_PATH and DENO_KV_PATH_PREFIX to help

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -1440,6 +1440,16 @@ static ENV_VARS: &[EnvVar] = &[
     example: None,
   },
   EnvVar {
+    name: "DENO_KV_DEFAULT_PATH",
+    description: "Set the default path for Deno.openKv() when no path is provided.",
+    example: None,
+  },
+  EnvVar {
+    name: "DENO_KV_PATH_PREFIX",
+    description: "Set a prefix to be added to all Deno.openKv() paths.",
+    example: None,
+  },
+  EnvVar {
     name: "DENO_EMIT_CACHE_MODE",
     description: "Control if the transpiled sources should be cached.",
     example: None,


### PR DESCRIPTION
## Summary
- Add `DENO_KV_DEFAULT_PATH` and `DENO_KV_PATH_PREFIX` environment variables to `deno help` output
- These env vars were added in #30320 but not documented in CLI help

Closes #31669