### PR TITLE
fix(serde_v8): use actual bytes written in to_utf8_slow

### DIFF
--- a/libs/serde_v8/de.rs
+++ b/libs/serde_v8/de.rs
@@ -764,7 +764,7 @@ fn to_utf8_slow(s: v8::Local<v8::String>, scope: &mut v8::PinScope) -> String {
   let capacity = s.utf8_length(scope);
   let mut buf = Vec::with_capacity(capacity);
 
-  s.write_utf8_uninit_v2(
+  let bytes_len = s.write_utf8_uninit_v2(
     scope,
     buf.spare_capacity_mut(),
     v8::WriteFlags::kReplaceInvalidUtf8,
@@ -773,7 +773,7 @@ fn to_utf8_slow(s: v8::Local<v8::String>, scope: &mut v8::PinScope) -> String {
 
   // SAFETY: write_utf8_uninit guarantees `bytes_len` bytes are initialized & valid utf8
   unsafe {
-    buf.set_len(capacity);
+    buf.set_len(bytes_len);
     String::from_utf8_unchecked(buf)
   }
 }


### PR DESCRIPTION
## Summary
- `to_utf8_slow` discarded the return value of `write_utf8_uninit_v2` and used the pre-estimated `capacity` for `Vec::set_len`
- This violated `set_len`'s safety contract (all bytes up to `len` must be initialized)
- Use the actual return value, matching what `to_utf8_fast` already does correctly

One-line fix — capture the return value instead of discarding it.

## Test plan
- `cargo check -p serde_v8` passes
- Existing serde_v8 tests cover deserialization paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)