### PR TITLE
fix(ext/node): enable test-zlib-invalid-input-memory and test-zlib-un…

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2,6 +2,12 @@
   "tests": {
     "abort/test-addon-register-signal-handler.js": {},
     "abort/test-addon-uv-handle-leak.js": {},
+    "abort/test-zlib-invalid-internals-usage.js": {
+      "darwin": false,
+      "linux": false,
+      "windows": false,
+      "reason": "Tests Node.js internal C++ binding (internalBinding('zlib').Zlib) which is not implemented in Deno"
+    },
     "es-module/test-cjs-prototype-pollution.js": {},
     "es-module/test-esm-assert-strict.mjs": {},
     "es-module/test-esm-child-process-fork-main.mjs": {},
@@ -1649,7 +1655,7 @@
     "parallel/test-zlib-from-gzip.js": {},
     "parallel/test-zlib-from-string.js": {},
     "parallel/test-zlib-invalid-arg-value-brotli-compress.js": {},
-    // "parallel/test-zlib-invalid-input-memory.js": {},
+    "parallel/test-zlib-invalid-input-memory.js": {},
     "parallel/test-zlib-invalid-input.js": {},
     "parallel/test-zlib-kmaxlength-rangeerror.js": {
       "darwin": false,
@@ -1668,7 +1674,7 @@
     "parallel/test-zlib-sync-no-event.js": {},
     "parallel/test-zlib-truncated.js": {},
     "parallel/test-zlib-type-error.js": {},
-    // "parallel/test-zlib-unused-weak.js": {},
+    "parallel/test-zlib-unused-weak.js": {},
     "parallel/test-zlib-unzip-one-byte-chunks.js": {},
     "parallel/test-zlib-write-after-close.js": {},
     "parallel/test-zlib-write-after-end.js": {},

--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -467,6 +467,9 @@ fn parse_flags(source: &str) -> (Vec<String>, Vec<String>) {
           "--expose-gc" => {
             v8_flags.push("--expose-gc".to_string());
           }
+          "--no-concurrent-array-buffer-sweeping" => {
+            v8_flags.push("--no-concurrent-array-buffer-sweeping".to_string());
+          }
           "--no-warnings" => {
             node_options.push("--no-warnings".to_string());
           }


### PR DESCRIPTION
  Fixes two previously disabled zlib Node.js compatibility tests.

  - **`parallel/test-zlib-invalid-input-memory.js`** — enabled and passing.
    Root cause was a two-layer problem:
    1. `AsyncResource` in `async_hooks.ts` did not call `emitInit()` in its constructor, so `createHook({ init })` callbacks never fired for `AsyncResource` instances. The test's `init` hook assumed any new async resource was the tracked GC object, and when Deno's streams machinery created `TickObject` resources during error handling, the init callback threw an `AssertionError` from inside a `process.nextTick`, silently swallowing the error event.
    2. In `zlib.js`, `processCallback` skipped calling the Transform write `cb()` when `kError` was set, preventing the stream's destroy sequence from running and thus the error event from being emitted.

  - **`parallel/test-zlib-unused-weak.js`** — enabled and passing. The test passes the V8 flag `--no-concurrent-array-buffer-sweeping` to ensure deterministic GC accounting. Deno's node-compat test runner's `parse_flags` function did not recognise this flag and silently dropped it, so it was never forwarded. Added the flag to `parse_flags` in `mod.rs`.

  - **`abort/test-zlib-invalid-internals-usage.js`** — added to `config.jsonc` as disabled. This test uses `internalBinding('zlib').Zlib` (a Node.js C++ internal) which Deno does not implement and cannot reasonably emulate.