### PR TITLE
chore: make approve_scripts tests less flaky

### DIFF
--- a/tests/integration/pm_tests.rs
+++ b/tests/integration/pm_tests.rs
@@ -178,7 +178,6 @@ fn approve_scripts_basic() {
       pty.write_line(" ");
       pty.write_line("\r\n");
       pty.expect("Approved npm:@denotest/node-lifecycle-scripts@1.0.0");
-      pty.expect("@denotest/node-lifecycle-scripts@1.0.0: running");
       pty.expect("Ran build script npm:@denotest/node-lifecycle-scripts@1.0.0");
     });
   context
@@ -192,6 +191,11 @@ fn approve_scripts_basic() {
       },
       "allowScripts": ["npm:@denotest/node-lifecycle-scripts@1.0.0"],
     }));
+  context
+    .temp_dir()
+    .path()
+    .join("install.txt")
+    .assert_matches_text("Installed by @denotest/node-lifecycle-scripts!");
 }
 
 #[test(flaky)]
@@ -219,7 +223,6 @@ fn approve_scripts_deny_some() {
       pty.write_line("\r\n");
       pty.expect("Denied npm:@denotest/print-npm-user-agent@1.0.0");
       pty.expect("Approved npm:@denotest/node-lifecycle-scripts@1.0.0");
-      pty.expect("@denotest/node-lifecycle-scripts@1.0.0: running");
       pty.expect("Ran build script npm:@denotest/node-lifecycle-scripts@1.0.0");
     });
   context.temp_dir().path().join("deno.json").assert_matches_json(json!({
@@ -233,4 +236,9 @@ fn approve_scripts_deny_some() {
       "deny": ["npm:@denotest/print-npm-user-agent@1.0.0"]
     },
   }));
+  context
+    .temp_dir()
+    .path()
+    .join("install.txt")
+    .assert_matches_text("Installed by @denotest/node-lifecycle-scripts!");
 }

--- a/tests/registry/npm/@denotest/node-lifecycle-scripts/1.0.0/install.js
+++ b/tests/registry/npm/@denotest/node-lifecycle-scripts/1.0.0/install.js
@@ -2,4 +2,10 @@ module.exports = {
   sayHi: () => 'Hi from node-lifecycle-scripts!'
 };
 
+const fs = require('fs');
+const path = require('path');
+
+fs.writeFileSync(path.join(process.env.INIT_CWD, 'install.txt'), 'Installed by @denotest/node-lifecycle-scripts!');
+
+
 console.log('install.js', module.exports.sayHi());

--- a/tests/registry/npm/@denotest/node-lifecycle-scripts/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/node-lifecycle-scripts/1.0.0/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "preinstall": "echo preinstall && node preinstall.js && node --require ./helper.js preinstall.js",
-    "install": "echo install && cli-esm 'hello from install script'",
+    "install": "echo install && cli-esm 'hello from install script' && node install.js",
     "postinstall": "echo postinstall && npx cowsay postinstall"
   },
   "exports": "./index.js",


### PR DESCRIPTION
We were looking for a line from the progress bar to see that the scripts _actually_ ran, but it's not guaranteed that part of the progress bar will be rendered (since it only renders every so often, some steps might not actually display). Instead, write a file as part of the install script and check that it exists