### PR TITLE
fix: correct typo 'occured' to 'occurred' in permissions lib

### DIFF
--- a/runtime/permissions/lib.rs
+++ b/runtime/permissions/lib.rs
@@ -2585,7 +2585,7 @@ pub enum RunDescriptorArg {
 }
 
 pub enum AllowRunDescriptorParseResult {
-  /// An error occured getting the descriptor that should
+  /// An error occurred getting the descriptor that should
   /// be surfaced as a warning when launching deno, but should
   /// be ignored when creating a worker.
   Unresolved(Box<which::Error>),


### PR DESCRIPTION
## Summary

Fixed a minor spelling typo in a Rust doc comment in `runtime/permissions/lib.rs`.

### Change

```rust
// Before:
/// An error occured getting the descriptor that should

// After:
/// An error occurred getting the descriptor that should
```

Simple documentation-only fix — no logic changes.