### PR TITLE
fix(node/compat): disable flaky test-fs-read-stream-pos on Windows

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -980,7 +980,7 @@
     "parallel/test-fs-read-stream-file-handle.js": {},
     "parallel/test-fs-read-stream-inherit.js": {},
     "parallel/test-fs-read-stream-patch-open.js": {},
-    "parallel/test-fs-read-stream-pos.js": {},
+    "parallel/test-fs-read-stream-pos.js": { "windows": false },
     "parallel/test-fs-read-stream-resume.js": {},
     "parallel/test-fs-read-stream-throw-type-error.js": {},
     "parallel/test-fs-read-stream.js": {},


### PR DESCRIPTION
## Summary

Disables `test-fs-read-stream-pos.js` on Windows. The test writes to a file every 1ms and reads it back every 10ms using `createReadStream` with a `start` position -- it's inherently timing-sensitive. On Windows CI, the 1ms write interval is unreliable (Windows timer granularity is ~15ms) and filesystem operations are slower, causing the test to hang and hit the 10-second compat runner timeout.

## Test plan
- Other platforms unaffected