### PR TITLE
fix(ext/node): unref stdin on pause to allow process exit

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -170,6 +170,7 @@ function _guessStdinType(fd) {
 }
 
 const _read = function (size) {
+  io.stdin?.[io.REF]();
   const p = Buffer.alloc(size || 16 * 1024);
   PromisePrototypeThen(io.stdin?.read(p), (length) => {
     // deno-lint-ignore prefer-primordials
@@ -264,6 +265,8 @@ export const initStdin = (warmup = false) => {
 
   function onpause() {
     if (!stdin._handle) {
+      // This allows the process to exit when stdin is paused.
+      io.stdin?.[io.UNREF]();
       return;
     }
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1147,6 +1147,7 @@
     "parallel/test-sqlite-timeout.js": {},
     "parallel/test-sqlite-transactions.js": {},
     "parallel/test-sqlite-typed-array-and-data-view.js": {},
+    "parallel/test-stdin-child-proc.js": {},
     "parallel/test-stdin-hang.js": {},
     "parallel/test-stdin-pause-resume-sync.js": {},
     "parallel/test-stdin-pause-resume.js": {},


### PR DESCRIPTION
When process.stdin is a pipe without a _handle (PIPE/TCP type), calling pause() did not unref the underlying Deno stdin resource. This caused pending reads to keep the event loop alive, preventing the process from exiting even after stdin was paused.

This fix adds `io.stdin[UNREF]()` in the onpause handler for handleless stdin, and `io.stdin[REF]()` in _read() to re-ref when reading resumes. This matches Node.js behavior where paused stdin does not keep the process alive.

Fixes node_compat test-stdin-child-proc.js timeout.