### PR TITLE
fix: skip empty dependency names in package.json

### DIFF
--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -560,6 +560,9 @@ impl PackageJson {
       };
       let mut result = IndexMap::with_capacity(deps.len());
       for (key, value) in deps {
+        if key.is_empty() {
+          continue;
+        }
         result
           .entry(StackString::from(key.as_str()))
           .or_insert_with(|| PackageJsonDepValue::parse(key, value));


### PR DESCRIPTION
## Summary
Fixes #32113.
**Root cause:** An empty dependency key (`"": "."`) in `package.json` creates a `PackageReq` with an empty name that serializes to `@.` in the lockfile. On the next run, deserialization fails with `Invalid package requirement '@.'`, corrupting the lockfile.
**Fix:** Skip dependencies with empty names when building the package.json deps map, preventing invalid entries from being written to the lockfile.
## Changes
- `libs/package_json/lib.rs`: Added empty key check to skip invalid dependency entries
## Testing
- Verified fix addresses reported scenario (empty dep key no longer corrupts lockfile)
- Change is minimal and follows existing code patterns