### PR TITLE
feat: disable ops and resources sanitizers by default in deno test

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -555,6 +555,8 @@ pub struct TestFlags {
   pub filter: Option<String>,
   pub shuffle: Option<u64>,
   pub trace_leaks: bool,
+  pub sanitize_ops: bool,
+  pub sanitize_resources: bool,
   pub watch: Option<WatchFlagsWithPaths>,
   pub reporter: TestReporterConfig,
   pub junit_path: Option<String>,
@@ -4359,6 +4361,20 @@ or <c>**/__tests__/**</>:
           .help_heading(TEST_HEADING),
       )
       .arg(
+        Arg::new("sanitize-ops")
+          .long("sanitize-ops")
+          .help("Enable the ops sanitizer, which ensures that all async ops started in a test are completed before the test ends")
+          .action(ArgAction::SetTrue)
+          .help_heading(TEST_HEADING),
+      )
+      .arg(
+        Arg::new("sanitize-resources")
+          .long("sanitize-resources")
+          .help("Enable the resources sanitizer, which ensures that all resources opened in a test are closed before the test ends")
+          .action(ArgAction::SetTrue)
+          .help_heading(TEST_HEADING),
+      )
+      .arg(
         Arg::new("doc")
           .long("doc")
           .help("Evaluate code blocks in JSDoc and Markdown")
@@ -7303,6 +7319,8 @@ fn test_parse(
 
   let no_run = matches.get_flag("no-run");
   let trace_leaks = matches.get_flag("trace-leaks");
+  let sanitize_ops = matches.get_flag("sanitize-ops");
+  let sanitize_resources = matches.get_flag("sanitize-resources");
   let doc = matches.get_flag("doc");
   let filter = matches.remove_one::<String>("filter");
   let clean = matches.get_flag("clean");
@@ -7370,6 +7388,8 @@ fn test_parse(
     permit_no_files: permit_no_files_parse(matches),
     parallel: matches.get_flag("parallel"),
     trace_leaks,
+    sanitize_ops,
+    sanitize_resources,
     watch: watch_arg_parse_with_paths(matches)?,
     reporter,
     junit_path,
@@ -11557,6 +11577,8 @@ mod tests {
           shuffle: None,
           parallel: false,
           trace_leaks: true,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: Some("cov".to_string()),
           coverage_raw_data_only: false,
           clean: true,
@@ -11664,6 +11686,8 @@ mod tests {
           },
           parallel: false,
           trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: None,
           coverage_raw_data_only: false,
           clean: false,
@@ -11708,6 +11732,8 @@ mod tests {
           },
           parallel: false,
           trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: None,
           coverage_raw_data_only: false,
           clean: false,
@@ -11846,6 +11872,8 @@ mod tests {
           },
           parallel: false,
           trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: None,
           coverage_raw_data_only: false,
           clean: false,
@@ -11883,6 +11911,8 @@ mod tests {
           },
           parallel: false,
           trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: None,
           coverage_raw_data_only: false,
           clean: false,
@@ -11919,6 +11949,8 @@ mod tests {
           },
           parallel: false,
           trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: None,
           coverage_raw_data_only: false,
           clean: false,
@@ -11957,6 +11989,8 @@ mod tests {
           },
           parallel: false,
           trace_leaks: false,
+          sanitize_ops: false,
+          sanitize_resources: false,
           coverage_dir: None,
           coverage_raw_data_only: false,
           clean: false,

--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -204,6 +204,8 @@ pub struct WorkspaceTestOptions {
   pub shuffle: Option<u64>,
   pub concurrent_jobs: NonZeroUsize,
   pub trace_leaks: bool,
+  pub sanitize_ops: bool,
+  pub sanitize_resources: bool,
   pub reporter: TestReporterConfig,
   pub junit_path: Option<String>,
   pub hide_stacktraces: bool,
@@ -220,6 +222,13 @@ impl WorkspaceTestOptions {
       no_run: test_flags.no_run,
       shuffle: test_flags.shuffle,
       trace_leaks: test_flags.trace_leaks,
+      sanitize_ops: test_flags.sanitize_ops
+        || std::env::var("DENO_TEST_SANITIZE_OPS").ok().as_deref() == Some("1"),
+      sanitize_resources: test_flags.sanitize_resources
+        || std::env::var("DENO_TEST_SANITIZE_RESOURCES")
+          .ok()
+          .as_deref()
+          == Some("1"),
       reporter: test_flags.reporter,
       junit_path: test_flags.junit_path.clone(),
       hide_stacktraces: test_flags.hide_stacktraces,

--- a/cli/js/40_test.js
+++ b/cli/js/40_test.js
@@ -263,8 +263,8 @@ function testInner(
   const defaults = {
     ignore: false,
     only: false,
-    sanitizeOps: true,
-    sanitizeResources: true,
+    sanitizeOps: Deno[Deno.internal].testSanitizeOps ?? false,
+    sanitizeResources: Deno[Deno.internal].testSanitizeResources ?? false,
     sanitizeExit: true,
     permissions: null,
   };

--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -331,6 +331,8 @@ impl TestRun {
               filter,
               shuffle: None,
               trace_leaks: false,
+              sanitize_ops: false,
+              sanitize_resources: false,
             },
           ))
         }

--- a/cli/tools/test/mod.rs
+++ b/cli/tools/test/mod.rs
@@ -590,6 +590,8 @@ pub struct TestSpecifierOptions {
   pub shuffle: Option<u64>,
   pub filter: TestFilter,
   pub trace_leaks: bool,
+  pub sanitize_ops: bool,
+  pub sanitize_resources: bool,
 }
 
 impl TestSummary {
@@ -702,6 +704,22 @@ async fn configure_main_worker(
       .execute_script_static(
         located_script_name!(),
         "Deno[Deno.internal].core.setLeakTracingEnabled(true);",
+      )
+      .map_err(|e| CoreErrorKind::Js(e).into_box())?;
+  }
+  if options.sanitize_ops {
+    worker
+      .execute_script_static(
+        located_script_name!(),
+        "Deno[Deno.internal].testSanitizeOps = true;",
+      )
+      .map_err(|e| CoreErrorKind::Js(e).into_box())?;
+  }
+  if options.sanitize_resources {
+    worker
+      .execute_script_static(
+        located_script_name!(),
+        "Deno[Deno.internal].testSanitizeResources = true;",
       )
       .map_err(|e| CoreErrorKind::Js(e).into_box())?;
   }
@@ -1683,6 +1701,8 @@ pub async fn run_tests(
         filter: TestFilter::from_flag(&workspace_test_options.filter),
         shuffle: workspace_test_options.shuffle,
         trace_leaks: workspace_test_options.trace_leaks,
+        sanitize_ops: workspace_test_options.sanitize_ops,
+        sanitize_resources: workspace_test_options.sanitize_resources,
       },
     },
   )
@@ -1908,6 +1928,8 @@ pub async fn run_tests_with_watch(
               filter: TestFilter::from_flag(&workspace_test_options.filter),
               shuffle: workspace_test_options.shuffle,
               trace_leaks: workspace_test_options.trace_leaks,
+              sanitize_ops: workspace_test_options.sanitize_ops,
+              sanitize_resources: workspace_test_options.sanitize_resources,
             },
           },
         )

--- a/cli/tsc/dts/lib.deno.ns.d.ts
+++ b/cli/tsc/dts/lib.deno.ns.d.ts
@@ -831,13 +831,19 @@ declare namespace Deno {
      * not await. This helps in preventing logic errors and memory leaks
      * in the application code.
      *
-     * @default {true} */
+     * Can also be enabled globally with the `--sanitize-ops` CLI flag or
+     * the `DENO_TEST_SANITIZE_OPS=1` environment variable.
+     *
+     * @default {false} */
     sanitizeOps?: boolean;
     /** Ensure the test step does not "leak" resources - like open files or
      * network connections - by ensuring the open resources at the start of the
      * test match the open resources at the end of the test.
      *
-     * @default {true} */
+     * Can also be enabled globally with the `--sanitize-resources` CLI flag or
+     * the `DENO_TEST_SANITIZE_RESOURCES=1` environment variable.
+     *
+     * @default {false} */
     sanitizeResources?: boolean;
     /** Ensure the test case does not prematurely cause the process to exit,
      * for example via a call to {@linkcode Deno.exit}.

--- a/tests/specs/test/ops_sanitizer_closed_inside_started_before/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_closed_inside_started_before/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --trace-leaks ops_sanitizer_closed_inside_started_before.ts",
+  "args": "test --sanitize-ops --trace-leaks ops_sanitizer_closed_inside_started_before.ts",
   "exitCode": 1,
   "output": "ops_sanitizer_closed_inside_started_before.out"
 }

--- a/tests/specs/test/ops_sanitizer_multiple_timeout_tests/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_multiple_timeout_tests/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --trace-leaks ops_sanitizer_multiple_timeout_tests.ts",
+  "args": "test --sanitize-ops --trace-leaks ops_sanitizer_multiple_timeout_tests.ts",
   "exitCode": 1,
   "output": "ops_sanitizer_multiple_timeout_tests.out"
 }

--- a/tests/specs/test/ops_sanitizer_multiple_timeout_tests_no_trace/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_multiple_timeout_tests_no_trace/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test ops_sanitizer_multiple_timeout_tests.ts",
+  "args": "test --sanitize-ops ops_sanitizer_multiple_timeout_tests.ts",
   "exitCode": 1,
   "output": "ops_sanitizer_multiple_timeout_tests_no_trace.out"
 }

--- a/tests/specs/test/ops_sanitizer_nexttick/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_nexttick/__test__.jsonc
@@ -1,4 +1,4 @@
 {
-  "args": "test --no-check ops_sanitizer_nexttick.ts",
+  "args": "test --sanitize-ops --no-check ops_sanitizer_nexttick.ts",
   "output": "ops_sanitizer_nexttick.out"
 }

--- a/tests/specs/test/ops_sanitizer_tcp/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_tcp/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --allow-net --trace-leaks ops_sanitizer_tcp.ts",
+  "args": "test --sanitize-ops --sanitize-resources --allow-net --trace-leaks ops_sanitizer_tcp.ts",
   "exitCode": 1,
   "output": "ops_sanitizer_tcp.out"
 }

--- a/tests/specs/test/ops_sanitizer_timeout_failure/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_timeout_failure/__test__.jsonc
@@ -1,4 +1,4 @@
 {
-  "args": "test ops_sanitizer_timeout_failure.ts",
+  "args": "test --sanitize-ops ops_sanitizer_timeout_failure.ts",
   "output": "ops_sanitizer_timeout_failure.out"
 }

--- a/tests/specs/test/ops_sanitizer_unstable/__test__.jsonc
+++ b/tests/specs/test/ops_sanitizer_unstable/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --trace-leaks ops_sanitizer_unstable.ts",
+  "args": "test --sanitize-ops --trace-leaks ops_sanitizer_unstable.ts",
   "exitCode": 1,
   "output": "ops_sanitizer_unstable.out"
 }

--- a/tests/specs/test/resource_sanitizer/__test__.jsonc
+++ b/tests/specs/test/resource_sanitizer/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --allow-read resource_sanitizer.ts",
+  "args": "test --sanitize-resources --allow-read resource_sanitizer.ts",
   "output": "resource_sanitizer.out",
   "exitCode": 1
 }

--- a/tests/specs/test/sanitizer_trace_ops_catch_error/__test__.jsonc
+++ b/tests/specs/test/sanitizer_trace_ops_catch_error/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test -A --trace-leaks main.ts",
+  "args": "test --sanitize-ops --sanitize-resources -A --trace-leaks main.ts",
   "output": "main.out",
   "exitCode": 0
 }

--- a/tests/specs/test/sanitizer_with_error/__test__.jsonc
+++ b/tests/specs/test/sanitizer_with_error/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --quiet main.js",
+  "args": "test --sanitize-ops --quiet main.js",
   "output": "main.out",
   "exitCode": 1
 }

--- a/tests/specs/test/sanitizer_with_top_level_ops/__test__.jsonc
+++ b/tests/specs/test/sanitizer_with_top_level_ops/__test__.jsonc
@@ -1,5 +1,5 @@
 {
-  "args": "test --quiet --allow-net main.js",
+  "args": "test --sanitize-ops --sanitize-resources --quiet --allow-net main.js",
   "output": "main.out",
   "flaky": true
 }


### PR DESCRIPTION
## Summary

Changes the default for `sanitizeOps` and `sanitizeResources` from `true` to `false` in `Deno.test()`. This aligns with what most users expect -- tests no longer fail due to leaked async ops or resources unless explicitly opted in.

### Before

```ts
// This test FAILS by default -- the timer leak triggers the ops sanitizer
Deno.test("my test", () => {
  setTimeout(() => {}, 1000);
});
```

```
ERRORS

my test => ./main.ts:1:6
error: Leaks detected:
  - A timer was started in this test, but never completed.
```

### After

```ts
// This test PASSES by default -- no sanitizers enabled
Deno.test("my test", () => {
  setTimeout(() => {}, 1000);
});
```

To re-enable sanitizers, users have three options:

**1. CLI flags (e.g. for CI)**
```sh
deno test --sanitize-ops --sanitize-resources
```

**2. Environment variables (e.g. for CI)**
```sh
DENO_TEST_SANITIZE_OPS=1 DENO_TEST_SANITIZE_RESOURCES=1 deno test
```

**3. Per-test opt-in**
```ts
Deno.test({
  name: "my test",
  sanitizeOps: true,
  sanitizeResources: true,
  fn() {
    setTimeout(() => {}, 1000);
  },
});
```

### What's unchanged

- `sanitizeExit` default remains `true`
- Per-test `sanitizeOps: true` / `sanitizeResources: true` continues to work
- Test steps still inherit sanitizer settings from their parent test

## Changes

| File | Change |
|------|--------|
| `cli/args/flags.rs` | Add `--sanitize-ops` and `--sanitize-resources` CLI flags |
| `cli/args/mod.rs` | Propagate flags + env var fallback (`DENO_TEST_SANITIZE_OPS`, `DENO_TEST_SANITIZE_RESOURCES`) |
| `cli/tools/test/mod.rs` | Wire flags through to JS runtime via `Deno[Deno.internal]` globals |
| `cli/js/40_test.js` | Change defaults from `true` to reading from globals, falling back to `false` |
| `cli/tsc/dts/lib.deno.ns.d.ts` | Update `@default` docs and add CLI/env var references |
| `cli/lsp/testing/execution.rs` | Add new fields to LSP test runner |
| `tests/specs/test/*` (11 files) | Add `--sanitize-ops`/`--sanitize-resources` to sanitizer spec tests |

## Test plan

- [x] All 12 sanitizer spec tests updated and passing
- [x] All 11 step spec tests passing (they explicitly set sanitizer options)
- [x] `cargo check` passes
- [x] `tools/format.js` and `tools/lint.js --js` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)