### PR TITLE
fix(ext/node): enforce maxHeaderSize in HTTP parser

### DIFF
--- a/ext/node/ops/llhttp/binding.rs
+++ b/ext/node/ops/llhttp/binding.rs
@@ -272,7 +272,7 @@ unsafe fn get_ctx<'a>(parser: *mut sys::llhttp_t) -> &'a mut ExecuteContext {
 /// Returns -1 (HPE_USER) if overflow, 0 if ok.
 /// Matches Node.js's TrackHeader() behavior in node_http_parser.cc.
 fn check_header_overflow(inner: &mut Inner) -> c_int {
-  if inner.max_header_size > 0 && inner.header_nread > inner.max_header_size {
+  if inner.max_header_size > 0 && inner.header_nread >= inner.max_header_size {
     inner.header_overflow = true;
     return -1;
   }

--- a/ext/node/ops/llhttp/binding.rs
+++ b/ext/node/ops/llhttp/binding.rs
@@ -72,6 +72,7 @@ struct Inner {
 
   max_header_size: u32,
   header_nread: u32,
+  header_overflow: bool,
   initialized: bool,
 
   /// The stream being consumed (for parser.consume optimization).
@@ -127,6 +128,7 @@ impl HTTPParser {
         pending_pause: false,
         max_header_size: 0,
         header_nread: 0,
+        header_overflow: false,
         initialized: false,
         consumed_stream: None,
         consume_callbacks: None,
@@ -266,6 +268,17 @@ unsafe fn get_ctx<'a>(parser: *mut sys::llhttp_t) -> &'a mut ExecuteContext {
   unsafe { &mut *((*parser).data as *mut ExecuteContext) }
 }
 
+/// Check if header size exceeds the configured maximum.
+/// Returns -1 (HPE_USER) if overflow, 0 if ok.
+/// Matches Node.js's TrackHeader() behavior in node_http_parser.cc.
+fn check_header_overflow(inner: &mut Inner) -> c_int {
+  if inner.max_header_size > 0 && inner.header_nread > inner.max_header_size {
+    inner.header_overflow = true;
+    return -1;
+  }
+  0
+}
+
 // ---- llhttp C callbacks ----
 
 unsafe extern "C" fn on_message_begin(parser: *mut sys::llhttp_t) -> c_int {
@@ -279,6 +292,7 @@ unsafe extern "C" fn on_message_begin(parser: *mut sys::llhttp_t) -> c_int {
   inner.current_header_value.clear();
   inner.in_header_value = false;
   inner.header_nread = 0;
+  inner.header_overflow = false;
 
   let (scope, cb_obj) = unsafe { ctx.scope_and_callbacks() };
   let cb = cb_obj.get_index(scope, K_ON_MESSAGE_BEGIN);
@@ -311,7 +325,7 @@ unsafe extern "C" fn on_url(
   let data = unsafe { std::slice::from_raw_parts(at as *const u8, length) };
   inner.url.extend_from_slice(data);
   inner.header_nread += length as u32;
-  0
+  check_header_overflow(inner)
 }
 
 unsafe extern "C" fn on_status(
@@ -324,7 +338,7 @@ unsafe extern "C" fn on_status(
   let data = unsafe { std::slice::from_raw_parts(at as *const u8, length) };
   inner.status_message.extend_from_slice(data);
   inner.header_nread += length as u32;
-  0
+  check_header_overflow(inner)
 }
 
 unsafe extern "C" fn on_header_field(
@@ -340,7 +354,7 @@ unsafe extern "C" fn on_header_field(
   }
   inner.current_header_field.extend_from_slice(data);
   inner.header_nread += length as u32;
-  0
+  check_header_overflow(inner)
 }
 
 unsafe extern "C" fn on_header_value(
@@ -354,7 +368,7 @@ unsafe extern "C" fn on_header_value(
   inner.in_header_value = true;
   inner.current_header_value.extend_from_slice(data);
   inner.header_nread += length as u32;
-  0
+  check_header_overflow(inner)
 }
 
 unsafe extern "C" fn on_header_value_complete(
@@ -859,14 +873,38 @@ impl HTTPParser {
     nread as i32
   }
 
-  /// Signal end of input.
-  #[fast]
-  fn finish(&self) -> i32 {
+  /// Signal end of input. Like execute(), this can trigger llhttp callbacks
+  /// (e.g. on_message_complete), so we must set up the ExecuteContext with
+  /// a valid scope and callbacks object.
+  #[nofast]
+  #[reentrant]
+  fn finish(
+    &self,
+    scope: &mut v8::PinScope,
+    callbacks: v8::Local<v8::Object>,
+  ) -> i32 {
     let inner = self.inner();
     if !inner.initialized {
       return -1;
     }
+
+    let scope_ptr = scope as *mut v8::PinScope as *mut ();
+    let callbacks_static: v8::Local<'static, v8::Object> =
+      unsafe { std::mem::transmute(callbacks) };
+
+    let mut ctx = ExecuteContext {
+      inner: inner as *mut Inner,
+      scope_ptr,
+      callbacks: callbacks_static,
+    };
+
+    inner.parser.data =
+      &mut ctx as *mut ExecuteContext as *mut std::ffi::c_void;
+
     let err = unsafe { sys::llhttp_finish(&mut inner.parser) };
+
+    inner.parser.data = std::ptr::null_mut();
+
     if err != sys::HPE_OK { -1 } else { 0 }
   }
 
@@ -898,6 +936,12 @@ impl HTTPParser {
 
   #[fast]
   fn remove(&self) {}
+
+  /// Check if the last parse error was caused by header overflow.
+  #[fast]
+  fn has_header_overflow(&self) -> bool {
+    self.inner().header_overflow
+  }
 
   /// Get the current buffer being parsed (for error reporting).
   #[buffer]

--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -600,7 +600,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
 
   if (ret instanceof Error) {
     prepareError(ret, parser, d);
-    socket.destroy(ret);
+    socketOnError.call(socket, ret);
     return;
   }
 

--- a/ext/node/polyfills/internal_binding/http_parser.ts
+++ b/ext/node/polyfills/internal_binding/http_parser.ts
@@ -151,9 +151,12 @@ HTTPParser.prototype.initialize = function (
   maxHeaderSize?: number,
   lenientFlags?: number,
 ) {
+  // Default to the global maxHeaderSize (16384) when not specified,
+  // matching Node.js behavior where 0 means "use the default".
+  const effectiveMaxHeaderSize = maxHeaderSize || 16384;
   this._native.initialize(
     type,
-    maxHeaderSize ?? 0,
+    effectiveMaxHeaderSize,
     lenientFlags ?? 0,
   );
 };
@@ -210,11 +213,27 @@ HTTPParser.prototype.execute = function (
     throw err;
   }
 
+  // On parser error, create an Error object with code/reason/bytesParsed
+  // matching Node.js behavior (node_http_parser.cc returns an Error object).
+  if (result < 0) {
+    const err: any = new Error("Parse Error");
+    if (this._native.hasHeaderOverflow()) {
+      err.code = "HPE_HEADER_OVERFLOW";
+      err.reason = "Header overflow";
+      err.message = "Parse Error: Header overflow";
+    } else {
+      err.code = "HPE_ERROR";
+      err.reason = "Parse Error";
+    }
+    err.bytesParsed = data.byteLength;
+    return err;
+  }
+
   return result;
 };
 
 HTTPParser.prototype.finish = function (this: any) {
-  return this._native.finish();
+  return this._native.finish(this);
 };
 
 HTTPParser.prototype.pause = function (this: any) {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -2507,6 +2507,54 @@ Deno.test(
   },
 );
 
+// Regression test: oversized headers must trigger HPE_HEADER_OVERFLOW on the
+// server's clientError event, and the default handler should respond with 431.
+// Previously maxHeaderSize was tracked but never enforced.
+// https://github.com/denoland/deno/issues/33060
+Deno.test(
+  "[node/http] server emits HPE_HEADER_OVERFLOW for oversized headers",
+  async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+
+    const server = http.createServer((_req, res) => {
+      res.end("should not reach");
+    });
+
+    let gotClientError = false;
+    server.on("clientError", (err: Error & { code?: string }, socket) => {
+      gotClientError = true;
+      assertEquals(err.code, "HPE_HEADER_OVERFLOW");
+      assertStringIncludes(err.message, "Header overflow");
+      if (socket.writable) {
+        socket.end(
+          "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n",
+        );
+      }
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      // Send a request with a header exceeding the 16KB default limit
+      const hugeHeader = "x".repeat(16384 + 1);
+      const sock = net.createConnection(port, "127.0.0.1", () => {
+        sock.write(
+          `GET / HTTP/1.1\r\nHost: localhost\r\nX-Huge: ${hugeHeader}\r\n\r\n`,
+        );
+      });
+      sock.on("data", () => {});
+      sock.on("close", () => {
+        assert(gotClientError, "clientError should have been emitted");
+        server.close(() => resolve());
+      });
+      sock.on("error", () => {
+        server.close(() => resolve());
+      });
+    });
+
+    await promise;
+  },
+);
+
 // Regression test: socket.write() + socket.end() in an upgrade handler
 // must not crash. Previously, llhttp_finish() was called without setting
 // up the ExecuteContext, causing a null pointer dereference when the

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -2555,6 +2555,106 @@ Deno.test(
   },
 );
 
+// Boundary test: header_nread tracks bytes from the URL, header fields,
+// and header values (not the framing \r\n separators). A request that
+// pushes header_nread to exactly maxHeaderSize must be rejected (>=).
+Deno.test(
+  "[node/http] header overflow boundary: exactly maxHeaderSize is rejected",
+  async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    // Use a small limit so we can construct precise test cases.
+    // header_nread counts: URL path + header field names + header values
+    // (NOT the "GET ", " HTTP/1.1\r\n", ": ", or "\r\n" framing).
+    // For "GET /xx HTTP/1.1\r\nH: V\r\n\r\n":
+    //   header_nread = len("/xx") + len("H") + len("V") = 3 + 1 + 1 = 5
+    const LIMIT = 100;
+
+    const server = http.createServer({
+      maxHeaderSize: LIMIT,
+    }, (_req, res) => {
+      res.end("should not reach");
+    });
+
+    let gotClientError = false;
+    server.on("clientError", (err: Error & { code?: string }, socket) => {
+      gotClientError = true;
+      assertEquals(err.code, "HPE_HEADER_OVERFLOW");
+      if (socket.writable) {
+        socket.end("HTTP/1.1 431 Too Large\r\n\r\n");
+      }
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      // header_nread = len("/") + len("Host") + len("x") + len("X-Pad") + len(value)
+      //             = 1 + 4 + 1 + 5 + value_len
+      //             = 11 + value_len
+      // We need 11 + value_len = LIMIT, so value_len = LIMIT - 11
+      const valueLen = LIMIT - 11;
+      const sock = net.createConnection(port, "127.0.0.1", () => {
+        sock.write(
+          `GET / HTTP/1.1\r\nHost: x\r\nX-Pad: ${"a".repeat(valueLen)}\r\n\r\n`,
+        );
+      });
+      sock.on("data", () => {});
+      sock.on("close", () => {
+        assert(
+          gotClientError,
+          "exactly maxHeaderSize should trigger overflow",
+        );
+        server.close(() => resolve());
+      });
+      sock.on("error", () => {
+        server.close(() => resolve());
+      });
+    });
+
+    await promise;
+  },
+);
+
+Deno.test(
+  "[node/http] header overflow boundary: maxHeaderSize - 1 is accepted",
+  async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const LIMIT = 100;
+
+    const server = http.createServer({
+      maxHeaderSize: LIMIT,
+    }, (_req, res) => {
+      res.end("accepted");
+    });
+
+    server.on("clientError", () => {
+      throw new Error("should not get clientError for headers under limit");
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      // header_nread = 11 + value_len; need < LIMIT, so value_len = LIMIT - 12
+      const valueLen = LIMIT - 12;
+      const sock = net.createConnection(port, "127.0.0.1", () => {
+        sock.write(
+          `GET / HTTP/1.1\r\nHost: x\r\nX-Pad: ${"a".repeat(valueLen)}\r\n\r\n`,
+        );
+      });
+      let data = "";
+      sock.on("data", (d) => {
+        data += d.toString();
+      });
+      sock.on("close", () => {
+        assertStringIncludes(data, "accepted");
+        server.close(() => resolve());
+      });
+      sock.on("error", () => {
+        server.close(() => resolve());
+      });
+    });
+
+    await promise;
+  },
+);
+
 // Regression test: socket.write() + socket.end() in an upgrade handler
 // must not crash. Previously, llhttp_finish() was called without setting
 // up the ExecuteContext, causing a null pointer dereference when the


### PR DESCRIPTION
## Summary

- **Enforce `maxHeaderSize` in the llhttp HTTP parser.** The binding tracked `header_nread` but never compared it against `max_header_size`, so oversized headers were silently accepted (200 OK instead of 431).
- Add `check_header_overflow()` that returns -1 when headers exceed the configured limit (default 16384 bytes, matching Node.js)
- Return `Error` objects from `parser.execute()` on parse errors with `code`, `reason`, and `bytesParsed` properties, matching Node.js behavior
- Default `maxHeaderSize` to 16384 when not explicitly set, matching Node.js
- Fix `onParserExecuteCommon` to call `socketOnError` directly (matching Node.js) instead of `socket.destroy`, so the 431 auto-response is written before the socket is destroyed

Closes #33060

## Test plan
- [x] `./x test-node http_test` passes
- [x] New unit test: server emits `clientError` with `HPE_HEADER_OVERFLOW` code for oversized headers
- [x] Manual test: client receives 431 response for 128KB headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)