### PR TITLE
repl/json: print full error on RunFailure

### DIFF
--- a/cli/tools/repl/mod.rs
+++ b/cli/tools/repl/mod.rs
@@ -359,7 +359,7 @@ async fn run_json(mut repl_session: ReplSession) -> Result<i32, AnyError> {
             repl_session.set_last_thrown_error(&result).await?;
 
             ReplMessage::RunFailure {
-              text: exception_details.text,
+              text: session::exception_description(&exception_details),
             }
           } else {
             repl_session

--- a/cli/tools/repl/session.rs
+++ b/cli/tools/repl/session.rs
@@ -472,18 +472,7 @@ impl ReplSession {
 
           Ok(if let Some(exception_details) = exception_details {
             session.set_last_thrown_error(&result).await?;
-            let description = match exception_details.exception {
-              Some(exception) => {
-                if let Some(description) = exception.description {
-                  description
-                } else if let Some(value) = exception.value {
-                  value.to_string()
-                } else {
-                  "undefined".to_string()
-                }
-              }
-              None => "Unknown exception".to_string(),
-            };
+            let description = exception_description(&exception_details);
             EvaluationOutput::Error(format!(
               "{} {}",
               exception_details.text, description
@@ -925,6 +914,24 @@ impl ReplSession {
       .await;
     serde_json::from_value(res).map_err(JsErrorBox::from_err)
   }
+}
+
+pub fn exception_description(
+  exception_details: &cdp::ExceptionDetails,
+) -> String {
+  let description = match &exception_details.exception {
+    Some(exception) => {
+      if let Some(description) = &exception.description {
+        description.to_string()
+      } else if let Some(value) = &exception.value {
+        value.to_string()
+      } else {
+        "undefined".to_string()
+      }
+    }
+    None => "Unknown exception".to_string(),
+  };
+  description
 }
 
 /// Walk an AST and get all import specifiers for analysis if any of them is


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Right now if an exception happens during execution in the repl in json mode, Deno will just populate the text field with `Uncaught` without any more details.

This PRs makes is so that the repl tui and json modes print the same error string
