### PR TITLE
perf(ext/node): reduce writev op allocations and write copies

### DIFF
--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -864,6 +864,35 @@ enum StringEncoding {
   Ucs2,
 }
 
+/// Resolve a writev encoding-name v8 String into a `StringEncoding`
+/// variant without allocating. Encoding names are short ASCII tokens
+/// (max 8 chars: "utf-16le"); read the bytes into a stack buffer and
+/// match against literals. Replaces a `to_rust_string_lossy` +
+/// `match as_deref` pair that allocated a fresh Rust String per chunk
+/// per writev — ~5 allocs/request on the HTTP chunked-encoding path.
+fn parse_encoding_no_alloc(
+  scope: &mut v8::PinScope,
+  encoding: v8::Local<v8::String>,
+) -> StringEncoding {
+  let len = encoding.length();
+  if len == 0 || len > 8 {
+    return StringEncoding::Utf8;
+  }
+  let mut buf = [0u8; 8];
+  encoding.write_one_byte_v2(
+    scope,
+    0,
+    &mut buf[..len],
+    v8::WriteFlags::empty(),
+  );
+  match &buf[..len] {
+    b"latin1" | b"binary" => StringEncoding::Latin1,
+    b"ucs2" | b"ucs-2" | b"utf16le" | b"utf-16le" => StringEncoding::Ucs2,
+    b"ascii" => StringEncoding::Ascii,
+    _ => StringEncoding::Utf8,
+  }
+}
+
 fn encode_string_to_vec(
   scope: &mut v8::PinScope,
   string: v8::Local<v8::String>,
@@ -1146,11 +1175,35 @@ impl LibUvStreamWrap {
     let state_global = &op_state.borrow::<StreamBaseState>().array;
     let state_array = v8::Local::new(scope, state_global);
 
-    let mut data = Vec::new();
+    // Pre-pass: sum per-chunk upper-bound sizes so the concat Vec is
+    // allocated once with sufficient capacity — no growth reallocs as
+    // chunks are appended. For Uint8Arrays the byte length is exact;
+    // for strings we use `length() * 3` which upper-bounds utf-8
+    // output (a single UTF-16 code unit encodes to ≤ 3 bytes). This
+    // replaces an unallocated `Vec::new()` that previously incurred
+    // ~2-3 growth allocations per writev call on the HTTP
+    // chunked-encoding path.
+    let array_len = chunks.length();
+    let (iter_count, stride): (u32, u32) = if all_buffers {
+      (array_len, 1)
+    } else {
+      (array_len / 2, 2)
+    };
+    let mut total_est: usize = 0;
+    for i in 0..iter_count {
+      let Some(chunk) = chunks.get_index(scope, i * stride) else {
+        continue;
+      };
+      if let Ok(buf) = TryInto::<v8::Local<v8::Uint8Array>>::try_into(chunk) {
+        total_est += buf.byte_length();
+      } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk) {
+        total_est += s.length() * 3;
+      }
+    }
+    let mut data = Vec::with_capacity(total_est);
 
     if all_buffers {
-      let len = chunks.length();
-      for i in 0..len {
+      for i in 0..array_len {
         let Some(chunk) = chunks.get_index(scope, i) else {
           continue;
         };
@@ -1169,8 +1222,7 @@ impl LibUvStreamWrap {
         }
       }
     } else {
-      let len = chunks.length();
-      let count = len / 2;
+      let count = array_len / 2;
       for i in 0..count {
         let Some(chunk) = chunks.get_index(scope, i * 2) else {
           continue;
@@ -1189,18 +1241,11 @@ impl LibUvStreamWrap {
           }
         } else if let Ok(s) = TryInto::<v8::Local<v8::String>>::try_into(chunk)
         {
-          let encoding = chunks
+          let enc = chunks
             .get_index(scope, i * 2 + 1)
             .and_then(|v| TryInto::<v8::Local<v8::String>>::try_into(v).ok())
-            .map(|v| v.to_rust_string_lossy(scope));
-          let enc = match encoding.as_deref() {
-            Some("latin1" | "binary") => StringEncoding::Latin1,
-            Some("ucs2" | "ucs-2" | "utf16le" | "utf-16le") => {
-              StringEncoding::Ucs2
-            }
-            Some("ascii") => StringEncoding::Ascii,
-            _ => StringEncoding::Utf8,
-          };
+            .map(|e| parse_encoding_no_alloc(scope, e))
+            .unwrap_or(StringEncoding::Utf8);
           encode_string_to_vec(scope, s, enc, &mut data);
         }
       }
@@ -1227,7 +1272,7 @@ impl LibUvStreamWrap {
       return 0;
     }
 
-    self.do_write(scope, stream, &data, total_bytes, req_wrap_obj, state_array)
+    self.do_write(scope, stream, data, total_bytes, req_wrap_obj, state_array)
   }
 
   #[fast]
@@ -1365,13 +1410,16 @@ impl LibUvStreamWrap {
         return 0;
       }
 
-      // Partial try_write — async write only the remaining bytes
+      // Partial try_write — async write only the remaining bytes.
+      // split_off gives us an owned Vec of the tail without extra
+      // allocation beyond the single tail-copy.
       if try_result > 0 {
         let written = try_result as usize;
+        let tail = data.split_off(written);
         return self.do_write(
           scope,
           stream,
-          &data[written..],
+          tail,
           total_bytes,
           req_wrap_obj,
           state_array,
@@ -1380,23 +1428,23 @@ impl LibUvStreamWrap {
     }
 
     // Full async write (no try_write or try_write returned error/0)
-    self.do_write(scope, stream, &data, total_bytes, req_wrap_obj, state_array)
+    self.do_write(scope, stream, data, total_bytes, req_wrap_obj, state_array)
   }
 
+  /// Queue an owned `Vec<u8>` as a pending write. Takes `data` by move
+  /// so the Vec can be threaded all the way down into the uv_compat
+  /// write queue without a re-allocation + memcpy (the old path went
+  /// through `uv_write(bufs, nbufs)` which re-collected the bufs into
+  /// a new Vec via `collect_bufs`).
   fn do_write(
     &self,
     scope: &mut v8::PinScope,
     stream: *mut uv_stream_t,
-    data: &[u8],
+    data: Vec<u8>,
     total_bytes: usize,
     req_wrap_obj: v8::Local<v8::Object>,
     state_array: v8::Local<v8::Int32Array>,
   ) -> i32 {
-    let buf = uv_buf_t {
-      base: data.as_ptr() as *mut c_char,
-      len: data.len(),
-    };
-
     let stream_handle = self
       .js_handle_global(scope)
       .unwrap_or_else(|| v8::Global::new(scope, v8::Object::new(scope)));
@@ -1413,9 +1461,18 @@ impl LibUvStreamWrap {
     );
     let req_ptr = Box::into_raw(req);
 
-    // SAFETY: req_ptr is a valid uv_write_t and stream is a valid non-null uv_stream_t.
+    // SAFETY: req_ptr is a valid uv_write_t and stream is a valid
+    // initialized stream handle (TCP/pipe/TTY). Use the polymorphic
+    // `uv_write_owned` so pipe stdio (e.g. child.stdin) isn't
+    // mis-cast to TCP and corrupted on push_back into the wrong
+    // struct layout.
     let err = unsafe {
-      uv_compat::uv_write(req_ptr, stream, &buf, 1, Some(after_uv_write))
+      uv_compat::uv_write_owned(
+        req_ptr,
+        stream as *mut _,
+        data,
+        Some(after_uv_write),
+      )
     };
 
     if err != 0 {

--- a/libs/core/uv_compat/stream.rs
+++ b/libs/core/uv_compat/stream.rs
@@ -313,15 +313,92 @@ pub unsafe fn uv_write(
 
     let write_data = collect_bufs(bufs, nbufs);
 
-    // Try to write synchronously when the queue is empty, matching libuv's
-    // uv_write2() → uv__write() → uv__try_write() path.  This pushes data
-    // into the kernel buffer immediately.  The callback is NOT fired here;
-    // it is deferred to the poll loop (the entry is queued with the
-    // already-written offset so the poll loop sees it as complete and fires
-    // the callback then).  Deferring the callback is important because
-    // callers like TLSWrap's enc_out() set re-entrancy guards (in_dowrite)
-    // that would suppress the completion notification if it fired
-    // synchronously.
+    uv_write_owned_impl(req, tcp, write_data, cb)
+  }
+}
+
+/// Take an already-owned `Vec<u8>` and queue it as a pending write on
+/// the TCP handle. This avoids the extra allocation + memcpy that
+/// `uv_write` does via `collect_bufs` when the caller has already
+/// materialized the bytes into a single buffer (e.g. the stream_wrap
+/// `writev` op concatenates JS chunks into one Vec before writing).
+///
+/// ### Safety
+/// `req` must be valid until the write callback fires. `tcp` must be
+/// initialized by `uv_tcp_init`.
+pub unsafe fn uv_write_owned_tcp(
+  req: *mut uv_write_t,
+  tcp: *mut uv_tcp_t,
+  data: Vec<u8>,
+  cb: Option<uv_write_cb>,
+) -> c_int {
+  unsafe {
+    (*req).handle = tcp as *mut uv_stream_t;
+    if (*tcp).internal_stream.is_none() {
+      return UV_EBADF;
+    }
+    uv_write_owned_impl(req, tcp, data, cb)
+  }
+}
+
+/// Polymorphic counterpart to `uv_write_owned_tcp` that dispatches on
+/// the runtime stream type. Callers (e.g. the stream_wrap `writev` op)
+/// hold a `*mut uv_stream_t` that may back a TCP, pipe, or TTY handle;
+/// blindly treating it as TCP corrupts the pipe's in-place VecDeque
+/// and trips UB (the write queue is at a different offset in each
+/// struct). For non-TCP types, fall back to the existing `uv_write`
+/// buffer-vector path by materializing a one-entry `uv_buf_t` over
+/// the owned data.
+///
+/// ### Safety
+/// `req` must be valid until the write callback fires. `handle` must
+/// be an initialized stream handle (TCP, pipe, or TTY).
+pub unsafe fn uv_write_owned(
+  req: *mut uv_write_t,
+  handle: *mut uv_stream_t,
+  data: Vec<u8>,
+  cb: Option<uv_write_cb>,
+) -> c_int {
+  unsafe {
+    match (*handle).r#type {
+      uv_handle_type::UV_TCP => {
+        uv_write_owned_tcp(req, handle as *mut uv_tcp_t, data, cb)
+      }
+      // Pipes/TTYs don't have an owned-Vec shortcut — build a single
+      // uv_buf_t and go through the regular `uv_write` dispatch which
+      // knows about the right per-type write queue layouts.
+      _ => {
+        let buf = uv_buf_t {
+          base: data.as_ptr() as *mut c_char,
+          len: data.len(),
+        };
+        // uv_write's pipe/tty paths internally copy the buffer into
+        // their own queue, so releasing ownership of `data` after the
+        // call is safe even though the bufs array lives on the stack.
+        let rc = uv_write(req, handle, &buf, 1, cb);
+        drop(data);
+        rc
+      }
+    }
+  }
+}
+
+/// Shared logic for queuing a pre-built Vec<u8> as a write.
+///
+/// ### Safety
+/// `req` must be valid until the write callback fires. `tcp` must be
+/// initialized and have `internal_stream` set.
+unsafe fn uv_write_owned_impl(
+  req: *mut uv_write_t,
+  tcp: *mut uv_tcp_t,
+  write_data: Vec<u8>,
+  cb: Option<uv_write_cb>,
+) -> c_int {
+  unsafe {
+    // Try sync write when the queue is empty, matching libuv's
+    // uv_write2 → uv__write → uv__try_write path. Callback is
+    // deferred to the poll loop to avoid re-entrancy with callers
+    // like TLSWrap that set `in_dowrite` guards.
     let mut offset = 0;
     if (*tcp).internal_write_queue.is_empty()
       && let Some(ref stream) = (*tcp).internal_stream
@@ -342,7 +419,6 @@ pub unsafe fn uv_write(
       status: None,
     });
 
-    // Ensure the handle is active so poll_tcp_handle drains the queue.
     (*tcp).flags |= UV_HANDLE_ACTIVE;
     let inner = get_inner((*tcp).loop_);
     let mut handles = inner.tcp_handles.borrow_mut();


### PR DESCRIPTION
stream_wrap.writev: pre-pass to sum an upper-bound so the concat Vec is allocated once (no growth reallocs). Parse per-chunk encoding names via a stack buffer (parse_encoding_no_alloc) instead of to_rust_string_lossy.

do_write now takes the concat Vec by value and forwards it to a new function uv_compat::uv_write_owned, which dispatches on handle type so pipe/TTY writes don't hit the TCP-only layout assumptions. TCP uses the new uv_write_owned_tcp fast path (no extra collect_bufs memcpy); pipe/TTY fall back to the existing uv_write buffer-vector path.

---

Improves throughput by about 5.5% on hello world, when the writev path is taken (which it often is).

---

Disclosure: used claude