### PR TITLE
fix(ext/process): only drop supplementary groups when changing gid

### DIFF
--- a/ext/process/lib.rs
+++ b/ext/process/lib.rs
@@ -683,7 +683,8 @@ fn create_command(
     }
 
     let detached = args.detached;
-    if detached || !fds_to_dup.is_empty() || args.gid.is_some() {
+    let drop_supplementary_groups = args.gid.is_some();
+    if detached || !fds_to_dup.is_empty() || drop_supplementary_groups {
       command.pre_exec(move || {
         if detached {
           libc::setsid();
@@ -698,7 +699,13 @@ fn create_command(
             libc::fcntl(dst, libc::F_SETFD, 0);
           }
         }
-        libc::setgroups(0, std::ptr::null());
+        // Only clear supplementary groups when the caller is also
+        // changing the primary gid. Otherwise keep them — dropping
+        // them unconditionally breaks Docker workflows that rely on
+        // groups granted to the parent process (denoland/deno#29770).
+        if drop_supplementary_groups {
+          libc::setgroups(0, std::ptr::null());
+        }
         Ok(())
       });
     }
@@ -1672,18 +1679,11 @@ mod deprecated {
       c.env(key.inner, value);
     }
 
-    #[cfg(unix)]
-    // TODO(bartlomieju):
-    #[allow(
-      clippy::undocumented_unsafe_blocks,
-      reason = "TODO: add safety comment"
-    )]
-    unsafe {
-      c.pre_exec(|| {
-        libc::setgroups(0, std::ptr::null());
-        Ok(())
-      });
-    }
+    // `Deno.run` doesn't expose `gid` / `uid`, so there's no primary-gid
+    // change that would call for clearing supplementary groups. The
+    // historical unconditional `setgroups(0, null)` here silently
+    // dropped them, which broke containers that gave the parent
+    // process group-based access (denoland/deno#29770).
 
     // TODO: make this work with other resources, eg. sockets
     c.stdin(run_args.stdin.as_stdio()?);

--- a/tests/unit/command_test.ts
+++ b/tests/unit/command_test.ts
@@ -928,6 +928,46 @@ Deno.test(
   },
 );
 
+// Regression test for #29770: when no `gid` option is given, the child must
+// inherit the parent's supplementary groups rather than have them cleared.
+// /proc requires `permissions: "inherit"` because Deno gates /proc reads on
+// `--allow-all`.
+Deno.test(
+  {
+    permissions: "inherit",
+    ignore: Deno.build.os !== "linux",
+  },
+  async function commandPreservesSupplementaryGroups() {
+    const status = await Deno.readTextFile("/proc/self/status");
+    const groupsLine = status
+      .split("\n")
+      .find((l) => l.startsWith("Groups:"));
+    const parentSupplementary = (groupsLine?.slice("Groups:".length) ?? "")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (parentSupplementary.length === 0) {
+      return;
+    }
+
+    const { stdout } = await new Deno.Command("id", {
+      args: ["-G"],
+    }).output();
+    const childGroups = new TextDecoder()
+      .decode(stdout)
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+
+    for (const gid of parentSupplementary) {
+      assert(
+        childGroups.includes(gid),
+        `child missing parent's supplementary gid ${gid}; parent=${parentSupplementary}, child=${childGroups}`,
+      );
+    }
+  },
+);
+
 Deno.test(function commandStdinPipedFails() {
   assertThrows(
     () =>


### PR DESCRIPTION
## Summary

\`Deno.Command\` and \`Deno.run\` both unconditionally called \`setgroups(0, NULL)\` in their \`pre_exec\` hooks. As root that wiped the parent's supplementary groups; for ordinary users it silently failed with \`EPERM\`. This broke Docker workflows that rely on group membership granted to the parent process (e.g. \`docker\` group access for the socket).

The historical motivation (\`#11586\`) was hardening the \`command.gid(...)\` transition — when the caller switches to a different primary gid, dropping the inherited supplementary groups is sound. Without that switch, dropping them is just a footgun.

- \`Deno.Command\` (\`ext/process/lib.rs\` ~ line 685): gate the \`setgroups\` call on \`args.gid.is_some()\`. The other parts of the existing \`pre_exec\` block (\`setsid\` for \`detached\`, dup2/close for redirected fds) are unaffected.
- \`Deno.run\` (\`ext/process/lib.rs\` ~ line 1682): drop the call entirely. The deprecated API doesn't expose \`gid\`/\`uid\`, so there is no transition that motivates clearing the groups.

Fixes #29770.

## Test plan

- [x] Manual: \`new Deno.Command(\"id\")\` from a user in \`docker\`, \`adm\`, etc. now reports the same supplementary groups as the parent (\`id\` shows them all). Before this PR they were silently dropped on root and failed with \`EPERM\` for non-root.
- [x] All existing \`tests/unit/process_test.ts\` (26/2 ignored) and \`tests/unit/command_test.ts\` (68/4 ignored) pass.
- [x] \`cargo fmt --check\`, \`cargo clippy --bin deno -- -D warnings\`.