### PR TITLE
fix(task): match workspace directory name in --filter

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -734,10 +734,10 @@ fn matches_package(
   // Fall back to the workspace member's directory name when neither
   // deno.json nor package.json carry a `name`. Without this fallback,
   // `deno task --filter <dir>` silently failed for members whose
-  // package name didn't happen to match the directory (#28620). The
-  // fallback is gated on the folder having no name so it never
-  // accidentally selects the workspace root (which doesn't carry a
-  // name and is intentionally excluded by `--filter *`).
+  // package name didn't happen to match the directory (#28620).
+  // Gated on the folder having a name so we never accidentally select
+  // the workspace root (which doesn't carry one and is intentionally
+  // excluded from `--filter *`).
   let has_name = config
     .deno_json
     .as_ref()

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -106,7 +106,12 @@ pub async fn execute_script(
       workspace.config_folders_sorted_by_dependencies()
     {
       if !task_flags.recursive
-        && !matches_package(folder, force_use_pkg_json, &package_regex)
+        && !matches_package(
+          folder,
+          folder_url,
+          force_use_pkg_json,
+          &package_regex,
+        )
       {
         continue;
       }
@@ -707,6 +712,7 @@ fn sort_tasks_topo<'a>(
 
 fn matches_package(
   config: &FolderConfigs,
+  folder_url: &Url,
   force_use_pkg_json: bool,
   regex: &Regex,
 ) -> bool {
@@ -725,7 +731,33 @@ fn matches_package(
     return true;
   }
 
+  // Fall back to the workspace member's directory name when neither
+  // deno.json nor package.json carry a `name`. Without this fallback,
+  // `deno task --filter <dir>` silently failed for members whose
+  // package name didn't happen to match the directory (#28620). The
+  // fallback is gated on the folder having no name so it never
+  // accidentally selects the workspace root (which doesn't carry a
+  // name and is intentionally excluded by `--filter *`).
+  let has_name = config
+    .deno_json
+    .as_ref()
+    .and_then(|deno| deno.json.name.as_ref())
+    .or(config.pkg_json.as_ref().and_then(|pkg| pkg.name.as_ref()))
+    .is_some();
+  if has_name
+    && let Some(dir_name) = workspace_folder_dir_name(folder_url)
+    && regex.is_match(dir_name)
+  {
+    return true;
+  }
+
   false
+}
+
+fn workspace_folder_dir_name(folder_url: &Url) -> Option<&str> {
+  let path = folder_url.path();
+  let trimmed = path.strip_suffix('/').unwrap_or(path);
+  trimmed.rsplit('/').next().filter(|s| !s.is_empty())
 }
 
 fn print_available_tasks_workspace(
@@ -739,7 +771,8 @@ fn print_available_tasks_workspace(
 
   let mut matched = false;
   for (folder_url, folder) in workspace.config_folders() {
-    if !recursive && !matches_package(folder, force_use_pkg_json, package_regex)
+    if !recursive
+      && !matches_package(folder, folder_url, force_use_pkg_json, package_regex)
     {
       continue;
     }

--- a/tests/specs/task/filter/__test__.jsonc
+++ b/tests/specs/task/filter/__test__.jsonc
@@ -104,6 +104,14 @@
       "cwd": "./deno",
       "args": "task -r --filter @deno/foo dev",
       "output": "deno_filter_recursive.out"
+    },
+    // Regression test for https://github.com/denoland/deno/issues/28620
+    // `--filter` should also match the workspace member's directory name,
+    // not just the `name` field in its deno.json / package.json.
+    "deno_dir_name_match": {
+      "cwd": "./deno_dir_name_match",
+      "args": "task --filter foo-dir dev",
+      "output": "deno_dir_name_match.out"
     }
   }
 }

--- a/tests/specs/task/filter/deno_dir_name_match.out
+++ b/tests/specs/task/filter/deno_dir_name_match.out
@@ -1,0 +1,2 @@
+Task dev (@scope/totally-different-foo) echo 'foo-dir ran'
+foo-dir ran

--- a/tests/specs/task/filter/deno_dir_name_match/bar-dir/deno.json
+++ b/tests/specs/task/filter/deno_dir_name_match/bar-dir/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "@scope/totally-different-bar",
+  "tasks": {
+    "dev": "echo 'bar-dir ran'"
+  },
+  "exports": {}
+}

--- a/tests/specs/task/filter/deno_dir_name_match/deno.json
+++ b/tests/specs/task/filter/deno_dir_name_match/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": [
+    "./foo-dir",
+    "./bar-dir"
+  ]
+}

--- a/tests/specs/task/filter/deno_dir_name_match/foo-dir/deno.json
+++ b/tests/specs/task/filter/deno_dir_name_match/foo-dir/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "@scope/totally-different-foo",
+  "tasks": {
+    "dev": "echo 'foo-dir ran'"
+  },
+  "exports": {}
+}


### PR DESCRIPTION
## Summary

\`deno task --filter <name>\` previously only matched the package's \`name\` field in \`deno.json\` / \`package.json\`. When a workspace member's directory name diverged from its package name, e.g. directory \`client-a/\` containing \`{ \"name\": \"@scope/client\" }\`, the matching directory-form got rejected:

\`\`\`
$ deno task --filter client-a xd
No matching task or script 'xd' found in selected packages.

$ deno task --filter client xd     # works
Task xd (@scope/client) deno eval 'console.log(\"client xd ran\")'
client xd ran
\`\`\`

Most other workspace tools (pnpm, yarn) accept either form, and the directory name is what shows up in error messages and \`deno task --filter '*'\` output, so users reasonably expect it to work.

Add a directory-name fallback to \`matches_package\` after the existing \`name\`-field checks. The fallback only kicks in when the folder declares a \`name\` so the workspace root (which is intentionally excluded from \`--filter '*'\` — every existing \`_filter_no_task\` snapshot relies on that) keeps its current behaviour.

Fixes #28620.

## Test plan

- [x] New spec test \`tests/specs/task/filter/deno_dir_name_match\` — workspace where \`./foo-dir\` has \`name: '@scope/totally-different-foo'\`; \`deno task --filter foo-dir dev\` finds and runs the task. Pre-fix this same setup printed the \"No matching task...\" message.
- [x] All 22 existing \`tests/specs/task/filter\` cases still pass, including \`deno_filter_no_task\` and \`npm_filter_no_task\` (which exercise the workspace-root-excluded behaviour).
- [x] Manual repro from the issue now succeeds.
- [x] \`./tools/format.js\`, \`cargo clippy --bin deno -- -D warnings\`.