### PR TITLE
chore(node_compat): ignore 3 crypto tests gated on encrypted-PEM/DER paths

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -476,6 +476,10 @@
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},
     "parallel/test-crypto-keygen-async-named-elliptic-curve.js": {},
+    "parallel/test-crypto-keygen-async-named-elliptic-curve-encrypted.js": {
+      "ignore": true,
+      "reason": "Generates a P-256 keypair with `type: 'sec1', cipher: 'aes-128-cbc', passphrase: 'secret'` for the SEC1 PEM private key. Deno does not currently emit the legacy `BEGIN EC PRIVATE KEY` + `Proc-Type: 4,ENCRYPTED` / `DEK-Info` form (only PKCS#8 encrypted PEM is supported -- same bucket as the existing `test-crypto-keygen-async-rsa.js` ignore), and the test additionally asserts on the OpenSSL-3-specific error string `error:07880109:common libcrypto routines::interrupted or cancelled` when calling testSignVerify without the passphrase. Could be revisited if SEC1 encrypted PEM emission lands; the OpenSSL error-string assertion would still need addressing separately"
+    },
     "parallel/test-crypto-keygen-async-rsa.js": {
       "ignore": true,
       "reason": "Decrypting legacy PEM encrypted private keys (Proc-Type/DEK-Info format) is not yet supported; only PKCS#8 encrypted key import works"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -472,6 +472,10 @@
     "parallel/test-crypto-hmac.js": {},
     "parallel/test-crypto-keygen.js": {},
     "parallel/test-crypto-keygen-async-dsa-key-object.js": {},
+    "parallel/test-crypto-keygen-async-encrypted-private-key.js": {
+      "ignore": true,
+      "reason": "Generates an RSA keypair with `format: 'der', cipher: 'aes-256-cbc'` for an encrypted PKCS#8 DER private key, then expects `testSignVerify` against the encrypted DER (without passphrase) to throw `ERR_MISSING_PASSPHRASE`. Deno's encrypted-PKCS#8-DER detection path does not detect the missing passphrase and the assert.throws collects 'Missing expected exception (TypeError)'. Could be revisited once Deno's DER PKCS#8 parser distinguishes `EncryptedPrivateKeyInfo` (rfc5958) from `PrivateKeyInfo` and surfaces the missing-passphrase case as a TypeError"
+    },
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-ec.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -533,8 +533,10 @@
     "parallel/test-crypto-pqc-key-objects-ml-kem.js": {},
     "parallel/test-crypto-pqc-key-objects-slh-dsa.js": {},
     "parallel/test-crypto-psychic-signatures.js": {},
-    // TODO(bartlomieju): requires encrypted PEM export (cipher+passphrase in privateKeyEncoding)
-    // "parallel/test-crypto-publicDecrypt-fails-first-time.js": {},
+    "parallel/test-crypto-publicDecrypt-fails-first-time.js": {
+      "ignore": true,
+      "reason": "Encrypts the PKCS#8 PEM private key with `cipher: 'aes-128-ecb'`. Deno's PEM PBES2 encoder rejects ECB modes (no IV, not in the PKCS#5 v2 recommended cipher list) with 'Unsupported cipher for PEM encryption: aes-128-ecb'. Adding ECB to the PBES2 emitter would be a security-questionable change. Could be revisited if there's a real-world need; the upstream Node test exists only as a regression for nodejs/node#40814 (a bug in OpenSSL's first-call EVP error stack)"
+    },
     "parallel/test-crypto-random.js": {},
     "parallel/test-crypto-randomfillsync-regression.js": {},
     "parallel/test-crypto-randomuuid.js": {},


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. All three depend on encrypted-PEM/DER paths Deno doesn't fully implement (legacy SEC1 PEM, ECB-mode PBES2, encrypted PKCS#8 DER missing-passphrase detection) plus, in two cases, OpenSSL-3-specific error string assertions. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-crypto-publicDecrypt-fails-first-time.js`

```
TypeError: Unsupported cipher for PEM encryption: aes-128-ecb
const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', { ...
```

The test encrypts the PKCS#8 PEM private key with `cipher: 'aes-128-ecb'`. Deno's PEM PBES2 encoder rejects ECB modes (no IV, not in the PKCS#5 v2 recommended cipher list). Adding ECB to PBES2 would be security-questionable. **Could be revisited** if there's a real-world need; the upstream Node test exists only as a regression for [nodejs/node#40814](https://github.com/nodejs/node/issues/40814) (a bug in OpenSSL's first-call EVP error stack). Replaces a commented-out TODO entry that was previously left in the config for the same test.

### `parallel/test-crypto-keygen-async-named-elliptic-curve-encrypted.js`

```
+ message: 'invalid PEM private k...'
- (regex: /^-----BEGIN EC PRIVATE KEY-----...AES-128-CBC.../)
```

Generates a P-256 keypair with `type: 'sec1', cipher: 'aes-128-cbc'` -- the legacy `BEGIN EC PRIVATE KEY` + `Proc-Type: 4,ENCRYPTED` / `DEK-Info` form. Deno only emits PKCS#8 encrypted PEM (same bucket as the existing `test-crypto-keygen-async-rsa.js` ignore). Plus the test asserts the OpenSSL-3-specific error string `error:07880109:...`. Same family as the just-ignored `test-crypto-keygen-async-named-elliptic-curve-encrypted-p256.js`. **Could be revisited** if SEC1 encrypted PEM emission lands; the error-string assertion would still need addressing.

### `parallel/test-crypto-keygen-async-encrypted-private-key.js`

```
AssertionError: Missing expected exception (TypeError).
  assert.throws(() => { ... testSignVerify(...) ... },
                { name: 'TypeError', code: 'ERR_MISSING_PASSPHRASE' });
```

Generates an RSA keypair with `format: 'der', cipher: 'aes-256-cbc'`, then expects `testSignVerify` (without passphrase) to throw `ERR_MISSING_PASSPHRASE`. Deno's encrypted-PKCS#8-DER detection does not distinguish `EncryptedPrivateKeyInfo` (RFC 5958) from `PrivateKeyInfo` and silently accepts the encrypted blob -- the test expects the throw and times out instead. **Could be revisited** once Deno's DER PKCS#8 parser distinguishes the two ASN.1 shapes and surfaces missing-passphrase as a TypeError.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
