### PR TITLE
fix(ext/node): throw ERR_INVALID_ARG_TYPE from Cipheriv/Decipheriv update

### DIFF
--- a/ext/node/polyfills/internal/crypto/cipher.ts
+++ b/ext/node/polyfills/internal/crypto/cipher.ts
@@ -55,7 +55,10 @@ import {
   isAnyArrayBuffer,
   isArrayBufferView,
 } from "ext:deno_node/internal/util/types.ts";
-import { ERR_CRYPTO_INVALID_STATE } from "ext:deno_node/internal/errors.ts";
+import {
+  ERR_CRYPTO_INVALID_STATE,
+  ERR_INVALID_ARG_TYPE,
+} from "ext:deno_node/internal/errors.ts";
 import { StringDecoder } from "node:string_decoder";
 import assert from "node:assert";
 import { normalizeEncoding } from "ext:deno_node/internal/util.mjs";
@@ -317,7 +320,13 @@ Cipheriv.prototype.update = function (
     throw new ERR_CRYPTO_INVALID_STATE("update");
   }
 
-  // TODO(kt3k): throw ERR_INVALID_ARG_TYPE if data is not string, Buffer, or ArrayBufferView
+  if (typeof data !== "string" && !isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      "data",
+      ["string", "Buffer", "TypedArray", "DataView"],
+      data,
+    );
+  }
   let buf = data;
   if (typeof data === "string") {
     buf = Buffer.from(data, inputEncoding);
@@ -595,7 +604,13 @@ Decipheriv.prototype.update = function (
     throw new ERR_CRYPTO_INVALID_STATE("update");
   }
 
-  // TODO(kt3k): throw ERR_INVALID_ARG_TYPE if data is not string, Buffer, or ArrayBufferView
+  if (typeof data !== "string" && !isArrayBufferView(data)) {
+    throw new ERR_INVALID_ARG_TYPE(
+      "data",
+      ["string", "Buffer", "TypedArray", "DataView"],
+      data,
+    );
+  }
   let buf = data;
   if (typeof data === "string") {
     buf = Buffer.from(data, inputEncoding);

--- a/tests/unit_node/crypto/crypto_cipher_test.ts
+++ b/tests/unit_node/crypto/crypto_cipher_test.ts
@@ -1015,3 +1015,37 @@ Deno.test({
     assertEquals(dec, plaintext);
   },
 });
+
+// Regression test for https://github.com/denoland/deno/issues/33646
+// `Cipheriv.update`/`Decipheriv.update` must throw `ERR_INVALID_ARG_TYPE`
+// (matching Node) when `data` is not a string, Buffer, or ArrayBufferView.
+Deno.test({
+  name: "Cipheriv/Decipheriv update - rejects non-string non-buffer data",
+  fn() {
+    const key = Buffer.alloc(32);
+    const iv = Buffer.alloc(16);
+
+    const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+    try {
+      // deno-lint-ignore no-explicit-any
+      const err = assertThrows(() => cipher.update(12345 as any), TypeError);
+      assertEquals((err as { code?: string }).code, "ERR_INVALID_ARG_TYPE");
+    } finally {
+      cipher.final();
+    }
+
+    const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
+    try {
+      const err = assertThrows(
+        // deno-lint-ignore no-explicit-any
+        () => decipher.update(12345 as any),
+        TypeError,
+      );
+      assertEquals((err as { code?: string }).code, "ERR_INVALID_ARG_TYPE");
+    } finally {
+      try {
+        decipher.final();
+      } catch { /* final may reject the empty input; we just need cleanup */ }
+    }
+  },
+});


### PR DESCRIPTION
## Summary

`Cipheriv.prototype.update` and `Decipheriv.prototype.update` did not validate the `data` argument: passing a number (or any value that isn't a string, `Buffer`, or `ArrayBufferView`) either silently misbehaved or threw the unhelpful `TypeError: Cannot read properties of undefined (reading 'length')`. Node.js throws `TypeError [ERR_INVALID_ARG_TYPE]` with a structured message in this case.

This is acknowledged with TODO comments at both call sites in `ext/node/polyfills/internal/crypto/cipher.ts`. This PR replaces them with the validation.

Closes #33646.

## Test plan

- [x] New `Cipheriv/Decipheriv update - rejects non-string non-buffer data` test in `tests/unit_node/crypto/crypto_cipher_test.ts` asserts both `err.name === "TypeError"` and `err.code === "ERR_INVALID_ARG_TYPE"` for both APIs
- [x] Test passes locally; existing `crypto_cipher_test.ts` cases continue to pass
- [x] Repro from the issue (`cipher.update(12345)`) now produces `name: TypeError code: ERR_INVALID_ARG_TYPE` matching Node v22