### PR TITLE
fix(ext/fs): clearer error when reading FsFile opened without read access

### DIFF
--- a/ext/fs/30_fs.js
+++ b/ext/fs/30_fs.js
@@ -547,7 +547,11 @@ function openSync(
     options,
   );
 
-  return new FsFile(rid, SymbolFor("Deno.internal.FsFile"));
+  return new FsFile(
+    rid,
+    SymbolFor("Deno.internal.FsFile"),
+    openOptionsToAccess(options),
+  );
 }
 
 async function open(
@@ -560,7 +564,25 @@ async function open(
     options,
   );
 
-  return new FsFile(rid, SymbolFor("Deno.internal.FsFile"));
+  return new FsFile(
+    rid,
+    SymbolFor("Deno.internal.FsFile"),
+    openOptionsToAccess(options),
+  );
+}
+
+// Mirror the Rust-side behaviour of `op_fs_open_*`: when no options are
+// provided the file is opened read-only; when options *are* provided the
+// `read` / `write` / `append` flags default to `false` and are only set
+// by explicit user opt-in.
+function openOptionsToAccess(options) {
+  if (options === undefined) {
+    return { read: true, write: false };
+  }
+  return {
+    read: options.read === true,
+    write: options.write === true || options.append === true,
+  };
 }
 
 function createSync(path) {
@@ -586,8 +608,16 @@ class FsFile {
 
   #readable;
   #writable;
+  // Access-tracking is opt-in: only `Deno.open` / `Deno.openSync` propagate
+  // the open options, so we know which side of the FD the caller asked for.
+  // Other call sites (child stdio, stdin/stdout/stderr) construct an
+  // `FsFile` without options and keep the historical "anything goes"
+  // behaviour.
+  #accessChecked = false;
+  #canRead = true;
+  #canWrite = true;
 
-  constructor(rid, symbol) {
+  constructor(rid, symbol, access) {
     ObjectDefineProperty(this, internalRidSymbol, {
       __proto__: null,
       enumerable: false,
@@ -597,6 +627,19 @@ class FsFile {
     if (!symbol || symbol !== SymbolFor("Deno.internal.FsFile")) {
       throw new TypeError(
         "'Deno.FsFile' cannot be constructed, use 'Deno.open()' or 'Deno.openSync()' instead",
+      );
+    }
+    if (access !== undefined) {
+      this.#accessChecked = true;
+      this.#canRead = access.read;
+      this.#canWrite = access.write;
+    }
+  }
+
+  #assertReadable(api) {
+    if (this.#accessChecked && !this.#canRead) {
+      throw new TypeError(
+        `${api}: file was opened without read access. Pass \`{ read: true }\` to 'Deno.open()' / 'Deno.openSync()'.`,
       );
     }
   }
@@ -618,10 +661,12 @@ class FsFile {
   }
 
   read(p) {
+    this.#assertReadable("FsFile.read");
     return read(this.#rid, p);
   }
 
   readSync(p) {
+    this.#assertReadable("FsFile.readSync");
     return readSync(this.#rid, p);
   }
 
@@ -655,6 +700,7 @@ class FsFile {
   }
 
   get readable() {
+    this.#assertReadable("FsFile.readable");
     if (this.#readable === undefined) {
       this.#readable = readableStreamForRid(this.#rid);
     }

--- a/tests/unit/files_test.ts
+++ b/tests/unit/files_test.ts
@@ -171,6 +171,40 @@ Deno.test({ permissions: { read: false } }, async function readPermFailure() {
   }, Deno.errors.NotCapable);
 });
 
+// Regression test for https://github.com/denoland/deno/issues/27497
+// Reading from a file opened without `read: true` used to surface as the
+// raw OS error ("Bad file descriptor (os error 9)"). Make sure we now
+// throw a TypeError with an actionable hint *before* hitting the kernel.
+Deno.test(
+  { permissions: { read: true, write: true } },
+  async function readWithoutReadAccessThrowsTypeError() {
+    const tempDir = await Deno.makeTempDir();
+    const filename = `${tempDir}/log.txt`;
+    await Deno.writeTextFile(filename, "hi\n");
+    using file = await Deno.open(filename, { append: true });
+
+    // The validation is synchronous — both `read` and `readSync` throw
+    // before dispatching to the kernel.
+    assertThrows(
+      () => file.readSync(new Uint8Array(8)),
+      TypeError,
+      "FsFile.readSync: file was opened without read access",
+    );
+    assertThrows(
+      () => file.read(new Uint8Array(8)),
+      TypeError,
+      "FsFile.read: file was opened without read access",
+    );
+    assertThrows(
+      () => file.readable,
+      TypeError,
+      "FsFile.readable: file was opened without read access",
+    );
+
+    await Deno.remove(tempDir, { recursive: true });
+  },
+);
+
 Deno.test(
   { permissions: { write: true } },
   async function writeNullBufferFailure() {


### PR DESCRIPTION
## Summary

Calling \`file.read()\` / \`file.readSync()\` / \`file.readable\` on a file that was opened without \`{ read: true }\` used to surface as the raw OS errno:

\`\`\`ts
const file = await Deno.open('log.json', { append: true });
const lines = await toText(file.readable);
// → Error: Bad file descriptor (os error 9)
\`\`\`

That's accurate but unhelpful: the user's mental model is \"I asked for an append handle, why is the kernel complaining about a bad fd?\".

Track whether the file was opened readable at JS-construction time (\`Deno.open\` / \`Deno.openSync\` propagate the access flags into the new \`FsFile\`) and throw a \`TypeError\` up front when the caller reaches for the read side, including a hint to add \`{ read: true }\` to the open options:

\`\`\`
TypeError: FsFile.readable: file was opened without read access. Pass \`{ read: true }\` to 'Deno.open()' / 'Deno.openSync()'.
\`\`\`

Behaviour for \`FsFile\`s constructed without an explicit access argument (child-process stdio in \`ext/process/40_process.js\`) is unchanged — they keep the historical \"both sides are allowed\" semantics.

Fixes #27497.

## Test plan

- [x] Added \`readWithoutReadAccessThrowsTypeError\` to \`tests/unit/files_test.ts\` covering all three entry points (\`read\`, \`readSync\`, \`readable\`).
- [x] All existing tests in \`tests/unit/files_test.ts\` (49), \`read_file_test.ts\` (17), \`process_test.ts\` (26 / 2 ignored), \`command_test.ts\` (68 / 4 ignored) pass.
- [x] Manual repro from the issue now prints the new TypeError instead of the os-error-9 message.
- [x] \`./tools/format.js\`, \`cargo clippy --bin deno -- -D warnings\`.