### PR TITLE
fix(install): all package.json aliases should be added to node_modules

### DIFF
--- a/libs/npm_installer/local.rs
+++ b/libs/npm_installer/local.rs
@@ -717,8 +717,7 @@ impl<
           )?;
         } else {
           // symlink the package into `node_modules/<alias>`
-          if setup_cache
-            .insert_root_symlink(&remote_pkg.id.nv.name, &target_folder_name)
+          if setup_cache.insert_root_symlink(remote_alias, &target_folder_name)
           {
             symlink_package_dir(
               sys.as_ref(),

--- a/tests/specs/npm/aliases_same_pkg_node_modules/__test__.jsonc
+++ b/tests/specs/npm/aliases_same_pkg_node_modules/__test__.jsonc
@@ -1,0 +1,28 @@
+{
+  "tempDir": true,
+  "tests": {
+    "multiple_aliases_same_package": {
+      "steps": [
+        // Install with just one alias. This populates the setup cache
+        // with ("@denotest/add", "@denotest+add@1.0.0").
+        {
+          "args": "install",
+          "output": "[WILDCARD]"
+        },
+        // Add a second alias to the exact same package+version.
+        // The bug: insert_root_symlink used the real package name
+        // as the cache key, so the second alias's symlink was skipped
+        // because the cache already had an entry for "@denotest/add"
+        // with the same target folder.
+        {
+          "args": "install add-v2@npm:@denotest/add@1.0.0",
+          "output": "[WILDCARD]"
+        },
+        {
+          "args": "run main.js",
+          "output": "add-v1: 3\nadd-v2: 3\n"
+        }
+      ]
+    }
+  }
+}

--- a/tests/specs/npm/aliases_same_pkg_node_modules/main.js
+++ b/tests/specs/npm/aliases_same_pkg_node_modules/main.js
@@ -1,0 +1,5 @@
+import { add as add1 } from "add-v1";
+import { add as add2 } from "add-v2";
+
+console.log(`add-v1: ${add1(1, 2)}`);
+console.log(`add-v2: ${add2(1, 2)}`);

--- a/tests/specs/npm/aliases_same_pkg_node_modules/package.json
+++ b/tests/specs/npm/aliases_same_pkg_node_modules/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "add-v1": "npm:@denotest/add@1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Fix setup cache key in root node_modules symlink creation to use the alias name instead of the real package name
- When multiple aliases point to the same package+version (e.g. `typescript-6.0.2` and `typescript-next` both resolving to `typescript@6.0.2`), the setup cache would deduplicate them under the real package name key, causing subsequent aliases to be skipped on re-install
- One-line fix in `libs/npm_installer/local.rs:721`

Fixes #33059

## Test plan
- [x] Added spec test `aliases_same_pkg_node_modules` that installs one alias, then adds a second alias to the same package+version, and verifies both are importable
- [x] Verified test fails without the fix and passes with it
- [x] Manually verified against the reproduction from the issue (`ts-ast-viewer` repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)