### PR TITLE
Update libffi-sys to 4.1.0 and libffi to 5.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6254,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "libffi"
-version = "4.1.2"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0feebbe0ccd382a2790f78d380540500d7b78ed7a3498b68fcfbc1593749a94"
+checksum = "0498fe5655f857803e156523e644dcdcdc3b3c7edda42ea2afdae2e09b2db87b"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -6264,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "3.3.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c6c6e17136d4bc439d43a2f3c6ccf0731cccc016d897473a29791d3c2160c3"
+checksum = "71d4f1d4ce15091955144350b75db16a96d4a63728500122706fb4d29a26afbb"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,8 +418,8 @@ x509-parser = "0.15.0"
 cranelift = "0.116"
 cranelift-native = "0.116"
 dlopen2 = "0.6.1"
-libffi = "=4.1.2"
-libffi-sys = "=3.3.3"
+libffi = "=5.1.0"
+libffi-sys = "=4.1.0"
 memmap2 = "0.9"
 
 # napi


### PR DESCRIPTION
Fixes #32281

Updates libffi-sys from 3.3.3 to 4.1.0, which resolves compilation issues on some systems as reported in the issue. Also updates libffi to 5.1.0 to maintain compatibility with the new libffi-sys version.

This change addresses the compilation failure that occurs with libffi-sys@3.3.3 on certain systems while maintaining the exact version pinning strategy used in the project.