### PR TITLE
fix(ext/node): emit correct error codes for unsupported PQC key types

### DIFF
--- a/ext/node/polyfills/internal/crypto/keys.ts
+++ b/ext/node/polyfills/internal/crypto/keys.ts
@@ -42,7 +42,6 @@ import {
   ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE,
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
-  NodeError,
 } from "ext:deno_node/internal/errors.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import type {
@@ -658,22 +657,12 @@ export function createPrivateKey(
       throw new TypeError(`Can not create private key from ${type} key`);
     }
   } else {
-    let handle;
-    try {
-      handle = op_node_create_private_key(
-        res.data,
-        res.format,
-        res.type ?? "",
-        res.passphrase,
-      );
-    } catch (e) {
-      if (
-        e instanceof TypeError && e.message === "unsupported private key oid"
-      ) {
-        throw new NodeError("ERR_OSSL_UNSUPPORTED", "unsupported");
-      }
-      throw e;
-    }
+    const handle = op_node_create_private_key(
+      res.data,
+      res.format,
+      res.type ?? "",
+      res.passphrase,
+    );
     return new PrivateKeyObject(handle);
   }
 }
@@ -696,21 +685,11 @@ export function createPublicKey(
       throw new TypeError(`Can not create private key from ${type} key`);
     }
   } else {
-    let handle;
-    try {
-      handle = op_node_create_public_key(
-        res.data,
-        res.format,
-        res.type ?? "",
-      );
-    } catch (e) {
-      if (
-        e instanceof TypeError && e.message === "unsupported private key oid"
-      ) {
-        throw new NodeError("ERR_OSSL_EVP_DECODE_ERROR", "unsupported");
-      }
-      throw e;
-    }
+    const handle = op_node_create_public_key(
+      res.data,
+      res.format,
+      res.type ?? "",
+    );
     return new PublicKeyObject(handle);
   }
 }

--- a/ext/node_crypto/keys.rs
+++ b/ext/node_crypto/keys.rs
@@ -570,6 +570,12 @@ pub enum EdRawError {
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
+#[class(generic)]
+#[error("unsupported")]
+#[property("code" = "ERR_OSSL_UNSUPPORTED")]
+pub struct UnsupportedPrivateKeyOidError;
+
+#[derive(Debug, thiserror::Error, deno_error::JsError)]
 #[class(type)]
 pub enum AsymmetricPrivateKeyError {
   #[error("invalid PEM private key: not valid utf8 starting at byte {0}")]
@@ -621,8 +627,13 @@ pub enum AsymmetricPrivateKeyError {
   InvalidEd25519PrivateKey,
   #[error("missing dh parameters")]
   MissingDhParameters,
-  #[error("unsupported private key oid")]
-  UnsupportedPrivateKeyOid,
+  #[class(inherit)]
+  #[error(transparent)]
+  UnsupportedPrivateKeyOid(
+    #[from]
+    #[inherit]
+    UnsupportedPrivateKeyOidError,
+  ),
 }
 
 #[derive(Debug, thiserror::Error, deno_error::JsError)]
@@ -714,8 +725,9 @@ pub enum AsymmetricPublicKeyError {
   #[class(type)]
   #[error("malformed or missing public key in dh spki")]
   MalformedOrMissingPublicKeyInDhSpki,
-  #[class(type)]
-  #[error("unsupported private key oid")]
+  #[class(generic)]
+  #[error("unsupported")]
+  #[property("code" = "ERR_OSSL_EVP_DECODE_ERROR")]
   UnsupportedPrivateKeyOid,
 }
 
@@ -914,7 +926,7 @@ impl KeyObjectHandle {
           params,
         })
       }
-      _ => return Err(AsymmetricPrivateKeyError::UnsupportedPrivateKeyOid),
+      _ => return Err(UnsupportedPrivateKeyOidError.into()),
     };
 
     Ok(KeyObjectHandle::AsymmetricPrivate(private_key))


### PR DESCRIPTION
## Summary
- When `createPublicKey` or `createPrivateKey` encounters an unsupported PQC key type (ML-KEM, ML-DSA, SLH-DSA), emit Node-compatible error codes (`ERR_OSSL_EVP_DECODE_ERROR` / `ERR_OSSL_UNSUPPORTED`) instead of a plain TypeError without a `code` property
- Enables 3 node_compat tests: `test-crypto-pqc-key-objects-{ml-dsa,ml-kem,slh-dsa}`

## Test plan
- [x] `cargo test --test node_compat -- test-crypto-pqc-key-objects-` passes (3/3 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)