### PR TITLE
ci: report passing-but-not-enabled tests in Slack thread

### DIFF
--- a/tests/node_compat/slack.ts
+++ b/tests/node_compat/slack.ts
@@ -470,7 +470,10 @@ async function main() {
           console.log("Unenabled passing thread posted:", unenableResult);
         }
       } catch (unenableError) {
-        console.error("Failed to post unenabled passing thread:", unenableError);
+        console.error(
+          "Failed to post unenabled passing thread:",
+          unenableError,
+        );
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Adds a second thread message to the daily node_compat Slack report listing tests that are passing but not yet enabled in `config.jsonc`
- Tests passing on all 3 platforms are sorted first, making it easy to spot low-hanging fruit for enabling
- Uses `@std/jsonc` to properly parse the config file (handles comments and trailing commas)
- Capped at 50 entries to keep the message readable
- No changes to the CI workflow needed — `config.jsonc` is already available in the checkout

## Test plan
- [x] Verified JSONC parsing against actual `config.jsonc` (1419 enabled tests parsed correctly)
- [x] `deno check` passes (only pre-existing type errors remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)