### PR TITLE
fix(ext/web): recheck state after signaling abort on writable stream

### DIFF
--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -4308,11 +4308,12 @@ function transformStreamUnblockWrite(stream) {
  * @returns {Promise<void>}
  */
 function writableStreamAbort(stream, reason) {
-  const state = stream[_state];
+  let state = stream[_state];
   if (state === "closed" || state === "errored") {
     return PromiseResolve(undefined);
   }
   stream[_controller][_signal][signalAbort](reason);
+  state = stream[_state];
   if (state === "closed" || state === "errored") {
     return PromiseResolve(undefined);
   }
@@ -4325,7 +4326,7 @@ function writableStreamAbort(stream, reason) {
     wasAlreadyErroring = true;
     reason = undefined;
   }
-  /** Deferred<void> */
+  /** @type {Deferred<void>} */
   const deferred = new Deferred();
   stream[_pendingAbortRequest] = {
     deferred,

--- a/tests/wpt/runner/expectation.json
+++ b/tests/wpt/runner/expectation.json
@@ -5329,12 +5329,8 @@
       "invalid-realm.tentative.window.html": false
     },
     "writable-streams": {
-      "aborting.any.html": [
-        "recursive abort() call from abort() aborting signal"
-      ],
-      "aborting.any.worker.html": [
-        "recursive abort() call from abort() aborting signal"
-      ],
+      "aborting.any.html": true,
+      "aborting.any.worker.html": true,
       "bad-strategies.any.html": true,
       "bad-strategies.any.worker.html": true,
       "bad-underlying-sinks.any.html": true,


### PR DESCRIPTION
See the note under [WritableStreamAbort](https://streams.spec.whatwg.org/#writable-stream-abort).
