### PR TITLE
fix(node/tty): emit "resize" on process.stdout when terminal is resized

### DIFF
--- a/ext/node/polyfills/_process/streams.mjs
+++ b/ext/node/polyfills/_process/streams.mjs
@@ -187,6 +187,24 @@ export function createWritableStdioStream(writer, name, warmup = false) {
     };
   }
 
+  // Node.js emits "resize" on process.stdout via tty.WriteStream._refreshSize,
+  // but WriteStream.prototype methods are lost after V8 snapshot deserialization.
+  // Bridge SIGWINCH to "resize" here since this Writable backs process.stdout.
+  if (!warmup && writer?.isTerminal()) {
+    Deno.addSignalListener("SIGWINCH", () => {
+      const size = Deno.consoleSize?.();
+      if (size) {
+        const oldCols = stream.columns;
+        const oldRows = stream.rows;
+        // Write through the setter so the cached _columns value is updated
+        stream._columns = size.columns;
+        if (oldCols !== size.columns || oldRows !== size.rows) {
+          stream.emit("resize");
+        }
+      }
+    });
+  }
+
   return stream;
 }
 


### PR DESCRIPTION
>[!NOTE]
> Disclaimer: I used an LLM to debug and write up this fix. While it does work for _my_ use case, it may be totally incorrect, so  please do not assume that I am right or that I know what I am doing with this codebase. I apologize if this is wasting the maintainers' time, but this did fix a really aggravating bug for me!

### Problem

`process.stdout` never emits "resize" on `SIGWINCH`, so `tty.WriteStream.prototype` methods (such as `on`, `_refreshSize`, `isTTY`, `cursorTo`, etc.) are lost after V8 snapshot deserialization. As a result `process.stdout` remains a plain Writable with no resize event wiring.

This breaks Ink and other Node.js TUI frameworks that rely on process.stdout.on("resize", ...), since the renderer keeps using stale dimensions after terminal resize, corrupting the display. This affects both deno run and deno compile.

My use case for this is with claude-code, where I'd seen Ryan Dahl tweet out the possibility of using the cli compiled with deno, leading to lower memory usage & little-to-no crashes; there's been none observed on my end so far :). The problem occurs when resizing the cli, especially when making it smaller; the output gets totally convoluted and it becomes unusable. When it's made larger, some components are not adapted but it's less of an issue as it doesn't get scrunched up.

### Solution

This commit registers `Deno.addSignalListener("SIGWINCH", ...)` directly in `createWritableStdioStream` for TTY streams. On each signal, it reads `Deno.consoleSize()` and emit "resize" if dimensions changed.

```js
// repro which fires in Node/Bun, but is silent in Deno before this fix
process.stdout.on("resize", () => {
   console.log(`[resize] ${process.stdout.columns}x${process.stdout.rows}`);
});
setInterval(() => {}, 1000);
```

The deeper issue, why WriteStream.prototype methods vanish during snapshot deserialization, is not addressed here. I'm not familiar enough with the codebase to tackle that honestly.