### PR TITLE
fix(core): free UvLoopInner on uv_loop_t drop to prevent worker memory leak

### DIFF
--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -102,6 +102,22 @@ pub struct uv_loop_t {
   stop_flag: Cell<bool>,
 }
 
+impl Drop for uv_loop_t {
+  fn drop(&mut self) {
+    if !self.internal.is_null() {
+      // SAFETY: `internal` was allocated by `uv_loop_init` as
+      // `Box::into_raw(Box::new(UvLoopInner::new()))`. We must free it
+      // unconditionally during drop — unlike `uv_loop_close` which
+      // returns UV_EBUSY when handles are still alive, there is no way
+      // to signal failure from Drop.
+      unsafe {
+        drop(Box::from_raw(self.internal as *mut UvLoopInner));
+      }
+      self.internal = std::ptr::null_mut();
+    }
+  }
+}
+
 #[repr(C)]
 pub struct uv_handle_t {
   pub r#type: uv_handle_type,


### PR DESCRIPTION
## Summary

- Add `Drop` impl for `uv_loop_t` to free the `UvLoopInner` allocation that was previously leaked on every Web Worker teardown
- Each worker's `JsRuntime` creates a `uv_loop_t` via `uv_loop_init`, which heap-allocates a `UvLoopInner` (~9 KB of HashMaps, BTreeSets, Vecs). When the runtime was torn down, `OpState::clear()` dropped the `Box<uv_loop_t>` but the raw `internal` pointer to `UvLoopInner` was never freed — `uv_loop_close()` was never called
- This caused RSS to grow linearly with worker count (~40 KB/worker on macOS, ~25 KB/worker on Linux including allocator fragmentation)

### Before (RSS grows linearly, never plateaus)
```
After 500 workers:  RSS=162.0 MB (+59.9 MB)
After 1000 workers: RSS=169.1 MB (+67.0 MB)
After 1500 workers: RSS=177.1 MB (+75.0 MB)
After 2000 workers: RSS=183.2 MB (+81.0 MB)
```

### After (RSS plateaus after warmup)
```
After 500 workers:  RSS=153.3 MB (+56.8 MB)
After 1000 workers: RSS=155.5 MB (+59.0 MB)
After 1500 workers: RSS=156.6 MB (+60.1 MB)
After 2000 workers: RSS=157.6 MB (+61.1 MB)
```

macOS `leaks` tool confirmed: 2177 leaked objects (917 KB) → 382 (48 KB) after 100 workers — **93% reduction** in leaked bytes.

Towards #26058

## Test plan
- [x] All 66 `deno_core` uv_compat tests pass
- [x] All 56 worker spec tests pass
- [x] Verified with macOS `leaks` tool and Linux valgrind
- [x] RSS growth test shows plateau after warmup instead of linear growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)