### PR TITLE
fix(node/buffer): fix copy-paste bug in Buffer.compare validation

### DIFF
--- a/ext/node/ops/buffer.rs
+++ b/ext/node/ops/buffer.rs
@@ -166,10 +166,14 @@ pub fn op_node_buffer_compare_offset(
   }
 
   if source_start > source_end {
-    panic!("source_start > source_end");
+    return Err(JsErrorBox::from_err(BufferError::OutOfRangeNamed(
+      "sourceEnd".to_string(),
+    )));
   }
   if target_start > target_end {
-    panic!("target_start > target_end");
+    return Err(JsErrorBox::from_err(BufferError::OutOfRangeNamed(
+      "targetEnd".to_string(),
+    )));
   }
 
   Ok(

--- a/ext/node/polyfills/internal/buffer.mjs
+++ b/ext/node/polyfills/internal/buffer.mjs
@@ -854,13 +854,13 @@ Buffer.prototype.compare = function compare(
   if (thisStart === undefined) {
     thisStart = 0;
   } else {
-    validateOffset(start, "sourceStart", 0, kMaxLength);
+    validateOffset(thisStart, "sourceStart", 0, kMaxLength);
   }
 
   if (thisEnd === undefined) {
     thisEnd = this.length;
   } else {
-    validateOffset(end, "sourceEnd", 0, this.length);
+    validateOffset(thisEnd, "sourceEnd", 0, this.length);
   }
 
   if (

--- a/tests/specs/node/buffer_compare_validation/__test__.jsonc
+++ b/tests/specs/node/buffer_compare_validation/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "tests": {
+    "validates_sourceStart_and_sourceEnd": {
+      "args": "run main.ts",
+      "output": "main.out"
+    }
+  }
+}

--- a/tests/specs/node/buffer_compare_validation/main.out
+++ b/tests/specs/node/buffer_compare_validation/main.out
@@ -1,0 +1,4 @@
+0
+sourceStart: ERR_OUT_OF_RANGE
+sourceEnd: ERR_OUT_OF_RANGE
+done

--- a/tests/specs/node/buffer_compare_validation/main.ts
+++ b/tests/specs/node/buffer_compare_validation/main.ts
@@ -1,0 +1,25 @@
+import { Buffer } from "node:buffer";
+
+const a = Buffer.from("abc");
+const b = Buffer.from("abc");
+
+// Valid compare should work
+console.log(a.compare(b, 0, 3, 0, 3));
+
+// Invalid sourceStart should throw ERR_OUT_OF_RANGE
+try {
+  a.compare(b, 0, 3, -1, 3);
+  console.log("FAIL: should have thrown for negative sourceStart");
+} catch (e: any) {
+  console.log(`sourceStart: ${e.code}`);
+}
+
+// Invalid sourceEnd (exceeds buffer length) should throw
+try {
+  a.compare(b, 0, 3, 0, 100);
+  console.log("FAIL: should have thrown for sourceEnd > length");
+} catch (e: any) {
+  console.log(`sourceEnd: ${e.code}`);
+}
+
+console.log("done");


### PR DESCRIPTION
## Summary

- **Copy-paste bug**: `Buffer.prototype.compare()` was validating `start`/`end` (target params) twice instead of validating `thisStart`/`thisEnd` (source params). This meant `sourceStart` and `sourceEnd` bypassed `validateOffset()` entirely, allowing invalid values to reach the native op.
- **Panic on user input**: The backing Rust op `op_node_buffer_compare_offset` used `panic!()` for out-of-range source/target bounds instead of returning a proper `ERR_OUT_OF_RANGE` error. Converted to `Result::Err` for defense in depth.

## Test plan
- Added spec test `tests/specs/node/buffer_compare_validation/` that verifies:
  - [x] Valid `compare()` works correctly
  - [x] Negative `sourceStart` throws `ERR_OUT_OF_RANGE`
  - [x] `sourceEnd` exceeding buffer length throws `ERR_OUT_OF_RANGE`