### PR TITLE
ci: shard node_compat tests into 3 parallel jobs

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -396,8 +396,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -807,8 +817,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -1103,8 +1123,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -1651,8 +1681,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -1944,8 +1984,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -2448,8 +2498,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -2718,8 +2778,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -3127,8 +3197,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -3592,8 +3672,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -4190,8 +4280,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -4679,8 +4779,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'
@@ -5266,8 +5376,18 @@ jobs:
           - test_crate: node_compat
             test_package: node_compat_tests
             shard_index: '0'
-            shard_total: '1'
-            shard_label: ''
+            shard_total: '3'
+            shard_label: '(1/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '1'
+            shard_total: '3'
+            shard_label: '(2/3) '
+          - test_crate: node_compat
+            test_package: node_compat_tests
+            shard_index: '2'
+            shard_total: '3'
+            shard_label: '(3/3) '
           - test_crate: specs
             test_package: specs_tests
             shard_index: '0'

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -971,11 +971,14 @@ const buildJobs = buildItems.map((rawBuildItem) => {
   const additionalJobs = [];
 
   {
-    const shardedCrates = new Set(["specs", "integration"]);
-    const shardCount = 2;
+    const shardedCrates = new Map([
+      ["specs", 2],
+      ["integration", 2],
+      ["node_compat", 3],
+    ]);
     const testMatrix = defineMatrix({
       include: testCrates.flatMap((tc) => {
-        const total = shardedCrates.has(tc.name) ? shardCount : 1;
+        const total = shardedCrates.get(tc.name) ?? 1;
         return Array.from({ length: total }, (_, i) => ({
           test_crate: tc.name,
           test_package: tc.package,


### PR DESCRIPTION
## Summary
- Shards `node_compat` tests into 3 parallel CI jobs on PRs (previously ran as a single job)
- Converts `shardedCrates` from a `Set` to a `Map` to allow per-crate shard counts (`specs`/`integration` stay at 2, `node_compat` gets 3)
- Matches the shard count used by the dedicated nightly `node_compat_test` workflow

## Test plan
- [ ] CI passes with the new sharded node_compat jobs
- [ ] Job names show as `test node_compat (1/3) ...`, `(2/3)`, `(3/3)`