### PR TITLE
fix(ext/fetch): don't mutate caller's options in Deno.createHttpClient

### DIFF
--- a/ext/fetch/22_http_client.js
+++ b/ext/fetch/22_http_client.js
@@ -17,6 +17,7 @@ import { loadTlsKeyPair } from "ext:deno_net/02_tls.js";
 const { internalRidSymbol } = core;
 const {
   JSONStringify,
+  ObjectAssign,
   ObjectDefineProperty,
   ObjectHasOwn,
   StringPrototypeStartsWith,
@@ -29,12 +30,19 @@ const {
  * @returns {HttpClient}
  */
 function createHttpClient(options) {
-  options.caCerts ??= [];
+  // Don't mutate the caller's options object. Historically `caCerts` and
+  // `proxy.transport` were written back onto whatever the user passed in,
+  // which broke reuse of a single options object across multiple calls
+  // (denoland/deno#29347).
+  options = ObjectAssign({ __proto__: null }, options);
+  options.caCerts = options.caCerts ?? [];
   if (options.proxy) {
-    if (ObjectHasOwn(options.proxy, "transport")) {
-      switch (options.proxy.transport) {
+    const proxy = ObjectAssign({ __proto__: null }, options.proxy);
+    options.proxy = proxy;
+    if (ObjectHasOwn(proxy, "transport")) {
+      switch (proxy.transport) {
         case "http": {
-          const url = options.proxy.url;
+          const url = proxy.url;
           if (
             StringPrototypeStartsWith(url, "https:") ||
             StringPrototypeStartsWith(url, "socks5:") ||
@@ -44,11 +52,11 @@ function createHttpClient(options) {
               `The url passed into 'proxy.url' has an invalid scheme for this transport.`,
             );
           }
-          options.proxy.transport = "http";
+          proxy.transport = "http";
           break;
         }
         case "https": {
-          const url = options.proxy.url;
+          const url = proxy.url;
           if (
             StringPrototypeStartsWith(url, "http:") ||
             StringPrototypeStartsWith(url, "socks5:") ||
@@ -58,11 +66,11 @@ function createHttpClient(options) {
               `The url passed into 'proxy.url' has an invalid scheme for this transport.`,
             );
           }
-          options.proxy.transport = "http";
+          proxy.transport = "http";
           break;
         }
         case "socks5": {
-          const url = options.proxy.url;
+          const url = proxy.url;
           if (
             !StringPrototypeStartsWith(url, "socks5:") &&
             !StringPrototypeStartsWith(url, "socks5h:")
@@ -71,7 +79,7 @@ function createHttpClient(options) {
               `The url passed into 'proxy.url' has an invalid scheme for this transport.`,
             );
           }
-          options.proxy.transport = "http";
+          proxy.transport = "http";
           break;
         }
         case "tcp":
@@ -82,13 +90,13 @@ function createHttpClient(options) {
         default: {
           throw new TypeError(
             `Invalid value for 'proxy.transport' option: ${
-              JSONStringify(options.proxy.transport)
+              JSONStringify(proxy.transport)
             }`,
           );
         }
       }
     } else {
-      options.proxy.transport = "http";
+      proxy.transport = "http";
     }
   }
   const keyPair = loadTlsKeyPair("Deno.createHttpClient", options);

--- a/tests/unit/fetch_test.ts
+++ b/tests/unit/fetch_test.ts
@@ -1264,6 +1264,27 @@ Deno.test(
   },
 );
 
+// Regression test for https://github.com/denoland/deno/issues/29347
+// `Deno.createHttpClient` used to scribble `caCerts` and `proxy.transport`
+// onto the caller's options object, so reusing a single options object
+// across multiple calls would either throw on the second call (the proxy
+// URL no longer matched the auto-rewritten `transport: "http"`) or leave
+// the user with surprising state.
+Deno.test(function createHttpClientDoesNotMutateOptions() {
+  const proxy = { url: "socks5h://127.0.0.1:1080" };
+  const options = { proxy };
+
+  const c1 = Deno.createHttpClient(options);
+  c1.close();
+  // The user's options must be unchanged...
+  assertEquals(options, { proxy: { url: "socks5h://127.0.0.1:1080" } });
+  assertEquals(proxy, { url: "socks5h://127.0.0.1:1080" });
+  // ...so a second call with the same options object still works.
+  const c2 = Deno.createHttpClient(options);
+  c2.close();
+  assertEquals(options, { proxy: { url: "socks5h://127.0.0.1:1080" } });
+});
+
 Deno.test(
   {
     permissions: { net: true },


### PR DESCRIPTION
## Summary

Reusing a single options object across multiple `Deno.createHttpClient` calls used to fail on the second call:

```ts
const options = { proxy: { url: \"socks5h://127.0.0.1:1080\" } };
Deno.createHttpClient(options); // ok
Deno.createHttpClient(options); // TypeError: invalid scheme for this transport
```

The JS shim wrote \`caCerts\` and \`proxy.transport\` back onto whatever object the user passed in. After the first call the same options object would have \`proxy.transport === \"http\"\` baked into it, so on the second call the SOCKS URL no longer matched the inferred \"http\" transport and the validator rejected it. Beyond the crash, mutating user input is just a footgun — anyone iterating an array of configs and re-using a base \`{ proxy }\` shape would see ghost fields appear.

Fix: shallow-clone \`options\` (and \`options.proxy\` when present) before any mutation, so the user's object is untouched and subsequent calls keep working.

Fixes #29347.

## Test plan

- [x] Added \`createHttpClientDoesNotMutateOptions\` to \`tests/unit/fetch_test.ts\` — runs \`createHttpClient\` twice with a SOCKS5 proxy options object, asserts both calls succeed and that the user-supplied options object is byte-for-byte unchanged across calls.
- [x] Manual repro from the issue now prints identical \`BEFORE\` / \`AFTER 1\` / \`AFTER 2\` JSON.
- [x] \`./tools/format.js\`, \`cargo clippy --bin deno -- -D warnings\`.