### PR TITLE
fix(ext/node): add stub exports for vm.Module, SourceTextModule, SyntheticModule

### DIFF
--- a/ext/node/polyfills/vm.js
+++ b/ext/node/polyfills/vm.js
@@ -390,6 +390,28 @@ export function measureMemory(_options) {
   notImplemented("measureMemory");
 }
 
+// vm.Module, SourceTextModule, and SyntheticModule are not implemented.
+// These require the --experimental-vm-modules flag in Node.js.
+// See https://github.com/denoland/deno/issues/29917 for tracking.
+
+export class Module {
+  constructor() {
+    notImplemented("Module");
+  }
+}
+
+export class SourceTextModule {
+  constructor() {
+    notImplemented("SourceTextModule");
+  }
+}
+
+export class SyntheticModule {
+  constructor() {
+    notImplemented("SyntheticModule");
+  }
+}
+
 const USE_MAIN_CONTEXT_DEFAULT_LOADER = Symbol(
   "USE_MAIN_CONTEXT_DEFAULT_LOADER",
 );
@@ -406,6 +428,9 @@ ObjectFreeze(constants);
 export default {
   Script,
   constants,
+  Module,
+  SourceTextModule,
+  SyntheticModule,
   createContext,
   createScript,
   runInContext,


### PR DESCRIPTION
## Summary

The node:vm module documentation shows `Module`, `SourceTextModule`, and `SyntheticModule` as available, but they are not actually implemented in Deno. This commit adds stub exports that throw `notImplemented` errors when instantiated.

## Changes

- Added stub classes for `Module`, `SourceTextModule`, `SyntheticModule` in `ext/node/polyfills/vm.js`
- These classes throw `notImplemented` errors when instantiated

## Notes

These features require the `--experimental-vm-modules` flag in Node.js.

See https://github.com/denoland/deno/issues/29917 for tracking implementation.

Fixes #30294