### PR TITLE
test: mark unsupported Node compat tests as ignored

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1737,122 +1737,183 @@
     "parallel/test-performance-measure-detail.js": {},
     "parallel/test-permission-allow-addons-cli.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-allow-child-process-cli.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-allow-inspector.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-allow-wasi-cli.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-allow-worker-cli.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-child-process-cli.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-child-process-inherit-flags.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-config-file.mjs": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-diagnostics-channel.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-absolute-path.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-internal-module-stat.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-read-entrypoint.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-read.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-relative-path.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-repeat-path.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-require.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-supported.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-symlink-relative.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-symlink-target-write.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-symlink.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-traversal-path.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-wildcard.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-fs-windows-path.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-write-report.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-write-v8.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-fs-write.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-has.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
-    // "parallel/test-permission-inspector-brk.js": {},
-    // "parallel/test-permission-inspector.js": {},
-    "parallel/test-permission-no-addons.js": {},
+    "parallel/test-permission-inspector-brk.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-inspector.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-allowed.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-dns.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-fetch.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-http.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-https.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-tcp.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-udp.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-uds.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-warning.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-net-websocket.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
+    "parallel/test-permission-no-addons.js": {
+      "ignore": true,
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
+    },
     "parallel/test-permission-processbinding.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-sqlite-load-extension.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-warning-flags.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-wasi.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-permission-worker-threads-cli.js": {
       "ignore": true,
-      "reason": "Node.js permission model (--experimental-permission) is not implemented in Deno"
+      "reason": "Deno has its own permission system; Node.js --experimental-permission is not applicable"
     },
     "parallel/test-pipe-head.js": {},
     "parallel/test-pipe-return-val.js": {},


### PR DESCRIPTION
## Summary

- Mark disabled node compat tests as ignored with reasons:
  - `test-debugger-*` (32 tests): require `node inspect` CLI subcommand
  - `test-node-output-*` (6 tests): snapshot output tests depend on exact Node.js CLI output formatting
  - `test-node-run.js`: tests `node --run` subcommand not implemented in Deno
  - `test-permission-*` (45 tests): Deno has its own permission system; Node.js `--experimental-permission` is not applicable
- More test categories to follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)