### PR TITLE
refactor(ext/node): prep for native TLSWrap

### DIFF
--- a/ext/node/ops/handle_wrap.rs
+++ b/ext/node/ops/handle_wrap.rs
@@ -207,6 +207,7 @@ pub enum ProviderType {
   TcpConnectWrap,
   TcpServerWrap,
   TcpWrap,
+  TlsWrap,
   TtyWrap,
   UdpSendWrap,
   UdpWrap,

--- a/ext/node/polyfills/_tls_common.ts
+++ b/ext/node/polyfills/_tls_common.ts
@@ -1,15 +1,158 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
-// deno-lint-ignore-file no-explicit-any
 
-export function createSecureContext(options: any) {
-  return {
-    ca: options?.ca,
-    cert: options?.cert,
-    key: options?.key,
+// TODO(petamoriken): enable prefer-primordials for node polyfills
+// deno-lint-ignore-file prefer-primordials no-explicit-any
+
+import {
+  ERR_TLS_INVALID_PROTOCOL_VERSION,
+  ERR_TLS_PROTOCOL_VERSION_CONFLICT,
+} from "ext:deno_node/internal/errors.ts";
+import { isArrayBufferView } from "ext:deno_node/internal/util/types.ts";
+
+// Map legacy secureProtocol strings to [minVersion, maxVersion] pairs.
+// Node.js maps these in src/crypto/crypto_context.cc.
+const kProtocolMap: Record<string, [string, string]> = {
+  "__proto__": null as any,
+  "TLSv1_method": ["TLSv1", "TLSv1"],
+  "TLSv1_client_method": ["TLSv1", "TLSv1"],
+  "TLSv1_server_method": ["TLSv1", "TLSv1"],
+  "TLSv1_1_method": ["TLSv1.1", "TLSv1.1"],
+  "TLSv1_1_client_method": ["TLSv1.1", "TLSv1.1"],
+  "TLSv1_1_server_method": ["TLSv1.1", "TLSv1.1"],
+  "TLSv1_2_method": ["TLSv1.2", "TLSv1.2"],
+  "TLSv1_2_client_method": ["TLSv1.2", "TLSv1.2"],
+  "TLSv1_2_server_method": ["TLSv1.2", "TLSv1.2"],
+  "SSLv23_method": ["TLSv1", "TLSv1.3"],
+  "SSLv23_client_method": ["TLSv1", "TLSv1.3"],
+  "SSLv23_server_method": ["TLSv1", "TLSv1.3"],
+  "TLS_method": ["TLSv1", "TLSv1.3"],
+  "TLS_client_method": ["TLSv1", "TLSv1.3"],
+  "TLS_server_method": ["TLSv1", "TLSv1.3"],
+};
+
+const kValidVersions: Set<string> = new Set([
+  "TLSv1",
+  "TLSv1.1",
+  "TLSv1.2",
+  "TLSv1.3",
+]);
+
+function toStringOrUndefined(val: any): string | undefined {
+  if (val == null) return undefined;
+  if (typeof val === "string") return val;
+  if (isArrayBufferView(val) || val instanceof globalThis.ArrayBuffer) {
+    return new TextDecoder().decode(val);
+  }
+  return `${val}`;
+}
+
+function normalizeCertValue(
+  val: any,
+): string | string[] | undefined {
+  if (val == null) return undefined;
+  if (globalThis.Array.isArray(val)) {
+    return val.map((v: any) => toStringOrUndefined(v)!).filter(
+      globalThis.Boolean,
+    );
+  }
+  return toStringOrUndefined(val);
+}
+
+function getProtocolRange(
+  options: any,
+): { minVersion: string; maxVersion: string } {
+  let minVersion = "TLSv1.2"; // Default per Node.js
+  let maxVersion = "TLSv1.3";
+
+  if (options.secureProtocol) {
+    const range = kProtocolMap[options.secureProtocol];
+    if (!range) {
+      throw new ERR_TLS_INVALID_PROTOCOL_VERSION(
+        options.secureProtocol,
+        "secureProtocol",
+      );
+    }
+
+    // If secureProtocol is set, minVersion/maxVersion must not also be set
+    if (options.minVersion || options.maxVersion) {
+      throw new ERR_TLS_PROTOCOL_VERSION_CONFLICT(
+        options.minVersion || options.maxVersion,
+        "secureProtocol",
+      );
+    }
+
+    [minVersion, maxVersion] = range;
+  } else {
+    if (options.minVersion) {
+      if (!kValidVersions.has(options.minVersion)) {
+        throw new ERR_TLS_INVALID_PROTOCOL_VERSION(
+          options.minVersion,
+          "minVersion",
+        );
+      }
+      minVersion = options.minVersion;
+    }
+    if (options.maxVersion) {
+      if (!kValidVersions.has(options.maxVersion)) {
+        throw new ERR_TLS_INVALID_PROTOCOL_VERSION(
+          options.maxVersion,
+          "maxVersion",
+        );
+      }
+      maxVersion = options.maxVersion;
+    }
+  }
+
+  return { minVersion, maxVersion };
+}
+
+export class SecureContext {
+  context: {
+    ca?: string | string[];
+    cert?: string;
+    key?: string;
+    minVersion: string;
+    maxVersion: string;
+    ciphers?: string;
+    passphrase?: string;
+    sigalgs?: string;
+    ecdhCurve?: string;
   };
+
+  constructor(options: any = {}) {
+    const { minVersion, maxVersion } = getProtocolRange(options);
+
+    this.context = {
+      ca: normalizeCertValue(options.ca),
+      cert: toStringOrUndefined(options.cert),
+      key: toStringOrUndefined(options.key),
+      minVersion,
+      maxVersion,
+      ciphers: options.ciphers,
+      passphrase: options.passphrase,
+      sigalgs: options.sigalgs,
+      ecdhCurve: options.ecdhCurve,
+    };
+  }
+
+  // Backward compat: current _tls_wrap.js accesses .ca, .cert, .key directly
+  get ca() {
+    return this.context.ca;
+  }
+  get cert() {
+    return this.context.cert;
+  }
+  get key() {
+    return this.context.key;
+  }
+}
+
+export function createSecureContext(options: any = {}) {
+  return new SecureContext(options);
 }
 
 export default {
+  SecureContext,
   createSecureContext,
 };


### PR DESCRIPTION
## Summary
- Add `ProviderType::TlsWrap` to `handle_wrap.rs` (the remaining handle_wrap prep — OwnedPtr, pub methods, and `set_state_closing` were already landed)
- Expand `_tls_common.ts` SecureContext from a 16-line stub to a proper implementation with:
  - `minVersion`/`maxVersion` validation and defaults (TLSv1.2–TLSv1.3)
  - Legacy `secureProtocol` string → version range mapping
  - Cert/key normalization (Buffer/ArrayBufferView → string)
  - `.context` sub-object for the upcoming native TLSWrap Rust code
  - Backward-compatible `.ca`/`.cert`/`.key` getters so existing `_tls_wrap.js` keeps working

This is prep work for landing a native `TLSWrap` cppgc object that uses the read interceptor infrastructure already in `stream_wrap.rs`.

## Test plan
- [x] `cargo check -p deno_node` passes
- [x] `tools/lint.js --js` passes
- [x] `./x test-spec tls` — all 3 tests pass
- [x] `./x test-unit tls` — all 2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)