### PR TITLE
perf(ext/fetch): cache Headers iteration for all guard types

### DIFF
--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -526,6 +526,13 @@ function headersEntries(headers) {
   return headers[_iterableHeaders];
 }
 
+/**
+ * @param {Headers} headers
+ */
+function invalidateHeaderListCache(headers) {
+  headers[_iterableHeadersCache] = undefined;
+}
+
 export {
   fillHeaders,
   getDecodeSplitHeader,
@@ -535,4 +542,5 @@ export {
   Headers,
   headersEntries,
   headersFromHeaderList,
+  invalidateHeaderListCache,
 };

--- a/ext/fetch/20_headers.js
+++ b/ext/fetch/20_headers.js
@@ -154,6 +154,7 @@ function appendHeader(headers, name, value) {
     }
   }
   ArrayPrototypePush(list, [name, value]);
+  headers[_iterableHeadersCache] = undefined;
 }
 
 /**
@@ -230,14 +231,11 @@ class Headers {
   [_guard];
 
   get [_iterableHeaders]() {
-    const list = this[_headerList];
-
-    if (
-      this[_guard] === "immutable" &&
-      this[_iterableHeadersCache] !== undefined
-    ) {
+    if (this[_iterableHeadersCache] !== undefined) {
       return this[_iterableHeadersCache];
     }
+
+    const list = this[_headerList];
 
     // The order of steps are not similar to the ones suggested by the
     // spec but produce the same result.
@@ -344,6 +342,7 @@ class Headers {
         i--;
       }
     }
+    this[_iterableHeadersCache] = undefined;
   }
 
   /**
@@ -442,6 +441,7 @@ class Headers {
     if (!added) {
       ArrayPrototypePush(list, [name, value]);
     }
+    this[_iterableHeadersCache] = undefined;
   }
 
   [SymbolFor("Deno.privateCustomInspect")](inspect, inspectOptions) {

--- a/ext/fetch/23_request.js
+++ b/ext/fetch/23_request.js
@@ -38,6 +38,7 @@ import {
   guardFromHeaders,
   headerListFromHeaders,
   headersFromHeaderList,
+  invalidateHeaderListCache,
 } from "ext:deno_fetch/20_headers.js";
 import { HttpClientPrototype } from "ext:deno_fetch/22_http_client.js";
 import {
@@ -417,6 +418,7 @@ class Request {
       );
       if (headerList.length !== 0) {
         ArrayPrototypeSplice(headerList, 0, headerList.length);
+        invalidateHeaderListCache(this[_headers]);
       }
       fillHeaders(this[_headers], headers);
     }

--- a/ext/fetch/23_response.js
+++ b/ext/fetch/23_response.js
@@ -29,6 +29,7 @@ import {
   guardFromHeaders,
   headerListFromHeaders,
   headersFromHeaderList,
+  invalidateHeaderListCache,
 } from "ext:deno_fetch/20_headers.js";
 const {
   ArrayPrototypeMap,
@@ -229,6 +230,7 @@ function initializeAResponse(response, init, bodyWithType) {
       }
       if (!hasContentType) {
         ArrayPrototypePush(list, ["Content-Type", contentType]);
+        invalidateHeaderListCache(headers);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Cache the `_iterableHeaders` computed entries for **all** guard types, not just `"immutable"`
- Invalidate cache on mutation (`append`, `set`, `delete`)

### Root cause

The `_iterableHeaders` getter rebuilds the sorted entries array on every access for non-immutable Headers (`guard !== "immutable"`), which is the common case for user-created `Headers` objects. Each rebuild lowercases all header names, builds a dedup map, creates entry arrays, and sorts — all discarded on the next iteration.

### Benchmark: release build vs system Deno 2.7.5 (8 headers × 1KB values)

| | System Deno 2.7.5 | This PR | Speedup |
|---|---|---|---|
| Headers `for...of` | 14.8 µs | 296 ns | **50x faster** |
| vs Map gap | 88x slower | 3x slower | |

The remaining ~3x gap vs Map is inherent overhead from the WebIDL iterator protocol.

Closes #20980

## Test plan

- [x] Verified with benchmark from the issue
- [x] `cargo test -p specs_tests -- fetch` (13 tests passed)
- [x] `cargo test -p specs_tests -- headers` (1 test passed)
- [x] Manual correctness tests for cache invalidation on append/set/delete, set-cookie non-combining, keys/values/forEach

🤖 Generated with [Claude Code](https://claude.com/claude-code)