### PR TITLE
fix(ext/node): fix spawnSync internal API for monkey-patching and killSignal

### DIFF
--- a/ext/node/polyfills/child_process.ts
+++ b/ext/node/polyfills/child_process.ts
@@ -19,12 +19,12 @@ import {
   normalizeSpawnArguments,
   setupChannel,
   type SpawnOptions,
-  spawnSync as _spawnSync,
   type SpawnSyncOptions,
   type SpawnSyncResult,
   stdioStringToArray,
   validateNullByteNotInArg,
 } from "ext:deno_node/internal/child_process.ts";
+import internalChildProcess from "ext:deno_node/internal/child_process.ts";
 import {
   validateAbortSignal,
   validateFunction,
@@ -304,9 +304,9 @@ export function spawnSync(
   validateMaxBuffer(options.maxBuffer);
 
   // Validate and translate the kill signal, if present.
-  sanitizeKillSignal(options.killSignal);
+  options.killSignal = sanitizeKillSignal(options.killSignal);
 
-  return _spawnSync(options.file, options.args, options);
+  return internalChildProcess.spawnSync(options);
 }
 
 interface ExecOptions extends

--- a/ext/node/polyfills/internal/child_process.ts
+++ b/ext/node/polyfills/internal/child_process.ts
@@ -1562,6 +1562,8 @@ export interface SpawnSyncOptions extends
     | "windowsVerbatimArguments"
     | "windowsHide"
   > {
+  file?: string;
+  args?: string[];
   input?: string | Buffer | DataView;
   timeout?: number;
   maxBuffer?: number;
@@ -1601,8 +1603,6 @@ function normalizeInput(input: unknown) {
 }
 
 export function spawnSync(
-  command: string,
-  args: string[],
   options: SpawnSyncOptions,
 ): SpawnSyncResult {
   const {
@@ -1618,6 +1618,8 @@ export function spawnSync(
     killSignal,
     windowsVerbatimArguments = false,
   } = options;
+  let command = options.file || "";
+  let args: string[] = options.args || [];
   const [
     stdin_ = "pipe",
     stdout_ = "pipe",

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -303,6 +303,7 @@
     "parallel/test-child-process-spawnsync-args.js": {},
     "parallel/test-child-process-spawnsync-env.js": {},
     "parallel/test-child-process-spawnsync-input.js": {},
+    "parallel/test-child-process-spawnsync-kill-signal.js": {},
     "parallel/test-child-process-spawnsync-maxbuf.js": {},
     "parallel/test-child-process-spawnsync-shell.js": {
       "ignore": true,


### PR DESCRIPTION
## Summary
- Change internal `spawnSync` to accept a single options object (matching Node.js's `lib/internal/child_process.js` API), so monkey-patching `require('internal/child_process').spawnSync` works correctly.
- Call internal `spawnSync` through the default export object rather than a captured import binding, so runtime monkey-patching is observable.
- Assign the result of `sanitizeKillSignal()` back to `options.killSignal` so string signal names (e.g. `'SIGKILL'`) are converted to their numeric values (e.g. `9`) before reaching the internal function.

Fixes the node compat test `test-child-process-spawnsync-kill-signal.js`.

## Test plan
- [x] `./x test-compat test-child-process-spawnsync-kill-signal.js` passes