### PR TITLE
fix(ext/node): initialize debuglog testEnabled with safe default

### DIFF
--- a/ext/node/polyfills/internal/util/debuglog.ts
+++ b/ext/node/polyfills/internal/util/debuglog.ts
@@ -4,10 +4,15 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-// `debugImpls` and `testEnabled` are deliberately not initialized so any call
-// to `debuglog()` before `initializeDebugEnv()` is called will throw.
-let debugImpls: Record<string, (...args: unknown[]) => void>;
-let testEnabled: (str: string) => boolean;
+// `debugImpls` and `testEnabled` are initialized with safe defaults so that
+// calls to `debuglog()` before `initializeDebugEnv()` do not crash. This can
+// happen when internal stream code triggers debug logging during bootstrap
+// before the Node process is fully initialized (e.g. when stdin is unavailable
+// in compiled binaries run as Windows services or detached processes).
+let debugImpls: Record<string, (...args: unknown[]) => void> = Object.create(
+  null,
+);
+let testEnabled: (str: string) => boolean = () => false;
 
 // `debugEnv` is initial value of process.env.NODE_DEBUG
 export function initializeDebugEnv(debugEnv: string) {


### PR DESCRIPTION
## Summary

- Initialize `testEnabled` and `debugImpls` in `debuglog.ts` with safe defaults (`() => false` and empty object) instead of leaving them deliberately uninitialized
- Fixes bootstrap crash `TypeError: testEnabled is not a function` that occurs when internal stream code triggers debug logging before `initializeDebugEnv()` has been called

This crash occurs when stdin is unavailable during Node process bootstrap — for example in compiled binaries run as Windows services (via nssm), or processes detached with `nohup`/`disown` on FreeBSD. In these cases, `initStdin()` creates a dummy Readable and calls `.push(null)`, which triggers `readableAddChunk` → `debug()` from the stream module's `debuglog("stream")`. If this happens before `initializeDebugEnv()` sets `testEnabled`, the process panics.

With this fix, early calls to `debuglog()` gracefully return a no-op logger instead of crashing. `initializeDebugEnv()` still overrides the defaults during normal bootstrap.

Closes #24208

## Test plan

- [x] Existing tests pass (`tools/format.js`, `tools/lint.js --js`)
- [ ] Verify on Windows with a compiled binary run as a service (nssm)
- [ ] Verify with `--watch` on a detached process (`nohup`/`disown`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)