### PR TITLE
fix(runtime): warn on unsupported web Worker options and fix recv panic

### DIFF
--- a/runtime/js/11_workers.js
+++ b/runtime/js/11_workers.js
@@ -10,6 +10,7 @@ import {
 } from "ext:core/ops";
 const {
   ArrayPrototypeFilter,
+  ArrayPrototypeJoin,
   Error,
   ObjectPrototypeIsPrototypeOf,
   String,
@@ -99,6 +100,21 @@ class Worker extends EventTarget {
       name,
       type = "classic",
     } = options;
+
+    if (options.env !== undefined || options.workerData !== undefined) {
+      const unsupported = [];
+      if (options.env !== undefined) unsupported[unsupported.length] = "env";
+      if (options.workerData !== undefined) {
+        unsupported[unsupported.length] = "workerData";
+      }
+      globalThis.console.warn(
+        `Warning: ${
+          ArrayPrototypeJoin(unsupported, ", ")
+        } option(s) are not supported ` +
+          "for web Workers and will be ignored. Use the " +
+          "node:worker_threads module instead.",
+      );
+    }
 
     const workerType = webidl.converters["WorkerType"](type);
 

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -287,7 +287,12 @@ fn op_create_worker(
   })?;
 
   // Receive WebWorkerHandle from newly created worker
-  let worker_handle = handle_receiver.recv().unwrap();
+  let worker_handle = handle_receiver.recv().map_err(|_| {
+    std::io::Error::new(
+      std::io::ErrorKind::Other,
+      "Worker thread terminated unexpectedly before initialization completed",
+    )
+  })?;
 
   let worker_thread = WorkerThread {
     worker_handle: worker_handle.into(),

--- a/runtime/ops/worker_host.rs
+++ b/runtime/ops/worker_host.rs
@@ -288,8 +288,7 @@ fn op_create_worker(
 
   // Receive WebWorkerHandle from newly created worker
   let worker_handle = handle_receiver.recv().map_err(|_| {
-    std::io::Error::new(
-      std::io::ErrorKind::Other,
+    std::io::Error::other(
       "Worker thread terminated unexpectedly before initialization completed",
     )
   })?;

--- a/tests/specs/worker/worker_unsupported_options/__test__.jsonc
+++ b/tests/specs/worker/worker_unsupported_options/__test__.jsonc
@@ -1,0 +1,14 @@
+{
+  "tests": {
+    "env_option": {
+      "args": "run --quiet --allow-read worker_env.ts",
+      "output": "worker_env.out",
+      "exitCode": 0
+    },
+    "workerData_option": {
+      "args": "run --quiet --allow-read worker_data.ts",
+      "output": "worker_data.out",
+      "exitCode": 0
+    }
+  }
+}

--- a/tests/specs/worker/worker_unsupported_options/worker_data.out
+++ b/tests/specs/worker/worker_unsupported_options/worker_data.out
@@ -1,0 +1,2 @@
+Warning: workerData option(s) are not supported for web Workers and will be ignored. Use the node:worker_threads module instead.
+hello from worker

--- a/tests/specs/worker/worker_unsupported_options/worker_data.ts
+++ b/tests/specs/worker/worker_unsupported_options/worker_data.ts
@@ -1,0 +1,8 @@
+const worker = new Worker(import.meta.resolve("./worker_target.ts"), {
+  type: "module",
+  workerData: { hello: "world" },
+} as unknown as WorkerOptions);
+worker.onmessage = (e) => {
+  console.log(e.data);
+  worker.terminate();
+};

--- a/tests/specs/worker/worker_unsupported_options/worker_env.out
+++ b/tests/specs/worker/worker_unsupported_options/worker_env.out
@@ -1,0 +1,2 @@
+Warning: env option(s) are not supported for web Workers and will be ignored. Use the node:worker_threads module instead.
+hello from worker

--- a/tests/specs/worker/worker_unsupported_options/worker_env.ts
+++ b/tests/specs/worker/worker_unsupported_options/worker_env.ts
@@ -1,0 +1,8 @@
+const worker = new Worker(import.meta.resolve("./worker_target.ts"), {
+  type: "module",
+  env: { IS_WORKER: "true" },
+} as unknown as WorkerOptions);
+worker.onmessage = (e) => {
+  console.log(e.data);
+  worker.terminate();
+};

--- a/tests/specs/worker/worker_unsupported_options/worker_target.ts
+++ b/tests/specs/worker/worker_unsupported_options/worker_target.ts
@@ -1,0 +1,1 @@
+self.postMessage("hello from worker");


### PR DESCRIPTION
## Summary

- Emit a console warning when node-specific options (`env`, `workerData`) are passed to the web `Worker()` constructor, directing users to `node:worker_threads` instead. These options are silently ignored by web Workers, which can lead to subtle bugs like infinite worker recursion.
- Replace `handle_receiver.recv().unwrap()` in `op_create_worker` with a proper error return, so a worker thread dying before initialization produces a JS error instead of a process panic.

Fixes #31058

## Root cause

The issue reporter passed `{ env: { IS_WORKER: "true" } }` to `new Worker()` (web worker). The web Worker constructor silently ignores `env` (it's a node:worker_threads option). The spawned worker couldn't detect it was a worker (`process.env.IS_WORKER` was never set), so it entered the main code path and recursively spawned more workers exponentially. This exhausted OS resources until Rust's thread initialization panicked trying to allocate a signal stack.

## Test plan

- [x] New spec tests: `tests/specs/worker/worker_unsupported_options/` — verifies warning for both `env` and `workerData`
- [x] Existing worker spec tests pass
- [x] Existing `node:worker_threads` spec tests pass
- [x] `cargo check -p deno_runtime` clean
- [x] JS lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)