### PR TITLE
fix: include Temporal types in deno types output

### DIFF
--- a/cli/tsc/mod.rs
+++ b/cli/tsc/mod.rs
@@ -73,6 +73,7 @@ pub fn get_types_declaration_file_text() -> String {
     "deno.net",
     "deno.shared_globals",
     "deno.cache",
+    "esnext.temporal",
     "deno.window",
     "deno.unstable",
   ];


### PR DESCRIPTION
## Summary

Add `"esnext.temporal"` to the `lib_names` list in `get_types_declaration_file_text()` so that `deno types` emits the Temporal namespace declarations from TypeScript's `lib.esnext.temporal.d.ts`.

This was accidentally removed in #32656 (typescript-go update) which dropped the `"deno.temporal"` entry added by #32571. Since `deno types` does flat concatenation (doesn't follow `/// <reference>` chains), the Temporal types were silently lost from the output, breaking docs generation at docs.deno.com.

Closes #32950

## Test plan

```sh
# Before: no output
deno types | grep "declare namespace Temporal"

# After:
deno types | grep "declare namespace Temporal"
# declare namespace Temporal {
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)