### PR TITLE
fix(ext/node): validate oaepHash in publicEncrypt/privateDecrypt

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -650,6 +650,14 @@ function checkUnsupportedKeyType(key) {
   }
 }
 
+function normalizeOaepHash(hash: string | undefined): string | undefined {
+  if (!hash) return undefined;
+  // Normalize to lowercase and strip WebCrypto-style hyphens
+  // (e.g. "SHA-256" -> "sha256") but keep sha3/sha512 sub-variants
+  // (e.g. "sha3-256", "sha512-224") intact.
+  return hash.toLowerCase().replace(/^(sha)-(?!3-)/, "$1");
+}
+
 export function privateEncrypt(
   privateKey: ArrayBufferView | string | KeyObject,
   buffer: ArrayBufferView,
@@ -657,7 +665,7 @@ export function privateEncrypt(
   checkUnsupportedKeyType(privateKey);
   const { data } = prepareKey(privateKey);
   const padding = privateKey.padding || 1;
-  const oaepHash = privateKey.oaepHash || undefined;
+  const oaepHash = normalizeOaepHash(privateKey.oaepHash);
   const oaepLabel = privateKey.oaepLabel || undefined;
 
   buffer = getArrayBufferOrView(buffer, "buffer");
@@ -673,7 +681,7 @@ export function privateDecrypt(
   checkUnsupportedKeyType(privateKey);
   const { data } = prepareKey(privateKey);
   const padding = privateKey.padding || 1;
-  const oaepHash = privateKey.oaepHash || undefined;
+  const oaepHash = normalizeOaepHash(privateKey.oaepHash);
   const oaepLabel = privateKey.oaepLabel || undefined;
 
   buffer = getArrayBufferOrView(buffer, "buffer");
@@ -689,7 +697,7 @@ export function publicEncrypt(
   checkUnsupportedKeyType(publicKey);
   const { data } = prepareKey(publicKey);
   const padding = publicKey.padding || 1;
-  const oaepHash = publicKey.oaepHash || undefined;
+  const oaepHash = normalizeOaepHash(publicKey.oaepHash);
   const oaepLabel = publicKey.oaepLabel || undefined;
 
   buffer = getArrayBufferOrView(buffer, "buffer");

--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -657,9 +657,13 @@ export function privateEncrypt(
   checkUnsupportedKeyType(privateKey);
   const { data } = prepareKey(privateKey);
   const padding = privateKey.padding || 1;
+  const oaepHash = privateKey.oaepHash || undefined;
+  const oaepLabel = privateKey.oaepLabel || undefined;
 
   buffer = getArrayBufferOrView(buffer, "buffer");
-  return Buffer.from(op_node_private_encrypt(data, buffer, padding));
+  return Buffer.from(
+    op_node_private_encrypt(data, buffer, padding, oaepHash, oaepLabel),
+  );
 }
 
 export function privateDecrypt(
@@ -669,9 +673,13 @@ export function privateDecrypt(
   checkUnsupportedKeyType(privateKey);
   const { data } = prepareKey(privateKey);
   const padding = privateKey.padding || 1;
+  const oaepHash = privateKey.oaepHash || undefined;
+  const oaepLabel = privateKey.oaepLabel || undefined;
 
   buffer = getArrayBufferOrView(buffer, "buffer");
-  return Buffer.from(op_node_private_decrypt(data, buffer, padding));
+  return Buffer.from(
+    op_node_private_decrypt(data, buffer, padding, oaepHash, oaepLabel),
+  );
 }
 
 export function publicEncrypt(
@@ -681,9 +689,13 @@ export function publicEncrypt(
   checkUnsupportedKeyType(publicKey);
   const { data } = prepareKey(publicKey);
   const padding = publicKey.padding || 1;
+  const oaepHash = publicKey.oaepHash || undefined;
+  const oaepLabel = publicKey.oaepLabel || undefined;
 
   buffer = getArrayBufferOrView(buffer, "buffer");
-  return Buffer.from(op_node_public_encrypt(data, buffer, padding));
+  return Buffer.from(
+    op_node_public_encrypt(data, buffer, padding, oaepHash, oaepLabel),
+  );
 }
 
 export function prepareKey(key) {

--- a/ext/node_crypto/lib.rs
+++ b/ext/node_crypto/lib.rs
@@ -355,14 +355,11 @@ fn create_oaep(
   label: Option<&[u8]>,
 ) -> Result<Oaep, PrivateEncryptDecryptError> {
   let hash = hash.unwrap_or("sha1");
-  let mut oaep = match hash {
-    "sha1" | "sha-1" => Oaep::new::<sha1::Sha1>(),
-    "sha224" | "sha-224" => Oaep::new::<sha2::Sha224>(),
-    "sha256" | "sha-256" => Oaep::new::<sha2::Sha256>(),
-    "sha384" | "sha-384" => Oaep::new::<sha2::Sha384>(),
-    "sha512" | "sha-512" => Oaep::new::<sha2::Sha512>(),
-    _ => return Err(PrivateEncryptDecryptError::InvalidDigest),
-  };
+  let mut oaep = digest::match_fixed_digest!(hash, fn <D>() {
+    Oaep::new::<D>()
+  }, _ => {
+    return Err(PrivateEncryptDecryptError::InvalidDigest);
+  });
   if let Some(label) = label {
     // The rsa crate stores the label as String but only uses
     // .as_bytes() on it, so the UTF-8 invariant is not relied upon.

--- a/ext/node_crypto/lib.rs
+++ b/ext/node_crypto/lib.rs
@@ -298,6 +298,9 @@ pub enum PrivateEncryptDecryptError {
   #[class(type)]
   #[error("Unknown padding")]
   UnknownPadding,
+  #[class(generic)]
+  #[error("Invalid digest used")]
+  InvalidDigest,
 }
 
 /// PKCS#1 v1.5 type 1 padding for private key encryption (signing).
@@ -347,11 +350,35 @@ fn pkcs1v15_type1_unpad(
   Ok(em[sep + 1..].to_vec())
 }
 
+fn create_oaep(
+  hash: Option<&str>,
+  label: Option<&[u8]>,
+) -> Result<Oaep, PrivateEncryptDecryptError> {
+  let hash = hash.unwrap_or("sha1");
+  let mut oaep = match hash {
+    "sha1" | "sha-1" => Oaep::new::<sha1::Sha1>(),
+    "sha224" | "sha-224" => Oaep::new::<sha2::Sha224>(),
+    "sha256" | "sha-256" => Oaep::new::<sha2::Sha256>(),
+    "sha384" | "sha-384" => Oaep::new::<sha2::Sha384>(),
+    "sha512" | "sha-512" => Oaep::new::<sha2::Sha512>(),
+    _ => return Err(PrivateEncryptDecryptError::InvalidDigest),
+  };
+  if let Some(label) = label {
+    // The rsa crate stores the label as String but only uses
+    // .as_bytes() on it, so the UTF-8 invariant is not relied upon.
+    // SAFETY: label bytes are only ever hashed, never interpreted as text.
+    oaep.label = Some(unsafe { String::from_utf8_unchecked(label.to_vec()) });
+  }
+  Ok(oaep)
+}
+
 #[op2]
 pub fn op_node_private_encrypt(
   #[serde] key: StringOrBuffer,
   #[serde] msg: StringOrBuffer,
   #[smi] padding: u32,
+  #[string] oaep_hash: Option<String>,
+  #[serde] oaep_label: Option<JsBuffer>,
 ) -> Result<Uint8Array, PrivateEncryptDecryptError> {
   let key = match std::str::from_utf8(&key) {
     Ok(pem) => RsaPrivateKey::from_pkcs8_pem(pem)
@@ -378,14 +405,8 @@ pub fn op_node_private_encrypt(
       Ok(result_bytes.into())
     }
     4 => {
-      // RSA_NO_PADDING is padding=3, OAEP is padding=4
-      // For OAEP with private encrypt, use the public key component
-      Ok(
-        key
-          .as_ref()
-          .encrypt(&mut rng, Oaep::new::<sha1::Sha1>(), &msg)?
-          .into(),
-      )
+      let oaep = create_oaep(oaep_hash.as_deref(), oaep_label.as_deref())?;
+      Ok(key.as_ref().encrypt(&mut rng, oaep, &msg)?.into())
     }
     _ => Err(PrivateEncryptDecryptError::UnknownPadding),
   }
@@ -396,6 +417,8 @@ pub fn op_node_private_decrypt(
   #[serde] key: StringOrBuffer,
   #[serde] msg: StringOrBuffer,
   #[smi] padding: u32,
+  #[string] oaep_hash: Option<String>,
+  #[serde] oaep_label: Option<JsBuffer>,
 ) -> Result<Uint8Array, PrivateEncryptDecryptError> {
   let key = match std::str::from_utf8(&key) {
     Ok(pem) => RsaPrivateKey::from_pkcs8_pem(pem)
@@ -408,7 +431,10 @@ pub fn op_node_private_decrypt(
 
   match padding {
     1 => Ok(key.decrypt(Pkcs1v15Encrypt, &msg)?.into()),
-    4 => Ok(key.decrypt(Oaep::new::<sha1::Sha1>(), &msg)?.into()),
+    4 => {
+      let oaep = create_oaep(oaep_hash.as_deref(), oaep_label.as_deref())?;
+      Ok(key.decrypt(oaep, &msg)?.into())
+    }
     _ => Err(PrivateEncryptDecryptError::UnknownPadding),
   }
 }
@@ -418,6 +444,8 @@ pub fn op_node_public_encrypt(
   #[serde] key: StringOrBuffer,
   #[serde] msg: StringOrBuffer,
   #[smi] padding: u32,
+  #[string] oaep_hash: Option<String>,
+  #[serde] oaep_label: Option<JsBuffer>,
 ) -> Result<Uint8Array, PrivateEncryptDecryptError> {
   let key = match std::str::from_utf8(&key) {
     Ok(pem) => RsaPublicKey::from_public_key_pem(pem)
@@ -448,11 +476,10 @@ pub fn op_node_public_encrypt(
   let mut rng = rand::thread_rng();
   match padding {
     1 => Ok(key.encrypt(&mut rng, Pkcs1v15Encrypt, &msg)?.into()),
-    4 => Ok(
-      key
-        .encrypt(&mut rng, Oaep::new::<sha1::Sha1>(), &msg)?
-        .into(),
-    ),
+    4 => {
+      let oaep = create_oaep(oaep_hash.as_deref(), oaep_label.as_deref())?;
+      Ok(key.encrypt(&mut rng, oaep, &msg)?.into())
+    }
     _ => Err(PrivateEncryptDecryptError::UnknownPadding),
   }
 }

--- a/tests/specs/node/crypto_public_encrypt_oaep_hash/__test__.jsonc
+++ b/tests/specs/node/crypto_public_encrypt_oaep_hash/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "oaep_hash_validation": {
+      "args": "run -A main.mjs",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/node/crypto_public_encrypt_oaep_hash/main.mjs
+++ b/tests/specs/node/crypto_public_encrypt_oaep_hash/main.mjs
@@ -1,0 +1,127 @@
+import crypto from "node:crypto";
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+// Invalid oaepHash should throw
+try {
+  crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "this-is-an-invalid-hash-name",
+    },
+    Buffer.from("test"),
+  );
+  console.log("FAIL: did not throw for invalid oaepHash");
+} catch {
+  console.log("PASS: invalid oaepHash throws");
+}
+
+// sha256 roundtrip
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha256",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha256",
+    },
+    encrypted,
+  );
+  console.log("PASS: sha256 roundtrip:", decrypted.toString());
+}
+
+// sha384 roundtrip
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha384",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha384",
+    },
+    encrypted,
+  );
+  console.log("PASS: sha384 roundtrip:", decrypted.toString());
+}
+
+// sha512 roundtrip
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha512",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha512",
+    },
+    encrypted,
+  );
+  console.log("PASS: sha512 roundtrip:", decrypted.toString());
+}
+
+// Default sha1 still works
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+    },
+    encrypted,
+  );
+  console.log("PASS: default sha1 roundtrip:", decrypted.toString());
+}
+
+// Mismatched hash should fail
+try {
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha256",
+    },
+    Buffer.from("test"),
+  );
+  crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha1",
+    },
+    encrypted,
+  );
+  console.log("FAIL: mismatched hash should have thrown");
+} catch {
+  console.log("PASS: mismatched hash throws");
+}

--- a/tests/specs/node/crypto_public_encrypt_oaep_hash/main.mjs
+++ b/tests/specs/node/crypto_public_encrypt_oaep_hash/main.mjs
@@ -103,6 +103,93 @@ try {
   console.log("PASS: default sha1 roundtrip:", decrypted.toString());
 }
 
+// Case-insensitive hash names
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "SHA256",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "SHA256",
+    },
+    encrypted,
+  );
+  console.log("PASS: SHA256 (uppercase) roundtrip:", decrypted.toString());
+}
+
+// WebCrypto-style hyphenated names
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "SHA-256",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "SHA-256",
+    },
+    encrypted,
+  );
+  console.log(
+    "PASS: SHA-256 (WebCrypto-style) roundtrip:",
+    decrypted.toString(),
+  );
+}
+
+// sha3-256 roundtrip
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha3-256",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "sha3-256",
+    },
+    encrypted,
+  );
+  console.log("PASS: sha3-256 roundtrip:", decrypted.toString());
+}
+
+// md5 roundtrip
+{
+  const encrypted = crypto.publicEncrypt(
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "md5",
+    },
+    Buffer.from("hello"),
+  );
+  const decrypted = crypto.privateDecrypt(
+    {
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: "md5",
+    },
+    encrypted,
+  );
+  console.log("PASS: md5 roundtrip:", decrypted.toString());
+}
+
 // Mismatched hash should fail
 try {
   const encrypted = crypto.publicEncrypt(

--- a/tests/specs/node/crypto_public_encrypt_oaep_hash/main.out
+++ b/tests/specs/node/crypto_public_encrypt_oaep_hash/main.out
@@ -1,0 +1,6 @@
+PASS: invalid oaepHash throws
+PASS: sha256 roundtrip: hello
+PASS: sha384 roundtrip: hello
+PASS: sha512 roundtrip: hello
+PASS: default sha1 roundtrip: hello
+PASS: mismatched hash throws

--- a/tests/specs/node/crypto_public_encrypt_oaep_hash/main.out
+++ b/tests/specs/node/crypto_public_encrypt_oaep_hash/main.out
@@ -3,4 +3,8 @@ PASS: sha256 roundtrip: hello
 PASS: sha384 roundtrip: hello
 PASS: sha512 roundtrip: hello
 PASS: default sha1 roundtrip: hello
+PASS: SHA256 (uppercase) roundtrip: hello
+PASS: SHA-256 (WebCrypto-style) roundtrip: hello
+PASS: sha3-256 roundtrip: hello
+PASS: md5 roundtrip: hello
 PASS: mismatched hash throws


### PR DESCRIPTION
## Summary

- Pass `oaepHash` and `oaepLabel` options from `crypto.publicEncrypt`,
  `crypto.privateEncrypt`, and `crypto.privateDecrypt` through to the
  Rust ops instead of silently ignoring them
- Validate the hash name and throw `"Invalid digest used"` for
  unrecognized values, matching Node.js behavior
- Support sha1 (default), sha224, sha256, sha384, and sha512 for OAEP
  padding instead of hardcoding SHA-1

Closes #33384

## Test plan

- Added spec test `tests/specs/node/crypto_public_encrypt_oaep_hash/`
  that verifies:
  - Invalid oaepHash throws an error
  - sha256, sha384, sha512 encrypt/decrypt roundtrips work
  - Default sha1 still works
  - Mismatched encrypt/decrypt hash correctly fails