### PR TITLE
feat(runtime): add Deno.osArgv and Deno.osArgv0 APIs

### DIFF
--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -4728,6 +4728,50 @@ declare namespace Deno {
    */
   export const args: string[];
 
+  /** The full argument vector as passed by the operating system to the
+   * current process.
+   *
+   * Unlike {@linkcode Deno.args} which contains only the script arguments,
+   * this includes the runtime path, subcommand, flags, and script specifier
+   * that Deno normally consumes.
+   *
+   * ```sh
+   * $ deno run --allow-net main.ts --flag value
+   * ```
+   *
+   * ```ts
+   * console.log(Deno.osArgv);
+   * // ["deno", "run", "--allow-net", "main.ts", "--flag", "value"]
+   * console.log(Deno.args);
+   * // ["--flag", "value"]
+   * ```
+   *
+   * The returned array is frozen and cannot be modified.
+   *
+   * @category Runtime
+   */
+  export const osArgv: readonly string[];
+
+  /** The original `argv[0]` value as passed by the operating system, or the
+   * npm binary command name when running an npm package.
+   *
+   * This may differ from {@linkcode Deno.execPath} — for example, if Deno
+   * was invoked via `$PATH`, this could be just `"deno"` rather than the
+   * fully resolved path. For npm binaries, this is the package binary name.
+   *
+   * ```sh
+   * $ deno run main.ts
+   * ```
+   *
+   * ```ts
+   * console.log(Deno.osArgv0); // "deno"
+   * console.log(Deno.execPath()); // "/usr/bin/deno"
+   * ```
+   *
+   * @category Runtime
+   */
+  export const osArgv0: string;
+
   /** The URL of the entrypoint module entered from the command-line. It
    * requires read permission to the CWD.
    *

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -10,6 +10,7 @@ import {
   op_bootstrap_args,
   op_bootstrap_is_from_unconfigured_runtime,
   op_bootstrap_no_color,
+  op_bootstrap_os_argv,
   op_bootstrap_pid,
   op_bootstrap_stderr_no_color,
   op_bootstrap_stdout_no_color,
@@ -36,6 +37,7 @@ const {
   ObjectAssign,
   ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectFreeze,
   ObjectHasOwn,
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
@@ -300,7 +302,9 @@ function importScripts(...urls) {
 }
 
 const opArgs = memoizeLazy(() => op_bootstrap_args());
+const opOsArgv = memoizeLazy(() => ObjectFreeze(op_bootstrap_os_argv()));
 const opPid = memoizeLazy(() => op_bootstrap_pid());
+let bootstrapOsArgv0 = "";
 setNoColorFns(
   () => op_bootstrap_stdout_no_color(),
   () => op_bootstrap_stderr_no_color(),
@@ -588,6 +592,8 @@ ObjectDefineProperties(finalDenoNs, {
   ppid: core.propGetterOnly(() => op_ppid()),
   noColor: core.propGetterOnly(() => op_bootstrap_no_color()),
   args: core.propGetterOnly(opArgs),
+  osArgv: core.propGetterOnly(opOsArgv),
+  osArgv0: core.propGetterOnly(() => bootstrapOsArgv0),
   mainModule: core.propGetterOnly(() => op_main_module()),
   exitCode: {
     __proto__: null,
@@ -642,6 +648,7 @@ function bootstrapMainRuntime(runtimeOptions, warmup = false) {
       16: autoServe,
     } = runtimeOptions;
 
+    bootstrapOsArgv0 = argv0 ?? "";
     denoNs.build.standalone = standalone;
 
     let serveIsMain_ = serveIsMain;
@@ -845,6 +852,7 @@ function bootstrapWorkerRuntime(
       15: standalone,
     } = runtimeOptions;
 
+    bootstrapOsArgv0 = argv0 ?? "";
     denoNs.build.standalone = standalone;
 
     closeOnIdle = runtimeOptions[14];

--- a/runtime/ops/bootstrap.rs
+++ b/runtime/ops/bootstrap.rs
@@ -10,6 +10,7 @@ deno_core::extension!(
   deno_bootstrap,
   ops = [
     op_bootstrap_args,
+    op_bootstrap_os_argv,
     op_bootstrap_pid,
     op_bootstrap_numcpus,
     op_bootstrap_user_agent,
@@ -81,6 +82,11 @@ pub fn op_snapshot_options(state: &mut OpState) -> SnapshotOptions {
 #[op2]
 pub fn op_bootstrap_args(state: &mut OpState) -> Vec<String> {
   state.borrow::<BootstrapOptions>().args.clone()
+}
+
+#[op2]
+pub fn op_bootstrap_os_argv(_state: &mut OpState) -> Vec<String> {
+  std::env::args().collect()
 }
 
 #[op2(fast)]

--- a/tests/specs/run/deno_os_argv/__test__.jsonc
+++ b/tests/specs/run/deno_os_argv/__test__.jsonc
@@ -1,0 +1,20 @@
+{
+  "tests": {
+    "basic": {
+      "args": "run --quiet deno_os_argv.ts --user-arg1 --user-arg2",
+      "output": "deno_os_argv.out"
+    },
+    "flags_visible": {
+      "args": "run --allow-read --allow-net deno_os_argv_flags.ts",
+      "output": "deno_os_argv_flags.out"
+    },
+    "eval_mode": {
+      "args": "eval console.log(typeof(Deno.osArgv0)+','+Array.isArray(Deno.osArgv))",
+      "output": "deno_os_argv_eval.out"
+    },
+    "length_relationship": {
+      "args": "run --quiet deno_os_argv_length.ts arg1 arg2 arg3",
+      "output": "deno_os_argv_length.out"
+    }
+  }
+}

--- a/tests/specs/run/deno_os_argv/deno_os_argv.out
+++ b/tests/specs/run/deno_os_argv/deno_os_argv.out
@@ -1,0 +1,8 @@
+is array: true
+frozen: true
+has runtime: true
+has subcommand: true
+has script: true
+has user args: true
+osArgv0 is string: true
+osArgv0 non-empty: true

--- a/tests/specs/run/deno_os_argv/deno_os_argv.ts
+++ b/tests/specs/run/deno_os_argv/deno_os_argv.ts
@@ -1,0 +1,24 @@
+const osArgv = Deno.osArgv;
+
+// osArgv should contain the full OS argv
+console.log("is array:", Array.isArray(osArgv));
+console.log("frozen:", Object.isFrozen(osArgv));
+
+// First element should be the runtime path/name
+console.log("has runtime:", osArgv[0].length > 0);
+
+// Should contain "run" subcommand
+console.log("has subcommand:", osArgv.includes("run"));
+
+// Should contain the script name
+console.log(
+  "has script:",
+  osArgv.some((a: string) => a.endsWith("deno_os_argv.ts")),
+);
+
+// Should contain user args
+console.log("has user args:", osArgv.includes("--user-arg1"));
+
+// osArgv0 should be a non-empty string
+console.log("osArgv0 is string:", typeof Deno.osArgv0 === "string");
+console.log("osArgv0 non-empty:", Deno.osArgv0.length > 0);

--- a/tests/specs/run/deno_os_argv/deno_os_argv_eval.out
+++ b/tests/specs/run/deno_os_argv/deno_os_argv_eval.out
@@ -1,0 +1,1 @@
+string,true

--- a/tests/specs/run/deno_os_argv/deno_os_argv_flags.out
+++ b/tests/specs/run/deno_os_argv/deno_os_argv_flags.out
@@ -1,0 +1,3 @@
+has allow-read: true
+has allow-net: true
+args has no flags: true

--- a/tests/specs/run/deno_os_argv/deno_os_argv_flags.ts
+++ b/tests/specs/run/deno_os_argv/deno_os_argv_flags.ts
@@ -1,0 +1,5 @@
+// Deno flags like --allow-read should appear in osArgv but NOT in Deno.args
+const osArgv = Deno.osArgv;
+console.log("has allow-read:", osArgv.includes("--allow-read"));
+console.log("has allow-net:", osArgv.includes("--allow-net"));
+console.log("args has no flags:", !Deno.args.includes("--allow-read"));

--- a/tests/specs/run/deno_os_argv/deno_os_argv_length.out
+++ b/tests/specs/run/deno_os_argv/deno_os_argv_length.out
@@ -1,0 +1,3 @@
+tail matches args: true
+osArgv longer: true
+args count: 3

--- a/tests/specs/run/deno_os_argv/deno_os_argv_length.ts
+++ b/tests/specs/run/deno_os_argv/deno_os_argv_length.ts
@@ -1,0 +1,16 @@
+// osArgv should end with the same args as Deno.args
+const osArgv = Deno.osArgv;
+const args = Deno.args;
+
+// The tail of osArgv should match Deno.args
+const tail = osArgv.slice(osArgv.length - args.length);
+console.log(
+  "tail matches args:",
+  JSON.stringify(tail) === JSON.stringify(args),
+);
+
+// osArgv should be longer than Deno.args (has runtime + subcommand + script prefix)
+console.log("osArgv longer:", osArgv.length > args.length);
+
+// Deno.args count check
+console.log("args count:", args.length);


### PR DESCRIPTION
## Summary

OS-level process arguments are exposed to user-land / runtime APIs.

- **`Deno.osArgv`** — the full raw OS argument vector (`std::env::args()`),
  including the runtime path, subcommand, flags, and script specifier that Deno
  normally consumes. Returns a frozen `readonly string[]`.

- **`Deno.osArgv0`** — the logical `argv[0]`: either the binary command name
  or the raw OS `argv[0]`.

these functions won't require any permission, consistent with Deno.args and
Deno.execPath().

they free users from using `nodecompat` layer and importing `node:process`.

### Why `osArgv0` is not just `osArgv[0]`

`Deno.osArgv0` comes from `BootstrapOptions.argv0`, which resolves the _logical_
program name - for binaries this is the package name (e.g. `"eser"`), not
the deno runtime path. `Deno.osArgv[0]` would always be the raw OS argv[0] (e.g.
`"deno"` or `"/usr/bin/deno"`).

### Motivation

CLI tools distributed across multiple registries (npm, jsr, Homebrew) and
runtimes (Deno, Node, Bun) face a problem when they need to register
themselves with external hooks or tools: **there's no way to reconstruct the
exact invocation command.**

For example, my own CLI tool `eser` could be invoked in many ways:

```sh
eser action                  # installed via Homebrew or deno install
deno x jsr:@eser/cli action  # run from jsr
deno run npm:eser action     # run from npm
npx eser action              # npx (but I use a compatibility layer here)
pnpm x eser action           # same as npx
/custom/path/deno run main.ts action  # development
```

When registering with a git hook or an external tool, the CLI needs to tell
that tool *how to call it back*. Today, `Deno.args` only contains script
arguments (`["action"]`), and `Deno.execPath()` resolves through
`std::env::current_exe()` — neither preserves the original runtime path,
subcommand, flags, or package specifier.

With `Deno.osArgv`, the CLI can extract the invocation prefix and register
it reliably:

```ts
// Strip the user args to get the "how to run me" prefix
const prefix = Deno.osArgv.slice(0, Deno.osArgv.length - Deno.args.length);

// → ["deno", "run", "npm:eser"] or ["/opt/homebrew/bin/eser"]
// Register this prefix with the external hook
registerHook([...prefix, "hook-handler"]);
```

### Disclaimer

During implementation I get assistance of AI, Still, all code was reviewed
and validated by me.

### Example

```sh
$ deno run --allow-net main.ts --flag value
```

```ts
Deno.osArgv; // ["deno", "run", "--allow-net", "main.ts", "--flag", "value"]
Deno.osArgv0; // "deno"
Deno.execPath(); // "/home/user/.deno/bin/deno"
Deno.args; // ["--flag", "value"]
```

For npm binaries (`deno run npm:eser bla`):

```ts
Deno.osArgv; // ["/path/to/deno", "run", "npm:eser", "bla"]
Deno.osArgv0; // "eser"  (logical binary name, not "deno")
```

## Test plan

- [x] New spec test: `tests/specs/run/deno_os_argv/` (4 test cases)
- [x] Existing `_028_args` test still passes
- [x] Manual verification with `deno eval`
