### PR TITLE
chore: respect char boundaries in node_compat test output truncation

### DIFF
--- a/tests/node_compat/mod.rs
+++ b/tests/node_compat/mod.rs
@@ -507,7 +507,7 @@ fn parse_flags(source: &str) -> (Vec<String>, Vec<String>) {
 
 fn truncate_output(output: &str, max_len: usize) -> String {
   if output.len() > max_len {
-    format!("{} ...", &output[..max_len])
+    format!("{} ...", &output[..output.floor_char_boundary(max_len)])
   } else {
     output.to_string()
   }


### PR DESCRIPTION
## Summary
- `truncate_output()` in the node_compat test harness sliced at a raw byte
  index, which panics when the index falls inside a multi-byte UTF-8 sequence
  (e.g. binary output from a DOS executable).
- Uses `str::floor_char_boundary()` to find the nearest valid UTF-8 boundary
  before truncating.