### PR TITLE
feat(upgrade): ability to verify zip archive against checksum

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -552,6 +552,7 @@ pub struct UpgradeFlags {
   pub version: Option<String>,
   pub output: Option<String>,
   pub version_or_hash_or_channel: Option<String>,
+  pub checksum: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -4336,6 +4337,13 @@ different location, use the <c>--output</> flag:
           .action(ArgAction::Append)
           .trailing_var_arg(true),
       )
+      .arg(
+        Arg::new("checksum")
+          .long("checksum")
+          .help("Verify the downloaded archive against the provided SHA256 checksum")
+          .value_parser(value_parser!(String))
+          .help_heading(UPGRADE_HEADING),
+      )
       .arg(ca_file_arg())
       .arg(unsafely_ignore_certificate_errors_arg())
   })
@@ -6813,6 +6821,7 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
   let output = matches.remove_one::<String>("output");
   let version_or_hash_or_channel =
     matches.remove_one::<String>("version-or-hash-or-channel");
+  let checksum = matches.remove_one::<String>("checksum");
   flags.subcommand = DenoSubcommand::Upgrade(UpgradeFlags {
     dry_run,
     force,
@@ -6821,6 +6830,7 @@ fn upgrade_parse(flags: &mut Flags, matches: &mut ArgMatches) {
     version,
     output,
     version_or_hash_or_channel,
+    checksum,
   });
 }
 
@@ -7518,6 +7528,7 @@ mod tests {
           version: None,
           output: None,
           version_or_hash_or_channel: None,
+          checksum: None,
         }),
         ..Flags::default()
       }
@@ -7538,6 +7549,7 @@ mod tests {
           version: None,
           output: Some(String::from("example.txt")),
           version_or_hash_or_channel: None,
+          checksum: None,
         }),
         ..Flags::default()
       }
@@ -11572,6 +11584,7 @@ mod tests {
           version: None,
           output: None,
           version_or_hash_or_channel: None,
+          checksum: None,
         }),
         ca_data: Some(CaData::File("example.crt".to_owned())),
         ..Flags::default()
@@ -11593,6 +11606,7 @@ mod tests {
           version: None,
           output: None,
           version_or_hash_or_channel: None,
+          checksum: None,
         }),
         ..Flags::default()
       }

--- a/tests/specs/upgrade/checksum/__test__.jsonc
+++ b/tests/specs/upgrade/checksum/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "tempDir": true,
+  "args": "run -A checksum_test.ts",
+  "output": "checksum_test.out",
+  "exitCode": 0
+}

--- a/tests/specs/upgrade/checksum/checksum_test.out
+++ b/tests/specs/upgrade/checksum/checksum_test.out
@@ -1,0 +1,14 @@
+Downloaded [WILDCARD] bytes
+Computed checksum: [WILDLINE]
+
+=== Test 1: Valid checksum ===
+[WILDCARD]Checksum verified
+[WILDCARD]
+
+=== Test 2: Invalid checksum ===
+[WILDCARD]Checksum verification failed.
+[WILDCARD]
+
+=== Test 3: Uppercase checksum ===
+[WILDCARD]Checksum verified
+[WILDCARD]

--- a/tests/specs/upgrade/checksum/checksum_test.ts
+++ b/tests/specs/upgrade/checksum/checksum_test.ts
@@ -1,0 +1,65 @@
+// Test script that fetches the upgrade zip, computes its checksum,
+// and then runs upgrade commands to verify checksum validation works.
+
+const version = "99.99.99";
+const target = Deno.build.target;
+const archiveName = `deno-${target}.zip`;
+const downloadUrl =
+  `http://localhost:4545/deno-upgrade/download/v${version}/${archiveName}`;
+
+// Fetch the archive and compute its SHA256 checksum
+const response = await fetch(downloadUrl);
+if (!response.ok) {
+  console.error(`Failed to fetch ${downloadUrl}: ${response.status}`);
+  Deno.exit(1);
+}
+
+const data = new Uint8Array(await response.arrayBuffer());
+const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+const hashArray = Array.from(new Uint8Array(hashBuffer));
+const correctChecksum = hashArray.map((b) => b.toString(16).padStart(2, "0"))
+  .join("");
+
+console.log(`Downloaded ${data.length} bytes`);
+console.log(`Computed checksum: ${correctChecksum}`);
+
+async function runUpgrade(args: string[]) {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["upgrade", ...args],
+    env: {
+      ...Deno.env.toObject(),
+      "DENO_TESTING_UPGRADE": "1",
+    },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  await command.output();
+}
+
+console.log("\n=== Test 1: Valid checksum ===");
+await runUpgrade([
+  "--version",
+  version,
+  "--dry-run",
+  "--checksum",
+  correctChecksum,
+]);
+
+console.log("\n=== Test 2: Invalid checksum ===");
+await runUpgrade([
+  "--version",
+  version,
+  "--dry-run",
+  "--checksum",
+  "0000000000000000000000000000000000000000000000000000000000000000",
+]);
+
+console.log("\n=== Test 3: Uppercase checksum ===");
+await runUpgrade([
+  "--version",
+  version,
+  "--dry-run",
+  "--checksum",
+  correctChecksum.toUpperCase(),
+]);


### PR DESCRIPTION
This allows someone to verify the zip archive against a provided checksum.

```sh
deno upgrade --checksum=<checksum-goes-here> 2.6.2
```

Closes https://github.com/denoland/deno/issues/31801