### PR TITLE
fix(ext/node): re-arm Windows named pipe server after accept

### DIFF
--- a/libs/core/uv_compat/pipe.rs
+++ b/libs/core/uv_compat/pipe.rs
@@ -663,6 +663,13 @@ pub unsafe fn uv_pipe_accept(
           (*server).internal_win_server = Some(new_server);
           (*server).internal_win_connect_fut = Some(connect_fut);
           (*server).flags |= UV_HANDLE_ACTIVE;
+
+          // Wake the event loop so it polls the new connect future.
+          // Without this, the loop never notices the next client
+          // attaching to the named pipe (same pattern as uv_pipe_listen).
+          if let Some(w) = (*server).internal_waker.as_ref() {
+            w.mark_ready();
+          }
         }
       }
       0

--- a/tests/specs/node/net_pipe_server_reaccept/__test__.jsonc
+++ b/tests/specs/node/net_pipe_server_reaccept/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "pipe_server_reaccept": {
+      "args": "run -A main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/node/net_pipe_server_reaccept/main.out
+++ b/tests/specs/node/net_pipe_server_reaccept/main.out
@@ -1,0 +1,7 @@
+connection 1
+data: hello from A
+connection 2
+data: hello from B
+connection 3
+data: hello from C
+total connections: 3

--- a/tests/specs/node/net_pipe_server_reaccept/main.ts
+++ b/tests/specs/node/net_pipe_server_reaccept/main.ts
@@ -1,0 +1,63 @@
+// Regression test for https://github.com/denoland/deno/issues/33366
+// After the first client disconnects from a pipe server, the server
+// must accept subsequent connections. On Windows this requires re-arming
+// the named pipe instance (calling mark_ready on the waker after
+// creating a new server in uv_pipe_accept).
+
+import { connect, createServer } from "node:net";
+import { randomUUID } from "node:crypto";
+
+const suffix = randomUUID().slice(0, 8);
+const pipePath = Deno.build.os === "windows"
+  ? `\\\\.\\pipe\\deno_test_reaccept_${suffix}`
+  : `${Deno.makeTempDirSync()}/reaccept_${suffix}.sock`;
+
+let connectionCount = 0;
+
+const server = createServer((socket) => {
+  connectionCount++;
+  console.log(`connection ${connectionCount}`);
+  socket.on("data", (chunk: Buffer) => {
+    console.log(`data: ${chunk.toString().trim()}`);
+  });
+  socket.on("end", () => {
+    socket.end();
+  });
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(pipePath, resolve);
+});
+
+async function connectAndSend(label: string): Promise<void> {
+  const sock = connect(pipePath);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error(`${label}: connect timeout`));
+    }, 5000);
+    sock.once("connect", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    sock.once("error", (e: Error) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+  sock.write(`hello from ${label}`);
+  // Wait for server to process the data before closing.
+  await new Promise((r) => setTimeout(r, 100));
+  sock.destroy();
+  // Wait for server-side close handling to complete.
+  await new Promise((r) => setTimeout(r, 100));
+}
+
+await connectAndSend("A");
+await connectAndSend("B");
+await connectAndSend("C");
+
+server.close();
+
+console.log(`total connections: ${connectionCount}`);


### PR DESCRIPTION
## Summary

Closes #33366

After `uv_pipe_accept` creates a new `NamedPipeServer` instance for the
next client, it sets up the connect future but never calls `mark_ready()`
on the waker. The event loop has no reason to re-enter `poll_pipe_handle`,
so the new future is never polled and subsequent client connections are
silently dropped — the client-side `connect` fires (the OS accepts the
connection) but the server never runs its `connection` callback.

The fix adds a `mark_ready()` call after the new server instance is
created, mirroring the pattern already used in `uv_pipe_listen`.

## Test plan
- Added spec test `net_pipe_server_reaccept` that connects three
  sequential clients to a pipe server, asserting all three connections
  are accepted and data is received
- On macOS/Linux this exercises Unix domain sockets; on Windows CI it
  exercises the named pipe re-accept path where the bug manifests