### PR TITLE
ci: replace Cirrus runners and cache with GitHub defaults

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -21,15 +21,12 @@ import {
 const cacheVersion = 98;
 
 const ubuntuX86Runner = "ubuntu-24.04";
-const ubuntuX86XlRunner = "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04";
-const ubuntuARMXlRunner = "ghcr.io/cirruslabs/ubuntu-runner-arm64:24.04-plus";
 const ubuntuARMRunner = "ubuntu-24.04-arm";
 const windowsX86Runner = "windows-2022";
 const windowsX86XlRunner = "windows-2022-xl";
 const windowsArmRunner = "windows-11-arm";
 const macosX86Runner = "macos-15-intel";
 const macosArmRunner = "macos-14";
-const selfHostedMacosArmRunner = "ghcr.io/cirruslabs/macos-runner:sonoma";
 
 // shared conditions
 const isDenoland = conditions.isRepository("denoland/deno");
@@ -50,14 +47,12 @@ const Runners = {
   linuxX86Xl: {
     os: "linux",
     arch: "x86_64",
-    runner: isDenoland.then(ubuntuX86XlRunner).else(ubuntuX86Runner),
-    testRunner: ubuntuX86Runner,
+    runner: ubuntuX86Runner,
   },
   linuxArm: {
     os: "linux",
     arch: "aarch64",
-    runner: ubuntuARMXlRunner,
-    testRunner: ubuntuARMRunner,
+    runner: ubuntuARMRunner,
   },
   macosX86: {
     os: "macos",
@@ -72,10 +67,7 @@ const Runners = {
   macosArmSelfHosted: {
     os: "macos",
     arch: "aarch64",
-    // actually use self-hosted runner only in denoland/deno on `main` branch and for tags (release) builds
-    runner: isDenoland.and(isMainOrTag).then(selfHostedMacosArmRunner)
-      .else(macosArmRunner),
-    testRunner: macosArmRunner,
+    runner: macosArmRunner,
   },
   windowsX86: {
     os: "windows",
@@ -293,7 +285,7 @@ function createRestoreAndSaveCacheSteps(m: {
   const path = m.path.join("\n");
   const restoreCacheStep = step({
     name: `Restore cache ${m.name}`,
-    uses: "cirruslabs/cache/restore@v4",
+    uses: "actions/cache/restore@v4",
     with: {
       path,
       key: "never_saved",
@@ -302,7 +294,7 @@ function createRestoreAndSaveCacheSteps(m: {
   });
   const saveCacheStep = step({
     name: `Cache ${m.name}`,
-    uses: "cirruslabs/cache/save@v4",
+    uses: "actions/cache/save@v4",
     with: {
       path,
       // We force saving a new cache on every main run so that PRs can

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && ''ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     timeout-minutes: 240
     defaults:
       run:
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 5
           submodules: false
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '(contains(github.event.pull_request.labels.*.name, ''ci-bench'') || github.ref == ''refs/heads/main'') && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -209,7 +209,7 @@ jobs:
           cat /proc/cpuinfo
           cat /proc/meminfo
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -255,7 +255,7 @@ jobs:
           cat /etc/hosts
           rm ~/.curlrc || true
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -268,7 +268,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-macos-x86_64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -325,7 +325,7 @@ jobs:
           path: target/debug/test_server
           retention-days: 3
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -337,7 +337,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-macos-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -418,7 +418,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -431,7 +431,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -507,7 +507,7 @@ jobs:
           name: 'test-results-macos-x86_64-debug-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -519,7 +519,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -577,7 +577,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -590,7 +590,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-macos-x86_64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -849,7 +849,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -862,7 +862,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-macos-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -982,7 +982,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: ./tools/install_prebuilt.js ld64.lld
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -995,7 +995,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-macos-aarch64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1052,7 +1052,7 @@ jobs:
           path: target/debug/test_server
           retention-days: 3
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1064,7 +1064,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-macos-aarch64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1145,7 +1145,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -1158,7 +1158,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -1248,7 +1248,7 @@ jobs:
           name: 'test-results-macos-aarch64-debug-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -1260,7 +1260,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -1289,7 +1289,7 @@ jobs:
           fetch-depth: 5
           submodules: false
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1302,7 +1302,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-macos-aarch64-test-libs-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -1366,7 +1366,7 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
         run: cargo test --locked --lib -p deno -p denort -p node_shim -p deno_lib -p deno_snapshots -p deno_bundle_runtime -p deno_cache -p deno_cron -p deno_crypto -p deno_fetch -p deno_ffi -p deno_fs -p deno_http -p deno_image -p deno_io -p deno_kv -p deno_napi -p napi_sym -p deno_net -p deno_node -p deno_node_crypto -p deno_node_sqlite -p denort_helper -p deno_signals -p deno_telemetry -p deno_url -p deno_web -p deno_webgpu -p deno_webidl -p deno_websocket -p deno_webstorage -p deno_config -p deno_crypto_provider -p deno_dotenv -p eszip -p deno_inspector_server -p deno_lockfile -p deno_maybe_sync -p node_resolver -p deno_npm -p deno_npm_cache -p deno_npm_installer -p deno_package_json -p deno_resolver -p deno_typescript_go_client_rust -p deno_runtime -p deno_features -p deno_permissions -p deno_subprocess_windows
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -1378,7 +1378,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-macos-aarch64-test-libs-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -1393,7 +1393,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''ghcr.io/cirruslabs/macos-runner:sonoma'' || ''macos-14'' }}'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''macos-14'' }}'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -1441,7 +1441,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: ./tools/install_prebuilt.js ld64.lld
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1454,7 +1454,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-macos-aarch64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1713,7 +1713,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -1726,7 +1726,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-macos-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -1843,7 +1843,7 @@ jobs:
       - name: Clone submodule ./tests/util/std
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1856,7 +1856,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-windows-x86_64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1913,7 +1913,7 @@ jobs:
           path: target/debug/test_server.exe
           retention-days: 3
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -1925,7 +1925,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-windows-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2006,7 +2006,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -2019,7 +2019,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -2086,7 +2086,7 @@ jobs:
           name: 'test-results-windows-x86_64-debug-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -2098,7 +2098,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -2127,7 +2127,7 @@ jobs:
           fetch-depth: 5
           submodules: false
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2140,7 +2140,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-windows-x86_64-test-libs-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -2181,7 +2181,7 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
         run: cargo test --locked --lib -p deno -p denort -p node_shim -p deno_lib -p deno_snapshots -p deno_bundle_runtime -p deno_cache -p deno_cron -p deno_crypto -p deno_fetch -p deno_ffi -p deno_fs -p deno_http -p deno_image -p deno_io -p deno_kv -p deno_napi -p napi_sym -p deno_net -p deno_node -p deno_node_crypto -p deno_node_sqlite -p denort_helper -p deno_signals -p deno_telemetry -p deno_url -p deno_web -p deno_webgpu -p deno_webidl -p deno_websocket -p deno_webstorage -p deno_config -p deno_crypto_provider -p deno_dotenv -p eszip -p deno_inspector_server -p deno_lockfile -p deno_maybe_sync -p node_resolver -p deno_npm -p deno_npm_cache -p deno_npm_installer -p deno_package_json -p deno_resolver -p deno_typescript_go_client_rust -p deno_runtime -p deno_features -p deno_permissions -p deno_subprocess_windows
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -2193,7 +2193,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-windows-x86_64-test-libs-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -2235,7 +2235,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2248,7 +2248,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-windows-x86_64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2545,7 +2545,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -2558,7 +2558,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-windows-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -2652,7 +2652,7 @@ jobs:
       - name: Clone submodule ./tests/util/std
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2665,7 +2665,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-windows-aarch64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2722,7 +2722,7 @@ jobs:
           path: target/debug/test_server.exe
           retention-days: 3
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2734,7 +2734,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-windows-aarch64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2815,7 +2815,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -2828,7 +2828,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -2895,7 +2895,7 @@ jobs:
           name: 'test-results-windows-aarch64-debug-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -2907,7 +2907,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -2949,7 +2949,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -2962,7 +2962,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-windows-aarch64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -3259,7 +3259,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -3272,7 +3272,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-windows-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -3342,7 +3342,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && ''ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -3372,7 +3372,7 @@ jobs:
           tar --exclude=".git*" --exclude=target --exclude=third_party/prebuilt \
               -czvf target/release/deno_src.tar.gz -C .. deno
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -3385,7 +3385,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-x86_64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -3638,7 +3638,7 @@ jobs:
           body_path: target/release/release-notes.md
           draft: true
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -3650,7 +3650,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -3731,7 +3731,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -3744,7 +3744,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -3900,7 +3900,7 @@ jobs:
           name: 'test-results-linux-x86_64-release-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -3912,7 +3912,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -3954,7 +3954,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/wpt/suite
       - name: Restore cache wpt and autobahn test run hashes
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4038,7 +4038,7 @@ jobs:
           ./target/release/deno run --allow-all --lock=tools/deno.lock.json \
               ./tools/upload_wptfyi.js $(git rev-parse HEAD) --ghstatus
       - name: Cache wpt and autobahn test run hashes
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4074,7 +4074,7 @@ jobs:
       - name: Clone submodule ./tests/util/std
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4087,7 +4087,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-x86_64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4226,7 +4226,7 @@ jobs:
           path: target/debug/test_server
           retention-days: 3
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4238,7 +4238,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-x86_64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4319,7 +4319,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -4332,7 +4332,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -4489,7 +4489,7 @@ jobs:
           name: 'test-results-linux-x86_64-debug-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4501,7 +4501,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-x86_64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4533,7 +4533,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
         if: '!startsWith(github.ref, ''refs/tags/'')'
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4546,7 +4546,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-x86_64-build-libs-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -4581,7 +4581,7 @@ jobs:
           cargo check --target wasm32-unknown-unknown --all-features -p deno_config
           cargo check -p deno --features=lsp-tracing
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4593,7 +4593,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-x86_64-build-libs-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4608,7 +4608,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: 'ghcr.io/cirruslabs/ubuntu-runner-arm64:24.04-plus'
+    runs-on: ubuntu-24.04-arm
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -4632,7 +4632,7 @@ jobs:
       - name: Clone submodule ./tests/util/std
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4645,7 +4645,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-aarch64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4702,7 +4702,7 @@ jobs:
           path: target/debug/test_server
           retention-days: 3
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4714,7 +4714,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-aarch64-build-main-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4795,7 +4795,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -4808,7 +4808,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -4887,7 +4887,7 @@ jobs:
           name: 'test-results-linux-aarch64-debug-${{ matrix.test_crate }}${{ matrix.shard_total > 1 && format(''-shard-{0}'', matrix.shard_index) || '''' }}.json'
           path: 'target/test_results_${{ matrix.test_crate }}.json'
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4899,7 +4899,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -4928,7 +4928,7 @@ jobs:
           fetch-depth: 5
           submodules: false
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -4941,7 +4941,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-aarch64-test-libs-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -4988,7 +4988,7 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: 0
         run: cargo test --locked --lib -p deno -p denort -p node_shim -p deno_lib -p deno_snapshots -p deno_bundle_runtime -p deno_cache -p deno_cron -p deno_crypto -p deno_fetch -p deno_ffi -p deno_fs -p deno_http -p deno_image -p deno_io -p deno_kv -p deno_napi -p napi_sym -p deno_net -p deno_node -p deno_node_crypto -p deno_node_sqlite -p denort_helper -p deno_signals -p deno_telemetry -p deno_url -p deno_web -p deno_webgpu -p deno_webidl -p deno_websocket -p deno_webstorage -p deno_config -p deno_crypto_provider -p deno_dotenv -p eszip -p deno_inspector_server -p deno_lockfile -p deno_maybe_sync -p node_resolver -p deno_npm -p deno_npm_cache -p deno_npm_installer -p deno_package_json -p deno_resolver -p deno_typescript_go_client_rust -p deno_runtime -p deno_features -p deno_permissions -p deno_subprocess_windows
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -5000,7 +5000,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-aarch64-test-libs-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -5015,7 +5015,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ghcr.io/cirruslabs/ubuntu-runner-arm64:24.04-plus'' }}'
+    runs-on: '${{ !contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'' && ''ubuntu-24.04'' || ''ubuntu-24.04-arm'' }}'
     environment:
       name: '${{ (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')) && ''build'' || '''' }}'
     timeout-minutes: 240
@@ -5042,7 +5042,7 @@ jobs:
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5055,7 +5055,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-aarch64-build-main-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5389,7 +5389,7 @@ jobs:
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'')'
         with:
           path: |-
@@ -5402,7 +5402,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-linux-aarch64-test-${{ matrix.test_crate }}-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && !(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (matrix.shard_index == 0 || github.event_name == ''pull_request'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -5601,7 +5601,7 @@ jobs:
       - name: Clone submodule ./tests/util/std
         run: git submodule update --init --recursive --depth=1 -- ./tests/util/std
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5614,7 +5614,7 @@ jobs:
           key: never_saved
           restore-keys: '98-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-lint-'
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: 'github.ref != ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5645,7 +5645,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: deno run --allow-write --allow-read --allow-run --allow-net --allow-env ./tools/lint.js
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5657,7 +5657,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-${{ matrix.os }}-${{ matrix.arch }}-lint-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: 'github.ref == ''refs/heads/main'' && !startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5672,7 +5672,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && ''ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
       run:
@@ -5694,7 +5694,7 @@ jobs:
           fetch-depth: 5
           submodules: false
       - name: Restore cache cargo home
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'')'
         with:
           path: |-
@@ -5707,7 +5707,7 @@ jobs:
           key: never_saved
           restore-keys: 98-cargo-home-linux-x86_64-deno-core-test-
       - name: Restore cache build output
-        uses: cirruslabs/cache/restore@v4
+        uses: actions/cache/restore@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref != ''refs/heads/main'''
         with:
           path: |-
@@ -5836,7 +5836,7 @@ jobs:
           cargo run -p deno_core --example op2
           cargo run -p deno_core --example op2 --features include_js_files_for_snapshotting
       - name: Cache cargo home
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -5848,7 +5848,7 @@ jobs:
             ~/.cargo/git/db
           key: '98-cargo-home-linux-x86_64-deno-core-test-${{ github.sha }}'
       - name: Cache build output
-        uses: cirruslabs/cache/save@v4
+        uses: actions/cache/save@v4
         if: '!startsWith(github.ref, ''refs/tags/'') && github.ref == ''refs/heads/main'''
         with:
           path: |-
@@ -5863,7 +5863,7 @@ jobs:
     needs:
       - pre_build
     if: needs.pre_build.outputs.skip_build != 'true'
-    runs-on: '${{ github.repository == ''denoland/deno'' && ''ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04'' || ''ubuntu-24.04'' }}'
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Replace Cirrus-hosted container runners (`ghcr.io/cirruslabs/`) with standard GitHub-hosted runners (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-14`)
- Replace `cirruslabs/cache/restore@v4` and `cirruslabs/cache/save@v4` with `actions/cache/restore@v4` and `actions/cache/save@v4`
- Remove now-redundant XL/self-hosted runner variables and simplify runner selection logic

## Test plan
- [ ] Verify `ci.yml` contains zero references to `cirrus`
- [ ] Verify all `runs-on` values are standard GitHub-hosted runners
- [ ] Verify cache actions use `actions/cache`
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)