### PR TITLE
fix: support DENO_SERVE_ADDRESS not being applied to the first server

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -733,7 +733,6 @@ function serve(arg1, arg2) {
   if (serveAddressOverrideConsumed) {
     return serveInner(options, handler);
   }
-  serveAddressOverrideConsumed = true;
 
   const {
     0: overrideKind,
@@ -742,6 +741,8 @@ function serve(arg1, arg2) {
     3: duplicateListener,
   } = op_http_serve_address_override();
   if (overrideKind) {
+    serveAddressOverrideConsumed = true;
+
     let envOptions = duplicateListener
       ? { __proto__: null, signal: options.signal, onError: options.onError }
       : options;


### PR DESCRIPTION
This can happen if you manually mess with `Deno.env.get` / `Deno.env.set` before calling `Deno.serve`.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
