### PR TITLE
chore: Use *mut _ and *const _ for type inference

### DIFF
--- a/ext/napi/node_api.rs
+++ b/ext/napi/node_api.rs
@@ -158,7 +158,7 @@ fn napi_fatal_error(
         std::ffi::CStr::from_ptr(location).to_str().unwrap()
       } else {
         let slice = std::slice::from_raw_parts(
-          location as *const u8,
+          location as *const _,
           location_len as usize,
         );
         std::str::from_utf8(slice).unwrap()
@@ -170,7 +170,7 @@ fn napi_fatal_error(
     unsafe { std::ffi::CStr::from_ptr(message).to_str().unwrap() }
   } else {
     let slice = unsafe {
-      std::slice::from_raw_parts(message as *const u8, message_len as usize)
+      std::slice::from_raw_parts(message as *const _, message_len as usize)
     };
     std::str::from_utf8(slice).unwrap()
   };

--- a/ext/napi/util.rs
+++ b/ext/napi/util.rs
@@ -122,7 +122,7 @@ pub(crate) unsafe fn check_new_from_utf8_len<'s>(
   let string = if len == NAPI_AUTO_LENGTH {
     unsafe { std::ffi::CStr::from_ptr(str_ as *const _) }.to_bytes()
   } else {
-    unsafe { std::slice::from_raw_parts(str_ as *const u8, len) }
+    unsafe { std::slice::from_raw_parts(str_ as *const _, len) }
   };
   let result = {
     let env = unsafe { &mut *(env as *mut Env) };

--- a/ext/node/ops/process.rs
+++ b/ext/node/ops/process.rs
@@ -90,7 +90,7 @@ unsafe fn compute_argv_info(
 ) -> ArgvInfo {
   // SAFETY: argv is valid and has argc entries (guaranteed by caller).
   unsafe {
-    let start = *argv as *mut u8;
+    let start = *argv as *mut _;
     let last_arg = *argv.add(argc - 1);
     let last_arg_len = libc::strlen(last_arg);
     let end = last_arg.add(last_arg_len + 1) as *const u8;

--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -379,7 +379,7 @@ fn free_uv_buf(buf: *const uv_buf_t) {
   unsafe {
     if !(*buf).base.is_null() && (*buf).len > 0 {
       let layout = std::alloc::Layout::from_size_align((*buf).len, 1).unwrap();
-      std::alloc::dealloc((*buf).base as *mut u8, layout);
+      std::alloc::dealloc((*buf).base as *mut _, layout);
     }
   }
 }


### PR DESCRIPTION
Replace explicit pointer type casts with underscore versions to allow the compiler to infer the correct types. This fixes type mismatch errors while maintaining type safety.

Noticed when running ./x lint on Linux aarch64
