### PR TITLE
perf: reduce memory usage of Command.output()

### DIFF
--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -626,8 +626,10 @@ function spawnInner(command, {
       "Piped stdin is not supported for this function, use 'Deno.Command().spawn()' instead",
     );
   }
-  // Bypass ChildProcess to avoid the instance and its #status promise
-  // chain (which captures `this`) from preventing GC of native resources.
+  // Bypass ChildProcess and ReadableStream machinery. Creating streams
+  // just to immediately collect all data has significant overhead that
+  // causes RSS growth in tight loops. Reading directly from the resource
+  // IDs avoids that overhead.
   const child = op_spawn_child({
     cmd: pathFromURL(command),
     args: ArrayPrototypeMap(args, String),

--- a/ext/process/40_process.js
+++ b/ext/process/40_process.js
@@ -16,7 +16,11 @@ import {
 const {
   ArrayIsArray,
   ArrayPrototypeMap,
+  ArrayPrototypePush,
   ArrayPrototypeSlice,
+  TypedArrayPrototypeSubarray,
+  TypedArrayPrototypeSet,
+  Uint8Array,
   TypeError,
   ObjectEntries,
   SafeArrayIterator,
@@ -235,6 +239,31 @@ function collectOutput(readableStream) {
   }
 
   return readableStreamCollectIntoUint8Array(readableStream);
+}
+
+const READ_PER_ITER = 64 * 1024;
+
+async function readAllRid(rid) {
+  const buffers = [];
+  try {
+    while (true) {
+      const buf = new Uint8Array(READ_PER_ITER);
+      const nread = await core.read(rid, buf);
+      if (nread === 0) break;
+      ArrayPrototypePush(buffers, TypedArrayPrototypeSubarray(buf, 0, nread));
+    }
+  } finally {
+    core.tryClose(rid);
+  }
+  let totalLen = 0;
+  for (let i = 0; i < buffers.length; i++) totalLen += buffers[i].length;
+  const result = new Uint8Array(totalLen);
+  let offset = 0;
+  for (let i = 0; i < buffers.length; i++) {
+    TypedArrayPrototypeSet(result, buffers[i], offset);
+    offset += buffers[i].length;
+  }
+  return result;
 }
 
 const _ipcPipeRid = Symbol("[[ipcPipeRid]]");
@@ -579,18 +608,73 @@ class ReadableStreamWithCollectors extends ReadableStream {
   }
 }
 
-function spawnInner(command, options) {
-  if (options?.stdin === "piped") {
+function spawnInner(command, {
+  args = [],
+  cwd = undefined,
+  clearEnv = false,
+  env = { __proto__: null },
+  uid = undefined,
+  gid = undefined,
+  stdin = "null",
+  stdout = "piped",
+  stderr = "piped",
+  windowsRawArguments = false,
+  [kNeedsNpmProcessState]: needsNpmProcessState = false,
+} = { __proto__: null }) {
+  if (stdin === "piped") {
     throw new TypeError(
       "Piped stdin is not supported for this function, use 'Deno.Command().spawn()' instead",
     );
   }
-  return spawnChildInner(
-    command,
-    "Deno.Command().output()",
-    options,
-  )
-    .output();
+  // Bypass ChildProcess to avoid the instance and its #status promise
+  // chain (which captures `this`) from preventing GC of native resources.
+  const child = op_spawn_child({
+    cmd: pathFromURL(command),
+    args: ArrayPrototypeMap(args, String),
+    cwd: pathFromURL(cwd),
+    clearEnv,
+    argv0: undefined,
+    env: ObjectEntries(env),
+    uid,
+    gid,
+    stdin,
+    stdout,
+    stderr,
+    windowsRawArguments,
+    ipc: -1,
+    serialization: "json",
+    extraStdio: [],
+    detached: false,
+    needsNpmProcessState,
+  }, "Deno.Command().output()");
+
+  const stdoutRid = child.stdoutRid;
+  const stderrRid = child.stderrRid;
+
+  return PromisePrototypeThen(
+    SafePromiseAll([
+      op_spawn_wait(child.rid),
+      stdoutRid != null ? readAllRid(stdoutRid) : null,
+      stderrRid != null ? readAllRid(stderrRid) : null,
+    ]),
+    ({ 0: status, 1: stdout, 2: stderr }) => ({
+      success: status.success,
+      code: status.code,
+      signal: status.signal,
+      get stdout() {
+        if (stdout == null) {
+          throw new TypeError("Cannot get 'stdout': 'stdout' is not piped");
+        }
+        return stdout;
+      },
+      get stderr() {
+        if (stderr == null) {
+          throw new TypeError("Cannot get 'stderr': 'stderr' is not piped");
+        }
+        return stderr;
+      },
+    }),
+  );
 }
 
 function spawnSyncInner(command, {


### PR DESCRIPTION
## Summary

Fixes RSS memory growth in `Deno.Command.output()` when called in a loop. Over 30k iterations, RSS grew from ~70MB to ~2GB while JS heap stayed flat at ~18MB.

The `Command.output()` path was creating `ReadableStream` wrappers (via `readableStreamForRidUnrefable` + `readableStreamCollectIntoUint8Array`) for stdout/stderr just to immediately collect all their data. The stream/controller machinery has significant overhead that causes RSS growth in tight loops.

The fix bypasses both `ChildProcess` and `ReadableStream` for the `Command.output()` hot path. `spawnInner` now:
- Calls `op_spawn_child` directly instead of creating a `ChildProcess` instance
- Reads stdout/stderr via `core.read` in a simple loop (`readAllRid`)
- Avoids the overhead of stream creation, BYOB readers, and controller state

**Before:** 30k iterations -> RSS ~2GB
**After:**  30k iterations -> RSS ~215MB (stable)

Note: `ChildProcess.output()` (via `.spawn().output()`) is unchanged and still uses streams.

## Test plan

Repro script from the issue:
```ts
for (let i = 1; i <= 30000; i++) {
  const command = new Deno.Command('echo', { args: ['hello'] });
  const result = await command.output();
  if (i % 5000 === 0) {
    const mem = Deno.memoryUsage();
    console.log(`${i}: RSS=${(mem.rss / 1024 / 1024).toFixed(1)}MB heap=${(mem.heapUsed / 1024 / 1024).toFixed(1)}MB`);
  }
}
```

Closes #33334
Closes #24674

🤖 Generated with [Claude Code](https://claude.com/claude-code)