### PR TITLE
fix(ext/node): support cross-worker file descriptor passing

### DIFF
--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -107,6 +109,85 @@ fn file_for_fd(
     .get(fd)
     .cloned()
     .ok_or_else(ebadf)
+}
+
+/// Like `file_for_fd`, but if the fd is not in this worker's FdTable
+/// and is a valid OS fd (e.g. opened in another worker and passed via
+/// workerData), `dup()` it and auto-register. This matches Node.js
+/// where fds are process-wide.
+fn file_for_fd_or_import(
+  state: &mut OpState,
+  fd: i32,
+) -> Result<Rc<dyn deno_io::fs::File>, FsError> {
+  if let Some(file) = state.borrow::<deno_io::FdTable>().get(fd).cloned() {
+    return Ok(file);
+  }
+  import_fd(state, fd)
+}
+
+/// Try to import a process-wide OS fd into this worker's FdTable.
+/// Uses dup() to create an independent copy so each worker can close
+/// its own copy without affecting others.
+fn import_fd(
+  state: &mut OpState,
+  fd: i32,
+) -> Result<Rc<dyn deno_io::fs::File>, FsError> {
+  #[cfg(unix)]
+  {
+    // SAFETY: dup() is safe to call with any fd; returns -1 if invalid.
+    let dup_fd = unsafe { libc::dup(fd) };
+    if dup_fd < 0 {
+      return Err(ebadf());
+    }
+    // SAFETY: dup_fd is a valid new fd returned by dup().
+    let std_file = unsafe { std::fs::File::from_raw_fd(dup_fd) };
+    let file: Rc<dyn deno_io::fs::File> =
+      Rc::new(deno_io::StdFileResourceInner::file(std_file, None));
+    state
+      .borrow_mut::<deno_io::FdTable>()
+      .register(fd, file.clone());
+    Ok(file)
+  }
+
+  #[cfg(windows)]
+  {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Foundation::DUPLICATE_SAME_ACCESS;
+    use windows_sys::Win32::Foundation::DuplicateHandle;
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    let handle = unsafe { libc::get_osfhandle(fd) };
+    if handle == -1 {
+      return Err(ebadf());
+    }
+    let mut dup_handle = std::ptr::null_mut();
+    let ok = unsafe {
+      DuplicateHandle(
+        GetCurrentProcess(),
+        handle as _,
+        GetCurrentProcess(),
+        &mut dup_handle,
+        0,
+        0,
+        DUPLICATE_SAME_ACCESS,
+      )
+    };
+    if ok == 0 {
+      return Err(ebadf());
+    }
+    let crt_fd = unsafe { libc::open_osfhandle(dup_handle as isize, 0) };
+    if crt_fd == -1 {
+      unsafe { CloseHandle(dup_handle) };
+      return Err(ebadf());
+    }
+    let std_file = unsafe { std::fs::File::from_raw_fd(crt_fd) };
+    let file: Rc<dyn deno_io::fs::File> =
+      Rc::new(deno_io::StdFileResourceInner::file(std_file, None));
+    state
+      .borrow_mut::<deno_io::FdTable>()
+      .register(fd, file.clone());
+    Ok(file)
+  }
 }
 
 /// When `sync_fs` is enabled, `FileSystemRc` is `Arc` (Send) and we can
@@ -952,7 +1033,7 @@ pub fn op_node_fs_read_sync(
   #[buffer] buf: &mut [u8],
   #[number] position: i64,
 ) -> Result<u32, FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   read_with_position(file, buf, position)
 }
 
@@ -1015,7 +1096,7 @@ pub fn op_node_fs_write_sync(
   #[buffer] buf: &[u8],
   #[number] position: i64,
 ) -> Result<u32, FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   write_with_position(file, buf, position)
 }
 
@@ -1045,7 +1126,7 @@ pub fn op_node_fs_seek_sync(
   #[number] offset: i64,
   #[smi] whence: i32,
 ) -> Result<u64, FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   let seek_from = match whence {
     0 => std::io::SeekFrom::Start(offset as u64),
     1 => std::io::SeekFrom::Current(offset),
@@ -1148,7 +1229,7 @@ pub fn op_node_fs_fstat_sync(
   state: &mut OpState,
   fd: i32,
 ) -> Result<NodeFsStat, FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   let stat = file.stat_sync()?;
   Ok(NodeFsStat::from(stat))
 }
@@ -1170,7 +1251,7 @@ pub fn op_node_fs_ftruncate_sync(
   fd: i32,
   #[number] len: u64,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   file.truncate_sync(len)?;
   Ok(())
 }
@@ -1191,7 +1272,7 @@ pub fn op_node_fs_fsync_sync(
   state: &mut OpState,
   fd: i32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   file.sync_sync()?;
   Ok(())
 }
@@ -1211,7 +1292,7 @@ pub fn op_node_fs_fdatasync_sync(
   state: &mut OpState,
   fd: i32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   file.datasync_sync()?;
   Ok(())
 }
@@ -1235,7 +1316,7 @@ pub fn op_node_fs_futimes_sync(
   #[number] mtime_secs: i64,
   #[smi] mtime_nanos: u32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   file.utime_sync(atime_secs, atime_nanos, mtime_secs, mtime_nanos)?;
   Ok(())
 }
@@ -1262,7 +1343,7 @@ pub fn op_node_fs_fchmod_sync(
   fd: i32,
   #[smi] mode: u32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   file.chmod_sync(mode)?;
   Ok(())
 }
@@ -1285,7 +1366,7 @@ pub fn op_node_fs_fchown_sync(
   #[smi] uid: u32,
   #[smi] gid: u32,
 ) -> Result<(), FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   file.chown_sync(Some(uid), Some(gid))?;
   Ok(())
 }
@@ -1308,7 +1389,7 @@ pub fn op_node_fs_read_file_sync(
   state: &mut OpState,
   fd: i32,
 ) -> Result<Vec<u8>, FsError> {
-  let file = file_for_fd(state, fd)?;
+  let file = file_for_fd_or_import(state, fd)?;
   let buf = file.read_all_sync()?;
   Ok(buf.to_vec())
 }


### PR DESCRIPTION
## Summary

When a file descriptor opened in one worker thread is passed to another via `workerData`, the receiving worker's `FdTable` doesn't know about it, causing `EBADF`. In Node.js, fds are process-wide integers that work across all threads.

**Fix:** when a sync fs op encounters an unknown fd, try to `dup()` it from the OS. If the fd is valid (opened by another thread), the dup succeeds and we auto-register the copy in the local `FdTable`. Each worker gets an independently-closable duplicate, matching Node.js semantics.

**Approach:**
- Add `file_for_fd_or_import()` that falls back to `import_fd()` when the fd isn't in the local table
- `import_fd()` calls `libc::dup(fd)` (Unix) or `DuplicateHandle` (Windows) to create an independent copy
- The dup'd fd is wrapped in a `StdFileResourceInner` and registered in the worker's `FdTable`
- Sync fs ops (`readSync`, `writeSync`, `fstatSync`, etc.) use the new function
- Async fs ops still use the read-only `file_for_fd()` (could be extended later)

**Limitations:**
- Only covers sync fs ops for now (async ops would need `Rc<RefCell<OpState>>` plumbing)
- Does not implement `FileHandle` transfer via `postMessage` `transferList` (Node.js's preferred API)

Closes #32696

## Test plan
- [x] `cargo test -p unit_node_tests -- fs` -- 28 tests pass
- [x] Manual test: worker reads file via fd opened in main thread

```js
// Main thread
const fd = fs.openSync(tmpFile, "r");
const worker = new Worker(url, { workerData: { fd } });

// Worker thread
const buf = Buffer.alloc(100);
fs.readSync(workerData.fd, buf); // Works!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)