### PR TITLE
fix(ext/bundle): clearer error when Deno.bundle is called in compiled binary

### DIFF
--- a/ext/bundle/src/lib.rs
+++ b/ext/bundle/src/lib.rs
@@ -42,8 +42,14 @@ impl BundleProvider for () {
     &self,
     _options: BundleOptions,
   ) -> Result<BuildResponse, AnyError> {
+    // Embedders that don't wire up a real provider (notably `denort`, used
+    // by `deno compile` outputs) fall through to this no-op implementation.
+    // Surface that limitation directly to the user instead of leaking the
+    // historical "default BundleProvider does not do anything" string.
+    // See denoland/deno#31597.
     Err(deno_core::anyhow::anyhow!(
-      "default BundleProvider does not do anything"
+      "Deno.bundle() is not available in compiled binaries (`deno compile`). \
+       Run with `deno run` instead, or pre-bundle the entrypoints at build time."
     ))
   }
 }

--- a/tests/specs/compile/bundle_unavailable/__test__.jsonc
+++ b/tests/specs/compile/bundle_unavailable/__test__.jsonc
@@ -1,0 +1,34 @@
+// Regression test for https://github.com/denoland/deno/issues/31597
+// `Deno.bundle()` is not (yet) wired up in the standalone (`deno compile`)
+// runtime. Make sure the failure surface is a clear user-facing message
+// rather than the historical "default BundleProvider does not do anything"
+// debug string.
+{
+  "tempDir": true,
+  "steps": [
+    {
+      "if": "unix",
+      "args": "compile --unstable-bundle --output main main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "if": "unix",
+      "commandName": "./main",
+      "args": [],
+      "exitCode": 1,
+      "output": "main.out"
+    },
+    {
+      "if": "windows",
+      "args": "compile --unstable-bundle --output main.exe main.ts",
+      "output": "[WILDCARD]"
+    },
+    {
+      "if": "windows",
+      "commandName": "./main.exe",
+      "args": [],
+      "exitCode": 1,
+      "output": "main.out"
+    }
+  ]
+}

--- a/tests/specs/compile/bundle_unavailable/main.out
+++ b/tests/specs/compile/bundle_unavailable/main.out
@@ -1,0 +1,1 @@
+[WILDCARD]Deno.bundle() is not available in compiled binaries (`deno compile`).[WILDCARD]

--- a/tests/specs/compile/bundle_unavailable/main.ts
+++ b/tests/specs/compile/bundle_unavailable/main.ts
@@ -1,0 +1,1 @@
+await Deno.bundle({ entrypoints: ["./main.ts"] });


### PR DESCRIPTION
## Summary

\`denort\` — the runtime that runs \`deno compile\` outputs — doesn't wire up a real \`BundleProvider\`, so calls to \`Deno.bundle()\` from a compiled binary fall through to the no-op default in \`ext/bundle/src/lib.rs\` and surface as:

\`\`\`
error: Uncaught (in promise) Error: default BundleProvider does not do anything
const result = await Deno.bundle({
                          ^
    at Object.bundle (ext:deno_bundle_runtime/bundle.ts:11:14)
\`\`\`

That string is an internal placeholder, not something a user can act on. Replace it with a message that explains what's happening and points at the workaround:

\`\`\`
error: Uncaught (in promise) Error: Deno.bundle() is not available in compiled binaries (\`deno compile\`). Run with \`deno run\` instead, or pre-bundle the entrypoints at build time.
\`\`\`

The underlying behaviour (\`Deno.bundle\` not working under \`deno compile\`) is unchanged. Wiring a real provider into \`denort\` is a much larger change because the existing \`CliBundleProvider\` pulls in the full CLI bundler (esbuild client, factory, npm resolver, …), so this PR just stops leaking the internal text and leaves the actual feature gap to be tackled separately.

Refs #31597.

## Test plan

- [x] Added \`tests/specs/compile/bundle_unavailable\` — compiles a script that calls \`Deno.bundle()\`, runs it, asserts the new diagnostic and exit code 1.
- [x] Manual repro from the issue (the linked Hladikes/deno-bundle-bug-repro shape) now prints the new message instead of the placeholder.
- [x] \`./tools/format.js\`, \`cargo clippy --bin deno -- -D warnings\`.