### PR TITLE
fix: add --minimum-dependency-age flag to deno info

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -3475,6 +3475,7 @@ The following information is shown:
       ))
       .arg(allow_import_arg())
       .arg(deny_import_arg())
+      .arg(min_dep_age_arg())
 }
 
 fn install_subcommand() -> Command {
@@ -6688,6 +6689,7 @@ fn info_parse(
   lock_args_parse(flags, matches);
   no_remote_arg_parse(flags, matches);
   no_npm_arg_parse(flags, matches);
+  min_dep_age_arg_parse(flags, matches);
   allow_and_deny_import_parse(flags, matches)?;
   let json = matches.get_flag("json");
   flags.subcommand = DenoSubcommand::Info(InfoFlags {


### PR DESCRIPTION
## Summary

The `--minimum-dependency-age` flag was available for other subcommands that resolve dependencies (e.g. `deno run`, `deno compile`, `deno outdated`) but was missing from `deno info`, causing an `unexpected argument` error.

This PR adds the flag definition to the `info_subcommand` and the corresponding arg parse call to `info_parse`.

Before:
```
> deno info --minimum-dependency-age test.ts
error: unexpected argument '--minimum-dependency-age' found
```

After:
```
> deno info --minimum-dependency-age test.ts
# works as expected
```

Closes #33126