### PR TITLE
fix(npm): `approve-scripts` detects packages when lockfile is disabled

### DIFF
--- a/cli/tools/pm/approve_scripts.rs
+++ b/cli/tools/pm/approve_scripts.rs
@@ -78,6 +78,10 @@ pub async fn approve_scripts(
       Vec::new(),
     )
   } else {
+    let npm_installer = factory.npm_installer().await?;
+    npm_installer
+      .ensure_top_level_package_json_install()
+      .await?;
     let npm_resolver = factory.npm_resolver().await?;
     let candidates = find_script_candidates(
       npm_resolver,

--- a/tests/specs/npm/approve_scripts_no_lock/__test__.jsonc
+++ b/tests/specs/npm/approve_scripts_no_lock/__test__.jsonc
@@ -1,0 +1,50 @@
+{
+  "tempDir": true,
+  "tests": {
+    "approve_scripts_explicit_package": {
+      "steps": [
+        {
+          // Set up package.json with a dep that has lifecycle scripts
+          "args": [
+            "eval",
+            "Deno.writeTextFileSync('package.json', JSON.stringify({ dependencies: { '@denotest/node-lifecycle-scripts': '*' } }))"
+          ],
+          "output": ""
+        },
+        {
+          // deno install should warn about scripts
+          "args": "install",
+          "output": "install.out"
+        },
+        {
+          // deno approve-scripts with explicit package should work with lock: false
+          "args": "approve-scripts npm:@denotest/node-lifecycle-scripts",
+          "output": "approve.out"
+        }
+      ]
+    },
+    "approve_scripts_detects_packages": {
+      "steps": [
+        {
+          "args": [
+            "eval",
+            "Deno.writeTextFileSync('package.json', JSON.stringify({ dependencies: { '@denotest/node-lifecycle-scripts': '*' } }))"
+          ],
+          "output": ""
+        },
+        {
+          "args": "install",
+          "output": "install.out"
+        },
+        {
+          // Without args, approve-scripts should detect packages (not say "nothing to approve").
+          // It will fail because there's no TTY for the interactive picker, but the error
+          // should NOT be "No npm packages with lifecycle scripts need approval."
+          "args": "approve-scripts",
+          "output": "approve_no_args.out",
+          "exitCode": 1
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/npm/approve_scripts_no_lock/approve.out
+++ b/tests/specs/npm/approve_scripts_no_lock/approve.out
@@ -1,0 +1,2 @@
+[WILDCARD]Approved[WILDCARD]@denotest/node-lifecycle-scripts[WILDCARD]
+[WILDCARD]Ran build script[WILDCARD]@denotest/node-lifecycle-scripts[WILDCARD]

--- a/tests/specs/npm/approve_scripts_no_lock/approve_no_args.out
+++ b/tests/specs/npm/approve_scripts_no_lock/approve_no_args.out
@@ -1,0 +1,1 @@
+error: [WILDCARD]

--- a/tests/specs/npm/approve_scripts_no_lock/deno.json
+++ b/tests/specs/npm/approve_scripts_no_lock/deno.json
@@ -1,0 +1,4 @@
+{
+  "lock": false,
+  "nodeModulesDir": "auto"
+}

--- a/tests/specs/npm/approve_scripts_no_lock/install.out
+++ b/tests/specs/npm/approve_scripts_no_lock/install.out
@@ -1,0 +1,8 @@
+[WILDCARD]
+╭ Warning
+│
+│  Ignored build scripts for packages:
+│  npm:@denotest/node-lifecycle-scripts@1.0.0
+│
+│  Run "deno approve-scripts" to run build scripts.
+╰─


### PR DESCRIPTION
## Summary
- Fix `deno approve-scripts` failing to detect packages with lifecycle scripts when `"lock": false` is set in `deno.json`
- The issue was that `approve-scripts` queried the npm resolution snapshot without first resolving packages — with no lockfile, the snapshot was empty
- Fix by calling `ensure_top_level_package_json_install()` before querying the snapshot

Closes #32781

## Test plan
- [x] Added spec test `approve_scripts_no_lock` with two cases:
  - `approve_scripts_explicit_package` — verifies explicit package approval works with `lock: false`
  - `approve_scripts_detects_packages` — verifies the no-args path finds packages (previously returned "nothing to approve")
- [x] Verified test fails without the fix (outputs "No npm packages with lifecycle scripts need approval" instead of detecting candidates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)