### PR TITLE
fix(ext/node): flush HTTP/2 client preface after settings submission

### DIFF
--- a/ext/node/polyfills/http2.ts
+++ b/ext/node/polyfills/http2.ts
@@ -2831,6 +2831,12 @@ function setupHandle(socket, type, options) {
 
   this.settings(settings);
 
+  // Flush the client connection preface + SETTINGS frame to the socket.
+  // The Rust send_pending_data() is a no-op when the stream is not consumed
+  // (JS write path), so we must explicitly drain nghttp2's output buffer
+  // via the JS sendPending override that calls getOutgoingData + socket.write.
+  handle.sendPending();
+
   if (
     type === NGHTTP2_SESSION_SERVER &&
     ArrayIsArray(options.origins)

--- a/tests/unit_node/http2_test.ts
+++ b/tests/unit_node/http2_test.ts
@@ -625,3 +625,63 @@ Deno.test("[node/http2 client] connect without net permission", {
     Deno.errors.NotCapable,
   );
 });
+
+// https://github.com/denoland/deno/issues/33009
+Deno.test("[node/http2 client] connect with pre-created socket", {
+  ignore: Deno.build.os === "windows",
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  const server = http2.createServer();
+  server.on("stream", (stream) => {
+    stream.respond({ ":status": 200, "content-type": "text/plain" });
+    stream.end("ok");
+  });
+
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as net.AddressInfo).port);
+    });
+  });
+
+  // Pre-create a connected socket before passing to http2.connect()
+  // (pattern used by @grpc/grpc-js)
+  const socket = await new Promise<net.Socket>((resolve, reject) => {
+    const s = net.connect({ host: "127.0.0.1", port }, () => resolve(s));
+    s.once("error", reject);
+  });
+
+  const client = http2.connect(`http://127.0.0.1:${port}`, {
+    createConnection: () => socket,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("remoteSettings timeout")),
+      5000,
+    );
+    client.once("remoteSettings", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    client.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+
+  const req = client.request({ ":method": "GET", ":path": "/" });
+  req.end();
+
+  const body = await new Promise<string>((resolve) => {
+    let data = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => (data += chunk));
+    req.on("end", () => resolve(data));
+  });
+
+  assertEquals(body, "ok");
+  client.close();
+  server.close();
+  await new Promise<void>((resolve) => server.on("close", resolve));
+});


### PR DESCRIPTION
## Summary

Fixes a deadlock in `node:http2` client connections where the HTTP/2
client connection preface (24 bytes) + initial SETTINGS frame (9 bytes)
get stuck in nghttp2's output buffer and are never written to the socket.

- In `setupHandle()`, after `this.settings()` submits the client
  SETTINGS to nghttp2, the Rust `send_pending_data()` is a no-op
  because `self.stream` is `None` (JS write path). The 33 bytes of
  queued output are never flushed.
- This causes a deadlock: the client waits for the server's SETTINGS
  (`remoteSettings` event) while the server waits for the client's
  connection preface.
- The fix adds `handle.sendPending()` after `this.settings()` to flush
  nghttp2's output via the JS override path (`getOutgoingData()` →
  `socket.write()`).

This bug affects **all** `http2.connect()` calls to a Deno HTTP/2
server. With external servers it manifests as a race condition (if the
server sends SETTINGS proactively, the socket `data` handler fires and
triggers `sendPending` as a side effect). The `@grpc/grpc-js` pattern of
pre-created sockets makes it more visible.

Closes #33009

## Test plan

- Verified `http2.connect()` against `http2.createServer()` with 4
  patterns (normal, inline createConnection, pre-created socket,
  pre-created + delay) — all pass (previously 0/4)
- Verified the original issue repro (pre-created socket, 20 iterations)
  — 20/20 pass (previously 0/20)
- `./x test-spec http2` passes
- `./x test-node http2` passes