### PR TITLE
fix: restore glibc < 2.27 compatibility for Linux release builds

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -126,6 +126,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -165,6 +166,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -177,6 +184,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -3339,6 +3352,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -3378,6 +3392,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -3390,6 +3410,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -3672,6 +3698,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -3711,6 +3738,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -3723,6 +3756,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -4005,6 +4044,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -4044,6 +4084,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -4056,6 +4102,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -4244,6 +4296,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -4283,6 +4336,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -4295,6 +4354,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -4977,6 +5042,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -5016,6 +5082,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -5028,6 +5100,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -5294,6 +5372,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -5333,6 +5412,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -5345,6 +5430,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -5599,6 +5690,7 @@ jobs:
           (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
           clang-21 -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+          clang-21 -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
           echo "Decompressing sysroot..."
           wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-`uname -m`.tar.xz -O /tmp/sysroot.tar.xz
@@ -5638,6 +5730,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1
@@ -5650,6 +5748,12 @@ jobs:
             -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
             -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
             -C link-arg=/tmp/memfd_create_shim.o
+            -C link-arg=/tmp/glibc_math_shim.o
+            -C link-arg=-Wl,--wrap=expf
+            -C link-arg=-Wl,--wrap=powf
+            -C link-arg=-Wl,--wrap=exp2f
+            -C link-arg=-Wl,--wrap=log2f
+            -C link-arg=-Wl,--wrap=logf
             --cfg tokio_unstable
             $RUSTFLAGS
           __1

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -132,6 +132,7 @@ ${installPkgsCommand} || (echo 'Failed. Trying again.' && sudo apt-get clean && 
 (yes '' | sudo update-alternatives --force --all) > /dev/null 2> /dev/null || true
 
 clang-${llvmVersion} -c -o /tmp/memfd_create_shim.o tools/memfd_create_shim.c -fPIC
+clang-${llvmVersion} -c -o /tmp/glibc_math_shim.o tools/glibc_math_shim.c -fPIC
 
 echo "Decompressing sysroot..."
 wget -q https://github.com/denoland/deno_sysroot_build/releases/download/sysroot-20250207/sysroot-\`uname -m\`.tar.xz -O /tmp/sysroot.tar.xz
@@ -171,6 +172,12 @@ RUSTFLAGS<<__1
   -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
   -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
   -C link-arg=/tmp/memfd_create_shim.o
+  -C link-arg=/tmp/glibc_math_shim.o
+  -C link-arg=-Wl,--wrap=expf
+  -C link-arg=-Wl,--wrap=powf
+  -C link-arg=-Wl,--wrap=exp2f
+  -C link-arg=-Wl,--wrap=log2f
+  -C link-arg=-Wl,--wrap=logf
   --cfg tokio_unstable
   $RUSTFLAGS
 __1
@@ -183,6 +190,12 @@ RUSTDOCFLAGS<<__1
   -C link-arg=-Wl,--thinlto-cache-dir=$(pwd)/target/release/lto-cache
   -C link-arg=-Wl,--thinlto-cache-policy,cache_size_bytes=700m
   -C link-arg=/tmp/memfd_create_shim.o
+  -C link-arg=/tmp/glibc_math_shim.o
+  -C link-arg=-Wl,--wrap=expf
+  -C link-arg=-Wl,--wrap=powf
+  -C link-arg=-Wl,--wrap=exp2f
+  -C link-arg=-Wl,--wrap=log2f
+  -C link-arg=-Wl,--wrap=logf
   --cfg tokio_unstable
   $RUSTFLAGS
 __1

--- a/tools/glibc_math_shim.c
+++ b/tools/glibc_math_shim.c
@@ -1,0 +1,37 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+// glibc 2.27 introduced new optimized versions of several libm functions.
+// When linking against a glibc >= 2.27 sysroot, the linker picks up the
+// GLIBC_2.27 versioned symbols, making the binary incompatible with older
+// systems (e.g. AWS Lambda, Amazon Linux 2, Fedora 27).
+//
+// This shim, combined with --wrap linker flags, redirects these calls to
+// the older base versions: GLIBC_2.2.5 on x86_64, GLIBC_2.17 on aarch64.
+//
+// See: https://github.com/denoland/deno/issues/30432
+
+#if defined(__aarch64__)
+#define GLIBC_BASE "GLIBC_2.17"
+#elif defined(__x86_64__)
+#define GLIBC_BASE "GLIBC_2.2.5"
+#else
+#error "unsupported architecture for glibc math shim"
+#endif
+
+__asm__(".symver __compat_expf, expf@" GLIBC_BASE);
+__asm__(".symver __compat_powf, powf@" GLIBC_BASE);
+__asm__(".symver __compat_exp2f, exp2f@" GLIBC_BASE);
+__asm__(".symver __compat_log2f, log2f@" GLIBC_BASE);
+__asm__(".symver __compat_logf, logf@" GLIBC_BASE);
+
+extern float __compat_expf(float);
+extern float __compat_powf(float, float);
+extern float __compat_exp2f(float);
+extern float __compat_log2f(float);
+extern float __compat_logf(float);
+
+float __wrap_expf(float x) { return __compat_expf(x); }
+float __wrap_powf(float x, float y) { return __compat_powf(x, y); }
+float __wrap_exp2f(float x) { return __compat_exp2f(x); }
+float __wrap_log2f(float x) { return __compat_log2f(x); }
+float __wrap_logf(float x) { return __compat_logf(x); }


### PR DESCRIPTION
## Summary

- Fixes Deno binary requiring `GLIBC_2.27` on Linux, which broke on older systems like AWS Lambda (Amazon Linux 2, glibc 2.26) and Fedora 27
- The root cause was the sysroot upgrade from Ubuntu Xenial (glibc 2.23) to Bionic (glibc 2.27) in cb738ee5da, which caused libm math functions (`expf`, `powf`, `exp2f`, `log2f`, `logf`) to link against their new `GLIBC_2.27` symbol versions
- Adds a C shim (`tools/glibc_math_shim.c`) using `--wrap` linker flags to redirect these functions to their pre-2.27 base versions (`GLIBC_2.2.5` on x86_64, `GLIBC_2.17` on aarch64), following the existing `memfd_create_shim` pattern

Closes #30432

## Test plan

- [ ] CI Linux builds succeed (the shim compiles and links correctly)
- [ ] Verify the output binary no longer references `GLIBC_2.27` math symbols: `objdump -T ./target/release/deno | grep GLIBC_2.27` should show only weak (`w`) symbols
- [ ] Binary runs on a system with glibc < 2.27 (e.g. Amazon Linux 2 container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)