### PR TITLE
fix(ext/node): implement getValidStdio for child_process

### DIFF
--- a/tests/node_compat/config.json
+++ b/tests/node_compat/config.json
@@ -195,6 +195,7 @@
     "parallel/test-child-process-stdio-overlapped.js": {},
     "parallel/test-child-process-stdout-flush-exit.js": {},
     "parallel/test-child-process-stdout-flush.js": {},
+    "parallel/test-child-process-validate-stdio.js": {},
     "parallel/test-client-request-destroy.js": {},
     "parallel/test-cluster-eaddrinuse.js": {},
     "parallel/test-cluster-uncaught-exception.js": {},


### PR DESCRIPTION
Implements the internal `getValidStdio` function used by Node.js's child_process module to validate stdio configurations. This function:

  - Validates stdio is a string ('ignore', 'pipe', 'inherit', 'overlapped') or array
  - Expands arrays to at least 3 elements
  - Converts stream objects (like process.stdin) to fd descriptors
  - Tracks IPC channel positions
  - Throws appropriate errors for invalid configurations

 Also, enables test-child-process-validate-stdio.js in node_compat.