### PR TITLE
fix(ext/node): use native libuv TCP connect instead of legacy path

### DIFF
--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -27,8 +27,7 @@
 // TODO(petamoriken): enable prefer-primordials for node polyfills
 // deno-lint-ignore-file prefer-primordials
 
-import { op_net_connect_tcp, TCP as NativeTCP } from "ext:core/ops";
-import { TcpConn } from "ext:deno_net/01_net.js";
+import { TCP as NativeTCP } from "ext:core/ops";
 import { primordials } from "ext:core/mod.js";
 const { Error } = primordials;
 import { notImplemented } from "ext:deno_node/_utils.ts";
@@ -41,7 +40,6 @@ import {
   kArrayBufferOffset,
   kBytesWritten,
   kReadBytesOrError,
-  kStreamBaseField,
   kUseNativeWrap,
   LibuvStreamWrap,
   ShutdownWrap,
@@ -106,8 +104,6 @@ export class TCP extends ConnectionWrap {
   #connections = 0;
 
   #closed = false;
-
-  #netPermToken?: object | undefined;
 
   // deno-lint-ignore no-explicit-any -- Native libuv TCP handle
   #native: any;
@@ -505,7 +501,18 @@ export class TCP extends ConnectionWrap {
     notImplemented("TCP.prototype.setSimultaneousAccepts");
   }
 
-  #nativeConnect(req: TCPConnectWrap, address: string, port: number) {
+  /**
+   * Connect to an IPv4 or IPv6 address.
+   * @param req A TCPConnectWrap instance.
+   * @param address The hostname to connect to.
+   * @param port The port to connect to.
+   * @return An error status code.
+   */
+  #connect(req: TCPConnectWrap, address: string, port: number): number {
+    this.#remoteAddress = address;
+    this.#remotePort = port;
+    this.#remoteFamily = getIPFamily(address);
+
     // deno-lint-ignore no-this-alias
     const self = this;
     this.#native.onconnect = function (status: number) {
@@ -552,56 +559,8 @@ export class TCP extends ConnectionWrap {
         }
       });
     }
-  }
 
-  /**
-   * Connect to an IPv4 or IPv6 address.
-   * @param req A TCPConnectWrap instance.
-   * @param address The hostname to connect to.
-   * @param port The port to connect to.
-   * @return An error status code.
-   */
-  #connect(req: TCPConnectWrap, address: string, port: number): number {
-    this.#remoteAddress = address;
-    this.#remotePort = port;
-    this.#remoteFamily = getIPFamily(address);
-
-    if (this[kUseNativeWrap]) {
-      this.#nativeConnect(req, address, port);
-      return 0;
-    } else {
-      this.#remoteAddress = address;
-      this.#remotePort = port;
-      this.#remoteFamily = getIPFamily(address);
-
-      op_net_connect_tcp(
-        { hostname: address ?? "127.0.0.1", port },
-        this.#netPermToken,
-      ).then(
-        ({ 0: rid, 1: localAddr, 2: remoteAddr }) => {
-          // Incorrect / backwards, but correcting the local address and port with
-          // what was actually used given we can't actually specify these in Deno.
-          this.#address = req.localAddress = localAddr.hostname;
-          this.#port = req.localPort = localAddr.port;
-          this[kStreamBaseField] = new TcpConn(rid, remoteAddr, localAddr);
-
-          try {
-            this.afterConnect(req, 0);
-          } catch {
-            // swallow callback errors.
-          }
-        },
-        () => {
-          try {
-            // TODO(cmorten): correct mapping of connection error to status code.
-            this.afterConnect(req, codeMap.get("ECONNREFUSED")!);
-          } catch {
-            // swallow callback errors.
-          }
-        },
-      );
-      return 0;
-    }
+    return 0;
   }
 
   /** Handle server closure. */
@@ -628,9 +587,5 @@ export class TCP extends ConnectionWrap {
     }
 
     return LibuvStreamWrap.prototype._onClose.call(this);
-  }
-
-  setNetPermToken(netPermToken: object | undefined) {
-    this.#netPermToken = netPermToken;
   }
 }

--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -970,9 +970,7 @@ function _lookupAndConnect(self: Socket, options: TcpSocketConnectOptions) {
         err: ErrnoException | null,
         ip: string,
         addressType: number,
-        netPermToken,
       ) {
-        self._handle?.setNetPermToken(netPermToken);
         self.emit("lookup", err, ip, addressType, host);
 
         // It's possible we were destroyed while looking this up.
@@ -1036,8 +1034,7 @@ function _lookupAndConnectMultiple(
   timeout: number | undefined,
 ) {
   defaultTriggerAsyncIdScope(self[asyncIdSymbol], function emitLookup() {
-    lookup(host, dnsopts, function emitLookup(err, addresses, _, netPermToken) {
-      self._handle?.setNetPermToken(netPermToken);
+    lookup(host, dnsopts, function emitLookup(err, addresses) {
       // It's possible we were destroyed while looking this up.
       // XXX it would be great if we could cancel the promise returned by
       // the look up.


### PR DESCRIPTION
## Summary
- Switches client TCP connections to always use the native libuv `uv_tcp_connect` path instead of the legacy `op_net_connect_tcp` + `TcpConn` + `kStreamBaseField` path
- Removes `kStreamBaseField` usage from `tcp_wrap.ts` entirely
- Removes `setNetPermToken` from TCP and its call sites in `net.ts` (the native `connect()` does its own `check_net` permission check in Rust)

Stacked on #33172.

## Test plan
- [ ] Existing node compat tests (net, http, tls) should pass — the native libuv connect path handles unbound sockets correctly (libuv auto-binds to `0.0.0.0:0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)