### PR TITLE
fix(ext/node): use primordials in `_fs_fchown.ts`

### DIFF
--- a/ext/node/polyfills/_fs/_fs_fchown.ts
+++ b/ext/node/polyfills/_fs/_fs_fchown.ts
@@ -29,7 +29,7 @@ export function fchown(
   PromisePrototypeThen(
     op_fs_fchown_async(fd, uid, gid),
     () => callback(null),
-    callback
+    callback,
   );
 }
 


### PR DESCRIPTION
Ref #24236

It doesn't seem like there's any tests for `fchown`?
