### PR TITLE
fix(ext/web): fix console.group duplicate messages in Chrome DevTools

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -3961,7 +3961,16 @@ class Console {
 
   group = (...label) => {
     if (label.length > 0) {
-      this.log(...new SafeArrayIterator(label));
+      // Use #printFunc directly instead of this.log to avoid sending
+      // a duplicate "log" event to the inspector. The inspector already
+      // receives a "startGroup" event via the V8 console binding.
+      this.#printFunc(
+        inspectArgs(label, {
+          ...getConsoleInspectOptions(noColorStdout()),
+          indentLevel: this.indentLevel,
+        }) + "\n",
+        1,
+      );
     }
     this.indentLevel++;
   };


### PR DESCRIPTION
## Summary

`console.group("label")` was showing misaligned indentation in Chrome
DevTools when debugging with `--inspect`. The root cause:

`console.group()` internally called `this.log()`, which is wrapped by
`callConsole` to forward to both the V8 inspector and Deno's console.
This meant DevTools received **two** events per `console.group()` call:
1. `startGroup("label")` — from the V8 inspector console binding
2. `log("label")` — from the `this.log()` call inside Deno's `group()`

The extra `log` event confused DevTools' group nesting, causing
misaligned indentation.

Fix: use `#printFunc` directly instead of `this.log()`, so only the
terminal output is produced without a duplicate inspector event.

Closes #30176

## Test plan
- [x] CLI output still correct (proper indentation with group/groupEnd)
- [ ] Manual test with `--inspect-wait` + Chrome DevTools shows correct grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)