### PR TITLE
docs: clarify mkdir does not throw with recursive: true

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -2639,7 +2639,8 @@ declare namespace Deno {
    * await Deno.mkdir("restricted_access_dir", { mode: 0o700 });
    * ```
    *
-   * Defaults to throwing error if the directory already exists.
+   * Throws if the directory already exists, unless `recursive` is set to
+   * `true`.
    *
    * Requires `allow-write` permission.
    *
@@ -2659,7 +2660,8 @@ declare namespace Deno {
    * Deno.mkdirSync("restricted_access_dir", { mode: 0o700 });
    * ```
    *
-   * Defaults to throwing error if the directory already exists.
+   * Throws if the directory already exists, unless `recursive` is set to
+   * `true`.
    *
    * Requires `allow-write` permission.
    *


### PR DESCRIPTION
The JSDoc for `Deno.mkdir` and `Deno.mkdirSync` said "Defaults to throwing error if the directory already exists" without mentioning that `recursive: true` suppresses this error.

The `MkdirOptions.recursive` property already documented this correctly, but the function-level docs were misleading. Changed to "Throws if the directory already exists, unless `recursive` is set to `true`."

Fixes #21768