### PR TITLE
feat(lsp): add test coverage support

### DIFF
--- a/cli/lsp/client.rs
+++ b/cli/lsp/client.rs
@@ -24,6 +24,7 @@ pub enum TestingNotification {
   Module(testing_lsp_custom::TestModuleNotificationParams),
   DeleteModule(testing_lsp_custom::TestModuleDeleteNotificationParams),
   Progress(testing_lsp_custom::TestRunProgressParams),
+  Coverage(testing_lsp_custom::CoverageNotificationParams),
 }
 
 #[derive(Clone)]
@@ -276,6 +277,12 @@ impl ClientTrait for TowerClient {
           .send_notification::<testing_lsp_custom::TestRunProgressNotification>(
             params,
           )
+          .await
+      }
+      TestingNotification::Coverage(params) => {
+        self
+          .0
+          .send_notification::<testing_lsp_custom::CoverageNotification>(params)
           .await
       }
     }

--- a/cli/lsp/testing/lsp_custom.rs
+++ b/cli/lsp/testing/lsp_custom.rs
@@ -186,3 +186,35 @@ impl lsp::notification::Notification for TestRunProgressNotification {
 
   const METHOD: &'static str = "deno/testRunProgress";
 }
+
+pub const COVERAGE_NOTIFICATION: &str = "deno/testCoverage";
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileCoverage {
+  /// The URI of the file
+  pub uri: lsp::Uri,
+  /// Lines that were executed (1-indexed line numbers)
+  pub covered_lines: Vec<u32>,
+  /// Lines that were not executed (1-indexed line numbers)
+  pub uncovered_lines: Vec<u32>,
+  /// Coverage percentage for this file
+  pub coverage_percent: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoverageNotificationParams {
+  /// The test run ID this coverage belongs to
+  pub id: u32,
+  /// Coverage data for each file
+  pub files: Vec<FileCoverage>,
+}
+
+pub enum CoverageNotification {}
+
+impl lsp::notification::Notification for CoverageNotification {
+  type Params = CoverageNotificationParams;
+
+  const METHOD: &'static str = COVERAGE_NOTIFICATION;
+}


### PR DESCRIPTION
Implements test coverage visualization for the LSP testing API (closes #18147).

When the test run kind is `coverage`, the LSP passes `--coverage=<temp_dir>` to `deno test`, collects the V8 coverage JSON files after execution, and sends a new `deno/testCoverage` notification to the client.

The notification payload includes:
- File URIs with their coverage data
- Arrays of covered and uncovered line numbers (1-indexed)
- Coverage percentage per file

The implementation parses the V8 ScriptCoverage format, converts character offsets to line numbers, and filters out external dependencies (only files under the workspace are reported).

**Technical details:**
- New types in `cli/lsp/testing/lsp_custom.rs`: `FileCoverage`, `CoverageNotificationParams`
- Coverage collection in `cli/lsp/testing/execution.rs`: `collect_coverage_from_dir()` reads and parses the JSON files
- The coverage directory is created in the system temp folder as `deno_lsp_coverage_{run_id}` and cleaned up after sending the notification

**Testing:**
To test locally, use the vscode_deno extension with the corresponding PR and run any test file with "Run with Coverage" from the Testing panel.

[1352](https://github.com/denoland/vscode_deno/pull/1352)

Screenshots will be added in a follow-up comment.
<img width="1000" height="659" alt="scr01" src="https://github.com/user-attachments/assets/7faa258d-5ab7-400f-b48e-fa35de2d3452" />

<img width="1000" height="659" alt="scr02" src="https://github.com/user-attachments/assets/ce8d5243-35da-4860-9634-72ae4af0acbe" />
