### PR TITLE
fix(watch): prevent Deno.exit() in SIGTERM handler from killing watcher

### DIFF
--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -406,6 +406,10 @@ where
     select! {
       _ = receiver_future => {},
       _ = deno_signals::ctrl_c() => {
+        // Suppress Deno.exit()/process.exit() during synthetic signal
+        // dispatch so SIGTERM handlers don't kill the watcher process.
+        deno_runtime::deno_os::suppress_exit();
+
         // Dispatch SIGINT (matching what Ctrl+C normally sends) and
         // SIGTERM to give JS code a chance for async cleanup. Some
         // libraries only listen for SIGINT, others for SIGTERM.
@@ -428,9 +432,15 @@ where
           )
           .await;
         }
+
+        deno_runtime::deno_os::unsuppress_exit();
         return Ok(());
       },
       _ = restart_rx.recv() => {
+        // Suppress Deno.exit()/process.exit() during synthetic signal
+        // dispatch so SIGTERM handlers don't kill the watcher process.
+        deno_runtime::deno_os::suppress_exit();
+
         // Dispatch SIGTERM to give JS code a chance for async cleanup
         // before restarting. If handlers are registered, wait for the
         // operation to finish gracefully before restarting.
@@ -445,6 +455,8 @@ where
           )
           .await;
         }
+
+        deno_runtime::deno_os::unsuppress_exit();
         deno_runtime::deno_inspector_server::notify_restart();
         print_after_restart();
         continue;

--- a/ext/os/lib.rs
+++ b/ext/os/lib.rs
@@ -6,6 +6,7 @@ use std::env;
 use std::ffi::OsString;
 use std::ops::ControlFlow;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 
@@ -39,6 +40,23 @@ impl ExitCode {
   pub fn set(&mut self, code: i32) {
     self.0.store(code, Ordering::Relaxed);
   }
+}
+
+/// Global flag: when true, `Deno.exit()` / `process.exit()` will NOT call
+/// `std::process::exit()`. Used by the file watcher to prevent SIGTERM
+/// handlers from killing the entire process during graceful restart.
+static EXIT_SUPPRESSED: AtomicBool = AtomicBool::new(false);
+
+pub fn suppress_exit() {
+  EXIT_SUPPRESSED.store(true, Ordering::Release);
+}
+
+pub fn unsuppress_exit() {
+  EXIT_SUPPRESSED.store(false, Ordering::Release);
+}
+
+fn is_exit_suppressed() -> bool {
+  EXIT_SUPPRESSED.load(Ordering::Acquire)
 }
 
 pub fn exit(code: i32) -> ! {
@@ -348,6 +366,11 @@ fn op_get_exit_code(state: &mut OpState) -> i32 {
 fn op_exit(state: &mut OpState) {
   if let Some(cbs) = state.try_borrow_mut::<OpExitCallbacks>() {
     cbs.run();
+  }
+  // In watch mode, during synthetic SIGTERM dispatch, suppress
+  // std::process::exit() so the watcher can restart the process.
+  if is_exit_suppressed() {
+    return;
   }
   if let Some(exit_code) = state.try_borrow::<ExitCode>() {
     exit(exit_code.get())


### PR DESCRIPTION
## Summary

Fixes #33043

When `--watch` mode dispatches synthetic SIGTERM before restarting (added in #32564), user code that calls `Deno.exit()` / `process.exit()` in the SIGTERM handler would call `std::process::exit()`, killing the entire OS process including the watcher. This prevented the restart.

**Fix:** A global `AtomicBool` flag (`EXIT_SUPPRESSED`) is set by the file watcher before dispatching synthetic signals and cleared after the graceful shutdown timeout. When the flag is set, `op_exit()` skips `std::process::exit()` and returns instead, allowing the event loop to drain naturally and the watcher to restart.

**Before:**
```
Watcher Process started.
Listening on http://0.0.0.0:8000/
Watcher Waiting for graceful termination...
Received SIGTERM. Cleaning up and exiting...
# process dead, no restart
```

**After:**
```
Watcher Process started.
Listening on http://0.0.0.0:8000/
Watcher Waiting for graceful termination...
Received SIGTERM. Cleaning up and exiting...
Watcher Restarting! File change detected: "main.ts"
Listening on http://0.0.0.0:8000/
```

## Test plan

- [x] Manual test: `deno run --watch --allow-net` with SIGTERM handler that calls `Deno.exit()` — watcher survives and restarts
- [ ] Existing watcher integration tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)