### PR TITLE
chore: upgrade V8 to 147.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11193,9 +11193,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "146.9.0"
+version = "147.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b21777080203cb33828681f177e53402fa2927a1e2d17adead072b0c26b401"
+checksum = "a98a7a54a2cbb941924658340efeff052840ab2dcb925c34260142ba85310023"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ deno_task_shell = "=0.29.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "146.9.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "147.0.0", default-features = false, features = ["simdutf"] }
 
 denokv_proto = "0.13.0"
 denokv_remote = "0.13.0"


### PR DESCRIPTION
## Summary

- Upgrade V8 crate from 146.9.0 to 147.0.0 (V8 engine 14.6 -> 14.7)

## Test plan

- [x] Builds clean
- [x] `deno eval 'console.log(Deno.version.v8)'` prints `14.7.173.7-rusty`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)