### PR TITLE
fix(audit): make 'Path' property more readable

### DIFF
--- a/cli/tools/pm/audit.rs
+++ b/cli/tools/pm/audit.rs
@@ -404,7 +404,11 @@ mod npm {
       if let Some(finding) = adv.findings.first()
         && let Some(path) = finding.paths.first()
       {
-        _ = writeln!(stdout, "│ {}       {}", colors::gray("Path:"), path);
+        let path_fmt = path
+          .split(">")
+          .collect::<Vec<_>>()
+          .join(colors::gray(" > ").to_string().as_str());
+        _ = writeln!(stdout, "│ {}       {}", colors::gray("Path:"), path_fmt);
       }
       if actions.is_empty() {
         _ = writeln!(stdout, "╰ {}      {}", colors::gray("Info:"), adv.url);

--- a/tests/specs/audit/deno_json_and_package_json/audit.out
+++ b/tests/specs/audit/deno_json_and_package_json/audit.out
@@ -12,7 +12,7 @@
 │ Package:    @edenotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln>@denotest/with-vuln2
+│ Path:       @denotest/using-vuln > @denotest/with-vuln2
 │ Info:       https://example.com/vuln/202020
 │ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
 ╰             review @denotest/with-vuln2

--- a/tests/specs/audit/deno_json_only/audit.out
+++ b/tests/specs/audit/deno_json_only/audit.out
@@ -12,7 +12,7 @@
 │ Package:    @edenotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln>@denotest/with-vuln2
+│ Path:       @denotest/using-vuln > @denotest/with-vuln2
 │ Info:       https://example.com/vuln/202020
 │ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
 ╰             review @denotest/with-vuln2

--- a/tests/specs/audit/package_json_only/audit.out
+++ b/tests/specs/audit/package_json_only/audit.out
@@ -12,7 +12,7 @@
 │ Package:    @edenotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln>@denotest/with-vuln2
+│ Path:       @denotest/using-vuln > @denotest/with-vuln2
 │ Info:       https://example.com/vuln/202020
 │ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
 ╰             review @denotest/with-vuln2

--- a/tests/specs/audit/package_json_only/audit_socket.out
+++ b/tests/specs/audit/package_json_only/audit_socket.out
@@ -12,7 +12,7 @@
 │ Package:    @edenotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln>@denotest/with-vuln2
+│ Path:       @denotest/using-vuln > @denotest/with-vuln2
 │ Info:       https://example.com/vuln/202020
 │ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
 ╰             review @denotest/with-vuln2

--- a/tests/specs/audit/package_json_only/audit_socket_authenticated.out
+++ b/tests/specs/audit/package_json_only/audit_socket_authenticated.out
@@ -12,7 +12,7 @@
 │ Package:    @edenotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln>@denotest/with-vuln2
+│ Path:       @denotest/using-vuln > @denotest/with-vuln2
 │ Info:       https://example.com/vuln/202020
 │ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
 ╰             review @denotest/with-vuln2

--- a/tests/specs/audit/quiet_flag/audit.out
+++ b/tests/specs/audit/quiet_flag/audit.out
@@ -12,7 +12,7 @@
 │ Package:    @edenotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln>@denotest/with-vuln2
+│ Path:       @denotest/using-vuln > @denotest/with-vuln2
 │ Info:       https://example.com/vuln/202020
 │ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
 ╰             review @denotest/with-vuln2


### PR DESCRIPTION
Makes report more readable by adding spaces in `Path` property.

Before:
```
╭ @denotest/with-vuln2 can steal crypto keys
│ Severity:   critical
│ Package:    @edenotest/with-vuln2
│ Vulnerable: <2.0.0
│ Patched:    >=2.0.0
│ Path:       @denotest/using-vuln>@denotest/with-vuln2
│ Info:       https://example.com/vuln/202020
│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
╰             review @denotest/with-vuln2
```
After:
```
╭ @denotest/with-vuln2 can steal crypto keys
│ Severity:   critical
│ Package:    @edenotest/with-vuln2
│ Vulnerable: <2.0.0
│ Patched:    >=2.0.0
│ Path:       @denotest/using-vuln > @denotest/with-vuln2
│ Info:       https://example.com/vuln/202020
│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
╰             review @denotest/with-vuln2
```