### PR TITLE
fix(ext/node): make TTY stdout/stderr indestructible

### DIFF
--- a/ext/node/polyfills/internal/tty.js
+++ b/ext/node/polyfills/internal/tty.js
@@ -338,6 +338,28 @@ export class WriteStream extends Socket {
         }
         cb();
       };
+
+      // Prevent actually closing stdout/stderr. Libraries like mute-stream
+      // (used by @inquirer/prompts) call destroy()/end() on the stream,
+      // which would close the underlying resource and break subsequent
+      // console.log calls (BadResource error). Match Node.js behavior
+      // where stdio streams are indestructible.
+      //
+      // Override _destroy to prevent Socket._destroy from calling
+      // this._handle.close(), which would close the Deno resource.
+      this._destroy = function (err, cb) {
+        cb(err);
+        this._undestroy();
+      };
+
+      // Also prevent the handle's _onClose from closing the underlying
+      // io.stdout/io.stderr resource. This handles the end() path:
+      // end() -> _final -> shutdown -> _onClose -> io.stdout.close().
+      // Without this, the Deno resource (rid 1/2) is removed from the
+      // resource table and op_print (used by console.log) fails.
+      this._handle._onClose = function () {
+        return 0;
+      };
     }
   }
 

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -3500,3 +3500,16 @@ fn process_stdout_write_order_pty() {
       console.expect("E");
     });
 }
+
+// Regression test for https://github.com/denoland/deno/issues/32513
+// Verifies that process.stdout survives destroy() calls (e.g. from mute-stream).
+#[test]
+fn process_stdout_destroy_undestroy_pty() {
+  TestContext::default()
+    .new_command()
+    .args_vec(["run", "run/process_stdout_destroy_undestroy.ts"])
+    .with_pty(|mut console| {
+      console.expect("before");
+      console.expect("after");
+    });
+}

--- a/tests/specs/node/process_stdout_indestructible/__test__.jsonc
+++ b/tests/specs/node/process_stdout_indestructible/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/node/process_stdout_indestructible/main.out
+++ b/tests/specs/node/process_stdout_indestructible/main.out
@@ -1,0 +1,3 @@
+before
+after
+from timeout

--- a/tests/specs/node/process_stdout_indestructible/main.ts
+++ b/tests/specs/node/process_stdout_indestructible/main.ts
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/denoland/deno/issues/32513
+// Verifies that process.stdout survives destroy() calls.
+// Libraries like mute-stream (used by @inquirer/prompts) call destroy()
+// on process.stdout, which should not actually close the underlying resource.
+import process from "node:process";
+
+console.log("before");
+process.stdout.destroy();
+console.log("after");
+
+setTimeout(() => {
+  console.log("from timeout");
+}, 100);

--- a/tests/testdata/run/process_stdout_destroy_undestroy.ts
+++ b/tests/testdata/run/process_stdout_destroy_undestroy.ts
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/denoland/deno/issues/32513
+// Verifies that process.stdout survives destroy() calls.
+// Libraries like mute-stream (used by @inquirer/prompts) call destroy()
+// on process.stdout, which should not actually close the underlying resource.
+import process from "node:process";
+
+console.log("before");
+process.stdout.destroy();
+console.log("after");


### PR DESCRIPTION
## Summary

- Libraries like `mute-stream` (used by `@inquirer/prompts`) call `destroy()` or `end()` on `process.stdout`, which previously closed the underlying Deno resource (rid 1/2). This broke subsequent `console.log` calls with `BadResource: Bad resource ID` because `op_print` looks up the resource in the table.
- Match Node.js behavior where stdio streams are indestructible:
  - Override `_destroy` with a dummy that calls `_undestroy()` to revert stream state without closing the handle (same as Node.js's `dummyDestroy` in `is_main_thread.js`)
  - Override `_handle._onClose` to prevent the `end()` -> `_final` -> `shutdown` -> `_onClose` path from closing the resource

Closes #32513

## Test plan

- [x] New spec test `process_stdout_indestructible` verifies `console.log` works after `process.stdout.destroy()`
- [x] New PTY integration test `process_stdout_destroy_undestroy_pty` 
- [x] Manually verified with `@inquirer/prompts` reproduction from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)