### PR TITLE
fix(resolver): fall through to .deno/ when BYONM node_modules version mismatches

### DIFF
--- a/libs/resolver/npm/byonm.rs
+++ b/libs/resolver/npm/byonm.rs
@@ -160,27 +160,45 @@ impl<TSys: ByonmNpmResolverSys> ByonmNpmResolver<TSys> {
     // now attempt to resolve if it's found in any package.json
     let maybe_pkg_json_and_alias =
       self.resolve_pkg_json_and_alias_for_req(req, referrer)?;
-    match maybe_pkg_json_and_alias {
-      Some((pkg_json, alias)) => {
-        // now try node resolution
-        if let Some(resolved) =
-          node_resolve_dir(&self.sys, &alias, pkg_json.dir_path())?
-        {
+    if let Some((pkg_json, alias)) = &maybe_pkg_json_and_alias {
+      // now try node resolution
+      if let Some(resolved) =
+        node_resolve_dir(&self.sys, alias, pkg_json.dir_path())?
+      {
+        // Verify the resolved package version actually satisfies the
+        // requirement. The package.json dep may intersect the req (e.g.,
+        // dep is ^1.3.5, req is @1.3.6) but the physically installed
+        // version might not satisfy it (e.g., 1.3.5 is installed).
+        // In that case, fall through to the .deno/ search.
+        let version_matches = self
+          .pkg_json_resolver
+          .load_package_json(&resolved.join("package.json"))
+          .ok()
+          .flatten()
+          .and_then(|pkg| {
+            let version =
+              Version::parse_from_npm(pkg.version.as_ref()?).ok()?;
+            Some(req.version_req.matches(&version))
+          })
+          .unwrap_or(true);
+        if version_matches {
           return Ok(resolved);
         }
+      }
+    }
 
+    // check if node_modules/.deno/ matches this constraint
+    if let Some(folder) = self.resolve_folder_in_root_node_modules(req) {
+      return Ok(folder);
+    }
+
+    match maybe_pkg_json_and_alias {
+      Some((_, alias)) => {
         Err(ByonmResolvePkgFolderFromDenoReqError::MissingAlias(alias))
       }
-      None => {
-        // now check if node_modules/.deno/ matches this constraint
-        if let Some(folder) = self.resolve_folder_in_root_node_modules(req) {
-          return Ok(folder);
-        }
-
-        Err(ByonmResolvePkgFolderFromDenoReqError::UnmatchedReq(
-          req.clone(),
-        ))
-      }
+      None => Err(ByonmResolvePkgFolderFromDenoReqError::UnmatchedReq(
+        req.clone(),
+      )),
     }
   }
 

--- a/tests/specs/npm/byonm_version_mismatch_fallback/__test__.jsonc
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/__test__.jsonc
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "resolves_exact_version_from_deno_dir": {
+      // When node_modules/@denotest/add has version 1.0.0 installed,
+      // but the user requests npm:@denotest/add@0.5.0, the resolver
+      // should fall through to node_modules/.deno/ and find 0.5.0
+      // instead of returning the mismatched 1.0.0.
+      // Ref: https://github.com/denoland/deno/issues/32972
+      "args": "run -A main.ts",
+      "output": "0.5.0\n"
+    }
+  }
+}

--- a/tests/specs/npm/byonm_version_mismatch_fallback/deno.json
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "manual"
+}

--- a/tests/specs/npm/byonm_version_mismatch_fallback/main.ts
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/main.ts
@@ -1,0 +1,2 @@
+import addPkg from "npm:@denotest/add@0.5.0/package.json" with { type: "json" };
+console.log(addPkg.version);

--- a/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@0.5.0/node_modules/@denotest/add/index.js
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@0.5.0/node_modules/@denotest/add/index.js
@@ -1,0 +1,1 @@
+module.exports.add = (a, b) => a + b;

--- a/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@0.5.0/node_modules/@denotest/add/package.json
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@0.5.0/node_modules/@denotest/add/package.json
@@ -1,0 +1,1 @@
+{ "name": "@denotest/add", "version": "0.5.0" }

--- a/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@1.0.0/node_modules/@denotest/add/index.js
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@1.0.0/node_modules/@denotest/add/index.js
@@ -1,0 +1,1 @@
+module.exports.add = (a, b) => a + b;

--- a/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@1.0.0/node_modules/@denotest/add/package.json
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/.deno/@denotest+add@1.0.0/node_modules/@denotest/add/package.json
@@ -1,0 +1,1 @@
+{ "name": "@denotest/add", "version": "1.0.0" }

--- a/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/@denotest/add/index.js
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/@denotest/add/index.js
@@ -1,0 +1,1 @@
+module.exports.add = (a, b) => a + b;

--- a/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/@denotest/add/package.json
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/node_modules/@denotest/add/package.json
@@ -1,0 +1,1 @@
+{ "name": "@denotest/add", "version": "1.0.0" }

--- a/tests/specs/npm/byonm_version_mismatch_fallback/package.json
+++ b/tests/specs/npm/byonm_version_mismatch_fallback/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/add": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- When resolving `npm:pkg@version` in BYONM mode, the resolver would find a matching package.json dep via `intersects` (e.g., dep `^1.3.5` intersects req `1.3.6`) but then resolve the directory by package **name** only, returning whatever version was physically installed in `node_modules/`
- If the installed version doesn't satisfy the requested version, the resolver now falls through to search `node_modules/.deno/` where the exact version may exist
- This is the root cause of the issue reported in #32972 — with `--config` pointing to a `deno.json` with `nodeModulesDir: "manual"`, `deno run npm:pkg@X.Y.Z` would silently use whatever version was cached instead of honoring the requested version

### Root cause

In `resolve_pkg_folder_from_deno_module_req`, the `Some((pkg_json, alias))` arm called `node_resolve_dir` which finds `node_modules/<pkg>` by name only and returned immediately without verifying the installed version satisfies `req.version_req`. The `.deno/` fallback (which does version matching) was only reached in the `None` arm.

### Fix

After `node_resolve_dir` finds a path, read the resolved `package.json` and verify the installed version satisfies the requirement. If it doesn't match, fall through to `resolve_folder_in_root_node_modules` which scans `.deno/` entries with proper version matching.

Closes #32972

## Test plan

- [x] New spec test `byonm_version_mismatch_fallback` — BYONM with `node_modules/@denotest/add` at 1.0.0, `.deno/` containing both 0.5.0 and 1.0.0, verifies `npm:@denotest/add@0.5.0` resolves to 0.5.0
- [x] All 35 existing BYONM spec tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)