### PR TITLE
fix: handle broken pipe gracefully instead of panicking

### DIFF
--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -523,6 +523,21 @@ fn setup_panic_hook() {
   //   should be reported to us.
   let orig_hook = std::panic::take_hook();
   std::panic::set_hook(Box::new(move |panic_info| {
+    // When stdout is a broken pipe (e.g. `deno info | head`), println! panics
+    // from Rust's stdio module. Detect this via the panic location and exit
+    // silently rather than printing a scary "Deno has panicked" message.
+    // Exit code 141 (128 + SIGPIPE) on Unix, 1 on Windows.
+    if let Some(location) = panic_info.location() {
+      if location.file().ends_with("io/stdio.rs")
+        || location.file().ends_with("io\\stdio.rs")
+      {
+        #[cfg(unix)]
+        std::process::exit(141);
+        #[cfg(not(unix))]
+        std::process::exit(1);
+      }
+    }
+
     eprintln!("\n============================================================");
     eprintln!("Deno has panicked. This is a bug in Deno. Please report this");
     eprintln!("at https://github.com/denoland/deno/issues/new.");


### PR DESCRIPTION
## Summary

When stdout is piped to a command that exits early (e.g. `deno info | head`,
`deno test | jq`), `println!` panics from Rust's stdio module, producing a
scary "Deno has panicked" message.

This adds a check in the existing panic hook that detects panics originating
from Rust's `io/stdio.rs` module and exits silently with code 141
(128 + SIGPIPE) on Unix or 1 on Windows, matching standard Unix CLI behavior.

This covers all 68+ `println!` callsites in the CLI without needing to:
- Modify each callsite individually to use a helper function
- Toggle SIGPIPE signal handlers globally or per-subcommand

Supersedes https://github.com/denoland/deno/pull/28383
Closes #28338
Closes #25258
Closes #24529
Closes #15767
Closes #15045

## Test plan

Tested all reported scenarios on macOS:
```
$ ./target/debug/deno info | echo    # was: panic, now: silent exit
$ ./target/debug/deno info | true    # was: panic, now: silent exit
$ ./target/debug/deno info | head -1 # was: panic, now: silent exit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)