### PR TITLE
test: cover additional Windows file URL decoding cases

### DIFF
--- a/tests/unit/path_from_url_test.ts
+++ b/tests/unit/path_from_url_test.ts
@@ -28,14 +28,34 @@ Deno.test(
       pathFromURL(new URL("file:///c:/space_ .txt")),
       "c:\\space_ .txt",
     );
+    assertEquals(
+      pathFromURL(new URL("file:///D:/weird_names/ampersand_&.txt")),
+      "D:\\weird_names\\ampersand_&.txt",
+    );
+    assertEquals(
+      pathFromURL(new URL("file:///D:/weird_names/at_@.txt")),
+      "D:\\weird_names\\at_@.txt",
+    );
+    assertEquals(
+      pathFromURL(new URL("file:///D:/weird_names/emoji_%F0%9F%99%83.txt")),
+      "D:\\weird_names\\emoji_🙃.txt",
+    );
+    assertEquals(
+      pathFromURL(new URL("file:///D:/weird_names/percent_%25.txt")),
+      "D:\\weird_names\\percent_%.txt",
+    );
+    assertEquals(
+      pathFromURL(new URL("file:///D:/weird_names/pound_%23.txt")),
+      "D:\\weird_names\\pound_#.txt",
+    );
+    assertEquals(
+      pathFromURL(
+        new URL(
+          "file:///D:/weird_names/swapped_surrogate_pair_%EF%BF%BD%EF%BF%BD.txt",
+        ),
+      ),
+      "D:\\weird_names\\swapped_surrogate_pair_\uFFFD\uFFFD.txt",
+    );
     assertThrows(() => pathFromURL(new URL("https://deno.land/welcome.ts")));
-    /* TODO(ry) Add tests for these situations
-     * ampersand_&.tx                 file:///D:/weird_names/ampersand_&.txt
-     * at_@.txt                       file:///D:/weird_names/at_@.txt
-     * emoji_🙃.txt                   file:///D:/weird_names/emoji_%F0%9F%99%83.txt
-     * percent_%.txt                  file:///D:/weird_names/percent_%25.txt
-     * pound_#.txt                    file:///D:/weird_names/pound_%23.txt
-     * swapped_surrogate_pair_��.txt  file:///D:/weird_names/swapped_surrogate_pair_%EF%BF%BD%EF%BF%BD.txt
-     */
   },
 );


### PR DESCRIPTION

**Repo:** denoland/deno (⭐ 98000)
**Type:** test
**Files changed:** 1
**Lines:** +28/-8

## What
This change expands `tests/unit/path_from_url_test.ts` to cover additional Windows `file:` URL decoding cases that were previously only documented in a TODO comment. The new assertions verify that `pathFromURL()` correctly handles unescaped special characters, percent-encoded reserved characters, emoji, and replacement-character sequences in Windows paths.

## Why
`pathFromURLWin32()` is shared infrastructure-level behavior for converting `file:` URLs into Windows filesystem paths, and regressions here would affect path handling broadly. Turning the existing TODO list into executable tests protects several tricky decoding cases that are easy to break accidentally while keeping the patch small and low risk.

## Testing
Attempted `./x test tests/unit/path_from_url_test.ts`, but it failed in this environment because `deno` is not installed on `PATH` (`env: deno: No such file or directory`). Verified the committed diff and the expected mappings against the existing `pathFromURLWin32()` decoding logic.

## Risk
Low / test-only change that adds coverage without modifying runtime behavior.
