### PR TITLE
fix: update spec tests for improved parse error display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,8 +2403,7 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.107.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06518571e56fef9ae4441b93445754f0b3c608404607b8143541ab672e589bf6"
+source = "git+https://github.com/bartlomieju/deno_graph.git?branch=fix%2Fimprove-parse-error-display#dd86fcdcbeb31c46f71b501221434402c356dde1"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,7 +1087,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.107.1"
-source = "git+https://github.com/bartlomieju/deno_graph.git?branch=fix%2Fimprove-parse-error-display#dd86fcdcbeb31c46f71b501221434402c356dde1"
+source = "git+https://github.com/bartlomieju/deno_graph.git?branch=fix%2Fimprove-parse-error-display#4e60a7cc316baff915a00d1e301098eccb967961"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,3 +601,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.twox-hash]
 opt-level = 3
+
+[patch.crates-io]
+deno_graph = { git = "https://github.com/bartlomieju/deno_graph.git", branch = "fix/improve-parse-error-display" }

--- a/tests/integration/watcher_tests.rs
+++ b/tests/integration/watcher_tests.rs
@@ -1036,15 +1036,16 @@ async fn test_watch_basic() {
   another_test.write("syntax error ^^");
   assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "Restarting");
   assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "error:");
-  assert_eq!(next_line(&mut stderr_lines).await.unwrap(), "");
+  assert_eq!(next_line(&mut stderr_lines).await.unwrap(), "  |");
   assert_eq!(
     next_line(&mut stderr_lines).await.unwrap(),
-    "  syntax error ^^"
+    "1 | syntax error ^^"
   );
   assert_eq!(
     next_line(&mut stderr_lines).await.unwrap(),
-    "         ~~~~~"
+    "  |        ~~~~~"
   );
+  assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "at file:");
   assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "Test failed");
 
   // Then restore the file
@@ -1429,15 +1430,16 @@ async fn bench_watch_basic() {
   another_test.write("syntax error ^^");
   assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "Restarting");
   assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "error:");
-  assert_eq!(next_line(&mut stderr_lines).await.unwrap(), "");
+  assert_eq!(next_line(&mut stderr_lines).await.unwrap(), "  |");
   assert_eq!(
     next_line(&mut stderr_lines).await.unwrap(),
-    "  syntax error ^^"
+    "1 | syntax error ^^"
   );
   assert_eq!(
     next_line(&mut stderr_lines).await.unwrap(),
-    "         ~~~~~"
+    "  |        ~~~~~"
   );
+  assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "at file:");
   assert_contains!(next_line(&mut stderr_lines).await.unwrap(), "Bench failed");
 
   // Then restore the file

--- a/tests/specs/run/error_syntax/error_syntax.js.out
+++ b/tests/specs/run/error_syntax/error_syntax.js.out
@@ -1,4 +1,5 @@
-error: The module's source code could not be parsed: Expected ',', got 'following' at [WILDCARD]/error_syntax.js:3:6
-
-  (the following is a syntax error  ^^ ! )
-       ~~~~~~~~~
+error: Expected ',', got 'following'
+    at [WILDCARD]/error_syntax.js:3:6
+  |
+3 | (the following is a syntax error  ^^ ! )
+  |      ~~~~~~~~~

--- a/tests/specs/run/error_syntax/error_syntax.js.out
+++ b/tests/specs/run/error_syntax/error_syntax.js.out
@@ -1,5 +1,5 @@
 error: Expected ',', got 'following'
-    at [WILDCARD]/error_syntax.js:3:6
   |
 3 | (the following is a syntax error  ^^ ! )
   |      ~~~~~~~~~
+    at [WILDCARD]/error_syntax.js:3:6

--- a/tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs.out
+++ b/tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs.out
@@ -1,5 +1,5 @@
 error: Expression expected
-    at [WILDCARD]/error_syntax_empty_trailing_line.mjs:2:22
   |
 2 | setTimeout(() => {}),
   |                      ~
+    at [WILDCARD]/error_syntax_empty_trailing_line.mjs:2:22

--- a/tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs.out
+++ b/tests/specs/run/error_syntax_empty_trailing_line/error_syntax_empty_trailing_line.mjs.out
@@ -1,4 +1,5 @@
-error: The module's source code could not be parsed: Expression expected at [WILDCARD]/error_syntax_empty_trailing_line.mjs:2:22
-
-  setTimeout(() => {}),
-                       ~
+error: Expression expected
+    at [WILDCARD]/error_syntax_empty_trailing_line.mjs:2:22
+  |
+2 | setTimeout(() => {}),
+  |                      ~

--- a/tests/specs/run/swc_syntax_error/swc_syntax_error.ts.out
+++ b/tests/specs/run/swc_syntax_error/swc_syntax_error.ts.out
@@ -1,5 +1,5 @@
 error: Unexpected token `}`. Expected an identifier, void, yield, null, await, break, a string literal, a numeric literal, true, false, `, -, import, this, typeof, {, [, (
-    at [WILDCARD]syntax_error.ts:4:1
   |
 4 | }
   | ~
+    at [WILDCARD]syntax_error.ts:4:1

--- a/tests/specs/run/swc_syntax_error/swc_syntax_error.ts.out
+++ b/tests/specs/run/swc_syntax_error/swc_syntax_error.ts.out
@@ -1,4 +1,5 @@
-error: The module's source code could not be parsed: Unexpected token `}`. Expected an identifier, void, yield, null, await, break, a string literal, a numeric literal, true, false, `, -, import, this, typeof, {, [, ( at [WILDCARD]syntax_error.ts:4:1
-
-  }
-  ~
+error: Unexpected token `}`. Expected an identifier, void, yield, null, await, break, a string literal, a numeric literal, true, false, `, -, import, this, typeof, {, [, (
+    at [WILDCARD]syntax_error.ts:4:1
+  |
+4 | }
+  | ~


### PR DESCRIPTION
## Summary

- Updates expected output files for syntax error spec tests to match the new structured parse error format from deno_graph
- Depends on https://github.com/denoland/deno_graph/pull/637

**Before:**
```
error: The module's source code could not be parsed: Expected ',', got 'following' at .../error_syntax.js:3:6

  (the following is a syntax error  ^^ ! )
       ~~~~~~~~~
```

**After:**
```
error: Expected ',', got 'following'
    at .../error_syntax.js:3:6
  |
3 | (the following is a syntax error  ^^ ! )
  |      ~~~~~~~~~
```

## Test plan
- [x] `specs::run::error_syntax` passes
- [x] `specs::run::error_syntax_empty_trailing_line` passes
- [x] `specs::run::swc_syntax_error` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)