### PR TITLE
fix: don't ever set 1005 outbound close code

### DIFF
--- a/ext/websocket/lib.rs
+++ b/ext/websocket/lib.rs
@@ -722,8 +722,8 @@ pub async fn op_ws_close(
 
   let frame = reason
     .map(|reason| match code {
-      Some(code) => Frame::close(code, reason.as_bytes()),
-      _ => Frame::close_raw(reason.as_bytes().into()),
+      Some(code) => Frame::close(code, &reason.into_bytes()),
+      _ => Frame::close_raw(reason.into_bytes().into()),
     })
     .unwrap_or_else(|| match code {
       Some(code) => Frame::close(code, EMPTY_PAYLOAD),


### PR DESCRIPTION
1005 should never be sent on the wire. Next.js errors when receiving this.