### PR TITLE
test: fetch latest canary hash dynamically in specific_canary test

### DIFF
--- a/tests/specs/upgrade/specific_canary/__test__.jsonc
+++ b/tests/specs/upgrade/specific_canary/__test__.jsonc
@@ -9,7 +9,7 @@
     },
     {
       "commandName": "./deno_copy",
-      "args": "upgrade --force --canary --version aaf2bf4bfbf90bed0b6e9812f337f057d1d24f93",
+      "args": "run -A upgrade.ts",
       "output": "upgrade.out",
       "exitCode": 0,
       "flaky": true

--- a/tests/specs/upgrade/specific_canary/upgrade.out
+++ b/tests/specs/upgrade/specific_canary/upgrade.out
@@ -1,6 +1,6 @@
 Current Deno version: [WILDCARD]
-Downloading https://dl.deno.land/canary/aaf2bf4bfbf90bed0b6e9812f337f057d1d24f93/deno-[WILDCARD].zip
-Deno is upgrading to version aaf2bf4bfbf90bed0b6e9812f337f057d1d24f93
+Downloading https://dl.deno.land/canary/[WILDCARD]/deno-[WILDCARD].zip
+Deno is upgrading to version [WILDCARD]
 
-Upgraded successfully to Deno aaf2bf4bfbf90bed0b6e9812f337f057d1d24f93 (canary)
+Upgraded successfully to Deno [WILDCARD] (canary)
 

--- a/tests/specs/upgrade/specific_canary/upgrade.ts
+++ b/tests/specs/upgrade/specific_canary/upgrade.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+// Fetch the latest canary hash and upgrade to it.
+const hash =
+  (await (await fetch("https://dl.deno.land/canary-latest.txt")).text()).trim();
+const { code } = await new Deno.Command("./deno_copy", {
+  args: ["upgrade", "--force", "--canary", "--version", hash],
+  stdout: "inherit",
+  stderr: "inherit",
+}).output();
+Deno.exit(code);

--- a/tests/specs/upgrade/specific_canary/version.out
+++ b/tests/specs/upgrade/specific_canary/version.out
@@ -1,3 +1,3 @@
-deno 2.0.0-rc.2+aaf2bf4 (canary, release, [WILDCARD])
-v8 12.9.202.13-rusty
-typescript 5.6.2
+deno [WILDCARD]+[WILDCARD] (canary, release, [WILDCARD])
+[WILDCARD]
+[WILDCARD]


### PR DESCRIPTION
## Summary
- Instead of hardcoding a stale canary commit hash, fetch the latest one from https://dl.deno.land/canary-latest.txt at test time
- Update `.out` files to use wildcards for the dynamic hash/version

🤖 Generated with [Claude Code](https://claude.com/claude-code)