### PR TITLE
fix(npm): memoize peer cache hit checks to prevent combinatorial explosion

### DIFF
--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -9247,7 +9247,9 @@ mod test {
     );
     for name in &pkg_names {
       assert!(
-        packages.iter().any(|p| p.pkg_id.starts_with(&format!("{}@", name))),
+        packages
+          .iter()
+          .any(|p| p.pkg_id.starts_with(&format!("{}@", name))),
         "should have {}",
         name
       );


### PR DESCRIPTION
## Summary

- Fixes `deno add npm:@aws-cdk/aws-ecs` (and similar large peer dep trees) hanging indefinitely
- Root cause: `find_peers_cache_hit_inner` in `libs/npm/resolution/graph.rs` recursively checks whether cached peer resolutions match the current context. For packages with many mutual peer dependencies (like AWS CDK v1 with ~33 packages and 1200+ cache entries), this causes **combinatorial explosion** — a single cache lookup for `@aws-cdk/aws-kms` triggered **2.5 million recursive calls** taking 17+ seconds
- Fix: since `parent_pkgs` is constant within a single `find_peers_cache_hit` call, the answer for any given `nv` never changes. A `HashMap` memo eliminates all redundant recursive work

## Before/After

| | Before | After |
|---|---|---|
| `deno add npm:@aws-cdk/aws-ecs` | Hangs indefinitely (killed at 120s) | Completes in seconds |

## Test plan

- [x] All 182 `deno_npm` unit tests pass
- [x] Manual test: `deno add npm:@aws-cdk/aws-ecs` completes successfully

Closes #26430

🤖 Generated with [Claude Code](https://claude.com/claude-code)