### PR TITLE
fix(ext/node): fix multiple http2 bugs

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -301,9 +301,10 @@ const nameForErrorCode = [
 ];
 
 // Session field indices
-const kSessionUint8FieldCount = 1;
+const kSessionUint8FieldCount = 2;
 const kSessionRemoteSettingsIsUpToDate = 0;
 const kSessionPriorityListenerCount = 0;
+const kSessionFrameErrorListenerCount = 1;
 const kBitfield = 0;
 
 // Private symbols

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -53,7 +53,11 @@ import {
 import net from "node:net";
 import assert from "node:assert";
 import http from "node:http";
-import { setupConnectionsTracking } from "node:_http_server";
+import {
+  httpServerPreClose,
+  Server as HttpServer,
+  setupConnectionsTracking,
+} from "node:_http_server";
 import { Duplex } from "node:stream";
 import tls from "node:tls";
 import { deprecate } from "node:util";
@@ -1383,7 +1387,12 @@ class Http2Stream extends Duplex {
     // Wrap the native write methods to flush pending h2 frames after
     // each write. The native writeBuffer/writeUtf8String are synchronous
     // (they buffer data in nghttp2's pending_data), so kLastWriteWasAsync
-    // stays 0 and afterWriteDispatched calls req.callback synchronously.
+    // must be 0 for afterWriteDispatched to call req.callback synchronously.
+    //
+    // scheduleSendPending() may write to the underlying socket (e.g. TLS),
+    // which can set kLastWriteWasAsync = 1 on the shared streamBaseState.
+    // We must reset it to 0 after flushing so that the h2 stream's own
+    // write is still considered synchronous by afterWriteDispatched.
     const nativeWriteUtf8String = FunctionPrototypeBind(
       handle.writeUtf8String,
       handle,
@@ -1392,11 +1401,13 @@ class Http2Stream extends Duplex {
     handle.writeUtf8String = function (req, data) {
       const err = nativeWriteUtf8String(req, data);
       scheduleSendPending(session);
+      streamBaseState[kLastWriteWasAsync] = 0;
       return err;
     };
     handle.writeBuffer = function (req, data) {
       const err = nativeWriteBuffer(req, data);
       scheduleSendPending(session);
+      streamBaseState[kLastWriteWasAsync] = 0;
       return err;
     };
     handle.writev = function (req, chunks, allBuffers) {
@@ -2725,13 +2736,15 @@ function setupHandle(socket, type, options) {
   };
 
   this[kHandle] = handle;
-  if (this[kNativeFields]) {
+  if (this[kNativeFields] && handle.fields) {
     // If some options have already been set before the handle existed, copy
     // those (and only those) that have manually been set over.
     this[kNativeFields].copyAssigned(handle.fields);
   }
 
-  this[kNativeFields] = handle.fields;
+  if (handle.fields) {
+    this[kNativeFields] = handle.fields;
+  }
 
   if (socket.encrypted) {
     this[kAlpnProtocol] = socket.alpnProtocol;

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -54,6 +54,7 @@ import net from "node:net";
 import assert from "node:assert";
 import http from "node:http";
 import {
+  _connectionListener as httpConnectionListener,
   httpServerPreClose,
   Server as HttpServer,
   setupConnectionsTracking,

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -53,6 +53,7 @@ import {
 import net from "node:net";
 import assert from "node:assert";
 import http from "node:http";
+import { setupConnectionsTracking } from "node:_http_server";
 import { Duplex } from "node:stream";
 import tls from "node:tls";
 import { deprecate } from "node:util";

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -505,6 +505,9 @@ Deno.test("[node/http2] createSecureServer with allowHTTP1", {
   const key = Deno.readTextFileSync("tests/testdata/tls/localhost.key");
   const ca = Deno.readTextFileSync("tests/testdata/tls/RootCA.pem");
 
+  // Verifies that createSecureServer with allowHTTP1 doesn't throw
+  // ReferenceError for setupConnectionsTracking/httpServerPreClose/HttpServer.
+  // TODO(denoland/deno#33317): test HTTP/1.1 fallback once that path works.
   const server = http2.createSecureServer(
     { allowHTTP1: true, cert, key },
     (_req, res) => {

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -495,6 +495,120 @@ Deno.test("[node/http2] Server.address() includes family property", async () => 
   }
 });
 
+Deno.test("[node/http2] createSecureServer with allowHTTP1", {
+  ignore: Deno.build.os === "windows",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const cert = Deno.readTextFileSync("tests/testdata/tls/localhost.crt");
+  const key = Deno.readTextFileSync("tests/testdata/tls/localhost.key");
+  const ca = Deno.readTextFileSync("tests/testdata/tls/RootCA.pem");
+
+  const server = http2.createSecureServer(
+    { allowHTTP1: true, cert, key },
+    (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    },
+  );
+
+  server.listen(0, () => {
+    const addr = server.address() as net.AddressInfo;
+    const client = http2.connect(`https://localhost:${addr.port}`, { ca });
+    client.on("error", reject);
+    const req = client.request({ ":path": "/" });
+    let data = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      assertEquals(data, "ok");
+      client.close();
+      server.close(() => resolve());
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});
+
+Deno.test("[node/http2] createSecureServer responds to client", {
+  ignore: Deno.build.os === "windows",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const cert = Deno.readTextFileSync("tests/testdata/tls/localhost.crt");
+  const key = Deno.readTextFileSync("tests/testdata/tls/localhost.key");
+  const ca = Deno.readTextFileSync("tests/testdata/tls/RootCA.pem");
+
+  const server = http2.createSecureServer({ cert, key }, (_req, res) => {
+    res.writeHead(200);
+    res.end("hello-tls");
+  });
+
+  server.listen(0, () => {
+    const addr = server.address() as net.AddressInfo;
+    const client = http2.connect(`https://localhost:${addr.port}`, { ca });
+    client.on("error", reject);
+    const req = client.request({ ":path": "/" });
+    let data = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      assertEquals(data, "hello-tls");
+      client.close();
+      server.close(() => resolve());
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});
+
+Deno.test("[node/http2] stream frameError listener does not throw", {
+  ignore: Deno.build.os === "windows",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+  const server = http2.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+
+  server.listen(0, () => {
+    const addr = server.address() as net.AddressInfo;
+    const client = http2.connect(`http://localhost:${addr.port}`);
+    client.on("error", reject);
+    const req = client.request({ ":path": "/" });
+    // Adding a frameError listener exercises kSessionFrameErrorListenerCount
+    // and should not throw a ReferenceError
+    req.once("frameError", () => {});
+    let data = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      assertEquals(data, "ok");
+      client.close();
+      server.close(() => resolve());
+    });
+    req.on("error", reject);
+    req.end();
+  });
+
+  await promise;
+});
+
 Deno.test("[node/http2 client] connect without net permission", {
   permissions: { net: false },
 }, async () => {


### PR DESCRIPTION
## Summary

Fixes three `node:http2` bugs:

- **`kSessionFrameErrorListenerCount` not defined** (#33153): The constant was used in `streamListenerAdded`/`streamListenerRemoved` but never declared, causing `undici@8.0.0` HTTP/2 requests to crash with `ReferenceError`.

- **`setupConnectionsTracking` not defined** (#33067): `Http2SecureServer` referenced `setupConnectionsTracking` and `httpServerPreClose`/`HttpServer` without importing them from `node:_http_server`, causing `createSecureServer` with `allowHTTP1: true` to crash.

- **`createSecureServer` gives empty response** (#33072): `streamBaseState[kLastWriteWasAsync]` is a shared global array. When `scheduleSendPending()` writes h2 frames to the underlying TLS socket, the TLS socket's write sets `kLastWriteWasAsync = 1`. This caused the h2 stream's own `afterWriteDispatched` to treat the write as async, so the write callback never fired, `_final` was never called, and the `END_STREAM` frame was never sent. Fix: reset `kLastWriteWasAsync = 0` after `scheduleSendPending()` since h2 stream writes are always synchronous.

Closes #33153
Closes #33067
Closes #33072

## Test plan

- [x] Added `createSecureServer with allowHTTP1` test
- [x] Added `createSecureServer responds to client` test  
- [x] Added `stream frameError listener does not throw` test
- [x] Verified `undici@8.0.0` HTTPS requests work: `deno eval 'import { request } from "npm:undici@8.0.0"; const { body } = await request("https://example.com/"); console.log(await body.text())'`
- [x] All existing `http2_test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)