### PR TITLE
feat: add `deno doc --agents`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -257,6 +257,7 @@ pub struct DocFlags {
   pub html: Option<DocHtmlFlag>,
   pub source_files: DocSourceFileFlag,
   pub filter: Option<String>,
+  pub agents: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2932,6 +2933,12 @@ Show documentation for runtime built-ins:
     <p(245)>deno doc</>
     <p(245)>deno doc --filter Deno.Listener</>
 
+Show agent-friendly documentation for the current project:
+    <p(245)>deno doc --agents</>
+
+Show agent skills for a specific package:
+    <p(245)>deno doc --agents jsr:@example/package@1.0.0</>
+
 <y>Read more:</> <c>https://docs.deno.com/go/doc</>"),
           UnstableArgsConfig::ResolutionOnly
     )
@@ -3025,6 +3032,17 @@ Show documentation for runtime built-ins:
             .long("lint")
             .help("Output documentation diagnostics.")
             .action(ArgAction::SetTrue).help_heading(DOC_HEADING),
+        )
+        .arg(
+          Arg::new("agents")
+            .long("agents")
+            .help("Output agent-friendly documentation for the project or a specific package")
+            .action(ArgAction::SetTrue)
+            .conflicts_with("json")
+            .conflicts_with("html")
+            .conflicts_with("lint")
+            .conflicts_with("filter")
+            .conflicts_with("private").help_heading(DOC_HEADING),
         )
         // TODO(nayeemrmn): Make `--builtin` a proper option. Blocked by
         // https://github.com/clap-rs/clap/issues/1794. Currently `--builtin` is
@@ -6168,6 +6186,7 @@ fn doc_parse(
   let private = matches.get_flag("private");
   let lint = matches.get_flag("lint");
   let json = matches.get_flag("json");
+  let agents = matches.get_flag("agents");
   let filter = matches.remove_one::<String>("filter");
   let html = if matches.get_flag("html") {
     let name = matches.remove_one::<String>("name");
@@ -6199,6 +6218,7 @@ fn doc_parse(
     html,
     filter,
     private,
+    agents,
   });
   Ok(())
 }
@@ -10227,6 +10247,7 @@ mod tests {
           html: None,
           lint: false,
           filter: None,
+          agents: false,
         }),
         import_map_path: Some("import_map.json".to_owned()),
         ..Flags::default()
@@ -11854,6 +11875,7 @@ mod tests {
           lint: false,
           source_files: DocSourceFileFlag::Paths(svec!["path/to/module.ts"]),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -11886,6 +11908,7 @@ mod tests {
           }),
           source_files: DocSourceFileFlag::Paths(svec!["path/to/module.ts"]),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -11917,6 +11940,7 @@ mod tests {
           lint: true,
           source_files: DocSourceFileFlag::Paths(svec!["path/to/module.ts"]),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -11945,6 +11969,7 @@ mod tests {
             "path/to/module.ts".to_string()
           ]),
           filter: Some("SomeClass.someField".to_string()),
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -11961,6 +11986,7 @@ mod tests {
           lint: false,
           source_files: Default::default(),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -11983,6 +12009,7 @@ mod tests {
           html: None,
           source_files: DocSourceFileFlag::Builtin,
           filter: Some("Deno.Listener".to_string()),
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -12006,6 +12033,7 @@ mod tests {
           html: None,
           source_files: DocSourceFileFlag::Paths(svec!["path/to/module.js"]),
           filter: None,
+          agents: false,
         }),
         no_npm: true,
         no_remote: true,
@@ -12032,6 +12060,7 @@ mod tests {
             "path/to/module2.js".to_string()
           ]),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -12057,6 +12086,7 @@ mod tests {
             "path/to/module2.js".to_string()
           ]),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }
@@ -12085,6 +12115,7 @@ mod tests {
             "path/to/module2.js".to_string()
           ]),
           filter: None,
+          agents: false,
         }),
         ..Flags::default()
       }

--- a/tests/specs/doc/agents/__test__.jsonc
+++ b/tests/specs/doc/agents/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "agents_overview_with_project": {
+      "args": "doc --agents",
+      "output": "agents_overview.out",
+      "exitCode": 0
+    },
+    "agents_conflicts_with_json": {
+      "args": "doc --agents --json mod.ts",
+      "output": "agents_conflict.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/doc/agents/agents_conflict.out
+++ b/tests/specs/doc/agents/agents_conflict.out
@@ -1,0 +1,2 @@
+error: the argument '--agents' cannot be used with '--json'
+[WILDCARD]

--- a/tests/specs/doc/agents/agents_overview.out
+++ b/tests/specs/doc/agents/agents_overview.out
@@ -1,0 +1,41 @@
+Deno Documentation for Agents
+
+Usage:
+
+  Get documentation for a module's public API:
+    deno doc ./path/to/module.ts
+
+  Get documentation for a specific symbol:
+    deno doc ./path/to/module.ts MyClass
+
+  Get documentation for a remote package:
+    deno doc jsr:@std/path
+
+  Get documentation for a specific package version:
+    deno doc jsr:@std/path@1.0.0
+
+  Get agent skills for a package:
+    deno doc --agents jsr:@example/package
+
+  Output documentation as JSON:
+    deno doc --json ./path/to/module.ts
+
+Project:
+
+  @example/my-project 1.0.0
+
+  Exports:
+    . -> ./mod.ts
+
+  To see documentation for this project:
+    deno doc ./mod.ts
+
+Dependencies:
+
+  @std/assert jsr:@std/assert@^1.0.0
+    doc: deno doc jsr:@std/assert@^1.0.0
+    skills: deno doc --agents jsr:@std/assert@^1.0.0
+  @std/path jsr:@std/path@^1.0.0
+    doc: deno doc jsr:@std/path@^1.0.0
+    skills: deno doc --agents jsr:@std/path@^1.0.0
+

--- a/tests/specs/doc/agents/deno.json
+++ b/tests/specs/doc/agents/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/my-project",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0",
+    "@std/assert": "jsr:@std/assert@^1.0.0"
+  }
+}

--- a/tests/specs/doc/agents/mod.ts
+++ b/tests/specs/doc/agents/mod.ts
@@ -1,0 +1,3 @@
+export function hello(): string {
+  return "hello";
+}


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/31987

This PR adds `deno doc --agents [specifier]` as described in https://github.com/denoland/deno/issues/31987. This command should be manually defined in an agents skill. The output includes:
- How to use `deno doc` effectively.
- Export mapping of the module
- Direct dependencies, versions resolved from lockfile and how to get their skills and docs.
- Custom user defined agent skills for JSR packages if it contains AGENTS.md.

