### PR TITLE
fix(ext/node): handle errors when piping object mode to non-object mode streams

### DIFF
--- a/ext/node/polyfills/internal/streams/transform.js
+++ b/ext/node/polyfills/internal/streams/transform.js
@@ -180,31 +180,35 @@ Transform.prototype._write = function (chunk, encoding, callback) {
   const wState = this._writableState;
   const length = rState.length;
 
-  this._transform(chunk, encoding, (err, val) => {
-    if (err) {
-      callback(err);
-      return;
-    }
+  try {
+    this._transform(chunk, encoding, (err, val) => {
+      if (err) {
+        callback(err);
+        return;
+      }
 
-    if (val != null) {
-      this.push(val);
-    }
+      if (val != null) {
+        this.push(val);
+      }
 
-    if (rState.ended) {
-      // If user has called this.push(null) we have to
-      // delay the callback to properly propagate the new
-      // state.
-      process.nextTick(callback);
-    } else if (
-      wState.ended || // Backwards compat.
-      length === rState.length || // Backwards compat.
-      rState.length < rState.highWaterMark
-    ) {
-      callback();
-    } else {
-      this[kCallback] = callback;
-    }
-  });
+      if (rState.ended) {
+        // If user has called this.push(null) we have to
+        // delay the callback to properly propagate the new
+        // state.
+        process.nextTick(callback);
+      } else if (
+        wState.ended || // Backwards compat.
+        length === rState.length || // Backwards compat.
+        rState.length < rState.highWaterMark
+      ) {
+        callback();
+      } else {
+        this[kCallback] = callback;
+      }
+    });
+  } catch (err) {
+    callback(err);
+  }
 };
 
 Transform.prototype._read = function () {

--- a/ext/node/polyfills/internal/streams/writable.js
+++ b/ext/node/polyfills/internal/streams/writable.js
@@ -521,11 +521,14 @@ function _write(stream, chunk, encoding, cb) {
       chunk = Stream._uint8ArrayToBuffer(chunk);
       encoding = "buffer";
     } else {
-      throw new ERR_INVALID_ARG_TYPE(
+      const err = new ERR_INVALID_ARG_TYPE(
         "chunk",
         ["string", "Buffer", "TypedArray", "DataView"],
         chunk,
       );
+      process.nextTick(cb, err);
+      errorOrDestroy(stream, err, true);
+      return err;
     }
   }
 
@@ -620,7 +623,11 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
       state.writecb = callback;
     }
     state[kState] |= kWriting | kSync | kExpectWriteCb;
-    stream._write(chunk, encoding, state.onwrite);
+    try {
+      stream._write(chunk, encoding, state.onwrite);
+    } catch (err) {
+      state.onwrite(err);
+    }
     state[kState] &= ~kSync;
   }
 
@@ -644,9 +651,17 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
   if ((state[kState] & kDestroyed) !== 0) {
     state.onwrite(new ERR_STREAM_DESTROYED("write"));
   } else if (writev) {
-    stream._writev(chunk, state.onwrite);
+    try {
+      stream._writev(chunk, state.onwrite);
+    } catch (err) {
+      state.onwrite(err);
+    }
   } else {
-    stream._write(chunk, encoding, state.onwrite);
+    try {
+      stream._write(chunk, encoding, state.onwrite);
+    } catch (err) {
+      state.onwrite(err);
+    }
   }
   state[kState] &= ~kSync;
 }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1955,6 +1955,7 @@
     "parallel/test-stream-pipe-manual-resume.js": {},
     "parallel/test-stream-pipe-multiple-pipes.js": {},
     "parallel/test-stream-pipe-needDrain.js": {},
+    "parallel/test-stream-pipe-objectmode-to-non-objectmode.js": {},
     "parallel/test-stream-pipe-same-destination-twice.js": {},
     "parallel/test-stream-pipe-unpipe-streams.js": {},
     "parallel/test-stream-pipe-without-listenerCount.js": {},


### PR DESCRIPTION
## Summary
- Fix `ERR_INVALID_ARG_TYPE` being thrown instead of emitted when piping objects from an object mode stream to a non-object mode stream
- Wrap synchronous `_write`/`_writev`/`_transform` calls in try-catch so user throws are caught and routed through the error handling path
- Enable `test-stream-pipe-objectmode-to-non-objectmode.js` compat test

## Test plan
- [x] `./x test-compat test-stream-pipe-objectmode-to-non-objectmode.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)