### PR TITLE
fix(core): prevent TLA hang when has_tick_scheduled is set during async module evaluation

### DIFF
--- a/libs/core/error.rs
+++ b/libs/core/error.rs
@@ -164,6 +164,12 @@ pub enum CoreErrorKind {
   PendingPromiseResolution,
   #[class(generic)]
   #[error(
+    "Module evaluation is still pending after multiple event loop iterations, \
+     but no stalled top-level await was found. This is a bug in Deno."
+  )]
+  ModuleEvaluationDeadlock,
+  #[class(generic)]
+  #[error(
     "Cannot evaluate dynamically imported module, because JavaScript execution has been terminated"
   )]
   EvaluateDynamicImportedModule,

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -1445,6 +1445,8 @@ impl ModuleMap {
     };
     self.evaluating_top_level.set(false);
 
+    let is_graph_async = module.is_graph_async();
+
     self.pending_mod_evaluation.set(true);
 
     // Update status after evaluating.
@@ -1569,7 +1571,16 @@ impl ModuleMap {
       // Under Explicit microtask policy, guard this checkpoint so that
       // nextTick callbacks can run before promise microtasks queued during
       // module evaluation (e.g., Promise.resolve().then(...)).
-      if !JsRealm::state_from_scope(tc_scope).has_tick_scheduled() {
+      //
+      // However, for async module graphs (with TLA), this checkpoint is
+      // critical for draining TLA resume microtasks that V8 enqueued
+      // during module.evaluate(). If skipped, the evaluation promise may
+      // never resolve because V8's internal async module evaluation state
+      // machine relies on these microtasks being processed. The nextTick
+      // ordering concern does not apply to V8-internal TLA resolution.
+      if is_graph_async
+        || !JsRealm::state_from_scope(tc_scope).has_tick_scheduled()
+      {
         tc_scope.perform_microtask_checkpoint();
       }
     }

--- a/libs/core/modules/map.rs
+++ b/libs/core/modules/map.rs
@@ -1555,6 +1555,8 @@ impl ModuleMap {
     };
     self.evaluating_top_level.set(false);
 
+    let is_graph_async = module.is_graph_async();
+
     self.pending_mod_evaluation.set(true);
 
     // Update status after evaluating.
@@ -1679,7 +1681,16 @@ impl ModuleMap {
       // Under Explicit microtask policy, guard this checkpoint so that
       // nextTick callbacks can run before promise microtasks queued during
       // module evaluation (e.g., Promise.resolve().then(...)).
-      if !JsRealm::state_from_scope(tc_scope).has_tick_scheduled() {
+      //
+      // However, for async module graphs (with TLA), this checkpoint is
+      // critical for draining TLA resume microtasks that V8 enqueued
+      // during module.evaluate(). If skipped, the evaluation promise may
+      // never resolve because V8's internal async module evaluation state
+      // machine relies on these microtasks being processed. The nextTick
+      // ordering concern does not apply to V8-internal TLA resolution.
+      if is_graph_async
+        || !JsRealm::state_from_scope(tc_scope).has_tick_scheduled()
+      {
         tc_scope.perform_microtask_checkpoint();
       }
     }

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2624,3 +2624,122 @@ async fn test_lazy_loaded_esm_with_tla_no_panic() {
   runtime.run_event_loop(Default::default()).await.unwrap();
   receiver.await.unwrap();
 }
+
+/// Regression test for https://github.com/denoland/deno/issues/32821
+///
+/// When an async module graph has TLA and `has_tick_scheduled` is set during
+/// module evaluation (e.g. CJS `process.nextTick()` calls), the
+/// `has_tick_scheduled` guard on the microtask checkpoint in `mod_evaluate`
+/// could prevent TLA resume microtasks from being drained. For large module
+/// graphs where the TLA op resolves during event loop processing (not during
+/// `module.evaluate()` itself), this leaves the evaluation promise permanently
+/// stuck in Pending, causing a panic at
+/// "Expected at least one stalled top-level await".
+#[tokio::test]
+async fn test_tla_with_tick_scheduled_no_hang() {
+  // An async op that resolves on the next event loop iteration (not eagerly)
+  #[op2]
+  async fn op_async_resolve() -> u32 {
+    // Yield to the event loop so this does NOT resolve eagerly
+    tokio::task::yield_now().await;
+    42
+  }
+
+  deno_core::extension!(
+    test_ext,
+    ops = [op_async_resolve],
+    lazy_loaded_esm = [
+      dir "modules/testdata",
+      "lazy_loaded.js",
+      "lazy_loaded_2.js",
+    ]
+  );
+
+  let loader = Rc::new(TestingModuleLoader::new(NoopModuleLoader));
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init()],
+    module_loader: Some(loader),
+    ..Default::default()
+  });
+
+  let module_map = runtime.module_map().clone();
+
+  // Build a module graph where:
+  //   main.js (main module)
+  //     +-- tick_mod.js  -- sets has_tick_scheduled (simulates CJS nextTick)
+  //     +-- tla_mod.js   -- has TLA on an async op + triggers lazy load
+  //
+  // The key scenario: tick_mod.js sets has_tick_scheduled = true during
+  // module evaluation, causing the checkpoint in mod_evaluate to be
+  // skipped. tla_mod.js has a TLA that resolves during event loop
+  // processing, not during module.evaluate(). Without the fix, the
+  // evaluation promise stays Pending forever.
+
+  let (mod_main, mod_tick, mod_tla) = {
+    deno_core::scope!(scope, runtime);
+
+    let mod_tick = module_map
+      .new_es_module(
+        scope,
+        false,
+        ascii_str!("file:///tick_mod.js").into(),
+        ascii_str!(
+          r#"
+          Deno.core.setHasTickScheduled(true);
+          "#
+        )
+        .into(),
+        false,
+        None,
+      )
+      .unwrap();
+
+    let mod_tla = module_map
+      .new_es_module(
+        scope,
+        false,
+        ascii_str!("file:///tla_mod.js").into(),
+        ascii_str!(
+          r#"
+          const lazy1 = Deno.core.createLazyLoader("ext:test_ext/lazy_loaded.js")();
+          if (lazy1.foo !== "foo") throw new Error("lazy1.foo: " + lazy1.foo);
+          const result = await Deno.core.ops.op_async_resolve();
+          if (result !== 42) throw new Error("unexpected: " + result);
+          "#
+        )
+        .into(),
+        false,
+        None,
+      )
+      .unwrap();
+
+    let mod_main = module_map
+      .new_es_module(
+        scope,
+        true,
+        ascii_str!("file:///main.js").into(),
+        ascii_str!(
+          r#"
+          import "./tick_mod.js";
+          import "./tla_mod.js";
+          "#
+        )
+        .into(),
+        false,
+        None,
+      )
+      .unwrap();
+
+    (mod_main, mod_tick, mod_tla)
+  };
+
+  runtime.instantiate_module(mod_tick).unwrap();
+  runtime.instantiate_module(mod_tla).unwrap();
+  runtime.instantiate_module(mod_main).unwrap();
+
+  // This should not panic or hang
+  let receiver = runtime.mod_evaluate(mod_main);
+  runtime.run_event_loop(Default::default()).await.unwrap();
+  receiver.await.unwrap();
+}

--- a/libs/core/modules/tests.rs
+++ b/libs/core/modules/tests.rs
@@ -2775,3 +2775,122 @@ async fn test_lazy_loaded_esm_with_tla_no_panic() {
   runtime.run_event_loop(Default::default()).await.unwrap();
   receiver.await.unwrap();
 }
+
+/// Regression test for https://github.com/denoland/deno/issues/32821
+///
+/// When an async module graph has TLA and `has_tick_scheduled` is set during
+/// module evaluation (e.g. CJS `process.nextTick()` calls), the
+/// `has_tick_scheduled` guard on the microtask checkpoint in `mod_evaluate`
+/// could prevent TLA resume microtasks from being drained. For large module
+/// graphs where the TLA op resolves during event loop processing (not during
+/// `module.evaluate()` itself), this leaves the evaluation promise permanently
+/// stuck in Pending, causing a panic at
+/// "Expected at least one stalled top-level await".
+#[tokio::test]
+async fn test_tla_with_tick_scheduled_no_hang() {
+  // An async op that resolves on the next event loop iteration (not eagerly)
+  #[op2]
+  async fn op_async_resolve() -> u32 {
+    // Yield to the event loop so this does NOT resolve eagerly
+    tokio::task::yield_now().await;
+    42
+  }
+
+  deno_core::extension!(
+    test_ext,
+    ops = [op_async_resolve],
+    lazy_loaded_esm = [
+      dir "modules/testdata",
+      "lazy_loaded.js",
+      "lazy_loaded_2.js",
+    ]
+  );
+
+  let loader = Rc::new(TestingModuleLoader::new(NoopModuleLoader));
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init()],
+    module_loader: Some(loader),
+    ..Default::default()
+  });
+
+  let module_map = runtime.module_map().clone();
+
+  // Build a module graph where:
+  //   main.js (main module)
+  //     +-- tick_mod.js  -- sets has_tick_scheduled (simulates CJS nextTick)
+  //     +-- tla_mod.js   -- has TLA on an async op + triggers lazy load
+  //
+  // The key scenario: tick_mod.js sets has_tick_scheduled = true during
+  // module evaluation, causing the checkpoint in mod_evaluate to be
+  // skipped. tla_mod.js has a TLA that resolves during event loop
+  // processing, not during module.evaluate(). Without the fix, the
+  // evaluation promise stays Pending forever.
+
+  let (mod_main, mod_tick, mod_tla) = {
+    deno_core::scope!(scope, runtime);
+
+    let mod_tick = module_map
+      .new_es_module(
+        scope,
+        false,
+        ascii_str!("file:///tick_mod.js").into(),
+        ascii_str!(
+          r#"
+          Deno.core.setHasTickScheduled(true);
+          "#
+        )
+        .into(),
+        false,
+        None,
+      )
+      .unwrap();
+
+    let mod_tla = module_map
+      .new_es_module(
+        scope,
+        false,
+        ascii_str!("file:///tla_mod.js").into(),
+        ascii_str!(
+          r#"
+          const lazy1 = Deno.core.createLazyLoader("ext:test_ext/lazy_loaded.js")();
+          if (lazy1.foo !== "foo") throw new Error("lazy1.foo: " + lazy1.foo);
+          const result = await Deno.core.ops.op_async_resolve();
+          if (result !== 42) throw new Error("unexpected: " + result);
+          "#
+        )
+        .into(),
+        false,
+        None,
+      )
+      .unwrap();
+
+    let mod_main = module_map
+      .new_es_module(
+        scope,
+        true,
+        ascii_str!("file:///main.js").into(),
+        ascii_str!(
+          r#"
+          import "./tick_mod.js";
+          import "./tla_mod.js";
+          "#
+        )
+        .into(),
+        false,
+        None,
+      )
+      .unwrap();
+
+    (mod_main, mod_tick, mod_tla)
+  };
+
+  runtime.instantiate_module(mod_tick).unwrap();
+  runtime.instantiate_module(mod_tla).unwrap();
+  runtime.instantiate_module(mod_main).unwrap();
+
+  // This should not panic or hang
+  let receiver = runtime.mod_evaluate(mod_main);
+  runtime.run_event_loop(Default::default()).await.unwrap();
+  receiver.await.unwrap();
+}

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2429,12 +2429,37 @@ impl JsRuntime {
       {
         // pass, will be polled again
       } else {
-        return Poll::Ready(Err(
-          CoreErrorKind::Js(find_and_report_stalled_level_await_in_any_realm(
+        // Last-resort: try one more microtask checkpoint before reporting
+        // a stalled TLA. Under Explicit microtask policy, V8's internal
+        // async module evaluation state machine may require an additional
+        // checkpoint to fully resolve the evaluation promise (e.g. when
+        // TLA resumes trigger lazy module loads whose nested checkpoints
+        // are no-ops due to V8's reentrancy guard).
+        scope.perform_microtask_checkpoint();
+        let modules = &realm.0.module_map();
+        if !modules.has_pending_module_evaluation() {
+          // The checkpoint resolved the evaluation -- keep going
+          self.inner.state.waker.wake();
+        } else if let Some(js_error) =
+          find_and_report_stalled_level_await_in_any_realm(
             scope, &realm.0,
-          ))
-          .into_box(),
-        ));
+          )
+        {
+          return Poll::Ready(Err(
+            CoreErrorKind::Js(js_error).into_box(),
+          ));
+        } else {
+          // V8 reports no stalled TLA but the evaluation promise is still
+          // pending. This can happen with large async module graphs under
+          // Explicit microtask policy. Give the event loop one more
+          // iteration to make progress.
+          #[cfg(debug_assertions)]
+          eprintln!(
+            "warning: module evaluation pending but no stalled top-level \
+             await found, retrying event loop iteration"
+          );
+          self.inner.state.waker.wake();
+        }
       }
     }
 
@@ -2449,12 +2474,22 @@ impl JsRuntime {
       {
         // pass, will be polled again
       } else if realm.modules_idle() {
-        return Poll::Ready(Err(
-          CoreErrorKind::Js(find_and_report_stalled_level_await_in_any_realm(
+        if let Some(js_error) =
+          find_and_report_stalled_level_await_in_any_realm(
             scope, &realm.0,
-          ))
-          .into_box(),
-        ));
+          )
+        {
+          return Poll::Ready(Err(
+            CoreErrorKind::Js(js_error).into_box(),
+          ));
+        } else {
+          #[cfg(debug_assertions)]
+          eprintln!(
+            "warning: dynamic module evaluation pending but no stalled \
+             top-level await found, retrying event loop iteration"
+          );
+          self.inner.state.waker.wake();
+        }
       } else {
         realm.increment_modules_idle();
         self.inner.state.waker.wake();
@@ -2468,7 +2503,7 @@ impl JsRuntime {
 fn find_and_report_stalled_level_await_in_any_realm(
   scope: &mut v8::PinScope,
   inner_realm: &JsRealmInner,
-) -> Box<JsError> {
+) -> Option<Box<JsError>> {
   let module_map = inner_realm.module_map();
   let messages = module_map.find_stalled_top_level_await(scope);
 
@@ -2479,10 +2514,10 @@ fn find_and_report_stalled_level_await_in_any_realm(
     // situation is gonna be very rare, if ever happening).
     let msg = v8::Local::new(scope, &messages[0]);
     let js_error = JsError::from_v8_message(scope, msg);
-    return js_error;
+    return Some(js_error);
   }
 
-  unreachable!("Expected at least one stalled top-level await");
+  None
 }
 
 fn create_context<'s, 'i>(

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2462,12 +2462,37 @@ impl JsRuntime {
       {
         // pass, will be polled again
       } else {
-        return Poll::Ready(Err(
-          CoreErrorKind::Js(find_and_report_stalled_level_await_in_any_realm(
+        // Last-resort: try one more microtask checkpoint before reporting
+        // a stalled TLA. Under Explicit microtask policy, V8's internal
+        // async module evaluation state machine may require an additional
+        // checkpoint to fully resolve the evaluation promise (e.g. when
+        // TLA resumes trigger lazy module loads whose nested checkpoints
+        // are no-ops due to V8's reentrancy guard).
+        scope.perform_microtask_checkpoint();
+        let modules = &realm.0.module_map();
+        if !modules.has_pending_module_evaluation() {
+          // The checkpoint resolved the evaluation -- keep going
+          self.inner.state.waker.wake();
+        } else if let Some(js_error) =
+          find_and_report_stalled_level_await_in_any_realm(
             scope, &realm.0,
-          ))
-          .into_box(),
-        ));
+          )
+        {
+          return Poll::Ready(Err(
+            CoreErrorKind::Js(js_error).into_box(),
+          ));
+        } else {
+          // V8 reports no stalled TLA but the evaluation promise is still
+          // pending. This can happen with large async module graphs under
+          // Explicit microtask policy. Give the event loop one more
+          // iteration to make progress.
+          #[cfg(debug_assertions)]
+          eprintln!(
+            "warning: module evaluation pending but no stalled top-level \
+             await found, retrying event loop iteration"
+          );
+          self.inner.state.waker.wake();
+        }
       }
     }
 
@@ -2482,12 +2507,22 @@ impl JsRuntime {
       {
         // pass, will be polled again
       } else if realm.modules_idle() {
-        return Poll::Ready(Err(
-          CoreErrorKind::Js(find_and_report_stalled_level_await_in_any_realm(
+        if let Some(js_error) =
+          find_and_report_stalled_level_await_in_any_realm(
             scope, &realm.0,
-          ))
-          .into_box(),
-        ));
+          )
+        {
+          return Poll::Ready(Err(
+            CoreErrorKind::Js(js_error).into_box(),
+          ));
+        } else {
+          #[cfg(debug_assertions)]
+          eprintln!(
+            "warning: dynamic module evaluation pending but no stalled \
+             top-level await found, retrying event loop iteration"
+          );
+          self.inner.state.waker.wake();
+        }
       } else {
         realm.increment_modules_idle();
         self.inner.state.waker.wake();
@@ -2501,7 +2536,7 @@ impl JsRuntime {
 fn find_and_report_stalled_level_await_in_any_realm(
   scope: &mut v8::PinScope,
   inner_realm: &JsRealmInner,
-) -> Box<JsError> {
+) -> Option<Box<JsError>> {
   let module_map = inner_realm.module_map();
   let messages = module_map.find_stalled_top_level_await(scope);
 
@@ -2512,10 +2547,10 @@ fn find_and_report_stalled_level_await_in_any_realm(
     // situation is gonna be very rare, if ever happening).
     let msg = v8::Local::new(scope, &messages[0]);
     let js_error = JsError::from_v8_message(scope, msg);
-    return js_error;
+    return Some(js_error);
   }
 
-  unreachable!("Expected at least one stalled top-level await");
+  None
 }
 
 fn create_context<'s, 'i>(

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2498,7 +2498,10 @@ impl JsRuntime {
               CoreErrorKind::ModuleEvaluationDeadlock.into_box(),
             ));
           }
-          #[allow(clippy::print_stderr, reason = "intentional debug diagnostic for TLA stall recovery")]
+          #[allow(
+            clippy::print_stderr,
+            reason = "intentional debug diagnostic for TLA stall recovery"
+          )]
           {
             eprintln!(
               "warning: module evaluation pending but no stalled top-level \
@@ -2536,7 +2539,10 @@ impl JsRuntime {
               CoreErrorKind::ModuleEvaluationDeadlock.into_box(),
             ));
           }
-          #[allow(clippy::print_stderr, reason = "intentional debug diagnostic for TLA stall recovery")]
+          #[allow(
+            clippy::print_stderr,
+            reason = "intentional debug diagnostic for TLA stall recovery"
+          )]
           {
             eprintln!(
               "warning: dynamic module evaluation pending but no stalled \

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -469,6 +469,10 @@ pub struct JsRuntimeState {
   inspector: RefCell<Option<Rc<JsRuntimeInspector>>>,
   has_inspector: Cell<bool>,
   lazy_extensions: Vec<&'static str>,
+  /// Counter for consecutive event loop iterations where module evaluation
+  /// is pending but V8 reports no stalled top-level await. Used to detect
+  /// deadlocks and avoid spinning the event loop indefinitely.
+  tla_stall_retries: Cell<u32>,
 }
 
 #[derive(Default)]
@@ -790,6 +794,7 @@ impl JsRuntime {
       function_templates: Default::default(),
       callsite_prototype: None.into(),
       lazy_extensions,
+      tla_stall_retries: Cell::new(0),
     });
 
     // ...now we're moving on to ops; set them up, create `OpCtx` for each op
@@ -2472,24 +2477,30 @@ impl JsRuntime {
         let modules = &realm.0.module_map();
         if !modules.has_pending_module_evaluation() {
           // The checkpoint resolved the evaluation -- keep going
+          self.inner.state.tla_stall_retries.set(0);
           self.inner.state.waker.wake();
         } else if let Some(js_error) =
-          find_and_report_stalled_level_await_in_any_realm(
-            scope, &realm.0,
-          )
+          find_and_report_stalled_level_await_in_any_realm(scope, &realm.0)
         {
-          return Poll::Ready(Err(
-            CoreErrorKind::Js(js_error).into_box(),
-          ));
+          self.inner.state.tla_stall_retries.set(0);
+          return Poll::Ready(Err(CoreErrorKind::Js(js_error).into_box()));
         } else {
           // V8 reports no stalled TLA but the evaluation promise is still
           // pending. This can happen with large async module graphs under
-          // Explicit microtask policy. Give the event loop one more
-          // iteration to make progress.
-          #[cfg(debug_assertions)]
+          // Explicit microtask policy. Give the event loop a few more
+          // iterations to make progress, but bail if we are stuck.
+          const MAX_TLA_STALL_RETRIES: u32 = 10;
+          let retries = self.inner.state.tla_stall_retries.get() + 1;
+          self.inner.state.tla_stall_retries.set(retries);
+          if retries > MAX_TLA_STALL_RETRIES {
+            self.inner.state.tla_stall_retries.set(0);
+            return Poll::Ready(Err(
+              CoreErrorKind::ModuleEvaluationDeadlock.into_box(),
+            ));
+          }
           eprintln!(
             "warning: module evaluation pending but no stalled top-level \
-             await found, retrying event loop iteration"
+             await found, retrying event loop iteration ({retries}/{MAX_TLA_STALL_RETRIES})"
           );
           self.inner.state.waker.wake();
         }
@@ -2508,18 +2519,24 @@ impl JsRuntime {
         // pass, will be polled again
       } else if realm.modules_idle() {
         if let Some(js_error) =
-          find_and_report_stalled_level_await_in_any_realm(
-            scope, &realm.0,
-          )
+          find_and_report_stalled_level_await_in_any_realm(scope, &realm.0)
         {
-          return Poll::Ready(Err(
-            CoreErrorKind::Js(js_error).into_box(),
-          ));
+          self.inner.state.tla_stall_retries.set(0);
+          return Poll::Ready(Err(CoreErrorKind::Js(js_error).into_box()));
         } else {
-          #[cfg(debug_assertions)]
+          const MAX_TLA_STALL_RETRIES: u32 = 10;
+          let retries = self.inner.state.tla_stall_retries.get() + 1;
+          self.inner.state.tla_stall_retries.set(retries);
+          if retries > MAX_TLA_STALL_RETRIES {
+            self.inner.state.tla_stall_retries.set(0);
+            return Poll::Ready(Err(
+              CoreErrorKind::ModuleEvaluationDeadlock.into_box(),
+            ));
+          }
           eprintln!(
             "warning: dynamic module evaluation pending but no stalled \
-             top-level await found, retrying event loop iteration"
+             top-level await found, retrying event loop iteration \
+             ({retries}/{MAX_TLA_STALL_RETRIES})"
           );
           self.inner.state.waker.wake();
         }

--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2498,10 +2498,13 @@ impl JsRuntime {
               CoreErrorKind::ModuleEvaluationDeadlock.into_box(),
             ));
           }
-          eprintln!(
-            "warning: module evaluation pending but no stalled top-level \
-             await found, retrying event loop iteration ({retries}/{MAX_TLA_STALL_RETRIES})"
-          );
+          #[allow(clippy::print_stderr, reason = "intentional debug diagnostic for TLA stall recovery")]
+          {
+            eprintln!(
+              "warning: module evaluation pending but no stalled top-level \
+               await found, retrying event loop iteration ({retries}/{MAX_TLA_STALL_RETRIES})"
+            );
+          }
           self.inner.state.waker.wake();
         }
       }
@@ -2533,11 +2536,14 @@ impl JsRuntime {
               CoreErrorKind::ModuleEvaluationDeadlock.into_box(),
             ));
           }
-          eprintln!(
-            "warning: dynamic module evaluation pending but no stalled \
-             top-level await found, retrying event loop iteration \
-             ({retries}/{MAX_TLA_STALL_RETRIES})"
-          );
+          #[allow(clippy::print_stderr, reason = "intentional debug diagnostic for TLA stall recovery")]
+          {
+            eprintln!(
+              "warning: dynamic module evaluation pending but no stalled \
+               top-level await found, retrying event loop iteration \
+               ({retries}/{MAX_TLA_STALL_RETRIES})"
+            );
+          }
           self.inner.state.waker.wake();
         }
       } else {


### PR DESCRIPTION
## Summary

- Fix module evaluation promise getting permanently stuck in Pending when `has_tick_scheduled` is true during async module evaluation with TLA
- Replace `unreachable!()` panic with graceful recovery when V8 reports no stalled TLA but evaluation is still pending

Fixes #32821

## Root cause

PR #32466 added a `has_tick_scheduled()` guard to the microtask checkpoint in `mod_evaluate` (`map.rs:1572`). For async module graphs with TLA, this checkpoint is critical for draining V8's TLA resume microtasks. When CJS module initialization calls `process.nextTick()` (setting `has_tick_scheduled = true`), the checkpoint is skipped, which can leave the evaluation promise permanently Pending in large module graphs.

## Changes

**`libs/core/modules/map.rs`** -- Primary fix:
- Always run the microtask checkpoint for async module graphs (`is_graph_async`), regardless of `has_tick_scheduled`
- The nextTick ordering concern only applies to user-visible promise callbacks, not to V8's internal TLA resolution

**`libs/core/runtime/jsruntime.rs`** -- Safety net:
- Replace `unreachable!("Expected at least one stalled top-level await")` with graceful handling
- Try one last microtask checkpoint before reporting a stalled TLA
- If V8 reports no stalled TLAs but evaluation is still pending, retry the event loop iteration instead of panicking

**`libs/core/modules/tests.rs`** -- Regression test:
- `test_tla_with_tick_scheduled_no_hang`: verifies async module evaluation with TLA completes when `has_tick_scheduled` is set during evaluation

## Test plan

- [x] New test: `test_tla_with_tick_scheduled_no_hang` -- async module graph with TLA + tick scheduled
- [x] Existing test: `test_lazy_loaded_esm_with_tla_no_panic` -- still passes
- [x] Existing test: `test_stalled_tla` -- stalled TLA error reporting still works
- [ ] Manual verification with the reporter's large module graph (500+ ESM modules, ~100 CJS packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)