### PR TITLE
fix(ext/node): rename _destroySsl to _destroySSL to match Node.js API

### DIFF
--- a/ext/node/polyfills/_tls_wrap.js
+++ b/ext/node/polyfills/_tls_wrap.js
@@ -442,7 +442,7 @@ function defineHandleReading(socket, handle) {
   });
 }
 
-TLSSocket.prototype._destroySsl = function _destroySsl() {
+TLSSocket.prototype._destroySSL = function _destroySSL() {
   if (!this.ssl) return;
   this.ssl.destroySsl();
   this.ssl = null;

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3126,6 +3126,7 @@
     "parallel/test-tls-snicallback-error.js": {},
     "parallel/test-tls-socket-allow-half-open-option.js": {},
     "parallel/test-tls-socket-constructor-alpn-options-parsing.js": {},
+    "parallel/test-tls-socket-destroy.js": {},
     "parallel/test-tls-timeout-server-2.js": {},
     "parallel/test-tls-tlswrap-segfault-2.js": {},
     "parallel/test-tls-transport-destroy-after-own-gc.js": {},


### PR DESCRIPTION
## Summary
- Renames `TLSSocket.prototype._destroySsl` to `_destroySSL` to match
  Node.js's naming convention
- Fixes `test-tls-socket-destroy.js` node_compat test which calls
  `socket._destroySSL()` and was getting `TypeError: not a function`

## Test plan
- [x] `./x test-compat test-tls-socket-destroy.js` passes