### PR TITLE
fix(ext/websocket): Add missing _remoteCloseCode and _remoteCloseReason symbols to WebSocketStream

### DIFF
--- a/ext/websocket/02_websocketstream.js
+++ b/ext/websocket/02_websocketstream.js
@@ -90,6 +90,8 @@ const _opened = Symbol("[[opened]]");
 const _closed = Symbol("[[closed]]");
 const _earlyClose = Symbol("[[earlyClose]]");
 const _closeSent = Symbol("[[closeSent]]");
+const _remoteCloseCode = Symbol("[[remoteCloseCode]]");
+const _remoteCloseReason = Symbol("[[remoteCloseReason]]");
 class WebSocketStream {
   [_rid];
 
@@ -388,6 +390,8 @@ class WebSocketStream {
   [_earlyClose] = false;
   [_closed] = new Deferred();
   [_closeSent] = new Deferred();
+  [_remoteCloseCode] = null;
+  [_remoteCloseReason] = null;
   get closed() {
     webidl.assertBranded(this, WebSocketStreamPrototype);
     return this[_closed].promise;


### PR DESCRIPTION
Fixes WPT test failure for WebSocketStream remote close code tracking.

The WebSocketStream implementation was missing the `_remoteCloseCode` and `_remoteCloseReason` private symbols that track remote close information. This caused the WPT test 'remote code and reason should be used' to fail.

**Changes:**
- Added `_remoteCloseCode` and `_remoteCloseReason` symbol declarations  
- Added initialization of both symbols to `null` in the WebSocketStream class

**Testing:**
- Verified symbols are present in WebSocketStream instances
- Should fix failing WPT test case for remote close tracking

The symbols are required by the WebSocketStream specification to track remote-initiated close codes and reasons.