### PR TITLE
test: enable ignored inspector tests with failure reasons

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1181,22 +1181,66 @@
     // "parallel/test-inspector-network-arbitrary-data.js": {},
     // "parallel/test-inspector-emit-protocol-event.js": {},
 
-    // TODO(bartlomieju): depends on `NodeRuntime` CDP domain
-    // "parallel/test-inspector-esm.js": {},
-    // "parallel/test-inspector-console.js": {},
-    // "parallel/test-inspector-async-stack-traces-promise-then.js": {},
-    // "parallel/test-inspector-exception.js": {},
-    // "parallel/test-inspector-async-hook-setup-at-inspect-brk.js": {},
-    // "parallel/test-inspector-async-stack-traces-set-interval.js": {},
-    // "parallel/test-inspector-scriptparsed-context.js": {},
-    // "parallel/test-inspector-break-e.js": {},
-    // "parallel/test-inspector-waiting-for-disconnect.js": {},
-    // "parallel/test-inspector-multisession-ws.js": {},
-    // "parallel/test-inspector-worker-target.js"
-    // "parallel/test-inspector-debug-brk-flag.js": {},
-    // "parallel/test-inspector-wait.mjs": {},
-    // "parallel/test-inspector-stop-profile-after-done.js": {},
-    // "parallel/test-inspector-break-when-eval.js": {},
+    "parallel/test-inspector-esm.js": {
+      "ignore": true,
+      "reason": "Missing Runtime.executionContextDestroyed notification on process.exit()"
+    },
+    "parallel/test-inspector-console.js": {
+      "ignore": true,
+      "reason": "Hangs waiting for Runtime.consoleAPICalled notification after script completion"
+    },
+    "parallel/test-inspector-async-stack-traces-promise-then.js": {
+      "ignore": true,
+      "reason": "Deno uses $deno$eval.mts instead of [eval] for inline script URL"
+    },
+    "parallel/test-inspector-exception.js": {
+      "ignore": true,
+      "reason": "Breaks on wrong line with --inspect-brk (line 1 instead of expected line)"
+    },
+    "parallel/test-inspector-async-hook-setup-at-inspect-brk.js": {
+      "ignore": true,
+      "reason": "Deno uses $deno$eval.mts instead of [eval] for inline script URL"
+    },
+    "parallel/test-inspector-async-stack-traces-set-interval.js": {
+      "ignore": true,
+      "reason": "Deno uses $deno$eval.mts instead of [eval] for inline script URL"
+    },
+    "parallel/test-inspector-scriptparsed-context.js": {
+      "ignore": true,
+      "reason": "Deno uses $deno$eval.mts instead of [eval] for inline script URL"
+    },
+    "parallel/test-inspector-break-e.js": {
+      "ignore": true,
+      "reason": "Deno uses $deno$eval.mts instead of [eval] for inline script URL"
+    },
+    "parallel/test-inspector-waiting-for-disconnect.js": {
+      "ignore": true,
+      "reason": "NodeRuntime.notifyWhenWaitingForDisconnect is not implemented"
+    },
+    "parallel/test-inspector-multisession-ws.js": {
+      "ignore": true,
+      "reason": "Times out — hangs during multi-session WebSocket inspector test"
+    },
+    "parallel/test-inspector-worker-target.js": {
+      "ignore": true,
+      "reason": "Times out waiting for inspector notification in worker target test"
+    },
+    "parallel/test-inspector-debug-brk-flag.js": {
+      "ignore": true,
+      "reason": "Breaks on wrong line with --inspect-brk (line 1 instead of line 0)"
+    },
+    "parallel/test-inspector-wait.mjs": {
+      "ignore": true,
+      "reason": "Times out waiting for console output — Runtime.consoleAPICalled not delivered"
+    },
+    "parallel/test-inspector-stop-profile-after-done.js": {
+      "ignore": true,
+      "reason": "Times out — hangs waiting for inspector disconnect after profiling"
+    },
+    "parallel/test-inspector-break-when-eval.js": {
+      "ignore": true,
+      "reason": "V8 reports 'Can only perform operation while paused' during Debugger.stepOver"
+    },
 
     // TODO(bartlomieju): depends on 'internal/deps/undici/undici' internal module
     // "parallel/test-inspector-network-fetch.js": {},


### PR DESCRIPTION
## Summary

- Uncomment 15 inspector tests that were disabled with a blanket "depends on NodeRuntime CDP domain" TODO
- Mark each with `ignore: true` and a specific `reason` explaining its actual blocker

## Failure breakdown

| Blocker | Tests |
|---------|-------|
| `$deno$eval.mts` vs `[eval]` URL mismatch | async-stack-traces-promise-then, async-hook-setup-at-inspect-brk, async-stack-traces-set-interval, scriptparsed-context, break-e |
| `--inspect-brk` breaks on wrong line | exception, debug-brk-flag |
| Missing `Runtime.executionContextDestroyed` on exit | esm |
| `Runtime.consoleAPICalled` not delivered | console, wait |
| `NodeRuntime.notifyWhenWaitingForDisconnect` not implemented | waiting-for-disconnect |
| Timeout (multi-session / profiling / worker) | multisession-ws, stop-profile-after-done, worker-target |
| V8 "Can only perform operation while paused" | break-when-eval |

## Test plan

- [x] Verified tests show as `ignored` in test runner
- [x] `./tools/format.js` passes
- [x] `./tools/lint.js --js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)