### PR TITLE
fix(prompt): prevent extra newline when stdin is closed

### DIFF
--- a/runtime/js/41_prompt.js
+++ b/runtime/js/41_prompt.js
@@ -1,6 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { core, primordials } from "ext:core/mod.js";
-import { op_read_line_prompt } from "ext:core/ops";
 const { ArrayPrototypePush, StringPrototypeCharCodeAt, Uint8Array } =
   primordials;
 
@@ -38,8 +37,19 @@ function prompt(message = "Prompt", defaultValue) {
     return null;
   }
 
-  const formattedMessage = message.length === 0 ? "" : `${message} `;
-  return op_read_line_prompt(formattedMessage, `${defaultValue}`);
+  let formattedMessage = message.length === 0 ? "" : `${message} `;
+  if (defaultValue !== "") {
+    formattedMessage += `[${defaultValue}] `;
+  }
+
+  core.print(formattedMessage, false);
+
+  const answer = readLineFromStdinSync();
+
+  if (answer === "" && defaultValue !== "") {
+    return defaultValue;
+  }
+  return answer === "" ? null : answer;
 }
 
 function readLineFromStdinSync() {

--- a/tests/specs/run/prompt_stdin_eof/__test__.jsonc
+++ b/tests/specs/run/prompt_stdin_eof/__test__.jsonc
@@ -1,0 +1,5 @@
+{
+  "args": "run --quiet --allow-all main.ts",
+  "stdin": "null",
+  "output": "What is your name? [Jane] Name: Jane\nEnter something: Input: null\n"
+}

--- a/tests/specs/run/prompt_stdin_eof/main.ts
+++ b/tests/specs/run/prompt_stdin_eof/main.ts
@@ -1,0 +1,8 @@
+// Test that prompt() does not output extra newline when stdin is closed
+// Issue: https://github.com/denoland/deno/issues/22956
+
+const name = prompt("What is your name?", "Jane");
+console.log(`Name: ${name}`);
+
+const input = prompt("Enter something:");
+console.log(`Input: ${input}`);


### PR DESCRIPTION
This change fixes an issue where prompt() would output an extra newline when stdin is closed (e.g., Ctrl+D), unlike confirm() which handles this correctly.

The fix replaces the use of op_read_line_prompt (which uses rustyline and outputs a newline on EOF) with readLineFromStdinSync (the same method used by confirm()), ensuring consistent behavior between prompt() and confirm().

Fixes #22956