### PR TITLE
fix(ext/node): honor requestCert/ca on node:tls server, populate getPeerCertificate()

### DIFF
--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -32,6 +32,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use deno_core::v8_static_strings;
 use deno_core::CppgcInherits;
 use deno_core::GarbageCollected;
 use deno_core::OpState;
@@ -3133,7 +3134,10 @@ fn build_server_config(
   let builder = if request_cert {
     let mut root_cert_store = rustls::RootCertStore::empty();
     let mut root_cert_ders: Vec<Vec<u8>> = Vec::new();
-    let ca_key = v8::String::new(scope, "ca").unwrap();
+    v8_static_strings! {
+      CA = "ca",
+    }
+    let ca_key = CA.v8_string(scope).unwrap();
     if let Some(ca_val) = context.get(scope, ca_key.into()) {
       let mut ca_pems: Vec<Vec<u8>> = Vec::new();
       if let Ok(arr) = v8::Local::<v8::Array>::try_from(ca_val) {
@@ -3157,13 +3161,15 @@ fn build_server_config(
             Ok(cert) => {
               root_cert_ders.push(cert.as_ref().to_vec());
               if let Err(e) = root_cert_store.add(cert) {
-                log::warn!(
+                log::debug!(
                   "TLSWrap: ignoring invalid client CA certificate: {e}"
                 );
               }
             }
             Err(e) => {
-              log::warn!("TLSWrap: failed to parse client CA PEM entry: {e}");
+              log::debug!(
+                "TLSWrap: failed to parse client CA PEM entry: {e}"
+              );
             }
           }
         }
@@ -3184,10 +3190,10 @@ fn build_server_config(
         }))
       }
       Err(e) => {
-        log::warn!(
-          "TLSWrap: failed to build client cert verifier, falling back to no client auth: {e}"
+        log::debug!(
+          "TLSWrap: failed to build client cert verifier: {e}"
         );
-        builder.with_no_client_auth()
+        return None;
       }
     }
   } else {

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -32,7 +32,6 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use deno_core::v8_static_strings;
 use deno_core::CppgcInherits;
 use deno_core::GarbageCollected;
 use deno_core::OpState;
@@ -45,6 +44,7 @@ use deno_core::uv_compat::uv_buf_t;
 use deno_core::uv_compat::uv_stream_t;
 use deno_core::uv_compat::uv_write_t;
 use deno_core::v8;
+use deno_core::v8_static_strings;
 use deno_node_crypto::x509::Certificate;
 use deno_node_crypto::x509::CertificateObject;
 use deno_tls::rustls;
@@ -3167,9 +3167,7 @@ fn build_server_config(
               }
             }
             Err(e) => {
-              log::debug!(
-                "TLSWrap: failed to parse client CA PEM entry: {e}"
-              );
+              log::debug!("TLSWrap: failed to parse client CA PEM entry: {e}");
             }
           }
         }
@@ -3190,9 +3188,7 @@ fn build_server_config(
         }))
       }
       Err(e) => {
-        log::debug!(
-          "TLSWrap: failed to build client cert verifier: {e}"
-        );
+        log::debug!("TLSWrap: failed to build client cert verifier: {e}");
         return None;
       }
     }

--- a/ext/node/ops/tls_wrap.rs
+++ b/ext/node/ops/tls_wrap.rs
@@ -2995,6 +2995,94 @@ fn build_client_config(
   Some(config)
 }
 
+/// A `ClientCertVerifier` for `node:tls` servers that wraps
+/// `WebPkiClientVerifier` with two pieces of extra leniency to match the
+/// OpenSSL-backed Node behaviour:
+///
+///  * `rejectUnauthorized: false` → verify_client_cert always returns Ok,
+///    so the TLS handshake succeeds regardless of chain validity and JS
+///    code can inspect the peer via `getPeerCertificate()` /
+///    `TLSSocket.authorized`.
+///  * Self-signed client certs used as their own CA (i.e. the cert DER is
+///    also in the trusted `ca` list) are accepted — rustls/webpki rejects
+///    these with `CaUsedAsEndEntity`, but OpenSSL/Node trusts them if
+///    they're in the configured `ca`. Mirrors `NodeServerCertVerifier`'s
+///    handling of the same case on the client side.
+#[derive(Debug)]
+struct NodeClientCertVerifier {
+  inner: Arc<dyn rustls::server::danger::ClientCertVerifier>,
+  root_cert_ders: Vec<Vec<u8>>,
+  reject_unauthorized: bool,
+}
+
+impl rustls::server::danger::ClientCertVerifier for NodeClientCertVerifier {
+  fn offer_client_auth(&self) -> bool {
+    true
+  }
+
+  fn client_auth_mandatory(&self) -> bool {
+    self.reject_unauthorized
+  }
+
+  fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+    self.inner.root_hint_subjects()
+  }
+
+  fn verify_client_cert(
+    &self,
+    end_entity: &rustls::pki_types::CertificateDer<'_>,
+    intermediates: &[rustls::pki_types::CertificateDer<'_>],
+    now: rustls::pki_types::UnixTime,
+  ) -> Result<rustls::server::danger::ClientCertVerified, rustls::Error> {
+    // Fast path: if the presented client cert is byte-identical to one of
+    // the trusted CA DERs, accept it even when webpki would say
+    // `CaUsedAsEndEntity`.
+    let ee_bytes: &[u8] = end_entity.as_ref();
+    if self.root_cert_ders.iter().any(|r| r.as_slice() == ee_bytes) {
+      return Ok(rustls::server::danger::ClientCertVerified::assertion());
+    }
+    match self
+      .inner
+      .verify_client_cert(end_entity, intermediates, now)
+    {
+      Ok(v) => Ok(v),
+      Err(e) => {
+        if self.reject_unauthorized {
+          Err(e)
+        } else {
+          // `rejectUnauthorized: false` — succeed the handshake and let the
+          // JS layer decide via `TLSSocket.authorized` / `authorizationError`.
+          Ok(rustls::server::danger::ClientCertVerified::assertion())
+        }
+      }
+    }
+  }
+
+  fn verify_tls12_signature(
+    &self,
+    message: &[u8],
+    cert: &rustls::pki_types::CertificateDer<'_>,
+    dss: &rustls::DigitallySignedStruct,
+  ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+  {
+    self.inner.verify_tls12_signature(message, cert, dss)
+  }
+
+  fn verify_tls13_signature(
+    &self,
+    message: &[u8],
+    cert: &rustls::pki_types::CertificateDer<'_>,
+    dss: &rustls::DigitallySignedStruct,
+  ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+  {
+    self.inner.verify_tls13_signature(message, cert, dss)
+  }
+
+  fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+    self.inner.supported_verify_schemes()
+  }
+}
+
 /// Build a rustls ServerConfig from a SecureContext JS object.
 fn build_server_config(
   scope: &mut v8::PinScope,
@@ -3032,10 +3120,81 @@ fn build_server_config(
   .ok()
   .flatten()?;
 
-  rustls::ServerConfig::builder_with_protocol_versions(protocol_versions)
-    .with_no_client_auth()
-    .with_single_cert(certs, private_key)
-    .ok()
+  let request_cert = get_js_bool(scope, context, "requestCert", false);
+  let reject_unauthorized =
+    get_js_bool(scope, context, "rejectUnauthorized", true);
+
+  let builder =
+    rustls::ServerConfig::builder_with_protocol_versions(protocol_versions);
+
+  // When `requestCert` is true, the server sends a CertificateRequest during
+  // the TLS handshake so the client presents its certificate. Without this
+  // the peer certificate is never available to `getPeerCertificate()`.
+  let builder = if request_cert {
+    let mut root_cert_store = rustls::RootCertStore::empty();
+    let mut root_cert_ders: Vec<Vec<u8>> = Vec::new();
+    let ca_key = v8::String::new(scope, "ca").unwrap();
+    if let Some(ca_val) = context.get(scope, ca_key.into()) {
+      let mut ca_pems: Vec<Vec<u8>> = Vec::new();
+      if let Ok(arr) = v8::Local::<v8::Array>::try_from(ca_val) {
+        for i in 0..arr.length() {
+          if let Some(v) = arr.get_index(scope, i)
+            && let Some(s) = v.to_string(scope)
+          {
+            ca_pems.push(s.to_rust_string_lossy(scope).into_bytes());
+          }
+        }
+      } else if !ca_val.is_undefined()
+        && !ca_val.is_null()
+        && let Some(s) = ca_val.to_string(scope)
+      {
+        ca_pems.push(s.to_rust_string_lossy(scope).into_bytes());
+      }
+      for pem in &ca_pems {
+        let reader = &mut std::io::BufReader::new(std::io::Cursor::new(pem));
+        for parsed in rustls_pemfile::certs(reader) {
+          match parsed {
+            Ok(cert) => {
+              root_cert_ders.push(cert.as_ref().to_vec());
+              if let Err(e) = root_cert_store.add(cert) {
+                log::warn!(
+                  "TLSWrap: ignoring invalid client CA certificate: {e}"
+                );
+              }
+            }
+            Err(e) => {
+              log::warn!("TLSWrap: failed to parse client CA PEM entry: {e}");
+            }
+          }
+        }
+      }
+    }
+
+    let mut verifier_builder =
+      rustls::server::WebPkiClientVerifier::builder(Arc::new(root_cert_store));
+    if !reject_unauthorized {
+      verifier_builder = verifier_builder.allow_unauthenticated();
+    }
+    match verifier_builder.build() {
+      Ok(inner) => {
+        builder.with_client_cert_verifier(Arc::new(NodeClientCertVerifier {
+          inner,
+          root_cert_ders,
+          reject_unauthorized,
+        }))
+      }
+      Err(e) => {
+        log::warn!(
+          "TLSWrap: failed to build client cert verifier, falling back to no client auth: {e}"
+        );
+        builder.with_no_client_auth()
+      }
+    }
+  } else {
+    builder.with_no_client_auth()
+  };
+
+  builder.with_single_cert(certs, private_key).ok()
 }
 
 #[cfg(test)]

--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -331,6 +331,7 @@ TLSSocket.prototype._wrapHandle = function (wrap, handle) {
   const secureContext = {
     ...(context?.context ?? context),
     rejectUnauthorized: options.rejectUnauthorized !== false,
+    requestCert: options.requestCert === true,
   };
 
   // Get the native TCP handle for attachment

--- a/tests/specs/node/https_server_get_peer_certificate/__test__.jsonc
+++ b/tests/specs/node/https_server_get_peer_certificate/__test__.jsonc
@@ -1,0 +1,4 @@
+{
+  "args": "run -A main.ts",
+  "output": "main.out"
+}

--- a/tests/specs/node/https_server_get_peer_certificate/main.out
+++ b/tests/specs/node/https_server_get_peer_certificate/main.out
@@ -1,0 +1,5 @@
+authorized: true
+peer has subject: true
+peer has issuer: true
+peer has fingerprint: true
+status: 200

--- a/tests/specs/node/https_server_get_peer_certificate/main.ts
+++ b/tests/specs/node/https_server_get_peer_certificate/main.ts
@@ -1,0 +1,68 @@
+// Regression test for https://github.com/denoland/deno/issues/33367
+// `https.createServer({ requestCert: true, ca, ... })` must actually ask the
+// client for a certificate during the TLS handshake and surface it via
+// `req.socket.getPeerCertificate()`. Previously the rustls ServerConfig was
+// built with `with_no_client_auth()` unconditionally, so no CertificateRequest
+// was sent and the peer certificate came back as `{}`.
+
+import * as https from "node:https";
+import { readFileSync } from "node:fs";
+
+const localhostCert = readFileSync(
+  new URL("../../../testdata/tls/localhost.crt", import.meta.url),
+);
+const localhostKey = readFileSync(
+  new URL("../../../testdata/tls/localhost.key", import.meta.url),
+);
+const rootCa = readFileSync(
+  new URL("../../../testdata/tls/RootCA.pem", import.meta.url),
+);
+
+const server = https.createServer(
+  {
+    key: localhostKey,
+    cert: localhostCert,
+    requestCert: true,
+    ca: [rootCa],
+  },
+  (req, res) => {
+    // deno-lint-ignore no-explicit-any
+    const socket = req.socket as any;
+    const peer = socket.getPeerCertificate();
+    // deno-lint-ignore no-explicit-any
+    console.log("authorized:", (req as any).client?.authorized);
+    console.log("peer has subject:", !!peer && !!peer.subject);
+    console.log("peer has issuer:", !!peer && !!peer.issuer);
+    console.log("peer has fingerprint:", !!peer && !!peer.fingerprint);
+    res.writeHead(200);
+    res.end("ok");
+    server.close();
+  },
+);
+
+await new Promise<void>((resolve) => server.listen(0, resolve));
+// deno-lint-ignore no-explicit-any
+const port = (server.address() as any).port;
+
+const status = await new Promise<number>((resolve, reject) => {
+  const req = https.request(
+    {
+      hostname: "localhost",
+      port,
+      method: "GET",
+      path: "/",
+      cert: localhostCert,
+      key: localhostKey,
+      ca: rootCa,
+      rejectUnauthorized: false,
+    },
+    (res) => {
+      res.resume();
+      res.on("end", () => resolve(res.statusCode ?? 0));
+    },
+  );
+  req.on("error", reject);
+  req.end();
+});
+
+console.log("status:", status);


### PR DESCRIPTION
## Summary

- `node:https`/`node:tls` servers built the rustls `ServerConfig` via `.with_no_client_auth()` unconditionally (`ext/node/ops/tls_wrap.rs` — the old `build_server_config`), so `requestCert`, `ca`, and `rejectUnauthorized` from the JS options never reached the handshake. No `CertificateRequest` was ever sent, and `req.socket.getPeerCertificate()` therefore returned `{}` even when `TLSSocket.authorized` reported `true` (since `verifyError()` was vacuously null in the no-client-auth world).
- Pipe `requestCert` through the SecureContext alongside the existing `rejectUnauthorized` in `ext/node/polyfills/_tls_wrap.js`.
- In `build_server_config`, when `requestCert === true`, parse the `ca` PEMs into a `RootCertStore` (keeping the raw DER bytes on the side) and install a new `NodeClientCertVerifier` wrapping rustls's `WebPkiClientVerifier`. The wrapper mirrors the OpenSSL-flavour leniency `NodeServerCertVerifier` already applies on the client side:
  - `CaUsedAsEndEntity`: accept the cert early when its DER matches one of the trusted CA DERs (self-signed cert used as its own CA — Node/OpenSSL accepts this; plain webpki rejects).
  - `rejectUnauthorized: false`: turn chain errors into handshake successes so JS code can still read the peer via `getPeerCertificate()` and decide via `TLSSocket.authorized` / `authorizationError`.

Fixes #33367.

## Behavior

The repro from the issue now works end-to-end — server prints the peer's `subject`, `issuer`, and `fingerprint`, and `authorized: true` now reflects a real handshake rather than "nothing was checked."

Before:
```
authorized: true
peer cert: {}
status: 200
```

After:
```
authorized: true
peer subject: { CN: "localhost" }
peer has issuer: true
peer has fingerprint: true
status: 200
```

## Test plan

- [x] Added spec test `tests/specs/node/https_server_get_peer_certificate` (uses the existing `tests/testdata/tls/{localhost.crt,localhost.key,RootCA.pem}` fixtures, exercises the full handshake including a live HTTPS client and asserts the peer certificate is populated).
- [x] Manual end-to-end rerun of the issue reporter's original PoC (self-signed cert as its own CA): previously hung at `peer cert: {}`, now surfaces `authorized: true` with populated fields.
- [x] `./x fmt` clean.
- [x] `./x lint` clean (full Rust + JS).