### PR TITLE
fix(node/crypto): Cipheriv construction fails when it is the first thing to be added to the resource table

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -216,9 +216,6 @@ export class Cipheriv extends Transform implements Cipher {
       !(cipher == "aes-128-gcm" || cipher == "aes-256-gcm" ||
         cipher == "aes-128-ctr" || cipher == "aes-192-ctr" ||
         cipher == "aes-256-ctr");
-    if (this.#context == 0) {
-      throw new TypeError("Unknown cipher");
-    }
   }
 
   final(encoding: string = getDefaultEncoding()): Buffer | string {


### PR DESCRIPTION
`op_node_create_cipheriv` returns either an error, or the index in the resource_table, which can be 0.
The problem is that the Cipheriv constructor considers 0 an error condition, which is not.

Since the error "Unknown cipher" is already taken into account in the `op_node_create_cipheriv`, this code can just be removed.

Note that I could not find any related problem in the bug tracker, and most likely in a "real world" scenario it just works because the op will never be the first one being run. Nevertheless, it should be fixed.