### PR TITLE
fix(ext/node): cancelling Readable.toWeb(req) no longer destroys the socket

### DIFF
--- a/ext/node/polyfills/internal/webstreams/adapters.js
+++ b/ext/node/polyfills/internal/webstreams/adapters.js
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { destroy } from "ext:deno_node/internal/streams/destroy.js";
+import { destroy, destroyer } from "ext:deno_node/internal/streams/destroy.js";
 import finished from "ext:deno_node/internal/streams/end-of-stream.js";
 import {
   isDestroyed,
@@ -559,7 +559,7 @@ export function newReadableStreamFromStreamReadable(
 
     cancel(reason) {
       isCanceled = true;
-      destroy.call(streamReadable, reason);
+      destroyer(streamReadable, reason);
     },
   };
   if (isByteStream) {

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -2745,3 +2745,50 @@ Deno.test(
     await promise;
   },
 );
+
+// https://github.com/denoland/deno/issues/33567
+Deno.test(
+  "[node/http] cancelling Readable.toWeb(req) does not destroy the socket",
+  async () => {
+    const { Readable } = await import("node:stream");
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+    const server = http.createServer(async (req, res) => {
+      try {
+        const body = Readable.toWeb(req) as ReadableStream<Uint8Array>;
+        const reader = body.getReader();
+        await reader.read();
+        await reader.cancel();
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        res.end("OK");
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    server.listen(0, async () => {
+      try {
+        const port = (server.address() as AddressInfo).port;
+        const res = await fetch(`http://127.0.0.1:${port}/`, {
+          method: "POST",
+          duplex: "half",
+          body: new ReadableStream({
+            async pull(controller) {
+              await new Promise((r) => setTimeout(r, 50));
+              controller.enqueue(new TextEncoder().encode("hello"));
+            },
+          }),
+        } as RequestInit);
+
+        assertEquals(res.status, 200);
+        assertEquals(await res.text(), "OK");
+      } finally {
+        server.close(() => resolve());
+      }
+    });
+
+    await promise;
+  },
+);

--- a/tests/unit_node/http_test.ts
+++ b/tests/unit_node/http_test.ts
@@ -2771,13 +2771,24 @@ Deno.test(
     server.listen(0, async () => {
       try {
         const port = (server.address() as AddressInfo).port;
+        const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
         const res = await fetch(`http://127.0.0.1:${port}/`, {
           method: "POST",
           duplex: "half",
           body: new ReadableStream({
             async pull(controller) {
-              await new Promise((r) => setTimeout(r, 50));
+              await new Promise<void>((r) => {
+                const t = setTimeout(() => {
+                  pendingTimers.delete(t);
+                  r();
+                }, 50);
+                pendingTimers.add(t);
+              });
               controller.enqueue(new TextEncoder().encode("hello"));
+            },
+            cancel() {
+              for (const t of pendingTimers) clearTimeout(t);
+              pendingTimers.clear();
             },
           }),
         } as RequestInit);


### PR DESCRIPTION
Fixes #33567

## Summary

- The HTTP rewrite (#33208) ported Node.js's `IncomingMessage._destroy()`, which destroys the underlying socket when the request body is not fully consumed. The webstreams adapter's `cancel()` callback called `destroy()` directly, bypassing the `destroyer()` helper that Node.js uses.
- In Node.js, `destroyer()` detects server requests (via `isServerRequest()`) and nullifies the socket reference before calling `destroy()`, so `_destroy()` skips socket teardown. This keeps the connection alive for the response.
- Uses `destroyer()` instead of `destroy()` in `newReadableStreamFromStreamReadable`'s cancel callback, matching Node.js's behavior.

## Test plan

- Added unit test in `tests/unit_node/http_test.ts` that creates an HTTP server, converts the request to a web ReadableStream via `Readable.toWeb()`, cancels the reader, then verifies the response can still be sent successfully.