### PR TITLE
fix(ext/web): narrow ReadableStreamBYOBRequest.view to Uint8Array

### DIFF
--- a/cli/tsc/dts/lib.deno_web.d.ts
+++ b/cli/tsc/dts/lib.deno_web.d.ts
@@ -820,7 +820,7 @@ declare var ReadableStreamBYOBReader: {
 
 /** @category Streams */
 interface ReadableStreamBYOBRequest {
-  readonly view: ArrayBufferView | null;
+  readonly view: Uint8Array<ArrayBuffer> | null;
   respond(bytesWritten: number): void;
   respondWithNewView(view: ArrayBufferView): void;
 }

--- a/ext/web/06_streams.js
+++ b/ext/web/06_streams.js
@@ -5804,10 +5804,10 @@ const ReadableStreamBYOBReaderPrototype = ReadableStreamBYOBReader.prototype;
 class ReadableStreamBYOBRequest {
   /** @type {ReadableByteStreamController} */
   [_controller];
-  /** @type {ArrayBufferView | null} */
+  /** @type {Uint8Array<ArrayBuffer> | null} */
   [_view];
 
-  /** @returns {ArrayBufferView | null} */
+  /** @returns {Uint8Array<ArrayBuffer> | null} */
   get view() {
     webidl.assertBranded(this, ReadableStreamBYOBRequestPrototype);
     return this[_view];

--- a/tests/unit/streams_test.ts
+++ b/tests/unit/streams_test.ts
@@ -755,3 +755,32 @@ Deno.test(async function readableStreamEmittingManyChunks() {
 
   assertEquals((await child.status).code, 0, "memory leak");
 });
+
+// Regression test for https://github.com/denoland/deno/issues/33476
+// `ReadableStreamBYOBRequest.view` is always constructed as a Uint8Array
+// (matching whatwg/streams#1367), so its type should be narrowed from
+// `ArrayBufferView | null` to `Uint8Array<ArrayBuffer> | null`. The runtime
+// check verifies the actual value, and the variable annotation acts as a
+// compile-time check via `deno check`.
+Deno.test("ReadableStreamBYOBRequest.view is a Uint8Array", async () => {
+  let viewIsUint8Array = false;
+  const stream = new ReadableStream({
+    type: "bytes",
+    pull(controller) {
+      const byobReq = controller.byobRequest;
+      if (byobReq === null) return;
+      // Compile-time type check: this assignment must succeed against the
+      // narrowed signature.
+      const view: Uint8Array<ArrayBuffer> | null = byobReq.view;
+      viewIsUint8Array = view instanceof Uint8Array;
+      view![0] = 42;
+      byobReq.respond(1);
+    },
+  });
+  const reader = stream.getReader({ mode: "byob" });
+  const result = await reader.read(new Uint8Array(8));
+  reader.releaseLock();
+  assertEquals(viewIsUint8Array, true);
+  assertEquals(result.value!.byteLength, 1);
+  assertEquals(result.value![0], 42);
+});


### PR DESCRIPTION
## Summary

Per the spec change at [whatwg/streams#1367](https://github.com/whatwg/streams/pull/1367), `ReadableStreamBYOBRequest.view` is always a `Uint8Array` — the BYOB controller already constructs it that way internally. Narrow the public type from `ArrayBufferView | null` to `Uint8Array<ArrayBuffer> | null`:

- `cli/tsc/dts/lib.deno_web.d.ts` — the user-facing TypeScript declaration.
- `ext/web/06_streams.js` — JSDoc on both the internal `[_view]` slot and the `view` getter.

Before this PR, code like `const v: Uint8Array = req.view!` failed type-checking with TS2740 against `ArrayBufferView<ArrayBufferLike>`. After, it compiles and rejects assignment to incompatible views (e.g. `DataView`) with a meaningful TS2322.

Fixes #33476.

## Test plan

- [x] Added a unit test in `tests/unit/streams_test.ts` (`ReadableStreamBYOBRequest.view is a Uint8Array`) that:
  - includes a `const view: Uint8Array<ArrayBuffer> | null = byobReq.view;` assignment that compile-fails without the fix and compiles with it,
  - verifies at runtime that the value is an `instanceof Uint8Array` and that writes through it round-trip back to the BYOB reader.
- [x] `./x build` clean; `./x fmt` clean; `./x lint` clean.