### PR TITLE
fix(ext/node): route console output through process.stdout/stderr

### DIFF
--- a/ext/node/polyfills/02_init.js
+++ b/ext/node/polyfills/02_init.js
@@ -11,6 +11,7 @@ import {
   kStreamBaseField,
   streamBaseState,
 } from "ext:deno_node/internal_binding/stream_wrap.ts";
+import { Console } from "ext:deno_web/01_console.js";
 import "node:module";
 
 let initialized = false;
@@ -165,3 +166,27 @@ nativeModuleExports["internal/console/constructor"].bindStreamsLazy(
   nativeModuleExports["console"],
   nativeModuleExports["process"],
 );
+
+// Replace the global console's output methods so that they route through
+// process.stdout/process.stderr. This is critical for Node.js compatibility:
+// npm packages commonly monkey-patch process.stdout.write/process.stderr.write
+// to intercept output (e.g., Ink, Jest, ConsolePatcher in @google/gemini-cli).
+// In Node.js, console.log internally calls process.stdout.write, so the
+// monkey-patching captures the output. Deno's console uses core.print which
+// bypasses process.stdout entirely, breaking these interception patterns.
+{
+  const proc = nativeModuleExports["process"];
+  const globalConsole = nativeModuleExports["console"];
+  const nodeConsole = new Console((msg, level) => {
+    if (level > 1) {
+      proc.stderr.write(msg);
+    } else {
+      proc.stdout.write(msg);
+    }
+  });
+  for (const key of Object.keys(nodeConsole)) {
+    if (typeof nodeConsole[key] === "function") {
+      globalConsole[key] = nodeConsole[key];
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Route `console.log`/`console.error`/etc. through `process.stdout.write`/`process.stderr.write` when Node compat is active
- Fixes npm packages that monkey-patch `process.stdout.write` or `process.stderr.write` to intercept console output

## Problem

In Node.js, `console.log` internally calls `process.stdout.write` and `console.error` calls `process.stderr.write`. Many npm packages rely on this to intercept output:

- **Ink** (React for CLI) patches `process.stdout.write` to capture output for its rendering pipeline
- **Jest** patches stdio to capture test output
- **gemini-cli** patches both via `patchStdio()` to route output through an event system

In Deno, `console.log`/`console.error` use `core.print` which writes directly to fd 1/2, completely bypassing `process.stdout`/`process.stderr`. This means monkey-patching silently fails:

```js
// This works in Node.js but not in Deno (before this fix):
process.stdout.write = () => true; // swallow output
console.log("should be hidden"); // still prints in Deno!
```

## Fix

During Node bootstrap in `02_init.js`, create a new `Console` instance whose `printFunc` routes through `process.stdout`/`process.stderr`, then copy its methods to the global console object.

## Test plan

- [x] Verified `console.log` output is captured when `process.stdout.write` is patched
- [x] Verified normal console output (including object inspection) still works
- [x] Verified `console.log = myFunc` replacement pattern still works
- [x] Existing node unit tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)