### PR TITLE
fix(ext/node): map NotCapable errors to EACCES in node:fs

### DIFF
--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -69,6 +69,7 @@ import {
   codeMap,
   errorMap,
   mapSysErrnoToUvErrno,
+  UV_EACCES,
   UV_EBADF,
 } from "ext:deno_node/internal_binding/uv.ts";
 import type * as nodeAssert from "node:assert";
@@ -2810,6 +2811,14 @@ export function denoErrorToNodeError(e: Error, ctx: UvExceptionContext) {
     });
   }
 
+  // NotCapable is Deno's permission error - map to EACCES
+  if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotCapable.prototype, e)) {
+    return uvException({
+      errno: UV_EACCES,
+      ...ctx,
+    });
+  }
+
   const errno = extractOsErrorNumberFromErrorMessage(e);
   if (typeof errno === "undefined") {
     return e;
@@ -2829,6 +2838,14 @@ export function denoWriteFileErrorToNodeError(
   if (ObjectPrototypeIsPrototypeOf(Deno.errors.BadResource.prototype, e)) {
     return uvException({
       errno: UV_EBADF,
+      ...ctx,
+    });
+  }
+
+  // NotCapable is Deno's permission error - map to EACCES
+  if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotCapable.prototype, e)) {
+    return uvException({
+      errno: UV_EACCES,
       ...ctx,
     });
   }
@@ -2860,6 +2877,22 @@ export const denoErrorToNodeSystemError = hideStackFrames((
   e: Error,
   syscall: string,
 ): Error => {
+  // NotCapable is Deno's permission error - map to EACCES
+  if (ObjectPrototypeIsPrototypeOf(Deno.errors.NotCapable.prototype, e)) {
+    const { 0: code, 1: message } = uvErrmapGet(UV_EACCES) || uvUnmappedError;
+    const ctx: NodeSystemErrorCtx = {
+      errno: UV_EACCES,
+      code,
+      message,
+      syscall,
+    };
+    return new NodeSystemError(
+      "ERR_SYSTEM_ERROR",
+      ctx,
+      "A system error occurred",
+    );
+  }
+
   const osErrno = extractOsErrorNumberFromErrorMessage(e);
   if (typeof osErrno === "undefined") {
     return e;

--- a/ext/node/polyfills/internal_binding/uv.ts
+++ b/ext/node/polyfills/internal_binding/uv.ts
@@ -533,6 +533,7 @@ export function mapSysErrnoToUvErrno(sysErrno: number): number {
   }
 }
 
+export const UV_EACCES = codeMap.get("EACCES")!;
 export const UV_EAI_MEMORY = codeMap.get("EAI_MEMORY")!;
 export const UV_EBADF = codeMap.get("EBADF")!;
 export const UV_ECANCELED = codeMap.get("ECANCELED")!;


### PR DESCRIPTION
When Deno permissions deny access, `node:fs` operations were throwing raw `NotCapable` errors instead of Node.js-compatible errors with `.code`, `.errno`, and `.syscall` properties.

This broke Node.js libraries that catch fs errors by `.code` property, such as Emscripten's NODEFS (used by Pyodide).

Now `NotCapable` errors are mapped to `EACCES` (permission denied) in the error conversion functions:
- `denoErrorToNodeError`
- `denoWriteFileErrorToNodeError`  
- `denoErrorToNodeSystemError`

### Before
```
name: NotCapable
code: undefined
errno: undefined
syscall: undefined
```

### After
```
name: Error
code: EACCES
errno: -13
syscall: open
message: EACCES: permission denied, open '/tmp/blocked.txt'
```

Fixes #32583