### PR TITLE
fix(ext/net): default Deno.listenDatagram hostname to 0.0.0.0

### DIFF
--- a/ext/net/01_net.js
+++ b/ext/net/01_net.js
@@ -660,7 +660,7 @@ function createListenDatagram(udpOpFn, unixOpFn) {
         const port = validatePort(args.port);
         const { 0: rid, 1: addr } = udpOpFn(
           {
-            hostname: args.hostname ?? "127.0.0.1",
+            hostname: args.hostname ?? "0.0.0.0",
             port,
           },
           args.reuseAddress ?? false,

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -1223,16 +1223,19 @@ Deno.test(
     const sender = Deno.listenDatagram({
       port: 4002,
       transport: "udp",
+      hostname: "127.0.0.1",
     });
     const listener1 = Deno.listenDatagram({
       port: 4000,
       transport: "udp",
       reuseAddress: true,
+      hostname: "127.0.0.1",
     });
     const listener2 = Deno.listenDatagram({
       port: 4000,
       transport: "udp",
       reuseAddress: true,
+      hostname: "127.0.0.1",
     });
 
     const sent = new Uint8Array([1, 2, 3]);

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -350,12 +350,20 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function netUdpSendReceive() {
-    const alice = Deno.listenDatagram({ port: listenPort, transport: "udp" });
+    const alice = Deno.listenDatagram({
+      port: listenPort,
+      transport: "udp",
+      hostname: "127.0.0.1",
+    });
     assert(alice.addr.transport === "udp");
     assertEquals(alice.addr.port, listenPort);
     assertEquals(alice.addr.hostname, "127.0.0.1");
 
-    const bob = Deno.listenDatagram({ port: listenPort2, transport: "udp" });
+    const bob = Deno.listenDatagram({
+      port: listenPort2,
+      transport: "udp",
+      hostname: "127.0.0.1",
+    });
     assert(bob.addr.transport === "udp");
     assertEquals(bob.addr.port, listenPort2);
     assertEquals(bob.addr.hostname, "127.0.0.1");
@@ -374,6 +382,21 @@ Deno.test(
     assertEquals(3, recvd[2]);
     alice.close();
     bob.close();
+  },
+);
+
+// Regression test for https://github.com/denoland/deno/issues/25581
+// `Deno.listenDatagram` with no `hostname` should bind to `0.0.0.0` (matching
+// the documented default and `Deno.listen`/`Deno.serve`), not `127.0.0.1`.
+// Binding to `127.0.0.1` made it impossible to send to a network broadcast
+// address such as `10.x.x.255` (the OS rejected the send with EINVAL/EFAULT).
+Deno.test(
+  { permissions: { net: true } },
+  function netUdpDefaultHostnameIsAnyAddress() {
+    const socket = Deno.listenDatagram({ port: 0, transport: "udp" });
+    assertEquals(socket.addr.transport, "udp");
+    assertEquals(socket.addr.hostname, "0.0.0.0");
+    socket.close();
   },
 );
 

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -640,7 +640,11 @@ Deno.test(
 Deno.test(
   { permissions: { net: true } },
   async function netUdpConcurrentSendReceive() {
-    const socket = Deno.listenDatagram({ port: listenPort, transport: "udp" });
+    const socket = Deno.listenDatagram({
+      port: listenPort,
+      transport: "udp",
+      hostname: "127.0.0.1",
+    });
     assert(socket.addr.transport === "udp");
     assertEquals(socket.addr.port, listenPort);
     assertEquals(socket.addr.hostname, "127.0.0.1");
@@ -667,6 +671,7 @@ Deno.test(
     const socket = Deno.listenDatagram({
       port: listenPort,
       transport: "udp",
+      hostname: "127.0.0.1",
     });
     // Panic happened on second send: BorrowMutError
     const a = socket.send(new Uint8Array(), socket.addr);

--- a/tests/unit/net_test.ts
+++ b/tests/unit/net_test.ts
@@ -394,7 +394,7 @@ Deno.test(
   { permissions: { net: true } },
   function netUdpDefaultHostnameIsAnyAddress() {
     const socket = Deno.listenDatagram({ port: 0, transport: "udp" });
-    assertEquals(socket.addr.transport, "udp");
+    assert(socket.addr.transport === "udp");
     assertEquals(socket.addr.hostname, "0.0.0.0");
     socket.close();
   },


### PR DESCRIPTION
## Summary

`Deno.listenDatagram` documents the default `hostname` as `0.0.0.0` (matching `Deno.listen`/`Deno.serve` for TCP), but the JS shim hard-coded `127.0.0.1`:

```js
// ext/net/01_net.js
hostname: args.hostname ?? "127.0.0.1",
```

Sending UDP to a network broadcast address (e.g. `10.x.x.255`) from a socket bound to `127.0.0.1` is rejected by the OS with `EINVAL`, so the omit-hostname form was unusable for broadcast — even though `net_listen_udp` in Rust already enables `SO_BROADCAST` on every listening UDP socket. The user's reported repro:

```ts
const server = Deno.listenDatagram({ port: 8080, transport: "udp" });
// hostname silently becomes 127.0.0.1
await server.send(new Uint8Array([0]), {
  hostname: "10.100.0.255",
  port: 8080,
  transport: "udp",
});
// → TypeError: Invalid argument (os error 22)
```

After the fix, the same code binds to `0.0.0.0` and the broadcast send succeeds, matching what the documentation has always promised.

Fixes #25581.

## Test plan

- [x] Added `netUdpDefaultHostnameIsAnyAddress` to `tests/unit/net_test.ts` asserting the implicit hostname is `0.0.0.0`.
- [x] Existing `netUdpSendReceive` updated to pass `hostname: "127.0.0.1"` explicitly so it stays a loopback test rather than implicitly tracking the default.
- [x] Manual repro from the issue (broadcast send to `10.x.x.255`) now succeeds.
- [x] `cargo clippy --bin deno -- -D warnings`, `./tools/format.js`.