### PR TITLE
fix(ext/node): support ipv6 host in `node:http`

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -98,8 +98,12 @@ import { methods as METHODS } from "node:_http_common";
 import { deprecate } from "node:util";
 
 const { internalRidSymbol } = core;
-const { ArrayIsArray, StringPrototypeToLowerCase, SafeArrayIterator } =
-  primordials;
+const {
+  ArrayIsArray,
+  StringPrototypeIncludes,
+  StringPrototypeToLowerCase,
+  SafeArrayIterator,
+} = primordials;
 
 type Chunk = string | Buffer | Uint8Array;
 
@@ -969,9 +973,9 @@ class ClientRequest extends OutgoingMessage {
       path = "/" + path;
     }
     const url = new URL(
-      `${protocol}//${auth ? `${auth}@` : ""}${host}${
-        port === 80 ? "" : `:${port}`
-      }${path}`,
+      `${protocol}//${auth ? `${auth}@` : ""}${
+        StringPrototypeIncludes(host, ":") ? `[${host}]` : host
+      }${port === 80 ? "" : `:${port}`}${path}`,
     );
     url.hash = hash;
     return url.href;


### PR DESCRIPTION
Closes #21864. Full reproduction of the bug:

```ts
import { once } from "node:events";
import { request } from "node:http";

await using _server = Deno.serve({ hostname: "::1" }, () => new Response());
const req = request("http://[::1]:8000").end();
const [res] = await once(req, "response");
console.log(res.statusCode); // should print `200`
```
