### PR TITLE
feat: instrument cron with OTEL

### DIFF
--- a/ext/cron/01_cron.ts
+++ b/ext/cron/01_cron.ts
@@ -1,15 +1,19 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 import { core, internals, primordials } from "ext:core/mod.js";
-const {
-  isPromise,
-} = core;
 import { op_cron_create, op_cron_next } from "ext:core/ops";
 const {
   ArrayPrototypeJoin,
   NumberPrototypeToString,
   TypeError,
 } = primordials;
+import {
+  builtinTracer,
+  enterSpan,
+  restoreSnapshot,
+  TRACING_ENABLED,
+} from "ext:deno_telemetry/telemetry.ts";
+import { updateSpanFromError } from "ext:deno_telemetry/util.ts";
 
 export function formatToCronSchedule(
   value?: number | { exact: number | number[] } | {
@@ -160,11 +164,33 @@ function cron(
       if (r === false) {
         break;
       }
+      let span;
+      if (TRACING_ENABLED) {
+        span = builtinTracer().startSpan("deno.cron", { kind: 0 });
+        span.setAttribute("deno.cron.name", name);
+        span.setAttribute("deno.cron.schedule", schedule);
+      }
       try {
-        const result = handler();
-        const _res = isPromise(result) ? (await result) : result;
+        if (span) {
+          const snapshot = enterSpan(span);
+          let result;
+          try {
+            result = handler();
+          } finally {
+            if (snapshot) restoreSnapshot(snapshot);
+          }
+          await result;
+          span.setStatus({ code: 1 });
+          span.end();
+        } else {
+          await handler();
+        }
         success = true;
       } catch (error) {
+        if (span) {
+          updateSpanFromError(span, error);
+          span.end();
+        }
         import.meta.log("error", `Exception in cron handler ${name}`, error);
         success = false;
       }

--- a/ext/telemetry/util.ts
+++ b/ext/telemetry/util.ts
@@ -32,6 +32,14 @@ export function updateSpanFromResponse(span: Span, response: Response) {
 
 // deno-lint-ignore no-explicit-any
 export function updateSpanFromError(span: Span, error: any) {
-  span.setAttribute("error.type", error.name ?? "Error");
+  const errorType = error.name ?? "Error";
+  span.setAttribute("error.type", errorType);
+  span.setAttribute("exception.type", errorType);
+  if (error.message != null) {
+    span.setAttribute("exception.message", error.message);
+  }
+  if (error.stack != null) {
+    span.setAttribute("exception.stacktrace", error.stack);
+  }
   span.setStatus({ code: 2, message: error.message ?? String(error) });
 }

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -88,6 +88,14 @@
     "propagators_api": {
       "args": "run -A main.ts propagators_api.ts",
       "output": "propagators_api.out"
+    },
+    "cron": {
+      "args": "run -A main.ts cron.ts",
+      "output": "cron.out"
+    },
+    "cron_error": {
+      "args": "run -A main.ts cron_error.ts",
+      "output": "cron_error.out"
     }
   }
 }

--- a/tests/specs/cli/otel_basic/cron.out
+++ b/tests/specs/cli/otel_basic/cron.out
@@ -1,0 +1,61 @@
+{
+  "spans": [
+    {
+      "traceId": "00000000000000000000000000000001",
+      "spanId": "0000000000000001",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "deno.cron",
+      "kind": 1,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "deno.cron.name",
+          "value": {
+            "stringValue": "test-cron"
+          }
+        },
+        {
+          "key": "deno.cron.schedule",
+          "value": {
+            "stringValue": "*/20 * * * *"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 1
+      }
+    },
+    {
+      "traceId": "00000000000000000000000000000001",
+      "spanId": "0000000000000002",
+      "traceState": "",
+      "parentSpanId": "0000000000000001",
+      "flags": 1,
+      "name": "inner span",
+      "kind": 1,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    }
+  ],
+  "logs": [],
+  "metrics": []
+}

--- a/tests/specs/cli/otel_basic/cron.ts
+++ b/tests/specs/cli/otel_basic/cron.ts
@@ -1,0 +1,25 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { trace } from "npm:@opentelemetry/api@1.9.0";
+
+Deno.env.set("DENO_CRON_TEST_SCHEDULE_OFFSET", "100");
+
+const tracer = trace.getTracer("example-tracer");
+
+let count = 0;
+const { promise, resolve } = Promise.withResolvers<void>();
+const ac = new AbortController();
+
+const c = Deno.cron("test-cron", "*/20 * * * *", { signal: ac.signal }, () => {
+  tracer.startActiveSpan("inner span", (span) => {
+    count++;
+    if (count >= 1) {
+      resolve();
+    }
+    span.end();
+  });
+});
+
+await promise;
+ac.abort();
+await c;

--- a/tests/specs/cli/otel_basic/cron_error.out
+++ b/tests/specs/cli/otel_basic/cron_error.out
@@ -1,0 +1,80 @@
+[WILDCARD]
+{
+  "spans": [
+    {
+      "traceId": "00000000000000000000000000000001",
+      "spanId": "0000000000000001",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "deno.cron",
+      "kind": 1,
+      "startTimeUnixNano": "[WILDCARD]",
+      "endTimeUnixNano": "[WILDCARD]",
+      "attributes": [
+        {
+          "key": "deno.cron.name",
+          "value": {
+            "stringValue": "test-cron-error"
+          }
+        },
+        {
+          "key": "deno.cron.schedule",
+          "value": {
+            "stringValue": "*/20 * * * *"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "Error"
+          }
+        },
+        {
+          "key": "exception.type",
+          "value": {
+            "stringValue": "Error"
+          }
+        },
+        {
+          "key": "exception.message",
+          "value": {
+            "stringValue": "test error"
+          }
+        },
+        {
+          "key": "exception.stacktrace",
+          "value": {
+            "stringValue": "[WILDCARD]"
+          }
+        }
+      ],
+      "droppedAttributesCount": 0,
+      "events": [],
+      "droppedEventsCount": 0,
+      "links": [],
+      "droppedLinksCount": 0,
+      "status": {
+        "message": "test error",
+        "code": 2
+      }
+    }
+  ],
+  "logs": [
+    {
+      "timeUnixNano": "[WILDCARD]",
+      "observedTimeUnixNano": "[WILDCARD]",
+      "severityNumber": 17,
+      "severityText": "ERROR",
+      "body": {
+        "stringValue": "[WILDCARD]"
+      },
+      "attributes": [],
+      "droppedAttributesCount": 0,
+      "flags": 0,
+      "traceId": "",
+      "spanId": ""
+    }
+  ],
+  "metrics": []
+}

--- a/tests/specs/cli/otel_basic/cron_error.ts
+++ b/tests/specs/cli/otel_basic/cron_error.ts
@@ -1,0 +1,24 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+Deno.env.set("DENO_CRON_TEST_SCHEDULE_OFFSET", "100");
+
+let count = 0;
+const { promise, resolve } = Promise.withResolvers<void>();
+const ac = new AbortController();
+
+const c = Deno.cron(
+  "test-cron-error",
+  "*/20 * * * *",
+  { signal: ac.signal },
+  () => {
+    count++;
+    if (count >= 1) {
+      resolve();
+    }
+    throw new Error("test error");
+  },
+);
+
+await promise;
+ac.abort();
+await c;

--- a/tests/specs/cli/otel_basic/fetch.out
+++ b/tests/specs/cli/otel_basic/fetch.out
@@ -168,6 +168,24 @@
           "value": {
             "stringValue": "TypeError"
           }
+        },
+        {
+          "key": "exception.type",
+          "value": {
+            "stringValue": "TypeError"
+          }
+        },
+        {
+          "key": "exception.message",
+          "value": {
+            "stringValue": "[WILDCARD]"
+          }
+        },
+        {
+          "key": "exception.stacktrace",
+          "value": {
+            "stringValue": "[WILDCARD]"
+          }
         }
       ],
       "droppedAttributesCount": 0,
@@ -225,6 +243,24 @@
           "key": "error.type",
           "value": {
             "stringValue": "AbortError"
+          }
+        },
+        {
+          "key": "exception.type",
+          "value": {
+            "stringValue": "AbortError"
+          }
+        },
+        {
+          "key": "exception.message",
+          "value": {
+            "stringValue": "The signal has been aborted"
+          }
+        },
+        {
+          "key": "exception.stacktrace",
+          "value": {
+            "stringValue": "[WILDCARD]"
           }
         }
       ],

--- a/tests/specs/cli/otel_basic/main.ts
+++ b/tests/specs/cli/otel_basic/main.ts
@@ -35,6 +35,7 @@ function onListen({ port }) {
       "--env-file=env_file",
       "-A",
       "-q",
+      "--unstable-cron",
       Deno.args[0],
     ],
     env: {


### PR DESCRIPTION
This PR adds OpenTelemetry tracing support to `Deno.cron()` handlers. When OTEL
tracing is enabled, each cron handler invocation is wrapped in a span named
`"deno.cron"` with `deno.cron.name` and `deno.cron.schedule` attributes. The
span is properly entered so that any child spans created within the handler are
correctly parented. On successful execution, the span status is set to `OK`
(code 1); on error, the span captures exception details using OTel semantic
conventions (`exception.type`, `exception.message`, `exception.stacktrace`) and
sets the status to `ERROR` (code 2). This also updates `updateSpanFromError` in
the telemetry utils to use the standard OTel exception attributes instead of the
previous `error.type` attribute.
