### PR TITLE
fix(ext/node): freeze os.constants.signals to match Node.js

### DIFF
--- a/ext/node/polyfills/internal_binding/constants.ts
+++ b/ext/node/polyfills/internal_binding/constants.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
+import { primordials } from "ext:core/mod.js";
+const { ObjectFreeze } = primordials;
 import { op_node_build_os, op_node_fs_constants } from "ext:core/ops";
 
 let os: {
@@ -633,6 +635,8 @@ if (buildOs === "darwin") {
     },
   };
 }
+
+ObjectFreeze(os.signals);
 
 export { os };
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1486,6 +1486,7 @@
       "windows": false,
       "reason": "Node.js specific behavior to check the return value of the C++ bindings"
     },
+    "parallel/test-os-constants-signals.js": {},
     "parallel/test-os-eol.js": {},
     "parallel/test-os-homedir-no-envvar.js": {},
     "parallel/test-os-process-priority.js": {},


### PR DESCRIPTION
## Summary
- Freezes `os.constants.signals` so that property assignment throws `TypeError` in strict mode, matching Node.js behavior
- Enables `parallel/test-os-constants-signals.js` in node compat tests

Closes https://github.com/denoland/deno/issues/32706

🤖 Generated with [Claude Code](https://claude.com/claude-code)