### PR TITLE
fix(node/buffer): fix base64 decoding for strings with hyphens

### DIFF
--- a/ext/node/polyfills/internal_binding/_utils.ts
+++ b/ext/node/polyfills/internal_binding/_utils.ts
@@ -21,8 +21,10 @@ export function base64ToBytes(str: string) {
   try {
     return forgivingBase64Decode(str);
   } catch {
-    str = base64clean(str);
+    // Convert base64url characters to standard base64 before cleaning,
+    // so that the padding logic in base64clean works correctly.
     str = str.replaceAll("-", "+").replaceAll("_", "/");
+    str = base64clean(str);
     return forgivingBase64Decode(str);
   }
 }
@@ -42,7 +44,8 @@ function base64clean(str: string) {
     case 0:
       return str;
     case 1:
-      return `${str}===`;
+      // A single base64 char can't encode a full byte; drop it like Node does
+      return str.substring(0, length - 1);
     case 2:
       return `${str}==`;
     case 3:

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -478,6 +478,26 @@ Deno.test({
   },
 });
 
+// https://github.com/denoland/deno/issues/24908
+Deno.test({
+  name: "[node/buffer] Buffer from base64 with non-base64 characters",
+  fn() {
+    // Strings with hyphens should not throw
+    const buf1 = Buffer.from("base64-encoded-bytes-from-browser", "base64");
+    assertEquals(buf1.length, 24);
+    assertEquals(
+      buf1.toString("hex"),
+      "6dab1eeb8f9e9dca1d79df9bcad7acf9fae89be6eba30b1e",
+    );
+
+    const buf2 = Buffer.from("not-valid-base64!!!", "base64");
+    assertEquals(buf2.length, 12);
+
+    // Single character (too short for base64)
+    assertEquals(Buffer.from("A", "base64").length, 0);
+  },
+});
+
 Deno.test({
   name: "[node/buffer] Buffer to string base64",
   fn() {


### PR DESCRIPTION
## Summary
- Fix `Buffer.from(str, "base64")` throwing on strings containing `-` characters (e.g. `"base64-encoded-bytes-from-browser"`)
- Two bugs in `base64ToBytes` / `base64clean`:
  1. Base64url character replacements (`-`→`+`, `_`→`/`) were applied **after** `base64clean`, so the padding calculation used the wrong string length
  2. `base64clean` appended `===` when `length % 4 == 1`, which is invalid base64 padding — now drops the trailing character to match Node.js behavior

## Test plan
- Added regression test in `tests/unit_node/buffer_test.ts` verifying:
  - `Buffer.from("base64-encoded-bytes-from-browser", "base64")` produces correct output matching Node.js
  - `Buffer.from("not-valid-base64!!!", "base64")` doesn't throw
  - `Buffer.from("A", "base64")` returns empty buffer (single char too short)
- Verified output matches Node.js exactly for all test cases

Closes #24908

🤖 Generated with [Claude Code](https://claude.com/claude-code)