### PR TITLE
feat(info): add `--depth` and `--collapse-modules`

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -306,6 +306,8 @@ pub struct InitFlags {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InfoFlags {
+  pub depth: Option<usize>,
+  pub collapse_modules: bool,
   pub json: bool,
   pub file: Option<String>,
 }
@@ -3455,6 +3457,22 @@ The following information is shown:
       .arg(node_modules_dir_arg())
       .arg(vendor_arg())
       .arg(
+        Arg::new("depth")
+          .long("depth")
+          .help("Limit the depth of the displayed dependency tree")
+          .requires("file")
+          .conflicts_with("json")
+          .value_parser(value_parser!(usize)),
+      )
+      .arg(
+        Arg::new("collapse-modules")
+          .long("collapse-modules")
+          .help("Collapse external module subtrees into a single line")
+          .requires("file")
+          .conflicts_with("json")
+          .action(ArgAction::SetTrue),
+      )
+      .arg(
         Arg::new("json")
           .long("json")
           .help("UNSTABLE: Outputs the information in JSON format")
@@ -6583,8 +6601,12 @@ fn info_parse(
   no_remote_arg_parse(flags, matches);
   no_npm_arg_parse(flags, matches);
   allow_and_deny_import_parse(flags, matches)?;
+  let depth = matches.remove_one::<usize>("depth");
+  let collapse_modules = matches.get_flag("collapse-modules");
   let json = matches.get_flag("json");
   flags.subcommand = DenoSubcommand::Info(InfoFlags {
+    depth,
+    collapse_modules,
     file: matches.remove_one::<String>("file"),
     json,
   });
@@ -9501,6 +9523,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: false,
           file: Some("script.ts".to_string()),
         }),
@@ -9513,6 +9537,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: false,
           file: Some("script.ts".to_string()),
         }),
@@ -9526,6 +9552,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: true,
           file: Some("script.ts".to_string()),
         }),
@@ -9538,6 +9566,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: false,
           file: None
         }),
@@ -9550,6 +9580,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: true,
           file: None
         }),
@@ -9569,6 +9601,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: false,
           file: None
         }),
@@ -9577,6 +9611,60 @@ mod tests {
         no_remote: true,
         ..Flags::default()
       }
+    );
+
+    let r = flags_from_vec(svec!["deno", "info", "--depth", "1", "script.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: Some(1),
+          collapse_modules: false,
+          json: false,
+          file: Some("script.ts".to_string()),
+        }),
+        ..Flags::default()
+      }
+    );
+
+    let r =
+      flags_from_vec(svec!["deno", "info", "--collapse-modules", "script.ts"]);
+    assert_eq!(
+      r.unwrap(),
+      Flags {
+        subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: true,
+          json: false,
+          file: Some("script.ts".to_string()),
+        }),
+        ..Flags::default()
+      }
+    );
+
+    let r = flags_from_vec(svec![
+      "deno",
+      "info",
+      "--json",
+      "--depth",
+      "1",
+      "script.ts"
+    ]);
+    assert_eq!(
+      r.unwrap_err().kind(),
+      clap::error::ErrorKind::ArgumentConflict
+    );
+
+    let r = flags_from_vec(svec![
+      "deno",
+      "info",
+      "--json",
+      "--collapse-modules",
+      "script.ts"
+    ]);
+    assert_eq!(
+      r.unwrap_err().kind(),
+      clap::error::ErrorKind::ArgumentConflict
     );
   }
 
@@ -10504,6 +10592,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           file: Some("script.ts".to_string()),
           json: false,
         }),
@@ -12161,6 +12251,8 @@ mod tests {
       r.unwrap(),
       Flags {
         subcommand: DenoSubcommand::Info(InfoFlags {
+          depth: None,
+          collapse_modules: false,
           json: false,
           file: Some("https://example.com".to_string()),
         }),

--- a/cli/tools/info.rs
+++ b/cli/tools/info.rs
@@ -28,6 +28,7 @@ use deno_npm_installer::graph::NpmCachingStrategy;
 use deno_path_util::resolve_url_or_path;
 use deno_resolver::DenoResolveErrorKind;
 use deno_resolver::display::DisplayTreeNode;
+use deno_semver::jsr::JsrPackageReqReference;
 use deno_semver::npm::NpmPackageReqReference;
 use deno_semver::package::PackageReq;
 use deno_terminal::colors;
@@ -192,6 +193,10 @@ pub async fn info(
       GraphDisplayContext::write(
         &graph,
         maybe_npm_info.as_ref().map(|(r, s)| (r.as_ref(), s)),
+        GraphDisplayOptions {
+          depth: info_flags.depth,
+          collapse_modules: info_flags.collapse_modules,
+        },
         &mut output,
       )?;
       display::write_to_stdout_ignore_sigpipe(output.as_bytes())?;
@@ -486,7 +491,27 @@ impl NpmInfo {
 struct GraphDisplayContext<'a> {
   graph: &'a ModuleGraph,
   npm_info: NpmInfo,
+  options: GraphDisplayOptions,
+  collapsed_labels: HashMap<String, String>,
   seen: HashSet<String>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct GraphDisplayOptions {
+  depth: Option<usize>,
+  collapse_modules: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SubtreeSummary {
+  file_count: usize,
+  size: u64,
+}
+
+impl SubtreeSummary {
+  fn has_files(self) -> bool {
+    self.file_count > 0
+  }
 }
 
 impl<'a> GraphDisplayContext<'a> {
@@ -496,6 +521,7 @@ impl<'a> GraphDisplayContext<'a> {
       &'a CliManagedNpmResolver,
       &'a NpmResolutionSnapshot,
     )>,
+    options: GraphDisplayOptions,
     writer: &mut TWrite,
   ) -> Result<(), AnyError> {
     let npm_info = match managed_npm_info {
@@ -507,6 +533,8 @@ impl<'a> GraphDisplayContext<'a> {
     Self {
       graph,
       npm_info,
+      options,
+      collapsed_labels: Default::default(),
       seen: Default::default(),
     }
     .into_writer(writer)
@@ -578,7 +606,7 @@ impl<'a> GraphDisplayContext<'a> {
           display::human_size(total_size),
         )?;
         writeln!(writer)?;
-        let root_node = self.build_module_info(root, false);
+        let root_node = self.build_module_info(root, false, 0, None);
         root_node.print(writer)?;
         Ok(())
       }
@@ -595,15 +623,21 @@ impl<'a> GraphDisplayContext<'a> {
     }
   }
 
-  fn build_dep_info(&mut self, dep: &Dependency) -> Vec<DisplayTreeNode> {
+  fn build_dep_info(
+    &mut self,
+    dep: &Dependency,
+    depth: usize,
+  ) -> Vec<DisplayTreeNode> {
     let mut children = Vec::with_capacity(2);
     if !dep.maybe_code.is_none()
-      && let Some(child) = self.build_resolved_info(&dep.maybe_code, false)
+      && let Some(child) =
+        self.build_resolved_info(&dep.maybe_code, false, depth)
     {
       children.push(child);
     }
     if !dep.maybe_type.is_none()
-      && let Some(child) = self.build_resolved_info(&dep.maybe_type, true)
+      && let Some(child) =
+        self.build_resolved_info(&dep.maybe_type, true, depth)
     {
       children.push(child);
     }
@@ -614,6 +648,8 @@ impl<'a> GraphDisplayContext<'a> {
     &mut self,
     module: &Module,
     type_dep: bool,
+    depth: usize,
+    display_specifier: Option<&ModuleSpecifier>,
   ) -> DisplayTreeNode {
     enum PackageOrSpecifier<'a> {
       Package {
@@ -637,10 +673,11 @@ impl<'a> GraphDisplayContext<'a> {
       }
       None => Specifier(module.specifier().clone()),
     };
-    let was_seen = !self.seen.insert(match &package_or_specifier {
+    let key = match &package_or_specifier {
       Package { package, .. } => package.id.as_serialized().into_string(),
       Specifier(specifier) => specifier.to_string(),
-    });
+    };
+    let was_seen = !self.seen.insert(key);
     let header_text = match &package_or_specifier {
       Package { package, sub_path } => {
         format!(
@@ -653,13 +690,43 @@ impl<'a> GraphDisplayContext<'a> {
       }
       Specifier(specifier) => specifier.to_string(),
     };
+    let can_collapse_module = self.should_collapse_module(module);
+    let should_collapse_module = !was_seen && can_collapse_module;
+    let collapsed_label = can_collapse_module.then(|| {
+      self
+        .collapsed_labels
+        .get(&header_text)
+        .cloned()
+        .unwrap_or_else(|| {
+          self.collapsed_module_label(module, display_specifier)
+        })
+    });
+    if let Some(label) = &collapsed_label
+      && should_collapse_module
+    {
+      self
+        .collapsed_labels
+        .insert(header_text.clone(), label.clone());
+    }
     let header_text = if was_seen {
+      let header_text = if let Some(label) = collapsed_label {
+        label
+      } else {
+        header_text
+      };
       let specifier_str = if type_dep {
         colors::italic_gray(header_text).to_string()
       } else {
         colors::gray(header_text).to_string()
       };
       format!("{} {}", specifier_str, colors::gray("*"))
+    } else if should_collapse_module {
+      let summary = self.summarize_module(module, true);
+      format!(
+        "{} {}",
+        collapsed_label.unwrap(),
+        subtree_summary_to_text(summary),
+      )
     } else {
       let header_text = if type_dep {
         colors::italic(header_text).to_string()
@@ -682,26 +749,46 @@ impl<'a> GraphDisplayContext<'a> {
 
     let mut tree_node = DisplayTreeNode::from_text(header_text);
 
-    if !was_seen {
+    if !was_seen && !should_collapse_module {
+      if self.should_truncate_children(depth) {
+        let summary = match &package_or_specifier {
+          Package { package, .. } => self.summarize_npm_package(package, false),
+          Specifier(_) => self.summarize_module(module, false),
+        };
+        if summary.has_files() {
+          tree_node.children.push(DisplayTreeNode::from_text(format!(
+            "... {}",
+            subtree_summary_to_text(summary)
+          )));
+        }
+        return tree_node;
+      }
+
       match &package_or_specifier {
         Package { package, .. } => {
-          tree_node.children.extend(self.build_npm_deps(package));
+          tree_node
+            .children
+            .extend(self.build_npm_deps(package, depth + 1));
         }
         Specifier(_) => match module {
           Module::Js(module) => {
             if let Some(types_dep) = &module.maybe_types_dependency
               && let Some(child) =
-                self.build_resolved_info(&types_dep.dependency, true)
+                self.build_resolved_info(&types_dep.dependency, true, depth + 1)
             {
               tree_node.children.push(child);
             }
             for dep in module.dependencies.values() {
-              tree_node.children.extend(self.build_dep_info(dep));
+              tree_node
+                .children
+                .extend(self.build_dep_info(dep, depth + 1));
             }
           }
           Module::Wasm(module) => {
             for dep in module.dependencies.values() {
-              tree_node.children.extend(self.build_dep_info(dep));
+              tree_node
+                .children
+                .extend(self.build_dep_info(dep, depth + 1));
             }
           }
           Module::Json(_)
@@ -717,6 +804,7 @@ impl<'a> GraphDisplayContext<'a> {
   fn build_npm_deps(
     &mut self,
     package: &NpmResolutionPackage,
+    depth: usize,
   ) -> Vec<DisplayTreeNode> {
     let mut deps = package.dependencies.values().collect::<Vec<_>>();
     deps.sort();
@@ -736,9 +824,19 @@ impl<'a> GraphDisplayContext<'a> {
           !self.seen.insert(package.id.as_serialized().into_string());
         if was_seen {
           child.text = format!("{} {}", child.text, colors::gray("*"));
+        } else if self.should_truncate_children(depth) {
+          let summary = self.summarize_npm_package(package, false);
+          if summary.has_files() {
+            child.children.push(DisplayTreeNode::from_text(format!(
+              "... {}",
+              subtree_summary_to_text(summary)
+            )));
+          }
         } else {
           let package = package.clone();
-          child.children.extend(self.build_npm_deps(&package));
+          child
+            .children
+            .extend(self.build_npm_deps(&package, depth + 1));
         }
       }
       children.push(child);
@@ -811,13 +909,16 @@ impl<'a> GraphDisplayContext<'a> {
     &mut self,
     resolution: &Resolution,
     type_dep: bool,
+    depth: usize,
   ) -> Option<DisplayTreeNode> {
     match resolution {
       Resolution::Ok(resolved) => {
         let specifier = &resolved.specifier;
         let resolved_specifier = self.graph.resolve(specifier);
         Some(match self.graph.try_get(resolved_specifier) {
-          Ok(Some(module)) => self.build_module_info(module, type_dep),
+          Ok(Some(module)) => {
+            self.build_module_info(module, type_dep, depth, Some(specifier))
+          }
           Err(err) => self.build_error_info(err, resolved_specifier),
           Ok(None) => DisplayTreeNode::from_text(format!(
             "{} {}",
@@ -834,6 +935,189 @@ impl<'a> GraphDisplayContext<'a> {
       _ => None,
     }
   }
+
+  fn should_truncate_children(&self, depth: usize) -> bool {
+    self.options.depth.is_some_and(|limit| depth >= limit)
+  }
+
+  fn should_collapse_module(&self, module: &Module) -> bool {
+    self.options.collapse_modules
+      && module.npm().is_none()
+      && module.specifier().scheme() != "file"
+  }
+
+  fn collapsed_module_label(
+    &self,
+    module: &Module,
+    display_specifier: Option<&ModuleSpecifier>,
+  ) -> String {
+    display_specifier
+      .and_then(Self::specifier_to_collapsed_label)
+      .or_else(|| Self::specifier_to_collapsed_label(module.specifier()))
+      .unwrap_or_else(|| module.specifier().to_string())
+  }
+
+  fn specifier_to_collapsed_label(
+    specifier: &ModuleSpecifier,
+  ) -> Option<String> {
+    JsrPackageReqReference::from_specifier(specifier)
+      .map(|req_ref| req_ref.to_string())
+      .ok()
+      .or_else(|| match specifier.scheme() {
+        "jsr" | "npm" => Some(specifier.to_string()),
+        _ => None,
+      })
+  }
+
+  fn summarize_module(
+    &self,
+    module: &Module,
+    include_self: bool,
+  ) -> SubtreeSummary {
+    let mut visited = HashSet::new();
+    self.summarize_module_with_visited(module, include_self, &mut visited)
+  }
+
+  fn summarize_module_with_visited(
+    &self,
+    module: &Module,
+    include_self: bool,
+    visited: &mut HashSet<String>,
+  ) -> SubtreeSummary {
+    if let Module::Npm(module) = module {
+      return self
+        .npm_info
+        .resolve_package(module.pkg_req_ref.req())
+        .map(|package| {
+          self.summarize_npm_package_with_visited(
+            package,
+            include_self,
+            visited,
+          )
+        })
+        .unwrap_or_default();
+    }
+
+    let key = module.specifier().to_string();
+    if !visited.insert(key) {
+      return SubtreeSummary::default();
+    }
+
+    let mut summary = SubtreeSummary::default();
+    if include_self {
+      summary.file_count += 1;
+      summary.size += match module {
+        Module::Js(module) => module.size() as u64,
+        Module::Json(module) => module.size() as u64,
+        Module::Wasm(module) => module.size() as u64,
+        Module::Node(_) | Module::Npm(_) | Module::External(_) => 0,
+      };
+    }
+
+    match module {
+      Module::Js(module) => {
+        if let Some(types_dep) = &module.maybe_types_dependency {
+          summary += self.summarize_resolution(&types_dep.dependency, visited);
+        }
+        for dep in module.dependencies.values() {
+          summary += self.summarize_dependency(dep, visited);
+        }
+      }
+      Module::Wasm(module) => {
+        for dep in module.dependencies.values() {
+          summary += self.summarize_dependency(dep, visited);
+        }
+      }
+      Module::Json(_)
+      | Module::Npm(_)
+      | Module::Node(_)
+      | Module::External(_) => {}
+    }
+
+    summary
+  }
+
+  fn summarize_dependency(
+    &self,
+    dep: &Dependency,
+    visited: &mut HashSet<String>,
+  ) -> SubtreeSummary {
+    let mut summary = SubtreeSummary::default();
+    if !dep.maybe_code.is_none() {
+      summary += self.summarize_resolution(&dep.maybe_code, visited);
+    }
+    if !dep.maybe_type.is_none() {
+      summary += self.summarize_resolution(&dep.maybe_type, visited);
+    }
+    summary
+  }
+
+  fn summarize_resolution(
+    &self,
+    resolution: &Resolution,
+    visited: &mut HashSet<String>,
+  ) -> SubtreeSummary {
+    match resolution {
+      Resolution::Ok(resolved) => {
+        let resolved_specifier = self.graph.resolve(&resolved.specifier);
+        match self.graph.try_get(resolved_specifier) {
+          Ok(Some(module)) => {
+            self.summarize_module_with_visited(module, true, visited)
+          }
+          _ => SubtreeSummary::default(),
+        }
+      }
+      _ => SubtreeSummary::default(),
+    }
+  }
+
+  fn summarize_npm_package(
+    &self,
+    package: &NpmResolutionPackage,
+    include_self: bool,
+  ) -> SubtreeSummary {
+    let mut visited = HashSet::new();
+    self.summarize_npm_package_with_visited(package, include_self, &mut visited)
+  }
+
+  fn summarize_npm_package_with_visited(
+    &self,
+    package: &NpmResolutionPackage,
+    include_self: bool,
+    visited: &mut HashSet<String>,
+  ) -> SubtreeSummary {
+    let key = package.id.as_serialized().into_string();
+    if !visited.insert(key) {
+      return SubtreeSummary::default();
+    }
+
+    let mut summary = SubtreeSummary::default();
+    if include_self {
+      summary.file_count += 1;
+      summary.size += self
+        .npm_info
+        .package_sizes
+        .get(&package.id)
+        .copied()
+        .unwrap_or_default();
+    }
+
+    for dep_id in package.dependencies.values() {
+      if let Some(dep_pkg) = self.npm_info.packages.get(dep_id) {
+        summary +=
+          self.summarize_npm_package_with_visited(dep_pkg, true, visited);
+      }
+    }
+
+    summary
+  }
+}
+
+impl std::ops::AddAssign for SubtreeSummary {
+  fn add_assign(&mut self, rhs: Self) {
+    self.file_count += rhs.file_count;
+    self.size += rhs.size;
+  }
 }
 
 fn maybe_size_to_text(maybe_size: Option<u64>) -> String {
@@ -845,4 +1129,17 @@ fn maybe_size_to_text(maybe_size: Option<u64>) -> String {
     }
   ))
   .to_string()
+}
+
+fn subtree_summary_to_text(summary: SubtreeSummary) -> String {
+  format!(
+    "(+ {} {}, {})",
+    summary.file_count,
+    if summary.file_count == 1 {
+      "file"
+    } else {
+      "files"
+    },
+    display::human_size(summary.size as f64),
+  )
 }

--- a/tests/specs/info/depth_and_collapse_modules/__test__.jsonc
+++ b/tests/specs/info/depth_and_collapse_modules/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tests": {
+    "depth": {
+      "args": "info --quiet --depth 1 mod.ts",
+      "output": "depth.out"
+    },
+    "collapse_modules": {
+      "args": "info --quiet --collapse-modules mod.ts",
+      "output": "collapse_modules.out"
+    },
+    "depth_and_collapse_modules": {
+      "args": "info --quiet --depth 1 --collapse-modules mod.ts",
+      "output": "depth_and_collapse_modules.out"
+    },
+    "collapse_modules_repeated": {
+      "args": "info --quiet --collapse-modules repeated.ts",
+      "output": "collapse_modules_repeated.out"
+    }
+  }
+}

--- a/tests/specs/info/depth_and_collapse_modules/collapse_modules.out
+++ b/tests/specs/info/depth_and_collapse_modules/collapse_modules.out
@@ -1,0 +1,9 @@
+local: [WILDLINE]mod.ts
+type: TypeScript
+dependencies: 4 unique
+size: [WILDLINE]
+
+file:///[WILDLINE]/mod.ts ([WILDLINE])
+├─┬ file:///[WILDLINE]/lib.ts ([WILDLINE])
+│ └── file:///[WILDLINE]/inner.ts ([WILDLINE])
+└── jsr:@denotest/module-graph[WILDCARD] (+ 2 files, [WILDLINE])

--- a/tests/specs/info/depth_and_collapse_modules/collapse_modules_repeated.out
+++ b/tests/specs/info/depth_and_collapse_modules/collapse_modules_repeated.out
@@ -1,0 +1,10 @@
+local: [WILDLINE]repeated.ts
+type: TypeScript
+dependencies: 4 unique
+size: [WILDLINE]
+
+file:///[WILDLINE]/repeated.ts ([WILDLINE])
+├─┬ file:///[WILDLINE]/repeat_a.ts ([WILDLINE])
+│ └── jsr:@denotest/module-graph[WILDCARD] (+ 2 files, [WILDLINE])
+└─┬ file:///[WILDLINE]/repeat_b.ts ([WILDLINE])
+  └── jsr:@denotest/module-graph[WILDCARD] *

--- a/tests/specs/info/depth_and_collapse_modules/depth.out
+++ b/tests/specs/info/depth_and_collapse_modules/depth.out
@@ -1,0 +1,10 @@
+local: [WILDLINE]mod.ts
+type: TypeScript
+dependencies: 4 unique
+size: [WILDLINE]
+
+file:///[WILDLINE]/mod.ts ([WILDLINE])
+├─┬ file:///[WILDLINE]/lib.ts ([WILDLINE])
+│ └── ... (+ 1 file, [WILDLINE])
+└─┬ [WILDLINE]/module-graph/[WILDLINE]/mod.ts ([WILDLINE])
+  └── ... (+ 1 file, [WILDLINE])

--- a/tests/specs/info/depth_and_collapse_modules/depth_and_collapse_modules.out
+++ b/tests/specs/info/depth_and_collapse_modules/depth_and_collapse_modules.out
@@ -1,0 +1,9 @@
+local: [WILDLINE]mod.ts
+type: TypeScript
+dependencies: 4 unique
+size: [WILDLINE]
+
+file:///[WILDLINE]/mod.ts ([WILDLINE])
+├─┬ file:///[WILDLINE]/lib.ts ([WILDLINE])
+│ └── ... (+ 1 file, [WILDLINE])
+└── jsr:@denotest/module-graph[WILDCARD] (+ 2 files, [WILDLINE])

--- a/tests/specs/info/depth_and_collapse_modules/inner.ts
+++ b/tests/specs/info/depth_and_collapse_modules/inner.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/tests/specs/info/depth_and_collapse_modules/lib.ts
+++ b/tests/specs/info/depth_and_collapse_modules/lib.ts
@@ -1,0 +1,1 @@
+import "./inner.ts";

--- a/tests/specs/info/depth_and_collapse_modules/mod.ts
+++ b/tests/specs/info/depth_and_collapse_modules/mod.ts
@@ -1,0 +1,2 @@
+import "./lib.ts";
+import "jsr:@denotest/module-graph@1.4";

--- a/tests/specs/info/depth_and_collapse_modules/repeat_a.ts
+++ b/tests/specs/info/depth_and_collapse_modules/repeat_a.ts
@@ -1,0 +1,1 @@
+import "jsr:@denotest/module-graph@1.4";

--- a/tests/specs/info/depth_and_collapse_modules/repeat_b.ts
+++ b/tests/specs/info/depth_and_collapse_modules/repeat_b.ts
@@ -1,0 +1,1 @@
+import "jsr:@denotest/module-graph@1.4";

--- a/tests/specs/info/depth_and_collapse_modules/repeated.ts
+++ b/tests/specs/info/depth_and_collapse_modules/repeated.ts
@@ -1,0 +1,2 @@
+import "./repeat_a.ts";
+import "./repeat_b.ts";


### PR DESCRIPTION
## Summary
- add `--depth` and `--collapse-modules` to `deno info`'s text tree output
- collapse external module subtrees while preserving repeated collapsed JSR labels
- cover depth-only, collapse-only, combined, and repeated-collapse cases in spec tests

## Example output

`deno info --depth 1 mod.ts`

```text
file:///.../mod.ts (60B)
├─┬ file:///.../lib.ts (21B)
│ └── ... (+ 1 file, 24B)
└─┬ http://127.0.0.1:4250/@denotest/module-graph/1.4.0/mod.ts (82B)
  └── ... (+ 1 file, 23B)
```

`deno info --collapse-modules mod.ts`

```text
file:///.../mod.ts (60B)
├─┬ file:///.../lib.ts (21B)
│ └── file:///.../inner.ts (24B)
└── jsr:@denotest/module-graph@1.4 (+ 2 files, 105B)
```

## Testing
- cargo test info --lib
- cargo test -p specs_tests specs::info::depth_and_collapse_modules --test specs -- --nocapture
- cargo build --bin deno
- cargo fmt --all --check
- deno fmt --check tests/specs/info/depth_and_collapse_modules/mod.ts tests/specs/info/depth_and_collapse_modules/lib.ts tests/specs/info/depth_and_collapse_modules/inner.ts tests/specs/info/depth_and_collapse_modules/repeated.ts tests/specs/info/depth_and_collapse_modules/repeat_a.ts tests/specs/info/depth_and_collapse_modules/repeat_b.ts

## Related
- none found