### PR TITLE
ci: fix mtime cache for node types

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -165,7 +165,8 @@ fn process_node_types(out_dir: &Path) {
   paths.sort();
 
   for path in &paths {
-    // print for each path so the mtime cache works
+    // print for each path instead of directory because
+    // the mtime cache works off files and not directories
     println!("cargo:rerun-if-changed={}", path.display());
   }
 


### PR DESCRIPTION
The CI was rebuilding due to the node types directory being watched and the mtimes cache not working with directories.

```
Run cargo build --locked --bin deno --bin denort --bin test_server --features=panic-trace
  15.297276208s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint: stale: changed "/Users/runner/work/deno/deno/cli/tsc/dts/node"
  15.297321958s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint:           (vs) "/Users/runner/work/deno/deno/target/debug/build/deno-3151f796994529d1/output"
  15.297324208s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint:                FileTime { seconds: 1771300770, nanos: 797632922 } < FileTime { seconds: 1771301233, nanos: 428111987 }
  15.441707666s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint: fingerprint dirty for deno v2.6.9 (/Users/runner/work/deno/deno/cli)/Build/TargetInner { name: "deno", ..: with_path("/Users/runner/work/deno/deno/cli/main.rs", Edition2024) }
  15.441754291s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint:     dirty: FsStatusOutdated(StaleDepFingerprint { name: "deno" })
  15.518314166s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint: fingerprint dirty for deno v2.6.9 (/Users/runner/work/deno/deno/cli)/Build/TargetInner { name_inferred: true, ..: lib_target("deno", ["lib"], "/Users/runner/work/deno/deno/cli/lib.rs", Edition2024) }
  15.518365458s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="deno"}: cargo::core::compiler::fingerprint:     dirty: FsStatusOutdated(StaleDepFingerprint { name: "build_script_build" })
  15.521291208s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="build-script-build"}: cargo::core::compiler::fingerprint: fingerprint dirty for deno v2.6.9 (/Users/runner/work/deno/deno/cli)/RunCustomBuild/TargetInner { ..: custom_build_target("build-script-build", "/Users/runner/work/deno/deno/cli/build.rs", Edition2024) }
  15.521307750s  INFO prepare_target{force=false package_id=deno v2.6.9 (/Users/runner/work/deno/deno/cli) target="build-script-build"}: cargo::core::compiler::fingerprint:     dirty: FsStatusOutdated(StaleItem(ChangedFile { reference: "/Users/runner/work/deno/deno/target/debug/build/deno-3151f796994529d1/output", reference_mtime: FileTime { seconds: 1771300770, nanos: 797632922 }, stale: "/Users/runner/work/deno/deno/cli/tsc/dts/node", stale_mtime: FileTime { seconds: 1771301233, nanos: 428111987 } }))
   Compiling deno v2.6.9 (/Users/runner/work/deno/deno/cli)
    Finished `dev` profile [unoptimized] target(s) in 1m 54s
```