### PR TITLE
fix(npm): handle read-only bin files when setting up node_modules/.bin

### DIFF
--- a/libs/npm_installer/bin_entries.rs
+++ b/libs/npm_installer/bin_entries.rs
@@ -494,6 +494,7 @@ mod test {
 
   use sys_traits::FsCreateDirAll;
   use sys_traits::FsRemoveDirAll;
+  #[cfg(unix)]
   use sys_traits::FsWrite;
 
   use super::*;


### PR DESCRIPTION
## Summary

- Some npm tarballs ship bin files with read+execute but **no write** permission (e.g. `@formatjs/cli@2.15.0` uses mode `555`). `make_executable_if_exists()` was opening these files with `O_RDWR` unconditionally, causing `EACCES` ("Permission denied").
- Fix: open read-only first to check the execute bit. Only reopen with write if chmod is actually needed.

```
$ curl -sL https://registry.npmjs.org/@formatjs/cli/-/cli-2.15.0.tgz | tar tvzf - | grep bin/formatjs
-r-xr-xr-x  0 0      0          81 26 Oct  1985 package/bin/formatjs
```

Closes #29847