### PR TITLE
fix(ext/web): prevent GC of AbortSignal.any()

### DIFF
--- a/tests/specs/run/abort_signal_any_gc/__test__.jsonc
+++ b/tests/specs/run/abort_signal_any_gc/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "dependent_signal_survives_gc": {
+      "args": "run --v8-flags=--expose-gc main.ts",
+      "output": "ok\n"
+    }
+  }
+}

--- a/tests/specs/run/abort_signal_any_gc/main.ts
+++ b/tests/specs/run/abort_signal_any_gc/main.ts
@@ -1,0 +1,33 @@
+// Regression test: AbortSignal.any() dependent signals must not be GC'd while
+// they have abort listeners and a source timer keeps the event loop alive.
+//
+// The dependent signal from AbortSignal.any() is only held via WeakRef in the
+// source signal's dependentSignals set. Without a strong reference, GC collects
+// it, the abort listener is lost, and the promise never resolves.
+
+declare const gc: (opts?: object) => void;
+
+const ac = new AbortController();
+const { promise, resolve } = Promise.withResolvers<void>();
+
+// Wrap signal creation in a function so the dependent signal is not held
+// on the current stack frame when GC runs.
+function setup() {
+  AbortSignal.any([
+    AbortSignal.timeout(500),
+    ac.signal,
+  ]).addEventListener("abort", () => resolve());
+}
+setup();
+
+// GC must run from a fresh macrotask so the setup() stack frame is fully
+// gone and V8 can see the dependent signal as unreachable (only weak refs).
+setTimeout(() => {
+  gc({ type: "major", execution: "sync" });
+}, 10);
+
+// Without the fix the dependent signal is collected, the abort listener
+// disappears, and this await hangs until the event loop exits with:
+// "Promise resolution is still pending but the event loop has already resolved"
+await promise;
+console.log("ok");


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/32095

Introduced with V8 bump https://github.com/denoland/deno/pull/31873

The new exposed `AbortSignal.any()`, stores dependent signals via `WeakRef` in the source signal's `dependentSignals` set. When the dependent signal is created as a temporary (e.g. `AbortSignal.any([...]).addEventListener("abort", cb)`), there are no strong references to it. V8's GC can collect it, destroying the abort listener and leaving promises unresolvable.

The fix stores a strong reference to dependent signals on the source signal (via an `activeDependents` set) whenever `addEventListener` refs a source timer. The strong reference is cleaned up in `removeEventListener` and `runAbortSteps`.