### PR TITLE
test: add per-file timeout and reduce CI job timeout

### DIFF
--- a/.github/workflows/ci.generate.ts
+++ b/.github/workflows/ci.generate.ts
@@ -1241,7 +1241,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
         name: jobNameForJob("wpt"),
         needs: [buildJob],
         runsOn: buildItem.testRunner ?? buildItem.runner,
-        timeoutMinutes: 240,
+        timeoutMinutes: 30,
         defaults,
         env,
         steps: step.if(isNotTag.and(buildItem.skip.not()))(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3938,7 +3938,7 @@ jobs:
     needs:
       - build-release-linux-x86_64
     runs-on: ubuntu-24.04
-    timeout-minutes: 240
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash

--- a/tests/wpt/runner/runner.ts
+++ b/tests/wpt/runner/runner.ts
@@ -90,6 +90,31 @@ export async function runSingleTest(
   reporter: (result: TestCaseResult) => void,
   inspectBrk: boolean,
   timeouts: { long: number; default: number },
+  fileTimeout = 2 * 60_000,
+): Promise<TestResult> {
+  const result = await Promise.race([
+    runSingleTestInner(url, _options, reporter, inspectBrk, timeouts),
+    new Promise<TestResult>((resolve) =>
+      setTimeout(() => {
+        resolve({
+          cases: [],
+          harnessStatus: null,
+          duration: fileTimeout,
+          status: 1,
+          stderr: `test file timed out after ${fileTimeout / 1000}s\n`,
+        });
+      }, fileTimeout)
+    ),
+  ]);
+  return result;
+}
+
+async function runSingleTestInner(
+  url: URL,
+  _options: ManifestTestOptions,
+  reporter: (result: TestCaseResult) => void,
+  inspectBrk: boolean,
+  timeouts: { long: number; default: number },
 ): Promise<TestResult> {
   const timeout = _options.timeout === "long"
     ? timeouts.long


### PR DESCRIPTION
## Summary
- Add a 2-minute per-file timeout wrapping the entire `runSingleTest` (including `generateBundle` fetch calls) using `Promise.race`, so the runner always moves on even if the WPT server becomes unresponsive
- Reduce WPT CI job timeout from 240 minutes to 30 minutes

## Test plan
- [ ] WPT CI job completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)