### PR TITLE
fix(ext/node): use non-blocking write in fs.writev

### DIFF
--- a/ext/node/polyfills/fs.ts
+++ b/ext/node/polyfills/fs.ts
@@ -2096,7 +2096,7 @@ function writev(
     let currentOffset = 0;
     // deno-lint-ignore prefer-primordials
     while (currentOffset < buffer.byteLength) {
-      currentOffset += await io.writeSync(fd, buffer.subarray(currentOffset));
+      currentOffset += await io.write(fd, buffer.subarray(currentOffset));
     }
     return currentOffset - offset;
   };

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -835,6 +835,9 @@
     "parallel/test-fs-write-optional-params.js": {},
     "parallel/test-fs-write-stream-encoding.js": {},
     "parallel/test-fs-write-sync-optional-params.js": {},
+    "parallel/test-fs-writev.js": {},
+    "parallel/test-fs-writev-promises.js": {},
+    "parallel/test-fs-writev-sync.js": {},
     "parallel/test-global-console-exists.js": {},
     "parallel/test-global-domexception.js": {},
     "parallel/test-global-encoder.js": {},
@@ -1596,6 +1599,7 @@
     },
     "parallel/test-pipe-head.js": {},
     "parallel/test-pipe-return-val.js": {},
+    "parallel/test-pipe-writev.js": {},
     "parallel/test-preload-worker.js": {},
     "parallel/test-primordials-apply.js": {
       "ignore": true,


### PR DESCRIPTION
fs.writev inner async function was calling io.writeSync (blocking) instead of io.write (async). \
This switches to the non-blocking variant.

Also, enables 4 node compat tests:
- test-fs-writev.js
- test-fs-writev-promises.js
- test-fs-writev-sync.js
- test-pipe-writev.js
