### PR TITLE
fix(ext/crypto): validate malformed X25519 imports

### DIFF
--- a/ext/crypto/00_crypto.js
+++ b/ext/crypto/00_crypto.js
@@ -2634,6 +2634,31 @@ function importKeyEd25519(
   }
 }
 
+function invalidOkpKeyDataError(kind = "key") {
+  if (kind === "key") {
+    return new DOMException("Invalid key data", "DataError");
+  }
+  return new DOMException(`Invalid ${kind} key data`, "DataError");
+}
+
+function validateOkpKeyDataLength(keyData, expectedLength, kind = "key") {
+  if (TypedArrayPrototypeGetByteLength(keyData) !== expectedLength) {
+    throw invalidOkpKeyDataError(kind);
+  }
+  return keyData;
+}
+
+function decodeOkpKeyData(encodedKeyData, expectedLength, kind = "key") {
+  let keyData;
+  try {
+    keyData = op_crypto_base64url_decode(encodedKeyData);
+  } catch (_) {
+    throw invalidOkpKeyDataError(kind);
+  }
+
+  return validateOkpKeyDataLength(keyData, expectedLength, kind);
+}
+
 function importKeyX25519(
   format,
   keyData,
@@ -2646,6 +2671,8 @@ function importKeyX25519(
       if (keyUsages.length > 0) {
         throw new DOMException("Invalid key usage", "SyntaxError");
       }
+
+      validateOkpKeyDataLength(keyData, 32);
 
       const handle = {};
       WeakMapPrototypeSet(KEY_STORE, handle, keyData);
@@ -2798,7 +2825,11 @@ function importKeyX25519(
       // 9.
       if (jwk.d !== undefined) {
         // https://www.rfc-editor.org/rfc/rfc8037#section-2
-        const privateKeyData = op_crypto_base64url_decode(jwk.d);
+        const privateKeyData = decodeOkpKeyData(jwk.d, 32, "private");
+        decodeOkpKeyData(jwk.x, 32, "public");
+        if (op_crypto_x25519_public_key(privateKeyData) !== jwk.x) {
+          throw new DOMException("Invalid key data", "DataError");
+        }
 
         const handle = {};
         WeakMapPrototypeSet(KEY_STORE, handle, privateKeyData);
@@ -2816,7 +2847,7 @@ function importKeyX25519(
         );
       } else {
         // https://www.rfc-editor.org/rfc/rfc8037#section-2
-        const publicKeyData = op_crypto_base64url_decode(jwk.x);
+        const publicKeyData = decodeOkpKeyData(jwk.x, 32, "public");
 
         const handle = {};
         WeakMapPrototypeSet(KEY_STORE, handle, publicKeyData);

--- a/tests/unit/webcrypto_test.ts
+++ b/tests/unit/webcrypto_test.ts
@@ -2193,6 +2193,68 @@ Deno.test(async function x25519ExportJwk() {
   assert(jwk.x);
 });
 
+// Regression test for https://github.com/denoland/deno/issues/33032
+Deno.test("crypto.subtle.importKey raw X25519 rejects malformed public keys", async () => {
+  await assertRejects(
+    () =>
+      crypto.subtle.importKey(
+        "raw",
+        new Uint8Array(0),
+        "X25519",
+        false,
+        [],
+      ),
+    DOMException,
+    "Invalid key data",
+  );
+});
+
+Deno.test("crypto.subtle.importKey jwk X25519 rejects missing or mismatched public keys", async () => {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "X25519",
+    },
+    true,
+    ["deriveKey"],
+  ) as CryptoKeyPair;
+
+  const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
+  assert(privateJwk.x);
+
+  const privateJwkWithoutX = { ...privateJwk };
+  delete privateJwkWithoutX.x;
+
+  await assertRejects(
+    () =>
+      crypto.subtle.importKey(
+        "jwk",
+        privateJwkWithoutX,
+        { name: "X25519" },
+        false,
+        ["deriveKey"],
+      ),
+    DOMException,
+    "Invalid public key data",
+  );
+
+  const mismatchedX = `${privateJwk.x.slice(0, -1)}${
+    privateJwk.x.endsWith("A") ? "B" : "A"
+  }`;
+
+  await assertRejects(
+    () =>
+      crypto.subtle.importKey(
+        "jwk",
+        { ...privateJwk, x: mismatchedX },
+        { name: "X25519" },
+        false,
+        ["deriveKey"],
+      ),
+    DOMException,
+    "Invalid key data",
+  );
+});
+
 // Regression test for https://github.com/denoland/deno/issues/30243
 // Importing a PKCS#8 RSA key with the wrong algorithm (ECDSA) should throw, not panic.
 Deno.test("crypto.subtle.importKey PKCS#8 with wrong algorithm does not panic", async () => {

--- a/tests/wpt/runner/expectations/WebCryptoAPI.json
+++ b/tests/wpt/runner/expectations/WebCryptoAPI.json
@@ -1828,62 +1828,6 @@
         "Invalid 'alg' field 'ED448': importKey(jwk (public) , {name: Ed448}, true, [verify])"
       ]
     },
-    "okp_importKey_failures_X25519.https.any.html": {
-      "expectedFailures": [
-        "Bad key length: importKey(raw, {name: X25519}, true, [])",
-        "Bad key length: importKey(raw, {name: X25519}, false, [])",
-        "Bad key length: importKey(jwk (public) , {name: X25519}, true, [])",
-        "Bad key length: importKey(jwk (public) , {name: X25519}, false, [])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])"
-      ]
-    },
-    "okp_importKey_failures_X25519.https.any.worker.html": {
-      "expectedFailures": [
-        "Bad key length: importKey(raw, {name: X25519}, true, [])",
-        "Bad key length: importKey(raw, {name: X25519}, false, [])",
-        "Bad key length: importKey(jwk (public) , {name: X25519}, true, [])",
-        "Bad key length: importKey(jwk (public) , {name: X25519}, false, [])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveBits])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveBits])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Bad key length: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits, deriveKey])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Missing JWK 'x' parameter: importKey(jwk(private), {name: X25519}, false, [deriveKey, deriveBits, deriveKey, deriveBits])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits, deriveKey])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveBits])",
-        "Invalid key pair: importKey(jwk(private), {name: X25519}, true, [deriveKey, deriveBits, deriveKey, deriveBits])"
-      ]
-    },
     "okp_importKey_failures_X448.https.any.html": {
       "expectedFailures": [
         "Empty usages: importKey(pkcs8, {name: X448}, true, [])",


### PR DESCRIPTION
## Summary
- reject malformed X25519 raw imports before they can reach deriveBits or deriveKey
- validate X25519 JWK imports for required 32-byte key material and matching private/public key pairs
- add focused WebCrypto regressions and drop the resolved X25519 WPT expected failures

Fixes #33032.

## Testing
- `cargo +stable test -p unit_tests --test unit -- x25519`
- `npx --yes dprint@0.47.2 check --config=.dprint.json ext/crypto/00_crypto.js tests/unit/webcrypto_test.ts`
- `git diff --check`

## Notes
- Repo-pinned Rust `1.92.0` cargo is broken on this host (`cargo.exe` reported it is not applicable to the `1.92.0-x86_64-pc-windows-msvc` toolchain), so the targeted unit run used `cargo +stable`.
- Building the full `deno` binary for repo-wide `tools/format.js` or WPT execution is blocked on this Windows host because `cmake` is not installed (`libz-sys` build script failure).