### PR TITLE
test: ignore test-child-process-spawnsync-shell compat test

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -303,6 +303,10 @@
     "parallel/test-child-process-spawnsync-env.js": {},
     "parallel/test-child-process-spawnsync-input.js": {},
     "parallel/test-child-process-spawnsync-maxbuf.js": {},
+    "parallel/test-child-process-spawnsync-shell.js": {
+      "ignore": true,
+      "reason": "Requires monkey-patching internal/child_process.spawnSync, which doesn't work with ESM static bindings"
+    },
     "parallel/test-child-process-spawnsync-timeout.js": {},
     "parallel/test-child-process-spawnsync-validation-errors.js": {},
     "parallel/test-child-process-spawnsync.js": {},


### PR DESCRIPTION
## Summary
- Ignore `test-child-process-spawnsync-shell` in the Node.js compat test suite
- The test monkey-patches `internal/child_process.spawnSync` and expects `child_process.spawnSync` to call through it, but in Deno the import is a static ESM binding (captured at import time), so patching the module export has no effect

## Test plan
- `./x test-compat test-child-process-spawnsync-shell.js` shows the test as `ignored`