### PR TITLE
fix(ext/node): accept all TypedArrays in spawnSync input option

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1585,10 +1585,7 @@ function normalizeInput(input: unknown) {
   if (typeof input === "string") {
     return Buffer.from(input);
   }
-  if (input instanceof Uint8Array) {
-    return input;
-  }
-  if (input instanceof DataView) {
+  if (ArrayBuffer.isView(input)) {
     return Buffer.from(input.buffer, input.byteOffset, input.byteLength);
   }
   throw new ERR_INVALID_ARG_TYPE("input", [

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -240,6 +240,7 @@
     "parallel/test-child-process-spawn-typeerror.js": {},
     "parallel/test-child-process-spawnsync-args.js": {},
     "parallel/test-child-process-spawnsync-env.js": {},
+    "parallel/test-child-process-spawnsync-input.js": {},
     "parallel/test-child-process-spawnsync-maxbuf.js": {},
     "parallel/test-child-process-spawnsync-validation-errors.js": {},
     "parallel/test-child-process-spawnsync.js": {},


### PR DESCRIPTION
`normalizeInput` only accepted `Uint8Array` and `DataView`, rejecting other TypedArrays like `Int8Array`. Node.js accepts any TypedArray.

Replaced the separate `instanceof Uint8Array` and `instanceof DataView` checks with a single `ArrayBuffer.isView()` that covers all TypedArray subtypes and DataView.