### PR TITLE
fix(audit): add serde(default) to advisories field in AuditResponse

### DIFF
--- a/cli/tools/pm/audit.rs
+++ b/cli/tools/pm/audit.rs
@@ -645,6 +645,7 @@ mod npm {
   pub struct AuditResponse {
     #[serde(default)]
     pub actions: Vec<AuditAction>,
+    #[serde(default)]
     pub advisories: HashMap<i32, AuditAdvisory>,
     pub metadata: AuditMetadata,
   }
@@ -976,6 +977,26 @@ mod tests {
     // This can happen with some npm registry responses
     let json = r#"{
       "advisories": {},
+      "metadata": {
+        "vulnerabilities": {
+          "low": 0,
+          "moderate": 0,
+          "high": 0,
+          "critical": 0
+        }
+      }
+    }"#;
+    let response: AuditResponse = serde_json::from_str(json).unwrap();
+    assert!(response.actions.is_empty());
+    assert!(response.advisories.is_empty());
+  }
+
+  #[test]
+  fn test_audit_response_deserialize_without_advisories() {
+    // Test that AuditResponse can be deserialized when the `advisories` field is missing
+    // This can happen with some npm registry responses (similar to issue #33287)
+    let json = r#"{
+      "actions": [],
       "metadata": {
         "vulnerabilities": {
           "low": 0,


### PR DESCRIPTION
Good day,

This PR fixes issue #33287 where `deno audit` crashes with `missing field 'advisories'` when the npm registry returns a response without the `advisories` field.

## Changes

1. Added `#[serde(default)]` to the `advisories` field in the `AuditResponse` struct, following the same pattern already used for the `actions` field.
2. Added a test `test_audit_response_deserialize_without_advisories` to verify deserialization works when the `advisories` field is missing.

This is a minimal, targeted fix that mirrors the approach used in PR #32234 (which fixed the same issue for the `actions` field).

## Verification

- [x] Code changes follow the same pattern as the existing `actions` field fix
- [x] New test added to cover the missing `advisories` case
- [x] Existing test for `actions` remains unchanged

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof