### PR TITLE
perf(ext/napi): use threadpool for async work instead of spawning threads

### DIFF
--- a/ext/napi/node_api.rs
+++ b/ext/napi/node_api.rs
@@ -595,7 +595,9 @@ pub(crate) fn napi_queue_async_work(
   // Per NAPI spec, `execute` runs on a worker thread and `complete` runs on
   // the main thread. Previously both ran on the main thread which caused
   // deadlocks when `execute` called threadsafe functions.
-  std::thread::spawn(move || {
+  // Uses tokio's blocking threadpool to reuse threads instead of spawning a
+  // new OS thread per call (which has high overhead on Linux).
+  deno_core::unsync::spawn_blocking(move || {
     let work = work.take();
     let work = unsafe { &*work };
 


### PR DESCRIPTION
## Summary

- Replace `std::thread::spawn` with `deno_core::unsync::spawn_blocking` (tokio's blocking threadpool) in `napi_queue_async_work`
- Threads are reused from a pool instead of creating a new OS thread per call, reducing overhead especially on Linux where `clone()` is expensive
- This is analogous to how Node.js uses libuv's `uv_queue_work` threadpool

## Context

PR #32560 fixed a deadlock bug by moving `execute` callbacks to worker threads via `std::thread::spawn`. This created a performance regression (#32773) because every async NAPI call spawns and tears down a fresh OS thread. The tokio blocking threadpool keeps threads alive for reuse (default 10s keep-alive), avoiding per-call thread creation overhead.

## Benchmark (macOS aarch64, napi-rs async add)

| Runtime | µs/call |
|---------|---------|
| Node.js | ~8.8 |
| Deno 2.7.5 (std::thread::spawn) | ~8.5-9 |
| Deno dev (spawn_blocking) | ~8.5 |

On macOS the steady-state is similar since thread creation is lightweight. On Linux (reporter's platform), `std::thread::spawn` is significantly more expensive due to `clone()` syscall cost — the reporter measured 62µs → 258µs regression.

## Test plan

- [x] `cargo test --test integration -- napi` — all NAPI tests pass (debug + release)
- [x] Benchmarked with napi-rs async functions — performance on par with Node.js

Closes #32773

🤖 Generated with [Claude Code](https://claude.com/claude-code)