### PR TITLE
fix(tools): exclude closed PRs from insights report

### DIFF
--- a/tools/issue_pr_insights.ts
+++ b/tools/issue_pr_insights.ts
@@ -43,6 +43,7 @@ interface GitHubItem {
    * NOT include review comments. */
   comments: number;
   pull_request?: unknown;
+  state: "open" | "closed";
 }
 
 interface GitHubComment {
@@ -401,8 +402,10 @@ async function main() {
   const newPRs = allPRs;
 
   const noResponseIssues = newIssues.filter((i) => i.comments === 0);
+  // Only consider open PRs for review/WIP lists
+  const openPRs = newPRs.filter((pr) => pr.state === "open");
   const [allNoResponsePRs, hotIssues] = await Promise.all([
-    filterNoResponsePRs(newPRs),
+    filterNoResponsePRs(openPRs),
     findHotIssues(sinceDate),
   ]);
 


### PR DESCRIPTION
Filters out closed/merged PRs from the 'PRs needing review' and 'WIP PRs' sections in the issue_pr_insights report.

The script fetches PRs with `state: "all"` to count total new PRs, but wasn't filtering out closed ones before categorizing them into review/WIP lists. This caused closed PRs to show up in the report as needing review.

Fix: filter PRs to only include `state === "open"` before passing to `filterNoResponsePRs()`.