### PR TITLE
fix(flags): extra trailing space in zsh directory completions

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -6844,7 +6844,25 @@ function _clap_dynamic_completer_NAME() {
   )}")
 
   if [[ -n $completions ]]; then
-      _describe -V 'values' completions -o nosort
+      local -a dirs=()
+      local -a other=()
+      local completion
+      for completion in $completions; do
+          local value="${completion%%:*}"
+          if [[ "$value" == */ ]]; then
+              local dir_no_slash="${value%/}"
+              if [[ "$completion" == *:* ]]; then
+                  local desc="${completion#*:}"
+                  dirs+=("$dir_no_slash:$desc")
+              else
+                  dirs+=("$dir_no_slash")
+              fi
+          else
+              other+=("$completion")
+          fi
+      done
+      [[ -n $dirs ]] && _describe -V 'values' dirs -o nosort -S '/' -r '/'
+      [[ -n $other ]] && _describe -V 'values' other -o nosort
   fi
 }
 


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/31809

Ref https://github.com/clap-rs/clap/commit/5571b83c8a322ee2cf4342402d930cf2806fa2f1