### PR TITLE
fix(node): use fs.readFileSync in CJS module loader for monkey-patch compat

### DIFF
--- a/ext/node/polyfills/01_require.js
+++ b/ext/node/polyfills/01_require.js
@@ -1147,14 +1147,26 @@ Module._extensions[".cjs"] = loadCjs;
 Module._extensions[".mjs"] = loadESMFromCJS;
 Module._extensions[".wasm"] = loadESMFromCJS;
 
+// Use fs.readFileSync so that monkey-patches (e.g. @volar/typescript's
+// runTsc which intercepts reads of tsc.js) are respected. Fall back to
+// the internal op for virtual files like $deno$eval.cjs that don't
+// exist on disk.
+function readFileForRequire(filename) {
+  try {
+    return fs.readFileSync(filename, "utf-8");
+  } catch {
+    return op_require_read_file(filename);
+  }
+}
+
 function loadMaybeCjs(module, filename) {
-  const content = op_require_read_file(filename);
+  const content = readFileForRequire(filename);
   const format = op_require_is_maybe_cjs(filename) ? undefined : "module";
   module._compile(content, filename, format);
 }
 
 function loadCjs(module, filename) {
-  const content = op_require_read_file(filename);
+  const content = readFileForRequire(filename);
   module._compile(content, filename, "commonjs");
 }
 
@@ -1179,7 +1191,7 @@ function stripBOM(content) {
 
 // Native extension for .json
 Module._extensions[".json"] = function (module, filename) {
-  const content = op_require_read_file(filename);
+  const content = readFileForRequire(filename);
 
   try {
     module.exports = JSONParse(stripBOM(content));

--- a/tests/specs/node/require_fs_readfilesync_intercept/__test__.jsonc
+++ b/tests/specs/node/require_fs_readfilesync_intercept/__test__.jsonc
@@ -1,0 +1,12 @@
+{
+  "tests": {
+    "intercept_cjs": {
+      "args": "run --allow-read main.cjs",
+      "output": "main.out"
+    },
+    "intercept_json": {
+      "args": "run --allow-read json_main.cjs",
+      "output": "json_main.out"
+    }
+  }
+}

--- a/tests/specs/node/require_fs_readfilesync_intercept/data.json
+++ b/tests/specs/node/require_fs_readfilesync_intercept/data.json
@@ -1,0 +1,1 @@
+{ "value": "original" }

--- a/tests/specs/node/require_fs_readfilesync_intercept/json_main.cjs
+++ b/tests/specs/node/require_fs_readfilesync_intercept/json_main.cjs
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+
+const origReadFileSync = fs.readFileSync;
+const targetPath = path.resolve(__dirname, "data.json");
+
+fs.readFileSync = function (...args) {
+  if (args[0] === targetPath) {
+    return '{"value": "patched"}';
+  }
+  return origReadFileSync.apply(this, args);
+};
+
+const result = require("./data.json");
+console.log(result.value);
+
+fs.readFileSync = origReadFileSync;

--- a/tests/specs/node/require_fs_readfilesync_intercept/json_main.out
+++ b/tests/specs/node/require_fs_readfilesync_intercept/json_main.out
@@ -1,0 +1,1 @@
+patched

--- a/tests/specs/node/require_fs_readfilesync_intercept/main.cjs
+++ b/tests/specs/node/require_fs_readfilesync_intercept/main.cjs
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+const origReadFileSync = fs.readFileSync;
+const targetPath = path.resolve(__dirname, "target.cjs");
+
+// Monkey-patch fs.readFileSync to return different content for target.cjs.
+// This pattern is used by tools like @volar/typescript (vue-tsc) to
+// transform source files during require().
+fs.readFileSync = function (...args) {
+  if (args[0] === targetPath) {
+    return 'module.exports = "patched";';
+  }
+  return origReadFileSync.apply(this, args);
+};
+
+const result = require("./target.cjs");
+console.log(result);
+
+fs.readFileSync = origReadFileSync;

--- a/tests/specs/node/require_fs_readfilesync_intercept/main.out
+++ b/tests/specs/node/require_fs_readfilesync_intercept/main.out
@@ -1,0 +1,1 @@
+patched

--- a/tests/specs/node/require_fs_readfilesync_intercept/target.cjs
+++ b/tests/specs/node/require_fs_readfilesync_intercept/target.cjs
@@ -1,0 +1,1 @@
+module.exports = "original";


### PR DESCRIPTION
## Summary

- Deno's CJS require system was using `op_require_read_file` (a direct Rust op)
  to read module source files, bypassing the `node:fs` module entirely. This
  broke tools like `vue-tsc` (`@volar/typescript`) that monkey-patch
  `fs.readFileSync` to intercept and transform source files during `require()`.
- Switch to `fs.readFileSync` in the CJS/JSON extension handlers so that
  monkey-patches are respected. Fall back to `op_require_read_file` for virtual
  files (like `$deno$eval.cjs`) that don't exist on disk.

### Root cause

`@volar/typescript`'s `runTsc()` works by monkey-patching `fs.readFileSync` to
intercept reads of TypeScript's `tsc.js` and return a transformed version with
Volar's `proxyCreateProgram` injected. Under Node.js this works because CJS
`Module._extensions` handlers use `fs.readFileSync` to read source files. Under
Deno, the handlers used `op_require_read_file` which goes directly to Rust,
so the monkey-patch was never triggered and `tsc.js` ran unmodified without
Vue SFC support.

Closes #30977

## Test plan

- [x] New spec test `require_fs_readfilesync_intercept` verifies that
  monkey-patching `fs.readFileSync` is respected when `require()` loads
  `.cjs` and `.json` files
- [x] Existing CJS spec tests pass (cjs_sub_path, cjs_with_deps,
  dual_cjs_esm, translate_cjs_to_esm, deno_run_cowsay, etc.)
- [x] Virtual file loading (`deno eval` with CJS) still works via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)