### PR TITLE
fix(audit): migrate to bulk advisory endpoint

### DIFF
--- a/cli/tools/pm/audit.rs
+++ b/cli/tools/pm/audit.rs
@@ -14,7 +14,6 @@ use eszip::v2::Url;
 use http::header::HeaderName;
 use http::header::HeaderValue;
 use serde::Deserialize;
-use serde::Serialize;
 
 use crate::args::AuditFlags;
 use crate::args::Flags;
@@ -29,7 +28,6 @@ pub async fn audit(
   audit_flags: AuditFlags,
 ) -> Result<i32, AnyError> {
   let factory = CliFactory::from_flags(flags);
-  let workspace = factory.workspace_resolver().await?;
   let npm_resolver = factory.npm_resolver().await?;
   let npm_resolver = npm_resolver.as_managed().unwrap();
   let snapshot = npm_resolver.resolution().snapshot();
@@ -42,14 +40,8 @@ pub async fn audit(
 
   let use_socket = audit_flags.socket;
 
-  let r = npm::call_audits_api(
-    audit_flags,
-    npm_url,
-    workspace,
-    &snapshot,
-    http_client,
-  )
-  .await?;
+  let r =
+    npm::call_audits_api(audit_flags, npm_url, &snapshot, http_client).await?;
 
   if use_socket {
     socket_dev::call_firewall_api(
@@ -66,13 +58,7 @@ mod npm {
   use std::collections::HashMap;
   use std::collections::HashSet;
 
-  use deno_npm::NpmPackageId;
-  use deno_package_json::PackageJsonDepValue;
-  use deno_resolver::workspace::WorkspaceResolver;
-  use deno_semver::package::PackageNv;
-
   use super::*;
-  use crate::sys::CliSys;
 
   #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
   enum AdvisorySeverity {
@@ -94,212 +80,45 @@ mod npm {
     }
   }
 
-  fn get_dependency_descriptors_for_deps(
-    seen: &mut HashSet<PackageNv>,
-    all_dependencies_snapshot: &NpmResolutionSnapshot,
-    dev_dependencies_snapshot: &NpmResolutionSnapshot,
-    package_id: &NpmPackageId,
-  ) -> HashMap<String, Box<DependencyDescriptor>> {
-    let mut is_dev = false;
-
-    let resolution_package =
-      match dev_dependencies_snapshot.package_from_id(package_id) {
-        Some(p) => {
-          is_dev = true;
-          p
-        }
-        None => all_dependencies_snapshot
-          .package_from_id(package_id)
-          .unwrap(),
-      };
-    let mut deps_map =
-      HashMap::with_capacity(resolution_package.dependencies.len());
-    for dep in resolution_package.dependencies.iter() {
-      if !seen.insert(dep.1.nv.clone()) {
-        continue;
-      }
-
-      let dep_deps = get_dependency_descriptors_for_deps(
-        seen,
-        all_dependencies_snapshot,
-        dev_dependencies_snapshot,
-        dep.1,
-      );
-      deps_map.insert(
-        dep.0.to_string(),
-        Box::new(DependencyDescriptor {
-          version: dep.1.nv.version.to_string(),
-          dev: is_dev,
-          requires: dep_deps
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.version.to_string()))
-            .collect(),
-          dependencies: dep_deps,
-        }),
-      );
-    }
-    deps_map
-  }
-
   pub async fn call_audits_api_inner(
     client: &HttpClient,
     npm_url: Url,
     body: serde_json::Value,
-  ) -> Result<AuditResponse, AnyError> {
-    let url = npm_url.join("-/npm/v1/security/audits").unwrap();
+  ) -> Result<BulkAuditResponse, AnyError> {
+    let url = npm_url.join("-/npm/v1/security/advisories/bulk").unwrap();
     let future = client.post_json(url, &body)?.send().boxed_local();
     let response = future.await?;
     let json_str = http_util::body_to_string(response)
       .await
       .context("Failed to read response from the npm registry API")?;
-    let response: AuditResponse = serde_json::from_str(&json_str)
+    let response: BulkAuditResponse = serde_json::from_str(&json_str)
       .context("Failed to deserialize response from the npm registry API")?;
     Ok(response)
-  }
-
-  /// Partition into as few groups as possible so that no partition
-  /// contains two entries with the same `name`.
-  pub fn partition_packages<'a>(
-    pkgs: &'a [&NpmPackageId],
-  ) -> Vec<Vec<&'a NpmPackageId>> {
-    // 1) Group by name
-    let mut by_name: HashMap<&str, Vec<&NpmPackageId>> = HashMap::new();
-    for p in pkgs {
-      by_name.entry(&p.nv.name[..]).or_default().push(p);
-    }
-
-    // 2) The minimal number of partitions is the max multiplicity per name
-    let k = by_name.values().map(|v| v.len()).max().unwrap_or(0);
-    if k == 0 {
-      return Vec::new();
-    }
-
-    // 3) Create k partitions
-    let mut partitions: Vec<Vec<&NpmPackageId>> = vec![Vec::new(); k];
-
-    // 4) Round-robin each name-group across the partitions
-    for group in by_name.values() {
-      for (i, item) in group.iter().enumerate() {
-        partitions[i].push(*item);
-      }
-    }
-
-    partitions
-  }
-
-  /// Merges multiple audit responses into a single consolidated response
-  fn merge_responses(responses: Vec<AuditResponse>) -> AuditResponse {
-    let mut merged_advisories = HashMap::new();
-    let mut merged_actions = Vec::new();
-    let mut total_low = 0;
-    let mut total_moderate = 0;
-    let mut total_high = 0;
-    let mut total_critical = 0;
-
-    for response in responses {
-      // Merge advisories (HashMap by advisory ID)
-      for (id, advisory) in response.advisories {
-        merged_advisories.insert(id, advisory);
-      }
-
-      // Merge actions
-      merged_actions.extend(response.actions);
-
-      // Sum up vulnerability counts
-      total_low += response.metadata.vulnerabilities.low;
-      total_moderate += response.metadata.vulnerabilities.moderate;
-      total_high += response.metadata.vulnerabilities.high;
-      total_critical += response.metadata.vulnerabilities.critical;
-    }
-
-    AuditResponse {
-      advisories: merged_advisories,
-      actions: merged_actions,
-      metadata: AuditMetadata {
-        vulnerabilities: AuditVulnerabilities {
-          low: total_low,
-          moderate: total_moderate,
-          high: total_high,
-          critical: total_critical,
-        },
-      },
-    }
   }
 
   pub async fn call_audits_api(
     audit_flags: AuditFlags,
     npm_url: &Url,
-    workspace: &WorkspaceResolver<CliSys>,
     npm_resolution_snapshot: &NpmResolutionSnapshot,
     client: HttpClient,
   ) -> Result<i32, AnyError> {
-    let top_level_packages = npm_resolution_snapshot
-      .top_level_packages()
-      .collect::<Vec<_>>();
-    // In deno.json users might define two different versions of the same package - so we need
-    // to partition top level packages into buckets, to check all versions used.
-    let top_level_packages_partitions = partition_packages(&top_level_packages);
-
-    let mut requires = HashMap::with_capacity(top_level_packages.len());
-    let mut dependencies = HashMap::with_capacity(top_level_packages.len());
-
-    // Collect all dev dependencies, so they can be properly marked in the request body - since
-    // there's no way to specify `devDependencies` in `deno.json`, this is only iterating
-    // through discovered `package.json` files.
-    let mut all_dev_deps = Vec::with_capacity(32);
-    for pkg_json in workspace.package_jsons() {
-      let deps = pkg_json.resolve_local_package_json_deps();
-      for v in deps.dev_dependencies.values() {
-        let Ok(PackageJsonDepValue::Req(package_req)) = v else {
-          continue;
-        };
-        all_dev_deps.push(package_req.clone());
-      }
+    // Build request body for the bulk advisory endpoint:
+    // { "pkg-name": ["ver1", "ver2"], ... }
+    let mut body_map: HashMap<String, HashSet<String>> = HashMap::new();
+    for pkg in npm_resolution_snapshot.all_packages_for_every_system() {
+      body_map
+        .entry(pkg.id.nv.name.to_string())
+        .or_default()
+        .insert(pkg.id.nv.version.to_string());
     }
-    let dev_dependencies_snapshot =
-      npm_resolution_snapshot.subset(&all_dev_deps);
+    let body: HashMap<String, Vec<String>> = body_map
+      .into_iter()
+      .map(|(k, v)| (k, v.into_iter().collect()))
+      .collect();
+    let body = serde_json::to_value(&body).unwrap();
 
-    let mut responses = Vec::with_capacity(top_level_packages_partitions.len());
-    // And now let's construct the request body we need for the npm audits API.
-    let seen = &mut HashSet::with_capacity(top_level_packages.len() * 100);
-    for partition in top_level_packages_partitions {
-      for package in partition {
-        let is_dev =
-          dev_dependencies_snapshot.package_from_id(package).is_some();
-        requires
-          .insert(package.nv.name.to_string(), package.nv.version.to_string());
-        seen.insert(package.nv.clone());
-        let package_deps = get_dependency_descriptors_for_deps(
-          seen,
-          npm_resolution_snapshot,
-          &dev_dependencies_snapshot,
-          package,
-        );
-        dependencies.insert(
-          package.nv.name.to_string(),
-          Box::new(DependencyDescriptor {
-            version: package.nv.version.to_string(),
-            dev: is_dev,
-            requires: package_deps
-              .iter()
-              .map(|(k, v)| (k.to_string(), v.version.to_string()))
-              .collect(),
-            dependencies: package_deps,
-          }),
-        );
-      }
-
-      let body = serde_json::json!({
-          "dev": false,
-          "install": [],
-          "metadata": {},
-          "remove": [],
-          "requires": requires,
-          "dependencies": dependencies,
-      });
-
-      let r = call_audits_api_inner(&client, npm_url.clone(), body).await;
-      let audit_response: AuditResponse = match r {
+    let bulk_response =
+      match call_audits_api_inner(&client, npm_url.clone(), body).await {
         Ok(s) => s,
         Err(err) => {
           if audit_flags.ignore_registry_errors {
@@ -310,21 +129,27 @@ mod npm {
           }
         }
       };
-      responses.push(audit_response);
+
+    // Convert bulk response to flat list of advisories
+    let mut advisories: Vec<AuditAdvisory> = Vec::new();
+    for (pkg_name, pkg_advisories) in &bulk_response {
+      for adv in pkg_advisories {
+        advisories.push(AuditAdvisory {
+          title: adv.title.clone(),
+          severity: adv.severity.clone(),
+          url: adv.url.clone(),
+          module_name: pkg_name.clone(),
+          vulnerable_versions: adv.vulnerable_versions.clone(),
+          patched_versions: adv.patched_versions.clone().unwrap_or_default(),
+          cves: adv.cves.clone(),
+        });
+      }
     }
-
-    // Merge all responses into a single response
-    let response = merge_responses(responses);
-
-    let mut advisories = response.advisories.values().collect::<Vec<_>>();
 
     // Filter out advisories where no installed version falls within
     // the vulnerable range. This handles package.json overrides that
-    // force a patched version -- the npm audit API returns advisories
-    // based on the dependency tree as declared, but overrides may have
-    // resolved a non-vulnerable version.
+    // force a patched version.
     {
-      // Collect all installed package versions from the snapshot.
       let mut installed_versions: HashMap<String, Vec<deno_semver::Version>> =
         HashMap::new();
       for pkg in npm_resolution_snapshot.all_packages_for_every_system() {
@@ -340,24 +165,11 @@ mod npm {
           // Can't parse the range; keep the advisory to be safe
           return true;
         };
-        // Use the finding paths to identify the actual installed
-        // package name (the last segment of each path).
-        let finding_pkg_names: Vec<&str> = adv
-          .findings
-          .iter()
-          .flat_map(|f| f.paths.iter())
-          .filter_map(|p| p.rsplit('>').next().map(str::trim))
-          .collect();
-        // Check if any installed version of the affected packages
-        // falls within the vulnerable range.
-        for name in &finding_pkg_names {
-          if let Some(versions) = installed_versions.get(*name)
-            && versions.iter().any(|v| vulnerable_range.matches(v))
-          {
-            return true;
-          }
+        if let Some(versions) = installed_versions.get(&adv.module_name) {
+          versions.iter().any(|v| vulnerable_range.matches(v))
+        } else {
+          false
         }
-        false
       });
     }
 
@@ -396,13 +208,7 @@ mod npm {
 
     let minimal_severity =
       AdvisorySeverity::parse(&audit_flags.severity).unwrap();
-    print_report(
-      &vulns,
-      advisories,
-      response.actions,
-      minimal_severity,
-      audit_flags.ignore_unfixable,
-    );
+    print_report(&vulns, &advisories, minimal_severity);
 
     // Exit code 1 only if there are vulnerabilities at or above the specified level
     let exit_code = if vulns.count_at_or_above(minimal_severity) > 0 {
@@ -415,10 +221,8 @@ mod npm {
 
   fn print_report(
     vulns: &AuditVulnerabilities,
-    advisories: Vec<&AuditAdvisory>,
-    actions: Vec<AuditAction>,
+    advisories: &[AuditAdvisory],
     minimal_severity: AdvisorySeverity,
-    ignore_unfixable: bool,
   ) {
     let stdout = &mut std::io::stdout();
 
@@ -427,11 +231,6 @@ mod npm {
         continue;
       };
       if severity < minimal_severity {
-        continue;
-      }
-
-      let actions = adv.find_actions(&actions);
-      if actions.is_empty() && ignore_unfixable {
         continue;
       }
 
@@ -459,37 +258,15 @@ mod npm {
         colors::gray("Vulnerable:"),
         adv.vulnerable_versions
       );
-      _ = writeln!(
-        stdout,
-        "│ {}    {}",
-        colors::gray("Patched:"),
-        adv.patched_versions
-      );
-      if let Some(finding) = adv.findings.first()
-        && let Some(path) = finding.paths.first()
-      {
-        let path_fmt = path
-          .split(">")
-          .collect::<Vec<_>>()
-          .join(colors::gray(" > ").to_string().as_str());
-        _ = writeln!(stdout, "│ {}       {}", colors::gray("Path:"), path_fmt);
+      if !adv.patched_versions.is_empty() {
+        _ = writeln!(
+          stdout,
+          "│ {}    {}",
+          colors::gray("Patched:"),
+          adv.patched_versions
+        );
       }
-      if actions.is_empty() {
-        _ = writeln!(stdout, "╰ {}      {}", colors::gray("Info:"), adv.url);
-      } else {
-        _ = writeln!(stdout, "│ {}       {}", colors::gray("Info:"), adv.url);
-      }
-      if actions.len() == 1 {
-        _ =
-          writeln!(stdout, "╰ {}    {}", colors::gray("Actions:"), actions[0]);
-      } else if actions.len() > 1 {
-        _ =
-          writeln!(stdout, "│ {}    {}", colors::gray("Actions:"), actions[0]);
-        for action in &actions[0..actions.len() - 2] {
-          _ = writeln!(stdout, "│             {}", action);
-        }
-        _ = writeln!(stdout, "╰             {}", actions[actions.len() - 1]);
-      }
+      _ = writeln!(stdout, "╰ {}       {}", colors::gray("Info:"), adv.url);
       _ = writeln!(stdout);
     }
 
@@ -512,107 +289,41 @@ mod npm {
     );
   }
 
-  #[derive(Debug, Serialize)]
-  #[serde(rename_all = "camelCase")]
-  struct DependencyDescriptor {
-    version: String,
-    dev: bool,
-    requires: HashMap<String, String>,
-    dependencies: HashMap<String, Box<DependencyDescriptor>>,
-  }
-
+  /// Advisory item from the bulk API response.
   #[derive(Debug, Deserialize)]
-  pub struct AuditActionResolve {
-    pub id: i32,
-    pub path: Option<String>,
-    // TODO(bartlomieju): currently not used, commented out so it's not flagged by clippy
-    // pub dev: bool,
-    // pub optional: bool,
-    // pub bundled: bool,
-  }
-
-  #[derive(Debug, Deserialize)]
-  pub struct AuditAction {
-    #[serde(rename = "isMajor", default)]
-    pub is_major: bool,
-    pub action: String,
-    pub resolves: Vec<AuditActionResolve>,
-    pub module: Option<String>,
-    pub target: Option<String>,
-  }
-
-  #[derive(Debug, Deserialize)]
-  pub struct AdvisoryFinding {
-    // TODO(bartlomieju): currently not used, commented out so it's not flagged by clippy
-    // pub version: String,
-    pub paths: Vec<String>,
-  }
-
-  #[derive(Debug, Deserialize)]
-  pub struct AuditAdvisory {
-    pub id: i32,
+  pub struct BulkAdvisoryItem {
+    pub url: String,
     pub title: String,
-    pub findings: Vec<AdvisoryFinding>,
+    pub severity: String,
+    pub vulnerable_versions: String,
+    #[serde(default)]
+    pub patched_versions: Option<String>,
     #[serde(default)]
     pub cves: Vec<String>,
-    // TODO(bartlomieju): currently not used, commented out so it's not flagged by clippy
-    // pub cwe: Vec<String>,
-    pub severity: String,
-    pub url: String,
-    pub module_name: String,
-    pub vulnerable_versions: String,
-    pub patched_versions: String,
+    #[serde(default)]
+    #[allow(dead_code, reason = "deserialized but not yet displayed")]
+    pub cwe: Vec<String>,
   }
 
-  impl AuditAdvisory {
-    fn find_actions(&self, actions: &[AuditAction]) -> Vec<String> {
-      let mut acts = Vec::new();
+  /// The bulk advisory endpoint response: { "package-name": [advisory, ...] }
+  pub type BulkAuditResponse = HashMap<String, Vec<BulkAdvisoryItem>>;
 
-      for action in actions {
-        if !action.resolves.iter().any(|r| r.id == self.id) {
-          continue;
-        }
-
-        let module = action
-          .module
-          .as_deref()
-          .map(str::to_owned)
-          .or_else(|| {
-            // Fallback to infer from dependency path
-            action.resolves.first().and_then(|r| {
-              r.path
-                .as_deref()
-                .and_then(|p| p.split('>').next_back())
-                .map(|s| s.trim().to_string())
-            })
-          })
-          .unwrap_or_else(|| "<unknown>".to_string());
-
-        let target = action
-          .target
-          .as_deref()
-          .map(|t| format!("@{}", t))
-          .unwrap_or_default();
-
-        let major = if action.is_major {
-          " (major upgrade)"
-        } else {
-          ""
-        };
-
-        acts.push(format!("{} {}{}{}", action.action, module, target, major));
-      }
-
-      acts
-    }
+  /// Internal advisory representation with module name from the response key.
+  struct AuditAdvisory {
+    title: String,
+    severity: String,
+    url: String,
+    module_name: String,
+    vulnerable_versions: String,
+    patched_versions: String,
+    cves: Vec<String>,
   }
 
-  #[derive(Debug, Deserialize)]
-  pub struct AuditVulnerabilities {
-    pub low: i32,
-    pub moderate: i32,
-    pub high: i32,
-    pub critical: i32,
+  struct AuditVulnerabilities {
+    low: i32,
+    moderate: i32,
+    high: i32,
+    critical: i32,
   }
 
   impl AuditVulnerabilities {
@@ -628,25 +339,6 @@ mod npm {
         AdvisorySeverity::Critical => self.critical,
       }
     }
-  }
-
-  #[derive(Debug, Deserialize)]
-  #[serde(rename_all = "camelCase")]
-  pub struct AuditMetadata {
-    pub vulnerabilities: AuditVulnerabilities,
-    // TODO(bartlomieju): currently not used, commented out so it's not flagged by clippy
-    // pub dependencies: i32,
-    // pub dev_dependencies: i32,
-    // pub optional_dependencies: i32,
-    // pub total_dependencies: i32,
-  }
-
-  #[derive(Debug, Deserialize)]
-  pub struct AuditResponse {
-    #[serde(default)]
-    pub actions: Vec<AuditAction>,
-    pub advisories: HashMap<i32, AuditAdvisory>,
-    pub metadata: AuditMetadata,
   }
 }
 
@@ -968,25 +660,51 @@ mod socket_dev {
 mod tests {
   use deno_core::serde_json;
 
-  use super::npm::AuditResponse;
+  use super::npm::BulkAuditResponse;
 
   #[test]
-  fn test_audit_response_deserialize_without_actions() {
-    // Test that AuditResponse can be deserialized when the `actions` field is missing
-    // This can happen with some npm registry responses
+  fn test_bulk_audit_response_deserialize_empty() {
+    let json = r#"{}"#;
+    let response: BulkAuditResponse = serde_json::from_str(json).unwrap();
+    assert!(response.is_empty());
+  }
+
+  #[test]
+  fn test_bulk_audit_response_deserialize_with_advisory() {
     let json = r#"{
-      "advisories": {},
-      "metadata": {
-        "vulnerabilities": {
-          "low": 0,
-          "moderate": 0,
-          "high": 0,
-          "critical": 0
-        }
-      }
+      "@denotest/with-vuln1": [{
+        "url": "https://example.com/vuln/101010",
+        "title": "test vulnerability",
+        "severity": "high",
+        "vulnerable_versions": "<1.1.0"
+      }]
     }"#;
-    let response: AuditResponse = serde_json::from_str(json).unwrap();
-    assert!(response.actions.is_empty());
-    assert!(response.advisories.is_empty());
+    let response: BulkAuditResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(response.len(), 1);
+    let advisories = &response["@denotest/with-vuln1"];
+    assert_eq!(advisories.len(), 1);
+    assert_eq!(advisories[0].severity, "high");
+    assert!(advisories[0].patched_versions.is_none());
+    assert!(advisories[0].cves.is_empty());
+  }
+
+  #[test]
+  fn test_bulk_audit_response_deserialize_with_optional_fields() {
+    let json = r#"{
+      "test-pkg": [{
+        "url": "https://example.com",
+        "title": "test",
+        "severity": "critical",
+        "vulnerable_versions": "<2.0.0",
+        "patched_versions": ">=2.0.0",
+        "cves": ["CVE-2025-0001"],
+        "cwe": ["CWE-1333"]
+      }]
+    }"#;
+    let response: BulkAuditResponse = serde_json::from_str(json).unwrap();
+    let advisories = &response["test-pkg"];
+    assert_eq!(advisories[0].patched_versions.as_deref(), Some(">=2.0.0"));
+    assert_eq!(advisories[0].cves, vec!["CVE-2025-0001"]);
+    assert_eq!(advisories[0].cwe, vec!["CWE-1333"]);
   }
 }

--- a/cli/tools/pm/audit.rs
+++ b/cli/tools/pm/audit.rs
@@ -208,7 +208,12 @@ mod npm {
 
     let minimal_severity =
       AdvisorySeverity::parse(&audit_flags.severity).unwrap();
-    print_report(&vulns, &advisories, minimal_severity);
+    print_report(
+      &vulns,
+      &advisories,
+      minimal_severity,
+      audit_flags.ignore_unfixable,
+    );
 
     // Exit code 1 only if there are vulnerabilities at or above the specified level
     let exit_code = if vulns.count_at_or_above(minimal_severity) > 0 {
@@ -223,6 +228,7 @@ mod npm {
     vulns: &AuditVulnerabilities,
     advisories: &[AuditAdvisory],
     minimal_severity: AdvisorySeverity,
+    ignore_unfixable: bool,
   ) {
     let stdout = &mut std::io::stdout();
 
@@ -231,6 +237,11 @@ mod npm {
         continue;
       };
       if severity < minimal_severity {
+        continue;
+      }
+
+      let has_fix = !adv.patched_versions.is_empty();
+      if !has_fix && ignore_unfixable {
         continue;
       }
 
@@ -258,15 +269,24 @@ mod npm {
         colors::gray("Vulnerable:"),
         adv.vulnerable_versions
       );
-      if !adv.patched_versions.is_empty() {
+      if has_fix {
         _ = writeln!(
           stdout,
           "│ {}    {}",
           colors::gray("Patched:"),
           adv.patched_versions
         );
+        _ = writeln!(stdout, "│ {}       {}", colors::gray("Info:"), adv.url);
+        _ = writeln!(
+          stdout,
+          "╰ {}    update {} to {}",
+          colors::gray("Actions:"),
+          adv.module_name,
+          adv.patched_versions
+        );
+      } else {
+        _ = writeln!(stdout, "╰ {}       {}", colors::gray("Info:"), adv.url);
       }
-      _ = writeln!(stdout, "╰ {}       {}", colors::gray("Info:"), adv.url);
       _ = writeln!(stdout);
     }
 

--- a/tests/specs/audit/deno_json_and_package_json/audit.out
+++ b/tests/specs/audit/deno_json_and_package_json/audit.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/deno_json_and_package_json/audit.out
+++ b/tests/specs/audit/deno_json_and_package_json/audit.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/deno_json_only/audit.out
+++ b/tests/specs/audit/deno_json_only/audit.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/deno_json_only/audit.out
+++ b/tests/specs/audit/deno_json_only/audit.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/ignore/ignore_nonexistent.out
+++ b/tests/specs/audit/ignore/ignore_nonexistent.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/ignore/ignore_nonexistent.out
+++ b/tests/specs/audit/ignore/ignore_nonexistent.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/ignore/ignore_single.out
+++ b/tests/specs/audit/ignore/ignore_single.out
@@ -1,12 +1,9 @@
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 1 vulnerabilities
 Severity: 0 low, 0 moderate, 0 high, 1 critical

--- a/tests/specs/audit/ignore/ignore_single.out
+++ b/tests/specs/audit/ignore/ignore_single.out
@@ -3,7 +3,8 @@
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 1 vulnerabilities
 Severity: 0 low, 0 moderate, 0 high, 1 critical

--- a/tests/specs/audit/level_flag/audit_high.out
+++ b/tests/specs/audit/level_flag/audit_high.out
@@ -1,11 +1,9 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 Found 1 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 0 critical

--- a/tests/specs/audit/level_flag/audit_high.out
+++ b/tests/specs/audit/level_flag/audit_high.out
@@ -3,7 +3,8 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 Found 1 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 0 critical

--- a/tests/specs/audit/module_fallback/audit.out
+++ b/tests/specs/audit/module_fallback/audit.out
@@ -3,7 +3,8 @@
 │ Package:    @denotest/with-vuln3
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/303030
+│ Info:       https://example.com/vuln/303030
+╰ Actions:    update @denotest/with-vuln3 to >=1.1.0
 
 Found 1 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 0 critical

--- a/tests/specs/audit/module_fallback/audit.out
+++ b/tests/specs/audit/module_fallback/audit.out
@@ -1,11 +1,9 @@
 ╭ @denotest/with-vuln3 has security vulnerability
 │ Severity:   high
-│ Package:    @edenotest/with-vuln3
+│ Package:    @denotest/with-vuln3
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln3
-│ Info:       https://example.com/vuln/303030
-╰ Actions:    install @denotest/with-vuln3@1.1.0
+╰ Info:       https://example.com/vuln/303030
 
 Found 1 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 0 critical

--- a/tests/specs/audit/package_json_only/audit.out
+++ b/tests/specs/audit/package_json_only/audit.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/package_json_only/audit.out
+++ b/tests/specs/audit/package_json_only/audit.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/package_json_only/audit_socket.out
+++ b/tests/specs/audit/package_json_only/audit_socket.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/package_json_only/audit_socket.out
+++ b/tests/specs/audit/package_json_only/audit_socket.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/package_json_only/audit_socket_authenticated.out
+++ b/tests/specs/audit/package_json_only/audit_socket_authenticated.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/package_json_only/audit_socket_authenticated.out
+++ b/tests/specs/audit/package_json_only/audit_socket_authenticated.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/quiet_flag/audit.out
+++ b/tests/specs/audit/quiet_flag/audit.out
@@ -3,14 +3,16 @@
 │ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-╰ Info:       https://example.com/vuln/101010
+│ Info:       https://example.com/vuln/101010
+╰ Actions:    update @denotest/with-vuln1 to >=1.1.0
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
 │ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-╰ Info:       https://example.com/vuln/202020
+│ Info:       https://example.com/vuln/202020
+╰ Actions:    update @denotest/with-vuln2 to >=2.0.0
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/specs/audit/quiet_flag/audit.out
+++ b/tests/specs/audit/quiet_flag/audit.out
@@ -1,21 +1,16 @@
 ╭ @denotest/with-vuln1 is susceptible to prototype pollution
 │ Severity:   high
-│ Package:    @edenotest/with-vuln1
+│ Package:    @denotest/with-vuln1
 │ Vulnerable: <1.1.0
 │ Patched:    >=1.1.0
-│ Path:       @denotest/with-vuln1
-│ Info:       https://example.com/vuln/101010
-╰ Actions:    install @denotest/with-vuln1@1.1.0
+╰ Info:       https://example.com/vuln/101010
 
 ╭ @denotest/with-vuln2 can steal crypto keys
 │ Severity:   critical
-│ Package:    @edenotest/with-vuln2
+│ Package:    @denotest/with-vuln2
 │ Vulnerable: <2.0.0
 │ Patched:    >=2.0.0
-│ Path:       @denotest/using-vuln > @denotest/with-vuln2
-│ Info:       https://example.com/vuln/202020
-│ Actions:    install @denotest/with-vuln2@2.0.0 (major upgrade)
-╰             review @denotest/with-vuln2
+╰ Info:       https://example.com/vuln/202020
 
 Found 2 vulnerabilities
 Severity: 0 low, 0 moderate, 1 high, 1 critical

--- a/tests/util/server/servers/npm_registry.rs
+++ b/tests/util/server/servers/npm_registry.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::net::Ipv6Addr;
@@ -223,14 +222,14 @@ async fn handle_req_for_registry(
   // serve the registry package files
   let uri_path = req.uri().path();
 
-  if uri_path == "/sub/path/-/npm/v1/security/audits" {
+  if uri_path == "/sub/path/-/npm/v1/security/advisories/bulk" {
     // This is for the test in `tests/specs/audit/subpath_registry/__test__.jsonc` that tests that audit works when the registry URL has a subpath.
     // This endpoint must return something different than the api endpoint at the root to verify the request is going to the correct URL with the subpath.
-    return npm_security_audits_always_succeed_no_vulns();
+    return npm_security_advisories_bulk_no_vulns();
   }
 
-  if uri_path == "/-/npm/v1/security/audits" {
-    return npm_security_audits(req).await;
+  if uri_path == "/-/npm/v1/security/advisories/bulk" {
+    return npm_security_advisories_bulk(req).await;
   }
 
   let mut file_path = root_dir.to_path_buf();
@@ -564,39 +563,23 @@ async fn download_url(url: &str) -> Result<bytes::Bytes, anyhow::Error> {
   Ok(response.bytes().await?)
 }
 
-fn npm_security_audits_always_succeed_no_vulns()
+fn npm_security_advisories_bulk_no_vulns()
 -> Result<Response<UnsyncBoxBody<Bytes, Infallible>>, anyhow::Error> {
-  let resp_body = json!({
-    "actions": [],
-    "advisories": {},
-    "muted": [],
-    "metadata": {
-      "vulnerabilities": {
-        "info": 0,
-        "low": 0,
-        "moderate": 0,
-        "high": 0,
-        "critical": 0,
-      },
-      "dependencies": 0,
-      "devDependencies": 0,
-      "optionalDependencies": 0,
-      "totalDependencies": 0
-    }
-  });
+  let resp_body = json!({});
 
   Response::builder()
     .body(string_body(&serde_json::to_string(&resp_body).unwrap()))
     .map_err(|e| e.into())
 }
 
-async fn npm_security_audits(
+async fn npm_security_advisories_bulk(
   req: Request<Incoming>,
 ) -> Result<Response<UnsyncBoxBody<Bytes, Infallible>>, anyhow::Error> {
   let body = req.into_body().collect().await?.to_bytes();
   let json_obj: serde_json::Value = serde_json::from_slice(&body)?;
 
-  let Some(resp_body) = process_npm_security_audits_body(json_obj) else {
+  let Some(resp_body) = process_npm_security_advisories_bulk_body(json_obj)
+  else {
     return Response::builder()
       .status(StatusCode::BAD_REQUEST)
       .body(empty_body())
@@ -608,169 +591,69 @@ async fn npm_security_audits(
     .map_err(|e| e.into())
 }
 
-fn process_npm_security_audits_body(
+fn process_npm_security_advisories_bulk_body(
   value: serde_json::Value,
 ) -> Option<serde_json::Value> {
-  let dependency_count = 0;
-  let dev_dependency_count = 0;
-  let optional_dependency_count = 0;
-  let mut actions = vec![];
-  let mut advisories = HashMap::new();
-  let vuln_info = 0;
-  let vuln_low = 0;
-  let vuln_moderate = 0;
-  let mut vuln_high = 0;
-  let mut vuln_critical = 0;
+  // The bulk endpoint request body is: { "pkg-name": ["ver1", "ver2"], ... }
+  let packages = value.as_object()?;
+  let package_names = packages.keys().cloned().collect::<Vec<_>>();
 
-  let requires_map = value.get("requires")?.as_object()?;
-  let requires_map_keys = requires_map.keys().cloned().collect::<Vec<_>>();
-  if requires_map_keys.contains(&"@denotest/with-vuln1".to_string()) {
-    actions.push(get_action_for_with_vuln1());
-    advisories.insert(101010, get_advisory_for_with_vuln1());
-    vuln_high += 1;
+  let mut response = serde_json::Map::new();
+
+  if package_names.contains(&"@denotest/with-vuln1".to_string()) {
+    response.insert(
+      "@denotest/with-vuln1".to_string(),
+      json!([get_advisory_for_with_vuln1()]),
+    );
   }
-  if requires_map_keys.contains(&"@denotest/using-vuln".to_string()) {
-    actions.extend_from_slice(&get_actions_for_with_vuln2());
-    advisories.insert(202020, get_advisory_for_with_vuln2());
-    vuln_critical += 1;
+  if package_names.contains(&"@denotest/with-vuln2".to_string()) {
+    response.insert(
+      "@denotest/with-vuln2".to_string(),
+      json!([get_advisory_for_with_vuln2()]),
+    );
   }
-  if requires_map_keys.contains(&"@denotest/with-vuln3".to_string()) {
-    actions.push(get_action_for_with_vuln3());
-    advisories.insert(303030, get_advisory_for_with_vuln3());
-    vuln_high += 1;
+  if package_names.contains(&"@denotest/with-vuln3".to_string()) {
+    response.insert(
+      "@denotest/with-vuln3".to_string(),
+      json!([get_advisory_for_with_vuln3()]),
+    );
   }
 
-  Some(json!({
-    "actions": actions,
-    "advisories": advisories,
-    "muted": [],
-    "metadata": {
-      "vulnerabilities": {
-        "info": vuln_info,
-        "low": vuln_low,
-        "moderate": vuln_moderate,
-        "high": vuln_high,
-        "critical":vuln_critical,
-      },
-      "dependencies": dependency_count,
-      "devDependencies": dev_dependency_count,
-      "optionalDependencies": optional_dependency_count,
-      "totalDependencies": dependency_count + dev_dependency_count + optional_dependency_count
-    }
-  }))
-}
-
-fn get_action_for_with_vuln1() -> serde_json::Value {
-  json!({
-    "isMajor": false,
-    "action": "install",
-    "resolves": [{
-      "id": 101010,
-      "path": "@denotest/with-vuln1",
-      "dev": false,
-      "optional": false,
-      "bundled": false,
-    }],
-    "module": "@denotest/with-vuln1",
-    "target": "1.1.0"
-  })
+  Some(serde_json::Value::Object(response))
 }
 
 fn get_advisory_for_with_vuln1() -> serde_json::Value {
   json!({
-    "findings": [
-      {"version": "1.0.0", "paths": ["@denotest/with-vuln1"]}
-    ],
-    "id": 101010,
-    "cves": ["CVE-2025-0001"],
-    "overview": "Lorem ipsum dolor sit amet",
+    "url": "https://example.com/vuln/101010",
     "title": "@denotest/with-vuln1 is susceptible to prototype pollution",
     "severity": "high",
-    "module_name": "@edenotest/with-vuln1",
     "vulnerable_versions": "<1.1.0",
-    "recommendations": "Upgrade to version 1.1.0 or later",
     "patched_versions": ">=1.1.0",
-    "url": "https://example.com/vuln/101010"
+    "cves": ["CVE-2025-0001"],
+    "cwe": ["CWE-1321"]
   })
-}
-
-fn get_actions_for_with_vuln2() -> Vec<serde_json::Value> {
-  vec![
-    json!({
-      "isMajor": true,
-      "action": "install",
-      "resolves": [{
-        "id": 202020,
-        "path": "@denotest/using-vuln>@denotest/with-vuln2",
-        "dev": false,
-        "optional": false,
-        "bundled": false,
-      }],
-      "module": "@denotest/with-vuln2",
-      "target": "2.0.0"
-    }),
-    json!({
-      "action": "review",
-      "resolves": [{
-        "id": 202020,
-        "path": "@denotest/using-vuln>@denotest/with-vuln2",
-        "dev": false,
-        "optional": false,
-        "bundled": false,
-      }],
-      "module": "@denotest/with-vuln2"
-    }),
-  ]
 }
 
 fn get_advisory_for_with_vuln2() -> serde_json::Value {
   json!({
-    "findings": [
-      {"version": "1.5.0", "paths": ["@denotest/using-vuln>@denotest/with-vuln2"]}
-    ],
-    "id": 202020,
-    "cves": ["CVE-2025-0002"],
-    "overview": "Lorem ipsum dolor sit amet",
+    "url": "https://example.com/vuln/202020",
     "title": "@denotest/with-vuln2 can steal crypto keys",
     "severity": "critical",
-    "module_name": "@edenotest/with-vuln2",
     "vulnerable_versions": "<2.0.0",
-    "recommendations": "Upgrade to version 2.0.0 or later",
     "patched_versions": ">=2.0.0",
-    "url": "https://example.com/vuln/202020"
-  })
-}
-
-fn get_action_for_with_vuln3() -> serde_json::Value {
-  json!({
-    "isMajor": false,
-    "action": "install",
-    "resolves": [{
-      "id": 303030,
-      "path": "@denotest/with-vuln3",
-      "dev": false,
-      "optional": false,
-      "bundled": false,
-    }],
-    // Note: "module" field is intentionally omitted to test fallback logic
-    "target": "1.1.0"
+    "cves": ["CVE-2025-0002"],
+    "cwe": ["CWE-326"]
   })
 }
 
 fn get_advisory_for_with_vuln3() -> serde_json::Value {
   json!({
-    "findings": [
-      {"version": "1.0.0", "paths": ["@denotest/with-vuln3"]}
-    ],
-    "id": 303030,
-    "cves": ["CVE-2025-0003"],
-    "overview": "Lorem ipsum dolor sit amet",
+    "url": "https://example.com/vuln/303030",
     "title": "@denotest/with-vuln3 has security vulnerability",
     "severity": "high",
-    "module_name": "@edenotest/with-vuln3",
     "vulnerable_versions": "<1.1.0",
-    "recommendations": "Upgrade to version 1.1.0 or later",
     "patched_versions": ">=1.1.0",
-    "url": "https://example.com/vuln/303030"
+    "cves": ["CVE-2025-0003"],
+    "cwe": ["CWE-79"]
   })
 }


### PR DESCRIPTION
## Summary
- Migrate `deno audit` from the retired `/-/npm/v1/security/audits` endpoint to the officially supported `/-/npm/v1/security/advisories/bulk` endpoint
- The legacy endpoint has been retired by npm and returns inconsistent/incomplete responses, causing deserialization crashes (#33287, #32233)
- The bulk endpoint uses a simpler request/response format, eliminating ~440 lines of dependency tree construction, request partitioning, and response merging code

Fixes #33287

## Test plan
- [x] All 3 new unit tests pass (`test_bulk_audit_response_deserialize_*`)
- [x] All 12 existing audit spec tests pass (no_vulns, deno_json_only, package_json_only, ignore, level_flag, module_fallback, overrides, quiet_flag, subpath_registry, ignore_registry_errors, socket integration)
- [x] Clean compile with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)