### PR TITLE
perf(libs/core): poll only ready handles and yield between I/O batches

### DIFF
--- a/libs/core/runtime/jsruntime.rs
+++ b/libs/core/runtime/jsruntime.rs
@@ -2296,19 +2296,20 @@ impl JsRuntime {
     }
 
     // ===== Phase 4: I/O =====
-    // Tight I/O loop: when run_io reads data and fires callbacks, the
-    // resulting JS work (nextTick/macrotasks from HTTP2 frame processing)
-    // may produce write calls. Drain those immediately and re-poll for
-    // more data, avoiding kqueue/kevent round-trip latency between batches.
+    // Single run_io call per tick, matching libuv's uv_run (one
+    // uv__io_poll per iteration, callbacks fire, then we return).
+    // Spinning run_io in place until it returns `false` batches more
+    // work per tick but under sustained inbound traffic never exits —
+    // tokio keeps delivering readiness as we poll — and traps the
+    // event loop processing hundreds of handles back-to-back, which
+    // crushes tail latency (p99 30–200 ms vs ~1 ms with a single
+    // call).
     if let Some(uv_inner_ptr) = context_state.uv_loop_inner.get() {
       unsafe {
         (*uv_inner_ptr).set_waker(cx.waker());
       }
-      for _io_spin in 0..8 {
-        let did_io = unsafe { (*uv_inner_ptr).run_io() };
-        if !did_io {
-          break;
-        }
+      let did_io = unsafe { (*uv_inner_ptr).run_io() };
+      if did_io {
         uv_did_io = true;
         // Flush microtasks from I/O callbacks, then drain ticks.
         // processTicksAndRejections runs op_run_microtasks internally,

--- a/libs/core/uv_compat.rs
+++ b/libs/core/uv_compat.rs
@@ -6,6 +6,7 @@ mod pipe;
 mod stream;
 mod tcp;
 mod tty;
+mod waker;
 
 #[cfg(all(not(miri), test))]
 mod tests;
@@ -17,6 +18,7 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::ffi::c_int;
 use std::ffi::c_void;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Waker;
 use std::time::Instant;
@@ -221,6 +223,10 @@ pub(crate) struct UvLoopInner {
   /// Cached loop time in milliseconds. Updated once per tick via
   /// `update_time()`, matching libuv's `uv_update_time` semantics.
   cached_time_ms: Cell<u64>,
+  /// Shared state between the loop and per-handle wakers. Waker
+  /// callbacks may fire from tokio's reactor thread, so access goes
+  /// through this Send+Sync struct instead of `UvLoopInner` directly.
+  pub(crate) shared: std::sync::Arc<waker::LoopShared>,
 }
 
 impl UvLoopInner {
@@ -240,6 +246,7 @@ impl UvLoopInner {
       closing_handles: RefCell::new(VecDeque::with_capacity(16)),
       time_origin: origin,
       cached_time_ms: Cell::new(0),
+      shared: waker::LoopShared::new(),
     }
   }
 
@@ -249,6 +256,9 @@ impl UvLoopInner {
       Some(existing) if existing.will_wake(waker) => {}
       _ => *slot = Some(waker.clone()),
     }
+    // Register with the shared AtomicWaker too, so handle wakers
+    // (which run on tokio's reactor thread) can wake the loop.
+    self.shared.loop_waker.register(waker);
   }
 
   /// Wake the event loop so it re-polls on the next tick. Used on
@@ -502,69 +512,102 @@ impl UvLoopInner {
   /// # Safety
   /// All TCP handle pointers in `tcp_handles` must be valid.
   pub(crate) unsafe fn run_io(&self) -> bool {
-    let noop = Waker::noop();
-    let waker_ref = self.waker.borrow();
-    let waker = waker_ref.as_ref().unwrap_or(noop);
-    let mut cx = Context::from_waker(waker);
-
-    let mut did_any_work = false;
-
-    for _pass in 0..16 {
+    // Drain ready queues once. Each popped handle is polled with a
+    // `Context` built from its own per-handle waker; tokio re-registers
+    // interest under that waker so the next readiness signal re-queues
+    // the handle for the next tick.
+    //
+    // Validate each popped pointer against the authoritative `*_handles`
+    // list before dereferencing — the handle may have been closed
+    // between a waker fire and the drain.
+    //
+    // One pass only: looping in place (e.g. `for _ in 0..16`) batches
+    // more I/O per event-loop tick but under sustained HTTP load the
+    // ready queues refill as tokio delivers new readiness while we're
+    // still polling, so the loop never exits. Handles whose data lands
+    // mid-tick then wait for the entire batch to drain before their
+    // response fires, pushing p99 from ~1 ms (Node-matching) to 30–200
+    // ms at 50 concurrent connections. Libuv's uv_run does one
+    // uv__io_poll per iteration for the same reason.
+    {
       let mut any_work = false;
 
-      // Snapshot the handle lists before iterating.  Callbacks fired
-      // during poll_tcp_handle (etc.) may close other handles, which
-      // removes them from tcp_handles via stop_tcp.  Index-based
-      // iteration over a list that shrinks during iteration would skip
-      // entries.  Snapshotting avoids this: each handle pointer is
-      // polled exactly once per pass regardless of mutations.
-      let tcp_snapshot: Vec<_> =
-        self.tcp_handles.borrow().iter().copied().collect();
-      for &tcp_ptr in &tcp_snapshot {
-        // SAFETY: tcp_ptr comes from tcp_handles; caller guarantees validity.
+      // --- TCP ---
+      // IMPORTANT: always call `reset_queued()` on every popped
+      // handle, even ones we skip (detached or inactive). If we
+      // skip without resetting, the per-handle `in_queue` flag
+      // stays `true` and a later `mark_ready()` from the same
+      // handle (e.g. after `uv_read_stop` cleared ACTIVE and then
+      // `uv_read_start` re-armed it) becomes a no-op — the handle
+      // never gets enqueued again and the event loop stops polling
+      // it entirely.
+      //
+      // Liveness is established by `handle_waker.live_ptr()`: the
+      // waker's ptr field is zeroed by `detach()` when the handle is
+      // torn down, so queued-then-closed entries self-invalidate.
+      // The Arc keeps the waker allocation alive across the handle's
+      // destruction, so the atomic load is always safe.
+      let mut tcp_ready: VecDeque<Arc<waker::TcpHandleWaker>> =
+        std::mem::take(&mut *self.shared.ready_tcp.borrow_mut());
+      while let Some(handle_waker) = tcp_ready.pop_front() {
+        handle_waker.reset_queued();
+        let ptr = handle_waker.live_ptr();
+        if ptr == 0 {
+          continue;
+        }
+        let tcp_ptr = ptr as *mut uv_tcp_t;
+        // SAFETY: ptr is non-zero, so the handle has not been detached.
         if unsafe { (*tcp_ptr).flags } & UV_HANDLE_ACTIVE == 0 {
           continue;
         }
+        let waker = std::task::Waker::from(handle_waker);
+        let mut cx = Context::from_waker(&waker);
+        // SAFETY: tcp_ptr is live per the ptr check above.
+        any_work |= unsafe { tcp::poll_tcp_handle(tcp_ptr, &mut cx) };
+      }
 
-        // SAFETY: tcp_ptr is valid; checked above.
-        let work = unsafe { tcp::poll_tcp_handle(tcp_ptr, &mut cx) };
-        any_work |= work;
-      } // end per-tcp-handle loop
-
-      {
-        let pipe_snapshot: Vec<_> =
-          self.pipe_handles.borrow().iter().copied().collect();
-        for &pipe_ptr in &pipe_snapshot {
-          // SAFETY: pipe_ptr comes from pipe_handles; caller guarantees validity.
-          if unsafe { (*pipe_ptr).flags } & UV_HANDLE_ACTIVE == 0 {
-            continue;
-          }
-
-          // SAFETY: pipe_ptr is valid; checked above.
-          let work = unsafe { pipe::poll_pipe_handle(pipe_ptr, &mut cx) };
-          any_work |= work;
+      // --- pipe ---
+      let mut pipe_ready: VecDeque<Arc<waker::PipeHandleWaker>> =
+        std::mem::take(&mut *self.shared.ready_pipe.borrow_mut());
+      while let Some(handle_waker) = pipe_ready.pop_front() {
+        handle_waker.reset_queued();
+        let ptr = handle_waker.live_ptr();
+        if ptr == 0 {
+          continue;
         }
-      } // end per-pipe-handle loop
+        let pipe_ptr = ptr as *mut uv_pipe_t;
+        // SAFETY: ptr is non-zero.
+        if unsafe { (*pipe_ptr).flags } & UV_HANDLE_ACTIVE == 0 {
+          continue;
+        }
+        let waker = std::task::Waker::from(handle_waker);
+        let mut cx = Context::from_waker(&waker);
+        // SAFETY: pipe_ptr is live.
+        any_work |= unsafe { pipe::poll_pipe_handle(pipe_ptr, &mut cx) };
+      }
 
-      let tty_snapshot: Vec<_> =
-        self.tty_handles.borrow().iter().copied().collect();
-      for &tty_ptr in &tty_snapshot {
-        // SAFETY: tty_ptr comes from tty_handles; caller guarantees validity.
+      // --- TTY ---
+      let mut tty_ready: VecDeque<Arc<waker::TtyHandleWaker>> =
+        std::mem::take(&mut *self.shared.ready_tty.borrow_mut());
+      while let Some(handle_waker) = tty_ready.pop_front() {
+        handle_waker.reset_queued();
+        let ptr = handle_waker.live_ptr();
+        if ptr == 0 {
+          continue;
+        }
+        let tty_ptr = ptr as *mut uv_tty_t;
+        // SAFETY: ptr is non-zero.
         if unsafe { (*tty_ptr).flags } & UV_HANDLE_ACTIVE == 0 {
           continue;
         }
-
-        // SAFETY: tty_ptr is valid; checked above.
+        let waker = std::task::Waker::from(handle_waker);
+        let mut cx = Context::from_waker(&waker);
+        // SAFETY: tty_ptr is live.
         any_work |= unsafe { tty::poll_tty_handle(tty_ptr, &mut cx) };
-      } // end per-tty-handle loop
-
-      if !any_work {
-        break;
       }
-      did_any_work = true;
-    } // end multi-pass loop
 
-    did_any_work
+      any_work
+    }
   }
 
   /// ### Safety
@@ -625,6 +668,9 @@ impl UvLoopInner {
     // SAFETY: Caller guarantees handle is valid and initialized.
     unsafe {
       let tty = &mut *handle;
+      if let Some(w) = tty.internal_waker.take() {
+        w.detach();
+      }
 
       // Always check if this fd is the globally tracked one, matching
       // libuv's unconditional check in uv__tty_close.
@@ -699,6 +745,12 @@ impl UvLoopInner {
     // SAFETY: Caller guarantees handle is valid and initialized.
     unsafe {
       let tcp = &mut *handle;
+      // Detach the per-handle waker so any late wake from tokio's
+      // reactor becomes a no-op. The Arc is dropped via take() so
+      // the waker memory is released.
+      if let Some(w) = tcp.internal_waker.take() {
+        w.detach();
+      }
       tcp.internal_reading = false;
       tcp.internal_alloc_cb = None;
       tcp.internal_read_cb = None;
@@ -749,6 +801,9 @@ impl UvLoopInner {
       .retain(|&h| !std::ptr::eq(h, handle));
     // SAFETY: Caller guarantees handle is valid and initialized.
     unsafe {
+      if let Some(w) = (*handle).internal_waker.take() {
+        w.detach();
+      }
       // Cancel in-flight write requests with UV_ECANCELED.
       while let Some(pw) = (*handle).internal_write_queue.pop_front() {
         if let Some(cb) = pw.cb {

--- a/libs/core/uv_compat/pipe.rs
+++ b/libs/core/uv_compat/pipe.rs
@@ -1246,6 +1246,47 @@ pub(crate) unsafe fn poll_pipe_handle(
     if !has_pending_work {
       (*pipe_ptr).flags &= !UV_HANDLE_ACTIVE;
     }
+
+    // Re-register tokio read/write interest for the next edge.
+    //
+    // `NamedPipeServer::poll_{read,write}_ready` only stores a waker
+    // when it returns Pending. If the drain above saw Ready and
+    // consumed all available data/space with `try_read` / `try_write`,
+    // no waker is registered — and since the ready-queue polling
+    // only re-enters `poll_pipe_handle` on a wake, the next event
+    // (EOF after child exit, more data arriving, write-side draining)
+    // would never reach us. Calling poll_*_ready here after the drain
+    // either stores a waker (Pending) or signals us to re-queue
+    // (Ready). Mirrors the re-register block at the end of
+    // `tcp::poll_tcp_handle`.
+    let mut needs_requeue = false;
+    if (*pipe_ptr).internal_reading {
+      if let Some(ref server) = (*pipe_ptr).internal_win_server
+        && matches!(server.poll_read_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+      if let Some(ref client) = (*pipe_ptr).internal_win_client
+        && matches!(client.poll_read_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+    }
+    if !(*pipe_ptr).internal_write_queue.is_empty() {
+      if let Some(ref server) = (*pipe_ptr).internal_win_server
+        && matches!(server.poll_write_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+      if let Some(ref client) = (*pipe_ptr).internal_win_client
+        && matches!(client.poll_write_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+    }
+    if needs_requeue && let Some(w) = (*pipe_ptr).internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
 
   any_work

--- a/libs/core/uv_compat/pipe.rs
+++ b/libs/core/uv_compat/pipe.rs
@@ -105,6 +105,8 @@ pub struct uv_pipe_t {
   pub(crate) internal_shutdown: Option<super::tcp::ShutdownPending>,
   pub(crate) pending_instances: i32,
   pub(crate) ipc: bool,
+  pub(crate) internal_waker:
+    Option<std::sync::Arc<crate::uv_compat::waker::PipeHandleWaker>>,
 }
 
 /// In-flight pipe connect operation.
@@ -193,6 +195,7 @@ pub fn new_pipe(ipc: bool) -> uv_pipe_t {
     internal_shutdown: None,
     pending_instances: 4, // libuv default
     ipc,
+    internal_waker: None,
   }
 }
 
@@ -210,6 +213,10 @@ pub unsafe fn uv_pipe_init(
     (*pipe).loop_ = loop_;
     // Match libuv: handles start ref'd so they keep the event loop alive.
     (*pipe).flags = super::UV_HANDLE_REF;
+    let shared = super::get_inner(loop_).shared.clone();
+    (*pipe).internal_waker = Some(
+      crate::uv_compat::waker::PipeHandleWaker::new(pipe as usize, shared),
+    );
   }
   0
 }
@@ -414,6 +421,9 @@ pub unsafe fn uv_pipe_listen(
     if !handles.iter().any(|&h| std::ptr::eq(h, pipe)) {
       handles.push(pipe);
     }
+    if let Some(w) = (*pipe).internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }
@@ -561,6 +571,9 @@ pub unsafe fn uv_pipe_connect(
     if !handles.iter().any(|&h| std::ptr::eq(h, pipe)) {
       handles.push(pipe);
     }
+    if let Some(w) = (*pipe).internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }
@@ -605,6 +618,9 @@ pub unsafe fn uv_pipe_listen(
     let mut handles = inner.pipe_handles.borrow_mut();
     if !handles.iter().any(|&h| std::ptr::eq(h, pipe)) {
       handles.push(pipe);
+    }
+    if let Some(w) = (*pipe).internal_waker.as_ref() {
+      w.mark_ready();
     }
   }
   0
@@ -705,6 +721,9 @@ pub unsafe fn uv_pipe_connect(
         let mut handles = inner.pipe_handles.borrow_mut();
         if !handles.iter().any(|&h| std::ptr::eq(h, pipe)) {
           handles.push(pipe);
+        }
+        if let Some(w) = (*pipe).internal_waker.as_ref() {
+          w.mark_ready();
         }
         0
       }
@@ -897,6 +916,9 @@ pub(crate) unsafe fn read_start_pipe(
     if !handles.iter().any(|&h| std::ptr::eq(h, pipe)) {
       handles.push(pipe);
     }
+    if let Some(w) = (*pipe).internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }
@@ -931,6 +953,9 @@ pub(crate) unsafe fn read_start_pipe(
     let mut handles = inner.pipe_handles.borrow_mut();
     if !handles.iter().any(|&h| std::ptr::eq(h, pipe)) {
       handles.push(pipe);
+    }
+    if let Some(w) = (*pipe).internal_waker.as_ref() {
+      w.mark_ready();
     }
   }
   0
@@ -1574,6 +1599,40 @@ pub(crate) unsafe fn poll_pipe_handle(
       || (*pipe_ptr).internal_shutdown.is_some();
     if !has_pending_work {
       (*pipe_ptr).flags &= !UV_HANDLE_ACTIVE;
+    }
+
+    // Re-register tokio readiness interest if the poll paths above
+    // consumed it without leaving a waker. See the matching comment
+    // in tcp::poll_tcp_handle for the full rationale — in short, if
+    // poll_*_ready returns Ready and we fully drain it, no waker is
+    // registered for the *next* edge, so we either re-register here
+    // (if still Pending) or re-queue the handle for another pass
+    // (if still Ready).
+    let mut needs_requeue = false;
+    if (*pipe_ptr).internal_reading {
+      if let Some(ref afd) = (*pipe_ptr).internal_async_fd {
+        if matches!(afd.poll_read_ready(cx), Poll::Ready(_)) {
+          needs_requeue = true;
+        }
+      } else if let Some(ref stream) = (*pipe_ptr).internal_stream
+        && matches!(stream.poll_read_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+    }
+    if !(*pipe_ptr).internal_write_queue.is_empty() {
+      if let Some(ref afd) = (*pipe_ptr).internal_async_fd {
+        if matches!(afd.poll_write_ready(cx), Poll::Ready(_)) {
+          needs_requeue = true;
+        }
+      } else if let Some(ref stream) = (*pipe_ptr).internal_stream
+        && matches!(stream.poll_write_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+    }
+    if needs_requeue && let Some(w) = (*pipe_ptr).internal_waker.as_ref() {
+      w.mark_ready();
     }
   }
 

--- a/libs/core/uv_compat/stream.rs
+++ b/libs/core/uv_compat/stream.rs
@@ -143,6 +143,9 @@ pub unsafe fn uv_read_start(
     if !handles.iter().any(|&h| std::ptr::eq(h, tcp)) {
       handles.push(tcp);
     }
+    if let Some(w) = tcp_ref.internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }
@@ -349,6 +352,9 @@ pub unsafe fn uv_write(
     if !handles.iter().any(|&h| std::ptr::eq(h, tcp)) {
       handles.push(tcp);
     }
+    if let Some(w) = (*tcp).internal_waker.as_ref() {
+      w.mark_ready();
+    }
     0
   }
 }
@@ -413,6 +419,9 @@ pub unsafe fn uv_shutdown(
       }
       (*pipe).flags |= UV_HANDLE_ACTIVE;
       drop(handles);
+      if let Some(w) = (*pipe).internal_waker.as_ref() {
+        w.mark_ready();
+      }
 
       // Wake the event loop so run_io processes the deferred shutdown.
       if let Some(waker) = inner.waker.borrow().as_ref() {
@@ -443,6 +452,9 @@ pub unsafe fn uv_shutdown(
     }
     (*tcp).flags |= UV_HANDLE_ACTIVE;
     drop(handles);
+    if let Some(w) = (*tcp).internal_waker.as_ref() {
+      w.mark_ready();
+    }
 
     // Wake the event loop so run_io processes the deferred shutdown.
     // Without this, shutdowns scheduled from nextTick/microtask
@@ -625,6 +637,9 @@ unsafe fn write_pipe(
       handles.push(pipe);
     }
     (*pipe).flags |= UV_HANDLE_ACTIVE;
+    if let Some(w) = (*pipe).internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }

--- a/libs/core/uv_compat/tcp.rs
+++ b/libs/core/uv_compat/tcp.rs
@@ -118,6 +118,12 @@ pub struct uv_tcp_t {
   pub(crate) internal_connection_cb: Option<uv_connection_cb>,
   pub(crate) internal_backlog: VecDeque<tokio::net::TcpStream>,
   pub(crate) internal_shutdown: Option<ShutdownPending>,
+  /// Per-handle waker. Used to register interest with tokio's reactor
+  /// and enqueue this handle on the loop's ready queue when the fd
+  /// becomes ready. `None` on handles constructed via `new_tcp()`
+  /// (tests, temporary values); real handles get one in `uv_tcp_init`.
+  pub(crate) internal_waker:
+    Option<std::sync::Arc<crate::uv_compat::waker::TcpHandleWaker>>,
 }
 
 /// In-flight TCP connect operation.
@@ -254,6 +260,9 @@ pub unsafe fn uv_tcp_init(loop_: *mut uv_loop_t, tcp: *mut uv_tcp_t) -> c_int {
     write(addr_of_mut!((*tcp).internal_connection_cb), None);
     write(addr_of_mut!((*tcp).internal_backlog), VecDeque::new());
     write(addr_of_mut!((*tcp).internal_shutdown), None);
+    let shared = crate::uv_compat::get_inner(loop_).shared.clone();
+    let w = crate::uv_compat::waker::TcpHandleWaker::new(tcp as usize, shared);
+    write(addr_of_mut!((*tcp).internal_waker), Some(w));
   }
   0
 }
@@ -436,6 +445,9 @@ pub unsafe fn uv_tcp_connect(
     let mut handles = inner.tcp_handles.borrow_mut();
     if !handles.iter().any(|&h| std::ptr::eq(h, tcp)) {
       handles.push(tcp);
+    }
+    if let Some(w) = (*tcp).internal_waker.as_ref() {
+      w.mark_ready();
     }
 
     // Take the pre-created socket from bind (if any). This preserves
@@ -691,6 +703,9 @@ pub unsafe fn uv_listen(
     if !handles.iter().any(|&h| std::ptr::eq(h, tcp)) {
       handles.push(tcp);
     }
+    if let Some(w) = tcp_ref.internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }
@@ -741,6 +756,7 @@ pub fn new_tcp() -> uv_tcp_t {
     internal_connection_cb: None,
     internal_backlog: VecDeque::new(),
     internal_shutdown: None,
+    internal_waker: None,
   }
 }
 
@@ -902,9 +918,15 @@ pub(crate) unsafe fn poll_tcp_handle(
               if count == 0 {
                 break;
               }
-              // Match libuv: if we didn't fill the buffer, the next
-              // read would likely return EAGAIN. Exit early to save
-              // a syscall (libuv's uv__read does the same).
+              // Match libuv's uv__read (src/unix/stream.c:1147):
+              // break on partial read to skip the predicted-EAGAIN
+              // syscall. tokio's readiness tracking is edge-style
+              // internally (`try_read` only clears the bit on
+              // WouldBlock), so this leaves readiness armed and
+              // unwoken. The re-register block at the end of this
+              // function detects that case and issues `mark_ready()`
+              // to put the handle back on the ready queue for the
+              // next run_io pass.
               if n < buflen {
                 break;
               }
@@ -1047,7 +1069,9 @@ pub(crate) unsafe fn poll_tcp_handle(
               break;
             }
             match stream.try_write(&pw.data[pw.offset..]) {
-              Ok(n) => pw.offset += n,
+              Ok(n) => {
+                pw.offset += n;
+              }
               Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 break;
               }
@@ -1101,6 +1125,37 @@ pub(crate) unsafe fn poll_tcp_handle(
     {
       crate::uv_compat::stream::complete_shutdown(tcp_ptr, cx);
       any_work = true;
+    }
+  }
+
+  // 6. Re-register tokio interest for the next edge.
+  //
+  // `poll_*_ready` stores a waker only when it returns Pending.
+  // Under normal operation the read/write loops above hit
+  // WouldBlock on their last iteration, which clears tokio's
+  // internal readiness bit; the paired poll_*_ready here then
+  // returns Pending and stores the waker, and we're good.
+  //
+  // The count==32 starvation break is an exception: it exits
+  // mid-stream with readiness still armed and no waker. In that
+  // case, poll_*_ready returns Ready (no waker stored) and we
+  // mark_ready to re-queue the handle for another run_io pass.
+  unsafe {
+    if let Some(ref stream) = (*tcp_ptr).internal_stream {
+      let mut needs_requeue = false;
+      if (*tcp_ptr).internal_reading
+        && matches!(stream.poll_read_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+      if !(*tcp_ptr).internal_write_queue.is_empty()
+        && matches!(stream.poll_write_ready(cx), Poll::Ready(_))
+      {
+        needs_requeue = true;
+      }
+      if needs_requeue && let Some(w) = (*tcp_ptr).internal_waker.as_ref() {
+        w.mark_ready();
+      }
     }
   }
 

--- a/libs/core/uv_compat/tty.rs
+++ b/libs/core/uv_compat/tty.rs
@@ -253,6 +253,9 @@ pub struct uv_tty_t {
   pub(crate) internal_line_read_result: Option<LineReadResult>,
   #[cfg(windows)]
   pub(crate) internal_line_read_pending: bool,
+
+  pub(crate) internal_waker:
+    Option<std::sync::Arc<crate::uv_compat::waker::TtyHandleWaker>>,
 }
 
 #[cfg(windows)]
@@ -1485,6 +1488,15 @@ pub unsafe fn uv_tty_init(
       write(addr_of_mut!((*tty).internal_line_read_result), None);
       write(addr_of_mut!((*tty).internal_line_read_pending), false);
     }
+
+    let shared = super::get_inner(loop_).shared.clone();
+    write(
+      addr_of_mut!((*tty).internal_waker),
+      Some(crate::uv_compat::waker::TtyHandleWaker::new(
+        tty as usize,
+        shared,
+      )),
+    );
   }
   0
 }
@@ -1750,6 +1762,9 @@ pub(crate) unsafe fn read_start_tty(
       handles.push(tty);
     }
     drop(handles);
+    if let Some(w) = (*tty).internal_waker.as_ref() {
+      w.mark_ready();
+    }
 
     // Wake the event loop so poll_tty_handle runs on the next tick.
     // This registers the RegisterWaitForSingleObject (for future
@@ -1977,6 +1992,9 @@ unsafe fn ensure_tty_registered(tty: *mut uv_tty_t) {
       handles.push(tty);
     }
     drop(handles);
+    if let Some(w) = (*tty).internal_waker.as_ref() {
+      w.mark_ready();
+    }
 
     // On Windows, wake the event loop so pending write callbacks are
     // processed promptly. Without this, deferred callbacks can stall
@@ -2016,6 +2034,9 @@ pub(crate) unsafe fn shutdown_tty(
       handles.push(tty);
     }
     (*tty).flags |= UV_HANDLE_ACTIVE;
+    if let Some(w) = (*tty).internal_waker.as_ref() {
+      w.mark_ready();
+    }
   }
   0
 }
@@ -2546,6 +2567,34 @@ pub(crate) unsafe fn poll_tty_handle(
     }
   }
 
+  // Re-register tokio read interest for the next edge.
+  //
+  // Our read loop hits WouldBlock on its last iteration and calls
+  // `guard.clear_ready()`, which clears tokio's internal readiness
+  // bit but does NOT store a new waker. Without a follow-up
+  // `poll_read_ready(cx)`, no waker is registered when the next
+  // input arrives, so tokio has nothing to fire and the handle
+  // never re-enters the ready queue — the PTY appears dead after
+  // the first read.
+  //
+  // Calling `poll_read_ready(cx)` here stores the per-handle waker
+  // if still Pending, or re-queues the handle for another pass if
+  // already Ready. Mirrors the block at the end of
+  // `tcp::poll_tcp_handle` / `pipe::poll_pipe_handle`.
+  #[cfg(unix)]
+  unsafe {
+    if (*tty_ptr).internal_reading
+      && let Some(ref reactor) = (*tty_ptr).internal_reactor
+      && matches!(
+        reactor.async_fd().poll_read_ready(cx),
+        std::task::Poll::Ready(_)
+      )
+      && let Some(w) = (*tty_ptr).internal_waker.as_ref()
+    {
+      w.mark_ready();
+    }
+  }
+
   any_work
 }
 
@@ -2597,6 +2646,7 @@ pub fn new_tty() -> uv_tty_t {
     internal_line_read_result: None,
     #[cfg(windows)]
     internal_line_read_pending: false,
+    internal_waker: None,
   }
 }
 

--- a/libs/core/uv_compat/waker.rs
+++ b/libs/core/uv_compat/waker.rs
@@ -1,0 +1,146 @@
+// Copyright 2018-2026 the Deno authors. MIT license.
+
+//! Per-handle wakers + ready queue for `UvLoopInner`.
+//!
+//! Each TCP / pipe / TTY handle owns its own `Waker`. When tokio's
+//! reactor signals readiness, the handle's waker pushes a clone of
+//! itself onto a per-kind ready queue and wakes the event loop.
+//! `run_io` then polls ONLY the handles in the ready queues, rather
+//! than scanning every live handle on every pass.
+//!
+//! The `in_queue` flag coalesces duplicate wakeups between drains.
+//! On close, the handle's waker pointer is zeroed via `detach()`:
+//! - future wakes become no-ops (push_ready checks ptr before queuing)
+//! - already-queued entries self-invalidate — `run_io` pops the Arc,
+//!   loads `ptr` (0 after detach), and skips
+//!
+//! Because the Arc keeps the waker allocation alive across the
+//! handle's destruction, inspecting `live_ptr()` after a pop is
+//! always safe — replacing what would otherwise be an O(n) scan of
+//! the live-handle list with a plain load.
+//!
+//! ## Threading
+//!
+//! Deno's event loop is single-threaded: the tokio current-thread
+//! runtime drives both the reactor and the executor on the same
+//! thread, so waker invocations never cross threads. That lets us
+//! use `Cell` / `RefCell` instead of atomics / `Mutex` for the
+//! queue and waker fields.
+//!
+//! `Arc` is still required (not `Rc`) because the `Wake` trait's
+//! method signatures are `fn wake(self: Arc<Self>)`. The `unsafe
+//! impl Send + Sync` on the waker types asserts the single-thread
+//! invariant; `std::task::Waker` requires `Send + Sync` of its
+//! backing data, so we lie at the type level and keep the
+//! invariant by construction.
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::task::Wake;
+
+use futures::task::AtomicWaker;
+
+/// State shared between `UvLoopInner` and every per-handle waker.
+/// Held behind an `Arc`; we assert `Sync` manually — see the module
+/// doc "Threading" section.
+#[derive(Default)]
+pub(crate) struct LoopShared {
+  pub loop_waker: AtomicWaker,
+  pub ready_tcp: RefCell<VecDeque<Arc<TcpHandleWaker>>>,
+  pub ready_pipe: RefCell<VecDeque<Arc<PipeHandleWaker>>>,
+  pub ready_tty: RefCell<VecDeque<Arc<TtyHandleWaker>>>,
+}
+
+// SAFETY: deno's event loop is single-threaded. All accesses to the
+// ready queues happen from that thread (either directly in run_io or
+// via tokio's current-thread reactor firing a waker). See module doc.
+unsafe impl Sync for LoopShared {}
+
+impl LoopShared {
+  pub fn new() -> Arc<Self> {
+    Arc::new(Self::default())
+  }
+}
+
+macro_rules! impl_handle_waker {
+  ($name:ident, $queue:ident) => {
+    pub(crate) struct $name {
+      /// Raw handle pointer (as usize). Zeroed by `detach()` when the
+      /// handle is torn down; queued entries self-invalidate and late
+      /// wakes become no-ops.
+      ptr: Cell<usize>,
+      /// Coalesces duplicate wakeups. `true` means this handle is
+      /// already sitting in its ready queue waiting to be drained.
+      in_queue: Cell<bool>,
+      shared: Arc<LoopShared>,
+    }
+
+    // SAFETY: single-threaded event loop — see module doc.
+    unsafe impl Send for $name {}
+    unsafe impl Sync for $name {}
+
+    impl $name {
+      pub fn new(ptr: usize, shared: Arc<LoopShared>) -> Arc<Self> {
+        Arc::new(Self {
+          ptr: Cell::new(ptr),
+          in_queue: Cell::new(false),
+          shared,
+        })
+      }
+
+      /// Zero the handle pointer so future wakes become no-ops and
+      /// already-queued entries self-invalidate.
+      pub fn detach(&self) {
+        self.ptr.set(0);
+      }
+
+      /// Mark this handle as no-longer-queued. Called by `run_io`
+      /// right before polling so a wake during the poll re-queues
+      /// the handle for the next pass.
+      pub fn reset_queued(&self) {
+        self.in_queue.set(false);
+      }
+
+      /// Returns the handle pointer, or 0 if detached. Safe to call
+      /// after handle memory has been freed — the Arc keeps the
+      /// waker allocation alive.
+      #[inline]
+      pub fn live_ptr(&self) -> usize {
+        self.ptr.get()
+      }
+
+      fn push_ready(self: &Arc<Self>) {
+        if self.ptr.get() == 0 {
+          return;
+        }
+        if !self.in_queue.replace(true) {
+          self.shared.$queue.borrow_mut().push_back(self.clone());
+          self.shared.loop_waker.wake();
+        }
+      }
+
+      /// Explicit (non-waker) request to poll this handle next tick.
+      /// Used after state changes like `uv_read_start` / `uv_write` /
+      /// `uv_listen` where tokio hasn't fired a readiness wake yet
+      /// but we need at least one poll to register interest.
+      pub fn mark_ready(self: &Arc<Self>) {
+        self.push_ready();
+      }
+    }
+
+    impl Wake for $name {
+      fn wake(self: Arc<Self>) {
+        (&self).push_ready();
+      }
+      fn wake_by_ref(self: &Arc<Self>) {
+        self.push_ready();
+      }
+    }
+  };
+}
+
+impl_handle_waker!(TcpHandleWaker, ready_tcp);
+impl_handle_waker!(PipeHandleWaker, ready_pipe);
+impl_handle_waker!(TtyHandleWaker, ready_tty);


### PR DESCRIPTION
Two coupled changes in the uv_compat event loop:

1. Ready-queue polling. Each TCP/pipe/TTY handle owns its own Waker that, when tokio's reactor signals readiness, pushes the handle onto a per-kind ready queue. run_io then polls only the handles in the ready queues instead of scanning every live handle on every pass. The `in_queue` flag coalesces duplicate wakeups and reset_queued() is called before skipping so a later state change (e.g. uv_read_stop → uv_read_start) re-enqueues the handle.

   Two follow-up fixes that must land with the refactor to avoid the handle going deaf:
   - poll_tcp/poll_pipe_handle re-register tokio interest at the end. If the inner drain loop exits with readiness still armed and no waker stored (e.g. hit the count==32 starvation break mid-stream), mark_ready() re-queues for the next pass.
   - Every popped handle calls reset_queued() even when skipped.

2. Drop the batch-in-place loops. run_io no longer spins up to 16 passes and phase 4 no longer spins up to 8; each returns after one round. Under sustained inbound traffic the ready queues refill as tokio delivers new readiness while we're still polling, so the loop never exits and traps the event loop processing hundreds of handles back-to-back, crushing tail latency. Libuv's uv_run does one uv__io_poll per iteration for the same reason.

This has a slightly positive to neutral effect on throughput, but improves p99 latency by avoiding scanning the entire handle list on each poll and avoiding starving handles later in the list.

```
  ┌───────────────────────────────────┬─────────────┬────────┬──────────────┬─────────┬───────────────────────────┐
  │           After commit            │ rps (local) │  p99   │    p99.99    │ slowest │    vs system baseline     │
  ├───────────────────────────────────┼─────────────┼────────┼──────────────┼─────────┼───────────────────────────┤
  │ system baseline (main@upstream)   │ 66.7k       │ 1.4 ms │ ~0.5 s       │ ~4 s    │ —                         │
  ├───────────────────────────────────┼─────────────┼────────┼──────────────┼─────────┼───────────────────────────┤
  │ poll ready + yield                │ 67.5k       │ 1.3 ms │ ~13 ms       │ ~60 ms  │ slowest 4s → 60ms (~65×)  │
```

Disclosure: used claude for code changes + pr description