### PR TITLE
refactor(ext/node): rewrite node:test to bypass Deno.test() layer

### DIFF
--- a/ext/node/polyfills/testing.ts
+++ b/ext/node/polyfills/testing.ts
@@ -1,25 +1,90 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-import { primordials } from "ext:core/mod.js";
+import { core, primordials } from "ext:core/mod.js";
+
+// These ops are only available when running under `deno test`.
+// Must be accessed lazily via core.ops since they are registered after the snapshot.
+const ops = core.ops;
 const {
   ArrayPrototypeForEach,
   ArrayPrototypeIndexOf,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
+  DateNow,
   Error,
+  MapPrototypeDelete,
+  MapPrototypeGet,
+  MapPrototypeSet,
+  NumberIsInteger,
   ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor,
+  ObjectGetPrototypeOf,
+  ObjectHasOwn,
   Promise,
-  PromisePrototypeThen,
   ReflectApply,
   SafeArrayIterator,
-  SafePromiseAll,
-  SafePromisePrototypeFinally,
+  SafeMap,
   String,
-  Symbol,
+  StringPrototypeCharCodeAt,
+  StringPrototypeReplaceAll,
+  SymbolToStringTag,
   TypeError,
+  TypedArrayPrototypeGetBuffer,
+  Uint8Array,
+  Uint32Array,
 } = primordials;
+
+// deno-lint-ignore no-explicit-any
+type CallbackFn = (...args: any[]) => unknown;
+
+// Inline escapeName since ext:cli/40_test_common.js is not available in the node polyfill snapshot
+const ESCAPE_ASCII_CHARS: [string, string][] = [
+  ["\b", "\\b"],
+  ["\f", "\\f"],
+  ["\t", "\\t"],
+  ["\n", "\\n"],
+  ["\r", "\\r"],
+  ["\v", "\\v"],
+];
+function escapeName(name: string): string {
+  for (let i = 0; i < name.length; i++) {
+    const ch = StringPrototypeCharCodeAt(name, i);
+    if (ch <= 13 && ch >= 8) {
+      for (
+        const pair of new SafeArrayIterator(ESCAPE_ASCII_CHARS)
+      ) {
+        name = StringPrototypeReplaceAll(name, pair[0], pair[1]);
+      }
+      return name;
+    }
+  }
+  return name;
+}
 import { notImplemented } from "ext:deno_node/_utils.ts";
 import assert from "node:assert";
+
+// Check if we're running in `deno test` subcommand.
+// Must be lazy since ops are added after snapshot.
+function isTestSubcommand(): boolean {
+  return typeof ops.op_register_test === "function";
+}
+
+const registerTestIdRetBuf = new Uint32Array(1);
+const registerTestIdRetBufU8 = new Uint8Array(
+  TypedArrayPrototypeGetBuffer(registerTestIdRetBuf),
+);
+
+let cachedOrigin: string | undefined = undefined;
+function getOrigin(): string {
+  if (cachedOrigin === undefined) {
+    cachedOrigin = ops.op_test_get_origin();
+  }
+  return cachedOrigin;
+}
+
+// --------------------------------------------------------------------------
+// Assert object for t.assert
+// --------------------------------------------------------------------------
 
 const methodsToCopy = [
   "deepEqual",
@@ -42,202 +107,547 @@ const methodsToCopy = [
   "ok",
 ];
 
-/** `assert` object available via t.assert */
-let assertObject = undefined;
-function getAssertObject() {
+let assertObject: Record<string, unknown> | undefined = undefined;
+function getAssertObject(plan?: TestPlan) {
+  if (plan) {
+    // When a plan is set, wrap each assertion to count it
+    const obj = { __proto__: null } as Record<string, unknown>;
+    ArrayPrototypeForEach(methodsToCopy, (method: string) => {
+      obj[method] = (...args: unknown[]) => {
+        plan.count();
+        return ReflectApply(
+          (assert as Record<string, CallbackFn>)[method],
+          assert,
+          args,
+        );
+      };
+    });
+    return obj;
+  }
   if (assertObject === undefined) {
-    assertObject = { __proto__: null };
-    ArrayPrototypeForEach(methodsToCopy, (method) => {
-      assertObject[method] = assert[method];
+    assertObject = { __proto__: null } as Record<string, unknown>;
+    ArrayPrototypeForEach(methodsToCopy, (method: string) => {
+      assertObject![method] = (assert as Record<string, unknown>)[method];
     });
   }
   return assertObject;
 }
 
-export function run() {
-  notImplemented("test.run");
+// --------------------------------------------------------------------------
+// Test state tracking (mirrors 40_test.js pattern)
+// --------------------------------------------------------------------------
+
+interface TestState {
+  children: StepDesc[];
+  completed: boolean;
+  failed: boolean;
+  lastError?: Error;
 }
+
+interface TestDesc {
+  id: number;
+  name: string;
+  origin: string;
+  location: { fileName: string; lineNumber: number; columnNumber: number };
+  ignore: boolean;
+  only: boolean;
+  fn: CallbackFn;
+}
+
+interface StepDesc extends TestDesc {
+  parent: TestDesc | StepDesc;
+  level: number;
+  rootId: number;
+  rootName: string;
+}
+
+const testStates = new SafeMap<number, TestState>();
+
+// --------------------------------------------------------------------------
+// TestPlan - assertion counting (t.plan)
+// --------------------------------------------------------------------------
+
+class TestPlan {
+  expected: number;
+  actual: number;
+
+  constructor(count: number) {
+    if (typeof count !== "number" || count < 0 || !NumberIsInteger(count)) {
+      throw new TypeError("plan count must be a non-negative integer");
+    }
+    this.expected = count;
+    this.actual = 0;
+  }
+
+  count() {
+    this.actual++;
+  }
+
+  check() {
+    if (this.actual !== this.expected) {
+      throw new Error(
+        `plan expected ${this.expected} assertions but received ${this.actual}`,
+      );
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
+// NodeTestContext - the `t` object passed to test functions
+// --------------------------------------------------------------------------
 
 function noop() {}
 
-const skippedSymbol = Symbol("skipped");
-
 class NodeTestContext {
-  #denoContext: Deno.TestContext;
-  #afterHooks: (() => void)[] = [];
-  #beforeHooks: (() => void)[] = [];
+  #name: string;
+  #testDesc: TestDesc | StepDesc;
   #parent: NodeTestContext | undefined;
   #skipped = false;
+  #todoMarked = false;
+  #abortController: AbortController;
+  #plan: TestPlan | null = null;
+  #afterHooks: CallbackFn[] = [];
+  #beforeEachHooks: CallbackFn[] = [];
+  #afterEachHooks: CallbackFn[] = [];
+  #assert: Record<string, unknown> | undefined;
 
-  constructor(t: Deno.TestContext, parent: NodeTestContext | undefined) {
-    this.#denoContext = t;
+  constructor(
+    name: string,
+    testDesc: TestDesc | StepDesc,
+    parent: NodeTestContext | undefined,
+    abortController: AbortController,
+  ) {
+    this.#name = name;
+    this.#testDesc = testDesc;
     this.#parent = parent;
+    this.#abortController = abortController;
   }
 
-  get [skippedSymbol]() {
-    return this.#skipped || (this.#parent?.[skippedSymbol] ?? false);
+  get [SymbolToStringTag]() {
+    return "TestContext";
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get signal(): AbortSignal {
+    return this.#abortController.signal;
   }
 
   get assert() {
-    return getAssertObject();
-  }
-
-  get signal() {
-    notImplemented("test.TestContext.signal");
-    return null;
-  }
-
-  get name() {
-    notImplemented("test.TestContext.name");
-    return null;
-  }
-
-  diagnostic(message) {
-    // deno-lint-ignore no-console
-    console.log("DIAGNOSTIC:", message);
+    if (this.#assert === undefined) {
+      this.#assert = getAssertObject(this.#plan ?? undefined);
+    }
+    return this.#assert;
   }
 
   get mock() {
     return mock;
   }
 
+  get fullName(): string {
+    if (this.#parent) {
+      return `${this.#parent.fullName} > ${this.#name}`;
+    }
+    return this.#name;
+  }
+
+  diagnostic(message: string) {
+    // deno-lint-ignore no-console
+    console.log("DIAGNOSTIC:", message);
+  }
+
+  plan(count: number) {
+    if (this.#plan !== null) {
+      throw new Error("cannot set plan more than once");
+    }
+    this.#plan = new TestPlan(count);
+    // Recreate assert object with plan-counting wrappers
+    this.#assert = undefined;
+  }
+
+  get _plan(): TestPlan | null {
+    return this.#plan;
+  }
+
+  skip(_message?: string) {
+    this.#skipped = true;
+  }
+
+  get _skipped(): boolean {
+    return this.#skipped || (this.#parent?._skipped ?? false);
+  }
+
+  todo(_message?: string) {
+    this.#todoMarked = true;
+    this.#skipped = true;
+  }
+
+  get _todoMarked(): boolean {
+    return this.#todoMarked;
+  }
+
   runOnly() {
-    notImplemented("test.TestContext.runOnly");
-    return null;
+    // Not implemented, but don't throw - just ignore
   }
 
-  skip() {
-    this.#skipped = true;
-    return null;
-  }
-
-  todo() {
-    this.#skipped = true;
-    return null;
-  }
-
-  test(name, options, fn) {
-    const prepared = prepareOptions(name, options, fn, {});
-    // deno-lint-ignore no-this-alias
-    const parentContext = this;
-    const after = async () => {
-      for (const hook of new SafeArrayIterator(this.#afterHooks)) {
-        await hook();
-      }
-    };
-    const before = async () => {
-      for (const hook of new SafeArrayIterator(this.#beforeHooks)) {
-        await hook();
-      }
-    };
-    return PromisePrototypeThen(
-      this.#denoContext.step({
-        name: prepared.name,
-        fn: async (denoTestContext) => {
-          const newNodeTextContext = new NodeTestContext(
-            denoTestContext,
-            parentContext,
-          );
-          try {
-            await before();
-            await prepared.fn(newNodeTextContext);
-            await after();
-          } catch (err) {
-            if (!newNodeTextContext[skippedSymbol]) {
-              throw err;
-            }
-            try {
-              await after();
-            } catch { /* ignore, test is already failing */ }
-          }
-        },
-        ignore: prepared.options.todo || prepared.options.skip,
-        sanitizeExit: false,
-        sanitizeOps: false,
-        sanitizeResources: false,
-      }),
-      () => undefined,
-    );
-  }
-
-  before(fn, _options) {
+  before(fn: CallbackFn, _options?: unknown) {
     if (typeof fn !== "function") {
       throw new TypeError("before() requires a function");
     }
-    ArrayPrototypePush(this.#beforeHooks, fn);
+    let ran = false;
+    ArrayPrototypePush(this.#beforeEachHooks, () => {
+      if (!ran) {
+        ran = true;
+        return fn();
+      }
+    });
   }
 
-  after(fn, _options) {
+  after(fn: CallbackFn, _options?: unknown) {
     if (typeof fn !== "function") {
       throw new TypeError("after() requires a function");
     }
     ArrayPrototypePush(this.#afterHooks, fn);
   }
 
-  beforeEach(_fn, _options) {
-    notImplemented("test.TestContext.beforeEach");
+  beforeEach(fn: CallbackFn, _options?: unknown) {
+    if (typeof fn !== "function") {
+      throw new TypeError("beforeEach() requires a function");
+    }
+    ArrayPrototypePush(this.#beforeEachHooks, fn);
   }
 
-  afterEach(_fn, _options) {
-    notImplemented("test.TestContext.afterEach");
-  }
-}
-
-let currentSuite: TestSuite | null = null;
-
-class TestSuite {
-  #denoTestContext: Deno.TestContext;
-  steps: Promise<boolean>[] = [];
-
-  constructor(t: Deno.TestContext) {
-    this.#denoTestContext = t;
+  afterEach(fn: CallbackFn, _options?: unknown) {
+    if (typeof fn !== "function") {
+      throw new TypeError("afterEach() requires a function");
+    }
+    ArrayPrototypePush(this.#afterEachHooks, fn);
   }
 
-  addTest(name, options, fn, overrides) {
-    const prepared = prepareOptions(name, options, fn, overrides);
-    const step = this.#denoTestContext.step({
-      name: prepared.name,
-      fn: async (denoTestContext) => {
-        const newNodeTextContext = new NodeTestContext(
-          denoTestContext,
-          undefined,
-        );
-        try {
-          return await prepared.fn(newNodeTextContext);
-        } catch (err) {
-          if (newNodeTextContext[skippedSymbol]) {
-            return undefined;
-          } else {
-            throw err;
+  async _runBeforeEachHooks() {
+    for (const hook of new SafeArrayIterator(this.#beforeEachHooks)) {
+      await hook();
+    }
+  }
+
+  async _runAfterEachHooks() {
+    for (const hook of new SafeArrayIterator(this.#afterEachHooks)) {
+      await hook();
+    }
+  }
+
+  async _runAfterHooks() {
+    for (const hook of new SafeArrayIterator(this.#afterHooks)) {
+      await hook();
+    }
+  }
+
+  test(
+    name: string | CallbackFn | Record<string, unknown>,
+    options?: unknown,
+    fn?: CallbackFn,
+  ) {
+    const prepared = prepareOptions(name, options, fn, {});
+    return this.#runSubtest(prepared);
+  }
+
+  async #runSubtest(prepared: PreparedTest): Promise<boolean> {
+    const parentDesc = this.#testDesc;
+    const state = MapPrototypeGet(testStates, parentDesc.id) as TestState;
+    if (state.completed) {
+      throw new Error(
+        "Cannot run test step after parent scope has finished execution.",
+      );
+    }
+
+    const level = ObjectHasOwn(parentDesc, "level")
+      ? (parentDesc as StepDesc).level + 1
+      : 1;
+    const rootId = ObjectHasOwn(parentDesc, "rootId")
+      ? (parentDesc as StepDesc).rootId
+      : parentDesc.id;
+    const rootName = ObjectHasOwn(parentDesc, "rootName")
+      ? (parentDesc as StepDesc).rootName
+      : parentDesc.name;
+
+    const location = core.currentUserCallSite();
+    const stepName = escapeName(prepared.name);
+
+    const stepId = ops.op_register_test_step(
+      stepName,
+      location.fileName,
+      location.lineNumber,
+      location.columnNumber,
+      level,
+      parentDesc.id,
+      rootId,
+      escapeName(rootName),
+    );
+
+    const stepDesc: StepDesc = {
+      id: stepId,
+      name: stepName,
+      origin: parentDesc.origin,
+      location,
+      ignore: prepared.options.skip || prepared.options.todo || false,
+      only: prepared.options.only || false,
+      fn: prepared.fn,
+      parent: parentDesc,
+      level,
+      rootId,
+      rootName,
+    };
+
+    const stepState: TestState = {
+      children: [],
+      completed: false,
+      failed: false,
+    };
+    MapPrototypeSet(testStates, stepId, stepState);
+    ArrayPrototypePush(state.children, stepDesc);
+
+    ops.op_test_event_step_wait(stepId);
+    const earlier = DateNow();
+
+    if (stepDesc.ignore) {
+      stepState.completed = true;
+      const elapsed = DateNow() - earlier;
+      ops.op_test_event_step_result_ignored(stepId, elapsed);
+      return true;
+    }
+
+    const childAbortController = new AbortController();
+    const childContext = new NodeTestContext(
+      prepared.name,
+      stepDesc,
+      this,
+      childAbortController,
+    );
+
+    let ok = true;
+    try {
+      // Run parent's beforeEach hooks for this child
+      await this._runBeforeEachHooks();
+
+      // Run the test function
+      if (prepared.fn.length >= 2) {
+        // Callback-style
+        await new Promise<void>((resolve, reject) => {
+          const done = (err?: Error) => {
+            if (err) reject(err);
+            else resolve();
+          };
+          try {
+            ReflectApply(prepared.fn, childContext, [childContext, done]);
+          } catch (err) {
+            reject(err);
           }
-        }
-      },
-      ignore: prepared.options.todo || prepared.options.skip,
-      sanitizeExit: false,
-      sanitizeOps: false,
-      sanitizeResources: false,
-    });
-    ArrayPrototypePush(this.steps, step);
+        });
+      } else {
+        await ReflectApply(prepared.fn, childContext, [childContext]);
+      }
+
+      // Check plan
+      if (childContext._plan !== null) {
+        childContext._plan.check();
+      }
+
+      // Run after hooks
+      await childContext._runAfterHooks();
+      // Run parent's afterEach hooks
+      await this._runAfterEachHooks();
+    } catch (err) {
+      if (!childContext._skipped) {
+        ok = false;
+        stepState.failed = true;
+        stepState.lastError = err;
+      }
+      try {
+        await childContext._runAfterHooks();
+      } catch { /* already failing */ }
+      try {
+        await this._runAfterEachHooks();
+      } catch { /* already failing */ }
+    }
+
+    // Report incomplete children
+    for (
+      const childDesc of new SafeArrayIterator(stepState.children)
+    ) {
+      const childState = MapPrototypeGet(
+        testStates,
+        childDesc.id,
+      ) as TestState;
+      if (!childState.completed) {
+        ops.op_test_event_step_result_failed(childDesc.id, "incomplete", 0);
+      }
+    }
+    // Check for failed children (subtests that failed within this step)
+    let failedSteps = 0;
+    for (
+      const childDesc of new SafeArrayIterator(stepState.children)
+    ) {
+      const childState = MapPrototypeGet(
+        testStates,
+        childDesc.id,
+      ) as TestState;
+      if (childState?.failed) {
+        failedSteps++;
+      }
+    }
+    if (failedSteps > 0 && ok) {
+      ok = false;
+      stepState.failed = true;
+    }
+
+    stepState.completed = true;
+
+    const elapsed = DateNow() - earlier;
+    if (ok) {
+      ops.op_test_event_step_result_ok(stepId, elapsed);
+    } else if (failedSteps > 0 && !stepState.lastError) {
+      ops.op_test_event_step_result_failed(
+        stepId,
+        { failedSteps },
+        elapsed,
+      );
+    } else {
+      ops.op_test_event_step_result_failed(
+        stepId,
+        {
+          jsError: core.destructureError(
+            stepState.lastError ?? new Error("test failed"),
+          ),
+        },
+        elapsed,
+      );
+    }
+
+    return ok;
   }
 
-  addSuite(name, options, fn, overrides) {
-    const prepared = prepareOptions(name, options, fn, overrides);
+  waitFor(
+    condition: () => unknown,
+    options?: { interval?: number; timeout?: number },
+  ): Promise<unknown> {
+    if (typeof condition !== "function") {
+      throw new TypeError("condition must be a function");
+    }
+    const interval = options?.interval ?? 50;
+    const timeout = options?.timeout ?? 1000;
+
     // deno-lint-ignore prefer-primordials
-    const { promise, resolve } = Promise.withResolvers();
-    const step = this.#denoTestContext.step({
-      name: prepared.name,
-      fn: wrapSuiteFn(prepared.fn, resolve),
-      ignore: prepared.options.todo || prepared.options.skip,
-      sanitizeExit: false,
-      sanitizeOps: false,
-      sanitizeResources: false,
-    });
-    ArrayPrototypePush(this.steps, step);
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    let lastError: unknown;
+    let pollerId: ReturnType<typeof setTimeout>;
+
+    const timeoutId = setTimeout(() => {
+      clearTimeout(pollerId);
+      const err = new Error("waitFor() timed out");
+      if (lastError !== undefined) {
+        (err as Error & { cause: unknown }).cause = lastError;
+      }
+      reject(err);
+    }, timeout);
+
+    const poller = async () => {
+      try {
+        const result = await condition();
+        clearTimeout(timeoutId);
+        resolve(result);
+      } catch (err) {
+        lastError = err;
+        pollerId = setTimeout(poller, interval);
+      }
+    };
+
+    poller();
     return promise;
   }
 }
 
-function prepareOptions(name, options, fn, overrides) {
+// --------------------------------------------------------------------------
+// Suite tracking
+// --------------------------------------------------------------------------
+
+let currentSuite: SuiteCollector | null = null;
+
+interface SuiteEntry {
+  type: "test" | "suite";
+  prepared: PreparedTest;
+}
+
+class SuiteCollector {
+  name: string;
+  options: Record<string, unknown>;
+  entries: SuiteEntry[] = [];
+  parent: SuiteCollector | null;
+  #beforeHooks: CallbackFn[] = [];
+  #afterHooks: CallbackFn[] = [];
+  #beforeEachHooks: CallbackFn[] = [];
+  #afterEachHooks: CallbackFn[] = [];
+
+  constructor(
+    name: string,
+    options: Record<string, unknown>,
+    parent: SuiteCollector | null,
+  ) {
+    this.name = name;
+    this.options = options;
+    this.parent = parent;
+  }
+
+  addBefore(fn: CallbackFn) {
+    ArrayPrototypePush(this.#beforeHooks, fn);
+  }
+
+  addAfter(fn: CallbackFn) {
+    ArrayPrototypePush(this.#afterHooks, fn);
+  }
+
+  addBeforeEach(fn: CallbackFn) {
+    ArrayPrototypePush(this.#beforeEachHooks, fn);
+  }
+
+  addAfterEach(fn: CallbackFn) {
+    ArrayPrototypePush(this.#afterEachHooks, fn);
+  }
+
+  get beforeHooks() {
+    return this.#beforeHooks;
+  }
+
+  get afterHooks() {
+    return this.#afterHooks;
+  }
+
+  get beforeEachHooks() {
+    return this.#beforeEachHooks;
+  }
+
+  get afterEachHooks() {
+    return this.#afterEachHooks;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Argument parsing helpers
+// --------------------------------------------------------------------------
+
+interface PreparedTest {
+  name: string;
+  fn: CallbackFn;
+  options: Record<string, unknown>;
+}
+
+function prepareOptions(
+  name: unknown,
+  options: unknown,
+  fn: unknown,
+  overrides: Record<string, unknown>,
+): PreparedTest {
   if (typeof name === "function") {
     fn = name;
   } else if (name !== null && typeof name === "object") {
@@ -251,200 +661,492 @@ function prepareOptions(name, options, fn, overrides) {
     options = {};
   }
 
-  const finalOptions = { ...options, ...overrides };
-  // TODO(bartlomieju): these options are currently not handled
-  // const { concurrency, timeout, signal } = finalOptions;
+  const finalOptions = {
+    ...(options as Record<string, unknown>),
+    ...overrides,
+  };
 
   if (typeof fn !== "function") {
     fn = noop;
   }
 
   if (typeof name !== "string" || name === "") {
-    name = fn.name || "<anonymous>";
+    name = (fn as CallbackFn).name || "<anonymous>";
   }
 
-  return { fn, options: finalOptions, name };
+  return { fn: fn as CallbackFn, options: finalOptions, name: name as string };
 }
 
-function wrapTestFn(fn, resolve) {
-  return async function (t) {
-    const nodeTestContext = new NodeTestContext(t, undefined);
+// --------------------------------------------------------------------------
+// Test execution wrappers
+// --------------------------------------------------------------------------
+
+function wrapTestFn(
+  prepared: PreparedTest,
+  suiteCollector: SuiteCollector | null,
+  testIdHolder: { id: number },
+): CallbackFn {
+  // This function is what gets registered with op_register_test.
+  // It must return a TestResult: "ok" | "ignored" | { failed: ... }
+  return async function nodeTestWrapper() {
+    const origin = getOrigin();
+    const id = testIdHolder.id;
+
+    const testDesc: TestDesc = {
+      id,
+      name: prepared.name,
+      origin,
+      location: { fileName: "", lineNumber: 0, columnNumber: 0 },
+      ignore: false,
+      only: false,
+      fn: prepared.fn,
+    };
+
+    const state: TestState = {
+      children: [],
+      completed: false,
+      failed: false,
+    };
+    MapPrototypeSet(testStates, id, state);
+
+    const abortController = new AbortController();
+    const ctx = new NodeTestContext(
+      prepared.name,
+      testDesc,
+      undefined,
+      abortController,
+    );
+
+    // If this is a suite, run the collector function to gather entries,
+    // then execute them as steps
+    if (suiteCollector) {
+      return await executeSuite(suiteCollector, ctx, testDesc, state);
+    }
+
+    // Regular test
+    let timeout: number | undefined;
+    if (typeof prepared.options.timeout === "number") {
+      timeout = prepared.options.timeout;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+
     try {
-      // Check if the test function expects a done callback (2 parameters)
-      if (fn.length >= 2) {
+      if (timeout !== undefined && timeout !== Infinity) {
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          abortController.abort();
+        }, timeout);
+      }
+
+      if (prepared.fn.length >= 2) {
         // Callback-style async test
-        await new Promise((testResolve, testReject) => {
+        await new Promise<void>((resolve, reject) => {
           const done = (err?: Error) => {
-            if (err) {
-              testReject(err);
-            } else {
-              testResolve(undefined);
-            }
+            if (err) reject(err);
+            else resolve();
           };
           try {
-            fn(nodeTestContext, done);
+            ReflectApply(prepared.fn, ctx, [ctx, done]);
           } catch (err) {
-            testReject(err);
+            reject(err);
           }
         });
       } else {
-        // Promise-style or sync test
-        await fn(nodeTestContext);
+        await ReflectApply(prepared.fn, ctx, [ctx]);
       }
-    } catch (err) {
-      if (!nodeTestContext[skippedSymbol]) {
-        throw err;
+
+      // Check plan
+      if (ctx._plan !== null) {
+        ctx._plan.check();
       }
+
+      // Run after hooks
+      await ctx._runAfterHooks();
+
+      if (timedOut) {
+        return {
+          failed: {
+            jsError: core.destructureError(
+              new Error(`test timed out after ${timeout}ms`),
+            ),
+          },
+        };
+      }
+
+      // Check for failed steps
+      let failedSteps = 0;
+      for (const childDesc of new SafeArrayIterator(state.children)) {
+        const childState = MapPrototypeGet(
+          testStates,
+          childDesc.id,
+        ) as TestState;
+        if (!childState.completed) {
+          return { failed: "incompleteSteps" };
+        }
+        if (childState.failed) {
+          failedSteps++;
+        }
+      }
+      state.completed = true;
+
+      if (ctx._skipped) {
+        return "ignored";
+      }
+
+      return failedSteps === 0 ? "ok" : { failed: { failedSteps } };
+    } catch (error) {
+      if (ctx._skipped) {
+        state.completed = true;
+        return "ignored";
+      }
+      try {
+        await ctx._runAfterHooks();
+      } catch { /* already failing */ }
+      state.completed = true;
+
+      if (timedOut) {
+        return {
+          failed: {
+            jsError: core.destructureError(
+              new Error(`test timed out after ${timeout}ms`),
+            ),
+          },
+        };
+      }
+
+      return { failed: { jsError: core.destructureError(error) } };
     } finally {
-      resolve();
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      state.completed = true;
     }
   };
 }
 
-function prepareDenoTest(name, options, fn, overrides) {
-  const prepared = prepareOptions(name, options, fn, overrides);
-
-  // TODO(iuioiua): Update once there's a primordial for `Promise.withResolvers()`.
-  // deno-lint-ignore prefer-primordials
-  const { promise, resolve } = Promise.withResolvers();
-
-  const denoTestOptions = {
-    name: prepared.name,
-    fn: wrapTestFn(prepared.fn, resolve),
-    only: prepared.options.only,
-    ignore: prepared.options.todo || prepared.options.skip,
-    sanitizeOnly: false,
-    sanitizeExit: false,
-    sanitizeOps: false,
-    sanitizeResources: false,
-  };
-  Deno.test(denoTestOptions);
-  return promise;
-}
-
-function wrapSuiteFn(fn, resolve) {
-  return function (t) {
-    const prevSuite = currentSuite;
-    const suite = currentSuite = new TestSuite(t);
-    try {
-      fn();
-    } finally {
-      currentSuite = prevSuite;
-    }
-    return SafePromisePrototypeFinally(SafePromiseAll(suite.steps), resolve);
-  };
-}
-
-function prepareDenoTestForSuite(name, options, fn, overrides) {
-  const prepared = prepareOptions(name, options, fn, overrides);
-
-  // deno-lint-ignore prefer-primordials
-  const { promise, resolve } = Promise.withResolvers();
-
-  const denoTestOptions = {
-    name: prepared.name,
-    fn: wrapSuiteFn(prepared.fn, resolve),
-    only: prepared.options.only,
-    ignore: prepared.options.todo || prepared.options.skip,
-    sanitizeOnly: false,
-    sanitizeExit: false,
-    sanitizeOps: false,
-    sanitizeResources: false,
-  };
-  Deno.test(denoTestOptions);
-  return promise;
-}
-
-export function test(name, options, fn, overrides) {
-  if (currentSuite) {
-    return currentSuite.addTest(name, options, fn, overrides);
+async function executeSuiteCollector(
+  collector: SuiteCollector,
+  ctx: NodeTestContext,
+) {
+  // Run before hooks
+  for (const hook of new SafeArrayIterator(collector.beforeHooks)) {
+    await hook();
   }
-  return prepareDenoTest(name, options, fn, overrides);
+
+  // Wire up beforeEach/afterEach from suite to context
+  for (const hook of new SafeArrayIterator(collector.beforeEachHooks)) {
+    ctx.beforeEach(hook);
+  }
+  for (const hook of new SafeArrayIterator(collector.afterEachHooks)) {
+    ctx.afterEach(hook);
+  }
+
+  // Execute each entry as a step
+  for (const entry of new SafeArrayIterator(collector.entries)) {
+    if (entry.type === "suite") {
+      const nestedCollector =
+        (entry as SuiteEntry & { _collector: SuiteCollector })._collector;
+      await ctx.test(
+        entry.prepared.name,
+        entry.prepared.options,
+        async (t: NodeTestContext) => {
+          await executeSuiteCollector(nestedCollector, t);
+        },
+      );
+    } else {
+      await ctx.test(
+        entry.prepared.name,
+        entry.prepared.options,
+        entry.prepared.fn,
+      );
+    }
+  }
+
+  // Run after hooks
+  for (const hook of new SafeArrayIterator(collector.afterHooks)) {
+    await hook();
+  }
 }
 
-test.skip = function skip(name, options, fn) {
+async function executeSuite(
+  collector: SuiteCollector,
+  ctx: NodeTestContext,
+  _desc: TestDesc,
+  state: TestState,
+) {
+  try {
+    await executeSuiteCollector(collector, ctx);
+
+    // Check for failed steps
+    let failedSteps = 0;
+    for (const childDesc of new SafeArrayIterator(state.children)) {
+      const childState = MapPrototypeGet(
+        testStates,
+        childDesc.id,
+      ) as TestState;
+      if (childState?.failed) {
+        failedSteps++;
+      }
+    }
+
+    state.completed = true;
+    return failedSteps === 0 ? "ok" : { failed: { failedSteps } };
+  } catch (error) {
+    state.completed = true;
+    return { failed: { jsError: core.destructureError(error) } };
+  }
+}
+
+// --------------------------------------------------------------------------
+// Top-level registration functions
+// --------------------------------------------------------------------------
+
+function registerTest(
+  prepared: PreparedTest,
+  suiteCollector: SuiteCollector | null,
+) {
+  if (!isTestSubcommand()) return;
+
+  const location = core.currentUserCallSite();
+  const testName = escapeName(prepared.name);
+
+  // Create an ID holder that will be populated after registration
+  const testIdHolder = { id: 0 };
+  const wrappedFn = wrapTestFn(prepared, suiteCollector, testIdHolder);
+
+  ops.op_register_test(
+    wrappedFn,
+    testName,
+    prepared.options.skip === true || prepared.options.todo === true, // ignore
+    prepared.options.only === true, // only
+    false, // sanitize_ops
+    false, // sanitize_resources
+    location.fileName,
+    location.lineNumber,
+    location.columnNumber,
+    registerTestIdRetBufU8,
+    false, // sanitize_only
+  );
+
+  // Capture the ID from the buffer after registration
+  testIdHolder.id = registerTestIdRetBuf[0];
+}
+
+function registerSuite(prepared: PreparedTest) {
+  if (!isTestSubcommand()) return;
+
+  // Collect suite entries synchronously by running the suite function
+  const collector = new SuiteCollector(
+    prepared.name,
+    prepared.options,
+    currentSuite,
+  );
+  const prevSuite = currentSuite;
+  currentSuite = collector;
+  try {
+    prepared.fn();
+  } finally {
+    currentSuite = prevSuite;
+  }
+
+  // Register as a single test that runs the suite
+  registerTest(prepared, collector);
+}
+
+// --------------------------------------------------------------------------
+// Public API: test()
+// --------------------------------------------------------------------------
+
+export function test(
+  name?: unknown,
+  options?: unknown,
+  fn?: unknown,
+  overrides?: Record<string, unknown>,
+) {
+  const prepared = prepareOptions(name, options, fn, overrides ?? {});
+
+  if (currentSuite) {
+    ArrayPrototypePush(currentSuite.entries, {
+      type: "test",
+      prepared,
+    });
+    return;
+  }
+
+  registerTest(prepared, null);
+}
+
+test.skip = function skip(name?: unknown, options?: unknown, fn?: unknown) {
   return test(name, options, fn, { skip: true });
 };
 
-test.todo = function todo(name, options, fn) {
+test.todo = function todo(name?: unknown, options?: unknown, fn?: unknown) {
   return test(name, options, fn, { todo: true });
 };
 
-test.only = function only(name, options, fn) {
+test.only = function only(name?: unknown, options?: unknown, fn?: unknown) {
   return test(name, options, fn, { only: true });
 };
 
-export function describe(name, options, fn) {
-  return suite(name, options, fn, {});
-}
+// --------------------------------------------------------------------------
+// Public API: describe() / suite()
+// --------------------------------------------------------------------------
 
-describe.skip = function skip(name, options, fn) {
-  return suite.skip(name, options, fn);
-};
-describe.todo = function todo(name, options, fn) {
-  return suite.todo(name, options, fn);
-};
-describe.only = function only(name, options, fn) {
-  return suite.only(name, options, fn);
-};
+export function suite(
+  name?: unknown,
+  options?: unknown,
+  fn?: unknown,
+  overrides?: Record<string, unknown>,
+) {
+  const prepared = prepareOptions(name, options, fn, overrides ?? {});
 
-export function suite(name, options, fn, overrides) {
   if (currentSuite) {
-    return currentSuite.addSuite(name, options, fn, overrides);
+    // Nested suite - just collect
+    const collector = new SuiteCollector(
+      prepared.name,
+      prepared.options,
+      currentSuite,
+    );
+    const prevSuite = currentSuite;
+    currentSuite = collector;
+    try {
+      prepared.fn();
+    } finally {
+      currentSuite = prevSuite;
+    }
+    ArrayPrototypePush(prevSuite.entries, {
+      type: "suite",
+      // Replace fn with noop since we already collected entries
+      prepared: { ...prepared, fn: noop },
+    });
+    // Stash the collector on the entry so executeSuite can use the already-collected entries
+    const entry = prevSuite.entries[prevSuite.entries.length - 1];
+    (entry as SuiteEntry & { _collector: SuiteCollector })._collector =
+      collector;
+    return;
   }
-  return prepareDenoTestForSuite(name, options, fn, overrides);
+
+  registerSuite(prepared);
 }
 
-suite.skip = function skip(name, options, fn) {
+suite.skip = function skip(name?: unknown, options?: unknown, fn?: unknown) {
   return suite(name, options, fn, { skip: true });
 };
-suite.todo = function todo(name, options, fn) {
+suite.todo = function todo(name?: unknown, options?: unknown, fn?: unknown) {
   return suite(name, options, fn, { todo: true });
 };
-suite.only = function only(name, options, fn) {
+suite.only = function only(name?: unknown, options?: unknown, fn?: unknown) {
   return suite(name, options, fn, { only: true });
 };
 
-export function it(name, options, fn) {
+export function describe(
+  name?: unknown,
+  options?: unknown,
+  fn?: unknown,
+) {
+  return suite(name, options, fn, {});
+}
+
+describe.skip = function skip(name?: unknown, options?: unknown, fn?: unknown) {
+  return suite.skip(name, options, fn);
+};
+describe.todo = function todo(name?: unknown, options?: unknown, fn?: unknown) {
+  return suite.todo(name, options, fn);
+};
+describe.only = function only(name?: unknown, options?: unknown, fn?: unknown) {
+  return suite.only(name, options, fn);
+};
+
+// --------------------------------------------------------------------------
+// Public API: it()
+// --------------------------------------------------------------------------
+
+export function it(
+  name?: unknown,
+  options?: unknown,
+  fn?: unknown,
+) {
   return test(name, options, fn, {});
 }
 
-it.skip = function skip(name, options, fn) {
+it.skip = function skip(name?: unknown, options?: unknown, fn?: unknown) {
   return test.skip(name, options, fn);
 };
-
-it.todo = function todo(name, options, fn) {
+it.todo = function todo(name?: unknown, options?: unknown, fn?: unknown) {
   return test.todo(name, options, fn);
 };
-
-it.only = function only(name, options, fn) {
+it.only = function only(name?: unknown, options?: unknown, fn?: unknown) {
   return test.only(name, options, fn);
 };
 
-export function before() {
-  notImplemented("test.before");
+// --------------------------------------------------------------------------
+// Public API: Module-level hooks
+// --------------------------------------------------------------------------
+
+export function before(fn: CallbackFn) {
+  if (currentSuite) {
+    currentSuite.addBefore(fn);
+    return;
+  }
+  if (!isTestSubcommand()) return;
+  if (typeof fn !== "function") {
+    throw new TypeError("before() requires a function");
+  }
+  ops.op_register_test_hook("beforeAll", fn);
 }
 
-export function after() {
-  notImplemented("test.after");
+export function after(fn: CallbackFn) {
+  if (currentSuite) {
+    currentSuite.addAfter(fn);
+    return;
+  }
+  if (!isTestSubcommand()) return;
+  if (typeof fn !== "function") {
+    throw new TypeError("after() requires a function");
+  }
+  ops.op_register_test_hook("afterAll", fn);
 }
 
-export function beforeEach() {
-  notImplemented("test.beforeEach");
+export function beforeEach(fn: CallbackFn) {
+  if (currentSuite) {
+    currentSuite.addBeforeEach(fn);
+    return;
+  }
+  if (!isTestSubcommand()) return;
+  if (typeof fn !== "function") {
+    throw new TypeError("beforeEach() requires a function");
+  }
+  ops.op_register_test_hook("beforeEach", fn);
 }
 
-export function afterEach() {
-  notImplemented("test.afterEach");
+export function afterEach(fn: CallbackFn) {
+  if (currentSuite) {
+    currentSuite.addAfterEach(fn);
+    return;
+  }
+  if (!isTestSubcommand()) return;
+  if (typeof fn !== "function") {
+    throw new TypeError("afterEach() requires a function");
+  }
+  ops.op_register_test_hook("afterEach", fn);
 }
 
-test.it = it;
-test.describe = describe;
-test.suite = suite;
+// --------------------------------------------------------------------------
+// Public API: run()
+// --------------------------------------------------------------------------
 
-// Store all active mocks for restoreAll()
+export function run() {
+  notImplemented("test.run");
+}
+
+// --------------------------------------------------------------------------
+// Mock implementation
+// --------------------------------------------------------------------------
+
 const activeMocks: MockFunctionContext[] = [];
 
-/** Represents a call to a mock function */
 interface MockCall {
   arguments: unknown[];
   error?: Error;
@@ -454,12 +1156,12 @@ interface MockCall {
   this: unknown;
 }
 
-/** Context for a mock function with call tracking */
 class MockFunctionContext {
   #calls: MockCall[] = [];
   #implementation: ((...args: unknown[]) => unknown) | undefined;
   #restore: (() => void) | undefined;
   #times: number | undefined;
+  #mocks: Map<number, CallbackFn> = new SafeMap();
 
   constructor(
     implementation?: (...args: unknown[]) => unknown,
@@ -471,35 +1173,48 @@ class MockFunctionContext {
     this.#times = times;
   }
 
-  /** Array of call information */
   get calls(): readonly MockCall[] {
     return this.#calls;
   }
 
-  /** Number of times the mock has been called */
   callCount(): number {
     return this.#calls.length;
   }
 
-  /** Reset the call history */
+  mockImplementation(implementation: (...args: unknown[]) => unknown): void {
+    if (typeof implementation !== "function") {
+      throw new TypeError("implementation must be a function");
+    }
+    this.#implementation = implementation;
+  }
+
+  mockImplementationOnce(
+    implementation: (...args: unknown[]) => unknown,
+    onCall?: number,
+  ): void {
+    if (typeof implementation !== "function") {
+      throw new TypeError("implementation must be a function");
+    }
+    const nextCall = this.#calls.length;
+    const call = onCall ?? nextCall;
+    MapPrototypeSet(this.#mocks, call, implementation);
+  }
+
   resetCalls(): void {
     ArrayPrototypeSplice(this.#calls, 0, this.#calls.length);
   }
 
-  /** Restore the original function */
   restore(): void {
     if (this.#restore) {
       this.#restore();
       this.#restore = undefined;
     }
-    // Remove from active mocks
     const idx = ArrayPrototypeIndexOf(activeMocks, this);
     if (idx !== -1) {
       ArrayPrototypeSplice(activeMocks, idx, 1);
     }
   }
 
-  /** Internal: record a call */
   _recordCall(
     thisArg: unknown,
     args: unknown[],
@@ -515,26 +1230,36 @@ class MockFunctionContext {
     });
   }
 
-  /** Internal: check if mock should still be active based on times limit */
   _shouldMock(): boolean {
     if (this.#times === undefined) return true;
     return this.#calls.length < this.#times;
   }
 
-  /** Internal: get the mock implementation */
   _getImplementation(): ((...args: unknown[]) => unknown) | undefined {
+    return this.#implementation;
+  }
+
+  _nextImpl(): ((...args: unknown[]) => unknown) | undefined {
+    const nextCall = this.#calls.length;
+    const onceImpl = MapPrototypeGet(this.#mocks, nextCall);
+    if (onceImpl) {
+      MapPrototypeDelete(this.#mocks, nextCall);
+      return onceImpl as (...args: unknown[]) => unknown;
+    }
     return this.#implementation;
   }
 }
 
-/** Creates a mock function wrapper */
 function createMockFunction(
   original: ((...args: unknown[]) => unknown) | undefined,
   implementation: ((...args: unknown[]) => unknown) | undefined,
   ctx: MockFunctionContext,
 ): (...args: unknown[]) => unknown {
   const mockFn = function (this: unknown, ...args: unknown[]): unknown {
-    const impl = ctx._shouldMock() ? (implementation ?? original) : original;
+    const oneTimeImpl = ctx._nextImpl();
+    const impl = ctx._shouldMock()
+      ? (oneTimeImpl ?? implementation ?? original)
+      : original;
 
     let result: unknown;
     let error: Error | undefined;
@@ -551,7 +1276,6 @@ function createMockFunction(
     return result;
   };
 
-  // Attach the mock context to the function
   ObjectDefineProperty(mockFn, "mock", {
     __proto__: null,
     value: ctx,
@@ -564,27 +1288,39 @@ function createMockFunction(
 }
 
 export const mock = {
-  /**
-   * Creates a mock function.
-   * @param original - Optional original function to wrap
-   * @param implementation - Optional mock implementation
-   * @param options - Optional configuration
-   */
   fn: (
-    original?: (...args: unknown[]) => unknown,
-    implementation?: (...args: unknown[]) => unknown,
+    original?: ((...args: unknown[]) => unknown) | Record<string, unknown>,
+    implementation?:
+      | ((...args: unknown[]) => unknown)
+      | Record<string, unknown>,
     options?: { times?: number },
   ): ((...args: unknown[]) => unknown) & { mock: MockFunctionContext } => {
+    // Handle overloaded signatures: fn(options), fn(original, options)
+    if (original !== null && typeof original === "object") {
+      options = original as { times?: number };
+      original = undefined;
+      implementation = undefined;
+    } else if (implementation !== null && typeof implementation === "object") {
+      options = implementation as { times?: number };
+      implementation = original as
+        | ((...args: unknown[]) => unknown)
+        | undefined;
+    }
+
     const ctx = new MockFunctionContext(
-      implementation ?? original,
+      (implementation ?? original) as
+        | ((...args: unknown[]) => unknown)
+        | undefined,
       undefined,
       options?.times,
     );
     ArrayPrototypePush(activeMocks, ctx);
 
     const mockFn = createMockFunction(
-      original,
-      implementation ?? original,
+      original as ((...args: unknown[]) => unknown) | undefined,
+      (implementation ?? original) as
+        | ((...args: unknown[]) => unknown)
+        | undefined,
       ctx,
     );
     return mockFn as ((...args: unknown[]) => unknown) & {
@@ -592,34 +1328,80 @@ export const mock = {
     };
   },
 
-  /**
-   * Mocks a getter on an object.
-   */
   getter: (
-    _object: object,
-    _methodName: string,
-    _implementation?: () => unknown,
-    _options?: { times?: number },
+    object: object,
+    methodName: string | symbol,
+    implementation?: () => unknown,
+    options?: { times?: number },
   ) => {
-    notImplemented("test.mock.getter");
+    if (implementation !== null && typeof implementation === "object") {
+      options = implementation as { times?: number };
+      implementation = undefined;
+    }
+    // deno-lint-ignore no-explicit-any
+    return mock.method(object as any, methodName, implementation, {
+      ...options,
+      getter: true,
+    });
   },
 
-  /**
-   * Mocks a method on an object.
-   * @param object - The object containing the method
-   * @param methodName - The name of the method to mock
-   * @param implementation - Optional mock implementation
-   * @param options - Optional configuration
-   */
+  setter: (
+    object: object,
+    methodName: string | symbol,
+    implementation?: (value: unknown) => void,
+    options?: { times?: number },
+  ) => {
+    if (implementation !== null && typeof implementation === "object") {
+      options = implementation as { times?: number };
+      implementation = undefined;
+    }
+    // deno-lint-ignore no-explicit-any
+    return mock.method(object as any, methodName, implementation, {
+      ...options,
+      setter: true,
+    });
+  },
+
   method: <T extends object>(
     object: T,
     methodName: keyof T,
-    implementation?: (...args: unknown[]) => unknown,
-    options?: { times?: number },
+    implementation?:
+      | ((...args: unknown[]) => unknown)
+      | Record<string, unknown>,
+    options?: { times?: number; getter?: boolean; setter?: boolean },
   ): ((...args: unknown[]) => unknown) & { mock: MockFunctionContext } => {
-    const original = object[methodName] as (
-      ...args: unknown[]
-    ) => unknown;
+    if (
+      implementation !== null && typeof implementation === "object" &&
+      typeof implementation !== "function"
+    ) {
+      options = implementation as {
+        times?: number;
+        getter?: boolean;
+        setter?: boolean;
+      };
+      implementation = undefined;
+    }
+
+    const descriptor = findPropertyDescriptor(object, methodName as string);
+    if (!descriptor) {
+      throw new TypeError(
+        `Cannot mock property '${
+          String(methodName)
+        }' because it does not exist`,
+      );
+    }
+
+    let original: CallbackFn | undefined;
+    const isGetter = options?.getter ?? false;
+    const isSetter = options?.setter ?? false;
+
+    if (isGetter) {
+      original = descriptor.get as CallbackFn | undefined;
+    } else if (isSetter) {
+      original = descriptor.set as CallbackFn | undefined;
+    } else {
+      original = descriptor.value as CallbackFn | undefined;
+    }
 
     if (typeof original !== "function") {
       throw new TypeError(
@@ -630,54 +1412,57 @@ export const mock = {
     }
 
     const restore = () => {
-      object[methodName] = original as T[keyof T];
+      ObjectDefineProperty(object, methodName as string, descriptor);
     };
 
+    const impl = implementation === undefined ? original : implementation;
     const ctx = new MockFunctionContext(
-      implementation,
+      impl as (...args: unknown[]) => unknown,
       restore,
       options?.times,
     );
     ArrayPrototypePush(activeMocks, ctx);
 
-    const mockFn = createMockFunction(original, implementation, ctx);
-    object[methodName] = mockFn as T[keyof T];
+    const mockFn = createMockFunction(
+      original as (...args: unknown[]) => unknown,
+      impl as (...args: unknown[]) => unknown,
+      ctx,
+    );
+
+    const mockDescriptor: PropertyDescriptor = {
+      configurable: descriptor.configurable,
+      enumerable: descriptor.enumerable,
+    };
+
+    if (isGetter) {
+      mockDescriptor.get = mockFn;
+      mockDescriptor.set = descriptor.set;
+    } else if (isSetter) {
+      mockDescriptor.get = descriptor.get;
+      mockDescriptor.set = mockFn;
+    } else {
+      mockDescriptor.writable = descriptor.writable;
+      mockDescriptor.value = mockFn;
+    }
+
+    ObjectDefineProperty(object, methodName as string, mockDescriptor);
 
     return mockFn as ((...args: unknown[]) => unknown) & {
       mock: MockFunctionContext;
     };
   },
 
-  /**
-   * Resets the call history of all mocks.
-   */
   reset: (): void => {
-    ArrayPrototypeForEach(activeMocks, (ctx) => {
+    ArrayPrototypeForEach(activeMocks, (ctx: MockFunctionContext) => {
       ctx.resetCalls();
     });
   },
 
-  /**
-   * Restores all mocked methods to their original implementations.
-   */
   restoreAll: (): void => {
-    // Restore in reverse order
     while (activeMocks.length > 0) {
       const ctx = activeMocks[activeMocks.length - 1];
       ctx.restore();
     }
-  },
-
-  /**
-   * Mocks a setter on an object.
-   */
-  setter: (
-    _object: object,
-    _methodName: string,
-    _implementation?: (value: unknown) => void,
-    _options?: { times?: number },
-  ) => {
-    notImplemented("test.mock.setter");
   },
 
   timers: {
@@ -696,7 +1481,27 @@ export const mock = {
   },
 };
 
+function findPropertyDescriptor(
+  obj: object,
+  name: string | symbol,
+): PropertyDescriptor | undefined {
+  let current = obj;
+  while (current !== null && current !== undefined) {
+    const desc = ObjectGetOwnPropertyDescriptor(current, name);
+    if (desc) return desc;
+    current = ObjectGetPrototypeOf(current);
+  }
+  return undefined;
+}
+
+// --------------------------------------------------------------------------
+// Wire up test.* properties
+// --------------------------------------------------------------------------
+
 test.test = test;
+test.it = it;
+test.describe = describe;
+test.suite = suite;
 test.mock = mock;
 
 export default test;

--- a/tests/specs/node/node_test_module/test.out
+++ b/tests/specs/node/node_test_module/test.out
@@ -1,23 +1,23 @@
 running 69 tests from ./test.js
-sync pass todo ... ok ([WILDLINE])
-sync pass todo with message ... ok ([WILDLINE])
-sync fail todo ... ok ([WILDLINE])
+sync pass todo ... ignored ([WILDLINE])
+sync pass todo with message ... ignored ([WILDLINE])
+sync fail todo ... ignored ([WILDLINE])
 todo thrown sub test ...
   test ... ok ([WILDLINE])
-todo thrown sub test ... ok ([WILDLINE])
-sync fail todo with message ... ok ([WILDLINE])
-sync skip pass ... ok ([WILDLINE])
-sync skip pass with message ... ok ([WILDLINE])
+todo thrown sub test ... ignored ([WILDLINE])
+sync fail todo with message ... ignored ([WILDLINE])
+sync skip pass ... ignored ([WILDLINE])
+sync skip pass with message ... ignored ([WILDLINE])
 skip thrown sub test ...
   test ... ok ([WILDLINE])
-skip thrown sub test ... ok ([WILDLINE])
+skip thrown sub test ... ignored ([WILDLINE])
 sync pass ...
 ------- output -------
 DIAGNOSTIC: this test should pass
 ----- output end -----
 sync pass ... ok ([WILDLINE])
 sync throw fail ... FAILED ([WILDLINE])
-async skip pass ... ok ([WILDLINE])
+async skip pass ... ignored ([WILDLINE])
 async pass ... ok ([WILDLINE])
 async throw fail ... FAILED ([WILDLINE])
 nested test ...
@@ -25,7 +25,7 @@ nested test ...
     nested 2 ... ok ([WILDLINE])
   nested 1 ... ok ([WILDLINE])
 nested test ... ok ([WILDLINE])
-async skip fail ... ok ([WILDLINE])
+async skip fail ... ignored ([WILDLINE])
 async assertion fail ... FAILED ([WILDLINE])
 resolve pass ... ok ([WILDLINE])
 reject fail ... FAILED ([WILDLINE])
@@ -57,8 +57,8 @@ suite ...
   test 1 ... ok ([WILDLINE])
   test 2 ... FAILED ([WILDLINE])
   sub suite 1 ...
-    nested test 2 ... FAILED ([WILDLINE])
     nested test 1 ... ok ([WILDLINE])
+    nested test 2 ... FAILED ([WILDLINE])
   sub suite 1 ... FAILED (due to 1 failed step) ([WILDLINE])
   sub suite 2 ...
     nested test 1 ... FAILED ([WILDLINE])
@@ -182,6 +182,6 @@ suite ... sub suite 1 ... nested test 2 => [WILDLINE]
 suite ... sub suite 2 ... nested test 1 => [WILDLINE]
 ./test.js (uncaught error)
 
-FAILED | 17 passed (23 steps) | 49 failed (5 steps) | 4 ignored ([WILDLINE])
+FAILED | 7 passed (23 steps) | 49 failed (5 steps) | 14 ignored ([WILDLINE])
 
 error: Test failed


### PR DESCRIPTION
## Summary

- Rewrites the `node:test` module implementation to register tests directly with the Rust test infrastructure via ops instead of wrapping `Deno.test()`
- Tests registered directly via `op_register_test()` / `op_register_test_step()` with proper parent/root linkage
- New `NodeTestContext` class with `plan()`, `skip()`, `todo()`, `diagnostic()`, `waitFor()`, context-level hooks, and subtest support
- `SuiteCollector` for synchronous suite entry collection with proper sub-suite failure propagation

## Test plan

- [ ] Existing `node_test_module` spec tests updated and passing
- [ ] Todo/skip tests correctly report as `ignored`
- [ ] Sub-suite failures properly propagate up

🤖 Generated with [Claude Code](https://claude.com/claude-code)