### PR TITLE
fix(coverage): warn instead of erroring when source files are missing

### DIFF
--- a/cli/tools/coverage/mod.rs
+++ b/cli/tools/coverage/mod.rs
@@ -523,7 +523,7 @@ pub fn cover_files(
   };
   let get_message = |specifier: &ModuleSpecifier| -> String {
     format!(
-      "Failed to fetch \"{}\" from cache. Before generating coverage report, run `deno test --coverage` to ensure consistent state.",
+      "Source not found for \"{}\" (was it deleted after coverage was collected?). Skipping.",
       specifier,
     )
   };
@@ -540,8 +540,14 @@ pub fn cover_files(
       file_fetcher.get_cached_source_or_local(&module_specifier);
     let file = match maybe_file_result {
       Ok(Some(file)) => TextDecodedFile::decode(file)?,
-      Ok(None) => return Err(anyhow!("{}", get_message(&module_specifier))),
-      Err(err) => return Err(err).context(get_message(&module_specifier)),
+      Ok(None) => {
+        log::warn!("{}", get_message(&module_specifier),);
+        continue;
+      }
+      Err(err) => {
+        log::warn!("{}: {}", get_message(&module_specifier), err,);
+        continue;
+      }
     };
 
     let original_source = file.source.clone();
@@ -568,16 +574,22 @@ pub fn cover_files(
         let module_kind = ModuleKind::from_is_cjs(
           cjs_tracker.is_maybe_cjs(&file.specifier, file.media_type)?,
         );
-        Some(match emitter.maybe_cached_emit(&file.specifier, module_kind, &file.source)? {
-          Some(code) => code,
-          None => {
-            return Err(anyhow!(
-              "Missing transpiled source code for: \"{}\".
-              Before generating coverage report, run `deno test --coverage` to ensure consistent state.",
-              file.specifier,
-            ))
-          }
-        })
+        Some(
+          match emitter.maybe_cached_emit(
+            &file.specifier,
+            module_kind,
+            &file.source,
+          )? {
+            Some(code) => code,
+            None => {
+              log::warn!(
+                "Missing transpiled source code for: \"{}\" (was it deleted after coverage was collected?). Skipping.",
+                file.specifier,
+              );
+              continue;
+            }
+          },
+        )
       }
       MediaType::SourceMap => {
         unreachable!()

--- a/tests/integration/coverage_tests.rs
+++ b/tests/integration/coverage_tests.rs
@@ -105,13 +105,11 @@ fn error_if_invalid_cache() {
   output.assert_exit_code(1);
   let out = output.combined_output();
 
-  // Expect error
+  // Expect warning about missing source and error about no covered files
   let error = util::strip_ansi_codes(out).to_string();
-  assert_contains!(error, "error: Missing transpiled source code");
-  assert_contains!(
-    error,
-    "Before generating coverage report, run `deno test --coverage` to ensure consistent state."
-  );
+  assert_contains!(error, "Missing transpiled source code for:");
+  assert_contains!(error, "was it deleted after coverage was collected?");
+  assert_contains!(error, "No covered files included in the report");
 }
 
 fn run_coverage_text(test_name: &str, extension: &str) {

--- a/tests/specs/coverage/missing_source_file/__test__.jsonc
+++ b/tests/specs/coverage/missing_source_file/__test__.jsonc
@@ -1,0 +1,19 @@
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "run --coverage=coverage main.ts",
+      "output": "hello\n"
+    },
+    {
+      // Delete a source file to simulate cleanup (e.g. build artifact removed)
+      "args": "task --eval rm helper.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      // Coverage should still work, warning about the missing file
+      "args": "coverage coverage",
+      "output": "missing_source.out"
+    }
+  ]
+}

--- a/tests/specs/coverage/missing_source_file/helper.ts
+++ b/tests/specs/coverage/missing_source_file/helper.ts
@@ -1,0 +1,3 @@
+export function helper(): string {
+  return "hello";
+}

--- a/tests/specs/coverage/missing_source_file/main.ts
+++ b/tests/specs/coverage/missing_source_file/main.ts
@@ -1,0 +1,3 @@
+import { helper } from "./helper.ts";
+
+console.log(helper());

--- a/tests/specs/coverage/missing_source_file/missing_source.out
+++ b/tests/specs/coverage/missing_source_file/missing_source.out
@@ -1,0 +1,5 @@
+Source not found for "[WILDCARD]helper.ts" (was it deleted after coverage was collected?). Skipping.
+| File      | Branch % | Line % |
+| --------- | -------- | ------ |
+| main.ts   |    100.0 |  100.0 |
+| All files |    100.0 |  100.0 |


### PR DESCRIPTION
When a source file is deleted after coverage was collected (e.g. a build artifact cleaned up before the report runs), `deno coverage` now prints a warning and skips the file instead of failing the entire report.

Closes https://github.com/denoland/deno/issues/32170