### PR TITLE
fix(ext/node): implement dns.reverse() and fix dns.lookup() family parameter

### DIFF
--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -368,9 +368,7 @@ fn assert_success_err(code: i32) -> DnsError {
   use crate::ops::constant;
 
   if code == 0 {
-    return DnsError::Io(std::io::Error::other(
-      "unexpected success code",
-    ));
+    return DnsError::Io(std::io::Error::other("unexpected success code"));
   }
 
   #[cfg(unix)]

--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -143,18 +143,18 @@ fn getaddrinfo_inner(
             Ok(())
           })
         };
-        if let Ok((_, sa)) = sockaddr {
-          if let Some(ip) = sa.as_socket() {
-            ips.push(ip.ip().to_string());
-          }
+        if let Ok((_, sa)) = sockaddr
+          && let Some(ip) = sa.as_socket()
+        {
+          ips.push(ip.ip().to_string());
         }
       }
       // SAFETY: following the linked list
       addr = unsafe { (*addr).ai_next };
     }
 
-    // SAFETY: freeing the result from getaddrinfo
     if !result.is_null() {
+      // SAFETY: freeing the result from getaddrinfo
       unsafe { libc::freeaddrinfo(result) };
     }
 
@@ -368,8 +368,7 @@ fn assert_success_err(code: i32) -> DnsError {
   use crate::ops::constant;
 
   if code == 0 {
-    return DnsError::Io(std::io::Error::new(
-      std::io::ErrorKind::Other,
+    return DnsError::Io(std::io::Error::other(
       "unexpected success code",
     ));
   }

--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -216,8 +216,13 @@ fn getaddrinfo_inner(
       // SAFETY: addr is not null and was returned by getaddrinfo
       let info = unsafe { &*addr };
       if !info.ai_addr.is_null() {
-        #[allow(clippy::unnecessary_cast)]
+        #[allow(
+          clippy::unnecessary_cast,
+          reason = "ai_addrlen is usize on Windows but u32 on Unix"
+        )]
         let addrlen = info.ai_addrlen as usize;
+        // SAFETY: ai_addr/ai_addrlen are valid from getaddrinfo,
+        // and SockAddr::try_init requires unsafe
         let sa_result = unsafe {
           SockAddr::try_init(|storage, len| {
             std::ptr::copy_nonoverlapping(
@@ -229,18 +234,18 @@ fn getaddrinfo_inner(
             Ok(())
           })
         };
-        if let Ok((_, sa)) = sa_result {
-          if let Some(ip) = sa.as_socket() {
-            ips.push(ip.ip().to_string());
-          }
+        if let Ok((_, sa)) = sa_result
+          && let Some(ip) = sa.as_socket()
+        {
+          ips.push(ip.ip().to_string());
         }
       }
       // SAFETY: following the linked list
       addr = unsafe { (*addr).ai_next };
     }
 
-    // SAFETY: freeing the result from getaddrinfo
     if !result.is_null() {
+      // SAFETY: freeing the result from getaddrinfo
       unsafe { WinSock::freeaddrinfo(result) };
     }
 

--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::rc::Rc;
-use std::str::FromStr;
 #[cfg(target_family = "windows")]
 use std::sync::OnceLock;
 
@@ -15,10 +14,7 @@ use deno_error::JsError;
 use deno_net::ops::NetPermToken;
 use deno_permissions::PermissionCheckError;
 use deno_permissions::PermissionsContainer;
-use hyper_util::client::legacy::connect::dns::GaiResolver;
-use hyper_util::client::legacy::connect::dns::Name;
 use socket2::SockAddr;
-use tower_service::Service;
 
 #[derive(Debug, thiserror::Error, JsError)]
 pub enum DnsError {
@@ -66,6 +62,7 @@ pub async fn op_node_getaddrinfo(
   state: Rc<RefCell<OpState>>,
   #[string] hostname: String,
   port: Option<u16>,
+  #[smi] family: i32,
 ) -> Result<NetPermToken, DnsError> {
   {
     let mut state_ = state.borrow_mut();
@@ -73,20 +70,186 @@ pub async fn op_node_getaddrinfo(
     permissions.check_net(&(hostname.as_str(), port), "node:dns.lookup()")?;
   }
 
-  let mut resolver = GaiResolver::new();
-  let name = Name::from_str(&hostname)
-    .map_err(|_| DnsError::Resolution(hostname.clone()))?;
-  let resolved_ips = resolver
-    .call(name)
-    .await
-    .map_err(|_| DnsError::Resolution(hostname.clone()))?
-    .map(|addr| addr.ip().to_string())
-    .collect::<Vec<_>>();
+  let hostname_clone = hostname.clone();
+  let resolved_ips =
+    spawn_blocking(move || getaddrinfo_inner(&hostname_clone, family))
+      .await
+      .map_err(|e| DnsError::Io(e.into()))??;
+
   Ok(NetPermToken {
     hostname,
     port,
     resolved_ips,
   })
+}
+
+fn getaddrinfo_inner(
+  hostname: &str,
+  family: i32,
+) -> Result<Vec<String>, DnsError> {
+  #[cfg(unix)]
+  {
+    let c_hostname = std::ffi::CString::new(hostname)
+      .map_err(|_| DnsError::Resolution(hostname.to_string()))?;
+
+    let ai_family = match family {
+      4 => libc::AF_INET,
+      6 => libc::AF_INET6,
+      _ => libc::AF_UNSPEC,
+    };
+
+    let hints = libc::addrinfo {
+      ai_flags: 0,
+      ai_family,
+      ai_socktype: libc::SOCK_STREAM,
+      ai_protocol: 0,
+      ai_addrlen: 0,
+      ai_addr: std::ptr::null_mut(),
+      ai_canonname: std::ptr::null_mut(),
+      ai_next: std::ptr::null_mut(),
+    };
+
+    let mut result: *mut libc::addrinfo = std::ptr::null_mut();
+
+    // SAFETY: Calling getaddrinfo with valid pointers
+    let code = unsafe {
+      libc::getaddrinfo(
+        c_hostname.as_ptr(),
+        std::ptr::null(),
+        &hints,
+        &mut result,
+      )
+    };
+
+    if code != 0 {
+      return Err(assert_success_err(code));
+    }
+
+    let mut ips = Vec::new();
+    let mut addr = result;
+    while !addr.is_null() {
+      // SAFETY: addr is not null and was returned by getaddrinfo
+      let info = unsafe { &*addr };
+      if !info.ai_addr.is_null() {
+        // SAFETY: ai_addr is not null
+        let sockaddr = unsafe {
+          SockAddr::try_init(|storage, len| {
+            std::ptr::copy_nonoverlapping(
+              info.ai_addr as *const u8,
+              storage as *mut u8,
+              info.ai_addrlen as usize,
+            );
+            *len = info.ai_addrlen;
+            Ok(())
+          })
+        };
+        if let Ok((_, sa)) = sockaddr {
+          if let Some(ip) = sa.as_socket() {
+            ips.push(ip.ip().to_string());
+          }
+        }
+      }
+      // SAFETY: following the linked list
+      addr = unsafe { (*addr).ai_next };
+    }
+
+    // SAFETY: freeing the result from getaddrinfo
+    if !result.is_null() {
+      unsafe { libc::freeaddrinfo(result) };
+    }
+
+    Ok(ips)
+  }
+  #[cfg(windows)]
+  {
+    use winapi::shared::minwindef::MAKEWORD;
+    use windows_sys::Win32::Networking::WinSock;
+
+    // SAFETY: winapi call
+    let wsa_startup_code = *WINSOCKET_INIT.get_or_init(|| unsafe {
+      let mut wsa_data: WinSock::WSADATA = std::mem::zeroed();
+      WinSock::WSAStartup(MAKEWORD(2, 2), &mut wsa_data)
+    });
+    if wsa_startup_code != 0 {
+      return Err(assert_success_err(wsa_startup_code));
+    }
+
+    let c_hostname = std::ffi::CString::new(hostname)
+      .map_err(|_| DnsError::Resolution(hostname.to_string()))?;
+
+    let ai_family = match family {
+      4 => WinSock::AF_INET as i32,
+      6 => WinSock::AF_INET6 as i32,
+      _ => WinSock::AF_UNSPEC as i32,
+    };
+
+    let hints = WinSock::ADDRINFOA {
+      ai_flags: 0,
+      ai_family,
+      ai_socktype: WinSock::SOCK_STREAM as _,
+      ai_protocol: 0,
+      ai_addrlen: 0,
+      ai_addr: std::ptr::null_mut(),
+      ai_canonname: std::ptr::null_mut(),
+      ai_next: std::ptr::null_mut(),
+    };
+
+    let mut result: *mut WinSock::ADDRINFOA = std::ptr::null_mut();
+
+    // SAFETY: Calling getaddrinfo with valid pointers
+    let code = unsafe {
+      WinSock::getaddrinfo(
+        c_hostname.as_ptr() as _,
+        std::ptr::null(),
+        &hints,
+        &mut result,
+      )
+    };
+
+    if code != 0 {
+      return Err(assert_success_err(code));
+    }
+
+    let mut ips = Vec::new();
+    let mut addr = result;
+    while !addr.is_null() {
+      // SAFETY: addr is not null and was returned by getaddrinfo
+      let info = unsafe { &*addr };
+      if !info.ai_addr.is_null() {
+        #[allow(clippy::unnecessary_cast)]
+        let addrlen = info.ai_addrlen as usize;
+        let sa_result = unsafe {
+          SockAddr::try_init(|storage, len| {
+            std::ptr::copy_nonoverlapping(
+              info.ai_addr as *const u8,
+              storage as *mut u8,
+              addrlen,
+            );
+            *len = info.ai_addrlen as _;
+            Ok(())
+          })
+        };
+        if let Ok((_, sa)) = sa_result {
+          if let Some(ip) = sa.as_socket() {
+            ips.push(ip.ip().to_string());
+          }
+        }
+      }
+      // SAFETY: following the linked list
+      addr = unsafe { (*addr).ai_next };
+    }
+
+    // SAFETY: freeing the result from getaddrinfo
+    if !result.is_null() {
+      unsafe { WinSock::freeaddrinfo(result) };
+    }
+
+    Ok(ips)
+  }
+  #[cfg(not(any(unix, windows)))]
+  {
+    Err(DnsError::UnsupportedPlatform)
+  }
 }
 
 #[op2(stack_trace)]
@@ -198,14 +361,17 @@ fn getnameinfo(socket_addr: SocketAddr) -> Result<(String, String), DnsError> {
 }
 
 #[cfg(any(unix, windows))]
-fn assert_success(code: i32) -> Result<(), DnsError> {
+fn assert_success_err(code: i32) -> DnsError {
   #[cfg(windows)]
   use windows_sys::Win32::Networking::WinSock;
 
   use crate::ops::constant;
 
   if code == 0 {
-    return Ok(());
+    return DnsError::Io(std::io::Error::new(
+      std::io::ErrorKind::Other,
+      "unexpected success code",
+    ));
   }
 
   #[cfg(unix)]
@@ -238,5 +404,13 @@ fn assert_success(code: i32) -> Result<(), DnsError> {
     _ => DnsError::Io(std::io::Error::from_raw_os_error(code)),
   };
 
-  Err(err)
+  err
+}
+
+#[cfg(any(unix, windows))]
+fn assert_success(code: i32) -> Result<(), DnsError> {
+  if code == 0 {
+    return Ok(());
+  }
+  Err(assert_success_err(code))
 }

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -599,7 +599,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
         if (part === "" && !emptyFound) {
           emptyFound = true;
           const missing = 8 - parts.filter((p) => p !== "").length;
-          for (let j = 0; j < missing + 1; j++) {
+          for (let j = 0; j < missing; j++) {
             expanded.push("0000");
           }
         } else if (part !== "") {

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -92,7 +92,11 @@ export function getaddrinfo(
     let error = 0;
     let netPermToken: object | undefined;
     try {
-      netPermToken = await op_node_getaddrinfo(hostname, req.port || undefined);
+      netPermToken = await op_node_getaddrinfo(
+        hostname,
+        req.port || undefined,
+        family,
+      );
       addresses.push(...op_net_get_ips_from_perm_token(netPermToken));
       if (addresses.length === 0) {
         error = codeMap.get("EAI_NODATA")!;
@@ -580,9 +584,41 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     return 0;
   }
 
-  getHostByAddr(_req: QueryReqWrap, _name: string): number {
-    // TODO(@bartlomieju): https://github.com/denoland/deno/issues/14432
-    notImplemented("cares.ChannelWrap.prototype.getHostByAddr");
+  getHostByAddr(req: QueryReqWrap, name: string): number {
+    let reverseName: string;
+
+    if (isIPv4(name)) {
+      const octets = name.split(".");
+      reverseName = octets.reverse().join(".") + ".in-addr.arpa";
+    } else if (isIPv6(name)) {
+      // Expand the IPv6 address to full form
+      const parts = name.split(":");
+      const expanded: string[] = [];
+      let emptyFound = false;
+      for (const part of parts) {
+        if (part === "" && !emptyFound) {
+          emptyFound = true;
+          const missing = 8 - parts.filter((p) => p !== "").length;
+          for (let j = 0; j < missing + 1; j++) {
+            expanded.push("0000");
+          }
+        } else if (part !== "") {
+          expanded.push(part.padStart(4, "0"));
+        }
+      }
+      const fullHex = expanded.join("");
+      reverseName = fullHex.split("").reverse().join(".") + ".ip6.arpa";
+    } else {
+      req.oncomplete(codeMap.get("EINVAL")!, []);
+      return 0;
+    }
+
+    this.#query(reverseName, "PTR").then(({ code, ret }) => {
+      const records = (ret as string[]).map((record) => fqdnToHostname(record));
+      req.oncomplete(code, records);
+    });
+
+    return 0;
   }
 
   getServers(): [string, number][] {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -82,6 +82,8 @@
     "es-module/test-vm-compile-function-lineoffset.js": {},
     "es-module/test-wasm-memory-out-of-bound.js": {},
     "es-module/test-wasm-simple.js": {},
+    "internet/test-dns-ipv4.js": {},
+    "internet/test-dns-ipv6.js": {},
     "internet/test-snapshot-dns-lookup.js": {
       "ignore": true,
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"
@@ -788,6 +790,10 @@
     "parallel/test-dns-memory-error.js": {},
     "parallel/test-dns-multi-channel.js": {},
     "parallel/test-dns-promises-exists.js": {},
+    "parallel/test-dns-resolve-promises.js": {
+      "ignore": true,
+      "reason": "Requires --expose-internals and internalBinding('cares_wrap') which is not supported in Deno"
+    },
     "parallel/test-dns-resolvens-typeerror.js": {},
     "parallel/test-dns-set-default-order.js": {},
     "parallel/test-dns-setservers-type-check.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -84,8 +84,7 @@
     "es-module/test-wasm-simple.js": {},
     "internet/test-dns-ipv4.js": {},
     "internet/test-dns-ipv6.js": {
-      "ignore": true,
-      "reason": "Requires IPv6 connectivity which is not available on all CI runners (Windows)"
+      "windows": false
     },
     "internet/test-snapshot-dns-lookup.js": {
       "ignore": true,

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -83,7 +83,10 @@
     "es-module/test-wasm-memory-out-of-bound.js": {},
     "es-module/test-wasm-simple.js": {},
     "internet/test-dns-ipv4.js": {},
-    "internet/test-dns-ipv6.js": {},
+    "internet/test-dns-ipv6.js": {
+      "ignore": true,
+      "reason": "Requires IPv6 connectivity which is not available on all CI runners (Windows)"
+    },
     "internet/test-snapshot-dns-lookup.js": {
       "ignore": true,
       "reason": "Node.js snapshot/heap profiling features (--build-snapshot, --heap-prof, --heapsnapshot-near-heap-limit) are not implemented in Deno"


### PR DESCRIPTION
## Summary
- Implements `ChannelWrap.prototype.getHostByAddr` which backs `dns.reverse()` / `dnsPromises.reverse()`. Converts IP addresses to reverse DNS format (`.in-addr.arpa` for IPv4, `.ip6.arpa` for IPv6) and queries PTR records.
- Fixes `dns.lookup()` with `family: 6` returning no results by replacing the `GaiResolver` (which always used `AF_UNSPEC`) with a direct `getaddrinfo` call that passes through the address family hint.
- Enables 2 Node.js compat tests: `internet/test-dns-ipv4.js`, `internet/test-dns-ipv6.js`

## Test plan
- [x] `./x test-compat test-dns-ipv4.js` passes
- [x] `./x test-compat test-dns-ipv6.js` passes