### PR TITLE
test(node_compat): enroll parallel/test-crypto-hash-stream-pipe.js

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -462,6 +462,7 @@
     "parallel/test-crypto-from-binary.js": {},
     "parallel/test-crypto-gcm-implicit-short-tag.js": {},
     "parallel/test-crypto-getcipherinfo.js": {},
+    "parallel/test-crypto-hash-stream-pipe.js": {},
     "parallel/test-crypto-hkdf.js": {},
     "parallel/test-crypto-hmac.js": {},
     "parallel/test-crypto-keygen.js": {},


### PR DESCRIPTION
## Summary

Enrolls `parallel/test-crypto-hash-stream-pipe.js` in the node_compat suite. The test was failing on the [2026-04-24 node-test-viewer run](https://node-test-viewer.deno.dev/results/2026-04-24) with `Error: Digest already called`, but the underlying fix has since landed: `ext/node_crypto/digest.rs` (added in [3d766d5](https://github.com/denoland/deno/commit/3d766d5f05dae7bf1953c39d21c6dcbda9be8160)) caches the digest bytes on first call so subsequent `h.digest(encoding)` calls return the cached value, which is exactly what this test wants.

The Node test is a regression check for [nodejs/node#28245](https://github.com/nodejs/node/issues/28245) (SHA3 segfault on second `digest()`); it pipes data into a `Hash` stream, asserts the streamed hex digest matches the expected SHA3-512, and then calls `h.digest('hex')` once more and asserts it returns the same value.

## Repro on current main

```
$ NODE_TEST_KNOWN_GLOBALS=0 NODE_SKIP_FLAG_CHECK=1 NO_COLOR=1 \
  ./target/debug/deno run -A --quiet --unstable-unsafe-proto --unstable-bare-node-builtins \
  tests/node_compat/runner/suite/test/parallel/test-crypto-hash-stream-pipe.js
$ echo $?
0
```

The pre-fix failure is captured in `linux.json`:
<https://node-test-viewer.deno.dev/results/2026-04-24/linux.json> -> `parallel/test-crypto-hash-stream-pipe.js` -> `[false, ...]`.

## Test plan

- [x] Test passes locally on `upstream/main` after a clean build.
- [x] No surrounding test regressions (`test-crypto-hmac`, `test-crypto-from-binary`, `test-crypto-classes`, `test-crypto-keygen` still pass).
- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); entry placed alphabetically between `test-crypto-getcipherinfo.js` and `test-crypto-hkdf.js`.
