### PR TITLE
fix: run on pre-Windows 10 version 1709

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3920,7 +3920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7441,16 +7441,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes denoland/deno#27635

The [`IsWow64Process2` line was removed](https://github.com/quinn-rs/quinn/commit/85011ef42e663e52fb52d490b4798f8936dd6517) in `0.5.9` so this patch bump resolves the issue for older versions of Windows.

I'm not sure how to make tests for this, but you can validate that the issue is resolved by successfully running `dino.exe` on any version of Windows before Windows 10 version 1709.