### PR TITLE
fix(test): throw when Deno.test() is called during test execution

### DIFF
--- a/cli/ops/testing.rs
+++ b/cli/ops/testing.rs
@@ -132,7 +132,7 @@ fn op_register_test(
   };
   state
     .borrow_mut::<TestContainer>()
-    .register(description, function);
+    .register(description, function)?;
   ret_buf.copy_from_slice(&(id as u32).to_le_bytes());
   Ok(())
 }

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -859,6 +859,11 @@ declare namespace Deno {
    *
    * `fn` can be async if required.
    *
+   * Tests are discovered before they are executed, so registrations must happen
+   * at module load time.
+   * Nested `Deno.test()` calls are not supported.
+   * Use `t.step()` for nested tests.
+   *
    * ```ts
    * import { assertEquals } from "jsr:@std/assert";
    *

--- a/tests/unit_node/_fs/_fs_open_test.ts
+++ b/tests/unit_node/_fs/_fs_open_test.ts
@@ -397,15 +397,13 @@ Deno.test("[std/node/fs] open callback isn't called twice if error is thrown", a
       await Deno.remove(tempFile);
     },
   });
+});
 
-  Deno.test({
-    name: "SYNC: open file with flag set to 0 (readonly)",
-    fn() {
-      const file = Deno.makeTempFileSync();
-      const fd = openSync(file, 0);
-      closeSync(fd);
-    },
-  });
+Deno.test("SYNC: open file with flag set to 0 (readonly)", async () => {
+  const file = Deno.makeTempFileSync();
+  const fd = openSync(file, 0);
+  closeSync(fd);
+  await Deno.remove(file);
 });
 
 Deno.test("[std/node/fs] openSync with custom flag", {


### PR DESCRIPTION
Fixes #30787.

`Deno.test()` was being accepted even when called from inside a running test callback.  
That means nested registrations could silently be ignored and tests looked like they passed.

Now `Deno.test()` calls made from inside a running test are rejected immediately.  
Instead of silently registering too late, they fail with a clear error:

`Nested Deno.test() calls are not supported. Use t.step() for nested tests.`

This makes the misuse explicit and points users to `t.step()`.

<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->
