### PR TITLE
fix(node/compat): disable flaky test-child-process-exec-kill-throws on Windows

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -211,7 +211,7 @@
     "parallel/test-child-process-exec-cwd.js": {},
     "parallel/test-child-process-exec-env.js": {},
     "parallel/test-child-process-exec-error.js": {},
-    "parallel/test-child-process-exec-kill-throws.js": {},
+    "parallel/test-child-process-exec-kill-throws.js": { "windows": false },
     "parallel/test-child-process-exec-maxbuf.js": {},
     "parallel/test-child-process-exec-std-encoding.js": {},
     "parallel/test-child-process-exec-stdout-stderr-data-string.js": {},


### PR DESCRIPTION
## Summary

Disables `test-child-process-exec-kill-throws.js` on Windows. The test sets `maxBuffer: 0` and expects the child to be killed before any stdout arrives (`assert.strictEqual(stdout, '')`). On Windows, the child process can flush `"foo\n"` before the kill signal lands, making the assertion fail intermittently.

## Test plan
- Other platforms unaffected