### PR TITLE
fix(ext/webidl): set ERR_INVALID_THIS code on brand-check failure

### DIFF
--- a/ext/webidl/00_webidl.js
+++ b/ext/webidl/00_webidl.js
@@ -1131,7 +1131,13 @@ function assertBranded(self, prototype) {
   if (
     !ObjectPrototypeIsPrototypeOf(prototype, self) || self[brand] !== brand
   ) {
-    throw new TypeError("Illegal invocation");
+    const err = new TypeError("Illegal invocation");
+    // Match Node's convention of attaching `code: 'ERR_INVALID_THIS'` to
+    // brand-check failures, so callers using node:crypto and other Node
+    // APIs that re-expose Web Platform classes can detect the error the
+    // same way.
+    err.code = "ERR_INVALID_THIS";
+    throw err;
   }
 }
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -2761,6 +2761,7 @@
     // "parallel/test-warn-sigprof.js": {},
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
+    "parallel/test-webcrypto-getRandomValues.js": {},
     "parallel/test-webcrypto-random.js": {},
     "parallel/test-webcrypto-keygen-kmac.js": {
       "ignore": true,


### PR DESCRIPTION
## Summary

Sets `err.code = 'ERR_INVALID_THIS'` on the `TypeError` that `webidl.assertBranded` throws when a Web Platform method is invoked with an unbranded receiver (e.g. `const { getRandomValues } = globalThis.crypto; getRandomValues(...)`). The `code` is what Node attaches in the same situation, so any `node:crypto` consumer asserting `{ code: 'ERR_INVALID_THIS' }` now passes.

The change is purely additive -- the error remains a `TypeError` with the same `Illegal invocation` message; only the `.code` is new. Same path applies for any Web Platform brand-check failure, matching Node's convention for "wrong this".

## Failure on `main`

From the [2026-04-24 node compat run](https://node-test-viewer.deno.dev/results/2026-04-24):

```
error: Uncaught (in promise) AssertionError: Expected values to be strictly deep-equal:
  Comparison {
+   ...empty...
-   code: 'ERR_INVALID_THIS'
  }

assert.throws(() => getRandomValues(new Uint8Array()), { code: 'ERR_INVALID_THIS' });
```

(`getRandomValues` was throwing a `TypeError("Illegal invocation")` correctly but without the `.code` property, so `assert.throws` collected an empty `Comparison {}`.)

## Test plan

- [x] `tests/node_compat/runner/suite/test/parallel/test-webcrypto-getRandomValues.js` passes locally; enrolled in `tests/node_compat/config.jsonc`.
- [x] No regression in neighboring crypto tests (`test-webcrypto-encrypt-decrypt`, `test-webcrypto-random`, `test-crypto-from-binary`, `test-crypto-classes`, `test-crypto-keygen`, `test-crypto-padding`).
- [x] `./tools/format.js` clean.
- [ ] CI green.
