### PR TITLE
fix(ext/node): add stdin/stdout/stderr properties to worker_threads Worker

### DIFF
--- a/ext/node/polyfills/worker_threads.ts
+++ b/ext/node/polyfills/worker_threads.ts
@@ -119,6 +119,13 @@ class NodeWorker extends EventEmitter {
     stackSizeMb: 4,
   };
 
+  // https://nodejs.org/api/worker_threads.html#workerstdin
+  stdin = null;
+  // https://nodejs.org/api/worker_threads.html#workerstdout
+  stdout = null;
+  // https://nodejs.org/api/worker_threads.html#workerstderr
+  stderr = null;
+
   constructor(specifier: URL | string, options?: WorkerOptions) {
     super();
 

--- a/tests/unit_node/worker_threads_test.ts
+++ b/tests/unit_node/worker_threads_test.ts
@@ -22,6 +22,24 @@ Deno.test("[node/worker_threads] MessageChannel are MessagePort are exported", (
 });
 
 Deno.test({
+  name: "[node/worker_threads] Worker stdin/stdout/stderr are null by default",
+  async fn() {
+    const worker = new workerThreads.Worker(
+      `
+      import { parentPort } from "node:worker_threads";
+      parentPort.postMessage("ok");
+      `,
+      { eval: true },
+    );
+    assertEquals(worker.stdin, null);
+    assertEquals(worker.stdout, null);
+    assertEquals(worker.stderr, null);
+    await once(worker, "message");
+    worker.terminate();
+  },
+});
+
+Deno.test({
   name: "[node/worker_threads] isMainThread",
   fn() {
     assertEquals(workerThreads.isMainThread, true);


### PR DESCRIPTION
## Summary

- Adds the missing `stdin`, `stdout`, and `stderr` properties to the `Worker` class in the `node:worker_threads` polyfill
- Per Node.js semantics, all three default to `null` when the corresponding boolean options are not passed to the Worker constructor
- Adds a unit test verifying the default `null` behavior

## Test plan

- [x] Added `[node/worker_threads] Worker stdin/stdout/stderr are null by default` test
- [x] All existing `worker_threads` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)