### PR TITLE
fix: make globalThis toStringTag return "global" to match Node.js

### DIFF
--- a/ext/web/04_global_interfaces.js
+++ b/ext/web/04_global_interfaces.js
@@ -22,6 +22,9 @@ class Window extends EventTarget {
   }
 
   get [SymbolToStringTag]() {
+    if (this === globalThis) {
+      return "global";
+    }
     return "Window";
   }
 }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -82,10 +82,7 @@
     "parallel/test-assert-calltracker-getCalls.js": {},
     "parallel/test-assert-calltracker-report.js": {},
     "parallel/test-assert-calltracker-verify.js": {},
-    "parallel/test-assert-checktag.js": {
-      "ignore": true,
-      "reason": "globalThis is now deeply equal to a plain object copy because Node.js timers are used as default globals, eliminating the proxy-based timer function difference that previously made them unequal"
-    },
+    "parallel/test-assert-checktag.js": {},
     "parallel/test-assert-class-destructuring.js": {},
     "parallel/test-assert-class.js": {},
     "parallel/test-assert-deep-with-error.js": {},


### PR DESCRIPTION
## Summary

- Change `Window` class's `Symbol.toStringTag` getter to return `"global"` when `this === globalThis`, matching Node.js behavior
- This makes `Object.prototype.toString.call(globalThis)` return `[object global]` instead of `[object Window]`, so `assert.notDeepEqual(fakeGlobal, globalThis)` works correctly
- Un-ignore `test-assert-checktag.js` compat test

## Test plan
- [x] `./x test-compat test-assert-checktag.js` passes
- [x] `./x lint` passes
- [ ] CI green (may need WPT expectation updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)