### PR TITLE
chore(deps): bump fqdn to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "fqdn"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f5d7f7b3eed2f771fc7f6fcb651f9560d7b0c483d75876082acb4649d266b3"
+checksum = "886ac788f62d16d6b0f26b2fa762b34ef16ebfb4b624c2c15fbcadc9173c0f72"
 
 [[package]]
 name = "from_variant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ fastwebsockets = { version = "^0.8.1", features = ["upgrade", "unstable-split"] 
 file_test_runner = "0.12.1"
 filetime = "0.2.16"
 flate2 = { version = "1.0.30", default-features = false }
-fqdn = "0.4.6"
+fqdn = "0.5"
 fs3 = "0.5.0"
 futures = "0.3.31"
 glob = "0.3.1"


### PR DESCRIPTION
## Problem
`fqdn` 0.4.6/0.4.7 are yanked on crates.io, so `fqdn = ^0.4.6` fails to resolve.

## Fix
Bump `fqdn` to 0.5 and update the lockfile.

## Tests
- `cargo check -p deno_runtime`
