### PR TITLE
Fix typo: succesful to successful

### DIFF
--- a/ext/node/ops/os/cpus.rs
+++ b/ext/node/ops/os/cpus.rs
@@ -338,7 +338,7 @@ pub fn cpu_info() -> Option<Vec<CpuInfo>> {
       std::ptr::null_mut(),
       0,
     );
-    // If res == 0, the sysctl call was succesful and
+    // If res == 0, the sysctl call was successful and
     // ncpuonline contains the number of online CPUs.
     if res != 0 {
       return None;


### PR DESCRIPTION
Fixes typo in ext/node/ops/os/cpus.rs where 'succesful' should be 'successful'.