### PR TITLE
fix(ext/node): http client compat improvements

### DIFF
--- a/ext/node/polyfills/_http_agent.js
+++ b/ext/node/polyfills/_http_agent.js
@@ -572,12 +572,22 @@ function asyncResetHandle(socket) {
   }
 }
 
-export const globalAgent = new Agent({
+export let globalAgent = new Agent({
   keepAlive: true,
   scheduling: "lifo",
   timeout: 5000,
 });
+
+export function setGlobalAgent(agent) {
+  globalAgent = agent;
+}
+
 export default {
   Agent,
-  globalAgent,
+  get globalAgent() {
+    return globalAgent;
+  },
+  set globalAgent(agent) {
+    globalAgent = agent;
+  },
 };

--- a/ext/node/polyfills/_http_agent.js
+++ b/ext/node/polyfills/_http_agent.js
@@ -105,14 +105,19 @@ export function Agent(options) {
 
     // In Node.js, nextTick (where 'free' is emitted) always runs before I/O,
     // so the socket is guaranteed to be writable here. In Deno, I/O can
-    // interleave with nextTick, so a server FIN may arrive first making the
-    // socket non-writable but not yet destroyed. Use `destroyed` as the
-    // primary check; the socket will be cleaned up by the 'close' listener.
+    // interleave with nextTick, so a server FIN may arrive before 'free'
+    // runs, making the socket non-writable but not yet destroyed.
     if (socket.destroyed) {
       return;
     }
 
+    // For queued requests, require the socket to be writable - don't hand
+    // a half-closed socket to a new request.
     const requests = this.requests[name];
+    if (requests && requests.length && !socket.writable) {
+      socket.destroy();
+      return;
+    }
     if (requests && requests.length) {
       const req = requests.shift();
       const reqAsyncRes = req[kRequestAsyncResource];

--- a/ext/node/polyfills/_http_agent.js
+++ b/ext/node/polyfills/_http_agent.js
@@ -103,8 +103,12 @@ export function Agent(options) {
     // case of socket.destroy() below this 'error' has no handler
     // and could cause unhandled exception.
 
-    if (!socket.writable) {
-      socket.destroy();
+    // In Node.js, nextTick (where 'free' is emitted) always runs before I/O,
+    // so the socket is guaranteed to be writable here. In Deno, I/O can
+    // interleave with nextTick, so a server FIN may arrive first making the
+    // socket non-writable but not yet destroyed. Use `destroyed` as the
+    // primary check; the socket will be cleaned up by the 'close' listener.
+    if (socket.destroyed) {
       return;
     }
 

--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -570,13 +570,8 @@ function socketCloseListener() {
   const socket = this;
   const req = socket._httpMessage;
 
-  // Guard against close firing on a socket whose request was already
-  // handled by responseKeepAlive. In Node.js, the close callback from
-  // uv_close fires on the next event loop iteration (after nextTick),
-  // so responseKeepAlive's removeListener always runs before close.
-  // In Deno, V8TaskSpawner may fire before nextTick, so close can
-  // fire before responseKeepAlive removes the listener.
-  if (!req || req.destroyed) {
+  // Guard against close firing on a socket that has no associated request.
+  if (!req) {
     return;
   }
 

--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -833,7 +833,6 @@ function responseKeepAlive(req) {
   socket.removeListener("data", socketOnData);
   socket.removeListener("end", socketOnEnd);
 
-
   // There are cases where _handle === null. Avoid those. Passing undefined to
   // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.
   const asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;

--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -833,6 +833,7 @@ function responseKeepAlive(req) {
   socket.removeListener("data", socketOnData);
   socket.removeListener("end", socketOnEnd);
 
+
   // There are cases where _handle === null. Avoid those. Passing undefined to
   // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.
   const asyncId = socket._handle ? socket._handle.getAsyncId() : undefined;
@@ -840,6 +841,8 @@ function responseKeepAlive(req) {
 
   req.destroyed = true;
   if (req.res) {
+    // Detach socket from IncomingMessage to avoid destroying the freed
+    // socket in IncomingMessage.destroy().
     req.res.socket = null;
   }
 }

--- a/ext/node/polyfills/_http_client.js
+++ b/ext/node/polyfills/_http_client.js
@@ -56,7 +56,7 @@ import {
   OutgoingMessage,
   parseUniqueHeadersOption,
 } from "node:_http_outgoing";
-import { globalAgent } from "node:_http_agent";
+import httpAgent from "node:_http_agent";
 import { Buffer } from "node:buffer";
 import { urlToHttpOptions } from "ext:deno_node/internal/url.ts";
 import { kOutHeaders } from "ext:deno_node/internal/http.ts";
@@ -156,7 +156,7 @@ function ClientRequest(input, options, cb) {
   }
 
   let agent = options.agent;
-  const defaultAgent = options._defaultAgent || globalAgent;
+  const defaultAgent = options._defaultAgent || httpAgent.globalAgent;
   if (agent === false) {
     agent = new defaultAgent.constructor();
   } else if (agent === null || agent === undefined) {

--- a/ext/node/polyfills/_http_outgoing.ts
+++ b/ext/node/polyfills/_http_outgoing.ts
@@ -28,6 +28,7 @@ import {
 const { async_id_symbol } = symbols;
 import {
   ERR_HTTP_BODY_NOT_ALLOWED,
+  ERR_HTTP_CONTENT_LENGTH_MISMATCH,
   ERR_HTTP_HEADERS_SENT,
   ERR_HTTP_INVALID_HEADER_VALUE,
   ERR_HTTP_TRAILER_INVALID,
@@ -456,6 +457,16 @@ Object.defineProperties(
 
       if (typeof callback === "function") {
         this.once("finish", callback);
+      }
+
+      if (
+        _checkStrictContentLength(this) &&
+        this[kBytesWritten] !== this._contentLength
+      ) {
+        throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(
+          this[kBytesWritten],
+          this._contentLength,
+        );
       }
 
       const finish = onFinish.bind(undefined, this);
@@ -1115,6 +1126,19 @@ function write_(
     len ??= typeof chunk === "string"
       ? Buffer.byteLength(chunk, encoding)
       : chunk.byteLength;
+
+    if (
+      _checkStrictContentLength(msg) &&
+      (fromEnd
+        ? msg[kBytesWritten] + len !== msg._contentLength
+        : msg[kBytesWritten] + len > msg._contentLength)
+    ) {
+      throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(
+        len + msg[kBytesWritten],
+        msg._contentLength,
+      );
+    }
+
     msg[kBytesWritten] += len;
   }
 

--- a/ext/node/polyfills/_http_server.js
+++ b/ext/node/polyfills/_http_server.js
@@ -462,7 +462,8 @@ function connectionListenerInternal(server, socket) {
   if (!server[kConnectionsKey]) server[kConnectionsKey] = new ConnectionsList();
   const connections = server[kConnectionsKey];
   connections.push(socket);
-  socket.on("close", () => connections.pop(socket));
+  const onConnectionClose = () => connections.pop(socket);
+  socket.on("close", onConnectionClose);
 
   if (server.timeout && typeof socket.setTimeout === "function") {
     socket.setTimeout(server.timeout);
@@ -492,6 +493,7 @@ function connectionListenerInternal(server, socket) {
     onData: null,
     onEnd: null,
     onClose: null,
+    onConnectionClose: onConnectionClose,
     onDrain: null,
     outgoing: [],
     incoming: [],
@@ -618,6 +620,19 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
       socket.destroy();
       return;
     }
+
+    // Detach the socket from the server by removing all server-added listeners.
+    // After this point the socket is fully owned by the connect/upgrade handler.
+    socket.removeListener("data", state.onData);
+    socket.removeListener("end", state.onEnd);
+    socket.removeListener("close", state.onClose);
+    socket.removeListener("close", state.onConnectionClose);
+    socket.removeListener("drain", state.onDrain);
+    socket.removeListener("error", socketOnError);
+    socket.removeListener("timeout", socketOnTimeout);
+    // Remove from connection tracking (normally done by the close listener)
+    const connections = server[kConnectionsKey];
+    if (connections) connections.pop(socket);
 
     parser.finish();
     freeParser(parser, req, socket);

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -7,11 +7,7 @@ import {
   validateHeaderValue,
 } from "node:_http_outgoing";
 import { ClientRequest } from "node:_http_client";
-import {
-  Agent,
-  globalAgent,
-  setGlobalAgent,
-} from "node:_http_agent";
+import { Agent, globalAgent, setGlobalAgent } from "node:_http_agent";
 import { IncomingMessage } from "node:_http_incoming";
 import {
   _connectionListener,

--- a/ext/node/polyfills/http.ts
+++ b/ext/node/polyfills/http.ts
@@ -7,7 +7,11 @@ import {
   validateHeaderValue,
 } from "node:_http_outgoing";
 import { ClientRequest } from "node:_http_client";
-import { Agent, globalAgent } from "node:_http_agent";
+import {
+  Agent,
+  globalAgent,
+  setGlobalAgent,
+} from "node:_http_agent";
 import { IncomingMessage } from "node:_http_incoming";
 import {
   _connectionListener,
@@ -119,7 +123,12 @@ export {
 export default {
   _connectionListener,
   Agent,
-  globalAgent,
+  get globalAgent() {
+    return globalAgent;
+  },
+  set globalAgent(value) {
+    setGlobalAgent(value);
+  },
   ClientRequest,
   STATUS_CODES,
   METHODS,

--- a/ext/node/polyfills/internal/errors.ts
+++ b/ext/node/polyfills/internal/errors.ts
@@ -1525,6 +1525,14 @@ export class ERR_HTTP_BODY_NOT_ALLOWED extends NodeError {
     );
   }
 }
+export class ERR_HTTP_CONTENT_LENGTH_MISMATCH extends NodeError {
+  constructor(bodyLength: number, contentLength: number) {
+    super(
+      "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+      `Response body's content-length of ${bodyLength} byte(s) does not match the content-length of ${contentLength} byte(s) set in header`,
+    );
+  }
+}
 export class ERR_HTTP_HEADERS_SENT extends NodeError {
   constructor(x: string) {
     super(

--- a/ext/node/polyfills/internal/url.ts
+++ b/ext/node/polyfills/internal/url.ts
@@ -50,6 +50,7 @@ export function toPathIfFileURL(
 export function urlToHttpOptions(url: URL): HttpOptions {
   validateObject(url, "url", { allowArray: true, allowFunction: true });
   const options: HttpOptions = {
+    ...url, // In case the url object was extended by the user.
     protocol: url.protocol,
     hostname: typeof url.hostname === "string" &&
         StringPrototypeStartsWith(url.hostname, "[")

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1148,6 +1148,8 @@
     "parallel/test-http-client-upload-buf.js": {},
     "parallel/test-http-client-upload.js": {},
     "parallel/test-http-common.js": {},
+    "parallel/test-http-connect-req-res.js": {},
+    "parallel/test-http-connect.js": {},
     "parallel/test-http-contentLength0.js": {},
     "parallel/test-http-correct-hostname.js": {},
     "parallel/test-http-createConnection.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1142,6 +1142,7 @@
     "parallel/test-http-client-res-destroyed.js": {},
     "parallel/test-http-client-set-timeout-after-end.js": {},
     "parallel/test-http-client-set-timeout.js": {},
+    "parallel/test-http-client-timeout-event.js": {},
     "parallel/test-http-client-timeout-with-data.js": {},
     "parallel/test-http-client-unescaped-path.js": {},
     "parallel/test-http-client-upload-buf.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1138,6 +1138,7 @@
     "parallel/test-http-client-race.js": {},
     "parallel/test-http-client-read-in-error.js": {},
     "parallel/test-http-client-reject-unexpected-agent.js": {},
+    "parallel/test-http-client-request-options.js": {},
     "parallel/test-http-client-res-destroyed.js": {},
     "parallel/test-http-client-set-timeout-after-end.js": {},
     "parallel/test-http-client-timeout-with-data.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1133,6 +1133,7 @@
     "parallel/test-http-client-insecure-http-parser-error.js": {},
     "parallel/test-http-client-invalid-path.js": {},
     "parallel/test-http-client-keep-alive-hint.js": {},
+    "parallel/test-http-client-override-global-agent.js": {},
     "parallel/test-http-client-race-2.js": {},
     "parallel/test-http-client-race.js": {},
     "parallel/test-http-client-read-in-error.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1150,6 +1150,7 @@
     "parallel/test-http-common.js": {},
     "parallel/test-http-connect-req-res.js": {},
     "parallel/test-http-connect.js": {},
+    "parallel/test-http-content-length-mismatch.js": {},
     "parallel/test-http-contentLength0.js": {},
     "parallel/test-http-correct-hostname.js": {},
     "parallel/test-http-createConnection.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1106,6 +1106,7 @@
     "parallel/test-http-addrequest-localaddress.js": {},
     "parallel/test-http-agent-close.js": {},
     "parallel/test-http-agent-getname.js": {},
+    "parallel/test-http-agent-keepalive.js": {},
     "parallel/test-http-agent-no-protocol.js": {},
     "parallel/test-http-agent-null.js": {},
     "parallel/test-http-allow-req-after-204-res.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1101,6 +1101,7 @@
     // "parallel/test-heap-prof-loop-drained.js": {},
     // "parallel/test-heap-prof-name.js": {},
     // "parallel/test-heap-prof-sigint.js": {},
+    "parallel/test-http-aborted.js": {},
     "parallel/test-http-abort-before-end.js": {},
     "parallel/test-http-addrequest-localaddress.js": {},
     "parallel/test-http-agent-close.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -1141,6 +1141,7 @@
     "parallel/test-http-client-request-options.js": {},
     "parallel/test-http-client-res-destroyed.js": {},
     "parallel/test-http-client-set-timeout-after-end.js": {},
+    "parallel/test-http-client-set-timeout.js": {},
     "parallel/test-http-client-timeout-with-data.js": {},
     "parallel/test-http-client-unescaped-path.js": {},
     "parallel/test-http-client-upload-buf.js": {},


### PR DESCRIPTION
## Summary

Several fixes to `node:http` client and server compatibility:

- **Fix response abort/error not emitting on `req.abort()`** - removed overly broad `req.destroyed` guard in `socketCloseListener` that prevented cleanup of the response stream
- **Fix keep-alive socket pooling with server-initiated close** - use `socket.destroyed` for early exit in agent's `'free'` handler, but still check `!socket.writable` before assigning to queued requests (prevents handing half-closed sockets to new requests)
- **Make `http.globalAgent` assignable** - `globalAgent` was a static import binding; now uses getter/setter so `http.globalAgent = newAgent` takes effect on subsequent requests
- **Spread URL object in `urlToHttpOptions`** - match Node's `...url` spread so user-added properties (like `headers`) on URL objects are preserved
- **Detach socket on HTTP CONNECT/upgrade** - remove all server-added listeners from the socket before emitting the `'connect'`/`'upgrade'` event, matching Node's behavior
- **Implement `ERR_HTTP_CONTENT_LENGTH_MISMATCH`** - add strict content-length validation in `write_()` and `end()` when `strictContentLength` is enabled

## New compat tests enabled
- `test-http-aborted.js`
- `test-http-agent-keepalive.js`
- `test-http-client-override-global-agent.js`
- `test-http-client-request-options.js`
- `test-http-client-set-timeout.js`
- `test-http-client-timeout-event.js`
- `test-http-connect-req-res.js`
- `test-http-connect.js`
- `test-http-content-length-mismatch.js`

## Test plan
- [x] All newly enabled compat tests pass
- [x] `./x test-node http` passes (5 tests)
- [x] Existing keep-alive compat tests still pass
- [x] `./x lint` and `./x fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)