### PR TITLE
fix(bundle): treat CSS same-document fragment URLs as external

### DIFF
--- a/cli/tools/bundle/mod.rs
+++ b/cli/tools/bundle/mod.rs
@@ -911,6 +911,26 @@ impl esbuild_client::PluginHandler for DenoPluginHandler {
       }));
     }
 
+    // Same-document fragment references in CSS — `url(#default#VML)`,
+    // `url(#gradient)` for SVG paint servers, etc. — are not file imports
+    // and must be left as-is in the output. Without this, `bundle_resolve`
+    // tries to resolve them as package import specifiers and fails (see
+    // denoland/deno#32232).
+    if matches!(
+      args.kind,
+      esbuild_client::protocol::ImportKind::UrlToken
+        | esbuild_client::protocol::ImportKind::ImportRule
+    ) && args.path.starts_with('#')
+    {
+      return Ok(Some(esbuild_client::OnResolveResult {
+        external: Some(true),
+        path: Some(args.path),
+        plugin_name: Some("deno".to_string()),
+        plugin_data: None,
+        ..Default::default()
+      }));
+    }
+
     let result = self.bundle_resolve(
       &args.path,
       args.importer.as_deref(),

--- a/tests/specs/bundle/fragment_url_css/__test__.jsonc
+++ b/tests/specs/bundle/fragment_url_css/__test__.jsonc
@@ -1,0 +1,8 @@
+{
+  "steps": [
+    {
+      "args": "bundle test.css",
+      "output": "bundle.out"
+    }
+  ]
+}

--- a/tests/specs/bundle/fragment_url_css/bundle.out
+++ b/tests/specs/bundle/fragment_url_css/bundle.out
@@ -1,0 +1,10 @@
+[WILDCARD]
+/* test.css */
+.vml {
+  behavior: url(#default#VML);
+}
+.icon {
+  filter: url(#blur);
+  fill: url(#gradient);
+  clip-path: url(#clip);
+}

--- a/tests/specs/bundle/fragment_url_css/test.css
+++ b/tests/specs/bundle/fragment_url_css/test.css
@@ -1,0 +1,8 @@
+.vml {
+  behavior: url(#default#VML);
+}
+.icon {
+  filter: url(#blur);
+  fill: url(#gradient);
+  clip-path: url(#clip);
+}


### PR DESCRIPTION
## Summary

`url(#default#VML)`, `url(#gradient)` (SVG paint servers), `url(#clip)` and friends are CSS local-document references — not imports. esbuild forwarded them through `on_resolve` with kind `url-token`/`import-rule`, and Deno's plugin tried to resolve `#…` as a package import specifier, which failed:

```
error: [ERR_PACKAGE_IMPORT_NOT_DEFINED] Package import specifier "#default#VML" is not defined in package /…/leaflet/1.9.4/package.json
    at file:///…/leaflet/1.9.4/dist/leaflet.css:124:11
```

This blocked anyone trying to `deno bundle` projects that pull in mainstream CSS — Leaflet was the issue's example, but the same shape lights up wherever a stylesheet uses SVG filters/gradients/clip-paths or the legacy `behavior: url(#default#VML)` IE shim.

Fix: in `DenoPluginHandler::on_resolve`, when the import kind is a CSS `url(...)` or `@import` and the path begins with `#`, mark the result as external and pass the URL through verbatim.

The PNG-loader errors mentioned in the same issue are a separate (esbuild-config) concern and aren't addressed here — they don't share a root cause.

Fixes #32232.

## Test plan

- [x] Added `tests/specs/bundle/fragment_url_css/` — bundles a stylesheet with `url(#default#VML)`, `url(#blur)`, `url(#gradient)`, `url(#clip)` and asserts the bundled output preserves them all.
- [x] Manually re-ran the issue's Leaflet repro: the `ERR_PACKAGE_IMPORT_NOT_DEFINED` for `#default#VML` is gone.
- [x] `./tools/format.js`, `cargo clippy --bin deno -- -D warnings`.