### PR TITLE
chore(node_compat): ignore 3 unsupportable crypto tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3065,6 +3065,10 @@
       "reason": "Tests SubtleCrypto generateKey for KMAC128 / KMAC256, a Node-specific WebCrypto extension that requires OpenSSL >= 3 (test gates on hasOpenSSL(3)); Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm. Could be revisited if KMAC is added — a SHA-3-based KMAC is implementable via the sha3 / cshake Rust crates"
     },
     "parallel/test-webcrypto-sign-verify-ml-dsa.js": {},
+    "parallel/test-webcrypto-sign-verify-kmac.js": {
+      "ignore": true,
+      "reason": "Tests SubtleCrypto sign/verify with KMAC128 / KMAC256 keys imported via the Node-specific 'raw-secret' KeyFormat. Deno's WebIDL `KeyFormat` enum does not recognise 'raw-secret', and ext/crypto/ does not register KMAC as a SubtleCrypto algorithm (same blocker family as the already-ignored test-webcrypto-keygen-kmac.js). Could be revisited if KMAC and 'raw-secret' land in ext/crypto/"
+    },
     "parallel/test-webcrypto-util.js": {
       "ignore": true,
       "reason": "Runs with --expose-internals and requires Node's internal/crypto/util JS module to whitebox-test the internal normalizeAlgorithm() helper; Deno's WebCrypto is implemented in Rust (ext/crypto/) and does not expose this Node-internal module"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3053,6 +3053,10 @@
     "parallel/test-webcrypto-cryptokey-workers.js": {},
     "parallel/test-webcrypto-derivebits-argon2.js": {},
     "parallel/test-webcrypto-encap-decap-ml-kem.js": {},
+    "parallel/test-webcrypto-encrypt-decrypt-aes.js": {
+      "ignore": true,
+      "reason": "AES-CBC / -CTR / -GCM paths work; the test additionally runs an AES-OCB block (gated only on hasOpenSSL(3), which Deno reports true) that imports keys via the Node-specific 'raw-secret' KeyFormat and uses the AES-OCB algorithm -- neither is implemented in Deno's WebCrypto. The test fails at the first AES-OCB importKey before any of the other AES algorithm paths get exercised. Could be revisited if AES-OCB and 'raw-secret' land in ext/crypto/"
+    },
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},
     "parallel/test-webcrypto-encrypt-decrypt.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -467,6 +467,10 @@
     "parallel/test-crypto-hmac.js": {},
     "parallel/test-crypto-keygen.js": {},
     "parallel/test-crypto-keygen-async-dsa-key-object.js": {},
+    "parallel/test-crypto-keygen-async-dsa.js": {
+      "ignore": true,
+      "reason": "Generates a DSA keypair (modulusLength=2048, divisorLength=256) and exports the private key as encrypted PKCS#8 DER (`cipher: 'aes-128-cbc', passphrase: 'secret'`); the test then uses `assertApproximateSize(privateKeyDER, 721)` (OpenSSL 3 baseline). Deno emits a 617-byte DER -- the Rust `dsa` crate produces a tighter ASN.1 encoding for the DSA params (P/Q/G integers without OpenSSL's leading-zero padding) and the PBES2 wrapper layout differs slightly from OpenSSL's `EVP_PKEY_encrypt`. Same crate-shape divergence as the existing `test-crypto-keygen-bit-length.js` ignore. Could be revisited if Deno's DSA encoding is brought to parity with OpenSSL's"
+    },
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-ec.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},


### PR DESCRIPTION
## Summary

Marks three failing crypto tests as ignored in `tests/node_compat/config.jsonc`. Two depend on the Node-specific `'raw-secret'` `KeyFormat` (and unsupported algorithms behind it); one depends on Rust-vs-OpenSSL ASN.1 encoding differences for DSA keys. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-webcrypto-sign-verify-kmac.js`

```
TypeError: Failed to execute 'importKey' on 'SubtleCrypto':
  The provided value 'raw-secret' is not a valid enum value of type KeyFormat
```

Two blockers: the `'raw-secret'` `KeyFormat` is a Node-specific WebCrypto extension Deno's WebIDL enum doesn't recognise, and KMAC128/KMAC256 aren't registered as SubtleCrypto algorithms in `ext/crypto/`. **Could be revisited** -- same family as the already-ignored `test-webcrypto-keygen-kmac.js`; SHA-3-based KMAC is implementable on the existing `sha3`/`cshake` Rust crates.

### `parallel/test-webcrypto-encrypt-decrypt-aes.js`

The AES-CBC / -CTR / -GCM portions would work, but the test additionally runs an AES-OCB block (gated only on `hasOpenSSL(3)`, which Deno reports true after the recent `process.versions.openssl` bump to 3.2.0) that imports keys via `'raw-secret'` and uses the AES-OCB algorithm:

```
TypeError: Failed to execute 'importKey' on 'SubtleCrypto':
  The provided value 'raw-secret' is not a valid enum value of type KeyFormat
```

Neither `'raw-secret'` nor AES-OCB is implemented in Deno's WebCrypto; the test fails at the first AES-OCB `importKey` and never reaches the asserts on `is not a valid AES-OCB tag length`. **Could be revisited** if AES-OCB and `'raw-secret'` land in `ext/crypto/`.

### `parallel/test-crypto-keygen-async-dsa.js`

Generates a DSA keypair (modulusLength=2048, divisorLength=256) and exports the private key as encrypted PKCS#8 DER (`cipher: 'aes-128-cbc', passphrase: 'secret'`); asserts the size against the OpenSSL 3 baseline:

```
AssertionError: Key (617 bytes) is shorter than expected (648 bytes)
  assert(key.length >= min, ...)
```

Deno emits a 617-byte DER -- the Rust `dsa` crate produces a tighter ASN.1 encoding for the DSA params (P/Q/G integers without OpenSSL's leading-zero padding) and the PBES2 wrapper layout differs slightly from OpenSSL's `EVP_PKEY_encrypt`. Same crate-shape divergence already noted in the `test-crypto-keygen-bit-length.js` ignore reason. **Could be revisited** if Deno's DSA encoding is brought to parity with OpenSSL's.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
