### PR TITLE
fix(ext/napi): pass valid env to tsfn call_js_cb after close race

### DIFF
--- a/ext/napi/node_api.rs
+++ b/ext/napi/node_api.rs
@@ -832,7 +832,7 @@ impl TsFn {
     self.sender.spawn(move |scope: &mut v8::PinScope<'_, '_>| {
       let data = data.take();
 
-      // If is_closed then the TsFn struct has been freed — don't read from
+      // If is_closed then the TsFn struct has been freed. Don't read from
       // the tsfn pointer. We still pass the real env (not null) because:
       // 1. The env is valid (leaked via Box::into_raw, never freed)
       // 2. V8 is alive (we're running on the V8 thread with a scope)

--- a/tests/napi/async_test.js
+++ b/tests/napi/async_test.js
@@ -32,8 +32,8 @@ Deno.test("napi async work with threadsafe function from execute", async () => {
 Deno.test("napi tsfn call_js_cb receives valid env after close race", async () => {
   // Reproduces a crash seen with node-pty: when a tsfn is released while
   // calls are still pending, the call_js_cb must receive a valid env (not
-  // null). The native test spawns two threads — one calling the tsfn and
-  // one releasing it — to trigger the race. The call_js_cb asserts env is
+  // null). The native test spawns two threads (one calling the tsfn and
+  // one releasing it) to trigger the race. The call_js_cb asserts env is
   // not null and uses it, which would SIGSEGV before the fix.
   await new Promise((resolve) => {
     asyncTask.test_tsfn_close_race(() => {

--- a/tests/napi/src/async.rs
+++ b/tests/napi/src/async.rs
@@ -141,7 +141,7 @@ unsafe extern "C" fn tsfn_call_js(
 ) {
   // Release the tsfn from the JS thread after being called.
   // We get the tsfn from the callback info that was stashed earlier.
-  // For simplicity, just do nothing here — the complete callback handles cleanup.
+  // For simplicity, just do nothing here. The complete callback handles cleanup.
   let _ = env;
 }
 
@@ -256,7 +256,7 @@ unsafe extern "C" fn tsfn_race_call_js(
   // Before the fix, env could be null here when the tsfn was already closed.
   assert!(
     !env.is_null(),
-    "call_js_cb received null env — this is the bug that crashes node-pty"
+    "call_js_cb received null env, this is the bug that crashes node-pty"
   );
   unsafe {
     let mut global: napi_value = ptr::null_mut();
@@ -349,7 +349,7 @@ extern "C" fn test_tsfn_close_race(
   // Thread B: releases the tsfn, which triggers the close (thread_count
   // drops from 1 to 0). The drop is queued via sender.spawn. If Thread A's
   // sender.spawn calls are interleaved with this, some calls will land in
-  // the queue after the drop — those calls see is_closed=true.
+  // the queue after the drop. Those calls see is_closed=true.
   let tsfn_b = tsfn_addr;
   std::thread::spawn(move || {
     let tsfn = tsfn_b as napi_threadsafe_function;
@@ -419,7 +419,7 @@ extern "C" fn test_tsfn_abort_race(
     }
   });
 
-  // Use abort mode to close — this forces close regardless of thread_count.
+  // Use abort mode to close. This forces close regardless of thread_count.
   let tsfn_b = tsfn_addr;
   std::thread::spawn(move || {
     let tsfn = tsfn_b as napi_threadsafe_function;


### PR DESCRIPTION
## Summary

- Fix SIGSEGV crash in native addons (e.g. node-pty) caused by a race condition in NAPI threadsafe function teardown
- When a tsfn is released while calls are still pending, `TsFn::drop` can run before a queued call is processed. Previously, the `call_js_cb` was invoked with `env=NULL`, crashing addons that dereference env without a null check (SIGSEGV at address 0x90)
- Fix captures the env pointer in the call closure so it's available after the TsFn is freed. The env is always valid (leaked via `Box::into_raw`, never freed) and V8 is alive (callback runs on V8 thread)
- Add regression test `test_tsfn_close_race` that spawns concurrent calling/releasing threads to exercise the race

Towards https://github.com/denoland/deno/issues/32846