### PR TITLE
fix(ext/napi): defer GC weak-callback finalizers to the event loop

### DIFF
--- a/ext/napi/js_native_api.rs
+++ b/ext/napi/js_native_api.rs
@@ -10,6 +10,7 @@ use std::ptr::NonNull;
 use libc::INT_MAX;
 use napi_sym::napi_sym;
 
+use super::util::SendPtr;
 use super::util::check_new_from_utf8;
 use super::util::check_new_from_utf8_len;
 use super::util::get_array_buffer_ptr;
@@ -128,19 +129,47 @@ impl Reference {
     let finalize_hint = reference.finalize_hint;
     reference.reset();
 
-    // copy this value before the finalize callback, since
-    // it might free the reference (which would be a UAF)
+    // Copy these before any callback, since the finalizer might free
+    // the reference (which would be a UAF).
     let ownership = reference.ownership;
-    if let Some(finalize_cb) = finalize_cb {
-      // Deregister before calling so it won't be called again at shutdown
-      let env = unsafe { &*reference.env };
-      env.remove_ref_finalizer(finalize_data);
-      unsafe {
-        finalize_cb(reference.env as _, finalize_data, finalize_hint);
-      }
-    }
+    let env_ptr = reference.env;
 
-    if ownership == ReferenceOwnership::Runtime {
+    if let Some(finalize_cb) = finalize_cb {
+      // Deregister before dispatching so it won't be called again at shutdown
+      let env = unsafe { &*env_ptr };
+      env.remove_ref_finalizer(finalize_data);
+
+      // Defer the finalizer to after GC completes. Calling user-provided
+      // finalizer callbacks during V8 GC is unsafe — they can re-enter V8,
+      // allocate GC'd objects, or trigger cascading weak callbacks, all of
+      // which lead to undefined behavior. Node.js defers these via
+      // EnqueueFinalizer; we use the cross-thread task spawner to schedule
+      // the callback on the next event loop tick.
+      let sender = env.async_work_sender.clone();
+      let env_send = SendPtr(env_ptr);
+      let data_send = SendPtr(finalize_data);
+      let hint_send = SendPtr(finalize_hint);
+      let ref_ptr = if ownership == ReferenceOwnership::Runtime {
+        SendPtr(reference as *mut Reference)
+      } else {
+        SendPtr(std::ptr::null_mut())
+      };
+      sender.spawn(move |_scope| {
+        unsafe {
+          finalize_cb(
+            env_send.take() as _,
+            data_send.take() as *mut c_void,
+            hint_send.take() as *mut c_void,
+          );
+        }
+        let ref_ptr = ref_ptr.take();
+        if !ref_ptr.is_null() {
+          unsafe { drop(Reference::from_raw(ref_ptr as *mut Reference)) }
+        }
+      });
+    } else if ownership == ReferenceOwnership::Runtime {
+      // No finalizer — just clean up the Reference. This only frees Rust
+      // heap memory (no V8 interaction), so it's safe during GC.
       unsafe { drop(Reference::from_raw(reference)) }
     }
   }
@@ -3822,10 +3851,27 @@ fn napi_add_finalizer(
 #[napi_sym]
 fn node_api_post_finalizer(
   env: *mut Env,
-  _finalize_cb: napi_finalize,
-  _finalize_data: *mut c_void,
-  _finalize_hint: *mut c_void,
+  finalize_cb: napi_finalize,
+  finalize_data: *mut c_void,
+  finalize_hint: *mut c_void,
 ) -> napi_status {
+  let env = check_env!(env);
+
+  // Schedule the finalizer to run on the next event loop tick,
+  // matching Node.js behavior. This is the public API equivalent
+  // of the internal deferred-finalizer mechanism.
+  let sender = env.async_work_sender.clone();
+  let env_send = SendPtr(env as *mut Env);
+  let data_send = SendPtr(finalize_data);
+  let hint_send = SendPtr(finalize_hint);
+  sender.spawn(move |_scope| unsafe {
+    finalize_cb(
+      env_send.take() as _,
+      data_send.take() as *mut c_void,
+      hint_send.take() as *mut c_void,
+    );
+  });
+
   napi_clear_last_error(env)
 }
 

--- a/tests/napi/deferred_finalizer_test.js
+++ b/tests/napi/deferred_finalizer_test.js
@@ -1,0 +1,25 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+import { assertEquals, loadTestLibrary } from "./common.js";
+
+const lib = loadTestLibrary();
+
+Deno.test("napi deferred finalizer runs after gc, not during", async () => {
+  // Create an external value with a finalizer that sets a flag when called.
+  // deno-lint-ignore no-unused-vars
+  let ext = lib.test_deferred_finalizer();
+  assertEquals(lib.test_deferred_finalizer_check(), false);
+
+  // Drop the reference and trigger GC.
+  ext = null;
+  globalThis.gc();
+
+  // The finalizer should be deferred — not yet called synchronously after gc().
+  assertEquals(lib.test_deferred_finalizer_check(), false);
+
+  // Yield to the event loop so the deferred finalizer can run.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // Now the finalizer should have run.
+  assertEquals(lib.test_deferred_finalizer_check(), true);
+});

--- a/tests/napi/src/finalizer.rs
+++ b/tests/napi/src/finalizer.rs
@@ -1,6 +1,8 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 use std::ptr;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 use napi_sys::ValueType::napi_object;
 use napi_sys::*;
@@ -186,6 +188,55 @@ extern "C" fn test_wrap_leak(
   args[0]
 }
 
+/// Flag for testing deferred finalizer behavior.
+static DEFERRED_FINALIZER_RAN: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn deferred_finalize_cb(
+  _env: napi_env,
+  data: *mut ::std::os::raw::c_void,
+  _hint: *mut ::std::os::raw::c_void,
+) {
+  unsafe {
+    let _ = Box::from_raw(data as *mut Thing);
+  }
+  DEFERRED_FINALIZER_RAN.store(true, Ordering::SeqCst);
+}
+
+/// Creates an external value with a finalizer that sets a flag when called.
+/// Used to test that GC finalizers are deferred to the event loop.
+extern "C" fn test_deferred_finalizer(
+  env: napi_env,
+  _: napi_callback_info,
+) -> napi_value {
+  // Reset the flag
+  DEFERRED_FINALIZER_RAN.store(false, Ordering::SeqCst);
+
+  let data = Box::into_raw(Box::new(Thing {
+    _allocation: vec![1, 2, 3],
+  }));
+
+  let mut result = ptr::null_mut();
+  assert_napi_ok!(napi_create_external(
+    env,
+    data as _,
+    Some(deferred_finalize_cb),
+    ptr::null_mut(),
+    &mut result
+  ));
+  result
+}
+
+/// Returns whether the deferred finalizer has been called.
+extern "C" fn test_deferred_finalizer_check(
+  env: napi_env,
+  _: napi_callback_info,
+) -> napi_value {
+  let ran = DEFERRED_FINALIZER_RAN.load(Ordering::SeqCst);
+  let mut result = ptr::null_mut();
+  assert_napi_ok!(napi_get_boolean(env, ran, &mut result));
+  result
+}
+
 pub fn init(env: napi_env, exports: napi_value) {
   let properties = &[
     napi_new_property!(env, "test_bind_finalizer", test_bind_finalizer),
@@ -202,6 +253,12 @@ pub fn init(env: napi_env, exports: napi_value) {
       test_static_external_buffer
     ),
     napi_new_property!(env, "test_wrap_leak", test_wrap_leak),
+    napi_new_property!(env, "test_deferred_finalizer", test_deferred_finalizer),
+    napi_new_property!(
+      env,
+      "test_deferred_finalizer_check",
+      test_deferred_finalizer_check
+    ),
   ];
 
   assert_napi_ok!(napi_define_properties(


### PR DESCRIPTION
## Summary

- Defer napi Reference weak-callback finalizers from V8 GC to the next event loop tick via `V8CrossThreadTaskSpawner`, matching Node.js's `EnqueueFinalizer` pattern
- Implement `node_api_post_finalizer` (was a no-op)
- Add regression test verifying finalizers run after GC, not during

## Background

Deep comparison of Node-API implementations between Node.js and Deno revealed that Deno was calling user-provided finalizer callbacks **directly during V8 GC pauses**. This is unsafe — finalizers can re-enter V8, allocate GC'd objects, or trigger cascading weak callbacks, all of which are undefined behavior during a GC pause. Node.js avoids this by deferring finalizers via `EnqueueFinalizer` to the event loop.

This is the most likely root cause of the intermittent `napi_unwrap` failures reported in #33137 (Vite 8 / rolldown builds). The timing-dependent nature of the bug matches: it only manifests when GC fires at a particular moment during napi class instance lifecycle.

## Test plan

- [x] New `deferred_finalizer_test.js`: creates an external with a finalizer, triggers GC, asserts finalizer has NOT run yet, yields to event loop, asserts finalizer HAS run
- [x] All existing napi tests pass (115 passed, 1 pre-existing failure in `cross_env_test.js`)
- [x] `cargo check`, `tools/format.js`, `tools/lint.js` all clean

Ref #33137

🤖 Generated with [Claude Code](https://claude.com/claude-code)