### PR TITLE
fix(console): find nodejs.util.inspect.custom on Proxy objects via get trap

### DIFF
--- a/ext/web/01_console.js
+++ b/ext/web/01_console.js
@@ -563,8 +563,18 @@ function formatValue(
       // to the `Deno` namespace in web workers. Remove when the `Deno`
       // namespace is always enabled.
       return String(value[privateCustomInspect](inspect, ctx));
-    } else if (ReflectHas(value, nodeCustomInspectSymbol)) {
-      const maybeCustom = value[nodeCustomInspectSymbol];
+    } else {
+      // Access the symbol directly instead of using `ReflectHas` (the `in`
+      // operator). Proxies may override `has` to hide symbols while still
+      // exposing them via `get` (e.g. nodejs-polars DataFrames). Node.js
+      // also accesses the symbol directly. Use try-catch because the
+      // Proxy's `get` trap may throw.
+      let maybeCustom;
+      try {
+        maybeCustom = value[nodeCustomInspectSymbol];
+      } catch {
+        // ignore - the proxy's get trap threw
+      }
       if (
         typeof maybeCustom === "function" &&
         // Filter out the util module, its inspect function is special.

--- a/tests/unit/console_test.ts
+++ b/tests/unit/console_test.ts
@@ -2378,6 +2378,36 @@ Deno.test(function inspectProxy() {
   );
 });
 
+Deno.test(function inspectProxyWithNodeCustomInspect() {
+  // Proxy that hides symbols from `has`/`ownKeys` but exposes them via `get`.
+  // This pattern is used by nodejs-polars DataFrames (issue #33236).
+  const nodeInspect = Symbol.for("nodejs.util.inspect.custom");
+  const target = {
+    [nodeInspect]() {
+      return "custom proxy output";
+    },
+  };
+  const proxy = new Proxy(target, {
+    has(_t, p) {
+      return typeof p === "string" && p === "x";
+    },
+    ownKeys() {
+      return ["x"];
+    },
+    getOwnPropertyDescriptor(_t, p) {
+      if (p === "x") return { configurable: true, enumerable: true, value: 1 };
+      return undefined;
+    },
+    get(t, p, r) {
+      return Reflect.get(t, p, r);
+    },
+  });
+  assertEquals(
+    stripAnsiCode(Deno.inspect(proxy)),
+    "custom proxy output",
+  );
+});
+
 Deno.test(function inspectError() {
   const error1 = new Error("This is an error");
   const error2 = new Error("This is an error", {


### PR DESCRIPTION
## Summary

Deno's `console.log`/`Deno.inspect` used `ReflectHas` (the `in` operator) to check for `Symbol.for('nodejs.util.inspect.custom')`. For Proxy objects that override the `has` trap to hide symbols while still exposing them via `get` (e.g. nodejs-polars DataFrames), this caused the custom inspect to be skipped entirely.

Node.js accesses the symbol directly without going through `has`. This commit matches that behavior.

**Before:** `console.log(df)` outputs `{}` for a nodejs-polars DataFrame
**After:** `console.log(df)` outputs the formatted table (via the custom inspect method)

## Test plan

- [x] Unit test `inspectProxyWithNodeCustomInspect` — Proxy that hides symbols from `has`/`ownKeys` but exposes via `get`
- [x] Existing `inspectProxy` tests pass (including the throwing-get-trap case)
- [x] `tools/format.js`, `tools/lint.js --js` clean

Closes #33236

🤖 Generated with [Claude Code](https://claude.com/claude-code)