### PR TITLE
fix(npm): resolve linked packages not published to npm registry

### DIFF
--- a/libs/npm/resolution/common.rs
+++ b/libs/npm/resolution/common.rs
@@ -15,6 +15,8 @@ use thiserror::Error;
 use crate::registry::NpmPackageInfo;
 use crate::registry::NpmPackageVersionInfo;
 use crate::registry::NpmPackageVersionInfosIterator;
+use crate::registry::NpmRegistryApi;
+use crate::registry::NpmRegistryPackageInfoLoadError;
 use crate::resolution::overrides::NpmOverrides;
 
 /// Error that occurs when the version is not found in the package information.
@@ -345,6 +347,60 @@ impl<'a> NpmPackageVersionResolver<'a> {
         dist_tag: tag.to_string(),
       })
     }
+  }
+}
+
+/// Creates a synthetic `NpmPackageInfo` from link package version infos.
+/// Used when a package exists only as a workspace link and is not published
+/// to the npm registry.
+fn create_link_package_info(
+  name: &PackageName,
+  versions: &[NpmPackageVersionInfo],
+) -> Arc<NpmPackageInfo> {
+  let mut version_map = HashMap::new();
+  let mut latest_version: Option<&Version> = None;
+  for info in versions {
+    let is_newer = latest_version.map(|v| info.version > *v).unwrap_or(true);
+    if is_newer {
+      latest_version = Some(&info.version);
+    }
+    version_map.insert(info.version.clone(), info.clone());
+  }
+  let mut dist_tags = HashMap::new();
+  if let Some(latest) = latest_version {
+    dist_tags.insert("latest".to_string(), latest.clone());
+  }
+  Arc::new(NpmPackageInfo {
+    name: name.clone(),
+    versions: version_map,
+    dist_tags,
+    time: HashMap::new(),
+  })
+}
+
+/// Fetches package info from the npm registry, falling back to link packages
+/// if the package does not exist on the registry. This allows packages that
+/// are only linked locally (not published to npm) to be resolved.
+pub async fn package_info_or_link_fallback(
+  api: &(impl NpmRegistryApi + ?Sized),
+  name: &str,
+  link_packages: &HashMap<PackageName, Vec<NpmPackageVersionInfo>>,
+) -> Result<Arc<NpmPackageInfo>, NpmRegistryPackageInfoLoadError> {
+  let package_name = PackageName::from_str(name);
+  let link_versions = link_packages.get(&package_name);
+  let has_link = link_versions.is_some_and(|v| !v.is_empty());
+
+  match api.package_info(name).await {
+    Ok(info) => Ok(info),
+    Err(NpmRegistryPackageInfoLoadError::PackageNotExists { .. })
+      if has_link =>
+    {
+      Ok(create_link_package_info(
+        &package_name,
+        link_versions.unwrap(),
+      ))
+    }
+    Err(err) => Err(err),
   }
 }
 

--- a/libs/npm/resolution/graph.rs
+++ b/libs/npm/resolution/graph.rs
@@ -31,6 +31,7 @@ use thiserror::Error;
 use super::common::NpmPackageVersionResolutionError;
 use super::common::NpmPackageVersionResolver;
 use super::common::NpmVersionResolver;
+use super::common::package_info_or_link_fallback;
 use super::overrides::NpmOverrides;
 use super::snapshot::NpmResolutionSnapshot;
 use crate::NpmPackageId;
@@ -827,7 +828,9 @@ impl Graph {
       }
 
       pending_futures.push_back(async move {
-        let package_info = api.package_info(&pkg_id.nv.name).await?;
+        let package_info =
+          package_info_or_link_fallback(api, &pkg_id.nv.name, link_packages)
+            .await?;
         Ok::<_, NpmRegistryPackageInfoLoadError>((
           pkg_id,
           dependencies,
@@ -1508,7 +1511,13 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       }
 
       // Resolve from registry and add to fallback (not root_packages)
-      let package_info = match self.api.package_info(name.as_str()).await {
+      let package_info = match package_info_or_link_fallback(
+        self.api,
+        name.as_str(),
+        &self.version_resolver.link_packages,
+      )
+      .await
+      {
         Ok(info) => info,
         Err(_) => continue,
       };
@@ -2493,6 +2502,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       parent_id: usize,
       work: &mut FuturesUnordered<WorkFuture<'a>>,
       api: &'a (impl NpmRegistryApi + ?Sized),
+      link_packages: &'a HashMap<PackageName, Vec<NpmPackageVersionInfo>>,
     ) {
       for (dep_index, dep) in deps.iter().enumerate() {
         let name = overrides
@@ -2500,7 +2510,8 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
           .cloned()
           .unwrap_or_else(|| dep.name.clone());
         work.push(Box::pin(async move {
-          let result = api.package_info(&name).await;
+          let result =
+            package_info_or_link_fallback(api, &name, link_packages).await;
           FetchEvent::DepInfo {
             parent_id,
             dep_index,
@@ -2518,6 +2529,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       work: &mut FuturesUnordered<WorkFuture<'a>>,
       trackers: &mut Vec<ParentState>,
       api: &'a (impl NpmRegistryApi + ?Sized),
+      link_packages: &'a HashMap<PackageName, Vec<NpmPackageVersionInfo>>,
     ) {
       while let Some(parent_path) = pending.pop_front() {
         let node_id = parent_path.node_id();
@@ -2540,6 +2552,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
             parent_id,
             work,
             api,
+            link_packages,
           );
           trackers.push(ParentState::Pending {
             path: parent_path,
@@ -2552,7 +2565,8 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
           trackers.push(ParentState::AwaitingParentInfo);
           let nv = pkg_nv;
           work.push(Box::pin(async move {
-            let result = api.package_info(&nv.name).await;
+            let result =
+              package_info_or_link_fallback(api, &nv.name, link_packages).await;
             FetchEvent::ParentInfo {
               id: parent_id,
               path: parent_path,
@@ -2565,6 +2579,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     }
 
     let api = self.api;
+    let link_packages = &*self.version_resolver.link_packages;
     let mut work: FuturesUnordered<WorkFuture<'_>> = FuturesUnordered::new();
     let mut trackers: Vec<ParentState> = Vec::new();
     let mut next_to_retire: usize = 0;
@@ -2576,6 +2591,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
       &mut work,
       &mut trackers,
       api,
+      link_packages,
     );
 
     while let Some(event) = work.next().await {
@@ -2603,6 +2619,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
               id,
               &mut work,
               api,
+              link_packages,
             );
             trackers[id] = ParentState::Pending {
               path,
@@ -2682,6 +2699,7 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
             &mut work,
             &mut trackers,
             api,
+            link_packages,
           );
         }
         next_to_retire += 1;
@@ -3033,8 +3051,10 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
           pending_dep_entries.push_back((node_id, deps.clone()));
         } else {
           let api = self.api;
+          let link_pkgs = &*self.version_resolver.link_packages;
           futures.push(async move {
-            let package_info = api.package_info(&nv.name).await?;
+            let package_info =
+              package_info_or_link_fallback(api, &nv.name, link_pkgs).await?;
             Result::<_, NpmResolutionError>::Ok((node_id, nv, package_info))
           });
         }
@@ -3288,7 +3308,13 @@ impl<'a, TNpmRegistryApi: NpmRegistryApi>
     by_version: &BTreeMap<Version, Vec<VersionReq>>,
   ) -> HashMap<VersionReq, Version> {
     // this should already be cached
-    let package_info = self.api.package_info(package_name).await.unwrap();
+    let package_info = package_info_or_link_fallback(
+      self.api,
+      package_name,
+      &self.version_resolver.link_packages,
+    )
+    .await
+    .unwrap();
     let version_resolver = self.version_resolver.get_for_package(&package_info);
 
     // collect unique reqs across all versions
@@ -6671,6 +6697,98 @@ mod test {
   }
 
   #[tokio::test]
+  async fn link_package_not_on_registry() {
+    // Test that a package which only exists as a link (not published to npm)
+    // can be resolved successfully. This is the scenario from issue #33010.
+    let api = TestNpmRegistryApi::default();
+    api.ensure_package_version("package-a", "1.0.0");
+    // package-a depends on local-only-pkg which is NOT on the registry
+    api.add_dependency(("package-a", "1.0.0"), ("local-only-pkg", "^1.0.0"));
+
+    let link_packages = HashMap::from([(
+      PackageName::from_static("local-only-pkg"),
+      vec![NpmPackageVersionInfo {
+        version: Version::parse_standard("1.0.0").unwrap(),
+        ..Default::default()
+      }],
+    )]);
+
+    let (packages, package_reqs) = run_resolver_with_options_and_get_output(
+      api,
+      RunResolverOptions {
+        reqs: vec!["package-a@1.0.0"],
+        link_packages: Some(&link_packages),
+        ..Default::default()
+      },
+    )
+    .await;
+
+    assert_eq!(
+      packages,
+      vec![
+        TestNpmResolutionPackage {
+          pkg_id: "local-only-pkg@1.0.0".to_string(),
+          copy_index: 0,
+          dependencies: Default::default(),
+        },
+        TestNpmResolutionPackage {
+          pkg_id: "package-a@1.0.0".to_string(),
+          copy_index: 0,
+          dependencies: BTreeMap::from([(
+            "local-only-pkg".to_string(),
+            "local-only-pkg@1.0.0".to_string(),
+          )]),
+        },
+      ]
+    );
+    assert_eq!(
+      package_reqs,
+      vec![("package-a@1.0.0".to_string(), "package-a@1.0.0".to_string())]
+    );
+  }
+
+  #[tokio::test]
+  async fn link_package_not_on_registry_as_root() {
+    // Test that a link-only package can be resolved when it is the
+    // root/top-level package requirement.
+    let api = TestNpmRegistryApi::default();
+
+    let link_packages = HashMap::from([(
+      PackageName::from_static("my-local-pkg"),
+      vec![NpmPackageVersionInfo {
+        version: Version::parse_standard("2.0.0").unwrap(),
+        ..Default::default()
+      }],
+    )]);
+
+    let (packages, package_reqs) = run_resolver_with_options_and_get_output(
+      api,
+      RunResolverOptions {
+        reqs: vec!["my-local-pkg@^2.0.0"],
+        link_packages: Some(&link_packages),
+        ..Default::default()
+      },
+    )
+    .await;
+
+    assert_eq!(
+      packages,
+      vec![TestNpmResolutionPackage {
+        pkg_id: "my-local-pkg@2.0.0".to_string(),
+        copy_index: 0,
+        dependencies: Default::default(),
+      }]
+    );
+    assert_eq!(
+      package_reqs,
+      vec![(
+        "my-local-pkg@^2.0.0".to_string(),
+        "my-local-pkg@2.0.0".to_string()
+      )]
+    );
+  }
+
+  #[tokio::test]
   async fn link_package_tag() {
     let api = TestNpmRegistryApi::default();
     api.ensure_package_version("package-a", "1.0.0");
@@ -7790,8 +7908,10 @@ mod test {
 
     for req in options.reqs {
       let req = PackageReq::from_str(req).unwrap();
-      resolver
-        .add_package_req(&req, &api.package_info(&req.name).await.unwrap())?;
+      let info = package_info_or_link_fallback(api, &req.name, &link_packages)
+        .await
+        .unwrap();
+      resolver.add_package_req(&req, &info)?;
     }
 
     resolver.resolve_pending().await?;

--- a/libs/npm/resolution/snapshot.rs
+++ b/libs/npm/resolution/snapshot.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 use super::NpmPackageVersionNotFound;
 use super::UnmetPeerDepDiagnostic;
 use super::common::NpmVersionResolver;
+use super::common::package_info_or_link_fallback;
 use super::graph::Graph;
 use super::graph::GraphDependencyResolver;
 use super::graph::NpmResolutionError;
@@ -314,6 +315,7 @@ impl NpmResolutionSnapshot {
     // convert the snapshot to a traversable graph
     let mut graph = Graph::from_snapshot(self);
 
+    let link_packages = &*options.version_resolver.link_packages;
     let reqs_with_in_graph = options
       .package_reqs
       .iter()
@@ -323,7 +325,9 @@ impl NpmResolutionSnapshot {
         let maybe_info = if let Some(nv) = maybe_nv {
           InfoOrNv::Nv(nv)
         } else {
-          InfoOrNv::InfoResult(api.package_info(&req.name).await)
+          InfoOrNv::InfoResult(
+            package_info_or_link_fallback(api, &req.name, link_packages).await,
+          )
         };
         (req, maybe_info)
       })

--- a/tests/specs/npm/link_npm_package_not_on_registry/__test__.jsonc
+++ b/tests/specs/npm/link_npm_package_not_on_registry/__test__.jsonc
@@ -1,0 +1,9 @@
+{
+  "tempDir": true,
+  "tests": {
+    "node_modules_dir_auto": {
+      "args": "run --node-modules-dir=auto main/main.ts",
+      "output": "[WILDCARD]Hello, world!\n"
+    }
+  }
+}

--- a/tests/specs/npm/link_npm_package_not_on_registry/main/deno.json
+++ b/tests/specs/npm/link_npm_package_not_on_registry/main/deno.json
@@ -1,0 +1,5 @@
+{
+  "links": [
+    "../my-local-pkg"
+  ]
+}

--- a/tests/specs/npm/link_npm_package_not_on_registry/main/main.ts
+++ b/tests/specs/npm/link_npm_package_not_on_registry/main/main.ts
@@ -1,0 +1,3 @@
+import { greet } from "@denotest/not-on-registry-local-pkg";
+
+console.log(greet("world"));

--- a/tests/specs/npm/link_npm_package_not_on_registry/main/package.json
+++ b/tests/specs/npm/link_npm_package_not_on_registry/main/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@denotest/not-on-registry-local-pkg": "^1.0.0"
+  }
+}

--- a/tests/specs/npm/link_npm_package_not_on_registry/my-local-pkg/main.mjs
+++ b/tests/specs/npm/link_npm_package_not_on_registry/my-local-pkg/main.mjs
@@ -1,0 +1,3 @@
+export function greet(name) {
+  return `Hello, ${name}!`;
+}

--- a/tests/specs/npm/link_npm_package_not_on_registry/my-local-pkg/package.json
+++ b/tests/specs/npm/link_npm_package_not_on_registry/my-local-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@denotest/not-on-registry-local-pkg",
+  "version": "1.0.0",
+  "exports": "./main.mjs"
+}


### PR DESCRIPTION
## Summary

- Fixes the case where `"links"` in `deno.json` references a local npm package that has **not been published** to the npm registry
- Added `package_info_or_link_fallback()` helper that falls back to creating a synthetic `NpmPackageInfo` from link package data when the registry returns `PackageNotExists`
- Applied this fallback at all `api.package_info()` call sites in the npm resolution code (`snapshot.rs` and `graph.rs`)

The link package data was already being properly parsed and stored, but the resolution code always fetched from the npm registry first. For unpublished packages, this failed before link packages were ever consulted.

Closes #33010

## Test plan

- [x] Added 2 unit tests in `libs/npm/resolution/graph.rs`: `link_package_not_on_registry` (transitive dep) and `link_package_not_on_registry_as_root` (root req)
- [x] Added spec test `tests/specs/npm/link_npm_package_not_on_registry/`
- [x] All existing `link_npm_package_*` spec tests pass (7/7)
- [x] All `deno_npm` crate tests pass (179/179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)