### PR TITLE
chore: run node_compat tests as flaky on ci

### DIFF
--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
 use test_util as util;
+use test_util::IS_CI;
 use test_util::test_runner::FlakyTestTracker;
 use test_util::test_runner::Parallelism;
 use test_util::test_runner::run_maybe_flaky_test;
@@ -172,7 +173,7 @@ fn main() {
         let test_config = config.tests.get(&test.data.test_path);
         run_maybe_flaky_test(
           &test.name,
-          test_config.is_some_and(|c| c.flaky),
+          test_config.is_some_and(|c| c.flaky) || *IS_CI,
           &flaky_test_tracker,
           None,
           || run_test(&cli_args, test, test_config, &results),
@@ -200,7 +201,7 @@ fn main() {
         let test_config = config.tests.get(&test.data.test_path);
         run_maybe_flaky_test(
           &test.name,
-          test_config.is_some_and(|c| c.flaky),
+          test_config.is_some_and(|c| c.flaky) || *IS_CI,
           &flaky_test_tracker,
           Some(&parallelism),
           || run_test(&cli_args, test, test_config, &results),


### PR DESCRIPTION
Ref https://github.com/denoland/deno/pull/31826#issuecomment-3744775109

This was an oversight when porting to Rust.