### PR TITLE
fix: update v8 crate to 147.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11248,9 +11248,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "147.2.0"
+version = "147.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76428cc491699b74b3bb7185d910b3991837c69b4f4e05bf5a2e2231bf1d79df"
+checksum = "34ab71899655e8368fa29d66044b4ba011178dc93c65cf0263068432e77e7359"
 dependencies = [
  "bindgen 0.72.1",
  "bitflags 2.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ deno_task_shell = "=0.29.0"
 deno_terminal = "=0.2.3"
 deno_unsync = { version = "0.4.4", default-features = false }
 deno_whoami = "0.1.0"
-v8 = { version = "147.2.0", default-features = false, features = ["simdutf"] }
+v8 = { version = "147.2.1", default-features = false, features = ["simdutf"] }
 
 denokv_proto = "0.13.0"
 denokv_remote = "0.13.0"


### PR DESCRIPTION
## Summary

- Updates the `v8` crate from `147.2.0` to `147.2.1`
- This includes the fix from denoland/rusty_v8#1962 which corrects an FFI type mismatch in `v8__String__NewExternalOneByte`: the C++ function declared `int length` (4 bytes) while the Rust FFI binding used `size_t` (8 bytes), causing panics when creating external one-byte strings

Fixes #32693
Fixes #32904

## Test plan

- [x] Cargo.toml and Cargo.lock updated
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)