### PR TITLE
fix(core): clamp large timer delays to TIMEOUT_MAX instead of 1ms

### DIFF
--- a/libs/core/02_timers.js
+++ b/libs/core/02_timers.js
@@ -342,8 +342,8 @@
     } else {
       after *= 1;
     }
-    if (!(after >= 1 && after <= TIMEOUT_MAX)) {
-      after = 1;
+    if (after < 1 || !(after <= TIMEOUT_MAX)) {
+      after = after > TIMEOUT_MAX ? TIMEOUT_MAX : 1;
     }
 
     const id = nextTimerId++;

--- a/tests/unit/timers_test.ts
+++ b/tests/unit/timers_test.ts
@@ -779,6 +779,20 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "AbortSignal.timeout() with large delay does not abort instantly",
+  fn: async () => {
+    const signal = AbortSignal.timeout(2 ** 53 - 1);
+    let aborted = false;
+    signal.onabort = () => {
+      aborted = true;
+    };
+    // Wait 500ms — the signal should NOT have aborted
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    assertEquals(aborted, false);
+  },
+});
+
 Deno.test(async function setTimeoutWithStringCallback() {
   const global = globalThis as unknown as {
     timeoutStringTest: number;


### PR DESCRIPTION
## Summary

`AbortSignal.timeout(2 ** 53 - 1)` was aborting instantly because
the JS timer clamping logic treated values above `TIMEOUT_MAX` (2^31-1)
the same as values below 1 — both got set to 1ms.

Fix: clamp values above `TIMEOUT_MAX` to `TIMEOUT_MAX` (~24.8 days)
instead of 1ms. Values below 1 (NaN, negative, zero) still clamp to 1ms.

Regression from #32543 (timer refactor moving processing from Rust to JS).

Closes #32858

## Test plan
- [x] `./x test-unit timers` passes
- [x] Manual: `AbortSignal.timeout(2**53-1)` no longer aborts instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)