### PR TITLE
chore(node_compat): ignore 3 OpenSSL-specific crypto tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -475,6 +475,10 @@
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},
     "parallel/test-crypto-keygen-async-named-elliptic-curve.js": {},
+    "parallel/test-crypto-keygen-async-named-elliptic-curve-encrypted-p256.js": {
+      "ignore": true,
+      "reason": "Generates a P-256 keypair with `cipher: 'aes-128-cbc', passphrase: 'top secret'` for the PKCS#8 PEM private key. Deno does not currently emit `BEGIN ENCRYPTED PRIVATE KEY` PEMs for EC keys (the output fails the test's `pkcs8EncExp` regex), and the test additionally asserts on the OpenSSL-3-specific error string `error:07880109:common libcrypto routines::interrupted or cancelled` when calling testSignVerify without the passphrase. Could be revisited if encrypted PKCS#8 PEM emission for EC keys lands; the OpenSSL error-string assertion would still need addressing separately"
+    },
     "parallel/test-crypto-keygen-async-rsa.js": {
       "ignore": true,
       "reason": "Decrypting legacy PEM encrypted private keys (Proc-Type/DEK-Info format) is not yet supported; only PKCS#8 encrypted key import works"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -439,6 +439,10 @@
     "parallel/test-crypto-default-shake-lengths-oneshot.js": {},
     "parallel/test-crypto-des3-wrap.js": {},
     "parallel/test-crypto-dh-constructor.js": {},
+    "parallel/test-crypto-dh-curves.js": {
+      "ignore": true,
+      "reason": "Asserts on OpenSSL `DH_check()` flag values via `dh.verifyError` (e.g. that `createDiffieHellman('02')` reports a non-zero verifyError indicating the prime is non-safe), plus several OpenSSL-shape error strings later in the file ('Failed to convert Buffer to EC_POINT', 'Failed to get ECDH public/private key'). Deno's pure-Rust DH does not compute or expose `DH_check`-equivalent flags. Could be revisited if a port of `DH_check`'s safe-prime / generator validation lands"
+    },
     "parallel/test-crypto-dh-errors.js": {},
     "parallel/test-crypto-dh-generate-keys.js": {},
     "parallel/test-crypto-dh-group-setters.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -538,6 +538,10 @@
     "parallel/test-crypto-randomfillsync-regression.js": {},
     "parallel/test-crypto-randomuuid.js": {},
     "parallel/test-crypto-prime.js": {},
+    "parallel/test-crypto-private-decrypt-gh32240.js": {
+      "ignore": true,
+      "reason": "Exports an RSA private key as PKCS#1 PEM with cipher+passphrase (the legacy `BEGIN RSA PRIVATE KEY` + Proc-Type/DEK-Info form), which Deno does not yet emit (only PKCS#8 encrypted PEM is supported), and asserts on the OpenSSL-3-specific error string `error:07880109:common libcrypto routines::interrupted or cancelled` when decrypting without the passphrase. Same legacy-PEM bucket as test-crypto-keygen-async-rsa.js; could be revisited if PKCS#1 encrypted PEM emission lands"
+    },
     "parallel/test-crypto-rsa-pss-default-salt-length.js": {},
     "parallel/test-crypto-sec-level.js": {},
     "parallel/test-crypto-secret-keygen.js": {},


### PR DESCRIPTION
## Summary

Marks three failing crypto tests as ignored in `tests/node_compat/config.jsonc`. Each one depends on either OpenSSL-internal `DH_check`/error-string semantics or legacy PKCS#1 encrypted PEM emission. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-crypto-dh-curves.js`

Asserts on OpenSSL `DH_check()` flag values via `dh.verifyError`:

```
error: Uncaught (in promise) AssertionError: Expected "actual" to be strictly unequal to: 0
assert.notStrictEqual(bad_dh.verifyError, 0);
```

`createDiffieHellman('02').verifyError` is expected to be non-zero because '02' isn't a safe prime, but Deno's pure-Rust DH does not compute or expose those check flags (Deno reports 0). The remainder of the test also hard-codes OpenSSL-shape error strings (`Failed to convert Buffer to EC_POINT`, `Failed to get ECDH public/private key`, `Invalid key pair`, `Public key is not valid for specified curve`) that don't match Deno's pure-Rust implementations. **Could be revisited** if a port of `DH_check` (safe-prime + generator validation per RFC 2412 / FIPS 186-3) lands in `ext/node_crypto`.

### `parallel/test-crypto-private-decrypt-gh32240.js`

Exports an RSA private key as **PKCS#1 PEM with cipher+passphrase** (the legacy `BEGIN RSA PRIVATE KEY` + `Proc-Type: 4,ENCRYPTED` / `DEK-Info` form), which Deno does not yet emit -- only PKCS#8 encrypted PEM is supported (same bucket as the existing `test-crypto-keygen-async-rsa.js` ignore). The test additionally asserts on the OpenSSL-3-specific error string:

```
+ message: 'PKCS#8 ASN.1 error: P[...]'           <- Deno's
- message: 'error:07880109:common libcrypto routines::interrupted or cancelled'
```

**Could be revisited** if PKCS#1 encrypted PEM emission lands; the OpenSSL error-string assertion would still need addressing separately.

### `parallel/test-crypto-keygen-async-named-elliptic-curve-encrypted-p256.js`

Generates a P-256 keypair with `cipher: 'aes-128-cbc', passphrase: 'top secret'` for the PKCS#8 PEM private key. Two blockers:

```
error: Uncaught (in promise) AssertionError: The input did not match the regular expression /^\-\-\-\-\-BEGIN ENCRYPTED PRIVATE KEY\-\-\-\-\-\n([a-zA-Z0-9\+/=]
```

1. Deno does not currently emit `BEGIN ENCRYPTED PRIVATE KEY` PEMs for EC keys -- the output fails the test's `pkcs8EncExp` regex immediately.
2. The test asserts on the OpenSSL-3-specific `error:07880109:...` string when calling `testSignVerify` without the passphrase.

**Could be revisited** if encrypted PKCS#8 PEM emission for EC keys lands (PBES2 with AES-128-CBC); the OpenSSL error-string assertion would still need addressing separately.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
