### PR TITLE
fix(ext/http): use clone_external in op_http_metric_handle_otel_error

### DIFF
--- a/ext/http/http_next.rs
+++ b/ext/http/http_next.rs
@@ -1713,8 +1713,8 @@ pub async fn op_raw_write_vectored(
 #[op2(fast)]
 pub fn op_http_metric_handle_otel_error(external: *const c_void) {
   let http =
-    // SAFETY: external is deleted before calling this op.
-    unsafe { take_external!(external, "op_http_metric_handle_otel_error") };
+    // SAFETY: op is called with external.
+    unsafe { clone_external!(external, "op_http_metric_handle_otel_error") };
 
   http.otel_info_set_error("user");
 }

--- a/tests/specs/cli/otel_basic/__test__.jsonc
+++ b/tests/specs/cli/otel_basic/__test__.jsonc
@@ -123,6 +123,10 @@
     "log_exception": {
       "args": "run -A main.ts log_exception.ts",
       "output": "log_exception.out"
+    },
+    "http_serve_error_with_otel": {
+      "args": "run -A main.ts http_serve_error_with_otel.ts",
+      "output": "http_serve_error_with_otel.out"
     }
   }
 }

--- a/tests/specs/cli/otel_basic/http_serve_error_with_otel.out
+++ b/tests/specs/cli/otel_basic/http_serve_error_with_otel.out
@@ -1,0 +1,14 @@
+[WILDCARD]{
+  "spans": [
+[WILDCARD]
+        {
+          "key": "error.type",
+          "value": {
+            "stringValue": "500"
+          }
+        }
+[WILDCARD]
+  ],
+  "logs": [WILDCARD],
+  "metrics": [WILDCARD]
+}

--- a/tests/specs/cli/otel_basic/http_serve_error_with_otel.ts
+++ b/tests/specs/cli/otel_basic/http_serve_error_with_otel.ts
@@ -1,0 +1,24 @@
+// Regression test for https://panic.deno.com/v2.7.8/aarch64-apple-darwin/g7y2Non_5uBwt-hvBwk-hvB4j-hvBow9zC434tWoq3tWw32tW
+// When both tracing and metrics are enabled and the onError handler throws,
+// op_http_metric_handle_otel_error must not consume the external pointer
+// before op_http_copy_span_to_otel_info can use it.
+
+const server = Deno.serve({
+  port: 0,
+  async onListen({ port }) {
+    try {
+      await (await fetch(`http://localhost:${port}/`)).text();
+    } finally {
+      server.shutdown();
+    }
+  },
+  handler: (_req) => {
+    throw new Error("handler error");
+  },
+  onError: (_error) => {
+    // onError itself throws, triggering the double-error path
+    // where both op_http_metric_handle_otel_error and
+    // op_http_copy_span_to_otel_info run on the same request.
+    throw new Error("onError error");
+  },
+});


### PR DESCRIPTION
## Summary

- Fix use-after-take panic in HTTP OTel integration when both metrics and tracing are enabled and the `onError` handler throws
- `op_http_metric_handle_otel_error` was using `take_external!` (consuming the pointer), then `op_http_copy_span_to_otel_info` tried to `clone_external!` on the same consumed pointer — UB manifesting as a `borrow_mut` panic
- Changed to `clone_external!` since this op only sets an error attribute, not takes ownership

Closes https://github.com/denoland/deno/issues/33006