### PR TITLE
tests(node/ext): ignore zlib kmaxlength tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1592,7 +1592,12 @@
     "parallel/test-zlib-brotli-flush.js": {},
     "parallel/test-zlib-brotli-from-brotli.js": {},
     "parallel/test-zlib-brotli-from-string.js": {},
-    // "parallel/test-zlib-brotli-kmaxlength-rangeerror.js": {},
+    "parallel/test-zlib-brotli-kmaxlength-rangeerror.js": {
+      "darwin": false,
+      "linux": false,
+      "windows": false,
+      "reason": "Deno pre-loads polyfills as ESM, so kMaxLength is a live binding that can't be snapshotted like Node.js CJS require"
+    },
     "parallel/test-zlib-brotli.js": {},
     "parallel/test-zlib-close-after-error.js": {},
     "parallel/test-zlib-close-after-write.js": {},
@@ -1621,7 +1626,12 @@
     "parallel/test-zlib-invalid-arg-value-brotli-compress.js": {},
     // "parallel/test-zlib-invalid-input-memory.js": {},
     "parallel/test-zlib-invalid-input.js": {},
-    // "parallel/test-zlib-kmaxlength-rangeerror.js": {},
+    "parallel/test-zlib-kmaxlength-rangeerror.js": {
+      "darwin": false,
+      "linux": false,
+      "windows": false,
+      "reason": "Deno pre-loads polyfills as ESM, so kMaxLength is a live binding that can't be snapshotted like Node.js CJS require"
+    },
     "parallel/test-zlib-maxOutputLength.js": {},
     "parallel/test-zlib-no-stream.js": {},
     "parallel/test-zlib-not-string-or-buffer.js": {},
@@ -1644,7 +1654,12 @@
     "parallel/test-zlib-zstd-flush.js": {},
     "parallel/test-zlib-zstd-from-string.js": {},
     "parallel/test-zlib-zstd-from-zstd.js": {},
-    // "parallel/test-zlib-zstd-kmaxlength-rangeerror.js": {},
+    "parallel/test-zlib-zstd-kmaxlength-rangeerror.js": {
+      "darwin": false,
+      "linux": false,
+      "windows": false,
+      "reason": "Deno pre-loads polyfills as ESM, so kMaxLength is a live binding that can't be snapshotted like Node.js CJS require"
+    },
     "parallel/test-zlib-zstd-pledged-src-size.js": {},
     "parallel/test-zlib-zstd.js": {},
     "parallel/test-zlib.js": {},


### PR DESCRIPTION
Deno pre-loads polyfills as ESM, so kMaxLength is a live binding that can't be snapshotted like Node.js CJS require

Ignore 3 node_compat tests:
- test-zlib-kmaxlength-rangeerror
- test-zlib-brotli-kmaxlength-rangeerror
- test-zlib-zstd-kmaxlength-rangeerror
