### PR TITLE
fix(ext/node): pass reusePort flags in Server.listen() without host

### DIFF
--- a/ext/node/polyfills/net.ts
+++ b/ext/node/polyfills/net.ts
@@ -2613,6 +2613,7 @@ Server.prototype.listen = function (...args: unknown[]) {
         backlog,
         undefined,
         options.exclusive,
+        flags,
       );
     }
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -281,6 +281,7 @@
     "parallel/test-child-process-ipc.js": {},
     "parallel/test-child-process-ipc-next-tick.js": {},
     "parallel/test-child-process-kill.js": {},
+    "parallel/test-child-process-net-reuseport.js": {},
     "parallel/test-child-process-no-deprecation.js": {},
     "parallel/test-child-process-promisified.js": {},
     "parallel/test-child-process-reject-null-bytes.js": {},


### PR DESCRIPTION
## Summary

- When `Server.listen({ port, reusePort: true })` is called without a `host`
  option, the `flags` parameter (carrying `UV_TCP_REUSEPORT`) was not passed to
  `_listenInCluster()`, so `SO_REUSEPORT` was never set on the socket.
- This caused `EADDRINUSE` when multiple processes tried to bind to the same
  port with `reusePort: true`. The code path _with_ a host (`_lookupAndListen`)
  already passed flags correctly.
- Enables the `test-child-process-net-reuseport.js` node compat test.

## Test plan

- [x] `./x test-compat test-child-process-net-reuseport.js` passes
- [x] `./x test-compat test-net-reuseport.js` still passes