### PR TITLE
docs: add GitHub Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,8 @@ to JavaScript — for instance filesystem operations and networking.
 - `cli/` — User-facing CLI implementation, subcommands, and tools
 - `runtime/` — JavaScript runtime assembly and integration
 - `ext/` — Extensions providing native functionality to JS (fs, net, etc.)
-- `libs/` — Shared Rust crates (core, resolver, npm, node_resolver, serde_v8, etc.)
+- `libs/` — Shared Rust crates (core, resolver, npm, node_resolver, serde_v8,
+  etc.)
 - `tests/specs/` — Integration tests (spec tests)
 - `tests/unit/` — Unit tests
 - `tests/testdata/` — Test fixtures and data files


### PR DESCRIPTION
- Adds `.github/copilot-instructions.md` to guide GitHub Copilot with project-specific context
- Documents network access requirements for `tools/format.js` and `tools/lint.js` (jsr.io, dprint.dev, GitHub)
- Includes PR title linting rules, codebase architecture, build/test/lint commands, and development workflows