### PR TITLE
fix(node/compat): fix shard report merging and fetching in CI reporting

### DIFF
--- a/tests/node_compat/add_day_summary_to_month_summary.ts
+++ b/tests/node_compat/add_day_summary_to_month_summary.ts
@@ -142,10 +142,11 @@ export async function fetchReport(
     }
   }
   // Recompute total/pass from merged results to stay consistent
-  // even if shards overlap due to a bug or retry
+  // even if shards overlap due to a bug or retry.
+  // Each result is a tuple [pass: bool | "IGNORE", error, info].
   const values = Object.values(merged.results);
-  merged.total = values.length;
-  merged.pass = values.filter((v) => v === true).length;
+  merged.total = values.filter((v) => v[0] !== "IGNORE").length;
+  merged.pass = values.filter((v) => v[0] === true).length;
   return merged;
 }
 

--- a/tests/node_compat/slack.ts
+++ b/tests/node_compat/slack.ts
@@ -2,8 +2,10 @@
 // deno-lint-ignore-file no-console
 
 import { LogLevel, WebClient } from "npm:@slack/web-api@7.8.0";
-import type { MonthSummary } from "./add_day_summary_to_month_summary.ts";
-import { toJson } from "@std/streams/to-json";
+import {
+  fetchReport,
+  type MonthSummary,
+} from "./add_day_summary_to_month_summary.ts";
 import { parse as parseJsonc } from "@std/jsonc";
 
 const token = Deno.env.get("SLACK_TOKEN");
@@ -116,18 +118,7 @@ async function fetchFullReport(
   date: string,
   os: OSName,
 ): Promise<FullReport | undefined> {
-  try {
-    const res = await fetch(
-      `https://dl.deno.land/node-compat-test/${date}/report-${os}.json.gz`,
-    );
-    if (res.status === 404) return undefined;
-    return await toJson(
-      res.body!.pipeThrough(new DecompressionStream("gzip")),
-    ) as FullReport;
-  } catch (e) {
-    console.error(`Failed to fetch report for ${date}/${os}:`, e);
-    return undefined;
-  }
+  return await fetchReport(date, os) as FullReport | undefined;
 }
 
 type TestStatus = "pass" | "fail" | "ignore" | "missing";


### PR DESCRIPTION
## Summary

Fixes two bugs introduced by the sharding PR (#33298) that caused the node compat Slack bot to report 0% passing on https://node-test-viewer.deno.dev/:

- **`add_day_summary_to_month_summary.ts`**: The shard merge logic compared the entire result tuple to `true` (`v === true`), but each result is a tuple `[pass, error, info]`. Arrays are never `=== true`, so `merged.pass` was always 0 and `merged.total` included ignored tests. Fixed to check `v[0]`.
- **`slack.ts`**: `fetchFullReport()` still fetched the old unsharded URL `report-${os}.json.gz`. Since reports are now `report-${os}-${shard_index}.json.gz`, this always 404'd, breaking all Slack thread insights. Fixed by reusing the shard-aware `fetchReport()` from the summary module.

## Test plan
- [ ] Wait for the next daily CI run and verify the Slack report shows correct pass percentages
- [ ] Verify thread insights (newly passing/failing, flaky, unenabled tests) are populated