### PR TITLE
fix(node/http): set IncomingMessage.complete on server-side requests

### DIFF
--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -2116,6 +2116,7 @@ export class IncomingMessageForServer extends NodeReadable {
   url: string;
   method: string;
   socket: Socket | FakeSocket;
+  complete: boolean;
 
   constructor(socket: FakeSocket | Socket) {
     const reader = socket instanceof FakeSocket
@@ -2129,12 +2130,18 @@ export class IncomingMessageForServer extends NodeReadable {
       objectMode: false,
       read: async function (_size) {
         if (!reader) {
+          this.complete = true;
           return this.push(null);
         }
 
         try {
           const { value } = await reader!.read();
-          this.push(value !== undefined ? Buffer.from(value) : null);
+          if (value === undefined) {
+            this.complete = true;
+            this.push(null);
+          } else {
+            this.push(Buffer.from(value));
+          }
         } catch (err) {
           this.destroy(err as Error);
         }
@@ -2149,6 +2156,7 @@ export class IncomingMessageForServer extends NodeReadable {
     this.method = "";
     this.socket = socket;
     this.upgrade = null;
+    this.complete = false;
     this[kRawHeaders] = [];
     socket?.on("error", (e) => {
       if (this.listenerCount("error") > 0) {


### PR DESCRIPTION
Per #33256, `IncomingMessageForServer` never set the `complete` property defined on Node's [`http.IncomingMessage`](https://nodejs.org/api/http.html#messagecomplete). The property was `undefined` at all times, while Node sets it to `true` once the request body has been fully received.

This was previously fixed for `IncomingMessageForClient` in #19302, but the server-side class was missed.

This PR initializes `complete` to `false` in the constructor and flips it to `true` when the underlying reader is exhausted (mirroring the client implementation). It unblocks libraries like `on-finished` that detect already-consumed requests, and fixes Express middleware stacks with multiple body parsers — the second parser no longer attempts to re-consume an already-finished stream.

Closes #33256