### PR TITLE
RFC: Added libdeno package that compiles deno to a static C library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5869,6 +5869,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdeno"
+version = "2.6.8"
+dependencies = [
+ "anyhow",
+ "deno",
+ "log",
+]
+
+[[package]]
+name = "libdeno_bindings"
+version = "2.6.8"
+
+[[package]]
 name = "libffi"
 version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@
 [workspace]
 resolver = "2"
 members = [
+  "libdeno",
+  "libdeno_bindings",
   "cli",
   "cli/lib",
   "cli/rt",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,11 @@ license.workspace = true
 repository.workspace = true
 description = "Provides the deno executable"
 
+[lib]
+name = "libdeno"
+path = "lib.rs"
+doc = false
+
 [[bin]]
 name = "deno"
 path = "main.rs"

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -1,0 +1,256 @@
+#![allow(unused)]
+
+pub mod args;
+pub mod cache;
+pub mod cdp;
+pub mod factory;
+pub mod file_fetcher;
+pub mod graph_container;
+pub mod graph_util;
+pub mod http_util;
+pub mod jsr;
+pub mod lsp;
+pub mod module_loader;
+pub mod node;
+pub mod npm;
+pub mod ops;
+pub mod registry;
+pub mod resolver;
+pub mod standalone;
+pub mod task_runner;
+pub mod tools;
+pub mod tsc;
+pub mod type_checker;
+pub mod util;
+pub mod worker;
+
+use std::path::PathBuf;
+
+use deno_core::unsync::JoinHandle;
+use deno_core::futures::FutureExt;
+pub use deno_lib::worker::LibWorkerFactoryRoots;
+use deno_runtime::UnconfiguredRuntime;
+pub use deno_terminal::colors;
+pub use factory::CliFactory;
+pub use deno_runtime::tokio_util::create_and_run_current_thread_with_maybe_metrics;
+pub use deno_core::error::AnyError;
+
+use crate::util::v8::init_v8_flags;
+use crate::util::v8::get_v8_flags_from_env;
+use crate::args::get_default_v8_flags;
+use crate::args::Flags;
+pub use crate::util::display;
+
+pub mod sys {
+  #[allow(clippy::disallowed_types)] // ok, definition
+  pub type CliSys = sys_traits::impls::RealSys;
+}
+
+pub(crate) fn unstable_exit_cb(feature: &str, api_name: &str) {
+  log::error!(
+    "Unstable API '{api_name}'. The `--unstable-{}` flag must be provided.",
+    feature
+  );
+  deno_runtime::exit(70);
+}
+
+
+/// Ensures that all subcommands return an i32 exit code and an [`AnyError`] error type.
+pub trait SubcommandOutput {
+  fn output(self) -> Result<i32, AnyError>;
+}
+
+impl SubcommandOutput for Result<i32, AnyError> {
+  fn output(self) -> Result<i32, AnyError> {
+    self
+  }
+}
+
+impl SubcommandOutput for Result<(), AnyError> {
+  fn output(self) -> Result<i32, AnyError> {
+    self.map(|_| 0)
+  }
+}
+
+impl SubcommandOutput for Result<(), std::io::Error> {
+  fn output(self) -> Result<i32, AnyError> {
+    self.map(|_| 0).map_err(|e| e.into())
+  }
+}
+
+/// Ensure that the subcommand runs in a task, rather than being directly executed. Since some of these
+/// futures are very large, this prevents the stack from getting blown out from passing them by value up
+/// the callchain (especially in debug mode when Rust doesn't have a chance to elide copies!).
+#[inline(always)]
+pub fn spawn_subcommand<F: Future<Output = T> + 'static, T: SubcommandOutput>(
+  f: F,
+) -> JoinHandle<Result<i32, AnyError>> {
+  // the boxed_local() is important in order to get windows to not blow the stack in debug
+  deno_core::unsync::spawn(
+    async move { f.map(|r| r.output()).await }.boxed_local(),
+  )
+}
+
+pub fn init_v8(flags: &Flags) {
+  let default_v8_flags = get_default_v8_flags();
+
+  let env_v8_flags = get_v8_flags_from_env();
+  let is_single_threaded = env_v8_flags
+    .iter()
+    .chain(&flags.v8_flags)
+    .any(|flag| flag == "--single-threaded");
+  init_v8_flags(&default_v8_flags, &flags.v8_flags, env_v8_flags);
+  let v8_platform = if is_single_threaded {
+    Some(::deno_core::v8::Platform::new_single_threaded(true).make_shared())
+  } else {
+    None
+  };
+
+  deno_core::JsRuntime::init_platform(v8_platform);
+}
+
+#[cfg(unix)]
+#[allow(clippy::type_complexity)]
+pub fn wait_for_start(
+  args: &[std::ffi::OsString],
+  roots: LibWorkerFactoryRoots,
+) -> Option<
+  impl Future<
+    Output = Result<
+      Option<(UnconfiguredRuntime, Vec<std::ffi::OsString>, PathBuf)>,
+      AnyError,
+    >,
+  > + use<>,
+> {
+  let startup_snapshot = deno_snapshots::CLI_SNAPSHOT?;
+  let addr = std::env::var("DENO_UNSTABLE_CONTROL_SOCK").ok()?;
+
+  #[allow(clippy::undocumented_unsafe_blocks)]
+  unsafe {
+    std::env::remove_var("DENO_UNSTABLE_CONTROL_SOCK")
+  };
+
+  let argv0 = args[0].clone();
+
+  Some(async move {
+    use tokio::io::AsyncBufReadExt;
+    use tokio::io::AsyncRead;
+    use tokio::io::AsyncWrite;
+    use tokio::io::AsyncWriteExt;
+    use tokio::io::BufReader;
+    use tokio::net::TcpListener;
+    use tokio::net::UnixSocket;
+    use crate::args::Flags;
+
+    #[cfg(any(
+      target_os = "android",
+      target_os = "linux",
+      target_os = "macos"
+    ))]
+    use tokio_vsock::VsockAddr;
+    #[cfg(any(
+      target_os = "android",
+      target_os = "linux",
+      target_os = "macos"
+    ))]
+    use tokio_vsock::VsockListener;
+
+
+    init_v8(&Flags::default());
+
+    let unconfigured = deno_runtime::UnconfiguredRuntime::new::<
+      deno_resolver::npm::DenoInNpmPackageChecker,
+      crate::npm::CliNpmResolver,
+      crate::sys::CliSys,
+    >(deno_runtime::UnconfiguredRuntimeOptions {
+      startup_snapshot,
+      create_params: deno_lib::worker::create_isolate_create_params(
+        &crate::sys::CliSys::default(),
+      ),
+      shared_array_buffer_store: Some(roots.shared_array_buffer_store.clone()),
+      compiled_wasm_module_store: Some(
+        roots.compiled_wasm_module_store.clone(),
+      ),
+      additional_extensions: vec![],
+    });
+
+    let (rx, mut tx): (
+      Box<dyn AsyncRead + Unpin>,
+      Box<dyn AsyncWrite + Send + Unpin>,
+    ) = match addr.split_once(':') {
+      Some(("tcp", addr)) => {
+        let listener = TcpListener::bind(addr).await?;
+        let (stream, _) = listener.accept().await?;
+        let (rx, tx) = stream.into_split();
+        (Box::new(rx), Box::new(tx))
+      }
+      Some(("unix", path)) => {
+        let socket = UnixSocket::new_stream()?;
+        socket.bind(path)?;
+        let listener = socket.listen(1)?;
+        let (stream, _) = listener.accept().await?;
+        let (rx, tx) = stream.into_split();
+        (Box::new(rx), Box::new(tx))
+      }
+      #[cfg(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "macos"
+      ))]
+      Some(("vsock", addr)) => {
+        let Some((cid, port)) = addr.split_once(':') else {
+          deno_core::anyhow::bail!("invalid vsock addr");
+        };
+        let cid = if cid == "-1" { u32::MAX } else { cid.parse()? };
+        let port = port.parse()?;
+        let addr = VsockAddr::new(cid, port);
+        let listener = VsockListener::bind(addr)?;
+        let (stream, _) = listener.accept().await?;
+        let (rx, tx) = stream.into_split();
+        (Box::new(rx), Box::new(tx))
+      }
+      _ => {
+        deno_core::anyhow::bail!("invalid control sock");
+      }
+    };
+
+    let mut buf = Vec::with_capacity(1024);
+    BufReader::new(rx).read_until(b'\n', &mut buf).await?;
+
+    tokio::spawn(async move {
+      deno_runtime::deno_http::SERVE_NOTIFIER.notified().await;
+
+      #[derive(deno_core::serde::Serialize)]
+      enum Event {
+        Serving,
+      }
+
+      let mut buf = deno_core::serde_json::to_vec(&Event::Serving).unwrap();
+      buf.push(b'\n');
+      let _ = tx.write_all(&buf).await;
+    });
+
+    #[derive(deno_core::serde::Deserialize)]
+    struct Start {
+      cwd: String,
+      args: Vec<String>,
+      env: Vec<(String, String)>,
+    }
+
+    let cmd: Start = deno_core::serde_json::from_slice(&buf)?;
+
+    std::env::set_current_dir(&cmd.cwd)?;
+
+    for (k, v) in cmd.env {
+      // SAFETY: We're doing this before any threads are created.
+      unsafe { std::env::set_var(k, v) };
+    }
+
+    let args = [argv0]
+      .into_iter()
+      .chain(cmd.args.into_iter().map(Into::into))
+      .collect();
+
+    Ok(Some((unconfigured, args, PathBuf::from(cmd.cwd))))
+  })
+}

--- a/cli/lsp/trace.rs
+++ b/cli/lsp/trace.rs
@@ -181,24 +181,24 @@ pub(crate) enum TracingCollector {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(default, rename_all = "camelCase")]
-pub(crate) struct TracingConfig {
+pub struct TracingConfig {
   /// Enable tracing.
-  pub(crate) enable: bool,
+  pub enable: bool,
 
   /// The collector to use. Defaults to `OpenTelemetry`.
   /// If `Logging` is used, the collected traces will be written to stderr.
-  pub(crate) collector: TracingCollector,
+  pub collector: TracingCollector,
 
   /// The filter to use. Defaults to `INFO`.
-  pub(crate) filter: Option<String>,
+  pub filter: Option<String>,
 
   /// The endpoint to use for the OpenTelemetry collector.
-  pub(crate) collector_endpoint: Option<String>,
+  pub collector_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
-pub(crate) enum TracingConfigOrEnabled {
+pub enum TracingConfigOrEnabled {
   Config(TracingConfig),
   Enabled(bool),
 }
@@ -222,7 +222,7 @@ impl From<TracingConfigOrEnabled> for TracingConfig {
 }
 
 impl TracingConfigOrEnabled {
-  pub(crate) fn enabled(&self) -> bool {
+  pub fn enabled(&self) -> bool {
     match self {
       TracingConfigOrEnabled::Config(config) => config.enable,
       TracingConfigOrEnabled::Enabled(enabled) => *enabled,

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -832,7 +832,7 @@ pub enum ExecError {
 }
 
 #[derive(Clone)]
-pub(crate) struct CompressedSource {
+pub struct CompressedSource {
   bytes: &'static [u8],
   uncompressed: OnceLock<Arc<str>>,
 }

--- a/libdeno/Cargo.toml
+++ b/libdeno/Cargo.toml
@@ -1,0 +1,21 @@
+# Copyright 2018-2026 the Deno authors. MIT license.
+
+[package]
+name = "libdeno"
+version = "2.6.8"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Provides deno as a c library"
+
+[lib]
+name = "deno"
+path = "lib.rs"
+doc = false
+crate-type = ["staticlib"]
+
+[dependencies]
+deno = { path = "../cli" }
+anyhow.workspace = true
+log.workspace = true

--- a/libdeno/lib.rs
+++ b/libdeno/lib.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use libdeno::LibWorkerFactoryRoots;
+use libdeno::create_and_run_current_thread_with_maybe_metrics;
+use libdeno::wait_for_start;
+use libdeno::tools::run::eval_command;
+use libdeno::args::EvalFlags;
+use libdeno::args::Flags;
+use libdeno::init_v8;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn deno_embedded_eval(code: *const c_char) -> i32 {
+    if code.is_null() {
+        return -1;
+    }
+
+    let c_str = unsafe { CStr::from_ptr(code) };
+    
+    let code = match c_str.to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return -2,
+    };
+
+    // TODO get from args
+    let flags = Arc::new(Flags::default());
+
+    let args: Vec<_> = std::env::args_os().collect();
+
+    let fut = async move {
+      let roots = LibWorkerFactoryRoots::default();
+      
+      #[cfg(unix)]
+      let (waited_unconfigured_runtime, _waited_args, _waited_cwd) =
+        match wait_for_start(&args, roots.clone()) {
+          Some(f) => match f.await {
+            Ok(v) => match v {
+              Some((u, a, c)) => (Some(u), Some(a), Some(c)),
+              None => (None, None, None),
+            },
+            Err(e) => {
+              panic!("Failure from control sock: {e}");
+            }
+          },
+          None => (None, None, None),
+        };
+
+      #[cfg(not(unix))]
+      let (waited_unconfigured_runtime, waited_args, waited_cwd) = (None, None, None);
+
+      // let args = waited_args.unwrap_or(args);
+      // let initial_cwd = waited_cwd.map(Some).unwrap_or_else(|| {
+      //   match std::env::current_dir().with_context(|| "Failed getting cwd.") {
+      //     Ok(cwd) => Some(cwd),
+      //     Err(err) => {
+      //       log::error!("Failed getting cwd: {err}");
+      //       None
+      //     }
+      //   }
+      // });
+
+      if waited_unconfigured_runtime.is_none() {
+        init_v8(&flags);
+      }
+
+      println!("Starting command {}", code);
+
+      eval_command(flags, EvalFlags{
+        print: false,
+        code,
+      }).await
+    };
+
+    
+    match create_and_run_current_thread_with_maybe_metrics(fut){
+        Ok(exit_code) => exit_code,
+        Err(err) => {
+          eprintln!("{}", err);
+          1
+        },
+    }
+}

--- a/libdeno_bindings/Cargo.toml
+++ b/libdeno_bindings/Cargo.toml
@@ -1,0 +1,14 @@
+# Copyright 2018-2026 the Deno authors. MIT license.
+
+[package]
+name = "libdeno_bindings"
+version = "2.6.8"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Provides deno as a c library"
+
+[lib]
+path = "lib.rs"
+doc = false

--- a/libdeno_bindings/lib.rs
+++ b/libdeno_bindings/lib.rs
@@ -1,0 +1,36 @@
+use std::env;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::path::PathBuf;
+
+
+/// Place this in your build.rs to link the libdeno static library
+pub fn build_setup(libdeno_path: Option<PathBuf>) {
+    let libdeno_path = match libdeno_path {
+        Some(libdeno_path) => libdeno_path,
+        None => PathBuf::from(env::var("LIBDENO_PATH").expect("Cannot find libdeno")),
+    };
+
+    println!("cargo:rustc-link-search=native={}", libdeno_path.to_str().expect("Cannot convert LIBDENO_PATH to string"));
+    println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
+
+    println!("cargo:rustc-link-lib=static=deno");
+
+    println!("cargo:rustc-link-lib=dylib=pthread");
+    println!("cargo:rustc-link-lib=dylib=dl");
+    println!("cargo:rustc-link-lib=dylib=m");
+    
+    println!("cargo:rustc-link-lib=dylib=stdc++");
+}
+
+pub fn deno_embedded_eval(code: &str) -> i32 {
+    let c_code = CString::new(code).expect("CString conversion failed");
+
+    unsafe extern "C" {
+        fn deno_embedded_eval(code: *const c_char) -> i32;
+    }
+
+    unsafe {
+        deno_embedded_eval(c_code.as_ptr())
+    }
+}


### PR DESCRIPTION
_Note: This is a rough POC that aims to demonstrate a statically linkable "batteries included" Deno library. The intention is to get the team's thoughts and if it's a direction you like, I'm happy to take on the development_

# What is this?

This PR adds two crates to the Deno project
- `libdeno`
  - Provides Deno functionality with a C FFI via a static C library
- `libdeno_bindings`
  - Provides high level Rust bindings for the C FFI
  - Maybe worth splitting into `libdeno_sys` and `libdeno_embeded` for C FFI and high level bindings respectively
- Updates `cli` to re-export initialization circuits
  - This currently duplicates a bunch, but would be refactored if the team likes the direction  

# Why?

Deno is a phenomenal JavaScript runtime and many projects would like to embed Deno functionality into their applications. Use cases for this are;
- FaaS platforms
- Game engines that want to use JavaScript capabilities
- Bundlers
- Databases that offer a JavaScript API for consumers

_Admittedly these are mostly my own personal and professional use cases, haha - but the point still stands_

# Current State

Deno currently exposes several crates, such as`deno_runtime` `deno_core` etc. These crates can be composed by the consumer to build a custom runtime for their use case. 

The challenge is that these crates do not contain the standard library, resolution logic, or Nodejs compatibility. 

An approximation of Deno can be built by manually stitching together crates like `deno_node` `deno_web` and `oxc_resolver`, however the maintenance burden is high and there are often versioning clashes (in the case of bundlers, swc in `deno_ast`).

# What this aims to solve

The idea with this PR is to offer a "batteries included" static C library that can be embedded within a consumer's binary and called to execute JavaScript as needed.

This is language independent, but with a focus on Rust consumers.

A static C library eliminates clashes of crate dependency versions.

This can also be distributed as a dynamic C library (`.so` `.dylib` `.dll`)

# What about customization / ops / snapshots?

Snapshots can be loaded using v8 args.

Deno's ops API might be portable to a C FFI.

Deno supports Node.js's napi - which allows the reuse of the work done on the napi-rs project by a useland library (not self promotion, but I achieved a similar outcome by [combining libnode and napi-rs](https://github.com/alshdavid/edon/tree/main?tab=readme-ov-file#native-extensions) - which I'd love to replace with an embedded Deno library)

# Demo

Example consumer:

```rust
// main.rs

fn main() {
    let exit_code = libdeno_bindings::deno_embedded_eval("console.log(42)");
    println!("Exited with {}", exit_code);
}
```

The idea is to provide the `eval` and `run` commands via an FFI. The API would be expanded to include permissions and flags. This, combined with native extensions via n-api, solves most use cases.

This can later be expanded to allow the direct creation of "Workers" and ideally v8 contexts on a Worker.

Currently the POC only implements `eval` without flags or permissions, but you get the idea.