### PR TITLE
fix(node/buffer): fix latin1Slice and hexSlice returning wrong results

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -1011,16 +1011,12 @@ Buffer.prototype.hexWrite = function hexWrite(string, offset, length) {
   );
 };
 
-Buffer.prototype.hexSlice = function hexSlice(string, offset, length) {
-  return _hexSlice(this, string, offset, length);
+Buffer.prototype.hexSlice = function hexSlice(offset, length) {
+  return _hexSlice(this, offset, length);
 };
 
-Buffer.prototype.latin1Slice = function latin1Slice(
-  string,
-  offset,
-  length,
-) {
-  return _latin1Slice(this, string, offset, length);
+Buffer.prototype.latin1Slice = function latin1Slice(offset, length) {
+  return _latin1Slice(this, offset, length);
 };
 
 Buffer.prototype.latin1Write = function latin1Write(
@@ -1192,7 +1188,12 @@ function _utf8Slice(buf, start, end) {
 
 function _latin1Slice(buf, start, end) {
   let ret = "";
-  end = MathMin(buf.length, end);
+  if (!start || start < 0) {
+    start = 0;
+  }
+  if (end === undefined || end > buf.length) {
+    end = buf.length;
+  }
   for (let i = start; i < end; ++i) {
     ret += StringFromCharCode(buf[i]);
   }

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -717,3 +717,24 @@ Deno.test({
     assertEquals(file instanceof Blob, true);
   },
 });
+
+Deno.test({
+  name: "[node/buffer] latin1Slice returns correct string",
+  fn() {
+    // deno-lint-ignore no-explicit-any
+    const buf: any = Buffer.of(1, 2, 3, 0xff);
+    assertEquals(buf.latin1Slice().length, 4);
+    assertEquals(buf.latin1Slice(), "\x01\x02\x03\xff");
+    assertEquals(buf.latin1Slice(1, 3), "\x02\x03");
+  },
+});
+
+Deno.test({
+  name: "[node/buffer] hexSlice returns correct string",
+  fn() {
+    // deno-lint-ignore no-explicit-any
+    const buf: any = Buffer.of(1, 2, 3, 0xff);
+    assertEquals(buf.hexSlice(), "010203ff");
+    assertEquals(buf.hexSlice(1, 3), "0203");
+  },
+});


### PR DESCRIPTION
## Summary
- Fix `Buffer.prototype.latin1Slice` and `Buffer.prototype.hexSlice` having an extraneous `string` parameter that shifted all arguments passed to the underlying `_latin1Slice`/`_hexSlice` functions
- Fix `_latin1Slice` not handling missing `start`/`end` arguments, causing it to return empty strings when called with no arguments
- Add unit tests for both methods

Fixes #32276

## Test plan
- [x] `cargo test unit_node::buffer_test` passes
- [x] Manually verified `Buffer.of(1,2,3,0xff).latin1Slice()` returns a 4-character string (previously returned empty string)
- [x] Manually verified `hexSlice()` and `hexSlice(start, end)` return correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)