### PR TITLE
fix(ext/node): support TypedArray and DataView targets in Buffer.copy()

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -17,7 +17,9 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeForEach,
   BigInt,
+  DataViewPrototypeGetBuffer,
   DataViewPrototypeGetByteLength,
+  DataViewPrototypeGetByteOffset,
   Float32Array,
   Float64Array,
   MathFloor,
@@ -1849,7 +1851,7 @@ Buffer.prototype.copy = function copy(
   sourceStart,
   sourceEnd,
 ) {
-  if (!isUint8Array(this)) {
+  if (!isArrayBufferView(this)) {
     throw new codes.ERR_INVALID_ARG_TYPE(
       "source",
       ["Buffer", "Uint8Array"],
@@ -1857,12 +1859,29 @@ Buffer.prototype.copy = function copy(
     );
   }
 
-  if (!isUint8Array(target)) {
+  if (!isArrayBufferView(target)) {
     throw new codes.ERR_INVALID_ARG_TYPE(
       "target",
       ["Buffer", "Uint8Array"],
       target,
     );
+  }
+
+  // For non-Uint8Array targets, create a Uint8Array view for byte-wise copying
+  if (!isUint8Array(target)) {
+    if (isDataView(target)) {
+      target = new Uint8Array(
+        DataViewPrototypeGetBuffer(target),
+        DataViewPrototypeGetByteOffset(target),
+        DataViewPrototypeGetByteLength(target),
+      );
+    } else {
+      target = new Uint8Array(
+        TypedArrayPrototypeGetBuffer(target),
+        TypedArrayPrototypeGetByteOffset(target),
+        TypedArrayPrototypeGetByteLength(target),
+      );
+    }
   }
 
   if (targetStart === undefined) {

--- a/tests/node_compat/config.toml
+++ b/tests/node_compat/config.toml
@@ -86,7 +86,7 @@
 "parallel/test-buffer-constructor-node-modules-paths.js" = {}
 "parallel/test-buffer-constructor-node-modules.js" = {}
 "parallel/test-buffer-constructor-outside-node-modules.js" = {}
-"parallel/test-buffer-copy.js" = { darwin = false, linux = false, windows = false, reason = "https://github.com/denoland/deno/issues/31637" }
+"parallel/test-buffer-copy.js" = {}
 "parallel/test-buffer-equals.js" = {}
 "parallel/test-buffer-failed-alloc-typed-arrays.js" = {}
 "parallel/test-buffer-fakes.js" = {}


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/31637

- `parallel/test-buffer-copy.js` now passes
- Allow `Buffer.copy()` to accept any `ArrayBufferView` (TypedArray or DataView) as the target, matching Node.js behavior
- Previously only `Uint8Array` targets were accepted, causing `TypeError` for other typed arrays
