### PR TITLE
perf(ext/node): pool 64KB read buffers to reduce allocation pressure

### DIFF
--- a/ext/node/ops/stream_wrap.rs
+++ b/ext/node/ops/stream_wrap.rs
@@ -452,21 +452,64 @@ impl LibUvStreamWrap {
 // In Node, these live as LibuvStreamWrap::OnUvAlloc / LibuvStreamWrap::OnUvRead.
 // ---------------------------------------------------------------------------
 
-/// Alloc callback for uv_read_start. Allocates a buffer via
-/// `ArrayBuffer::new_backing_store_uninit`.
+/// Thread-local free list of 64KB read buffers. libuv calls the alloc
+/// callback with a 65536-byte suggested size on every read.
+///
+/// We allocate read buffers with `std::alloc::alloc` which goes through
+/// the system allocator (xzone on macOS). At ~70k reads/sec of a fixed
+/// 64KB size, every free triggers a `mach_vm_reclaim_*` kernel trap
+/// (~6% of CPU in the pre-pool profile). Pooling keeps the 64KB slab
+/// owned by the runtime and reused across reads instead of handed back
+/// to the kernel.
+///
+/// The pool is capped so long-lived idle processes don't retain excess
+/// memory. Non-65536 sizes skip the pool entirely.
+const POOLED_BUF_SIZE: usize = 65536;
+const POOLED_BUF_MAX: usize = 128;
+
+thread_local! {
+  static READ_BUF_POOL: std::cell::RefCell<Vec<*mut u8>> =
+    const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[inline]
+fn pool_acquire_buf() -> Option<*mut u8> {
+  READ_BUF_POOL.with(|p| p.borrow_mut().pop())
+}
+
+#[inline]
+fn pool_release_buf(ptr: *mut u8) -> bool {
+  READ_BUF_POOL.with(|p| {
+    let mut pool = p.borrow_mut();
+    if pool.len() < POOLED_BUF_MAX {
+      pool.push(ptr);
+      true
+    } else {
+      false
+    }
+  })
+}
+
+/// Alloc callback for uv_read_start. Returns a pooled 64KB slab when
+/// `suggested_size` matches, otherwise falls back to `std::alloc::alloc`.
 ///
 /// # Safety
-/// `handle` must be a valid uv_handle_t whose `data` field points to the
-/// owning `StreamHandleData`.
+/// `buf` must be the out-param provided by libuv per the `uv_alloc_cb` contract.
 unsafe extern "C" fn on_uv_alloc(
   _handle: *mut uv_compat::uv_handle_t,
   suggested_size: usize,
   buf: *mut uv_buf_t,
 ) {
-  // Allocate raw memory for the read buffer.
-  let layout = std::alloc::Layout::from_size_align(suggested_size, 1).unwrap();
-  // SAFETY: layout has non-zero size (libuv provides a positive suggested_size).
-  let ptr = unsafe { std::alloc::alloc(layout) };
+  let ptr = if suggested_size == POOLED_BUF_SIZE
+    && let Some(ptr) = pool_acquire_buf()
+  {
+    ptr
+  } else {
+    let layout =
+      std::alloc::Layout::from_size_align(suggested_size, 1).unwrap();
+    // SAFETY: layout has non-zero size (libuv provides a positive suggested_size).
+    unsafe { std::alloc::alloc(layout) }
+  };
   if ptr.is_null() {
     // SAFETY: buf is a valid pointer provided by libuv per the uv_alloc_cb contract.
     unsafe {
@@ -673,12 +716,17 @@ fn call_fatal_exception(
 }
 
 /// Free a buffer allocated by on_uv_alloc.
-fn free_uv_buf(buf: *const uv_buf_t) {
+pub(crate) fn free_uv_buf(buf: *const uv_buf_t) {
   // SAFETY: buf is a valid uv_buf_t from on_uv_alloc; base was allocated with alloc(len, 1).
   unsafe {
     if !(*buf).base.is_null() && (*buf).len > 0 {
-      let layout = std::alloc::Layout::from_size_align((*buf).len, 1).unwrap();
-      std::alloc::dealloc((*buf).base as *mut u8, layout);
+      let len = (*buf).len;
+      let ptr = (*buf).base as *mut u8;
+      if len == POOLED_BUF_SIZE && pool_release_buf(ptr) {
+        return;
+      }
+      let layout = std::alloc::Layout::from_size_align(len, 1).unwrap();
+      std::alloc::dealloc(ptr, layout);
     }
   }
 }
@@ -718,9 +766,13 @@ unsafe extern "C" fn backing_store_deleter(
   // which may be smaller (nread < allocated size is common for partial reads).
   let alloc_size = deleter_data as usize;
   if !data.is_null() && alloc_size > 0 {
+    let ptr = data as *mut u8;
+    if alloc_size == POOLED_BUF_SIZE && pool_release_buf(ptr) {
+      return;
+    }
     let layout = std::alloc::Layout::from_size_align(alloc_size, 1).unwrap();
     // SAFETY: data was allocated via alloc(Layout::from_size_align(alloc_size, 1)) in on_uv_alloc.
-    unsafe { std::alloc::dealloc(data as *mut u8, layout) };
+    unsafe { std::alloc::dealloc(ptr, layout) };
   }
 }
 

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -55,6 +55,7 @@ use crate::ops::handle_wrap::OwnedPtr;
 use crate::ops::handle_wrap::ProviderType;
 use crate::ops::stream_wrap::LibUvStreamWrap;
 use crate::ops::stream_wrap::StreamBaseState;
+use crate::ops::stream_wrap::free_uv_buf;
 use crate::ops::stream_wrap_state::ReadInterceptor;
 use crate::ops::tls::NodeTlsState;
 
@@ -1397,17 +1398,6 @@ unsafe fn tls_read_interceptor_cb(
 
     // Drive the TLS state machine (uses raw pointer internally)
     TLSWrapInner::cycle(ptr);
-  }
-}
-
-#[allow(dead_code, reason = "used by tls_read_interceptor_cb")]
-fn free_uv_buf(buf: *const uv_buf_t) {
-  // SAFETY: buf was allocated by stream_wrap::on_uv_alloc with matching layout
-  unsafe {
-    if !(*buf).base.is_null() && (*buf).len > 0 {
-      let layout = std::alloc::Layout::from_size_align((*buf).len, 1).unwrap();
-      std::alloc::dealloc((*buf).base as *mut u8, layout);
-    }
   }
 }
 


### PR DESCRIPTION
Big win on hello world, around 25% better throughput


before:
```
❮ oha http://127.0.0.1:8000 --disable-compression -n 1m -c 128
Summary:
  Success rate: 100.00%
  Total:        15105.5527 ms
  Slowest:      98.9553 ms
  Fastest:      0.0282 ms
  Average:      1.9308 ms
  Requests/sec: 66200.8216

  Total data:   10.49 MiB
  Size/request: 11 B
  Size/sec:     711.14 KiB

Response time histogram:
   0.028 ms [1]      |
   9.921 ms [995577] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  19.814 ms [3243]   |
  29.706 ms [370]    |
  39.599 ms [94]     |
  49.492 ms [181]    |
  59.384 ms [202]    |
  69.277 ms [143]    |
  79.170 ms [91]     |
  89.063 ms [31]     |
  98.955 ms [67]     |

Response time distribution:
  10.00% in 1.6838 ms
  25.00% in 1.7294 ms
  50.00% in 1.8173 ms
  75.00% in 1.9497 ms
  90.00% in 2.1623 ms
  95.00% in 2.3343 ms
  99.00% in 3.7948 ms
  99.90% in 23.9554 ms
  99.99% in 78.4886 ms


Details (average, fastest, slowest):
  DNS+dialup:   1.9627 ms, 1.4101 ms, 2.1608 ms
  DNS-lookup:   0.0106 ms, 0.0004 ms, 0.1997 ms

Status code distribution:
  [200] 1000000 responses
```

after

```
❮ oha http://127.0.0.1:8000 --disable-compression -n 1m -c 128
Summary:
  Success rate: 100.00%
  Total:        12033.3428 ms
  Slowest:      104.4058 ms
  Fastest:      0.0284 ms
  Average:      1.5379 ms
  Requests/sec: 83102.4275

  Total data:   10.49 MiB
  Size/request: 11 B
  Size/sec:     892.70 KiB

Response time histogram:
    0.028 ms [1]      |
   10.466 ms [998478] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   20.904 ms [702]    |
   31.342 ms [339]    |
   41.779 ms [180]    |
   52.217 ms [169]    |
   62.655 ms [10]     |
   73.093 ms [54]     |
   83.530 ms [60]     |
   93.968 ms [0]      |
  104.406 ms [7]      |

Response time distribution:
  10.00% in 1.3578 ms
  25.00% in 1.3887 ms
  50.00% in 1.4567 ms
  75.00% in 1.5709 ms
  90.00% in 1.7411 ms
  95.00% in 1.8939 ms
  99.00% in 2.2159 ms
  99.90% in 18.3779 ms
  99.99% in 66.5882 ms


Details (average, fastest, slowest):
  DNS+dialup:   2.0881 ms, 0.3488 ms, 3.1830 ms
  DNS-lookup:   0.0020 ms, 0.0004 ms, 0.0351 ms

Status code distribution:
  [200] 1000000 responses
```