### PR TITLE
fix(ci): rename `trusted-signing-action` to `artifact-signing-action`

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -850,7 +850,7 @@ const ci = {
             "github.repository == 'denoland/deno' &&",
             "(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))",
           ].join("\n"),
-          uses: "azure/trusted-signing-action@v0",
+          uses: "Azure/artifact-signing-action@v0",
           with: {
             "endpoint": "https://eus.codesigning.azure.net/",
             "trusted-signing-account-name": "deno-cli-code-signing",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
           matrix.profile == 'release' &&
           github.repository == 'denoland/deno' &&
           (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
-        uses: azure/trusted-signing-action@v0
+        uses: Azure/artifact-signing-action@v0
         with:
           endpoint: 'https://eus.codesigning.azure.net/'
           trusted-signing-account-name: deno-cli-code-signing

--- a/.github/workflows/promote_to_release.yml
+++ b/.github/workflows/promote_to_release.yml
@@ -58,7 +58,7 @@ jobs:
           enable-AzPSSession: true
 
       - name: Code sign deno.exe
-        uses: azure/trusted-signing-action@v0
+        uses: Azure/artifact-signing-action@v0
         with:
           cache-dependencies: false
           trace: true


### PR DESCRIPTION
The GitHub action `Azure/trusted-signing-action` has been renamed to `Azure/artifact-signing-action`.

Ref: https://github.com/Azure/artifact-signing-action/issues/107

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
