### PR TITLE
chore: fix duplicate words in source comments

### DIFF
--- a/libs/lockfile/graphs.rs
+++ b/libs/lockfile/graphs.rs
@@ -276,7 +276,7 @@ impl LockfilePackageGraph {
 
   fn remove_root_pkg_by_id(&mut self, id: &LockfilePkgId) {
     // The ideal goal here is to only disassociate the package
-    // from the root so that the the current dependencies can be
+    // from the root so that the current dependencies can be
     // reused in the new dependency resolution thereby causing
     // minimal changes in the lockfile. After we let deno_npm or
     // deno_graph clean up any stragglers.

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -1853,7 +1853,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
           let new_value = (old_resolved_id.clone(), new_resolved_id.clone());
           match self.graph.moved_package_ids.entry(old_node_id) {
             indexmap::map::Entry::Occupied(occupied_entry) => {
-              // move it the the back of the index map
+              // move it to the back of the index map
               occupied_entry.shift_remove();
               self.graph.moved_package_ids.insert(old_node_id, new_value);
             }


### PR DESCRIPTION
## Summary
- fix duplicated words in two Rust source comments
- no behavioral code changes

## Related issue
- none (small typo/comment cleanup)

## Testing
- CI is running on this PR
- no local test run (comment-only changes)