### PR TITLE
fix(core): prevent WouldBlock errors on stdio from TTY O_NONBLOCK leak

### DIFF
--- a/libs/core/ops_builtin.rs
+++ b/libs/core/ops_builtin.rs
@@ -220,13 +220,27 @@ pub fn op_print(
   #[string] msg: &str,
   is_err: bool,
 ) -> Result<(), std::io::Error> {
-  if is_err {
-    stderr().write_all(msg.as_bytes())?;
-    stderr().flush().unwrap();
+  let mut out: Box<dyn Write> = if is_err {
+    Box::new(stderr())
   } else {
-    stdout().write_all(msg.as_bytes())?;
-    stdout().flush().unwrap();
+    Box::new(stdout())
+  };
+  // Use a manual write loop instead of write_all because the fd may be in
+  // non-blocking mode (e.g. when a TTY stream sets O_NONBLOCK). write_all
+  // does not retry on WouldBlock, only on Interrupted.
+  let mut buf = msg.as_bytes();
+  while !buf.is_empty() {
+    match out.write(buf) {
+      Ok(n) => buf = &buf[n..],
+      Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+        std::thread::yield_now();
+        continue;
+      }
+      Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+      Err(e) => return Err(e),
+    }
   }
+  out.flush().unwrap();
   Ok(())
 }
 

--- a/libs/core/uv_compat/tty.rs
+++ b/libs/core/uv_compat/tty.rs
@@ -1312,9 +1312,25 @@ pub unsafe fn uv_tty_init(
         }
       }
 
+      // For stdio fds (0, 1, 2), if the reopen above didn't happen,
+      // dup the fd so that setting O_NONBLOCK below doesn't affect the
+      // original fd. Without this, other users of fd 1 (e.g. op_print /
+      // console.log) can get WouldBlock errors when the pipe buffer is
+      // near capacity.
+      if !reopened && fd <= 2 {
+        let dup_fd = libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3);
+        if dup_fd >= 0 {
+          actual_fd = dup_fd;
+          reopened = true;
+        }
+      }
+
       // Set non-blocking.
       let cur_flags = libc::fcntl(actual_fd, libc::F_GETFL);
       if cur_flags == -1 {
+        if reopened {
+          libc::close(actual_fd);
+        }
         return -std::io::Error::last_os_error()
           .raw_os_error()
           .unwrap_or(libc::EINVAL);
@@ -1324,6 +1340,7 @@ pub unsafe fn uv_tty_init(
           == -1
       {
         if reopened {
+          libc::close(actual_fd);
           libc::fcntl(fd, libc::F_SETFL, saved_flags);
         }
         return -std::io::Error::last_os_error()


### PR DESCRIPTION
## Summary
- **Root cause fix**: In `uv_tty_init`, when a stdio fd (0, 1, 2) is not a TTY slave (common in containers/serverless where stdout is a pipe), dup the fd before setting `O_NONBLOCK` so the original fd is never modified
- **Defense in depth**: In `op_print`, replace `write_all` with a manual write loop that retries on `WouldBlock`, protecting against any source of non-blocking stdio
- **Bonus**: Fixed fd leak in `uv_tty_init` error paths when `fcntl(F_GETFL)` or `fcntl(F_SETFL)` fails after a reopen/dup

## Background
Since v2.7.6 (#32777 TTY rewrite), `uv_tty_init` sets `O_NONBLOCK` on the fd it initializes. When the fd is a TTY slave, it reopens to get a private fd. But when stdout is a pipe (serverless, containers), the reopen doesn't apply and `O_NONBLOCK` gets set on the original fd 1. This causes intermittent `WouldBlock (os error 11)` when `console.log` writes to a near-full pipe buffer, because `write_all` doesn't retry on `WouldBlock`.

## Test plan
- Existing TTY and stdio tests pass
- The `op_print` change is backward-compatible (only adds retry behavior)
- The `uv_tty_init` change only affects Unix stdio fds 0-2

Fixes #33069

🤖 Generated with [Claude Code](https://claude.com/claude-code)