### PR TITLE
refactor(ext/node): remove JS LibuvStreamWrap class

### DIFF
--- a/ext/node/polyfills/internal/stream_base_commons.ts
+++ b/ext/node/polyfills/internal/stream_base_commons.ts
@@ -21,12 +21,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import { ownerSymbol } from "ext:deno_node/internal/async_hooks.ts";
+import { HandleWrap } from "ext:deno_node/internal_binding/handle_wrap.ts";
 import {
   kArrayBufferOffset,
   kBytesWritten,
   kLastWriteWasAsync,
   kReadBytesOrError,
-  LibuvStreamWrap,
   streamBaseState,
   WriteWrap,
 } from "ext:deno_node/internal_binding/stream_wrap.ts";
@@ -136,10 +136,10 @@ function onWriteComplete(this: any, status: number) {
 }
 
 function createWriteWrap(
-  handle: LibuvStreamWrap,
+  handle: HandleWrap,
   callback: (err?: Error | null) => void,
 ) {
-  const req = new WriteWrap<LibuvStreamWrap>();
+  const req = new WriteWrap<HandleWrap>();
 
   req.handle = handle;
   req.oncomplete = onWriteComplete;

--- a/ext/node/polyfills/internal_binding/stream_wrap.ts
+++ b/ext/node/polyfills/internal_binding/stream_wrap.ts
@@ -32,8 +32,6 @@ const {
   Int32Array,
 } = primordials;
 
-import { Buffer } from "node:buffer";
-import { notImplemented } from "ext:deno_node/_utils.ts";
 import { HandleWrap } from "ext:deno_node/internal_binding/handle_wrap.ts";
 import {
   AsyncWrap,
@@ -81,87 +79,3 @@ export class ShutdownWrap<H extends HandleWrap> extends AsyncWrap {
   }
 }
 
-/**
- * Base class for stream handles (TCP, Pipe, etc.).
- *
- * Subclasses (TCP, Pipe) override readStart/readStop/writeBuffer/writev/shutdown
- * with native libuv implementations. The base class provides the interface
- * contract and shared state.
- */
-export class LibuvStreamWrap extends HandleWrap {
-  reading!: boolean;
-  destroyed = false;
-  writeQueueSize = 0;
-  bytesRead = 0;
-  bytesWritten = 0;
-
-  onread!:
-    | ((_arrayBuffer: Uint8Array, _nread: number) => Uint8Array | undefined)
-    | undefined;
-
-  constructor(provider: providerType) {
-    super(provider);
-  }
-
-  readStart(): number {
-    notImplemented("LibuvStreamWrap.prototype.readStart");
-  }
-
-  readStop(): number {
-    notImplemented("LibuvStreamWrap.prototype.readStop");
-  }
-
-  shutdown(req: ShutdownWrap<LibuvStreamWrap>): number {
-    const status = this._onClose();
-
-    try {
-      req.oncomplete(status);
-    } catch {
-      // swallow callback error.
-    }
-
-    return 0;
-  }
-
-  useUserBuffer(_userBuf: unknown): number {
-    notImplemented("LibuvStreamWrap.prototype.useUserBuffer");
-  }
-
-  writeBuffer(
-    _req: WriteWrap<LibuvStreamWrap>,
-    _data: Uint8Array,
-  ): number {
-    notImplemented("LibuvStreamWrap.prototype.writeBuffer");
-  }
-
-  writev(
-    _req: WriteWrap<LibuvStreamWrap>,
-    _chunks: Buffer[] | (string | Buffer)[],
-    _allBuffers: boolean,
-  ): number {
-    notImplemented("LibuvStreamWrap.prototype.writev");
-  }
-
-  writeAsciiString(req: WriteWrap<LibuvStreamWrap>, data: string): number {
-    const buffer = new TextEncoder().encode(data);
-    return this.writeBuffer(req, buffer);
-  }
-
-  writeUtf8String(req: WriteWrap<LibuvStreamWrap>, data: string): number {
-    const buffer = new TextEncoder().encode(data);
-    return this.writeBuffer(req, buffer);
-  }
-
-  writeUcs2String(_req: WriteWrap<LibuvStreamWrap>, _data: string): number {
-    notImplemented("LibuvStreamWrap.prototype.writeUcs2String");
-  }
-
-  writeLatin1String(req: WriteWrap<LibuvStreamWrap>, data: string): number {
-    const buffer = Buffer.from(data, "latin1");
-    return this.writeBuffer(req, buffer);
-  }
-
-  override _onClose(): number {
-    return 0;
-  }
-}

--- a/ext/node/polyfills/internal_binding/stream_wrap.ts
+++ b/ext/node/polyfills/internal_binding/stream_wrap.ts
@@ -78,4 +78,3 @@ export class ShutdownWrap<H extends HandleWrap> extends AsyncWrap {
     super(providerType.SHUTDOWNWRAP);
   }
 }
-

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -270,10 +270,7 @@
     "parallel/test-child-process-spawnsync.js": {},
     "parallel/test-child-process-stdin-ipc.js": {},
     "parallel/test-child-process-stdin.js": {},
-    "parallel/test-child-process-stdio-big-write-end.js": {
-      "ignore": true,
-      "reason": "Timeout — child process stdin large buffered write with end() does not flush correctly"
-    },
+    "parallel/test-child-process-stdio-big-write-end.js": {},
     "parallel/test-child-process-stdio-inherit.js": {},
     "parallel/test-child-process-stdio-overlapped.js": {},
     "parallel/test-child-process-stdio.js": {},


### PR DESCRIPTION
## Summary
- Remove the JS `LibuvStreamWrap` class from `stream_wrap.ts` -- TCP, Pipe, and TTY all use native Rust CppGC objects that inherit from the Rust `LibUvStreamWrap`, making the JS class dead code
- `stream_base_commons.ts` uses `HandleWrap` instead of `LibuvStreamWrap` for its `createWriteWrap` typing

## Test plan
- [x] `test-cli-syntax-bad.js` passes
- [x] `specs::node::child_process_extra_pipes` passes
- [x] `specs::node::net_socket_fd` passes (all 4 sub-tests)
- [x] `unit_node::child_process_test` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)