### PR TITLE
fix(ext/node): return pid from spawnSync

### DIFF
--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1728,6 +1728,8 @@ export function spawnSync(
       stderr = stderr && stderr.toString(encoding);
     }
 
+    // deno-lint-ignore no-explicit-any
+    result.pid = (output as any)._pid;
     result.status = status;
     result.signal = output.signal;
     result.stdout = stdout;

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -17,6 +17,7 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypeSlice,
   TypeError,
+  ObjectDefineProperty,
   ObjectEntries,
   SafeArrayIterator,
   String,
@@ -499,7 +500,7 @@ function spawnSyncInner(command, {
     input,
     argv0,
   });
-  return {
+  const output = {
     success: result.status.success,
     code: result.status.code,
     signal: result.status.signal,
@@ -516,6 +517,13 @@ function spawnSyncInner(command, {
       return result.stderr;
     },
   };
+  // Internal field used by node:child_process, hidden from Deno public API.
+  ObjectDefineProperty(output, "_pid", {
+    __proto__: null,
+    value: result.pid,
+    enumerable: false,
+  });
+  return output;
 }
 
 class Command {

--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -396,6 +396,7 @@ impl TryFrom<ExitStatus> for ChildStatus {
 
 #[derive(ToV8)]
 pub struct SpawnOutput {
+  pid: u32,
   status: ChildStatus,
   stdout: Option<Uint8Array>,
   stderr: Option<Uint8Array>,
@@ -1125,6 +1126,10 @@ fn op_spawn_sync(
     command: command.get_program().to_string_lossy().into_owned(),
     error: Box::new(e.into()),
   })?;
+  #[cfg(unix)]
+  let pid = child.id();
+  #[cfg(windows)]
+  let pid = child.id().expect("Process ID should be set.");
   if let Some(input) = input {
     let mut stdin = child.stdin.take().ok_or_else(|| {
       ProcessError::Io(std::io::Error::other("stdin is not available"))
@@ -1140,6 +1145,7 @@ fn op_spawn_sync(
         error: Box::new(e.into()),
       })?;
   Ok(SpawnOutput {
+    pid,
     status: output.status.try_into()?,
     stdout: if stdout {
       Some(output.stdout.into())

--- a/tests/unit_node/child_process_test.ts
+++ b/tests/unit_node/child_process_test.ts
@@ -1358,3 +1358,10 @@ Deno.test(function spawnSyncShellMetacharactersEscaped() {
   assertEquals(ret.status, 0);
   assertEquals(ret.stdout.trim(), "a&b|c<d>e");
 });
+
+Deno.test(function spawnSyncReturnsPid() {
+  const ret = spawnSync(Deno.execPath(), ["eval", "console.log('hi')"]);
+  assertEquals(ret.status, 0);
+  assertEquals(typeof ret.pid, "number");
+  assert(ret.pid > 0);
+});


### PR DESCRIPTION
## Summary
- Returns `pid` from `op_spawn_sync` so `child_process.spawnSync()` results include the `pid` field as Node.js expects
- Factored out from #32810

## Test plan
- [x] `./x test-node child_process` passes (new `spawnSyncReturnsPid` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)