### PR TITLE
chore(node_compat): ignore 3 paramEncoding='explicit' EC keygen tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -474,6 +474,10 @@
       "ignore": true,
       "reason": "Same `paramEncoding: 'explicit'` blocker as test-crypto-keygen-async-explicit-elliptic-curve.js, plus asserts on the OpenSSL-3-specific error string `error:07880109:common libcrypto routines::interrupted or cancelled` when signing without the passphrase. Both depend on OpenSSL internals Deno doesn't embed; the explicit-encoding side is the harder requirement"
     },
+    "parallel/test-crypto-keygen-async-explicit-elliptic-curve-encrypted-p256.js": {
+      "ignore": true,
+      "reason": "Same `paramEncoding: 'explicit'` blocker as test-crypto-keygen-async-explicit-elliptic-curve.js (P-256 + PKCS#8-encrypted-PEM variant), plus asserts on the OpenSSL-3-specific error string `error:07880109:common libcrypto routines::interrupted or cancelled` when signing without the passphrase"
+    },
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-ec.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -466,6 +466,10 @@
     "parallel/test-crypto-hmac.js": {},
     "parallel/test-crypto-keygen.js": {},
     "parallel/test-crypto-keygen-async-dsa-key-object.js": {},
+    "parallel/test-crypto-keygen-async-explicit-elliptic-curve.js": {
+      "ignore": true,
+      "reason": "Tests EC keypair generation with `paramEncoding: 'explicit'`, which emits the curve parameters (prime / a / b / generator / order / cofactor) explicitly inside the SPKI/SEC1/PKCS#8 DER instead of just the curve OID. Deno's keygen path returns 'Explicit encoding is not supported' -- the Rust `p224`/`p256`/`p384`/`p521` crates don't expose an API for emitting the explicit parameter ASN.1, and OpenSSL's `EVP_PKEY_paramgen` is what Node uses. Could be revisited if a pure-Rust DER builder for explicit EC params lands"
+    },
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-ec.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -470,6 +470,10 @@
       "ignore": true,
       "reason": "Tests EC keypair generation with `paramEncoding: 'explicit'`, which emits the curve parameters (prime / a / b / generator / order / cofactor) explicitly inside the SPKI/SEC1/PKCS#8 DER instead of just the curve OID. Deno's keygen path returns 'Explicit encoding is not supported' -- the Rust `p224`/`p256`/`p384`/`p521` crates don't expose an API for emitting the explicit parameter ASN.1, and OpenSSL's `EVP_PKEY_paramgen` is what Node uses. Could be revisited if a pure-Rust DER builder for explicit EC params lands"
     },
+    "parallel/test-crypto-keygen-async-explicit-elliptic-curve-encrypted.js.js": {
+      "ignore": true,
+      "reason": "Same `paramEncoding: 'explicit'` blocker as test-crypto-keygen-async-explicit-elliptic-curve.js, plus asserts on the OpenSSL-3-specific error string `error:07880109:common libcrypto routines::interrupted or cancelled` when signing without the passphrase. Both depend on OpenSSL internals Deno doesn't embed; the explicit-encoding side is the harder requirement"
+    },
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-ec.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},


### PR DESCRIPTION
## Summary

Marks three failing crypto-keygen tests as ignored in `tests/node_compat/config.jsonc`. All three depend on Node's `paramEncoding: 'explicit'` option for EC keypair generation, which emits the curve parameters (prime / a / b / generator / order / cofactor) explicitly inside the SPKI/SEC1/PKCS#8 DER instead of just the curve OID. Two of them additionally assert on an OpenSSL-3-specific error string. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-crypto-keygen-async-explicit-elliptic-curve.js`

```
error: Uncaught (in promise) TypeError: Explicit encoding is not supported
  generateKeyPair('ec', {
  ^
    at createJob (ext:deno_node/internal/crypto/keygen.ts:...)
```

`paramEncoding: 'explicit'` is unimplemented in `ext/node/polyfills/internal/crypto/keygen.ts`. Implementing it requires a DER builder that can emit the full SEC1 `ECParameters` Choice -- the named-curve OID branch is what Deno does today; the explicit-curve branch needs to encode `FieldID` + `Curve` + `base` + `order` + `cofactor`. The Rust `p224`/`p256`/`p384`/`p521` crates don't expose this directly, so the path is non-trivial. **Could be revisited** if a pure-Rust DER builder for explicit EC params lands.

### `parallel/test-crypto-keygen-async-explicit-elliptic-curve-encrypted.js.js`

Same `paramEncoding: 'explicit'` blocker, plus:

```js
assert.throws(() => testSignVerify(publicKey, privateKey),
              hasOpenSSL3 ? {
                message: 'error:07880109:common libcrypto ' +
                         'routines::interrupted or cancelled'
              } : { ... });
```

The exact OpenSSL error string is checked when signing with an encrypted key without the passphrase. Even with explicit encoding implemented, this would still need OpenSSL-shape error messages.

### `parallel/test-crypto-keygen-async-explicit-elliptic-curve-encrypted-p256.js`

P-256 + PKCS#8-encrypted-PEM variant of the same blocker, with the same `error:07880109` OpenSSL-string assertion.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
