### PR TITLE
test: ignore 2 unsupportable crypto tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -401,10 +401,6 @@
     "parallel/test-crypto-domains.js": {},
     "parallel/test-crypto-ecdh-convert-key.js": {},
     "parallel/test-crypto-ecb.js": {},
-    "parallel/test-crypto-encap-decap.js": {
-      "ignore": true,
-      "reason": "Tests crypto.encapsulate / crypto.decapsulate (Node 24+ KEM API, requires OpenSSL >= 3 for RSASVE and OpenSSL >= 3.2 for DHKEM); Deno does not implement these APIs. Could be revisited if a KEM implementation lands in ext/node/ops/crypto/"
-    },
     "parallel/test-crypto-from-binary.js": {},
     "parallel/test-crypto-getcipherinfo.js": {},
     "parallel/test-crypto-hmac.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2708,6 +2708,10 @@
     // "parallel/test-warn-sigprof.js": {},
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
+    "parallel/test-webcrypto-keygen-kmac.js": {
+      "ignore": true,
+      "reason": "Tests SubtleCrypto generateKey for KMAC128 / KMAC256, a Node-specific WebCrypto extension that requires OpenSSL >= 3 (test gates on hasOpenSSL(3)); Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm. Could be revisited if KMAC is added — a SHA-3-based KMAC is implementable via the sha3 / cshake Rust crates"
+    },
     "parallel/test-webcrypto-util.js": {
       "ignore": true,
       "reason": "Runs with --expose-internals and requires Node's internal/crypto/util JS module to whitebox-test the internal normalizeAlgorithm() helper; Deno's WebCrypto is implemented in Rust (ext/crypto/) and does not expose this Node-internal module"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2704,6 +2704,10 @@
     // "parallel/test-warn-sigprof.js": {},
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
+    "parallel/test-webcrypto-util.js": {
+      "ignore": true,
+      "reason": "Runs with --expose-internals and requires Node's internal/crypto/util JS module to whitebox-test the internal normalizeAlgorithm() helper; Deno's WebCrypto is implemented in Rust (ext/crypto/) and does not expose this Node-internal module"
+    },
     "parallel/test-websocket.js": {},
     "parallel/test-webstream-string-tag.js": {},
     "parallel/test-webstreams-compose.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -401,6 +401,10 @@
     "parallel/test-crypto-domains.js": {},
     "parallel/test-crypto-ecdh-convert-key.js": {},
     "parallel/test-crypto-ecb.js": {},
+    "parallel/test-crypto-encap-decap.js": {
+      "ignore": true,
+      "reason": "Tests crypto.encapsulate / crypto.decapsulate (Node 24+ KEM API, requires OpenSSL >= 3 for RSASVE and OpenSSL >= 3.2 for DHKEM); Deno does not implement these APIs. Could be revisited if a KEM implementation lands in ext/node/ops/crypto/"
+    },
     "parallel/test-crypto-from-binary.js": {},
     "parallel/test-crypto-getcipherinfo.js": {},
     "parallel/test-crypto-hmac.js": {},


### PR DESCRIPTION
## Summary

Marks two failing crypto tests as ignored in `tests/node_compat/config.jsonc`. Each one depends on either Node-internal JS modules or a Node-specific WebCrypto extension that Deno does not yet implement. Failure outputs come from the [2026-04-24 node compat run](https://node-test-viewer.deno.dev/results/2026-04-24); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

> Originally this PR also ignored `parallel/test-crypto-encap-decap.js` (Node 24+ KEM API). On reflection that one is implementable on top of pure-Rust crates (`rsa` for RSASVE, `p256`/`p384`/`p521`/`x25519-dalek` + `hkdf` for DHKEM, `ml-kem` for ML-KEM) and shouldn't be ignored — that commit has been reverted. It will be tackled as a fix in a separate PR.

### `parallel/test-webcrypto-util.js`

Runs with `--expose-internals` and exists solely to whitebox-test the `normalizeAlgorithm()` helper imported from `internal/crypto/util`:

```
error: Uncaught (in promise) TypeError: normalizeAlgorithm is not a function
  assert.strictEqual(normalizeAlgorithm(algorithm, 'sign') !== algorithm, true);
```

Deno's WebCrypto is in Rust under `ext/crypto/` and has no equivalent JS module. **Effectively permanent ignore.**

### `parallel/test-webcrypto-keygen-kmac.js`

Tests `subtle.generateKey({ name: 'KMAC128' | 'KMAC256' })`, a Node-specific WebCrypto extension that gates on `hasOpenSSL(3)`. Deno does not register KMAC as a recognised SubtleCrypto algorithm:

```
error: Uncaught (in promise) NotSupportedError: Unrecognized algorithm name
  const key = await subtle.generateKey({
                            ^
```

**Could be revisited** if KMAC is added to `ext/crypto/` — SHA-3-based KMAC is implementable in pure Rust via the existing sha3 / cshake crates.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); both new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the two tests now skipped.
