### PR TITLE
refactor(runtime): modernize permission prompt visual style

### DIFF
--- a/runtime/permissions/prompter.rs
+++ b/runtime/permissions/prompter.rs
@@ -378,12 +378,10 @@ impl PermissionPrompter for TtyPrompter {
     let api_name = api_name.map(escape_control_characters);
 
     // print to stderr so that if stdout is piped this is still displayed.
-    let opts: String = if is_unary {
-      format!(
-        "[y/n/A] (y = yes, allow; n = no, deny; A = allow all {name} permissions)"
-      )
+    let prompt_hint: String = if is_unary {
+      "[1/2/3]".to_string()
     } else {
-      "[y/n] (y = yes, allow; n = no, deny)".to_string()
+      "[1/2]".to_string()
     };
 
     // output everything in one shot to make the tests more reliable
@@ -393,57 +391,69 @@ impl PermissionPrompter for TtyPrompter {
       write!(&mut output, "{}", colors::bold("Deno requests ")).unwrap();
       write!(&mut output, "{}", colors::bold(message.clone())).unwrap();
       writeln!(&mut output, "{}", colors::bold(".")).unwrap();
+      writeln!(&mut output, "┃").unwrap();
       if let Some(api_name) = api_name.clone() {
         writeln!(
           &mut output,
-          "┠─ Requested by `{}` API.",
+          "┃  Requested by `{}` API",
           colors::bold(api_name)
         )
         .unwrap();
+        writeln!(&mut output, "┃").unwrap();
       }
       let stack_lines_count = if let Some(get_stack) = get_stack {
         let stack = get_stack();
         let len = stack.len();
-        for (idx, frame) in stack.into_iter().enumerate() {
+        writeln!(&mut output, "┃  Stack trace:").unwrap();
+        for frame in stack.into_iter() {
           writeln!(
             &mut output,
-            "┃  {} {}",
-            colors::gray(if idx != len - 1 { "├─" } else { "└─" }),
+            "┃    {}",
             colors::gray(frame),
           )
           .unwrap();
         }
-        len
+        writeln!(&mut output, "┃").unwrap();
+        2 + len
       } else {
-        writeln!(
-          &mut output,
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.",
-        ).unwrap();
-        1
+        0
       };
       let msg = format!(
-        "Learn more at: {}",
+        "Learn more: {}",
         colors::cyan_with_underline(&format!(
           "https://docs.deno.com/go/--allow-{}",
           name
         ))
       );
-      writeln!(&mut output, "┠─ {}", colors::italic(&msg)).unwrap();
+      writeln!(&mut output, "┃  {}", colors::italic(&msg)).unwrap();
       let msg = if crate::is_standalone() {
         format!(
-          "Specify the required permissions during compile time using `deno compile --allow-{name}`."
+          "Specify the required permissions during compile time using `deno compile --allow-{name}`"
         )
       } else {
         format!("Run again with --allow-{name} to bypass this prompt.")
       };
-      writeln!(&mut output, "┠─ {}", colors::italic(&msg)).unwrap();
-      write!(&mut output, "┗ {}", colors::bold("Allow?")).unwrap();
-      write!(&mut output, " {opts} > ").unwrap();
+      writeln!(&mut output, "┃  {}", colors::italic(&msg)).unwrap();
+      writeln!(&mut output, "┃").unwrap();
+      writeln!(&mut output, "┃  1. Allow   (y)").unwrap();
+      writeln!(&mut output, "┃  2. Deny    (n)").unwrap();
+      if is_unary {
+        writeln!(
+          &mut output,
+          "┃  3. Allow all {name} permissions   (A)"
+        )
+        .unwrap();
+      }
+      writeln!(&mut output, "┃").unwrap();
+      write!(&mut output, "┗ {prompt_hint} > ").unwrap();
 
       stderr_lock.write_all(output.as_bytes()).unwrap();
 
       stack_lines_count
     };
+
+    // Number of option lines: 2 for binary, 3 for unary
+    let option_lines: usize = if is_unary { 3 } else { 2 };
 
     let value = loop {
       // Clear stdin each time we loop around in case the user accidentally pasted
@@ -463,22 +473,23 @@ impl PermissionPrompter for TtyPrompter {
         break PromptResponse::Deny;
       };
 
-      let clear_n = if api_name.is_some() { 5 } else { 4 } + stack_lines_count;
+      // Header(1) + blank(1) + [api(2)] + [stack(2+len)] + info(2) + blank(1) + options + blank(1) + prompt(1)
+      let clear_n = if api_name.is_some() { 10 } else { 8 } + option_lines + stack_lines_count;
 
       match input.as_bytes()[0] as char {
-        'y' | 'Y' => {
+        'y' | 'Y' | '1' => {
           clear_n_lines(&mut stderr_lock, clear_n);
           let msg = format!("Granted {message}.");
           writeln!(stderr_lock, "✅ {}", colors::bold(&msg)).unwrap();
           break PromptResponse::Allow;
         }
-        'n' | 'N' | '\x1b' => {
+        'n' | 'N' | '\x1b' | '2' => {
           clear_n_lines(&mut stderr_lock, clear_n);
           let msg = format!("Denied {message}.");
           writeln!(stderr_lock, "❌ {}", colors::bold(&msg)).unwrap();
           break PromptResponse::Deny;
         }
-        'A' if is_unary => {
+        'A' | '3' if is_unary => {
           clear_n_lines(&mut stderr_lock, clear_n);
           let msg = format!("Granted all {name} access.");
           writeln!(stderr_lock, "✅ {}", colors::bold(&msg)).unwrap();
@@ -489,8 +500,8 @@ impl PermissionPrompter for TtyPrompter {
           clear_n_lines(&mut stderr_lock, 1);
           write!(
             stderr_lock,
-            "┗ {} {opts} > ",
-            colors::bold("Unrecognized option. Allow?")
+            "┗ {} {prompt_hint} > ",
+            colors::bold("Unrecognized option.")
           )
           .unwrap();
         }

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -168,22 +168,34 @@ fn _090_run_permissions_request() {
     .with_pty(|mut console| {
       console.expect(concat!(
         "┏ ⚠️  Deno requests run access to \"ls\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-run\r\n",
-        "┠─ Run again with --allow-run to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all run permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-run\r\n",
+        "┃  Run again with --allow-run to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all run permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("y");
       console.expect("Granted run access to \"ls\".");
       console.expect(concat!(
         "┏ ⚠️  Deno requests run access to \"cat\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-run\r\n",
-        "┠─ Run again with --allow-run to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all run permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-run\r\n",
+        "┃  Run again with --allow-run to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all run permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("n");
@@ -201,22 +213,34 @@ fn _090_run_permissions_request_sync() {
     .with_pty(|mut console| {
       console.expect(concat!(
         "┏ ⚠️  Deno requests run access to \"ls\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-run\r\n",
-        "┠─ Run again with --allow-run to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all run permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-run\r\n",
+        "┃  Run again with --allow-run to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all run permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("y");
       console.expect("Granted run access to \"ls\".");
       console.expect(concat!(
         "┏ ⚠️  Deno requests run access to \"cat\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-run\r\n",
-        "┠─ Run again with --allow-run to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all run permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-run\r\n",
+        "┃  Run again with --allow-run to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all run permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("n");
@@ -235,11 +259,17 @@ fn permissions_prompt_allow_all() {
       // "run" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests run access to \"FOO\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-run\r\n",
-        "┠─ Run again with --allow-run to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all run permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-run\r\n",
+        "┃  Run again with --allow-run to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all run permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -247,11 +277,17 @@ fn permissions_prompt_allow_all() {
       // "read" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests read access to \"FOO\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-        "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+        "┃  Run again with --allow-read to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all read permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -259,11 +295,17 @@ fn permissions_prompt_allow_all() {
       // "write" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests write access to \"FOO\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-write\r\n",
-        "┠─ Run again with --allow-write to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all write permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-write\r\n",
+        "┃  Run again with --allow-write to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all write permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -271,11 +313,17 @@ fn permissions_prompt_allow_all() {
       // "net" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests net access to \"foo\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-net\r\n",
-        "┠─ Run again with --allow-net to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all net permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-net\r\n",
+        "┃  Run again with --allow-net to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all net permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -283,11 +331,17 @@ fn permissions_prompt_allow_all() {
       // "env" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests env access to \"FOO\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-env\r\n",
-        "┠─ Run again with --allow-env to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all env permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-env\r\n",
+        "┃  Run again with --allow-env to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all env permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -295,11 +349,17 @@ fn permissions_prompt_allow_all() {
       // "sys" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests sys access to \"loadavg\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-sys\r\n",
-        "┠─ Run again with --allow-sys to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all sys permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-sys\r\n",
+        "┃  Run again with --allow-sys to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all sys permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -307,11 +367,17 @@ fn permissions_prompt_allow_all() {
       // "ffi" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests ffi access to \"FOO\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-ffi\r\n",
-        "┠─ Run again with --allow-ffi to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all ffi permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-ffi\r\n",
+        "┃  Run again with --allow-ffi to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all ffi permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -329,10 +395,15 @@ fn permissions_prompt_allow_all_2() {
       // "env" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests env access to \"FOO\".\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-env\r\n",
-        "┠─ Run again with --allow-env to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all env permissions)",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-env\r\n",
+        "┃  Run again with --allow-env to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all env permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -341,26 +412,38 @@ fn permissions_prompt_allow_all_2() {
       // "sys" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests sys access to \"loadavg\".\r\n",
-        "┠─ Requested by `Deno.loadavg()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-sys\r\n",
-        "┠─ Run again with --allow-sys to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all sys permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.loadavg()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-sys\r\n",
+        "┃  Run again with --allow-sys to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all sys permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
       console.expect("Granted all sys access.");
 
-      let text = console.read_until("Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)");
+      let text = console.read_until("[1/2/3] > ");
       // "read" permissions
       test_util::assertions::assert_wildcard_match(&text, concat!(
         "\r\n",
         "┏ ⚠️  Deno requests read access to \"[WILDCARD]tests[WILDCHAR]testdata\".\r\n",
-        "┠─ Requested by `Deno.lstatSync()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-        "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.lstatSync()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+        "┃  Run again with --allow-read to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all read permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("A");
@@ -377,11 +460,17 @@ fn permissions_prompt_allow_all_lowercase_a() {
       // "run" permissions
       console.expect(concat!(
         "┏ ⚠️  Deno requests run access to \"FOO\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-run\r\n",
-        "┠─ Run again with --allow-run to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all run permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-run\r\n",
+        "┃  Run again with --allow-run to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all run permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("a");
@@ -412,11 +501,17 @@ fn permissions_cache() {
       console.expect(concat!(
         "prompt\r\n",
         "┏ ⚠️  Deno requests read access to \"foo\".\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-        "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+        "┃  Run again with --allow-read to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all read permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("y");
@@ -433,17 +528,26 @@ fn permissions_trace() {
     .env("DENO_TRACE_PERMISSIONS", "1")
     .args_vec(["run", "--quiet", "run/permissions_trace.ts"])
     .with_pty(|mut console| {
-      let text = console.read_until("Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all sys permissions)");
+      let text = console.read_until("[1/2/3] > ");
       test_util::assertions::assert_wildcard_match(&text, concat!(
       "┏ ⚠️  Deno requests sys access to \"hostname\".\r\n",
-      "┠─ Requested by `Deno.hostname()` API.\r\n",
-      "┃  ├─ Object.hostname (ext:deno_os/30_os.js:43:10)\r\n",
-      "┃  ├─ foo (file://[WILDCARD]/run/permissions_trace.ts:2:8)\r\n",
-      "┃  ├─ bar (file://[WILDCARD]/run/permissions_trace.ts:6:3)\r\n",
-      "┃  └─ file://[WILDCARD]/run/permissions_trace.ts:9:1\r\n",
-      "┠─ Learn more at: https://docs.deno.com/go/--allow-sys\r\n",
-      "┠─ Run again with --allow-sys to bypass this prompt.\r\n",
-      "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all sys permissions)",
+      "┃\r\n",
+      "┃  Requested by `Deno.hostname()` API\r\n",
+      "┃\r\n",
+      "┃  Stack trace:\r\n",
+      "┃    Object.hostname (ext:deno_os/30_os.js:43:10)\r\n",
+      "┃    foo (file://[WILDCARD]/run/permissions_trace.ts:2:8)\r\n",
+      "┃    bar (file://[WILDCARD]/run/permissions_trace.ts:6:3)\r\n",
+      "┃    file://[WILDCARD]/run/permissions_trace.ts:9:1\r\n",
+      "┃\r\n",
+      "┃  Learn more: https://docs.deno.com/go/--allow-sys\r\n",
+      "┃  Run again with --allow-sys to bypass this prompt.\r\n",
+      "┃\r\n",
+      "┃  1. Allow   (y)\r\n",
+      "┃  2. Deny    (n)\r\n",
+      "┃  3. Allow all sys permissions   (A)\r\n",
+      "┃\r\n",
+      "┗ [1/2/3] > ",
       ));
 
       console.human_delay();
@@ -1542,21 +1646,33 @@ mod permissions {
       .with_pty(|mut console| {
         console.expect(concat!(
           "┏ ⚠️  Deno requests read access to \"foo\".\r\n",
-          "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-          "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-          "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-          "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+          "┃\r\n",
+          "┃  Requested by `Deno.permissions.request()` API\r\n",
+          "┃\r\n",
+          "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+          "┃  Run again with --allow-read to bypass this prompt.\r\n",
+          "┃\r\n",
+          "┃  1. Allow   (y)\r\n",
+          "┃  2. Deny    (n)\r\n",
+          "┃  3. Allow all read permissions   (A)\r\n",
+          "┃\r\n",
+          "┗ [1/2/3] > ",
         ));
         console.human_delay();
         console.write_line_raw("y");
         console.expect(concat!(
           "┏ ⚠️  Deno requests read access to \"bar\".\r\n",
-          "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-          "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-          "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-          "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+          "┃\r\n",
+          "┃  Requested by `Deno.permissions.request()` API\r\n",
+          "┃\r\n",
+          "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+          "┃  Run again with --allow-read to bypass this prompt.\r\n",
+          "┃\r\n",
+          "┃  1. Allow   (y)\r\n",
+          "┃  2. Deny    (n)\r\n",
+          "┃  3. Allow all read permissions   (A)\r\n",
+          "┃\r\n",
+          "┗ [1/2/3] > ",
         ));
         console.human_delay();
         console.write_line_raw("n");
@@ -1574,21 +1690,33 @@ mod permissions {
       .with_pty(|mut console| {
         console.expect(concat!(
           "┏ ⚠️  Deno requests read access to \"foo\".\r\n",
-          "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-          "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-          "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-          "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+          "┃\r\n",
+          "┃  Requested by `Deno.permissions.request()` API\r\n",
+          "┃\r\n",
+          "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+          "┃  Run again with --allow-read to bypass this prompt.\r\n",
+          "┃\r\n",
+          "┃  1. Allow   (y)\r\n",
+          "┃  2. Deny    (n)\r\n",
+          "┃  3. Allow all read permissions   (A)\r\n",
+          "┃\r\n",
+          "┗ [1/2/3] > ",
         ));
         console.human_delay();
         console.write_line_raw("y");
         console.expect(concat!(
           "┏ ⚠️  Deno requests read access to \"bar\".\r\n",
-          "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-          "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-          "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-          "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+          "┃\r\n",
+          "┃  Requested by `Deno.permissions.request()` API\r\n",
+          "┃\r\n",
+          "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+          "┃  Run again with --allow-read to bypass this prompt.\r\n",
+          "┃\r\n",
+          "┃  1. Allow   (y)\r\n",
+          "┃  2. Deny    (n)\r\n",
+          "┃  3. Allow all read permissions   (A)\r\n",
+          "┃\r\n",
+          "┗ [1/2/3] > ",
         ));
         console.human_delay();
         console.write_line_raw("n");
@@ -1606,11 +1734,17 @@ mod permissions {
       .with_pty(|mut console| {
         console.expect(concat!(
           "┏ ⚠️  Deno requests read access.\r\n",
-          "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-          "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-          "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-          "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+          "┃\r\n",
+          "┃  Requested by `Deno.permissions.request()` API\r\n",
+          "┃\r\n",
+          "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+          "┃  Run again with --allow-read to bypass this prompt.\r\n",
+          "┃\r\n",
+          "┃  1. Allow   (y)\r\n",
+          "┃  2. Deny    (n)\r\n",
+          "┃  3. Allow all read permissions   (A)\r\n",
+          "┃\r\n",
+          "┗ [1/2/3] > ",
         ));
         console.human_delay();
         console.write_line_raw("y\n");
@@ -1631,11 +1765,17 @@ mod permissions {
       .with_pty(|mut console| {
         console.expect(concat!(
           "┏ ⚠️  Deno requests read access.\r\n",
-          "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-          "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-          "┠─ Learn more at: https://docs.deno.com/go/--allow-read\r\n",
-          "┠─ Run again with --allow-read to bypass this prompt.\r\n",
-          "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions)",
+          "┃\r\n",
+          "┃  Requested by `Deno.permissions.request()` API\r\n",
+          "┃\r\n",
+          "┃  Learn more: https://docs.deno.com/go/--allow-read\r\n",
+          "┃  Run again with --allow-read to bypass this prompt.\r\n",
+          "┃\r\n",
+          "┃  1. Allow   (y)\r\n",
+          "┃  2. Deny    (n)\r\n",
+          "┃  3. Allow all read permissions   (A)\r\n",
+          "┃\r\n",
+          "┗ [1/2/3] > ",
         ));
         console.human_delay();
         console.write_line_raw("y");
@@ -1709,21 +1849,32 @@ fn issue9750() {
       console.write_line_raw("yy");
       console.expect(concat!(
         "┏ ⚠️  Deno requests env access.\r\n",
-        "┠─ Requested by `Deno.permissions.request()` API.\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-env\r\n",
-        "┠─ Run again with --allow-env to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all env permissions)",
+        "┃\r\n",
+        "┃  Requested by `Deno.permissions.request()` API\r\n",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-env\r\n",
+        "┃  Run again with --allow-env to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all env permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("n");
       console.expect("Denied env access.");
       console.expect(concat!(
         "┏ ⚠️  Deno requests env access to \"SECRET\".\r\n",
-        "┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.\r\n",
-        "┠─ Learn more at: https://docs.deno.com/go/--allow-env\r\n",
-        "┠─ Run again with --allow-env to bypass this prompt.\r\n",
-        "┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all env permissions)",
+        "┃\r\n",
+        "┃  Learn more: https://docs.deno.com/go/--allow-env\r\n",
+        "┃  Run again with --allow-env to bypass this prompt.\r\n",
+        "┃\r\n",
+        "┃  1. Allow   (y)\r\n",
+        "┃  2. Deny    (n)\r\n",
+        "┃  3. Allow all env permissions   (A)\r\n",
+        "┃\r\n",
+        "┗ [1/2/3] > ",
       ));
       console.human_delay();
       console.write_line_raw("n");
@@ -2718,7 +2869,7 @@ fn file_fetcher_preserves_permissions() {
       console.write_line(
         "const a = await import('http://localhost:4545/run/019_media_types.ts');",
       );
-      console.expect("Allow?");
+      console.expect("[1/2/3] > ");
       console.human_delay();
       console.write_line_raw("y");
       console.expect_all(&["success", "true"]);
@@ -2747,7 +2898,7 @@ fn stdio_streams_are_locked_in_permission_prompt() {
       console.expect(malicious_output);
       console.write_line(r#"Deno.readTextFileSync('../Cargo.toml');"#);
       // We will get a permission prompt
-      console.expect("Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions) > ");
+      console.expect("[1/2/3] > ");
       // The worker is blocked, so nothing else should get written here
       console.human_delay();
       console.write_line_raw("i");
@@ -2762,16 +2913,16 @@ fn stdio_streams_are_locked_in_permission_prompt() {
         // outputs a bunch of control characters, so we instead rely on the last assertion
         // in this test that checks to ensure we didn't receive any malicious output during
         // the permission prompts
-        console.expect("Unrecognized option. Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions) >");
+        console.expect("Unrecognized option. [1/2/3] > ");
         console.human_delay();
         console.write_line_raw("y");
         console.expect("Granted read access to");
       } else {
-        console.expect_raw_next(format!("i{newline}\u{1b}[1A\u{1b}[0J┗ Unrecognized option. Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions) > "));
+        console.expect_raw_next(format!("i{newline}\u{1b}[1A\u{1b}[0J┗ Unrecognized option. [1/2/3] > "));
         console.human_delay();
         console.write_line_raw("y");
         // We ensure that nothing gets written here between the permission prompt and this text, despite the delay
-        console.expect_raw_next(format!("y{newline}\x1b[6A\x1b[0J✅ Granted read access to \""));
+        console.expect_raw_next(format!("y{newline}\x1b[13A\x1b[0J✅ Granted read access to \""));
       }
 
       // Back to spamming!
@@ -2779,7 +2930,7 @@ fn stdio_streams_are_locked_in_permission_prompt() {
 
       // Ensure during the permission prompt showing we didn't receive any malicious output
       let all_text = console.all_output();
-      let start_prompt_index = all_text.find("Allow?").unwrap();
+      let start_prompt_index = all_text.find("[1/2/3]").unwrap();
       let end_prompt_index = all_text.find("Granted read access to").unwrap();
       let prompt_text = &all_text[start_prompt_index..end_prompt_index];
       assert!(!prompt_text.contains(malicious_output), "Prompt text: {:?}", prompt_text);


### PR DESCRIPTION
## Summary
- Refreshes the permission prompt layout with `┃` + blank line separators instead of cramped `┠─` connectors
- Replaces the dense `[y/n/A] (y = yes, allow; n = no, deny; A = allow all ...)` line with clearly listed numbered options
- Stack traces now use simple indentation with an explicit "Stack trace:" label instead of tree-drawing characters
- Removes the "To see a stack trace..." message when no trace is available
- Accepts both `1/2/3` and legacy `y/n/A` input for backwards compatibility

### Before
```
┏ ⚠️  Deno requests read access to "foo".
┠─ Requested by `Deno.readFile()` API.
┠─ To see a stack trace for this prompt, set the DENO_TRACE_PERMISSIONS environmental variable.
┠─ Learn more at: https://docs.deno.com/go/--allow-read
┠─ Run again with --allow-read to bypass this prompt.
┗ Allow? [y/n/A] (y = yes, allow; n = no, deny; A = allow all read permissions) >
```

### After
```
┏ ⚠️  Deno requests read access to "foo".
┃
┃  Requested by `Deno.readFile()` API
┃
┃  Learn more: https://docs.deno.com/go/--allow-read
┃  Run again with --allow-read to bypass this prompt.
┃
┃  1. Allow   (y)
┃  2. Deny    (n)
┃  3. Allow all read permissions   (A)
┃
┗ [1/2/3] >
```

## Test plan
- [x] `cargo check -p deno_runtime` passes
- [ ] `cargo test` for integration tests with permission prompts
- [ ] Manual test: `./target/debug/deno run script.ts` that triggers a permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)