### PR TITLE
docs: fix duplicated words in test message and comments

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -10417,7 +10417,7 @@ mod tests {
       "--reload=http://deno.land/a,http://deno.land/b",
       "script.ts"
     ]);
-    assert!(r.is_ok(), "should accept accept multiple valid urls");
+    assert!(r.is_ok(), "should accept multiple valid urls");
 
     let r = flags_from_vec(svec![
       "deno",

--- a/cli/lsp/tsc.rs
+++ b/cli/lsp/tsc.rs
@@ -2307,7 +2307,7 @@ impl NavigateToItem {
     }
 
     // The field `deprecated` is deprecated but SymbolInformation does not have
-    // a default, therefore we have to supply the deprecated deprecated
+    // a default, therefore we have to supply the deprecated
     // field. It is like a bad version of Inception.
     #[allow(deprecated)]
     Some(lsp::SymbolInformation {
@@ -2526,7 +2526,7 @@ impl NavigationTree {
         };
 
         // The field `deprecated` is deprecated but DocumentSymbol does not have
-        // a default, therefore we have to supply the deprecated deprecated
+        // a default, therefore we have to supply the deprecated
         // field. It is like a bad version of Inception.
         #[allow(deprecated)]
         document_symbols.push(lsp::DocumentSymbol {


### PR DESCRIPTION
## Summary
- fix duplicated words in one test assertion message and two comments
- no behavioral code changes

## Related issue
- none (minor typo cleanup)

## Testing
- CI will run on this PR
- no local test run for this typo-only update
