### PR TITLE
fix(ext/http): treat empty Host header as missing in request URL

### DIFF
--- a/ext/http/request_properties.rs
+++ b/ext/http/request_properties.rs
@@ -353,6 +353,14 @@ fn req_host<'a>(
 
   // TODO(mmastrac): Most requests will use this path and we probably will want to optimize it in the future
   if let Some(host) = headers.get(HOST) {
+    // An empty `Host` header value is treated as if no Host header was sent,
+    // so the listener's fallback authority is used and `request.url` stays a
+    // valid URL. Hyper's HTTP/1 parser already trims OWS from header values,
+    // so whitespace-only `Host:` values reach us as empty bytes.
+    // See https://github.com/denoland/deno/issues/29872.
+    if host.is_empty() {
+      return None;
+    }
     return Some(match host.to_str() {
       Ok(host) => Cow::Borrowed(host),
       Err(_) => Cow::Owned(

--- a/tests/unit/serve_test.ts
+++ b/tests/unit/serve_test.ts
@@ -971,8 +971,10 @@ function createUrlTest(
     const conn = await Deno.connect({ port });
 
     const encoder = new TextEncoder();
+    // `null` omits the Host header entirely; `""` sends `Host:` with an
+    // empty value, which is a separate code path.
     const body = `${methodAndPath} HTTP/1.1\r\n${
-      host ? ("Host: " + host + "\r\n") : ""
+      host !== null ? ("Host: " + host + "\r\n") : ""
     }Content-Length: 5\r\n\r\n12345`;
     const writeResult = await conn.write(encoder.encode(body));
     assertEquals(body.length, writeResult);
@@ -1058,6 +1060,16 @@ createUrlTest(
   "CONNECT /path",
   null,
   400,
+);
+
+// Regression test for https://github.com/denoland/deno/issues/29872: an empty
+// `Host:` header must fall back to the listener's authority instead of
+// producing `request.url = "http:///path"` (which parses as hostname "path").
+createUrlTest(
+  "WithEmptyHostHeader",
+  "GET /path",
+  "",
+  "http://HOST:PORT/path",
 );
 
 Deno.test(


### PR DESCRIPTION
Fixes #29872.

## Problem

When a client sends an HTTP/1.1 request with an empty `Host:` header, `Deno.serve()` produced a `request.url` that was either unparseable or — worse — silently promoted the URL path to the hostname:

- `GET / HTTP/1.1\r\nHost:\r\n\r\n` → `request.url = "http:///"` → `new URL(request.url)` throws `TypeError: Invalid URL`
- `GET /path HTTP/1.1\r\nHost:\r\n\r\n` → `request.url = "http:///path"`, which `new URL()` parses as `http://path/`. The path component becomes the URL hostname, which is a correctness and security concern for handlers that route on `new URL(request.url).hostname`.

The original report (#29872) hit the first case on Deno 2.1.6 via a production server receiving a bot probe. The naked IP form (`90.151.171.106:443`) shown in the issue stack trace is now rejected by hyper as 400 before reaching the handler, but the underlying invariant — "`request.url` is always a valid URL that identifies the actual server" — was still broken via the empty-Host path.

## Root cause

`ext/http/request_properties.rs::req_host` returned `Some("")` for an empty `Host:` header. The op in `http_next.rs` forwarded that empty string verbatim to JS, and `ext/http/00_serve.ts` used `??` to coalesce the authority with the listener's fallback host — but `??` does not coalesce empty strings, so `""` reached the URL builder and produced `http://` + `""` + `/path` = `http:///path`.

## Fix

Treat an empty `Host:` header value as if no Host header were sent, so `req_host` returns `None` and the listener's fallback authority (already computed at listen time) is used. Hyper's HTTP/1 parser already trims OWS from header values, so whitespace-only `Host:` values arrive here as empty bytes and are covered by the same check.

The change is scoped to one function. The `??` coalesce in `00_serve.ts` is unchanged and still load-bearing for the case where no Host header is sent at all.

## Verification

Reproduced the bug locally, applied the fix, rebuilt `deno`, ran the new test against both versions:

**Before the fix** (`httpServerUrlWithEmptyHostHeader` added to the existing `createUrlTest` table):
```
httpServerUrlWithEmptyHostHeader ... FAILED
  [Diff] Actual / Expected
  -   http://path/
  +   http://localhost:42449/path
```

**After the fix**:
```
running 14 tests from ./tests/unit/serve_test.ts
httpServerUrlWithPath ... ok (6ms)
... (12 other URL-shape cases) ...
httpServerUrlWithEmptyHostHeader ... ok (5ms)

ok | 14 passed | 0 failed
```

Also ran an end-to-end probe via raw TCP against a patched `Deno.serve`:
```
Empty Host hdr   -> HTTP/1.1 200 OK | body=OK url=http://localhost:PORT/ parsed=http://localhost:PORT/
Host with just IP -> HTTP/1.1 200 OK | body=OK url=http://90.151.171.106:443/ parsed=http://90.151.171.106:443/
GET absolute URI  -> HTTP/1.1 200 OK | body=OK url=http://example.com/ parsed=http://example.com/
```

The broader `tests/unit/serve_test.ts` suite passes (160/162; the 2 failures are `httpServerVsock*` tests that require kernel vsock support unavailable in my WSL2 environment, unrelated to this change).

## Test

Added `WithEmptyHostHeader` as a new row in the existing `createUrlTest` table in `tests/unit/serve_test.ts`. The helper previously used `host ? ...` which conflated `null` (omit header) with `""` (send `Host:` with empty value); changed to `host !== null ? ...` so the two cases are distinguishable. Existing rows continue to use `null` and are unchanged.

## Checklist

- [x] `cargo build --bin deno` succeeds
- [x] `cargo clippy -p deno_http -- -D warnings` clean
- [x] `dprint check` clean on the two changed files (with the pinned toolchain's rustfmt for the Rust file)
- [x] `deno lint` clean on the test file
- [x] All `httpServerUrl*` tests pass (14/14)
- [x] Related issue referenced (#29872)

## AI disclosure

I used Claude (an AI assistant) to help investigate the code path, draft the fix, and write the regression test. I reviewed every change, reproduced the bug locally, and verified the fix end-to-end before opening this PR.