### PR TITLE
fix(ext/node): propagate ref/unref to child process stdio streams

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -599,10 +599,28 @@ export class ChildProcess extends EventEmitter {
 
   ref() {
     this.#process.ref();
+    if (this.stdout && typeof this.stdout.ref === "function") {
+      this.stdout.ref();
+    }
+    if (this.stderr && typeof this.stderr.ref === "function") {
+      this.stderr.ref();
+    }
+    if (this.stdin && typeof this.stdin.ref === "function") {
+      this.stdin.ref();
+    }
   }
 
   unref() {
     this.#process.unref();
+    if (this.stdout && typeof this.stdout.unref === "function") {
+      this.stdout.unref();
+    }
+    if (this.stderr && typeof this.stderr.unref === "function") {
+      this.stderr.unref();
+    }
+    if (this.stdin && typeof this.stdin.unref === "function") {
+      this.stdin.unref();
+    }
   }
 
   async #_waitForChildStreamsToClose() {

--- a/tests/specs/test/preload_child_process_unref/__test__.jsonc
+++ b/tests/specs/test/preload_child_process_unref/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "test --allow-all --preload=preload.ts test.ts",
+  "exitCode": 0,
+  "output": "test.out"
+}

--- a/tests/specs/test/preload_child_process_unref/preload.ts
+++ b/tests/specs/test/preload_child_process_unref/preload.ts
@@ -1,0 +1,10 @@
+import { spawn } from "node:child_process";
+
+// Any long-running process works — using "cat" for simplicity
+const child = spawn("cat", [], { stdio: "pipe" });
+
+child.stdout?.on("data", () => {});
+child.stderr?.on("data", () => {});
+child.unref(); // Should allow the event loop to proceed, not hang the preload
+
+console.log("preload done");

--- a/tests/specs/test/preload_child_process_unref/test.out
+++ b/tests/specs/test/preload_child_process_unref/test.out
@@ -1,0 +1,12 @@
+[WILDCARD]------- pre-test output -------
+preload done
+----- pre-test output end -----
+running 1 test from ./test.ts
+should run ...
+------- output -------
+test executed
+----- output end -----
+should run ... ok ([WILDCARD])
+
+ok | 1 passed | 0 failed ([WILDCARD])
+

--- a/tests/specs/test/preload_child_process_unref/test.ts
+++ b/tests/specs/test/preload_child_process_unref/test.ts
@@ -1,0 +1,3 @@
+Deno.test("should run", () => {
+  console.log("test executed");
+});


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/32122

`ChildProcess.unref()` now also unrefs stdout, stderr, and stdin streams, so their pending read/write ops no longer keep the event loop alive.
`ChildProcess.ref()` correspondingly re-refs the stdio streams.
