### PR TITLE
refactor: move FdTable to ext/io

### DIFF
--- a/ext/io/fd_table.rs
+++ b/ext/io/fd_table.rs
@@ -1,0 +1,58 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::fs::File;
+
+/// Central table that owns file descriptor -> File mappings.
+///
+/// Both Deno's resource table (for `Deno.stdin`/`stdout`/`stderr`) and
+/// Node's fd-based ops (`op_node_fs_read_sync`, `op_node_fs_write_sync`,
+/// etc.) reference the same `Rc<dyn File>` entries. This ensures that
+/// closing an fd from either side is visible to the other.
+///
+/// Async reads use the raw OS fd directly (no dup/clone), so closing
+/// the fd naturally interrupts any blocking read on a spawned thread.
+pub struct FdTable {
+  entries: HashMap<i32, Rc<dyn File>>,
+}
+
+impl FdTable {
+  pub fn new() -> Self {
+    Self {
+      entries: HashMap::new(),
+    }
+  }
+
+  /// Register an fd with its File. Returns false if the fd was already
+  /// registered (caller should handle this as appropriate).
+  pub fn register(&mut self, fd: i32, file: Rc<dyn File>) -> bool {
+    if self.entries.contains_key(&fd) {
+      return false;
+    }
+    self.entries.insert(fd, file);
+    true
+  }
+
+  /// Get the File for an fd.
+  pub fn get(&self, fd: i32) -> Option<&Rc<dyn File>> {
+    self.entries.get(&fd)
+  }
+
+  /// Remove and return the File for an fd.
+  pub fn remove(&mut self, fd: i32) -> Option<Rc<dyn File>> {
+    self.entries.remove(&fd)
+  }
+
+  /// Check if an fd is registered.
+  pub fn contains(&self, fd: i32) -> bool {
+    self.entries.contains_key(&fd)
+  }
+}
+
+impl Default for FdTable {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/ext/io/lib.rs
+++ b/ext/io/lib.rs
@@ -61,6 +61,7 @@ use winapi::um::processenv::GetStdHandle;
 #[cfg(windows)]
 use winapi::um::winbase;
 
+mod fd_table;
 pub mod fs;
 mod pipe;
 #[cfg(windows)]
@@ -74,6 +75,7 @@ pub use bi_pipe::BiPipeResource;
 pub use bi_pipe::BiPipeWrite;
 pub use bi_pipe::RawBiPipeHandle;
 pub use bi_pipe::bi_pipe_pair_raw;
+pub use fd_table::FdTable;
 pub use pipe::AsyncPipeRead;
 pub use pipe::AsyncPipeWrite;
 pub use pipe::PipeRead;
@@ -237,6 +239,8 @@ deno_core::extension!(deno_io,
     _ => op,
   },
   state = |state, options| {
+    let mut fd_table = FdTable::new();
+
     if let Some(stdio) = options.stdio {
       #[cfg(windows)]
       let stdin_state = {
@@ -249,57 +253,52 @@ deno_core::extension!(deno_io,
 
       let t = &mut state.resource_table;
 
-      let rid = t.add(fs::FileResource::new(
-        Rc::new(match stdio.stdin.pipe {
-          StdioPipeInner::Inherit => StdFileResourceInner::new(
-            StdFileResourceKind::Stdin(stdin_state),
-            STDIN_HANDLE.try_clone().unwrap(),
-            None,
-          ),
-          StdioPipeInner::File(pipe) => StdFileResourceInner::file(pipe, None),
-        }),
-        "stdin".to_string(),
-      ));
+      let stdin_file: Rc<dyn fs::File> = Rc::new(match stdio.stdin.pipe {
+        StdioPipeInner::Inherit => StdFileResourceInner::new(
+          StdFileResourceKind::Stdin(stdin_state),
+          STDIN_HANDLE.try_clone().unwrap(),
+          None,
+        ),
+        StdioPipeInner::File(pipe) => StdFileResourceInner::file(pipe, None),
+      });
+      fd_table.register(0, stdin_file.clone());
+      let rid = t.add(fs::FileResource::new(stdin_file, "stdin".to_string()));
       assert_eq!(rid, 0, "stdin must have ResourceId 0");
 
-      let (stdout_inner, child_stdout) = match stdio.stdout.pipe {
+      let (stdout_file, child_stdout): (Rc<dyn fs::File>, StdFile) = match stdio.stdout.pipe {
         StdioPipeInner::Inherit => (
-          StdFileResourceInner::new(
+          Rc::new(StdFileResourceInner::new(
             StdFileResourceKind::Stdout,
             STDOUT_HANDLE.try_clone().unwrap(),
             None,
-          ),
+          )),
           STDOUT_HANDLE.try_clone().unwrap(),
         ),
         StdioPipeInner::File(pipe) => {
           let child_handle = pipe.try_clone().unwrap();
-          (StdFileResourceInner::file(pipe, None), child_handle)
+          (Rc::new(StdFileResourceInner::file(pipe, None)), child_handle)
         }
       };
-      let rid = t.add(FileResource::new(
-        Rc::new(stdout_inner),
-        "stdout".to_string(),
-      ));
+      fd_table.register(1, stdout_file.clone());
+      let rid = t.add(FileResource::new(stdout_file, "stdout".to_string()));
       assert_eq!(rid, 1, "stdout must have ResourceId 1");
 
-      let (stderr_inner, child_stderr) = match stdio.stderr.pipe {
+      let (stderr_file, child_stderr): (Rc<dyn fs::File>, StdFile) = match stdio.stderr.pipe {
         StdioPipeInner::Inherit => (
-          StdFileResourceInner::new(
+          Rc::new(StdFileResourceInner::new(
             StdFileResourceKind::Stderr,
             STDERR_HANDLE.try_clone().unwrap(),
             None,
-          ),
+          )),
           STDERR_HANDLE.try_clone().unwrap(),
         ),
         StdioPipeInner::File(pipe) => {
           let child_handle = pipe.try_clone().unwrap();
-          (StdFileResourceInner::file(pipe, None), child_handle)
+          (Rc::new(StdFileResourceInner::file(pipe, None)), child_handle)
         }
       };
-      let rid = t.add(FileResource::new(
-        Rc::new(stderr_inner),
-        "stderr".to_string(),
-      ));
+      fd_table.register(2, stderr_file.clone());
+      let rid = t.add(FileResource::new(stderr_file, "stderr".to_string()));
       assert_eq!(rid, 2, "stderr must have ResourceId 2");
 
       state.put(ChildProcessStdio {
@@ -307,6 +306,8 @@ deno_core::extension!(deno_io,
         stderr: child_stderr,
       });
     }
+
+    state.put(fd_table);
   },
 );
 

--- a/ext/node/lib.rs
+++ b/ext/node/lib.rs
@@ -204,7 +204,6 @@ deno_core::extension!(deno_node,
     ops::fs::op_node_rmdir,
     ops::fs::op_node_statfs_sync,
     ops::fs::op_node_statfs,
-    ops::fs::op_node_file_from_fd,
     ops::fs::op_node_register_fd,
     ops::fs::op_node_create_pipe,
     ops::fs::op_node_fd_set_blocking,
@@ -627,7 +626,6 @@ deno_core::extension!(deno_node,
   },
   state = |state, options| {
     state.put(options.fs.clone());
-    state.put(ops::fs::NodeFsState::new());
 
     if let Some(init) = &options.maybe_init {
       state.put(init.sys.clone());

--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -2,7 +2,6 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -17,7 +16,6 @@ use deno_core::v8;
 use deno_fs::FileSystemRc;
 use deno_fs::FsFileType;
 use deno_fs::OpenOptions;
-use deno_io::fs::FileResource;
 use deno_io::fs::FsResult;
 use deno_permissions::CheckedPath;
 use deno_permissions::CheckedPathBuf;
@@ -28,27 +26,6 @@ use serde::Serialize;
 use tokio::task::JoinError;
 
 use crate::ops::constant::UV_FS_COPYFILE_EXCL;
-
-/// State tracking file descriptors opened through node:fs.
-/// Maps real OS file descriptors to the underlying File trait object,
-/// bypassing the resource table entirely.
-pub struct NodeFsState {
-  pub open_fds: HashMap<i32, Rc<dyn deno_io::fs::File>>,
-}
-
-impl NodeFsState {
-  pub fn new() -> Self {
-    Self {
-      open_fds: HashMap::new(),
-    }
-  }
-}
-
-impl Default for NodeFsState {
-  fn default() -> Self {
-    Self::new()
-  }
-}
 
 /// Extract the real OS file descriptor from a File trait object.
 /// On Unix, this is the raw fd (already an i32).
@@ -126,30 +103,22 @@ fn eexist() -> FsError {
     libc::EEXIST,
     #[cfg(windows)]
     {
-      // Win32 ERROR_ALREADY_EXISTS, which maps to Node's EEXIST
+      // Win32 ERROR_ALREADY_EXISTS
       183
     },
   ))
 }
 
-/// Get the File trait object for an OS file descriptor.
-/// Checks NodeFsState first (covers files opened via node:fs, including
-/// cases where the OS reuses fd 0/1/2 after stdio is closed). Falls back
-/// to the resource table for stdio fds that were never reopened.
+/// Get the File trait object for an OS file descriptor from FdTable.
 fn file_for_fd(
   state: &OpState,
   fd: i32,
 ) -> Result<Rc<dyn deno_io::fs::File>, FsError> {
-  if let Some(file) = state.borrow::<NodeFsState>().open_fds.get(&fd) {
-    return Ok(file.clone());
-  }
-  // Stdio fds (0, 1, 2) are pre-registered in the resource table at
-  // RIDs 0, 1, 2. Only fall back here if the fd wasn't opened via node:fs.
-  if (0..=2).contains(&fd) {
-    return FileResource::get_file(state, fd as ResourceId)
-      .map_err(|_| ebadf());
-  }
-  Err(ebadf())
+  state
+    .borrow::<deno_io::FdTable>()
+    .get(fd)
+    .cloned()
+    .ok_or_else(ebadf)
 }
 
 /// When `sync_fs` is enabled, `FileSystemRc` is `Arc` (Send) and we can
@@ -374,7 +343,7 @@ pub fn op_node_open_sync(
   )?;
   let file = fs.open_sync(&path, options)?;
   let fd = raw_fd_for_file(file.clone())?;
-  state.borrow_mut::<NodeFsState>().open_fds.insert(fd, file);
+  state.borrow_mut::<deno_io::FdTable>().register(fd, file);
   Ok(fd)
 }
 
@@ -404,7 +373,7 @@ pub async fn op_node_open(
   let fd = raw_fd_for_file(file.clone())?;
 
   let mut state = state.borrow_mut();
-  state.borrow_mut::<NodeFsState>().open_fds.insert(fd, file);
+  state.borrow_mut::<deno_io::FdTable>().register(fd, file);
   Ok(fd)
 }
 #[derive(Debug, Serialize)]
@@ -787,50 +756,6 @@ fn temp_path_append_suffix(prefix: &str) -> String {
   format!("{}{}", prefix, suffix)
 }
 
-/// Create a file resource from a raw file descriptor.
-/// This is used for wrapping PTYs and other non-socket file descriptors
-/// that can't be wrapped as Unix streams.
-#[cfg(unix)]
-#[op2(fast)]
-#[smi]
-pub fn op_node_file_from_fd(
-  state: &mut OpState,
-  fd: i32,
-) -> Result<ResourceId, FsError> {
-  use std::fs::File as StdFile;
-  use std::os::unix::io::FromRawFd;
-
-  if fd < 0 {
-    return Err(FsError::Io(std::io::Error::new(
-      std::io::ErrorKind::InvalidInput,
-      "Invalid file descriptor",
-    )));
-  }
-
-  // SAFETY: The caller is responsible for passing a valid fd that they own.
-  // The fd will be owned by the created File from this point on.
-  let std_file = unsafe { StdFile::from_raw_fd(fd) };
-
-  let file = Rc::new(deno_io::StdFileResourceInner::file(std_file, None));
-  let rid = state
-    .resource_table
-    .add(FileResource::new(file, "pipe".to_string()));
-  Ok(rid)
-}
-
-#[cfg(not(unix))]
-#[op2(fast)]
-#[smi]
-pub fn op_node_file_from_fd(
-  _state: &mut OpState,
-  _fd: i32,
-) -> Result<ResourceId, FsError> {
-  Err(FsError::Io(std::io::Error::new(
-    std::io::ErrorKind::Unsupported,
-    "op_node_file_from_fd is not supported on this platform",
-  )))
-}
-
 #[op2(fast, stack_trace)]
 pub fn op_node_rmdir_sync(
   state: &mut OpState,
@@ -884,10 +809,15 @@ pub fn op_node_register_fd(
     return Err(ebadf());
   }
 
+  // Stdio fds (0/1/2) are pre-registered in FdTable at startup.
+  // For these, Pipe.open(fd) is a no-op since both Deno and Node
+  // share the same entry.
+  if (0..=2).contains(&fd) && state.borrow::<deno_io::FdTable>().contains(fd) {
+    return Ok(());
+  }
+
   // Reject if the fd is already tracked (e.g. from fs.openSync()).
-  // Silently replacing via HashMap::insert would drop the previous File,
-  // closing the underlying fd on Unix and leaking CRT bookkeeping on Windows.
-  if state.borrow::<NodeFsState>().open_fds.contains_key(&fd) {
+  if state.borrow::<deno_io::FdTable>().contains(fd) {
     return Err(eexist());
   }
 
@@ -897,7 +827,7 @@ pub fn op_node_register_fd(
   let std_file = unsafe { StdFile::from_raw_fd(fd) };
   let file: Rc<dyn deno_io::fs::File> =
     Rc::new(deno_io::StdFileResourceInner::file(std_file, None));
-  state.borrow_mut::<NodeFsState>().open_fds.insert(fd, file);
+  state.borrow_mut::<deno_io::FdTable>().register(fd, file);
   Ok(())
 }
 
@@ -918,8 +848,13 @@ pub fn op_node_register_fd(
     return Err(ebadf());
   }
 
+  // Stdio fds (0/1/2) are pre-registered in FdTable at startup.
+  if (0..=2).contains(&fd) && state.borrow::<deno_io::FdTable>().contains(fd) {
+    return Ok(());
+  }
+
   // Reject if the fd is already tracked (e.g. from fs.openSync()).
-  if state.borrow::<NodeFsState>().open_fds.contains_key(&fd) {
+  if state.borrow::<deno_io::FdTable>().contains(fd) {
     return Err(eexist());
   }
 
@@ -956,12 +891,12 @@ pub fn op_node_register_fd(
   let std_file = unsafe { StdFile::from_raw_handle(dup_handle) };
   let file: Rc<dyn deno_io::fs::File> =
     Rc::new(deno_io::StdFileResourceInner::file(std_file, None));
-  state.borrow_mut::<NodeFsState>().open_fds.insert(fd, file);
+  state.borrow_mut::<deno_io::FdTable>().register(fd, file);
   Ok(())
 }
 
 /// Create an anonymous pipe pair and return (read_fd, write_fd).
-/// The returned fds are NOT registered in NodeFsState; the caller
+/// The returned fds are NOT registered in FdTable; the caller
 /// is responsible for registering or closing them.
 #[cfg(unix)]
 #[op2]
@@ -1073,11 +1008,22 @@ pub fn op_node_fd_set_blocking(_fd: i32, _blocking: bool) -> i32 {
 
 #[op2(fast)]
 pub fn op_node_fs_close(state: &mut OpState, fd: i32) -> Result<(), FsError> {
+  // FdTable.remove() drops the Rc<dyn File> and cancels the cancel handle,
+  // which will abort any in-flight async reads on this fd.
   let file = state
-    .borrow_mut::<NodeFsState>()
-    .open_fds
-    .remove(&fd)
+    .borrow_mut::<deno_io::FdTable>()
+    .remove(fd)
     .ok_or_else(ebadf)?;
+
+  // For stdio fds (0/1/2), also remove the corresponding resource table
+  // entry so that Deno.stdin/stdout/stderr see the fd as closed and
+  // release their Rc clone of the same File.
+  if (0..=2).contains(&fd)
+    && let Ok(resource) = state.resource_table.take_any(fd as ResourceId)
+  {
+    resource.close();
+  }
+
   // Dropping the Rc<dyn File> will close the underlying OS file descriptor
   // when the reference count reaches zero (via std::fs::File Drop).
   drop(file);
@@ -1098,6 +1044,8 @@ pub fn op_node_fs_close(state: &mut OpState, fd: i32) -> Result<(), FsError> {
   Ok(())
 }
 
+/// Read from a raw OS fd using libc. No dup, no clone -- the read uses the
+/// fd number directly, so closing the fd from another thread interrupts the
 /// Positioned read: if position >= 0, uses pread to read without moving the
 /// file cursor. If position < 0, reads from the current position.
 fn read_with_position(
@@ -1126,8 +1074,10 @@ pub fn op_node_fs_read_sync(
   read_with_position(file, buf, position)
 }
 
-/// Async read for node:fs. Both positioned and non-positioned reads run
-/// on a blocking thread so the event loop stays responsive.
+/// Async read for node:fs. Runs a blocking read on a spawned thread using
+/// the raw OS fd directly (no dup/clone). When the fd is closed via
+/// Async read for node:fs. Uses the File trait from FdTable for proper
+/// I/O through the file handle.
 #[op2]
 #[smi]
 pub async fn op_node_fs_read_deferred(


### PR DESCRIPTION
## Summary

Introduces `FdTable` in `ext/io` as the central owner of `fd -> Rc<dyn File>` mappings, replacing `NodeFsState.open_fds`.

- **FdTable** stored in `OpState`, always initialized
- Stdio fds 0/1/2 registered at startup with the same `Rc<dyn File>` used by the resource table
- `NodeFsState` removed from `ext/node`
- `op_node_register_fd` is no-op for fds already in FdTable (e.g. stdio)
- `op_node_fs_close` removes from FdTable and also closes resource table entry for stdio fds
- `file_for_fd` simplified to single FdTable lookup

This is a prerequisite for #33154 (process stdio rewrite) and the NativePipe work, enabling both Deno's resource table and Node's fd-based ops to share the same file handles without double-ownership conflicts.

## Test plan
- [x] `./x test-node _fs_read_test` -- passes
- [x] `cargo check` -- compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)