### PR TITLE
fix(ext/node): track bytesRead on HTTP server request sockets

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -163,6 +163,8 @@ const kBindToAbortSignal = Symbol("kBindToAbortSignal");
 class FakeSocket extends EventEmitter {
   /** Stores the underlying request for lazily binding to abort signal */
   #request: Request | undefined;
+  bytesRead = 0;
+  bytesWritten = 0;
   constructor(
     opts: {
       encrypted?: boolean | undefined;
@@ -2134,7 +2136,14 @@ export class IncomingMessageForServer extends NodeReadable {
 
         try {
           const { value } = await reader!.read();
-          this.push(value !== undefined ? Buffer.from(value) : null);
+          if (value !== undefined) {
+            if (socket instanceof FakeSocket) {
+              socket.bytesRead += value.byteLength;
+            }
+            this.push(Buffer.from(value));
+          } else {
+            this.push(null);
+          }
         } catch (err) {
           this.destroy(err as Error);
         }
@@ -2378,6 +2387,22 @@ export class ServerImpl extends EventEmitter {
         request.headers.get("connection")?.toLowerCase().includes("upgrade") &&
         request.headers.get("upgrade");
       req[kRawHeaders] = request.headers;
+
+      // Estimate the bytes received for the HTTP request head (request line +
+      // headers). Body bytes are tracked separately as they are consumed from
+      // the reader in IncomingMessageForServer.
+      if (socket instanceof FakeSocket) {
+        // "METHOD /path HTTP/1.1\r\n"
+        let headBytes = request.method.length + 1 +
+          (req.url?.length || 1) + 11;
+        for (const [key, value] of request.headers) {
+          // "Key: Value\r\n"
+          headBytes += key.length + 2 + value.length + 2;
+        }
+        // "\r\n" (end of headers)
+        headBytes += 2;
+        socket.bytesRead = headBytes;
+      }
 
       // Don't fire the "upgrade" event for h2c (HTTP/2 cleartext) upgrades.
       // These are protocol-level upgrades that aren't meant for user-space

--- a/tests/specs/node/http_server_socket_bytes_read/__test__.jsonc
+++ b/tests/specs/node/http_server_socket_bytes_read/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/node/http_server_socket_bytes_read/main.out
+++ b/tests/specs/node/http_server_socket_bytes_read/main.out
@@ -1,0 +1,2 @@
+bytesRead type: number
+bytesRead > 0: true

--- a/tests/specs/node/http_server_socket_bytes_read/main.ts
+++ b/tests/specs/node/http_server_socket_bytes_read/main.ts
@@ -1,0 +1,22 @@
+import http from "node:http";
+
+// Test that req.socket.bytesRead is a number (not undefined) on HTTP server
+// requests. Regression test for https://github.com/denoland/deno/issues/33090
+
+const server = http.createServer((req, res) => {
+  req.on("end", () => {
+    const bytesRead = req.socket.bytesRead;
+    console.log(`bytesRead type: ${typeof bytesRead}`);
+    console.log(`bytesRead > 0: ${bytesRead > 0}`);
+    res.end("ok");
+    server.close();
+  });
+  req.resume();
+});
+
+server.listen(0, () => {
+  const port = (server.address() as { port: number }).port;
+  const req = http.request({ method: "PUT", port, hostname: "127.0.0.1" });
+  req.write("hello");
+  req.end();
+});


### PR DESCRIPTION
Closes #33090

## Summary

`req.socket.bytesRead` returns `undefined` in Deno's `node:http` server because the HTTP server uses a `FakeSocket` (an `EventEmitter` subclass) instead of a real `Socket` with a TCP handle. Node.js returns the total bytes received on the underlying TCP connection.

This PR:
- Adds `bytesRead` and `bytesWritten` properties to `FakeSocket`, initialized to `0`
- Estimates the HTTP request head size (request line + headers) and sets `bytesRead` accordingly when a new request arrives
- Tracks body bytes as they are consumed from the `ReadableStream` reader in `IncomingMessageForServer`

The estimate may not be byte-exact compared to Node.js (Deno's `Deno.serve()` handles HTTP parsing internally, so the raw TCP byte count is unavailable), but it provides a meaningful value instead of `undefined`, which is what libraries relying on this property need.

### Verification

Built with `cargo build --features hmr` and ran the exact reproducer from the issue:

```js
import http from "node:http";
const server = http.createServer((req, res) => {
  req.on("end", () => {
    console.log(req.socket.bytesRead);
    res.end("ok");
    server.close();
  });
  req.resume();
});
server.listen(0, () => {
  const port = server.address().port;
  const req = http.request({ method: "PUT", port, hostname: "127.0.0.1" });
  req.write("hello");
  req.end();
});
```

| | Output |
|---|---|
| **Stock Deno 2.7.12 (before)** | `undefined` |
| **HMR build with fix (after)** | `74` |

Node.js outputs `107` for the same request (includes raw TCP framing for chunked transfer encoding). The difference is expected because `Deno.serve()` handles HTTP parsing internally and only exposes decoded body bytes — the exact raw TCP byte count is unavailable. The important fix is that `bytesRead` is now a `number > 0` instead of `undefined`.

## Test plan
- [x] Added spec test `tests/specs/node/http_server_socket_bytes_read/` that verifies `req.socket.bytesRead` is a `number` > 0 after the request body is consumed
- [x] Verified fix locally using `cargo build --features hmr`
- [x] `deno fmt --check` passes on changed files
- [x] `deno lint` passes on changed files

## AI disclosure

This PR was authored with assistance from Claude Code.