### PR TITLE
fix(ext/node): update process.versions.napi to 9

### DIFF
--- a/ext/node/polyfills/_process/process.ts
+++ b/ext/node/polyfills/_process/process.ts
@@ -191,7 +191,7 @@ export const versions = {
   ares: "1.18.1",
   modules: "108",
   nghttp2: "1.47.0",
-  napi: "8",
+  napi: "9",
   llhttp: "6.0.10",
   openssl: "3.0.7+quic",
   cldr: "41.0",

--- a/tests/unit_node/process_test.ts
+++ b/tests/unit_node/process_test.ts
@@ -104,6 +104,8 @@ Deno.test({
     assertEquals(typeof process.versions.modules, "string");
     assertEquals(typeof process.versions.nghttp2, "string");
     assertEquals(typeof process.versions.napi, "string");
+    // Must match the NAPI_VERSION in ext/napi/js_native_api.rs
+    assertEquals(process.versions.napi, "9");
     assertEquals(typeof process.versions.llhttp, "string");
     assertEquals(typeof process.versions.openssl, "string");
     assertEquals(typeof process.versions.cldr, "string");


### PR DESCRIPTION
## Summary

Closes #30091

`process.versions.napi` was hardcoded to `"8"` but the actual NAPI implementation (`ext/napi/js_native_api.rs`) defines `NAPI_VERSION: u32 = 9`. This mismatch caused `node-pre-gyp` and similar tools to reject NAPI v9 native modules (like `get-windows`) with:

> This Node instance does not support builds for Node-API version 9

### Changes
- Update `process.versions.napi` from `"8"` to `"9"` in `ext/node/polyfills/_process/process.ts`
- Add value assertion in `tests/unit_node/process_test.ts` to prevent future drift

## Test plan
- [x] `./x test-node process` passes
- [x] `deno eval "console.log(process.versions.napi)"` prints `9`


🤖 Generated with [Claude Code](https://claude.com/claude-code)