### PR TITLE
fix(testing/bdd): preserve original test error when afterEach/afterAll hooks also fail

### DIFF
--- a/tests/specs/test/bdd_aftereach_masks_error/__test__.jsonc
+++ b/tests/specs/test/bdd_aftereach_masks_error/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "aftereach_masks_error": {
+      "args": "test main.ts",
+      "output": "main.out",
+      "exitCode": 1
+    }
+  }
+}

--- a/tests/specs/test/bdd_aftereach_masks_error/deno.json
+++ b/tests/specs/test/bdd_aftereach_masks_error/deno.json
@@ -1,0 +1,3 @@
+{
+  "importMap": "../../../../import_map.json"
+}

--- a/tests/specs/test/bdd_aftereach_masks_error/main.out
+++ b/tests/specs/test/bdd_aftereach_masks_error/main.out
@@ -1,0 +1,22 @@
+Check [WILDCARD]main.ts
+running 1 test from ./main.ts
+failure is not apparent ...
+  failing 'it' block ... FAILED [WILDCARD]
+failure is not apparent ... FAILED (due to 1 failed step) [WILDCARD]
+
+ ERRORS 
+
+failure is not apparent ... failing 'it' block [WILDCARD]
+error: AggregateError: Multiple errors: test failure followed by afterEach hook failure
+    Error: original test failure
+[WILDCARD]
+    Error: afterEach failure, perhaps a side-effect of the original failure
+[WILDCARD]
+
+ FAILURES 
+
+failure is not apparent ... failing 'it' block [WILDCARD]
+
+FAILED | 0 passed | 1 failed (1 step) [WILDCARD]
+
+error: Test failed

--- a/tests/specs/test/bdd_aftereach_masks_error/main.ts
+++ b/tests/specs/test/bdd_aftereach_masks_error/main.ts
@@ -1,0 +1,12 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+
+describe("failure is not apparent", () => {
+  it("failing 'it' block", () => {
+    throw new Error("original test failure");
+  });
+  afterEach(() => {
+    throw new Error(
+      "afterEach failure, perhaps a side-effect of the original failure",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- When a test body throws and the subsequent `afterEach` or `afterAll` hook also throws, JavaScript's `try/finally` semantics silently discard the original error — only the hook's error is shown in the test output
- Changed `try/finally` to explicit `try/catch` error handling in `@std/testing/bdd`'s `_test_suite.ts`. When both the test and hook fail, both errors are now combined into an `AggregateError`
- Added a spec test reproducing the exact scenario from the issue

**Before:** only the `afterEach` error appears in the ERRORS section
```
 ERRORS

failure is not apparent ... failing 'it' block => ...
error: Error: fail here also, perhaps it is a side-effect of the original failure
```

**After:** both the original test error and the hook error appear
```
 ERRORS

failure is not apparent ... failing 'it' block => ...
error: AggregateError: Multiple errors: test failure followed by afterEach hook failure
    Error: original test failure
        ...
    Error: afterEach failure, perhaps a side-effect of the original failure
        ...
```

Fixes #30219

## Test plan

- [x] New spec test `tests/specs/test/bdd_aftereach_masks_error` verifies both errors appear in output
- [x] All existing `specs::test::hooks` tests pass (8/8)
- [x] `tools/format.js` and `tools/lint.js --js` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)