### PR TITLE
test(npm): add regression test for update breaking peer dep lockfile entries

### DIFF
--- a/tests/registry/npm/@denotest/peer-dep-base/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/peer-dep-base/1.0.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@denotest/peer-dep-base",
+  "version": "1.0.0"
+}

--- a/tests/registry/npm/@denotest/peer-dep-base/1.1.0/package.json
+++ b/tests/registry/npm/@denotest/peer-dep-base/1.1.0/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@denotest/peer-dep-base",
+  "version": "1.1.0"
+}

--- a/tests/registry/npm/@denotest/peer-dep-consumer-2/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/peer-dep-consumer-2/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest/peer-dep-consumer-2",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@denotest/peer-dep-base": "*"
+  }
+}

--- a/tests/registry/npm/@denotest/peer-dep-consumer/1.0.0/package.json
+++ b/tests/registry/npm/@denotest/peer-dep-consumer/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@denotest/peer-dep-consumer",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@denotest/peer-dep-base": "*"
+  }
+}

--- a/tests/specs/outdated/update_peer_dep/__test__.jsonc
+++ b/tests/specs/outdated/update_peer_dep/__test__.jsonc
@@ -1,0 +1,21 @@
+{
+  // Regression test for https://github.com/denoland/deno/issues/31523
+  // `deno update` should update peer dependency references in the lockfile
+  // when the base package is updated, not leave stale references that cause
+  // multiple versions at runtime.
+  "tempDir": true,
+  "steps": [
+    {
+      "args": "install",
+      "output": "[WILDCARD]"
+    },
+    {
+      "args": "outdated --update --latest",
+      "output": "update.out"
+    },
+    {
+      "args": "-A print_file.ts ./deno.lock",
+      "output": "deno.lock.out"
+    }
+  ]
+}

--- a/tests/specs/outdated/update_peer_dep/deno.json
+++ b/tests/specs/outdated/update_peer_dep/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@denotest/peer-dep-base": "npm:@denotest/peer-dep-base@~1.0.0",
+    "@denotest/peer-dep-consumer": "npm:@denotest/peer-dep-consumer@^1.0.0",
+    "@denotest/peer-dep-consumer-2": "npm:@denotest/peer-dep-consumer-2@^1.0.0"
+  }
+}

--- a/tests/specs/outdated/update_peer_dep/deno.lock.out
+++ b/tests/specs/outdated/update_peer_dep/deno.lock.out
@@ -1,0 +1,35 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@denotest/peer-dep-base@1.1": "1.1.0",
+    "npm:@denotest/peer-dep-consumer-2@1": "1.0.0_@denotest+peer-dep-base@1.1.0",
+    "npm:@denotest/peer-dep-consumer@1": "1.0.0_@denotest+peer-dep-base@1.1.0"
+  },
+  "npm": {
+    "@denotest/peer-dep-base@1.1.0": {
+      "integrity": "[WILDCARD]",
+      "tarball": "[WILDCARD]"
+    },
+    "@denotest/peer-dep-consumer-2@1.0.0_@denotest+peer-dep-base@1.1.0": {
+      "integrity": "[WILDCARD]",
+      "dependencies": [
+        "@denotest/peer-dep-base"
+      ],
+      "tarball": "[WILDCARD]"
+    },
+    "@denotest/peer-dep-consumer@1.0.0_@denotest+peer-dep-base@1.1.0": {
+      "integrity": "[WILDCARD]",
+      "dependencies": [
+        "@denotest/peer-dep-base"
+      ],
+      "tarball": "[WILDCARD]"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@denotest/peer-dep-base@1.1",
+      "npm:@denotest/peer-dep-consumer-2@1",
+      "npm:@denotest/peer-dep-consumer@1"
+    ]
+  }
+}

--- a/tests/specs/outdated/update_peer_dep/print_file.ts
+++ b/tests/specs/outdated/update_peer_dep/print_file.ts
@@ -1,0 +1,2 @@
+const file = Deno.args[0];
+console.log(Deno.readTextFileSync(file).trim());

--- a/tests/specs/outdated/update_peer_dep/update.out
+++ b/tests/specs/outdated/update_peer_dep/update.out
@@ -1,0 +1,2 @@
+[WILDCARD]Updated 1 dependency:
+ - npm:@denotest/peer-dep-base ~1.0.0 -> ~1.1.0


### PR DESCRIPTION
## Summary

Adds a regression test for #31523 where `deno update` would leave stale peer dependency references in the lockfile when updating a package that other packages depend on via `peerDependencies`.

The bug was: updating `react@19.2.0` → `19.2.1` would leave packages like `use-prefers-color-scheme` and `raviger` still pointing to `react@19.2.0` in their lockfile peer dep suffix, causing two React versions at runtime and breaking the app.

This was fixed by the two-phase peer dependency resolution with dedup pass introduced in #32358.

The test:
- Creates mock packages: `peer-dep-base` (versions 1.0.0, 1.1.0) and two consumer packages with `peer-dep-base` as a peer dependency
- Installs with `~1.0.0` constraint (pins to 1.0.0)
- Runs `deno outdated --update --latest` (bumps to 1.1.0)
- Asserts the lockfile has all consumers pointing to `@1.1.0` with no stale `@1.0.0` references

Closes #31523

## Test plan
- [x] `./x test-spec outdated::update_peer_dep` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)