### PR TITLE
fix(ext/node): strip trailing dot from SRV target in dns.resolveSrv()

### DIFF
--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -402,7 +402,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
                 priority,
                 weight,
                 port,
-                name: target,
+                name: fqdnToHostname(target),
               }),
           );
         }),
@@ -562,7 +562,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
           priority,
           weight,
           port,
-          name: target,
+          name: fqdnToHostname(target),
         }),
       );
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -789,6 +789,8 @@
     "parallel/test-dns-multi-channel.js": {},
     "parallel/test-dns-promises-exists.js": {},
     "parallel/test-dns-resolvens-typeerror.js": {},
+    "parallel/test-dns-resolvesrv.js": {},
+    "parallel/test-dns-resolvesrv-econnrefused.js": {},
     "parallel/test-dns-set-default-order.js": {},
     "parallel/test-dns-setservers-type-check.js": {},
     "parallel/test-domain-add-remove.js": {},


### PR DESCRIPTION
## Summary
- Strips trailing dot from the SRV record `target` field in `querySrv` and `queryAny` by applying `fqdnToHostname()`, matching Node.js behavior.
- Enables 2 Node.js compat tests: `parallel/test-dns-resolvesrv.js`, `parallel/test-dns-resolvesrv-econnrefused.js`

## Test plan
- [x] `./x test-compat test-dns-resolvesrv` — both pass