### PR TITLE
fix(node/tty): preserve reopened stdio tty fds

### DIFF
--- a/ext/node/polyfills/tty.js
+++ b/ext/node/polyfills/tty.js
@@ -11,7 +11,7 @@ import {
   ERR_INVALID_FD,
   ERR_TTY_INIT_FAILED,
 } from "ext:deno_node/internal/errors.ts";
-import { op_tty_check_fd_permission, TTY } from "ext:core/ops";
+import { op_node_is_tty, op_tty_check_fd_permission, TTY } from "ext:core/ops";
 import { Socket } from "node:net";
 import { setReadStream } from "ext:deno_node/_process/streams.mjs";
 import { WriteStream } from "ext:deno_node/internal/tty.js";
@@ -21,7 +21,7 @@ function isatty(fd) {
   if (typeof fd !== "number" || fd >> 0 !== fd || fd < 0) {
     return false;
   }
-  return TTY.isTTY(fd);
+  return op_node_is_tty(fd);
 }
 
 // ReadStream needs to be callable without `new` to match Node.js behavior.

--- a/tests/unit_node/tty_test.ts
+++ b/tests/unit_node/tty_test.ts
@@ -65,6 +65,88 @@ Deno.test("[node/tty isatty] returns false for raw file fd", () => {
 });
 
 Deno.test({
+  name: "[node/tty isatty] preserves reopened stdio tty descriptors",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const helper = `
+      import fs from "node:fs";
+      import tty from "node:tty";
+
+      const descriptors = [
+        [0, "/dev/stdin", "r"],
+        [1, "/dev/stdout", "w"],
+        [2, "/dev/stderr", "w"],
+      ];
+
+      if (!descriptors.every(([fd]) => tty.isatty(fd))) {
+        console.log("SKIP");
+        process.exit(0);
+      }
+
+      for (const [fd, path, flags] of descriptors) {
+        const reopenedFd = fs.openSync(path, flags);
+        try {
+          if (!tty.isatty(reopenedFd)) {
+            console.error(
+              "NOT_TTY:" + JSON.stringify({ fd, path, reopenedFd }),
+            );
+            process.exit(1);
+          }
+        } finally {
+          fs.closeSync(reopenedFd);
+        }
+      }
+
+      console.log("OK");
+    `;
+
+    const tmpScript = await Deno.makeTempFile({ suffix: ".mjs" });
+    await Deno.writeTextFile(tmpScript, helper);
+    const denoCmd =
+      `${Deno.execPath()} run --allow-read --allow-write ${tmpScript}`;
+    const scriptArgs = Deno.build.os === "linux"
+      ? ["-q", "/dev/null", "-c", denoCmd]
+      : [
+        "-q",
+        "/dev/null",
+        Deno.execPath(),
+        "run",
+        "--allow-read",
+        "--allow-write",
+        tmpScript,
+      ];
+
+    let output;
+    try {
+      output = await new Deno.Command("script", {
+        args: scriptArgs,
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+    } catch (error) {
+      await Deno.remove(tmpScript);
+      if (error instanceof Deno.errors.NotFound) {
+        return;
+      }
+      throw error;
+    }
+
+    await Deno.remove(tmpScript);
+    const stdout = new TextDecoder().decode(output.stdout);
+    const stderr = new TextDecoder().decode(output.stderr);
+
+    if (stdout.includes("SKIP")) {
+      return;
+    }
+
+    assert(
+      output.success,
+      `Reopened stdio descriptors should preserve tty status: ${stdout} ${stderr}`,
+    );
+  },
+});
+
+Deno.test({
   name: "[node/tty] HandleWrap.close calls uv_close for TTY handles",
   ignore: Deno.build.os === "windows",
   fn: async () => {


### PR DESCRIPTION
Fixes #32995.

## Summary
- switch `node:tty`'s `isatty()` polyfill from `TTY.isTTY(fd)`/`uv_guess_handle()` to the dedicated `op_node_is_tty(fd)` platform check
- add a Unix regression that runs under `script(1)` and reopens `/dev/stdin`, `/dev/stdout`, and `/dev/stderr` so the reopened descriptors are verified against a real PTY

## Validation
- `git diff --check`
- `cargo +stable build -p test_server`
- `cargo +stable test -p unit_node_tests --test unit_node -- --list | Select-String tty`
- `cargo +stable build -p deno` currently fails on this Windows host because `cmake` is not installed, so I could not run the patched `tty_test.ts` end-to-end locally