### PR TITLE
docs: document --env-file flag in Deno.Env type definitions

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -1591,9 +1591,7 @@ declare namespace Deno {
    * deno run --env-file --allow-env main.ts
    * ```
    *
-   * Note that environment variables from `.env` files do not override existing
-   * environment variables. If a variable is defined both in the environment and
-   * in the `.env` file, the value from the environment is used.
+   * Learn more at [the Deno docs](https://docs.deno.com/runtime/reference/env_variables/).
    *
    * @tags allow-env
    * @category Runtime


### PR DESCRIPTION
Updates `lib.deno.ns.d.ts` to mention how to load environment variables from `.env` files using the `--env-file` flag.

This helps users discover the feature when:
- Browsing the type definitions
- Using IDE hover docs on `Deno.env`
- Reading the generated API documentation

The documentation explains:
- Basic usage with `--env-file=.env`
- Default behavior when `--env-file` is specified without a value
- That existing environment variables take precedence over `.env` file values