### PR TITLE
fix(fmt): apply newlineKind option to JSON and Markdown files

### DIFF
--- a/cli/tools/fmt.rs
+++ b/cli/tools/fmt.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::Ordering;
 
 use async_trait::async_trait;
 use deno_ast::ParsedSource;
+use deno_config::deno_json::NewLineKind;
 use deno_config::deno_json::VueComponentCase as DenoVueComponentCase;
 use deno_config::glob::FileCollector;
 use deno_config::glob::FilePatterns;
@@ -1486,6 +1487,25 @@ fn get_resolved_markdown_config(
     });
   }
 
+  if let Some(new_line_kind) = options.new_line_kind {
+    builder.new_line_kind(match new_line_kind {
+      NewLineKind::Auto => dprint_core::configuration::NewLineKind::Auto,
+      NewLineKind::CarriageReturnLineFeed => {
+        dprint_core::configuration::NewLineKind::CarriageReturnLineFeed
+      }
+      NewLineKind::LineFeed => {
+        dprint_core::configuration::NewLineKind::LineFeed
+      }
+      NewLineKind::System => {
+        if cfg!(windows) {
+          dprint_core::configuration::NewLineKind::CarriageReturnLineFeed
+        } else {
+          dprint_core::configuration::NewLineKind::LineFeed
+        }
+      }
+    });
+  }
+
   builder.build()
 }
 
@@ -1507,6 +1527,25 @@ fn get_resolved_json_config(
 
   if let Some(indent_width) = options.indent_width {
     builder.indent_width(indent_width);
+  }
+
+  if let Some(new_line_kind) = options.new_line_kind {
+    builder.new_line_kind(match new_line_kind {
+      NewLineKind::Auto => dprint_core::configuration::NewLineKind::Auto,
+      NewLineKind::CarriageReturnLineFeed => {
+        dprint_core::configuration::NewLineKind::CarriageReturnLineFeed
+      }
+      NewLineKind::LineFeed => {
+        dprint_core::configuration::NewLineKind::LineFeed
+      }
+      NewLineKind::System => {
+        if cfg!(windows) {
+          dprint_core::configuration::NewLineKind::CarriageReturnLineFeed
+        } else {
+          dprint_core::configuration::NewLineKind::LineFeed
+        }
+      }
+    });
   }
 
   builder.build()


### PR DESCRIPTION
## Summary

Fixes an issue where the `fmt.newlineKind` option in `deno.json` was not applied to JSON and Markdown files, even though it worked correctly for TypeScript/JavaScript files.

## Problem

When setting `fmt.newlineKind` to "system" in `deno.json`:

- `.ts` files: Correctly uses system-appropriate line endings
- `.json` files: Always uses default line endings (ignored the option)
- `.md` files: Always uses default line endings (ignored the option)

## Root Cause

In `cli/tools/fmt.rs`:
- `get_typescript_config_builder` correctly handled `new_line_kind`
- `get_resolved_json_config` and `get_resolved_markdown_config` did NOT handle `new_line_kind`

## Solution

Added `new_line_kind` handling to both `get_resolved_json_config` and `get_resolved_markdown_config` functions, following the same pattern as `get_typescript_config_builder`.

## Changes

- `cli/tools/fmt.rs` (+39 lines)
- Added import for `deno_config::deno_json::NewLineKind`
- Added new_line_kind conversion logic to both JSON and Markdown config builders

## Testing

- Code follows existing patterns in `get_typescript_config_builder`
- CI will verify compilation and tests

Fixes #30665