### PR TITLE
fix(ext/web): AbortSignal.timeout() memory leak with long-lived signals

### DIFF
--- a/ext/web/03_abort_signal.js
+++ b/ext/web/03_abort_signal.js
@@ -59,6 +59,15 @@ const dependentSignalCleanupRegistry = new SafeFinalizationRegistry(
   },
 );
 
+// When an AbortSignal.timeout() signal is GC'd before its timer fires,
+// cancel the underlying timer so it doesn't leak. The timer callback uses
+// a WeakRef to the signal, so this is the cleanup path for the timer itself.
+const timeoutCleanupRegistry = new SafeFinalizationRegistry(
+  (timerIdValue) => {
+    core.cancelTimer(timerIdValue);
+  },
+);
+
 class AbortSignal extends EventTarget {
   [abortReason] = undefined;
   [abortAlgos] = null;
@@ -96,11 +105,17 @@ class AbortSignal extends EventTarget {
     );
 
     const signal = new AbortSignal(illegalConstructorKey);
+    // Use a WeakRef so the timer callback does not prevent the signal
+    // from being garbage collected. If the signal is GC'd before the
+    // timer fires, the FinalizationRegistry cancels the timer.
+    const weakSignal = new SafeWeakRef(signal);
     signal[timerId] = core.createTimer(
       () => {
-        core.cancelTimer(signal[timerId]);
-        signal[timerId] = null;
-        signal[signalAbort](
+        const s = WeakRefPrototypeDeref(weakSignal);
+        if (s === undefined) return;
+        core.cancelTimer(s[timerId]);
+        s[timerId] = null;
+        s[signalAbort](
           new DOMException("Signal timed out.", "TimeoutError"),
         );
       },
@@ -110,6 +125,7 @@ class AbortSignal extends EventTarget {
       false, // start unrefed (like Node.js)
       true, // system timer: excluded from leak sanitizer
     );
+    timeoutCleanupRegistry.register(signal, signal[timerId]);
     return signal;
   }
 


### PR DESCRIPTION
## Summary
- The timer callback in `AbortSignal.timeout()` held a strong reference to the signal via closure, preventing GC even when no JS code referenced the signal anymore
- This caused unbounded memory growth (~10MB/iteration) when creating many timeout signals, e.g. via `util.aborted()` + `AbortSignal.timeout()` in a loop
- Fixed by using a `WeakRef` in the timer callback (matching Node.js's approach) and a `FinalizationRegistry` to cancel the timer when the signal is GC'd
- Before: heap grew linearly (18MB -> 103MB over 10 iterations of 10k signals)
- After: heap stays flat (~12MB)

Fixes #33125

## How it works

Node.js uses a three-part strategy that we now match:

1. **WeakRef in timer callback** -- the `setTimeout` callback closes over a `WeakRef` to the signal instead of the signal itself, so the timer doesn't prevent GC
2. **FinalizationRegistry** -- when the signal is GC'd, the registry callback calls `cancelTimer()` to clean up the underlying timer
3. **Existing ref/unref** -- Deno already had the ref/unref pattern (timer starts unrefed, gets refed when listeners are added, unrefed when removed)

## Test plan
- [x] Repro script from #33125 shows stable memory (~12MB) instead of linear growth
- [x] `AbortSignal.timeout()` still fires correctly
- [x] `AbortSignal.any()` with timeout sources still works
- [x] `util.aborted()` still resolves on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)