### PR TITLE
fix(lint): respect `include` for plugin rules

### DIFF
--- a/cli/js/40_lint.js
+++ b/cli/js/40_lint.js
@@ -89,12 +89,17 @@ const state = {
   plugins: [],
   installedPlugins: new Set(),
   ignoredRules: new Set(),
+  // When non-empty, only rule IDs in this set are activated; mirrors how
+  // the `include` field of the deno.json `rules` block already works for
+  // built-in rules. See denoland/deno#31017.
+  includedRules: new Set(),
 };
 
 function resetState() {
   state.plugins = [];
   state.installedPlugins.clear();
   state.ignoredRules.clear();
+  state.includedRules.clear();
 }
 
 /**
@@ -455,11 +460,17 @@ function materializeComments(ctx) {
 /**
  * @param {Deno.lint.Plugin[]} plugins
  * @param {string[]} exclude
+ * @param {string[]} include
  */
-export function installPlugins(plugins, exclude) {
+export function installPlugins(plugins, exclude, include) {
   if (Array.isArray(exclude)) {
     for (let i = 0; i < exclude.length; i++) {
       state.ignoredRules.add(exclude[i]);
+    }
+  }
+  if (Array.isArray(include)) {
+    for (let i = 0; i < include.length; i++) {
+      state.includedRules.add(include[i]);
     }
   }
 
@@ -1231,6 +1242,11 @@ export function runPluginsForFile(fileName, serializedAst) {
       const rule = plugin.rules[name];
       const id = `${plugin.name}/${name}`;
 
+      // When `include` is configured, drop everything that isn't on
+      // the allow-list. `exclude` always takes precedence.
+      if (state.includedRules.size > 0 && !state.includedRules.has(id)) {
+        continue;
+      }
       // Check if this rule is excluded
       if (state.ignoredRules.has(id)) {
         continue;

--- a/cli/lsp/lint.rs
+++ b/cli/lsp/lint.rs
@@ -136,6 +136,7 @@ impl LspLinterResolver {
           let load_plugins_result = LOAD_PLUGINS_THREAD.load_plugins(
             lint_options.plugins.clone(),
             lint_options.rules.exclude.clone(),
+            lint_options.rules.include.clone(),
           );
           match load_plugins_result {
             Ok(runner) => {
@@ -165,6 +166,7 @@ impl LspLinterResolver {
 struct LoadPluginsRequest {
   plugins: Vec<Url>,
   exclude: Option<Vec<String>>,
+  include: Option<Vec<String>>,
   response_tx: std::sync::mpsc::Sender<Result<PluginHostProxy, AnyError>>,
 }
 
@@ -187,6 +189,7 @@ impl LoadPluginsThread {
               lsp_log!("pluggin runner - {}", msg);
             }),
             request.exclude,
+            request.include,
           )
           .await;
           request.response_tx.send(result).unwrap();
@@ -203,12 +206,14 @@ impl LoadPluginsThread {
     &self,
     plugins: Vec<Url>,
     exclude: Option<Vec<String>>,
+    include: Option<Vec<String>>,
   ) -> Result<PluginHostProxy, AnyError> {
     let request_tx = self.request_tx.as_ref().unwrap();
     let (response_tx, response_rx) = std::sync::mpsc::channel();
     let _ = request_tx.send(LoadPluginsRequest {
       plugins,
       exclude,
+      include,
       response_tx,
     });
     response_rx.recv().unwrap()

--- a/cli/tools/lint/mod.rs
+++ b/cli/tools/lint/mod.rs
@@ -290,6 +290,7 @@ impl WorkspaceLinter {
     self.file_count += paths.len();
 
     let exclude = lint_options.rules.exclude.clone();
+    let include = lint_options.rules.include.clone();
 
     let plugin_specifiers = lint_options.plugins.clone();
     let lint_rules = self
@@ -332,6 +333,7 @@ impl WorkspaceLinter {
         plugin_specifiers,
         logger,
         exclude,
+        include,
       )
       .await?;
       plugin_runner = Some(Arc::new(runner));

--- a/cli/tools/lint/plugins.rs
+++ b/cli/tools/lint/plugins.rs
@@ -39,6 +39,7 @@ pub enum PluginHostRequest {
   LoadPlugins {
     specifiers: Vec<ModuleSpecifier>,
     exclude_rules: Option<Vec<String>>,
+    include_rules: Option<Vec<String>>,
     tx: oneshot::Sender<PluginHostResponse>,
   },
   Run {
@@ -267,9 +268,12 @@ impl PluginHost {
         PluginHostRequest::LoadPlugins {
           specifiers,
           exclude_rules,
+          include_rules,
           tx,
         } => {
-          let r = self.load_plugins(specifiers, exclude_rules).await;
+          let r = self
+            .load_plugins(specifiers, exclude_rules, include_rules)
+            .await;
           let _ = tx.send(PluginHostResponse::LoadPlugin(r));
         }
         PluginHostRequest::Run {
@@ -368,6 +372,7 @@ impl PluginHost {
     &mut self,
     plugin_specifiers: Vec<ModuleSpecifier>,
     exclude: Option<Vec<String>>,
+    include: Option<Vec<String>>,
   ) -> Result<Vec<PluginInfo>, AnyError> {
     let mut load_futures = Vec::with_capacity(plugin_specifiers.len());
     for specifier in plugin_specifiers {
@@ -413,6 +418,15 @@ impl PluginHost {
 
         v8::Array::new_with_elements(scope, elems.as_slice()).into()
       });
+    let include_v8: v8::Local<v8::Value> =
+      include.map_or(v8::null(scope).into(), |v| {
+        let elems = v
+          .iter()
+          .map(|item| v8::String::new(scope, item).unwrap().into())
+          .collect::<Vec<_>>();
+
+        v8::Array::new_with_elements(scope, elems.as_slice()).into()
+      });
 
     let undefined = v8::undefined(scope);
 
@@ -426,7 +440,7 @@ impl PluginHost {
       }
       arr
     };
-    let args = &[local_handles.into(), exclude_v8];
+    let args = &[local_handles.into(), exclude_v8, include_v8];
 
     log::debug!("Installing lint plugins...");
 
@@ -454,6 +468,7 @@ impl PluginHostProxy {
     &self,
     specifiers: Vec<ModuleSpecifier>,
     exclude_rules: Option<Vec<String>>,
+    include_rules: Option<Vec<String>>,
   ) -> Result<(), AnyError> {
     let (tx, rx) = oneshot::channel();
     self
@@ -461,6 +476,7 @@ impl PluginHostProxy {
       .send(PluginHostRequest::LoadPlugins {
         specifiers,
         exclude_rules,
+        include_rules,
         tx,
       })
       .await?;
@@ -522,9 +538,12 @@ pub async fn create_runner_and_load_plugins(
   plugin_specifiers: Vec<ModuleSpecifier>,
   logger: PluginLogger,
   exclude: Option<Vec<String>>,
+  include: Option<Vec<String>>,
 ) -> Result<PluginHostProxy, AnyError> {
   let host_proxy = PluginHost::create(logger)?;
-  host_proxy.load_plugins(plugin_specifiers, exclude).await?;
+  host_proxy
+    .load_plugins(plugin_specifiers, exclude, include)
+    .await?;
   Ok(host_proxy)
 }
 


### PR DESCRIPTION
## Summary

The \`include\` field of the \`lint.rules\` block was ignored for rules defined by lint plugins — only \`exclude\` reached the JS plugin host (\`installPlugins\`). Built-in rules already supported \`include\`, so users with large plugins were forced to write verbose \`exclude\` lists just to enable a handful of rules:

\`\`\`jsonc
// deno.json
{
  \"lint\": {
    \"plugins\": [\"./plugin.ts\"],
    \"rules\": {
      \"include\": [\"my-plugin/rule-a\"]   // silently ignored — both plugin rules ran
    }
  }
}
\`\`\`

Plumb \`include\` from \`LintOptions\` through \`create_runner_and_load_plugins\` into the plugin host (and the LSP variant in \`cli/lsp/lint.rs\`). \`installPlugins\` in \`cli/js/40_lint.js\` now stores the allow-list and the per-rule loop in \`runPluginsForFile\` filters anything not in it. \`exclude\` still wins on conflicts.

Fixes #31017.

## Test plan

- [x] Manual end-to-end test (\`/tmp/repro_31017\` with a 2-rule plugin):
  - Default config — both \`my-plugin/rule-a\` and \`my-plugin/rule-b\` fire.
  - \`rules.include: [\"my-plugin/rule-a\"]\` — only \`rule-a\` fires.
  - \`rules.exclude: [\"my-plugin/rule-a\"]\` — only \`rule-b\` fires.
- [x] \`cargo fmt --check\`, \`cargo clippy --bin deno -- -D warnings\`.