### PR TITLE
feat(ext/telemetry): add OTEL event loop metrics

### DIFF
--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -2800,8 +2800,9 @@ fn op_otel_collect_event_loop_metrics(scope: &mut v8::PinScope<'_, '_>) {
   let context = scope.get_current_context();
   // SAFETY: slot is set during realm creation and contains a valid Rc<ContextState>
   let context_state = unsafe {
-    let ptr = context
-      .get_aligned_pointer_from_embedder_data(deno_core::CONTEXT_STATE_SLOT_INDEX);
+    let ptr = context.get_aligned_pointer_from_embedder_data(
+      deno_core::CONTEXT_STATE_SLOT_INDEX,
+    );
     let rc = ptr as *const deno_core::ContextState;
     std::rc::Rc::increment_strong_count(rc);
     std::rc::Rc::from_raw(rc)
@@ -2809,8 +2810,18 @@ fn op_otel_collect_event_loop_metrics(scope: &mut v8::PinScope<'_, '_>) {
   let Some(vals) = context_state.event_loop_metrics.borrow_mut().read() else {
     return;
   };
-  let [min, max, mean, stddev, p50, p90, p99, util, active_delta, idle_delta] =
-    vals;
+  let [
+    min,
+    max,
+    mean,
+    stddev,
+    p50,
+    p90,
+    p99,
+    util,
+    active_delta,
+    idle_delta,
+  ] = vals;
 
   data.delay_min.record(min, &[]);
   data.delay_max.record(max, &[]);

--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -117,6 +117,8 @@ deno_core::extension!(
     op_otel_metric_observable_record3,
     op_otel_metric_wait_to_observe,
     op_otel_metric_observation_done,
+    op_otel_enable_event_loop_metrics,
+    op_otel_collect_event_loop_metrics,
   ],
   objects = [OtelTracer, OtelMeter, OtelSpan],
   esm = ["telemetry.ts", "util.ts"],
@@ -2703,4 +2705,121 @@ fn op_otel_collect_isolate_metrics(scope: &mut v8::PinScope<'_, '_>) {
       .physical_size
       .record(space.physical_space_size() as _, &attributes);
   }
+}
+
+#[derive(Clone)]
+struct EventLoopMetricData {
+  delay_min: Gauge<f64>,
+  delay_max: Gauge<f64>,
+  delay_mean: Gauge<f64>,
+  delay_stddev: Gauge<f64>,
+  delay_p50: Gauge<f64>,
+  delay_p90: Gauge<f64>,
+  delay_p99: Gauge<f64>,
+  utilization: Gauge<f64>,
+  time: opentelemetry::metrics::Counter<f64>,
+}
+
+#[op2(fast)]
+fn op_otel_enable_event_loop_metrics(scope: &mut v8::PinScope<'_, '_>) {
+  if scope.get_slot::<EventLoopMetricData>().is_some() {
+    return;
+  }
+
+  let Some(globals) = OTEL_GLOBALS.get() else {
+    return;
+  };
+  let meter = globals.meter_provider.meter("deno");
+
+  let delay_min = meter
+    .f64_gauge("deno.eventloop.delay.min")
+    .with_unit("s")
+    .with_description("Minimum event loop delay")
+    .build();
+  let delay_max = meter
+    .f64_gauge("deno.eventloop.delay.max")
+    .with_unit("s")
+    .with_description("Maximum event loop delay")
+    .build();
+  let delay_mean = meter
+    .f64_gauge("deno.eventloop.delay.mean")
+    .with_unit("s")
+    .with_description("Mean event loop delay")
+    .build();
+  let delay_stddev = meter
+    .f64_gauge("deno.eventloop.delay.stddev")
+    .with_unit("s")
+    .with_description("Standard deviation of event loop delay")
+    .build();
+  let delay_p50 = meter
+    .f64_gauge("deno.eventloop.delay.p50")
+    .with_unit("s")
+    .with_description("50th percentile event loop delay")
+    .build();
+  let delay_p90 = meter
+    .f64_gauge("deno.eventloop.delay.p90")
+    .with_unit("s")
+    .with_description("90th percentile event loop delay")
+    .build();
+  let delay_p99 = meter
+    .f64_gauge("deno.eventloop.delay.p99")
+    .with_unit("s")
+    .with_description("99th percentile event loop delay")
+    .build();
+  let utilization = meter
+    .f64_gauge("deno.eventloop.utilization")
+    .with_unit("1")
+    .with_description("Event loop utilization")
+    .build();
+  let time = meter
+    .f64_counter("deno.eventloop.time")
+    .with_unit("s")
+    .with_description("Cumulative event loop time")
+    .build();
+
+  scope.set_slot(EventLoopMetricData {
+    delay_min,
+    delay_max,
+    delay_mean,
+    delay_stddev,
+    delay_p50,
+    delay_p90,
+    delay_p99,
+    utilization,
+    time,
+  });
+}
+
+#[op2(fast)]
+fn op_otel_collect_event_loop_metrics(
+  scope: &mut v8::PinScope<'_, '_>,
+  min: f64,
+  max: f64,
+  mean: f64,
+  stddev: f64,
+  p50: f64,
+  p90: f64,
+  p99: f64,
+  util: f64,
+  active_delta: f64,
+  idle_delta: f64,
+) {
+  let Some(data) = scope.get_slot::<EventLoopMetricData>() else {
+    return;
+  };
+  let data = data.clone();
+
+  data.delay_min.record(min, &[]);
+  data.delay_max.record(max, &[]);
+  data.delay_mean.record(mean, &[]);
+  data.delay_stddev.record(stddev, &[]);
+  data.delay_p50.record(p50, &[]);
+  data.delay_p90.record(p90, &[]);
+  data.delay_p99.record(p99, &[]);
+  data.utilization.record(util, &[]);
+
+  let active_attr = [KeyValue::new("deno.eventloop.state", "active")];
+  let idle_attr = [KeyValue::new("deno.eventloop.state", "idle")];
+  data.time.add(active_delta, &active_attr);
+  data.time.add(idle_delta, &idle_attr);
 }

--- a/ext/telemetry/lib.rs
+++ b/ext/telemetry/lib.rs
@@ -2791,23 +2791,26 @@ fn op_otel_enable_event_loop_metrics(scope: &mut v8::PinScope<'_, '_>) {
 }
 
 #[op2(fast)]
-fn op_otel_collect_event_loop_metrics(
-  scope: &mut v8::PinScope<'_, '_>,
-  min: f64,
-  max: f64,
-  mean: f64,
-  stddev: f64,
-  p50: f64,
-  p90: f64,
-  p99: f64,
-  util: f64,
-  active_delta: f64,
-  idle_delta: f64,
-) {
+fn op_otel_collect_event_loop_metrics(scope: &mut v8::PinScope<'_, '_>) {
   let Some(data) = scope.get_slot::<EventLoopMetricData>() else {
     return;
   };
   let data = data.clone();
+
+  let context = scope.get_current_context();
+  // SAFETY: slot is set during realm creation and contains a valid Rc<ContextState>
+  let context_state = unsafe {
+    let ptr = context
+      .get_aligned_pointer_from_embedder_data(deno_core::CONTEXT_STATE_SLOT_INDEX);
+    let rc = ptr as *const deno_core::ContextState;
+    std::rc::Rc::increment_strong_count(rc);
+    std::rc::Rc::from_raw(rc)
+  };
+  let Some(vals) = context_state.event_loop_metrics.borrow_mut().read() else {
+    return;
+  };
+  let [min, max, mean, stddev, p50, p90, p99, util, active_delta, idle_delta] =
+    vals;
 
   data.delay_min.record(min, &[]);
   data.delay_max.record(max, &[]);

--- a/ext/telemetry/telemetry.ts
+++ b/ext/telemetry/telemetry.ts
@@ -43,17 +43,11 @@ const {
   ArrayPrototypeReverse,
   ArrayPrototypeShift,
   ArrayPrototypeSlice,
-  ArrayPrototypeSort,
-  DateNow,
   DatePrototype,
   DatePrototypeGetTime,
   decodeURIComponent,
   encodeURIComponent,
   Error,
-  MathCeil,
-  MathMax,
-  MathMin,
-  MathSqrt,
   MapPrototypeEntries,
   MapPrototypeKeys,
   Number,
@@ -89,85 +83,9 @@ export let PROPAGATORS: TextMapPropagator[] = [];
 let ISOLATE_METRICS = false;
 let EVENT_LOOP_METRICS = false;
 
-// Event loop metrics state
-let elSamples: number[] = [];
-let elLastSampleTime = 0;
-let elActiveTime = 0;
-let elIdleTime = 0;
-let elLastObserveActive = 0;
-let elLastObserveIdle = 0;
-const EL_SAMPLE_INTERVAL = 10; // ms
-
-function eventLoopSample() {
-  const now = DateNow();
-  if (elLastSampleTime > 0) {
-    const elapsed = now - elLastSampleTime;
-    const delay = MathMax(0, elapsed - EL_SAMPLE_INTERVAL);
-    ArrayPrototypePush(elSamples, delay);
-    // Active time is the delay portion, idle is the expected interval
-    elActiveTime += MathMin(delay, elapsed);
-    elIdleTime += MathMax(0, elapsed - delay);
-  }
-  elLastSampleTime = now;
-}
-
-function collectEventLoopMetrics() {
-  if (elSamples.length === 0) return;
-
-  ArrayPrototypeSort(elSamples, (a: number, b: number) => a - b);
-  const len = elSamples.length;
-
-  let sum = 0;
-  let min = elSamples[0];
-  let max = elSamples[0];
-  for (let i = 0; i < len; i++) {
-    const v = elSamples[i];
-    sum += v;
-    if (v < min) min = v;
-    if (v > max) max = v;
-  }
-  const mean = sum / len;
-
-  let variance = 0;
-  for (let i = 0; i < len; i++) {
-    const diff = elSamples[i] - mean;
-    variance += diff * diff;
-  }
-  const stddev = MathSqrt(variance / len);
-
-  const p50 = elSamples[MathMin(MathCeil(len * 0.5) - 1, len - 1)];
-  const p90 = elSamples[MathMin(MathCeil(len * 0.9) - 1, len - 1)];
-  const p99 = elSamples[MathMin(MathCeil(len * 0.99) - 1, len - 1)];
-
-  const totalTime = elActiveTime + elIdleTime;
-  const utilization = totalTime > 0 ? elActiveTime / totalTime : 0;
-
-  const activeDelta = (elActiveTime - elLastObserveActive) / 1000;
-  const idleDelta = (elIdleTime - elLastObserveIdle) / 1000;
-  elLastObserveActive = elActiveTime;
-  elLastObserveIdle = elIdleTime;
-
-  // Convert ms to seconds
-  op_otel_collect_event_loop_metrics(
-    min / 1000,
-    max / 1000,
-    mean / 1000,
-    stddev / 1000,
-    p50 / 1000,
-    p90 / 1000,
-    p99 / 1000,
-    utilization,
-    MathMax(0, activeDelta),
-    MathMax(0, idleDelta),
-  );
-
-  elSamples = [];
-}
-
 function enableEventLoopMetrics() {
   op_otel_enable_event_loop_metrics();
   EVENT_LOOP_METRICS = true;
-  core.queueSystemTimer(undefined, true, EL_SAMPLE_INTERVAL, eventLoopSample);
   startObserving();
 }
 
@@ -1229,7 +1147,7 @@ async function observe(): Promise<void> {
     op_otel_collect_isolate_metrics();
   }
   if (EVENT_LOOP_METRICS) {
-    collectEventLoopMetrics();
+    op_otel_collect_event_loop_metrics();
   }
 
   const promises: Promise<void>[] = [];

--- a/ext/telemetry/telemetry.ts
+++ b/ext/telemetry/telemetry.ts
@@ -2,7 +2,9 @@
 
 import { core, primordials } from "ext:core/mod.js";
 import {
+  op_otel_collect_event_loop_metrics,
   op_otel_collect_isolate_metrics,
+  op_otel_enable_event_loop_metrics,
   op_otel_enable_isolate_metrics,
   op_otel_log,
   op_otel_log_foreign,
@@ -41,11 +43,17 @@ const {
   ArrayPrototypeReverse,
   ArrayPrototypeShift,
   ArrayPrototypeSlice,
+  ArrayPrototypeSort,
+  DateNow,
   DatePrototype,
   DatePrototypeGetTime,
   decodeURIComponent,
   encodeURIComponent,
   Error,
+  MathCeil,
+  MathMax,
+  MathMin,
+  MathSqrt,
   MapPrototypeEntries,
   MapPrototypeKeys,
   Number,
@@ -79,6 +87,89 @@ export let TRACING_ENABLED = false;
 export let METRICS_ENABLED = false;
 export let PROPAGATORS: TextMapPropagator[] = [];
 let ISOLATE_METRICS = false;
+let EVENT_LOOP_METRICS = false;
+
+// Event loop metrics state
+let elSamples: number[] = [];
+let elLastSampleTime = 0;
+let elActiveTime = 0;
+let elIdleTime = 0;
+let elLastObserveActive = 0;
+let elLastObserveIdle = 0;
+const EL_SAMPLE_INTERVAL = 10; // ms
+
+function eventLoopSample() {
+  const now = DateNow();
+  if (elLastSampleTime > 0) {
+    const elapsed = now - elLastSampleTime;
+    const delay = MathMax(0, elapsed - EL_SAMPLE_INTERVAL);
+    ArrayPrototypePush(elSamples, delay);
+    // Active time is the delay portion, idle is the expected interval
+    elActiveTime += MathMin(delay, elapsed);
+    elIdleTime += MathMax(0, elapsed - delay);
+  }
+  elLastSampleTime = now;
+}
+
+function collectEventLoopMetrics() {
+  if (elSamples.length === 0) return;
+
+  ArrayPrototypeSort(elSamples, (a: number, b: number) => a - b);
+  const len = elSamples.length;
+
+  let sum = 0;
+  let min = elSamples[0];
+  let max = elSamples[0];
+  for (let i = 0; i < len; i++) {
+    const v = elSamples[i];
+    sum += v;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const mean = sum / len;
+
+  let variance = 0;
+  for (let i = 0; i < len; i++) {
+    const diff = elSamples[i] - mean;
+    variance += diff * diff;
+  }
+  const stddev = MathSqrt(variance / len);
+
+  const p50 = elSamples[MathMin(MathCeil(len * 0.5) - 1, len - 1)];
+  const p90 = elSamples[MathMin(MathCeil(len * 0.9) - 1, len - 1)];
+  const p99 = elSamples[MathMin(MathCeil(len * 0.99) - 1, len - 1)];
+
+  const totalTime = elActiveTime + elIdleTime;
+  const utilization = totalTime > 0 ? elActiveTime / totalTime : 0;
+
+  const activeDelta = (elActiveTime - elLastObserveActive) / 1000;
+  const idleDelta = (elIdleTime - elLastObserveIdle) / 1000;
+  elLastObserveActive = elActiveTime;
+  elLastObserveIdle = elIdleTime;
+
+  // Convert ms to seconds
+  op_otel_collect_event_loop_metrics(
+    min / 1000,
+    max / 1000,
+    mean / 1000,
+    stddev / 1000,
+    p50 / 1000,
+    p90 / 1000,
+    p99 / 1000,
+    utilization,
+    MathMax(0, activeDelta),
+    MathMax(0, idleDelta),
+  );
+
+  elSamples = [];
+}
+
+function enableEventLoopMetrics() {
+  op_otel_enable_event_loop_metrics();
+  EVENT_LOOP_METRICS = true;
+  core.queueSystemTimer(undefined, true, EL_SAMPLE_INTERVAL, eventLoopSample);
+  startObserving();
+}
 
 // Note: These start at 0 in the JS library,
 // but start at 1 when serialized with JSON.
@@ -1137,6 +1228,9 @@ async function observe(): Promise<void> {
   if (ISOLATE_METRICS) {
     op_otel_collect_isolate_metrics();
   }
+  if (EVENT_LOOP_METRICS) {
+    collectEventLoopMetrics();
+  }
 
   const promises: Promise<void>[] = [];
   // Primordials are not needed, because this is a SafeMap.
@@ -1874,6 +1968,7 @@ export function bootstrap(
     if (METRICS_ENABLED) {
       otel.metrics = MeterProvider;
       enableIsolateMetrics();
+      enableEventLoopMetrics();
     }
     if (PROPAGATORS.length > 0) {
       otel.propagation = new CompositePropagator(PROPAGATORS);

--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -133,7 +133,9 @@ impl EventLoopMetrics {
       return None;
     }
 
-    self.samples.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+    self
+      .samples
+      .sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
     let len = self.samples.len();
 
     let mut sum = 0.0;
@@ -141,8 +143,12 @@ impl EventLoopMetrics {
     let mut max = f64::MIN;
     for &v in &self.samples {
       sum += v;
-      if v < min { min = v; }
-      if v > max { max = v; }
+      if v < min {
+        min = v;
+      }
+      if v > max {
+        max = v;
+      }
     }
     let mean = sum / len as f64;
 
@@ -154,7 +160,9 @@ impl EventLoopMetrics {
     let stddev = (variance / len as f64).sqrt();
 
     let percentile = |p: f64| -> f64 {
-      let idx = ((len as f64 * p).ceil() as usize).saturating_sub(1).min(len - 1);
+      let idx = ((len as f64 * p).ceil() as usize)
+        .saturating_sub(1)
+        .min(len - 1);
       self.samples[idx]
     };
     let p50 = percentile(0.5);
@@ -162,7 +170,11 @@ impl EventLoopMetrics {
     let p99 = percentile(0.99);
 
     let total = self.active_time + self.idle_time;
-    let utilization = if total > 0.0 { self.active_time / total } else { 0.0 };
+    let utilization = if total > 0.0 {
+      self.active_time / total
+    } else {
+      0.0
+    };
 
     let active_delta = self.active_time - self.last_read_active;
     let idle_delta = self.idle_time - self.last_read_idle;
@@ -171,7 +183,18 @@ impl EventLoopMetrics {
 
     self.samples.clear();
 
-    Some([min, max, mean, stddev, p50, p90, p99, utilization, active_delta, idle_delta])
+    Some([
+      min,
+      max,
+      mean,
+      stddev,
+      p50,
+      p90,
+      p99,
+      utilization,
+      active_delta,
+      idle_delta,
+    ])
   }
 }
 

--- a/libs/core/runtime/jsrealm.rs
+++ b/libs/core/runtime/jsrealm.rs
@@ -7,6 +7,7 @@ use std::hash::BuildHasherDefault;
 use std::hash::Hasher;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Instant;
 
 use super::exception_state::ExceptionState;
 #[cfg(test)]
@@ -72,6 +73,108 @@ pub(crate) const IMM_IDX_COUNT: usize = 0;
 pub(crate) const IMM_IDX_REF_COUNT: usize = 1;
 pub(crate) const IMM_IDX_HAS_OUTSTANDING: usize = 2;
 
+/// Tracks event loop timing metrics for OTEL instrumentation.
+/// Updated by the event loop in `poll_event_loop_inner`.
+pub struct EventLoopMetrics {
+  /// Delay samples (in seconds) collected since last read.
+  samples: Vec<f64>,
+  /// Cumulative active time in seconds.
+  active_time: f64,
+  /// Cumulative idle time in seconds.
+  idle_time: f64,
+  /// Last time we finished a poll (used to measure idle gap).
+  last_poll_end: Option<Instant>,
+  /// Active/idle at last read (for computing deltas).
+  last_read_active: f64,
+  last_read_idle: f64,
+}
+
+impl Default for EventLoopMetrics {
+  fn default() -> Self {
+    Self {
+      samples: Vec::new(),
+      active_time: 0.0,
+      idle_time: 0.0,
+      last_poll_end: None,
+      last_read_active: 0.0,
+      last_read_idle: 0.0,
+    }
+  }
+}
+
+impl EventLoopMetrics {
+  /// Called at the start of each poll_event_loop_inner iteration.
+  /// Records the idle gap since the last poll ended.
+  pub fn on_poll_start(&mut self) -> Instant {
+    let now = Instant::now();
+    if let Some(last_end) = self.last_poll_end {
+      let idle = now.duration_since(last_end).as_secs_f64();
+      self.idle_time += idle;
+      // The idle gap is also the "event loop delay" — how long
+      // callbacks had to wait before the loop came back around.
+      self.samples.push(idle);
+    }
+    now
+  }
+
+  /// Called at the end of each poll_event_loop_inner iteration.
+  pub fn on_poll_end(&mut self, poll_start: Instant) {
+    let now = Instant::now();
+    let active = now.duration_since(poll_start).as_secs_f64();
+    self.active_time += active;
+    self.last_poll_end = Some(now);
+  }
+
+  /// Read and reset collected samples. Returns None if no samples.
+  /// Returns (min, max, mean, stddev, p50, p90, p99, utilization,
+  /// active_delta, idle_delta).
+  pub fn read(&mut self) -> Option<[f64; 10]> {
+    if self.samples.is_empty() {
+      return None;
+    }
+
+    self.samples.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+    let len = self.samples.len();
+
+    let mut sum = 0.0;
+    let mut min = f64::MAX;
+    let mut max = f64::MIN;
+    for &v in &self.samples {
+      sum += v;
+      if v < min { min = v; }
+      if v > max { max = v; }
+    }
+    let mean = sum / len as f64;
+
+    let mut variance = 0.0;
+    for &v in &self.samples {
+      let diff = v - mean;
+      variance += diff * diff;
+    }
+    let stddev = (variance / len as f64).sqrt();
+
+    let percentile = |p: f64| -> f64 {
+      let idx = ((len as f64 * p).ceil() as usize).saturating_sub(1).min(len - 1);
+      self.samples[idx]
+    };
+    let p50 = percentile(0.5);
+    let p90 = percentile(0.9);
+    let p99 = percentile(0.99);
+
+    let total = self.active_time + self.idle_time;
+    let utilization = if total > 0.0 { self.active_time / total } else { 0.0 };
+
+    let active_delta = self.active_time - self.last_read_active;
+    let idle_delta = self.idle_time - self.last_read_idle;
+    self.last_read_active = self.active_time;
+    self.last_read_idle = self.idle_time;
+
+    self.samples.clear();
+
+    Some([min, max, mean, stddev, p50, p90, p99, utilization, active_delta, idle_delta])
+  }
+}
+
 pub struct ContextState {
   pub(crate) task_spawner_factory: Arc<V8TaskSpawnerFactory>,
   pub(crate) timers: WebTimers<(v8::Global<v8::Function>, u32), DefaultReactor>,
@@ -125,6 +228,8 @@ pub struct ContextState {
   /// # Safety
   /// Same lifetime requirements as `uv_loop_inner` above.
   pub(crate) uv_loop_ptr: Cell<Option<*mut crate::uv_compat::uv_loop_t>>,
+  /// Event loop timing metrics for OTEL instrumentation.
+  pub event_loop_metrics: RefCell<EventLoopMetrics>,
 }
 
 impl ContextState {
@@ -167,6 +272,7 @@ impl ContextState {
       event_loop_phases: Default::default(),
       uv_loop_inner: Cell::new(None),
       uv_loop_ptr: Cell::new(None),
+      event_loop_metrics: Default::default(),
     }
   }
 }

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2133,6 +2133,8 @@ impl JsRuntime {
     let modules = &realm.0.module_map;
     let context_state = &realm.0.context_state;
 
+    let poll_start = context_state.event_loop_metrics.borrow_mut().on_poll_start();
+
     let exception_state = &context_state.exception_state;
 
     // Tight I/O loop: when run_io does work, re-run I/O phases immediately
@@ -2249,6 +2251,8 @@ impl JsRuntime {
       unsafe { (*uv_inner_ptr).run_close() };
     }
     scope.perform_microtask_checkpoint();
+
+    context_state.event_loop_metrics.borrow_mut().on_poll_end(poll_start);
 
     // Evaluate pending state
     let pending_state =

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2133,7 +2133,10 @@ impl JsRuntime {
     let modules = &realm.0.module_map;
     let context_state = &realm.0.context_state;
 
-    let poll_start = context_state.event_loop_metrics.borrow_mut().on_poll_start();
+    let poll_start = context_state
+      .event_loop_metrics
+      .borrow_mut()
+      .on_poll_start();
 
     let exception_state = &context_state.exception_state;
 
@@ -2252,7 +2255,10 @@ impl JsRuntime {
     }
     scope.perform_microtask_checkpoint();
 
-    context_state.event_loop_metrics.borrow_mut().on_poll_end(poll_start);
+    context_state
+      .event_loop_metrics
+      .borrow_mut()
+      .on_poll_end(poll_start);
 
     // Evaluate pending state
     let pending_state =

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -96,6 +96,13 @@
     "cron_error": {
       "args": "run -A main.ts cron_error.ts",
       "output": "cron_error.out"
+    },
+    "event_loop_metric": {
+      "envs": {
+        "OTEL_METRIC_EXPORT_INTERVAL": "1000"
+      },
+      "args": "run -A main_event_loop.ts event_loop_metric.ts",
+      "output": "event_loop_metric.out"
     }
   }
 }

--- a/tests/specs/cli/otel_basic/event_loop_metric.out
+++ b/tests/specs/cli/otel_basic/event_loop_metric.out
@@ -1,0 +1,9 @@
+deno.eventloop.delay.max gauge s
+deno.eventloop.delay.mean gauge s
+deno.eventloop.delay.min gauge s
+deno.eventloop.delay.p50 gauge s
+deno.eventloop.delay.p90 gauge s
+deno.eventloop.delay.p99 gauge s
+deno.eventloop.delay.stddev gauge s
+deno.eventloop.time sum s
+deno.eventloop.utilization gauge 1

--- a/tests/specs/cli/otel_basic/event_loop_metric.ts
+++ b/tests/specs/cli/otel_basic/event_loop_metric.ts
@@ -1,0 +1,18 @@
+// Block the event loop briefly to produce measurable delay
+function blockEventLoop(ms: number) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // busy wait
+  }
+}
+
+// Block a few times to ensure delay samples are collected
+blockEventLoop(50);
+await new Promise((r) => setTimeout(r, 100));
+blockEventLoop(50);
+await new Promise((r) => setTimeout(r, 100));
+
+// Keep alive long enough for at least one metric export
+const timer = setTimeout(() => {}, 100000);
+await new Promise((r) => setTimeout(r, 2000));
+clearTimeout(timer);

--- a/tests/specs/cli/otel_basic/main.ts
+++ b/tests/specs/cli/otel_basic/main.ts
@@ -62,7 +62,7 @@ function onListen({ port }) {
         Number(BigInt(`0x${a.spanId}`) - BigInt(`0x${b.spanId}`))
       );
       // v8js metrics are non-deterministic
-      data.metrics = data.metrics.filter((m) => !m.name.startsWith("v8js"));
+      data.metrics = data.metrics.filter((m) => !m.name.startsWith("v8js") && !m.name.startsWith("deno.eventloop"));
       data.metrics.sort((a, b) => a.name.localeCompare(b.name));
       for (const metric of data.metrics) {
         if ("histogram" in metric) {

--- a/tests/specs/cli/otel_basic/main.ts
+++ b/tests/specs/cli/otel_basic/main.ts
@@ -62,7 +62,9 @@ function onListen({ port }) {
         Number(BigInt(`0x${a.spanId}`) - BigInt(`0x${b.spanId}`))
       );
       // v8js metrics are non-deterministic
-      data.metrics = data.metrics.filter((m) => !m.name.startsWith("v8js") && !m.name.startsWith("deno.eventloop"));
+      data.metrics = data.metrics.filter((m) =>
+        !m.name.startsWith("v8js") && !m.name.startsWith("deno.eventloop")
+      );
       data.metrics.sort((a, b) => a.name.localeCompare(b.name));
       for (const metric of data.metrics) {
         if ("histogram" in metric) {

--- a/tests/specs/cli/otel_basic/main_event_loop.ts
+++ b/tests/specs/cli/otel_basic/main_event_loop.ts
@@ -1,0 +1,75 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// Collector that only keeps deno.eventloop metrics for testing.
+
+const data = {
+  metrics: [],
+};
+
+async function handler(req) {
+  const body = await req.json();
+  body.resourceMetrics?.forEach((rMetrics) => {
+    rMetrics.scopeMetrics.forEach((sMetrics) => {
+      data.metrics.push(...sMetrics.metrics);
+    });
+  });
+  return Response.json({ partialSuccess: {} }, { status: 200 });
+}
+
+let server;
+
+function onListen({ port }) {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--env-file=env_file",
+      "-A",
+      "-q",
+      Deno.args[0],
+    ],
+    env: {
+      OTEL_EXPORTER_OTLP_ENDPOINT: `https://localhost:${port}`,
+    },
+    stdout: "null",
+  });
+  const child = command.spawn();
+  child.status
+    .then((status) => {
+      if (status.signal) {
+        throw new Error("child process failed: " + JSON.stringify(status));
+      }
+      return server.shutdown();
+    })
+    .then(() => {
+      // Only keep deno.eventloop metrics
+      const elMetrics = data.metrics.filter((m) =>
+        m.name.startsWith("deno.eventloop")
+      );
+      // Deduplicate by name (multiple export cycles may report same metric)
+      const seen = new Set();
+      const unique = [];
+      for (const m of elMetrics) {
+        if (!seen.has(m.name)) {
+          seen.add(m.name);
+          unique.push(m);
+        }
+      }
+      unique.sort((a, b) => a.name.localeCompare(b.name));
+      // Output metric names, types, and units
+      for (const m of unique) {
+        let type = "unknown";
+        if ("gauge" in m) type = "gauge";
+        if ("sum" in m) type = "sum";
+        if ("histogram" in m) type = "histogram";
+        console.log(`${m.name} ${type} ${m.unit}`);
+      }
+    });
+}
+
+server = Deno.serve({
+  key: Deno.readTextFileSync("../../../testdata/tls/localhost.key"),
+  cert: Deno.readTextFileSync("../../../testdata/tls/localhost.crt"),
+  port: 0,
+  onListen,
+  handler,
+});


### PR DESCRIPTION
## Summary
- Adds event loop delay, utilization, and time metrics following the [Node.js runtime metrics OpenTelemetry spec](https://opentelemetry.io/docs/specs/semconv/runtime/nodejs-metrics/), prefixed with `deno.` instead of `nodejs.`
- Implements timer-based sampling from JS (same technique as Node.js `monitorEventLoopDelay()`) using `core.queueSystemTimer` at 10ms intervals
- Metrics: `deno.eventloop.delay.{min,max,mean,stddev,p50,p90,p99}` (Gauge), `deno.eventloop.utilization` (Gauge), `deno.eventloop.time` (Counter by state)

Closes #27913

## Test plan
- [ ] `cargo check -p deno_telemetry` passes
- [ ] Existing `otel_basic::metric` spec tests still pass (metric filtering updated in `main.ts`)
- [ ] New `event_loop_metric` spec test validates all 9 metric names appear with correct types
- [ ] Manual verification with `OTEL_DENO=1 OTEL_DENO_METRICS=1 ./target/debug/deno run script.ts`

> **WIP**: Metric tests need debugging — existing `otel_basic::metric` tests are failing, likely related to the metric filtering or test infrastructure interaction. The core implementation compiles and the Rust ops are wired up correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)