### PR TITLE
fix(lsp): qualify diagnostic source and message from tsgo

### DIFF
--- a/cli/lsp/tsgo.rs
+++ b/cli/lsp/tsgo.rs
@@ -886,6 +886,16 @@ impl TsGoServerInner {
   }
 }
 
+fn qualify_tsgo_diagnostic(diagnostic: &mut lsp::Diagnostic) {
+  diagnostic.source = Some("deno-ts".to_string());
+  if let Some(lsp::NumberOrString::Number(code)) = &diagnostic.code {
+    diagnostic.message = crate::tsc::go::maybe_rewrite_message(
+      std::mem::take(&mut diagnostic.message),
+      *code as _,
+    );
+  }
+}
+
 #[derive(Debug)]
 pub struct TsGoServer {
   deno_dir: DenoDir,
@@ -1013,6 +1023,9 @@ impl TsGoServer {
           };
           !IGNORED_DIAGNOSTIC_CODES.contains(&(*code as _))
         });
+      for diagnostic in &mut report.full_document_diagnostic_report.items {
+        qualify_tsgo_diagnostic(diagnostic);
+      }
     }
     Ok(report)
   }

--- a/cli/tsc/go.rs
+++ b/cli/tsc/go.rs
@@ -164,7 +164,7 @@ fn diagnostic_category(category: &str) -> super::DiagnosticCategory {
   }
 }
 
-fn maybe_rewrite_message(message: String, code: u64) -> String {
+pub fn maybe_rewrite_message(message: String, code: u64) -> String {
   if code == 2304 && message.starts_with("Cannot find name 'Deno'") {
     r#"Cannot find name 'Deno'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'deno.ns' or add a triple-slash directive to the top of your entrypoint (main file): /// <reference lib="deno.ns" />"#.to_string()
   } else if code == 2581 {

--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 //
-mod go;
+pub mod go;
 mod js;
 
 use std::collections::HashMap;

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17415,8 +17415,8 @@ fn lsp_workspace_compiler_options_root_dirs() {
   client.shutdown();
 }
 
-#[test(timeout = 300)]
-fn lsp_tsconfig_scopes() {
+#[test(timeout = 300, fork_with_suffix = "_tsgo")]
+fn lsp_tsconfig_scopes(use_tsgo: bool) {
   let context = TestContextBuilder::new()
     .use_http_server()
     .use_temp_cwd()
@@ -17444,7 +17444,7 @@ fn lsp_tsconfig_scopes() {
     .to_string(),
   );
   let file2 = temp_dir.source_file("project2/file.ts", "Deno;\ndocument;\n");
-  let mut client = context.new_lsp_command().build();
+  let mut client = context.new_lsp_command().set_use_tsgo(use_tsgo).build();
   client.initialize_default();
   client.did_open_file(&file1);
   let diagnostics = client.did_open_file(&file2);

--- a/tests/util/lib/lsp.rs
+++ b/tests/util/lib/lsp.rs
@@ -540,6 +540,19 @@ impl LspClientBuilder {
     self
   }
 
+  pub fn set_use_tsgo(mut self, use_tsgo: bool) -> Self {
+    if use_tsgo {
+      self
+        .envs
+        .insert("DENO_UNSTABLE_TSGO_LSP".into(), "1".into());
+    } else {
+      self
+        .envs
+        .remove("DENO_UNSTABLE_TSGO_LSP".as_ref() as &OsStr);
+    }
+    self
+  }
+
   pub fn build(&self) -> LspClient {
     self.build_result().unwrap()
   }


### PR DESCRIPTION
Also adds a forking option to the test macro to conveniently run each test again with the typescript-go backend:

---

<img width="1010" height="384" alt="image" src="https://github.com/user-attachments/assets/dd2ae427-c802-4f2d-9193-b7755f8e42d6" />

---

<img width="941" height="150" alt="image" src="https://github.com/user-attachments/assets/67e15340-061d-47cb-b2d8-fce132701bf6" />