### PR TITLE
fix(ext/node): fix EEXIST error and file corruption with writeFileSync on Windows

### DIFF
--- a/ext/fs/interface.rs
+++ b/ext/fs/interface.rs
@@ -85,7 +85,8 @@ impl From<i32> for OpenOptions {
     }
     if (flags & libc::O_EXCL) == libc::O_EXCL {
       options.create_new = true;
-      options.write = true;
+      // Note: O_EXCL only controls create_new semantics. The write access
+      // mode is determined separately by O_WRONLY or O_RDWR flags.
       flags &= !libc::O_EXCL;
     }
     if (flags & libc::O_RDWR) == libc::O_RDWR {

--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -1043,7 +1043,12 @@ fn open_options(options: OpenOptions) -> fs::OpenOptions {
   open_options.read(options.read);
   open_options.create(options.create);
   open_options.write(options.write);
-  open_options.truncate(options.truncate);
+  // On Windows, truncate and create_new produce conflicting
+  // dwCreationDisposition flags (TRUNCATE_EXISTING vs CREATE_NEW).
+  // When create_new is set, the file must not exist, so truncation
+  // is meaningless. Passing both can cause spurious "os error 0"
+  // (ERROR_SUCCESS) failures and file corruption on Windows.
+  open_options.truncate(options.truncate && !options.create_new);
   open_options.append(options.append);
   open_options.create_new(options.create_new);
   open_options

--- a/tests/unit_node/fs_test.ts
+++ b/tests/unit_node/fs_test.ts
@@ -102,6 +102,51 @@ Deno.test(
 );
 
 Deno.test(
+  "[node/fs writeFileSync] overwrite existing file with default 'w' flag",
+  () => {
+    const filename = mkdtempSync(join(tmpdir(), "foo-")) + "/test.txt";
+
+    // Create a file with initial content
+    writeFileSync(filename, "initial content");
+    assertEquals(readFileSync(filename, "utf8"), "initial content");
+
+    // Overwrite the same file — should NOT throw EEXIST
+    writeFileSync(filename, "new content");
+    assertEquals(readFileSync(filename, "utf8"), "new content");
+  },
+);
+
+Deno.test(
+  "[node/fs writeFileSync] 'wx' flag fails with EEXIST on existing file",
+  () => {
+    const filename = mkdtempSync(join(tmpdir(), "foo-")) + "/test.txt";
+
+    // Create a file first
+    writeFileSync(filename, "original");
+
+    // Writing with 'wx' should fail since file exists
+    assertThrows(
+      () => writeFileSync(filename, "overwrite", { flag: "wx" }),
+      Error,
+    );
+
+    // Original content should be preserved (no truncation/corruption)
+    assertEquals(readFileSync(filename, "utf8"), "original");
+  },
+);
+
+Deno.test(
+  "[node/fs writeFileSync] 'wx' flag succeeds for new file",
+  () => {
+    const filename = mkdtempSync(join(tmpdir(), "foo-")) + "/new.txt";
+
+    // 'wx' on a new file should succeed
+    writeFileSync(filename, "exclusive write", { flag: "wx" });
+    assertEquals(readFileSync(filename, "utf8"), "exclusive write");
+  },
+);
+
+Deno.test(
   "[node/fs existsSync] path",
   { permissions: { read: true } },
   () => {


### PR DESCRIPTION
## Summary

Fixes a bug where `node:fs.writeFileSync` with the `'wx'` flag on Windows could:
1. Throw a spurious `EEXIST` error with the message "操作成功完成" (os error 0 / ERROR_SUCCESS)
2. Truncate the existing file to 0 bytes before failing, causing data loss

## Root Cause

When `writeFileSync` is called with flag `'wx'` (exclusive write), the flags `O_TRUNC | O_CREAT | O_WRONLY | O_EXCL` are passed to the Rust file open logic. This results in both `truncate(true)` and `create_new(true)` being set on `std::fs::OpenOptions`.

On Windows, these produce conflicting `CreateFileW` disposition flags (`TRUNCATE_EXISTING` vs `CREATE_NEW`), leading to undefined behavior — the file gets truncated before the exclusive-create check fails.

## Changes

- **`ext/fs/std_fs.rs`**: Don't pass `truncate(true)` when `create_new` is set, since truncation is meaningless for a file that must not already exist
- **`ext/fs/interface.rs`**: Remove incorrect `write = true` from the `O_EXCL` flag handler — write access should only come from `O_WRONLY` or `O_RDWR`

## Test plan

Added regression tests in `tests/unit_node/fs_test.ts`:
- [x] `writeFileSync` overwrites existing file with default `'w'` flag
- [x] `writeFileSync` with `'wx'` flag fails with EEXIST on existing file **without corrupting it**
- [x] `writeFileSync` with `'wx'` flag succeeds for new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)