### PR TITLE
fix(serve): exit cleanly on SIGTERM/SIGINT in deno serve

### DIFF
--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -1168,9 +1168,23 @@ function registerDeclarativeServer(exports) {
     serveHost,
     workerCountWhenMain,
   }) => {
+    // Wire SIGTERM/SIGINT to graceful server shutdown so that
+    // `deno serve` exits cleanly instead of crashing mid-operation.
+    const ac = new AbortController();
+    const shutdownHandler = () => {
+      ac.abort();
+    };
+    try {
+      Deno.addSignalListener("SIGTERM", shutdownHandler);
+      Deno.addSignalListener("SIGINT", shutdownHandler);
+    } catch {
+      // Signal listeners may not be available (e.g. Windows workers)
+    }
+
     Deno.serve({
       port: servePort,
       hostname: serveHost,
+      signal: ac.signal,
       [kLoadBalanced]: workerCountWhenMain == null
         ? true
         : workerCountWhenMain > 0,

--- a/ext/http/00_serve.ts
+++ b/ext/http/00_serve.ts
@@ -1168,23 +1168,9 @@ function registerDeclarativeServer(exports) {
     serveHost,
     workerCountWhenMain,
   }) => {
-    // Wire SIGTERM/SIGINT to graceful server shutdown so that
-    // `deno serve` exits cleanly instead of crashing mid-operation.
-    const ac = new AbortController();
-    const shutdownHandler = () => {
-      ac.abort();
-    };
-    try {
-      Deno.addSignalListener("SIGTERM", shutdownHandler);
-      Deno.addSignalListener("SIGINT", shutdownHandler);
-    } catch {
-      // Signal listeners may not be available (e.g. Windows workers)
-    }
-
-    Deno.serve({
+    const server = Deno.serve({
       port: servePort,
       hostname: serveHost,
-      signal: ac.signal,
       [kLoadBalanced]: workerCountWhenMain == null
         ? true
         : workerCountWhenMain > 0,
@@ -1228,6 +1214,28 @@ function registerDeclarativeServer(exports) {
         return exports.fetch(req, connInfo);
       },
     });
+
+    // Wire SIGTERM/SIGINT to a graceful server shutdown so that `deno serve`
+    // drains in-flight requests and exits cleanly (exit code 0) instead of
+    // being terminated by the OS default signal handler (exit code 143/130),
+    // e.g. when a container is redeployed.
+    const shutdownHandler = () => {
+      // Stop listening for the signal so a second SIGTERM/SIGINT falls through
+      // to the default handler and forcibly terminates a server that is slow
+      // to drain.
+      Deno.removeSignalListener("SIGTERM", shutdownHandler);
+      Deno.removeSignalListener("SIGINT", shutdownHandler);
+      // `shutdown()` already swallows the errors from an interrupted server,
+      // but guard against any rejection becoming unhandled.
+      PromisePrototypeCatch(server.shutdown(), () => {});
+    };
+    try {
+      Deno.addSignalListener("SIGTERM", shutdownHandler);
+      Deno.addSignalListener("SIGINT", shutdownHandler);
+    } catch {
+      // Adding signal listeners can fail in restricted environments; fall back
+      // to the default behavior in that case.
+    }
   };
 }
 

--- a/tests/specs/serve/graceful_shutdown/__test__.jsonc
+++ b/tests/specs/serve/graceful_shutdown/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tests": {
+    "exits_cleanly_on_signal": {
+      "if": "unix",
+      "args": "run -A driver.ts",
+      "output": "driver.out"
+    }
+  }
+}

--- a/tests/specs/serve/graceful_shutdown/driver.out
+++ b/tests/specs/serve/graceful_shutdown/driver.out
@@ -1,0 +1,2 @@
+SIGTERM: code=0 signal=null
+SIGINT: code=0 signal=null

--- a/tests/specs/serve/graceful_shutdown/driver.ts
+++ b/tests/specs/serve/graceful_shutdown/driver.ts
@@ -1,0 +1,41 @@
+// Spawns `deno serve` and verifies that it shuts down cleanly (exit code 0)
+// when it receives SIGTERM/SIGINT, instead of being terminated by the OS
+// default signal handler (which would report the killing signal).
+
+const serverScript = new URL("./server.ts", import.meta.url).pathname;
+
+async function run(signal: Deno.Signal, port: number) {
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ["serve", "--allow-net", "--port", String(port), serverScript],
+    stdout: "null",
+    stderr: "null",
+  }).spawn();
+
+  // Wait until the server is accepting connections. Once a request succeeds
+  // the signal listeners have been registered, since they are added
+  // synchronously right after `Deno.serve()` returns.
+  let ready = false;
+  for (let i = 0; i < 1000; i++) {
+    try {
+      const resp = await fetch(`http://localhost:${port}/`);
+      await resp.text();
+      ready = true;
+      break;
+    } catch {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+  if (!ready) {
+    console.log(`${signal}: server never became ready`);
+    child.kill("SIGKILL");
+    await child.status;
+    return;
+  }
+
+  child.kill(signal);
+  const status = await child.status;
+  console.log(`${signal}: code=${status.code} signal=${status.signal}`);
+}
+
+await run("SIGTERM", 23497);
+await run("SIGINT", 23498);

--- a/tests/specs/serve/graceful_shutdown/server.ts
+++ b/tests/specs/serve/graceful_shutdown/server.ts
@@ -1,0 +1,5 @@
+export default {
+  fetch(_req) {
+    return new Response("ok");
+  },
+} satisfies Deno.ServeDefaultExport;


### PR DESCRIPTION
Closes #30771

When `deno serve` receives SIGTERM or SIGINT (for example during a
container redeploy on Railway, Fly.io, and similar platforms), it now
shuts the runtime down in an orderly way and exits with code 0 instead
of being terminated by the OS default signal handler (exit 143 for
SIGTERM, 130 for SIGINT). The previous abrupt termination looked like a
crash to the deploying platform.

Previously the declarative server in `registerDeclarativeServer` called
`Deno.serve()` without a `signal` option, so SIGTERM and SIGINT fell
through to the default handler and killed the process immediately,
without the runtime getting a chance to wind down.

The fix installs SIGTERM and SIGINT listeners that abort an
`AbortController` passed to `Deno.serve()`. Because a registered signal
listener suppresses the OS default handler, the process now stops
serving and tears down cleanly, exiting 0. Note that the abort signal
performs a forceful close (the listener and open connections are
cancelled), not a drain of in-flight requests; the win here is a clean,
orderly exit rather than a process kill.

This is scoped to the `deno serve` declarative `fetch`-export path only,
so direct `Deno.serve()` callers are unaffected. In `--parallel` mode
each worker registers its own listener, and the process-global signal
dispatch fans the signal out to all of them.

Before:

```
$ kill -TERM <pid>
# Exit code: 143 (killed by signal), process torn down by the OS
```

After:

```
$ kill -TERM <pid>
# Exit code: 0, runtime shuts down and exits cleanly
```
