### PR TITLE
fix(ext/web): allow transferring non-serializable types in structuredClone

### DIFF
--- a/ext/web/13_message_port.js
+++ b/ext/web/13_message_port.js
@@ -565,8 +565,11 @@ function structuredClone(value, options) {
   // still silently serialize as {} because V8's ValueSerializer doesn't
   // know about Web API platform types. Fixing this fully requires a
   // custom V8 serializer delegate in C++/Rust.
+  // Skip the check when the value itself is in the transfer list, since
+  // transferring is not the same as serializing.
   if (
-    value !== null && typeof value === "object" && value[kNotSerializable]
+    value !== null && typeof value === "object" && value[kNotSerializable] &&
+    !ArrayPrototypeIncludes(options.transfer, value)
   ) {
     throw new DOMException(
       "Cannot clone object of unsupported type.",

--- a/tests/wpt/runner/expectations/html.json
+++ b/tests/wpt/runner/expectations/html.json
@@ -994,7 +994,6 @@
           "An object whose interface is deleted from the global must still deserialize",
           "A subclass instance will deserialize as its closest serializable superclass",
           "Growable SharedArrayBuffer",
-          "A subclass instance will be received as its closest transferable superclass",
           "Transferring OOB TypedArray throws"
         ]
       },
@@ -1023,7 +1022,6 @@
           "An object whose interface is deleted from the global must still deserialize",
           "A subclass instance will deserialize as its closest serializable superclass",
           "Growable SharedArrayBuffer",
-          "A subclass instance will be received as its closest transferable superclass",
           "Transferring OOB TypedArray throws"
         ]
       },

--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -267,7 +267,7 @@ Options:
     const iter = pooledMap(cores, partitionedTests, async (tests) => {
       for (const test of tests) {
         if (!inParallel) {
-          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}`);
+          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
         }
         let result = await runSingleTest(
           test.url,
@@ -319,7 +319,7 @@ Options:
         }
         results.push({ test, result });
         if (inParallel) {
-          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}`);
+          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
         }
         reportVariation(result, test.expectation);
       }
@@ -522,7 +522,7 @@ Options:
     const results = [];
 
     for (const test of tests) {
-      console.log(`${blue("-".repeat(40))}\n${bold(test.path)}`);
+      console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
       const result = await runSingleTest(
         test.url,
         test.options,

--- a/tests/wpt/wpt.ts
+++ b/tests/wpt/wpt.ts
@@ -267,7 +267,7 @@ Options:
     const iter = pooledMap(cores, partitionedTests, async (tests) => {
       for (const test of tests) {
         if (!inParallel) {
-          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
+          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}`);
         }
         let result = await runSingleTest(
           test.url,
@@ -319,7 +319,7 @@ Options:
         }
         results.push({ test, result });
         if (inParallel) {
-          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
+          console.log(`${blue("-".repeat(40))}\n${bold(test.path)}`);
         }
         reportVariation(result, test.expectation);
       }
@@ -522,7 +522,7 @@ Options:
     const results = [];
 
     for (const test of tests) {
-      console.log(`${blue("-".repeat(40))}\n${bold(test.path)}\n`);
+      console.log(`${blue("-".repeat(40))}\n${bold(test.path)}`);
       const result = await runSingleTest(
         test.url,
         test.options,


### PR DESCRIPTION
## Summary

Fixes a regression from #33465 where `structuredClone(value, { transfer: [value] })` threw `DataCloneError` for `ReadableStream`, `WritableStream`, and `TransformStream`. The `kNotSerializable` check was firing even when the value was being **transferred**, not cloned.

The fix skips the check when the value is present in the transfer list.

## Test plan

- `./x test-compat test-webstream-structured-clone-no-leftovers` -- now passes
- `./x test-spec structured_clone_non_serializable` -- still passes (cloning without transfer still throws)