### PR TITLE
test: ignore parallel/test-crypto-fips.js

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -401,6 +401,10 @@
     "parallel/test-crypto-domains.js": {},
     "parallel/test-crypto-ecdh-convert-key.js": {},
     "parallel/test-crypto-ecb.js": {},
+    "parallel/test-crypto-fips.js": {
+      "ignore": true,
+      "reason": "Tests Node's FIPS mode (--enable-fips/--force-fips, OPENSSL_CONF, --openssl-config CLI flags) and uses internalBinding('crypto').testFipsCrypto via require('internal/test/binding'); FIPS is an OpenSSL-specific feature and Deno does not embed OpenSSL"
+    },
     "parallel/test-crypto-from-binary.js": {},
     "parallel/test-crypto-getcipherinfo.js": {},
     "parallel/test-crypto-hmac.js": {},


### PR DESCRIPTION
## Summary

Marks `parallel/test-crypto-fips.js` as ignored in `tests/node_compat/config.jsonc`. The test cannot reasonably run in Deno because:

- it is run with `--expose-internals` and imports `internal/test/binding` to call `internalBinding('crypto').testFipsCrypto` — a Node-internal hook into OpenSSL,
- the entire test exercises Node's FIPS mode (`--enable-fips`, `--force-fips`, `--openssl-config=…`, `OPENSSL_CONF=…`), all of which are OpenSSL-specific Node CLI flags / env vars,
- Deno does not embed OpenSSL, and `crypto.setFips()` already throws `Error: FIPS mode is not supported in Deno.`

## Failure on `main`

From the [2026-04-24 node compat run](https://node-test-viewer.deno.dev/results/2026-04-24):

```
error: Uncaught (in promise) TypeError: testFipsCrypto is not a function
```

(The test fails at the top-level `internalBinding('crypto').testFipsCrypto` lookup; even if the binding existed, every subsequent assertion would still fail because Deno cannot toggle FIPS mode at all.)

## Could this ever be revisited?

Only if Deno gains an OpenSSL-backed FIPS implementation, which is not a planned direction — the underlying primitives in `ext/crypto` and `ext/node/ops/crypto/` use Rust crates (`ring`, `rsa`, `ecdsa`, `aes-gcm`, …) rather than OpenSSL, so the `testFipsCrypto` semantics this test depends on cannot be expressed. Treat this ignore as effectively permanent.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); entry placed alphabetically between `test-crypto-ecb.js` and `test-crypto-from-binary.js`.
- [ ] CI: green on `node_compat_tests` with the test now skipped.