### PR TITLE
fix: drop config-only unstable features from unstable_args()

### DIFF
--- a/cli/args/mod.rs
+++ b/cli/args/mod.rs
@@ -1359,11 +1359,21 @@ impl CliOptions {
   }
 
   /// Returns unstable feature flags as CLI arguments (e.g., "--unstable-unsafe-proto").
-  /// This includes features from both CLI flags and config file.
+  /// This includes features from both CLI flags and config file. Features that
+  /// are only valid in `deno.json` (e.g. `fmt-component`, `fmt-sql`) and don't
+  /// have a registered CLI flag are filtered out, otherwise child processes
+  /// spawned with these args (e.g. via `deno x`) would reject them with
+  /// "unexpected argument".
   pub fn unstable_args(&self) -> Vec<String> {
+    let cli_flag_names: std::collections::HashSet<&str> =
+      deno_runtime::UNSTABLE_FEATURES
+        .iter()
+        .map(|f| f.name)
+        .collect();
     self
       .unstable_features()
       .into_iter()
+      .filter(|f| cli_flag_names.contains(*f))
       .map(|f| format!("--unstable-{}", f))
       .collect()
   }

--- a/tests/specs/x/unstable_config_only_features/__test__.jsonc
+++ b/tests/specs/x/unstable_config_only_features/__test__.jsonc
@@ -1,0 +1,11 @@
+{
+  "tempDir": true,
+  // Regression test for https://github.com/denoland/deno/issues/33115
+  // Config-file-only unstable features (here `fmt-component`) must not be
+  // forwarded to the spawned `deno run` invocation as `--unstable-*` flags;
+  // doing so previously errored with "unexpected argument
+  // '--unstable-fmt-component'".
+  "cwd": "./config_only",
+  "args": "x -y jsr:@denotest/bin-package one two",
+  "output": "ok.out"
+}

--- a/tests/specs/x/unstable_config_only_features/config_only/deno.json
+++ b/tests/specs/x/unstable_config_only_features/config_only/deno.json
@@ -1,0 +1,3 @@
+{
+  "unstable": ["fmt-component"]
+}

--- a/tests/specs/x/unstable_config_only_features/ok.out
+++ b/tests/specs/x/unstable_config_only_features/ok.out
@@ -1,0 +1,2 @@
+[WILDCARD]one
+two


### PR DESCRIPTION
## Summary

`CliOptions::unstable_args()` (`cli/args/mod.rs:1363`) formatted every entry from `unstable_features()` as `--unstable-{name}`. But the set of valid `unstable` config entries is wider than the set of registered CLI flags — `fmt-component`, `fmt-sql`, and `npm-lazy-caching` are explicitly tolerated as config-only entries (`cli/args/mod.rs:1342`), and `fmt-component` / `fmt-sql` have no corresponding `--unstable-*` arg on `deno run`.

`deno x` then forwarded those bogus flags into the spawned `deno run` subprocess (`cli/tools/x.rs:153, 539, 546`), which clap rejected:

```
error: unexpected argument '--unstable-fmt-component' found
  tip: a similar argument exists: '--unstable-cron'
Usage: deno run [OPTIONS] [SCRIPT_ARG]...
```

That broke `deno x` for any project whose `deno.json` had `"unstable": ["fmt-component"]` (or `fmt-sql`) — including the issue reporter's `deno x shadcn-svelte@latest init` command.

Filter `unstable_args()` against the actual CLI flag set from `deno_runtime::UNSTABLE_FEATURES`. Config-only features still apply normally — the child process loads the same `deno.json` and turns them on from there — they just don't need to be re-emitted as flags.

Fixes #33115.

## Repro (before)

```sh
$ mkdir /tmp/r && cd /tmp/r
$ echo '{ "unstable": ["fmt-component"] }' > deno.json
$ deno x -y npm:cowsay hi
error: unexpected argument '--unstable-fmt-component' found
  ...
```

After this PR, the same command runs cowsay normally.

## Test plan

- [x] Added `tests/specs/x/unstable_config_only_features` — runs `deno x` against `jsr:@denotest/bin-package` from a directory whose `deno.json` declares `"unstable": ["fmt-component"]`. Fails with the original `unexpected argument` error before this change; passes after.
- [x] Existing `tests/specs/x/unstable_flags` tests (which exercise `--unstable-unsafe-proto` from CLI, from the env, and from `deno.json`) continue to pass.
- [x] Manually reran the user-reported repro shape (`deno.json` with `fmt-component` + `deno x npm:cowsay hi`).
- [x] `./x fmt` clean.
- [x] `./x lint` clean (full Rust + JS).