### PR TITLE
fix(runtime): suppress newline after EOF in prompt()

### DIFF
--- a/runtime/ops/tty.rs
+++ b/runtime/ops/tty.rs
@@ -486,7 +486,14 @@ pub fn op_read_line_prompt(
       }
       Ok(None)
     }
-    Err(ReadlineError::Eof) => Ok(None),
+    Err(ReadlineError::Eof) => {
+      // Move cursor up to counteract the newline that rustyline outputs on EOF.
+      // This makes prompt() behave consistently with confirm() and alert().
+      // See: https://github.com/denoland/deno/issues/22956
+      #[allow(clippy::print_stdout)]
+      print!("\x1b[1A");
+      Ok(None)
+    }
     Err(err) => Err(JsReadlineError(err)),
   }
 }


### PR DESCRIPTION
## Description

When stdin is closed (EOF), `prompt()` was outputting an extra newline compared to `confirm()` and `alert()`. This inconsistency was caused by rustyline's internal terminal handling.

## Root Cause

- `prompt()` uses `op_read_line_prompt()` which internally uses rustyline's `Editor::readline_with_initial`
- `confirm()` and `alert()` use `readLineFromStdinSync()` which is a manual byte-by-byte read
- When rustyline receives EOF, it outputs a newline as part of its terminal restoration

## Fix

This PR adds an ANSI escape sequence (`\x1b[1A`) to move the cursor up after EOF is received, counteracting the unwanted newline that rustyline outputs.

## Testing

```bash
# Before fix - note the newline after 'Prompt'
$ echo '' | deno eval 'prompt()'
Prompt 
$

# After fix - no extra newline (matches confirm behavior)
$ echo '' | deno eval 'prompt()'
Prompt $
```

Fixes #22956