### PR TITLE
fix(console): prevent multi-line object values in console.table

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -3771,6 +3771,7 @@ class Console {
         ...getConsoleInspectOptions(noColorStdout()),
         depth: 1,
         compact: true,
+        breakLength: Infinity,
       });
     const toTable = (header, body) => this.log(cliTable(header, body));
 

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -1722,6 +1722,35 @@ Deno.test(function consoleTable() {
 `,
     );
   });
+  // Objects with long values should stay on a single line (#18828)
+  mockConsole((console, out) => {
+    console.table([
+      ["b0a6d0c1-7b6c-4fea-9efa-cb2629ce6068", {
+        id: "b0a6d0c1-7b6c-4fea-9efa-cb2629ce6068",
+        name: "Trenitalia",
+        countryCode: "IT",
+      }],
+      ["371fe41e-349c-40b7-be93-10c58fbbb95f", {
+        id: "371fe41e-349c-40b7-be93-10c58fbbb95f",
+        name: "Deutsche Bahn",
+        countryCode: "DE",
+      }],
+    ]);
+    const output = stripAnsiCode(out.toString());
+    // Each row should be a single line (no newlines within cell values)
+    const rows = output.split("\n").filter((line) => line.startsWith("│"));
+    for (const row of rows) {
+      // The row should not contain embedded newlines (the cell value should be flat)
+      assert(!row.includes("\n  "), "Table row should be single-line");
+    }
+    // Verify object values are rendered on one line
+    assert(
+      output.includes(
+        'name: "Deutsche Bahn", countryCode: "DE"',
+      ),
+      "Object should be on single line",
+    );
+  });
   mockConsole((console, out) => {
     console.table([]);
     assertEquals(


### PR DESCRIPTION
## Summary

- Objects in `console.table` could break the table layout when their `Deno.inspect` output exceeded the default `breakLength` (72 chars), causing some rows to wrap across multiple lines
- Fix: set `breakLength: Infinity` in the inspect options for table cell values, ensuring single-line rendering

Before:
```
│     1 │ "371fe41e-..." │ { id: "371fe41e-...",
  name: "Deutsche Bahn",
  countryCode: "DE" } │
```

After:
```
│     1 │ "371fe41e-..." │ { id: "371fe41e-...", name: "Deutsche Bahn", countryCode: "DE" } │
```

Fixes #18828

## Test plan

- [x] Added unit test in `console_test.ts` verifying objects with long values stay on single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)