### PR TITLE
fix(ext/node): use constant-time comparison for GCM auth tag verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,6 +2828,7 @@ dependencies = [
  "signature 2.2.0",
  "sm3",
  "spki 0.7.3",
+ "subtle",
  "thiserror 2.0.12",
  "tokio",
  "x25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,6 +415,7 @@ sha3 = "0.10.8"
 signature = "2.1"
 sm3 = "0.4.2"
 spki = "0.7.2"
+subtle = "2.6.1"
 x25519-dalek = "2.0.0"
 x509-parser = "0.15.0"
 

--- a/ext/node_crypto/Cargo.toml
+++ b/ext/node_crypto/Cargo.toml
@@ -61,6 +61,7 @@ sha3 = { workspace = true, features = ["oid"] }
 signature.workspace = true
 sm3.workspace = true
 spki.workspace = true
+subtle.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 x25519-dalek = { workspace = true, features = ["static_secrets"] }

--- a/ext/node_crypto/cipher.rs
+++ b/ext/node_crypto/cipher.rs
@@ -14,6 +14,7 @@ use deno_core::Resource;
 use deno_error::JsErrorClass;
 use digest::KeyInit;
 use digest::generic_array::GenericArray;
+use subtle::ConstantTimeEq;
 
 type Tag = Option<Vec<u8>>;
 
@@ -867,7 +868,7 @@ impl Decipher {
         } else {
           tag_slice
         };
-        if truncated_tag == auth_tag {
+        if truncated_tag.ct_eq(auth_tag).into() {
           Ok(())
         } else {
           Err(DecipherError::DataAuthenticationFailed)
@@ -881,7 +882,7 @@ impl Decipher {
         } else {
           tag_slice
         };
-        if truncated_tag == auth_tag {
+        if truncated_tag.ct_eq(auth_tag).into() {
           Ok(())
         } else {
           Err(DecipherError::DataAuthenticationFailed)


### PR DESCRIPTION
## Summary

- Replace direct `==` comparison with `subtle::ConstantTimeEq` for AES-GCM authentication tag verification in both AES-128-GCM and AES-256-GCM decrypt paths
- The standard `==` operator short-circuits on the first differing byte, making it susceptible to timing side-channel attacks
- This matches Node.js/OpenSSL behavior which uses `CRYPTO_memcmp` for AEAD tag verification