### PR TITLE
fix(watch): reduce graceful shutdown timeout from 5s to 500ms

### DIFF
--- a/cli/util/file_watcher.rs
+++ b/cli/util/file_watcher.rs
@@ -39,7 +39,7 @@ use crate::util::fs::canonicalize_path;
 
 const CLEAR_SCREEN: &str = "\x1B[H\x1B[2J\x1B[3J";
 const DEBOUNCE_INTERVAL: Duration = Duration::from_millis(200);
-const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 
 struct DebouncedReceiver {
   // The `recv()` call could be used in a tokio `select!` macro,


### PR DESCRIPTION
## Summary

- Reduces `GRACEFUL_SHUTDOWN_TIMEOUT` from 5 seconds to 500ms

The 5-second grace period introduced in #32564 causes frustrating reload delays during development when a SIGTERM handler is registered (e.g. for production graceful DB shutdown). 500ms is enough time for most cleanup tasks (closing connections, flushing logs) while keeping the dev reload loop snappy.

## Test plan

- [x] Existing watcher tests pass (they check SIGTERM dispatch, not timeout duration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)