### PR TITLE
fix(lsp): align RequestInit with deno check

### DIFF
--- a/cli/tsc/dts/node/globals.d.cts
+++ b/cli/tsc/dts/node/globals.d.cts
@@ -2,19 +2,21 @@ export {}; // Make this a module
 
 // #region Fetch and friends
 // Conditional type aliases, used at the end of this file.
-// Will either be empty if lib.dom (or lib.webworker) is included, or the undici version otherwise.
-type _Request = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").Request;
-type _Response = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").Response;
-type _FormData = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").FormData;
-type _Headers = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").Headers;
-type _MessageEvent = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").MessageEvent;
-type _RequestInit = typeof globalThis extends { onmessage: any } ? {}
+// Deno's web globals do not expose `onmessage` on `globalThis`, so detect an
+// existing web platform surface via `Blob` before falling back to undici.
+type _HasWebFetchGlobals = typeof globalThis extends { Blob: any } ? true : false;
+type _Request = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").Request;
+type _Response = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").Response;
+type _FormData = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").FormData;
+type _Headers = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").Headers;
+type _MessageEvent = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").MessageEvent;
+type _RequestInit = _HasWebFetchGlobals extends true ? {}
     : import("./undici/index.d.ts").RequestInit;
-type _ResponseInit = typeof globalThis extends { onmessage: any } ? {}
+type _ResponseInit = _HasWebFetchGlobals extends true ? {}
     : import("./undici/index.d.ts").ResponseInit;
-type _WebSocket = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").WebSocket;
-type _EventSource = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").EventSource;
-type _CloseEvent = typeof globalThis extends { onmessage: any } ? {} : import("./undici/index.d.ts").CloseEvent;
+type _WebSocket = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").WebSocket;
+type _EventSource = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").EventSource;
+type _CloseEvent = _HasWebFetchGlobals extends true ? {} : import("./undici/index.d.ts").CloseEvent;
 // #endregion Fetch and friends
 
 // Conditional type definitions for webstorage interface, which conflicts with lib.dom otherwise.

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -17488,6 +17488,32 @@ fn lsp_tsconfig_node_modules_dts_diagnostics(use_tsgo: bool) {
 }
 
 #[test(timeout = 300, fork_with_suffix = "_tsgo")]
+fn lsp_requestinit_matches_check(use_tsgo: bool) {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("deno.json", json!({}).to_string());
+  temp_dir.write(
+    "tsconfig.json",
+    json!({
+      "include": ["scoped-by-tsconfig.ts"],
+    })
+    .to_string(),
+  );
+  let file = temp_dir.source_file(
+    "main.ts",
+    concat!(
+      "const init: Parameters<typeof fetch>[1] = {};\n",
+      "const _request = new Request(\"https://deno.com\", init);\n",
+    ),
+  );
+  let mut client = context.new_lsp_command().set_use_tsgo(use_tsgo).build();
+  client.initialize_default();
+  let diagnostics = client.did_open_file(&file);
+  assert_eq!(diagnostics.all(), vec![]);
+  client.shutdown();
+}
+
+#[test(timeout = 300, fork_with_suffix = "_tsgo")]
 fn lsp_tsconfig_root_dirs(use_tsgo: bool) {
   let context = TestContextBuilder::new()
     .use_http_server()


### PR DESCRIPTION
## Summary
- treat Deno's existing web fetch globals as the source of truth in `cli/tsc/dts/node/globals.d.cts` instead of falling back to undici when `globalThis.onmessage` is absent
- add an LSP regression that matches the issue repro where `Parameters<typeof fetch>[1]` should stay assignable to `new Request(..., init)` under a `tsconfig`-scoped file

## Testing
- `rustup run stable cargo test -p integration_tests --test integration lsp_requestinit_matches_check --no-run`
- `rustup run stable cargo fmt --check --all`
- `git diff --check`

## Local note
I also reran `rustup run stable cargo test -p integration_tests --test integration lsp_requestinit_matches_check -- --exact`, which now compiles the new integration target cleanly on this host but cannot execute the LSP harness because `target/debug/deno.exe` still isn't available locally. After adding a portable CMake binary, the remaining blocker for building `deno.exe` here is a missing `libclang` installation on this Windows machine.

Fixes #33012.