### PR TITLE
chore(node_compat): ignore 3 SubtleCrypto algorithm-matrix tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3059,6 +3059,10 @@
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
     "parallel/test-webcrypto-export-import-ml-dsa.js": {},
     "parallel/test-webcrypto-export-import-ml-kem.js": {},
+    "parallel/test-webcrypto-export-import.js": {
+      "ignore": true,
+      "reason": "Exercises symmetric-key import/export across every SubtleCrypto symmetric algorithm; the AES-OCB / KMAC / Argon2 / chacha20-poly1305 paths use the Node-specific 'raw-secret' KeyFormat. Deno's WebIDL `KeyFormat` enum does not recognise 'raw-secret' (it isn't in the WebCrypto Level 1/2 spec), so the test fails at the first 'raw-secret' importKey before any of the format / round-trip logic is exercised. Could be revisited if 'raw-secret' lands in ext/crypto/"
+    },
     "parallel/test-webcrypto-getRandomValues.js": {},
     "parallel/test-webcrypto-random.js": {},
     "parallel/test-webcrypto-keygen-kmac.js": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3082,6 +3082,10 @@
       "ignore": true,
       "reason": "Tests Node's internal/crypto/webidl JS module (WebIDL converters such as converters.boolean, converters.DOMString, requiredArguments) via require('internal/crypto/webidl') with --expose-internals; Deno's WebCrypto is implemented in Rust (ext/crypto/) and does not expose this internal module"
     },
+    "parallel/test-webcrypto-wrap-unwrap.js": {
+      "ignore": true,
+      "reason": "Iterates wrap/unwrap pairs across SubtleCrypto algorithms. The AES-KW / Curve448 paths self-skip via `printSkipMessage`, but the loop continues into algorithms Deno's WebCrypto doesn't recognise (e.g. ChaCha20-Poly1305 wrapping, KMAC) and `subtle.generateKey` rejects with `NotSupportedError: Unrecognized algorithm name`. Could be revisited as Deno's algorithm coverage grows -- this test is effectively a coverage census of the full SubtleCrypto algorithm matrix"
+    },
     "parallel/test-websocket.js": {},
     "parallel/test-webstorage-without-sqlite.js": {},
     "parallel/test-webstream-string-tag.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3053,6 +3053,10 @@
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-cryptokey-workers.js": {},
     "parallel/test-webcrypto-derivebits-argon2.js": {},
+    "parallel/test-webcrypto-derivekey.js": {
+      "ignore": true,
+      "reason": "Iterates HKDF/PBKDF2 deriveKey across every supported derived-key algorithm. SHA-3 source hashes self-skip via `printSkipMessage`, but the loop then derives into algorithms Deno's WebCrypto doesn't recognise (e.g. AES-KW, ChaCha20-Poly1305, KMAC) and `subtle.deriveKey` rejects with `NotSupportedError: Unrecognized algorithm name`. Could be revisited piece-by-piece as Deno's algorithm coverage grows"
+    },
     "parallel/test-webcrypto-encap-decap-ml-kem.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. All three are coverage-census tests over the full SubtleCrypto algorithm matrix; each fails on an algorithm Deno doesn't (and largely shouldn't try to) implement until the underlying `ext/crypto/` algorithm support exists. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-webcrypto-export-import.js`

```
TypeError: Failed to execute 'importKey' on 'SubtleCrypto':
  The provided value 'raw-secret' is not a valid enum value of type KeyFormat
```

Symmetric-key import/export across every algorithm; the AES-OCB / KMAC / Argon2 / chacha20-poly1305 paths use the Node-specific `'raw-secret'` `KeyFormat` (not in the WebCrypto Level 1/2 spec). Deno's WebIDL `KeyFormat` enum doesn't recognise it. Same blocker family as the just-ignored `test-webcrypto-encrypt-decrypt-aes.js` and `test-webcrypto-sign-verify-kmac.js`. **Could be revisited** if `'raw-secret'` lands in `ext/crypto/`.

### `parallel/test-webcrypto-wrap-unwrap.js`

```
NotSupportedError: Unrecognized algorithm name
  const keys = await subtle.generateKey(params.algorithm, true, usages);
```

Iterates `wrapKey`/`unwrapKey` across the algorithm matrix. AES-KW and Curve448 paths self-skip; the loop continues into ChaCha20-Poly1305 wrapping, KMAC etc. and `subtle.generateKey` rejects. **Could be revisited** piece-by-piece as Deno's algorithm coverage grows.

### `parallel/test-webcrypto-derivekey.js`

```
NotSupportedError: Unrecognized algorithm name
  const derived = await subtle.deriveKey(...)
```

Iterates HKDF/PBKDF2 `deriveKey` across every derived-key algorithm. SHA-3 source hashes self-skip; the loop then derives into AES-KW / ChaCha20-Poly1305 / KMAC. **Could be revisited** as Deno's algorithm coverage grows.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
