### PR TITLE
fix(ext/console): handle throwing Symbol.toStringTag getter gracefully

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -714,7 +714,11 @@ function formatRaw(ctx, value, recurseTimes, typedArray, proxyDetails) {
 
   let tag;
   if (!proxyDetails) {
-    tag = value[SymbolToStringTag];
+    try {
+      tag = value[SymbolToStringTag];
+    } catch {
+      // Symbol.toStringTag getter may throw (e.g. circular JSON.stringify)
+    }
   }
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -377,6 +377,27 @@ Deno.test(function consoleTestStringifyCircular() {
   assertEquals(stripAnsiCode(Deno.inspect(nestedObj)), nestedObjExpected);
 });
 
+Deno.test(function consoleTestStringifyToStringTagGetterThrows() {
+  // Symbol.toStringTag getter that throws should not crash console.log
+  // https://github.com/denoland/deno/issues/32894
+  class Circular {
+    self: Circular;
+    constructor() {
+      this.self = this;
+    }
+    get [Symbol.toStringTag]() {
+      // This throws due to circular reference
+      JSON.stringify(this);
+      return "Circular";
+    }
+  }
+  const obj = new Circular();
+  // Should not throw, should handle the error gracefully
+  const result = stringify(obj);
+  assertStringIncludes(result, "Circular");
+  assertStringIncludes(result, "[Circular");
+});
+
 Deno.test(function consoleTestStringifyMultipleCircular() {
   const y = { a: { b: {} }, foo: { bar: {} } };
   y.a.b = y.a;


### PR DESCRIPTION
## Summary

When `console.log` formats an object, it accesses `Symbol.toStringTag` which may be a getter that throws. For example, [quick-lru](https://www.npmjs.com/package/quick-lru)'s `Symbol.toStringTag` getter calls `JSON.stringify(this)` which fails on circular structures. This caused an `[Internal Formatting Error]` instead of printing the object.

Fix by wrapping the `Symbol.toStringTag` access in a try-catch, matching Node.js behavior (see `lib/internal/util/inspect.js` line 1221-1225).

Before:
```
[Internal Formatting Error] TypeError: Converting circular structure to JSON
```

After:
```
<ref *1> Bot {
  chatEventEmitter: BotChatEmitter { bot: [Circular *1] },
  cache: QuickLRU(0) {}
}
```

Fixes #32894

## Test plan

- [x] Added unit test with a `Symbol.toStringTag` getter that throws
- [x] `./x test-unit console_test` passes
- [x] Verified with the exact reproducer from the issue (quick-lru@7.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)