### PR TITLE
feat(task): turn off failglob by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "deno_task_shell"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078f9f536187d5bdf536104c139aeb49d23a3bbc2b6f23626fa04487bd819615"
+checksum = "29499442dc26a6c025b29beb9ba889d9fd6c9bbbd28a65eab25031c935965846"
 dependencies = [
  "anyhow",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ deno_media_type = { version = "=0.4.0", features = ["module_specifier"] }
 deno_native_certs = "0.3.0"
 deno_path_util = "=0.6.4"
 deno_semver = "=0.9.1"
-deno_task_shell = "=0.28.0"
+deno_task_shell = "=0.29.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"


### PR DESCRIPTION
* https://github.com/denoland/deno_task_shell/pull/168

This is technically a breaking change, but should mostly be ok because it means less stuff will error by default.

It can be turned back on with `shopt -s failglob`.

Closes https://github.com/denoland/deno/issues/31936