### PR TITLE
feat(ext/bundle): Add `--keep-names` flag

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -591,6 +591,7 @@ pub struct BundleFlags {
   pub external: Vec<String>,
   pub format: BundleFormat,
   pub minify: bool,
+  pub keep_names: bool,
   pub code_splitting: bool,
   pub inline_imports: bool,
   pub packages: PackageHandling,
@@ -2533,6 +2534,12 @@ If no output file is given, the output is written to standard output:
         Arg::new("minify")
           .long("minify")
           .help("Minify the output")
+          .action(ArgAction::SetTrue),
+      )
+      .arg(
+        Arg::new("keep-names")
+          .long("keep-names")
+          .help("Keep function and class names")
           .action(ArgAction::SetTrue),
       )
       .arg(
@@ -6011,6 +6018,7 @@ fn bundle_parse(
     format: matches.remove_one::<BundleFormat>("format").unwrap(),
     packages: matches.remove_one::<PackageHandling>("packages").unwrap(),
     minify: matches.get_flag("minify"),
+    keep_names: matches.get_flag("keep-names"),
     code_splitting: matches.get_flag("code-splitting"),
     inline_imports: matches.get_flag("inline-imports"),
     platform: matches.remove_one::<BundlePlatform>("platform").unwrap(),

--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -1818,6 +1818,10 @@ fn configure_esbuild_flags(
       PackageHandling::Bundle => esbuild_client::PackagesHandling::Bundle,
     });
 
+  if bundle_flags.keep_names {
+    builder.raw_flag("--keep-names");
+  }
+
   if let Some(sourcemap_type) = bundle_flags.sourcemap {
     builder.sourcemap(match sourcemap_type {
       SourceMapType::Linked => esbuild_client::Sourcemap::Linked,

--- a/cli/tools/bundle/provider.rs
+++ b/cli/tools/bundle/provider.rs
@@ -30,6 +30,7 @@ impl From<RtBundleOptions> for crate::args::BundleFlags {
       external: value.external,
       format: value.format,
       minify: value.minify,
+      keep_names: value.keep_names,
       code_splitting: value.code_splitting,
       platform: value.platform,
       watch: false,

--- a/cli/tsc/dts/lib.deno.unstable.d.ts
+++ b/cli/tsc/dts/lib.deno.unstable.d.ts
@@ -75,6 +75,10 @@ declare namespace Deno {
        */
       minify?: boolean;
       /**
+       * Whether to keep function and class names.
+       */
+      keepNames?: boolean;
+      /**
        * Whether to enable code splitting.
        */
       codeSplitting?: boolean;

--- a/ext/bundle/src/lib.rs
+++ b/ext/bundle/src/lib.rs
@@ -68,6 +68,8 @@ pub struct BundleOptions {
   #[from_v8(default)]
   pub minify: bool,
   #[from_v8(default)]
+  pub keep_names: bool,
+  #[from_v8(default)]
   pub code_splitting: bool,
   #[from_v8(default = true)]
   pub inline_imports: bool,


### PR DESCRIPTION
Exposes the esbuild flag `--keep-names` to users of `deno bundle`

Moving forward with this as there has been no response to my questions in the issue so far. If you want to discuss this further, feel free to add your feedback.

Fixes #32109