### PR TITLE
fix(ext/node): emit tlsClientError instead of crashing on TLS init failure

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -854,6 +854,7 @@ function tlsConnectionListener(rawSocket) {
     const err = socket._initError;
     socket._initError = null;
     this.emit("tlsClientError", err, rawSocket);
+    socket.destroy();
     rawSocket.destroy();
     return;
   }

--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -349,6 +349,12 @@ TLSSocket.prototype._wrapHandle = function (wrap, handle) {
     servername,
   );
 
+  // If TLS initialization failed (e.g. missing cert/key), store the error
+  // so it can be emitted asynchronously instead of crashing the process.
+  if (res._initError) {
+    this._initError = res._initError;
+  }
+
   res._parent = handle; // C++ "wrap" object: TCPWrap, etc.
   res._parentWrap = wrap; // JS object: net.Socket, etc.
   res._secureContext = context;
@@ -630,6 +636,15 @@ TLSSocket.prototype._start = function () {
 
   if (!this._handle) return;
 
+  // If TLS init failed (e.g. unsupported protocol on client side),
+  // emit the error and tear down instead of proceeding with the handshake.
+  if (this._initError) {
+    const err = this._initError;
+    this._initError = null;
+    this.destroy(err);
+    return;
+  }
+
   this._handle.start();
 
   // For JS streams, drain any encrypted output produced by start()
@@ -831,6 +846,17 @@ function tlsConnectionListener(rawSocket) {
     SNICallback: this._SNICallback,
     pauseOnConnect: this.pauseOnConnect,
   });
+
+  // TLS init can fail synchronously (e.g. missing cert/key, unsupported
+  // protocol).  Emit as tlsClientError like Node does for handshake
+  // failures instead of letting it surface as an uncaught exception.
+  if (socket._initError) {
+    const err = socket._initError;
+    socket._initError = null;
+    this.emit("tlsClientError", err, rawSocket);
+    rawSocket.destroy();
+    return;
+  }
 
   // Start the TLS handshake for server-side sockets
   socket._start();

--- a/ext/node/polyfills/internal_binding/tls_wrap.ts
+++ b/ext/node/polyfills/internal_binding/tls_wrap.ts
@@ -45,7 +45,13 @@ export function wrap(
     // rustls cannot negotiate TLSv1.0/TLSv1.1, so surface the closest
     // OpenSSL-style error instead of hanging the socket.
     (err as Error & { code?: string }).code = "ERR_SSL_UNSUPPORTED_PROTOCOL";
-    throw err;
+    // Store the init error on the handle so the caller can detect and
+    // report it instead of throwing synchronously.  A throw from here
+    // surfaces as an uncaught exception when the TLSSocket is created
+    // inside a native libuv callback (e.g. server_connection_cb) because
+    // there is no native TryCatch scope on the call stack.
+    res._initError = err;
+    return res;
   }
 
   const nativeHandle = handle;

--- a/tests/unit_node/tls_test.ts
+++ b/tests/unit_node/tls_test.ts
@@ -779,6 +779,40 @@ Deno.test("tls.connect socket upgrade derives SNI from socket._host", async () =
 });
 
 // https://github.com/denoland/deno/issues/30170
+// https://github.com/denoland/deno/issues/33391
+// TLS server without cert/key should emit tlsClientError, not crash with
+// an uncaught "unsupported protocol" exception on stdout.
+Deno.test("tls server without certs emits tlsClientError instead of crashing", async () => {
+  const { promise, resolve, reject } = Promise.withResolvers<Error>();
+
+  // Server with no cert/key — initServerTls will fail for every connection.
+  const server = tls.createServer((_socket) => {
+    reject(new Error("should not reach request handler"));
+  });
+
+  server.on("tlsClientError", (err: Error) => {
+    resolve(err);
+  });
+
+  server.listen(0, () => {
+    // deno-lint-ignore no-explicit-any
+    const port = (server.address() as any).port;
+    // Plain TCP connection triggers tlsConnectionListener on the server.
+    const socket = net.connect(port, "127.0.0.1", () => {
+      socket.write("hello");
+    });
+    socket.on("error", () => {});
+  });
+
+  const err = await promise;
+  assertEquals(err.message, "unsupported protocol");
+  // deno-lint-ignore no-explicit-any
+  assertEquals((err as any).code, "ERR_SSL_UNSUPPORTED_PROTOCOL");
+
+  server.close();
+  await new Promise<void>((r) => server.on("close", r));
+});
+
 Deno.test("tls.connect strips trailing dot from servername", async () => {
   const listener = Deno.listenTls({
     port: 0,


### PR DESCRIPTION
## Summary
- When `tls.createServer()` is called without cert/key and a client connects, the server no longer crashes with an uncaught "unsupported protocol" exception on stdout
- Instead, the error is emitted as a `tlsClientError` event on the server, matching Node.js behavior
- Replaced the synchronous `throw` in `tls_wrap.ts:wrap()` with a deferred error pattern (`_initError`), since the throw occurs inside a native libuv callback where V8 has no `TryCatch` scope

Closes #33391

## Test plan
- Added unit test: `tls server without certs emits tlsClientError instead of crashing`
- Verified existing TLS/HTTPS spec and unit tests still pass