### PR TITLE
fix(fs): replace unwrap with error propagation in parallel cp

### DIFF
--- a/ext/fs/std_fs.rs
+++ b/ext/fs/std_fs.rs
@@ -719,19 +719,27 @@ fn cp(from: &Path, to: &Path) -> FsResult<()> {
       entries
         .into_par_iter()
         .map(|file_name| {
-          cp_(
-            fs::symlink_metadata(from.join(&file_name)).unwrap(),
-            &from.join(&file_name),
-            &to.join(&file_name),
-          )
-          .map_err(|err| {
+          let from_path = from.join(&file_name);
+          let to_path = to.join(&file_name);
+          let meta = fs::symlink_metadata(&from_path).map_err(|err| {
             io::Error::new(
               err.kind(),
               format!(
                 "failed to copy '{}' to '{}': {:?}",
-                from.join(&file_name).display(),
-                to.join(&file_name).display(),
-                err
+                from_path.display(),
+                to_path.display(),
+                err,
+              ),
+            )
+          })?;
+          cp_(meta, &from_path, &to_path).map_err(|err| {
+            io::Error::new(
+              err.kind(),
+              format!(
+                "failed to copy '{}' to '{}': {:?}",
+                from_path.display(),
+                to_path.display(),
+                err,
               ),
             )
           })


### PR DESCRIPTION
## Summary

- `fs::symlink_metadata(...).unwrap()` in the parallel directory copy (`cp_` in `ext/fs/std_fs.rs`) panics if a file is deleted between `read_dir` and the metadata call (TOCTOU race condition)
- This is inside a `rayon` parallel iterator, so the panic brings down the process
- Fix: propagate the error with `?` instead of unwrapping, with the same error formatting as the existing `cp_` error path

## Test plan
- [x] All existing `fs_cp` spec tests pass (`node_fs_cp`, `fs_cp_ignored_permissions`, `fs_cp_sync_filter_function_throws`)
- [x] `cargo check -p deno_fs` clean