### PR TITLE
fix(ext/node): make `setAutoPadding(false)` a no-op for GCM ciphers

### DIFF
--- a/ext/node_crypto/cipher.rs
+++ b/ext/node_crypto/cipher.rs
@@ -505,12 +505,6 @@ pub enum DecipherError {
   #[error("Failed to authenticate data")]
   DataAuthenticationFailed,
   #[class(type)]
-  #[error("setAutoPadding(false) not supported for Aes128Gcm yet")]
-  SetAutoPaddingFalseAes128GcmUnsupported,
-  #[class(type)]
-  #[error("setAutoPadding(false) not supported for Aes256Gcm yet")]
-  SetAutoPaddingFalseAes256GcmUnsupported,
-  #[class(type)]
   #[error("Unknown cipher {0}")]
   UnknownCipher(String),
 }
@@ -806,7 +800,7 @@ impl Decipher {
         );
         Ok(())
       }
-      (Aes128Gcm(decipher, auth_tag_length), true) => {
+      (Aes128Gcm(decipher, auth_tag_length), _) => {
         let tag = decipher.finish();
         let tag_slice = tag.as_slice();
         let truncated_tag = if let Some(len) = auth_tag_length {
@@ -820,10 +814,7 @@ impl Decipher {
           Err(DecipherError::DataAuthenticationFailed)
         }
       }
-      (Aes128Gcm(..), false) => {
-        Err(DecipherError::SetAutoPaddingFalseAes128GcmUnsupported)
-      }
-      (Aes256Gcm(decipher, auth_tag_length), true) => {
+      (Aes256Gcm(decipher, auth_tag_length), _) => {
         let tag = decipher.finish();
         let tag_slice = tag.as_slice();
         let truncated_tag = if let Some(len) = auth_tag_length {
@@ -836,9 +827,6 @@ impl Decipher {
         } else {
           Err(DecipherError::DataAuthenticationFailed)
         }
-      }
-      (Aes256Gcm(..), false) => {
-        Err(DecipherError::SetAutoPaddingFalseAes256GcmUnsupported)
       }
       (Aes256Cbc(decryptor), true) => {
         assert_block_len!(input.len(), 16);


### PR DESCRIPTION
## Summary

- GCM is a stream cipher mode that doesn't use block padding. In Node.js, `setAutoPadding()` is a no-op for GCM modes, but Deno was throwing `setAutoPadding(false) not supported for Aes128Gcm/Aes256Gcm yet` when called on GCM deciphers.
- This broke npm packages like `ssh2` that set auto-padding to false by default.
- Merges the `auto_pad=false` arms into the existing `auto_pad=true` arms (using `_` wildcard) for both `Aes128Gcm` and `Aes256Gcm` in `Decipher::final()`, and removes the now-unused error variants.

Closes #29425
Closes #28589