### PR TITLE
feat(task): `globstar`, `failglob`, `nullglob`, and `pipefail` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,11 +2939,12 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c8906a44dee412f17bf3ec79da41548612c5da3741fd0023c718408d6fe685"
+checksum = "078f9f536187d5bdf536104c139aeb49d23a3bbc2b6f23626fa04487bd819615"
 dependencies = [
  "anyhow",
+ "bitflags 2.9.3",
  "deno_path_util",
  "futures",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ deno_native_certs = "0.3.0"
 deno_npm = "=0.42.3"
 deno_path_util = "=0.6.4"
 deno_semver = "=0.9.1"
-deno_task_shell = "=0.26.2"
+deno_task_shell = "=0.28.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"


### PR DESCRIPTION
Defaults: `failglob`, `globstar`

* `shopt -u failglob && ...` - Disable failglob.
* `shopt -u failglob && shopt -s nullglob && ...` - Disable failglob and enable nullglob.
* `shopt -u globstar && ...` - Disable globstar.
* `set -o pipefail` - Enable pipefail.

Note that these shell options do not propagate down into `deno task ...` subprocesses.