### PR TITLE
fix(ext/node): implement uv_ref for native TCP handles

### DIFF
--- a/ext/node/ops/libuv_stream.rs
+++ b/ext/node/ops/libuv_stream.rs
@@ -724,6 +724,18 @@ impl TCP {
   }
 
   #[fast]
+  #[rename("ref")]
+  fn ref_handle(&self) {
+    let tcp = self.raw();
+    // SAFETY: tcp handle pointer is valid and initialized
+    unsafe {
+      if !tcp.is_null() {
+        uv_compat::uv_ref(tcp.cast());
+      }
+    }
+  }
+
+  #[fast]
   fn unref(&self) {
     let tcp = self.raw();
     // SAFETY: tcp handle pointer is valid and initialized

--- a/ext/node/polyfills/internal_binding/tcp_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tcp_wrap.ts
@@ -390,7 +390,7 @@ export class TCP extends ConnectionWrap {
 
   override ref() {
     if (this[kUseNativeWrap] && this.#native) {
-      // TODO(@littledivy): implement uv_ref on native handle
+      this.#native.ref();
       return;
     }
 
@@ -405,7 +405,6 @@ export class TCP extends ConnectionWrap {
 
   override unref() {
     if (this[kUseNativeWrap] && this.#native) {
-      // TODO(@littledivy): implement uv_unref on native handle
       this.#native.unref();
       return;
     }

--- a/tests/specs/node/tcp_server_ref_unref/__test__.jsonc
+++ b/tests/specs/node/tcp_server_ref_unref/__test__.jsonc
@@ -1,0 +1,12 @@
+{
+  "tests": {
+    "unref_allows_exit": {
+      "args": "run -A unref_allows_exit.ts",
+      "output": "unref_allows_exit.out"
+    },
+    "ref_prevents_exit": {
+      "args": "run -A ref_prevents_exit.ts",
+      "output": "ref_prevents_exit.out"
+    }
+  }
+}

--- a/tests/specs/node/tcp_server_ref_unref/ref_prevents_exit.out
+++ b/tests/specs/node/tcp_server_ref_unref/ref_prevents_exit.out
@@ -1,0 +1,1 @@
+still alive after ref

--- a/tests/specs/node/tcp_server_ref_unref/ref_prevents_exit.ts
+++ b/tests/specs/node/tcp_server_ref_unref/ref_prevents_exit.ts
@@ -1,0 +1,15 @@
+// A ref'd TCP server (after unref + ref) should keep the event loop alive.
+// We use a timeout to prove the server kept the process running, then clean up.
+import net from "node:net";
+
+const server = net.createServer(() => {});
+server.listen(0, () => {
+  // unref then re-ref — server should still keep the process alive
+  server.unref();
+  server.ref();
+
+  setTimeout(() => {
+    console.log("still alive after ref");
+    server.close();
+  }, 100);
+});

--- a/tests/specs/node/tcp_server_ref_unref/unref_allows_exit.out
+++ b/tests/specs/node/tcp_server_ref_unref/unref_allows_exit.out
@@ -1,0 +1,1 @@
+server unref'd

--- a/tests/specs/node/tcp_server_ref_unref/unref_allows_exit.ts
+++ b/tests/specs/node/tcp_server_ref_unref/unref_allows_exit.ts
@@ -1,0 +1,9 @@
+// An unref'd TCP server should not keep the event loop alive.
+import net from "node:net";
+
+const server = net.createServer(() => {});
+server.listen(0, () => {
+  server.unref();
+  console.log("server unref'd");
+  // Process should exit naturally since the server is unref'd
+});


### PR DESCRIPTION
## Summary
- Adds `ref()` method to the native libuv TCP class (`uv_ref`), matching the existing `unref()` (`uv_unref`)
- Updates `TCP.ref()` in `tcp_wrap.ts` to call through to the native handle instead of being a no-op
- Removes both TODO comments from `ref()` and `unref()`

## Test plan
- [x] New spec tests `tests/specs/node/tcp_server_ref_unref/` verify:
  - `unref_allows_exit`: an unref'd TCP server does not keep the process alive
  - `ref_prevents_exit`: re-ref'ing a server after unref keeps the process alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)