### PR TITLE
docs: clarify --watch-hmr does not restart on file changes

### DIFF
--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5479,14 +5479,14 @@ fn hmr_arg(takes_files: bool) -> Arg {
       .require_equals(true)
       .help(
         cstr!(
-        "Watch for file changes and restart process automatically.
+        "Watch for file changes and hot-replace modules. Does not restart the process.
   <p(245)>Local files from entry point module graph are watched by default.
   Additional paths might be watched by passing them as arguments to this flag.</>"),
       )
       .value_hint(ValueHint::AnyPath)
   } else {
     arg.action(ArgAction::SetTrue).help(cstr!(
-      "Watch for file changes and restart process automatically.
+      "Watch for file changes and hot-replace modules. Does not restart the process.
   <p(245)>Only local files from entry point module graph are watched.</>"
     ))
   }

--- a/cli/args/flags.rs
+++ b/cli/args/flags.rs
@@ -5479,14 +5479,14 @@ fn hmr_arg(takes_files: bool) -> Arg {
       .require_equals(true)
       .help(
         cstr!(
-        "Watch for file changes and hot-replace modules. Does not restart the process.
+        "Watch for file changes and hot-replace modules. The process restarts if hot replacement fails.
   <p(245)>Local files from entry point module graph are watched by default.
   Additional paths might be watched by passing them as arguments to this flag.</>"),
       )
       .value_hint(ValueHint::AnyPath)
   } else {
     arg.action(ArgAction::SetTrue).help(cstr!(
-      "Watch for file changes and hot-replace modules. Does not restart the process.
+      "Watch for file changes and hot-replace modules. The process restarts if hot replacement fails.
   <p(245)>Only local files from entry point module graph are watched.</>"
     ))
   }


### PR DESCRIPTION
Fixes #30017: Clarifies that `--watch-hmr` does NOT restart the process on file changes — it does hot-replace modules instead.