### PR TITLE
fix(ext/telemetry): add `log.iostream` attribute to console logs

### DIFF
--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -1291,6 +1291,16 @@ fn op_otel_log<'s>(
   log_record.set_body(owned_string(scope, message).into());
   log_record.set_severity_number(severity);
   log_record.set_severity_text(severity.name());
+
+  // console.warn (level 2) and console.error (level 3) write to stderr,
+  // everything else writes to stdout.
+  let iostream = if level == 2 || level == 3 {
+    "stderr"
+  } else {
+    "stdout"
+  };
+  log_record.add_attribute("log.iostream", iostream);
+
   if let Some(span) =
     deno_core::_ops::try_unwrap_cppgc_object::<OtelSpan>(scope, span)
   {
@@ -1355,6 +1365,14 @@ fn op_otel_log_foreign(
   log_record.set_body(message.into());
   log_record.set_severity_number(severity);
   log_record.set_severity_text(severity.name());
+
+  let iostream = if level == 2 || level == 3 {
+    "stderr"
+  } else {
+    "stdout"
+  };
+  log_record.add_attribute("log.iostream", iostream);
+
   if trace_id != TraceId::INVALID && span_id != SpanId::INVALID {
     log_record.set_trace_context(
       trace_id,

--- a/tests/specs/cli/otel_basic/basic.out
+++ b/tests/specs/cli/otel_basic/basic.out
@@ -168,7 +168,14 @@
       "body": {
         "stringValue": "log 1\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 1,
       "traceId": "00000000000000000000000000000001",
@@ -182,7 +189,14 @@
       "body": {
         "stringValue": "log 2\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 1,
       "traceId": "00000000000000000000000000000001",

--- a/tests/specs/cli/otel_basic/deno_dot_exit.out
+++ b/tests/specs/cli/otel_basic/deno_dot_exit.out
@@ -9,7 +9,14 @@
       "body": {
         "stringValue": "log 1\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 0,
       "traceId": "",

--- a/tests/specs/cli/otel_basic/http_propagators.out
+++ b/tests/specs/cli/otel_basic/http_propagators.out
@@ -242,7 +242,14 @@
       "body": {
         "stringValue": "server 1\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 1,
       "traceId": "00000000000000000000000000000001",
@@ -256,7 +263,14 @@
       "body": {
         "stringValue": "alice\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 1,
       "traceId": "00000000000000000000000000000001",
@@ -270,7 +284,14 @@
       "body": {
         "stringValue": "server 2\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 1,
       "traceId": "00000000000000000000000000000001",

--- a/tests/specs/cli/otel_basic/natural_exit.out
+++ b/tests/specs/cli/otel_basic/natural_exit.out
@@ -9,7 +9,14 @@
       "body": {
         "stringValue": "log 1\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 0,
       "traceId": "",

--- a/tests/specs/cli/otel_basic/propagators_api.out
+++ b/tests/specs/cli/otel_basic/propagators_api.out
@@ -9,7 +9,14 @@
       "body": {
         "stringValue": "alice\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 0,
       "traceId": "",
@@ -23,7 +30,14 @@
       "body": {
         "stringValue": "userId=alice\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 0,
       "traceId": "",

--- a/tests/specs/cli/otel_basic/uncaught.out
+++ b/tests/specs/cli/otel_basic/uncaught.out
@@ -13,7 +13,14 @@ throw new Error("uncaught");
       "body": {
         "stringValue": "log 1\n"
       },
-      "attributes": [],
+      "attributes": [
+        {
+          "key": "log.iostream",
+          "value": {
+            "stringValue": "stdout"
+          }
+        }
+      ],
       "droppedAttributesCount": 0,
       "flags": 0,
       "traceId": "",


### PR DESCRIPTION
## Summary

- Add `log.iostream` semantic convention attribute to OTel log records from console methods
- `console.warn` / `console.error` → `log.iostream: "stderr"`
- `console.log` / `console.info` / `console.debug` / `console.trace` → `log.iostream: "stdout"`
- Applied to both `op_otel_log` and `op_otel_log_foreign` code paths

Per the [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/log/#log-iostream).

Closes #27910

## Test plan

- [x] Updated all existing `.out` test expectations for the new attribute
- [x] All previously passing `otel_basic` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)