### PR TITLE
chore(runtime): correct typo in run permissions comment

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -2585,7 +2585,7 @@ pub enum RunDescriptorArg {
 }
 
 pub enum AllowRunDescriptorParseResult {
-  /// An error occured getting the descriptor that should
+  /// An error occurred getting the descriptor that should
   /// be surfaced as a warning when launching deno, but should
   /// be ignored when creating a worker.
   Unresolved(Box<which::Error>),


### PR DESCRIPTION
## Summary
- fix a typo in a permissions parser comment: `occured` -> `occurred`.

## Why
Small cleanup that improves readability in the runtime permissions code.
