### PR TITLE
perf(install): avoid unnecessary package info fetches when running lifecycle scripts

### DIFF
--- a/cli/factory.rs
+++ b/cli/factory.rs
@@ -602,6 +602,7 @@ impl CliFactory {
             Arc::new(DenoTaskLifeCycleScriptsExecutor::new(
               managed_npm_resolver.clone(),
               self.text_only_progress_bar().clone(),
+              cli_options.npm_system_info(),
             )) as Arc<dyn LifecycleScriptsExecutor>
           }
           None => Arc::new(NullLifecycleScriptsExecutor),

--- a/cli/npm.rs
+++ b/cli/npm.rs
@@ -346,6 +346,7 @@ pub enum DenoTaskLifecycleScriptsError {
 pub struct DenoTaskLifeCycleScriptsExecutor {
   progress_bar: ProgressBar,
   npm_resolver: ManagedNpmResolverRc<CliSys>,
+  system_info: deno_npm::NpmSystemInfo,
 }
 
 #[async_trait::async_trait(?Send)]
@@ -514,10 +515,12 @@ impl DenoTaskLifeCycleScriptsExecutor {
   pub fn new(
     npm_resolver: ManagedNpmResolverRc<CliSys>,
     progress_bar: ProgressBar,
+    system_info: deno_npm::NpmSystemInfo,
   ) -> Self {
     Self {
       npm_resolver,
       progress_bar,
+      system_info,
     }
   }
 
@@ -634,10 +637,16 @@ impl DenoTaskLifeCycleScriptsExecutor {
         &mut bin_entries,
         baseline,
         snapshot,
-        package
-          .dependencies
-          .values()
-          .map(|id| snapshot.package_from_id(id).unwrap()),
+        package.dependencies.iter().filter_map(|(name, id)| {
+          let dep = snapshot.package_from_id(id).unwrap();
+          // Skip optional dependencies that don't match the current system
+          if package.optional_dependencies.contains(name)
+            && !dep.system.matches_system(&self.system_info)
+          {
+            return None;
+          }
+          Some(dep)
+        }),
       )
       .await
   }


### PR DESCRIPTION
This was happening at the end of the install pipeline, and for some packages lead to a bunch of extra package info fetches. Speeds up installs a lot when you have only a lockfile

astro starter, 
```bash
> hyperfine --warmup 1 --prepare "deno clean; rm -rf node_modules" "deno install --allow-scripts" "~/Documents/Code/deno/target/release-lite/deno install --allow-scripts"
Benchmark 1: deno install --allow-scripts
  Time (mean ± σ):      5.062 s ±  0.321 s    [User: 0.807 s, System: 2.596 s]
  Range (min … max):    4.505 s …  5.555 s    10 runs

Benchmark 2: ~/Documents/Code/deno/target/release-lite/deno install --allow-scripts
  Time (mean ± σ):      2.355 s ±  0.442 s    [User: 0.687 s, System: 2.668 s]
  Range (min … max):    2.028 s …  3.586 s    10 runs
```