### PR TITLE
fix(install): use DENO_INSTALL_ROOT directly without appending bin

### DIFF
--- a/cli/tools/installer/global.rs
+++ b/cli/tools/installer/global.rs
@@ -735,10 +735,19 @@ fn get_installer_bin_dir(
     get_installer_root()?
   };
 
-  Ok(if !root.ends_with("bin") {
-    root.join("bin")
-  } else {
+  Ok(if root_flag.is_some() {
+    // User specified --root: apply bin logic
+    if !root.ends_with("bin") {
+      root.join("bin")
+    } else {
+      root
+    }
+  } else if env::var_os("DENO_INSTALL_ROOT").is_some_and(|v| !v.is_empty()) {
+    // DENO_INSTALL_ROOT is set: use directly as installation dir (no append)
     root
+  } else {
+    // Default: get_installer_root returns $HOME/.deno, append /bin
+    root.join("bin")
   })
 }
 

--- a/tests/integration/install_tests.rs
+++ b/tests/integration/install_tests.rs
@@ -196,7 +196,7 @@ fn install_custom_dir_env_var() {
     .skip_output_check()
     .assert_exit_code(0);
 
-  let mut file_path = temp_dir.path().join("bin/echo_test");
+  let mut file_path = temp_dir.path().join("echo_test");
   assert!(file_path.exists());
 
   if cfg!(windows) {
@@ -207,7 +207,6 @@ fn install_custom_dir_env_var() {
   // shim should point to a per-command config
   let config_path = temp_dir
     .path()
-    .join("bin")
     .canonicalize()
     .join(".echo_test")
     .join("deno.json");


### PR DESCRIPTION
﻿Fixes #26442

## Problem

The documentation states that DENO_INSTALL_ROOT defaults to $HOME/.deno/bin. However, get_installer_root() returns $HOME/.deno (without /bin), and /bin is appended later in get_installer_bin_dir().

When a user sets DENO_INSTALL_ROOT=$HOME/.deno/bin (matching the documented default), packages were incorrectly installed to $HOME/.deno/bin/bin because the code appended /bin again.

## Solution

When DENO_INSTALL_ROOT is set, use its value directly as the installation directory without appending /bin. This aligns with user expectations: the env var specifies the exact directory where executables should be installed.

- Default (env var not set): get_installer_root() returns $HOME/.deno, and we append /bin to get $HOME/.deno/bin
- Env var set (e.g. $HOME/.deno/bin): Use the value directly as $HOME/.deno/bin

The --root flag behavior is unchanged: it still applies bin logic (append /bin if the path doesn't already end with bin).
