### PR TITLE
fix(ext/node): only fire upgrade event for websocket, not all upgrade types

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -2379,12 +2379,14 @@ export class ServerImpl extends EventEmitter {
         request.headers.get("upgrade");
       req[kRawHeaders] = request.headers;
 
-      // Don't fire the "upgrade" event for h2c (HTTP/2 cleartext) upgrades.
-      // These are protocol-level upgrades that aren't meant for user-space
-      // handlers (like WebSocket). Treating them as regular requests lets
-      // the server respond normally with HTTP/1.1.
+      // Only fire the "upgrade" event for WebSocket upgrades. Other upgrade
+      // types (like h2c) are protocol-level and not meant for user-space
+      // handlers. Because upgradeHttpRaw() irrevocably commits the
+      // connection to upgrade mode (unlike Node where the raw socket is
+      // passed to the listener), we must filter here rather than letting
+      // the listener decide.
       if (
-        req.upgrade && req.upgrade.toLowerCase() !== "h2c" &&
+        req.upgrade && req.upgrade.toLowerCase() === "websocket" &&
         this.listenerCount("upgrade") > 0
       ) {
         const { conn, response } = upgradeHttpRaw(request);

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -2432,10 +2432,10 @@ Deno.test("[node/http] upgrade request can be rejected with non-101 status", asy
 });
 
 // Regression test for https://github.com/denoland/deno/issues/32857
-// h2c upgrade requests should not fire the "upgrade" event and should
-// be handled as normal HTTP/1.1 requests.
+// Only WebSocket upgrades should fire the "upgrade" event. Other upgrade
+// types (h2c, etc.) should be handled as normal HTTP/1.1 requests.
 Deno.test(
-  "[node/http] h2c upgrade does not hang when upgrade listener exists",
+  "[node/http] non-websocket upgrade does not hang when upgrade listener exists",
   { permissions: { net: true } },
   async () => {
     const { promise, resolve } = Promise.withResolvers<void>();
@@ -2445,21 +2445,31 @@ Deno.test(
     });
     server.on("upgrade", (_req, socket) => {
       // This listener exists (e.g. for WebSocket) but should NOT be
-      // triggered for h2c upgrades.
+      // triggered for non-websocket upgrades.
       socket.end();
     });
 
     server.listen(0, "127.0.0.1", async () => {
       const addr = server.address() as { port: number };
-      // Send a request with Upgrade: h2c header, simulating what browsers do
-      const res = await fetch(`http://127.0.0.1:${addr.port}/`, {
+      // h2c upgrade
+      const res1 = await fetch(`http://127.0.0.1:${addr.port}/`, {
         headers: {
           "Connection": "Upgrade, HTTP2-Settings",
           "Upgrade": "h2c",
         },
       });
-      assertEquals(res.status, 200);
-      assertEquals(await res.text(), "ok");
+      assertEquals(res1.status, 200);
+      assertEquals(await res1.text(), "ok");
+
+      // Arbitrary non-websocket upgrade (e.g. some custom protocol)
+      const res2 = await fetch(`http://127.0.0.1:${addr.port}/`, {
+        headers: {
+          "Connection": "Upgrade",
+          "Upgrade": "TLS/1.0",
+        },
+      });
+      assertEquals(res2.status, 200);
+      assertEquals(await res2.text(), "ok");
 
       server.close(() => resolve());
     });


### PR DESCRIPTION
## Summary

- Switch the HTTP upgrade check from blacklisting `h2c` to whitelisting `websocket`
- The previous fix (#32866) only excluded `h2c`, but any other non-websocket `Upgrade` header would still trigger `upgradeHttpRaw()` and hang the connection
- Unlike Node.js where the raw socket is passed to the listener (letting it decide), Deno's `upgradeHttpRaw()` irrevocably commits the connection to upgrade mode, so we must filter before calling it
- Updated existing regression test to also cover arbitrary non-websocket upgrade headers (e.g. `TLS/1.0`)

Ref: #32998

## Test plan

- [x] Updated `[node/http] non-websocket upgrade does not hang when upgrade listener exists` test to cover both h2c and arbitrary upgrade headers
- [x] `./x test-unit http_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)