### PR TITLE
fix(ext/web): remove QuotaExceededError from DOMException error names table

### DIFF
--- a/ext/web/01_dom_exception.js
+++ b/ext/web/01_dom_exception.js
@@ -82,7 +82,6 @@ const nameToCodeMapping = ObjectCreate(null, {
   NetworkError: { value: NETWORK_ERR },
   AbortError: { value: ABORT_ERR },
   URLMismatchError: { value: URL_MISMATCH_ERR },
-  QuotaExceededError: { value: QUOTA_EXCEEDED_ERR },
   TimeoutError: { value: TIMEOUT_ERR },
   InvalidNodeTypeError: { value: INVALID_NODE_TYPE_ERR },
   DataCloneError: { value: DATA_CLONE_ERR },

--- a/tests/unit/dom_exception_test.ts
+++ b/tests/unit/dom_exception_test.ts
@@ -30,3 +30,11 @@ Deno.test(function hasStackAccessor() {
   assert(typeof desc.get === "function");
   assert(typeof desc.set === "function");
 });
+
+Deno.test(function quotaExceededErrorCodeIsZero() {
+  // Per https://github.com/whatwg/webidl/pull/1465, QuotaExceededError is no
+  // longer in the DOMException error names table, so its code should be 0.
+  const e = new DOMException("test", "QuotaExceededError");
+  assertEquals(e.code, 0);
+  assertEquals(e.name, "QuotaExceededError");
+});


### PR DESCRIPTION
## Description

Per [whatwg/webidl#1465](https://github.com/whatwg/webidl/pull/1465), `QuotaExceededError` has been updated from a legacy DOMException name to a proper DOMException subclass. This PR implements the minimal change: removing `QuotaExceededError` from the error names table so that its `.code` returns `0` instead of `22`, aligning with the updated WebIDL spec.

## Changes

- Removed `QuotaExceededError` entry from `nameToCodeMapping` in `ext/web/01_dom_exception.js`
- Added unit test verifying `new DOMException('msg', 'QuotaExceededError').code === 0`

## Testing

Added a test in `tests/unit/dom_exception_test.ts` that asserts the new behavior.

Fixes #30028