### PR TITLE
fix(ext/node): support URL in child_process.fork modulePath

### DIFF
--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -45,6 +45,7 @@ import {
   convertToValidSignal,
   kEmptyObject,
 } from "ext:deno_node/internal/util.mjs";
+import { toPathIfFileURL } from "ext:deno_node/internal/url.ts";
 import { kNeedsNpmProcessState } from "ext:deno_process/40_process.js";
 
 const {
@@ -69,10 +70,11 @@ type ForkOptions = ChildProcessOptions;
  * @returns
  */
 export function fork(
-  modulePath: string,
+  modulePath: string | URL,
   _args?: string[],
   _options?: ForkOptions,
 ) {
+  modulePath = toPathIfFileURL(modulePath) as string;
   validateString(modulePath, "modulePath");
   validateNullByteNotInArg(modulePath, "modulePath");
 

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -537,6 +537,32 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "[node/child_process] child_process.fork with URL",
+  async fn() {
+    const testdataDir = path.join(
+      path.dirname(path.fromFileUrl(import.meta.url)),
+      "testdata",
+    );
+    const script = path.join(
+      testdataDir,
+      "node_modules",
+      "foo",
+      "index.js",
+    );
+    const scriptUrl = path.toFileUrl(script);
+    const p = Promise.withResolvers<void>();
+    const cp = CP.fork(scriptUrl, [], { cwd: testdataDir, stdio: "pipe" });
+    let output = "";
+    cp.on("close", () => p.resolve());
+    cp.stdout?.on("data", (data) => {
+      output += data;
+    });
+    await p.promise;
+    assertEquals(output, "foo\ntrue\ntrue\ntrue\n");
+  },
+});
+
 Deno.test("[node/child_process execFileSync] 'inherit' stdout and stderr", () => {
   execFileSync(Deno.execPath(), ["--help"], { stdio: "inherit" });
 });


### PR DESCRIPTION
## Summary
- Adds support for passing `URL` objects as the `modulePath` argument to `child_process.fork()`, matching Node.js behavior
- Converts URL to file path using `toPathIfFileURL()` before string validation
- Adds unit test for `fork()` with a URL argument

Closes #28137

## Test plan
- [x] `cargo test child_process_test` passes
- [x] Manual test with `a.mjs` / `b.js` reproduction from the issue works

🤖 Generated with [Claude Code](https://claude.com/claude-code)