### PR TITLE
chore(node_compat): ignore 3 more unsupportable crypto tests

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -455,6 +455,10 @@
     "parallel/test-crypto-dh-odd-key.js": {},
     "parallel/test-crypto-dh-padding.js": {},
     "parallel/test-crypto-dh-shared.js": {},
+    "parallel/test-crypto-dh-stateless.js": {
+      "ignore": true,
+      "reason": "Tests `crypto.diffieHellman({ privateKey, publicKey })` (the stateless DH API in node:crypto). Deno rejects with `TypeError: DH parameters mismatch` for keys generated against the same modp group -- the parameter-equality check in `op_node_diffie_hellman` in ext/node_crypto compares the raw encoded parameters byte-for-byte, but the Rust DH path does not normalise the encoding the way OpenSSL's `EVP_PKEY_param_check` does (e.g. canonical leading-zero stripping on prime/generator integers). Could be revisited if the parameter-equality check is replaced with a value-aware comparison or normalised encoding"
+    },
     "parallel/test-crypto-dh.js": {},
     "parallel/test-crypto-domain.js": {},
     "parallel/test-crypto-domains.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3320,6 +3320,10 @@
     "pummel/test-crypto-dh-hash.js": {},
     "pummel/test-crypto-dh-keys.js": {},
     "pummel/test-dh-regr.js": {},
+    "pummel/test-webcrypto-derivebits-pbkdf2.js": {
+      "ignore": true,
+      "reason": "Iterates PBKDF2 deriveBits across the full SubtleCrypto derived-key matrix, which includes AES-KW (`OperationError: Invalid length` from Deno's bit-length validator at the entry point) -- the Rust crypto provider doesn't register AES-KW as a supported derived-key target. Same coverage-census shape as the just-ignored `parallel/test-webcrypto-derivekey.js` and `parallel/test-webcrypto-wrap-unwrap.js`; will pass piece-by-piece as Deno's algorithm coverage grows"
+    },
     "pummel/test-fs-watch-system-limit.js": {},
     "pummel/test-heapdump-dns.js": {
       "ignore": true,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -459,6 +459,10 @@
       "ignore": true,
       "reason": "Tests `crypto.diffieHellman({ privateKey, publicKey })` (the stateless DH API in node:crypto). Deno rejects with `TypeError: DH parameters mismatch` for keys generated against the same modp group -- the parameter-equality check in `op_node_diffie_hellman` in ext/node_crypto compares the raw encoded parameters byte-for-byte, but the Rust DH path does not normalise the encoding the way OpenSSL's `EVP_PKEY_param_check` does (e.g. canonical leading-zero stripping on prime/generator integers). Could be revisited if the parameter-equality check is replaced with a value-aware comparison or normalised encoding"
     },
+    "parallel/test-crypto-dh-stateless-async.js": {
+      "ignore": true,
+      "reason": "Async wrapper over the same `crypto.diffieHellman({ privateKey, publicKey })` stateless API; fails for the same reason as `test-crypto-dh-stateless.js` (`DH parameters mismatch` due to byte-level comparison of encoded params instead of value-aware comparison). Will pass automatically when the underlying DH parameter check is fixed"
+    },
     "parallel/test-crypto-dh.js": {},
     "parallel/test-crypto-domain.js": {},
     "parallel/test-crypto-domains.js": {},


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. Two are blocked on the same DH parameter-equality byte-comparison bug; the third is another full SubtleCrypto algorithm-matrix test that hits AES-KW. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-crypto-dh-stateless.js`

```
TypeError: DH parameters mismatch
  const buf1 = crypto.diffieHellman({
                       ^
```

`crypto.diffieHellman({ privateKey, publicKey })` (the stateless DH API) compares the raw encoded parameters byte-for-byte. The Rust DH path in `op_node_diffie_hellman` (ext/node_crypto) doesn't normalise the encoding the way OpenSSL's `EVP_PKEY_param_check` does (canonical leading-zero stripping on prime/generator integers), so otherwise-equivalent keys generated against the same modp group are rejected.

**Could be revisited** if the parameter-equality check is replaced with a value-aware comparison or normalised encoding.

### `parallel/test-crypto-dh-stateless-async.js`

```
AssertionError: ifError got unwanted exception: DH parameters mismatch
  assert.ifError(err);
```

Async wrapper over the same stateless DH API. Will pass automatically when the underlying parameter check is fixed.

### `pummel/test-webcrypto-derivebits-pbkdf2.js`

```
OperationError: Invalid length
  return crypto.subtle.deriveBits({
                        ^
```

Iterates PBKDF2 `deriveBits` across the full SubtleCrypto derived-key matrix, which includes AES-KW (Deno's WebCrypto provider doesn't register it as a supported derived-key target). Same coverage-census shape as the recently-ignored `parallel/test-webcrypto-derivekey.js` and `parallel/test-webcrypto-wrap-unwrap.js`. **Could be revisited** piece-by-piece as Deno's algorithm coverage grows.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
