### PR TITLE
fix(ext/node): provide CJS globals in worker_threads eval mode

### DIFF
--- a/tests/specs/node/worker_threads/__test__.jsonc
+++ b/tests/specs/node/worker_threads/__test__.jsonc
@@ -35,6 +35,12 @@
       },
       "output": "message_port_unref.out",
       "exitCode": 0
+    },
+    "eval_cjs_require": {
+      // Test for https://github.com/denoland/deno/issues/27181
+      "args": "run --quiet eval_cjs_require.mjs",
+      "output": "ok\n",
+      "exitCode": 0
     }
   }
 }

--- a/tests/specs/node/worker_threads/eval_cjs_require.mjs
+++ b/tests/specs/node/worker_threads/eval_cjs_require.mjs
@@ -1,0 +1,17 @@
+import { Worker } from "node:worker_threads";
+import { once } from "node:events";
+
+// Test that eval workers can use require() (CJS globals),
+// matching Node.js behavior where eval code runs as CommonJS.
+// See https://github.com/denoland/deno/issues/27181
+const worker = new Worker(
+  `
+const { parentPort } = require("worker_threads");
+parentPort.postMessage("ok");
+`,
+  { eval: true },
+);
+
+const [msg] = await once(worker, "message");
+console.log(msg);
+worker.terminate();


### PR DESCRIPTION
## Summary
- When using `new Worker(code, { eval: true })` in `node:worker_threads`, Node.js evaluates the code as CommonJS, making `require()` available. Deno was wrapping the code in a `data:text/javascript` URL (ESM), causing `require is not defined` errors.
- Wraps eval worker code with CJS globals (`require`, `__filename`, `__dirname`, `module`, `exports`) by prepending ESM imports from `node:module` and `node:process`.
- Adds a spec test verifying `require("worker_threads")` works in eval workers.

Closes #27181
Closes #27167

## Test plan
- [x] New spec test `eval_cjs_require` passes — creates an eval worker using `require("worker_threads")` and verifies it can communicate back via `parentPort`
- [x] All existing `worker_threads` spec tests continue to pass
- [x] Manually verified the exact reproduction from the issue works

🤖 Generated with [Claude Code](https://claude.com/claude-code)