### PR TITLE
chore: error when creating error message in lint script

### DIFF
--- a/tools/lint.js
+++ b/tools/lint.js
@@ -382,7 +382,7 @@ async function ensureNoNewTopLevelEntries() {
     throw new Error(
       `New top-level entries detected: ${newEntries.join(", ")}. ` +
         `Only the following top-level entries are allowed: ${
-          allowed.join(", ")
+          Array.from(allowed).join(", ")
         }`,
     );
   }


### PR DESCRIPTION
There is no `.join()` on `Set`.
