### PR TITLE
fix(ext/console): support iterators in console.table

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -3741,8 +3741,12 @@ class Console {
     let resultData;
     const isSetObject = isSet(data);
     const isMapObject = isMap(data);
+    const isIteratorObject = !isSetObject && !isMapObject &&
+      !ArrayIsArray(data) && typeof data[SymbolIterator] === "function";
     const valuesKey = "Values";
-    const indexKey = isSetObject || isMapObject ? "(iter idx)" : "(idx)";
+    const indexKey = isSetObject || isMapObject || isIteratorObject
+      ? "(iter idx)"
+      : "(idx)";
 
     if (isSetObject) {
       resultData = [...new SafeSetIterator(data)];
@@ -3754,6 +3758,8 @@ class Console {
         resultData[idx] = { Key: k, Values: v };
         idx++;
       });
+    } else if (isIteratorObject) {
+      resultData = ArrayFrom(data);
     } else {
       resultData = data;
     }

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -1856,6 +1856,56 @@ Deno.test(function consoleTable() {
 `,
     );
   });
+  // console.table with iterators (https://github.com/denoland/deno/issues/20725)
+  mockConsole((console, out) => {
+    console.table(
+      new Map([[1, 1], [2, 2], [3, 3]]).entries(),
+    );
+    assertEquals(
+      stripAnsiCode(out.toString()),
+      `\
+┌────────────┬───┬───┐
+│ (iter idx) │ 0 │ 1 │
+├────────────┼───┼───┤
+│          0 │ 1 │ 1 │
+│          1 │ 2 │ 2 │
+│          2 │ 3 │ 3 │
+└────────────┴───┴───┘
+`,
+    );
+  });
+  mockConsole((console, out) => {
+    console.table(
+      new Map([[1, 1], [2, 2], [3, 3]]).values(),
+    );
+    assertEquals(
+      stripAnsiCode(out.toString()),
+      `\
+┌────────────┬────────┐
+│ (iter idx) │ Values │
+├────────────┼────────┤
+│          0 │      1 │
+│          1 │      2 │
+│          2 │      3 │
+└────────────┴────────┘
+`,
+    );
+  });
+  mockConsole((console, out) => {
+    console.table(new Set([1, 2, 3]).values());
+    assertEquals(
+      stripAnsiCode(out.toString()),
+      `\
+┌────────────┬────────┐
+│ (iter idx) │ Values │
+├────────────┼────────┤
+│          0 │      1 │
+│          1 │      2 │
+│          2 │      3 │
+└────────────┴────────┘
+`,
+    );
+  });
 });
 
 // console.log(Error) test


### PR DESCRIPTION
## Summary
- Fix `console.table` to properly display data when given iterator objects (e.g., `map.entries()`, `map.values()`, `set.values()`)
- Previously iterators rendered as empty tables because `ObjectKeys` returns nothing useful for iterator objects
- Detects iterables via `Symbol.iterator` and converts them to arrays before rendering

Closes #20725

## Test plan
- Added unit tests for `Map.entries()`, `Map.values()`, and `Set.values()` iterators passed to `console.table`
- Verified existing `console.table` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)