### PR TITLE
chore(node_compat): ignore 3 crypto tests gated on missing WebCrypto algorithms

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3089,6 +3089,10 @@
       "reason": "Tests SubtleCrypto generateKey for KMAC128 / KMAC256, a Node-specific WebCrypto extension that requires OpenSSL >= 3 (test gates on hasOpenSSL(3)); Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm. Could be revisited if KMAC is added — a SHA-3-based KMAC is implementable via the sha3 / cshake Rust crates"
     },
     "parallel/test-webcrypto-sign-verify-ml-dsa.js": {},
+    "parallel/test-webcrypto-sign-verify.js": {
+      "ignore": true,
+      "reason": "After RSASSA-PKCS1-v1_5 / RSA-PSS / ECDSA / HMAC blocks pass and the Ed448 case self-skips, the test continues into a `hasOpenSSL(3)`-gated KMAC128 / KMAC256 sign/verify block. Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm (`NotSupportedError: Unrecognized algorithm name`), so the test fails before reaching the Ed25519 cases. Same blocker family as the already-ignored `test-webcrypto-keygen-kmac.js` and `test-webcrypto-sign-verify-kmac.js`. Could be revisited if KMAC is added"
+    },
     "parallel/test-webcrypto-util.js": {
       "ignore": true,
       "reason": "Runs with --expose-internals and requires Node's internal/crypto/util JS module to whitebox-test the internal normalizeAlgorithm() helper; Deno's WebCrypto is implemented in Rust (ext/crypto/) and does not expose this Node-internal module"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3078,6 +3078,10 @@
     "parallel/test-webcrypto-encrypt-decrypt.js": {},
     "parallel/test-webcrypto-export-import-ml-dsa.js": {},
     "parallel/test-webcrypto-export-import-ml-kem.js": {},
+    "parallel/test-webcrypto-get-public-key.mjs": {
+      "ignore": true,
+      "reason": "Tests `subtle.getPublicKey(privateKey, usages)` -- the WebCrypto Level 2 method that derives a public CryptoKey from a private one. Deno does not implement this method (`TypeError: subtle.getPublicKey is not a function`). Implementable on top of Deno's existing per-algorithm export/import paths, but would need to handle every supported algorithm (ECDH, ECDSA, Ed25519, RSA-OAEP, RSA-PSS, RSASSA-PKCS1-v1_5, X25519). Could be revisited as a discrete WebCrypto Level 2 add-on"
+    },
     "parallel/test-webcrypto-getRandomValues.js": {},
     "parallel/test-webcrypto-random.js": {},
     "parallel/test-webcrypto-keygen-kmac.js": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3068,6 +3068,10 @@
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-cryptokey-workers.js": {},
     "parallel/test-webcrypto-derivebits-argon2.js": {},
+    "parallel/test-webcrypto-digest.js": {
+      "ignore": true,
+      "reason": "Tests SubtleCrypto.digest with cSHAKE128 / cSHAKE256 (Customizable SHAKE per NIST SP 800-185, a Node-specific WebCrypto extension that requires OpenSSL >= 3 for the customization-string wrapper). Deno's ext/crypto/ does not register cSHAKE as a recognised digest algorithm (only the underlying SHAKE128/SHAKE256 are supported). Could be revisited if a SHA3-based cSHAKE implementation lands -- the cshake-rs crate (or a small wrapper around the existing sha3 / cshake crates) would cover the customization-string path"
+    },
     "parallel/test-webcrypto-encap-decap-ml-kem.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. All three depend on WebCrypto algorithms / Level 2 APIs Deno doesn't implement. Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-webcrypto-digest.js`

```
NotSupportedError: Unrecognized algorithm name
  new Uint8Array(await subtle.digest({ name: 'cSHAKE128', length: ... }, ...))
```

cSHAKE (Customizable SHAKE per NIST SP 800-185) is a Node-specific WebCrypto extension that requires OpenSSL >= 3 for the customization-string wrapper. Deno's `ext/crypto/` only exposes the underlying SHAKE128 / SHAKE256 via `crypto.createHash()`. **Could be revisited** if a SHA3-based cSHAKE implementation lands -- the existing `sha3` / `cshake` Rust crates would cover the customization-string path.

### `parallel/test-webcrypto-get-public-key.mjs`

```
TypeError: subtle.getPublicKey is not a function
  const publicKey = await subtle.getPublicKey(privateKey, usages);
```

The WebCrypto Level 2 method that derives a public CryptoKey from a private one. Deno does not implement it. Implementable on top of Deno's existing per-algorithm export/import paths, but would need to handle every supported algorithm (ECDH, ECDSA, Ed25519, RSA-OAEP, RSA-PSS, RSASSA-PKCS1-v1_5, X25519). **Could be revisited** as a discrete WebCrypto Level 2 add-on -- same surface that the already-ignored `test-webcrypto-supports.mjs` advertises.

### `parallel/test-webcrypto-sign-verify.js`

```
NotSupportedError: Unrecognized algorithm name
  const key = await subtle.generateKey({
                       ^
```

After the RSASSA-PKCS1-v1_5 / RSA-PSS / ECDSA / HMAC blocks pass and Ed448 self-skips, the test continues into a `hasOpenSSL(3)`-gated KMAC128 / KMAC256 sign/verify block. Same blocker family as the already-ignored `test-webcrypto-keygen-kmac.js` and `test-webcrypto-sign-verify-kmac.js`. **Could be revisited** if KMAC is added.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
