### PR TITLE
fix(ext/node): fix Buffer.concat truncating buffers larger than 4GB

### DIFF
--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -423,7 +423,7 @@ Buffer.alloc = function alloc(size, fill, encoding) {
 
 function _allocUnsafe(size) {
   assertSize(size);
-  return createBuffer(size < 0 ? 0 : checked(size) | 0);
+  return createBuffer(size < 0 ? 0 : checked(size));
 }
 
 /**
@@ -465,7 +465,7 @@ function fromString(string, encoding) {
   }
 
   const maxLength = Buffer.poolSize >>> 1;
-  const length = byteLength(string, encoding) | 0;
+  const length = MathTrunc(byteLength(string, encoding));
   if (length >= maxLength) {
     let buf = createBuffer(length);
     const actual = buf.write(string, encoding);
@@ -518,7 +518,7 @@ function checked(length) {
         NumberPrototypeToString(kMaxLength, 16) + " bytes",
     );
   }
-  return length | 0;
+  return MathTrunc(length);
 }
 
 export function SlowBuffer(length) {

--- a/tests/unit_node/buffer_test.ts
+++ b/tests/unit_node/buffer_test.ts
@@ -279,6 +279,29 @@ Deno.test({
 });
 
 Deno.test({
+  name: "[node/buffer] Buffer.allocUnsafe does not truncate lengths > 2^32",
+  ignore: true, // requires >4GB of memory
+  fn() {
+    const size = 2 ** 32 + 5;
+    const buf = Buffer.allocUnsafe(size);
+    assertEquals(buf.length, size);
+  },
+});
+
+Deno.test({
+  name: "[node/buffer] Buffer concat does not truncate buffers larger than 4GB",
+  ignore: true, // requires >4GB of memory
+  fn() {
+    const size = 2 ** 32 + 5;
+    const largeBuffer = Buffer.alloc(size);
+    largeBuffer.fill(111);
+    const result = Buffer.concat([largeBuffer]);
+    assertEquals(result.length, size);
+    assertEquals(Array.from(result.subarray(0, 5)), [111, 111, 111, 111, 111]);
+  },
+});
+
+Deno.test({
   name: "[node/buffer] Buffer 8 bit unsigned integers",
   fn() {
     const buffer = Buffer.from([0xff, 0x2a, 0x2a, 0x2a]);


### PR DESCRIPTION
## Summary

- Replace `| 0` (32-bit integer truncation) with `MathTrunc()` in `checked()`, `_allocUnsafe()`, and `fromString()` in the Node.js Buffer polyfill
- This fixes `Buffer.concat` and `Buffer.allocUnsafe` silently truncating buffers with sizes exceeding 2^32 (e.g. `(2**32 + 5) | 0` → `5`)

Closes #32895

## Test plan

- [x] Added tests for `Buffer.allocUnsafe` and `Buffer.concat` with >4GB sizes (marked `ignore: true` due to memory requirements)
- [x] Existing buffer tests pass (`./x test-node buffer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)