### PR TITLE
fix(ext/node): add _idleStart and _idleTimeout to Timeout

### DIFF
--- a/ext/node/polyfills/internal/timers.mjs
+++ b/ext/node/polyfills/internal/timers.mjs
@@ -13,6 +13,7 @@ const {
   immediateRefCount,
 } = core;
 const {
+  DateNow,
   FunctionPrototypeCall,
   MapPrototypeDelete,
   MapPrototypeGet,
@@ -105,6 +106,7 @@ export function Timeout(callback, after, args, isRepeat, isRefed) {
     after = 1;
   }
   this._idleTimeout = after;
+  this._idleStart = DateNow();
   this._onTimeout = callback;
   this._timerArgs = args;
   this._repeat = isRepeat;
@@ -221,6 +223,8 @@ Timeout.prototype[createTimer] = function () {
 Timeout.prototype[kDestroy] = function () {
   if (!this._destroyed) {
     this._destroyed = true;
+    this._idleTimeout = -1;
+    this._idleStart = DateNow();
     this._onTimeout = null;
     cancelTimer_(this._timer);
     MapPrototypeDelete(activeTimers, this[kTimerId]);
@@ -258,6 +262,7 @@ Timeout.prototype.refresh = function () {
   } else {
     refreshTimer_(this._timer);
   }
+  this._idleStart = DateNow();
   return this;
 };
 

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -3134,6 +3134,7 @@
     "parallel/test-tls-wrap-econnreset-socket.js": {},
     "parallel/test-tls-wrap-econnreset.js": {},
     "parallel/test-tls-wrap-event-emmiter.js": {},
+    "parallel/test-tls-wrap-timeout.js": {},
     "parallel/test-tls-zero-clear-in.js": {},
     "parallel/test-trace-events-api.js": {
       "ignore": true,

--- a/tests/specs/run/node_prefix_missing/node_globals.out
+++ b/tests/specs/run/node_prefix_missing/node_globals.out
@@ -11,6 +11,7 @@ Immediate {
 }
 Timeout {
   _idleTimeout: 1000,
+  _idleStart: [WILDLINE],
   _onTimeout: [Function (anonymous)],
   _timerArgs: [],
   _repeat: false,


### PR DESCRIPTION
## Summary
- Adds `_idleStart` property to `Timeout` objects, set to `Date.now()` on creation, refresh, and destroy — matching Node.js behavior
- Sets `_idleTimeout = -1` in `kDestroy` to signal a cleared timer, matching Node.js's unenroll semantics
- Enables `parallel/test-tls-wrap-timeout.js` Node.js compat test

## Test plan
- [x] `./x test-compat test-tls-wrap-timeout.js` passes