### PR TITLE
fix: graceful server shutdown with open, un-upgraded connections

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -874,7 +874,8 @@ async fn serve_http2_autodetect(
   options: Options,
 ) -> Result<(), HttpNextError> {
   let prefix = NetworkStreamPrefixCheck::new(io, HTTP2_PREFIX);
-  let (matches, io) = prefix.match_prefix().await?;
+  let (matches, io) =
+    prefix.match_prefix().try_or_cancel(cancel.clone()).await?;
   if matches {
     serve_http2_unconditional(io, svc, cancel, options.http2_builder_hook)
       .await


### PR DESCRIPTION
Connections that are open but have not yet received a request (and thus
have not been upgraded to HTTP/1 or HTTP/2 and handed off to Hyper),
will now be closed gracefully when the server is shut down instead of
preventing shutdown indefinitely.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
