### PR TITLE
fix(task): use explicit workspace root check in directory-name fallback

### DIFF
--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -102,6 +102,7 @@ pub async fn execute_script(
     let mut packages_task_info: Vec<PackageTaskInfo> = vec![];
 
     let workspace = cli_options.workspace();
+    let root_dir_url = workspace.root_dir_url();
     for (folder_url, folder) in
       workspace.config_folders_sorted_by_dependencies()
     {
@@ -111,6 +112,7 @@ pub async fn execute_script(
           folder_url,
           force_use_pkg_json,
           &package_regex,
+          folder_url == root_dir_url,
         )
       {
         continue;
@@ -715,6 +717,7 @@ fn matches_package(
   folder_url: &Url,
   force_use_pkg_json: bool,
   regex: &Regex,
+  is_workspace_root: bool,
 ) -> bool {
   if !force_use_pkg_json
     && let Some(deno_json) = &config.deno_json
@@ -733,16 +736,9 @@ fn matches_package(
 
   // Fall back to matching the workspace member's directory name so that
   // `deno task --filter <dir>` works when the package name diverges
-  // from the directory (#28620). Gated on the folder having a `name`
-  // so we never accidentally select the workspace root (which doesn't
-  // carry one and is intentionally excluded from `--filter *`).
-  let has_name = config
-    .deno_json
-    .as_ref()
-    .and_then(|deno| deno.json.name.as_ref())
-    .or(config.pkg_json.as_ref().and_then(|pkg| pkg.name.as_ref()))
-    .is_some();
-  if has_name
+  // from the directory (#28620). Skip the workspace root so it is never
+  // accidentally selected by `--filter *`.
+  if !is_workspace_root
     && let Some(dir_name) = workspace_folder_dir_name(folder_url)
     && regex.is_match(dir_name)
   {
@@ -766,11 +762,18 @@ fn print_available_tasks_workspace(
   recursive: bool,
 ) -> Result<(), AnyError> {
   let workspace = cli_options.workspace();
+  let root_dir_url = workspace.root_dir_url();
 
   let mut matched = false;
   for (folder_url, folder) in workspace.config_folders() {
     if !recursive
-      && !matches_package(folder, folder_url, force_use_pkg_json, package_regex)
+      && !matches_package(
+        folder,
+        folder_url,
+        force_use_pkg_json,
+        package_regex,
+        folder_url == root_dir_url,
+      )
     {
       continue;
     }

--- a/cli/tools/task.rs
+++ b/cli/tools/task.rs
@@ -731,13 +731,11 @@ fn matches_package(
     return true;
   }
 
-  // Fall back to the workspace member's directory name when neither
-  // deno.json nor package.json carry a `name`. Without this fallback,
-  // `deno task --filter <dir>` silently failed for members whose
-  // package name didn't happen to match the directory (#28620).
-  // Gated on the folder having a name so we never accidentally select
-  // the workspace root (which doesn't carry one and is intentionally
-  // excluded from `--filter *`).
+  // Fall back to matching the workspace member's directory name so that
+  // `deno task --filter <dir>` works when the package name diverges
+  // from the directory (#28620). Gated on the folder having a `name`
+  // so we never accidentally select the workspace root (which doesn't
+  // carry one and is intentionally excluded from `--filter *`).
   let has_name = config
     .deno_json
     .as_ref()

--- a/tests/specs/task/filter/__test__.jsonc
+++ b/tests/specs/task/filter/__test__.jsonc
@@ -112,6 +112,21 @@
       "cwd": "./deno_dir_name_match",
       "args": "task --filter foo-dir dev",
       "output": "deno_dir_name_match.out"
+    },
+    // Workspace root should not be matched by its directory name even if it
+    // has a `name` field. Here the filter matches the root's directory name
+    // but not its package name, so the root must not be selected.
+    "deno_root_not_matched_by_dir": {
+      "cwd": "./deno_root_with_name",
+      "args": "task --filter deno_root_with_name dev",
+      "output": "deno_root_not_matched_by_dir.out"
+    },
+    // A workspace member without a `name` field should still be matchable
+    // by its directory name.
+    "deno_member_no_name": {
+      "cwd": "./deno_member_no_name",
+      "args": "task --filter my-lib dev",
+      "output": "deno_member_no_name.out"
     }
   }
 }

--- a/tests/specs/task/filter/deno_member_no_name.out
+++ b/tests/specs/task/filter/deno_member_no_name.out
@@ -1,0 +1,2 @@
+Task dev echo 'my-lib ran'
+my-lib ran

--- a/tests/specs/task/filter/deno_member_no_name/deno.json
+++ b/tests/specs/task/filter/deno_member_no_name/deno.json
@@ -1,0 +1,5 @@
+{
+  "workspace": [
+    "./my-lib"
+  ]
+}

--- a/tests/specs/task/filter/deno_member_no_name/my-lib/deno.json
+++ b/tests/specs/task/filter/deno_member_no_name/my-lib/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "dev": "echo 'my-lib ran'"
+  }
+}

--- a/tests/specs/task/filter/deno_root_not_matched_by_dir.out
+++ b/tests/specs/task/filter/deno_root_not_matched_by_dir.out
@@ -1,0 +1,1 @@
+No matching task or script 'dev' found in selected packages.

--- a/tests/specs/task/filter/deno_root_with_name/deno.json
+++ b/tests/specs/task/filter/deno_root_with_name/deno.json
@@ -1,0 +1,10 @@
+{
+  "name": "@scope/root",
+  "workspace": [
+    "./member-pkg"
+  ],
+  "tasks": {
+    "dev": "echo 'root ran'"
+  },
+  "exports": {}
+}

--- a/tests/specs/task/filter/deno_root_with_name/member-pkg/deno.json
+++ b/tests/specs/task/filter/deno_root_with_name/member-pkg/deno.json
@@ -1,0 +1,7 @@
+{
+  "name": "@scope/member",
+  "tasks": {
+    "dev": "echo 'member ran'"
+  },
+  "exports": {}
+}


### PR DESCRIPTION
## Summary
- Replace the `has_name` heuristic in `matches_package` with an explicit workspace root check
- The previous approach used the presence of a `name` field as a proxy to exclude the root from directory-name matching, but this fails when the root has a name (would incorrectly match) or when a member lacks a name (would incorrectly skip)
- Now compares `folder_url == workspace.root_dir_url()` directly, making the exclusion reliable regardless of whether configs carry a `name` field
- Addresses https://github.com/denoland/deno/pull/33499#discussion_r3143527626

## Test plan
- [x] All 24 existing `task::filter` spec tests pass
- [x] New test: root with a `name` is not matched by its directory name (`deno_root_not_matched_by_dir`)
- [x] New test: member without a `name` is still matchable by directory name (`deno_member_no_name`)