### PR TITLE
fix(cli): parse --frozen flag for deno update and deno outdated

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -14671,12 +14671,10 @@ Usage: deno repl [OPTIONS] [-- [ARGS]...]\n"
 
   #[test]
   fn update_subcommand_frozen_flag() {
-    let r =
-      flags_from_vec(svec!["deno", "update", "--frozen=false"]).unwrap();
+    let r = flags_from_vec(svec!["deno", "update", "--frozen=false"]).unwrap();
     assert_eq!(r.frozen_lockfile, Some(false));
 
-    let r =
-      flags_from_vec(svec!["deno", "update", "--frozen"]).unwrap();
+    let r = flags_from_vec(svec!["deno", "update", "--frozen"]).unwrap();
     assert_eq!(r.frozen_lockfile, Some(true));
   }
 


### PR DESCRIPTION
## Summary

- `outdated_parse()` was missing a call to `lock_args_parse()`, so `--frozen`, `--lock`, and `--no-lock` flags were never parsed for `deno update` and `deno outdated`
- This caused `deno update --frozen=false` to fail with "The lockfile is out of date" because `frozen_lockfile` remained `None` (defaulting to true)
- Add unit tests for `--frozen=false` and `--frozen` on both commands

Fixes #32969

## Test plan

- [x] `cargo test update_subcommand_frozen_flag` passes
- [x] `cargo test outdated_subcommand_frozen_flag` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)