### PR TITLE
fix(ext/node): support fs ops on inherited extra stdio fds

### DIFF
--- a/ext/node/ops/fs.rs
+++ b/ext/node/ops/fs.rs
@@ -98,15 +98,69 @@ fn ebadf() -> FsError {
 }
 
 /// Get the File trait object for an OS file descriptor from FdTable.
+///
+/// If the fd is not in the table (e.g. an inherited pipe from
+/// `child_process.spawn`), validates and wraps the raw OS fd so that
+/// `fs.write(fd)` / `fs.read(fd)` work on any open descriptor.
 fn file_for_fd(
   state: &OpState,
   fd: i32,
 ) -> Result<Rc<dyn deno_io::fs::File>, FsError> {
-  state
-    .borrow::<deno_io::FdTable>()
-    .get(fd)
-    .cloned()
-    .ok_or_else(ebadf)
+  if let Some(file) = state.borrow::<deno_io::FdTable>().get(fd) {
+    return Ok(file.clone());
+  }
+  // The fd may be a valid OS fd not registered in FdTable (e.g., an
+  // extra stdio pipe inherited from a parent process). Dup it so the
+  // wrapper won't close the original fd when dropped.
+  wrap_raw_fd(fd)
+}
+
+#[cfg(unix)]
+fn wrap_raw_fd(fd: i32) -> Result<Rc<dyn deno_io::fs::File>, FsError> {
+  use std::os::unix::io::FromRawFd;
+  // SAFETY: libc calls with a valid fd argument
+  let duped = unsafe { libc::dup(fd) };
+  if duped < 0 {
+    return Err(ebadf());
+  }
+  // SAFETY: duped is a new valid fd returned by dup()
+  let std_file = unsafe { std::fs::File::from_raw_fd(duped) };
+  Ok(Rc::new(deno_io::StdFileResourceInner::file(std_file, None)))
+}
+
+#[cfg(windows)]
+fn wrap_raw_fd(fd: i32) -> Result<Rc<dyn deno_io::fs::File>, FsError> {
+  use std::os::windows::io::FromRawHandle;
+
+  use windows_sys::Win32::Foundation::DUPLICATE_SAME_ACCESS;
+  use windows_sys::Win32::Foundation::DuplicateHandle;
+  use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+  // SAFETY: _get_osfhandle returns the OS handle for a CRT fd
+  let handle = unsafe { libc::get_osfhandle(fd) };
+  if handle == -1 {
+    return Err(ebadf());
+  }
+  // Duplicate the handle so we don't close the original on drop.
+  let mut new_handle: isize = 0;
+  // SAFETY: handle is a valid OS handle from get_osfhandle
+  let ok = unsafe {
+    DuplicateHandle(
+      GetCurrentProcess(),
+      handle,
+      GetCurrentProcess(),
+      &mut new_handle,
+      0,
+      0, // not inheritable
+      DUPLICATE_SAME_ACCESS,
+    )
+  };
+  if ok == 0 {
+    return Err(ebadf());
+  }
+  // SAFETY: new_handle is a valid duplicated OS handle
+  let std_file = unsafe { std::fs::File::from_raw_handle(new_handle as _) };
+  Ok(Rc::new(deno_io::StdFileResourceInner::file(std_file, None)))
 }
 
 /// When `sync_fs` is enabled, `FileSystemRc` is `Arc` (Send) and we can

--- a/tests/specs/node/child_process_extra_pipe_fd/__test__.jsonc
+++ b/tests/specs/node/child_process_extra_pipe_fd/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "extra_pipe_fd": {
+      "args": "run -A parent.ts",
+      "output": "parent.out"
+    }
+  }
+}

--- a/tests/specs/node/child_process_extra_pipe_fd/child.ts
+++ b/tests/specs/node/child_process_extra_pipe_fd/child.ts
@@ -1,0 +1,4 @@
+import { createWriteStream } from "node:fs";
+
+const ws = createWriteStream(null as unknown as string, { fd: 3 });
+ws.write("hello from fd 3\n");

--- a/tests/specs/node/child_process_extra_pipe_fd/parent.out
+++ b/tests/specs/node/child_process_extra_pipe_fd/parent.out
@@ -1,0 +1,2 @@
+parent got: hello from fd 3
+child exit: 0

--- a/tests/specs/node/child_process_extra_pipe_fd/parent.ts
+++ b/tests/specs/node/child_process_extra_pipe_fd/parent.ts
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/denoland/deno/issues/33368
+// Spawn a child with an extra pipe at fd 3 and verify the child can
+// write to it via fs.createWriteStream and the parent can read from it.
+
+import { spawn } from "node:child_process";
+
+const child = spawn(process.execPath, [import.meta.dirname + "/child.ts"], {
+  stdio: ["inherit", "inherit", "inherit", "pipe"],
+});
+
+child.stdio[3]!.on("data", (d: Buffer) => {
+  console.log("parent got: " + d.toString().trim());
+});
+
+child.on("exit", (code: number | null) => {
+  console.log("child exit: " + code);
+});


### PR DESCRIPTION
## Summary

Closes #33368

`fs.write(fd)` / `fs.read(fd)` and other node:fs ops go through `file_for_fd()` which looks up the fd in `FdTable`. File descriptors inherited from a parent process via `child_process.spawn({ stdio: [..., 'pipe'] })` are valid OS fds but were never registered in the table, causing EBADF.

This was introduced in #33165 (2.7.12) when `file_for_fd` was changed to use `FdTable` instead of the old resource-table-based lookup.

When an fd is not in `FdTable`, `file_for_fd` now validates it against the OS and wraps it via `dup()` on Unix / `DuplicateHandle` on Windows, so the operation succeeds without closing the original fd on drop.

## Test plan
- Added spec test `child_process_extra_pipe_fd` — spawns a child with `stdio: ['inherit', 'inherit', 'inherit', 'pipe']`, child writes to fd 3 via `fs.createWriteStream(null, { fd: 3 })`, parent reads from `child.stdio[3]`
- Verified the original repro from #33368 now works