### PR TITLE
fix(lsp): load --env-file for testing.args in deno/testRun

### DIFF
--- a/cli/lsp/testing/execution.rs
+++ b/cli/lsp/testing/execution.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -17,6 +18,7 @@ use deno_core::futures::stream;
 use deno_core::parking_lot::RwLock;
 use deno_core::unsync::spawn;
 use deno_core::unsync::spawn_blocking;
+use deno_path_util::url_to_file_path;
 use deno_runtime::deno_permissions::Permissions;
 use deno_runtime::deno_permissions::PermissionsContainer;
 use deno_runtime::tokio_util::create_and_run_current_thread;
@@ -44,6 +46,8 @@ use crate::tools::test::FailFastTracker;
 use crate::tools::test::TestFailure;
 use crate::tools::test::TestFailureFormatOptions;
 use crate::tools::test::create_test_event_channel;
+use crate::util::env::load_env_variables_from_env_files;
+use crate::util::env::resolve_cwd;
 
 /// Logic to convert a test request into a set of test modules to be tested and
 /// any filters to be applied to those tests
@@ -229,9 +233,19 @@ impl TestRun {
   ) -> Result<(), AnyError> {
     let args = self.get_args();
     lsp_log!("Executing test run with arguments: {}", args.join(" "));
-    let flags = Arc::new(flags_from_vec(
+    let flags = flags_from_vec(
       args.into_iter().map(|s| From::from(s.as_ref())).collect(),
-    )?);
+    )?;
+    if let Some(env_files) = &flags.env_file {
+      let root_path = maybe_root_uri
+        .and_then(|url| url_to_file_path(url).ok());
+      let cwd = match resolve_cwd(root_path.as_deref()) {
+        Ok(cwd) => cwd.into_owned(),
+        Err(_) => PathBuf::from("."),
+      };
+      load_env_variables_from_env_files(&cwd, env_files, flags.log_level);
+    }
+    let flags = Arc::new(flags);
     let factory = CliFactory::from_flags(flags);
     let cli_options = factory.cli_options()?;
     let permission_desc_parser = factory.permission_desc_parser()?;

--- a/tests/integration/lsp_tests.rs
+++ b/tests/integration/lsp_tests.rs
@@ -14699,6 +14699,80 @@ fn lsp_testing_api_failure() {
   client.shutdown();
 }
 
+// Regression test for https://github.com/denoland/deno/issues/33284
+// When `deno.testing.args` contains `--env-file=…`, variables from that file
+// must be loaded for the test run just like `deno test --env-file=…` does on
+// the CLI.
+#[test(timeout = 300)]
+fn lsp_testing_api_env_file() {
+  let context = TestContextBuilder::new().use_temp_cwd().build();
+  let temp_dir = context.temp_dir();
+  temp_dir.write("./deno.json", json!({}).to_string());
+  temp_dir.write("./test.env", "LSP_TESTING_ENV_VAR=from-env-file\n");
+  let file = temp_dir.source_file(
+    "test.ts",
+    r#"
+      Deno.test("env_file_loaded", () => {
+        const actual = Deno.env.get("LSP_TESTING_ENV_VAR");
+        if (actual !== "from-env-file") {
+          throw new Error("expected 'from-env-file', got " + JSON.stringify(actual));
+        }
+      });
+    "#,
+  );
+  let mut client = context.new_lsp_command().build();
+  client.initialize_default();
+  client.change_configuration(json!({
+    "deno": {
+      "enable": true,
+      "testing": {
+        "args": ["--allow-env", "--no-check", "--env-file=test.env"],
+      },
+    },
+  }));
+  client.did_open_file(&file);
+  let _ = client.read_notification_with_method::<Value>("deno/testModule");
+  let res = client.write_request_with_res_as::<TestRunResponseParams>(
+    "deno/testRun",
+    json!({
+      "id": 1,
+      "kind": "run",
+    }),
+  );
+  assert_eq!(res.enqueued.len(), 1);
+  let id = res.enqueued[0].ids[0].clone();
+  // started
+  let _ = client.read_notification_with_method::<Value>("deno/testRunProgress");
+  // Look for the passed/failed message for our test id.
+  loop {
+    let notification = client
+      .read_notification_with_method::<Value>("deno/testRunProgress")
+      .unwrap();
+    let message = notification.get("message").unwrap().as_object().unwrap();
+    match message.get("type").and_then(|v| v.as_str()) {
+      Some("passed") => {
+        assert_eq!(
+          message.get("test"),
+          Some(&json!({
+            "textDocument": { "uri": file.uri() },
+            "id": id,
+          })),
+        );
+        break;
+      }
+      Some("failed") => {
+        panic!(
+          "test run failed; env-file likely not applied: {}",
+          json!(notification)
+        );
+      }
+      Some("end") => panic!("test run ended without a pass/fail for the test"),
+      _ => continue,
+    }
+  }
+  client.shutdown();
+}
+
 #[test(timeout = 300)]
 fn lsp_testing_api_describe_it_failure() {
   let context = TestContextBuilder::new()


### PR DESCRIPTION
## Summary

- On the CLI, `deno test --env-file=FOO` loads variables from `FOO` into the process environment before the test run begins (`cli/lib.rs:740-752`).
- The LSP `deno/testRun` path parses `testing.args` (including `--env-file=…`) into a `Flags` struct via `flags_from_vec` but never called `load_env_variables_from_env_files`, so VS Code Test Explorer runs ran without the env-file variables even though the logged CLI command looked identical.
- Match CLI behavior by loading `flags.env_file` against a resolved cwd (workspace root URI if available, otherwise the process cwd) before handing the flags to `CliFactory`.

Fixes #33284.

## Behavior

Given a workspace with:

```
// .vscode/settings.json
{ "deno.enable": true, "deno.testing.args": ["--allow-env", "--env-file=env.test.args.env"] }

// env.test.args.env
MYVAR=from_test_arg
```

and a `Deno.test` that asserts `Deno.env.get("MYVAR") === "from_test_arg"`:

- Before: Test Explorer run fails — env vars are unset.
- After: Test Explorer run passes, matching `deno test --env-file=env.test.args.env` on the CLI.

## Test plan

- [x] Added integration test `lsp_testing_api_env_file` (drives the LSP with `deno/testRun`, writes a `test.env` file, and asserts the test passes). Verified it **fails on `main`** (`Error: expected 'from-env-file', got undefined`) and **passes with this change**.
- [x] `./x fmt` clean.
- [x] `./x lint` clean (full Rust + JS lint).