### PR TITLE
fix(ext/node): implement dns.reverse() and fix dns.lookup() family parameter

### DIFF
--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::rc::Rc;
-use std::str::FromStr;
 #[cfg(target_family = "windows")]
 use std::sync::OnceLock;
 
@@ -15,10 +14,7 @@ use deno_error::JsError;
 use deno_net::ops::NetPermToken;
 use deno_permissions::PermissionCheckError;
 use deno_permissions::PermissionsContainer;
-use hyper_util::client::legacy::connect::dns::GaiResolver;
-use hyper_util::client::legacy::connect::dns::Name;
 use socket2::SockAddr;
-use tower_service::Service;
 
 #[derive(Debug, thiserror::Error, JsError)]
 pub enum DnsError {
@@ -66,6 +62,7 @@ pub async fn op_node_getaddrinfo(
   state: Rc<RefCell<OpState>>,
   #[string] hostname: String,
   port: Option<u16>,
+  #[smi] family: i32,
 ) -> Result<NetPermToken, DnsError> {
   {
     let mut state_ = state.borrow_mut();
@@ -73,20 +70,178 @@ pub async fn op_node_getaddrinfo(
     permissions.check_net(&(hostname.as_str(), port), "node:dns.lookup()")?;
   }
 
-  let mut resolver = GaiResolver::new();
-  let name = Name::from_str(&hostname)
-    .map_err(|_| DnsError::Resolution(hostname.clone()))?;
-  let resolved_ips = resolver
-    .call(name)
-    .await
-    .map_err(|_| DnsError::Resolution(hostname.clone()))?
-    .map(|addr| addr.ip().to_string())
-    .collect::<Vec<_>>();
+  let hostname_clone = hostname.clone();
+  let resolved_ips =
+    spawn_blocking(move || getaddrinfo_inner(&hostname_clone, family))
+      .await
+      .map_err(|e| DnsError::Io(e.into()))??;
+
   Ok(NetPermToken {
     hostname,
     port,
     resolved_ips,
   })
+}
+
+fn getaddrinfo_inner(
+  hostname: &str,
+  family: i32,
+) -> Result<Vec<String>, DnsError> {
+  #[cfg(unix)]
+  {
+    use std::ffi::CString;
+
+    let ai_family = match family {
+      4 => libc::AF_INET,
+      6 => libc::AF_INET6,
+      _ => libc::AF_UNSPEC,
+    };
+
+    let c_hostname = CString::new(hostname)
+      .map_err(|_| DnsError::Resolution(hostname.to_string()))?;
+
+    let hints = libc::addrinfo {
+      ai_flags: 0,
+      ai_family,
+      ai_socktype: libc::SOCK_STREAM,
+      ai_protocol: 0,
+      ai_addrlen: 0,
+      ai_addr: std::ptr::null_mut(),
+      ai_canonname: std::ptr::null_mut(),
+      ai_next: std::ptr::null_mut(),
+    };
+
+    let mut result: *mut libc::addrinfo = std::ptr::null_mut();
+
+    // SAFETY: Calling getaddrinfo with valid pointers
+    let code = unsafe {
+      libc::getaddrinfo(
+        c_hostname.as_ptr(),
+        std::ptr::null(),
+        &hints,
+        &mut result,
+      )
+    };
+
+    if code != 0 {
+      return Err(assert_success_err(code));
+    }
+
+    let mut ips = Vec::new();
+    let mut current = result;
+    while !current.is_null() {
+      // SAFETY: current is a valid pointer from getaddrinfo linked list
+      let addr = unsafe { &*current };
+      let sock_addr =
+        // SAFETY: ai_addr/ai_addrlen are valid from getaddrinfo
+        unsafe { SockAddr::new(
+          *(addr.ai_addr as *const libc::sockaddr_storage),
+          addr.ai_addrlen,
+        ) };
+      if let Some(ip) = sock_addr.as_socket() {
+        ips.push(ip.ip().to_string());
+      }
+      // SAFETY: Advancing to next node in getaddrinfo linked list
+      current = unsafe { (*current).ai_next };
+    }
+
+    // SAFETY: Freeing the result from getaddrinfo
+    unsafe { libc::freeaddrinfo(result) };
+
+    if ips.is_empty() {
+      return Err(DnsError::Resolution(hostname.to_string()));
+    }
+
+    Ok(ips)
+  }
+
+  #[cfg(windows)]
+  {
+    use winapi::shared::minwindef::MAKEWORD;
+    use windows_sys::Win32::Networking::WinSock;
+
+    let ai_family = match family {
+      4 => WinSock::AF_INET as i32,
+      6 => WinSock::AF_INET6 as i32,
+      _ => WinSock::AF_UNSPEC as i32,
+    };
+
+    // SAFETY: winapi call
+    let wsa_startup_code = *WINSOCKET_INIT.get_or_init(|| unsafe {
+      let mut wsa_data: WinSock::WSADATA = std::mem::zeroed();
+      WinSock::WSAStartup(MAKEWORD(2, 2), &mut wsa_data)
+    });
+    if wsa_startup_code != 0 {
+      return Err(DnsError::Resolution(hostname.to_string()));
+    }
+
+    let c_hostname: Vec<u8> =
+      hostname.bytes().chain(std::iter::once(0)).collect();
+
+    let hints = WinSock::ADDRINFOA {
+      ai_flags: 0,
+      ai_family,
+      ai_socktype: WinSock::SOCK_STREAM as _,
+      ai_protocol: 0,
+      ai_addrlen: 0,
+      ai_canonname: std::ptr::null_mut(),
+      ai_addr: std::ptr::null_mut(),
+      ai_next: std::ptr::null_mut(),
+    };
+
+    let mut result: *mut WinSock::ADDRINFOA = std::ptr::null_mut();
+
+    // SAFETY: Calling getaddrinfo with valid pointers
+    let code = unsafe {
+      WinSock::getaddrinfo(
+        c_hostname.as_ptr() as _,
+        std::ptr::null(),
+        &hints,
+        &mut result,
+      )
+    };
+
+    if code != 0 {
+      return Err(assert_success_err(code));
+    }
+
+    let mut ips = Vec::new();
+    let mut current = result;
+    // SAFETY: Iterating linked list returned by getaddrinfo
+    while !current.is_null() {
+      let addr = unsafe { &*current };
+      if let Some(sock_addr) = SockAddr::try_init(|storage, len| {
+        std::ptr::copy_nonoverlapping(
+          addr.ai_addr as *const u8,
+          storage as *mut u8,
+          addr.ai_addrlen as usize,
+        );
+        *len = addr.ai_addrlen as _;
+        Ok(())
+      })
+      .ok()
+      .and_then(|(_, sa)| sa.as_socket())
+      {
+        ips.push(sock_addr.ip().to_string());
+      }
+      current = unsafe { (*current).ai_next };
+    }
+
+    // SAFETY: Freeing the result from getaddrinfo
+    unsafe { WinSock::freeaddrinfo(result) };
+
+    if ips.is_empty() {
+      return Err(DnsError::Resolution(hostname.to_string()));
+    }
+
+    Ok(ips)
+  }
+
+  #[cfg(not(any(unix, windows)))]
+  {
+    let _ = (hostname, family);
+    Err(DnsError::UnsupportedPlatform)
+  }
 }
 
 #[op2(stack_trace)]
@@ -198,15 +353,11 @@ fn getnameinfo(socket_addr: SocketAddr) -> Result<(String, String), DnsError> {
 }
 
 #[cfg(any(unix, windows))]
-fn assert_success(code: i32) -> Result<(), DnsError> {
+fn assert_success_err(code: i32) -> DnsError {
   #[cfg(windows)]
   use windows_sys::Win32::Networking::WinSock;
 
   use crate::ops::constant;
-
-  if code == 0 {
-    return Ok(());
-  }
 
   #[cfg(unix)]
   let err = match code {
@@ -238,5 +389,13 @@ fn assert_success(code: i32) -> Result<(), DnsError> {
     _ => DnsError::Io(std::io::Error::from_raw_os_error(code)),
   };
 
-  Err(err)
+  err
+}
+
+#[cfg(any(unix, windows))]
+fn assert_success(code: i32) -> Result<(), DnsError> {
+  if code == 0 {
+    return Ok(());
+  }
+  Err(assert_success_err(code))
 }

--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -217,7 +217,7 @@ fn getaddrinfo_inner(
           std::ptr::copy_nonoverlapping(
             addr.ai_addr as *const u8,
             storage as *mut u8,
-            addr.ai_addrlen as usize,
+            addr.ai_addrlen.try_into().unwrap(),
           );
           *len = addr.ai_addrlen as _;
           Ok(())

--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -207,23 +207,27 @@ fn getaddrinfo_inner(
 
     let mut ips = Vec::new();
     let mut current = result;
-    // SAFETY: Iterating linked list returned by getaddrinfo
     while !current.is_null() {
+      // SAFETY: current is a valid pointer from getaddrinfo linked list
       let addr = unsafe { &*current };
-      if let Some(sock_addr) = SockAddr::try_init(|storage, len| {
-        std::ptr::copy_nonoverlapping(
-          addr.ai_addr as *const u8,
-          storage as *mut u8,
-          addr.ai_addrlen as usize,
-        );
-        *len = addr.ai_addrlen as _;
-        Ok(())
-      })
-      .ok()
-      .and_then(|(_, sa)| sa.as_socket())
+      // SAFETY: ai_addr/ai_addrlen are valid from getaddrinfo,
+      // and SockAddr::try_init requires unsafe
+      let sa_result = unsafe {
+        SockAddr::try_init(|storage, len| {
+          std::ptr::copy_nonoverlapping(
+            addr.ai_addr as *const u8,
+            storage as *mut u8,
+            addr.ai_addrlen as usize,
+          );
+          *len = addr.ai_addrlen as _;
+          Ok(())
+        })
+      };
+      if let Some(sock_addr) = sa_result.ok().and_then(|(_, sa)| sa.as_socket())
       {
         ips.push(sock_addr.ip().to_string());
       }
+      // SAFETY: Advancing to next node in getaddrinfo linked list
       current = unsafe { (*current).ai_next };
     }
 

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -241,6 +241,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   #servers: [string, number][] | null = null;
   #timeout: number;
   #tries: number;
+  #pendingQueries: Set<QueryReqWrap> = new Set();
 
   constructor(timeout: number, tries: number) {
     super(providerType.DNSCHANNEL);
@@ -249,8 +250,13 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     this.#tries = tries;
   }
 
-  async #query(query: string, recordType: Deno.RecordType, ttl?: boolean) {
-    let code: number;
+  async #query(
+    query: string,
+    recordType: Deno.RecordType,
+    ttl?: boolean,
+  ) {
+    // deno-lint-ignore no-explicit-any
+    let code: any;
     let ret: Awaited<ReturnType<typeof Deno.resolveDns>>;
 
     if (this.#servers !== null && this.#servers.length) {
@@ -286,7 +292,8 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     resolveOptions?: Deno.ResolveDnsOptions,
     ttl?: boolean,
   ): Promise<{
-    code: number;
+    // deno-lint-ignore no-explicit-any
+    code: any;
     // deno-lint-ignore no-explicit-any
     ret: any[];
   }> {
@@ -294,11 +301,25 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     let code = 0;
 
     try {
-      const res = await op_dns_resolve({
+      let dnsPromise: Promise<Deno.RecordWithTtl[]> = op_dns_resolve({
         query,
         recordType,
         options: resolveOptions,
       }, /* useEdns0 */ false);
+
+      if (this.#timeout >= 0) {
+        dnsPromise = Promise.race([
+          dnsPromise,
+          new Promise<never>((_resolve, reject) => {
+            setTimeout(
+              () => reject(new Error("ETIMEOUT")),
+              this.#timeout,
+            );
+          }),
+        ]);
+      }
+
+      const res = await dnsPromise;
       if (ttl) {
         ret = res;
       } else {
@@ -307,6 +328,8 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     } catch (e) {
       if (e instanceof Deno.errors.NotFound) {
         code = codeMap.get("EAI_NODATA")!;
+      } else if (e instanceof Error && e.message === "ETIMEOUT") {
+        code = "ETIMEOUT";
       } else {
         // TODO(cmorten): map errors to appropriate error codes.
         code = codeMap.get("UNKNOWN")!;
@@ -322,6 +345,8 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     //
     // Ideally we move to using the "ANY" / "*" DNS query in future
     // REF: https://github.com/denoland/deno/issues/14492
+    this.#pendingQueries.add(req);
+
     (async () => {
       const records: { type: Deno.RecordType; [key: string]: unknown }[] = [];
 
@@ -417,6 +442,9 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
         }),
       ]);
 
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const err = records.length ? 0 : codeMap.get("EAI_NODATA")!;
 
       req.oncomplete(err, records);
@@ -426,7 +454,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryA(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "A", req.ttl).then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       let recordsWithTtl;
       if (req.ttl) {
         recordsWithTtl = (ret as Deno.RecordWithTtl[]).map((val) => ({
@@ -442,7 +475,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryAaaa(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "AAAA", req.ttl).then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       let recordsWithTtl;
       if (req.ttl) {
         recordsWithTtl = (ret as Deno.RecordWithTtl[]).map((val) => ({
@@ -458,7 +496,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryCaa(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "CAA").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.CaaRecord[]).map(
         ({ critical, tag, value }) => ({
           [tag]: value,
@@ -473,7 +516,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryCname(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "CNAME").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       req.oncomplete(code, ret);
     });
 
@@ -481,7 +529,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryMx(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "MX").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.MxRecord[]).map(
         ({ preference, exchange }) => ({
           priority: preference,
@@ -496,7 +549,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryNaptr(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "NAPTR").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.NaptrRecord[]).map(
         ({ order, preference, flags, services, regexp, replacement }) => ({
           flags,
@@ -515,7 +573,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryNs(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "NS").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as string[]).map((record) => fqdnToHostname(record));
 
       req.oncomplete(code, records);
@@ -525,7 +588,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryPtr(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "PTR").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as string[]).map((record) => fqdnToHostname(record));
 
       req.oncomplete(code, records);
@@ -535,7 +603,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   querySoa(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "SOA").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       let record = {};
 
       if (ret.length) {
@@ -560,7 +633,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   querySrv(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "SRV").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.SrvRecord[]).map(
         ({ priority, weight, port, target }) => ({
           priority,
@@ -577,7 +655,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryTxt(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
+
     this.#query(name, "TXT").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       req.oncomplete(code, ret);
     });
 
@@ -610,7 +693,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
       return codeMap.get("EINVAL")!;
     }
 
+    this.#pendingQueries.add(req);
+
     this.#query(reverseName, "PTR").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as string[]).map((record) => fqdnToHostname(record));
       req.oncomplete(code, records);
     });
@@ -646,7 +734,10 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   cancel() {
-    notImplemented("cares.ChannelWrap.prototype.cancel");
+    for (const req of this.#pendingQueries) {
+      req.oncomplete("ECANCELLED", []);
+    }
+    this.#pendingQueries.clear();
   }
 }
 

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -92,7 +92,11 @@ export function getaddrinfo(
     let error = 0;
     let netPermToken: object | undefined;
     try {
-      netPermToken = await op_node_getaddrinfo(hostname, req.port || undefined);
+      netPermToken = await op_node_getaddrinfo(
+        hostname,
+        req.port || undefined,
+        family,
+      );
       addresses.push(...op_net_get_ips_from_perm_token(netPermToken));
       if (addresses.length === 0) {
         error = codeMap.get("EAI_NODATA")!;
@@ -580,9 +584,38 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     return 0;
   }
 
-  getHostByAddr(_req: QueryReqWrap, _name: string): number {
-    // TODO(@bartlomieju): https://github.com/denoland/deno/issues/14432
-    notImplemented("cares.ChannelWrap.prototype.getHostByAddr");
+  getHostByAddr(req: QueryReqWrap, name: string): number {
+    let reverseName: string;
+
+    if (isIPv4(name)) {
+      reverseName = name.split(".").reverse().join(".") + ".in-addr.arpa";
+    } else if (isIPv6(name)) {
+      // Expand IPv6 address to full form then reverse nibbles
+      const parts = name.split(":");
+      const expanded: string[] = [];
+      for (let i = 0; i < parts.length; i++) {
+        if (parts[i] === "") {
+          // Handle :: expansion
+          const missing = 8 - parts.filter((p) => p !== "").length;
+          for (let j = 0; j < missing; j++) {
+            expanded.push("0000");
+          }
+        } else {
+          expanded.push(parts[i].padStart(4, "0"));
+        }
+      }
+      reverseName = expanded.join("").split("").reverse().join(".") +
+        ".ip6.arpa";
+    } else {
+      return codeMap.get("EINVAL")!;
+    }
+
+    this.#query(reverseName, "PTR").then(({ code, ret }) => {
+      const records = (ret as string[]).map((record) => fqdnToHostname(record));
+      req.oncomplete(code, records);
+    });
+
+    return 0;
   }
 
   getServers(): [string, number][] {

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -675,17 +675,21 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     } else if (isIPv6(name)) {
       // Expand IPv6 address to full form then reverse nibbles
       const parts = name.split(":");
+      const nonEmpty = parts.filter((p) => p !== "");
+      const missing = name.includes("::") ? 8 - nonEmpty.length : 0;
       const expanded: string[] = [];
-      for (let i = 0; i < parts.length; i++) {
-        if (parts[i] === "") {
-          // Handle :: expansion
-          const missing = 8 - parts.filter((p) => p !== "").length;
-          for (let j = 0; j < missing; j++) {
-            expanded.push("0000");
+      let didExpand = false;
+      for (const part of parts) {
+        if (part === "") {
+          if (!didExpand) {
+            for (let j = 0; j < missing; j++) {
+              expanded.push("0000");
+            }
+            didExpand = true;
           }
-        } else {
-          expanded.push(parts[i].padStart(4, "0"));
+          continue;
         }
+        expanded.push(part.padStart(4, "0"));
       }
       reverseName = expanded.join("").split("").reverse().join(".") +
         ".ip6.arpa";

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -431,7 +431,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
                 priority,
                 weight,
                 port,
-                name: target,
+                name: fqdnToHostname(target),
               }),
           );
         }),
@@ -644,7 +644,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
           priority,
           weight,
           port,
-          name: target,
+          name: fqdnToHostname(target),
         }),
       );
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -82,6 +82,8 @@
     "es-module/test-vm-compile-function-lineoffset.js": {},
     "es-module/test-wasm-memory-out-of-bound.js": {},
     "es-module/test-wasm-simple.js": {},
+    "internet/test-dns-ipv4.js": {},
+    "internet/test-dns-ipv6.js": {},
     "internet/test-snapshot-dns-lookup.js": {
       "ignore": true,
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -794,6 +794,10 @@
     "parallel/test-dns-memory-error.js": {},
     "parallel/test-dns-multi-channel.js": {},
     "parallel/test-dns-promises-exists.js": {},
+    "parallel/test-dns-resolve-promises.js": {
+      "ignore": true,
+      "reason": "Requires --expose-internals and internalBinding('cares_wrap') which is not supported in Deno"
+    },
     "parallel/test-dns-resolvens-typeerror.js": {},
     "parallel/test-dns-resolvesrv.js": {},
     "parallel/test-dns-resolvesrv-econnrefused.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -795,6 +795,8 @@
     "parallel/test-dns-multi-channel.js": {},
     "parallel/test-dns-promises-exists.js": {},
     "parallel/test-dns-resolvens-typeerror.js": {},
+    "parallel/test-dns-resolvesrv.js": {},
+    "parallel/test-dns-resolvesrv-econnrefused.js": {},
     "parallel/test-dns-set-default-order.js": {},
     "parallel/test-dns-setservers-type-check.js": {},
     "parallel/test-domain-add-remove.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -777,6 +777,10 @@
     // TODO(bartlomieju): this test was disabled during work on `node:inspector`, it never worked
     // "parallel/test-disable-sigusr1.js": {},
     "parallel/test-disable-sigusr1.js": {},
+    "parallel/test-dns-cancel-reverse-lookup.js": {},
+    "parallel/test-dns-channel-cancel.js": {},
+    "parallel/test-dns-channel-cancel-promise.js": {},
+    "parallel/test-dns-channel-timeout.js": {},
     "parallel/test-dns-default-order-ipv4.js": {},
     "parallel/test-dns-default-order-ipv6.js": {},
     "parallel/test-dns-default-order-verbatim.js": {},


### PR DESCRIPTION
## Summary
- Implements `ChannelWrap.prototype.getHostByAddr` which backs `dns.reverse()` / `dnsPromises.reverse()`. Converts IP addresses to reverse DNS format (`.in-addr.arpa` for IPv4, `.ip6.arpa` for IPv6) and queries PTR records.
- Fixes `dns.lookup()` with `family: 6` returning no results by replacing the `GaiResolver` (which always used `AF_UNSPEC`) with a direct `getaddrinfo` call that passes through the address family hint.
- Implements `ChannelWrap.prototype.cancel()` which aborts all pending DNS queries with `ECANCELLED` error code.
- Wires up the `timeout` option in the Resolver constructor to race DNS queries against a timer, returning `ETIMEOUT` on expiry.
- Strips trailing dot from SRV `target` field in `querySrv` and `queryAny` via `fqdnToHostname()`.
- Enables 8 Node.js compat tests:
  - `internet/test-dns-ipv4.js`
  - `internet/test-dns-ipv6.js`
  - `parallel/test-dns-cancel-reverse-lookup.js`
  - `parallel/test-dns-channel-cancel.js`
  - `parallel/test-dns-channel-cancel-promise.js`
  - `parallel/test-dns-channel-timeout.js`
  - `parallel/test-dns-resolvesrv.js`
  - `parallel/test-dns-resolvesrv-econnrefused.js`

## Test plan
- [x] `./x test-compat test-dns-ipv4.js` passes
- [x] `./x test-compat test-dns-ipv6.js` passes
- [x] `./x test-compat test-dns-channel` — all 3 pass (cancel, cancel-promise, timeout)
- [x] `./x test-compat test-dns-cancel-reverse-lookup` passes
- [x] `./x test-compat test-dns-resolvesrv` — both pass
- [x] `./x test-compat test-dns` — all 8 new tests pass, other failures are pre-existing