### PR TITLE
ci: declare explicit permissions across release and compatibility workflows

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -2,6 +2,8 @@ name: cargo_publish
 
 on: workflow_dispatch
 
+permissions: {}
+
 # Ensures only one publish is running at a time
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ecosystem_compat_test.yml
+++ b/.github/workflows/ecosystem_compat_test.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 10 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: '${{ matrix.runner }}'

--- a/.github/workflows/node_compat_test.yml
+++ b/.github/workflows/node_compat_test.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 10 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: '${{ matrix.runner }}'

--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   update-dl-version:
     name: update dl.deno.land version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+permissions: {}
+
 # WARNING: This workflow runs in the context of the base repository so the
 # GITHUB_TOKEN it has access to has full write permissions to the repository.
 jobs:

--- a/.github/workflows/start_release.yml
+++ b/.github/workflows/start_release.yml
@@ -13,6 +13,9 @@ on:
           - major
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: start release

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -14,6 +14,8 @@ on:
           - rc
         required: true
 
+permissions: {}
+
 jobs:
   build:
     name: version bump


### PR DESCRIPTION
## Summary\nAdd explicit token permissions to workflows currently relying on implicit defaults:\n\n- `.github/workflows/cargo_publish.yml`\n- `.github/workflows/ecosystem_compat_test.yml`\n- `.github/workflows/node_compat_test.yml`\n- `.github/workflows/post_publish.yml`\n- `.github/workflows/pr.yml`\n- `.github/workflows/start_release.yml`\n- `.github/workflows/version_bump.yml`\n\n## Permission choices\n- Read-only checkout workflows: `contents: read`\n- Workflows using dedicated PAT/service account auth (no default token needed): `permissions: {}`\n\n## Why\nThis follows least-privilege guidance and makes the intended auth model explicit while preserving current behavior.\n\n## Notes\n- configuration-only change\n- no release/test logic changes\n