### PR TITLE
fix(ext/node): fix promisified `setImmediate`

### DIFF
--- a/ext/node/polyfills/internal/timers.mjs
+++ b/ext/node/polyfills/internal/timers.mjs
@@ -12,8 +12,12 @@ const {
   MapPrototypeGet,
   MapPrototypeSet,
   NumberIsFinite,
+  ObjectDefineProperty,
   ReflectApply,
   SafeArrayIterator,
+  PromiseReject,
+  PromiseWithResolvers,
+  SafePromisePrototypeFinally,
   SafeMap,
   Symbol,
   SymbolToPrimitive,
@@ -25,8 +29,11 @@ import {
 } from "ext:core/ops";
 import { inspect } from "ext:deno_node/internal/util/inspect.mjs";
 import {
+  validateAbortSignal,
+  validateBoolean,
   validateFunction,
   validateNumber,
+  validateObject,
 } from "ext:deno_node/internal/validators.mjs";
 import { ERR_OUT_OF_RANGE } from "ext:deno_node/internal/errors.ts";
 import { emitWarning } from "node:process";
@@ -36,6 +43,9 @@ import {
   setTimeout as setTimeout_,
 } from "ext:deno_web/02_timers.js";
 import { runNextTicks } from "ext:deno_node/_next_tick.ts";
+import { kResistStopPropagation } from "ext:deno_node/internal/event_target.mjs";
+import { kEmptyObject } from "ext:deno_node/internal/util.mjs";
+import { AbortError } from "ext:deno_node/internal/errors.ts";
 
 // Timeout values > TIMEOUT_MAX are set to 1.
 export const TIMEOUT_MAX = 2 ** 31 - 1;

--- a/ext/node/polyfills/timers/promises.ts
+++ b/ext/node/polyfills/timers/promises.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
+
 import timers from "node:timers";
 
 export const setTimeout = timers.promises.setTimeout;
-export const setImmediate = timers.promises.setImmediate;
 export const setInterval = timers.promises.setInterval;
-
+export const setImmediate = timers.promises.setImmediate;
 export const scheduler = timers.promises.scheduler;
 
 export default {


### PR DESCRIPTION
Sadly this still doesn't make `tests/node_compat/runner/suite/test/parallel/test-timers-immediate-promisified.js` because of call to `<process.execPath> -pe ...` which we don't support. I might look into that before landing. 