### PR TITLE
fix(ext/node): add missing http2 header constants

### DIFF
--- a/ext/node/ops/http2/types.rs
+++ b/ext/node/ops/http2/types.rs
@@ -152,6 +152,10 @@ pub struct Http2Constants {
   http2_header_transfer_encoding: &'static str,
   http2_header_keep_alive: &'static str,
   http2_header_proxy_connection: &'static str,
+  http2_header_accept: &'static str,
+  http2_header_accept_encoding: &'static str,
+  http2_header_accept_language: &'static str,
+  http2_header_accept_ranges: &'static str,
 
   http2_method_connect: &'static str,
   http2_method_delete: &'static str,
@@ -302,6 +306,10 @@ pub fn op_http2_constants() -> Http2Constants {
     http2_header_transfer_encoding: "transfer-encoding",
     http2_header_keep_alive: "keep-alive",
     http2_header_proxy_connection: "proxy-connection",
+    http2_header_accept: "accept",
+    http2_header_accept_encoding: "accept-encoding",
+    http2_header_accept_language: "accept-language",
+    http2_header_accept_ranges: "accept-ranges",
 
     http2_method_connect: "CONNECT",
     http2_method_delete: "DELETE",


### PR DESCRIPTION
Adds missing HTTP2_HEADER_ACCEPT_ENCODING and related constants that grpc-js depends on. Without these, grpc-js server crashes with:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at normalizeKey (metadata.js:38:16)
    at Metadata.remove (metadata.js:103:15)
```

when trying to normalize header keys in `BaseServerInterceptingCall`.

### Added constants:
- `HTTP2_HEADER_ACCEPT`
- `HTTP2_HEADER_ACCEPT_ENCODING`
- `HTTP2_HEADER_ACCEPT_LANGUAGE`
- `HTTP2_HEADER_ACCEPT_RANGES`

### Testing
With this fix, grpc-js server can handle requests:
```
$ grpcurl -plaintext -d '{"name":"Deno"}' localhost:50051 test.Greeter/SayHello
{
  "message": "Hello Deno"
}
```

Found while testing #26436 (which is fixed by the http2 rewrite).