### PR TITLE
perf(ops): consolidate conversion error handling with ok_or_throw helper

### DIFF
--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -2210,6 +2210,23 @@ pub fn format_frame<F: ErrorFormat>(
   result
 }
 
+/// Unwraps a `Result`, throwing the error as a JS exception if it fails.
+/// Returns `Some(value)` on success, `None` on error (after throwing).
+/// Used by generated op code: `let Some(v) = ok_or_throw(...) else { return 1; };`
+#[inline]
+pub fn ok_or_throw<'s, 'i, T, E: JsErrorClass>(
+  scope: &mut v8::PinCallbackScope<'s, 'i>,
+  result: Result<T, E>,
+) -> Option<T> {
+  match result {
+    Ok(t) => Some(t),
+    Err(err) => {
+      throw_error_js_error_class(scope, &err);
+      None
+    }
+  }
+}
+
 pub fn throw_error_one_byte_info(
   info: &v8::FunctionCallbackInfo,
   message: &str,

--- a/libs/core/lib.rs
+++ b/libs/core/lib.rs
@@ -205,6 +205,7 @@ pub mod _ops {
   pub use super::cppgc::try_unwrap_cppgc_base_persistent_object;
   pub use super::cppgc::try_unwrap_cppgc_object;
   pub use super::cppgc::try_unwrap_cppgc_persistent_object;
+  pub use super::error::ok_or_throw;
   pub use super::error::throw_error_js_error_class;
   pub use super::error::throw_error_one_byte;
   pub use super::error::throw_error_one_byte_info;

--- a/libs/core/runtime/ops_rust_to_v8.rs
+++ b/libs/core/runtime/ops_rust_to_v8.rs
@@ -429,7 +429,7 @@ typedarray!(f64, Float64Array);
 impl<'a, T: serde::Serialize> RustToV8Fallible<'a>
   for RustToV8Marker<SerdeMarker, T>
 {
-  #[inline(always)]
+  #[inline]
   fn to_v8_fallible<'i>(
     self,
     scope: &mut v8::PinScope<'a, 'i>,
@@ -444,7 +444,7 @@ impl<'a, T: serde::Serialize> RustToV8Fallible<'a>
 impl<'a, T: crate::cppgc::GarbageCollected + 'static> RustToV8<'a>
   for RustToV8Marker<CppGcMarker, T>
 {
-  #[inline(always)]
+  #[inline]
   fn to_v8<'i>(
     self,
     scope: &mut v8::PinScope<'a, 'i>,
@@ -471,7 +471,7 @@ impl<'a> RustToV8<'a> for RustToV8Marker<Undefined, ()> {
 impl<'a, T: crate::ToV8<'a>> RustToV8Fallible<'a>
   for RustToV8Marker<ToV8Marker, T>
 {
-  #[inline(always)]
+  #[inline]
   fn to_v8_fallible<'i>(
     self,
     scope: &mut v8::PinScope<'a, 'i>,

--- a/libs/ops/op2/dispatch_slow.rs
+++ b/libs/ops/op2/dispatch_slow.rs
@@ -639,15 +639,9 @@ pub fn from_arg(
     Arg::SerdeV8(_class) => {
       *needs_scope = true;
       let scope = scope.clone();
-      let err = format_ident!("{}_err", arg_ident);
-      let throw_exception = throw_type_error_string(generator_state, &err);
       quote! {
-        let #arg_ident = match deno_core::_ops::serde_v8_to_rust(&mut #scope, #arg_ident) {
-          Ok(t) => t,
-          Err(#err) => {
-            #throw_exception;
-          }
-        };
+        let #arg_ident = deno_core::_ops::serde_v8_to_rust(&mut #scope, #arg_ident);
+        let Some(#arg_ident) = deno_core::_ops::ok_or_throw(&mut #scope, #arg_ident) else { return 1; };
       }
     }
     Arg::FromV8(ty, true) => {
@@ -655,20 +649,13 @@ pub fn from_arg(
       let ty = syn::parse_str::<syn::Type>(ty)
         .map_err(|_| "failed to reparse type")?;
       let scope = scope.clone();
-      let err = format_ident!("{}_err", arg_ident);
-      let throw_exception = throw_type_error_string(generator_state, &err);
       quote! {
         let #arg_ident = {
           use deno_core::FromV8;
           use deno_core::FromV8Scopeless;
-
-          match <#ty>::from_v8(&mut #scope, #arg_ident) {
-            Ok(t) => t,
-            Err(#err) => {
-              #throw_exception;
-            }
-          }
+          <#ty>::from_v8(&mut #scope, #arg_ident)
         };
+        let Some(#arg_ident) = deno_core::_ops::ok_or_throw(&mut #scope, #arg_ident) else { return 1; };
       }
     }
     Arg::FromV8(ty, false) => {
@@ -690,8 +677,6 @@ pub fn from_arg(
       let ty = syn::parse_str::<syn::Type>(ty)
         .map_err(|_| "failed to reparse type")?;
       let scope = scope.clone();
-      let err = format_ident!("{}_err", arg_ident);
-      let throw_exception = throw_type_error_string(generator_state, &err);
       let prefix = get_prefix(generator_state);
       let context = format!("Argument {}", index);
 
@@ -763,18 +748,14 @@ pub fn from_arg(
       quote! {
         #default
         #alias
-        let #arg_ident = match <#ty as deno_core::webidl::WebIdlConverter>::convert(
+        let #arg_ident = <#ty as deno_core::webidl::WebIdlConverter>::convert(
           &mut #scope,
           #arg_ident,
           #prefix.into(),
           deno_core::webidl::ContextFn::new_borrowed(&|| std::borrow::Cow::Borrowed(#context)),
           &#options,
-        ) {
-          Ok(t) => t,
-          Err(#err) => {
-            #throw_exception;
-          }
-        };
+        );
+        let Some(#arg_ident) = deno_core::_ops::ok_or_throw(&mut #scope, #arg_ident) else { return 1; };
       }
     }
     Arg::CppGcResource(proto, ty) => {
@@ -1110,14 +1091,11 @@ pub fn return_value_infallible(
     }
     ArgSlowRetval::RetValFallible => {
       generator_state.needs_scope = true;
-      let err = format_ident!("{}_err", generator_state.retval);
-      let throw_exception = throw_type_error_string(generator_state, &err);
 
-      gs_quote!(generator_state(scope, retval) => (match deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope) {
-        Ok(v) => #retval.set(v),
-        Err(#err) => {
-          #throw_exception
-        },
+      gs_quote!(generator_state(scope, retval) => ({
+        let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope);
+        let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut #scope, rv_result) else { return 1; };
+        #retval.set(rv_v8);
       }))
     }
     ArgSlowRetval::V8Local => {
@@ -1129,14 +1107,11 @@ pub fn return_value_infallible(
     }
     ArgSlowRetval::V8LocalFalliable => {
       generator_state.needs_scope = true;
-      let err = format_ident!("{}_err", generator_state.retval);
-      let throw_exception = throw_type_error_string(generator_state, &err);
 
-      gs_quote!(generator_state(scope, retval) => (match deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope) {
-        Ok(v) => #retval.set(v),
-        Err(#err) => {
-          #throw_exception
-        },
+      gs_quote!(generator_state(scope, retval) => ({
+        let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope);
+        let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut #scope, rv_result) else { return 1; };
+        #retval.set(rv_v8);
       }))
     }
     ArgSlowRetval::None => return Err("a slow return value"),

--- a/libs/ops/op2/test_cases/async/async_arg_return.out
+++ b/libs/ops/op2/test_cases/async/async_arg_return.out
@@ -46,10 +46,8 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             if args.length() < (1u8 as i32) + 1i32 {
                 let msg = format!(
                     "{}: {} {} required, but only {} present",
-                    "Failed to execute 'UNINIT.call'",
-                    1u8,
-                    "argument",
-                    args.length() - 1i32,
+                    "Failed to execute 'UNINIT.call'", 1u8, "argument", args.length() -
+                    1i32
                 );
                 let msg = deno_core::v8::String::new(&mut scope, &msg).unwrap();
                 let exception = deno_core::v8::Exception::type_error(

--- a/libs/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/libs/ops/op2/test_cases/async/async_jsbuffer.out
@@ -74,15 +74,16 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                     deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
                 },
             ) {
-                match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
-                    result,
-                    &mut scope,
-                ) {
-                    Ok(v) => rv.set(v),
-                    Err(rv_err) => {
-                        deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+                {
+                    let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                        result,
+                        &mut scope,
+                    );
+                    let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                    else {
                         return 1;
-                    }
+                    };
+                    rv.set(rv_v8);
                 };
                 return 0;
             }

--- a/libs/ops/op2/test_cases/sync/buffers_out.out
+++ b/libs/ops/op2/test_cases/sync/buffers_out.out
@@ -56,12 +56,16 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
                 Self::call(arg0)
             };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }
@@ -143,12 +147,16 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                 };
                 Self::call(arg0)
             };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }

--- a/libs/ops/op2/test_cases/sync/from_v8.out
+++ b/libs/ops/op2/test_cases/sync/from_v8.out
@@ -48,16 +48,10 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
                 let arg0 = {
                     use deno_core::FromV8;
                     use deno_core::FromV8Scopeless;
-                    match <Foo>::from_v8(&mut scope, arg0) {
-                        Ok(t) => t,
-                        Err(arg0_err) => {
-                            deno_core::_ops::throw_error_js_error_class(
-                                &mut scope,
-                                &arg0_err,
-                            );
-                            return 1;
-                        }
-                    }
+                    <Foo>::from_v8(&mut scope, arg0)
+                };
+                let Some(arg0) = deno_core::_ops::ok_or_throw(&mut scope, arg0) else {
+                    return 1;
                 };
                 Self::call(arg0)
             };

--- a/libs/ops/op2/test_cases/sync/object_wrap.out
+++ b/libs/ops/op2/test_cases/sync/object_wrap.out
@@ -311,10 +311,8 @@ impl Foo {
                 if args.length() < (1u8 as i32) + 0i32 {
                     let msg = format!(
                         "{}: {} {} required, but only {} present",
-                        "Failed to execute 'call' on 'Foo'",
-                        1u8,
-                        "argument",
-                        args.length() - 0i32,
+                        "Failed to execute 'call' on 'Foo'", 1u8, "argument", args
+                        .length() - 0i32
                     );
                     let msg = deno_core::v8::String::new(&mut scope, &msg).unwrap();
                     let exception = deno_core::v8::Exception::type_error(

--- a/libs/ops/op2/test_cases/sync/serde_v8.out
+++ b/libs/ops/op2/test_cases/sync/serde_v8.out
@@ -45,30 +45,25 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             );
             let result = {
                 let arg0 = args.get(0usize as i32);
-                let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
-                    Ok(t) => t,
-                    Err(arg0_err) => {
-                        deno_core::_ops::throw_error_js_error_class(
-                            &mut scope,
-                            &arg0_err,
-                        );
-                        return 1;
-                    }
+                let arg0 = deno_core::_ops::serde_v8_to_rust(&mut scope, arg0);
+                let Some(arg0) = deno_core::_ops::ok_or_throw(&mut scope, arg0) else {
+                    return 1;
                 };
                 Self::call(arg0)
             };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
-                deno_core::_ops::RustToV8Marker::<
-                    deno_core::_ops::SerdeMarker,
-                    _,
-                >::from(result),
-                &mut scope,
-            ) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    deno_core::_ops::RustToV8Marker::<
+                        deno_core::_ops::SerdeMarker,
+                        _,
+                    >::from(result),
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }

--- a/libs/ops/op2/test_cases/sync/string_option_return.out
+++ b/libs/ops/op2/test_cases/sync/string_option_return.out
@@ -52,12 +52,16 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
                 };
                 Self::call(arg0)
             };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }

--- a/libs/ops/op2/test_cases/sync/string_return.out
+++ b/libs/ops/op2/test_cases/sync/string_return.out
@@ -41,12 +41,16 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             let mut scope = scope.init();
             let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }
@@ -106,12 +110,16 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             let mut scope = scope.init();
             let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }
@@ -171,12 +179,16 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             let mut scope = scope.init();
             let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }

--- a/libs/ops/op2/test_cases/sync/to_v8.out
+++ b/libs/ops/op2/test_cases/sync/to_v8.out
@@ -41,18 +41,19 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             let mut scope = scope.init();
             let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
-                deno_core::_ops::RustToV8Marker::<
-                    deno_core::_ops::ToV8Marker,
-                    _,
-                >::from(result),
-                &mut scope,
-            ) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    deno_core::_ops::throw_error_js_error_class(&mut scope, &rv_err);
+            {
+                let rv_result = deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    deno_core::_ops::RustToV8Marker::<
+                        deno_core::_ops::ToV8Marker,
+                        _,
+                    >::from(result),
+                    &mut scope,
+                );
+                let Some(rv_v8) = deno_core::_ops::ok_or_throw(&mut scope, rv_result)
+                else {
                     return 1;
-                }
+                };
+                rv.set(rv_v8);
             };
             return 0;
         }

--- a/libs/ops/op2/test_cases/sync/webidl.out
+++ b/libs/ops/op2/test_cases/sync/webidl.out
@@ -45,7 +45,7 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
             );
             let result = {
                 let arg0 = args.get(0usize as i32);
-                let arg0 = match <String as deno_core::webidl::WebIdlConverter>::convert(
+                let arg0 = <String as deno_core::webidl::WebIdlConverter>::convert(
                     &mut scope,
                     arg0,
                     "Failed to execute 'UNINIT.call'".into(),
@@ -53,18 +53,12 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                         &|| std::borrow::Cow::Borrowed("Argument 0"),
                     ),
                     &Default::default(),
-                ) {
-                    Ok(t) => t,
-                    Err(arg0_err) => {
-                        deno_core::_ops::throw_error_js_error_class(
-                            &mut scope,
-                            &arg0_err,
-                        );
-                        return 1;
-                    }
+                );
+                let Some(arg0) = deno_core::_ops::ok_or_throw(&mut scope, arg0) else {
+                    return 1;
                 };
                 let arg1 = args.get(1usize as i32);
-                let arg1 = match <u32 as deno_core::webidl::WebIdlConverter>::convert(
+                let arg1 = <u32 as deno_core::webidl::WebIdlConverter>::convert(
                     &mut scope,
                     arg1,
                     "Failed to execute 'UNINIT.call'".into(),
@@ -72,15 +66,9 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                         &|| std::borrow::Cow::Borrowed("Argument 1"),
                     ),
                     &Default::default(),
-                ) {
-                    Ok(t) => t,
-                    Err(arg1_err) => {
-                        deno_core::_ops::throw_error_js_error_class(
-                            &mut scope,
-                            &arg1_err,
-                        );
-                        return 1;
-                    }
+                );
+                let Some(arg1) = deno_core::_ops::ok_or_throw(&mut scope, arg1) else {
+                    return 1;
                 };
                 Self::call(arg0, arg1)
             };

--- a/libs/ops/webidl/test_cases/dict_and_enum.out
+++ b/libs/ops/webidl/test_cases/dict_and_enum.out
@@ -50,7 +50,7 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for GPURequestAdapterOptions {
                             format!(
                                 "{} ({})",
                                 "'forceFallbackAdapter' of 'GPURequestAdapterOptions'",
-                                __context.call(),
+                                __context.call()
                             )
                                 .into()
                         },
@@ -84,8 +84,8 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for GPURequestAdapterOptions {
                         &|| {
                             format!(
                                 "{} ({})",
-                                "'powerPreference' of 'GPURequestAdapterOptions'",
-                                __context.call(),
+                                "'powerPreference' of 'GPURequestAdapterOptions'", __context
+                                .call()
                             )
                                 .into()
                         },


### PR DESCRIPTION
## Summary

- Add shared `ok_or_throw` helper in `deno_core::error` that replaces per-op generated match/throw/return patterns for fallible conversions
- Update op2 codegen for SerdeV8, FromV8, WebIDL args and fallible return values to use the helper
- Downgrade `#[inline(always)]` to `#[inline]` on generic `RustToV8Marker` impls (Serde, CppGc, ToV8) to let the compiler make better inlining decisions

Follow-up to #32889 — same philosophy of consolidating per-op generated boilerplate into shared runtime helpers.

## Test plan

- [x] `cargo test -p deno_ops --lib` (122 tests pass)
- [x] `cargo test -p deno_core` (all pass)
- [x] `cargo check --bin deno` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)