### PR TITLE
fix(core): use c_char instead of i8 in uv_buf_t base cast

### DIFF
--- a/libs/core/uv_compat/tests.rs
+++ b/libs/core/uv_compat/tests.rs
@@ -2,6 +2,7 @@
 
 use std::cell::Cell;
 use std::cell::RefCell;
+use std::ffi::c_char;
 use std::ffi::c_void;
 use std::future::poll_fn;
 use std::rc::Rc;
@@ -1791,7 +1792,7 @@ async fn tcp_close_cancels_pending_writes() {
     unsafe {
       (*write_req.as_mut_ptr()).data = write_status_ptr as *mut c_void;
       let buf = uv_buf_t {
-        base: msg.as_ptr() as *mut i8,
+        base: msg.as_ptr() as *mut c_char,
         len: msg.len(),
       };
       assert_ok(uv_write(


### PR DESCRIPTION
Ran into this in nixpkgs, build fails for `aarch64-linux`: https://github.com/NixOS/nixpkgs/issues/506707

## Summary

- On aarch64-linux, `c_char` resolves to `u8` (unsigned) rather than `i8` (signed), per the ARM Linux ABI
- The test code was casting `msg.as_ptr()` to `*mut i8`, which mismatches `uv_buf_t.base: *mut c_char` on that platform
- Changed the cast to `*mut c_char` so it resolves correctly on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)