### PR TITLE
fix(ext/node): remove kUseNativeWrap on TLS TCP handles to fix HTTPS regression

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -315,7 +315,6 @@ TLSSocket.prototype._wrapHandle = function (wrap, handle) {
     handle = options.pipe
       ? new Pipe(PipeConstants.SOCKET)
       : new TCP(TCPConstants.SOCKET);
-    handle[kUseNativeWrap] = true;
   }
 
   // Wrap socket's handle with TLSWrap


### PR DESCRIPTION
## Summary

Removes `handle[kUseNativeWrap] = true` from `TLSSocket._wrapHandle` in `_tls_wrap.js`, fixing an HTTPS client regression introduced in v2.7.12.

## AI Disclosure

This PR was written with assistance from Claude (Anthropic). This PR was fully authored with Claude Code (Anthropic). Claude performed the version bisection testing, identified the breaking commit by diffing v2.7.11 and v2.7.12, traced the root cause through the source code, wrote the fix, and drafted the commit message and PR description.

## Problem

PR #33184 (`3ec37cc7e012`) added `kUseNativeWrap = true` on freshly created TCP handles inside `_wrapHandle`. This forces the handle into the `#nativeConnect` path which **never populates `kStreamBaseField`**.

When `http.ts:_writeHeader` later reads `handle[kStreamBaseField][internalRidSymbol]` to get the connection rid for `op_node_http_request_with_conn`, it crashes:

```
TypeError: Cannot read properties of undefined (reading 'Symbol(Deno.internal.rid)')
    at node:http:370:49
    at HttpsClientRequest._writeHeader (node:http:603:7)
```

This breaks **all HTTPS client requests** via Node compat — affects Playwright (#33229), `@deno/sandbox`, and any npm package using `https.request()`.

## Regression bisection

| Version | Status |
|---------|--------|
| 2.7.0 | ✅ Works |
| 2.7.5 | ✅ Works |
| 2.7.11 | ✅ Works |
| **2.7.12** | ❌ Broken |

## Fix

Remove the `kUseNativeWrap = true` assignment (1 line) so freshly created TCP handles use the legacy connect path that populates `kStreamBaseField` with a `TcpConn` carrying a valid rid.

The native `TLSWrap` still works — it just wraps a handle that went through the legacy connect path.

## Reproduction

```typescript
// Any HTTPS request via Node compat crashes on 2.7.12:
import https from "node:https";
https.get("https://example.com", (res) => console.log(res.statusCode));
// TypeError: Cannot read properties of undefined (reading 'Symbol(Deno.internal.rid)')
```

## Test plan

The existing Node compat test suite for `https` and `tls` covers this path. A minimal test:

```typescript
Deno.test("node:https GET request works", async () => {
  const https = await import("node:https");
  const status = await new Promise((resolve, reject) => {
    https.get("https://example.com", (res) => resolve(res.statusCode)).on("error", reject);
  });
  assertEquals(status, 200);
});
```

Fixes #33231
Fixes #33229