### PR TITLE
fix: use locked-tripwire to prevent unlocked cargo installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "libc",
  "libsui",
  "libz-sys",
+ "locked-tripwire",
  "log",
  "lol_html",
  "lsp-types",
@@ -5966,6 +5967,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "locked-tripwire"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18841f136ee0993c6637a1387eb3758acc9fa24d558f540d329b2d8bb901c67"
 
 [[package]]
 name = "log"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -141,6 +141,7 @@ keyring = { version = "3.6.3", features = ["apple-native", "sync-secret-service"
 lazy-regex.workspace = true
 libc.workspace = true
 libz-sys.workspace = true
+locked-tripwire = "0.1.1"
 log = { workspace = true, features = ["serde"] }
 lol_html = "2.6.0"
 lsp-types.workspace = true


### PR DESCRIPTION
Very neat crate: https://crates.io/crates/locked-tripwire