### PR TITLE
fix(ext/node): remove fs.promises.fstat, not a public Node.js API

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -24,7 +24,7 @@ import { exists, existsSync } from "ext:deno_node/_fs/_fs_exists.ts";
 import { fchmod, fchmodSync } from "ext:deno_node/_fs/_fs_fchmod.ts";
 import { fchown, fchownSync } from "ext:deno_node/_fs/_fs_fchown.ts";
 import { fdatasync, fdatasyncSync } from "ext:deno_node/_fs/_fs_fdatasync.ts";
-import { fstat, fstatPromise, fstatSync } from "ext:deno_node/_fs/_fs_fstat.ts";
+import { fstat, fstatSync } from "ext:deno_node/_fs/_fs_fstat.ts";
 import { fsync, fsyncSync } from "ext:deno_node/_fs/_fs_fsync.ts";
 import { ftruncate, ftruncateSync } from "ext:deno_node/_fs/_fs_ftruncate.ts";
 import { futimes, futimesSync } from "ext:deno_node/_fs/_fs_futimes.ts";
@@ -185,7 +185,6 @@ const promises = {
   lstat: lstatPromise,
   stat: statPromise,
   statfs: statfsPromise,
-  fstat: fstatPromise,
   link: linkPromise,
   unlink: unlinkPromise,
   chmod: chmodPromise,

--- a/ext/node/polyfills/fs/promises.ts
+++ b/ext/node/polyfills/fs/promises.ts
@@ -17,7 +17,6 @@ export const symlink = fsPromises.symlink;
 export const lstat = fsPromises.lstat;
 export const stat = fsPromises.stat;
 export const statfs = fsPromises.statfs;
-export const fstat = fsPromises.fstat;
 export const link = fsPromises.link;
 export const unlink = fsPromises.unlink;
 export const chmod = fsPromises.chmod;


### PR DESCRIPTION
Closes https://github.com/denoland/deno/issues/27423

`fs.promises` in Node.js does not expose `fstat` or other `f`-prefixed APIs. The promise-based equivalent is `FileHandle.stat()`, which is already supported via `handle.ts`.

This removes the erroneous `fs.promises.fstat` export from both `polyfills/fs/promises.ts` and the `promises` object in `polyfills/fs.ts`.
