### PR TITLE
fix(ext/web): support %j JSON format specifier in console.log

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -195,6 +195,7 @@ const {
   Uint32Array,
   WeakMap,
   WeakMapPrototype,
+  JSONStringify,
   WeakSet,
   WeakSetPrototype,
 } = primordials;
@@ -247,6 +248,34 @@ class AssertionError extends Error {
 function assert(cond, msg = "Assertion failed") {
   if (!cond) {
     throw new AssertionError(msg);
+  }
+}
+
+// Attempt to JSON.stringify, returning "[Circular]" only for circular
+// reference errors (matching Node.js behavior).
+const firstErrorLine = (error) =>
+  StringPrototypeSplit(error.message, "\n", 1)[0];
+let CIRCULAR_ERROR_MESSAGE;
+function tryStringify(arg) {
+  try {
+    return JSONStringify(arg);
+  } catch (err) {
+    if (!CIRCULAR_ERROR_MESSAGE) {
+      try {
+        const a = {};
+        a.a = a;
+        JSONStringify(a);
+      } catch (circularError) {
+        CIRCULAR_ERROR_MESSAGE = firstErrorLine(circularError);
+      }
+    }
+    if (
+      err.name === "TypeError" &&
+      firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE
+    ) {
+      return "[Circular]";
+    }
+    throw err;
   }
 }
 
@@ -3537,11 +3566,7 @@ function inspectArgs(args, inspectOptions = { __proto__: null }) {
             }
           } else if (char == "j") {
             // Format as JSON.
-            try {
-              formattedArg = JSON.stringify(args[a++]);
-            } catch {
-              formattedArg = "[Circular]";
-            }
+            formattedArg = tryStringify(args[a++]);
           } else if (ArrayPrototypeIncludes(["O", "o"], char)) {
             // Format as an object.
             formattedArg = formatValue(ctx, args[a++], 0);

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -1221,12 +1221,17 @@ Deno.test(function consoleTestWithJsonFormatSpecifier() {
   assertEquals(stringify("%j", "foo"), `"foo"`);
   assertEquals(stringify("%j", null), "null");
   assertEquals(stringify("%j", [1, 2, 3]), "[1,2,3]");
-  assertEquals(stringify("%j %s", { foo: "bar" }, "Hello"), `{"foo":"bar"} Hello`);
+  assertEquals(
+    stringify("%j %s", { foo: "bar" }, "Hello"),
+    `{"foo":"bar"} Hello`,
+  );
   assertEquals(stringify("%j %j", { a: 1 }, { b: 2 }), `{"a":1} {"b":2}`);
   // Circular reference
   const circular: Record<string, unknown> = {};
   circular.self = circular;
   assertEquals(stringify("%j", circular), "[Circular]");
+  // Non-circular errors (e.g., BigInt) should be re-thrown
+  assertThrows(() => stringify("%j", BigInt(1)));
 });
 
 Deno.test(function consoleTestWithStyleSpecifier() {


### PR DESCRIPTION
## Summary
- Add support for the `%j` format specifier in `console.log` and related methods, which JSON-stringifies the argument (matching Node.js behavior)
- Circular references output `[Circular]` instead of throwing

Closes #32680

## Test plan
- [x] Added unit tests for `%j` with objects, primitives, arrays, multiple specifiers, and circular references
- [x] `./x test-unit console` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)