### PR TITLE
fix(ext/crypto): handle wrong algorithm in subtle.importKey without panicking

### DIFF
--- a/ext/crypto/import_key.rs
+++ b/ext/crypto/import_key.rs
@@ -686,7 +686,7 @@ fn import_key_ec(
         .parameters
         .ok_or(ImportKeyError::MalformedParameters)?
         .try_into()
-        .unwrap();
+        .map_err(|_| ImportKeyError::MalformedParameters)?;
 
       let pk_named_curve = match named_curve_alg {
         // id-secp256r1

--- a/tests/unit_node/crypto/crypto_key_test.ts
+++ b/tests/unit_node/crypto/crypto_key_test.ts
@@ -19,7 +19,7 @@ import {
 } from "node:crypto";
 import { promisify } from "node:util";
 import { Buffer } from "node:buffer";
-import { assert, assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 
 const RUN_SLOW_TESTS = Deno.env.get("SLOW_TESTS") === "1";
 
@@ -1066,4 +1066,31 @@ Deno.test("generateKeyPair async ec secp256k1", async () => {
   const data = Buffer.from("async test");
   const signature = sign("sha256", data, privateKey);
   assert(verify("sha256", data, publicKey, signature));
+});
+
+// Regression test for https://github.com/denoland/deno/issues/30243
+// Importing a PKCS#8 RSA key with the wrong algorithm (ECDSA) should throw, not panic.
+Deno.test("crypto.subtle.importKey PKCS#8 with wrong algorithm does not panic", async () => {
+  const rsaKey = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", rsaKey.privateKey);
+
+  await assertRejects(() =>
+    crypto.subtle.importKey(
+      "pkcs8",
+      pkcs8,
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign"],
+    )
+  );
 });


### PR DESCRIPTION
## Summary
- Fixes #30243. Passing a valid PKCS#8 DER key with the wrong algorithm (e.g., an RSA key imported as ECDSA) to `crypto.subtle.importKey` caused a panic due to an `.unwrap()` on a `try_into()` conversion in `import_key_ec`.
- Replaced the `.unwrap()` with `.map_err(|_| ImportKeyError::MalformedParameters)?` so it returns a proper error instead of panicking.
- Added a regression test that generates an RSA PKCS#8 key and attempts to import it as ECDSA, asserting that it rejects.

## Test plan
- [x] Added unit test in `tests/unit_node/crypto/crypto_key_test.ts`
- [ ] `cargo test -p deno_crypto` passes
- [ ] New test passes with `./target/debug/deno test tests/unit_node/crypto/crypto_key_test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)