### PR TITLE
perf(npm): actually improve `npm install -g deno` binary startup performance

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -168,6 +168,18 @@ jobs:
           echo "$ACTUAL"
           [ "$ACTUAL" = "$EXPECTED_VERSION" ] || { echo "Version mismatch: expected '$EXPECTED_VERSION', got '$ACTUAL'"; exit 1; }
           deno eval "console.log('global npm install works')"
+          # Verify the global bin entry points directly at the native binary, not bin.cjs
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            DENO_CMD="$(npm prefix -g)/deno.cmd"
+            grep -q "bin.cjs" "$DENO_CMD" && { echo "ERROR: deno.cmd still points to bin.cjs"; exit 1; }
+            echo "deno.cmd correctly points to native binary"
+          else
+            DENO_LINK="$(which deno)"
+            LINK_TARGET="$(readlink "$DENO_LINK")"
+            echo "deno symlink target: $LINK_TARGET"
+            echo "$LINK_TARGET" | grep -q "bin.cjs" && { echo "ERROR: deno symlink still points to bin.cjs"; exit 1; }
+            echo "deno symlink correctly points to native binary"
+          fi
           npm uninstall -g deno
 
       - name: Test npm global install deno (--ignore-scripts)

--- a/tools/release/npm/install_api.cjs
+++ b/tools/release/npm/install_api.cjs
@@ -191,6 +191,22 @@ function replaceBinEntry(exePath) {
 }
 
 function findBinDir() {
+  // For global installs, npm sets npm_config_global=true and npm_config_prefix
+  // to the install prefix. The bin dir is {prefix}/bin on Linux/Mac or
+  // {prefix} on Windows (e.g. %APPDATA%\npm).
+  if (process.env.npm_config_global === "true") {
+    const prefix = process.env.npm_config_prefix;
+    if (prefix) {
+      const binDir = os.platform() === "win32"
+        ? prefix
+        : path.join(prefix, "bin");
+      if (isBinDirForThisPackage(binDir)) {
+        return binDir;
+      }
+    }
+  }
+
+  // For local installs, walk up looking for node_modules/.bin
   let dir = __dirname;
   for (let i = 0; i < 64; i++) {
     const parent = path.dirname(dir);


### PR DESCRIPTION
Last pr didn't work: https://github.com/denoland/deno/pull/32439