### PR TITLE
refactor(runtime): use tokio LocalRuntime instead of MaskFutureAsSend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,7 +1546,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.9.3",
  "crossterm_winapi",
- "mio 1.0.3",
+ "mio 1.2.0",
  "parking_lot",
  "rustix",
  "signal-hook",
@@ -3171,6 +3171,7 @@ dependencies = [
  "sys_traits",
  "test_util",
  "thiserror 2.0.12",
+ "tokio",
  "twox-hash 2.1.0",
  "url",
 ]
@@ -3406,7 +3407,7 @@ dependencies = [
  "quinn",
  "serde",
  "serde_json",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5644,7 +5645,7 @@ dependencies = [
  "hyper 1.6.0",
  "libc",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -6101,17 +6102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
-dependencies = [
- "bitflags 2.9.3",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6446,9 +6436,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdbus-sys"
@@ -6879,14 +6869,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9355,12 +9345,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.0.3",
+ "mio 1.2.0",
  "signal-hook",
 ]
 
@@ -9507,12 +9497,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10633,22 +10623,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
- "mio 1.0.3",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10663,9 +10650,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12086,6 +12073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ tempfile = "3.4.0"
 termcolor = "1.1.3"
 testing_macros = "1.0.0"
 thiserror = "2.0.12"
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.52.0", features = ["full"] }
 tokio-eld = "0.2"
 tokio-metrics = { version = "0.3.0", features = ["rt"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["aws_lc_rs", "tls12"] }

--- a/libs/core/lib.rs
+++ b/libs/core/lib.rs
@@ -59,7 +59,7 @@ pub use deno_path_util::normalize_path;
 pub use deno_path_util::resolve_path;
 pub use deno_path_util::resolve_url_or_path;
 pub use deno_path_util::specifier_has_uri_scheme;
-pub use deno_unsync as unsync;
+pub mod unsync;
 pub use futures;
 pub use parking_lot;
 pub use serde;

--- a/libs/core/reactor_tokio.rs
+++ b/libs/core/reactor_tokio.rs
@@ -42,7 +42,7 @@ impl Reactor for TokioReactor {
     &self,
     fut: Pin<Box<dyn Future<Output = ()> + 'static>>,
   ) -> Pin<Box<dyn Future<Output = ()>>> {
-    let handle = deno_unsync::spawn(fut);
+    let handle = tokio::task::spawn_local(fut);
     Box::pin(async move {
       let _ = handle.await;
     })

--- a/libs/core/runtime/op_driver/futures_unordered_driver.rs
+++ b/libs/core/runtime/op_driver/futures_unordered_driver.rs
@@ -15,12 +15,12 @@ use std::task::ready;
 
 use bit_set::BitSet;
 use deno_error::JsErrorClass;
-use deno_unsync::JoinHandle;
 use deno_unsync::UnsyncWaker;
-use deno_unsync::spawn;
 use futures::FutureExt;
 use futures::Stream;
 use futures::stream::FuturesUnordered;
+use tokio::task::JoinHandle;
+use tokio::task::spawn_local as spawn;
 
 use super::OpDriver;
 use super::OpInflightStats;

--- a/libs/core/unsync.rs
+++ b/libs/core/unsync.rs
@@ -1,0 +1,25 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Re-exports for async task spawning primitives.
+//!
+//! With tokio's `LocalRuntime`, we can use `spawn_local` directly instead of
+//! the `MaskFutureAsSend` workaround that `deno_unsync` used. This module
+//! re-exports tokio's native task spawning alongside the remaining utilities
+//! from `deno_unsync`.
+
+// Task spawning - use tokio's native local spawning instead of deno_unsync's
+// MaskFutureAsSend workaround.
+pub use deno_unsync::Flag;
+pub use deno_unsync::MaskFutureAsSend;
+pub use deno_unsync::TaskQueue;
+pub use deno_unsync::TaskQueuePermit;
+pub use deno_unsync::TaskQueuePermitAcquireFuture;
+pub use deno_unsync::UnsendMarker;
+pub use deno_unsync::UnsyncWaker;
+// Re-export remaining deno_unsync utilities
+pub use deno_unsync::future;
+pub use deno_unsync::mpsc;
+pub use deno_unsync::sync;
+pub use tokio::task::JoinHandle;
+pub use tokio::task::spawn_blocking;
+pub use tokio::task::spawn_local as spawn;

--- a/libs/inspector_server/lib.rs
+++ b/libs/inspector_server/lib.rs
@@ -154,12 +154,12 @@ pub enum InspectorServerError {
   },
 }
 
-fn create_basic_runtime() -> tokio::runtime::Runtime {
+fn create_basic_runtime() -> tokio::runtime::LocalRuntime {
   tokio::runtime::Builder::new_current_thread()
     .enable_io()
     .enable_time()
     .max_blocking_threads(4)
-    .build()
+    .build_local(Default::default())
     .unwrap()
 }
 
@@ -185,18 +185,14 @@ impl InspectorServer {
 
     let thread_handle = thread::spawn(move || {
       let rt = create_basic_runtime();
-      let local = tokio::task::LocalSet::new();
-      local.block_on(
-        &rt,
-        server(
-          tcp_listener,
-          register_inspector_rx,
-          shutdown_server_rx,
-          reset_rx,
-          name,
-          publish_uid,
-        ),
-      )
+      rt.block_on(server(
+        tcp_listener,
+        register_inspector_rx,
+        shutdown_server_rx,
+        reset_rx,
+        name,
+        publish_uid,
+      ))
     });
 
     Ok(Self {

--- a/libs/npm_cache/rt.rs
+++ b/libs/npm_cache/rt.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 #[cfg(not(target_arch = "wasm32"))]
-use deno_unsync::JoinHandle;
+use tokio::task::JoinHandle;
 #[cfg(target_arch = "wasm32")]
 pub type JoinHandle<T> =
   std::future::Ready<Result<T, std::convert::Infallible>>;
@@ -19,7 +19,7 @@ pub fn spawn_blocking<
   }
   #[cfg(not(target_arch = "wasm32"))]
   {
-    deno_unsync::spawn_blocking(f)
+    tokio::task::spawn_blocking(f)
   }
 }
 

--- a/libs/npm_installer/flag.rs
+++ b/libs/npm_installer/flag.rs
@@ -137,7 +137,7 @@ mod inner {
                 // runtime and this is time sensitive so we don't want it to update
                 // at the whims of whatever is occurring on the runtime thread.
                 let sys = sys.clone();
-                deno_unsync::spawn_blocking({
+                tokio::task::spawn_blocking({
                   let poll_file = poll_file.clone();
                   move || loop {
                     sys

--- a/libs/npm_installer/graph.rs
+++ b/libs/npm_installer/graph.rs
@@ -79,7 +79,7 @@ impl<TNpmCacheHttpClient: NpmCacheHttpClient, TSys: NpmInstallerSys>
       if let Some(npm_installer) = &self.npm_installer {
         let npm_installer = npm_installer.clone();
         let package_name = package_name.to_string();
-        deno_unsync::spawn(async move {
+        tokio::task::spawn_local(async move {
           let _ignore = npm_installer.cache_package_info(&package_name).await;
         });
       }

--- a/libs/npm_installer/rt.rs
+++ b/libs/npm_installer/rt.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 #[cfg(not(target_arch = "wasm32"))]
-use deno_unsync::JoinHandle;
+use tokio::task::JoinHandle;
 #[cfg(target_arch = "wasm32")]
 pub type JoinHandle<T> =
   std::future::Ready<Result<T, std::convert::Infallible>>;
@@ -19,6 +19,6 @@ pub fn spawn_blocking<
   }
   #[cfg(not(target_arch = "wasm32"))]
   {
-    deno_unsync::spawn_blocking(f)
+    tokio::task::spawn_blocking(f)
   }
 }

--- a/libs/resolver/Cargo.toml
+++ b/libs/resolver/Cargo.toml
@@ -68,6 +68,9 @@ thiserror.workspace = true
 twox-hash.workspace = true
 url.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio.workspace = true
+
 [dev-dependencies]
 node_resolver.workspace = true
 sys_traits = { workspace = true, features = ["memory", "real", "serde_json"] }

--- a/libs/resolver/rt.rs
+++ b/libs/resolver/rt.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
 #[cfg(not(target_arch = "wasm32"))]
-use deno_unsync::JoinHandle;
+use tokio::task::JoinHandle;
 
 #[cfg(target_arch = "wasm32")]
 pub type JoinHandle<T> =
@@ -20,6 +20,6 @@ pub fn spawn_blocking<
   }
   #[cfg(not(target_arch = "wasm32"))]
   {
-    deno_unsync::spawn_blocking(f)
+    tokio::task::spawn_blocking(f)
   }
 }

--- a/runtime/tokio_util.rs
+++ b/runtime/tokio_util.rs
@@ -2,7 +2,6 @@
 use std::fmt::Debug;
 use std::str::FromStr;
 
-use deno_core::unsync::MaskFutureAsSend;
 #[cfg(tokio_unstable)]
 use tokio_metrics::RuntimeMonitor;
 
@@ -22,7 +21,7 @@ where
   }
 }
 
-pub fn create_basic_runtime() -> tokio::runtime::Runtime {
+pub fn create_basic_runtime() -> tokio::runtime::LocalRuntime {
   let (event_interval, global_queue_interval, max_io_events_per_tick) =
     tokio_configuration();
 
@@ -52,7 +51,7 @@ pub fn create_basic_runtime() -> tokio::runtime::Runtime {
     } else {
       32
     })
-    .build()
+    .build_local(Default::default())
     .unwrap()
 }
 
@@ -63,7 +62,7 @@ fn create_and_run_current_thread_inner<F, R>(
 ) -> R
 where
   F: std::future::Future<Output = R> + 'static,
-  R: Send + 'static,
+  R: 'static,
 {
   let rt = create_basic_runtime();
 
@@ -72,23 +71,18 @@ where
   // function #[inline(always)] to avoid holding the unboxed, unused future on the stack.
 
   #[cfg(debug_assertions)]
-  // SAFETY: this is guaranteed to be running on a current-thread executor
-  let future = Box::pin(unsafe { MaskFutureAsSend::new(future) });
-
-  #[cfg(not(debug_assertions))]
-  // SAFETY: this is guaranteed to be running on a current-thread executor
-  let future = unsafe { MaskFutureAsSend::new(future) };
+  let future = Box::pin(future);
 
   #[cfg(tokio_unstable)]
   let join_handle = if metrics_enabled {
-    rt.spawn(async move {
+    rt.spawn_local(async move {
       let metrics_interval: u64 = std::env::var("DENO_TOKIO_METRICS_INTERVAL")
         .ok()
         .and_then(|val| val.parse().ok())
         .unwrap_or(1000);
       let handle = tokio::runtime::Handle::current();
       let runtime_monitor = RuntimeMonitor::new(&handle);
-      tokio::spawn(async move {
+      tokio::task::spawn_local(async move {
         #[allow(
           clippy::print_stderr,
           reason = "we actually want to output here"
@@ -105,13 +99,13 @@ where
       future.await
     })
   } else {
-    rt.spawn(future)
+    rt.spawn_local(future)
   };
 
   #[cfg(not(tokio_unstable))]
-  let join_handle = rt.spawn(future);
+  let join_handle = rt.spawn_local(future);
 
-  let r = rt.block_on(join_handle).unwrap().into_inner();
+  let r = rt.block_on(join_handle).unwrap();
   // Forcefully shutdown the runtime - we're done executing JS code at this
   // point, but there might be outstanding blocking tasks that were created and
   // latered "unrefed". They won't terminate on their own, so we're forcing
@@ -124,7 +118,7 @@ where
 pub fn create_and_run_current_thread<F, R>(future: F) -> R
 where
   F: std::future::Future<Output = R> + 'static,
-  R: Send + 'static,
+  R: 'static,
 {
   create_and_run_current_thread_inner(future, false)
 }
@@ -133,7 +127,7 @@ where
 pub fn create_and_run_current_thread_with_maybe_metrics<F, R>(future: F) -> R
 where
   F: std::future::Future<Output = R> + 'static,
-  R: Send + 'static,
+  R: 'static,
 {
   let metrics_enabled = std::env::var("DENO_TOKIO_METRICS").ok().is_some();
   create_and_run_current_thread_inner(future, metrics_enabled)

--- a/tests/integration/run_tests.rs
+++ b/tests/integration/run_tests.rs
@@ -2645,7 +2645,7 @@ where
   Fut::Output: Send + 'static,
 {
   fn execute(&self, fut: Fut) {
-    deno_unsync::spawn(fut);
+    tokio::task::spawn_local(fut);
   }
 }
 

--- a/tests/util/server/servers/hyper_utils.rs
+++ b/tests/util/server/servers/hyper_utils.rs
@@ -51,7 +51,7 @@ where
       loop {
         let (stream, _) = listener.accept().await?;
         let io = TokioIo::new(stream);
-        deno_unsync::spawn(hyper_serve_connection(
+        tokio::task::spawn_local(hyper_serve_connection(
           io,
           handler,
           options.error_msg,
@@ -85,7 +85,7 @@ pub async fn run_server_with_acceptor<A, F, S>(
       while let Some(result) = acceptor.next().await {
         let stream = result?;
         let io = TokioIo::new(stream);
-        deno_unsync::spawn(hyper_serve_connection(
+        tokio::task::spawn_local(hyper_serve_connection(
           io, handler, error_msg, kind,
         ));
       }
@@ -115,7 +115,7 @@ pub async fn run_server_with_remote_addr<F, S>(
       loop {
         let (stream, addr) = listener.accept().await?;
         let io = TokioIo::new(stream);
-        deno_unsync::spawn(hyper_serve_connection(
+        tokio::task::spawn_local(hyper_serve_connection(
           io,
           move |req| handler(req, addr),
           options.error_msg,
@@ -148,7 +148,7 @@ async fn hyper_serve_connection<I, F, S>(
   let result: Result<(), anyhow::Error> = match kind {
     ServerKind::Auto => {
       let builder =
-        hyper_util::server::conn::auto::Builder::new(DenoUnsyncExecutor);
+        hyper_util::server::conn::auto::Builder::new(LocalSpawnExecutor);
       builder
         .serve_connection(io, service)
         .await
@@ -163,7 +163,7 @@ async fn hyper_serve_connection<I, F, S>(
     }
     ServerKind::OnlyHttp2 => {
       let builder =
-        hyper::server::conn::http2::Builder::new(DenoUnsyncExecutor);
+        hyper::server::conn::http2::Builder::new(LocalSpawnExecutor);
       builder
         .serve_connection(io, service)
         .await
@@ -180,14 +180,14 @@ async fn hyper_serve_connection<I, F, S>(
 }
 
 #[derive(Clone)]
-struct DenoUnsyncExecutor;
+struct LocalSpawnExecutor;
 
-impl<Fut> hyper::rt::Executor<Fut> for DenoUnsyncExecutor
+impl<Fut> hyper::rt::Executor<Fut> for LocalSpawnExecutor
 where
   Fut: Future + 'static,
   Fut::Output: 'static,
 {
   fn execute(&self, fut: Fut) {
-    deno_unsync::spawn(fut);
+    tokio::task::spawn_local(fut);
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade tokio from 1.47.1 to 1.52.0 to get the stabilized `LocalRuntime`
- Replace `MaskFutureAsSend` + `rt.spawn()` pattern with `LocalRuntime::spawn_local()` which natively supports `!Send` futures without unsafe
- Replace `deno_unsync::spawn` / `spawn_blocking` / `JoinHandle` with tokio's native `spawn_local` / `spawn_blocking` / `JoinHandle` across the codebase
- Convert inspector server from `Runtime` + `LocalSet` to `LocalRuntime`, eliminating the `LocalSet` indirection
- Create `libs/core/unsync.rs` as a re-export module so all existing `deno_core::unsync::spawn(...)` callsites automatically use `tokio::task::spawn_local`

`MaskFutureAsSend` remains available (and used in `cli/module_loader.rs`) for the case where a `!Send` future must be moved across a thread boundary -- that's a Rust `Send` constraint, not a tokio runtime issue.

The sync primitives from `deno_unsync` (`AtomicFlag`, `TaskQueue`, `UnsyncWaker`, etc.) are unaffected and still used.

## Test plan
- [x] `cargo check` passes
- [x] `./x fmt` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)