### PR TITLE
build(flake): update rusty-v8 hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,8 @@
   outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
+        inherit (nixpkgs.lib) mapAttrsToList concatStringsSep;
+
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
@@ -26,19 +28,20 @@
 
         cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
         rustyV8Version = (builtins.head (builtins.filter (p: p.name == "v8") cargoLock.package)).version;
-        rustyV8Target = {
+        rustyV8Targets = {
           "x86_64-linux" = "x86_64-unknown-linux-gnu";
           "aarch64-linux" = "aarch64-unknown-linux-gnu";
           "x86_64-darwin" = "x86_64-apple-darwin";
           "aarch64-darwin" = "aarch64-apple-darwin";
-        }.${system};
+        };
+        rustyV8Target = rustyV8Targets.${system};
         rustyV8 = pkgs.fetchurl {
           url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${rustyV8Target}.a.gz";
           sha256 = {
-            "x86_64-linux" = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
-            "aarch64-linux" = "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=";
-            "x86_64-darwin" = "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=";
-            "aarch64-darwin" = "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=";
+            "x86_64-linux" = "sha256-PYCBh8+RY1nvPOKXMCns5mDRo2j0SB3Edw/ut7npjxo=";
+            "aarch64-linux" = "sha256-EGlTttOowHhoFBy8FQeokCnbPLi4tfkIhSek28TfcGQ=";
+            "x86_64-darwin" = "sha256-61d4tQ/PcNPUvDuQsMNTNUO43zLZSVEHOjdGFG0u4W8=";
+            "aarch64-darwin" = "sha256-BMKybPdxP9+7QD/yfbnPnFxD8N7kHPUkMcEEf4P4iSE=";
           }.${system};
         };
 
@@ -91,6 +94,23 @@
           denort = buildDenoBin { pname = "denort"; };
 
           default = self.packages.${system}.deno;
+        };
+
+        apps.nix-update-rusty-v8 = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "update-rusty-v8" ''
+            set -euo pipefail
+
+            function update() {
+              sys=$1
+              target=$2
+              url="https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_$target.a.gz"
+              hash=$(nix store prefetch-file --json "$url" | ${pkgs.lib.getExe pkgs.jq} -r '.hash')
+              sed -i "s|\"$sys\" = \"sha256-[^\"]*\";|\"$sys\" = \"$hash\";|" flake.nix
+            }
+
+            ${concatStringsSep "\n" (mapAttrsToList (sys: target: "update ${sys} ${target}") rustyV8Targets)}
+          '');
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://docs.deno.com/runtime/manual/references/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
7. Open as a draft PR if your work is still in progress. The CI won't run
   all steps, but you can add '[ci]' to a commit message to force it to.
8. If you would like to run the benchmarks on the CI, add the 'ci-bench' label.
-->

Deno can't be build from main branch using nix, as rusty-v8 hashes are outdated, fixed the hashes and included a basic script to do it automatically