### PR TITLE
docs: Added Scoop to Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ choco install deno
 winget install --id=DenoLand.Deno
 ```
 
-[Scoop](https://scoop.sh/#/apps?q=deno&id=678d8fb557b611df996989c675b1099630a5bbee) (Windows):
+[Scoop](https://scoop.sh/#/apps?q=deno&id=678d8fb557b611df996989c675b1099630a5bbee)
+(Windows):
 
 ```powershell
 scoop install main/deno


### PR DESCRIPTION
Scoop downloads directly from Deno's repo on GitHub.  See https://github.com/ScoopInstaller/Main/blob/master/bucket/deno.json
