### PR TITLE
fix(node/child_process): use correct syscall name in spawn error

### DIFF
--- a/tests/node_compat/config.json
+++ b/tests/node_compat/config.json
@@ -180,6 +180,7 @@
     "parallel/test-child-process-send-cb.js": {},
     "parallel/test-child-process-set-blocking.js": {},
     "parallel/test-child-process-silent.js": {},
+    "parallel/test-child-process-spawn-error.js": {},
     "parallel/test-child-process-spawn-event.js": {},
     "parallel/test-child-process-spawn-typeerror.js": {},
     "parallel/test-child-process-spawnsync-args.js": {},


### PR DESCRIPTION
The error object from spawn() was incorrectly setting syscall to "spawnSync <file>" instead of "spawn <file>". 