### PR TITLE
chore: upgrade sys_traits 0.1.25 -> 0.1.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10175,9 +10175,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.25"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24954f769b36305ab4dc502d095da5cfd9c697c73a8f2c0636a7fca76ff1f24b"
+checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
 dependencies = [
  "filetime",
  "getrandom 0.2.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ sourcemap = "9.1.2"
 static_assertions = "1"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
-sys_traits = "=0.1.25"
+sys_traits = "=0.1.27"
 tar = "=0.4.45"
 tempfile = "3.4.0"
 termcolor = "1.1.3"


### PR DESCRIPTION
## Summary
- Upgrades `sys_traits` crate from 0.1.25 to 0.1.27 (latest)

## Test plan
- [x] `cargo check` passes
- [x] `./x fmt` passes
- [x] `./x lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)