### PR TITLE
perf(install): use aws-lc-rs for tarball integrity hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ name = "deno_npm_cache"
 version = "0.53.0"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "boxed_error",
  "deno_cache_dir",

--- a/libs/npm_cache/Cargo.toml
+++ b/libs/npm_cache/Cargo.toml
@@ -31,8 +31,6 @@ parking_lot.workspace = true
 percent-encoding.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sha1.workspace = true
-sha2.workspace = true
 sys_traits.workspace = true
 tar.workspace = true
 thiserror.workspace = true
@@ -41,9 +39,12 @@ url.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 deno_error = { workspace = true, features = ["serde", "serde_json", "tokio"] }
 deno_unsync = { workspace = true, features = ["tokio"] }
+aws-lc-rs.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 flate2 = { workspace = true, features = ["rust_backend"] }
+sha2.workspace = true
+sha1.workspace = true
 
 [dev-dependencies]
 sys_traits = { workspace = true, features = ["real"] }


### PR DESCRIPTION
It's just generally faster at hashing. Small perf improvement but we already use aws-lc-rs elsewhere anyway

```
Benchmark 1: ~/Documents/Code/deno/target/release-lite/deno install
  Time (mean ± σ):      2.373 s ±  0.204 s    [User: 0.927 s, System: 1.002 s]
  Range (min … max):    2.144 s …  2.701 s    10 runs

Benchmark 2: ~/Documents/Code/deno/target/deno-baseline install
  Time (mean ± σ):      2.429 s ±  0.233 s    [User: 0.947 s, System: 1.067 s]
  Range (min … max):    2.218 s …  2.870 s    10 runs

Summary
  ~/Documents/Code/deno/target/release-lite/deno install ran
    1.02 ± 0.13 times faster than ~/Documents/Code/deno/target/deno-baseline inst
```
