### PR TITLE
ci: remove stale gha-creds cleanup after gcloud removal

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -685,7 +685,7 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
           echo ${{ github.sha }} > canary-latest.txt
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
+          rm canary-latest.txt
       - name: Build product size info
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
@@ -1529,7 +1529,7 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
           echo ${{ github.sha }} > canary-latest.txt
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
+          rm canary-latest.txt
       - name: Build product size info
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
@@ -2325,7 +2325,7 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
           echo ${{ github.sha }} > canary-latest.txt
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
+          rm canary-latest.txt
       - name: Build product size info
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
@@ -3004,7 +3004,7 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
           echo ${{ github.sha }} > canary-latest.txt
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
+          rm canary-latest.txt
       - name: Build product size info
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && github.repository == ''denoland/deno'' && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-
@@ -3436,7 +3436,7 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
           echo ${{ github.sha }} > canary-latest.txt
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
+          rm canary-latest.txt
       - name: Build product size info
         if: 'github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')'
         run: |-
@@ -5076,7 +5076,7 @@ jobs:
           aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"
           echo ${{ github.sha }} > canary-latest.txt
           aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt
-          rm canary-latest.txt gha-creds-*.json
+          rm canary-latest.txt
       - name: Build product size info
         if: '!(!contains(github.event.pull_request.labels.*.name, ''ci-full'') && github.event_name == ''pull_request'') && (github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/''))'
         run: |-

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -750,7 +750,7 @@ const buildJobs = buildItems.map((rawBuildItem) => {
               'aws s3 sync ./target/release/ s3://dl-deno-land/canary/$(git rev-parse HEAD)/ --exclude "*" --include "*.symcache"',
               "echo ${{ github.sha }} > canary-latest.txt",
               'aws s3 cp canary-latest.txt s3://dl-deno-land/canary-$(rustc -vV | sed -n "s|host: ||p")-latest.txt',
-              "rm canary-latest.txt gha-creds-*.json",
+              "rm canary-latest.txt",
             ],
           }),
         );


### PR DESCRIPTION
## Summary

- #33088 removed the gcloud auth step (`setupGcloudStep`) but left `rm gha-creds-*.json` in the canary upload step
- Since gcloud auth no longer runs, no `gha-creds-*.json` file is created and the `rm` glob fails with exit code 1, breaking all 6 release builds
- Fix: remove the stale `gha-creds-*.json` from the cleanup command

Failure log: `rm: gha-creds-*.json: No such file or directory`

## Test plan

- [ ] CI canary upload step no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)