### PR TITLE
chore(node_compat): ignore 3 crypto tests gated on createPrivateKey/importKey corner cases

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3079,6 +3079,10 @@
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
     "parallel/test-webcrypto-export-import-ml-dsa.js": {},
     "parallel/test-webcrypto-export-import-ml-kem.js": {},
+    "parallel/test-webcrypto-export-import-rsa.js": {
+      "ignore": true,
+      "reason": "Asserts on the exact reject message regex `/Invalid key type/` for cross-algorithm import attempts (e.g. importing an RSA-OAEP SPKI as RSA-PSS). Deno's importKey path emits `unsupported algorithm` instead. Same shape and root cause as the upcoming `test-webcrypto-export-import-ec.js` and `test-webcrypto-export-import-cfrg.js` divergences; the test additionally exercises SHA-3 hashes which self-skip via `printSkipMessage`. Could be revisited if Deno's WebCrypto importKey path's mismatched-algorithm error string is brought into line with the WebCrypto spec / Node's wording"
+    },
     "parallel/test-webcrypto-getRandomValues.js": {},
     "parallel/test-webcrypto-random.js": {},
     "parallel/test-webcrypto-keygen-kmac.js": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -474,6 +474,10 @@
     "parallel/test-crypto-hmac.js": {},
     "parallel/test-crypto-keygen.js": {},
     "parallel/test-crypto-keygen-async-dsa-key-object.js": {},
+    "parallel/test-crypto-keygen-async-encrypted-private-key-der.js": {
+      "ignore": true,
+      "reason": "Generates an RSA keypair as PKCS#8 DER without specifying `cipher`/`passphrase` in `privateKeyEncoding`, then later passes the unencrypted DER to `testSignVerify` with a stray `passphrase: 'secret'`. Node tolerates the unused passphrase; Deno's `createPrivateKey({ key, passphrase })` path treats the presence of `passphrase` as a signal that the input is encrypted and rejects with `TypeError: invalid encrypted PKCS#8 private key`. Could be revisited once Deno's createPrivateKey only attempts decryption when the input ASN.1 actually has the EncryptedPrivateKeyInfo wrapper"
+    },
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-ec.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk.js": {},
     "parallel/test-crypto-keygen-async-elliptic-curve-jwk-rsa.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -499,6 +499,10 @@
     "parallel/test-crypto-pqc-keygen-slh-dsa.js": {},
     "parallel/test-crypto-pqc-sign-verify-ml-dsa.js": {},
     "parallel/test-crypto-keygen-empty-passphrase-no-error.js": {},
+    "parallel/test-crypto-keygen-empty-passphrase-no-prompt.js": {
+      "ignore": true,
+      "reason": "Generates an RSA keypair encrypted with an empty passphrase string (`cipher: 'aes-256-cbc', passphrase: ''`) and then expects `createPrivateKey({ key, passphrase: '' })` to round-trip successfully. Deno's PEM decryptor rejects empty passphrases with `TypeError: invalid encrypted PEM private key` -- it normalises `''` and `Buffer.alloc(0)` to no-passphrase before checking. Plus the test asserts on the OpenSSL-3-specific `error:07880109:common libcrypto routines::interrupted or cancelled` string when signing without a passphrase. Could be revisited once empty-string passphrases are accepted as a valid (zero-length) PBKDF2 input"
+    },
     "parallel/test-crypto-keygen-invalid-parameter-encoding-dsa.js": {},
     "parallel/test-crypto-keygen-invalid-parameter-encoding-ec.js": {},
     "parallel/test-crypto-keygen-key-object-without-encoding.js": {},


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. Two depend on Deno's `createPrivateKey({ key, passphrase })` path being too eager about treating the input as encrypted; one is an importKey error-message divergence. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-crypto-keygen-empty-passphrase-no-prompt.js`

```
TypeError: invalid encrypted PEM private key
  const privateKeyObject = createPrivateKey({
                            ^
```

Generates an RSA keypair encrypted with an *empty* passphrase string (`cipher: 'aes-256-cbc', passphrase: ''`) and expects `createPrivateKey({ key, passphrase: '' })` and `createPrivateKey({ key, passphrase: Buffer.alloc(0) })` to round-trip successfully. Deno's PEM decryptor normalises `''` / zero-length buffers to no-passphrase before checking, so the encrypted-key parse fails. The test additionally asserts on the OpenSSL-3-specific `error:07880109:common libcrypto routines::interrupted or cancelled` string. **Could be revisited** once empty-string passphrases are accepted as a valid (zero-length) PBKDF2 input.

### `parallel/test-crypto-keygen-async-encrypted-private-key-der.js`

```
TypeError: invalid encrypted PKCS#8 private key
  const signature = signFn('SHA256', message, privateKey);
```

Generates an RSA keypair as PKCS#8 DER **without** specifying `cipher`/`passphrase` in `privateKeyEncoding` (the DER is unencrypted), then passes the unencrypted DER to `testSignVerify` with a stray `passphrase: 'secret'`. Node tolerates the unused passphrase on an unencrypted key; Deno's `createPrivateKey({ key, passphrase })` path treats the presence of `passphrase` as a signal that the input is encrypted and rejects. **Could be revisited** once Deno only attempts decryption when the input ASN.1 actually has the `EncryptedPrivateKeyInfo` wrapper (RFC 5958).

### `parallel/test-webcrypto-export-import-rsa.js`

```
+ message: 'unsupported algorithm'
- message: /Invalid key type/
```

Asserts on the regex `/Invalid key type/` for cross-algorithm import attempts (importing an RSA-OAEP SPKI as RSA-PSS, etc.). Deno's importKey path emits `unsupported algorithm`. Same shape as the divergences expected in `test-webcrypto-export-import-ec.js` and `-cfrg.js`. The test additionally exercises SHA-3 hashes which self-skip via `printSkipMessage`. **Could be revisited** if the importKey error string is brought into line with WebCrypto / Node's wording.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
