### PR TITLE
fix(lsp): support new VSCode js/ts.* settings format

### DIFF
--- a/cli/lsp/config.rs
+++ b/cli/lsp/config.rs
@@ -833,6 +833,22 @@ impl WorkspaceSettings {
       .as_object()
       .and_then(|o| o.get("typescript").cloned())
       .unwrap_or_default();
+    // VSCode recently merged "typescript.*" and "javascript.*" settings into "js/ts.*"
+    // Use "js/ts" settings as fallback when "javascript" or "typescript" settings are not provided
+    let js_ts = deno
+      .as_object()
+      .and_then(|o| o.get("js/ts").cloned())
+      .unwrap_or_default();
+    let javascript = if javascript.is_null() {
+      js_ts.clone()
+    } else {
+      javascript
+    };
+    let typescript = if typescript.is_null() {
+      js_ts
+    } else {
+      typescript
+    };
     Self::from_raw_settings(deno, javascript, typescript)
   }
 }


### PR DESCRIPTION
## Summary

VSCode recently merged `typescript.*` and `javascript.*` settings into a unified `js/ts.*` settings format. This change adds support for the new format by using `js/ts` settings as fallback when `javascript` or `typescript` settings are not provided.

This ensures backward compatibility with existing settings while supporting the new VSCode settings format.

## Changes

- Modified `WorkspaceSettings::from_initialization_options` to check for `js/ts` settings
- When `javascript` settings is null, use `js/ts` settings as fallback
- When `typescript` settings is null, use `js/ts` settings as fallback

## Testing

The code follows the same pattern used for other settings fallbacks in the file.

Fixes #32940