### PR TITLE
fix(ext/node): read from stdin when spawns node with no args

### DIFF
--- a/ext/node/ops/node_cli_parser.rs
+++ b/ext/node/ops/node_cli_parser.rs
@@ -77,11 +77,7 @@ pub fn op_node_translate_cli_args(
   // `node` with no args reads and executes piped stdin.
   if args.is_empty() {
     return Ok(TranslatedArgs {
-      deno_args: vec![
-        "run".to_string(),
-        "-A".to_string(),
-        "-".to_string(),
-      ],
+      deno_args: vec!["run".to_string(), "-A".to_string(), "-".to_string()],
       node_options: vec![],
       needs_npm_process_state: script_in_npm_package,
     });

--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -170,7 +170,6 @@ function _guessStdinType(fd) {
 }
 
 const _read = function (size) {
-  io.stdin?.[io.REF]();
   const p = Buffer.alloc(size || 16 * 1024);
   PromisePrototypeThen(io.stdin?.read(p), (length) => {
     // deno-lint-ignore prefer-primordials
@@ -265,8 +264,6 @@ export const initStdin = (warmup = false) => {
 
   function onpause() {
     if (!stdin._handle) {
-      // This allows the process to exit when stdin is paused.
-      io.stdin?.[io.UNREF]();
       return;
     }
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1147,7 +1147,6 @@
     "parallel/test-sqlite-timeout.js": {},
     "parallel/test-sqlite-transactions.js": {},
     "parallel/test-sqlite-typed-array-and-data-view.js": {},
-    "parallel/test-stdin-child-proc.js": {},
     "parallel/test-stdin-hang.js": {},
     "parallel/test-stdin-pause-resume-sync.js": {},
     "parallel/test-stdin-pause-resume.js": {},


### PR DESCRIPTION
When child_process.spawn(process.execPath, []) is used (equivalent to running `node` with no args), the CLI arg translator produced `deno run -A` which fails because no script is specified.

In Node.js, `node` with no args and piped stdin reads and executes the piped code. Adding `-` to the translated args makes Deno read from stdin, matching this behavior.

Enables node_compat test-stdin-script-child.js.