### PR TITLE
fix: skip flaky test-process-threadCpuUsage-worker-threads on Windows

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1698,7 +1698,10 @@
     "parallel/test-process-title-cli.js": {},
     "parallel/test-process-release.js": {},
     "parallel/test-process-threadCpuUsage-main-thread.js": {},
-    "parallel/test-process-threadCpuUsage-worker-threads.js": {},
+    "parallel/test-process-threadCpuUsage-worker-threads.js": {
+      "windows": false,
+      "reason": "flaky on Windows CI"
+    },
     "parallel/test-process-umask-mask.js": {},
     "parallel/test-process-umask.js": {},
     "parallel/test-process-uptime.js": {},


### PR DESCRIPTION
Skip `parallel/test-process-threadCpuUsage-worker-threads.js` on Windows CI where it is flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)