### PR TITLE
fix(napi): remove unimplemented Node-API symbols from napi_sys

### DIFF
--- a/libs/napi_sys/src/functions.rs
+++ b/libs/napi_sys/src/functions.rs
@@ -815,31 +815,10 @@ generate!(
       length: usize,
       result: *mut napi_value,
     ) -> napi_status;
-    fn node_api_create_property_key_latin1(
-      env: napi_env,
-      str_: *const c_char,
-      length: usize,
-      result: *mut napi_value,
-    ) -> napi_status;
-    fn node_api_create_property_key_utf8(
-      env: napi_env,
-      str_: *const c_char,
-      length: usize,
-      result: *mut napi_value,
-    ) -> napi_status;
-    fn node_api_create_object_with_properties(
-      env: napi_env,
-      result: *mut napi_value,
-      property_count: usize,
-      keys: *const napi_value,
-      values: *const napi_value,
-    ) -> napi_status;
-    fn node_api_create_object_with_named_properties(
-      env: napi_env,
-      result: *mut napi_value,
-      property_count: usize,
-      names: *const *const c_char,
-      values: *const napi_value,
-    ) -> napi_status;
+    // TODO(denoland): add these once they are implemented in ext/napi
+    // fn node_api_create_property_key_latin1(...) -> napi_status;
+    // fn node_api_create_property_key_utf8(...) -> napi_status;
+    // fn node_api_create_object_with_properties(...) -> napi_status;
+    // fn node_api_create_object_with_named_properties(...) -> napi_status;
   }
 );


### PR DESCRIPTION
## Summary

- Removes 4 unimplemented Node-API functions from `libs/napi_sys/src/functions.rs`: `node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, `node_api_create_object_with_properties`, `node_api_create_object_with_named_properties`
- Fixes Windows debug CI failures introduced by #32582 where `GetProcAddress` failure messages for these symbols pollute stdout, causing the `napi cleanup_hook` test to fail (expected 4 lines, got 8)
- These functions were never in `symbol_exports.json` or implemented in `ext/napi` — they can be re-added when their implementations land