### PR TITLE
fix: skip empty dependency names to prevent lockfile corruption

### DIFF
--- a/libs/package_json/lib.rs
+++ b/libs/package_json/lib.rs
@@ -560,6 +560,11 @@ impl PackageJson {
       };
       let mut result = IndexMap::with_capacity(deps.len());
       for (key, value) in deps {
+        // Skip empty dependency names — they are not valid npm package
+        // identifiers and would corrupt the lockfile on serialization.
+        if key.is_empty() {
+          continue;
+        }
         result
           .entry(StackString::from(key.as_str()))
           .or_insert_with(|| PackageJsonDepValue::parse(key, value));

--- a/libs/resolver/lockfile.rs
+++ b/libs/resolver/lockfile.rs
@@ -392,6 +392,7 @@ impl<TSys: LockfileSys> LockfileLock<TSys> {
             deps
               .map(|i| {
                 i.iter()
+                  .filter(|(k, _)| !k.is_empty())
                   .filter_map(|(k, v)| PackageJsonDepValue::parse(k, v).ok())
                   .filter_map(|dep| match dep {
                     PackageJsonDepValue::Req(req) => {


### PR DESCRIPTION
## Problem

When `package.json` contains an empty-string dependency key (e.g., `"": "."`), Deno works on the first run but corrupts the lockfile. On the second run, deserialization fails with:

```
Invalid workspace section: Invalid package requirement '@.'
```

Fixes #32113

## Root Cause

An empty dependency name passes through `PackageJsonDepValue::parse("", ".")` and gets serialized into the lockfile as an invalid package requirement. When the lockfile is read back, the deserializer cannot parse it.

## Fix

Skip empty-string dependency names at two locations:

1. **`libs/package_json/lib.rs`** (`resolve_local_package_json_deps`): Filter out empty keys when building the dependency map. This prevents the invalid entry from entering the system at the parsing level.

2. **`libs/resolver/lockfile.rs`** (`collect_deps`): Filter out empty keys when collecting link package deps for the lockfile. Belt-and-suspenders defense for the lockfile path specifically.

Empty-string dependency names are not valid npm package identifiers and serve no purpose, so silently ignoring them is the correct behavior.

## Testing

Manually verified with the reproduction case from #32113:

```json
{
    "dependencies": {
        "": "."
    }
}
```

Before: lockfile corruption on second run. After: empty entry is silently skipped.