### PR TITLE
fix(ext/node): implement dns Resolver cancel() and timeout support

### DIFF
--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -952,6 +952,7 @@ pub struct ResolveAddrArgs {
 #[derive(FromV8)]
 pub struct ResolveDnsOption {
   name_server: Option<NameServer>,
+  timeout_ms: Option<u64>,
 }
 
 #[derive(FromV8)]
@@ -974,6 +975,8 @@ pub async fn op_dns_resolve(
     cancel_rid,
   } = args;
 
+  let timeout_ms = options.as_ref().and_then(|o| o.timeout_ms);
+
   let (config, opts) = if let Some(name_server) =
     options.as_ref().and_then(|o| o.name_server.as_ref())
   {
@@ -986,6 +989,10 @@ pub async fn op_dns_resolve(
       let mut opts = ResolverOpts::default();
       if use_edns {
         opts.edns0 = true;
+      }
+      if let Some(ms) = timeout_ms {
+        opts.timeout = std::time::Duration::from_millis(ms);
+        opts.attempts = 1;
       }
       opts
     })

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -993,7 +993,6 @@ pub async fn op_dns_resolve(
     system_conf::read_system_conf()?
   };
 
-
   // When a cancel handle is provided, use a short resolver timeout so
   // that hickory's background connection tasks clean up quickly after
   // cancellation (they are not aborted by the cancel handle itself).

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -952,7 +952,6 @@ pub struct ResolveAddrArgs {
 #[derive(FromV8)]
 pub struct ResolveDnsOption {
   name_server: Option<NameServer>,
-  timeout_ms: Option<u64>,
 }
 
 #[derive(FromV8)]
@@ -975,8 +974,6 @@ pub async fn op_dns_resolve(
     cancel_rid,
   } = args;
 
-  let timeout_ms = options.as_ref().and_then(|o| o.timeout_ms);
-
   let (config, opts) = if let Some(name_server) =
     options.as_ref().and_then(|o| o.name_server.as_ref())
   {
@@ -989,11 +986,6 @@ pub async fn op_dns_resolve(
       let mut opts = ResolverOpts::default();
       if use_edns {
         opts.edns0 = true;
-      }
-      if let Some(ms) = timeout_ms {
-        opts.timeout =
-          std::time::Duration::from_millis(ms.max(1));
-        opts.attempts = 1;
       }
       opts
     })

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -991,7 +991,8 @@ pub async fn op_dns_resolve(
         opts.edns0 = true;
       }
       if let Some(ms) = timeout_ms {
-        opts.timeout = std::time::Duration::from_millis(ms);
+        opts.timeout =
+          std::time::Duration::from_millis(ms.max(1));
         opts.attempts = 1;
       }
       opts

--- a/ext/net/ops.rs
+++ b/ext/net/ops.rs
@@ -974,7 +974,7 @@ pub async fn op_dns_resolve(
     cancel_rid,
   } = args;
 
-  let (config, opts) = if let Some(name_server) =
+  let (config, mut opts) = if let Some(name_server) =
     options.as_ref().and_then(|o| o.name_server.as_ref())
   {
     let group = NameServerConfigGroup::from_ips_clear(
@@ -992,6 +992,15 @@ pub async fn op_dns_resolve(
   } else {
     system_conf::read_system_conf()?
   };
+
+
+  // When a cancel handle is provided, use a short resolver timeout so
+  // that hickory's background connection tasks clean up quickly after
+  // cancellation (they are not aborted by the cancel handle itself).
+  if cancel_rid.is_some() {
+    opts.timeout = std::time::Duration::from_secs(1);
+    opts.attempts = 1;
+  }
 
   {
     let mut s = state.borrow_mut();

--- a/ext/node/ops/dns.rs
+++ b/ext/node/ops/dns.rs
@@ -372,9 +372,7 @@ fn assert_success_err(code: i32) -> DnsError {
 
   use crate::ops::constant;
 
-  if code == 0 {
-    return DnsError::Io(std::io::Error::other("unexpected success code"));
-  }
+  debug_assert!(code != 0, "assert_success_err called with success code");
 
   #[cfg(unix)]
   let err = match code {

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -36,6 +36,7 @@ import {
 } from "ext:deno_node/internal_binding/async_wrap.ts";
 import { ares_strerror } from "ext:deno_node/internal_binding/ares.ts";
 import { notImplemented } from "ext:deno_node/_utils.ts";
+import { core } from "ext:core/mod.js";
 import {
   op_dns_resolve,
   op_net_get_ips_from_perm_token,
@@ -299,37 +300,31 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     // deno-lint-ignore no-explicit-any
     let code: any = 0;
 
+    let cancelRid: number | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
     try {
-      const options = this.#timeout >= 0
-        ? {
-          ...resolveOptions,
-          timeout_ms: this.#timeout,
-        }
-        : resolveOptions;
-
-      let dnsPromise: Promise<Deno.RecordWithTtl[]> = op_dns_resolve({
-        query,
-        recordType,
-        options,
-      }, /* useEdns0 */ false);
-
       if (this.#timeout >= 0) {
-        dnsPromise = Promise.race([
-          dnsPromise,
-          new Promise<never>((_resolve, reject) =>
-            setTimeout(() => reject("ETIMEOUT"), this.#timeout)
-          ),
-        ]);
+        cancelRid = core.createCancelHandle();
+        timer = setTimeout(() => {
+          core.tryClose(cancelRid!);
+          cancelRid = undefined;
+        }, this.#timeout);
       }
 
-      const res = await dnsPromise;
+      const res = await op_dns_resolve({
+        query,
+        recordType,
+        options: resolveOptions,
+        cancelRid,
+      }, /* useEdns0 */ false);
       if (ttl) {
         ret = res;
       } else {
         ret = res.map((recordWithTtl) => recordWithTtl.data);
       }
     } catch (e) {
-      if (e === "ETIMEOUT") {
+      if (e instanceof Deno.errors.Interrupted) {
         code = "ETIMEOUT";
       } else if (e instanceof Deno.errors.NotFound) {
         code = codeMap.get("EAI_NODATA")!;
@@ -337,6 +332,9 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
         // TODO(cmorten): map errors to appropriate error codes.
         code = codeMap.get("UNKNOWN")!;
       }
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      if (cancelRid !== undefined) core.tryClose(cancelRid);
     }
 
     return { code, ret };

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -697,7 +697,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
       return 0;
     }
 
+    this.#pendingQueries.add(req);
+
     this.#query(reverseName, "PTR").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as string[]).map((record) => fqdnToHostname(record));
       req.oncomplete(code, records);
     });

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -237,6 +237,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   #servers: [string, number][] | null = null;
   #timeout: number;
   #tries: number;
+  #pendingQueries: Set<QueryReqWrap> = new Set();
 
   constructor(timeout: number, tries: number) {
     super(providerType.DNSCHANNEL);
@@ -265,7 +266,10 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
           ttl,
         ));
 
-        if (code === 0 || code === codeMap.get("EAI_NODATA")!) {
+        if (
+          code === 0 || code === codeMap.get("EAI_NODATA")! ||
+          code === "ETIMEOUT"
+        ) {
           break;
         }
       }
@@ -282,26 +286,48 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     resolveOptions?: Deno.ResolveDnsOptions,
     ttl?: boolean,
   ): Promise<{
-    code: number;
+    // deno-lint-ignore no-explicit-any
+    code: any;
     // deno-lint-ignore no-explicit-any
     ret: any[];
   }> {
     let ret = [];
-    let code = 0;
+    // deno-lint-ignore no-explicit-any
+    let code: any = 0;
 
     try {
-      const res = await op_dns_resolve({
+      const options = this.#timeout >= 0
+        ? {
+          ...resolveOptions,
+          timeout_ms: this.#timeout,
+        }
+        : resolveOptions;
+
+      let dnsPromise: Promise<Deno.RecordWithTtl[]> = op_dns_resolve({
         query,
         recordType,
-        options: resolveOptions,
+        options,
       }, /* useEdns0 */ false);
+
+      if (this.#timeout >= 0) {
+        dnsPromise = Promise.race([
+          dnsPromise,
+          new Promise<never>((_resolve, reject) =>
+            setTimeout(() => reject("ETIMEOUT"), this.#timeout)
+          ),
+        ]);
+      }
+
+      const res = await dnsPromise;
       if (ttl) {
         ret = res;
       } else {
         ret = res.map((recordWithTtl) => recordWithTtl.data);
       }
     } catch (e) {
-      if (e instanceof Deno.errors.NotFound) {
+      if (e === "ETIMEOUT") {
+        code = "ETIMEOUT";
+      } else if (e instanceof Deno.errors.NotFound) {
         code = codeMap.get("EAI_NODATA")!;
       } else {
         // TODO(cmorten): map errors to appropriate error codes.
@@ -318,6 +344,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     //
     // Ideally we move to using the "ANY" / "*" DNS query in future
     // REF: https://github.com/denoland/deno/issues/14492
+    this.#pendingQueries.add(req);
     (async () => {
       const records: { type: Deno.RecordType; [key: string]: unknown }[] = [];
 
@@ -413,6 +440,9 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
         }),
       ]);
 
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const err = records.length ? 0 : codeMap.get("EAI_NODATA")!;
 
       req.oncomplete(err, records);
@@ -422,7 +452,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryA(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "A", req.ttl).then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       let recordsWithTtl;
       if (req.ttl) {
         recordsWithTtl = (ret as Deno.RecordWithTtl[]).map((val) => ({
@@ -438,7 +472,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryAaaa(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "AAAA", req.ttl).then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       let recordsWithTtl;
       if (req.ttl) {
         recordsWithTtl = (ret as Deno.RecordWithTtl[]).map((val) => ({
@@ -454,7 +492,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryCaa(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "CAA").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.CaaRecord[]).map(
         ({ critical, tag, value }) => ({
           [tag]: value,
@@ -469,7 +511,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryCname(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "CNAME").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       req.oncomplete(code, ret);
     });
 
@@ -477,7 +523,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryMx(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "MX").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.MxRecord[]).map(
         ({ preference, exchange }) => ({
           priority: preference,
@@ -492,7 +542,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryNaptr(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "NAPTR").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.NaptrRecord[]).map(
         ({ order, preference, flags, services, regexp, replacement }) => ({
           flags,
@@ -511,7 +565,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryNs(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "NS").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as string[]).map((record) => fqdnToHostname(record));
 
       req.oncomplete(code, records);
@@ -521,7 +579,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryPtr(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "PTR").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as string[]).map((record) => fqdnToHostname(record));
 
       req.oncomplete(code, records);
@@ -531,7 +593,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   querySoa(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "SOA").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       let record = {};
 
       if (ret.length) {
@@ -556,7 +622,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   querySrv(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "SRV").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       const records = (ret as Deno.SrvRecord[]).map(
         ({ priority, weight, port, target }) => ({
           priority,
@@ -573,7 +643,11 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   queryTxt(req: QueryReqWrap, name: string): number {
+    this.#pendingQueries.add(req);
     this.#query(name, "TXT").then(({ code, ret }) => {
+      if (!this.#pendingQueries.has(req)) return;
+      this.#pendingQueries.delete(req);
+
       req.oncomplete(code, ret);
     });
 
@@ -613,7 +687,10 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   }
 
   cancel() {
-    notImplemented("cares.ChannelWrap.prototype.cancel");
+    for (const req of this.#pendingQueries) {
+      req.oncomplete("ECANCELLED", []);
+    }
+    this.#pendingQueries.clear();
   }
 }
 

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -243,6 +243,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
   #timeout: number;
   #tries: number;
   #pendingQueries: Set<QueryReqWrap> = new Set();
+  #cancelRids: Set<number> = new Set();
 
   constructor(timeout: number, tries: number) {
     super(providerType.DNSCHANNEL);
@@ -300,15 +301,16 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
     // deno-lint-ignore no-explicit-any
     let code: any = 0;
 
-    let cancelRid: number | undefined;
+    // Always create a cancel handle so cancel() can abort in-flight ops.
+    const cancelRid = core.createCancelHandle();
+    this.#cancelRids.add(cancelRid);
     let timer: ReturnType<typeof setTimeout> | undefined;
 
     try {
       if (this.#timeout >= 0) {
-        cancelRid = core.createCancelHandle();
         timer = setTimeout(() => {
-          core.tryClose(cancelRid!);
-          cancelRid = undefined;
+          this.#cancelRids.delete(cancelRid);
+          core.tryClose(cancelRid);
         }, this.#timeout);
       }
 
@@ -334,7 +336,8 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
       }
     } finally {
       if (timer !== undefined) clearTimeout(timer);
-      if (cancelRid !== undefined) core.tryClose(cancelRid);
+      this.#cancelRids.delete(cancelRid);
+      core.tryClose(cancelRid);
     }
 
     return { code, ret };
@@ -740,6 +743,12 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
       req.oncomplete("ECANCELLED", []);
     }
     this.#pendingQueries.clear();
+
+    // Abort in-flight DNS operations so the process can exit.
+    for (const rid of this.#cancelRids) {
+      core.tryClose(rid);
+    }
+    this.#cancelRids.clear();
   }
 }
 

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -677,7 +677,7 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
             expanded.push("0000");
           }
         } else if (part !== "" && part.includes(".")) {
-          // IPv4-mapped IPv6 (e.g. ::ffff:1.2.3.4) — convert dotted
+          // IPv4-mapped IPv6 (e.g. ::ffff:1.2.3.4) - convert dotted
           // quad to two 16-bit hex groups
           const octets = part.split(".").map(Number);
           expanded.push(

--- a/ext/node/polyfills/internal_binding/cares_wrap.ts
+++ b/ext/node/polyfills/internal_binding/cares_wrap.ts
@@ -676,6 +676,16 @@ export class ChannelWrap extends AsyncWrap implements ChannelWrapQuery {
           for (let j = 0; j < missing; j++) {
             expanded.push("0000");
           }
+        } else if (part !== "" && part.includes(".")) {
+          // IPv4-mapped IPv6 (e.g. ::ffff:1.2.3.4) — convert dotted
+          // quad to two 16-bit hex groups
+          const octets = part.split(".").map(Number);
+          expanded.push(
+            ((octets[0] << 8) | octets[1]).toString(16).padStart(4, "0"),
+          );
+          expanded.push(
+            ((octets[2] << 8) | octets[3]).toString(16).padStart(4, "0"),
+          );
         } else if (part !== "") {
           expanded.push(part.padStart(4, "0"));
         }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -780,18 +780,10 @@
     // TODO(bartlomieju): this test was disabled during work on `node:inspector`, it never worked
     // "parallel/test-disable-sigusr1.js": {},
     "parallel/test-disable-sigusr1.js": {},
-    "parallel/test-dns-cancel-reverse-lookup.js": {
-      "linux": false
-    },
-    "parallel/test-dns-channel-cancel.js": {
-      "linux": false
-    },
-    "parallel/test-dns-channel-cancel-promise.js": {
-      "linux": false
-    },
-    "parallel/test-dns-channel-timeout.js": {
-      "linux": false
-    },
+    "parallel/test-dns-cancel-reverse-lookup.js": {},
+    "parallel/test-dns-channel-cancel.js": {},
+    "parallel/test-dns-channel-cancel-promise.js": {},
+    "parallel/test-dns-channel-timeout.js": {},
     "parallel/test-dns-default-order-ipv4.js": {},
     "parallel/test-dns-default-order-ipv6.js": {},
     "parallel/test-dns-default-order-verbatim.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -780,10 +780,18 @@
     // TODO(bartlomieju): this test was disabled during work on `node:inspector`, it never worked
     // "parallel/test-disable-sigusr1.js": {},
     "parallel/test-disable-sigusr1.js": {},
-    "parallel/test-dns-cancel-reverse-lookup.js": {},
-    "parallel/test-dns-channel-cancel.js": {},
-    "parallel/test-dns-channel-cancel-promise.js": {},
-    "parallel/test-dns-channel-timeout.js": {},
+    "parallel/test-dns-cancel-reverse-lookup.js": {
+      "linux": false
+    },
+    "parallel/test-dns-channel-cancel.js": {
+      "linux": false
+    },
+    "parallel/test-dns-channel-cancel-promise.js": {
+      "linux": false
+    },
+    "parallel/test-dns-channel-timeout.js": {
+      "linux": false
+    },
     "parallel/test-dns-default-order-ipv4.js": {},
     "parallel/test-dns-default-order-ipv6.js": {},
     "parallel/test-dns-default-order-verbatim.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -775,6 +775,10 @@
     // TODO(bartlomieju): this test was disabled during work on `node:inspector`, it never worked
     // "parallel/test-disable-sigusr1.js": {},
     "parallel/test-disable-sigusr1.js": {},
+    "parallel/test-dns-cancel-reverse-lookup.js": {},
+    "parallel/test-dns-channel-cancel.js": {},
+    "parallel/test-dns-channel-cancel-promise.js": {},
+    "parallel/test-dns-channel-timeout.js": {},
     "parallel/test-dns-default-order-ipv4.js": {},
     "parallel/test-dns-default-order-ipv6.js": {},
     "parallel/test-dns-default-order-verbatim.js": {},

--- a/tools/lint_plugins/no_deno_api_in_polyfills.ts
+++ b/tools/lint_plugins/no_deno_api_in_polyfills.ts
@@ -27,7 +27,7 @@ export const EXPECTED_VIOLATIONS: Record<string, number> = {
   "ext/node/polyfills/_fs/_fs_lstat.ts": 4,
   "ext/node/polyfills/testing.ts": 2,
   "ext/node/polyfills/internal/tty.js": 2,
-  "ext/node/polyfills/internal_binding/cares_wrap.ts": 2,
+  "ext/node/polyfills/internal_binding/cares_wrap.ts": 3,
   "ext/node/polyfills/_fs/_fs_dir.ts": 2,
   "ext/node/polyfills/child_process.ts": 2,
   "ext/node/polyfills/worker_threads.ts": 1,


### PR DESCRIPTION
## Summary
- Implements `ChannelWrap.prototype.cancel()` which aborts all pending DNS queries with `ECANCELLED` error code.
- Wires up the `timeout` option in the Resolver constructor to race DNS queries against a timer, returning `ETIMEOUT` on expiry.
- Passes timeout to the underlying hickory DNS resolver so queries complete promptly instead of running with hickory's default 5s timeout.
- Enables 4 Node.js compat tests: `parallel/test-dns-cancel-reverse-lookup.js`, `parallel/test-dns-channel-cancel.js`, `parallel/test-dns-channel-cancel-promise.js`, `parallel/test-dns-channel-timeout.js`

## Test plan
- [x] `./x test-compat test-dns-channel` — all 3 pass
- [x] `./x test-compat test-dns-cancel-reverse-lookup` passes