### PR TITLE
fix(ext/node): fix http2 client hangs with got/http2-wrapper

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -552,7 +552,8 @@ TLSSocket.prototype._finishInit = function () {
     this._handle.getAlpnNegotiatedProtocol(alpnOut);
     this.alpnProtocol = alpnOut.alpnProtocol || false;
     if (this.servername === null) {
-      this.servername = this._handle.getServername?.() ?? null;
+      this.servername = this._handle.getServername?.() ??
+        this._tlsOptions?.servername ?? null;
     }
   } catch (_e) {
     // getAlpnNegotiatedProtocol/getServername may not be available

--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -2665,6 +2665,8 @@ function setupHandle(socket, type, options) {
 
   // Pump data from socket to session via JS events.
   // After receiving data, flush outgoing h2 frames back to the socket.
+  // Pump data from socket to session via JS events.
+  // After receiving data, flush outgoing h2 frames back to the socket.
   socket.on("data", (buf) => {
     if (!this.destroyed) {
       handle.receive(buf);
@@ -2840,11 +2842,18 @@ function finishSessionClose(session, error) {
     // Always wait for writable side to finish.
     socket.end((err) => {
       debugSessionObj(session, "finishSessionClose socket end", err, error);
-      // If session.destroy() was called, destroy the underlying socket.
-      // Delay it a bit to try to avoid ECONNRESET on Windows.
+      // If session.destroy() was called (not graceful close via close()),
+      // destroy the underlying socket. Delay it a bit to try to avoid
+      // ECONNRESET on Windows.
       if (!session.closed) {
         setImmediate(() => {
           socket.destroy(error);
+        });
+      } else {
+        // For graceful close, destroy the socket after end() so we don't
+        // keep the event loop alive waiting for the peer to close.
+        socket.once("finish", () => {
+          socket.destroy();
         });
       }
     });

--- a/ext/node/polyfills/internal/http2/util.ts
+++ b/ext/node/polyfills/internal/http2/util.ts
@@ -185,8 +185,18 @@ const kNoPayloadMethods = new SafeSet([
 // the native side with values that are filled in on demand, the js code then
 // reads those values out. The set of IDX constants that follow identify the
 // relevant data positions within these buffers.
-const { settingsBuffer, optionsBuffer, sessionState, streamState } =
-  op_http2_http_state();
+// These buffers are backed by thread-local memory in Rust. They must be
+// initialized at runtime (not snapshot time) so the pointers are valid.
+let settingsBuffer: Uint32Array;
+let optionsBuffer: Uint32Array;
+let sessionState: Float32Array;
+let streamState: Float32Array;
+
+function initHttp2State() {
+  if (settingsBuffer) return;
+  ({ settingsBuffer, optionsBuffer, sessionState, streamState } =
+    op_http2_http_state());
+}
 
 const IDX_SETTINGS_HEADER_TABLE_SIZE = 0;
 const IDX_SETTINGS_ENABLE_PUSH = 1;
@@ -232,6 +242,7 @@ const IDX_OPTIONS_STRICT_HTTP_FIELD_WHITESPACE_VALIDATION = 12;
 const IDX_OPTIONS_FLAGS = 13;
 
 function updateOptionsBuffer(options) {
+  initHttp2State();
   let flags = 0;
   if (typeof options.maxDeflateDynamicTableSize === "number") {
     flags |= 1 << IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE;
@@ -339,6 +350,7 @@ function getDefaultSettings() {
 // Remote is a boolean. true to fetch remote settings, false to fetch local.
 // this is only called internally
 function getSettings(session, remote) {
+  initHttp2State();
   if (remote) {
     session.remoteSettings();
   } else {
@@ -363,6 +375,7 @@ function getSettings(session, remote) {
 }
 
 function updateSettingsBuffer(settings) {
+  initHttp2State();
   let flags = 0;
   let numCustomSettings = 0;
 


### PR DESCRIPTION
## Summary

Fixes three issues that caused `got` with `http2: true` (and other `http2-wrapper` users) to hang or fail:

- **Settings buffer stale after snapshot**: `op_http2_http_state()` was called at snapshot time, so the `Uint32Array` views pointed to stale thread-local memory at runtime. `remoteSettings` returned all zeros (`maxConcurrentStreams: 0`), causing `http2-wrapper` to refuse to create streams. Fix: lazy-init the shared buffers on first use.

- **`TLSSocket.servername` always null**: `getServername()` is not implemented on `TLSWrap`, and `setServername()` is a no-op. `servername` stayed `null`, causing `session.originSet` to return the IP address instead of hostname. `http2-wrapper` compared this against the requested origin, got a mismatch, and destroyed the session. Fix: fall back to `_tlsOptions.servername` in `_finishInit`.

- **Process hangs after `client.close()`**: `finishSessionClose` only called `socket.end()` but never `socket.destroy()` in the graceful close path, leaving the socket in half-open state keeping the event loop alive indefinitely. Fix: destroy the socket after the `finish` event.

**Known limitation**: `got` requests to URLs that redirect (e.g. `google.com` → `www.google.com`) still fail because the `remoteSettings` event doesn't fire for the second session. The SETTINGS frame is received by nghttp2 but the JS callback isn't triggered — likely a data flow issue where the server's response to the connection preface isn't read from the socket. This is a pre-existing issue and will be addressed separately.

Closes #31738

## Test plan

- [x] `deno eval 'import got from "npm:got"; const r = await got("https://httpbin.org/get", { http2: true }); console.log(r.statusCode, r.body.length)'` → prints `200 309` and exits cleanly (was: hung indefinitely)
- [x] Direct `http2.connect` + `client.close()` exits cleanly (was: hung)
- [x] `session.remoteSettings.maxConcurrentStreams` returns correct values (was: 0)
- [x] `session.originSet` returns hostname-based origins (was: IP-based)
- [x] All existing `http2_test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)