### PR TITLE
fix(runtime): filter spurious fs watch events for removed files

### DIFF
--- a/runtime/ops/fs_events.rs
+++ b/runtime/ops/fs_events.rs
@@ -182,7 +182,22 @@ fn start_watcher(
             })
           }) {
             let _ = sender.try_send(Ok(event.clone()));
-          } else if event.paths.iter().any(is_file_removed) {
+          } else if event.paths.iter().any(|event_path| {
+            // For removed files, we can't use canonicalize or is_same_file
+            // since the file no longer exists. Instead, check that the
+            // removed file's parent is within a watched path before
+            // forwarding the event, to avoid sending spurious remove
+            // events for unrelated temporary files (e.g. during atomic
+            // saves by editors like Vim).
+            is_file_removed(event_path)
+              && paths.iter().any(|path| {
+                same_file::is_same_file(event_path, path).unwrap_or(false)
+                  || starts_with_canonicalized(event_path, path)
+                  || event_path
+                    .parent()
+                    .is_some_and(|p| starts_with_canonicalized(p, path))
+              })
+          }) {
             let remove_event = FsEvent {
               kind: "remove",
               paths: event.paths.clone(),

--- a/tests/unit/fs_events_test.ts
+++ b/tests/unit/fs_events_test.ts
@@ -164,6 +164,53 @@ Deno.test(
   },
 );
 
+// Regression test for https://github.com/denoland/deno/issues/27558
+// Removing a file outside the watched directory should not produce events.
+Deno.test(
+  { permissions: { read: true, write: true } },
+  async function watchFsNoSpuriousEventsFromSiblingDir() {
+    const parentDir = await makeTempDir();
+    const watchedDir = parentDir + "/watched";
+    const otherDir = parentDir + "/other";
+    Deno.mkdirSync(watchedDir);
+    Deno.mkdirSync(otherDir);
+    await delay(100);
+
+    using watcher = Deno.watchFs(watchedDir);
+
+    // Create and immediately remove a file in the sibling directory.
+    // Before the fix, this would send a spurious "remove" event to
+    // watchers on watchedDir because the is_file_removed fallback had
+    // no path filtering.
+    const otherFile = otherDir + "/temp.txt";
+    Deno.writeFileSync(otherFile, new Uint8Array([1, 2, 3]));
+    Deno.removeSync(otherFile);
+
+    // Now create a real file in the watched directory so we have
+    // something to observe.
+    await delay(100);
+    const realFile = watchedDir + "/real.txt";
+    Deno.writeFileSync(realFile, new Uint8Array([1, 2, 3]));
+
+    // Collect events -- the first meaningful event should be for real.txt,
+    // not a spurious remove for temp.txt.
+    for await (const event of watcher) {
+      // We should never see events for files in otherDir
+      for (const path of event.paths) {
+        assert(
+          !path.includes("other"),
+          `Received spurious event for file outside watched dir: ${path}`,
+        );
+      }
+      // Once we see the expected create, we're done
+      if (event.kind === "create" || event.kind === "modify") {
+        assert(event.paths[0].includes("real.txt"));
+        break;
+      }
+    }
+  },
+);
+
 Deno.test(
   { permissions: { read: true, write: true } },
   async function watchFsRemove() {


### PR DESCRIPTION
## Summary
- The `is_file_removed` fallback in the fs watcher (added in #27041) had no path filtering, so any file removal anywhere would emit events to all watchers
- This caused Vite's HMR to break under Deno >= 2.1.2 with editors that do atomic saves (Vim, WebStorm, Kate), triggering full page reloads on every save
- Added path filtering to the remove-detection branch by checking the removed file's parent directory against watched paths
- Added regression test verifying that file removal in a sibling directory doesn't produce events

Fixes #27558

## Test plan
- [x] New unit test `watchFsNoSpuriousEventsFromSiblingDir` verifies no spurious events from sibling dirs
- [x] Existing `watchFsRemove` test still passes (legitimate remove events still work)
- [x] All fs_events unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)