### PR TITLE
chore(node_compat): ignore 3 WebCrypto error-wording divergences

### DIFF
--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3088,6 +3088,10 @@
       "ignore": true,
       "reason": "Tests SubtleCrypto generateKey for KMAC128 / KMAC256, a Node-specific WebCrypto extension that requires OpenSSL >= 3 (test gates on hasOpenSSL(3)); Deno's ext/crypto/ does not register KMAC as a recognised SubtleCrypto algorithm. Could be revisited if KMAC is added — a SHA-3-based KMAC is implementable via the sha3 / cshake Rust crates"
     },
+    "parallel/test-webcrypto-sign-verify-eddsa.js": {
+      "ignore": true,
+      "reason": "Asserts on the regex `/Unable to use this key to sign/` when `subtle.sign` is called on Ed25519 with a key whose usages don't include 'sign' (the Ed448 portion self-skips). Deno's WebCrypto sign path emits the spec wording `'The requested operation is not valid for the provided key'`. Same root cause as the already-ignored `test-webcrypto-sign-verify-hmac.js` and `test-webcrypto-sign-verify-ecdsa.js`. Will pass automatically when the wrong-usages-on-sign error wording is unified"
+    },
     "parallel/test-webcrypto-sign-verify-ml-dsa.js": {},
     "parallel/test-webcrypto-util.js": {
       "ignore": true,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3068,6 +3068,10 @@
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-cryptokey-workers.js": {},
     "parallel/test-webcrypto-derivebits-argon2.js": {},
+    "parallel/test-webcrypto-derivebits-cfrg.js": {
+      "ignore": true,
+      "reason": "Asserts on the regex `/derived bit length is too small/` for ECDH-on-CFRG (X25519) `subtle.deriveBits` with a `length` larger than the curve's secret; the X448 portion self-skips. Deno's WebCrypto X25519 deriveBits emits `'Invalid length'` instead of Node's regex. Will pass automatically when `test-webcrypto-derivebits-ecdh.js` does"
+    },
     "parallel/test-webcrypto-derivebits-ecdh.js": {
       "ignore": true,
       "reason": "Asserts on the regex `/derived bit length is too small/` for ECDH `subtle.deriveBits` with a `length` larger than the EC curve's secret. Deno's WebCrypto deriveBits emits `'Invalid length'` (the spec's `OperationError` message) instead of Node's regex. Could be revisited if the WebCrypto deriveBits length-too-large error wording is brought into line with Node"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3068,6 +3068,10 @@
     "parallel/test-weakref.js": {},
     "parallel/test-webcrypto-cryptokey-workers.js": {},
     "parallel/test-webcrypto-derivebits-argon2.js": {},
+    "parallel/test-webcrypto-derivebits-ecdh.js": {
+      "ignore": true,
+      "reason": "Asserts on the regex `/derived bit length is too small/` for ECDH `subtle.deriveBits` with a `length` larger than the EC curve's secret. Deno's WebCrypto deriveBits emits `'Invalid length'` (the spec's `OperationError` message) instead of Node's regex. Could be revisited if the WebCrypto deriveBits length-too-large error wording is brought into line with Node"
+    },
     "parallel/test-webcrypto-encap-decap-ml-kem.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-chacha20-poly1305.js": {},
     "parallel/test-webcrypto-encrypt-decrypt-rsa.js": {},


### PR DESCRIPTION
## Summary

Marks three more failing crypto tests as ignored in `tests/node_compat/config.jsonc`. All three depend on Deno's WebCrypto error wording diverging from Node (the same theme as recent ignore batches). Failure outputs come from the [2026-04-26 node compat run](https://node-test-viewer.deno.dev/results/2026-04-26); pure-config-change ignores so I did not rebuild Deno locally to re-confirm.

### `parallel/test-webcrypto-derivebits-ecdh.js`

```
+ message: 'Invalid length'
- message: /derived bit length is too small/
```

ECDH `subtle.deriveBits` with `length` larger than the EC curve's secret. Deno emits the spec's `OperationError` wording; Node uses a regex matching its own message. **Could be revisited** if WebCrypto deriveBits length-too-large error wording is unified with Node.

### `parallel/test-webcrypto-derivebits-cfrg.js`

```
+ message: 'Invalid length'
- message: /derived bit length is too small/
```

Same root cause for X25519 (X448 portion self-skips). Will pass automatically when `-ecdh.js` does.

### `parallel/test-webcrypto-sign-verify-eddsa.js`

```
+ message: 'The requested operation is not valid for the provided key'
- message: /Unable to use this key to sign/
```

`subtle.sign` on Ed25519 with wrong-usages key (Ed448 self-skips). Same root cause as the already-ignored `test-webcrypto-sign-verify-hmac.js` and `-ecdsa.js`. Will pass automatically when the wrong-usages-on-sign error wording is unified.

## Test plan

- [x] JSONC parses (`Deno.readTextFileSync` + `@std/jsonc`); all three new entries readable as `{ignore: true, reason: ...}`.
- [ ] CI: green on `node_compat_tests` with the three tests now skipped.
