### PR TITLE
fix(ext/otel): don't mark server spans as error for 4xx responses

### DIFF
--- a/ext/fetch/26_fetch.js
+++ b/ext/fetch/26_fetch.js
@@ -67,9 +67,9 @@ import {
   TRACING_ENABLED,
 } from "ext:deno_telemetry/telemetry.ts";
 import {
+  updateSpanFromClientResponse,
   updateSpanFromError,
   updateSpanFromRequest,
-  updateSpanFromResponse,
 } from "ext:deno_telemetry/util.ts";
 
 const REQUEST_BODY_HEADER_NAMES = [
@@ -450,7 +450,7 @@ function fetch(input, init = { __proto__: null }) {
             responseObject = fromInnerResponse(response, "immutable");
 
             if (span) {
-              updateSpanFromResponse(span, responseObject);
+              updateSpanFromClientResponse(span, responseObject);
             }
 
             resolve(responseObject);

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -104,7 +104,7 @@ import {
 } from "ext:deno_telemetry/telemetry.ts";
 import {
   updateSpanFromRequest,
-  updateSpanFromResponse,
+  updateSpanFromServerResponse,
 } from "ext:deno_telemetry/util.ts";
 
 const _upgraded = Symbol("_upgraded");
@@ -602,7 +602,7 @@ function mapToCallback(context, callback, onError) {
     }
 
     if (span) {
-      updateSpanFromResponse(span, response);
+      updateSpanFromServerResponse(span, response);
     }
 
     const inner = toInnerResponse(response);

--- a/ext/telemetry/util.ts
+++ b/ext/telemetry/util.ts
@@ -19,15 +19,38 @@ export function updateSpanFromRequest(span: Span, request: Request) {
   span.setAttribute("url.query", StringPrototypeSlice(url.search, 1));
 }
 
-export function updateSpanFromResponse(span: Span, response: Response) {
+function setResponseAttributes(
+  span: Span,
+  response: Response,
+  errorThreshold: number,
+) {
   span.setAttribute(
     "http.response.status_code",
     String(response.status),
   );
-  if (response.status >= 400) {
+  if (response.status >= errorThreshold) {
     span.setAttribute("error.type", String(response.status));
     span.setStatus({ code: 2, message: response.statusText });
   }
+}
+
+// Per OTel HTTP semantic conventions, client spans should have ERROR status
+// for all >= 400 responses.
+export function updateSpanFromClientResponse(
+  span: Span,
+  response: Response,
+) {
+  setResponseAttributes(span, response, 400);
+}
+
+// Per OTel HTTP semantic conventions, server spans should only have ERROR
+// status for 5xx responses. 4xx responses are client errors, not server
+// errors.
+export function updateSpanFromServerResponse(
+  span: Span,
+  response: Response,
+) {
+  setResponseAttributes(span, response, 500);
 }
 
 // deno-lint-ignore no-explicit-any

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -96,6 +96,10 @@
     "cron_error": {
       "args": "run -A main.ts cron_error.ts",
       "output": "cron_error.out"
+    },
+    "http_server_status": {
+      "args": "run -A main.ts http_server_status.ts",
+      "output": "http_server_status.out"
     }
   }
 }

--- a/tests/specs/cli/otel_basic/http_server_status.out
+++ b/tests/specs/cli/otel_basic/http_server_status.out
@@ -1,0 +1,144 @@
+{
+  "spans": [
+    {
+      "traceId": "[WILDLINE]",
+      "spanId": "[WILDLINE]",
+      "traceState": "",
+      "parentSpanId": "",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+[WILDCARD]
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    },
+    {
+      "traceId": "[WILDLINE]",
+      "spanId": "[WILDLINE]",
+      "traceState": "",
+      "parentSpanId": "[WILDLINE]",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+[WILDCARD]
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    },
+    {
+[# client span for /not-found: 404 IS an error for clients]
+      "traceId": "[WILDLINE]",
+      "spanId": "[WILDLINE]",
+      "traceState": "",
+      "parentSpanId": "[WILDLINE]",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+[WILDCARD]
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "404"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "404"
+          }
+        }
+      ],
+[WILDCARD]
+      "status": {
+        "message": "Not Found",
+        "code": 2
+      }
+    },
+    {
+[# server span for /not-found: 404 is NOT an error for servers]
+      "traceId": "[WILDLINE]",
+      "spanId": "[WILDLINE]",
+      "traceState": "",
+      "parentSpanId": "[WILDLINE]",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+[WILDCARD]
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "404"
+          }
+        }
+      ],
+[WILDCARD]
+      "status": {
+        "message": "",
+        "code": 0
+      }
+    },
+    {
+[# client span for /error: 500 IS an error for clients]
+      "traceId": "[WILDLINE]",
+      "spanId": "[WILDLINE]",
+      "traceState": "",
+      "parentSpanId": "[WILDLINE]",
+      "flags": 1,
+      "name": "GET",
+      "kind": 3,
+[WILDCARD]
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "500"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "500"
+          }
+        }
+      ],
+[WILDCARD]
+      "status": {
+        "message": "Internal Server Error",
+        "code": 2
+      }
+    },
+    {
+[# server span for /error: 500 IS an error for servers too]
+      "traceId": "[WILDLINE]",
+      "spanId": "[WILDLINE]",
+      "traceState": "",
+      "parentSpanId": "[WILDLINE]",
+      "flags": 1,
+      "name": "GET",
+      "kind": 2,
+[WILDCARD]
+        {
+          "key": "http.response.status_code",
+          "value": {
+            "stringValue": "500"
+          }
+        },
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "500"
+          }
+        }
+      ],
+[WILDCARD]
+      "status": {
+        "message": "[WILDCARD]",
+        "code": 2
+      }
+    }
+  ],
+  "logs": [],
+  "metrics": [WILDCARD]
+}

--- a/tests/specs/cli/otel_basic/http_server_status.ts
+++ b/tests/specs/cli/otel_basic/http_server_status.ts
@@ -1,0 +1,22 @@
+const server = Deno.serve({
+  port: 0,
+  async onListen({ port }) {
+    try {
+      await (await fetch(`http://localhost:${port}/ok`)).text();
+      await (await fetch(`http://localhost:${port}/not-found`)).text();
+      await (await fetch(`http://localhost:${port}/error`)).text();
+    } finally {
+      server.shutdown();
+    }
+  },
+  handler: (req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/ok") {
+      return new Response("ok", { status: 200 });
+    } else if (url.pathname === "/not-found") {
+      return new Response("not found", { status: 404 });
+    } else {
+      return new Response("internal server error", { status: 500 });
+    }
+  },
+});


### PR DESCRIPTION
## Summary

- Per [OTel HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/), server spans should only have ERROR status for 5xx responses. 4xx responses are client errors — the server handled the request correctly.
- Previously, `updateSpanFromResponse` treated all >= 400 responses as errors regardless of span kind, causing 404s to show as faults/errors in tracing backends (AWS X-Ray, Grafana Tempo, etc.).
- Split into `updateSpanFromClientResponse` (errors on >= 400) and `updateSpanFromServerResponse` (errors on >= 500) with a shared `setResponseAttributes` helper.

Fixes #29615

## Test plan

- [x] Added `http_server_status` spec test covering 200, 404, and 500 responses with both client and server spans
- [x] Server 404 span: no `error.type`, `status.code: 0` (UNSET)
- [x] Server 500 span: `error.type: "500"`, `status.code: 2` (ERROR)
- [x] Client 404 span: `error.type: "404"`, `status.code: 2` (ERROR) — unchanged
- [x] Existing `otel_basic::fetch` test passes (client-side behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)