### PR TITLE
chore(node_compat): ignore 3 WebCrypto sign/verify error-shape divergences

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3080,6 +3080,10 @@
       "ignore": true,
       "reason": "Tests SubtleCrypto generateKey for KMAC128 / KMAC256, a Node-specific WebCrypto extension that requires OpenSSL >= 3 (test gates on hasOpenSSL(3)); Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm. Could be revisited if KMAC is added — a SHA-3-based KMAC is implementable via the sha3 / cshake Rust crates"
     },
+    "parallel/test-webcrypto-sign-verify-hmac.js": {
+      "ignore": true,
+      "reason": "Asserts on the regex `/Unable to use this key to verify/` for the case where `subtle.verify` is called with a key whose usages don't include 'verify'. Deno's WebCrypto verify path emits the WebCrypto-spec wording `'The requested operation is not valid for the provided key'` (the spec's `InvalidAccessError` message) instead. Same shape as the failures in `test-webcrypto-sign-verify-ecdsa.js` and the `test-webcrypto-export-import-{rsa,ec,cfrg}.js` ignore family. Could be revisited if the WebCrypto wrong-usages-on-verify error message is brought into line with Node's wording"
+    },
     "parallel/test-webcrypto-sign-verify-ml-dsa.js": {},
     "parallel/test-webcrypto-util.js": {
       "ignore": true,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3080,6 +3080,10 @@
       "ignore": true,
       "reason": "Tests SubtleCrypto generateKey for KMAC128 / KMAC256, a Node-specific WebCrypto extension that requires OpenSSL >= 3 (test gates on hasOpenSSL(3)); Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm. Could be revisited if KMAC is added — a SHA-3-based KMAC is implementable via the sha3 / cshake Rust crates"
     },
+    "parallel/test-webcrypto-sign-verify-ecdsa.js": {
+      "ignore": true,
+      "reason": "Asserts on the regex `/Unable to use this key to verify/` when `subtle.verify` is called with an ECDSA key whose usages don't include 'verify'. Same root cause as `test-webcrypto-sign-verify-hmac.js`: Deno emits the WebCrypto-spec wording `'The requested operation is not valid for the provided key'`. Will pass automatically when the wrong-usages-on-verify error wording is brought into line with Node"
+    },
     "parallel/test-webcrypto-sign-verify-hmac.js": {
       "ignore": true,
       "reason": "Asserts on the regex `/Unable to use this key to verify/` for the case where `subtle.verify` is called with a key whose usages don't include 'verify'. Deno's WebCrypto verify path emits the WebCrypto-spec wording `'The requested operation is not valid for the provided key'` (the spec's `InvalidAccessError` message) instead. Same shape as the failures in `test-webcrypto-sign-verify-ecdsa.js` and the `test-webcrypto-export-import-{rsa,ec,cfrg}.js` ignore family. Could be revisited if the WebCrypto wrong-usages-on-verify error message is brought into line with Node's wording"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3089,6 +3089,10 @@
       "reason": "Asserts on the regex `/Unable to use this key to verify/` for the case where `subtle.verify` is called with a key whose usages don't include 'verify'. Deno's WebCrypto verify path emits the WebCrypto-spec wording `'The requested operation is not valid for the provided key'` (the spec's `InvalidAccessError` message) instead. Same shape as the failures in `test-webcrypto-sign-verify-ecdsa.js` and the `test-webcrypto-export-import-{rsa,ec,cfrg}.js` ignore family. Could be revisited if the WebCrypto wrong-usages-on-verify error message is brought into line with Node's wording"
     },
     "parallel/test-webcrypto-sign-verify-ml-dsa.js": {},
+    "parallel/test-webcrypto-sign-verify-rsa.js": {
+      "ignore": true,
+      "reason": "Asserts the rejection from `subtle.sign` for RSA-PSS with a saltLength larger than the modulus has `err.name === 'OperationError'`. Deno's WebCrypto sign path raises a plain `Error` instead of the spec-required `OperationError` (a DOMException with `name: 'OperationError'`). Could be revisited if the RSA-PSS error path in ext/crypto/ is migrated to throw via DOMException so the spec's `OperationError` semantics propagate"
+    },
     "parallel/test-webcrypto-util.js": {
       "ignore": true,
       "reason": "Runs with --expose-internals and requires Node's internal/crypto/util JS module to whitebox-test the internal normalizeAlgorithm() helper; Deno's WebCrypto is implemented in Rust (ext/crypto/) and does not expose this Node-internal module"


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. All three depend on Deno's WebCrypto error wording / class diverging from Node. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-webcrypto-sign-verify-hmac.js`

```
+ message: 'The requested operation is not valid for the provided key'
- message: /Unable to use this key to verify/
```

`subtle.verify` with a key whose usages don't include `'verify'`. Deno emits the WebCrypto-spec wording (the spec's `InvalidAccessError` message); Node uses a shorter form. **Could be revisited** if the WebCrypto wrong-usages-on-verify error message is brought into line with Node's wording (or a shim translates).

### `parallel/test-webcrypto-sign-verify-ecdsa.js`

Same root cause as the HMAC variant: ECDSA `subtle.verify` with wrong usages emits the same WebCrypto-spec wording. Will pass automatically when `-hmac.js` does.

### `parallel/test-webcrypto-sign-verify-rsa.js`

```
+ 'Error'
- 'OperationError'

  assert.strictEqual(err.name, 'OperationError');
```

RSA-PSS `subtle.sign` with `saltLength` larger than the modulus raises a plain `Error` instead of the spec-required `OperationError` (a `DOMException` with `name: 'OperationError'`). **Could be revisited** if the RSA-PSS error path in `ext/crypto/` throws via `DOMException`.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
