### PR TITLE
test: prevent task/signals spec test from hanging in CI

### DIFF
--- a/tests/specs/task/signals/__test__.jsonc
+++ b/tests/specs/task/signals/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "timeout": 60,
+  "timeout": 45,
   // signals don't really exist on windows
   "if": "unix",
   // this runs a deno task

--- a/tests/specs/task/signals/sender.ts
+++ b/tests/specs/task/signals/sender.ts
@@ -40,16 +40,39 @@ const command = new Deno.Command(Deno.execPath(), {
 
 const child = command.spawn();
 const reader = new StdoutReader(child.stdout!);
-await reader.waitForText("Ready");
 
-for (const signal of signals) {
-  if (signal === "SIGTERM") {
-    continue;
+// Hard timeout: if anything hangs, SIGKILL the child (uncatchable) and fail.
+// This prevents the test from hanging for 30m waiting on CI timeout, since
+// the listener intercepts all signals including SIGTERM.
+const hardTimeout = setTimeout(() => {
+  console.error("Test timed out, sending SIGKILL to child");
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // child may have already exited
   }
-  console.error("Sending", signal);
-  child.kill(signal);
-  await reader.waitForText("Received " + signal);
-}
+  Deno.exit(1);
+}, 30_000);
 
-console.error("Sending SIGTERM");
-child.kill("SIGTERM");
+try {
+  await reader.waitForText("Ready");
+
+  for (const signal of signals) {
+    if (signal === "SIGTERM") {
+      continue;
+    }
+    console.error("Sending", signal);
+    child.kill(signal);
+    await reader.waitForText("Received " + signal);
+  }
+
+  console.error("Sending SIGTERM");
+  child.kill("SIGTERM");
+  const status = await child.status;
+  if (!status.success) {
+    console.error("Child exited with code", status.code);
+    Deno.exit(1);
+  }
+} finally {
+  clearTimeout(hardTimeout);
+}


### PR DESCRIPTION
## Summary

- The `task/signals` spec test registers signal handlers for **all** signals including SIGTERM in `listener.ts`, which means the test harness cannot kill it when the timeout fires — causing 30+ minute CI hangs
- Added a 30s hard timeout in `sender.ts` that SIGKILLs the child process (uncatchable) and exits with failure, so hangs fail fast with a clear error
- Now awaits `child.status` after sending SIGTERM to prevent orphaned processes

## Test plan
- [x] `./x test-spec signals` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)