### PR TITLE
fix(ext/node): "node:readline" handles emoji width correctly

### DIFF
--- a/ext/node/polyfills/internal/util/inspect.mjs
+++ b/ext/node/polyfills/internal/util/inspect.mjs
@@ -286,6 +286,8 @@ const ansiPattern = "[\\u001B\\u009B][[\\]()#;?]*" +
   "|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))";
 const ansi = new SafeRegExp(ansiPattern, "g");
 
+const reEmojiPresentation = new SafeRegExp("^\\p{Emoji_Presentation}$", "u");
+
 /**
  * Returns the number of columns required to display the given string.
  */
@@ -298,7 +300,10 @@ export function getStringWidth(str, removeControlChars = true) {
   str = StringPrototypeNormalize(str, "NFC");
   for (const char of new SafeStringIterator(str)) {
     const code = StringPrototypeCodePointAt(char, 0);
-    if (isFullWidthCodePoint(code)) {
+    if (
+      isFullWidthCodePoint(code) ||
+      RegExpPrototypeTest(reEmojiPresentation, char)
+    ) {
       width += 2;
     } else if (!isZeroWidthCodePoint(code)) {
       width++;
@@ -345,6 +350,14 @@ const isFullWidthCodePoint = (code) => {
     // Miscellaneous Symbols and Pictographs 0x1f300 - 0x1f5ff
     // Emoticons 0x1f600 - 0x1f64f
     (code >= 0x1f300 && code <= 0x1f64f) ||
+    // Transport and Map Symbols
+    (code >= 0x1f680 && code <= 0x1f6ff) ||
+    // Supplemental Symbols and Pictographs
+    (code >= 0x1f900 && code <= 0x1f9ff) ||
+    // Chess Symbols
+    (code >= 0x1fa00 && code <= 0x1fa6f) ||
+    // Symbols and Pictographs Extended-A
+    (code >= 0x1fa70 && code <= 0x1faff) ||
     // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
     (code >= 0x20000 && code <= 0x3fffd)
   );


### PR DESCRIPTION
## Summary
- Characters with the Unicode `Emoji_Presentation` property (like ⚡ U+26A1) are rendered as width 2 in terminals, but `getStringWidth` was returning 1 since they aren't classified as East Asian Wide. This caused cursor positioning issues in `node:readline` when emoji were used in prompts.
- Added a `\p{Emoji_Presentation}` regex check in `getStringWidth` to properly detect emoji that should be wide
- Extended `isFullWidthCodePoint` to cover missing SMP emoji ranges (Transport/Map Symbols 0x1F680-0x1F6FF, Supplemental Symbols 0x1F900-0x1F9FF, Chess Symbols 0x1FA00-0x1FA6F, Symbols Extended-A 0x1FA70-0x1FAFF)

Closes #30042

## Test plan
- [x] Verified `⚡` prompt now reports correct cursor position (cols=3 for "⚡ " instead of cols=2)
- [x] Verified other Emoji_Presentation=Yes characters (🚀, 🤔, ⌚, 🩺) also report width 2
- [x] Verified non-emoji-presentation characters (like ☀ without VS16) still report width 1
- [x] Verified ASCII and CJK characters are unaffected
- [ ] Run existing readline spec tests
- [ ] Run `test-icu-stringwidth` node compat test

🤖 Generated with [Claude Code](https://claude.com/claude-code)