### PR TITLE
fix(node_resolver): fall back to JS main when types not found for npm packages

### DIFF
--- a/libs/node_resolver/resolution.rs
+++ b/libs/node_resolver/resolution.rs
@@ -2018,6 +2018,21 @@ impl<
       }
     }
 
+    // When resolving for types and we couldn't find declaration files,
+    // fall back to the JS main entry if it exists. This allows tools like
+    // `deno doc` to process npm packages that don't ship type declarations.
+    if resolution_kind.is_types() {
+      if let Some(main) = self.legacy_fallback_resolve(package_json) {
+        let guess = package_json.path.parent().unwrap().join(main).clean();
+        if self.sys.is_file(Cow::Borrowed(&guess)) {
+          return Ok(MaybeTypesResolvedUrl(LocalUrlOrPath::Path(LocalPath {
+            path: guess,
+            known_exists: true,
+          })));
+        }
+      }
+    }
+
     self.legacy_index_resolve(
       package_json.path.parent().unwrap(),
       maybe_referrer,

--- a/tests/specs/doc/npm_no_types/__test__.jsonc
+++ b/tests/specs/doc/npm_no_types/__test__.jsonc
@@ -1,0 +1,6 @@
+{
+  "tempDir": true,
+  "args": "doc --json main.ts",
+  "output": "main.out",
+  "exitCode": 0
+}

--- a/tests/specs/doc/npm_no_types/deno.json
+++ b/tests/specs/doc/npm_no_types/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "none"
+}

--- a/tests/specs/doc/npm_no_types/main.out
+++ b/tests/specs/doc/npm_no_types/main.out
@@ -1,0 +1,3 @@
+Download [WILDCARD]
+Download [WILDCARD]
+{[WILDCARD]}

--- a/tests/specs/doc/npm_no_types/main.ts
+++ b/tests/specs/doc/npm_no_types/main.ts
@@ -1,0 +1,2 @@
+import { getValue } from "npm:@denotest/cjs-this-in-exports@1.0.0";
+console.log(getValue());


### PR DESCRIPTION
## Summary
- When resolving types for npm packages (used by `deno doc`), if no `.d.ts` files are found, fall back to the JS entry point from the package.json `main` field
- Previously, `deno doc --json` would fail fatally on npm packages without type declarations (like `npm:debug@4.4.0`)
- The types resolution would fall through to `legacy_index_resolve` which hardcoded `index.js` in the error, ignoring the actual `main` field

## The fix
In `legacy_main_resolve`, after exhausting all type declaration file searches, try the JS `main` entry as a last resort before falling through to `legacy_index_resolve`. This mirrors TypeScript's behavior of gracefully handling JS modules without types.

## Test plan
- Added spec test `doc::npm_no_types` using `@denotest/cjs-this-in-exports` (a package with no `.d.ts` files)
- All existing `doc::npm*` spec tests pass (7 tests)
- Manually verified `deno doc --json` works with `npm:debug@4.4.0`

Fixes #33033

🤖 Generated with [Claude Code](https://claude.com/claude-code)