### PR TITLE
chore(node_compat): ignore 3 crypto tests gated on WebCrypto error wording

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3072,6 +3072,10 @@
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
+    "parallel/test-webcrypto-export-import-ec.js": {
+      "ignore": true,
+      "reason": "Asserts on the exact reject message regex `/Invalid key /` for cross-algorithm EC import attempts (e.g. importing a P-256 SPKI as P-384). Deno's importKey path emits `unsupported algorithm` instead. Same shape and root cause as the already-ignored `test-webcrypto-export-import-rsa.js`. Could be revisited if Deno's WebCrypto importKey path's mismatched-algorithm error string is brought into line with the WebCrypto spec / Node's wording"
+    },
     "parallel/test-webcrypto-export-import-ml-dsa.js": {},
     "parallel/test-webcrypto-export-import-ml-kem.js": {},
     "parallel/test-webcrypto-getRandomValues.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3068,6 +3068,10 @@
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-cryptokey-workers.js": {},
     "parallel/test-webcrypto-derivebits-argon2.js": {},
+    "parallel/test-webcrypto-derivekey-cfrg.js": {
+      "ignore": true,
+      "reason": "Asserts that `subtle.deriveKey({ name: 'X25519' })` (no `public` field) rejects with `code: 'ERR_MISSING_OPTION'`. Deno's WebIDL dictionary converter throws `TypeError(\"...is required in 'EcdhKeyDeriveParams'...\")` without attaching Node's `code` property. Same shape as `test-webcrypto-derivekey-ecdh.js`. Could be revisited if the WebIDL `required: true` throw is generalised to attach `ERR_MISSING_OPTION` (the analogue of the existing `ERR_INVALID_THIS` / `ERR_ILLEGAL_CONSTRUCTOR` code attachments)"
+    },
     "parallel/test-webcrypto-encap-decap-ml-kem.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3072,6 +3072,10 @@
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
+    "parallel/test-webcrypto-export-import-cfrg.js": {
+      "ignore": true,
+      "reason": "Asserts on cross-algorithm import-error message shape for the CFRG curve family (Ed25519 / X25519; X448 / Ed448 cases self-skip). Deno's importKey path emits `Invalid key data` rather than the regex `/Invalid key type/` the test expects. Same family as the already-ignored `test-webcrypto-export-import-rsa.js` and `-ec.js` divergences. Could be revisited if the importKey mismatched-algorithm error wording is brought into line with the WebCrypto spec / Node"
+    },
     "parallel/test-webcrypto-export-import-ec.js": {
       "ignore": true,
       "reason": "Asserts on the exact reject message regex `/Invalid key /` for cross-algorithm EC import attempts (e.g. importing a P-256 SPKI as P-384). Deno's importKey path emits `unsupported algorithm` instead. Same shape and root cause as the already-ignored `test-webcrypto-export-import-rsa.js`. Could be revisited if Deno's WebCrypto importKey path's mismatched-algorithm error string is brought into line with the WebCrypto spec / Node's wording"


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. All three depend on Deno's WebCrypto error wording / `code` attachment diverging from the WebCrypto spec / Node. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-webcrypto-export-import-ec.js`

```
+ message: 'unsupported algorithm'
- message: /Invalid key /
```

Asserts on the regex `/Invalid key /` for cross-algorithm EC import attempts (e.g. importing a P-256 SPKI as P-384). Deno's importKey path emits `unsupported algorithm`. Same shape as the already-ignored `test-webcrypto-export-import-rsa.js`. **Could be revisited** when Deno's importKey error wording is brought into line with WebCrypto / Node.

### `parallel/test-webcrypto-export-import-cfrg.js`

```
+ message: 'Invalid key data'
- message: /Invalid key type/
```

Same family for the CFRG curve set (Ed25519 / X25519; X448 / Ed448 self-skip). **Could be revisited** as one fix that retunes the importKey error strings across all key types.

### `parallel/test-webcrypto-derivekey-cfrg.js`

```
+ Comparison {}
- Comparison { code: 'ERR_MISSING_OPTION' }
```

Asserts that `subtle.deriveKey({ name: 'X25519' })` (no `public` field) rejects with `code: 'ERR_MISSING_OPTION'`. Deno's WebIDL dictionary converter throws `TypeError("...is required in 'EcdhKeyDeriveParams'...")` without attaching the code. Same shape as the still-failing `test-webcrypto-derivekey-ecdh.js`. **Could be revisited** by generalising the WebIDL `required: true` throw site to attach `ERR_MISSING_OPTION`, parallel to the existing `ERR_INVALID_THIS` and `ERR_ILLEGAL_CONSTRUCTOR` code attachments.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
