### PR TITLE
fix(ext/node): defer JS stream encOut to avoid reentrant CppGC borrow

### DIFF
--- a/ext/node/polyfills/internal_binding/tls_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tls_wrap.ts
@@ -61,11 +61,14 @@ export function wrap(
     // Wire up the encrypted output callback: when TLSWrap has encrypted
     // data to send, it calls res.encOut(arrayBuffer). We write that
     // to the JSStreamSocket's underlying Duplex stream.
+    // The write is deferred via queueMicrotask to avoid reentrant borrows:
+    // cycle() -> encOut -> duplexpair -> other side -> write to TCPWrap
+    // would re-enter the TCPWrap's CppGC RefCell if done synchronously.
     const jsStreamOwner = nativeHandle[kOwner];
     res.encOut = (data: ArrayBuffer) => {
       const buf = new Uint8Array(data);
       if (jsStreamOwner?.stream) {
-        jsStreamOwner.stream.write(buf);
+        queueMicrotask(() => jsStreamOwner.stream.write(buf));
       }
     };
 

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -20,6 +20,71 @@ const key = Deno.readTextFileSync(join(tlsTestdataDir, "localhost.key"));
 const cert = Deno.readTextFileSync(join(tlsTestdataDir, "localhost.crt"));
 const rootCaCert = Deno.readTextFileSync(join(tlsTestdataDir, "RootCA.pem"));
 
+// Regression test for https://github.com/denoland/deno/issues/30724
+// TLS over a back-to-back Duplex pair (like native-duplexpair used by
+// tedious/mssql) previously panicked with "RefCell already borrowed"
+// because encOut synchronously wrote to the paired stream, re-entering
+// the same CppGC RefCell.
+Deno.test("tls over js-backed duplex pair does not panic", async () => {
+  const server = tls.createServer({ cert, key }, (socket) => {
+    socket.on("error", () => {});
+    socket.write("hello from server");
+    socket.end();
+  });
+
+  const { promise: listening, resolve: resolveListening } = Promise
+    .withResolvers<void>();
+  server.listen(0, () => resolveListening());
+  await listening;
+  const { port } = server.address() as net.AddressInfo;
+
+  // Raw TCP connection to the TLS server.
+  const rawSocket = net.connect(port, "localhost");
+  const { promise: connected, resolve: resolveConnected } = Promise
+    .withResolvers<void>();
+  rawSocket.on("connect", () => resolveConnected());
+  await connected;
+
+  // Wrap rawSocket in a plain Duplex (NOT a net.Socket) to trigger
+  // JSStreamSocket in _tls_wrap.js, mimicking tedious/mssql TLS-over-TDS.
+  const wrapper = new stream.Duplex({
+    read() {},
+    write(
+      chunk: Uint8Array,
+      _enc: string,
+      cb: (err?: Error | null) => void,
+    ) {
+      if (rawSocket.destroyed) {
+        cb();
+        return;
+      }
+      rawSocket.write(chunk, cb);
+    },
+  });
+  rawSocket.on("data", (d: Uint8Array) => wrapper.push(d));
+  rawSocket.on("end", () => wrapper.push(null));
+
+  const tlsSocket = tls.connect({
+    socket: wrapper as net.Socket,
+    rejectUnauthorized: false,
+  });
+
+  const received = await new Promise<string>((resolve, reject) => {
+    let data = "";
+    tlsSocket.on("error", reject);
+    tlsSocket.on("data", (chunk: Uint8Array) => {
+      data += chunk.toString();
+    });
+    tlsSocket.on("end", () => resolve(data));
+  });
+
+  assertEquals(received, "hello from server");
+
+  tlsSocket.destroy();
+  rawSocket.destroy();
+  server.close();
+});
+
 for (
   const [alpnServer, alpnClient, expected] of [
     [["a", "b"], ["a"], ["a"]],


### PR DESCRIPTION
## Summary

- When TLSWrap is attached to a JS-backed stream (e.g. `native-duplexpair` used by tedious/mssql), the `encOut` callback writes encrypted data synchronously to the Duplex stream. With duplexpair this synchronously delivers data to the paired side, which writes back to the TCP socket, re-entering the same `LibUvStreamWrap` CppGC `RefCell` and panicking with `RefCell already borrowed`.
- Fixed by deferring the `encOut` write via `queueMicrotask` to break the synchronous reentrant chain.

Closes #30724

## Test plan
- [x] `cargo test -p unit_node_tests -- tls` -- 26 tests pass
- [x] Manually tested mssql (`npm:mssql@11`) streaming queries with `encrypt: true` against Azure SQL Edge in Docker -- non-streaming, streaming (100 rows), and large streaming (1000 rows) all pass without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)