### PR TITLE
tests: mark test-sqlite-session as flaky

### DIFF
--- a/tests/node_compat/config.json
+++ b/tests/node_compat/config.json
@@ -1022,7 +1022,9 @@
       "reason": "https://github.com/denoland/deno/issues/31634"
     },
     "parallel/test-sqlite-named-parameters.js": {},
-    "parallel/test-sqlite-session.js": {},
+    "parallel/test-sqlite-session.js": {
+      "flaky": true
+    },
     "parallel/test-sqlite-statement-sync-columns.js": {},
     "parallel/test-sqlite-timeout.js": {},
     "parallel/test-sqlite-transactions.js": {},


### PR DESCRIPTION
The `test-sqlite-session` test is failing a lot, it seems something related to slow IO of GH actions because I tried many times locally and couldn't be replicated.

Examples: 
https://github.com/denoland/deno/actions/runs/20941682365/job/60176397557?pr=31825
https://github.com/denoland/deno/actions/runs/20945503852/job/60187704262?pr=31829