### PR TITLE
perf(npm): improve decompression speed more

### DIFF
--- a/libs/npm_cache/tarball_extract.rs
+++ b/libs/npm_cache/tarball_extract.rs
@@ -102,7 +102,9 @@ fn decompress_gzip(
   if decompressed.try_reserve(size_hint).is_err() {
     return decompress_gzip_streaming(data);
   }
-  decompressed.resize(size_hint, 0);
+  // SAFETY: we reserved `size_hint` bytes above and libdeflate will
+  // write into this buffer, then we truncate to the actual size.
+  unsafe { decompressed.set_len(size_hint) };
   match decompressor.gzip_decompress(data, &mut decompressed) {
     Ok(actual_size) => {
       decompressed.truncate(actual_size);


### PR DESCRIPTION
Saw this in a flamegraph. We're going to overwrite it so we don't need to fill with zeroes.

<img width="423" height="199" alt="image" src="https://github.com/user-attachments/assets/fe216eb3-6302-43e8-9b1a-67bf3ea9d164" />
