### PR TITLE
fix(ext/node): improve process.hrtime argument validation

### DIFF
--- a/ext/node/polyfills/process.ts
+++ b/ext/node/polyfills/process.ts
@@ -102,6 +102,7 @@ const lazyLoadFsUtils = core.createLazyLoader<typeof fsUtils>(
 );
 
 const {
+  ArrayIsArray,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperty,
   ObjectPrototypeIsPrototypeOf,
@@ -333,8 +334,20 @@ export function hrtime(time?: [number, number]): [number, number] {
   if (!time) {
     return [sec, nano];
   }
+  if (!ArrayIsArray(time)) {
+    throw new ERR_INVALID_ARG_TYPE("time", "Array", time);
+  }
+  if (time.length !== 2) {
+    throw new ERR_OUT_OF_RANGE("time", 2, time.length);
+  }
   const [prevSec, prevNano] = time;
-  return [sec - prevSec, nano - prevNano];
+  let diffSec = sec - prevSec;
+  let diffNano = nano - prevNano;
+  if (diffNano < 0) {
+    diffSec -= 1;
+    diffNano += 1_000_000_000;
+  }
+  return [diffSec, diffNano];
 }
 
 hrtime.bigint = function (): bigint {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1679,6 +1679,7 @@
     "parallel/test-process-features.js": {},
     "parallel/test-process-getgroups.js": {},
     "parallel/test-process-hrtime-bigint.js": {},
+    "parallel/test-process-hrtime.js": {},
     "parallel/test-process-kill-null.js": {},
     "parallel/test-process-kill-pid.js": {},
     "parallel/test-process-next-tick.js": {},
@@ -2528,6 +2529,7 @@
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"
     },
     // "pummel/test-heapdump-inspector.js": {},
+    "pummel/test-process-hrtime.js": {},
     "pummel/test-string-decoder-large-buffer.js": {},
     "sequential/test-buffer-creation-regression.js": {},
     "sequential/test-child-process-exit.js": {},


### PR DESCRIPTION
## Summary
- Adds proper `ERR_INVALID_ARG_TYPE` validation when `process.hrtime()` receives a non-array argument
- Adds `ERR_OUT_OF_RANGE` validation when the array length is not 2
- Fixes nanosecond underflow bug by borrowing from seconds when `nano - prevNano` is negative
- Enables `parallel/test-process-hrtime.js` and `pummel/test-process-hrtime.js` node compat tests

Closes https://github.com/denoland/deno/issues/32706

🤖 Generated with [Claude Code](https://claude.com/claude-code)