### PR TITLE
fix: honor --fail-fast in --check

### DIFF
--- a/tests/specs/fmt/check_tests/__test__.jsonc
+++ b/tests/specs/fmt/check_tests/__test__.jsonc
@@ -11,6 +11,11 @@
     "fmt_check_ignore": {
       "args": "fmt --check --ignore=regular/formatted1.js regular/",
       "output": "Checked 3 files\n"
+    },
+    "fmt_check_fail_fast": {
+      "args": "fmt --check --fail-fast fail_fast/a.ts fail_fast/b.ts",
+      "output": "fail_fast_check.out",
+      "exitCode": 1
     }
   }
 }

--- a/tests/specs/fmt/check_tests/fail_fast/a.ts
+++ b/tests/specs/fmt/check_tests/fail_fast/a.ts
@@ -1,0 +1,3 @@
+function foo(   ): any   {
+ console.log(  "hello")
+    }

--- a/tests/specs/fmt/check_tests/fail_fast/b.ts
+++ b/tests/specs/fmt/check_tests/fail_fast/b.ts
@@ -1,0 +1,3 @@
+function bar(   ): any   {
+ console.log(  "world")
+    }

--- a/tests/specs/fmt/check_tests/fail_fast_check.out
+++ b/tests/specs/fmt/check_tests/fail_fast_check.out
@@ -1,0 +1,10 @@
+
+from [WILDCARD]a.ts:
+1 | -function foo(   ): any   {
+1 | +function foo(): any {
+2 | - console.log(  "hello")
+2 | +  console.log("hello");
+3 | -    }
+3 | +}
+
+error: Found 1 not formatted file in 1 file


### PR DESCRIPTION
Stop fmt --check as soon as the first formatting error is found, and add a spec to cover fail-fast behavior.

Fixes #26585